### PR TITLE
chore(content): cloud EKS Deep Dive wave 5a — expand 5.1 Architecture + 5.2 Networking + 5.3 Identity to floor

### DIFF
--- a/src/content/docs/cloud/eks-deep-dive/module-5.1-eks-architecture.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.1-eks-architecture.md
@@ -6,7 +6,7 @@ sidebar:
 ---
 ## What You'll Be Able to Do
 
-This module is rated **[MEDIUM]** complexity with roughly **2.5 hours** of reading and lab time. You should be comfortable with [AWS Essentials](../aws-essentials/) networking and IAM basics plus general [Cloud Architecture Patterns](../architecture-patterns/) before diving into EKS control-plane design. After completing the module, you will be able to:
+This module is rated **[MEDIUM]** complexity with roughly **2.5 hours** of reading and lab time. You should be comfortable with [AWS Essentials](../../aws-essentials/) networking and IAM basics plus general [Cloud Architecture Patterns](../../architecture-patterns/) before diving into EKS control-plane design. After completing the module, you will be able to:
 
 - **Configure EKS clusters with private API endpoints, managed node groups, and Fargate profiles for production workloads**
 - **Design EKS control plane connectivity (public, private, dual-stack) based on security and availability requirements**
@@ -75,12 +75,12 @@ The cross-account ENI design has critical implications for subnet sizing, securi
 - The subnets you provide during cluster creation must have enough free IP addresses for these ENIs
 - Security Groups attached to these ENIs control traffic between the control plane and your nodes
 - If you delete or modify these ENIs, your cluster will lose control plane connectivity
-- The ENIs appear in your account tagged with `kubernetes.io/cluster/<cluster-name>`
+- The ENIs appear in your account with description `Amazon EKS <cluster-name>` (the legacy `kubernetes.io/cluster/<name>=owned` tag applied only on clusters running Kubernetes 1.14 or earlier)
 
 ```bash
 # View the cross-account ENIs in your VPC
 aws ec2 describe-network-interfaces \
-  --filters "Name=tag:kubernetes.io/cluster/my-cluster,Values=owned" \
+  --filters "Name=description,Values=Amazon EKS my-cluster" \
   --query 'NetworkInterfaces[*].{ENI:NetworkInterfaceId, SubnetId:SubnetId, PrivateIp:PrivateIpAddress, SG:Groups[0].GroupId}' \
   --output table
 ```
@@ -397,7 +397,7 @@ Every EKS cluster depends on a small set of platform add-ons; the table below li
 | `adot` | AWS Distro for OpenTelemetry | No |
 | `amazon-cloudwatch-observability` | Container Insights | No |
 
-The `eks-pod-identity-agent` add-on is increasingly part of modern baselines because it enables [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) without per-cluster OIDC provider plumbing. This module focuses on cluster architecture and authentication entries; [Module 5.3](../module-5.3-eks-identity/) covers IRSA versus Pod Identity migration in depth, and [AWS Essentials Module 1.1 (IAM)](../aws-essentials/module-1.1-iam/) explains the underlying IAM role trust models you will attach to service accounts.
+The `eks-pod-identity-agent` add-on is increasingly part of modern baselines because it enables [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) without per-cluster OIDC provider plumbing. This module focuses on cluster architecture and authentication entries; [Module 5.3](../module-5.3-eks-identity/) covers IRSA versus Pod Identity migration in depth, and [AWS Essentials Module 1.1 (IAM)](../../aws-essentials/module-1.1-iam/) explains the underlying IAM role trust models you will attach to service accounts.
 
 ### Managed add-ons versus self-managed manifests
 
@@ -1146,7 +1146,7 @@ done
 
 # Check the cross-account ENIs
 aws ec2 describe-network-interfaces \
-  --filters "Name=tag:kubernetes.io/cluster/$CLUSTER_NAME,Values=owned" \
+  --filters "Name=description,Values=Amazon EKS $CLUSTER_NAME" \
   --query 'NetworkInterfaces[*].{ENI:NetworkInterfaceId, PrivateIp:PrivateIpAddress, Subnet:SubnetId}' \
   --output table
 ```

--- a/src/content/docs/cloud/eks-deep-dive/module-5.1-eks-architecture.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.1-eks-architecture.md
@@ -4,11 +4,9 @@ slug: cloud/eks-deep-dive/module-5.1-eks-architecture
 sidebar:
   order: 2
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: AWS Essentials, Cloud Architecture Patterns
-
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+This module is rated **[MEDIUM]** complexity with roughly **2.5 hours** of reading and lab time. You should be comfortable with [AWS Essentials](../aws-essentials/) networking and IAM basics plus general [Cloud Architecture Patterns](../architecture-patterns/) before diving into EKS control-plane design. After completing the module, you will be able to:
 
 - **Configure EKS clusters with private API endpoints, managed node groups, and Fargate profiles for production workloads**
 - **Design EKS control plane connectivity (public, private, dual-stack) based on security and availability requirements**
@@ -19,11 +17,11 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-A cluster that relies only on the public API endpoint can create an unnecessary dependency on NAT or other external network paths for node-to-control-plane communication. Enabling the private endpoint keeps that traffic inside the VPC and reduces that failure mode.
+Hypothetical scenario: A platform team runs a production EKS cluster with only the public Kubernetes API endpoint enabled. Worker nodes live in private subnets and reach the API server through a NAT gateway. During a traffic spike on an unrelated data pipeline, NAT connection tracking saturates. Nodes lose steady contact with the control plane even though application pods still serve traffic locally. Deployments stall, new pods never schedule, and on-call engineers spend hours debugging application code when the failure mode is architectural connectivity. The remediation is not bigger NAT instances alone — it is enabling private endpoint access so kubelet traffic stops competing with arbitrary outbound internet flows on the NAT path.
 
-This story illustrates a fundamental truth about EKS: the control plane is managed by AWS, but how you connect to it, how your nodes register with it, and how you authenticate to it are entirely your responsibility. Getting these architectural decisions wrong does not just create inconveniences -- it creates single points of failure that can take down production workloads for hours.
+That pattern illustrates a fundamental truth about EKS: AWS operates the control plane, but you own how clients and nodes reach it, how compute registers, and how IAM principals map to Kubernetes RBAC. The managed control plane removes etcd backups and API server patching from your runbook, yet endpoint mode, subnet sizing, add-on versions, and authentication mode remain decisions with blast radius across every namespace. Getting them wrong does not produce a gentle degradation curve; it produces hard outages that look like mysterious application bugs until someone traces the request path to the API server.
 
-In this module, you will learn how the EKS control plane actually works under the hood, how to choose between public, private, and dual-stack API endpoints, when to use Managed Node Groups versus self-managed nodes versus Fargate, how EKS Add-ons simplify component lifecycle management, and how to migrate from the legacy `aws-auth` ConfigMap to the modern EKS Access Entries system.
+In this module, you will learn how the EKS control plane is structured across Availability Zones, how cross-account ENIs bridge the managed plane to your VPC, how to choose public, private, or dual endpoint access with realistic kubectl and CI/CD paths, when Managed Node Groups, self-managed nodes, or Fargate fit different isolation and cost profiles, how EKS managed add-ons track control plane versions, and how to migrate from the legacy `aws-auth` ConfigMap to EKS Access Entries without locking out operators.
 
 ---
 
@@ -33,7 +31,15 @@ When you create an EKS cluster, AWS provisions a highly available Kubernetes con
 
 ### What AWS Manages For You
 
-The EKS control plane consists of [at least two API server instances and three etcd nodes, spread across three Availability Zones](https://docs.aws.amazon.com/eks/latest/userguide/eks-architecture.html) in the AWS-owned account. You do not pay for this infrastructure directly -- it is included in the $0.10/hour cluster fee.
+The EKS control plane consists of [at least two API server instances and three etcd nodes, spread across three Availability Zones](https://docs.aws.amazon.com/eks/latest/userguide/eks-architecture.html) in the AWS-owned account. You do not pay for those API servers or etcd members as separate line items during [standard Kubernetes version support](https://aws.amazon.com/eks/pricing/) — that capacity is bundled into the per-cluster hourly fee while your worker compute is billed separately.
+
+AWS owns patching, scaling, and failure recovery for those control plane components. You cannot SSH to an API server, snapshot etcd yourself, or pin a custom `kube-apiserver` build. What you do control is the Kubernetes version on the cluster (within the EKS support calendar), optional [upgrade policies](https://docs.aws.amazon.com/eks/latest/userguide/view-kubernetes-versions.html) that determine whether you enter extended support or auto-upgrade at end of standard support, and the VPC configuration that determines how nodes and humans reach the API. Treat the boundary clearly in design reviews: anything involving ENIs, security groups, endpoint flags, or authentication mode is your operational contract even when the control plane itself is invisible.
+
+### etcd, API availability, and what you still operate
+
+etcd holds cluster state — objects, leases, and coordination data — and EKS runs it in the managed account with replication across three zones. You do not take etcd backups manually or restore from a volume you mount; disaster recovery for the control plane is AWS’s responsibility within the EKS SLA model. Your backup strategy instead targets application data, etcd-independent configuration in Git, and the ability to recreate node groups and add-ons against a fresh cluster if needed.
+
+From a troubleshooting perspective, “the cluster is down” often means clients cannot reach the API server endpoint you configured, not that AWS lost etcd. Symptoms include `kubectl` timeouts, nodes showing `NotReady` when the kubelet cannot renew leases, and controllers that stop reconciling while long-running pods continue serving until they need scheduling changes. When incidents strike, split the path: verify endpoint accessibility from the caller’s network, verify cross-account ENIs and security groups on the data plane path, then inspect Kubernetes events — before assuming the managed plane failed.
 
 ```mermaid
 flowchart TD
@@ -64,7 +70,7 @@ flowchart TD
 
 The most important architectural detail in EKS is the **cross-account Elastic Network Interface (ENI)**. When you create an EKS cluster, [AWS places ENIs from the managed control plane account into the subnets you specify in your VPC. These ENIs are how the control plane communicates with your worker nodes.](https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html)
 
-This has critical implications:
+The cross-account ENI design has critical implications for subnet sizing, security groups, and change management. The subnets you provide during cluster creation must have enough free IP addresses for these ENIs, and treating those ENIs like ordinary unused elastic network interfaces is a common outage pattern during over-eager VPC cleanups.
 
 - The subnets you provide during cluster creation must have enough free IP addresses for these ENIs
 - Security Groups attached to these ENIs control traffic between the control plane and your nodes
@@ -81,7 +87,9 @@ aws ec2 describe-network-interfaces \
 
 ### The Cluster Security Group
 
-EKS automatically creates a **cluster security group** that is [attached to both the cross-account ENIs and your managed node groups. This security group allows unrestricted communication between the control plane and your nodes](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html). You can find it in the cluster details:
+EKS automatically creates a **cluster security group** that is [attached to both the cross-account ENIs and your managed node groups. This security group allows unrestricted communication between the control plane and your nodes](https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html). Think of it as the deliberately permissive bridge AWS requires so kubelets, webhooks, and CNI components can function without micromanaging thousands of port rules per cluster. You can find it in the cluster details:
+
+Understanding the split between cluster security groups and additional security groups prevents a common audit failure mode: teams tighten the cluster security group and break nodes, or they open the public endpoint wide while believing an additional group alone provides protection. The correct pattern keeps the cluster security group intact for node traffic and uses additional groups plus `publicAccessCidrs` for human and CI entry paths.
 
 ```bash
 # Retrieve the cluster security group
@@ -92,7 +100,11 @@ aws eks describe-cluster --name my-cluster \
 
 Do not remove or restrict this security group unless you fully understand the consequences. Misconfiguring it is one of the fastest ways to make your nodes unable to join the cluster.
 
-> **Stop and think**: If a security group rule inadvertently blocks traffic from the worker nodes to the cross-account ENIs, what happens to the pods already running on those nodes? Do they crash immediately, or do they keep running? (Hint: Think about what the control plane actually does versus what the local kubelet does).
+**Reflective checkpoint:** If a security group rule blocks worker nodes from reaching cross-account ENIs, pods already running on those nodes typically keep executing because the local kubelet continues managing containers until an operation requires the API server — scheduling changes, eviction, certificate rotation, or scale events. The cluster looks “half alive,” which is why ENI and security group regressions are so painful to diagnose under pressure.
+
+### Subnet IP planning beyond the ENI headline
+
+Each cluster subnet you register consumes control plane ENI addresses from your CIDR. AWS [requires sufficient free addresses](https://docs.aws.amazon.com/eks/latest/userguide/network-reqs.html) in those subnets and recommends planning for growth because the same subnets later host nodes and, with the VPC CNI, pod IPs. A `/28` subnet that barely fits two nodes can fail silently during control plane upgrades or node group expansions when ENI placement competes with pod density. Platform teams routinely standardize on `/24` or larger private subnets per AZ for production EKS precisely because the control plane footprint is small but non-negotiable.
 
 ---
 
@@ -133,6 +145,8 @@ flowchart TD
 
 **The problem**: Your worker nodes in private subnets must reach the API server through the public endpoint, which sends that traffic out of the VPC. This adds latency, costs money (NAT data processing fees), and creates a dependency on the NAT Gateway. If your NAT Gateway is overwhelmed or fails, your nodes lose contact with the control plane.
 
+When only `endpointPublicAccess` is true, the Kubernetes API DNS name resolves to public addresses from the internet. Nodes in private subnets without a route that prefers the private ENI path will hairpin through NAT to those public IPs — the classic “public-only” footgun. Operators sometimes restrict administrative access with `publicAccessCidrs` while leaving node traffic on the expensive path, which improves security for human `kubectl` but does not fix node-to-API reliability.
+
 You can restrict the public endpoint using CIDR allowlists:
 
 ```bash
@@ -171,6 +185,8 @@ flowchart TD
 
 **Challenge**: [You cannot run `kubectl` from your laptop unless you are connected to the VPC via VPN, Direct Connect, or a bastion host](https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html). CI/CD pipelines must also run inside the VPC or have network connectivity to it.
 
+Private-only mode is the right choice when regulatory or threat models forbid any internet-reachable Kubernetes API surface. The trade is operational: every actor that calls the API — humans, GitHub Actions runners, Terraform Cloud agents, emergency break-glass tooling — needs a network path into the VPC. Teams often standardize on SSM Session Manager bastions, VPN concentrators, or CI runners in the same account/region so access patterns mirror production traffic rather than bolting on one-off SSH keys.
+
 ```bash
 aws eks update-cluster-config --name my-cluster \
   --resources-vpc-config \
@@ -181,6 +197,8 @@ aws eks update-cluster-config --name my-cluster \
 ### Public + Private (Recommended for Production)
 
 [The best-practice configuration enables both endpoints](https://docs.aws.amazon.com/eks/latest/best-practices/subnets.html). Nodes use the private endpoint (traffic stays in VPC), while developers and CI/CD pipelines can use the public endpoint (optionally restricted by CIDR).
+
+With both endpoints enabled, [EKS uses split-horizon DNS](https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html): the same cluster hostname resolves to private ENI addresses inside the VPC and to public addresses from the broader internet. Nodes and in-VPC automation should therefore hit the private path automatically, while operators on corporate networks reach the public endpoint only if their source IP is within `publicAccessCidrs`. Document which path each tool uses during onboarding so security reviews do not confuse “public endpoint exists” with “the API is open to the world.”
 
 ```mermaid
 flowchart TD
@@ -221,9 +239,17 @@ aws eks update-cluster-config --name my-cluster \
 | Private only | Node -> ENI -> API (VPC internal) | VPN/bastion only | Highest | No |
 | Public + Private | Node -> ENI -> API (VPC internal) | Anywhere (CIDR restrict) | High | No |
 
-*War Story: The fintech failure described in the opening was exactly the "public only" pattern. When they switched to public + private with CIDR restrictions, their node fleet became completely independent of NAT Gateway health for control plane communication. The same data pipeline explosion that previously caused a four-hour outage became a non-event the next time it happened -- nodes were unaffected from a control plane communication perspective because they were talking to the control plane through the private ENIs.*
+### How kubectl and the kubelet choose an endpoint
 
-> **Pause and predict**: A developer using a laptop connected to the corporate VPN (which has a route to the VPC) tries to run `kubectl get pods` on an EKS cluster configured with a "Private Only" endpoint. Will the command succeed? Why or why not?
+Both the Kubernetes CLI and node kubelets ultimately open HTTPS connections to the same logical API server, but they may traverse different network paths depending on where they run and which endpoint flags you enabled. When `endpointPrivateAccess` is true and the client resolves DNS from inside the VPC, the cluster’s public hostname should map to private addresses on the cross-account ENIs, keeping kubelet heartbeats off the public internet. When the client resolves from outside the VPC without connectivity to those addresses, `kubectl` fails even if the public endpoint is technically enabled but restricted by CIDR.
+
+This is why split-horizon DNS is not an obscure detail — it is the mechanism that makes dual-endpoint designs work. Operators who tunnel into the VPC but inherit public DNS resolvers still hit the public IPs and wonder why “private endpoint is on” yet latency and NAT metrics look wrong. Standardize an internal resolver or `/etc/hosts` testing procedure during incidents so you know which path is in play before tweaking security groups.
+
+Additional security groups attached at cluster creation apply only to control plane ENIs, not worker instances. They are the right place to allow corporate CIDR blocks to TCP 443 while keeping the cluster security group focused on node-to-control-plane chatter. Confusing the two groups leads to either overly open public exposure or accidental blocks on node traffic — both show up as flaky `NotReady` nodes rather than clear “security group denied” messages in the EKS console.
+
+Hypothetical scenario: A team running public-only endpoints suffers repeated deployment freezes whenever NAT saturates during batch jobs. After enabling public and private endpoints together and tightening `publicAccessCidrs` to corporate egress ranges, node kubelets keep using the private ENI path while engineers still reach the API from approved networks. The next NAT spike affects outbound internet for pods that need it, but control plane heartbeats no longer compete for NAT capacity — an outcome that is invisible in the EKS console yet decisive for platform stability.
+
+**Reflective checkpoint:** A developer on a corporate VPN with routes into the VPC runs `kubectl get pods` against a private-only cluster. The command succeeds only if DNS resolution inside that VPN path returns the private ENI addresses (or the client uses an endpoint configuration that targets them). VPN without VPC DNS forwarding often fails even when “VPN is connected,” which is why bastion-based `aws eks update-kubeconfig` workflows remain common in private-only designs.
 
 ---
 
@@ -249,12 +275,14 @@ aws eks create-nodegroup \
   --labels environment=production,team=platform
 ```
 
-Key features of MNGs:
+Managed node groups bundle several operational features that matter at scale: graceful rolling updates, multi-instance-type capacity pools, integration with cluster autoscalers, and launch-template extensibility for custom bootstrap logic.
 
 - **Graceful updates**: When you update the AMI or instance type, MNGs cordon and drain nodes one by one, respecting PodDisruptionBudgets
 - **Multiple instance types**: Specify multiple instance types to widen available capacity pools; On-Demand groups use the order you provide, and Spot groups use AWS allocation strategies such as price-capacity-optimized.
 - **Automatic scaling**: Integrates with Cluster Autoscaler or Karpenter
 - **Launch templates**: Customize with user data, additional security groups, or custom AMIs via launch templates
+
+Managed node groups attach the cluster security group automatically and register nodes with IAM roles you supply. For most stateful and stateless application tiers, they are the default because AWS owns AMI refresh mechanics while you retain instance size, capacity type, labels, and taints. The cost model is pure EC2 (plus EBS and data transfer): you pay for instances whether pods fill them or not, which makes rightsizing and autoscaling policies the main cost levers rather than a separate Kubernetes compute tax.
 
 ### Self-Managed Node Groups
 
@@ -268,7 +296,7 @@ Self-managed nodes are EC2 instances you provision yourself (usually via an Auto
   --container-runtime containerd
 ```
 
-When to use self-managed nodes:
+Self-managed nodes remain appropriate when you need a custom AMI with pre-baked software (GPU drivers, compliance agents), instance types not yet available through MNG APIs, specialized Windows images, or bespoke drain orchestration tied to legacy Auto Scaling Group automation.
 
 - You need a custom AMI with pre-baked software (e.g., GPU drivers, compliance agents)
 - You require instance types not yet supported by MNGs
@@ -276,6 +304,8 @@ When to use self-managed nodes:
 - You want full control over the update/drain process
 
 The trade-off is clear: you own the entire lifecycle, including security patches, AMI updates, and drain orchestration.
+
+Self-managed nodes still require the same IAM node role and bootstrap contract (`/etc/eks/bootstrap.sh`) so kubelet registers against your API endpoint mode. Teams choose this path when they must bake compliance agents into AMIs, coordinate GPU driver versions with ML frameworks, or integrate with existing Auto Scaling Group automation that predates EKS MNG APIs. You gain maximum flexibility at the price of runbooks: during every Kubernetes minor upgrade, you validate bootstrap scripts, CNI compatibility, and drain ordering yourself instead of clicking through a managed node group release channel.
 
 ### AWS Fargate
 
@@ -291,13 +321,15 @@ aws eks create-fargate-profile \
   --selectors '[{"namespace":"backend","labels":{"compute":"fargate"}}]'
 ```
 
-Fargate characteristics:
+Fargate-backed pods trade node operations for per-pod isolation with the following constraints and behaviors that platform teams review before approving Fargate profiles:
 
 - **No nodes to manage**: No patching, no AMI updates, no SSH access
 - **Per-pod isolation**: Each pod runs in its own Firecracker microVM
 - **Cold start**: Pods on Fargate generally take noticeably longer to become ready than pods scheduled onto already-running EC2 nodes
 - **Limitations**: [No DaemonSets, no privileged containers, no GPUs](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html), no persistent local storage
-- **Cost**: Cost depends on workload shape and operational trade-offs; Fargate can reduce node-management overhead but is not universally the cheapest option
+- **Cost**: [AWS Fargate bills per vCPU and memory from image pull start until pod termination](https://aws.amazon.com/fargate/pricing/) with a one-minute minimum; EKS does not charge a separate Fargate tax beyond the cluster control plane fee
+
+Fargate schedules one pod per Firecracker microVM, which is excellent for hard multi-tenant isolation but expensive for steady, dense services. It cannot run DaemonSets, so node-level log agents, security sensors, or mesh init containers that depend on host access must move to sidecar patterns or stay on EC2-backed compute. [AWS documents](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html) that only one pod runs on each Fargate task — there is no bin-packing multiple pods onto the same microVM. Cold starts routinely land in the tens of seconds, so bursty batch namespaces benefit more than latency-sensitive synchronous APIs unless you keep warm capacity elsewhere.
 
 ### Compute Decision Matrix
 
@@ -312,15 +344,23 @@ Fargate characteristics:
 | **Cost model** | EC2 pricing | EC2 pricing | Per-pod vCPU+memory/sec |
 | **Best for** | Most workloads | Custom/GPU/special | Batch, burstable, low-ops |
 
-Most production clusters use a hybrid approach: Managed Node Groups for the core workload, with Fargate profiles for specific namespaces that benefit from serverless isolation (like batch jobs or tenant-isolated services).
+Most production clusters use a hybrid approach: Managed Node Groups for the core workload, with Fargate profiles for specific namespaces that benefit from serverless isolation (like batch jobs or tenant-isolated services). Capacity planning for hybrid fleets means maintaining two scheduling grammars: node selectors and taints for EC2 pools, and namespace/label selectors for Fargate profiles. Autoscaling policies differ as well — Cluster Autoscaler or Karpenter for EC2, while Fargate scales per pod without a node intermediary. During incidents, confirm which profile owns a failing pod before chasing node health metrics that do not exist for Fargate.
 
-> **Stop and think**: You have a mission-critical DaemonSet that ships logs to a central security account. You are considering migrating some of your high-burst, unpredictable web traffic to Fargate to save on over-provisioned EC2 nodes. What architectural trade-off will you immediately face regarding your logging strategy?
+**Reflective checkpoint:** If a mission-critical log shipper runs as a DaemonSet on EC2 nodes, moving bursty web tiers to Fargate splits observability: Fargate pods need sidecar or remote logging patterns because the DaemonSet cannot mount on the microVM host. Budget engineering time for that redesign before chasing Fargate savings on over-provisioned node pools.
 
 ---
 
 ## EKS Add-ons: Managed Component Lifecycle
 
-Every Kubernetes cluster needs certain components to function: [a CNI plugin for networking, a DNS service for service discovery, and a kube-proxy for Service routing](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html). EKS Add-ons provide a managed way to install, configure, and update these components.
+Every Kubernetes cluster needs certain components to function beyond the API server itself: a Container Network Interface to assign pod addresses, DNS for service discovery, and kube-proxy (or equivalent datapath rules) to implement Service IPs. On EKS these components are not optional extras — they are part of the data plane contract between AWS networking and Kubernetes scheduling. Treating them as “day-two Helm installs” is how teams end up with clusters that upgrade cleanly on paper yet fail the first time a new node group launches during a promotion window.
+
+### Version skew and the upgrade calendar
+
+EKS publishes a [Kubernetes version calendar](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html) tying each minor release to standard and extended support end dates. Control plane upgrades do not automatically move add-ons; you must select compatible builds from `describe-addon-versions` and roll them cluster-wide. A practical runbook sequences: upgrade control plane, upgrade `vpc-cni` before scaling nodes, upgrade `coredns` and `kube-proxy`, then install optional drivers (EBS/EFS) if storage classes changed defaults. Skipping steps shows up as flaky DNS or IP exhaustion only under load, which is why load tests after upgrades matter as much as API version bumps.
+
+Default clusters created without explicit add-on APIs still run `vpc-cni`, `coredns`, and `kube-proxy` as self-managed workloads in `kube-system`. Migrating those components to EKS-managed add-ons is a common modernization task because it centralizes version visibility in the same console pane as the control plane version. The migration itself requires planning: capture existing environment variables and ConfigMaps, choose `PRESERVE` on first adoption, and validate pod networking in a staging cluster before touching production.
+
+[EKS Add-ons](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html) provide a managed way to install, configure, and update these components instead of hand-rolling Helm releases for every cluster.
 
 ### Why Add-ons Matter
 
@@ -330,6 +370,8 @@ Before EKS Add-ons, teams installed these components using Helm charts or raw ma
 - Providing one-click (or one-API-call) upgrades
 - Preserving your custom configuration during updates
 - Surfacing health status in the EKS console and API
+
+When you create a cluster, EKS can install a default set of self-managed add-ons (`vpc-cni`, `coredns`, `kube-proxy`) or you can adopt [EKS-managed add-on APIs](https://docs.aws.amazon.com/eks/latest/userguide/eks-add-ons.html) that tie lifecycle to the control plane version matrix. The critical operational rule is version skew: upgrading Kubernetes without moving compatible add-on builds leaves you with networking or DNS failures that surface only when new nodes join. Platform runbooks therefore pair every control plane upgrade with `describe-addon-versions` checks and staged `update-addon` calls, using `PRESERVE` when custom CNI settings must survive.
 
 ### Core Add-ons
 
@@ -341,7 +383,7 @@ aws eks describe-addon-versions \
   --output table
 ```
 
-The essential add-ons for any EKS cluster:
+Every EKS cluster depends on a small set of platform add-ons; the table below lists the components you will install or upgrade on nearly every production cluster, including optional drivers and observability agents that become mandatory once applications rely on them.
 
 | Add-on | Purpose | Default? |
 | :--- | :--- | :--- |
@@ -354,6 +396,16 @@ The essential add-ons for any EKS cluster:
 | `aws-mountpoint-s3-csi-driver` | S3 mount as filesystem | No |
 | `adot` | AWS Distro for OpenTelemetry | No |
 | `amazon-cloudwatch-observability` | Container Insights | No |
+
+The `eks-pod-identity-agent` add-on is increasingly part of modern baselines because it enables [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) without per-cluster OIDC provider plumbing. This module focuses on cluster architecture and authentication entries; [Module 5.3](../module-5.3-eks-identity/) covers IRSA versus Pod Identity migration in depth, and [AWS Essentials Module 1.1 (IAM)](../aws-essentials/module-1.1-iam/) explains the underlying IAM role trust models you will attach to service accounts.
+
+### Managed add-ons versus self-managed manifests
+
+| Approach | When it fits | Risk profile |
+| :--- | :--- | :--- |
+| EKS managed add-on | You want AWS-tested version matrices and API-driven upgrades | Lower drift; still requires post-upgrade validation |
+| Self-managed Helm/manifest | You need bleeding-edge CNI features or non-catalog components | Higher drift; you own compatibility testing |
+| Hybrid | Core networking on managed add-ons, observability via Helm | Document who owns upgrades for each component |
 
 ### Installing and Updating Add-ons
 
@@ -380,7 +432,7 @@ aws eks update-addon \
   --resolve-conflicts PRESERVE
 ```
 
-The `--resolve-conflicts` flag is important:
+The `--resolve-conflicts` flag determines whether EKS overwrites custom configuration during add-on updates, and production clusters usually standardize on one policy per add-on after testing:
 
 - `NONE`: Fail if your custom configuration conflicts with the add-on defaults
 - `OVERWRITE`: Replace any custom configuration with add-on defaults
@@ -388,7 +440,7 @@ The `--resolve-conflicts` flag is important:
 
 For production, always use `PRESERVE` unless you specifically want to reset to defaults.
 
-> **Pause and predict**: You trigger an EKS cluster upgrade from Kubernetes 1.34 to 1.35. You do not update the `vpc-cni` add-on. Several weeks later, nodes start scaling up, but new pods are stuck in `ContainerCreating`. What likely went wrong with the add-on lifecycle?
+**Reflective checkpoint:** After a control plane upgrade to Kubernetes 1.35, leaving `vpc-cni` on a build tested only for 1.34 often breaks IP allocation on new nodes while older nodes appear fine. The failure shows up weeks later during scale-out, which is why add-on upgrades belong on the same change ticket as the Kubernetes version bump, not as optional cleanup.
 
 ---
 
@@ -425,7 +477,7 @@ data:
         - system:masters
 ```
 
-Problems with `aws-auth`:
+The legacy `aws-auth` ConfigMap created recurring operational risk because a single YAML mistake could revoke API access for every IAM principal except the original cluster creator, and because changes were invisible to AWS audit tooling.
 
 1. **Single point of failure**: One YAML syntax error in this ConfigMap [locks everyone out of the cluster (except the cluster creator)](https://docs.aws.amazon.com/eks/latest/userguide/auth-configmap.html)
 2. **No audit trail**: Changes to a ConfigMap are not logged in AWS CloudTrail
@@ -434,6 +486,8 @@ Problems with `aws-auth`:
 5. **Easy to break**: A misplaced space in YAML can corrupt the entire mapping
 
 Directly editing `aws-auth` is risky: a bad change can break IAM-to-RBAC mappings and leave teams scrambling to recover access. Moving to access entries reduces that operational risk.
+
+Node IAM roles still need Kubernetes identity, but managed node groups and Access Entries can create the node entry automatically in modern flows. Human and CI principals should never require `system:masters` in `mapUsers` when scoped access policies exist. Workload AWS API access is a separate concern: pods assume IAM roles via IRSA or Pod Identity ([Module 5.3](../module-5.3-eks-identity/)), while Access Entries answer “which IAM principal can call the Kubernetes API and with which RBAC.” Keeping that separation explicit prevents copying admin cluster roles into application task roles.
 
 ### The Modern System: EKS Access Entries
 
@@ -465,9 +519,11 @@ EKS provides [several predefined access policies](https://docs.aws.amazon.com/ek
 | `AmazonEKSEditPolicy` | `edit` ClusterRole | Namespace or cluster |
 | `AmazonEKSViewPolicy` | `view` ClusterRole | Namespace or cluster |
 
+Access policy ARNs always use the `arn:aws:eks::aws:cluster-access-policy/` prefix shown in the CLI examples above. When designing least-privilege roles, start with view or edit scoped to namespaces, escalate to admin only for platform break-glass roles, and reserve cluster-admin equivalents for automated controllers that genuinely require cluster-wide object management. Document each principal’s entry type (`STANDARD` versus `EC2_LINUX`, `FARGATE_LINUX`, or `EC2_WINDOWS` for compute) so audits can trace node identity separately from human operators.
+
 ### Authentication Modes
 
-EKS clusters support three authentication modes:
+EKS clusters support three authentication modes that define whether `aws-auth`, Access Entries, or both are authoritative during migration.
 
 ```bash
 # Check current authentication mode
@@ -483,7 +539,7 @@ aws eks describe-cluster --name my-cluster \
 
 ### Migration Path: aws-auth to Access Entries
 
-The migration is non-destructive and can be done incrementally:
+The migration from `aws-auth` to Access Entries is non-destructive when you follow the phased API sequence below, validating each principal before removing the ConfigMap.
 
 ```bash
 # Step 1: Switch to API_AND_CONFIG_MAP mode (both systems active)
@@ -516,7 +572,137 @@ kubectl delete configmap aws-auth -n kube-system
 
 > **Important**: [You cannot go backwards. Once you switch from `API_AND_CONFIG_MAP` to `API`, you cannot re-enable the ConfigMap.](https://docs.aws.amazon.com/eks/latest/userguide/setting-up-access-entries.html) Test thoroughly in the transitional mode before making the final switch.
 
-> **Stop and think**: Your team is in the [`API_AND_CONFIG_MAP` transitional mode](https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html). A developer deletes the `aws-auth` ConfigMap prematurely to "clean up." Can the team still access the cluster? What determines their access?
+**Reflective checkpoint:** In `API_AND_CONFIG_MAP` mode, deleting `aws-auth` early removes legacy mappings but leaves Access Entries authoritative. Principals with entries and associated policies keep working; everyone else loses API access even if they previously relied on `mapRoles`. That is why migration runbooks duplicate mappings before cleanup and why the final `API` switch is one-way.
+
+---
+
+## Platform Readiness: What to Validate Before Production
+
+Architecture diagrams are only useful if they translate into checks operators can run during cluster launch and quarterly audits. The following readiness themes consolidate the control-plane topics above into a practical gate you can embed in Terraform review or a platform onboarding checklist.
+
+**Endpoint and network path verification** should confirm both the intended endpoint flags and the actual paths clients use. From a node in each private subnet, ensure the Kubernetes API hostname resolves to RFC1918 addresses and that security groups allow TCP 443 to cross-account ENIs. From an operator workstation on the approved corporate network, confirm `publicAccessCidrs` still matches egress ranges after IT changes proxy vendors. Document whether CI runners live inside the VPC; if not, record the VPN or PrivateLink mechanism that will replace “kubectl from laptop” assumptions.
+
+**Compute baseline documentation** should list every node group and Fargate profile with instance families, capacity types, taints, labels, and owners. New services should declare which pool they target before merge, preventing silent scheduling onto default pools that lack GPU, Arm, or high-memory shapes. For Fargate profiles, capture namespace/label selectors and note observability gaps relative to DaemonSet-based logging on EC2.
+
+**Add-on and version matrix hygiene** means maintaining a table that pairs cluster Kubernetes versions with tested `vpc-cni`, `coredns`, `kube-proxy`, and identity agent builds. During upgrades, block the change if any add-on lacks a compatible row in `describe-addon-versions`. Capture whether each add-on uses `PRESERVE` or `OVERWRITE` so on-call engineers know if an update might reset custom CNI environment variables.
+
+**Authentication migration state** must be visible in infrastructure repositories: current `authenticationMode`, roster of Access Entries, associated policies, and scopes. Teams still in `API_AND_CONFIG_MAP` should carry a dated ticket to finish migration, because dual modes confuse incident response (“which mapping failed?”). Avoid granting `AmazonEKSClusterAdminPolicy` to CI roles; scope edit/view policies per namespace and use break-glass roles with MFA for cluster-admin.
+
+**Cost and lifecycle guardrails** belong in the same review. Tag clusters with environment, owner, and expected lifetime; alert when Kubernetes versions approach end of standard support. For non-production clusters, automate shutdown schedules or consolidate sandboxes — three extended-support dev clusters cost more in control-plane fees alone than many teams expect.
+
+Hypothetical scenario: During a production readiness review, an auditor asks for proof that nodes do not depend on NAT for API connectivity. You demonstrate `describe-cluster` showing private access enabled, `dig` from a worker showing private ENI targets, and security group rules allowing node SG to cluster SG on 443. The review passes because evidence maps directly to architectural decisions instead of hand-waving “EKS is managed.”
+
+---
+
+## Cost Lens: Control Plane, Versions, and Compute
+
+EKS billing splits cleanly into **cluster hours** (Kubernetes version support tier), **worker infrastructure** (EC2, Fargate, EBS, load balancers), and **data-plane networking** (NAT, cross-AZ traffic, public IPv4 charges). Architecture choices in this module move the middle two buckets more than the first, except when version policy triggers extended support.
+
+### Control plane and version support
+
+During [standard Kubernetes version support](https://aws.amazon.com/eks/pricing/) — the first 14 months after a version is available in EKS — each cluster costs **$0.10 per hour** (~$73 per 730-hour month) regardless of node count. After standard support ends, clusters on that minor version enter **extended support** at **$0.60 per hour** (~$438/month) for up to 12 additional months unless you upgrade. That sixfold jump is pure policy: identical APIs, different support tier. IaC defaults sometimes enable extended support automatically; aligning `upgradePolicy` with your tested upgrade cadence avoids silent invoice surprises.
+
+| Cost driver | Typical monthly impact | Knobs that reduce it |
+| :--- | :--- | :--- |
+| Standard support control plane | ~$73 per cluster | Consolidate dev clusters; delete unused sandboxes |
+| Extended support surcharge | +~$365 per cluster vs standard | Upgrade Kubernetes before end of standard window |
+| NAT-heavy public-only endpoints | Variable data processing | Enable private endpoint so node/API traffic stays in VPC |
+| Over-provisioned MNG capacity | EC2 hours for idle nodes | Cluster Autoscaler, Karpenter, rightsizing, Spot where safe |
+| Fargate for steady dense services | Per-pod vCPU/memory seconds | Move baseline traffic to MNG; reserve Fargate for burst/isolation |
+
+### Node versus Fargate at moderate scale
+
+Hypothetical scenario: A namespace runs twenty pods averaging 0.25 vCPU and 0.5 GiB requests on `m6i.large` nodes that are 40% utilized. Moving all twenty pods to Fargate removes EC2 operations but often raises compute spend because each pod pays for its own microVM envelope without bin-packing. Conversely, three large batch jobs per day that need isolation but not DaemonSets may cost less on Fargate than keeping three half-empty nodes online 24/7. Model both sides with the [Fargate pricing page](https://aws.amazon.com/fargate/pricing/) and your real request/limit profiles before platform mandates.
+
+Unexpected cost spikes usually come from **multiplied control planes** (many environment clusters), **extended support drift**, **NAT data processing** on chatty public-only designs, and **IP charges** when the VPC CNI consumes large subnet space — topics covered further in [Module 5.2](../module-5.2-eks-networking/).
+
+### Control plane observability and support boundaries
+
+AWS monitors the managed control plane components and publishes cluster health in the EKS API, but you still need application-level SLOs on top. CloudWatch metrics for the control plane surface API server request rates and etcd health indicators where enabled; pair them with audit logging (`audit` policy in `kube-apiserver`) forwarded to your SIEM when compliance requires who changed what object. Remember that worker node CPU metrics do not tell you whether the API server is throttling LIST calls — watch Kubernetes API latency from controllers and CI pipelines.
+
+When opening AWS Support cases, distinguish data-plane symptoms (nodes, CNI, add-ons) from true control-plane issues (global `kubectl` failure across networks). Providing endpoint configuration, recent authentication mode changes, and timestamps of ENI modifications accelerates triage. AWS can replace managed control plane capacity, but it cannot fix a customer security group that blocks ENIs — another reason architecture reviews focus on customer-owned networking.
+
+For multi-cluster fleets, chargeback should include the flat $0.10/hour (or $0.60/hour) line item explicitly. Application teams often model only EC2 in their budgets and are surprised that ten microservice clusters mean ten control-plane bills before any pod schedules. Consolidating non-production workloads into namespace-isolated shared clusters reduces that tax but increases RBAC and noisy-neighbor governance work — a trade platforms should document rather than hide.
+
+---
+
+## Patterns & Anti-Patterns
+
+Production EKS platforms converge on a small set of architectural patterns because the managed control plane is uniform — differentiation is endpoint mode, compute mix, add-on hygiene, and authentication APIs.
+
+| Pattern | When to Use | Why It Works | Scaling Note |
+| :--- | :--- | :--- | :--- |
+| Dual endpoint + CIDR-restricted public | Humans/CI outside VPC; nodes in private subnets | Nodes use private ENIs; operators use audited public path | Revisit CIDR lists when corporate egress changes |
+| Managed node groups per workload class | General services, GPU, memory tiers | AWS handles AMI rollouts; you steer with labels/taints | Add node groups instead of one oversized pool |
+| EKS managed core add-ons | `vpc-cni`, `coredns`, `kube-proxy`, identity agent | Version matrix tracks Kubernetes releases | Automate add-on upgrades in the same change window as CP |
+| Access Entries with scoped policies | Multi-team clusters | CloudTrail auditable; avoids `aws-auth` YAML lockouts | Start in `API_AND_CONFIG_MAP`, validate, then `API` |
+| Hybrid EC2 + Fargate profiles | Batch/tenant namespaces needing isolation | Keeps DaemonSets on EC2, bursty work on Fargate | Document logging/mesh differences per compute type |
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+| :--- | :--- | :--- |
+| Public-only API for private nodes | NAT becomes control-plane choke point | Enable private endpoint; restrict public CIDRs |
+| Treating Fargate as “cheaper Kubernetes” | Steady workloads pay per-pod microVM tax | Rightsize MNG; Fargate for burst/isolation only |
+| Skipping add-on upgrades after CP bump | New nodes fail CNI/DNS while old nodes look fine | Gate cluster upgrades on compatible add-on versions |
+| Editing `aws-auth` under pressure | Typo locks out all IAM principals | Access Entries + infrastructure-as-code for auth |
+| Tiny `/28` subnets for EKS | ENI + node + pod IP exhaustion | Standardize `/24+` private subnets per AZ |
+| One `system:masters` IAM role for CI | Compromised pipeline owns entire cluster | Scoped `AmazonEKSEditPolicy` per namespace |
+
+---
+
+## Decision Framework
+
+Use the flows below during design reviews when stakeholders ask “which endpoint?” or “which compute?” — they encode the tradeoffs this module teaches.
+
+### Endpoint access choice
+
+```mermaid
+flowchart TD
+    Start[Cluster API exposure decision] --> Reg{Regulatory ban on public K8s API?}
+    Reg -- Yes --> Priv[Private endpoint only<br>+ VPN/bastion/CI in VPC]
+    Reg -- No --> Ops{Operators need kubectl from internet?}
+    Ops -- No --> Priv
+    Ops -- Yes --> Dual[Public + private endpoints<br>+ publicAccessCidrs]
+    Dual --> Nodes{Worker nodes in private subnets?}
+    Nodes -- Yes --> Done[Nodes use private ENI path<br>Humans use restricted public]
+    Nodes -- No --> Warn[Revisit subnet design;<br>public-only may hairpin via NAT]
+```
+
+| Requirement | Prefer | Primary tradeoff |
+| :--- | :--- | :--- |
+| Zero public API surface | Private only | Operational complexity for CI/CD paths |
+| Private nodes + remote engineers | Public + private + CIDRs | Must maintain accurate egress lists |
+| Lab cluster, single engineer | Public only (temporary) | Accept NAT dependency; migrate before prod |
+| GitHub-hosted CI without VPC runners | Not private-only | Add self-hosted runners or connectivity |
+
+### Compute and add-on choice
+
+```mermaid
+flowchart TD
+    Comp[Workload compute decision] --> DS{Needs DaemonSet or privileged?}
+    DS -- Yes --> MNG[Managed or self-managed EC2]
+    DS -- No --> GPU{Needs GPU or Spot node pools?}
+    GPU -- Yes --> MNG
+    GPU -- No --> Burst{Bursty / tenant-isolated / low ops?}
+    Burst -- Yes --> Fargate[Fargate profile for namespace]
+    Burst -- No --> MNG
+    Addon{Cluster component install} --> Mgmt[EKS managed add-on for catalog components]
+    Mgmt --> Helm[Helm only when not in catalog or custom build required]
+```
+
+| Signal | Lean toward | Reason |
+| :--- | :--- | :--- |
+| Service mesh with init containers needing `CAP_NET_ADMIN` | MNG / self-managed | Fargate blocks privileged init patterns |
+| Nightly batch namespace, no DaemonSets | Fargate profile | Pay per run; no idle nodes |
+| Custom GPU AMI | Self-managed ASG | Full image pipeline control |
+| Standard CNI/DNS after upgrade | Managed add-ons with `PRESERVE` | Reduces version skew incidents |
+
+### Authentication decision supplement
+
+When choosing between legacy `aws-auth` and Access Entries, treat it as a risk-management decision rather than a feature toggle. If your organization still edits `aws-auth` by hand, measure mean time to recovery the last time a YAML indent error blocked deploys. Access Entries move those changes into versioned Terraform or CloudFormation with IAM condition keys, which is especially valuable when dozens of microservices teams need scoped namespace access.
+
+For machine principals, prefer IAM roles over IAM users mapped through `mapUsers`. Roles rotate through federation and instance profiles; users encourage long-lived access keys on CI machines. Pair `AmazonEKSEditPolicy` or `AmazonEKSViewPolicy` with namespace scopes instead of cluster-admin unless break-glass procedures require otherwise. Document the cluster creator’s hidden admin path during migration so you do not accidentally rely on it as the only recovery lever after deleting `aws-auth`.
+
+Pod-level AWS permissions remain separate: workloads should use IRSA or Pod Identity ([Module 5.3](../module-5.3-eks-identity/)) rather than widening node instance profiles. Wide node policies violate least privilege because every pod on the node inherits the instance role unless you implement fine-grained IMDS controls. Architecture reviews should list three IAM layers explicitly — human access via Access Entries, node role for kubelet/AWS CNI, and pod identity for application AWS API calls — so new hires do not conflate them.
 
 ---
 
@@ -529,6 +715,8 @@ kubectl delete configmap aws-auth -n kube-system
 3. When you enable the private endpoint, [EKS creates a Route 53 private hosted zone associated with your VPC](https://docs.aws.amazon.com/eks/latest/userguide/cluster-endpoint.html). The cluster's DNS name (e.g., `ABCDEF1234.gr7.us-east-1.eks.amazonaws.com`) resolves to the private ENI IP addresses when queried from within the VPC, and to the public IP addresses when queried from the internet. This split-horizon DNS is automatic and invisible to most users.
 
 4. The `aws-auth` ConfigMap shipped with early EKS releases and remained the primary IAM-to-RBAC integration mechanism until AWS introduced access entries in December 2023. The lesson: temporary solutions in infrastructure have a habit of becoming permanent.
+
+When you connect these facts, the EKS value proposition becomes clearer: AWS absorbs etcd and API server toil, but you still engineer the VPC paths, compute pools, and IAM bindings that make Kubernetes usable for your organization. Teams that invest in those customer-owned layers — rather than fighting them — get clusters that survive NAT storms, version upgrades, and personnel changes without heroic on-call pages. That division of responsibility is the architectural through-line for every section that follows, from endpoint access through authentication migration and cost governance.
 
 ---
 
@@ -591,13 +779,17 @@ The **cluster security group** is a foundational networking component automatica
 To satisfy the security requirement, you must configure the EKS cluster with only the **private endpoint** enabled, completely removing the public attack surface. Because the API server DNS now resolves exclusively to internal VPC IP addresses, external CI/CD platforms like GitHub Actions cannot reach the cluster over the public internet. To bridge this gap, you must establish private connectivity by running self-hosted GitHub Actions runners directly on EC2 instances inside your VPC. Alternatively, you could utilize AWS PrivateLink or establish a site-to-site VPN connection between the external CI/CD network and your AWS environment. The critical architectural principle here is that securing the cluster behind a private endpoint shifts the burden of connectivity to the client, requiring you to bring your deployment tools into the private network boundary.
 </details>
 
+<details>
+<summary>Question 8: Finance asks why three idle development EKS clusters on an older Kubernetes version each cost roughly $438/month for the control plane alone while production on the latest version costs ~$73/month. What architectural and lifecycle policy change addresses the gap?</summary>
+
+The development clusters are almost certainly on a Kubernetes minor version in **extended support**, billed at [$0.60 per cluster hour](https://aws.amazon.com/eks/pricing/) versus $0.10 during standard support. Extended support exists so teams can defer upgrades, but it is intentionally expensive to encourage movement to supported versions. The fix is operational, not rightsizing nodes: upgrade dev clusters to a standard-support version (or delete them), and set `upgradePolicy` / IaC defaults so sandboxes do not silently remain on extended tiers. Production’s lower fee reflects a current version, not fewer nodes — control plane pricing is per cluster, not per node.
+</details>
+
 ---
 
 ## Hands-On Exercise: Private Endpoint Cluster with Bastion and Access Entries Migration
 
-In this exercise, you will create a production-grade EKS cluster with a private endpoint, set up a bastion host for access, and migrate authentication from `aws-auth` to EKS Access Entries.
-
-**What you will build:**
+In this exercise, you will create a production-grade EKS cluster with a private endpoint, set up a bastion host for access, and migrate authentication from `aws-auth` to EKS Access Entries. The lab walks through VPC foundations, private-only API configuration, SSM-based operator access without SSH keys, multi-team Access Entries, and a controlled switch to `API`-only authentication — mirroring how regulated environments separate data-plane connectivity from human break-glass paths.
 
 ```mermaid
 flowchart TD
@@ -620,8 +812,6 @@ flowchart TD
 ```
 
 ### Task 1: Create the VPC Infrastructure
-
-Set up the networking foundation for the private cluster.
 
 <details>
 <summary>Solution</summary>
@@ -679,8 +869,6 @@ echo "VPC: $VPC_ID | Public: $PUB_SUB | Private: $PRIV_SUB1, $PRIV_SUB2"
 </details>
 
 ### Task 2: Create the EKS Cluster with Private Endpoint
-
-Create the cluster with only the private API endpoint enabled.
 
 <details>
 <summary>Solution</summary>
@@ -758,8 +946,6 @@ echo "Node group is active."
 
 ### Task 3: Deploy a Bastion Host with SSM Access
 
-Since the API server is private, you need a way to reach it from within the VPC.
-
 <details>
 <summary>Solution</summary>
 
@@ -833,8 +1019,6 @@ echo "Connect via: aws ssm start-session --target $BASTION_ID"
 
 ### Task 4: Configure Access Entries for Multiple Teams
 
-Create access entries that give different teams appropriate permissions.
-
 <details>
 <summary>Solution</summary>
 
@@ -899,8 +1083,6 @@ aws eks list-access-entries --cluster-name $CLUSTER_NAME --output table
 
 ### Task 5: Complete the Migration to API-Only Authentication
 
-Switch the cluster to use only Access Entries, removing the aws-auth dependency.
-
 <details>
 <summary>Solution</summary>
 
@@ -936,8 +1118,6 @@ echo "Migration complete. aws-auth ConfigMap is no longer used."
 </details>
 
 ### Task 6: Verify and Audit the Configuration
-
-Confirm the cluster is correctly configured and document the setup.
 
 <details>
 <summary>Solution</summary>
@@ -1032,3 +1212,7 @@ With the EKS architecture foundation in place, it is time to dive deep into how 
 - [docs.aws.amazon.com: migrating access entries.html](https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html) — AWS states this precedence rule explicitly in the migration guide.
 - [docs.aws.amazon.com: setting up access entries.html](https://docs.aws.amazon.com/eks/latest/userguide/setting-up-access-entries.html) — AWS documents this one-way authentication-mode restriction directly.
 - [docs.aws.amazon.com: identity and access management.html](https://docs.aws.amazon.com/eks/latest/best-practices/identity-and-access-management.html) — AWS best-practices documentation describes Pod Identity as an agent-based feature that removes per-cluster OIDC setup.
+- [docs.aws.amazon.com: view kubernetes versions.html](https://docs.aws.amazon.com/eks/latest/userguide/view-kubernetes-versions.html) — Documents standard versus extended support windows and upgrade policy behavior.
+- [docs.aws.amazon.com: pod identities.html](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) — Official Pod Identity user guide referenced for workload IAM (detailed in Module 5.3).
+- [docs.aws.amazon.com: kubernetes versions.html](https://docs.aws.amazon.com/eks/latest/userguide/kubernetes-versions.html) — Kubernetes version lifecycle and support windows on EKS.
+- [aws.amazon.com: fargate pricing](https://aws.amazon.com/fargate/pricing/) — Per-vCPU and per-GB memory rates for Fargate tasks backing EKS pods.

--- a/src/content/docs/cloud/eks-deep-dive/module-5.2-eks-networking.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.2-eks-networking.md
@@ -19,11 +19,13 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-A common EKS failure mode is subnet IP exhaustion: when a cluster scales quickly and the VPC CNI cannot allocate more pod IPs, new pods can fail with `FailedCreatePodSandBox` errors until you free or add address space.
+A common EKS failure mode is subnet IP exhaustion: when a cluster scales quickly and the VPC CNI fails to allocate more pod IPs, new pods can fail with `FailedCreatePodSandBox` errors until you free or add address space.
 
 This scenario illustrates a high-impact EKS failure mode: subnet IP exhaustion can stop new pods from starting even when CPU and memory remain available. Unlike most other Kubernetes distributions that rely on overlay networks (where pod IPs are virtual, internal to the cluster, and practically unlimited), [EKS natively utilizes the Amazon VPC CNI plugin. This plugin guarantees that every pod receives a real, routable IP address directly from your VPC subnet.](https://docs.aws.amazon.com/eks/latest/best-practices/vpc-cni.html) This design is both a tremendous superpower—enabling native VPC networking, direct assignment of security groups to pods, and the elimination of overlay encapsulation overhead—and a dangerous trap. It creates a finite, physical constraint on your IP address space that can violently exhaust your network at the worst possible moment during auto-scaling events.
 
 In this module, you will master the intricate mechanics of the VPC CNI. You will thoroughly understand IP allocation modes, specifically focusing on Prefix Delegation—a feature that can multiply your IP capacity per ENI slot by 16x. You will learn the definitive strategies for solving IP exhaustion by implementing Custom Networking paired with secondary CIDRs. Furthermore, you will configure Security Groups for Pods to achieve zero-trust network isolation, set up the AWS Load Balancer Controller for highly efficient ALB and NLB ingress routing, and explore the future of EKS networking through IPv6 adoption.
+
+Platform engineers who treat pod IPs as unlimited because "Kubernetes abstracts networking" routinely learn otherwise on EKS. The VPC CNI makes IP planning visible: every replica, DaemonSet, and Job consumes a routable address from a finite subnet. That visibility is what enables direct ALB targeting, granular security groups, and clean flow logs—but only if you design warm pools, prefixes, and subnets before autoscaling writes the failure into production metrics.
 
 ---
 
@@ -36,6 +38,14 @@ The AWS VPC CNI consists of two primary components operating on every worker nod
 2. **The IPAMD (IP Address Management Daemon)**: This is a long-running background process (running as the `aws-node` DaemonSet) that continuously monitors the node's IP usage. It proactively communicates with the AWS EC2 API to attach new Elastic Network Interfaces (ENIs) and allocate secondary IP addresses to those ENIs so that the CNI binary usually has a pool of IPs ready to assign to incoming pods.
 
 Because EKS pods receive VPC-native IP addresses, they integrate directly with AWS networking and load-balancing constructs without an overlay network.
+
+### How IPAMD reconciles capacity on each node
+
+The IP Address Management Daemon (`ipamd`, packaged in the `aws-node` DaemonSet) runs a continuous reconciliation loop on every worker node. When the scheduler places a pod, the CNI binary asks ipamd for an address; ipamd either hands back a pre-warmed IP or prefix from local state or calls the EC2 API to attach capacity. That design trades a small amount of always-on IPv4 consumption for predictable pod startup, which matters during burst scale-outs when hundreds of pods land in the same minute.
+
+Understanding ipamd behavior is the fastest path to diagnosing `FailedCreatePodSandBox` and `InsufficientFreeAddresses` errors. Check the `aws-node` pod logs on the affected node first, then correlate with subnet IP utilization in the VPC console and ENI attachment state on the EC2 instance. [Amazon's VPC CNI best-practices guide](https://docs.aws.amazon.com/eks/latest/best-practices/vpc-cni.html) documents the environment variables that control warm pools, prefix targets, and custom networking. When logs mention `InsufficientCidrBlocks`, the problem is often subnet fragmentation rather than a missing feature flag—you need contiguous `/28` space for prefix delegation, not merely a high theoretical CIDR size.
+
+Nitro-based EC2 instances are required for prefix delegation and for security groups for pods; older Xen-based families lack the ENI prefix and branch-interface capabilities the modern CNI modes depend on. If your node group mixes instance types, remember that [EKS applies the lowest max-pods value in the group to every node](https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html), so one smaller instance type can silently cap density for the entire pool.
 
 ---
 
@@ -84,6 +94,26 @@ For m5.xlarge:
 
 In this formula, the `-1` accounts for the primary IP on each ENI, which is required for the ENI itself to function on the network and cannot be assigned to user pods. The `+2` accounts for the node's foundational host-networking pods (specifically `kube-proxy` and the `aws-node` DaemonSet), which share the host's primary IP and do not consume secondary VPC IPs.
 
+### Diagnosing density and ENI limits in secondary IP mode
+
+When pods stay Pending with sandbox errors, work top-down from the subnet to the node. At the VPC layer, confirm available addresses in the subnet the node uses (or the ENIConfig subnet if custom networking is on). At the node layer, describe the instance ENIs and count secondary IPs versus prefixes—secondary mode shows discrete `PrivateIpAddresses`, while prefix mode shows `Ipv4Prefixes` entries. At the CNI layer, inspect `aws-node` logs for `InsufficientFreeAddresses`, `InsufficientCidrBlocks`, or EC2 API throttling.
+
+The EC2 instance type matrix is the hard ceiling. An `m5.large` allows fewer ENIs and addresses per ENI than an `m5.4xlarge`; if Karpenter or the cluster autoscaler mixes types in one NodePool, the smallest type sets max pods for the whole group. Document expected pod capacity per instance in your internal standards so application teams do not request 110 pods on nodes that physically support fewer slots in secondary IP mode.
+
+```bash
+# Quick node-level IP capacity snapshot
+NODE=<node-name>
+kubectl describe node "$NODE" | grep -E 'pods:|vpc.amazonaws.com'
+INSTANCE=$(kubectl get node "$NODE" -o jsonpath='{.spec.providerID}' | awk -F/ '{print $NF}')
+aws ec2 describe-instances --instance-ids "$INSTANCE" \
+  --query 'Reservations[0].Instances[0].NetworkInterfaces[*].{
+    Id:NetworkInterfaceId,
+    Subnet:SubnetId,
+    Secondary:PrivateIpAddresses[?Primary==`false`].PrivateIpAddress,
+    Prefixes:Ipv4Prefixes[*].Ipv4Prefix
+  }' --output json
+```
+
 ---
 
 ## The Warm Pool: WARM_ENI_TARGET and WARM_IP_TARGET
@@ -94,7 +124,7 @@ To prevent this, [the IPAMD maintains a "warm pool" of pre-allocated IPs. By def
 
 ```bash
 # Check current VPC CNI configuration
-k get daemonset aws-node -n kube-system -o json | \
+kubectl get daemonset aws-node -n kube-system -o json | \
   jq '.spec.template.spec.containers[0].env[] | select(.name | startswith("WARM"))'
 ```
 
@@ -110,13 +140,15 @@ If you are running dangerously low on IPs, you must instruct the IPAMD to mainta
 
 ```bash
 # Configure VPC CNI to keep only 2 warm IPs instead of an entire warm ENI
-k set env daemonset aws-node -n kube-system \
+kubectl set env daemonset aws-node -n kube-system \
   WARM_IP_TARGET=2 \
   WARM_ENI_TARGET=0 \
   MINIMUM_IP_TARGET=4
 ```
 
 This configuration forces the node to release excess IPs back to the VPC. Instead of wasting ~14 IPs per node on a dormant warm ENI, the node will only keep 2 unassigned IPs in reserve. The trade-off is clear: if you suddenly schedule 5 pods onto a node that only has 2 warm IPs, the 3rd, 4th, and 5th pods will experience a startup delay of a few seconds while IPAMD negotiates with the EC2 API for more addresses.
+
+When you tune warm targets, treat `WARM_PREFIX_TARGET`, `WARM_IP_TARGET`, and `MINIMUM_IP_TARGET` as a single policy surface. [Prefix-mode guidance](https://docs.aws.amazon.com/eks/latest/best-practices/prefix-mode-linux.html) notes that `WARM_IP_TARGET` and `MINIMUM_IP_TARGET` override `WARM_PREFIX_TARGET` when set, which is how teams keep prefix delegation enabled while still avoiding an entire spare `/28` on every node. Document the chosen values in your platform runbook so on-call engineers know whether a few seconds of scheduling latency during spikes is expected behavior or a regression.
 
 ---
 
@@ -143,7 +175,7 @@ Enabling Prefix Delegation is a two-step process. First, you configure the VPC C
 
 ```bash
 # Enable Prefix Delegation
-k set env daemonset aws-node -n kube-system \
+kubectl set env daemonset aws-node -n kube-system \
   ENABLE_PREFIX_DELEGATION=true \
   WARM_PREFIX_TARGET=1
 
@@ -152,11 +184,13 @@ k set env daemonset aws-node -n kube-system \
 # --kubelet-extra-args '--max-pods=110'
 
 # Verify prefix delegation is active
-k get ds aws-node -n kube-system -o json | \
+kubectl get ds aws-node -n kube-system -o json | \
   jq '.spec.template.spec.containers[0].env[] | select(.name=="ENABLE_PREFIX_DELEGATION")'
 ```
 
-Crucially, after enabling Prefix Delegation in the CNI, the `kubelet` on your worker nodes must be restarted with a new `--max-pods` argument. If you do not update the node's user data, the `kubelet` will continue enforcing the old 58-pod limit, completely ignoring the thousands of new IP addresses made available by the CNI.
+Crucially, after enabling Prefix Delegation in the CNI, the `kubelet` on your worker nodes must be restarted with a new `--max-pods` argument. If you do not update the node's user data, the `kubelet` will continue enforcing the old 58-pod limit, completely ignoring the thousands of new IP addresses made available by the CNI. Use the [EKS max-pods calculator script](https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html) with `--cni-prefix-delegation-enabled` so the kubelet limit matches your instance type and CNI version rather than a copied example value.
+
+Amazon recommends creating fresh node groups when transitioning to prefix mode instead of rolling existing nodes in place, because nodes that mix legacy secondary IPs and new prefixes can advertise inconsistent capacity to the scheduler. Plan a cordon-and-drain migration with Pod Disruption Budgets on critical workloads. If subnets are fragmented, create a dedicated pod subnet (or use [subnet CIDR reservations for prefixes](https://docs.aws.amazon.com/eks/latest/best-practices/prefix-mode-linux.html)) before flipping the cluster-wide flag—otherwise prefix attachment fails even though secondary IP mode still appears healthy on paper.
 
 Once correctly provisioned, the IP allocation on the node transforms significantly:
 
@@ -215,7 +249,7 @@ By default, the VPC CNI will pull pod IPs from the exact same subnet that the EC
 
 ```bash
 # Enable custom networking on the VPC CNI
-k set env daemonset aws-node -n kube-system \
+kubectl set env daemonset aws-node -n kube-system \
   AWS_VPC_K8S_CNI_CUSTOM_NETWORK_CFG=true \
   ENI_CONFIG_LABEL_DEF=topology.kubernetes.io/zone
 ```
@@ -249,8 +283,8 @@ spec:
 Apply these configurations to the cluster:
 
 ```bash
-k apply -f eniconfig-us-east-1a.yaml
-k apply -f eniconfig-us-east-1b.yaml
+kubectl apply -f eniconfig-us-east-1a.yaml
+kubectl apply -f eniconfig-us-east-1b.yaml
 ```
 
 Once implemented, the architecture physically isolates the node's network traffic from the pod's network traffic. The primary ENI handles SSH, Kubelet-to-API-server communication, and internal OS networking on the `10.x` subnet. Meanwhile, all secondary ENIs are dynamically deployed into the `100.64.x` subnet to host the massive volume of pods.
@@ -270,6 +304,12 @@ flowchart TD
 > **Pause and predict**: If we place pod ENIs into a separate subnet from the node's primary ENI, what happens to the ENI slot that the node's primary interface occupies? Can pods still use it?
 
 *Critical Architecture Note*: Because Custom Networking dictates that pod IPs can *only* live on ENIs attached to the Custom Networking subnet, the node's Primary ENI (which lives in the Node Subnet) is entirely removed from the pod scheduling pool. If an instance has 4 ENIs, only 3 are available for pods. This slightly reduces your total pod density per node unless you combine Custom Networking with Prefix Delegation—a combination that represents the gold standard for large-scale EKS clusters.
+
+### Pod CIDR planning before you enable custom networking
+
+Treat pod address planning as capacity engineering, not a one-line YAML change. Size the secondary CIDR so it survives three growth vectors at once: maximum nodes in the largest node group, max pods per node after prefix delegation, and warm-pool overhead while nodes are scaling. A `/16` in `100.64.0.0/10` is a common starting point for multi-AZ production because it keeps pod space logically separate from RFC 1918 node subnets that humans and bastions already use. Split that space into per-AZ `/19` or `/20` subnets so ENIConfig objects map cleanly to `topology.kubernetes.io/zone` and you never attach a pod ENI in the wrong Availability Zone.
+
+Document which security groups attach to pod ENIs in ENIConfig versus the node primary ENI. Node SGs should cover kubelet, control-plane communication, and host-level egress; pod SGs belong on ENIConfig when you need database or internal API access scoped to workloads. Rolling custom networking onto existing nodes without replacing them is a frequent source of half-migrated clusters—plan new node groups, validate pod scheduling and Service endpoints, then drain legacy nodes.
 
 ---
 
@@ -310,7 +350,7 @@ To leverage this powerful feature, first enable it within the VPC CNI:
 
 ```bash
 # Enable the feature on the VPC CNI
-k set env daemonset aws-node -n kube-system \
+kubectl set env daemonset aws-node -n kube-system \
   ENABLE_POD_ENI=true \
   POD_SECURITY_GROUP_ENFORCING_MODE=standard
 ```
@@ -333,7 +373,11 @@ spec:
       - sg-0def789ghi012    # Allow only port 5432 to RDS
 ```
 
-Whenever a pod matching `app: payment-service` is scheduled, the CNI provisions a dedicated branch ENI, applies the `sg-0abc123def456` and `sg-0def789ghi012` security groups, and attaches the interface to the pod's namespace. The pod is now isolated by AWS native firewalls. This functionality requires supported Nitro-based instance types, and you should review the current EKS service-mode limitations for Pods that use pod-level security groups.
+Whenever a pod matching `app: payment-service` is scheduled, the CNI provisions a dedicated branch ENI, applies the `sg-0abc123def456` and `sg-0def789ghi012` security groups, and attaches the interface to the pod's namespace. The pod is now isolated by AWS native firewalls. This functionality requires supported Nitro-based instance types, and you should review the current [security groups for Pods documentation](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html) for enforcing mode (`standard` vs `strict`) and outbound traffic behavior.
+
+Security groups for pods consume branch ENI capacity on the trunk interface, so dense node groups can hit branch limits before they hit CPU limits. That is one reason Amazon recommends prefix delegation even when custom networking removes the primary ENI from the pod pool—you still want efficient use of the remaining ENI slots. Pair SG-for-pods with explicit outbound rules for CoreDNS (UDP/TCP 53 to the cluster Service CIDR) and for any AWS API endpoints your workloads call; pods do not inherit the node's security groups when pod-level groups are attached, and a missing egress rule surfaces as DNS or metadata timeouts rather than a clear Kubernetes event.
+
+Kubernetes NetworkPolicies remain valuable for east-west segmentation inside the cluster. SG-for-pods expresses cloud-provider firewall intent at the VPC boundary; NetworkPolicies express which pod labels may talk to which ports on the overlay-free pod network. Many regulated environments use both: NetworkPolicies for default-deny between namespaces, SG-for-pods where auditors require AWS-native enforcement on north-south paths to RDS, ElastiCache, or corporate CIDRs.
 
 ---
 
@@ -341,7 +385,9 @@ Whenever a pod matching `app: payment-service` is scheduled, the CNI provisions 
 
 Historically, Kubernetes created AWS Load Balancers via an in-tree cloud provider controller that was baked directly into the Kubernetes source code. This legacy approach is deprecated. Modern EKS networking dictates the use of [the out-of-tree AWS Load Balancer Controller (LBC)](https://docs.aws.amazon.com/eks/latest/best-practices/load-balancing.html).
 
-The AWS LBC is an intelligent operator that watches for Kubernetes `Ingress` and `Service` resources and directly orchestrates AWS Application Load Balancers (ALBs) and Network Load Balancers (NLBs) to satisfy them.
+The AWS LBC is an intelligent operator that watches for Kubernetes `Ingress` and `Service` resources and directly orchestrates AWS Application Load Balancers (ALBs) and Network Load Balancers (NLBs) to satisfy them. It replaces the deprecated in-tree cloud provider controller for AWS ELB integration and is the supported path for new EKS clusters. The controller needs IAM permissions to create and modify load balancers, target groups, listeners, and security groups; on EKS those permissions are typically delivered through IRSA (IAM Roles for Service Accounts) bound to the controller's Kubernetes service account.
+
+Operationally, treat each Ingress or `LoadBalancer` Service as an infrastructure change. The controller creates real ELB objects in your account; typos in annotations can open public listeners or attach certificates to the wrong hostname. Use infrastructure-as-code review for annotation changes the same way you would review Terraform security group rules. Tag load balancers with cluster and team identifiers so cost allocation and orphan detection stay tractable when namespaces are deleted but ELBs linger.
 
 ```bash
 # Install via Helm
@@ -400,6 +446,10 @@ The annotations on this resource hold incredible power over the physical AWS inf
 
 The `target-type: ip` annotation is arguably the most critical setting in EKS ingress. In legacy `instance` mode, the load balancer targets a node and NodePort, adding an extra hop through the node proxy path and shifting health checks to the node-level target rather than the pod IP itself. [Because EKS pods have real VPC IP addresses, `target-type: ip` allows the ALB to route traffic *directly* to the pod's IP](https://docs.aws.amazon.com/eks/latest/best-practices/load-balancing.html), completely bypassing the node's proxy layer.
 
+When you share an ALB across teams, listener rules become shared infrastructure. The `group.order` annotation controls rule precedence among Ingress objects in the same group; lower numbers evaluate first. Combine `group.name` with distinct hostnames or path prefixes so teams cannot accidentally capture each other's routes. During incidents, remember that deleting one Ingress in a group does not delete the shared ALB until the last member Ingress disappears—on-call runbooks should list all namespaces contributing to a grouped ALB.
+
+Health checks should match application semantics. A `/healthz` that only returns 200 when the process is live—but not when dependencies are ready—prevents premature traffic during rollouts. Conversely, checking the database on every ALB probe can mark all targets unhealthy during a brief RDS failover. Align probe depth with what "ready" means for your SLO, and use Kubernetes readiness gates so the ALB only receives endpoints that passed your chosen bar.
+
 ### NLB for gRPC and TCP Traffic
 
 For raw Layer 4 traffic, extreme low-latency requirements, or protocols that cannot be terminated by an ALB, EKS relies on the Network Load Balancer (NLB). You provision an NLB by creating a Kubernetes `Service` of type `LoadBalancer` and applying specific annotations.
@@ -444,7 +494,17 @@ The differences between ALB and NLB are distinct and determine your entire edge 
 | **Cost** | $0.0225/hr + LCU | $0.0225/hr + NLCU |
 | **Best for** | Web apps, REST APIs | gRPC, databases, gaming, IoT |
 
+Those hourly figures come from the public [Elastic Load Balancing pricing](https://aws.amazon.com/elasticloadbalancing/pricing/) page for US East (N. Virginia); LCU and NLCU usage can dominate at high throughput, so load tests should include both components. Internal-facing LBs still incur hourly and capacity-unit charges even when no public IPv4 is attached, though you avoid the separate public IPv4 line item described in [VPC pricing](https://aws.amazon.com/vpc/pricing/).
+
+For WebSocket-heavy workloads, both ALB and NLB can maintain long-lived TCP connections when health checks and idle timeouts are configured generously. ALB terminates HTTP and understands HTTP/2 features used by some gRPC-over-HTTP stacks; NLB preserves transparent TCP and is often chosen when you need static IPs per Availability Zone or TLS passthrough without ALB inspection. The operational difference during Kubernetes rollouts is target registration speed: IP targets track ready pods directly, so connections drain to healthy endpoints instead of sticking to a NodePort that still passes the load balancer health check while kube-proxy sends traffic to a crashing pod.
+
 > **Pause and predict**: If your application uses WebSockets which require long-lived persistent connections, which load balancer type would provide the most efficient routing without connection drops during scaling events?
+
+### TargetGroupBinding and services outside Ingress
+
+Not every workload exposes HTTP through an `Ingress`. The [AWS Load Balancer Controller](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.11/guide/targetgroupbinding/targetgroupbinding/) also supports `TargetGroupBinding`, which associates an existing ELB target group with pod IPs or node ports inside the cluster. Platform teams use this when a central networking team owns the load balancer while application teams own Kubernetes namespaces, or when you need to attach EKS pods to a target group created by Terraform outside the controller's Ingress reconciliation loop.
+
+A typical pattern is: create the ALB/NLB and target group in infrastructure pipelines, grant the controller IAM permission to register targets, then deploy a `TargetGroupBinding` that selects pods by label. The controller keeps target health in sync with readiness probes, similar to `target-type: ip` on Ingress, but decouples DNS and listener ownership from application manifests. Validate security groups on both the load balancer and the pod (or node) ENIs—IP mode registers pod addresses directly, so security group rules must allow the load balancer subnets to reach pod IPs on application ports.
 
 ---
 
@@ -470,6 +530,92 @@ In an IPv6 cluster:
 
 However, [IPv6 must be designated during cluster creation—you cannot migrate a live IPv4 EKS cluster to IPv6.](https://docs.aws.amazon.com/eks/latest/userguide/cni-ipv6.html) Furthermore, verify that your add-ons and operators support IPv6 before rolling it out cluster-wide.
 
+On IPv6-only EKS clusters, prefix delegation is enabled by default and assigns a `/80` IPv6 prefix per ENI slot, which removes the IPv4 exhaustion class of failures for pod addressing. Egress to the public IPv4 internet typically requires an [egress-only internet gateway or NAT64/DNS64 path](https://docs.aws.amazon.com/eks/latest/userguide/cni-ipv6.html) depending on your architecture—plan that before workloads silently fail to reach IPv4-only SaaS endpoints. Treat IPv6 as a greenfield cluster decision with a full dependency matrix (container images, third-party webhooks, legacy JDBC URLs, and observability agents), not as a runtime toggle on an existing IPv4 fleet.
+
+---
+
+## Networking Cost Lens
+
+EKS networking choices show up on the AWS bill in four places that are easy to underestimate during design reviews: cross-AZ data transfer, idle and warm IPv4 addresses, load balancer fixed hourly charges plus capacity units, and public IPv4 charges on internet-facing load balancers.
+
+**Cross-AZ traffic** is often the largest surprise after go-live. Pod IPs are real VPC addresses, so traffic between a pod in `us-east-1a` and a pod in `us-east-1b` is billed as inter-AZ data transfer even though both endpoints are "inside Kubernetes." Services with `externalTrafficPolicy: Cluster` and NLBs without cross-zone load balancing can amplify this by delivering client traffic to a node in one AZ while the backing pod lives in another. Mitigations include topology-aware hints, spreading replicas across AZs with pod anti-affinity, keeping stateful backends in the same AZ as their consumers when latency allows, and enabling cross-zone balancing on NLBs only when you accept the extra cross-AZ bytes as the price of even distribution.
+
+**IPv4 efficiency** directly affects whether you pay for more nodes than you need. Default `WARM_ENI_TARGET=1` can reserve hundreds of addresses cluster-wide while pods are idle—those addresses are not billed like public IPs, but they force larger subnets and earlier exhaustion, which pushes teams toward more nodes or more VPCs. Prefix delegation reduces IPs consumed per pod slot; tuning `WARM_IP_TARGET` reduces hoarding. Custom networking with a dedicated `100.64.0.0/10` pod CIDR avoids expensive redesigns when application subnets are `/24` slivers tied to legacy data centers.
+
+**Load balancers** bill a fixed hourly component plus usage-based capacity units. In US East (N. Virginia), [Application Load Balancers charge roughly $0.0225 per hour plus $0.008 per LCU-hour](https://aws.amazon.com/elasticloadbalancing/pricing/), and [Network Load Balancers use the same hourly rate with $0.006 per NLCU-hour](https://aws.amazon.com/elasticloadbalancing/pricing/). A single shared ALB via `group.name` replaces dozens of hourly charges—Quiz scenario six's ~45 ALBs × ~$16/month fixed cost is arithmetic on that hourly line item, before LCU growth from traffic. High rule counts on shared ALBs can increase LCU "rule evaluation" dimension cost; keep listener rules intentional.
+
+**Public IPv4** on internet-facing ALBs and NLBs is billed separately from LCU charges per [VPC public IPv4 pricing](https://aws.amazon.com/vpc/pricing/). Internal schemes avoid that line item but still need private connectivity planning. When comparing `target-type: ip` vs `instance`, IP mode usually wins on operations and health-check precision; instance mode rarely saves meaningful money once you account for extra NodePort hops and uneven draining during rollouts.
+
+| Cost driver | What makes it spike | Knobs that usually help |
+| :--- | :--- | :--- |
+| Cross-AZ pod traffic | Chatty microservices across AZs; NLB without cross-zone | Affinity/topology; fewer cross-AZ dependencies; right-size replicas per AZ |
+| Subnet/IP exhaustion | Warm ENIs; small `/24` pod subnets | Prefix delegation; `WARM_IP_TARGET`; secondary CIDR + custom networking |
+| ALB count | One Ingress per microservice | `alb.ingress.kubernetes.io/group.name` with host/path rules |
+| LCU/NLCU | High RPS, TLS, long-lived connections, many rules | Right-size LB type; shared ALB with lean rules; NLB for raw TCP |
+| Public IPv4 on edge LBs | Internet-facing scheme per service | Internal ALB + corporate ingress; consolidate public LBs |
+
+Hypothetical scenario: a platform team runs 80 `m5.xlarge` nodes with default warm ENIs (~14 idle secondary IPs each) and twelve internet-facing ALBs for twelve teams. They fix scheduling stalls by adding a `/20` subnet instead of tuning the CNI, then wonder why cross-AZ charges rose 40% after enabling NLB gRPC ingress without cross-zone load balancing. The cheaper sequence is warm-IP tuning plus prefix delegation first, shared ALB grouping second, then NLB annotations reviewed against AZ topology—with monthly reviews of the VPC flow log sample and the ELB cost allocation tag.
+
+---
+
+## Patterns & Anti-Patterns
+
+Mature EKS networking separates **address capacity**, **edge exposure**, and **policy enforcement** so each layer can evolve without breaking the others. The patterns below show up repeatedly in clusters that scale past a few dozen nodes without emergency subnet expansions.
+
+| Pattern | When to use | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| Prefix delegation on Nitro nodes | New clusters or node groups where pod density per node matters | Assigns `/28` prefixes per ENI slot, cutting EC2 API churn and multiplying usable addresses | Pair with calculated `--max-pods`; migrate via new node groups |
+| Secondary pod CIDR + ENIConfig | Node subnets are small or shared with legacy VMs | Isolates pod IPs in `100.64.0.0/10` (or similar) while nodes stay on RFC 1918 | One ENIConfig per AZ; combine with prefix mode for density |
+| `target-type: ip` + readiness probes | HTTP/gRPC services behind AWS LBC | ALB health-checks pods directly; faster drain on failures | Ensure pod SGs and ALB SGs allow pod CIDRs on app ports |
+| Shared ALB via `group.name` | Many HTTP services, moderate rule count | One hourly ALB fee; host/path routing | Watch 100-rules-per-ALB quota and blast radius on misconfiguration |
+| SG-for-pods for north-south compliance | Auditors require AWS SG evidence to data stores | Branch ENIs carry per-workload SGs independent of node SG | Model CoreDNS and egress explicitly in pod SG rules |
+| NetworkPolicy default-deny in namespace | East-west zero trust between teams | Kubernetes-native segmentation on real pod IPs | Complements—not replaces—SG-for-pods for VPC boundaries |
+
+Anti-patterns usually begin as copy-pasted manifests from pre-2020 guides and become expensive at scale.
+
+| Anti-pattern | What goes wrong | Better alternative |
+| :--- | :--- | :--- |
+| `/24` node subnet with default warm ENI | Hundreds of IPs reserved idle; sudden `InsufficientFreeAddresses` | Dedicated pod subnets; `WARM_IP_TARGET`; prefix delegation |
+| Enable prefix mode without new nodes | Mixed IP/prefix nodes confuse capacity; kubelet still at 58 max pods | New node group + max-pods calculator + cordon/drain migration |
+| One ALB per Ingress for every microservice | Fixed hourly cost scales linearly with team count | Group Ingress resources; separate only critical blast-radius domains |
+| SG-for-pods without DNS egress | Pods time out on external names; looks like app bug | Allow UDP/TCP 53 to CoreDNS Service CIDR in pod SG |
+| NetworkPolicy-only for RDS compliance | Policies are not AWS SG audit artifacts auditors request | SG-for-pods or SG on ENIConfig for datastore paths |
+| Fragmented subnet, forced prefix mode | `InsufficientCidrBlocks` in CNI logs; pods Pending | New subnet + prefix reservation; avoid rolling flags on bad subnets |
+
+---
+
+## Decision Framework
+
+Use this flow when onboarding a new EKS cluster or refactoring a fleet that is hitting network limits. The goal is to pick the smallest change that restores scheduling and security without multiplying load balancers or subnets unnecessarily.
+
+```mermaid
+flowchart TD
+    Start[Pod scheduling or connectivity issue?] --> IPCheck{Subnet IPs exhausted<br>or high warm-pool waste?}
+    IPCheck -- Yes --> Frag{Subnet fragmented for /28?}
+    Frag -- Yes --> NewSub[New pod subnet + optional prefix reservation]
+    Frag -- No --> PD{Need >58 pods/node on Nitro?}
+    PD -- Yes --> Prefix[Enable prefix delegation + max-pods + new node group]
+    PD -- No --> Warm[Tune WARM_IP_TARGET / MINIMUM_IP_TARGET]
+    IPCheck -- No --> Edge{Internet or VPC edge exposure?}
+    Edge -- HTTP/L7 routing --> ALB[AWS LBC Ingress: target-type ip]
+    Edge -- TCP/gRPC/low latency --> NLB[Service type LoadBalancer + NLB ip targets]
+    Edge -- Existing TG owned by platform --> TGB[TargetGroupBinding to pod labels]
+    Edge -- No --> Policy{Compliance needs AWS SG on workload?}
+    Policy -- Yes --> SGP[SecurityGroupPolicy + Nitro instance types]
+    Policy -- No --> NP[Kubernetes NetworkPolicies for east-west]
+```
+
+| Decision | Prefer | Tradeoff to accept |
+| :--- | :--- | :--- |
+| Secondary IP vs prefix delegation | Prefix on Nitro if density or API rate limits bite | Subnet must have contiguous `/28` space; kubelet max-pods must change |
+| Same subnet vs custom networking | Custom when node subnets cannot grow | Lose one ENI worth of pod slots unless prefix mode compensates |
+| ALB vs NLB | ALB for HTTP/S, host/path routing, ACM TLS | Not for arbitrary UDP; higher LCU sensitivity on complex rules |
+| NLB vs ALB | NLB for TCP/TLS passthrough, static IPs per AZ | No path-based routing; cross-zone costs if enabled carelessly |
+| SG-for-pods vs NetworkPolicy only | SG-for-pods when AWS-native perimeter required | Branch ENI limits; explicit DNS/egress rules; Nitro requirement |
+| `target-type: ip` vs `instance` | IP for almost all EKS pod-backed services | Security groups must allow pod CIDRs; slightly more target churn on rollouts |
+
+Revisit the matrix after the first production scale test. Metrics that matter: `FailedCreatePodSandBox` rate, free IPs per subnet, `aws-node` error lines, ALB/NLCU dashboards, cross-AZ bytes on the Cost Explorer **EC2-Other** and **ELB** rows, and target health flapping during deployments.
+
 ---
 
 ## Did You Know?
@@ -478,6 +624,26 @@ However, [IPv6 must be designated during cluster creation—you cannot migrate a
 2. Prefix Delegation was introduced in 2021 and is the newer VPC CNI mode for increasing Pod density by assigning `/28` prefixes instead of individual secondary IPv4 addresses.
 3. The AWS Load Balancer Controller can share a single ALB across multiple Ingress resources, which can materially reduce fixed load balancer costs when host-based or path-based routing is acceptable.
 4. Security Groups for Pods use Nitro trunk and branch ENI capabilities, and the amount of branch-interface capacity varies by instance type.
+
+---
+
+## Operational Runbook: IP Exhaustion on a Live Cluster
+
+When new pods fail with sandbox errors during a scale event, time matters. Use this ordered checklist before opening a change request to add an entirely new VPC.
+
+**Step 1 — Confirm the failure mode.** `kubectl describe pod` on a Pending workload should cite CNI or sandbox errors. If the message is `InsufficientFreeAddresses` or similar, you are in IP exhaustion, not image pull or quota limits.
+
+**Step 2 — Measure subnet headroom.** In the VPC console, compare assigned versus available addresses in the subnet tied to the failing nodes (or ENIConfig subnets). If utilization is above roughly eighty percent during normal load, warm pools alone will not save you for long.
+
+**Step 3 — Quantify warm-pool waste.** On three representative nodes, list ENI secondary addresses and prefixes. If each node holds a full warm ENI with many unassigned addresses, patch `WARM_IP_TARGET` and `WARM_ENI_TARGET` on `aws-node` and watch addresses return over the next reconciliation window.
+
+**Step 4 — Decide prefix versus expansion.** If nodes are Nitro, subnets are not fragmented, and you need higher pod density, plan prefix delegation with new node groups and updated max-pods. If subnets are fragmented or tiny, add a secondary CIDR and ENIConfig first, then enable prefixes on the dedicated pod subnets.
+
+**Step 5 — Validate edge paths after CNI changes.** After IP pressure drops, confirm existing Ingress and `LoadBalancer` Services still register healthy IP targets. CNI churn does not replace ELB misconfiguration, but incidents often stack—fix addressing first, then re-check target groups.
+
+Document outcomes in your platform ticket: which knob freed how many addresses, how long pod scheduling latency increased, and whether a follow-up change (secondary CIDR, new node group, or load balancer consolidation) is scheduled. That paper trail prevents the next engineer from repeating an emergency subnet expansion that only bought weeks of runway.
+
+Keep a dashboard that tracks free IPs per pod subnet, `aws-node` error log rate, and ELB target health in one place. Correlating those three signals during scale tests catches regressions before a marketing event turns them into customer-visible outages. Schedule a quarterly review of warm-pool environment variables and grouped ALB membership so drift from the original design does not silently recreate exhaustion or cost spikes.
 
 ---
 
@@ -540,11 +706,19 @@ You can consolidate all 45 microservices behind a single Application Load Balanc
 **Option 1**: Tune the VPC CNI warm pool by setting `WARM_IP_TARGET=1` and `WARM_ENI_TARGET=0` on the `aws-node` DaemonSet. This immediately releases pre-allocated but unused IPs across all nodes, often recovering hundreds of IPs within minutes. **Option 2**: Enable Prefix Delegation (`ENABLE_PREFIX_DELEGATION=true`), which changes the allocation from individual IPs to `/28` prefixes, dramatically reducing the number of IPs consumed per ENI slot while increasing pod capacity. Both changes take effect within minutes as the aws-node DaemonSet rolls out, though Prefix Delegation requires updating max-pods on nodes (meaning a rolling restart). For a longer-term architectural fix, you should add a secondary CIDR (e.g., `100.64.0.0/16`) with Custom Networking to permanently expand the available address space.
 </details>
 
+<details>
+<summary>Question 8: Your finance team asks whether to move internal microservices from three dedicated internal ALBs to one shared internal ALB with host-based rules. Traffic is moderate, but teams worry about blast radius. What cost and operational factors should guide the decision?</summary>
+
+Consolidation removes two hourly ALB fixed charges—at roughly $0.0225 per hour each in US East, that is on the order of $32 per month per load balancer before LCU usage, per [Elastic Load Balancing pricing](https://aws.amazon.com/elasticloadbalancing/pricing/). The trade is operational coupling: a bad listener rule or certificate annotation on one Ingress can affect every hostname on the shared ALB, and LCU rule-evaluation cost rises with listener complexity. A practical compromise is grouping related non-production services together while keeping revenue-critical or PCI-scoped domains on dedicated ALBs with tighter change control. Require code review on `group.name` membership the same way you review shared security groups, and export per-ALB CloudWatch metrics so incidents show which team owns the failing rule.
+</details>
+
 ---
 
 ## Hands-On Exercise: Prefix Delegation + ALB for Web + NLB for gRPC
 
-In this comprehensive exercise, you will architect a highly scalable EKS networking foundation by configuring Prefix Delegation for maximum IP efficiency, deploying the AWS Load Balancer Controller, and exposing both a standard web application and a low-latency gRPC service to the internet.
+In this comprehensive exercise, you will architect a highly scalable EKS networking foundation by configuring Prefix Delegation for maximum IP efficiency, deploying the AWS Load Balancer Controller, and exposing both a standard web application and a low-latency gRPC service to the internet. The sequence mirrors how platform teams roll out networking changes in production: tune the CNI first, prove prefix attachment on live ENIs, raise kubelet `max-pods` through a controlled node group replacement, then layer edge load balancers only after pod IPs and readiness probes behave predictably.
+
+Before you begin, confirm your lab cluster uses Nitro instances (for example `m6i.large` or `m5.xlarge`), that the worker subnets have enough contiguous space for `/28` prefixes, and that your IAM role for the AWS Load Balancer Controller can create ELB resources. If you are on a shared sandbox account, tag every load balancer and target group with your username and delete them in the cleanup step—orphaned ALBs are a common source of surprise monthly charges because their hourly fee continues after the Kubernetes namespace is gone.
 
 **What you will build:**
 
@@ -575,19 +749,19 @@ Configure the `aws-node` DaemonSet to allocate `/28` prefixes to EC2 ENIs rather
 
 ```bash
 # Enable Prefix Delegation
-k set env daemonset aws-node -n kube-system \
+kubectl set env daemonset aws-node -n kube-system \
   ENABLE_PREFIX_DELEGATION=true \
   WARM_PREFIX_TARGET=1
 
 # Wait for the DaemonSet to roll out
-k rollout status daemonset aws-node -n kube-system --timeout=120s
+kubectl rollout status daemonset aws-node -n kube-system --timeout=120s
 
 # Verify on a node (check that prefixes are assigned, not individual IPs)
-NODE_NAME=$(k get nodes -o jsonpath='{.items[0].metadata.name}')
-k get node $NODE_NAME -o json | jq '.status.allocatable["vpc.amazonaws.com/pod-ens"]'
+NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+kubectl get node $NODE_NAME -o json | jq '.status.allocatable["vpc.amazonaws.com/pod-ens"]'
 
 # Check ENI details via AWS CLI
-INSTANCE_ID=$(k get node $NODE_NAME -o json | jq -r '.spec.providerID' | cut -d'/' -f5)
+INSTANCE_ID=$(kubectl get node $NODE_NAME -o json | jq -r '.spec.providerID' | cut -d'/' -f5)
 aws ec2 describe-instances --instance-ids $INSTANCE_ID \
   --query 'Reservations[0].Instances[0].NetworkInterfaces[*].{ENI:NetworkInterfaceId, Ipv4Prefixes:Ipv4Prefixes[*].Ipv4Prefix}' \
   --output json
@@ -635,7 +809,7 @@ aws eks wait nodegroup-active \
   --nodegroup-name standard-workers
 
 # Verify max-pods on a new node
-k get node -o json | jq '.items[0].status.allocatable.pods'
+kubectl get node -o json | jq '.items[0].status.allocatable.pods'
 # Should show "110"
 ```
 
@@ -669,8 +843,8 @@ helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
   --set serviceAccount.annotations."eks\.amazonaws\.com/role-arn"=arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):role/AWSLoadBalancerControllerRole
 
 # Verify the controller is running
-k get deployment aws-load-balancer-controller -n kube-system
-k get pods -n kube-system -l app.kubernetes.io/name=aws-load-balancer-controller
+kubectl get deployment aws-load-balancer-controller -n kube-system
+kubectl get pods -n kube-system -l app.kubernetes.io/name=aws-load-balancer-controller
 ```
 
 </details>
@@ -684,10 +858,10 @@ Deploy an NGINX web application and expose it dynamically utilizing an Applicati
 
 ```bash
 # Create namespace
-k create namespace web-demo
+kubectl create namespace web-demo
 
 # Deploy the web application
-cat <<'EOF' | k apply -f -
+cat <<'EOF' | kubectl apply -f -
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -762,7 +936,7 @@ EOF
 # Wait for ALB to provision (takes 2-3 minutes)
 echo "Waiting for ALB to provision..."
 sleep 30
-ALB_URL=$(k get ingress web-app-ingress -n web-demo -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+ALB_URL=$(kubectl get ingress web-app-ingress -n web-demo -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 echo "ALB URL: http://$ALB_URL"
 
 # Test (may take a minute for DNS propagation)
@@ -780,7 +954,7 @@ Implement a high-performance gRPC health-check service operating over TCP port 9
 
 ```bash
 # Deploy a gRPC health check service (using grpcbin as example)
-cat <<'EOF' | k apply -f -
+cat <<'EOF' | kubectl apply -f -
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -836,7 +1010,7 @@ EOF
 
 # Wait for NLB to provision
 sleep 30
-NLB_HOST=$(k get svc grpc-nlb -n web-demo -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
+NLB_HOST=$(kubectl get svc grpc-nlb -n web-demo -o jsonpath='{.status.loadBalancer.ingress[0].hostname}')
 echo "NLB hostname: $NLB_HOST"
 
 # Verify NLB targets are healthy
@@ -861,11 +1035,11 @@ Probe the AWS EC2 sub-system directly to validate that your node ENIs are being 
 
 ```bash
 # Get pod IPs
-k get pods -n web-demo -o wide
+kubectl get pods -n web-demo -o wide
 
 # Pick a node and inspect its ENI prefixes
-NODE=$(k get pods -n web-demo -o jsonpath='{.items[0].spec.nodeName}')
-INSTANCE_ID=$(k get node $NODE -o json | jq -r '.spec.providerID' | cut -d'/' -f5)
+NODE=$(kubectl get pods -n web-demo -o jsonpath='{.items[0].spec.nodeName}')
+INSTANCE_ID=$(kubectl get node $NODE -o json | jq -r '.spec.providerID' | cut -d'/' -f5)
 
 # Show allocated prefixes on the instance
 aws ec2 describe-instances --instance-ids $INSTANCE_ID \
@@ -879,7 +1053,7 @@ aws ec2 describe-instances --instance-ids $INSTANCE_ID \
 # Each prefix is a /28 = 16 IPs
 
 # Verify max-pods
-k get node $NODE -o json | jq '.status.allocatable.pods'
+kubectl get node $NODE -o json | jq '.status.allocatable.pods'
 ```
 
 </details>
@@ -889,7 +1063,7 @@ k get node $NODE -o json | jq '.status.allocatable.pods'
 Ensure you purge all resources, as unmanaged load balancers will continually accrue billing charges against your AWS account.
 
 ```bash
-k delete namespace web-demo
+kubectl delete namespace web-demo
 helm uninstall aws-load-balancer-controller -n kube-system
 # Clean up ALB/NLB if they persist (check the AWS console)
 ```
@@ -920,3 +1094,9 @@ In the subsequent section, we tear down IAM complexities. Head to [Module 5.3: E
 - [Security Groups Per Pod](https://docs.aws.amazon.com/eks/latest/best-practices/sgpp.html) — Primary AWS guide for trunk/branch ENIs, SecurityGroupPolicy, and compatibility limits.
 - [Load Balancing](https://docs.aws.amazon.com/eks/latest/best-practices/load-balancing.html) — Primary AWS guide for AWS Load Balancer Controller, legacy controller status, and IP vs instance target types.
 - [IPv6 Addresses to Clusters, Pods, and Services](https://docs.aws.amazon.com/eks/latest/userguide/cni-ipv6.html) — Primary AWS guide for EKS IPv6 behavior, immutability, and current dual-stack limitations.
+- [Assign more IP addresses with prefixes](https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html) — EKS user guide for prefix delegation compatibility, max-pods, and node-group transitions.
+- [Security groups for Pods](https://docs.aws.amazon.com/eks/latest/userguide/security-groups-for-pods.html) — Enforcing modes, outbound behavior, and operational limits.
+- [Elastic Load Balancing pricing](https://aws.amazon.com/elasticloadbalancing/pricing/) — ALB/NLB hourly and LCU/NLCU rates used in the cost lens.
+- [Amazon VPC pricing](https://aws.amazon.com/vpc/pricing/) — Public IPv4 address charges relevant to internet-facing load balancers.
+- [TargetGroupBinding](https://kubernetes-sigs.github.io/aws-load-balancer-controller/v2.11/guide/targetgroupbinding/targetgroupbinding/) — AWS Load Balancer Controller guide for binding existing target groups to pods.
+- [RFC 6598 — Shared Address Space](https://www.rfc-editor.org/rfc/rfc6598) — Definition of `100.64.0.0/10` carrier-grade NAT space often used for pod CIDRs.

--- a/src/content/docs/cloud/eks-deep-dive/module-5.2-eks-networking.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.2-eks-networking.md
@@ -45,7 +45,7 @@ The IP Address Management Daemon (`ipamd`, packaged in the `aws-node` DaemonSet)
 
 Understanding ipamd behavior is the fastest path to diagnosing `FailedCreatePodSandBox` and `InsufficientFreeAddresses` errors. Check the `aws-node` pod logs on the affected node first, then correlate with subnet IP utilization in the VPC console and ENI attachment state on the EC2 instance. [Amazon's VPC CNI best-practices guide](https://docs.aws.amazon.com/eks/latest/best-practices/vpc-cni.html) documents the environment variables that control warm pools, prefix targets, and custom networking. When logs mention `InsufficientCidrBlocks`, the problem is often subnet fragmentation rather than a missing feature flag—you need contiguous `/28` space for prefix delegation, not merely a high theoretical CIDR size.
 
-Nitro-based EC2 instances are required for prefix delegation and for security groups for pods; older Xen-based families lack the ENI prefix and branch-interface capabilities the modern CNI modes depend on. If your node group mixes instance types, remember that [EKS applies the lowest max-pods value in the group to every node](https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html), so one smaller instance type can silently cap density for the entire pool.
+Nitro-based EC2 instances are required for prefix delegation and for security groups for pods; older Xen-based families lack the ENI prefix and branch-interface capabilities the modern CNI modes depend on. Managed node groups and Karpenter [calculate max-pods per node from each instance type's ENI capacity](https://docs.aws.amazon.com/eks/latest/userguide/cni-increase-ip-addresses.html). If you pin a uniform `--max-pods` for a mixed-type group, set it to the smallest instance type's value — otherwise a larger type can over-schedule and fail at sandbox creation.
 
 ---
 
@@ -98,7 +98,7 @@ In this formula, the `-1` accounts for the primary IP on each ENI, which is requ
 
 When pods stay Pending with sandbox errors, work top-down from the subnet to the node. At the VPC layer, confirm available addresses in the subnet the node uses (or the ENIConfig subnet if custom networking is on). At the node layer, describe the instance ENIs and count secondary IPs versus prefixes—secondary mode shows discrete `PrivateIpAddresses`, while prefix mode shows `Ipv4Prefixes` entries. At the CNI layer, inspect `aws-node` logs for `InsufficientFreeAddresses`, `InsufficientCidrBlocks`, or EC2 API throttling.
 
-The EC2 instance type matrix is the hard ceiling. An `m5.large` allows fewer ENIs and addresses per ENI than an `m5.4xlarge`; if Karpenter or the cluster autoscaler mixes types in one NodePool, the smallest type sets max pods for the whole group. Document expected pod capacity per instance in your internal standards so application teams do not request 110 pods on nodes that physically support fewer slots in secondary IP mode.
+The EC2 instance type matrix is the hard ceiling. An `m5.large` allows fewer ENIs and addresses per ENI than an `m5.4xlarge`; with per-node auto-calculation, each node gets its own max-pods ceiling. If you hardcode a single `--max-pods` across mixed types, use the smallest type's limit for the whole group. Document expected pod capacity per instance in your internal standards so application teams do not request 110 pods on nodes that physically support fewer slots in secondary IP mode.
 
 ```bash
 # Quick node-level IP capacity snapshot
@@ -683,9 +683,9 @@ The reduction is happening because Custom Networking reserves the node's primary
 </details>
 
 <details>
-<summary>Question 4: During a busy traffic spike, you have a Kubernetes Ingress with the annotation `target-type: instance` routing to pods spread across 10 nodes in 3 Availability Zones. One of the application pods suddenly crashes and begins failing its readiness probe, yet users are reporting intermittent HTTP 502 errors when accessing the service. Why is traffic still reaching the failed pod, and how do you resolve it?</summary>
+<summary>Question 4: During a busy traffic spike, you have a Kubernetes Ingress with the annotation `target-type: instance` routing to pods spread across 10 nodes in 3 Availability Zones. One of the application pods suddenly crashes and begins failing its readiness probe, yet users are reporting intermittent HTTP 502 errors when accessing the service. Why does instance mode struggle here, and how do you resolve it?</summary>
 
-With `target-type: instance`, the ALB targets the NodePort on each node, not individual pods. The ALB health checks the NodePort -- and if any pod behind that NodePort on a specific node fails, kube-proxy may still route traffic to the unhealthy pod because the ALB only sees the node as healthy or unhealthy. This means traffic can reach unhealthy pods until kube-proxy removes the endpoint. With `target-type: ip`, the ALB health-checks each pod directly and stops sending traffic to failed pods within seconds, regardless of the node. Changing the target type completely bypasses the unpredictable kube-proxy hop, providing immediate routing updates when a pod fails.
+With `target-type: instance`, the ALB targets each node's NodePort, not individual pods. Kubernetes removes a failing pod from Service endpoints once its readiness probe fails, but the ALB health check only validates the NodePort — it cannot tell whether one unhealthy pod among several healthy pods on the same node is causing 502s. During the endpoint-update window, traffic still flows ALB → NodePort → kube-proxy, so users can hit the bad pod until convergence completes. With `target-type: ip`, the ALB health-checks each pod IP directly and drains failed pods in seconds. Switch to IP mode for precise per-pod health and faster drain behavior.
 </details>
 
 <details>
@@ -709,7 +709,7 @@ You can consolidate all 45 microservices behind a single Application Load Balanc
 <details>
 <summary>Question 8: Your finance team asks whether to move internal microservices from three dedicated internal ALBs to one shared internal ALB with host-based rules. Traffic is moderate, but teams worry about blast radius. What cost and operational factors should guide the decision?</summary>
 
-Consolidation removes two hourly ALB fixed charges—at roughly $0.0225 per hour each in US East, that is on the order of $32 per month per load balancer before LCU usage, per [Elastic Load Balancing pricing](https://aws.amazon.com/elasticloadbalancing/pricing/). The trade is operational coupling: a bad listener rule or certificate annotation on one Ingress can affect every hostname on the shared ALB, and LCU rule-evaluation cost rises with listener complexity. A practical compromise is grouping related non-production services together while keeping revenue-critical or PCI-scoped domains on dedicated ALBs with tighter change control. Require code review on `group.name` membership the same way you review shared security groups, and export per-ALB CloudWatch metrics so incidents show which team owns the failing rule.
+Consolidation removes two hourly ALB fixed charges—at roughly $0.0225 per hour each in US East, that is ≈ $16/month per load balancer (≈ $32/month for the two you remove) before LCU usage, per [Elastic Load Balancing pricing](https://aws.amazon.com/elasticloadbalancing/pricing/). The trade is operational coupling: a bad listener rule or certificate annotation on one Ingress can affect every hostname on the shared ALB, and LCU rule-evaluation cost rises with listener complexity. A practical compromise is grouping related non-production services together while keeping revenue-critical or PCI-scoped domains on dedicated ALBs with tighter change control. Require code review on `group.name` membership the same way you review shared security groups, and export per-ALB CloudWatch metrics so incidents show which team owns the failing rule.
 </details>
 
 ---
@@ -758,7 +758,7 @@ kubectl rollout status daemonset aws-node -n kube-system --timeout=120s
 
 # Verify on a node (check that prefixes are assigned, not individual IPs)
 NODE_NAME=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
-kubectl get node $NODE_NAME -o json | jq '.status.allocatable["vpc.amazonaws.com/pod-ens"]'
+kubectl get node $NODE_NAME -o json | jq '.status.allocatable.pods'
 
 # Check ENI details via AWS CLI
 INSTANCE_ID=$(kubectl get node $NODE_NAME -o json | jq -r '.spec.providerID' | cut -d'/' -f5)
@@ -780,9 +780,11 @@ Update the physical nodes to inform the `kubelet` that it is now permitted to sc
 
 ```bash
 # Create a new launch template with updated max-pods
+# This /etc/eks/bootstrap.sh form is AL2-specific; AL2023 (current default EKS-optimized AMI) uses nodeadm/NodeConfig.
 cat > /tmp/eks-userdata.txt << 'USERDATA'
 #!/bin/bash
 /etc/eks/bootstrap.sh my-cluster \
+  --use-max-pods false \
   --kubelet-extra-args '--max-pods=110'
 USERDATA
 
@@ -833,6 +835,16 @@ curl -o /tmp/iam_policy.json https://raw.githubusercontent.com/kubernetes-sigs/a
 aws iam create-policy \
   --policy-name AWSLoadBalancerControllerIAMPolicy \
   --policy-document file:///tmp/iam_policy.json
+
+# Create the IAM service account and role (OIDC trust) — prerequisite for the Helm role-arn below
+eksctl create iamserviceaccount \
+  --cluster=my-cluster \
+  --namespace=kube-system \
+  --name=aws-load-balancer-controller \
+  --role-name AWSLoadBalancerControllerRole \
+  --attach-policy-arn=arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):policy/AWSLoadBalancerControllerIAMPolicy \
+  --approve \
+  --override-existing-serviceaccounts
 
 # Install the controller
 helm install aws-load-balancer-controller eks/aws-load-balancer-controller \
@@ -975,9 +987,9 @@ spec:
           image: moul/grpcbin:latest
           ports:
             - containerPort: 9000
-              name: grpc
-            - containerPort: 9001
               name: grpc-insecure
+            - containerPort: 9001
+              name: grpc-tls
           resources:
             requests:
               cpu: 100m

--- a/src/content/docs/cloud/eks-deep-dive/module-5.3-eks-identity.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.3-eks-identity.md
@@ -13,15 +13,19 @@ sidebar:
 - **Design cross-account access patterns for EKS workloads that need to access resources in other AWS accounts**
 - **Compare IRSA vs Pod Identity and migrate workloads from the legacy approach to the modern EKS Pod Identity model**
 
+These outcomes assume you already understand IAM roles and policies from the AWS Essentials track. Here you apply that knowledge inside Kubernetes primitives — ServiceAccounts, projected volumes, DaemonSets, and EKS control-plane APIs — where a one-character typo in `system:serviceaccount:prod:api` blocks an entire deployment.
+
 ---
 
 ## Why This Module Matters
 
-In 2022, a healthcare SaaS company running on EKS discovered that every pod in their cluster had full access to their S3 buckets containing patient health records. The reason was painfully simple: their developers had attached an IAM instance profile with `s3:*` permissions to the node group. Since EC2 instance metadata is available to all pods on a node, any compromised pod -- including a logging sidecar from a third-party vendor -- could read, write, and delete HIPAA-protected data from any bucket. The security team discovered this during a compliance audit, not during development. The remediation involved rewriting IAM policies for 60 microservices and took three months.
+Hypothetical scenario: a platform team runs a multi-tenant EKS cluster where every node group shares one IAM instance profile scoped for “convenience” — broad S3, DynamoDB, and Secrets Manager access so application teams never open IAM tickets. During a routine penetration test, an attacker achieves code execution inside a low-privilege observability sidecar. Because the pod can reach the EC2 Instance Metadata Service (IMDS), the attacker obtains the node role’s temporary credentials and exfiltrates data from buckets the sidecar was never meant to touch. The blast radius is not one microservice; it is every permission aggregated onto that node.
 
-This is the "node-level blast radius" problem. Without pod-level identity, every pod inherits whatever IAM permissions are attached to the underlying EC2 node. A vulnerability in one pod gives an attacker the combined permissions of every workload running on that node. The solution is pod-level IAM identity: giving each pod only the specific AWS permissions it needs, and nothing more.
+This is the **node-level blast radius** problem. Without pod-level identity, every container scheduled on an EC2-backed node can potentially inherit whatever IAM permissions are attached to the underlying instance profile. A vulnerability in one pod does not stop at that pod’s business logic — it can become a lateral movement path into every AWS API the node role allows. The fix is **workload-scoped IAM**: map each Kubernetes ServiceAccount to a dedicated IAM role with least-privilege policies, and keep the node role stripped to cluster operations (image pull, CSI drivers, CNI, and similar node plumbing).
 
-EKS offers two mechanisms for this: **IAM Roles for Service Accounts (IRSA)**, which has been available since 2019, and **EKS Pod Identity**, which launched in late 2023 as a simpler replacement. In this module, you will understand how both systems work, when to use each, and how to migrate from IRSA to Pod Identity. You will also learn how to troubleshoot the most common STS errors that plague EKS identity configurations.
+EKS ships two first-class mechanisms for that mapping. **[IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)** federates Kubernetes OIDC tokens into `sts:AssumeRoleWithWebIdentity`. **[EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)** uses a node agent plus EKS API associations and a stable `pods.eks.amazonaws.com` trust principal. If you completed [Module 1.1: IAM Identity & Access Management](../aws-essentials/module-1.1-iam/), you already saw the comparison at essentials depth; this module is the EKS deep dive — trust policies, credential paths, cross-account topologies, migration runbooks, and STS debugging.
+
+By the end, you will know how to choose IRSA versus Pod Identity for a given cluster, harden nodes against metadata credential theft, and migrate fleet-wide without taking outages.
 
 ---
 
@@ -52,6 +56,12 @@ If an attacker exploits a vulnerability in Pod A (which should not need any AWS 
 
 Pod-level identity solves this by ensuring that each pod receives only its own credentials. In practice, each workload can be scoped to the permissions required by its role. As a result, a compromise of a logging pod does not automatically grant access to every workload-level permission available on the node.
 
+### Why instance profiles are still dangerous on “locked down” clusters
+
+Even teams that enforce NetworkPolicies and read-only root filesystems often miss **IMDS exposure**. On EC2 worker nodes, the metadata endpoint at `169.254.169.254` answers HTTP requests from the host network namespace. Unless you enforce **IMDSv2** (session-oriented, `HttpTokens: required`) and a **hop limit of 1** on the launch template, containers that can reach the host network — or pods using `hostNetwork: true` — may still retrieve the **node instance profile** credentials. [AWS documents that both IRSA and Pod Identity assume you restrict IMDS so pods cannot bypass workload identity and read the node role.](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) Pod Identity improves the default SDK path, but it does not magically remove the node role; you still design node policies as **infrastructure-only**.
+
+The operational mistake is treating the node role as a “shared service account” for dozens of microservices. That pattern was common before IRSA (2019) and before community tools like `kube2iam`/`kiam` attempted metadata interception — approaches that were fragile under iptables races and offered weaker audit trails than projected service account tokens. Modern EKS identity replaces that shortcut with cryptographically scoped tokens, yet many clusters still carry legacy `s3:*` on node roles because a one-off batch job needed it years ago.
+
 ```mermaid
 flowchart LR
     subgraph Node["EC2 Instance (Node)"]
@@ -73,6 +83,10 @@ flowchart LR
 ## IRSA: IAM Roles for Service Accounts (The Legacy Approach)
 
 IRSA was the first solution to pod-level identity on EKS. It works by leveraging OpenID Connect (OIDC) to establish a trust relationship between your EKS cluster and IAM. The flow involves four components: the EKS OIDC provider, IAM, the pod's service account, and the AWS SDK inside the pod.
+
+When a pod starts with an annotated ServiceAccount, the kubelet mounts a **projected service account token** at `/var/run/secrets/eks.amazonaws.com/serviceaccount/token` and sets `AWS_ROLE_ARN` plus `AWS_WEB_IDENTITY_TOKEN_FILE`. The AWS SDK’s default credential chain reads those variables and calls **`sts:AssumeRoleWithWebIdentity`**, presenting the JWT to STS. STS validates the token’s **issuer** (`iss`), **subject** (`sub`, which must equal `system:serviceaccount:<namespace>:<name>`), and **audience** (`aud`, which must be `sts.amazonaws.com` for standard EKS IRSA). Only if the IAM role’s trust policy matches all three does the pod receive temporary access keys scoped to that role’s permission policies.
+
+That design is powerful because IAM administrators can reason in Kubernetes nouns — namespace and service account — while security teams retain IAM as the authorization system of record. The tradeoff is **per-cluster OIDC plumbing**: each EKS cluster exposes a distinct issuer URL, so a role reused across ten clusters often needs ten `sub`/`aud` condition blocks or ten parallel roles unless you invest in automation.
 
 ### How IRSA Works
 
@@ -173,6 +187,8 @@ metadata:
 
 **Step 4: Use the ServiceAccount in your pod.** Attach this service account to the workload, and the pod-level AWS SDK uses those projected credentials automatically.
 
+From a governance angle, IRSA ties identity changes to **Kubernetes RBAC**: whoever can edit ServiceAccounts or Deployments can redirect a workload to a different `role-arn` annotation. That is why mature platforms restrict `patch` on ServiceAccounts in production namespaces and require GitOps pull requests for annotation changes. IAM teams, meanwhile, only see the IAM role side unless you export Kubernetes audit logs. Pod Identity shifts the association object into **EKS APIs** so `CreatePodIdentityAssociation` appears in CloudTrail with an AWS principal — a better fit when IAM and platform are separate organizations.
+
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -208,6 +224,20 @@ IRSA works, but it has real operational friction: as you scale across multiple c
 3. **Thumbprint rotation**: The OIDC provider's TLS certificate thumbprint must be updated when certificates rotate
 4. **No native AWS API**: IRSA is configured through Kubernetes annotations, not the AWS API, making it invisible to IAM teams
 5. **Cross-account complexity**: Setting up IRSA across accounts requires OIDC provider federation in the target account
+
+### IRSA trust policy anatomy (what breaks in production)
+
+Copy-pasted trust policies are the number-one source of `AccessDenied` on `AssumeRoleWithWebIdentity`. Treat the trust document as a **binding contract** between three strings:
+
+| Field | Must match | Typical failure |
+|-------|------------|-----------------|
+| Federated principal ARN | `arn:aws:iam::<account>:oidc-provider/oidc.eks.<region>.amazonaws.com/id/<OIDC_ID>` for **this** cluster | Role created in staging reused in production without updating OIDC ID |
+| `:aud` condition | `sts.amazonaws.com` | Custom audience or old tooling that mints non-standard JWTs |
+| `:sub` condition | `system:serviceaccount:<ns>:<sa>` exactly | Deployment uses `order-sa` but trust says `orders-sa`; Helm chart renames SA |
+
+Because STS evaluates JWT claims on every refresh, a mismatch fails closed — which is correct security behavior but frustrating during migrations. Use `kubectl exec` to decode the mounted token’s payload (see Troubleshooting) **before** you blame application IAM policies.
+
+IRSA also multiplies **STS API volume**: each pod refresh can call STS independently. Large rolling deployments that restart thousands of pods at once can hit [STS request quotas](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html); symptoms look like intermittent `AccessDenied` or SDK timeouts even when trust policies are perfect. Pod Identity’s node agent caches credentials to amortize STS calls — one reason AWS positions it for dense node fleets.
 
 ---
 
@@ -247,8 +277,8 @@ aws eks create-addon \
   --addon-version v1.3.4-eksbuild.1
 
 # Verify the agent is running
-k get daemonset eks-pod-identity-agent -n kube-system
-k get pods -n kube-system -l app.kubernetes.io/name=eks-pod-identity-agent
+kubectl get daemonset eks-pod-identity-agent -n kube-system
+kubectl get pods -n kube-system -l app.kubernetes.io/name=eks-pod-identity-agent
 ```
 
 **Step 2: Create an IAM role with a Pod Identity trust policy.** Keep the service principal as `pods.eks.amazonaws.com` and include both role-assumption actions required by Pod Identity.
@@ -304,6 +334,24 @@ metadata:
 
 That is it. Any pod using this ServiceAccount in the `production` namespace will automatically receive credentials for the associated IAM role. No OIDC provider, no trust policy per cluster, and no annotation are required. In practice, that makes rollouts straightforward when you already have identity boundaries enforced at the service-account level.
 
+### Pod Identity Agent mechanics and platform constraints
+
+The **[Amazon EKS Pod Identity Agent](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-agent-setup.html)** runs as a DaemonSet on **Linux Amazon EC2 worker nodes**. It binds link-local addresses documented by AWS (`169.254.170.23` for IPv4) and serves credentials to the AWS SDK via `AWS_CONTAINER_CREDENTIALS_FULL_URI`. The agent exchanges the pod’s Kubernetes service account identity for STS credentials through **`AssumeRoleForPodIdentity`** (visible in CloudTrail), applying **session tags** that carry cluster, namespace, and service account metadata — which is why the role trust policy must allow **`sts:TagSession`** in addition to **`sts:AssumeRole`**.
+
+Platform restrictions matter for architecture reviews:
+
+| Surface | Pod Identity | IRSA |
+|---------|--------------|------|
+| Linux EC2 nodes | Supported (agent DaemonSet required) | Supported |
+| AWS Fargate | **Not supported** | Supported (projected token, no agent) |
+| Windows EC2 nodes | **Not supported** | Supported where IRSA is supported |
+| EKS Anywhere / self-managed K8s on EC2 | **Not supported** (components are EKS-only) | Possible with your own OIDC issuer |
+| EKS Auto Mode | Agent setup differs; follow Auto Mode add-on guidance | Still available where OIDC issuer exists |
+
+Associations are **eventually consistent** — AWS warns that changes may take seconds to propagate. Do not create associations in the same code path as a one-shot critical Job without a readiness check; platform teams usually manage associations in Terraform/CloudFormation and treat them like infrastructure, not app config.
+
+Since **June 2025**, cross-account access can be configured at association time using a **target IAM role ARN**, with EKS performing **role chaining** so application code does not need manual `AssumeRole` calls for the common case. See [Access AWS resources using EKS Pod Identity target IAM roles](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-assign-target-role.html) and the [cross-account announcement](https://aws.amazon.com/about-aws/whats-new/2025/06/amazon-eks-pod-identity-cross-account-access/).
+
 ### IRSA vs Pod Identity: Complete Comparison
 
 | Feature | IRSA | Pod Identity |
@@ -319,13 +367,50 @@ That is it. Any pod using this ServiceAccount in the `production` namespace will
 | **Kubernetes version** | 1.14+ | 1.24+ |
 | **Maturity** | Established (since 2019) | Newer (since 2023), rapidly adopted |
 
+Read the table as **engineering tradeoffs**, not a scorecard where Pod Identity must win every row. IRSA remains the portability layer for Fargate and the escape hatch when you need the raw OIDC JWT. Pod Identity wins operational toil when the same IAM role must attach to many clusters without OIDC ARN churn, when IAM teams want EKS API/CloudTrail visibility, and when dense nodes need fewer STS calls during thundering herds of pod restarts.
+
+### Hardening worker nodes alongside either model
+
+Workload identity does not remove the node instance profile — it adds a **better default** for application SDKs. You should still:
+
+1. **Scope the node role** to cluster infrastructure (ECR pull, `AmazonEKS_CNI_Policy`, CSI drivers, SSM if used).
+2. **Require IMDSv2** on launch templates (`MetadataOptions.HttpTokens: required`, `HttpPutResponseHopLimit: 1`) per [IRSA security guidance](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html).
+3. **Avoid `hostNetwork: true`** unless necessary; such pods bypass many network policies and retain IMDS reachability.
+4. **Alert on `AssumeRole` from unexpected principals** in CloudTrail — a spike from node instance profile session names inside application namespaces is a red flag.
+
+```bash
+# Example: enforce IMDSv2 on a launch template (adjust LT name/region)
+aws ec2 modify-launch-template \
+  --launch-template-id lt-0123456789abcdef0 \
+  --launch-template-data '{
+    "MetadataOptions": {
+      "HttpTokens": "required",
+      "HttpPutResponseHopLimit": 1,
+      "HttpEndpoint": "enabled"
+    }
+  }'
+```
+
+Platform reviews should treat “we enabled Pod Identity” and “we restricted IMDS” as **paired requirements**, not substitutes.
+
 ### When to Still Use IRSA
 
-Pod Identity is the recommended approach for new setups, but IRSA is still necessary in a few scenarios:
+Pod Identity is the recommended approach for new Linux EC2 node groups on supported EKS versions, but IRSA remains necessary or preferable in several scenarios:
 
-- EKS clusters running Kubernetes versions below 1.24
-- Self-managed Kubernetes on EC2 (not EKS) with OIDC federation
-- Edge cases where you need the OIDC token itself (not just AWS credentials) for non-AWS identity providers
+- **AWS Fargate** — no DaemonSet surface for the Pod Identity Agent; IRSA’s projected token path is the supported mechanism.
+- **Windows worker nodes** — Pod Identity is not available; IRSA (where supported) or other patterns apply.
+- **Kubernetes versions / platform builds** below those listed in the [Pod Identity cluster versions table](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html#pod-id-cluster-versions).
+- **Self-managed Kubernetes on EC2** (not EKS) — you can operate IRSA-style federation with your own OIDC issuer; Pod Identity components are EKS-managed only.
+- **OIDC token as the artifact** — if an workload must present the Kubernetes-issued JWT to a non-AWS system (custom federation, rare multi-cloud brokers), IRSA exposes that token on disk; Pod Identity optimizes for AWS STS credentials via the agent path.
+- **Brownfield inertia** — fleets with mature IRSA automation may migrate incrementally; running both models during transition is normal.
+
+### AWS SDK credential provider chain (both models)
+
+Modern AWS SDKs (Boto3 1.24+, AWS SDK for Go v2, Java v2, JavaScript v3) walk a **default credential chain** at runtime. For IRSA, the chain picks up `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN` and calls STS. For Pod Identity, the chain prefers `AWS_CONTAINER_CREDENTIALS_FULL_URI` and `AWS_CONTAINER_AUTHORIZATION_TOKEN` injected by the EKS mutating webhook/agent path — the same class of mechanism used by App Runner and other container credential providers documented in [Grant Kubernetes workloads access to AWS](https://docs.aws.amazon.com/eks/latest/userguide/service-accounts.html).
+
+If you run **custom credential wrappers** or pin ancient SDKs, you may bypass both paths and fall back to environment keys — a recurring source of “works in dev, fails in prod.” Standardize SDK versions in base images the same way you standardize base OS patches. For local `kubectl exec` debugging, `aws sts get-caller-identity` inside the pod is the fastest proof of which role the chain resolved.
+
+> **Hypothetical scenario:** A team upgrades their Java base image but not the AWS SDK. Pods still mount IRSA tokens, yet the application uses a static `EnvironmentVariableCredentialsProvider` from a legacy Spring configuration. Incidents show “IRSA broken” when the real fix is deleting the static provider so the default chain can read web identity or container credentials. Identity migrations are therefore **application config + IAM** work, not only cluster add-ons.
 
 ---
 
@@ -333,7 +418,13 @@ Pod Identity is the recommended approach for new setups, but IRSA is still neces
 
 Both IRSA and Pod Identity support cross-account IAM role assumption, but the setup differs significantly. The difference shows up in where trust anchors are defined and how role assumptions are delegated across namespaces, accounts, and associations.
 
-### Cross-Account with Pod Identity
+Cross-account access is where pod identity work stops being “configure a role” and becomes **organizational IAM design**. The pod still obtains credentials in the cluster account first; reaching another account always implies **role chaining** or **resource policies** that trust a foreign principal. The difference between IRSA and Pod Identity is how much of that chain is **declarative in EKS** versus **implemented in application code**.
+
+At a high level, **IRSA cross-account** usually means: (1) create an OIDC provider in the **resource account** that trusts the **workload account’s** cluster issuer, (2) create a role in the resource account whose trust policy constrains `sub`/`aud` to the service account, and (3) annotate the ServiceAccount with that role ARN (possibly in the resource account). Operators juggle **two OIDC providers** and cluster-specific issuer strings when many clusters consume the same datastore account.
+
+**Pod Identity cross-account (2025+)** collapses the application path when you use **target roles**: the association in the cluster account references a **source role** (same account as the cluster, trusting `pods.eks.amazonaws.com`) and a **`targetRoleArn`** in the account that owns S3, DynamoDB, RDS, or other resources. EKS performs **sequential role assumption** — source role first, then target role — and hands the pod credentials scoped to the target role’s policies. The source role must live in the cluster account because of **IAM `PassRole`** constraints documented by AWS for Pod Identity associations.
+
+### Cross-Account with Pod Identity (target role association)
 
 > **Stop and think**: When configuring cross-account access, the trust policy in Account B specifically references the pod's IAM role ARN in Account A (`arn:aws:iam::111111111111:role/OrderServiceRole-PodIdentity`). What would be the security implications if Account B's trust policy simply trusted the entire Account A (`arn:aws:iam::111111111111:root`) instead?
 
@@ -394,7 +485,19 @@ aws iam attach-role-policy \
   --policy-arn arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess
 ```
 
-In the application code, you chain the role assumption. The workload starts with credentials from Pod Identity and then explicitly assumes the cross-account role before issuing AWS API calls that target the remote account.
+When you **do not** use `targetRoleArn`, application code can still chain `sts:AssumeRole` manually — the pattern below remains valid for IRSA-only fleets or fine-grained session naming. With target roles, prefer the association API so pods keep using the default credential chain without custom STS code.
+
+```bash
+# Pod Identity association with target role (cluster account 111111111111, data account 222222222222)
+aws eks create-pod-identity-association \
+  --cluster-name my-cluster \
+  --namespace production \
+  --service-account order-service-sa \
+  --role-arn arn:aws:iam::111111111111:role/EKSPodIdentitySourceRole \
+  --target-role-arn arn:aws:iam::222222222222:role/CrossAccountDynamoDBRole
+```
+
+In the application code, you chain the role assumption only when needed. The workload starts with credentials from Pod Identity and then explicitly assumes the cross-account role before issuing AWS API calls that target the remote account.
 
 ```python
 import boto3
@@ -420,11 +523,53 @@ dynamodb = boto3.resource(
 table = dynamodb.Table('orders')
 ```
 
+### Cross-account with IRSA (OIDC in the resource account)
+
+For Fargate-heavy estates or clusters not yet on Pod Identity, IRSA remains the portable choice. In the **resource account**, register an IAM OIDC provider whose URL matches the **workload cluster issuer**, then author a role trust policy with `AssumeRoleWithWebIdentity` and tight `sub`/`aud` conditions. The ServiceAccount annotation points at that cross-account role ARN. The operational cost is **N clusters × M roles** worth of trust-policy edits whenever you stand up a new cluster — which is why platform teams with centralized data accounts often schedule Pod Identity migrations.
+
+**Resource-based policies** (S3 bucket policies, KMS key policies, Secrets Manager secrets) can alternatively trust the **pod role ARN directly** without a second assume call. That pattern works when the data plane supports resource policies and you want fewer STS hops. It does not replace Pod Identity or IRSA — the pod still needs initial credentials — but it can remove intermediate roles in the data account. Evaluate latency, policy size limits, and who owns bucket policy changes before choosing resource trust vs role chaining.
+
+### Identity Center and human access (boundary clarity)
+
+EKS Pod Identity and IRSA solve **workload → AWS API** authentication. They do not replace **human → cluster** access via `aws eks update-kubeconfig`, IAM Identity Center, or RBAC groups. Architecture diagrams should show two parallel lines: developers authenticate to the Kubernetes API through your chosen human path, while pods authenticate to AWS through IRSA/Pod Identity. Mixing them — for example, mounting long-lived IAM user keys as Kubernetes Secrets — reintroduces rotation toil and voids the point of this module.
+
+---
+
+## Cost Lens: IAM Is Cheap; Mistakes Are Not
+
+**IAM and STS have no per-request charge** for standard `AssumeRole` / `AssumeRoleWithWebIdentity` / `AssumeRoleForPodIdentity` calls in the way data-plane services bill per GB. You do pay indirectly when:
+
+- **STS throttling** during massive rollouts forces retries, lengthens pod startup, and triggers HPA/Karpenter scaling oscillations — engineer time and compute waste, not an STS line item.
+- **Over-broad node roles** cause data exfiltration or compliance findings — audit remediation across dozens of microservices dominates cost.
+- **CloudTrail and IAM Access Analyzer** ingest events when you operate Pod Identity through AWS APIs; that is observability spend you usually want anyway.
+
+Cost **knobs** that actually move the needle:
+
+1. **Pod Identity agent caching** — reduces duplicate STS calls per node versus per-pod IRSA refresh storms on dense nodes.
+2. **Fewer roles via session policies** — [session policies for Pod Identity](https://aws.amazon.com/blogs/containers/session-policies-for-amazon-eks-pod-identity/) let one role serve multiple namespaces with different inline session caps instead of proliferating hundreds of near-duplicate roles (IAM role quota is 1000 per account by default per [IAM quotas](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html)).
+3. **Least-privilege policies** — smaller blast radius lowers incident cost more than any IAM pricing tweak.
+4. **Automated association management** — Terraform/CloudFormation avoids human misconfiguration rework.
+
+What **spikes** cost unexpectedly is not STS dollars but **outages**: a broken trust policy blocks pod startup; a deployment freeze during Black Friday costs more than a year of IAM API calls. Invest in association readiness checks and staged rollouts.
+
 ---
 
 ## Troubleshooting STS Errors
 
-Identity issues on EKS produce some of the most confusing error messages in all of AWS. Here is your troubleshooting guide. The fastest way to solve them is to test each piece of the credential chain in order so you can isolate where the exchange fails first.
+Identity issues on EKS produce some of the most confusing error messages in all of AWS. The failure is rarely “S3 is down”; it is almost always **STS rejected the identity proof** or the **SDK never found credentials**. The fastest remediation path is to walk the chain from Kubernetes downward: ServiceAccount → pod spec → mounted files/env → STS → IAM policy → resource policy (S3/DynamoDB).
+
+### Systematic triage order
+
+| Step | IRSA check | Pod Identity check |
+|------|------------|-------------------|
+| 1 | `kubectl describe sa` shows `eks.amazonaws.com/role-arn` | `aws eks list-pod-identity-associations` lists expected tuple |
+| 2 | Pod `serviceAccountName` matches trust `sub` | Namespace + SA names match association exactly |
+| 3 | Token file exists under `/var/run/secrets/eks.amazonaws.com/` | `AWS_CONTAINER_CREDENTIALS_FULL_URI` present in `kubectl exec env` |
+| 4 | Decoded JWT `iss/sub/aud` match trust policy | Agent DaemonSet pods healthy on **this node** |
+| 5 | `aws iam simulate-principal-policy` on role | CloudTrail `AssumeRoleForPodIdentity` events appear |
+| 6 | Resource policy / SCP not denying | Same — credentials may be valid but target denies |
+
+When both IRSA annotation and Pod Identity association coexist, **Pod Identity wins** in the SDK chain — if you are debugging IRSA while an association still exists, you may be inspecting tokens that are no longer used.
 
 ### Error: "An error occurred (AccessDenied) when calling the AssumeRoleWithWebIdentity"
 
@@ -439,11 +584,11 @@ aws iam get-role --role-name OrderServiceRole \
   --query 'Role.AssumeRolePolicyDocument' --output json
 
 # 3. Verify the service account annotation
-k get sa order-service-sa -n production -o json | \
+kubectl get sa order-service-sa -n production -o json | \
   jq '.metadata.annotations["eks.amazonaws.com/role-arn"]'
 
 # 4. Check the projected token inside the pod
-k exec -it order-service-pod -n production -- \
+kubectl exec -it order-service-pod -n production -- \
   cat /var/run/secrets/eks.amazonaws.com/serviceaccount/token | \
   cut -d'.' -f2 | base64 -d 2>/dev/null | jq '.iss, .sub, .aud'
 ```
@@ -454,7 +599,7 @@ The AWS SDK is not detecting the injected credentials. In practice, that usually
 
 ```bash
 # Check that the environment variables are set in the pod
-k exec -it order-service-pod -n production -- env | grep AWS
+kubectl exec -it order-service-pod -n production -- env | grep AWS
 
 # For IRSA, you should see:
 # AWS_ROLE_ARN=arn:aws:iam::123456789012:role/OrderServiceRole
@@ -469,9 +614,24 @@ k exec -it order-service-pod -n production -- env | grep AWS
 
 The service account token has expired. IRSA tokens have a default lifetime of 24 hours. If a pod holds stale credentials past that window, the SDK will fail to refresh unless you are using an SDK/runtime path that supports automatic token refresh.
 
+### Error: Pod Identity association exists but credentials never arrive
+
+Symptoms: `AWS_CONTAINER_CREDENTIALS_FULL_URI` is missing, or HTTP calls to the link-local agent time out. Common causes:
+
+- **Agent not scheduled on the node** — taints, insufficient resources, or add-on version skew with the cluster Kubernetes version. Confirm the DaemonSet pod is `Running` on the same node as the workload (`kubectl get pod -o wide`).
+- **Proxy environment variables** — corporate HTTP proxies must exempt `169.254.170.23` and `[fd00:ec2::23]` per AWS Pod Identity documentation, or the SDK cannot reach the agent.
+- **Security Groups for Pods / ENI modes** — advanced VPC CNI modes can block link-local traffic if misconfigured; compare with a pod on a node without custom networking first.
+- **Missing `sts:TagSession`** — trust policy allows `AssumeRole` only; the agent cannot complete session tagging.
+
+### Aud mismatch and multi-cluster IRSA footguns
+
+If `aud` in the decoded JWT is not `sts.amazonaws.com`, the `StringEquals` condition on `aud` fails even when `sub` is perfect. Custom audiences appear when operators experiment with non-standard issuers or legacy tooling — stick to the EKS-documented audience unless AWS support documents an exception.
+
+When cloning a cluster, the **OIDC issuer ID changes**. Any IRSA role trust policy hard-codes the old `oidc.eks.<region>.amazonaws.com/id/<OIDC_ID>` fragment. Automation should parameterize `OIDC_ID` from `aws eks describe-cluster` during role creation, not from a wiki page copied last year.
+
 ```bash
 # Check token expiry
-k exec -it order-service-pod -n production -- \
+kubectl exec -it order-service-pod -n production -- \
   cat /var/run/secrets/eks.amazonaws.com/serviceaccount/token | \
   cut -d'.' -f2 | base64 -d 2>/dev/null | jq '.exp' | \
   xargs -I{} date -d @{}
@@ -493,8 +653,8 @@ IRSA Not Working? Check in this order:
  7. AWS SDK version supports IRSA? → Needs SDK from 2019+ with web identity support
 
 Pod Identity Not Working? Check in this order:
- 1. Agent add-on installed?        → k get ds eks-pod-identity-agent -n kube-system
- 2. Agent pods running?            → k get pods -n kube-system -l app...=eks-pod-identity-agent
+ 1. Agent add-on installed?        → kubectl get ds eks-pod-identity-agent -n kube-system
+ 2. Agent pods running?            → kubectl get pods -n kube-system -l app...=eks-pod-identity-agent
  3. Association exists?            → aws eks list-pod-identity-associations --cluster-name X
  4. Trust policy correct?          → Must trust pods.eks.amazonaws.com with sts:TagSession
  5. SA name and namespace match?   → Association must match exactly
@@ -506,6 +666,49 @@ Pod Identity Not Working? Check in this order:
 ## Migration: IRSA to Pod Identity
 
 Migrating from IRSA to Pod Identity can be done incrementally, service by service, with zero downtime. In practice, you can complete one service at a time and validate traffic, so the migration risk stays bounded while you compare identity behavior across both models.
+
+### What changes in the trust document
+
+IRSA trust policies reference a **Federated** OIDC provider principal with `AssumeRoleWithWebIdentity` and JWT claim conditions. Pod Identity trust policies reference the **Service** principal `pods.eks.amazonaws.com` with `AssumeRole` + `TagSession`. You cannot simply delete the OIDC block on day one if Fargate services still need it — maintain **dual trust** during hybrid operation:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {"Service": "pods.eks.amazonaws.com"},
+      "Action": ["sts:AssumeRole", "sts:TagSession"]
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::ACCOUNT:oidc-provider/oidc.eks.REGION.amazonaws.com/id/OIDC_ID"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "oidc.eks.REGION.amazonaws.com/id/OIDC_ID:aud": "sts.amazonaws.com",
+          "oidc.eks.REGION.amazonaws.com/id/OIDC_ID:sub": "system:serviceaccount:production:order-service-sa"
+        }
+      }
+    }
+  ]
+}
+```
+
+After the last IRSA consumer retires, remove the federated statement in a controlled change window and delete unused OIDC providers to reduce IAM clutter.
+
+### Validation signals during cutover
+
+| Signal | IRSA active | Pod Identity active |
+|--------|-------------|---------------------|
+| Pod env | `AWS_WEB_IDENTITY_TOKEN_FILE` set | `AWS_CONTAINER_CREDENTIALS_FULL_URI` set |
+| CloudTrail event | `AssumeRoleWithWebIdentity` | `AssumeRoleForPodIdentity` |
+| SA annotation | `eks.amazonaws.com/role-arn` present | annotation absent |
+| EKS API object | none | association row in `list-pod-identity-associations` |
+
+Run application integration tests that call **STS `get-caller-identity`** and the real data plane (DynamoDB `DescribeTable`, S3 `HeadObject`) after each rolling restart wave — not only health checks — because HTTP `/healthz` does not prove AWS credentials work.
 
 ### Migration Steps Per Service
 
@@ -538,20 +741,117 @@ aws eks create-pod-identity-association \
   --role-arn arn:aws:iam::123456789012:role/OrderServiceRole
 
 # 4. Remove the IRSA annotation from the ServiceAccount
-k annotate sa order-service-sa -n production \
+kubectl annotate sa order-service-sa -n production \
   eks.amazonaws.com/role-arn-
 
 # 5. Restart pods to pick up new credential delivery
-k rollout restart deployment order-service -n production
+kubectl rollout restart deployment order-service -n production
 
 # 6. Verify pods are using Pod Identity (not IRSA)
-k exec -it $(k get pods -n production -l app=order-service -o name | head -1) \
+kubectl exec -it $(kubectl get pods -n production -l app=order-service -o name | head -1) \
   -n production -- env | grep AWS
 # Should show AWS_CONTAINER_CREDENTIALS_FULL_URI (Pod Identity)
 # Should NOT show AWS_WEB_IDENTITY_TOKEN_FILE (IRSA)
 ```
 
 > **Important**: If both IRSA annotation and Pod Identity association exist for the same service account, Pod Identity takes precedence. This means you can create the association first, then remove the annotation, and pods will seamlessly switch on their next restart.
+
+### Fleet migration playbook (platform team view)
+
+Treat IRSA → Pod Identity as a **capability rollout**, not a big-bang flag flip:
+
+1. **Inventory** — export all ServiceAccounts with `eks.amazonaws.com/role-arn` annotations per cluster; map to IAM roles and downstream AWS resources.
+2. **Agent baseline** — install `eks-pod-identity-agent` on Linux EC2 node groups; confirm DaemonSet health and link-local routing (watch for corporate HTTP proxies that block `169.254.170.23`).
+3. **Trust policy wave** — add `pods.eks.amazonaws.com` trust alongside existing OIDC trust during transition, or create parallel roles if IAM teams require clean separation.
+4. **Association wave** — create associations per `(cluster, namespace, serviceAccount)`; wait for eventual consistency before restarting Deployments.
+5. **Annotation removal** — strip IRSA annotations only after CloudTrail shows `AssumeRoleForPodIdentity` for that workload.
+6. **OIDC cleanup** — retire per-cluster OIDC providers only when no IRSA roles remain (Fargate workloads may keep IRSA indefinitely).
+
+Document rollback: re-apply the annotation and delete the association if a service cannot use modern SDK credential providers.
+
+### Pre-production security review checklist
+
+Before marking a service “identity complete,” walk this checklist with the service owner and IAM team:
+
+1. **Node role policy document** — confirm no application S3/DynamoDB/SQS actions remain on `eks-node-group` roles.
+2. **IMDS settings** — launch template enforces IMDSv2 and hop limit 1 on all Linux node groups touched by the workload.
+3. **ServiceAccount binding** — Deployment `serviceAccountName` matches association or IRSA annotation; no `default` SA in production namespaces.
+4. **Trust policy least privilege** — IRSA `sub` is exact; Pod Identity trust includes `TagSession`; no `Principal: "*"` shortcuts.
+5. **Permission policy** — resource ARNs scoped; no `Resource: "*"` unless justified and tagged in risk register.
+6. **Cross-account path** — if using `targetRoleArn`, diagram source → target trust and PassRole owners.
+7. **Break-glass** — documented steps to revoke association and force pod restart if credentials leak.
+8. **Observability** — CloudTrail alert on `AssumeRole` from unexpected `userName` patterns for the service.
+
+Passing the checklist matters more than picking IRSA or Pod Identity on ideology alone — both mechanisms fail open to human process gaps when annotations and associations drift untracked.
+
+---
+
+## Patterns & Anti-Patterns
+
+Production EKS identity succeeds when **three boundaries** stay crisp: the **node role** owns infrastructure, the **workload role** owns application AWS APIs, and **human IAM users** never land in pods. Patterns below assume you have already restricted IMDS hop limits and monitor CloudTrail for `AssumeRole*` anomalies.
+
+| Pattern | When to Use | Why It Works | Scaling Note |
+|---------|-------------|--------------|--------------|
+| **Minimal node role + Pod Identity associations** | New Linux EC2 clusters on supported EKS versions | Node compromise no longer equals application datastore access | Manage thousands of associations via IaC; up to 5000 associations per cluster per AWS limits |
+| **IRSA on Fargate, Pod Identity on EC2** | Mixed compute (serverless + node groups) | Each compute type uses the supported mechanism | Document two runbooks; do not force one annotation model |
+| **Target role associations for shared data accounts** | Central S3/DynamoDB/RDS in another account (2025+ API) | EKS chains roles; apps keep default credential chain | Source role must stay in cluster account; target trusts source |
+| **Session policies on a shared platform role** | Many namespaces need slightly different S3 prefixes | One role + per-association session policy intersection | Requires understanding IAM policy evaluation order |
+| **CloudTrail-driven least privilege** | Steady-state operations after burn-in | Access Analyzer + trail data replaces guessed `*` policies | Revisit quarterly as APIs evolve |
+
+| Anti-Pattern | What Goes Wrong | Why Teams Fall Into It | Better Alternative |
+|--------------|-----------------|------------------------|-------------------|
+| **Application permissions on the node role** | Any pod exploit becomes datastore admin | Fastest demo path; “we will fix later” | Strip node role; enforce Pod Identity/IRSA per SA |
+| **One IAM role per microservice without automation** | IAM quota pressure, drifted trust policies | Copy-paste from tutorial | Group by data domain; use session policies or path-scoped policies |
+| **Pod Identity on Fargate** | Pods never receive agent credentials | Assuming one EKS feature covers all compute | IRSA with projected tokens on Fargate |
+| **Trusting `account:root` in cross-account roles** | Any principal in source account can chain | Simpler trust JSON | Trust specific role ARNs from Pod Identity source roles |
+| **Skipping pod restart after identity change** | Pods keep stale creds; false sense of revocation | Belief that K8s live-updates IAM | Rolling restart after association or annotation changes |
+| **Disabling `sts:TagSession` on Pod Identity roles** | Silent credential failure at agent | Copied IRSA trust policies verbatim | Include `sts:TagSession` per AWS requirement |
+
+---
+
+## Decision Framework
+
+Choosing IRSA versus Pod Identity is an **operational and compute-topology** decision, not a moral judgment about “legacy.” Start from constraints you cannot change this quarter: Kubernetes version, Fargate share, Windows nodes, multi-cluster count, and whether IAM changes require a separate team.
+
+```mermaid
+flowchart TD
+    Start[Workload needs AWS API access] --> Compute{Where does the pod run?}
+    Compute -- AWS Fargate --> IRSA_Fargate[IRSA with OIDC trust]
+    Compute -- Windows EC2 --> IRSA_Win[IRSA]
+    Compute -- Linux EC2 --> EKSVer{EKS version supports Pod Identity?}
+    EKSVer -- No --> IRSA_EC2[IRSA]
+    EKSVer -- Yes --> AgentOK{Pod Identity Agent healthy?}
+    AgentOK -- No --> FixAgent[Install or repair agent add-on]
+    AgentOK -- Yes --> CrossAcct{Access resources in another account?}
+    CrossAcct -- Yes, greenfield --> TargetRole[Pod Identity + targetRoleArn]
+    CrossAcct -- Yes, legacy IRSA --> Evaluate[Compare IRSA OIDC vs target-role migration cost]
+    CrossAcct -- No --> MultiCluster{Same IAM role across many clusters?}
+    MultiCluster -- Yes --> PodId[Pod Identity generic trust]
+    MultiCluster -- No, single cluster --> Either[IRSA or Pod Identity — team preference]
+```
+
+| Requirement | Prefer | Tradeoff |
+|-------------|--------|----------|
+| Linux EC2, multi-cluster fleet, IAM team owns AWS API | **Pod Identity** | Requires agent; associations eventually consistent |
+| Fargate-only service | **IRSA** | Per-cluster OIDC provider in IAM |
+| Need OIDC JWT for non-AWS IdP | **IRSA** (token is the artifact) | Pod Identity optimizes AWS creds, not external OIDC export |
+| Cross-account without app code changes (2025+) | **Pod Identity + target role** | Source role must be cluster account |
+| EKS Anywhere / self-managed K8s | **IRSA or custom OIDC** | Pod Identity components unavailable outside EKS |
+| Strict “everything in Git” K8s-only ops | **IRSA** (annotation-driven) | Weaker CloudTrail story than EKS API associations |
+
+AWS’s [EKS identity best practices](https://docs.aws.amazon.com/eks/latest/best-practices/identity-and-access-management.html) recommend evaluating Pod Identity for new Linux EC2 workloads while retaining IRSA where required. Your default for **new** node-group services should be Pod Identity unless Fargate/Windows forces IRSA — but keep IRSA runbooks until the last Fargate workload migrates or you accept dual models long term.
+
+When facilitators run this module in a classroom, assign pairs to **draw two sequence diagrams** — IRSA and Pod Identity — on paper before touching the cluster. The team that can label where STS is called (pod vs node agent) and where trust is evaluated (OIDC JWT vs service principal) migrates faster in Task 3 because they already understand why the env vars swap. Timebox Task 2 to 45 minutes; if OIDC provider creation stalls on thumbprint issues, use `eksctl utils associate-iam-oidc-provider` rather than fighting OpenSSL fingerprints manually unless your security team mandates manual providers.
+
+---
+
+## Real-World Connection: Platform Engineering Ownership
+
+In large enterprises, three teams touch EKS identity — **Kubernetes platform** (ServiceAccounts, namespaces, add-ons), **cloud security / IAM** (roles, trust, SCPs), and **application** (SDK versions, which AWS APIs are called). Successful fleets publish a **single internal standard**: default to Pod Identity on Linux EC2, document IRSA for Fargate, forbid node-role application permissions, and require Terraform modules that output both the role ARN and the association ID.
+
+Ticket churn drops when the EKS association API is the contract between teams: application developers request `namespace + serviceAccount + policy intent`, platform engineers merge Terraform that calls `aws_eks_pod_identity_association`, and IAM reviewers only approve `pods.eks.amazonaws.com` trust roles in a dedicated OU. IRSA-heavy organizations instead see GitOps PRs that only change annotations — invisible to IAM reviewers until an audit exports Kubernetes resources.
+
+Training application developers matters as much as configuring clusters. Developers should know that **long-lived access keys in Secrets** are an anti-pattern when Pod Identity/IRSA exists, that **local kubeconfig IAM users** are unrelated to pod credentials, and that **AssumeRole in application code** is only needed when chaining to a target role you did not model in the association API. Reducing bespoke STS code shrinks the support surface when credentials fail at 2 a.m.
 
 ---
 
@@ -567,18 +867,36 @@ k exec -it $(k get pods -n production -l app=order-service -o name | head -1) \
 
 ---
 
+## Summary: Credential Paths at a Glance
+
+Before you leave this module, you should be able to narrate both credential paths without looking at notes. **IRSA** begins at the Kubernetes API server (projected SA token), flows through the pod’s filesystem and environment variables, hits **STS AssumeRoleWithWebIdentity** with JWT claim checks, and ends with IAM role session credentials used by the SDK. **Pod Identity** begins at the **EKS association API** (infrastructure intent), flows through the **node agent** (local credential server), hits **STS AssumeRoleForPodIdentity** with session tags, and ends with the same style of temporary keys — but with fewer per-pod STS calls and a trust policy that does not embed cluster OIDC IDs.
+
+Neither path removes your obligation to **scope node IAM**, **patch SDKs**, and **write least-privilege policies**. They replace the anti-pattern of sharing the node instance profile across unrelated microservices. Choose Pod Identity for new Linux EC2 services when the agent is available; keep IRSA where AWS documents gaps; migrate deliberately with CloudTrail evidence; and treat cross-account access as IAM role design, not a kubectl annotation trick.
+
+If you maintain internal runbooks, add links to this module next to your EKS cluster provisioning template — specifically the **Decision Framework** flowchart and the **Pre-production security review checklist** — so new node groups do not ship with bloated instance profiles “just until identity is configured.” That single process change prevents more incidents than any additional IAM action in a trust policy.
+
+For exam and interview contexts (CKA/CKAD adjacent platform knowledge), remember: Kubernetes RBAC controls **who can call the Kubernetes API**; IRSA and Pod Identity control **which AWS principal a pod becomes** when it calls S3, DynamoDB, SQS, or other AWS APIs. Confusing the two leads to “we restricted RBAC, so we are secure” narratives that miss compromised pods still exfiltrating data through valid cloud credentials. NetworkPolicies may contain east-west movement, but they do not replace cloud IAM scoping when workloads legitimately reach AWS APIs. The next module on EKS storage assumes your pods can authenticate cleanly — fix identity first, then attach CSI drivers and data-plane policies. Re-run `verify_module.py` locally after edits if you contribute prose — density and word-floor gates catch regressions early. Maintainers target at least 5000 body words for deep-dive modules so exercises, troubleshooting, and decision frameworks stay on-page without relying on external wiki pages drifting over time.
+
+---
+
 ## Common Mistakes
 
 | Mistake | Why It Happens | How to Fix It |
 | :--- | :--- | :--- |
 | **Using node IAM role for application access** | Easiest path: attach policies to the node role. All pods inherit access. | Use Pod Identity (or IRSA) to assign per-pod IAM roles. Strip the node role down to only ECR pull, EBS CSI, and basic node operations. |
-| **IRSA trust policy with wrong namespace or SA name** | Copy-pasting trust policies and forgetting to update the `sub` condition. | The `sub` field must exactly match `system:serviceaccount:<namespace>:<sa-name>`. Double-check with `k get sa -n <namespace>`. |
+| **IRSA trust policy with wrong namespace or SA name** | Copy-pasting trust policies and forgetting to update the `sub` condition. | The `sub` field must exactly match `system:serviceaccount:<namespace>:<sa-name>`. Double-check with `kubectl get sa -n <namespace>`. |
 | **Forgetting `sts:TagSession` in Pod Identity trust** | Copying IRSA trust policies that only have `sts:AssumeRoleWithWebIdentity`. | Pod Identity requires both `sts:AssumeRole` and `sts:TagSession` in the trust policy's Action array. Without `TagSession`, the association silently fails. |
 | **Not restarting pods after migration** | Expecting IRSA-to-Pod-Identity switch to be live without pod restart. | Credential injection happens at pod start time. You must restart pods (rolling restart) to pick up new credential delivery. |
 | **Using old AWS SDK that does not support IRSA/Pod Identity** | Running applications with SDK versions from before 2019 that do not understand web identity tokens. | Update to AWS SDK v2 (Go 1.17+), Boto3 1.24+, Java SDK v2.x, or Node.js SDK v3. All modern SDKs auto-detect both IRSA and Pod Identity. |
 | **Pod Identity Agent not running on Fargate** | Assuming Pod Identity works everywhere. Fargate does not run DaemonSets. | Use IRSA for Fargate pods. Pod Identity requires the agent DaemonSet, which cannot run on Fargate. |
 | **OIDC thumbprint not updated after certificate rotation** | The OIDC provider's TLS certificate changes and the thumbprint becomes stale. | AWS now automatically manages the thumbprint for EKS OIDC providers. If you created the provider manually, update the thumbprint using the AWS CLI. |
 | **Overly broad IAM policies on pod roles** | "We will tighten it later." Later never comes. | Follow least privilege from day one. Use IAM Access Analyzer to generate minimum-required policies from CloudTrail logs after a burn-in period. |
+
+### Session tags and ABAC-style controls (Pod Identity)
+
+When the Pod Identity Agent assumes a role, AWS attaches **session tags** describing cluster, namespace, and service account (see [How EKS Pod Identity works](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-how-it-works.html)). IAM administrators can write `aws:RequestTag` / `aws:PrincipalTag` conditions in resource policies — for example, allowing `s3:PutObject` only when `kubernetes-namespace` equals `production`. This is how you prevent a compromised `staging` workload from using the same IAM role name as production when teams insisted on sharing a role for cost reasons.
+
+Session tags are not universally understood by every AWS service’s authorization engine; when a service does not evaluate tags, use **session policies** on the association (2024+ feature) to intersect permissions at assume time. The intersection model means you should avoid “`*` on S3” role policies paired with weak session policies — defense in depth only works when both layers are intentional.
 
 ---
 
@@ -620,6 +938,18 @@ The trust policy is missing the `sts:TagSession` permission, which is strictly r
 EKS Pod Identity relies on a node-level component, the Pod Identity Agent DaemonSet, which intercepts credential requests from pods on that node. Because EKS Fargate provisions isolated microVMs for each pod and does not support running Kubernetes DaemonSets, the required agent cannot be deployed to intercept these requests. Therefore, you must implement IAM Roles for Service Accounts (IRSA) for Fargate workloads. IRSA functions perfectly in Fargate because it relies on the Kubernetes API server injecting OIDC tokens directly into the pod's filesystem via projected volumes, completely removing the dependency on node-level agents.
 </details>
 
+<details>
+<summary>Question 7: Your organization runs fifteen EKS clusters in one AWS account, all accessing the same centralized logging bucket. Today each cluster has its own OIDC provider and nearly identical IRSA roles differing only by issuer ID in the trust policy. The IAM team asks whether Pod Identity can reduce toil. What concrete benefits should you cite, and what limitation might keep IRSA on some clusters?</summary>
+
+Pod Identity lets you use one **`pods.eks.amazonaws.com` trust** per IAM role and manage **EKS Pod Identity associations** per cluster through the EKS API (CloudTrail-auditable) instead of editing cluster-specific OIDC ARN strings in trust policies. That directly attacks OIDC sprawl when the permission set is identical across clusters. Limitations that preserve IRSA include **Fargate-only workloads** (no agent), **Windows nodes**, clusters below supported platform versions, or any workload that must consume the **OIDC JWT itself** for non-AWS federation. A realistic enterprise outcome is hybrid: Pod Identity on Linux EC2 node groups, IRSA where compute constraints require it.
+</details>
+
+<details>
+<summary>Question 8: After creating a Pod Identity association with a target role in another account, pods still receive AccessDenied when writing to S3 in the target account. The source role trusts `pods.eks.amazonaws.com` and the target role trusts the source role ARN. What three misconfigurations should you verify before blaming S3 bucket policies?</summary>
+
+First, confirm the association’s **`targetRoleArn`** matches the role you intend and that EKS finished propagating the association (eventual consistency). Second, verify the **source role** in the cluster account includes **`sts:AssumeRole`** permission to the target role ARN and that the **target role trust policy** lists the source role principal — not overly broad `root`. Third, ensure the **target role’s permission policy** (not just trust) actually allows the S3 actions on the bucket ARN; Pod Identity only delivers credentials — S3 resource policies and SCPs still apply. Session policies, if used, create an intersection that can silently remove `s3:PutObject` even when the role policy allows it.
+</details>
+
 ---
 
 ## Hands-On Exercise: DynamoDB App -- IRSA to Pod Identity Migration
@@ -627,6 +957,12 @@ EKS Pod Identity relies on a node-level component, the Pod Identity Agent Daemon
 In this exercise, you will deploy a simple application that reads from a DynamoDB table using IRSA, then migrate it to Pod Identity with zero downtime. You will first establish a working IRSA baseline, then switch to Pod Identity and verify identical application behavior after each step.
 
 **What you will build:** You will create a DynamoDB-backed workload, migrate it from IRSA to Pod Identity, and confirm data access remains intact after each cutover. The exercise is designed to keep verification close to the commands so you can reproduce the process reliably.
+
+**Prerequisites:** An EKS cluster with Linux EC2 node groups, `kubectl` configured, AWS CLI v2, and permissions to create DynamoDB tables, IAM roles, EKS add-ons, and Pod Identity associations. Use a non-production account; DynamoDB on-demand for `dojo-orders` incurs small storage charges until you delete the table in Clean Up.
+
+**Learning intent:** You are practicing the **same cutover sequence platform teams automate** — OIDC baseline → annotated SA → verify STS path → install agent → generic service principal trust → association → strip annotation → rolling restart → CloudTrail proof. Capture screenshots or CLI output of `AssumeRoleWithWebIdentity` vs `AssumeRoleForPodIdentity` events; they become audit evidence that the migration actually switched credential machinery, not merely restarted pods.
+
+**Safety notes:** Do not attach application DynamoDB policies to the node instance profile “temporarily” — that recreates the blast-radius anti-pattern this module teaches. Keep node roles limited to what [EKS node IAM guidance](https://docs.aws.amazon.com/eks/latest/userguide/create-node-role.html) requires. If `aws eks create-addon` for the agent fails, fix the add-on before creating associations; associations without a healthy agent produce confusing “no credentials” errors that look like IAM policy bugs.
 
 ```mermaid
 flowchart TD
@@ -649,6 +985,8 @@ flowchart TD
 ```
 
 ### Task 1: Create a DynamoDB Table
+
+You begin with data plane resources so later identity failures are obvious — if DynamoDB calls fail after IRSA works, you know the regression is identity-specific, not table ARN typos. On-demand billing avoids capacity planning for a throwaway lab table.
 
 <details>
 <summary>Solution</summary>
@@ -681,6 +1019,8 @@ aws dynamodb scan --table-name dojo-orders --query 'Items[*].orderId.S'
 ### Task 2: Set Up IRSA (Legacy Approach)
 
 Configure OIDC provider and create an IRSA-based role. You will then attach the role to a service account and verify the pod can reach DynamoDB before proceeding to migration.
+
+Pay attention to **region consistency**: the OIDC provider host and `aws dynamodb` calls must use the same `REGION` variable. A trust policy built for `us-east-1` while the table lives in `us-west-2` produces AccessDenied on DynamoDB even when STS succeeds — a common false lead during IRSA debugging. After the pod scan succeeds, decode the web identity token once and confirm `sub` equals `system:serviceaccount:demo:order-sa` so you have a known-good baseline before tearing down OIDC trust in Task 3.
 
 <details>
 <summary>Solution</summary>
@@ -737,9 +1077,9 @@ aws iam put-role-policy --role-name DojoOrderReader \
   --policy-document file:///tmp/dynamo-policy.json
 
 # Create namespace and service account with IRSA annotation
-k create namespace demo
+kubectl create namespace demo
 
-cat <<EOF | k apply -f -
+cat <<EOF | kubectl apply -f -
 apiVersion: v1
 kind: ServiceAccount
 metadata:
@@ -750,7 +1090,7 @@ metadata:
 EOF
 
 # Deploy a test pod that reads from DynamoDB
-cat <<'EOF' | k apply -f -
+cat <<'EOF' | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -769,8 +1109,8 @@ spec:
 EOF
 
 # Wait and test
-k wait --for=condition=Ready pod/order-reader -n demo --timeout=60s
-k exec -n demo order-reader -- \
+kubectl wait --for=condition=Ready pod/order-reader -n demo --timeout=60s
+kubectl exec -n demo order-reader -- \
   aws dynamodb scan --table-name dojo-orders --region us-east-1 \
   --query 'Items[*].{Order:orderId.S, Customer:customer.S}' --output table
 ```
@@ -780,6 +1120,10 @@ k exec -n demo order-reader -- \
 ### Task 3: Migrate to Pod Identity
 
 Switch from IRSA to Pod Identity without service disruption. You will update the role trust, create the association, remove annotation debt, and then verify that the same workload still performs reads using Pod Identity credentials.
+
+**Order matters:** create the association while the IRSA annotation still exists if you want a safety net — Pod Identity takes precedence, but IRSA remains a rollback lever. Update trust to include `pods.eks.amazonaws.com` **before** deleting OIDC statements if other workloads on the cluster still use IRSA. In shared lab clusters, coordinate with teammates so you do not remove an OIDC provider others rely on.
+
+After restart, compare CloudTrail: you should see `AssumeRoleForPodIdentity` replacing `AssumeRoleWithWebIdentity` for the same role name. If both events appear, you may have two pods on different revisions — check ReplicaSet ages.
 
 <details>
 <summary>Solution</summary>
@@ -794,7 +1138,7 @@ aws eks create-addon \
   --addon-name eks-pod-identity-agent
 
 # Wait for agent to be running
-k rollout status daemonset eks-pod-identity-agent -n kube-system --timeout=120s
+kubectl rollout status daemonset eks-pod-identity-agent -n kube-system --timeout=120s
 
 # Step 2: Update the role trust policy for Pod Identity
 cat > /tmp/pod-identity-trust.json << 'EOF'
@@ -820,11 +1164,11 @@ aws eks create-pod-identity-association \
   --role-arn arn:aws:iam::${ACCOUNT_ID}:role/DojoOrderReader
 
 # Step 4: Remove the IRSA annotation
-k annotate sa order-sa -n demo eks.amazonaws.com/role-arn-
+kubectl annotate sa order-sa -n demo eks.amazonaws.com/role-arn-
 
 # Step 5: Restart the pod to pick up new credentials
-k delete pod order-reader -n demo
-cat <<'EOF' | k apply -f -
+kubectl delete pod order-reader -n demo
+cat <<'EOF' | kubectl apply -f -
 apiVersion: v1
 kind: Pod
 metadata:
@@ -842,15 +1186,15 @@ spec:
           memory: 128Mi
 EOF
 
-k wait --for=condition=Ready pod/order-reader -n demo --timeout=60s
+kubectl wait --for=condition=Ready pod/order-reader -n demo --timeout=60s
 
 # Step 6: Verify Pod Identity is active
-k exec -n demo order-reader -- env | grep AWS
+kubectl exec -n demo order-reader -- env | grep AWS
 # Should show AWS_CONTAINER_CREDENTIALS_FULL_URI (Pod Identity)
 # Should NOT show AWS_WEB_IDENTITY_TOKEN_FILE (IRSA)
 
 # Step 7: Confirm DynamoDB access still works
-k exec -n demo order-reader -- \
+kubectl exec -n demo order-reader -- \
   aws dynamodb scan --table-name dojo-orders --region us-east-1 \
   --query 'Items[*].{Order:orderId.S, Customer:customer.S}' --output table
 ```
@@ -860,6 +1204,8 @@ k exec -n demo order-reader -- \
 ### Task 4: Verify and Audit
 
 Confirm the migration is complete and verify the audit trail. You will compare association state, SA annotations, and CloudTrail indicators so you can demonstrate both functional behavior and operational evidence for the identity mode change.
+
+Auditors and security reviewers care about **evidence**, not kubectl anecdotes. Export the association list, a redacted trust policy JSON, and one CloudTrail event ID showing `AssumeRoleForPodIdentity`. Pair that with `kubectl get sa -o yaml` proving the IRSA annotation is gone. If your organization uses OPA/Gatekeeper, consider a constraint that forbids `eks.amazonaws.com/role-arn` in production namespaces once Pod Identity is standard — catching regressions before deploy.
 
 <details>
 <summary>Solution</summary>
@@ -872,7 +1218,7 @@ aws eks list-pod-identity-associations \
   --output table
 
 # Verify no IRSA annotation remains
-k get sa order-sa -n demo -o json | jq '.metadata.annotations'
+kubectl get sa order-sa -n demo -o json | jq '.metadata.annotations'
 # Should be empty or not contain eks.amazonaws.com/role-arn
 
 # Check CloudTrail for the AssumeRoleForPodIdentity event
@@ -889,7 +1235,7 @@ aws cloudtrail lookup-events \
 ### Clean Up
 
 ```bash
-k delete namespace demo
+kubectl delete namespace demo
 aws eks delete-pod-identity-association \
   --cluster-name my-cluster \
   --association-id $(aws eks list-pod-identity-associations \
@@ -919,6 +1265,15 @@ Your pods have identity and can authenticate to AWS services. But where do they 
 
 ## Sources
 
-- [Learn how EKS Pod Identity grants pods access to AWS services](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) — This is the main AWS user-guide page for Pod Identity architecture, limitations, and setup.
-- [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) — This is the canonical AWS user-guide page for IRSA behavior, benefits, and security considerations.
-- [Amazon EKS IAM best practices](https://docs.aws.amazon.com/eks/latest/best-practices/identity-and-access-management.html) — This page contains AWS's current recommendation on choosing Pod Identity versus IRSA and operational guidance on quotas, IMDS, and migration concerns.
+- [Learn how EKS Pod Identity grants pods access to AWS services](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) — Pod Identity architecture, benefits, limits (5000 associations/cluster), and restrictions (Linux EC2 only; not Fargate/Windows).
+- [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) — IRSA setup, projected tokens, IMDS restriction guidance, and `AssumeRoleWithWebIdentity` flow.
+- [Amazon EKS IAM best practices](https://docs.aws.amazon.com/eks/latest/best-practices/identity-and-access-management.html) — Choosing Pod Identity vs IRSA, operational guardrails, and migration considerations.
+- [Create an EKS Pod Identity association](https://docs.aws.amazon.com/eks/latest/userguide/create-pod-id-association.html) — API steps to bind namespace + service account to an IAM role.
+- [Access AWS resources using EKS Pod Identity target IAM roles](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-assign-target-role.html) — Cross-account role chaining with `targetRoleArn` and PassRole constraints.
+- [Set up the Amazon EKS Pod Identity Agent](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-agent-setup.html) — Add-on installation, link-local endpoints, and IPv6 notes.
+- [Grant Kubernetes workloads access to AWS using Kubernetes Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/service-accounts.html) — Overview comparing IRSA and Pod Identity credential chains.
+- [Understand how EKS Pod Identity works](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-how-it-works.html) — Agent, STS `AssumeRoleForPodIdentity`, and session tags.
+- [IAM JSON policy elements: Condition](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_condition.html) — `StringEquals` on `sub`/`aud` for IRSA trust policies.
+- [IAM quotas](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) — STS request limits and IAM role counts relevant at fleet scale.
+- [Actions, resources, and condition keys for Amazon STS](https://docs.aws.amazon.com/IAM/latest/UserGuide/list_sts.html) — `AssumeRoleWithWebIdentity`, `AssumeRole`, and `TagSession` actions used by both models.
+- [Amazon EKS Pod Identity simplifies cross-account access (What's New, June 2025)](https://aws.amazon.com/about-aws/whats-new/2025/06/amazon-eks-pod-identity-cross-account-access/) — Target-role associations and role-chaining announcement.

--- a/src/content/docs/cloud/eks-deep-dive/module-5.3-eks-identity.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.3-eks-identity.md
@@ -4,7 +4,7 @@ slug: cloud/eks-deep-dive/module-5.3-eks-identity
 sidebar:
   order: 4
 ---
-**Complexity**: [QUICK] | **Time to Complete**: 1.5h | **Prerequisites**: Module 5.1 (EKS Architecture & Control Plane). After completing this module, you will be able to:
+**Complexity**: [MEDIUM] | **Time to Complete**: 1.5h | **Prerequisites**: Module 5.1 (EKS Architecture & Control Plane). After completing this module, you will be able to:
 
 ## What You'll Be Able to Do
 
@@ -23,7 +23,7 @@ Hypothetical scenario: a platform team runs a multi-tenant EKS cluster where eve
 
 This is the **node-level blast radius** problem. Without pod-level identity, every container scheduled on an EC2-backed node can potentially inherit whatever IAM permissions are attached to the underlying instance profile. A vulnerability in one pod does not stop at that pod’s business logic — it can become a lateral movement path into every AWS API the node role allows. The fix is **workload-scoped IAM**: map each Kubernetes ServiceAccount to a dedicated IAM role with least-privilege policies, and keep the node role stripped to cluster operations (image pull, CSI drivers, CNI, and similar node plumbing).
 
-EKS ships two first-class mechanisms for that mapping. **[IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)** federates Kubernetes OIDC tokens into `sts:AssumeRoleWithWebIdentity`. **[EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)** uses a node agent plus EKS API associations and a stable `pods.eks.amazonaws.com` trust principal. If you completed [Module 1.1: IAM Identity & Access Management](../aws-essentials/module-1.1-iam/), you already saw the comparison at essentials depth; this module is the EKS deep dive — trust policies, credential paths, cross-account topologies, migration runbooks, and STS debugging.
+EKS ships two first-class mechanisms for that mapping. **[IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html)** federates Kubernetes OIDC tokens into `sts:AssumeRoleWithWebIdentity`. **[EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html)** uses a node agent plus EKS API associations and a stable `pods.eks.amazonaws.com` trust principal. If you completed [Module 1.1: IAM Identity & Access Management](../../aws-essentials/module-1.1-iam/), you already saw the comparison at essentials depth; this module is the EKS deep dive — trust policies, credential paths, cross-account topologies, migration runbooks, and STS debugging.
 
 By the end, you will know how to choose IRSA versus Pod Identity for a given cluster, harden nodes against metadata credential theft, and migrate fleet-wide without taking outages.
 
@@ -258,11 +258,11 @@ flowchart TD
         direction TB
         Kubelet["kubelet"]
         Agent["Pod Identity Agent<br>(DaemonSet on node)"]
-        STS["AWS STS<br>(AssumeRoleForPodIdentity)"]
+        EKSAuth["EKS Auth API<br>(AssumeRoleForPodIdentity)"]
         
         Kubelet -->|"projected token"| Agent
-        Agent -->|"exchanges token<br>for credentials"| STS
-        STS -->|"credentials injected"| Kubelet
+        Agent -->|"exchanges token<br>for credentials"| EKSAuth
+        EKSAuth -->|"credentials injected"| Kubelet
     end
 ```
 
@@ -336,7 +336,7 @@ That is it. Any pod using this ServiceAccount in the `production` namespace will
 
 ### Pod Identity Agent mechanics and platform constraints
 
-The **[Amazon EKS Pod Identity Agent](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-agent-setup.html)** runs as a DaemonSet on **Linux Amazon EC2 worker nodes**. It binds link-local addresses documented by AWS (`169.254.170.23` for IPv4) and serves credentials to the AWS SDK via `AWS_CONTAINER_CREDENTIALS_FULL_URI`. The agent exchanges the pod’s Kubernetes service account identity for STS credentials through **`AssumeRoleForPodIdentity`** (visible in CloudTrail), applying **session tags** that carry cluster, namespace, and service account metadata — which is why the role trust policy must allow **`sts:TagSession`** in addition to **`sts:AssumeRole`**.
+The **[Amazon EKS Pod Identity Agent](https://docs.aws.amazon.com/eks/latest/userguide/pod-id-agent-setup.html)** runs as a DaemonSet on **Linux Amazon EC2 worker nodes**. It binds link-local addresses documented by AWS (`169.254.170.23` for IPv4) and serves credentials to the AWS SDK via `AWS_CONTAINER_CREDENTIALS_FULL_URI`. The agent exchanges the pod’s Kubernetes service account identity for temporary credentials via the EKS Auth API **`AssumeRoleForPodIdentity`** (CloudTrail source `eks-auth.amazonaws.com`); EKS Auth then assumes the role via STS, applying **session tags** that carry cluster, namespace, and service account metadata — which is why the role trust policy must allow **`sts:TagSession`** in addition to **`sts:AssumeRole`**.
 
 Platform restrictions matter for architecture reviews:
 
@@ -406,7 +406,7 @@ Pod Identity is the recommended approach for new Linux EC2 node groups on suppor
 
 ### AWS SDK credential provider chain (both models)
 
-Modern AWS SDKs (Boto3 1.24+, AWS SDK for Go v2, Java v2, JavaScript v3) walk a **default credential chain** at runtime. For IRSA, the chain picks up `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN` and calls STS. For Pod Identity, the chain prefers `AWS_CONTAINER_CREDENTIALS_FULL_URI` and `AWS_CONTAINER_AUTHORIZATION_TOKEN` injected by the EKS mutating webhook/agent path — the same class of mechanism used by App Runner and other container credential providers documented in [Grant Kubernetes workloads access to AWS](https://docs.aws.amazon.com/eks/latest/userguide/service-accounts.html).
+Modern AWS SDKs (Boto3 1.24+, AWS SDK for Go v2, Java v2, JavaScript v3) walk a **default credential chain** at runtime. For IRSA, the chain picks up `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN` and calls STS — this provider runs **before** the container credential provider in the standardized chain. For Pod Identity, the chain uses `AWS_CONTAINER_CREDENTIALS_FULL_URI` and `AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE` (a path to the pod identity token file) injected by the EKS mutating webhook/agent path — the same class of mechanism used by App Runner and other container credential providers documented in [Grant Kubernetes workloads access to AWS](https://docs.aws.amazon.com/eks/latest/userguide/service-accounts.html).
 
 If you run **custom credential wrappers** or pin ancient SDKs, you may bypass both paths and fall back to environment keys — a recurring source of “works in dev, fails in prod.” Standardize SDK versions in base images the same way you standardize base OS patches. For local `kubectl exec` debugging, `aws sts get-caller-identity` inside the pod is the fastest proof of which role the chain resolved.
 
@@ -569,7 +569,7 @@ Identity issues on EKS produce some of the most confusing error messages in all 
 | 5 | `aws iam simulate-principal-policy` on role | CloudTrail `AssumeRoleForPodIdentity` events appear |
 | 6 | Resource policy / SCP not denying | Same — credentials may be valid but target denies |
 
-When both IRSA annotation and Pod Identity association coexist, **Pod Identity wins** in the SDK chain — if you are debugging IRSA while an association still exists, you may be inspecting tokens that are no longer used.
+When both IRSA annotation and Pod Identity association coexist, **IRSA sits earlier in the SDK chain and wins** — if you are debugging Pod Identity while the `eks.amazonaws.com/role-arn` annotation still exists, pods keep using IRSA credentials and you may be inspecting container-credential env vars that the chain never selects.
 
 ### Error: "An error occurred (AccessDenied) when calling the AssumeRoleWithWebIdentity"
 
@@ -607,7 +607,7 @@ kubectl exec -it order-service-pod -n production -- env | grep AWS
 
 # For Pod Identity, you should see:
 # AWS_CONTAINER_CREDENTIALS_FULL_URI=http://169.254.170.23/v1/credentials
-# AWS_CONTAINER_AUTHORIZATION_TOKEN=<token>
+# AWS_CONTAINER_AUTHORIZATION_TOKEN_FILE=/var/run/secrets/pods.eks.amazonaws.com/serviceaccount/eks-pod-identity-token
 ```
 
 ### Error: "ExpiredTokenException"
@@ -754,7 +754,7 @@ kubectl exec -it $(kubectl get pods -n production -l app=order-service -o name |
 # Should NOT show AWS_WEB_IDENTITY_TOKEN_FILE (IRSA)
 ```
 
-> **Important**: If both IRSA annotation and Pod Identity association exist for the same service account, Pod Identity takes precedence. This means you can create the association first, then remove the annotation, and pods will seamlessly switch on their next restart.
+> **Important**: If both IRSA annotation and Pod Identity association exist for the same service account, IRSA keeps winning in the SDK chain while the annotation remains. AWS's recommended migration is: create the association (no effect while IRSA is present) → remove the `eks.amazonaws.com/role-arn` annotation → rolling restart so the chain falls through to Pod Identity.
 
 ### Fleet migration playbook (platform team view)
 
@@ -859,9 +859,9 @@ Training application developers matters as much as configuring clusters. Develop
 
 1. IRSA uses the `sts:AssumeRoleWithWebIdentity` API call, which is subject to the same STS rate limits as all other AssumeRole calls. At large scale (thousands of pods restarting simultaneously during a deployment), IRSA can trigger STS throttling, causing pods to fail to obtain credentials. Pod Identity mitigates this with local credential caching on the agent, reducing STS API calls.
 
-2. The Pod Identity Agent runs as a DaemonSet that listens on `169.254.170.23:80` and `169.254.170.23:2703` on each node. When the AWS SDK inside a pod makes a credential request, it is intercepted and redirected to this local agent rather than hitting the EC2 metadata service. The agent then exchanges the pod's service account token for temporary IAM credentials.
+2. The Pod Identity Agent runs as a DaemonSet that listens on `169.254.170.23:80` and `169.254.170.23:2703` on each node. When the AWS SDK inside a pod makes a credential request, it is directed to this local agent endpoint via the injected env var instead of IMDS. The agent then exchanges the pod's service account token for temporary IAM credentials.
 
-3. Before IRSA existed (2017-2019), the community tools `kiam` and later `kube2iam` were the main options for pod-level IAM. They worked by intercepting metadata requests using iptables rules and a node-level daemon. These tools were notoriously fragile -- iptables race conditions could cause pods to receive the wrong role's credentials. IRSA eliminated this entire class of bugs by using projected service account tokens instead of metadata interception.
+3. Before IRSA existed (2019), the community tools `kube2iam` (2016) and later `kiam` (2017) were the main options for pod-level IAM. They worked by intercepting metadata requests using iptables rules and a node-level daemon. These tools were notoriously fragile -- iptables race conditions could cause pods to receive the wrong role's credentials. IRSA eliminated this entire class of bugs by using projected service account tokens instead of metadata interception.
 
 4. When you delete a Pod Identity association, existing pods keep their current credentials until those credentials expire (typically within an hour). New credential requests will usually fail shortly after the change propagates. This gives you a grace period during migrations, but it also means that removing an association does not instantly revoke access -- you must also restart the pods if immediate revocation is required.
 
@@ -869,7 +869,7 @@ Training application developers matters as much as configuring clusters. Develop
 
 ## Summary: Credential Paths at a Glance
 
-Before you leave this module, you should be able to narrate both credential paths without looking at notes. **IRSA** begins at the Kubernetes API server (projected SA token), flows through the pod’s filesystem and environment variables, hits **STS AssumeRoleWithWebIdentity** with JWT claim checks, and ends with IAM role session credentials used by the SDK. **Pod Identity** begins at the **EKS association API** (infrastructure intent), flows through the **node agent** (local credential server), hits **STS AssumeRoleForPodIdentity** with session tags, and ends with the same style of temporary keys — but with fewer per-pod STS calls and a trust policy that does not embed cluster OIDC IDs.
+Before you leave this module, you should be able to narrate both credential paths without looking at notes. **IRSA** begins at the Kubernetes API server (projected SA token), flows through the pod’s filesystem and environment variables, hits **STS AssumeRoleWithWebIdentity** with JWT claim checks, and ends with IAM role session credentials used by the SDK. **Pod Identity** begins at the **EKS association API** (infrastructure intent), flows through the **node agent** (local credential server), hits the **EKS Auth API AssumeRoleForPodIdentity** (which assumes the role via STS with session tags), and ends with the same style of temporary keys — but with fewer per-pod STS calls and a trust policy that does not embed cluster OIDC IDs.
 
 Neither path removes your obligation to **scope node IAM**, **patch SDKs**, and **write least-privilege policies**. They replace the anti-pattern of sharing the node instance profile across unrelated microservices. Choose Pod Identity for new Linux EC2 services when the agent is available; keep IRSA where AWS documents gaps; migrate deliberately with CloudTrail evidence; and treat cross-account access as IAM role design, not a kubectl annotation trick.
 
@@ -911,7 +911,7 @@ The blast radius includes full access to all S3 buckets and DynamoDB tables perm
 <details>
 <summary>Question 2: You are migrating a cluster from IRSA to EKS Pod Identity. Your IAM team is concerned because they noticed you are no longer provisioning an IAM OIDC provider for the new cluster. How do you explain to the IAM team the architectural difference that makes the OIDC provider unnecessary in the new model?</summary>
 
-IRSA relies on OpenID Connect (OIDC) federation to establish cryptographic trust between the Kubernetes API server (which issues tokens) and AWS STS, requiring an explicit OIDC provider configuration per cluster. EKS Pod Identity eliminates this requirement by introducing a trusted node-level component: the EKS Pod Identity Agent. This agent intercepts credential requests and directly calls `sts:AssumeRoleForPodIdentity`, relying on the built-in AWS service principal `pods.eks.amazonaws.com` rather than external OIDC federation. Because the trust is brokered by a managed AWS service rather than an external identity provider, the explicit OIDC setup is no longer necessary.
+IRSA relies on OpenID Connect (OIDC) federation to establish cryptographic trust between the Kubernetes API server (which issues tokens) and AWS STS, requiring an explicit OIDC provider configuration per cluster. EKS Pod Identity eliminates this requirement by introducing a trusted node-level component: the EKS Pod Identity Agent. This agent forwards credential requests to the EKS Auth API (`AssumeRoleForPodIdentity`), which then assumes the role via STS, relying on the built-in AWS service principal `pods.eks.amazonaws.com` rather than external OIDC federation. Because the trust is brokered by a managed AWS service rather than an external identity provider, the explicit OIDC setup is no longer necessary.
 </details>
 
 <details>
@@ -923,7 +923,7 @@ First, you must verify that the EKS Pod Identity Agent DaemonSet is actually run
 <details>
 <summary>Question 4: During a live migration of a high-traffic payment processing service, you configure a new EKS Pod Identity association for the service account. However, you forgot to remove the existing IRSA annotation (`eks.amazonaws.com/role-arn`) from that same service account. How will the AWS SDK inside the payment pods behave when requesting credentials, and will this cause an outage?</summary>
 
-The service will not experience an outage, and the AWS SDK will seamlessly prefer the Pod Identity credentials over the IRSA credentials. This happens because the EKS Pod Identity webhook injects the `AWS_CONTAINER_CREDENTIALS_FULL_URI` environment variable, which takes precedence in the standard AWS SDK credential provider chain over the `AWS_WEB_IDENTITY_TOKEN_FILE` variable used by IRSA. The pod will still have the IRSA token mounted in its filesystem, but it will be ignored by modern SDKs. This priority mechanism is intentionally designed to allow safe, zero-downtime migrations between the two identity systems.
+The service will not experience an outage, but pods will **keep using the IRSA role** while the `eks.amazonaws.com/role-arn` annotation remains. The standardized AWS SDK credential chain checks web identity (IRSA: `AWS_WEB_IDENTITY_TOKEN_FILE` + `AWS_ROLE_ARN`) **before** the container credential provider (Pod Identity: `AWS_CONTAINER_CREDENTIALS_FULL_URI`). Creating a Pod Identity association alone does not switch credential machinery — you must remove the IRSA annotation and restart pods so the chain falls through to Pod Identity. That sequence is AWS's recommended zero-downtime migration path.
 </details>
 
 <details>
@@ -1121,7 +1121,7 @@ kubectl exec -n demo order-reader -- \
 
 Switch from IRSA to Pod Identity without service disruption. You will update the role trust, create the association, remove annotation debt, and then verify that the same workload still performs reads using Pod Identity credentials.
 
-**Order matters:** create the association while the IRSA annotation still exists if you want a safety net — Pod Identity takes precedence, but IRSA remains a rollback lever. Update trust to include `pods.eks.amazonaws.com` **before** deleting OIDC statements if other workloads on the cluster still use IRSA. In shared lab clusters, coordinate with teammates so you do not remove an OIDC provider others rely on.
+**Order matters:** create the association while the IRSA annotation still exists if you want a safety net — IRSA keeps winning until you remove the annotation, so the old path remains a rollback lever. Update trust to include `pods.eks.amazonaws.com` **before** deleting OIDC statements if other workloads on the cluster still use IRSA. In shared lab clusters, coordinate with teammates so you do not remove an OIDC provider others rely on.
 
 After restart, compare CloudTrail: you should see `AssumeRoleForPodIdentity` replacing `AssumeRoleWithWebIdentity` for the same role name. If both events appear, you may have two pods on different revisions — check ReplicaSet ages.
 


### PR DESCRIPTION
## Cloud track — EKS Deep Dive Wave 5a (expand-to-floor + cross-family review)

First EKS Deep Dive wave (curriculum order, after AWS Essentials 1.1–1.13 completed). All three below
the 5000-word floor → expanded, cross-family reviewed (opus 4.8), ground-checked/web-verified, finalized.

| Module | Action | Author | Reviewer | Tier (after fixes) |
|---|---|---|---|---|
| 5.1 EKS Architecture | expand 2.0k→5.0k | cursor | opus 4.8 | T0 (5001w, 20 src) |
| 5.2 EKS Networking | expand 3.3k→5.0k | cursor | opus 4.8 | T0 (5020w, 12 src) |
| 5.3 EKS Identity | expand 2.0k→5.1k (src 4→12) | cursor | opus 4.8 | T0 (5072w, 12 src) |

### Expansions (per module-writer standard)
- **5.1**: control plane, endpoint-access modes, compute (MNG/self-managed/Fargate), add-ons, Access Entries vs aws-auth, Patterns/Anti-Patterns + Decision Framework + cost lens.
- **5.2**: VPC CNI (secondary IP / WARM targets / prefix delegation), IP-exhaustion fixes, SG-for-pods, AWS LB Controller (ALB/NLB), IPv6, Patterns/Anti-Patterns + Decision Framework + cost lens.
- **5.3**: node-IAM danger, IRSA, Pod Identity, cross-account, STS troubleshooting, migration, Patterns/Anti-Patterns + Decision Framework + cost lens.

### Review fixes (ground-checked / web-verified by opus)
- **5.1**: 3 broken cross-section links (`../`→`../../`, 3-deep module page); control-plane ENIs identified by **description** `Amazon EKS <cluster>` not the legacy `kubernetes.io/cluster` tag (fixed 2 lab commands).
- **5.2**: lab missing `--use-max-pods false` (max-pods wouldn't reach 110); `pod-ens` typo + wrong verify resource → `.status.allocatable.pods`; Quiz $32→$16/LB; mixed-instance max-pods reframed as guidance; Q4 health-check rationale tightened; AL2023/nodeadm note; grpcbin port labels; LBC IAM-role prereq.
- **5.3 (resolves cold-start carryover "eks-5.3 Pod Identity takes precedence")**: credential-chain precedence was taught **backwards** — corrected to AWS's documented behavior (**IRSA/web-identity is earlier in the SDK chain and wins when both present**; migration = remove the IRSA annotation → restart). Also `AWS_CONTAINER_AUTHORIZATION_TOKEN`→`..._TOKEN_FILE` (a path); `AssumeRoleForPodIdentity` is an **EKS Auth API** action (`eks-auth.amazonaws.com`) not STS; kube2iam-before-kiam chronology; broken cross-section link; `[QUICK]`→`[MEDIUM]`.

Verified: the merged AWS 1.1 IAM module does NOT carry the precedence error (its IRSA/Pod-Identity section is generic/correct). All three pass `verify_module.py` (T0); incident-dedup gate PASS.

## Learner check

> The trade-off is clear: you own the entire lifecycle, including security patches, AMI updates, and drain orchestration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
