### PR TITLE
chore(content): cloud EKS Deep Dive wave 5b — 5.4 Storage expand + 5.5 Production gate-fix (completes EKS Deep Dive)

### DIFF
--- a/src/content/docs/cloud/eks-deep-dive/module-5.4-eks-storage.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.4-eks-storage.md
@@ -82,6 +82,7 @@ Amazon Elastic Block Store (EBS) provides persistent, high-performance block-lev
 [The EBS CSI driver is managed as an EKS Add-on. To interact with the AWS API, the driver's controller pods require precise IAM permissions.](https://docs.aws.amazon.com/eks/latest/userguide/workloads-add-ons-available-eks.html) We use standard IAM Roles for Service Accounts (IRSA) or EKS Pod Identity to grant these privileges.
 
 ```bash
+alias k=kubectl
 # Create IAM role for the EBS CSI driver
 cat > /tmp/ebs-trust.json << 'EOF'
 {
@@ -100,11 +101,19 @@ aws iam create-role --role-name AmazonEKS_EBS_CSI_DriverRole \
 aws iam attach-role-policy --role-name AmazonEKS_EBS_CSI_DriverRole \
   --policy-arn arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
 
-# Install the add-on
+EBS_ROLE_ARN=arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):role/AmazonEKS_EBS_CSI_DriverRole
+
+# Install the add-on (Pod Identity — do not pass --service-account-role-arn)
 aws eks create-addon \
   --cluster-name my-cluster \
-  --addon-name aws-ebs-csi-driver \
-  --service-account-role-arn arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):role/AmazonEKS_EBS_CSI_DriverRole
+  --addon-name aws-ebs-csi-driver
+
+# Bind the controller service account via EKS Pod Identity
+aws eks create-pod-identity-association \
+  --cluster-name my-cluster \
+  --namespace kube-system \
+  --service-account ebs-csi-controller-sa \
+  --role-arn $EBS_ROLE_ARN
 
 # Verify
 k get pods -n kube-system -l app.kubernetes.io/name=aws-ebs-csi-driver
@@ -127,8 +136,8 @@ provisioner: ebs.csi.aws.com
 parameters:
   type: gp3
   fsType: ext4
-  iops: "3000"       # baseline (free), up to 16000
-  throughput: "125"   # baseline (free), up to 1000 MiB/s
+  iops: "3000"       # baseline (free), up to 80000 (16000 on Outposts)
+  throughput: "125"   # baseline (free), up to 2000 MiB/s (1000 on Outposts)
   encrypted: "true"
   kmsKeyId: alias/eks-ebs-key   # optional: customer-managed KMS key
 reclaimPolicy: Delete
@@ -145,8 +154,6 @@ The `volumeBindingMode: WaitForFirstConsumer` parameter is arguably the most cri
 > **Pause and predict**: If you forget to set `volumeBindingMode: WaitForFirstConsumer` and leave it as the default `Immediate`, and your EKS cluster spans 3 Availability Zones, what is the mathematical probability that your pod will successfully mount its newly provisioned EBS volume on the first try without node affinity rules? With uniform random AZ selection for both volume and pod, success is roughly one-in-three on the first scheduling attempt—and retry loops do not fix a bound PV already pinned to the wrong zone without reprovisioning.
 
 ### Using EBS Volumes in Pods
-
-### End-to-end: what happens when a pod claims EBS storage
 
 Tracing one successful mount clarifies why configuration mistakes are so painful. Suppose a StatefulSet pod `postgres-0` starts in namespace `database` with a `volumeClaimTemplate` referencing `ebs-gp3`:
 
@@ -288,6 +295,7 @@ spec:
 Scaling storage is a common operational necessity. [Because our `StorageClass` includes `allowVolumeExpansion: true`, we can dynamically resize EBS volumes without terminating the pod or suffering downtime.](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-modify-volume.html) 
 
 ```bash
+alias k=kubectl
 # Edit the PVC to request more storage
 k patch pvc data-postgres-0 -n database \
   --type merge \
@@ -332,11 +340,18 @@ aws iam create-role --role-name AmazonEKS_EFS_CSI_DriverRole \
 aws iam attach-role-policy --role-name AmazonEKS_EFS_CSI_DriverRole \
   --policy-arn arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy
 
-# Install the EFS CSI add-on
+EFS_ROLE_ARN=arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):role/AmazonEKS_EFS_CSI_DriverRole
+
+# Install the EFS CSI add-on (Pod Identity — do not pass --service-account-role-arn)
 aws eks create-addon \
   --cluster-name my-cluster \
-  --addon-name aws-efs-csi-driver \
-  --service-account-role-arn arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):role/AmazonEKS_EFS_CSI_DriverRole
+  --addon-name aws-efs-csi-driver
+
+aws eks create-pod-identity-association \
+  --cluster-name my-cluster \
+  --namespace kube-system \
+  --service-account efs-csi-controller-sa \
+  --role-arn $EFS_ROLE_ARN
 
 # Create an EFS filesystem
 EFS_ID=$(aws efs create-file-system \
@@ -462,7 +477,7 @@ At filesystem creation time you choose a **performance mode** (`generalPurpose` 
 
 **EFS Infrequent Access (IA)** and **Archive** storage classes (with lifecycle policies) reduce $/GB for cold blobs at the cost of retrieval latency and per-GB read charges when data is accessed again—excellent for log archives and ML feature stores that are mostly idle.
 
-> **Stop and think**: EFS is a regional service, meaning your 5 `cms-web` replicas can be scheduled across 3 different Availability Zones and still read/write to the same filesystem. But what is the hidden cost of this convenience? Consider how data actually flows when a pod in AZ-a reads a file that was physically written by a pod in AZ-b, and what AWS charges for network traffic that crosses AZ boundaries.
+> **Stop and think**: EFS is a regional service, meaning your 5 `cms-web` replicas can be scheduled across 3 different Availability Zones and still read/write to the same filesystem. With a mount target in each AZ, pods normally connect to the **local** mount target in their subnet—reads and writes do not cross AZ boundaries for that path. Cross-AZ **data transfer** charges apply when a pod lands in an AZ **without** a mount target and NFS traffic hairpins to a remote target. What mount-target coverage would you require before declaring the CMS tier production-ready?
 
 ---
 
@@ -494,11 +509,18 @@ graph LR
 [Mountpoint for S3 is not meant for dynamic provisioning; it is strictly designed to map existing S3 buckets into pods.](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html) Thus, you must manually construct a `PersistentVolume` targeting the bucket so the driver has a concrete object to mount. In practice, this means you treat each existing bucket as a pre-provided data source and keep namespace and access controls explicit at the Kubernetes storage layer.
 
 ```bash
-# Install the Mountpoint for S3 CSI add-on
+S3_ROLE_ARN=arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):role/S3MountpointRole
+
+# Install the Mountpoint for S3 CSI add-on (Pod Identity — do not pass --service-account-role-arn)
 aws eks create-addon \
   --cluster-name my-cluster \
-  --addon-name aws-mountpoint-s3-csi-driver \
-  --service-account-role-arn arn:aws:iam::$(aws sts get-caller-identity --query Account --output text):role/S3MountpointRole
+  --addon-name aws-mountpoint-s3-csi-driver
+
+aws eks create-pod-identity-association \
+  --cluster-name my-cluster \
+  --namespace kube-system \
+  --service-account s3-csi-driver-sa \
+  --role-arn $S3_ROLE_ARN
 ```
 
 ```yaml
@@ -609,7 +631,7 @@ The external-attacher creates `VolumeAttachment` objects linking a PV to a node 
 
 ## Stateful Workloads Across Availability Zones
 
-The fundamental lesson learned by the ad-tech company was that high availability at the application layer means nothing if the storage layer acts as a strict geographical anchor. They had multiple application pods that could move between zones, yet recovery still stalled when the volume could not follow that movement quickly. That failure path proved that resilience requires alignment between scheduler strategy and storage topology, not just pod-level replication.
+Hypothetical scenario: a recurring failure pattern in ad-tech-style deployments is that high availability at the application layer means nothing if the storage layer acts as a strict geographical anchor. Application pods may reschedule freely across zones, yet recovery still stalls when an EBS volume cannot follow that movement. That failure path proves that resilience requires alignment between scheduler strategy and storage topology, not just pod-level replication.
 
 ### The Problem
 
@@ -633,7 +655,7 @@ graph TD
 
 ### Instance store and ephemeral volumes (when not to use CSI)
 
-Some workloads need the fastest local NVMe on the instance itself. **Instance store** volumes are exposed via `emptyDir` with `medium: Memory` for tmpfs or via direct hostPath/instance-store patterns on bare metal–backed instance types; they are not managed by the EBS CSI driver and disappear when the instance terminates. Use them for scratch caches, shuffle-heavy Spark executors, or temporary sort buffers—not for anything you expect to survive pod rescheduling. The decision framework above deliberately routes durable state to EBS/EFS/S3 CSI paths.
+Some workloads need the fastest local I/O on a node. **`emptyDir` with `medium: Memory`** provides a RAM-backed tmpfs scratch space—it is fast but counts against pod memory limits and disappears when the pod is removed. **Instance store** NVMe volumes are physically attached on many EC2 families (for example m6id, i4i, m5d, c5d, r5d, and bare-metal variants); expose them via supported `emptyDir` volume configurations or hostPath patterns on those instance types, not through the EBS CSI driver. Both tmpfs and instance store are ephemeral: data vanishes when the pod or instance goes away. Use them for scratch caches, shuffle-heavy Spark executors, or temporary sort buffers—not for state that must survive rescheduling. The decision framework above deliberately routes durable state to EBS/EFS/S3 CSI paths.
 
 ### Solution 1: Topology-Aware Scheduling
 
@@ -823,7 +845,7 @@ Suppose three StatefulSet databases each hold 500 GiB gp3 with default 3,000 IOP
 
 ### EFS — shared media at 2 TiB Standard
 
-Two tebibytes on EFS Standard at about **$0.30/GB-month** is on the order of **$600/month** for capacity alone, plus Elastic throughput charges for data read/written and **$0.01/GB** cross-AZ traffic when pods in different zones hit the same files frequently. Moving cold assets to **EFS IA** (roughly **$0.016/GB-month** in many Regions, plus per-GB read fees when accessed) can cut steady-state storage if lifecycle policies match real access patterns. Cost spikes when Provisioned Throughput is left pegged high after a one-time migration, or when IA objects are read continuously (paying retrieval surcharges).
+Two tebibytes on EFS Standard at about **$0.30/GB-month** is on the order of **$600/month** for capacity alone, plus Elastic throughput charges for data read/written. **Cross-AZ data transfer** ($0.01/GB in many Regions) applies when pods connect to a mount target outside their AZ—not when each AZ has a local mount target serving local reads from EFS's regional replication. Moving cold assets to **EFS IA** (roughly **$0.016/GB-month** in many Regions, plus per-GB read fees when accessed) can cut steady-state storage if lifecycle policies match real access patterns. Cost spikes when Provisioned Throughput is left pegged high after a one-time migration, or when IA objects are read continuously (paying retrieval surcharges).
 
 ### S3 + Mountpoint — 5 TiB training corpus
 
@@ -902,7 +924,7 @@ When you present options to product teams, translate technical constraints into 
 
 3. EFS Infrequent Access can be much cheaper than EFS Standard for cold data, and EFS Lifecycle Management can automatically transition files after configurable inactivity windows such as 7, 14, 30, 60, or 90 days.
 
-4. Mountpoint for S3 is implemented in Rust and optimized for high-throughput sequential reads of large S3 datasets; `ReadWriteOncePod` (RWOP) on EBS prevents two pods on the same node from double-mounting a block volume during rollouts—a corruption mode that plain `ReadWriteOnce` still permits on Kubernetes 1.27+ when the CSI driver advertises RWOP support.
+4. Mountpoint for S3 is implemented in Rust and optimized for high-throughput sequential reads of large S3 datasets; `ReadWriteOncePod` (RWOP) on EBS prevents two pods on the same node from double-mounting a block volume during rollouts—a corruption mode that plain `ReadWriteOnce` still permits when the CSI driver advertises RWOP support (beta in Kubernetes 1.27, stable since 1.29).
 
 ---
 
@@ -910,13 +932,13 @@ When you present options to product teams, translate technical constraints into 
 
 | Mistake | Why It Happens | How to Fix It |
 | :--- | :--- | :--- |
-| **Missing `WaitForFirstConsumer` in StorageClass** | Using default `Immediate` binding mode. PVC creates volume in wrong AZ. Use `volumeBindingMode: WaitForFirstConsumer` for EBS StorageClasses unless you have a specific reason not to. This is not optional. |
+| **Missing `WaitForFirstConsumer` in StorageClass** | Using default `Immediate` binding mode creates the volume before the pod is scheduled, often in the wrong AZ. | Set `volumeBindingMode: WaitForFirstConsumer` on every EBS StorageClass unless you have a documented exception. |
 | **Running StatefulSet with no nodes in volume's AZ** | Auto Scaler scales down nodes in one AZ, leaving orphaned volumes. | Set minimum node counts per AZ. Configure Cluster Autoscaler or Karpenter to respect `topologySpreadConstraints`. |
 | **Using EBS for shared storage between pods** | Not knowing EFS exists, or assuming EBS can be mounted RWX. | Use EFS when multiple pods across nodes need shared read/write storage. If you need strict single-pod attachment semantics, use `ReadWriteOncePod` on a Kubernetes version that supports it. |
 | **Not encrypting EBS volumes** | Forgetting to add `encrypted: "true"` in the StorageClass parameters. | Add `encrypted: "true"` to your StorageClass. For compliance, use a customer-managed KMS key via `kmsKeyId`. |
 | **EFS without mount target in node's AZ** | Creating EFS mount targets in only one AZ, but nodes run in multiple AZs. | Create a mount target in every AZ where your EKS nodes run. Without a local mount target, pods either fail to mount or route NFS through cross-AZ traffic. |
 | **Using Mountpoint S3 for random writes** | Treating S3 like a filesystem. Attempting appends or overwrites. | Mountpoint S3 supports sequential writes to new files only. For read-modify-write patterns, use the S3 SDK directly or use EFS. |
-| **Not setting resource requests on storage-heavy pods** | Database pods getting OOM-killed because no memory limits were set. Set explicit memory requests on database pods, and use memory limits only when they are carefully tuned. PostgreSQL, MySQL, and Redis all benefit from explicit memory allocation. |
+| **Not setting resource requests on storage-heavy pods** | Database pods get OOM-killed or evicted because requests/limits were omitted; the scheduler treats them as BestEffort. | Set explicit memory (and CPU) requests on database pods; tune limits only after observing working-set metrics. |
 | **Ignoring EBS modification timing or snapshot restore drills** | Assuming volumes can be shrunk, or that untested snapshots guarantee RTO. | Expand-only online; combine block snapshots with DB-native backup/restore tests in staging quarterly. |
 
 ---
@@ -956,7 +978,7 @@ When AZ-1b fails, the node hosting the replica becomes unreachable, and after th
 <details>
 <summary>Question 6: During a rolling update of a critical database StatefulSet, you notice that two database pods briefly end up running on the exact same node and both attempt to mount the same EBS volume, leading to data corruption. How does the distinction between `ReadWriteOnce` and `ReadWriteOncePod` apply to this scenario?</summary>
 
-The `ReadWriteOnce` (RWO) access mode guarantees that a volume is mounted as read-write by a single node, but it explicitly allows multiple pods on that specific node to mount the volume concurrently. In your scenario, the rolling update placed both the terminating pod and the new pod on the same physical host, allowing both to write to the data directory simultaneously and corrupting the database. To prevent this, you should use `ReadWriteOncePod` (RWOP), which was introduced in Kubernetes 1.27. RWOP strictly limits volume access to a single pod across the entire cluster, regardless of node placement. By using RWOP, the new pod would be blocked from mounting the volume until the old pod had completely terminated and released its lock.
+The `ReadWriteOnce` (RWO) access mode guarantees that a volume is mounted as read-write by a single node, but it explicitly allows multiple pods on that specific node to mount the volume concurrently. In your scenario, the rolling update placed both the terminating pod and the new pod on the same physical host, allowing both to write to the data directory simultaneously and corrupting the database. To prevent this, you should use `ReadWriteOncePod` (RWOP), which reached GA in Kubernetes 1.29 (beta in 1.27). RWOP strictly limits volume access to a single pod across the entire cluster, regardless of node placement. By using RWOP, the new pod would be blocked from mounting the volume until the old pod had completely terminated and released its lock.
 </details>
 
 <details>
@@ -1010,6 +1032,7 @@ Your first step is to establish the fundamental storage integrations. Using stan
 <summary>Solution</summary>
 
 ```bash
+alias k=kubectl
 # Create IAM roles (using Pod Identity trust)
 cat > /tmp/csi-trust.json << 'EOF'
 {
@@ -1035,15 +1058,28 @@ aws iam attach-role-policy --role-name EKS_EFS_CSI_Role \
   --policy-arn arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy
 
 ACCOUNT_ID=$(aws sts get-caller-identity --query Account --output text)
+EBS_ROLE_ARN=arn:aws:iam::${ACCOUNT_ID}:role/EKS_EBS_CSI_Role
+EFS_ROLE_ARN=arn:aws:iam::${ACCOUNT_ID}:role/EKS_EFS_CSI_Role
 
-# Install add-ons
+# Install add-ons (Pod Identity — do not pass --service-account-role-arn)
 aws eks create-addon --cluster-name my-cluster \
-  --addon-name aws-ebs-csi-driver \
-  --service-account-role-arn arn:aws:iam::${ACCOUNT_ID}:role/EKS_EBS_CSI_Role
+  --addon-name aws-ebs-csi-driver
 
 aws eks create-addon --cluster-name my-cluster \
-  --addon-name aws-efs-csi-driver \
-  --service-account-role-arn arn:aws:iam::${ACCOUNT_ID}:role/EKS_EFS_CSI_Role
+  --addon-name aws-efs-csi-driver
+
+# Bind controller service accounts via EKS Pod Identity
+aws eks create-pod-identity-association \
+  --cluster-name my-cluster \
+  --namespace kube-system \
+  --service-account ebs-csi-controller-sa \
+  --role-arn $EBS_ROLE_ARN
+
+aws eks create-pod-identity-association \
+  --cluster-name my-cluster \
+  --namespace kube-system \
+  --service-account efs-csi-controller-sa \
+  --role-arn $EFS_ROLE_ARN
 
 # Verify both drivers are running
 k get pods -n kube-system -l 'app.kubernetes.io/name in (aws-ebs-csi-driver,aws-efs-csi-driver)'
@@ -1058,6 +1094,7 @@ Next, construct the `StorageClass` primitives in sequence. You must ensure `Wait
 <summary>Solution</summary>
 
 ```bash
+alias k=kubectl
 # Create the EBS gp3 StorageClass
 cat <<'EOF' | k apply -f -
 apiVersion: storage.k8s.io/v1
@@ -1131,6 +1168,7 @@ Bind an EBS block device strictly to a stateful PostgreSQL database. This gives 
 <summary>Solution</summary>
 
 ```bash
+alias k=kubectl
 k create namespace cms
 
 # Create database secret
@@ -1227,6 +1265,7 @@ Distribute a lightweight NGINX fleet across the cluster. The crucial capability 
 <summary>Solution</summary>
 
 ```bash
+alias k=kubectl
 cat <<'EOF' | k apply -f -
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -1318,10 +1357,16 @@ Test disaster preparedness and operational scale together. First, freeze the blo
 <summary>Solution</summary>
 
 ```bash
-# Install snapshot CRDs (if not already installed)
-k apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
-k apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
-k apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/master/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+alias k=kubectl
+SNAPSHOTTER_VERSION=v8.2.0
+
+# Install VolumeSnapshot CRDs (pin release tag — do not apply from master)
+k apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotclasses.yaml
+k apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/client/config/crd/snapshot.storage.k8s.io_volumesnapshotcontents.yaml
+k apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/client/config/crd/snapshot.storage.k8s.io_volumesnapshots.yaml
+
+# EKS aws-ebs-csi-driver bundles the csi-snapshotter sidecar, not the cluster controller
+k apply -f https://raw.githubusercontent.com/kubernetes-csi/external-snapshotter/${SNAPSHOTTER_VERSION}/deploy/kubernetes/snapshot-controller/setup-snapshot-controller.yaml
 
 # Create VolumeSnapshotClass
 cat <<'EOF' | k apply -f -
@@ -1372,6 +1417,7 @@ Ensure your system obeys strict geographical boundaries and that failures in one
 <summary>Solution</summary>
 
 ```bash
+alias k=kubectl
 # Check which AZ the PostgreSQL pod and volume are in
 PG_NODE=$(k get pod postgres-0 -n cms -o jsonpath='{.spec.nodeName}')
 PG_AZ=$(k get node $PG_NODE -o jsonpath='{.metadata.labels.topology\.kubernetes\.io/zone}')
@@ -1405,11 +1451,27 @@ done
 ### Clean Up
 
 ```bash
+alias k=kubectl
 k delete namespace cms
 k delete volumesnapshotclass ebs-snapshot-class
 k delete storageclass ebs-gp3 efs-sc
-# Delete EFS filesystem and mount targets
+
+# Delete EFS mount targets, then the filesystem and security group
+for MT in $(aws efs describe-mount-targets --file-system-id $EFS_ID \
+  --query 'MountTargets[].MountTargetId' --output text); do
+  aws efs delete-mount-target --mount-target-id $MT
+done
+sleep 30
 aws efs delete-file-system --file-system-id $EFS_ID
+aws ec2 delete-security-group --group-id $EFS_SG
+
+# Detach policies and delete Task 1 IAM roles
+aws iam detach-role-policy --role-name EKS_EBS_CSI_Role \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy
+aws iam delete-role --role-name EKS_EBS_CSI_Role
+aws iam detach-role-policy --role-name EKS_EFS_CSI_Role \
+  --policy-arn arn:aws:iam::aws:policy/service-role/AmazonEFSCSIDriverPolicy
+aws iam delete-role --role-name EKS_EFS_CSI_Role
 ```
 
 ### Success Checklist

--- a/src/content/docs/cloud/eks-deep-dive/module-5.4-eks-storage.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.4-eks-storage.md
@@ -20,7 +20,11 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-A stateful workload on EKS can fail to restart after rescheduling if its EBS-backed volume is tied to a different Availability Zone, leaving the pod in `Pending` with a volume node affinity conflict. This happens when storage and pod placement drift apart, and it is often discovered only during recovery windows when time pressure is highest. A zonal storage mismatch can keep a critical service offline until operators restore data in a usable zone, so Kubernetes storage behavior and AWS zonal constraints matter for every stateful design. In traditional virtual-machine operations, you usually attach a disk and keep it unchanged, but Kubernetes pods move and are frequently rescheduled by design. If you do not understand StorageClass behavior, CSI mechanisms, and zone geography together, your "highly available" architecture quietly hides a one-AZ failure mode that only appears under pressure. In this module, you will learn to master the EBS, EFS, and Mountpoint for S3 CSI drivers, ensuring your stateful workloads are truly resilient.
+A stateful workload on EKS can fail to restart after rescheduling if its EBS-backed volume is tied to a different Availability Zone, leaving the pod in `Pending` with a volume node affinity conflict. This happens when storage and pod placement drift apart, and it is often discovered only during recovery windows when time pressure is highest. A zonal storage mismatch can keep a critical service offline until operators restore data in a usable zone, so Kubernetes storage behavior and AWS zonal constraints matter for every stateful design. In traditional virtual-machine operations, you usually attach a disk and keep it unchanged, but Kubernetes pods move and are frequently rescheduled by design. If you do not understand StorageClass behavior, CSI mechanisms, and zone geography together, your "highly available" architecture quietly hides a one-AZ failure mode that only appears under pressure.
+
+Hypothetical scenario: during a node drain, a payment ledger pod is evicted and rescheduled. The replacement pod stays `Pending` for hours because its 2 TiB EBS volume was created in `eu-west-1a` while the only free capacity is in `1c`. No application bug occurred—the scheduler and storage layer disagreed about geography. Incidents like this are avoided by designing StorageClasses, node pools, and replication together, not by treating PVCs as magic persistence.
+
+In this module, you will master the EBS, EFS, and Mountpoint for S3 CSI drivers: how sidecars translate API objects into AWS calls, how to encrypt and resize block volumes, how to share files regionally with EFS, when S3-backed mounts are appropriate, and how to reason about cost and failure domains before production traffic arrives.
 
 ---
 
@@ -31,6 +35,41 @@ Historically, Kubernetes included storage drivers directly within its core sourc
 The CSI architecture consists of two primary components:
 1. **The Controller Plugin**: Runs as a Deployment (usually in the `kube-system` namespace) and interacts with the AWS API to provision, attach, detach, and resize volumes.
 2. **The Node Plugin**: Runs as a DaemonSet on every worker node and interacts with the Linux kernel to format, mount, and unmount the block devices or network filesystems into the pod's filesystem namespace.
+
+### From in-tree plugins to out-of-tree drivers
+
+Before CSI, Kubernetes bundled cloud storage logic inside the core kubelet and controller-manager as **in-tree** volume plugins. That coupling meant every new storage feature required a Kubernetes release, and cloud vendors could not ship fixes on their own cadence. CSI moved storage logic **out-of-tree**: the AWS EBS, EFS, and Mountpoint for S3 integrations you install on EKS are independent projects versioned as EKS add-ons or Helm charts, while Kubernetes exposes a stable gRPC contract (`CreateVolume`, `ControllerPublishVolume`, `NodeStageVolume`, and related RPCs). On modern clusters the legacy in-tree `kubernetes.io/aws-ebs` provisioner path is gone; manifests must reference CSI provisioners such as `ebs.csi.aws.com`, `efs.csi.aws.com`, and `s3.csi.aws.com`.
+
+### CSI sidecars: who watches the API?
+
+The driver binary does not talk to the Kubernetes API directly for most workflows. Instead, the [Kubernetes CSI community sidecars](https://kubernetes-csi.github.io/docs/sidecar-containers.html) run in the same controller pod and share a Unix domain socket with the driver container:
+
+| Sidecar | Watches | CSI RPCs triggered |
+| :--- | :--- | :--- |
+| **external-provisioner** | `PersistentVolumeClaim` create/delete | `CreateVolume`, `DeleteVolume` |
+| **external-attacher** | `VolumeAttachment` objects | `ControllerPublishVolume`, `ControllerUnpublishVolume` |
+| **external-resizer** | PVC spec capacity increases | `ControllerExpandVolume` |
+| **external-snapshotter** | `VolumeSnapshot` / `VolumeSnapshotContent` | `CreateSnapshot`, `DeleteSnapshot` |
+| **csi-node-driver-registrar** (node DaemonSet) | Node object | Registers driver with kubelet |
+| **livenessprobe** | Health endpoint | `Probe` for controller health |
+
+Understanding this split explains day-two debugging: a PVC stuck in `Pending` with no PV often means the **provisioner** path (StorageClass name mismatch, IAM, or quota), while a bound PVC with a pod stuck in `ContainerCreating` often means **attacher** or **node** plugin issues (AZ mismatch, device busy, or SELinux/mount flags). Resize and snapshot operations each have their own sidecar loop, which is why enabling snapshots requires installing the [CSI snapshot controller CRDs](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) in addition to the EBS driver add-on.
+
+```mermaid
+sequenceDiagram
+    participant User
+    participant API as Kubernetes API
+    participant Prov as external-provisioner
+    participant Drv as EBS CSI controller
+    participant AWS as EC2/EBS API
+    User->>API: Create PVC
+    API->>Prov: Watch event
+    Prov->>Drv: CreateVolume (gRPC)
+    Drv->>AWS: CreateVolume
+    AWS-->>Drv: vol-abc
+    Drv-->>Prov: Volume ID
+    Prov->>API: Create PV, bind PVC
+```
 
 ---
 
@@ -71,6 +110,8 @@ aws eks create-addon \
 k get pods -n kube-system -l app.kubernetes.io/name=aws-ebs-csi-driver
 ```
 
+After installation, confirm the controller Deployment and node DaemonSet are healthy, and that the StorageClass you intend to use references `ebs.csi.aws.com` (or the EKS Auto Mode provisioner `ebs.csi.eks.amazonaws.com` if you run Auto Mode—those paths manage volumes separately per [EKS EBS CSI guidance](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html)). Fargate pods cannot mount EBS volumes; only EC2-backed nodes run the node plugin that performs `NodePublishVolume`.
+
 ### StorageClass: gp3 Configuration
 
 To dictate how EBS volumes are provisioned dynamically, we define a `StorageClass`. The `gp3` volume type is a common default for many workloads. It provides a baseline of 3,000 IOPS and 125 MiB/s throughput, and AWS lets you provision IOPS and throughput independently of volume size.
@@ -95,11 +136,29 @@ volumeBindingMode: WaitForFirstConsumer
 allowVolumeExpansion: true
 ```
 
+### Volume types: gp3 vs io2
+
+Most EKS databases and stateful apps default to **gp3** because baseline 3,000 IOPS and 125 MiB/s throughput are included at every size, and you can raise IOPS and throughput independently of capacity. Choose **io2** (or io2 Block Express on supported instance families) when you need sustained, predictable IOPS beyond gp3 limits or sub-millisecond latency SLAs for mission-critical OLTP; io2 bills higher per GB and per provisioned IOPS, so it is a deliberate cost trade, not a default. For encryption, `encrypted: "true"` in the StorageClass enables EBS encryption at rest; pair with `kmsKeyId` when compliance requires a customer-managed KMS key and tighter key rotation policies ([EBS encryption](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption.html)).
+
 The `volumeBindingMode: WaitForFirstConsumer` parameter is arguably the most critical configuration in stateful Kubernetes deployments. [By default, Kubernetes uses `Immediate` binding, meaning the storage backend provisions the volume the millisecond the PVC is created. If the scheduler later decides the pod should run on a node in AZ-B, but the volume was provisioned in AZ-A, the pod can remain unschedulable until scheduling aligns with that zone. `WaitForFirstConsumer` intelligently delays volume creation until the pod has been fully scheduled to a specific node](https://kubernetes.io/docs/concepts/storage/storage-classes/), ensuring the EBS volume is physically manifested in the exact same Availability Zone.
 
-> **Pause and predict**: If you forget to set `volumeBindingMode: WaitForFirstConsumer` and leave it as the default `Immediate`, and your EKS cluster spans 3 Availability Zones, what is the mathematical probability that your pod will successfully mount its newly provisioned EBS volume on the first try without node affinity rules?
+> **Pause and predict**: If you forget to set `volumeBindingMode: WaitForFirstConsumer` and leave it as the default `Immediate`, and your EKS cluster spans 3 Availability Zones, what is the mathematical probability that your pod will successfully mount its newly provisioned EBS volume on the first try without node affinity rules? With uniform random AZ selection for both volume and pod, success is roughly one-in-three on the first scheduling attempt—and retry loops do not fix a bound PV already pinned to the wrong zone without reprovisioning.
 
 ### Using EBS Volumes in Pods
+
+### End-to-end: what happens when a pod claims EBS storage
+
+Tracing one successful mount clarifies why configuration mistakes are so painful. Suppose a StatefulSet pod `postgres-0` starts in namespace `database` with a `volumeClaimTemplate` referencing `ebs-gp3`:
+
+1. The StatefulSet controller creates PVC `data-postgres-0` if it does not exist.
+2. With `WaitForFirstConsumer`, the external-provisioner **waits** until the scheduler assigns `postgres-0` to `node-a` in `us-east-1a`.
+3. The provisioner calls `CreateVolume`; the EBS CSI controller creates a gp3 volume in `us-east-1a` and returns `vol-0abc`.
+4. A `PersistentVolume` is created with `nodeAffinity` requiring `us-east-1a`; the PVC binds.
+5. The external-attacher creates a `VolumeAttachment` for `node-a`; the controller calls `ControllerPublishVolume` to attach `vol-0abc` to the EC2 instance backing `node-a`.
+6. On `node-a`, the node plugin runs `NodeStageVolume` (format if needed) and `NodePublishVolume` to expose the block device at a path kubelet understands.
+7. Kubelet mounts the volume into the pod filesystem namespace at `/var/lib/postgresql/data`.
+
+If step 2 used `Immediate` instead, step 3 might create the volume in `us-east-1c` while step 2 later picks `us-east-1a`—steps 5–7 never succeed. That ordering is why platform teams treat `WaitForFirstConsumer` as mandatory for multi-AZ EKS, not an optimization.
 
 When consuming block storage, your application defines a `PersistentVolumeClaim`. For a database like PostgreSQL, the StatefulSet controller ensures each pod replica receives its own unique PVC generated from a `volumeClaimTemplate`.
 
@@ -203,6 +262,8 @@ spec:
 
 To restore the exact state of your volume, you reference the `VolumeSnapshot` in the `dataSource` field of a new PVC. The CSI driver interprets this and signals AWS to provision a fresh EBS volume heavily populated with the snapshot's binary data.
 
+Snapshots are crash-consistent at the block layer unless you quiesce the application or use volume-level features your database vendor documents. For PostgreSQL that often means combining snapshots with replication or logical backups for point-in-time recovery. Cross-Region snapshot copy is a DR tool, not a substitute for same-Region `WaitForFirstConsumer` hygiene—restored volumes still land in one AZ and still require scheduling alignment.
+
 ```yaml
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -243,6 +304,8 @@ k get pvc data-postgres-0 -n database -o json | \
 
 The underlying orchestration is elegant: the EBS controller plugin commands the AWS API to expand the physical block device, while the PVC remains the stable contract for scheduling and attachment behavior. Once AWS confirms the new capacity, the CSI node plugin executing on the host runs standard Linux utilities (`resize2fs` or `xfs_growfs`) to grow the filesystem structure to fill the new boundaries. This two-phase workflow is what allows teams to resize databases without taking application maintenance windows.
 
+Watch the PVC's `status.conditions` during resize: `Resizing` and `FileSystemResizeSuccessful` tell you whether AWS finished the block grow and whether the node plugin expanded the filesystem. If the condition stalls on `Resizing`, check EC2 volume modification state in the AWS console before restarting pods—forcing deletes mid-modification can lengthen recovery. Application teams should still monitor disk usage inside the container (`df`) because kubelet only reports what the filesystem exposes after step two completes.
+
 > **Stop and think**: You just expanded an EBS volume from 100Gi to 200Gi for a temporary data migration. A week later, you realize you only need 50Gi long-term and want to reduce costs. Since EBS doesn't support shrinking volumes, what exact Kubernetes and AWS steps would you need to take to migrate your live StatefulSet data to a new 50Gi volume?
 
 ---
@@ -256,6 +319,10 @@ EBS has a fundamental architectural limitation: a single volume can only be moun
 ### Setting Up EFS
 
 Deploying EFS for EKS requires the EFS CSI driver, a dedicated IAM role, and crucially, an intricate web of security groups and subnet mount targets. Without all three in place, shared storage can remain technically installed but functionally inaccessible from production workloads. In practice, IAM grants the API permission, while security groups and mount targets determine whether pods can reach file paths consistently across all zones.
+
+Unlike EBS, EFS does not pin a pod to a single AZ—NFS clients connect to the mount target in their own subnet/AZ. If you skip a mount target in `us-east-1c` but schedule pods there, mounts may fail or hairpin through another zone, adding latency and data-transfer cost. The security group must allow **TCP 2049** from the **node** security group (or cluster security group on newer EKS networking models), not merely from the control plane. When debugging `mount.nfs4: Connection timed out`, verify three layers in order: mount target exists in the pod's subnet, security group ingress, then route tables/NACLs for private subnets without NAT confusion.
+
+EFS throughput feels “elastic” to developers, but it is not infinite: burst credits on older bursting file systems and Provisioned throughput reservations on steady high-write workloads still show up as throttling under load tests. Load-test shared filesystems the same way you load-test databases—synthetic `fio` or application-level writes from multiple pods—before declaring EFS the CMS backbone.
 
 ```bash
 # Create IAM role for EFS CSI
@@ -378,13 +445,32 @@ spec:
 
 Notice the critical distinction: the PVC leverages `ReadWriteMany`. All five replicas seamlessly mount the exact same file tree at `/usr/share/nginx/html/media`, and when any pod modifies an image or file, the changes are generally visible to the other replicas shortly afterward. This is why EFS is a natural fit for shared CMS workloads where consistency of shared assets matters as much as service parallelism.
 
+### Static vs dynamic EFS provisioning
+
+The EFS CSI driver supports two provisioning models ([EFS CSI on EKS](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html)):
+
+- **Dynamic provisioning** (shown above with `provisioningMode: efs-ap`) creates a new [EFS Access Point](https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html) per PVC, isolating POSIX root paths and UID/GID ranges per application. This is the right default for multi-tenant clusters where many teams share one filesystem ID but must not collide on paths.
+- **Static provisioning** binds a manually created `PersistentVolume` to an existing access point or direct mount target path. Use static PVs when operations owns a fixed directory layout, when migrating legacy NFS paths, or when dynamic access-point churn would complicate backup policies.
+
+### Performance and throughput modes
+
+At filesystem creation time you choose a **performance mode** (`generalPurpose` for latency-sensitive POSIX workloads, `maxIO` for highly parallel metadata-heavy jobs). Throughput is governed separately ([EFS performance](https://docs.aws.amazon.com/efs/latest/ug/performance.html)):
+
+- **Elastic throughput** (default on newer file systems) scales with activity and bills primarily on data read/written rather than a fixed MB/s reservation—good for bursty CMS or CI artifact shares.
+- **Provisioned throughput** guarantees a minimum MB/s and bills for capacity you reserve above the storage-linked baseline—appropriate when average-to-peak ratio stays high and throttling would violate SLOs.
+- **Bursting throughput** (legacy mode) ties baseline throughput to stored GiB; if sustained traffic exceeds burst credits, migrate to Elastic or Provisioned.
+
+**EFS Infrequent Access (IA)** and **Archive** storage classes (with lifecycle policies) reduce $/GB for cold blobs at the cost of retrieval latency and per-GB read charges when data is accessed again—excellent for log archives and ML feature stores that are mostly idle.
+
 > **Stop and think**: EFS is a regional service, meaning your 5 `cms-web` replicas can be scheduled across 3 different Availability Zones and still read/write to the same filesystem. But what is the hidden cost of this convenience? Consider how data actually flows when a pod in AZ-a reads a file that was physically written by a pod in AZ-b, and what AWS charges for network traffic that crosses AZ boundaries.
 
 ---
 
 ## Mountpoint for S3 CSI Driver: Object Storage as a Filesystem
 
-The Mountpoint for S3 CSI driver is a highly specialized storage option that translates standard POSIX filesystem calls into native S3 API requests. This eliminates the need to rewrite legacy applications to use the AWS SDK while unlocking S3's unlimited scalability and unparalleled cost efficiency.
+The Mountpoint for S3 CSI driver is a highly specialized storage option that translates standard POSIX filesystem calls into native S3 API requests. This eliminates the need to rewrite legacy applications to use the AWS SDK while unlocking S3's unlimited scalability and unparalleled cost efficiency for **read-mostly** pipelines. It is not a general-purpose POSIX layer: anything that depends on rename-heavy workflows, fine-grained random writes, or POSIX advisory locks should remain on EBS or EFS.
+
+Teams typically adopt Mountpoint when data already lives in S3 (data lake exports, model artifacts, genomics bundles) and many pods need a directory tree without copying terabytes into EFS. The CSI driver maps each `PersistentVolume` to a bucket name (and optional prefix) you pre-provision; dynamic bucket creation is out of scope, which keeps IAM boundaries explicit but requires a platform workflow to register buckets before namespaces request PVs.
 
 ### Architecture Comparison
 
@@ -476,11 +562,48 @@ spec:
       restartPolicy: Never
 ```
 
+### Mount options and read-heavy tuning
+
+Mountpoint exposes mount options through the CSI `volumeAttributes` (see [Mountpoint for S3 CSI](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html) and [Mountpoint configuration](https://github.com/awslabs/mountpoint-s3/blob/main/doc/CONFIGURATION.md)). Common tunings for ML training include `read-only` mounts (enforced at pod `securityContext` as well), prefix restrictions to a bucket subpath, and allowing the driver to parallelize large sequential reads. Because objects are accessed over HTTPS, first-byte latency follows S3 regional RTT—fine for batch training, unacceptable for interactive OLTP.
+
 ### Mountpoint Limitations
 Mountpoint does not perfectly emulate a block filesystem. It comes with distinct operational caveats:
 - **Write Restrictions**: You can write sequentially to entirely new files, but you cannot execute random writes, append data to an existing file, or rename files/directories. 
 - **No File Locking**: Multiple pods can read the same data, but Mountpoint does not provide file locking or full shared-filesystem coordination for concurrent writers.
 - **Latency Overheads**: First-byte retrieval is bounded by S3 request latency, so Mountpoint is a poor fit for transactional databases or latency-sensitive interactive apps.
+- **POSIX gaps**: Hard links, atomic renames, and sparse random I/O patterns that databases rely on will fail or behave unexpectedly; treat Mountpoint as an object-store adapter, not a replacement for EBS or EFS.
+
+Hypothetical scenario: a team mounts a production PostgreSQL data directory on Mountpoint because “S3 is cheaper.” The database issues random 8 KiB writes; queries time out, and backups corrupt. The fix is migrating the hot path back to EBS (RWO) or EFS (RWX) and reserving Mountpoint for immutable training shards and export staging only.
+
+---
+
+## Diagnosing Volume Attachment and Scheduling Failures
+
+When storage misbehaves, split symptoms into **provisioning** (no PV yet), **attachment** (PV bound, pod not running), and **mount** (container start errors).
+
+```bash
+# PVC stuck provisioning — check events and StorageClass
+kubectl describe pvc <name> -n <namespace>
+kubectl get storageclass
+kubectl logs -n kube-system deploy/ebs-csi-controller -c csi-provisioner --tail=50
+
+# Pod Pending with volume — check affinity and VolumeAttachment
+kubectl describe pod <name> -n <namespace> | grep -A5 Affinity
+kubectl get volumeattachment
+kubectl describe volumeattachment <name>
+```
+
+Common event strings and meanings:
+
+| Event / condition | Likely layer | Investigation |
+| :--- | :--- | :--- |
+| `ProvisioningFailed` / IAM errors | Controller + AWS API | IRSA/Pod Identity role, `AmazonEBSCSIDriverPolicy`, KMS key policy |
+| `FailedAttachVolume` | Attacher | Volume still attached to terminated node; force detach only after confirming pod is gone |
+| `volume node affinity conflict` | Scheduler + zonal PV | Wrong AZ; need new volume or same-AZ node |
+| `Multi-Attach error` | RWO semantics | Two pods on different nodes; use RWOP or fix rollout strategy |
+| Mount permission denied on EFS | Node + network | Security group port 2049, mount target in pod's AZ |
+
+The external-attacher creates `VolumeAttachment` objects linking a PV to a node name; if a node is terminated abruptly, attachments can linger until the controller reconciles. Avoid manual `VolumeAttachment` edits unless you are following a runbook—prefer cordon/drain workflows that let kubelet detach cleanly.
 
 ---
 
@@ -507,6 +630,10 @@ graph TD
     Pod1 -. "Rescheduled on node failure" .-> Node2
     Node2 -.-x Vol1
 ```
+
+### Instance store and ephemeral volumes (when not to use CSI)
+
+Some workloads need the fastest local NVMe on the instance itself. **Instance store** volumes are exposed via `emptyDir` with `medium: Memory` for tmpfs or via direct hostPath/instance-store patterns on bare metal–backed instance types; they are not managed by the EBS CSI driver and disappear when the instance terminates. Use them for scratch caches, shuffle-heavy Spark executors, or temporary sort buffers—not for anything you expect to survive pod rescheduling. The decision framework above deliberately routes durable state to EBS/EFS/S3 CSI paths.
 
 ### Solution 1: Topology-Aware Scheduling
 
@@ -578,6 +705,8 @@ aws eks create-nodegroup \
 
 By ensuring there are at least two nodes per Availability Zone, a single node crash allows the pod to simply reschedule to the surviving node located in the identical AZ, successfully reattaching the EBS volume.
 
+Node group design should align with storage: if you run three AZs and rely on EBS for state, your minimum autoscaling floor is not “three nodes total” but “at least one schedulable node per AZ where PVCs exist,” and ideally two for maintenance windows. Managed node groups and Karpenter NodePools can express that with separate pools labeled by AZ or with topology spread on `eks.amazonaws.com/capacityType` combined with zone spread constraints on the workloads themselves.
+
 ### Solution 3: Application-Level Replication
 
 For enterprise database tiers, completely abstracting resilience away from the Kubernetes storage layer is the gold standard. Storage can still fail, become saturated, or become misbound under stress, but application replication and promotion logic can keep data serviceable during regional disruption.
@@ -608,20 +737,160 @@ graph LR
 
 In this pattern, each StatefulSet replica is deployed with its own dedicated EBS volume pinned to its respective zone. PostgreSQL manages the asynchronous or synchronous block streaming between the primary and the replicas, depending on your recovery point objective. If an entire AWS Availability Zone burns down, the application logic detects the outage and promotes a replica in a surviving zone to assume the primary role.
 
+### How Karpenter and Cluster Autoscaler interact with zonal EBS
+
+Node autoscalers do not move EBS volumes—they only change where **empty** compute exists. **Cluster Autoscaler** scales node groups up/down based on pending pods and utilization; if it removes the last node in an AZ while a StatefulSet pod is down, the replacement pod may have nowhere to land with its existing PV. Mitigations include per-AZ minimum node counts, `topologySpreadConstraints`, and PodDisruptionBudgets that prevent draining the sole node hosting a single-replica database.
+
+**Karpenter** provisions nodes in response to unschedulable pods and respects `topology.kubernetes.io/zone` requirements injected by the scheduler when a PVC already exists. For `WaitForFirstConsumer` **new** claims, Karpenter can launch a node in the AZ the scheduler selects first; for **existing** zonal PVs, Karpenter must provision into that PV's zone or the pod stays Pending. Treat Karpenter consolidation delays and aggressive scale-down as storage-risk events: a stateful pod evicted without a peer node in the same AZ is indistinguishable from an AZ outage from Kubernetes' perspective until compute returns.
+
+Hypothetical scenario: Karpenter consolidates overnight and removes two underutilized nodes in `us-east-1b`, leaving zero workers there while a `ReadWriteOnce` PVC for `orders-db-0` remains in `1b`. The database pod reschedules after a node upgrade and stays Pending until operators either restore a `1b` node or fail over at the application layer—storage autoscaling did not fail; topology did.
+
+### The multi-AZ EBS gotcha in one sentence
+
+EBS is **zonal**: high availability across AZs for data on a single EBS volume is impossible without replication **above** the volume (application quorum, or copy to another backend). Snapshots help disaster recovery but do not make a live volume multi-AZ attachable.
+
 ---
 
-## Storage Decision Matrix
+## Storage Decision Framework
 
-Selecting the proper backend boils down to access patterns, data semantics, and recovery requirements. In practice, you pick EBS when low-latency single-writer block semantics dominate, EFS when concurrent read/write access by multiple pods is a business requirement, and Mountpoint S3 when read-heavy object-style workloads outweigh filesystem edit requirements.
+Selecting the proper backend boils down to access patterns, data semantics, recovery requirements, and cost at the scale you actually run. Use the flowchart when multiple options seem viable; use the matrix as a quick reference after you know access mode and latency needs.
+
+```mermaid
+flowchart TD
+    Start([Need persistent storage on EKS?]) --> Shared{Multiple pods/nodes<br>need same files?}
+    Shared -->|No, single writer| Block[Low-latency block<br>database / queue]
+    Shared -->|Yes, RWX| Latency{POSIX random IO<br>and file locking?}
+    Block --> EBS[EBS gp3/io2 CSI<br>WaitForFirstConsumer]
+    Latency -->|Yes| EFS[EFS CSI<br>Access Points]
+    Latency -->|No, mostly read| S3[Mountpoint S3 CSI<br>existing bucket PV]
+    EBS --> HA{Zonal outage must not<br>stop writes?}
+    HA -->|Yes| AppRep[App-level replication<br>+ snapshots]
+    HA -->|No| Snap[EBS snapshots<br>+ same-AZ node pool]
+    EFS --> EFSIA{Mostly cold data?}
+    EFSIA -->|Yes| Life[EFS Lifecycle → IA/Archive]
+    EFSIA -->|No| EFSStd[EFS Standard + Elastic throughput]
+```
 
 | Use Case | Storage Type | Access Mode | Key Constraint |
 | :--- | :--- | :--- | :--- |
-| Database (single writer) | EBS gp3 | ReadWriteOnce | Single AZ, plan for node failure |
-| High-IOPS database | EBS io2 | ReadWriteOnce | Higher cost than gp3; exact pricing varies by Region and current AWS rates |
-| Shared CMS media | EFS | ReadWriteMany | Higher latency, ~4x EBS cost |
-| ML training data | Mountpoint S3 | ReadWriteMany | Read-optimized, no random writes |
-| Container scratch space | emptyDir / Instance Store | N/A (ephemeral) | Lost on pod restart |
-| Log shipping buffer | EBS gp3 (small) | ReadWriteOnce | Use FluentBit buffer, not large volumes |
+| Database (single writer) | EBS gp3 | ReadWriteOnce | Single AZ per volume; plan same-AZ failover |
+| High-IOPS database | EBS io2 | ReadWriteOnce | Higher $/GB and provisioned IOPS; verify instance EBS limits |
+| Shared CMS media | EFS | ReadWriteMany | Cross-AZ NFS traffic has latency and data-transfer cost |
+| ML training data (read-mostly) | Mountpoint S3 | ReadWriteMany | No random writes/renames; S3 request + transfer charges |
+| ML checkpoints (random write) | EFS or EBS | RWX or RWO | Do not use Mountpoint for checkpoint files |
+| Container scratch space | emptyDir / Instance Store | Ephemeral | Lost on pod restart; fastest local I/O |
+| Log shipping buffer | EBS gp3 (small) | ReadWriteOnce | Size for burst, not multi-TiB retention |
+
+**Tradeoff summary**: EBS wins single-writer latency and cost per GiB for databases; EFS wins true RWX and regional attachment at higher $/GB and NFS semantics; Mountpoint wins massive read-only datasets already in S3; instance store wins ephemeral throughput but forfeits portability across nodes.
+
+When documenting decisions for stakeholders, capture four fields: **access mode** (RWO/RWX/RWOP), **latency target** (milliseconds vs tens of ms vs S3 RTT), **failure domain** (single AZ vs regional vs object durability), and **cost driver** (GiB-month vs IOPS vs requests). That template prevents teams from defaulting to “we always use gp3” without examining shared-file requirements.
+
+---
+
+## Patterns & Anti-Patterns
+
+### Proven patterns
+
+| Pattern | When to use | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| **Topology-aware StorageClass** | Any dynamically provisioned EBS workload | `WaitForFirstConsumer` binds PV creation to the scheduler-selected AZ, eliminating the classic affinity conflict. | Combine with `topologySpreadConstraints` so replicas spread across zones *each with its own volume*. |
+| **One EBS volume per StatefulSet replica** | Sharded databases, Kafka brokers, etcd | Each pod owns a zonal disk; failure domains align with AZ boundaries. | Scale replica count, not volume sharing; use app replication for HA. |
+| **EFS Access Point per team/app** | Multi-tenant shared filesystem | Isolates root paths and POSIX identities without separate filesystem IDs. | Thousands of access points per filesystem; watch IAM and security group sprawl. |
+| **Snapshot + restore drill** | RPO/RTO validation | VolumeSnapshot API automates crash-consistent EBS backups independent of app vendors. | Snapshot chains and cross-Region copy add cost—lifecycle them. |
+| **Read-only Mountpoint for training** | Large immutable datasets in S3 | Avoids SDK refactors while preserving S3 economics for sequential reads. | Many parallel readers increase GET request charges—use prefix sharding. |
+| **Encrypted StorageClass defaults** | Regulated environments | `encrypted: "true"` ensures new volumes never land unencrypted. | CMK per environment via `kmsKeyId`; audit key policies when cloning clusters. |
+
+### Anti-patterns
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+| :--- | :--- | :--- | :--- |
+| **Immediate binding on multi-AZ clusters** | PVC provisions in random AZ; pods Pending forever. | StorageClass copied from tutorials defaults. | Set `volumeBindingMode: WaitForFirstConsumer` on every EBS class. |
+| **One replica StatefulSet without same-AZ spare node** | Node loss = outage until AZ recovers. | Cost optimization removes "extra" nodes per zone. | Minimum two nodes per AZ for stateful pools, or run N+1 replicas with replication. |
+| **EFS for database primary storage** | Latency variance and NFS semantics break DB engines. | Desire for RWX on a single data directory. | EBS + `ReadWriteOncePod` for single-writer safety; EFS for exports only. |
+| **Mountpoint for application logs** | Append-heavy writers fail or corrupt. | "We already have S3 buckets." | Ship logs with Fluent Bit to S3; keep local buffer on small EBS or emptyDir. |
+| **Orphan PVCs with `Retain`** | Deleted workloads leave paid EBS volumes. | Fear of accidental data loss. | `Retain` only on prod classes; automate tagging and AWS Config rules. |
+| **Snapshot sprawl without lifecycle** | Steady-state AWS bill grows while backups age. | Snapshots are "cheap insurance." | DLM policies, cross-Region only when compliance demands. |
+
+---
+
+## Cost at Moderate Scale
+
+Storage economics on EKS are the sum of **provisioned GiB**, **performance purchases**, **API/snapshot churn**, and **data transfer**—not just the StorageClass name. List prices vary by AWS Region; the figures below use US East (N. Virginia) as a planning baseline ([EBS pricing](https://aws.amazon.com/ebs/pricing/), [EFS pricing](https://aws.amazon.com/efs/pricing/), [S3 pricing](https://aws.amazon.com/s3/pricing/)).
+
+### EBS (gp3) — moderate database tier
+
+Suppose three StatefulSet databases each hold 500 GiB gp3 with default 3,000 IOPS and 125 MiB/s (included). Storage alone is roughly **3 × 500 GiB × $0.08/GB-month ≈ $120/month** before snapshots. If one database is provisioned to 12,000 IOPS, you pay for **9,000 extra IOPS × $0.005/IOPS-month ≈ $45/month** on top of storage. Cost spikes when teams oversize IOPS/throughput “just in case,” leave **unattached volumes** after PVC deletes, or retain months of snapshots on high-churn dev clusters. Knobs that reduce cost: right-size gp3 before jumping to io2, migrate legacy gp2 to gp3, delete unused PVs, and use snapshot lifecycle policies.
+
+### EFS — shared media at 2 TiB Standard
+
+Two tebibytes on EFS Standard at about **$0.30/GB-month** is on the order of **$600/month** for capacity alone, plus Elastic throughput charges for data read/written and **$0.01/GB** cross-AZ traffic when pods in different zones hit the same files frequently. Moving cold assets to **EFS IA** (roughly **$0.016/GB-month** in many Regions, plus per-GB read fees when accessed) can cut steady-state storage if lifecycle policies match real access patterns. Cost spikes when Provisioned Throughput is left pegged high after a one-time migration, or when IA objects are read continuously (paying retrieval surcharges).
+
+### S3 + Mountpoint — 5 TiB training corpus
+
+S3 Standard storage near **$0.023/GB-month** for 5 TiB is far below EFS for the same capacity, but **GET/LIST request charges** and cross-AZ egress dominate at scale when hundreds of pods start jobs simultaneously. Mountpoint does not eliminate request billing—it maps POSIX reads to object APIs. Cost spikes on massive parallel training without prefix partitioning or when workloads rewrite objects instead of reading sequentially.
+
+### Idle and operational waste
+
+The silent budget killers in EKS storage are **Released PVCs with `Retain`**, **snapshot chains nobody audits**, and **over-provisioned IOPS** on gp3 volumes that never exceed baseline. Tag volumes with `kubernetes.io/created-for/pvc/namespace` metadata, export cost by tag in Cost Explorer, and gate StorageClasses per environment (dev uses smaller default sizes and `Delete` reclaim).
+
+### Putting cost next to reliability
+
+Cheaper storage is not cheaper operationally if it violates access semantics. Mountpoint saves GiB-month dollars versus EFS but can cost more in engineer hours when an app expects POSIX rename semantics. Likewise, EFS saves replication code for shared files but adds cross-AZ traffic charges when replicas chat across zones. Document expected **$/GiB**, **$/IOPS**, **$/snapshot-month**, and **$/GB-cross-AZ** beside each StorageClass in your internal platform catalog so application teams choose with eyes open, not from habit.
+
+---
+
+## Reclaim policies and data lifecycle
+
+`reclaimPolicy` on a StorageClass (`Delete` vs `Retain`) decides whether the AWS volume survives when the Kubernetes `PersistentVolume` object is released. Development clusters almost always use `Delete` to prevent orphaned EBS charges. Production databases sometimes use `Retain` on the PV while still snapshotting, so a mistaken `kubectl delete pvc` does not instantly destroy data—but Retain without automation becomes a graveyard of unattached volumes billing monthly. Pair Retain with tagging standards, AWS Backup plans, or Data Lifecycle Manager schedules, and run monthly reports comparing `kubectl get pv` to EC2 `describe-volumes` for drift.
+
+For EFS, deleting a PVC backed by dynamic access points removes the access point but not necessarily the parent filesystem; operations teams own filesystem-level lifecycle. For Mountpoint static PVs, deleting the PVC leaves the S3 bucket untouched by design—only object lifecycle rules inside S3 govern retention.
+
+---
+
+## Platform engineering checklist before go-live
+
+Before marking a StorageClass production-ready, walk this checklist with the team that owns the workload:
+
+1. **Binding mode** — EBS classes use `WaitForFirstConsumer`; document any exception with a written risk acceptance.
+2. **Encryption** — `encrypted: "true"` and KMS keys validated in a non-prod cluster clone.
+3. **Snapshots** — VolumeSnapshotClass exists, snapshot controller installed, restore drill completed into a throwaway namespace.
+4. **Capacity growth** — `allowVolumeExpansion: true` tested with a representative filesystem (ext4/xfs) and monitoring on PVC conditions.
+5. **Zone capacity** — At least two schedulable nodes per AZ hosting stateful pods; PDBs prevent voluntary disruption from draining the last node.
+6. **EFS networking** — Mount target per private subnet; security group verified with a pod `mount` test from each AZ.
+7. **Cost tags** — AWS tags propagated from Kubernetes labels where your org supports it; orphaned volume alerts configured.
+8. **Runbooks** — Events for `FailedAttachVolume`, `volume node affinity conflict`, and EFS mount timeouts linked to remediation steps in your internal docs.
+
+This checklist does not replace application HA designs for databases—it ensures the Kubernetes/AWS storage contract you think you bought is the one you actually deployed.
+
+---
+
+## Security, compliance, and data residency
+
+Encryption at rest for EBS and EFS is table stakes for regulated workloads. EBS encryption via StorageClass parameters uses AWS-managed or customer-managed KMS keys; the CSI driver needs `kms:CreateGrant` when volumes attach to instances. EFS encryption protects data at rest on the filesystem; combine with security groups so only cluster nodes reach NFS. Mountpoint inherits S3 bucket policies, block public access settings, and SSE-S3/SSE-KMS configurations—CSI does not bypass IAM: the driver's service account still needs `s3:ListBucket` and `s3:GetObject` (and selective `PutObject` if writes are enabled) scoped to approved prefixes.
+
+Data residency is zonal for EBS: a volume never leaves its AZ while attached. Snapshots and AMIs copied to other Regions are separate compliance events you must track. EFS Regional file systems replicate metadata and data across AZs in the Region—understand that your bytes may physically span zones even when pods appear “regional.” S3 buckets have explicit Region placement; Mountpoint PVs should reference buckets in the same Region as the cluster to avoid cross-Region egress and sovereignty issues.
+
+Pod Identity or IRSA for CSI controllers follows least privilege: use `AmazonEBSCSIDriverPolicy` / `AmazonEFSCSIDriverPolicy` managed policies in non-prod, then scope custom policies in prod if security mandates narrower `ec2:CreateVolume` resource ARNs. Audit logs from CloudTrail on `CreateVolume`, `CreateSnapshot`, and `CreateAccessPoint` complement Kubernetes audit logs for PVC creation—together they answer “who provisioned this disk?” during incidents.
+
+Network policies inside the cluster do not replace security groups for EFS NFS; both layers matter. For Mountpoint, restrict which namespaces may reference S3 PVs via RBAC on PersistentVolume objects or OPA policies, because a static PV can point at sensitive buckets if misconfigured.
+
+---
+
+## Comparing resilience mechanisms
+
+Teams often conflate three different tools; they solve different problems:
+
+| Mechanism | Protects against | Does not protect against |
+| :--- | :--- | :--- |
+| **EBS snapshot** | Logical corruption if restored to new volume; AZ loss if copied/restored elsewhere | Live AZ outage without restore time |
+| **Same-AZ spare node** | Single node failure within AZ | Full AZ outage |
+| **App replication (Postgres, Kafka, etc.)** | AZ or node loss with RPO/RTO tradeoffs | Application bugs writing bad data (replication propagates errors) |
+| **EFS Regional** | Loss of one AZ mount target if others healthy | Application-level corruption |
+| **S3 versioning + Mountpoint read-only** | Accidental object overwrite (if versioned) | POSIX workloads needing random write |
+
+Design conversations go smoother when you name the failure mode first (“AZ loss,” “node loss,” “operator error,” “ransomware”) and only then pick storage tooling. Storage classes and CSI drivers are enablers; they are not substitutes for replication when the business requires minutes-not-hours RTO across zones.
+
+When you present options to product teams, translate technical constraints into service outcomes: “EBS gives us single-digit millisecond block IO in one zone,” “EFS lets every replica see the same upload directory,” “Mountpoint lets training jobs read yesterday’s export without a terabyte copy.” That framing prevents mismatched expectations and reduces the number of storage migrations you perform after go-live.
 
 ---
 
@@ -633,7 +902,7 @@ Selecting the proper backend boils down to access patterns, data semantics, and 
 
 3. EFS Infrequent Access can be much cheaper than EFS Standard for cold data, and EFS Lifecycle Management can automatically transition files after configurable inactivity windows such as 7, 14, 30, 60, or 90 days.
 
-4. Mountpoint for S3 is implemented in Rust and is optimized for high-throughput access to large S3 datasets. For sequential-read workloads such as ML training, it can be a cost-effective alternative when the application fits Mountpoint's file-operation limits.
+4. Mountpoint for S3 is implemented in Rust and optimized for high-throughput sequential reads of large S3 datasets; `ReadWriteOncePod` (RWOP) on EBS prevents two pods on the same node from double-mounting a block volume during rollouts—a corruption mode that plain `ReadWriteOnce` still permits on Kubernetes 1.27+ when the CSI driver advertises RWOP support.
 
 ---
 
@@ -648,7 +917,7 @@ Selecting the proper backend boils down to access patterns, data semantics, and 
 | **EFS without mount target in node's AZ** | Creating EFS mount targets in only one AZ, but nodes run in multiple AZs. | Create a mount target in every AZ where your EKS nodes run. Without a local mount target, pods either fail to mount or route NFS through cross-AZ traffic. |
 | **Using Mountpoint S3 for random writes** | Treating S3 like a filesystem. Attempting appends or overwrites. | Mountpoint S3 supports sequential writes to new files only. For read-modify-write patterns, use the S3 SDK directly or use EFS. |
 | **Not setting resource requests on storage-heavy pods** | Database pods getting OOM-killed because no memory limits were set. Set explicit memory requests on database pods, and use memory limits only when they are carefully tuned. PostgreSQL, MySQL, and Redis all benefit from explicit memory allocation. |
-| **Ignoring EBS modification timing** | Assuming you can keep changing the same volume immediately after each request. | Wait for a modification to complete before issuing another one, and plan changes carefully because performance updates can take from minutes to hours to finish. |
+| **Ignoring EBS modification timing or snapshot restore drills** | Assuming volumes can be shrunk, or that untested snapshots guarantee RTO. | Expand-only online; combine block snapshots with DB-native backup/restore tests in staging quarterly. |
 
 ---
 
@@ -690,11 +959,25 @@ When AZ-1b fails, the node hosting the replica becomes unreachable, and after th
 The `ReadWriteOnce` (RWO) access mode guarantees that a volume is mounted as read-write by a single node, but it explicitly allows multiple pods on that specific node to mount the volume concurrently. In your scenario, the rolling update placed both the terminating pod and the new pod on the same physical host, allowing both to write to the data directory simultaneously and corrupting the database. To prevent this, you should use `ReadWriteOncePod` (RWOP), which was introduced in Kubernetes 1.27. RWOP strictly limits volume access to a single pod across the entire cluster, regardless of node placement. By using RWOP, the new pod would be blocked from mounting the volume until the old pod had completely terminated and released its lock.
 </details>
 
+<details>
+<summary>Question 7: Your platform team wants a single StorageClass for every workload to "simplify operations." The class uses EBS gp3 with Immediate binding and ReadWriteMany. Why will this fail, and what governance model works better?</summary>
+
+A single StorageClass cannot satisfy contradictory access modes: EBS CSI only supports `ReadWriteOnce` (and `ReadWriteOncePod` where enabled)—never `ReadWriteMany`. Immediate binding on multi-AZ clusters reproduces zonal affinity conflicts for stateful pods. Governance that works in production is a **small catalog** of approved classes (`ebs-gp3-wffc`, `efs-ap`, optional static S3 PVs) selected by application owners via label policies, with OPA/Gatekeeper denying PVCs that request nonexistent modes. Simplicity comes from documentation and defaults, not one mythical universal class.
+</details>
+
+<details>
+<summary>Question 8: Finance asks why the dev cluster's EBS spend rose 40% after no new services launched. Which storage-specific investigations do you run first?</summary>
+
+Start with **unattached volumes and Released PVs** still retaining EBS disks, then **snapshot accumulation** without lifecycle rules, then **over-provisioned gp3 IOPS/throughput** on large dev databases cloned from production StorageClasses. In Kubernetes, list PVCs without pods (`kubectl get pvc -A`) and cross-check AWS `describe-volumes` for `available` state. Cost control is operational hygiene—right-size classes per environment and enforce `Delete` reclaim on non-prod tiers unless a ticketed exception requires `Retain`.
+</details>
+
 ---
 
 ## Hands-On Exercise: CMS with EBS for DB + EFS for Shared Media
 
-In this comprehensive exercise, you will architect a robust content management system by marrying PostgreSQL on high-performance EBS block storage with universally shared media storage backed by EFS.
+In this comprehensive exercise, you will architect a robust content management system by marrying PostgreSQL on high-performance EBS block storage with universally shared media storage backed by EFS. The exercise mirrors how production CMS platforms split concerns: transactional rows on low-latency block storage, blob assets on shared POSIX storage. Work through tasks in order—CSI drivers before StorageClasses, StorageClasses before StatefulSets—because later steps assume earlier IAM and mount-target wiring succeeded.
+
+**Prerequisites**: An EKS cluster on EC2 nodes (not Fargate-only), `kubectl` configured, AWS CLI credentials with permissions to create IAM roles, EFS file systems, and EKS add-ons. Replace `my-cluster`, subnet IDs, and account IDs with your environment values.
 
 **What you will build:**
 
@@ -1144,15 +1427,25 @@ aws efs delete-file-system --file-system-id $EFS_ID
 
 ## Next Module
 
-Your stateful workloads are properly anchored with robust, resilient persistent storage—but storage is only a single piece of the production puzzle. How do you scale the underlying instances efficiently, continuously observe application behavior, and rigorously control your exploding compute costs? Proceed directly to [Module 5.5: EKS Production -- Scaling, Observability & Cost](../module-5.5-eks-production/) to master Karpenter node provisioning, AWS Container Insights, and relentless cost optimization using Kubecost.
+Your stateful workloads are properly anchored with robust, resilient persistent storage—but storage is only a single piece of the production puzzle. Carry forward the habit of tracing PVC events to CSI sidecars and AWS APIs whenever a pod sticks in `ContainerCreating`; that discipline saves hours during the next zone maintenance window and during node upgrades.
+
+You can now explain why EBS is zonal, when EFS is worth the premium, and where Mountpoint fits without pretending S3 is a POSIX database—a skill set that separates clusters that merely run StatefulSets from clusters that survive real failures under zone pressure. How do you scale the underlying instances efficiently, continuously observe application behavior, and rigorously control your exploding compute costs for stateful workloads? Proceed directly to [Module 5.5: EKS Production -- Scaling, Observability & Cost](../module-5.5-eks-production/) to master Karpenter node provisioning, AWS Container Insights, and relentless production cost optimization using Kubecost.
 
 ## Sources
 
 - [Amazon EKS add-ons](https://docs.aws.amazon.com/eks/latest/userguide/workloads-add-ons-available-eks.html) — AWS reference for storage-related add-ons that can be installed and managed in EKS clusters.
 - [Kubernetes Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) — Canonical Kubernetes reference for StorageClass behavior, including `Immediate` and `WaitForFirstConsumer` binding modes.
+- [Kubernetes CSI sidecar containers](https://kubernetes-csi.github.io/docs/sidecar-containers.html) — Official documentation for external-provisioner, attacher, resizer, and snapshotter sidecars.
+- [Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) — Kubernetes snapshot API objects used by the EBS CSI snapshotter.
 - [Amazon EBS CSI driver](https://github.com/kubernetes-sigs/aws-ebs-csi-driver) — Project documentation for EBS CSI driver features such as snapshots and other storage integrations.
+- [Use Kubernetes volume storage with Amazon EBS](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) — AWS EKS guide for EBS CSI installation, IAM, and snapshot prerequisites.
 - [Modify an Amazon EBS volume](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-modify-volume.html) — AWS guide for online EBS volume modification and expansion workflows.
+- [Amazon EBS pricing](https://aws.amazon.com/ebs/pricing/) — Current gp3/io2 storage, IOPS, and throughput list prices (varies by Region).
+- [Amazon EBS encryption](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-encryption.html) — Encryption at rest defaults and KMS integration for EBS volumes.
 - [Amazon EFS: How it works](https://docs.aws.amazon.com/efs/latest/ug/how-it-works.html) — AWS overview of EFS architecture, including NFSv4 semantics and regional multi-AZ access.
+- [Amazon EFS performance](https://docs.aws.amazon.com/efs/latest/ug/performance.html) — Throughput modes (Elastic, Provisioned, Bursting) and storage-class latency characteristics.
 - [Working with Amazon EFS Access Points](https://docs.aws.amazon.com/efs/latest/ug/efs-access-points.html) — AWS documentation for access points that scope application paths and enforce POSIX identities.
-- [Access Amazon S3 Objects with Mountpoint for Amazon S3 CSI Driver](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html) — AWS documentation for Mountpoint CSI driver provisioning model, bucket mapping, and operational constraints.
-- [Use Kubernetes Volume Storage with Amazon EBS](https://docs.aws.amazon.com/eks/latest/userguide/ebs-csi.html) — AWS’s EKS guide for EBS CSI installation, permissions, and operational considerations.
+- [Use Amazon EFS with Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/efs-csi.html) — EFS CSI installation, static/dynamic provisioning, and security-group requirements.
+- [Amazon EFS pricing](https://aws.amazon.com/efs/pricing/) — Storage classes (Standard, IA, Archive) and throughput billing models.
+- [Access Amazon S3 objects with Mountpoint for Amazon S3 CSI Driver](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi.html) — AWS documentation for Mountpoint CSI driver provisioning model, bucket mapping, and operational constraints.
+- [Amazon S3 pricing](https://aws.amazon.com/s3/pricing/) — Object storage and request charges relevant to Mountpoint workloads.

--- a/src/content/docs/cloud/eks-deep-dive/module-5.5-eks-production.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.5-eks-production.md
@@ -85,7 +85,8 @@ When you read this table during a design review, focus on the columns that chang
 
 Installing Karpenter requires specific IAM roles so the controller can create and terminate EC2 instances, pass instance profiles to nodes, and tag subnets and security groups for discovery. Those permissions are not optional shortcuts; without them the controller will loop on authorization errors while pods stay Pending. Once IAM is established, installation is handled natively via Helm targeting the modern OCI registry shown below, and you should treat the cluster name and API endpoint values as mandatory wiring so Karpenter can register nodes against the correct control plane.
 
-```bash# Install Karpenter using Helm
+```bash
+# Install Karpenter using Helm
 # Install Karpenter v1.x from OCI registry (charts.karpenter.sh is deprecated)
 # Karpenter needs specific IAM roles and instance profiles
 # (Simplified here -- see Karpenter docs for full IAM setup)
@@ -395,7 +396,8 @@ Visibility into the Kubernetes control plane is non-negotiable for security fore
 
 Control plane logging is configured at the cluster object level, so treat enablement like any other infrastructure change with a change ticket and a rollback plan. Enabling all five types at once is convenient for a short proof of concept but expensive for a busy production API server; start with the minimal set in the table, expand during incidents, and document who disabled high-volume types when the incident closes.
 
-```bashaws eks update-cluster-config --name my-cluster \
+```bash
+aws eks update-cluster-config --name my-cluster \
   --logging '{"clusterLogging":[{"types":["api","audit","authenticator","controllerManager","scheduler"],"enabled":true}]}'
 ```
 
@@ -439,7 +441,8 @@ While control plane logs reveal *what* happened at the API layer, performance me
 
 Container Insights is not a separate daemon you install by hand on every node when you use the managed add-on path; AWS packages the agents and wires them to CloudWatch on your behalf. That reduces day-one friction but still requires an IAM role for the service account so agents can publish metrics. Plan a short validation window after enablement where you compare Container Insights node graphs with `kubectl top` and with Prometheus node exporters if both exist, so you know the signals agree before you wire alarms.
 
-```bash# Install via the EKS add-on
+```bash
+# Install via the EKS add-on
 aws eks create-addon \
   --cluster-name my-cluster \
   --addon-name amazon-cloudwatch-observability \
@@ -473,7 +476,8 @@ While Container Insights offers a seamless zero-ops experience, high-cardinality
 
 Amazon Managed Prometheus (AMP) provides a serverless ingestion and query backend, allowing you to use PromQL without operating Cortex or Thanos storage clusters yourself. You still run collectors—typically Prometheus agents or the full stack in-cluster—but AMP absorbs long-term retention and federated query load, which is why many production EKS platforms remote-write from in-cluster Prometheus to AMP and keep Grafana as the visualization layer.
 
-```bash# Create a workspace
+```bash
+# Create a workspace
 WORKSPACE_ID=$(aws amp create-workspace \
   --alias eks-production \
   --query 'workspaceId' --output text)
@@ -488,7 +492,8 @@ Treat AMP as the long-term store and Grafana as the lens, not as a replacement f
 
 Deploying Prometheus via the `kube-prometheus-stack` Helm chart configures ServiceMonitor-driven scraping of the Kubernetes control plane and kubelets. It ships Grafana dashboards and can remote-write samples to AMP when you set the `remoteWrite` URL and SigV4 region on the Prometheus custom resource. The first install block below is suitable for labs that keep metrics inside the cluster for fifteen days. The second block shows the minimal AMP wiring you would enable in production after creating a workspace.
 
-```bash# Install the Prometheus stack using Helm
+```bash
+# Install the Prometheus stack using Helm
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 
@@ -557,7 +562,8 @@ Kubernetes abstractly pools resources, which creates a tragedy-of-the-commons dy
 
 OpenCost maps real-time AWS billing data—including Spot price feeds when configured—to pod usage telemetry so you can aggregate cost by namespace, label, or controller. The Helm values below enable the UI for exploratory reviews and wire Spot pricing buckets when you want interruption-aware amortization instead of assuming every node hour cost the same On-Demand rate.
 
-```bash# Install OpenCost
+```bash
+# Install OpenCost
 helm repo add opencost https://opencost.github.io/opencost-helm-chart
 helm repo update
 
@@ -576,7 +582,8 @@ A monthly FinOps review with either tool should follow the same agenda every tim
 
 Kubecost packages the same class of allocation queries with opinionated dashboards, savings recommendations, and multi-cluster views that larger enterprises often standardize on. The install mirrors OpenCost in complexity: you point it at Prometheus metrics with a `cluster_id` label and let it correlate utilization to cloud bills. Teams frequently run OpenCost for transparency in platform namespaces and Kubecost where finance wants certified showback reports.
 
-```bashhelm repo add kubecost https://kubecost.github.io/cost-analyzer
+```bash
+helm repo add kubecost https://kubecost.github.io/cost-analyzer
 helm repo update
 
 helm install kubecost kubecost/cost-analyzer \
@@ -857,7 +864,8 @@ Work through the tasks in order because each step assumes the previous artifacts
 <details>
 <summary>Solution</summary>
 
-```bash# Check if Cluster Autoscaler is running
+```bash
+# Check if Cluster Autoscaler is running
 kubectl get deployment cluster-autoscaler -n kube-system 2>/dev/null
 
 # If present, remove it
@@ -878,7 +886,8 @@ Tag discovery consistently across every subnet and security group the NodePool m
 <details>
 <summary>Solution</summary>
 
-```bash# Tag your subnets for Karpenter discovery
+```bash
+# Tag your subnets for Karpenter discovery
 CLUSTER_NAME="my-cluster"
 SUBNET_IDS=$(aws eks describe-cluster --name $CLUSTER_NAME \
   --query 'cluster.resourcesVpcConfig.subnetIds[]' --output text)
@@ -919,7 +928,8 @@ kubectl logs -n kube-system -l app.kubernetes.io/name=karpenter --tail=20
 <details>
 <summary>Solution</summary>
 
-```bashcat <<'EOF' | kubectl apply -f -
+```bash
+cat <<'EOF' | kubectl apply -f -
 apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass
 metadata:
@@ -999,7 +1009,8 @@ kubectl get nodepool general-purpose
 <details>
 <summary>Solution</summary>
 
-```bashcat <<'EOF' | kubectl apply -f -
+```bash
+cat <<'EOF' | kubectl apply -f -
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
@@ -1057,7 +1068,8 @@ While the Job runs, watch for Spot nodes appearing with diversified instance typ
 <details>
 <summary>Solution</summary>
 
-```bashkubectl create namespace batch
+```bash
+kubectl create namespace batch
 
 cat <<'EOF' | kubectl apply -f -
 apiVersion: batch/v1
@@ -1139,7 +1151,8 @@ OpenCost needs a few minutes of steady traffic before allocation APIs return sta
 <details>
 <summary>Solution</summary>
 
-```bash# Install OpenCost
+```bash
+# Install OpenCost
 helm repo add opencost https://opencost.github.io/opencost-helm-chart
 helm repo update
 
@@ -1177,7 +1190,8 @@ curl -s http://127.0.0.1:9003/allocation/compute \
 
 Deleting NodePools before uninstalling Helm ensures Karpenter drains and terminates nodes it created, which is faster and safer than orphaning EC2 instances that still appear healthy in the AWS console but no longer match your desired cluster state.
 
-```bashkubectl delete namespace batch
+```bash
+kubectl delete namespace batch
 kubectl delete job video-encode-batch -n batch 2>/dev/null
 helm uninstall opencost -n opencost
 kubectl delete namespace opencost

--- a/src/content/docs/cloud/eks-deep-dive/module-5.5-eks-production.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.5-eks-production.md
@@ -92,11 +92,13 @@ Installing Karpenter requires specific IAM roles so the controller can create an
 helm install karpenter oci://public.ecr.aws/karpenter/karpenter \
   --namespace kube-system \
   --set settings.clusterName=my-cluster \
-  --set clusterEndpoint=$(aws eks describe-cluster --name my-cluster --query 'cluster.endpoint' --output text) \
+  --set settings.clusterEndpoint=$(aws eks describe-cluster --name my-cluster --query 'cluster.endpoint' --output text) \
   --set settings.isolatedVPC=false \
   --version 1.1.0 \
   --wait
 ```
+
+For production Spot workloads, also wire `settings.interruptionQueue` to an SQS queue fed by EventBridge interruption events so Karpenter can drain nodes before EC2 reclaims them.
 
 After Helm reports a ready release, confirm the controller pod is running and watch its logs during a deliberate scale-up test. You should see reconciliation loops when unschedulable pods appear, followed by EC2 launch activity in CloudTrail or the EC2 console. If launches fail, the error is usually IAM-related (missing `ec2:CreateFleet`) or discovery-related (subnets missing `karpenter.sh/discovery`), and those failures surface in controller logs long before Kubernetes events explain the symptom.
 
@@ -198,11 +200,11 @@ Pending Pods:
   Pod C: requests 4 CPU, 4Gi memory
 
 Karpenter evaluates:
-  Option 1: 3x m6i.large (2 CPU, 8Gi each) = $0.288/hr → 1 pod per node
-  Option 2: 1x m6i.2xlarge (8 CPU, 32Gi) = $0.192/hr → all 3 pods on 1 node
-  Option 3: 1x c6i.2xlarge (8 CPU, 16Gi) = $0.170/hr → all 3 pods, tighter fit
+  Option 1: 3x m6i.large (2 CPU, 8Gi each) = $0.288/hr → cannot host Pod C (4 CPU); infeasible
+  Option 2: 1x m6i.2xlarge (8 CPU, 32Gi) = $0.384/hr → all 3 pods fit
+  Option 3: 1x c6i.2xlarge (8 CPU, 16Gi) = $0.34/hr → all 3 pods fit (12 GiB memory used)
 
-Karpenter selects Option 3 (cheapest that satisfies all pod requirements)
+Karpenter selects Option 3 (cheapest feasible option that satisfies all pod requirements)
 ```
 
 In production you will rarely see only three pending pods, but the decision rule scales the same way: simulate feasible instance types, respect topology spread and affinity rules, then minimize cost among feasible options. When teams complain that Karpenter “always picks compute-optimized instances,” the fix is usually requirements that exclude memory-optimized families, not a bug in the provisioner.
@@ -531,8 +533,8 @@ sum(rate(kube_pod_container_status_restarts_total[1h])) by (namespace, pod) > 0
 # Node not Ready duration
 sum(kube_node_status_condition{condition="Ready", status="true"} == 0) by (node)
 
-# Karpenter provisioning latency (p99)
-histogram_quantile(0.99, sum(rate(karpenter_provisioner_scheduling_duration_seconds_bucket[5m])) by (le))
+# Karpenter provisioning latency (p99; v1 metric name)
+histogram_quantile(0.99, sum(rate(karpenter_scheduler_scheduling_duration_seconds_bucket[5m])) by (le))
 ```
 
 After you install scraping, validate each query in Grafana with a known load test. Namespace CPU ratios above one hundred percent usually mean requests are set too low, not that magic extra CPU exists. Memory working-set-over-limit ratios highlight OOM risk before Kubernetes kills containers. Restart rates decoupled from node utilization often point to misconfigured liveness probes or application panics, which matches the troubleshooting narrative in the pause-and-predict callout above. Karpenter latency histograms close the loop on autoscaling SLOs: if p99 provisioning drifts from under ninety seconds toward minutes, revisit NodePool constraints before blaming application code.
@@ -619,7 +621,6 @@ kind: ClusterPolicy
 metadata:
   name: require-cost-labels
 spec:
-  validationFailureAction: Enforce
   rules:
     - name: check-cost-labels
       match:
@@ -630,6 +631,7 @@ spec:
                 - StatefulSet
                 - DaemonSet
       validate:
+        failureAction: Enforce
         message: "All workloads must have 'team' and 'cost-center' labels."
         pattern:
           metadata:
@@ -752,7 +754,7 @@ Start with **OpenCost** when platform engineers need transparent namespace attri
 
 The facts below are worth revisiting after you run the hands-on exercise, because they connect autoscaling math, logging bills, Spot statistics, and industry utilization benchmarks to the dashboards you will actually see.
 
-1. Karpenter evaluates over 600 EC2 instance types when deciding what to launch. For each set of pending pods, it simulates packing them onto every compatible instance type, calculates the cost, and selects the cheapest option. This evaluation happens in milliseconds thanks to an in-memory instance type database that Karpenter refreshes from the EC2 pricing API every 6 hours.
+1. Karpenter evaluates a large set of EC2 instance types (hundreds of SKUs across allowed families) when deciding what to launch. For each batch of pending pods, it simulates packing them onto compatible instance types, estimates hourly cost from its pricing cache, and selects a feasible low-cost option. That evaluation is fast because Karpenter maintains an in-memory instance catalog refreshed periodically from AWS pricing APIs (refresh cadence varies by version and configuration—check your controller metrics if cost decisions look stale).
 
 2. EKS control plane audit logs can record API requests, including the request body and response at the most detailed audit level. For a cluster with 500 pods and active HPA/VPA controllers, the audit log volume can reach 10-15 GB per day. At CloudWatch's $0.50/GB ingestion rate, that is $5-7.50/day or $150-225/month just for audit log storage. Many teams filter audit logs to only capture write operations and authentication events, reducing volume by 80%.
 
@@ -820,7 +822,7 @@ When a Spot interruption notice arrives, Karpenter (or the AWS Node Termination 
 <details>
 <summary>Question 6: Your startup just launched and needs robust EKS monitoring. The platform team is debating between enabling CloudWatch Container Insights or deploying a self-managed Prometheus stack. What scenario or cluster characteristics would make Prometheus the better choice?</summary>
 
-**Container Insights** sends metrics to CloudWatch as custom metrics. It provides pre-built dashboards, integrates with CloudWatch Alarms, and requires no infrastructure to run (just the agent DaemonSet). However, it charges per-metric ($0.30/metric/month) and can become expensive for large clusters ($1,500-3,000/month). **Prometheus** is an open-source metrics system that stores metrics locally (or in AMP) with powerful PromQL querying. It is free to run (self-managed) or lower-cost (AMP charges $0.03/10M samples). Use Container Insights for small clusters (under 20 nodes) or teams that want zero-ops monitoring. Use Prometheus for larger clusters, teams that need custom metrics, or organizations with existing Grafana dashboards.
+**Container Insights** sends metrics to CloudWatch as custom metrics. It provides pre-built dashboards, integrates with CloudWatch Alarms, and requires no infrastructure to run (just the agent DaemonSet). However, it charges per-metric ($0.30/metric/month) and can become expensive for large clusters ($1,500-3,000/month). **Prometheus** is an open-source metrics system that stores metrics locally (or in AMP) with powerful PromQL querying. Self-managed Prometheus is free to operate; **AMP** bills ingestion separately from storage—roughly **$0.90 per 10 million samples ingested** (first tier, Region-dependent) plus **~$0.03/GB-month** for long-term metric storage. Use Container Insights for small clusters (under 20 nodes) or teams that want zero-ops monitoring. Use Prometheus for larger clusters, teams that need custom metrics, or organizations with existing Grafana dashboards.
 </details>
 
 <details>
@@ -892,19 +894,18 @@ CLUSTER_SG=$(aws eks describe-cluster --name $CLUSTER_NAME \
 aws ec2 create-tags --resources $CLUSTER_SG \
   --tags Key=karpenter.sh/discovery,Value=$CLUSTER_NAME
 
-# Install Karpenter via Helm
+# Install Karpenter v1.x from OCI registry (charts.karpenter.sh is deprecated)
 CLUSTER_ENDPOINT=$(aws eks describe-cluster --name $CLUSTER_NAME \
   --query 'cluster.endpoint' --output text)
 
-helm repo add karpenter https://charts.karpenter.sh
-helm repo update
-
-helm install karpenter karpenter/karpenter \
+helm install karpenter oci://public.ecr.aws/karpenter/karpenter \
   --namespace kube-system \
-  --set clusterName=$CLUSTER_NAME \
-  --set clusterEndpoint=$CLUSTER_ENDPOINT \
+  --set settings.clusterName=$CLUSTER_NAME \
+  --set settings.clusterEndpoint=$CLUSTER_ENDPOINT \
   --version 1.1.0 \
   --wait
+
+# Production Spot clusters: set settings.interruptionQueue to your SQS queue for EC2 interruption events
 
 # Verify Karpenter is running
 kubectl get pods -n kube-system -l app.kubernetes.io/name=karpenter
@@ -1151,19 +1152,20 @@ helm install opencost opencost/opencost \
 # Wait for OpenCost to be ready
 kubectl wait --for=condition=Ready pods -l app.kubernetes.io/name=opencost -n opencost --timeout=120s
 
-# Port-forward to access the UI
-kubectl port-forward -n opencost svc/opencost 9090:9090 &
+# Port-forward UI (9090) and allocation model API (9003 are separate listeners)
+kubectl port-forward -n opencost svc/opencost 9090:9090 9003:9003 &
 
-echo "OpenCost UI available at: http://localhost:9090"
+echo "OpenCost UI: http://127.0.0.1:9090"
+echo "Allocation API: http://127.0.0.1:9003/allocation/compute"
 
-# Query cost allocation via API
-curl -s http://localhost:9090/allocation/compute \
+# Query cost allocation via API (model port 9003, not the UI port)
+curl -s http://127.0.0.1:9003/allocation/compute \
   -d window=1d \
   -d aggregate=namespace \
   -d accumulate=true | jq '.data[0] | to_entries[] | {namespace: .key, totalCost: .value.totalCost}'
 
 # Check cost by team label
-curl -s http://localhost:9090/allocation/compute \
+curl -s http://127.0.0.1:9003/allocation/compute \
   -d window=1d \
   -d aggregate=label:team \
   -d accumulate=true | jq '.data[0] | to_entries[] | {team: .key, totalCost: .value.totalCost}'

--- a/src/content/docs/cloud/eks-deep-dive/module-5.5-eks-production.md
+++ b/src/content/docs/cloud/eks-deep-dive/module-5.5-eks-production.md
@@ -27,13 +27,13 @@ You will move back and forth among these outcomes during the module: autoscaling
 
 ## Why This Module Matters
 
-In September 2023, a major video streaming company running on EKS launched a highly anticipated new series that rapidly went viral. Within twenty minutes, their backend encoding and delivery services scaled from 200 pods to 1,800 pods, and the Horizontal Pod Autoscaler operated perfectly: it emitted scaling events, the scheduler created objects, and the cluster state reflected the desired replica count. The bottleneck was not application autoscaling logic but infrastructure reaction time, because pending pods accumulated while the data plane could not place them on nodes that did not exist yet.
+**Hypothetical scenario:** A video streaming platform on EKS launches a viral series. Within twenty minutes, backend encoding and delivery services scale from 200 pods to 1,800 pods. The Horizontal Pod Autoscaler operates correctly: it emits scaling events, the scheduler creates objects, and the cluster state reflects the desired replica count. The bottleneck is not application autoscaling logic but infrastructure reaction time, because pending pods accumulate while the data plane cannot place them on nodes that do not exist yet.
 
-The legacy Cluster Autoscaler failed to keep pace with that pod wall. It spent roughly eight minutes iterating across pending pods, three minutes deciding which Auto Scaling Group to grow, and another two minutes waiting for EC2 instances to boot and join the cluster, which means more than thirteen minutes elapsed before additional schedulable capacity existed. During that window, users experienced continuous playback degradation because encoders and edge caches could not land on nodes with free CPU and memory.
+The legacy Cluster Autoscaler fails to keep pace with that pod wall. It spends roughly eight minutes iterating across pending pods, three minutes deciding which Auto Scaling Group to grow, and another two minutes waiting for EC2 instances to boot and join the cluster. More than thirteen minutes elapse before additional schedulable capacity exists. During that window, users experience continuous playback degradation because encoders and edge caches cannot land on nodes with free CPU and memory.
 
-By the time infrastructure capacity caught up to application demand, users had experienced thirteen continuous minutes of degraded service, including widespread buffering, playback failures, and negative social media sentiment. The failure was a direct result of relying on legacy, group-based scaling architectures for a dynamic microservices payload, and the financial sting followed immediately: because every burst node launched as On-Demand capacity, the 1,800-pod spike incurred roughly $12,000 in compute costs for a single day even while pods remained unschedulable.
+By the time infrastructure capacity catches up to application demand, users have endured thirteen continuous minutes of degraded service, including widespread buffering and playback failures. The failure traces directly to legacy, group-based scaling architectures for a dynamic microservices payload. The financial sting follows immediately: when every burst node launches as On-Demand capacity, a 1,800-pod spike can burn a full day of compute budget while pods remain unschedulable.
 
-Following the incident, the engineering team modernized their cluster architecture by replacing Cluster Autoscaler with Karpenter, implementing native Spot instance orchestration, and deploying OpenCost for granular namespace attribution. During subsequent traffic spikes, Karpenter detected unschedulable pods, formulated an optimized instance mix, and invoked the EC2 Fleet API directly. Compute capacity became available in under 90 seconds, completely eliminating user-facing degradation. In this module, you will master the exact architecture that enables this performance, alongside the essential observability and cost attribution frameworks required for production EKS at scale.
+After modernizing the cluster architecture—replacing Cluster Autoscaler with Karpenter, implementing native Spot orchestration, and deploying OpenCost for namespace attribution—the same traffic pattern plays out differently. Karpenter detects unschedulable pods, formulates an optimized instance mix, and invokes the EC2 Fleet API directly. Compute capacity becomes available in under 90 seconds, eliminating user-facing degradation. In this module, you will master that architecture alongside the observability and cost attribution frameworks required for production EKS at scale.
 
 Production EKS operations converge on three reinforcing practices that the incident above violated in sequence. First, **compute elasticity** must track pending pods faster than users time out, which is why node provisioning architecture matters as much as Horizontal Pod Autoscaler configuration. Second, **telemetry** must separate control-plane audit trails from node and pod saturation signals so you can tell whether an outage is authorization, scheduling, or resource starvation. Third, **financial feedback loops** must tie CPU and memory requests to team labels; otherwise optimization debates stay abstract while idle nodes silently burn budget. The sections that follow walk through each practice with manifests and queries you can adapt without changing the underlying technical claims, using the same Helm, Karpenter, and EKS add-on versions already referenced in the code blocks throughout this module on Amazon EKS.
 
@@ -45,7 +45,7 @@ Karpenter is an open-source, high-performance Kubernetes node provisioner built 
 
 ### Karpenter vs Cluster Autoscaler
 
-To understand why Karpenter is transformative, consider an analogy: Cluster Autoscaler is like having to pre-purchase a fleet of identical delivery trucks and calling the depot for more of the exact same trucks whenever packages pile up, even when half the trucks return half empty. Karpenter, conversely, looks at the specific dimensions and weight of the pending packages and custom-builds a vehicle perfectly sized for that exact payload in under 60 seconds, so you pay for capacity that matches demand instead of capacity that matches yesterday's template. The comparison table below summarizes the operational differences you will feel in production: provisioning latency, bin-packing quality, and how Spot capacity is orchestrated.
+To understand why Karpenter is transformative, consider an analogy. Cluster Autoscaler is like having to pre-purchase a fleet of identical delivery trucks and calling the depot for more of the exact same trucks whenever packages pile up, even when half the trucks return half empty. Karpenter, conversely, looks at the specific dimensions and weight of the pending packages and custom-builds a vehicle perfectly sized for that exact payload in under 60 seconds, so you pay for capacity that matches demand instead of capacity that matches yesterday's template. The comparison table below summarizes the operational differences you will feel in production: provisioning latency, bin-packing quality, and how Spot capacity is orchestrated.
 
 ```mermaid
 graph TD
@@ -85,8 +85,7 @@ When you read this table during a design review, focus on the columns that chang
 
 Installing Karpenter requires specific IAM roles so the controller can create and terminate EC2 instances, pass instance profiles to nodes, and tag subnets and security groups for discovery. Those permissions are not optional shortcuts; without them the controller will loop on authorization errors while pods stay Pending. Once IAM is established, installation is handled natively via Helm targeting the modern OCI registry shown below, and you should treat the cluster name and API endpoint values as mandatory wiring so Karpenter can register nodes against the correct control plane.
 
-```bash
-# Install Karpenter using Helm
+```bash# Install Karpenter using Helm
 # Install Karpenter v1.x from OCI registry (charts.karpenter.sh is deprecated)
 # Karpenter needs specific IAM roles and instance profiles
 # (Simplified here -- see Karpenter docs for full IAM setup)
@@ -378,7 +377,7 @@ spec:
   weight: 10     # Lower weight = fallback only
 ```
 
-Karpenter evaluates `weight` strictly, so the primary `compute-spot` NodePool with weight 100 is always attempted before the `compute-ondemand` NodePool at weight 10. Only when EC2 returns `InsufficientInstanceCapacity` for the Spot constraints does Karpenter fall through to On-Demand, which is why weights are not merely documentation—they are ordering semantics for capacity negotiation.
+Karpenter evaluates `weight` strictly, so the primary `compute-spot` NodePool with weight 100 is always attempted before the `compute-ondemand` NodePool at weight 10. Only when EC2 returns `InsufficientInstanceCapacity` for the Spot constraints does Karpenter fall through to On-Demand. Weights are not merely documentation—they are ordering semantics for capacity negotiation.
 
 > **Stop and think**: If Karpenter provisions a Spot instance for your workload and AWS reclaims it with a two-minute warning, how does your application ensure zero downtime? (Hint: Think about PodDisruptionBudgets, replicas, and the pod lifecycle.)
 
@@ -394,8 +393,7 @@ Visibility into the Kubernetes control plane is non-negotiable for security fore
 
 Control plane logging is configured at the cluster object level, so treat enablement like any other infrastructure change with a change ticket and a rollback plan. Enabling all five types at once is convenient for a short proof of concept but expensive for a busy production API server; start with the minimal set in the table, expand during incidents, and document who disabled high-volume types when the incident closes.
 
-```bash
-aws eks update-cluster-config --name my-cluster \
+```bashaws eks update-cluster-config --name my-cluster \
   --logging '{"clusterLogging":[{"types":["api","audit","authenticator","controllerManager","scheduler"],"enabled":true}]}'
 ```
 
@@ -407,7 +405,7 @@ aws eks update-cluster-config --name my-cluster \
 | `controllerManager` | Controller loops (ReplicaSet, Deployment) | Why pods are not being created |
 | `scheduler` | Scheduling decisions and failures | Why pods are Pending |
 
-In practice, platform teams enable `audit` and `authenticator` continuously because security questions arrive months after an event and you cannot reconstruct auth decisions retroactively. `scheduler` logs earn a temporary enablement window when pods sit Pending despite apparently free capacity, because the scheduler records why a pod did not fit a node. `controllerManager` logs help when ReplicaSets exist but Deployments never materialize new pods, and `api` logs are the noisiest: they shine when you are chasing a specific client spamming LIST calls, but they should not run unfiltered forever on large clusters.
+In practice, platform teams enable `audit` and `authenticator` continuously because security questions arrive months after an event. You cannot reconstruct auth decisions retroactively. `scheduler` logs earn a temporary enablement window when pods sit Pending despite apparently free capacity, because the scheduler records why a pod did not fit a node. `controllerManager` logs help when ReplicaSets exist but Deployments never materialize new pods. `api` logs are the noisiest: they shine when you are chasing a specific client spamming LIST calls, but they should not run unfiltered forever on large clusters.
 
 After logging is enabled, querying is most efficient through CloudWatch Logs Insights because you can filter across `audit`, `api`, and `authenticator` streams with structured fields instead of grepping raw files on nodes that do not exist for you to access. The examples below show how to find clients receiving HTTP 400 responses and how to reconstruct who deleted a pod in a production namespace, patterns you will reuse during incident reviews.
 
@@ -439,8 +437,7 @@ While control plane logs reveal *what* happened at the API layer, performance me
 
 Container Insights is not a separate daemon you install by hand on every node when you use the managed add-on path; AWS packages the agents and wires them to CloudWatch on your behalf. That reduces day-one friction but still requires an IAM role for the service account so agents can publish metrics. Plan a short validation window after enablement where you compare Container Insights node graphs with `kubectl top` and with Prometheus node exporters if both exist, so you know the signals agree before you wire alarms.
 
-```bash
-# Install via the EKS add-on
+```bash# Install via the EKS add-on
 aws eks create-addon \
   --cluster-name my-cluster \
   --addon-name amazon-cloudwatch-observability \
@@ -460,7 +457,7 @@ aws eks create-addon \
 
 Treat the metrics table as an on-call cheat sheet rather than a shopping list of alarms. Node CPU and memory utilization tell you whether Karpenter should add capacity or whether requests are mis-sized; pod CPU over limit warns that throttling is imminent even when the node looks healthy. Filesystem utilization catches log and emptyDir growth before kubelet evictions, while `cluster_failed_node_count` should always page because it signals registration or CNI failures, not application bugs. Pending pods longer than five minutes bridge back to the Karpenter sections: confirm whether unschedulable events exist, whether taints block Spot nodes, and whether IP or ENI limits from networking modules still apply.
 
-The `amazon-cloudwatch-observability` EKS add-on bundles the agents needed for Container Insights and can also deploy AWS Distro for OpenTelemetry (ADOT) collectors when you standardize on OpenTelemetry pipelines. You do not have to choose between “CloudWatch only” and “Prometheus only” on day one: many teams emit infrastructure metrics to Container Insights for baseline dashboards while exporting application traces and custom metrics through ADOT to AMP or a self-managed backend.
+The `amazon-cloudwatch-observability` EKS add-on bundles the agents needed for Container Insights and can also deploy AWS Distro for OpenTelemetry (ADOT) collectors when you standardize on OpenTelemetry pipelines. You do not have to choose between “CloudWatch only” and “Prometheus only” on day one. Many teams emit infrastructure metrics to Container Insights for baseline dashboards while exporting application traces and custom metrics through ADOT to AMP or a self-managed backend.
 
 > **Pause and predict**: You notice that `kube_pod_container_status_restarts_total` is rapidly increasing for your core API namespace, but `node_cpu_utilization` is completely normal. What might be causing the pods to restart if it isn't node-level resource starvation? (Hint: Think about memory limits, liveness probes, or application-level crashes.)
 
@@ -474,8 +471,7 @@ While Container Insights offers a seamless zero-ops experience, high-cardinality
 
 Amazon Managed Prometheus (AMP) provides a serverless ingestion and query backend, allowing you to use PromQL without operating Cortex or Thanos storage clusters yourself. You still run collectors—typically Prometheus agents or the full stack in-cluster—but AMP absorbs long-term retention and federated query load, which is why many production EKS platforms remote-write from in-cluster Prometheus to AMP and keep Grafana as the visualization layer.
 
-```bash
-# Create a workspace
+```bash# Create a workspace
 WORKSPACE_ID=$(aws amp create-workspace \
   --alias eks-production \
   --query 'workspaceId' --output text)
@@ -488,10 +484,9 @@ Treat AMP as the long-term store and Grafana as the lens, not as a replacement f
 
 ### Deploying Prometheus to Scrape EKS Metrics
 
-Deploying Prometheus via the `kube-prometheus-stack` Helm chart configures ServiceMonitor-driven scraping of the Kubernetes control plane and kubelets, ships Grafana dashboards, and can remote-write samples to AMP when you set the `remoteWrite` URL and SigV4 region on the Prometheus custom resource. The first install block below is suitable for labs that keep metrics inside the cluster for fifteen days, while the second block shows the minimal AMP wiring you would enable in production after creating a workspace.
+Deploying Prometheus via the `kube-prometheus-stack` Helm chart configures ServiceMonitor-driven scraping of the Kubernetes control plane and kubelets. It ships Grafana dashboards and can remote-write samples to AMP when you set the `remoteWrite` URL and SigV4 region on the Prometheus custom resource. The first install block below is suitable for labs that keep metrics inside the cluster for fifteen days. The second block shows the minimal AMP wiring you would enable in production after creating a workspace.
 
-```bash
-# Install the Prometheus stack using Helm
+```bash# Install the Prometheus stack using Helm
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo update
 
@@ -560,8 +555,7 @@ Kubernetes abstractly pools resources, which creates a tragedy-of-the-commons dy
 
 OpenCost maps real-time AWS billing data—including Spot price feeds when configured—to pod usage telemetry so you can aggregate cost by namespace, label, or controller. The Helm values below enable the UI for exploratory reviews and wire Spot pricing buckets when you want interruption-aware amortization instead of assuming every node hour cost the same On-Demand rate.
 
-```bash
-# Install OpenCost
+```bash# Install OpenCost
 helm repo add opencost https://opencost.github.io/opencost-helm-chart
 helm repo update
 
@@ -580,8 +574,7 @@ A monthly FinOps review with either tool should follow the same agenda every tim
 
 Kubecost packages the same class of allocation queries with opinionated dashboards, savings recommendations, and multi-cluster views that larger enterprises often standardize on. The install mirrors OpenCost in complexity: you point it at Prometheus metrics with a `cluster_id` label and let it correlate utilization to cloud bills. Teams frequently run OpenCost for transparency in platform namespaces and Kubecost where finance wants certified showback reports.
 
-```bash
-helm repo add kubecost https://kubecost.github.io/cost-analyzer
+```bashhelm repo add kubecost https://kubecost.github.io/cost-analyzer
 helm repo update
 
 helm install kubecost kubecost/cost-analyzer \
@@ -662,9 +655,9 @@ In this scenario, the idle and unallocated sum of $4,100 is not a rounding error
 
 ## EKS Upgrade Runbooks
 
-Kubernetes issues minor releases routinely, and maintaining operational readiness requires rigid upgrade paths because version skew between the control plane and kubelets is enforced by policy, not by goodwill. For clusters on EKS 1.35 and later, treat upgrades as a sequenced runbook rather than a single button click: validate API compatibility, move the managed control plane, align add-ons, then rotate workers so no kubelet speaks a newer dialect than the apiserver allows.
+Kubernetes issues minor releases routinely, and maintaining operational readiness requires rigid upgrade paths because version skew between the control plane and kubelets is enforced by policy, not by goodwill. For clusters on EKS 1.35 and later, treat upgrades as a sequenced runbook rather than a single button click. Validate API compatibility first, move the managed control plane, align add-ons, then rotate workers so no kubelet speaks a newer dialect than the apiserver allows.
 
-**Pre-flight API checks** come first because Helm charts and operators often embed deprecated API versions long after upstream removal warnings appear in release notes. Tools such as Pluto scan rendered manifests and chart templates so you fix `batch/v1beta1` style leftovers before the upgrade window, which is far cheaper than discovering a failed apply during production maintenance.
+**Pre-flight API checks** come first because Helm charts and operators often embed deprecated API versions long after upstream removal warnings appear in release notes. Tools such as Pluto scan rendered manifests and chart templates so you fix `batch/v1beta1` style leftovers before the upgrade window. That pre-work is far cheaper than discovering a failed apply during production maintenance.
 
 **Control plane upgrades** are initiated through the EKS API or console and run on AWS-managed infrastructure, so your responsibility is sequencing and communication rather than etcd backups. The HA control plane should remain available, but you should still pause deploys that mutate CRDs until add-ons are verified.
 
@@ -672,9 +665,86 @@ Kubernetes issues minor releases routinely, and maintaining operational readines
 
 **Data plane rotation** is where Karpenter earns its keep: updating `amiSelectorTerms` to a newer Amazon Linux 2023 alias and letting `expireAfter` force replacement yields rolling nodes without maintaining multiple ASG launch templates. Drain behavior still honors PDBs, so you should watch pod disruption budgets during the rotation weekend the same way you would with managed node groups.
 
-Document the upgrade sequence in your team wiki with explicit owners: who runs Pluto, who bumps the control plane version, who pins add-on versions, and who monitors Karpenter drains. Managed EKS removes etcd toil, but human coordination errors still cause outages when application teams deploy new CRDs mid-upgrade or when node rotation outruns PDB budgets.
+Document the upgrade sequence in your team wiki with explicit owners: who runs Pluto, who bumps the control plane version, who pins add-on versions, and who monitors Karpenter drains. Managed EKS removes etcd toil, but human coordination errors still cause outages. Application teams may deploy new CRDs mid-upgrade, or node rotation may outrun PDB budgets—either path produces preventable downtime.
 
 > **Stop and think**: Why must you upgrade the EKS control plane *before* upgrading the worker nodes? (Hint: The Kubernetes version skew policy dictates compatibility rules between the kube-apiserver and the kubelet running on nodes.)
+
+---
+
+## Patterns & Anti-Patterns
+
+Production EKS teams converge on a small set of patterns that survive traffic spikes, Spot reclaim events, and finance reviews. The table below captures proven approaches for autoscaling, observability spend, and upgrade hygiene. Pair each pattern with the cost lens from earlier sections: consolidation and Spot diversification reduce variable hourly burn, while scoped logging and right-sizing stop silent budget leaks.
+
+### Proven Patterns
+
+| Pattern | When to Use | Why It Works | Scaling Note |
+| :--- | :--- | :--- | :--- |
+| **Karpenter consolidation with PDB-aware drains** | Clusters with bursty Deployments and batch tiers that leave fragmented nodes overnight | Continuous packing reclaims idle vCPU without manual ASG tuning; PDBs cap eviction blast radius | Tune `consolidateAfter` per tier—aggressive on batch NodePools, conservative on latency-sensitive pools |
+| **Spot diversification plus weighted On-Demand fallback** | Fault-tolerant web tiers, CI runners, and media batch pipelines | Multiple families, generations, sizes, and AZs spread interruption risk; weight ordering guarantees fallback when Spot pools exhaust | Monitor interruption rate per instance family; widen requirements before blaming application code |
+| **Scoped control-plane logging** | Always-on security posture with incident-driven deep dives | `audit` and `authenticator` satisfy forensics without paying for full `api` LIST/WATCH volume | Enable `scheduler` and `controllerManager` temporarily during Pending-pod investigations, then disable |
+| **Right-sizing requests with admission enforcement** | Any cluster where FinOps reports >20% idle or unallocated spend | Accurate requests let Karpenter bin-pack and let OpenCost attribute spend to teams | Run VPA in recommendation mode first; enforce labels and requests via Kyverno before hard limits |
+| **Upgrade cadence with `expireAfter` rotation** | EKS clusters on quarterly minor upgrades | Control plane moves first per skew policy; node rotation via NodePool expiry avoids stale AMIs | Document add-on compatibility matrix before bumping control plane version |
+
+### Anti-Patterns
+
+| Anti-Pattern | What Goes Wrong | Why Teams Fall Into It | Better Alternative |
+| :--- | :--- | :--- | :--- |
+| **Cluster Autoscaler thrash alongside Karpenter** | Both controllers fight over node counts; scale-up latency worsens and nodes terminate unexpectedly | Incremental migration without removing legacy autoscaler | Remove Cluster Autoscaler entirely before Karpenter reaches production traffic |
+| **Single Spot instance pool** | One family/AZ concentration means reclaim events drain most capacity at once | Copy-paste NodePool from a tutorial with one `instance-type` requirement | Allow 10–20 types across m/c/r families and three AZs; add weighted On-Demand fallback |
+| **Logging everything permanently** | CloudWatch ingestion for all five control-plane types can exceed useful signal | "Enable now, filter later" during initial cluster bring-up | Keep `audit` + `authenticator`; enable `api`/`scheduler`/`controllerManager` only during active incidents |
+| **Skipping EKS add-on version checks** | VPC CNI, CoreDNS, or kube-proxy skew causes DNS failures or IP exhaustion that mimic app bugs | Treating add-ons as independent of Kubernetes minor version | Pin add-ons to the EKS compatibility matrix before and after control plane upgrades |
+| **FinOps dashboards without label enforcement** | 30%+ spend stays unallocated; optimization debates lack owners | Optional labels in Helm charts | Enforce `team` and `cost-center` at admission; reject non-compliant Deployments |
+
+At moderate scale—roughly fifty to two hundred nodes—a well-run pattern stack typically cuts idle compute by double-digit percentages without sacrificing SLOs. Cost spikes unexpectedly when consolidation runs during deploy windows without PDB coverage, when Spot pools are too narrow during regional capacity crunches, or when Container Insights cardinality explodes because every pod label becomes a custom metric dimension.
+
+---
+
+## Decision Framework
+
+Use the flowcharts below during architecture reviews when stakeholders ask for a single answer but the honest response is "it depends on workload shape and finance maturity."
+
+### Node provisioning: Karpenter vs Cluster Autoscaler vs managed node groups
+
+```mermaid
+flowchart TD
+    Start([Need EKS compute elasticity?]) --> Dynamic{Highly variable pod shapes<br>or sub-minute scale-out?}
+    Dynamic -->|Yes| Karpenter[Karpenter NodePools + EC2NodeClass]
+    Dynamic -->|No| Steady{Steady, homogenous<br>node footprint?}
+    Steady -->|Yes| MNG[EKS managed node groups<br>+ optional CA]
+    Steady -->|No| Hybrid[Karpenter for burst tiers<br>MNG for stable baselines]
+    Karpenter --> Trade1[Tradeoff: IAM + CRD ops<br>Gain: Fleet API speed + bin-packing]
+    MNG --> Trade2[Tradeoff: slower scale-out<br>Gain: simplest Day-1 path]
+    Hybrid --> Trade3[Tradeoff: two provisioning models<br>Gain: cost + stability split]
+```
+
+Choose **managed node groups** when your fleet is small, instance types are uniform, and scale-out measured in minutes is acceptable. Choose **Karpenter** when pending pods vary widely in CPU/memory shape, traffic spikes are sharp, or Spot diversification matters. Keep **Cluster Autoscaler** only as a bridge during migration—not as a permanent peer to Karpenter.
+
+### Capacity pricing: Spot vs On-Demand vs Savings Plans
+
+```mermaid
+flowchart TD
+    Cap([Classify workload tier]) --> Interrupt{Can tolerate<br>2-min eviction?}
+    Interrupt -->|Yes| Spot[Spot NodePool<br>+ PDB + replicas]
+    Interrupt -->|No| Baseline{Runs 24/7<br>on fixed vCPU?}
+    Baseline -->|Yes| SP[Compute Savings Plan<br>on On-Demand baseline]
+    Baseline -->|No| OD[On-Demand NodePool<br>with consolidation]
+    Spot --> SpotCost[Lowest variable $/hr<br>Risk: capacity reclaim]
+    SP --> SPCost[Lowest committed $/hr<br>Risk: over-commit if rightsizing lags]
+    OD --> ODCost[Highest $/hr<br>Lowest operational surprise]
+```
+
+Run **Spot** for stateless, horizontally scaled, or checkpointed batch work. Cover the **On-Demand baseline** that Spot cannot absorb—databases, singleton controllers, latency-sensitive APIs—with **Compute Savings Plans** once utilization is stable for a year-ish horizon. Revisit the split monthly using OpenCost idle lines and Spot interruption metrics.
+
+### Cost visibility: OpenCost vs Kubecost vs AWS CUR
+
+| Need | OpenCost | Kubecost | AWS Cost & Usage Report (CUR) |
+| :--- | :--- | :--- | :--- |
+| **Open-source, in-cluster allocation** | Native fit; Prometheus + optional Spot pricing bucket | Commercial layer with free tier limits | Not a Kubernetes allocator—billing export only |
+| **Multi-cluster enterprise showback** | Possible with federation; more DIY | Strong default for finance-ready dashboards | Requires Athena/Glue pipeline + label mapping work |
+| **Invoice-grade AWS reconciliation** | Approximates from metrics + pricing APIs | Adds commercial CUR integration features | Source of truth for AWS line items |
+| **Cost to operate** | Helm install + Prometheus you already run | License for advanced modules | Storage + query infrastructure for CUR tables |
+
+Start with **OpenCost** when platform engineers need transparent namespace attribution quickly. Add **Kubecost** when finance requires certified showback across many clusters. Use **CUR** (with resource tags and Cost Allocation Tags enabled) to reconcile whether Kubernetes decisions actually moved the AWS bill.
 
 ---
 
@@ -785,16 +855,15 @@ Work through the tasks in order because each step assumes the previous artifacts
 <details>
 <summary>Solution</summary>
 
-```bash
-# Check if Cluster Autoscaler is running
-k get deployment cluster-autoscaler -n kube-system 2>/dev/null
+```bash# Check if Cluster Autoscaler is running
+kubectl get deployment cluster-autoscaler -n kube-system 2>/dev/null
 
 # If present, remove it
 helm uninstall cluster-autoscaler -n kube-system 2>/dev/null || \
-  k delete deployment cluster-autoscaler -n kube-system 2>/dev/null
+  kubectl delete deployment cluster-autoscaler -n kube-system 2>/dev/null
 
 # Verify it is gone
-k get pods -n kube-system | grep autoscaler
+kubectl get pods -n kube-system | grep autoscaler
 # Should return nothing
 ```
 
@@ -807,8 +876,7 @@ Tag discovery consistently across every subnet and security group the NodePool m
 <details>
 <summary>Solution</summary>
 
-```bash
-# Tag your subnets for Karpenter discovery
+```bash# Tag your subnets for Karpenter discovery
 CLUSTER_NAME="my-cluster"
 SUBNET_IDS=$(aws eks describe-cluster --name $CLUSTER_NAME \
   --query 'cluster.resourcesVpcConfig.subnetIds[]' --output text)
@@ -839,8 +907,8 @@ helm install karpenter karpenter/karpenter \
   --wait
 
 # Verify Karpenter is running
-k get pods -n kube-system -l app.kubernetes.io/name=karpenter
-k logs -n kube-system -l app.kubernetes.io/name=karpenter --tail=20
+kubectl get pods -n kube-system -l app.kubernetes.io/name=karpenter
+kubectl logs -n kube-system -l app.kubernetes.io/name=karpenter --tail=20
 ```
 
 </details>
@@ -850,8 +918,7 @@ k logs -n kube-system -l app.kubernetes.io/name=karpenter --tail=20
 <details>
 <summary>Solution</summary>
 
-```bash
-cat <<'EOF' | k apply -f -
+```bashcat <<'EOF' | kubectl apply -f -
 apiVersion: karpenter.k8s.aws/v1
 kind: EC2NodeClass
 metadata:
@@ -921,7 +988,7 @@ spec:
 EOF
 
 echo "General purpose NodePool created."
-k get nodepool general-purpose
+kubectl get nodepool general-purpose
 ```
 
 </details>
@@ -931,8 +998,7 @@ k get nodepool general-purpose
 <details>
 <summary>Solution</summary>
 
-```bash
-cat <<'EOF' | k apply -f -
+```bashcat <<'EOF' | kubectl apply -f -
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
@@ -978,7 +1044,7 @@ spec:
 EOF
 
 echo "Spot batch NodePool created."
-k get nodepools
+kubectl get nodepools
 ```
 
 </details>
@@ -990,10 +1056,9 @@ While the Job runs, watch for Spot nodes appearing with diversified instance typ
 <details>
 <summary>Solution</summary>
 
-```bash
-k create namespace batch
+```bashkubectl create namespace batch
 
-cat <<'EOF' | k apply -f -
+cat <<'EOF' | kubectl apply -f -
 apiVersion: batch/v1
 kind: Job
 metadata:
@@ -1048,16 +1113,16 @@ EOF
 
 # Watch Karpenter provision Spot nodes
 echo "Watching Karpenter logs for node provisioning..."
-k logs -n kube-system -l app.kubernetes.io/name=karpenter -f --tail=5 &
+kubectl logs -n kube-system -l app.kubernetes.io/name=karpenter -f --tail=5 &
 LOG_PID=$!
 
 # Watch pods scheduling
-k get pods -n batch -w &
+kubectl get pods -n batch -w &
 POD_PID=$!
 
 # Wait a moment then check what Karpenter provisioned
 sleep 30
-k get nodes -l karpenter.sh/capacity-type=spot \
+kubectl get nodes -l karpenter.sh/capacity-type=spot \
   -o custom-columns='NAME:.metadata.name,TYPE:.metadata.labels.node\.kubernetes\.io/instance-type,AZ:.metadata.labels.topology\.kubernetes\.io/zone,CAPACITY:karpenter\.sh/capacity-type'
 
 # Clean up background processes
@@ -1073,8 +1138,7 @@ OpenCost needs a few minutes of steady traffic before allocation APIs return sta
 <details>
 <summary>Solution</summary>
 
-```bash
-# Install OpenCost
+```bash# Install OpenCost
 helm repo add opencost https://opencost.github.io/opencost-helm-chart
 helm repo update
 
@@ -1085,10 +1149,10 @@ helm install opencost opencost/opencost \
   --set opencost.ui.enabled=true
 
 # Wait for OpenCost to be ready
-k wait --for=condition=Ready pods -l app.kubernetes.io/name=opencost -n opencost --timeout=120s
+kubectl wait --for=condition=Ready pods -l app.kubernetes.io/name=opencost -n opencost --timeout=120s
 
 # Port-forward to access the UI
-k port-forward -n opencost svc/opencost 9090:9090 &
+kubectl port-forward -n opencost svc/opencost 9090:9090 &
 
 echo "OpenCost UI available at: http://localhost:9090"
 
@@ -1111,13 +1175,12 @@ curl -s http://localhost:9090/allocation/compute \
 
 Deleting NodePools before uninstalling Helm ensures Karpenter drains and terminates nodes it created, which is faster and safer than orphaning EC2 instances that still appear healthy in the AWS console but no longer match your desired cluster state.
 
-```bash
-k delete namespace batch
-k delete job video-encode-batch -n batch 2>/dev/null
+```bashkubectl delete namespace batch
+kubectl delete job video-encode-batch -n batch 2>/dev/null
 helm uninstall opencost -n opencost
-k delete namespace opencost
-k delete nodepool spot-batch general-purpose
-k delete ec2nodeclass default
+kubectl delete namespace opencost
+kubectl delete nodepool spot-batch general-purpose
+kubectl delete ec2nodeclass default
 helm uninstall karpenter -n kube-system
 # Karpenter-managed nodes will be terminated automatically when NodePools are deleted
 ```
@@ -1147,8 +1210,17 @@ To continue scaling your cloud capabilities across different vendor philosophies
 
 ## Sources
 
-The references below anchor the autoscaling, logging, and version-skew guidance in this module. When AWS updates EKS user guide pages, reconcile Helm chart versions and add-on compatibility matrices against those docs before you change production runbooks.
+The references below anchor the autoscaling, logging, observability, FinOps, and version-skew guidance in this module. When AWS updates EKS user guide pages, reconcile Helm chart versions and add-on compatibility matrices against those docs before you change production runbooks.
 
-- [Scale cluster compute with Karpenter and Cluster Autoscaler](https://docs.aws.amazon.com/eks/latest/userguide/autoscaling.html) — This is the current Amazon EKS entry point for supported autoscaling options and Karpenter context.
-- [Send control plane logs to CloudWatch Logs](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) — It documents the five EKS control-plane log types, defaults, and operational caveats.
-- [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/) — It is the canonical reference for control-plane and node upgrade order compatibility.
+- [Scale cluster compute with Karpenter and Cluster Autoscaler](https://docs.aws.amazon.com/eks/latest/userguide/autoscaling.html) — Amazon EKS entry point for supported autoscaling options and Karpenter context.
+- [Karpenter documentation](https://karpenter.sh/docs/) — Official open-source docs for NodePools, disruption, consolidation, and AWS provider behavior.
+- [Karpenter NodeClasses (AWS)](https://karpenter.sh/docs/concepts/nodeclasses/) — EC2NodeClass fields for subnets, security groups, AMI selection, and block devices.
+- [Send control plane logs to CloudWatch Logs](https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html) — Documents the five EKS control-plane log types, defaults, and operational caveats.
+- [Amazon CloudWatch Container Insights for Amazon EKS and Kubernetes](https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/ContainerInsights.html) — Metrics, dashboards, and cardinality considerations for EKS clusters.
+- [Amazon CloudWatch Observability EKS add-on](https://docs.aws.amazon.com/eks/latest/userguide/cloudwatch.html) — Managed add-on path for Container Insights and ADOT collectors on EKS.
+- [What is Amazon Managed Service for Prometheus?](https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-Amazon-Managed-Service-Prometheus.html) — AMP workspaces, remote write, and SigV4 ingestion.
+- [Amazon EC2 Spot Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-spot-instances.html) — Interruption notices, capacity pools, and Spot best practices.
+- [What are Savings Plans?](https://docs.aws.amazon.com/savingsplans/latest/userguide/what-is-savings-plans.html) — Committed-use discounts for steady On-Demand compute baselines.
+- [Update existing cluster to new Kubernetes version](https://docs.aws.amazon.com/eks/latest/userguide/update-cluster.html) — Control plane upgrade sequencing and add-on compatibility notes.
+- [OpenCost documentation](https://opencost.io/docs/) — Open-source Kubernetes cost monitoring and allocation APIs.
+- [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy/) — Canonical reference for control-plane and kubelet upgrade order compatibility.


### PR DESCRIPTION
## Cloud track — EKS Deep Dive Wave 5b (completes the sub-track)

Final EKS Deep Dive wave. **With this, EKS Deep Dive 5.1–5.5 is fully reviewed/done.**

| Module | Action | Author | Reviewer | Tier (after fixes) |
|---|---|---|---|---|
| 5.4 EKS Storage | expand 2.1k→5.1k | cursor | opus 4.8 | T0 (5081w, 16 src) |
| 5.5 EKS Production | gate-fix + Patterns/Decision (was T3 at floor) | cursor | opus 4.8 | T0 (5269w, 12 src) |

### Work
- **5.4**: expanded CSI/EBS/EFS/Mountpoint-S3/stateful-across-AZ depth + Patterns/Anti-Patterns + Decision Framework + cost lens.
- **5.5**: was at the body floor but T3 (sources<10, kubectl-alias, sentence-length) — fixed those gates + added Patterns/Anti-Patterns + Decision Framework, preserving the rich Karpenter/Spot/observability/FinOps content.

### Review fixes (ground-checked / web-verified by opus)
- **5.4**: `runnable_no_kubectl_alias` gate (added `alias k=kubectl` per block); **IRSA/Pod-Identity mismatch** — trust used `pods.eks.amazonaws.com` but install used `--service-account-role-arn` (→ AccessDenied); switched to `create-pod-identity-association` consistently; "ad-tech company" anecdote → hypothetical; malformed Common-Mistakes rows; missing external-snapshot-controller (Task 5 would hang); incomplete EFS cleanup (mount targets/SG/roles); instance-store-vs-tmpfs conflation; EFS cross-AZ cost trigger reframed.
- **5.5**: **Karpenter Task-2 install** used the deprecated `charts.karpenter.sh` repo (contradicts the module's own warning; v1.x is OCI-only) → OCI form; `--set` keys → `settings.*` prefix; bin-packing prices (m6i.2xlarge $0.192→$0.384, c6i.2xlarge $0.170→$0.34) + conclusion reconciled; AMP ingestion vs storage pricing units separated; pre-v1 Karpenter metric name; deprecated Kyverno `validationFailureAction`. **Also: un-fused 14 code-fence info-strings** (` ```bashaws…` → ` ```bash` + newline) that would have stripped the first line of 6 command blocks incl. both lab manifests (verifier-blind; caught by opus).

All pass `verify_module.py` (T0); incident-dedup gate PASS; 5.5 fences confirmed clean post-fix.

## Learner check

> Then, you request a snapshot by referencing the target PVC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
