### PR TITLE
chore(content): cloud GCP Essentials wave 6a — expand 2.1 IAM + 2.2 VPC + 2.3 Compute to floor

### DIFF
--- a/src/content/docs/cloud/gcp-essentials/module-2.1-iam.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.1-iam.md
@@ -130,7 +130,7 @@ When Policy Troubleshooter or audit logs explain a decision, they walk the same 
 4. Default: DENY                    →  "No matching allow → reject."
 ```
 
-**Deny wins over allow.** A principal with `roles/owner` still cannot delete a project if an org-level deny policy blocks `cloudresourcemanager.googleapis.com/projects.delete` without an exception. **IAM Conditions** on allow bindings add a fourth dimension: the binding exists, but only when a CEL expression (time, resource name, tags) evaluates to true. Conditions do not replace deny policies; they narrow when an allow applies.
+**Deny wins over allow.** A principal with `roles/owner` still cannot delete a project if an org-level deny policy blocks `cloudresourcemanager.googleapis.com/projects.delete` without an exception. **IAM Conditions** on allow bindings add a fourth dimension: the binding exists, but only when a CEL expression (time, resource name, tags) evaluates to true. Conditions do not replace deny policies; they narrow when an allow applies. Review condition expressions in pull requests the same way you review role names.
 
 ```bash
 # Search IAM bindings for a user across the org (requires Cloud Asset Inventory API)
@@ -140,8 +140,8 @@ gcloud asset search-all-iam-policies \
 
 # Effective IAM policy for one resource (includes inherited allows)
 gcloud asset get-effective-iam-policy \
-  --project=PROJECT_ID \
-  //storage.googleapis.com/projects/PROJECT_ID/buckets/my-bucket
+  --scope=projects/PROJECT_ID \
+  --full-resource-name=//storage.googleapis.com/projects/_/buckets/my-bucket
 ```
 
 ### Organization Policies vs IAM Policies
@@ -161,15 +161,17 @@ New GCP practitioners often confuse **Organization Policies** with **IAM policie
 gcloud org-policies list --organization=ORGANIZATION_ID
 
 # Set a constraint to deny external IPs on all VMs in a folder
-gcloud org-policies set-policy policy.yaml --folder=FOLDER_ID
+gcloud org-policies set-policy policy.yaml
 ```
 
-To block external IPs on every VM under a folder, you attach an organization policy document such as the following `policy.yaml` (the constraint name is what the API enforces; the list policy denies all values):
+To block external IPs on every VM under a folder, you attach an organization policy document such as the following `policy.yaml` (v2 API shape—the folder is encoded in `name`, not a separate `--folder` flag):
 
 ```yaml
-constraint: constraints/compute.vmExternalIpAccess
-listPolicy:
-  allValues: DENY
+name: folders/FOLDER_ID/policies/compute.vmExternalIpAccess
+spec:
+  rules:
+  - enforce: true
+    denyAll: true
 ```
 
 ### Shared VPC and IAM (cross-project networking)
@@ -369,9 +371,7 @@ Conditions apply to **allow policies** (version 3 when any binding uses a condit
 gcloud projects add-iam-policy-binding my-project \
   --member="user:contractor@example.com" \
   --role="roles/compute.instanceAdmin.v1" \
-  --condition-title="contractor_expires" \
-  --condition-description="Access ends after engagement" \
-  --condition-expression='request.time < timestamp("2026-09-30T23:59:59Z")'
+  --condition='expression=request.time < timestamp("2026-09-30T23:59:59Z"),title=contractor_expires,description=Access ends after engagement'
 
 # Lint a condition expression before applying (alpha)
 gcloud alpha iam policies lint-condition \
@@ -409,7 +409,7 @@ gcloud iam service-accounts create gcs-reader \
   --project=my-project
 
 # Grant it only the permissions it needs
-gcloud projects add-iam-binding my-project \
+gcloud projects add-iam-policy-binding my-project \
   --member="serviceAccount:gcs-reader@my-project.iam.gserviceaccount.com" \
   --role="roles/storage.objectViewer"
 
@@ -524,12 +524,12 @@ gcloud iam service-accounts create github-deployer \
   --project=my-project
 
 # Step 4: Grant the service account permissions it needs
-gcloud projects add-iam-binding my-project \
+gcloud projects add-iam-policy-binding my-project \
   --member="serviceAccount:github-deployer@my-project.iam.gserviceaccount.com" \
   --role="roles/run.admin"
 
 # Step 5: Allow the GitHub repo to impersonate the service account
-gcloud iam service-accounts add-iam-binding \
+gcloud iam service-accounts add-iam-policy-binding \
   github-deployer@my-project.iam.gserviceaccount.com \
   --project="my-project" \
   --role="roles/iam.workloadIdentityUser" \
@@ -575,7 +575,7 @@ gcloud iam service-accounts create gke-app \
   --display-name="GKE app identity" \
   --project=my-project
 
-gcloud projects add-iam-binding my-project \
+gcloud projects add-iam-policy-binding my-project \
   --member="serviceAccount:gke-app@my-project.iam.gserviceaccount.com" \
   --role="roles/cloudsql.client"
 
@@ -637,14 +637,14 @@ Treat recommender output as a **prioritized backlog**, not auto-remediation. Per
 ```bash
 # Who can act as this service account? (impersonation graph)
 gcloud asset analyze-iam-policy \
-  --project=my-project \
+  --scope=projects/my-project \
   --identity="serviceAccount:data-pipeline@my-project.iam.gserviceaccount.com" \
   --permissions="iam.serviceAccounts.actAs" \
   --expand-groups
 
 # Which principals have a role on a specific bucket resource?
 gcloud asset analyze-iam-policy \
-  --project=my-project \
+  --scope=projects/my-project \
   --full-resource-name="//storage.googleapis.com/projects/my-project/buckets/sensitive-data" \
   --roles="roles/storage.objectAdmin"
 ```
@@ -1016,12 +1016,12 @@ gcloud iam service-accounts create data-pipeline \
 export DEV_SA="data-pipeline@${DEV_PROJECT}.iam.gserviceaccount.com"
 
 # Grant minimal permissions: read GCS objects
-gcloud projects add-iam-binding $DEV_PROJECT \
+gcloud projects add-iam-policy-binding $DEV_PROJECT \
   --member="serviceAccount:$DEV_SA" \
   --role="roles/storage.objectViewer"
 
 # Grant permission to write logs
-gcloud projects add-iam-binding $DEV_PROJECT \
+gcloud projects add-iam-policy-binding $DEV_PROJECT \
   --member="serviceAccount:$DEV_SA" \
   --role="roles/logging.logWriter"
 
@@ -1047,7 +1047,7 @@ gcloud iam service-accounts create artifact-reader \
 export PROD_SA="artifact-reader@${PROD_PROJECT}.iam.gserviceaccount.com"
 
 # Grant it read access to the DEV project's storage (cross-project)
-gcloud projects add-iam-binding $DEV_PROJECT \
+gcloud projects add-iam-policy-binding $DEV_PROJECT \
   --member="serviceAccount:$PROD_SA" \
   --role="roles/storage.objectViewer"
 
@@ -1090,7 +1090,7 @@ gcloud iam workload-identity-pools providers create-oidc "github-provider" \
 export PROJECT_NUM=$(gcloud projects describe $DEV_PROJECT --format="value(projectNumber)")
 export REPO_NAME="my-org/my-repo"
 
-gcloud iam service-accounts add-iam-binding $DEV_SA \
+gcloud iam service-accounts add-iam-policy-binding $DEV_SA \
   --project=$DEV_PROJECT \
   --role="roles/iam.workloadIdentityUser" \
   --member="principalSet://iam.googleapis.com/projects/${PROJECT_NUM}/locations/global/workloadIdentityPools/github-actions-pool/attribute.repository/${REPO_NAME}"
@@ -1177,7 +1177,7 @@ gcloud iam roles create safeStorageReader \
 gcloud iam roles describe safeStorageReader --project=$PROD_PROJECT
 
 # Grant the custom role to the prod service account
-gcloud projects add-iam-binding $PROD_PROJECT \
+gcloud projects add-iam-policy-binding $PROD_PROJECT \
   --member="serviceAccount:$PROD_SA" \
   --role="projects/${PROD_PROJECT}/roles/safeStorageReader"
 ```

--- a/src/content/docs/cloud/gcp-essentials/module-2.1-iam.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.1-iam.md
@@ -19,17 +19,21 @@ When you finish this module, you will be able to configure IAM across the full r
 
 ## Why This Module Matters
 
-In September 2020, a mid-sized fintech company discovered that their entire Google Cloud production environment had been compromised. The root cause was not a sophisticated exploit or a zero-day vulnerability. A developer had created a service account with Project Owner permissions "temporarily" to debug an integration issue with Cloud Storage. That service account key was committed to a private GitHub repository. When the repository was briefly made public during an open-source release, automated scanners harvested the key within minutes. Because the service account had Owner-level access to the production project, the attacker was able to exfiltrate customer financial records, spin up cryptocurrency mining instances across multiple regions, and delete audit logs. The total cost exceeded $2.3 million in direct damages, not including the regulatory fines that followed.
+**Hypothetical scenario:** A platform team grants a CI service account `roles/owner` on a production project to unblock a weekend deploy. Someone exports a JSON key into a pipeline secret store that later syncs to a public artifact bucket. Within hours, an automated scanner uses the key to list buckets, read objects, and create VMs in other regions. Cleanup costs balloon because billing, data egress, and incident response all run through the same compromised project. The breach was not a novel exploit; it was IAM design that treated convenience as temporary but left standing privileges in place.
 
-This incident reveals the fundamental truth about Google Cloud Platform security: **the resource hierarchy is your blast radius, and IAM is the control plane for everything**. Unlike traditional infrastructure where network firewalls form the primary defense, in GCP almost every action---creating a VM, reading a storage object, deploying a Cloud Run service---is governed by IAM. If your IAM posture is weak, every other security measure becomes irrelevant. An attacker with the right IAM permissions can bypass VPC firewalls, read encrypted data, and delete entire projects with a single API call.
+That pattern is common because **the resource hierarchy is your blast radius, and IAM is the control plane for everything**. Unlike traditional on-premises networks where perimeter firewalls are the primary control, in GCP almost every action—creating a VM, reading a storage object, deploying Cloud Run—is authorized through IAM. Weak IAM makes other controls easier to bypass. An identity with `storage.objects.get` and `compute.instances.create` can exfiltrate data and burn budget even when VPC rules look strict on paper.
 
-In this module, you will learn how GCP organizes resources into a hierarchy (Organization, Folders, and Projects), how IAM policies are inherited through that hierarchy, and how to design access control that follows the principle of least privilege. You will understand the critical differences between basic roles, predefined roles, and custom roles. Most importantly, you will learn how to handle service accounts correctly---because misconfigured service accounts remain the number one attack vector in cloud breaches.
+If you come from AWS, the mental model shift matters. AWS isolates accounts by default; cross-account access needs explicit trust. GCP stacks Organization → Folder → Project → resource, and **allow policies inherit downward** unless a deny policy or organization constraint blocks the action. You will learn that hierarchy, the difference between basic, predefined, and custom roles, and how to run workloads without long-lived service account keys—still the most common cloud identity failure mode in production reviews.
 
 ---
 
 ## The Resource Hierarchy: Your Organizational Blueprint
 
 Before you can understand IAM in GCP, you must understand *where* IAM policies live. In GCP, resources are organized into a strict hierarchy, and IAM policies **inherit downward** through that hierarchy. This is fundamentally different from AWS, where each account is largely isolated and cross-account access requires explicit trust policies.
+
+The Google Cloud console **Permissions** tab on a project shows bindings **on that resource**. It does not list every inherited binding from parent folders or the organization in one flat view. That UI gap causes false confidence: an engineer sees “no Owner on this project” while still inheriting Owner from a parent folder. Use `gcloud asset search-all-iam-policies`, Policy Analyzer, or the IAM “Policy Troubleshooter” and “Policy Analyzer” entries in the console to see effective access. Terraform and Config Controller plans should print binding changes at the correct resource name (`google_project_iam_member` vs `google_folder_iam_member`) so reviewers catch hierarchy mistakes in pull requests.
+
+Billing accounts sit **outside** the resource hierarchy tree shown in Resource Manager, but they still interact with IAM: `roles/billing.admin` and project billing linkage are separate from `roles/owner` on a project. A finance team might manage budgets without holding data-plane access—model that with billing-level roles instead of handing out Editor on production projects.
 
 ### The Four Levels
 
@@ -101,7 +105,44 @@ gcloud projects get-iam-policy PROJECT_ID \
   --format="table(bindings.role)"
 ```
 
-A practical analogy: Think of the resource hierarchy like a building. The Organization is the master key---anyone with the master key can open every door. Folders are floor-level keys, and Projects are individual room keys. You can always grant more specific access at lower levels, but you cannot take away access that was granted at a higher level (without using deny policies, which we will cover shortly).
+A practical analogy: think of the hierarchy like a building. The Organization is a master key—anyone holding it can open every door below. Folders are floor keys; projects are room keys. You can grant narrower access lower in the tree, but you **cannot subtract** an inherited allow binding at a child project. Security teams that expect AWS-style “deny at the child account” often get surprised until they adopt **IAM Deny policies** or organization policy constraints.
+
+#### AWS vs GCP: inheritance and blast radius
+
+| Dimension | AWS (typical enterprise) | GCP |
+| :--- | :--- | :--- |
+| **Isolation unit** | Account per environment or team | Project (folder groups projects) |
+| **Default cross-env access** | Blocked unless trust policy allows | Inherited allows flow down the tree |
+| **Subtracting access** | SCPs, permission boundaries, explicit denies | IAM Deny policies + org policy constraints |
+| **Human access pattern** | IAM Identity Center / SSO roles per account | Groups at org/folder/project levels |
+| **Machine identity** | IAM roles for workloads (IRSA on EKS) | Service accounts + Workload Identity Federation |
+
+The AWS model encourages **many accounts** with guardrails at the org root. GCP encourages **fewer projects** with fine-grained IAM and deny guardrails. Neither is “more secure” by default—GCP rewards explicit deny design and least-privilege at the lowest attachment point.
+
+#### Effective access: allow, deny, and constraints
+
+When Policy Troubleshooter or audit logs explain a decision, they walk the same stack:
+
+```text
+1. Organization Policy Constraints  →  "May this configuration exist?"
+2. IAM Deny Policies                →  "Is this API call explicitly denied?"
+3. IAM Allow Policies (+ Conditions)→  "Is there a matching allow binding?"
+4. Default: DENY                    →  "No matching allow → reject."
+```
+
+**Deny wins over allow.** A principal with `roles/owner` still cannot delete a project if an org-level deny policy blocks `cloudresourcemanager.googleapis.com/projects.delete` without an exception. **IAM Conditions** on allow bindings add a fourth dimension: the binding exists, but only when a CEL expression (time, resource name, tags) evaluates to true. Conditions do not replace deny policies; they narrow when an allow applies.
+
+```bash
+# Search IAM bindings for a user across the org (requires Cloud Asset Inventory API)
+gcloud asset search-all-iam-policies \
+  --scope=organizations/ORGANIZATION_ID \
+  --query="policy:alice@example.com"
+
+# Effective IAM policy for one resource (includes inherited allows)
+gcloud asset get-effective-iam-policy \
+  --project=PROJECT_ID \
+  //storage.googleapis.com/projects/PROJECT_ID/buckets/my-bucket
+```
 
 ### Organization Policies vs IAM Policies
 
@@ -131,6 +172,16 @@ listPolicy:
   allValues: DENY
 ```
 
+### Shared VPC and IAM (cross-project networking)
+
+**Shared VPC** splits host and service projects. The host project owns subnets; service projects attach workloads. IAM is still evaluated per resource, but operators need roles in **both** projects to deploy: network admin on the host, workload deployer on the service project. A common mistake is granting `roles/compute.networkAdmin` only in the service project while VMs fail to pick subnets in the host.
+
+Use groups such as `gcp-network-admins@` on the host project and `gcp-app-deployers@` on service projects. Document which predefined roles map to each duty (`roles/compute.networkUser` vs `roles/compute.instanceAdmin.v1`). Shared VPC does not bypass IAM inheritance—it adds a second project boundary you must model in access reviews.
+
+### Tag-based access and organization policy tags
+
+Organization **tags** (key/value pairs applied to projects, folders, or resources) integrate with IAM Conditions (`resource.matchTag`) and organization policies. Tags let you express “production” or “pci” once and enforce consistent conditions on bindings. They are not a replacement for deny policies on destructive APIs, but they reduce duplicated project-level bindings when many projects share the same compliance tier.
+
 ---
 
 ## Principals and IAM Roles: The Access Control Model
@@ -149,6 +200,8 @@ A **principal** in GCP is any identity that can be authenticated and then author
 | **allUsers** | `allUsers` | Anyone on the internet (very dangerous) |
 
 **Best Practice**: Use Google Groups for human access in most cases. Granting roles to individual users creates an audit nightmare and makes offboarding error-prone. When an engineer leaves, you remove them from the group. You do not need to hunt through dozens of IAM policies across projects.
+
+**Cloud Identity / Google Workspace domain** principals (`domain:example.com`) grant every user in the directory a binding. That is convenient for sandboxes and dangerous for production; prefer groups with membership approval. **`allAuthenticatedUsers`** and **`allUsers`** are almost never correct on data-plane resources—if you need public read access to an object, use signed URLs or a front-end service with deliberate IAM, not a bucket ACL shortcut.
 
 ### The Three Types of Roles
 
@@ -232,9 +285,30 @@ gcloud iam roles update customStorageReader \
 
 Custom roles trade precision for operational ownership: they can be created at the organization or project level (not on folders), support up to 3,000 permissions, and exclude some permissions whose launch stage is `TESTING` or `NOT_SUPPORTED` in the IAM catalog. Most importantly, Google does not auto-update your custom roles when a service ships new APIs—you must review release notes and patch roles yourself, unlike predefined roles that track service growth for you.
 
+**Lifecycle discipline** keeps custom roles maintainable. Start from `gcloud iam roles describe roles/SIMILAR_ROLE` and subtract permissions in a staging project before promoting the role ID to production. Version custom roles (`--stage=GA` vs `BETA`) consciously—downstream audits treat GA bindings as production commitments. When a predefined role later covers your use case, migrate principals back to predefined and delete the custom role to avoid two sources of truth.
+
+| Role type | Maintenance owner | AWS analogue (rough) | When it wins |
+| :--- | :--- | :--- | :--- |
+| Basic (Owner/Editor/Viewer) | Google (deprecated path) | PowerUser/Administrator style breadth | Bootstrap only |
+| Predefined | Google adds permissions | AWS managed policies per service | Default for apps and operators |
+| Custom | Your platform team | Customer-managed IAM policy with explicit actions | Regulated least-privilege |
+
+Binding limits matter at scale: each policy has a maximum number of bindings (including conditional bindings). Large enterprises automate binding management with Terraform or Config Controller rather than console edits, so every change has a pull request and plan output.
+
 ### IAM Deny Policies
 
 Introduced in 2022, **IAM Deny Policies** solve the inheritance problem that frustrates security teams: allow policies are additive, so you cannot subtract an inherited `roles/editor` at a child project, but a deny policy can block specific permissions for everyone except principals you list as exceptions.
+
+Deny policies attach at organization, folder, or project levels using the `policies` API (`--kind=denypolicies`). They use **principal sets** (`principalSet://goog/public:all` or specific subjects) rather than only legacy `member:` strings. Exception principals are how break-glass admins retain delete access while the broader org cannot call `projects.delete`. Test denies in a sandbox folder before attaching at the organization root—a misconfigured deny can halt legitimate automation until you patch exceptions.
+
+| Control | Stops what | Does not replace |
+| :--- | :--- | :--- |
+| **IAM Deny** | Specific API permissions for matching principals | Least-privilege allows—you still need narrow roles |
+| **Org policy constraint** | Resource configurations (external IP, regions) | Application-level authorization |
+| **VPC firewall** | Network packets | Data-plane IAM on Cloud Storage or BigQuery |
+| **IAM Condition** | When an allow binding applies | A deny on the same permission |
+
+AWS **Service Control Policies (SCPs)** resemble deny + guardrails at the org level. GCP splits the idea: SCP-like “what can exist” often lives in **organization policies**, while API-level denial uses **IAM Deny policies**. Many enterprises use both.
 
 ```bash
 # Create a deny policy that prevents anyone from deleting projects
@@ -277,6 +351,41 @@ At evaluation time, deny policies run **before** allow policies, and organizatio
 
 ---
 
+## IAM Conditions: Attribute-Based Access on Allow Bindings
+
+**IAM Conditions** attach a Common Expression Language (CEL) expression to a single role binding. The binding grants access only when the expression evaluates to `true` at request time—useful for time-bound contractor access, environment tags, or resource name prefixes without maintaining separate projects per rule.
+
+Conditions apply to **allow policies** (version 3 when any binding uses a condition). They do not replace deny policies or organization constraints; they refine *when* an allow counts.
+
+| Use case | Example CEL idea | Why teams use it |
+| :--- | :--- | :--- |
+| **Expiring access** | `request.time < timestamp("2026-12-31T23:59:59Z")` | On-call or vendor access auto-expires |
+| **Business hours** | `request.time.getHours("America/Chicago") >= 9 && ... <= 17` | Sensitive admin only during local business day |
+| **Resource scope** | `resource.name.startsWith("projects/.../buckets/prod-")` | Same role, different buckets by prefix |
+| **Tagged resources** | `resource.matchTag("123456789012/env", "prod")` | Tag-based ABAC aligned with org policy tags |
+
+```bash
+# Grant Compute instance admin only until a fixed UTC timestamp
+gcloud projects add-iam-policy-binding my-project \
+  --member="user:contractor@example.com" \
+  --role="roles/compute.instanceAdmin.v1" \
+  --condition-title="contractor_expires" \
+  --condition-description="Access ends after engagement" \
+  --condition-expression='request.time < timestamp("2026-09-30T23:59:59Z")'
+
+# Lint a condition expression before applying (alpha)
+gcloud alpha iam policies lint-condition \
+  --condition-from-file=condition.yaml \
+  --resource-type=cloudresourcemanager.googleapis.com/Project \
+  --resource-name=projects/my-project
+```
+
+Policy Troubleshooter and Policy Analyzer both surface condition text on bindings they report. If a user “has” a role in the console but still gets `403`, check whether the binding includes a condition that fails for the current `request.time` or resource attributes.
+
+> **AWS contrast:** AWS IAM condition keys in trust and identity policies are the closest analogue. GCP conditions are per-binding on the same hierarchy as the role, not a separate policy document type—plan reviews around binding + condition pairs, not only role names.
+
+---
+
 ## Service Accounts: Machine Identity Done Right
 
 Service accounts are the most critical---and most frequently misconfigured---aspect of GCP IAM. They represent non-human identities used by applications, VMs, and services.
@@ -289,7 +398,9 @@ Service accounts are the most critical---and most frequently misconfigured---asp
 | **Default** | GCP (auto) | `PROJECT_NUMBER-compute@developer.gserviceaccount.com` | You (but auto-created) |
 | **Google-managed** | GCP | `service-PROJECT_NUMBER@compute-system.iam.gserviceaccount.com` | Google (do not modify) |
 
-**War Story**: The default Compute Engine service account (`PROJECT_NUMBER-compute@developer.gserviceaccount.com`) is automatically granted the `roles/editor` role on the project. This means that every VM you create without specifying a service account gets Editor access to your entire project. This is the single most common privilege escalation vector in GCP. Create dedicated service accounts with minimal permissions whenever possible.
+**Hypothetical scenario:** A security scanner flags a VM that can list every secret in Secret Manager. The VM was created with default settings. Its identity is the default Compute Engine service account, which still holds `roles/editor` on many legacy projects. The fix is not “patch the VM”—it is replace the runtime identity, remove Editor from the default SA, and deny key creation org-wide.
+
+The default Compute Engine service account (`PROJECT_NUMBER-compute@developer.gserviceaccount.com`) is created when you enable the Compute Engine API. Google historically granted it `roles/editor` so tutorials worked out of the box. New organizations should treat that binding as technical debt. Create dedicated service accounts per workload class (batch, API, ETL) and set an organization policy or automation rule that rejects instance creates using the default SA email.
 
 ```bash
 # Create a dedicated service account
@@ -357,11 +468,17 @@ gcloud config unset auth/impersonate_service_account
 
 Impersonation only succeeds when the human or service account calling `gcloud` already holds `roles/iam.serviceAccountTokenCreator` (or a broader role that includes `iam.serviceAccounts.getAccessToken`) on the target service account, because that permission is what authorizes the token exchange.
 
+Grant **`roles/iam.serviceAccountUser`** when a principal should *run as* the SA (attach it to a VM or Cloud Run revision). Grant **`roles/iam.serviceAccountTokenCreator`** when a principal should mint short-lived tokens for impersonation (CI job, admin workstation). Confusing the two produces either “cannot deploy with this SA” or “CI can mint tokens for every SA in the project”—review both bindings during access audits.
+
+Google-managed service accounts (names ending in `@gcp-sa-...` or system suffixes) back Google-managed services. Do not delete them or strip their bindings unless documentation explicitly tells you to; instead, isolate your application identities as user-managed SAs.
+
 ---
 
 ## Workload Identity Federation: Keyless Authentication
 
 Workload Identity Federation allows external identities (from AWS, Azure, GitHub Actions, GitLab CI, or any OIDC/SAML provider) to access GCP resources **without service account keys**. This is the modern, recommended approach for any workload running outside of GCP.
+
+Compared to AWS **IAM Roles for Service Accounts (IRSA)** on EKS, GCP external federation uses a **workload identity pool + provider** mapped to a GSA. The external JWT is exchanged at the Security Token Service (STS). Attribute mappings (for example `attribute.repository` on GitHub) restrict which external identities may impersonate which GSA—similar in spirit to trust policy `StringEquals` conditions on an AWS role, but configured on the provider resource in GCP.
 
 ### How It Works
 
@@ -446,6 +563,47 @@ jobs:
           image: us-central1-docker.pkg.dev/my-project/my-repo/my-api:latest
 ```
 
+### Workload Identity Federation for GKE (keyless pods)
+
+**Workload Identity Federation for GKE** links a Kubernetes service account (KSA) to a Google Cloud IAM service account (GSA). Pods receive short-lived credentials from the GKE metadata server—no JSON key mounted in the cluster. This is distinct from **external** Workload Identity Federation (GitHub, AWS, Azure OIDC) but uses the same `roles/iam.workloadIdentityUser` binding pattern on the GSA.
+
+Autopilot and most new GKE clusters enable Workload Identity by default. The setup is two bindings plus one annotation:
+
+```bash
+# 1) Create a dedicated GSA with least-privilege roles on the project
+gcloud iam service-accounts create gke-app \
+  --display-name="GKE app identity" \
+  --project=my-project
+
+gcloud projects add-iam-binding my-project \
+  --member="serviceAccount:gke-app@my-project.iam.gserviceaccount.com" \
+  --role="roles/cloudsql.client"
+
+# 2) Let the KSA impersonate the GSA (member uses the GKE workload identity pool)
+export PROJECT_ID=my-project
+export KSA_NAMESPACE=default
+export KSA_NAME=app-ksa
+gcloud iam service-accounts add-iam-policy-binding \
+  gke-app@${PROJECT_ID}.iam.gserviceaccount.com \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:${PROJECT_ID}.svc.id.goog[${KSA_NAMESPACE}/${KSA_NAME}]"
+
+# 3) Annotate the KSA so the pod uses the GSA
+kubectl annotate serviceaccount ${KSA_NAME} \
+  --namespace=${KSA_NAMESPACE} \
+  iam.gke.io/gcp-service-account=gke-app@${PROJECT_ID}.iam.gserviceaccount.com
+```
+
+Pods that use the Google client libraries then obtain tokens for `gke-app@...` automatically. **Do not** reuse the node’s default Compute Engine service account for application code—that account often still carries legacy `roles/editor` on the project.
+
+| Authentication path | Keys on disk? | Best for |
+| :--- | :--- | :--- |
+| **Attached GSA on GCE VM / Cloud Run** | No (metadata server) | First-party GCP runtimes |
+| **Workload Identity for GKE** | No (KSA → GSA) | In-cluster workloads |
+| **External Workload Identity Federation** | No (OIDC/SAML exchange) | GitHub Actions, AWS, on-prem |
+| **Service account JSON key** | Yes | Legacy only; org policy should block creation |
+| **User ADC (`gcloud auth application-default login`)** | Local user creds | Developer laptops, not production |
+
 ---
 
 ## IAM Best Practices and Audit
@@ -461,11 +619,63 @@ gcloud recommender recommendations list \
   --location=global \
   --recommender=google.iam.policy.Recommender \
   --format="table(content.operationGroups[0].operations[0].resource, content.operationGroups[0].operations[0].value.bindings[0].role)"
+
+# Apply a specific recommendation (after human review)
+gcloud recommender recommendations list \
+  --project=my-project \
+  --location=global \
+  --recommender=google.iam.policy.Recommender \
+  --filter="stateInfo.state=ACTIVE"
 ```
+
+Treat recommender output as a **prioritized backlog**, not auto-remediation. Permissions used once during a migration may still be required next quarter; pair recommendations with change windows and Policy Analyzer queries that show who still holds the broad role.
+
+### Policy Analyzer (org-wide allow visibility)
+
+**Policy Analyzer** (Policy Intelligence) answers set questions across a scope: “Which principals have `storage.objects.delete` on this bucket?”, “What can this service account access in the org?”, “Who has `roles/owner` anywhere under this folder?” It walks inherited allow policies and reports bindings—including **conditions** attached to those bindings.
+
+```bash
+# Who can act as this service account? (impersonation graph)
+gcloud asset analyze-iam-policy \
+  --project=my-project \
+  --identity="serviceAccount:data-pipeline@my-project.iam.gserviceaccount.com" \
+  --permissions="iam.serviceAccounts.actAs" \
+  --expand-groups
+
+# Which principals have a role on a specific bucket resource?
+gcloud asset analyze-iam-policy \
+  --project=my-project \
+  --full-resource-name="//storage.googleapis.com/projects/my-project/buckets/sensitive-data" \
+  --roles="roles/storage.objectAdmin"
+```
+
+Required permissions include `cloudasset.assets.analyzeIamPolicy` and related Asset Inventory search roles. Large orgs export long-running analyses to BigQuery or Cloud Storage for compliance dashboards. Use Policy Analyzer for **periodic access reviews**; use Policy Troubleshooter for **one-off 403 debugging** on a single principal + permission + resource.
 
 ### Audit Logging
 
-Every IAM change and most data-plane call leaves a trail in **Cloud Audit Logs**, which splits into three families you configure differently. **Admin Activity** logs (always on, no charge) capture IAM policy updates and resource lifecycle events. **Data Access** logs (opt-in, billable) record who read or wrote sensitive payloads such as object bytes or query results. **System Event** logs (always on) capture Google-managed operations like live migration. For investigations, Admin Activity is where `SetIamPolicy` appears; enable Data Access when compliance requires proving who opened a specific record.
+Every IAM change and most data-plane call leaves a trail in **Cloud Audit Logs**, which splits into three families you configure differently. **Admin Activity** logs are always on. They capture IAM policy updates and resource lifecycle events. **Data Access** logs are opt-in for most services. They record reads and writes of user data and can generate large volume. **System Event** logs are always on. They capture Google-managed operations such as live migration.
+
+For investigations, Admin Activity is where `SetIamPolicy` appears. Enable Data Access when compliance requires proving who read a specific record. Viewing Data Access entries needs the **Private Logs Viewer** role (`roles/logging.privateLogViewer`), not just `roles/logging.viewer`.
+
+```bash
+# Export recent IAM admin changes to JSON for a ticket
+gcloud logging read \
+  'logName="projects/my-project/logs/cloudaudit.googleapis.com%2Factivity" AND protoPayload.methodName="SetIamPolicy"' \
+  --project=my-project \
+  --limit=20 \
+  --format=json
+
+# Sample auditConfigs snippet when enabling Storage DATA_READ (review cost first)
+# Add under auditConfigs in project IAM policy:
+# - service: storage.googleapis.com
+#   auditLogConfigs:
+#   - logType: ADMIN_READ
+#   - logType: DATA_READ
+```
+
+**Denied** audit log entries (Policy Denied) help prove a deny policy or organization constraint blocked an action even when the principal holds a broad allow. Include denied logs in detection rules when testing new deny policies, so you see false positives before developers file tickets.
+
+Pair audit logs with **Cloud Asset Inventory** history when investigating “when did this binding appear?” `gcloud asset get-history` and saved IAM policy analyses in BigQuery support quarterly access certifications required by SOC2 and ISO controls.
 
 ```bash
 # Enable Data Access audit logs for Cloud Storage
@@ -497,17 +707,178 @@ The output will clearly state whether access is `GRANTED` or `DENIED` and, cruci
 
 **Pro-tip for troubleshooting with Audit Logs**: If you don't know exactly which permission is missing, look at the Cloud Audit Logs first. Find the `403` error in the logs, look at the `protoPayload.authorizationInfo` field, and it will tell you exactly which permission was evaluated and returned false. Then, use the Policy Troubleshooter to determine *why* they don't have that permission.
 
+### Operational playbooks teams reuse
+
+**Onboarding a human engineer:** add them to a Google Group that already holds predefined roles on the dev folder; never clone a former employee’s direct bindings. Verify with Policy Analyzer that no `roles/owner` binding exists on production projects for that group.
+
+**Onboarding a workload:** create a user-managed service account per application; grant predefined roles on the project; attach the SA to Cloud Run or link KSA→GSA on GKE; block key creation with org constraint `iam.disableServiceAccountKeyCreation` except in a break-glass project.
+
+**Emergency break-glass:** time-bound Owner or a custom break-glass role with IAM Condition on `request.time`; log every `SetIamPolicy` to a security SIEM; run Policy Analyzer after the incident to remove stale bindings.
+
+**Quarterly access review:** export Analyzer results for `roles/owner`, `roles/editor`, and `roles/iam.serviceAccountTokenCreator` across the org; reconcile with HR offboarding tickets; apply IAM Recommender suggestions in batches with change advisory board approval.
+
+**Migrating from AWS:** map IAM Identity Center permission sets to Google Groups + predefined roles per GCP project; replace “account vending” with folder-per-environment + deny policies; replace IRSA with Workload Identity for GKE or external federation for CI.
+
+---
+
+## Patterns & Anti-Patterns
+
+Mature GCP IAM designs treat the hierarchy, deny policies, and keyless workload identity as one system—not a checklist applied once at project creation. The patterns below show up repeatedly in organizations that pass external audits without slowing delivery; the anti-patterns are what incident responders see after keys leak or inherited `roles/editor` survives a reorg.
+
+When you adopt a pattern, document **who approves binding changes** and **which tool owns steady state** (Terraform module path, folder ID, group email). Patterns fail in practice when engineering can still click “Grant access” in the console on production without a ticket. Many teams combine Google Group membership approval (Workspace) with mandatory IaC for project-level `google_project_iam_*` resources so the audit trail lives in Git and Cloud Audit Logs together.
+
+| Pattern | When to use it | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| **Grant at the lowest level** | Team owns one project or bucket | Limits blast radius; matches AWS “small account” instinct translated to GCP | Automate with Terraform modules per project |
+| **Groups for humans, SAs for machines** | Any org with more than a handful of engineers | Offboarding removes one group membership; audit exports list group → role | Sync groups from Cloud Identity / Workspace |
+| **Predefined roles first** | Standard app + operator duties | Google maintains permission sets as APIs evolve | Recommender shrinks over-provisioned bindings over time |
+| **Deny guardrails at org/folder** | Must block delete/export regardless of Owner | Deny evaluated before allow; exceptions are explicit principals | Pair with `constraints/iam.disableServiceAccountKeyCreation` |
+| **Workload Identity over keys** | CI/CD, GKE, hybrid IdP | Short-lived tokens; no secret rotation of JSON files | Separate pools/providers per environment |
+| **IAM Conditions for temporary access** | Contractors, break-glass, migrations | Binding auto-stops without a second revoke ticket | Lint expressions; document timezone in title |
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+| :--- | :--- | :--- | :--- |
+| **Owner/Editor for “speed”** | One compromised identity owns billing, IAM, data | Basic roles are familiar from early tutorials | Predefined roles + break-glass Owner with MFA + deny on delete |
+| **Org-level group with Editor** | Entire company inherits write access | “Everyone needs GCP” during pilot | Folder-scoped groups; project-level roles per team |
+| **Default Compute Engine SA on VMs** | Every VM inherits broad project write | Omitting `--service-account` on `gcloud compute instances create` | Dedicated SA per workload class; org policy to restrict default |
+| **Exported SA keys in CI secrets** | Keys work from any IP until deleted | Vendor docs still show `keys create` | Workload Identity Federation + `workloadIdentityUser` binding |
+| **`allUsers` on a bucket “temporarily”** | Public data exfiltration scanners | Confusing auth errors with IAM errors | Fix application auth; use signed URLs with short TTL |
+| **Custom role copy-paste** | 3,000 permissions “just in case” | Fear of missing one API for a legacy script | Start from predefined; diff permissions with Policy Analyzer |
+| **Ignoring inherited allows after folder moves** | Project inherits finance policies in eng folder | Reorgs treated as billing-only | Run `search-all-iam-policies` before and after moves |
+| **Data Access logs everywhere** | Logging bill spikes on high-QPS services | Compliance asks for “full audit” without scoping | Enable per service; sample or exclude dev projects |
+
+---
+
+## Decision Framework
+
+Use this framework when choosing role types, machine identity mechanisms, and guardrail layers. The goal is not maximal restriction—it is **observable, reversible** decisions that match how the workload authenticates and how far damage spreads if credentials leak.
+
+```mermaid
+flowchart TD
+  Start["Need to grant access"]
+  Human{"Human user?"}
+  Group["Use Google Group at lowest scope"]
+  Machine{"Workload location?"}
+  GCPRuntime["GCP runtime: GCE / GKE / Cloud Run"]
+  External["External: CI, AWS, on-prem"]
+  BasicCheck{"Basic role Owner/Editor/Viewer?"}
+  Predef["Predefined role(s) on project or resource"]
+  Custom{"Predefined too broad/narrow?"}
+  CustomRole["Custom role at org or project"]
+  Attached["Attached SA or Workload Identity"]
+  WIF["Workload Identity Federation pool + provider"]
+  Keys{"Only option is JSON key?"}
+  Block["Stop: enable keyless path or org policy block"]
+  DenyNeed{"Must block action for all allows?"}
+  Deny["IAM Deny policy or org constraint"]
+  Cond{"Need time/tag/network scope?"}
+  Condition["IAM Condition on allow binding"]
+
+  Start --> Human
+  Human -->|yes| Group
+  Human -->|no| Machine
+  Machine --> GCPRuntime
+  Machine --> External
+  GCPRuntime --> Attached
+  External --> WIF
+  Group --> BasicCheck
+  Attached --> BasicCheck
+  WIF --> BasicCheck
+  BasicCheck -->|yes, non-bootstrap| Block
+  BasicCheck -->|no| Predef
+  Predef --> Custom
+  Custom -->|yes| CustomRole
+  Custom -->|no| DenyNeed
+  CustomRole --> DenyNeed
+  DenyNeed -->|yes| Deny
+  DenyNeed -->|no| Cond
+  Cond -->|yes| Condition
+  Cond -->|no| Done["Document binding + review quarterly"]
+  Deny --> Done
+  Condition --> Done
+  Keys -->|yes| Block
+```
+
+| Decision | Prefer | Tradeoff |
+| :--- | :--- | :--- |
+| **Basic vs predefined** | Predefined service roles (`roles/run.admin`, `roles/storage.objectViewer`) | Basic roles bundle thousands of permissions; auditors flag them instantly |
+| **Predefined vs custom** | Predefined unless a permission set is stable and unique | Custom roles need ongoing maintenance when APIs add permissions |
+| **SA key vs federation** | Federation or metadata-based identity for every automated path | Keys are portable across networks—attackers love portable credentials |
+| **Allow at org vs project** | Project (or resource) unless identity truly spans all children | Org-level allows are hard to see in the console and survive folder moves |
+| **Deny policy vs org constraint** | Org constraint when the rule is about resource shape (no external IP) | Deny policies target API permissions; constraints target configuration existence |
+| **Troubleshooter vs Analyzer** | Troubleshooter for one failed API call | Analyzer for “show me everyone with delete on prod buckets” |
+
+Revisit decisions after the first production incident or access review. Federation pools, condition expressions, and deny exceptions that made sense during migration often need tightening once real principals and tags exist.
+
+### Console, CLI, and infrastructure-as-code together
+
+Teams argue about “console vs Terraform” for IAM, but the real requirement is **one source of truth**. Pick Terraform or Config Controller for steady-state bindings. Use the console or `gcloud` for break-glass and troubleshooting. Export console edits back into code within 24 hours or they will diverge.
+
+When reviewing a Terraform plan, check four fields on every `google_*_iam_*` resource: `member` prefix (`user:`, `group:`, `serviceAccount:`), `role` string (prefer `roles/` over project Owner), `condition` block if present, and the target `project`/`folder`/`organization` ID. A plan that only touches the service project but grants `roles/compute.networkAdmin` may still be wrong for Shared VPC—the host project might be the correct attachment point.
+
+For local development, `gcloud auth application-default login` binds credentials to your user identity. That is appropriate on a laptop. Production code should never ship user ADC files. Pair developer access with a sandbox project and group-based roles instead of handing production Editor to every engineer.
+
+---
+
+## Cost Lens: IAM Is Free; Mistakes Are Not
+
+**IAM policy storage and evaluation have no per-request charge.** You pay indirectly through blast radius, operations toil, and observability choices—not through “per binding” pricing.
+
+| Cost surface | What drives spend | Knobs that reduce it |
+| :--- | :--- | :--- |
+| **Over-permission blast radius** | Stolen Owner/Editor SA or key creates VMs, egress, crypto mining | Least-privilege roles, deny on `projects.delete`, key creation org constraint |
+| **Service account key leakage** | Incident response, data breach notification, regulatory fines | Workload Identity Federation; rotate by deleting keys, not “extending” |
+| **Data Access audit logs** | High-volume APIs (Bigtable, Spanner, Storage reads) logged at DATA_READ | Enable per service; exclude dev projects; use log exclusions after 30-day review |
+| **Admin Activity logs** | Stored in `_Required` bucket ~400 days | No ingestion charge for Admin Activity in standard pricing model |
+| **Policy Analyzer / Asset Inventory** | Large org exports to BigQuery | Scope queries to folder; schedule quarterly instead of continuous export |
+| **Recommender + human remediation** | Engineer time applying role changes | Batch changes; test in staging project first |
+
+Cloud Logging pricing is **volume-based** for logs in the `_Default` bucket and user-defined buckets. **Admin Activity** and **System Event** audit logs go to the `_Required` bucket where Logging does not charge for storage of those audit types per [Google Cloud Observability pricing](https://cloud.google.com/products/observability/pricing). **Data Access** audit logs are disabled by default for most services because volume can dominate bills—BigQuery is the common exception where teams enable them deliberately.
+
+Hypothetical scenario: a security lead enables full Data Access logging on a high-QPS microservice project “for compliance.” Ingestion beyond the monthly free log allotment is billed per GiB ingested (see current Observability pricing page for rates). The fix is not to turn off auditing entirely—it is to log **admin** changes everywhere, enable **data access** only on regulated datasets, and route long-term retention through exclusions or shorter retention buckets.
+
+**Cost spike you might not forecast:** a compromised `roles/editor` identity can create GPUs, multi-region buckets, and egress-heavy VMs faster than your FinOps dashboards update. The economic control is IAM at the project boundary, not waiting for the monthly invoice.
+
+---
+
+## Permission Strings, Testing, and Change Safety
+
+IAM permissions use the format `service.resource.verb` (for example `storage.objects.get`). Roles are named bundles of those strings. When Policy Troubleshooter reports DENIED, it names the exact permission the API checked—not the role display name. Teach your team to copy that string into documentation and Terraform comments so fixes target the right binding.
+
+```bash
+# List permissions inside a predefined role (pipe to grep for one API)
+gcloud iam roles describe roles/storage.objectViewer --format="value(includedPermissions)"
+
+# Test whether your user can call an API (uses your current credentials)
+gcloud storage ls gs://my-bucket/
+
+# Impersonate the SA you are about to attach to a workload
+gcloud storage ls gs://my-bucket/ \
+  --impersonate-service-account=WORKLOAD_SA@PROJECT.iam.gserviceaccount.com
+```
+
+**Change safety** practices reduce outage risk when tightening IAM:
+
+1. **Shadow period:** add a narrower role alongside the old role; monitor denials in audit logs; remove the broad role after a week.
+2. **Staging project:** mirror production bindings on a staging project with test principals; run integration tests before touching prod.
+3. **Deny validation:** attach deny policies to low-risk principals first; confirm Policy Denied audit entries; then enforce org-wide.
+4. **Break-glass documentation:** record who holds time-bound Owner, how to page them, and how to revoke via group removal.
+
+AWS practitioners often use IAM policy simulator. GCP combines **Policy Troubleshooter** (single check) and **Policy Analyzer** (set queries). Export Analyzer output when auditors require proof that inherited folder grants were reviewed—not only project-local console screenshots.
+
+When APIs add new permissions, predefined roles update automatically. Custom roles do not. Quarterly, diff custom roles against the nearest predefined role and merge where possible. The IAM Recommender only sees permissions used in its observation window—do not delete permissions required by rare batch jobs.
+
 ---
 
 ## Did You Know?
 
-1. **GCP has over 11,000 individual IAM permissions** spread across hundreds of services. The `roles/editor` basic role grants access to roughly 6,000 of them. This is why narrower predefined or custom roles are usually the better choice.
+1. **GCP has thousands of discrete IAM permissions** across hundreds of services. The `roles/editor` basic role still bundles a very large fraction of them. Narrow predefined roles exist so you do not grant six thousand permissions when you meant to grant six.
 
-2. **Service account keys never expire by default**. Unlike AWS access keys (which have no built-in expiration either), GCP does not enforce rotation. An abandoned key from 2019 is still valid today unless someone explicitly deletes it. Google recommends setting an Organization Policy to disable key creation entirely (`constraints/iam.disableServiceAccountKeyCreation`).
+2. **Service account keys do not expire automatically**. Unlike short-lived OAuth user sessions, a downloaded JSON key remains valid until deleted. Google documents org constraint `constraints/iam.disableServiceAccountKeyCreation` to block new keys org-wide while you migrate to federation.
 
-3. **The project number (not the project ID) is what GCP uses internally**. When you see `service-481726359042@compute-system.iam.gserviceaccount.com`, the number is the project number. Project IDs are just human-friendly aliases. Even if you delete a project, its project ID can never be reused by anyone, ever.
+3. **The project number (not the project ID) appears in system service account emails**. Project IDs are human-chosen aliases; project numbers are numeric and stable for IAM principal sets like `PROJECT.svc.id.goog[...]` in Workload Identity bindings. Deleted project IDs cannot be reused globally.
 
-4. **IAM Conditions let you create time-bound access**. You can grant a role that automatically expires. For example, you can give an on-call engineer `roles/compute.instanceAdmin` that is only valid for 8 hours, or grant access only during business hours in a specific timezone. This eliminates the "forgot to revoke access" problem entirely.
+4. **IAM Conditions use CEL on individual bindings** so access can expire or scope to resource name prefixes without a separate cron job to remove bindings. Policy Analyzer and Troubleshooter both display condition text when explaining access decisions.
 
 ---
 
@@ -531,31 +902,49 @@ The output will clearly state whether access is `GRANTED` or `DENIED` and, cruci
 <details>
 <summary>1. Scenario: An engineer leaves the company. You remove them from the 'gcp-developers' Google Group. However, they are still able to modify instances in the 'sandbox' project. Why might this happen, and how do you find out?</summary>
 
-They likely have a direct IAM binding on the project or a specific resource (like a VM), bypassing the Google Group. In GCP, IAM policies are purely additive and inherit downward through the resource hierarchy. This means that removing them from the group only revokes the group's inherited permissions, but any directly assigned roles remain intact. To definitively find out where these lingering permissions exist, you should use `gcloud asset search-all-iam-policies` to search across the entire organization for their specific email address. Alternatively, you can use the Policy Troubleshooter if you already know which specific resource they are still modifying.
+They likely retain a **direct IAM binding** on the project or a resource, bypassing the group. Allow policies are additive down the hierarchy. Removing the user from the group only revokes group-based access. Direct bindings stay until you delete them. Run `gcloud asset search-all-iam-policies` scoped to the org with `policy:USER_EMAIL` to list every binding. Use Policy Troubleshooter when you already know which resource they can still modify.
 </details>
 
 <details>
 <summary>2. Scenario: Your CI/CD pipeline in GitLab needs to deploy a container to Cloud Run. The security team has strictly forbidden the creation of long-lived service account JSON keys. How do you authenticate the pipeline?</summary>
 
-You must implement Workload Identity Federation to securely authenticate without persistent keys. This process involves creating a Workload Identity Pool and a Provider that is explicitly configured to trust GitLab's OIDC issuer. During the deployment, the GitLab pipeline uses its native JWT to authenticate to the GCP provider, which then exchanges it for a short-lived GCP STS token. The pipeline subsequently uses this temporary token to impersonate a specific GCP service account that has been granted the `roles/run.admin` permission. This approach completely eliminates the need for long-lived secrets, satisfying the security team's requirements while maintaining automated deployment capabilities.
+Implement **Workload Identity Federation** with a pool and OIDC provider that trusts GitLab’s issuer. The pipeline presents its job JWT. STS returns a short-lived credential. The job impersonates a deployer service account with `roles/run.admin` (or narrower custom permissions). No JSON key is stored in GitLab. Attribute mappings should pin `attribute.repository` or equivalent so only approved repos can impersonate the GSA.
 </details>
 
 <details>
 <summary>3. Scenario: You assign <code>roles/storage.objectAdmin</code> to a service account at the Folder level. You want to prevent this service account from deleting objects in one specific production project within that folder. Can you do this by removing the role in the project's IAM policy? Why or why not?</summary>
 
-No, you cannot achieve this by modifying the project's allow policy because of how IAM inheritance works. In GCP, IAM allow policies are strictly additive and inherit downward from the Organization to Folders to Projects. This means you cannot subtract or override an inherited allow permission by simply omitting it at a lower level in the hierarchy. To successfully block the deletion action, you must create an IAM Deny Policy attached directly to the production project that explicitly denies the `storage.objects.delete` permission for that specific service account. Because Deny policies are evaluated before Allow policies, this will effectively override the inherited permissions and protect the objects.
+No. Inherited allows cannot be subtracted at the child project. Folder-level `objectAdmin` still applies in Prod. Create an **IAM Deny policy** on the Prod project that denies `storage.objects.delete` for that service account (or use a deny rule with a narrow exception list). Deny is evaluated before allow, so delete stays blocked while read/list may still work if granted separately.
 </details>
 
 <details>
 <summary>4. Scenario: A developer complains they are getting a `403 Permission Denied` when trying to view Cloud SQL backups. They insist they have the `roles/editor` role on the project. How do you systematically identify the missing permission without blindly guessing?</summary>
 
-First, you should check the Cloud Audit Logs for the specific `403` error event generated by the developer's action. By expanding the `protoPayload.authorizationInfo` field in the log entry, you can identify the exact API permission that was evaluated and rejected (e.g., `cloudsql.backupRuns.get`). Once you have isolated the exact permission string, you should use the IAM Policy Troubleshooter in the console or CLI. By inputting the developer's email, the target resource name, and the identified permission, the troubleshooter will analyze the role bindings. It will then provide a clear explanation of exactly why the permission is missing or if it is being actively blocked by an overriding deny policy.
+Start in **Cloud Audit Logs** on the failed call. Open `protoPayload.authorizationInfo` to read the permission string (for example `cloudsql.backupRuns.get`). `roles/editor` does not include every API—Editor is broad but not complete. Feed the principal, full resource name, and permission into **Policy Troubleshooter**. The tool shows missing allows, failed conditions, or an overriding deny.
 </details>
 
 <details>
 <summary>5. Scenario: A developer manually created a VM to run an internal script without explicitly specifying a service account. Two days later, a security scanner alerts that the VM has full read-write access to every resource in the project. Why did this happen?</summary>
 
 When a Compute Engine VM is created without specifying a service account, GCP automatically assigns it the default Compute Engine service account. This default service account is inherently dangerous because it is automatically granted the legacy `roles/editor` role on the project when the Compute API is first enabled. Because the `roles/editor` role grants sweeping read-write access to almost all GCP services, the VM effectively inherited broad administrative power over the entire project. This design violates the principle of least privilege and serves as a common vector for privilege escalation. To prevent this, you should enforce the use of dedicated, least-privilege service accounts for every VM whenever practical.
+</details>
+
+<details>
+<summary>6. Scenario: Your security architect wants contractors to have <code>roles/compute.instanceAdmin.v1</code> only during their two-week engagement, without a calendar reminder to revoke access. What GCP feature do you use, and what happens after the end date?</summary>
+
+Use an **IAM Condition** on the role binding with a CEL expression comparing `request.time` to an expiration timestamp (for example `request.time < timestamp("2026-10-15T23:59:59Z")`). The binding remains in the policy document, but the IAM engine treats it as non-matching after the cutoff, so API calls fail with permission denied even though the console still shows the role name. This is safer than relying on a ticket to remove the binding, because automation does not forget. Pair with an audit log alert on `SetIamPolicy` if someone removes the condition while extending the contract.
+</details>
+
+<details>
+<summary>7. Scenario: An auditor asks, “List every principal that can delete objects in any bucket under the Production folder.” Policy Troubleshooter on one bucket is too narrow. Which tool and scope do you choose?</summary>
+
+Use **Policy Analyzer** via `gcloud asset analyze-iam-policy` (or the Policy Intelligence console) with scope set to the Production **folder** or organization, filtering for permission `storage.objects.delete` or role `roles/storage.objectAdmin` without restricting to a single bucket resource. Policy Analyzer evaluates inherited allow policies across descendants and returns bindings, including principals and any **conditions**. Policy Troubleshooter is the wrong tool here because it answers one principal + one resource + one permission, not a set query across a subtree.
+</details>
+
+<details>
+<summary>8. Scenario: A GKE pod using the node’s default Compute Engine service account can write to every bucket in the project. You enable Workload Identity on the cluster. What two bindings/annotations must exist before the pod uses a least-privilege GSA?</summary>
+
+Grant `roles/iam.workloadIdentityUser` on the target GSA to the member `serviceAccount:PROJECT_ID.svc.id.goog[NAMESPACE/KSA_NAME]`, which authorizes that Kubernetes service account to impersonate the GSA. Annotate the Kubernetes ServiceAccount with `iam.gke.io/gcp-service-account=GSA_NAME@PROJECT.iam.gserviceaccount.com` so the workload selects the correct identity. The pod must run as that KSA (via `serviceAccountName` in the Pod spec). Without both steps, the pod may still fall back to the node’s broader identity. Remove unused Editor grants from the default Compute Engine SA as a separate hardening step.
 </details>
 
 ---
@@ -566,6 +955,10 @@ When a Compute Engine VM is created without specifying a service account, GCP au
 
 You will stand up a realistic two-project lab (Dev and Prod) with dedicated service accounts, cross-project least-privilege grants, a Workload Identity Federation pool for GitHub-style deploys, a custom role, and Policy Troubleshooter checks—then tear everything down so no billable resources linger.
 
+This lab mirrors how platform teams separate **build** (Dev) from **consume** (Prod) without sharing one service account identity. Cross-project `roles/storage.objectViewer` on the Dev project models artifact promotion: Prod reads build outputs but cannot deploy into Dev. Workload Identity Federation configuration is included even if you do not run GitHub Actions today, because the pool and provider resources are the same ones you would wire to `google-github-actions/auth` later. Policy Troubleshooter closes the loop between theory and a concrete DENIED result on `storage.objects.delete`.
+
+Expect the exercise to take longer than the quick labs in Module 1. IAM propagation and project creation are eventually consistent. If a binding does not appear immediately, wait one minute and re-run `get-iam-policy`. Do not grant Editor “just to make it work”—fix the member string, role name, or project ID instead.
+
 ### Prerequisites
 
 - `gcloud` CLI installed and authenticated
@@ -574,7 +967,7 @@ You will stand up a realistic two-project lab (Dev and Prod) with dedicated serv
 
 ### Tasks
 
-**Task 1: Create the Project Structure.** Create two projects that simulate a Dev/Prod split, link billing, and enable the Storage and IAM APIs so later tasks have a working foundation.
+**Task 1: Create the Project Structure.** Create two projects that simulate a Dev/Prod split, link billing, and enable the Storage and IAM APIs so later tasks have a working foundation. Write down both project IDs and numbers—you will need the project number for Workload Identity Federation principal strings. If your organization restricts project creation, ask an admin for two sandbox projects instead of using `gcloud projects create`.
 
 <details>
 <summary>Solution</summary>
@@ -609,7 +1002,7 @@ echo "Prod Project: $PROD_PROJECT"
 ```
 </details>
 
-**Task 2: Create Dedicated Service Accounts.** In the Dev project, create a data-pipeline service account that can read Cloud Storage objects and write logs—without using the default Compute Engine service account.
+**Task 2: Create Dedicated Service Accounts.** In the Dev project, create a data-pipeline service account that can read Cloud Storage objects and write logs—without using the default Compute Engine service account. Notice you grant `roles/logging.logWriter` at project scope: log sinks and agent behavior may also need `roles/monitoring.metricWriter` in real pipelines, but this lab keeps the binding set minimal so Policy Troubleshooter output stays easy to read.
 
 <details>
 <summary>Solution</summary>
@@ -640,7 +1033,7 @@ gcloud projects get-iam-policy $DEV_PROJECT \
 ```
 </details>
 
-**Task 3: Create a Prod Service Account with Cross-Project Access.** Create a Prod service account that reads artifacts from a Dev bucket, which models a promotion pipeline where production workloads pull build outputs from a lower environment.
+**Task 3: Create a Prod Service Account with Cross-Project Access.** Create a Prod service account that reads artifacts from a Dev bucket, which models a promotion pipeline where production workloads pull build outputs from a lower environment. Cross-project IAM is normal in GCP: the member is still `serviceAccount:...` but the binding attaches to the **Dev** project because that is where the bucket lives. This is the GCP equivalent of an S3 bucket policy trusting an IAM role ARN from another account—except the binding is a project IAM policy entry, not a separate bucket policy document.
 
 <details>
 <summary>Solution</summary>
@@ -672,7 +1065,7 @@ gcloud storage ls gs://${DEV_PROJECT}-artifacts/ \
 ```
 </details>
 
-**Task 4: Configure Workload Identity Federation for GitHub Actions.** Create a workload identity pool and OIDC provider, then bind a repository principal to the Dev service account so a GitHub workflow could deploy without JSON keys.
+**Task 4: Configure Workload Identity Federation for GitHub Actions.** Create a workload identity pool and OIDC provider, then bind a repository principal to the Dev service account so a GitHub workflow could deploy without JSON keys. The `principalSet://.../attribute.repository/...` member must match the repo slug GitHub puts in the OIDC token—typos here cause “permission denied” in CI with no obvious project IAM change. You are not required to run Actions in this lab; creating the pool proves you understand the binding model.
 
 <details>
 <summary>Solution</summary>
@@ -704,7 +1097,7 @@ gcloud iam service-accounts add-iam-binding $DEV_SA \
 ```
 </details>
 
-**Task 5: Diagnose Access with Policy Troubleshooter.** Use the troubleshooter to confirm the Dev service account is denied `storage.objects.delete` because you granted only `objectViewer`, not because of a mysterious org-wide deny.
+**Task 5: Diagnose Access with Policy Troubleshooter.** Use the troubleshooter to confirm the Dev service account is denied `storage.objects.delete` because you granted only `objectViewer`, not because of a mysterious org-wide deny. Save the troubleshooter JSON or screenshot for your runbook: it is the template you will paste into access-request tickets when developers ask “why denied?” in production.
 
 <details>
 <summary>Solution</summary>
@@ -722,7 +1115,7 @@ gcloud policy-troubleshoot iam \
 ```
 </details>
 
-**Task 6: Audit the IAM Configuration.** Dump IAM bindings for both projects and flag any basic roles (`roles/editor`, `roles/owner`) still attached to humans or service accounts.
+**Task 6: Audit the IAM Configuration.** Dump IAM bindings for both projects and flag any basic roles (`roles/editor`, `roles/owner`) still attached to humans or service accounts. If your org has Asset Inventory enabled, run `gcloud asset search-all-iam-policies` with scope set to your Dev project and search for `roles/editor`—you may find inherited bindings from a parent folder that do not appear in the project console summary table.
 
 <details>
 <summary>Solution</summary>
@@ -757,7 +1150,7 @@ done
 ```
 </details>
 
-**Task 7: Implement a Custom Role.** Define a project-level custom role that lists and reads GCS objects but omits delete permissions, then assign it to the Prod artifact reader.
+**Task 7: Implement a Custom Role.** Define a project-level custom role that lists and reads GCS objects but omits delete permissions, then assign it to the Prod artifact reader. Compare your permission list to `roles/storage.objectViewer`—if they are identical, prefer the predefined role in real life and treat this task as practice for the times when you must omit one permission (for example `storage.objects.list` without `storage.buckets.list`).
 
 <details>
 <summary>Solution</summary>
@@ -790,7 +1183,7 @@ gcloud projects add-iam-binding $PROD_PROJECT \
 ```
 </details>
 
-**Task 8: Clean Up.** Delete buckets and projects so the lab does not incur ongoing storage or compute charges (projects enter a 30-day recovery window).
+**Task 8: Clean Up.** Delete buckets and projects so the lab does not incur ongoing storage or compute charges (projects enter a 30-day recovery window). Confirm no user-managed service account keys were created during the lab (`gcloud iam service-accounts keys list` on each SA). Keys left behind outlive the deleted project’s VMs and are a common post-lab finding in security scans.
 
 <details>
 <summary>Solution</summary>
@@ -817,6 +1210,9 @@ echo "Cleanup complete. Projects scheduled for deletion (30-day recovery window)
 - [ ] Custom role created and assigned
 - [ ] No basic roles (Editor/Owner) granted to service accounts
 - [ ] All resources cleaned up
+- [ ] No service account JSON keys created during the lab
+
+After cleanup, skim Cloud Audit Logs for `SetIamPolicy` on the lab projects. You should see your own admin identity creating and removing bindings. That review habit transfers directly to every production IAM policy change and to security incident investigations.
 
 ---
 
@@ -826,6 +1222,18 @@ Next up: **[Module 2.2: VPC Networking](../module-2.2-vpc/)** --- Learn how GCP'
 
 ## Sources
 
-- [IAM Overview](https://cloud.google.com/iam/docs/overview) — Primary reference for how permissions, roles, principals, and policy inheritance work in Google Cloud.
-- [Workload Identity Federation for Deployment Pipelines](https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines) — Directly covers the GitHub Actions and external-CI use cases this module teaches.
-- [Troubleshoot IAM Policies](https://cloud.google.com/iam/docs/troubleshoot-policies) — Best primary reference for how Policy Troubleshooter explains allow, deny, and inherited access decisions.
+- [IAM Overview](https://cloud.google.com/iam/docs/overview) — Permissions, roles, principals, and allow policy inheritance on the resource hierarchy.
+- [Resource hierarchy](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy) — Organization, folder, and project relationships.
+- [IAM Deny policies](https://cloud.google.com/iam/docs/deny-overview) — How deny policies override allow bindings and evaluation order.
+- [Overview of IAM Conditions](https://cloud.google.com/iam/docs/conditions-overview) — CEL expressions on role bindings for attribute-based access.
+- [Manage conditional role bindings](https://cloud.google.com/iam/docs/managing-conditional-role-bindings) — Creating and updating version 3 allow policies with conditions.
+- [Create and manage service accounts](https://cloud.google.com/iam/docs/service-accounts-create) — User-managed vs default service accounts and key guidance.
+- [Workload Identity Federation](https://cloud.google.com/iam/docs/workload-identity-federation) — External OIDC/SAML workloads without service account keys.
+- [Workload Identity Federation for deployment pipelines](https://cloud.google.com/iam/docs/workload-identity-federation-with-deployment-pipelines) — GitHub Actions and CI/CD keyless patterns.
+- [Workload Identity Federation for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) — Linking Kubernetes service accounts to IAM service accounts.
+- [Policy Analyzer overview](https://cloud.google.com/policy-intelligence/docs/policy-analyzer-overview) — Org-wide analysis of allow policies and inheritance.
+- [Analyze IAM policies (gcloud)](https://cloud.google.com/policy-intelligence/docs/analyze-iam-policies) — CLI queries for principals, roles, and resources.
+- [Troubleshoot access with Policy Troubleshooter](https://cloud.google.com/iam/docs/troubleshooting-access) — Single-request allow/deny/condition explanations.
+- [Cloud Audit Logs overview](https://cloud.google.com/logging/docs/audit) — Admin Activity vs Data Access logs and enablement costs.
+- [Google Cloud Observability pricing](https://cloud.google.com/products/observability/pricing) — Log ingestion and retention charges relevant to audit strategy.
+- [Organization policy constraints](https://cloud.google.com/resource-manager/docs/organization-policy/overview) — Resource guardrails complementary to IAM allows.

--- a/src/content/docs/cloud/gcp-essentials/module-2.2-vpc.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.2-vpc.md
@@ -59,6 +59,10 @@ flowchart LR
 
 > **Stop and think**: If a GCP VPC spans the globe by default, what happens if an application team in `europe-west1` requests a new subnet with the CIDR block `10.10.0.0/20` when the `us-central1` team is already using that exact range? How does this differ from managing CIDRs across multiple AWS regions?
 
+The global VPC model has deep implications that go beyond the simple convenience of automatic cross-region routing. When you create a subnet in `us-central1` and another in `europe-west1`, both subnets share the same VPC-level route table. Google's software-defined networking fabric automatically installs routes between every subnet in the VPC without you configuring a single route entry, peering connection, or transit gateway. The subnet CIDR ranges become part of the VPC's routing topology immediately upon creation, and every VM in every region learns these routes through the virtual network interface. This means a VM in Tokyo can send a packet to a VM in Sao Paulo using only its private IP address, and the packet never leaves Google's private backbone until it reaches the destination subnet's virtual switch. The latency between these two VMs is determined purely by the speed of light through Google's fiber, not by any overlay tunneling or gateway processing overhead that you would incur with inter-region VPC peering in AWS.
+
+This same property also makes CIDR planning a single-point-of-failure discipline. Since subnets across all regions share one VPC, you cannot have overlapping IP ranges between any two subnets in the same VPC, regardless of how far apart they are geographically. If your Tokyo team accidentally provisions `10.20.0.0/16` and your London team later tries to create `10.20.1.0/24`, the second operation fails because the VPC enforces non-overlapping CIDR ranges globally. In AWS, each regional VPC is an independent IP namespace, so `us-east-1` and `eu-west-1` can both use `10.0.0.0/16` without conflict until you peer them. The GCP model forces you to think about IP allocation as a global resource from day one, which is initially more work but ultimately prevents the painful renumbering projects that happen when AWS organizations grow organically and later try to interconnect overlapping VPCs.
+
 This has massive implications:
 
 | Feature | AWS VPC | GCP VPC |
@@ -125,6 +129,57 @@ gcloud compute networks subnets describe prod-us-central1 \
   --region=us-central1 \
   --format="get(privateIpGoogleAccess)"
 ```
+
+Private Google Access works by installing a special route that directs traffic destined for Google API IP ranges (`199.36.153.4/30` and `199.36.153.8/30`, known as the `private.googleapis.com` and `restricted.googleapis.com` VIP ranges) to remain on Google's internal network rather than following the default internet route. When enabled on a subnet, any VM in that subnet that sends a packet to a Google API domain (like `storage.googleapis.com`) will have that traffic routed through the internal backbone, bypassing the public internet entirely. This is important to understand because Private Google Access does not require Cloud NAT, does not consume NAT gateway capacity, and does not generate internet egress charges for API traffic. However, it only works for Google APIs and services — it does not provide general internet access for package repositories, third-party APIs, or any non-Google endpoint. For those, you still need Cloud NAT. The two features complement each other: enable Private Google Access for Google services, and layer Cloud NAT on top for everything else.
+
+---
+
+## VPC Routes: The Hidden Routing Topology
+
+Every GCP VPC has a route table that determines how packets flow between subnets, to the internet, and to peered networks. Understanding this table is critical because route priority determines which path traffic takes when multiple routes could match a destination.
+
+### Route Types and Priority
+
+GCP routes have a strict priority ordering that you must internalize because it directly affects troubleshooting. When a VM sends a packet, the virtual network interface evaluates all applicable routes and selects the one with the lowest priority value (where lower numbers win). The route categories, from highest to lowest priority, are:
+
+| Priority Range | Route Type | Who Creates It | Example |
+| :--- | :--- | :--- | :--- |
+| **Always wins** | Subnet routes | GCP (automatic) | Route to every subnet CIDR in the VPC |
+| **Custom static** | User-defined static routes | You | Route `10.200.0.0/16` to a VPN tunnel |
+| **Dynamic (BGP)** | Cloud Router-learned routes | Cloud Router | Routes from on-premises via BGP |
+| **System-generated** | Default internet route, Private Google Access | GCP (automatic) | `0.0.0.0/0` → default internet gateway |
+
+Subnet routes are immutable and always take precedence because they represent the VPC's own address space. You cannot override a subnet route with a custom static route — if you try to create a static route to `10.10.0.0/20` when that CIDR is already assigned to an existing subnet, GCP rejects it. This is a safety mechanism that prevents you from accidentally blackholing traffic to your own subnets. Custom static routes come next and are useful for directing specific CIDR blocks to VPN tunnels, interconnect attachments, or third-party virtual appliances. Dynamic routes learned via BGP from Cloud Router come after static routes, giving you the ability to override BGP-advertised routes with manually defined ones. Finally, the system-generated default route (`0.0.0.0/0` with next-hop `default-internet-gateway`) handles all traffic that does not match any more specific route.
+
+```bash
+# View all routes in a VPC (system, custom, and dynamic)
+gcloud compute routes list \
+  --filter="network=prod-vpc" \
+  --format="table(name, destRange, nextHopType, priority, tags)"
+
+# Create a custom static route to send a CIDR block through a VPN tunnel
+gcloud compute routes create route-to-onprem-db \
+  --network=prod-vpc \
+  --destination-range=192.168.100.0/24 \
+  --next-hop-vpn-tunnel=vpn-tunnel-to-onprem \
+  --priority=500 \
+  --tags=needs-onprem-access
+
+# Create a route that sends internet-bound traffic through a third-party firewall appliance
+gcloud compute routes create route-via-nva \
+  --network=prod-vpc \
+  --destination-range=0.0.0.0/0 \
+  --next-hop-instance=firewall-nva \
+  --next-hop-instance-zone=us-central1-a \
+  --priority=800 \
+  --tags=via-firewall
+```
+
+> **Did You Know?** Subnet routes have an effective priority of 0 — but you never see priority 0 in `gcloud compute routes list`. The subnet routes are managed internally by the VPC control plane and are not user-visible as discrete route entries. They are, however, always evaluated first.
+
+### Tags and Route Applicability
+
+Network tags on custom routes let you selectively apply routes to specific VMs. When you attach a tag like `--tags=needs-onprem-access` to a route, only VMs that carry that network tag will install the route. This gives you VM-level routing policy without needing separate VPCs. A common pattern is to use tagged routes for egress inspection: tag your firewall appliance VMs with `via-firewall`, create a tagged default route that sends all their traffic through the appliance, and leave the rest of the VMs using the system-generated default internet route. This keeps the routing table clean and avoids forcing every VM through an unnecessary inspection hop.
 
 ---
 
@@ -291,6 +346,8 @@ gcloud compute firewall-policies associations create \
   --organization=ORGANIZATION_ID
 ```
 
+Hierarchical policies solve a governance problem that VPC-level rules cannot address on their own: the principle of least privilege at the organizational boundary. Without hierarchical policies, every project owner can open any port to the internet by creating a VPC firewall rule with a high priority. With an organization-level `DENY` rule for port 22 from `0.0.0.0/0`, no project-level rule can override it, regardless of priority. This is structurally identical to how AWS Organizations SCPs work at the IAM layer, but applied to the network layer. Large enterprises typically deploy a baseline hierarchical policy that blocks common attack vectors — SSH, RDP, database ports — from the public internet, then selectively allow them through IAP or VPN ranges at the folder level for projects that have a legitimate need.
+
 ---
 
 ## Cloud NAT: Giving Private VMs Internet Access
@@ -305,7 +362,7 @@ flowchart TD
         VM3[VM-3<br/>10.10.0.4<br/>no ext IP]
         CR[Cloud Router<br/>Manages BGP routing]
         NAT[Cloud NAT Gateway<br/>Translates internal IPs<br/>to external NAT IPs]
-        
+
         VM1 --> CR
         VM2 --> CR
         VM3 --> CR
@@ -372,11 +429,15 @@ gcloud compute routers nats update prod-nat \
   --log-filter=ERRORS_ONLY
 ```
 
+### Why Cloud NAT Scales Differently from AWS NAT Gateway
+
+If you are used to AWS NAT Gateway, the Cloud NAT scaling model requires an adjustment. AWS NAT Gateway is a managed instance in your VPC with a fixed bandwidth ceiling (scaling from roughly 5 Gbps to 100 Gbps depending on the number of gateways you deploy), and if you exceed that ceiling, your connections drop. You solve this by provisioning more NAT gateways across availability zones and distributing workloads. Cloud NAT is different because it is not a virtual instance at all — it is a software-defined service in Google's networking fabric that operates outside your VPC. There is no single point of failure, no bandwidth ceiling to provision, and no instance to patch or maintain. Cloud NAT scales its total throughput automatically as your workload grows, limited only by the number of NAT IP addresses and the port allocation per VM. The practical implication is that you never need to provision "bigger" Cloud NAT gateways or add more of them for bandwidth reasons — you only add more NAT IPs if you need more unique external source IPs for allowlisting or if you hit port exhaustion on a single IP. For most workloads, a single NAT gateway with auto-allocated IPs handles all outbound traffic in a region without any tuning.
+
 ---
 
 ## Cloud Router and Hybrid Connectivity
 
-Cloud Router is the BGP speaker that dynamically exchanges routes between your VPC and external networks (on-premises data centers, other clouds, or other VPCs).
+Cloud Router is the BGP speaker that dynamically exchanges routes between your VPC and external networks (on-premises data centers, other clouds, or other VPCs). It also serves as the control plane for Cloud NAT and Cloud Interconnect, making it one of the busiest components in any VPC that connects to external networks.
 
 ### Cloud Router with VPN
 
@@ -417,6 +478,8 @@ gcloud compute networks update prod-vpc \
   --bgp-routing-mode=global
 ```
 
+When you set `--bgp-routing-mode=global`, Cloud Router advertises every subnet in the VPC to your BGP peers, regardless of which region the router itself lives in. This is the preferred mode for multi-region VPCs because it eliminates the need to deploy a Cloud Router in every region just to advertise local subnets. A single Cloud Router in `us-central1` with global routing mode will advertise `10.10.0.0/20` (us-central1), `10.11.0.0/20` (europe-west1), and `10.12.0.0/20` (asia-east1) to your on-premises router. The BGP peer sees the VPC as a single autonomous system with a unified routing table, which matches the reality of the global VPC's internal routing fabric. Regional mode, by contrast, limits the router to advertising only the subnets within its own region, which is useful when you want to implement region-specific network segmentation or when you are using separate VPN tunnels per region for traffic engineering.
+
 ---
 
 ## Shared VPC: Multi-Project Networking
@@ -434,7 +497,7 @@ flowchart TD
             Sub2[Subnet: app-tier<br/>10.10.1.0/24<br/>Region: us-central1]
             Sub3[Subnet: data-tier<br/>10.10.2.0/24<br/>Region: us-central1]
             Sub4[Subnet: europe-web<br/>10.11.0.0/24<br/>Region: europe-west1]
-            
+
             CentralRules[Firewall Rules, Cloud NAT, Cloud Router<br/>centrally managed]
             Sub1 ~~~ Sub2
             Sub3 ~~~ Sub4
@@ -542,6 +605,262 @@ gcloud compute networks peerings create peer-b-to-a \
 
 ---
 
+## Private Service Connect
+
+Private Service Connect (PSC) is GCP's mechanism for privately consuming services — both Google-managed and third-party — without traffic ever leaving Google's network. Think of it as a private endpoint that creates a unidirectional connection from your VPC to a service producer's network, without the full bidirectional routing exposure of VPC peering.
+
+### Why PSC Exists
+
+Before PSC, consuming a managed service privately required either VPC peering (which exposes both networks to each other and creates a bidirectional trust relationship) or routing traffic through the public internet with access controls. Neither option was ideal for service consumption at scale. VPC peering between a consumer and a producer creates an administrative burden for both sides — the producer must manage peering connections with thousands of consumers, and every consumer's VPC learns routes to the producer's entire address space. PSC solves this by creating a one-way forwarding rule in the consumer's VPC that maps a local IP address to the producer's service endpoint. Traffic flows from consumer to producer only, and the producer never sees the consumer's internal IP space or routing topology.
+
+```bash
+# Create a Private Service Connect endpoint for Cloud SQL
+gcloud compute addresses create psql-psc-ip \
+  --region=us-central1 \
+  --subnet=app-tier
+
+gcloud compute forwarding-rules create psql-endpoint \
+  --region=us-central1 \
+  --network=prod-vpc \
+  --address=psql-psc-ip \
+  --target-service-attachment=projects/sql-producer/regions/us-central1/serviceAttachments/psql-sa
+```
+
+### Published vs Connected Services
+
+PSC operates on a producer-consumer model. The service producer creates a **Service Attachment** in their VPC that defines which consumer projects can connect, which subnets the service listens on, and whether the connection requires explicit approval. The consumer creates a **PSC Endpoint** (a forwarding rule with a local IP address) that points to the producer's service attachment. When the endpoint is created, GCP establishes a NAT-like translation between the consumer's local endpoint IP and the producer's actual service IP, but unlike Cloud NAT, this translation is bidirectional within the established connection — return traffic flows back through the same path. This architecture means that the consumer's VPC never contains routes to the producer's subnet, and the producer's VPC never learns routes to the consumer's subnet. The two networks remain fully isolated while the specific service connection works as if they were adjacent on the same switch.
+
+### When to Use PSC vs VPC Peering
+
+The general rule: use PSC when you are consuming a specific service (Cloud SQL, a partner's SaaS API, or a shared internal microservice), and use VPC peering when you need full network-to-network connectivity between two environments that trust each other. PSC gives the consumer the ability to consume a service without exposing their network topology to the producer, and it gives the producer the ability to offer a service without managing thousands of peering connections. This is the networking equivalent of an API contract — the producer defines what the consumer can access, and the consumer connects to that contract without seeing what else exists in the producer's network.
+
+---
+
+## VPC Flow Logs
+
+VPC Flow Logs capture a sampled record of every IP flow (5-tuple: source IP, destination IP, source port, destination port, protocol) entering or leaving a subnet's virtual network interface. They are the fundamental observability tool for GCP network troubleshooting, security forensics, and usage analysis, and they operate at the subnet level — you enable them per subnet, not per VPC or per VM.
+
+### What Flow Logs Capture and What They Do Not
+
+Each flow log record contains the 5-tuple plus metadata: bytes sent, packets sent, the VM instance name that generated the traffic, the VPC network, the region, and whether the traffic matched a firewall rule. Critically, flow logs are sampled — by default, GCP captures roughly one out of every two packets, but the sampling rate is adaptive and can be tuned. Flow logs do not capture the packet payload; they are metadata records, not Deep Packet Inspection. They also do not capture traffic that is dropped by the implied deny rules (the pre-firewall evaluation). If a packet is rejected by a firewall rule that has logging enabled, that rejection appears in firewall logs, not in flow logs — these are complementary data sources.
+
+```bash
+# Enable VPC Flow Logs on a subnet with default settings
+gcloud compute networks subnets update prod-us-central1 \
+  --region=us-central1 \
+  --enable-flow-logs
+
+# Enable with custom aggregation and sampling
+gcloud compute networks subnets update prod-us-central1 \
+  --region=us-central1 \
+  --enable-flow-logs \
+  --flow-sampling=0.5 \
+  --flow-aggregation=SRC_DEST_PORT_PROTO
+
+# Query flow logs to find top talkers by bytes
+gcloud logging read \
+  'resource.type="gce_subnetwork" AND logName:"compute.googleapis.com/vpc_flows"' \
+  --limit=10 \
+  --format="json" \
+  --freshness=1h
+```
+
+### Flow Log Aggregation Options
+
+| Aggregation Level | What's Grouped | When to Use |
+| :--- | :--- | :--- |
+| `SRC_DEST_PORT_PROTO` | All 5-tuple fields | Detailed debugging, security forensics |
+| `SRC_DEST` | Source + destination IP only | Bandwidth analysis, inter-service traffic mapping |
+| `DEST_PORT_PROTO` | Destination port + protocol | Identifying which services receive the most traffic |
+| `SRC_DEST_VM` | Source + destination VM | Per-VM traffic baselines, anomaly detection |
+
+The aggregation level is a cost-versus-granularity tradeoff. `SRC_DEST_PORT_PROTO` generates the most log entries because every unique flow creates a separate record — useful for pinpointing which specific connection caused a problem, but expensive in log volume at scale. `SRC_DEST` aggregates all ports between two IPs into a single record, which is sufficient for understanding bandwidth patterns between services without the per-port noise. For most operational monitoring use cases, `SRC_DEST` at a 50% sampling rate provides enough fidelity to detect anomalies without overwhelming your logging budget.
+
+---
+
+## Cloud Load Balancing in GCP
+
+GCP's load balancing family is unique among cloud providers because it spans both Layer 4 and Layer 7 and is natively global. Unlike AWS, where an Application Load Balancer is regional and requires Route 53 or Global Accelerator for cross-region failover, GCP's external HTTP(S) load balancer is global by default — a single anycast IP address receives traffic at the nearest Google edge point-of-presence and routes it to the closest healthy backend region.
+
+### Load Balancer Family Overview
+
+| Load Balancer | Layer | Scope | Use Case |
+| :--- | :--- | :--- | :--- |
+| **External HTTP(S)** | L7 | Global | Web applications, multi-region failover, URL-based routing |
+| **Internal HTTP(S)** | L7 | Regional | Microservices within a VPC, traffic splitting |
+| **External TCP/UDP Network** | L4 | Regional | Non-HTTP workloads, preserving client IP |
+| **Internal TCP/UDP Network** | L4 | Regional | Internal service discovery, database load balancing |
+| **External SSL Proxy** | L4 (SSL) | Global | SSL-terminated non-HTTP traffic |
+| **External TCP Proxy** | L4 (TCP) | Global | TCP traffic without SSL termination |
+
+```bash
+# Create a global external HTTP(S) load balancer
+gcloud compute url-maps create web-map \
+  --default-service=web-backend
+
+gcloud compute target-http-proxies create web-proxy \
+  --url-map=web-map
+
+gcloud compute forwarding-rules create web-rule \
+  --global \
+  --target-http-proxy=web-proxy \
+  --ports=80
+```
+
+### Why Global Load Balancing Changes Architecture
+
+The global anycast frontend means you do not need DNS-based failover or regional load balancer pairs. A single forwarding rule IP address serves traffic from every Google edge location, and the load balancer's backend service can include instance groups in multiple regions. If the `us-central1` backend group becomes unhealthy, traffic automatically shifts to `europe-west1` without any DNS TTL propagation delay, any configuration change, or any client-side retry logic. The health checks that drive this failover run from each edge location independently, meaning a regional network partition that isolates `us-central1` from the rest of the world is detected by the edge locations within seconds, and traffic is redirected before most clients experience a timeout. This is architecturally simpler than the equivalent AWS setup (ALB + Route 53 failover + health checks at the DNS layer) because the data plane itself handles failover rather than relying on DNS control-plane convergence.
+
+---
+
+## Cost Lens: What GCP Networking Actually Costs
+
+Networking costs in GCP follow patterns that differ significantly from AWS, and understanding these patterns prevents unpleasant billing surprises.
+
+### Internet Egress Pricing Model
+
+GCP charges for data that leaves Google's network to the public internet. Traffic between GCP regions on the same continent is charged at a lower rate than intercontinental egress, and traffic within the same region is free (assuming both endpoints are in the same VPC). The key cost drivers are:
+
+| Traffic Path | Cost Behavior | Typical Monthly Impact |
+| :--- | :--- | :--- |
+| Same region, same zone | Free | Zero |
+| Same region, different zones | Free (within same VPC) | Zero |
+| Inter-region (same continent) | Charged per GB egress | Moderate — ~$0.01/GB |
+| Inter-region (intercontinental) | Charged per GB at higher rate | Significant — ~$0.08-0.12/GB |
+| Internet egress | Charged per GB at highest rate | Largest cost — ~$0.08-0.23/GB depending on volume tier |
+| Google API traffic via Private Google Access | Free (stays on internal network) | Zero |
+
+The most important takeaway: inter-region traffic between subnets in the same global VPC is not free just because it is automatic. The VPC routes the traffic for you without configuration, but GCP still meters and bills inter-region bytes. Teams that migrate from single-region to multi-region architectures often see a 3-5x increase in their networking line item because what was previously free intra-region traffic becomes billable cross-region traffic. You control this by co-locating services that communicate heavily in the same region and using Private Google Access for API calls to avoid routing them through the internet.
+
+### Cloud NAT Costs
+
+Cloud NAT has two cost components: an hourly charge for the NAT gateway itself and a per-GB charge for data processed through it. The NAT gateway is regional — you pay per gateway per region — and the data charge applies to all traffic that passes through the NAT, including traffic that stays within Google's network (unlike Private Google Access, which is free). The practical implication is that you should not use Cloud NAT as a universal egress path when Private Google Access can handle Google API traffic for free. For a moderate-scale deployment processing 10 TB of outbound data monthly through Cloud NAT across two regions, the combined NAT cost is material but not dominant. The cost spike, however, comes from the data processing charge at scale — if your workload begins streaming large volumes of telemetry or log data to an external service through the NAT gateway, the per-GB charge multiplies. Mitigation strategies include using Private Service Connect for Google and partner services (which avoids NAT data charges), co-locating heavy egress workloads in a single region to reduce the number of NAT gateways, and monitoring NAT data volume through Cloud Monitoring to catch unexpected growth before the billing cycle closes.
+
+### Load Balancer Costs
+
+Load balancer pricing is per forwarding rule plus per GB of data processed. Global external HTTP(S) load balancers charge for the first five forwarding rules per project and for data processed through the load balancer's data plane. The per-GB rate is modest, but the cost multiplies when you have many forwarding rules (one per hostname in a multi-tenant setup) or when you are serving high-throughput content like video or large file downloads. Regional network load balancers have a simpler pricing model with lower per-GB rates but lack the global anycast capability. The cost optimization rule is straightforward: use global HTTP(S) load balancers for internet-facing HTTP workloads because the global footprint eliminates the need for regional load balancer pairs and DNS failover infrastructure; use regional network load balancers for internal TCP/UDP traffic or for workloads where you explicitly need to preserve the client's source IP address at Layer 4.
+
+### Cost Optimization Principles
+
+Monitor your Cloud Billing reports for the "Compute Engine Network" line items, which aggregate inter-region egress, internet egress, and NAT data processing. Set budget alerts on these SKUs specifically — they are the ones most likely to grow silently as teams add cross-region service dependencies. For greenfield designs, co-locate services that communicate synchronously within the same region to eliminate inter-region egress, and use Private Google Access and Private Service Connect to keep Google API and partner service traffic off the metered paths entirely.
+
+---
+
+## Patterns and Anti-Patterns
+
+### Proven Patterns
+
+#### Pattern 1: Shared VPC with IAM-Conditioned Subnet Delegation
+
+**What**: Create a single Shared VPC in a dedicated host project with subnets organized by environment tier (web, app, data, management) rather than by team. Grant service projects `compute.networkUser` with IAM conditions that restrict access to only the subnets that team's workloads require.
+
+**Why it works**: This pattern separates the control plane (networking, managed by a small central team) from the data plane (compute, managed by application teams). The IAM conditions enforce least privilege at the network boundary — a developer in the web team cannot accidentally deploy a VM into the database subnet, and a compromised service account cannot expand its network footprint beyond its authorized subnets.
+
+**Scaling note**: As you grow beyond 50 service projects, the host project's IAM policy grows large because every subnet delegation needs a binding. Mitigate this by using IAM groups as members rather than individual service accounts, and by grouping subnets into related sets that can share a single IAM condition expression. At very large scale (200+ service projects), consider using Terraform or Config Connector to manage the IAM bindings rather than `gcloud` commands, so that drift detection and remediation are automated.
+
+#### Pattern 2: Service Account-First Firewalling with Implicit Deny
+
+**What**: Use service accounts as the sole target for all firewall rules, never network tags. Create a dedicated service account for each logical service role (web, app, database, cache, queue) and write firewall rules that reference these service accounts for both source and target. Add an explicit low-priority `DENY all` rule at priority 65000 to make the security baseline visible and auditable.
+
+**Why it works**: Service accounts are IAM-controlled identities — granting a principal the ability to attach a service account to a VM is a separate permission from granting the ability to use the VM. This eliminates the tag-typo and tag-reuse attack vectors described in the firewall section. The explicit DENY rule makes the security posture visible in `gcloud compute firewall-rules list` rather than relying on the invisible implied-deny at priority 65535, which improves auditability.
+
+**Scaling note**: Managing per-role service accounts across dozens of teams requires a naming convention (`svc-{team}-{role}@{project}.iam.gserviceaccount.com`) and automated provisioning. Use Terraform modules that accept a team name and role list and produce the service accounts, IAM bindings, and firewall rules as a unit.
+
+#### Pattern 3: Regional Cloud NAT with Private Google Access
+
+**What**: Deploy one Cloud NAT gateway per region that has private VMs, combined with Private Google Access enabled on every subnet. Route Google API traffic through Private Google Access (free, internal) and all other internet-bound traffic through Cloud NAT. Use `--nat-custom-subnet-ip-ranges` to explicitly list the subnets that need NAT rather than using `--nat-all-subnet-ip-ranges`, so that new subnets do not automatically inherit NAT access.
+
+**Why it works**: Private Google Access offloads Google API traffic from the NAT gateway data processing meter, reducing cost and latency. Explicit subnet range selection creates a conscious opt-in model — when a team creates a new subnet, they must explicitly add it to the NAT configuration, which forces a conversation about whether the subnet's VMs genuinely need internet access.
+
+**Scaling note**: In a multi-region deployment with 5+ regions, the Cloud NAT hourly charges accumulate. If a region only has non-production VMs that need occasional package updates, you can consolidate those workloads into a single region's NAT gateway by routing their traffic through the VPC's internal backbone to the NAT region, though this adds latency and is only appropriate for non-latency-sensitive traffic.
+
+### Anti-Patterns
+
+| Anti-Pattern | What Goes Wrong | Why Teams Fall Into It | Better Alternative |
+| :--- | :--- | :--- | :--- |
+| **Using the default VPC** | Auto-mode subnets in every region consume massive IP space and conflict with on-premises networks. Firewall rules `default-allow-ssh` and `default-allow-icmp` are open to `0.0.0.0/0` by default. | "It works out of the box" — teams that are new to GCP and want to prototype quickly. | Delete the default VPC on project creation. Use a Terraform module that creates a custom-mode VPC with planned CIDR ranges and no default-allow rules. |
+| **Network tags as the sole firewall mechanism** | A single typo in a tag name creates a silent security hole. Any principal with `setTags` can change a VM's network identity without an audit trail. | Tags are visible in the console and easy to understand. The migration to service accounts requires understanding IAM and the SA lifecycle. | Use service accounts for all new deployments. Create a migration script that inventories existing tag-based firewall rules and generates equivalent SA-based rules. Run it in audit mode first to identify gaps before switching. |
+| **Cloud NAT as a universal egress solution** | All outbound traffic — including Google API calls — goes through the NAT gateway, incurring unnecessary data processing charges. | NAT "just works" for all outbound traffic, and Private Google Access requires an additional configuration step per subnet. | Enable Private Google Access on every subnet first, then layer Cloud NAT on top. Use `--nat-custom-subnet-ip-ranges` to restrict NAT to subnets that need non-Google internet access. |
+| **Per-team VPCs with VPC peering** | Each team builds their own VPC and peers them in a full-mesh. At 5 teams, this requires 10 peering connections; at 20 teams, 190 connections. Peering is non-transitive, so east-west traffic between teams that are not directly peered fails silently. | Teams want autonomy over their network configuration, and VPC peering feels like the natural way to connect independent networks. | Shared VPC with host-managed subnets gives the network team central control while application teams still manage their compute. For cross-organization connectivity where Shared VPC is not possible, use Network Connectivity Center as a hub-and-spoke model instead of full-mesh peering. |
+| **Hard-coded IP addresses in application config** | Services reference each other by internal IP addresses that change when VMs restart or migrate. | IPs feel "static" during development when VMs stay up for days or weeks. The convenience of a hard-coded IP bypasses the need to set up DNS or service discovery. | Use Cloud DNS private zones for service discovery within the VPC. Create A records that point to load balancer IPs or directly to VM IPs (with caution). For GKE workloads, use Kubernetes ClusterIP Services. |
+| **Leaving firewall logging disabled** | When a connection fails, there is no record of whether the packet was dropped by a firewall rule or never reached the VPC. Troubleshooting becomes guesswork. | Logging adds cost and teams do not realize it is off by default until they need it. | Enable firewall logging with at least `--log-metadata=INCLUDE_ALL_METADATA` on critical rules (SSH, database, inter-service). Configure log exclusions to filter high-volume flows and keep logging costs predictable. |
+
+---
+
+## Decision Framework
+
+When designing GCP networking for a new workload or migrating an existing one, the following decision tree and matrix help you select the right combination of connectivity, serving, and access patterns.
+
+```mermaid
+flowchart TD
+    START[New Workload: Need Private VMs?] --> Q_PRIV{Do VMs need<br/>public IPs?}
+    Q_PRIV -->|Yes, inbound from internet| Q_LB{What type<br/>of traffic?}
+    Q_PRIV -->|No, private only| Q_EGRESS{Need internet<br/>egress?}
+
+    Q_LB -->|HTTP/HTTPS| EXT_HTTP[Global external HTTP(S) LB]
+    Q_LB -->|TCP/UDP (non-HTTP)| EXT_TCP[Regional external TCP/UDP Network LB]
+    Q_LB -->|TCP with SSL offload| EXT_SSL[Global external SSL Proxy LB]
+
+    Q_EGRESS -->|Yes, all traffic| NAT[Cloud NAT + Cloud Router]
+    Q_EGRESS -->|Only Google APIs| PGA[Private Google Access only]
+    Q_EGRESS -->|Google + partner services| PSC[Private Service Connect]
+
+    EXT_HTTP --> Q_MULTI{Multi-region?}
+    EXT_TCP --> Q_MULTI
+    EXT_SSL --> Q_MULTI
+
+    Q_MULTI -->|Yes, global LB| GLOBAL_OK[Single global anycast IP<br/>Backends in multiple regions]
+    Q_MULTI -->|No, single region| REG_OK[Regional backend service<br/>Single region]
+
+    NAT --> Q_NAT_MULTI{Multiple regions<br/>with private VMs?}
+    Q_NAT_MULTI -->|Yes| NAT_PER_REGION[One Cloud NAT per region<br/>Consolidate if non-critical]
+    Q_NAT_MULTI -->|No| NAT_SINGLE[Single Cloud NAT gateway]
+
+    PGA --> PGA_OK[Enable on every subnet<br/>No additional cost]
+    PSC --> PSC_OK[Create PSC endpoint per service<br/>Unidirectional, no route exposure]
+```
+
+### Decision Matrix: Shared VPC vs VPC Peering
+
+| Criterion | Shared VPC | VPC Peering |
+| :--- | :--- | :--- |
+| **Administrative boundary** | Single organization | Cross-organization or same org |
+| **Firewall management** | Centralized (host project controls rules) | Decentralized (each VPC has own rules) |
+| **Subnet visibility** | All subnets visible to all service projects | Each VPC sees only its own subnets |
+| **Route propagation** | Automatic (all subnets in one VPC) | Manual (must create peering in both directions) |
+| **IAM integration** | `compute.networkUser` with conditions per subnet | Separate IAM policies per project |
+| **IP overlap tolerance** | None (single VPC = single namespace) | None (peered VPCs must not overlap) |
+| **Transitive routing** | N/A (same network) | Not supported (non-transitive) |
+| **Service project count** | Up to 1,000 per host project | Practical limit ~25 before mesh complexity |
+| **Best for** | Teams in same org needing central network control | Partner orgs, M&A scenarios, temporary connections |
+
+### Decision Matrix: Global vs Regional Load Balancer
+
+| Criterion | Global External HTTP(S) LB | Regional External Network LB |
+| :--- | :--- | :--- |
+| **Frontend IP** | Single anycast IP, serves all regions | Regional IP, serves one region |
+| **Failover** | Automatic cross-region based on health checks | Requires DNS failover or multi-region deployment |
+| **Layer** | 7 (HTTP/HTTPS) | 4 (TCP/UDP) |
+| **SSL termination** | Built-in | Requires SSL Proxy LB or application-level TLS |
+| **Client IP preservation** | Via `X-Forwarded-For` header | Preserved in packet (Layer 4) |
+| **URL/path-based routing** | Yes | No |
+| **Best for** | Web applications, REST APIs, multi-region HTTP | Non-HTTP protocols, gaming, VoIP, preserving source IP |
+
+### When Cloud NAT (and when not)
+
+| Scenario | Recommendation | Reasoning |
+| :--- | :--- | :--- |
+| Private VMs need OS package updates | Cloud NAT | Apt/yum repositories are not Google services |
+| Private VMs access Cloud Storage | Private Google Access | Free, internal, lower latency |
+| Private VMs call a third-party SaaS API | Cloud NAT | External service, not reachable via PGA |
+| Private VMs need to run `kubectl` against GKE API | Private Google Access | GKE API is a Google service |
+| Private VMs pull Docker images from Docker Hub | Cloud NAT | External registry |
+| Private VMs pull from Artifact Registry | Private Google Access | Google service |
+| Private VMs access a partner's PSC-published service | Private Service Connect | PSC endpoints avoid NAT entirely |
+| Batch processing VMs upload results to BigQuery | Private Google Access | Google service, high throughput → avoid NAT data charges |
+
+---
+
 ## Did You Know?
 
 1. **GCP firewall rules have a hidden "implied deny all ingress" rule at priority 65535** and an "implied allow all egress" rule at priority 65535. You cannot see these rules in the console or CLI, but they are always present. This means a brand-new VPC with no custom firewall rules will block all inbound traffic and allow all outbound traffic.
@@ -630,9 +949,9 @@ Build a Shared VPC architecture with a host project and two service projects, us
 
 ### Tasks
 
-**Task 1: Create the Project Structure and VPC**
+Task 1: Create the Project Structure and VPC.
 
-Create a host project with a custom VPC and two subnets.
+In this first task, you establish the foundational networking layer by creating a dedicated host project and building a custom-mode VPC with regionally scoped subnets. The key design decision here is to use custom mode rather than auto mode, which gives you explicit control over your CIDR ranges and prevents GCP from automatically provisioning subnets in regions you do not intend to use. The two subnets you create — web-tier and app-tier — will later be shared across service projects, so choosing non-overlapping, well-documented CIDR ranges now prevents renumbering pain when you add more subnets later.
 
 <details>
 <summary>Solution</summary>
@@ -689,7 +1008,9 @@ gcloud compute networks subnets list \
 ```
 </details>
 
-**Task 2: Enable Shared VPC and Attach Service Projects**
+Task 2: Enable Shared VPC and Attach Service Projects.
+
+Now you activate the Shared VPC capability on the host project and formally associate your two service projects with it. Enabling Shared VPC is a privileged operation that requires Organization-level permissions because it fundamentally changes how the project's network resources are shared across the organization. Once the service projects are attached, their service accounts and VMs gain the ability to reference the host project's subnets, but they still cannot use those subnets until you explicitly grant the `compute.networkUser` IAM role — which you will handle in the next task. This two-step model (associate, then grant) is what enforces least privilege in Shared VPC: being attached is necessary but not sufficient to consume a subnet.
 
 <details>
 <summary>Solution</summary>
@@ -710,7 +1031,9 @@ gcloud compute shared-vpc list-associated-resources $HOST_PROJECT
 ```
 </details>
 
-**Task 3: Create Service Accounts for Firewall Targeting**
+Task 3: Create Service Accounts for Firewall Targeting.
+
+This task implements the service-account-based firewall model that the module advocates over network tags. You create a dedicated service account in each service project — `web-sa` for the web tier in project A, and `app-sa` for the application tier in project B. Then you grant these service accounts the `compute.networkUser` role on the host project, which is the permission that allows VMs running under these identities to attach to the shared subnets. Notice that the service accounts live in the service projects, but the IAM role granting subnet access lives on the host project — this cross-project IAM binding is one of the most common points of confusion when debugging Shared VPC connectivity failures, and getting it right here ensures your firewall rules will work correctly in the next task.
 
 <details>
 <summary>Solution</summary>
@@ -745,7 +1068,9 @@ gcloud projects get-iam-policy $HOST_PROJECT \
 ```
 </details>
 
-**Task 4: Create Service Account-Based Firewall Rules**
+Task 4: Create Service Account-Based Firewall Rules.
+
+Now you define the security perimeter for your shared network using service-account-targeted firewall rules in the host project. The three rules you create implement a defense-in-depth model: public internet traffic reaches only the web tier on ports 80 and 443, web-tier VMs can reach app-tier VMs on port 8080, and SSH access is restricted exclusively to Identity-Aware Proxy tunnel ranges rather than being open to the public internet. The explicit `DENY all` rule at priority 65000 makes your security baseline visible — without it, the implied deny at 65535 is invisible in the console and cannot be audited. Pay attention to how the firewall rules reference service accounts from different projects using the fully qualified email format, which is what makes cross-project service-account firewalling possible under Shared VPC.
 
 <details>
 <summary>Solution</summary>
@@ -801,7 +1126,9 @@ gcloud compute firewall-rules list \
 ```
 </details>
 
-**Task 5: Deploy VMs in Service Projects Using the Shared VPC**
+Task 5: Deploy VMs in Service Projects Using the Shared VPC.
+
+This is where you see the Shared VPC model in action from the application team's perspective. You create a web server VM in service project A and an app server VM in service project B, both referencing the host project's subnets using the fully qualified subnet path format. Neither VM receives a public IP address — the `--no-address` flag enforces the private-only design, and all access goes through the Cloud NAT or Private Google Access paths you studied earlier. The startup scripts install a simple web server and a Python HTTP server so you can immediately validate the firewall rules by verifying that the web server can reach the app server on port 8080 while the reverse direction is blocked.
 
 <details>
 <summary>Solution</summary>
@@ -843,7 +1170,9 @@ gcloud compute ssh web-server-1 \
 ```
 </details>
 
-**Task 6: Clean Up**
+Task 6: Clean Up.
+
+Always tear down lab resources immediately after completing the exercise to avoid unexpected charges. The cleanup sequence matters: you must delete the VMs first because they hold references to the shared subnets, then detach the service projects from the Shared VPC configuration, disable Shared VPC on the host project, and finally delete the projects themselves. If you delete the host project before detaching the service projects, the Shared VPC association becomes orphaned and requires manual intervention through the Cloud Console or a support ticket to resolve. The cleanup script follows this safe ordering so you can run it without worrying about dependency conflicts.
 
 <details>
 <summary>Solution</summary>
@@ -896,3 +1225,13 @@ Next up: **[Module 2.3: Compute Engine](../module-2.3-compute/)** --- Learn mach
 - [VPC firewall rules](https://docs.cloud.google.com/firewall/docs/firewalls) — Covers firewall rule scope, implied rules, priorities, tags, and service-account filtering.
 - [Cloud NAT overview](https://docs.cloud.google.com/nat/docs/overview) — Explains Cloud NAT architecture, outbound-only behavior, availability model, and scaling properties.
 - [Shared VPC](https://docs.cloud.google.com/vpc/docs/shared-vpc) — Best primary doc for host-project and service-project roles, subnet delegation, and centralized networking.
+- [VPC network overview](https://cloud.google.com/vpc/docs/vpc) — Canonical VPC overview including subnet creation, secondary ranges, and VPC network maximums.
+- [VPC routes](https://cloud.google.com/vpc/docs/routes) — System-generated, custom static, and dynamic routes, route priority ordering, and next-hop configuration.
+- [Private Service Connect](https://cloud.google.com/vpc/docs/private-service-connect) — PSC architecture, service attachments, endpoint configuration, and producer-consumer model.
+- [VPC Flow Logs](https://cloud.google.com/vpc/docs/flow-logs) — Flow log record format, sampling, aggregation intervals, and log query examples.
+- [Choose a load balancer](https://cloud.google.com/load-balancing/docs/choosing-load-balancer) — Decision tree for selecting between global and regional, Layer 4 and Layer 7 load balancers.
+- [Cloud Load Balancing overview](https://cloud.google.com/load-balancing/docs/load-balancing-overview) — Global anycast architecture, backend services, health checking, and traffic distribution.
+- [Hierarchical firewall policies](https://cloud.google.com/vpc/docs/firewall-policies) — Organization-level and folder-level firewall policy creation, rule evaluation order, and association.
+- [VPC Network Peering](https://cloud.google.com/vpc/docs/vpc-peering) — Peering requirements, non-transitive behavior, subnet route exchange, and cross-project peering.
+- [Cloud Router overview](https://cloud.google.com/network-connectivity/docs/router/concepts/overview) — BGP routing modes, dynamic route advertisement, and Cloud NAT control-plane role.
+- [VPC network pricing](https://cloud.google.com/vpc/network-pricing) — Internet egress tiers, inter-region rates, and NAT data processing charges.

--- a/src/content/docs/cloud/gcp-essentials/module-2.2-vpc.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.2-vpc.md
@@ -19,7 +19,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-In March 2021, a logistics company running on GCP experienced a cascading outage that took down their entire order-tracking system for 14 hours. The root cause was a firewall rule misconfiguration during a routine deployment. An engineer had added a new firewall rule using network tags to allow traffic from their monitoring system to a set of backend VMs. The tag name had a typo---`monitoring-target` instead of `monitor-target`---and because GCP firewall rules are deny-by-default, the monitoring traffic was silently dropped. No alerts fired because the monitoring system itself was what stopped working. Meanwhile, a second engineer had created an overly broad "debug" firewall rule allowing all ingress from `0.0.0.0/0` on port 8080 to any VM with the tag `debug`, not realizing that 34 production VMs still carried that tag from a previous troubleshooting session. Within hours, automated scanners found the exposed endpoints and began probing for vulnerabilities. The incident cost the company over $800,000 in lost revenue and required a full security audit.
+**Hypothetical scenario:** During a routine deployment, an engineer adds a firewall rule using network tags to allow traffic from a monitoring system to backend VMs. The tag name has a typo, and because GCP firewall rules are deny-by-default, monitoring traffic is silently dropped. No alerts fire because the monitoring system itself is what stopped working. Meanwhile, a lingering broad "debug" firewall rule allows all ingress from `0.0.0.0/0` on port 8080 to any VM still carrying a stale `debug` tag from an earlier troubleshooting session—exposing endpoints that production traffic was never meant to reach.
 
 This story illustrates two truths about GCP networking. First, **GCP's VPC model is global by default**, which is both its greatest strength and its most dangerous trap. A single misconfigured firewall rule can affect VMs across every region. Second, **network tags are fragile**---they are arbitrary strings with no validation, and a typo creates a silent failure. Understanding VPC architecture, firewall rule design, and the difference between tag-based and service-account-based firewalling is not optional knowledge---it is the foundation that every other GCP service builds on.
 
@@ -89,7 +89,7 @@ gcloud compute networks subnets create prod-us-central1 \
   --network=prod-vpc \
   --region=us-central1 \
   --range=10.10.0.0/20 \
-  --secondary-ranges=pods=10.20.0.0/16,services=10.30.0.0/20 \
+  --secondary-range=pods=10.20.0.0/16,services=10.30.0.0/20 \
   --enable-private-ip-google-access
 
 gcloud compute networks subnets create prod-europe-west1 \
@@ -107,7 +107,7 @@ gcloud compute networks subnets create prod-europe-west1 \
 | **Production use** | Not recommended | Always use this |
 | **Default VPC** | Auto mode (created automatically) | Must be explicitly created |
 
-**War Story**: The auto-mode VPC creates a subnet with a `/20` range in every GCP region (currently over 40 regions). That consumes a massive amount of IP space from the `10.128.0.0/9` range, and these subnets often conflict with on-premises networks. Every GCP Well-Architected Review starts with "delete the default VPC and create a custom one."
+**War Story**: The auto-mode VPC creates a subnet with a `/20` range in every GCP region (currently over 40 regions). That consumes a massive amount of IP space from the `10.128.0.0/9` range, and these subnets often conflict with on-premises networks. Many Well-Architected reviews recommend replacing the default auto-mode VPC with a custom one when you outgrow tutorials.
 
 ```bash
 # Delete the default auto-mode VPC (do this in every new project)
@@ -130,7 +130,11 @@ gcloud compute networks subnets describe prod-us-central1 \
   --format="get(privateIpGoogleAccess)"
 ```
 
-Private Google Access works by installing a special route that directs traffic destined for Google API IP ranges (`199.36.153.4/30` and `199.36.153.8/30`, known as the `private.googleapis.com` and `restricted.googleapis.com` VIP ranges) to remain on Google's internal network rather than following the default internet route. When enabled on a subnet, any VM in that subnet that sends a packet to a Google API domain (like `storage.googleapis.com`) will have that traffic routed through the internal backbone, bypassing the public internet entirely. This is important to understand because Private Google Access does not require Cloud NAT, does not consume NAT gateway capacity, and does not generate internet egress charges for API traffic. However, it only works for Google APIs and services — it does not provide general internet access for package repositories, third-party APIs, or any non-Google endpoint. For those, you still need Cloud NAT. The two features complement each other: enable Private Google Access for Google services, and layer Cloud NAT on top for everything else.
+Basic **Private Google Access** (`--enable-private-ip-google-access`) lets VMs without external IPs reach default `*.googleapis.com` endpoints over Google's internal backbone—it does not require Cloud NAT and does not bill general internet egress for that API traffic. It does **not** automatically install a route to the restricted-access VIP ranges below; those require explicit DNS configuration (for example Private DNS zones pointing at `private.googleapis.com` or `restricted.googleapis.com`).
+
+The **`private.googleapis.com`** VIP range is `199.36.153.8/30` (broader Google API access over private paths). The **`restricted.googleapis.com`** VIP range is `199.36.153.4/30` (VPC Service Controls–compatible restricted endpoints). Use restricted VIPs when your organization enforces VPC-SC perimeters; use private VIPs when you need broader API coverage without traversing the public internet.
+
+When enabled on a subnet, a VM resolving `storage.googleapis.com` (or another supported API hostname) sends traffic through the internal backbone rather than the default internet route. Private Google Access only covers Google APIs and services—it does not provide general internet access for package repositories, third-party APIs, or any non-Google endpoint. For those, you still need Cloud NAT. The two features complement each other: enable Private Google Access for Google services, and layer Cloud NAT on top for everything else.
 
 ---
 
@@ -140,16 +144,16 @@ Every GCP VPC has a route table that determines how packets flow between subnets
 
 ### Route Types and Priority
 
-GCP routes have a strict priority ordering that you must internalize because it directly affects troubleshooting. When a VM sends a packet, the virtual network interface evaluates all applicable routes and selects the one with the lowest priority value (where lower numbers win). The route categories, from highest to lowest priority, are:
+GCP evaluates routes in two steps: **longest-prefix match** (most-specific destination CIDR wins), then **priority value** (lower numbers win when multiple routes match the same prefix). Subnet routes for a subnet's own CIDR cannot be overridden by a custom static route—you cannot blackhole traffic to your own address space. When destination and priority tie, **static routes beat dynamic (BGP) routes**; otherwise the lower priority number wins regardless of route type.
 
-| Priority Range | Route Type | Who Creates It | Example |
+| Route Type | Who Creates It | Typical Priority | Example |
 | :--- | :--- | :--- | :--- |
-| **Always wins** | Subnet routes | GCP (automatic) | Route to every subnet CIDR in the VPC |
-| **Custom static** | User-defined static routes | You | Route `10.200.0.0/16` to a VPN tunnel |
-| **Dynamic (BGP)** | Cloud Router-learned routes | Cloud Router | Routes from on-premises via BGP |
-| **System-generated** | Default internet route, Private Google Access | GCP (automatic) | `0.0.0.0/0` → default internet gateway |
+| **Subnet routes** | GCP (automatic) | 0 (implicit) | Route to every subnet CIDR in the VPC |
+| **Custom static routes** | You | 1–65535 (you choose) | Route `10.200.0.0/16` to a VPN tunnel at priority 500 |
+| **Dynamic (BGP) routes** | Cloud Router | From BGP (often 100+) | Routes from on-premises via BGP |
+| **System-generated default** | GCP (automatic) | 1000 | `0.0.0.0/0` → default internet gateway |
 
-Subnet routes are immutable and always take precedence because they represent the VPC's own address space. You cannot override a subnet route with a custom static route — if you try to create a static route to `10.10.0.0/20` when that CIDR is already assigned to an existing subnet, GCP rejects it. This is a safety mechanism that prevents you from accidentally blackholing traffic to your own subnets. Custom static routes come next and are useful for directing specific CIDR blocks to VPN tunnels, interconnect attachments, or third-party virtual appliances. Dynamic routes learned via BGP from Cloud Router come after static routes, giving you the ability to override BGP-advertised routes with manually defined ones. Finally, the system-generated default route (`0.0.0.0/0` with next-hop `default-internet-gateway`) handles all traffic that does not match any more specific route.
+Subnet routes appear in `gcloud compute routes list` with `nextHopNetwork` set to the VPC—they are not hidden from the CLI. Custom static routes let you direct specific CIDR blocks to VPN tunnels, interconnect attachments, or third-party virtual appliances. Dynamic routes learned via BGP integrate with Cloud Router; override them with static routes only when you need a deliberate, equal-or-better match. The system default internet route uses destination `0.0.0.0/0` at **priority 1000**—a normal numeric value, not "lowest priority" in the sense of losing to every custom route.
 
 ```bash
 # View all routes in a VPC (system, custom, and dynamic)
@@ -175,7 +179,7 @@ gcloud compute routes create route-via-nva \
   --tags=via-firewall
 ```
 
-> **Did You Know?** Subnet routes have an effective priority of 0 — but you never see priority 0 in `gcloud compute routes list`. The subnet routes are managed internally by the VPC control plane and are not user-visible as discrete route entries. They are, however, always evaluated first.
+> **Did You Know?** Subnet routes use implicit priority 0 for their own CIDRs. You **do** see them in `gcloud compute routes list` with `nextHopNetwork` pointing at the VPC network—they are managed by the control plane but are visible for troubleshooting.
 
 ### Tags and Route Applicability
 
@@ -650,12 +654,13 @@ gcloud compute networks subnets update prod-us-central1 \
   --region=us-central1 \
   --enable-flow-logs
 
-# Enable with custom aggregation and sampling
+# Enable with custom sampling, aggregation interval, and metadata
 gcloud compute networks subnets update prod-us-central1 \
   --region=us-central1 \
   --enable-flow-logs \
-  --flow-sampling=0.5 \
-  --flow-aggregation=SRC_DEST_PORT_PROTO
+  --logging-flow-sampling=0.5 \
+  --logging-aggregation-interval=INTERVAL_5_SEC \
+  --logging-metadata=include-all
 
 # Query flow logs to find top talkers by bytes
 gcloud logging read \
@@ -665,16 +670,17 @@ gcloud logging read \
   --freshness=1h
 ```
 
-### Flow Log Aggregation Options
+### Flow Log Tuning Options
 
-| Aggregation Level | What's Grouped | When to Use |
+GCP flow logs always record the full 5-tuple (source/destination IP and port, protocol). The platform aggregates packets from the same connection over a **time interval**—you do not choose alternate 5-tuple aggregation modes. Tune cost versus freshness with sampling and interval instead.
+
+| Setting | Values | Tradeoff |
 | :--- | :--- | :--- |
-| `SRC_DEST_PORT_PROTO` | All 5-tuple fields | Detailed debugging, security forensics |
-| `SRC_DEST` | Source + destination IP only | Bandwidth analysis, inter-service traffic mapping |
-| `DEST_PORT_PROTO` | Destination port + protocol | Identifying which services receive the most traffic |
-| `SRC_DEST_VM` | Source + destination VM | Per-VM traffic baselines, anomaly detection |
+| **`--logging-aggregation-interval`** | `INTERVAL_5_SEC`, `INTERVAL_30_SEC`, `INTERVAL_1_MIN`, `INTERVAL_5_MIN`, `INTERVAL_10_MIN`, `INTERVAL_15_MIN` | Shorter intervals produce more log entries and fresher visibility; longer intervals reduce volume |
+| **`--logging-flow-sampling`** | `0.0`–`1.0` (for example `0.5` = 50%) | Lower sampling cuts cost but may miss short-lived flows |
+| **`--logging-metadata`** | `include-all`, `exclude-all`, `custom` | Controls whether VM names, geo, and other metadata fields are exported |
 
-The aggregation level is a cost-versus-granularity tradeoff. `SRC_DEST_PORT_PROTO` generates the most log entries because every unique flow creates a separate record — useful for pinpointing which specific connection caused a problem, but expensive in log volume at scale. `SRC_DEST` aggregates all ports between two IPs into a single record, which is sufficient for understanding bandwidth patterns between services without the per-port noise. For most operational monitoring use cases, `SRC_DEST` at a 50% sampling rate provides enough fidelity to detect anomalies without overwhelming your logging budget.
+For operational monitoring, `INTERVAL_5_MIN` or `INTERVAL_1_MIN` at 50% sampling often balances anomaly detection with logging budget. Use `INTERVAL_5_SEC` only when debugging a live incident where per-connection timing matters.
 
 ---
 
@@ -683,6 +689,8 @@ The aggregation level is a cost-versus-granularity tradeoff. `SRC_DEST_PORT_PROT
 GCP's load balancing family is unique among cloud providers because it spans both Layer 4 and Layer 7 and is natively global. Unlike AWS, where an Application Load Balancer is regional and requires Route 53 or Global Accelerator for cross-region failover, GCP's external HTTP(S) load balancer is global by default — a single anycast IP address receives traffic at the nearest Google edge point-of-presence and routes it to the closest healthy backend region.
 
 ### Load Balancer Family Overview
+
+> **Naming note:** Google Cloud documentation now groups products as **Application Load Balancer** (HTTP/HTTPS), **Network Load Balancer** (TCP/UDP), **Proxy Network Load Balancer**, and **Classic** variants. The table below uses the long-standing CLI resource names you will still see in `gcloud` commands.
 
 | Load Balancer | Layer | Scope | Use Case |
 | :--- | :--- | :--- | :--- |
@@ -1221,11 +1229,10 @@ Next up: **[Module 2.3: Compute Engine](../module-2.3-compute/)** --- Learn mach
 
 ## Sources
 
-- [VPC networks](https://docs.cloud.google.com/vpc/docs/vpc) — Primary reference for global VPC behavior, subnet scope, and auto versus custom mode.
+- [VPC networks](https://docs.cloud.google.com/vpc/docs/vpc) — Primary reference for global VPC behavior, subnet scope, secondary ranges, and auto versus custom mode.
 - [VPC firewall rules](https://docs.cloud.google.com/firewall/docs/firewalls) — Covers firewall rule scope, implied rules, priorities, tags, and service-account filtering.
 - [Cloud NAT overview](https://docs.cloud.google.com/nat/docs/overview) — Explains Cloud NAT architecture, outbound-only behavior, availability model, and scaling properties.
 - [Shared VPC](https://docs.cloud.google.com/vpc/docs/shared-vpc) — Best primary doc for host-project and service-project roles, subnet delegation, and centralized networking.
-- [VPC network overview](https://cloud.google.com/vpc/docs/vpc) — Canonical VPC overview including subnet creation, secondary ranges, and VPC network maximums.
 - [VPC routes](https://cloud.google.com/vpc/docs/routes) — System-generated, custom static, and dynamic routes, route priority ordering, and next-hop configuration.
 - [Private Service Connect](https://cloud.google.com/vpc/docs/private-service-connect) — PSC architecture, service attachments, endpoint configuration, and producer-consumer model.
 - [VPC Flow Logs](https://cloud.google.com/vpc/docs/flow-logs) — Flow log record format, sampling, aggregation intervals, and log query examples.

--- a/src/content/docs/cloud/gcp-essentials/module-2.3-compute.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.3-compute.md
@@ -8,7 +8,7 @@ sidebar:
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to deploy Compute Engine resources with confidence, balance pricing and reliability choices, and apply repeatable OS Login and lifecycle controls at team scale.
+After completing this module, you will be able to deploy Compute Engine resources with confidence, balance pricing and reliability choices, and apply repeatable OS Login and lifecycle controls at team scale. You will also be able to explain why GCP's automatic sustained-use discounts change FinOps sequencing compared with clouds where reservations are the first lever, and how that interacts with Spot and committed-use paths on the same fleet.
 
 - **Deploy Compute Engine instances with custom machine types, preemptible VMs, and managed instance groups**
 - **Configure instance templates and autoscaling policies for self-healing compute clusters on GCP**
@@ -21,15 +21,23 @@ After completing this module, you will be able to deploy Compute Engine resource
 
 Teams that run fixed pools of Compute Engine VMs without autoscaling can be overwhelmed by sudden traffic spikes, turning slow boot times and manual scaling into lost revenue because demand often rises faster than response times. In production, this delay is usually what hurts you: queues grow, error budgets shrink, and users perceive the service as unstable.
 
+**Hypothetical scenario:** A product team launches a regional web API on three hand-built `e2-standard-4` VMs in a single zone. Traffic doubles over a weekend, but nobody changes capacity until Monday. Latency climbs, the database connection pool saturates, and on-call spends hours manually cloning VMs and editing firewall rules. A regional Managed Instance Group behind an external Application Load Balancer would have absorbed the spike by adding replicas in zones that still had capacity, while sustained-use discounts would have quietly reduced the bill for VMs that ran all month—without anyone purchasing a commitment.
+
 This module captures why Compute Engine is more than "just VMs." Choosing the right machine family, configuring instance templates, using Managed Instance Groups with autoscaling, and setting up global load balancing are the difference between an architecture that handles traffic spikes gracefully and one that collapses under load. Compute Engine is a foundational GCP compute service, and understanding it helps you reason about how many Google Cloud workloads are executed.
 
-In this module, you will learn how to select the right machine family for your workload, leverage preemptible and Spot VMs for massive cost savings, build golden images with custom images, configure Managed Instance Groups for automatic scaling and self-healing, and tie everything together with Cloud Load Balancing.
+On GCP, compute cost is a **stack of automatic and deliberate choices**, not a single on-demand rate. Sustained-use discounts apply automatically after roughly 25% of a billing month for eligible series; committed-use discounts trade flexibility for predictable savings on steady cores; Spot VMs trade interruption tolerance for discounts of up to 91% off on-demand pricing for many machine types. That combination is materially different from clouds where you must buy Savings Plans or Reserved Instances to see comparable baseline discounts—here, long-running VMs often get cheaper by simply staying up, which changes how you right-size before you commit.
+
+In this module, you will learn how to select the right machine family for your workload, leverage Spot VMs and committed-use discounts, build golden images with custom images and startup scripts, configure Managed Instance Groups for automatic scaling and self-healing, compare zonal versus regional MIG tradeoffs, and tie everything together with Cloud Load Balancing—while keeping a clear cost lens on what spikes your bill and which knobs pull it back down.
 
 ---
 
 ## Machine Families: Choosing the Right Hardware
 
 Compute Engine offers several machine families; this module focuses on four common categories for learning purposes. Selecting the wrong family is one of the most common ways to overspend. For real-world planning, hardware choice is about expected throughput, memory pressure, and predictability, so the default response is to align workload shape with the family before you benchmark pricing.
+
+Think of machine families as **hardware menus**, not a single slider labeled "size." Each menu optimizes a different bottleneck: general-purpose balances vCPU and RAM for web and microservices; compute-optimized maximizes per-core performance; memory-optimized maximizes RAM per socket for in-memory engines; accelerator-optimized attaches GPUs for parallel work. The billing system then layers discounts on top—E2 is inexpensive but ineligible for sustained-use discounts on the same terms as N2, while N2 running all month may accrue automatic SUD credits you never asked for. That is why a literal size-for-size comparison with another cloud's "m5" equivalent can mislead you: GCP rewards **duration and series choice**, not just vCPU count.
+
+When you evaluate a family, collect three numbers from a representative week: p95 CPU utilization, p95 memory utilization, and p95 disk IOPS. If CPU is low but memory is pegged, a custom high-memory N2 shape beats jumping to M-series. If CPU is pegged but memory is idle, C3 or a smaller predefined type may win. If both are low, the rightsizing recommender is telling you the truth—downsize before you finance a CUD.
 
 ### The Four Families
 
@@ -44,6 +52,8 @@ flowchart TD
 ```
 
 ### [General Purpose: The Workhorse](https://cloud.google.com/compute/docs/general-purpose-machines)
+
+General-purpose series are where most teams should start and often stay. **E2** is the cost leader for dev/test and bursty internal tools: shared-core shapes (`e2-micro` through `e2-medium`) trade CPU burst fairness for hourly savings, while standard E2 sizes scale to 32 vCPUs with a 1:4 vCPU:memory ratio. **N2** and **N2D** are production workhorses on Intel and AMD respectively; they support custom machine types and sustained-use discounts on vCPU and memory, but not every discount stacks with CUD-covered usage. **T2D** targets scale-out fleets that benefit from AMD price-performance. **N1** remains for legacy lift-and-shift only—new designs should default to N2/N2D/E2 unless a dependency forces N1.
 
 | Series | CPU | vCPU:Memory Ratio | Best For | Notes |
 | :--- | :--- | :--- | :--- | :--- |
@@ -95,9 +105,12 @@ gcloud compute instances create high-mem-vm \
 ```
 
 Rules for custom machine types exist for a reason: you must stay within series-specific constraints, or provisioning can fail unexpectedly; for this reason, validate vCPU counts and memory boundaries before running any `--custom-cpu` or `--custom-memory` command.
+
 - Allowed vCPU counts depend on the machine series; check the current custom-machine-type limits for the series you selected.
 - Allowed memory ranges depend on the machine series, and extended-memory limits are defined per series rather than by one universal GB-per-vCPU rule.
 - Extended memory costs more per GB than standard memory.
+
+The `--custom-extensions` flag unlocks extended memory ratios on supported series (commonly N2) when your workload needs more RAM per vCPU than the default shape allows—think large Java heaps or caching layers. That flexibility is not free: extended memory GB pricing is higher, so you should still attempt a predefined highmem shape first. Custom types also affect MIG instance flexibility: wildly exotic shapes may reduce the pool of zones where Google can place replacements during scale-out events.
 
 ### Shared-Core Machines
 
@@ -108,6 +121,40 @@ For lightweight workloads that do not need a full vCPU, E2 offers shared-core op
 | `e2-micro` | 0.25 shared | 1 GB | Micro-services, tiny APIs | Lower-cost than `e2-medium` |
 | `e2-small` | 0.5 shared | 2 GB | Low-traffic web, dev | Lower-cost than `e2-medium` |
 | `e2-medium` | 1 shared | 4 GB | Moderate web, Jenkins agents | Baseline |
+
+### Compute-Optimized, Memory-Optimized, and Accelerator Families
+
+Beyond general-purpose shapes, production platforms routinely land on specialized families when a single dimension—CPU throughput, RAM, or accelerators—dominates the bottleneck. The compute-optimized **C2**, **C2D**, and newer **C3** / **C3D** series target HPC, gaming backends, and numeric batch jobs where you want high vCPU performance per dollar rather than the widest memory envelope. Memory-optimized **M1**, **M2**, and **M3** machines exist for in-memory databases and SAP-scale footprints; Google documents M3 configurations up to very large vCPU and memory counts for workloads that cannot shard cheaply. Accelerator-optimized **A2**, **A3**, and **G2** families attach NVIDIA GPUs for ML training and inference; Spot pricing extends to GPUs, but preemption and maintenance behavior differ from standard VMs, so treat GPU pools as interruption-aware capacity.
+
+| Series | Processor / accelerator | Typical workload | Cost note |
+| :--- | :--- | :--- | :--- |
+| **C3 / C3D** | Intel / AMD latest gen | Latency-sensitive APIs, simulation | Compare against N2/N2D in-region; CUDs may apply where SUDs do not |
+| **M2 / M3** | High memory per vCPU | SAP HANA, large caches | Hourly rates are high—justify with residency needs, not default choice |
+| **A2 / A3 / G2** | NVIDIA GPUs | Training, inference, video | Spot can discount GPU hours; live migration not available on Spot |
+| **T2D / T2A** | AMD / Arm | Scale-out Linux fleets | Good when software stack is Arm-ready; benchmark before mass migration |
+
+### Custom Machine Types and Sole-Tenant Nodes
+
+Custom machine types let you pick vCPU and memory independently within a series, which is how you stop paying for RAM you never touch or vCPUs that sit idle while memory is pegged. Extended-memory custom shapes cost more per GB above the standard ratio for that series, so the billing signal should push you back toward predefined types when you are only slightly off-size. **Sole-tenant nodes** dedicate physical hosts to your project—useful for license compliance, noisy-neighbor isolation, or colocation-style placement. You pay for the entire node capacity, so sole-tenant is a deliberate premium unless regulation or performance isolation demands it; it is not a default cost-optimization path.
+
+```bash
+# List sole-tenant node types available in a zone
+gcloud compute sole-tenancy node-types list --zone=us-central1-a
+
+# Create a node group (reserves physical capacity)
+gcloud compute sole-tenancy node-groups create analytics-hosts \
+  --node-type=n2-node-96-240 \
+  --node-count=1 \
+  --zone=us-central1-a
+
+# Create a VM on that node group
+gcloud compute instances create isolated-db \
+  --node-group=analytics-hosts \
+  --zone=us-central1-a \
+  --machine-type=n2-custom-16-65536 \
+  --image-family=debian-12 \
+  --image-project=debian-cloud
+```
 
 ---
 
@@ -125,6 +172,8 @@ GCP offers three pricing tiers for the same hardware, and each tier optimizes a 
 | **Preemptible (legacy)** | 60-91% | 24 hours max | Preempted at 24h, or earlier | Use Spot instead (superset) |
 
 [**Spot VMs** replaced Preemptible VMs as the recommended ephemeral option. They offer the same discount but without the 24-hour maximum lifetime. Both can be preempted at any time with a 30-second warning.](https://cloud.google.com/compute/docs/instances/preemptible)
+
+When architects compare GCP Spot to AWS Spot, the important difference is operational shape, not the headline percent-off. GCP Spot has no legacy 24-hour cap; AWS Spot instances can run until interrupted but with different capacity pools and savings-plan interactions. On GCP, combine Spot MIGs with load balancer-backed services only if your app tier tolerates member loss; frontends should drain connections using connection draining and health checks, while workers should checkpoint. Premium operating systems on Spot still bill licensing rules when stopped—Spot saves compute, not necessarily Windows/SQL license minimums documented in the Spot guide.
 
 ```bash
 # Create a Spot VM
@@ -151,6 +200,10 @@ gcloud compute instances create legacy-worker \
 
 ### Handling Preemption Gracefully
 
+Spot preemption is a contract, not a surprise outage. Google signals preemption through instance metadata (`preempted=TRUE`) and then begins a shutdown window—historically up to 30 seconds for the ACPI soft-off path, with optional longer notice durations on newer Spot configurations documented in the Spot VM guide. Your job is to **drain work**: flush queues, checkpoint to Cloud Storage, remove the VM from load balancer backends, and exit cleanly. MIGs will recreate Spot VMs when capacity returns, but they will not replay unfinished business logic unless you designed idempotent workers.
+
+Batch systems should shard work into tasks smaller than median time-between-preemptions in your zone, and should use Spot MIGs with `instance-termination-action=DELETE` only when local disk state is disposable. Use `STOP` when you want a chance to restart the same disk identity after preemption if capacity returns—helpful for long downloads or resumable transforms.
+
 ```bash
 # Inside the VM: check if a preemption notice has been issued
 # (the metadata server returns a termination timestamp 30s before preemption)
@@ -174,6 +227,10 @@ gcloud compute instances create batch-worker \
 
 For steady-state production workloads, CUDs offer significant savings without any preemption risk. This model is strongest when you can tolerate a long commitment and can confidently forecast utilization across the relevant machines. If workloads drop unexpectedly, it is still useful to re-evaluate commitments during billing cycles because commitment math changes with team growth.
 
+Resource-based commitments attach to vCPU and memory in a region—you are promising capacity, not a specific VM name. Spend-based commitments discount broader eligible spend on the billing account, which helps heterogeneous fleets but requires finance alignment on what counts toward the commitment. Neither type replaces architecture discipline: if you commit to 200 N2 vCPUs while the fleet migrates to C3, you may pay for unused commitment until the term ends or you sell reshaping options your contract allows.
+
+Operationally, pair CUD purchases with **autoscaling bounds**: commitments cover the baseline; autoscaler handles peaks above baseline on on-demand or Spot. Document that split so engineers do not cap `max-num-replicas` at committed cores during incidents. FinOps hub and billing export show realized savings from CUDs, rightsizing, and idle resource removal—use those reports to justify the next commitment tranche instead of guessing from a spreadsheet.
+
 | Commitment | Duration | Discount |
 | :--- | :--- | :--- |
 | **Resource-based** | 1 year | Varies by eligible resource and current pricing model |
@@ -195,6 +252,35 @@ gcloud compute commitments list --region=us-central1
 
 Sustained Use Discounts (SUDs) apply automatically to eligible machine families---no commitment required. After 25% of monthly use, Google Cloud applies incremental discounts, and the maximum discount depends on the machine series and resource type. This means you can stack behavior-based savings with workload rightsizing, and you should compare SUD and CUD impacts before changing a migration plan.
 
+### GCP Compute Cost Model (and How It Differs from "Buy a Reservation First")
+
+Understanding GCP pricing starts with what happens **without** anyone filing a purchase order. For eligible N1/N2/N2D/C2/M-series vCPU and memory—and some sole-tenant premium components—[sustained-use discounts](https://cloud.google.com/compute/docs/sustained-use-discounts) accrue automatically once a resource runs more than 25% of a billing month. Discounts step at 25%, 50%, 75%, and 100% utilization thresholds, reaching up to **30% net discount** on many N-family shapes and up to **20%** on several C2 resources. SUDs do **not** apply to E2, nor to usage already covered by committed-use discounts, which is why FinOps reviews often show E2 for bursty tiers and N2/N2D for always-on cores.
+
+Committed-use discounts (CUDs) are the deliberate mirror image: you commit to vCPU, memory, or spend for one or three years and receive lower rates in exchange for forecast risk. Resource-based CUDs attach to machine families; spend-based CUDs attach to billing-account spend. A common mistake is buying a three-year CUD for a fleet you plan to migrate to a different series next quarter—commitment savings evaporate if the workload moves off eligible SKUs. Spot VMs sit at the opposite end of the flexibility spectrum: [up to 91% off on-demand](https://cloud.google.com/compute/docs/instances/spot) for many machine types, no minimum or maximum runtime (unlike legacy preemptible's 24-hour cap), but preemption can happen anytime with as little as a 30-second shutdown window by default.
+
+| Pricing lever | Who turns it on | Interruption risk | Best when |
+| :--- | :--- | :--- | :--- |
+| On-demand | Default | None | Unknown shape, short-lived sandboxes |
+| SUD (automatic) | Google Cloud after ~25% monthly use | None | Steady VMs on eligible families without CUD |
+| CUD (1y / 3y) | You purchase commitment | None if you stay on committed SKUs | Baseline production cores with stable forecasts |
+| Spot | `--provisioning-model=SPOT` | Preemption anytime | Batch, CI, stateless workers with checkpoints |
+
+**Cost lens — what spikes unexpectedly:** Autoscaled MIGs growing `max-num-replicas` during an attack or viral event; premium OS licenses still billing when Spot VMs stop; Hyperdisk provisioned IOPS/throughput above baseline; GPUs left attached to stopped VMs; and **orphaned persistent disks** after instance deletes (disk charges continue). **Knobs that pull spend down:** rightsizing via the [VM machine type recommender](https://cloud.google.com/compute/docs/instances/apply-machine-type-recommendations-for-instances), stopping [idle VMs](https://cloud.google.com/compute/docs/instances/idle-vm-recommendations-overview) flagged by Recommender, deleting disks surfaced by the idle disk recommender, moving fault-tolerant tiers to Spot, and layering CUDs only after SUD-eligible baselines are visible in billing export.
+
+```bash
+# Inspect rightsizing recommendations (8-day utilization window by default)
+gcloud recommender recommendations list \
+  --project="${PROJECT_ID}" \
+  --location=us-central1 \
+  --recommender=google.compute.instance.MachineTypeRecommender
+
+# Inspect idle VM recommendations
+gcloud recommender recommendations list \
+  --project="${PROJECT_ID}" \
+  --location=us-central1 \
+  --recommender=google.compute.instance.IdleResourceRecommender
+```
+
 > **Pause and predict**: You are designing a video rendering pipeline. If a rendering job is interrupted, it must start over from the beginning. Some jobs take up to 36 hours. Should you use Spot VMs to save costs here?
 
 ---
@@ -204,6 +290,10 @@ Sustained Use Discounts (SUDs) apply automatically to eligible machine families-
 ### Why Custom Images Matter
 
 Every time you create a VM from a public image (like `debian-12`), you start with a bare OS. Installing your application, dependencies, and configuration on every new VM wastes time and creates inconsistency. Custom images solve this by baking your software into a reusable image.
+
+The operational win is **time-to-ready**: autoscaling adds capacity during incidents, and boot latency becomes part of your incident budget. Golden images also shrink drift—two VMs created from the same family name should have identical packages, reducing "works on VM-3 only" mysteries. The tradeoff is process: you need a pipeline to rebuild images when CVEs land, deprecate old versions safely, and prove smoke tests before a family pointer moves. Teams that skip this pipeline often panic-patch individual VMs, which MIG self-healing will undo on the next health failure anyway.
+
+Public image families (`debian-12`, `ubuntu-2204-lts`) remain the right boot source for generic Linux; custom families are for **your** software stack. Document which family each environment uses (dev/stage/prod) so Terraform modules do not accidentally point staging at a bleeding-edge builder image.
 
 ```bash
 # Step 1: Create a VM and configure it
@@ -263,6 +353,27 @@ gcloud compute images deprecate my-app-v1-1 \
 
 > **Pause and predict**: You need to apply a critical security patch to an OS used by 50 VMs. If you're using image families, what steps must you take to ensure all VMs run the patched OS?
 
+### Startup Scripts, Metadata, and Golden-Image Hygiene
+
+Instance metadata is how Compute Engine injects configuration at boot without rebaking an image for every change. A **startup script** runs on first boot (and on reboot when configured) and is ideal for registering with a config service, formatting data disks, or pulling secrets from Secret Manager. Keep scripts idempotent where possible: MIG recreates and rolling updates will execute them again on fresh VMs. For secrets, prefer workload identity and Secret Manager over long-lived keys in metadata, because metadata is visible to anyone with `compute.instances.get` on the instance.
+
+```bash
+# Startup script via metadata on create
+gcloud compute instances create app-node \
+  --zone=us-central1-a \
+  --metadata=startup-script='#!/bin/bash
+    set -euo pipefail
+    apt-get update && apt-get install -y nginx
+    systemctl enable --now nginx' \
+  --image-family=debian-12 \
+  --image-project=debian-cloud
+
+# View startup-script output when debugging
+gcloud compute instances get-serial-port-output app-node --zone=us-central1-a
+```
+
+Golden images capture everything that is **slow or risky** to install live (compilers, agents, baseline sysctl). Startup scripts capture everything that should stay **dynamic** (version pins, feature flags). Mixing the two without discipline produces "snowflake" VMs that pass health checks once and fail after the next template rollout.
+
 ---
 
 ## Instance Templates and Managed Instance Groups
@@ -270,6 +381,10 @@ gcloud compute images deprecate my-app-v1-1 \
 ### Instance Templates
 
 An instance template is a blueprint that defines the machine type, image, disks, network, and other settings for a VM. [Templates are **immutable**---to change a setting, you create a new template.](https://cloud.google.com/compute/docs/instance-templates) That immutability is important because every scale or replacement event can use the same known-good definition, which is much easier to audit than manually configured one-off VM launches.
+
+Templates should encode the **non-negotiables**: service account, network tags, shielded options, disk types, and metadata keys your org policy requires. Keep application version drift in image families or startup scripts, not in one-off `gcloud` flags. Version templates in names (`web-template-v3`) so rollbacks are unambiguous in change tickets. When you adopt Spot in a MIG, the template sets `provisioning-model=SPOT` and termination action—every recreated VM inherits the same interruption contract, which is safer than mixing Spot and standard instances in one group.
+
+Disks declared in templates deserve the same scrutiny as machine types: a template that always attaches 500 GB `pd-ssd` will multiply waste across autoscale events. Prefer smaller boot disks plus separately managed data disks when state must persist, and mark ephemeral disks `auto-delete=yes` unless you have a recovery workflow.
 
 ```bash
 # Create an instance template
@@ -309,6 +424,10 @@ gcloud compute instance-templates create web-template-v2 \
 ### Managed Instance Groups (MIGs)
 
 A MIG is a group of identical VMs created from an instance template. [MIGs provide autoscaling, self-healing, rolling updates, and load balancer integration.](https://cloud.google.com/compute/docs/instance-groups) In practice, the combination of identity by template and lifecycle by controller gives you consistency under scale, because all replacement VMs inherit the same contract.
+
+**Stateful versus stateless** is the line that decides whether a MIG is appropriate. Stateless app tiers—web APIs, workers with external queues—fit MIGs well because replacement means "boot template and join pool." Stateful tiers—single-primary databases, license-bound appliances—need attached disks, failover orchestration, or managed services instead of naive recreate semantics. For stateful data on VMs, use retained disks, startup scripts that mount by device name, and health checks that validate database readiness, not just port open.
+
+**Instance flexibility** (optional advanced feature) lets a regional MIG choose among several machine types in a family to reduce preemption or capacity errors—especially valuable for Spot fleets where Google can shift shapes toward available inventory. You still standardize on a template per software generation; flexibility is about hardware fallback, not about mixing Debian and Ubuntu in one group.
 
 ```bash
 # Create a regional MIG (recommended: spans all zones in a region)
@@ -391,6 +510,43 @@ gcloud compute instance-groups managed rolling-action start-update web-mig \
 | `--minimal-action=REPLACE` | Replace entire VM | When image/template changes |
 | `--minimal-action=RESTART` | Just restart existing VM | When only metadata changes |
 
+### Regional vs Zonal MIGs
+
+A **zonal MIG** keeps all VMs in one zone. It is simpler and sometimes required for legacy designs, but it is a single blast-radius if that zone degrades. A **regional MIG** spreads VMs across zones in a region, which is the default recommendation for production web tiers because autoscaler can add capacity wherever spare host inventory exists. Regional MIGs pair naturally with global external Application Load Balancers: each regional backend registers its own instance group, and the front end steers users to healthy endpoints.
+
+Tradeoffs matter at update time: regional rolling updates coordinate replacements across zones, which can take longer but preserve zone diversity. Zonal MIGs update faster in one place yet concentrate risk. For stateful workloads that cannot tolerate multiple live copies, neither MIG shape fixes data gravity—you still need external durable storage and a real failover story.
+
+```bash
+# Zonal MIG (single zone — use only with eyes open)
+gcloud compute instance-groups managed create batch-zonal \
+  --template=web-template-v1 \
+  --size=3 \
+  --zone=us-central1-a
+
+# Regional MIG (multi-zone — preferred for HA web)
+gcloud compute instance-groups managed create web-mig-regional \
+  --template=web-template-v1 \
+  --size=3 \
+  --region=us-central1 \
+  --distribution-policy-zones=us-central1-a,us-central1-b,us-central1-f
+```
+
+### Autoscaling Signals Beyond CPU
+
+CPU target utilization is the default autoscaling signal because it is universally available, but production systems often scale on **HTTP load**, **custom metrics** exported to Cloud Monitoring, or **schedules** for predictable cron-shaped traffic. Load-based scaling ties replica count to request pressure seen by the load balancer, which tracks user-visible work better than OS CPU alone for I/O-heavy APIs. Scheduled scaling adds replicas before a known event (payroll run, product launch) and sheds them afterward—cheaper than leaving peak capacity running 24/7.
+
+```bash
+# Schedule-based scaling: scale out before business hours
+gcloud compute instance-groups managed update-autoscaling web-mig \
+  --region=us-central1 \
+  --set-schedule=scale-up-morning \
+  --schedule-cron='30 6 * * Mon-Fri' \
+  --schedule-duration-sec=3600 \
+  --schedule-time-zone='America/Chicago' \
+  --schedule-min-required-replicas=10 \
+  --schedule-description='Weekday morning scale-out'
+```
+
 ### Self-Healing
 
 When a health check fails, the MIG automatically recreates the unhealthy VM. This is the simplest form of self-healing in GCP. It protects request handling by replacing only the failed instance and then letting the control plane drive it back to healthy state through the same template.
@@ -416,6 +572,12 @@ flowchart LR
 
 > **Stop and think**: If you manually SSH into a VM managed by a MIG and update a configuration file, what will happen if the VM fails a health check later that day?
 
+### Observability: What to Watch in Production
+
+Managed platforms only reduce toil if signals are visible. For MIGs, monitor `instance_group_manager/instance_count`, autoscaler recommended size versus current size, and rolling update progress fields in `describe` output during deploys. For load balancers, alert on backend unhealthy fraction and elevated latency on the backend service—those often precede user-facing outages. For Spot fleets, track preemption rate indirectly via task retry counts and MIG recreate churn.
+
+Logging agents on VMs should ship nginx/app logs to Cloud Logging with `resource.type=gce_instance` labels so you can correlate a bad canary revision with request failures. Uptime checks against the global LB IP validate the path users actually traverse, not just per-VM `/health` on internal IPs. Cost anomalies belong on the same dashboard: sudden vCPU hour spikes often correlate with autoscaler max raised for a launch, while disk spend spikes may be orphaned volumes—not mysterious "Google tax."
+
 ---
 
 ## Cloud Load Balancing
@@ -423,6 +585,12 @@ flowchart LR
 GCP offers multiple load balancer types, but the most common is the **External Application Load Balancer** (formerly known as the External HTTP(S) Load Balancer). We use this layer for production-like web endpoints because it pairs naturally with MIG-managed targets and provides consistent global request distribution for HTTPS traffic.
 
 The key point is not only scale, but operational velocity: with a shared frontend plus managed backends, most rollout events become routine capacity transitions instead of one-off networking edits.
+
+External Application Load Balancers terminate HTTP(S) close to users via Google's anycast edge, then forward to regional backends you register—usually regional MIGs. That separation matters for cost and reliability: you pay for load balancing and egress on their own curves, while compute autoscaling can react per region. **Connection draining** lets you remove a backend VM without dropping in-flight sessions during rolling updates, which is why MIG updates and LB configuration should be designed together. **Session affinity** can stick users to a VM when your app still has local state, but affinity fights horizontal scale; prefer externalized sessions unless you are mid-migration.
+
+Internal Application Load Balancers cover east-west microservice traffic inside a VPC without exposing services publicly. Network load balancers handle TCP/UDP when you are not in HTTP land—gaming UDP, legacy TLS on TCP, or protocols that do not fit URL maps. Choosing the wrong layer creates expensive glue: do not force non-HTTP protocols through HTTP proxies; do not expose internal-only admin APIs on a global external frontend when an internal LB plus IAP would shrink attack surface.
+
+From a cost angle, load balancers add fixed hourly components plus processing charges depending on rules and traffic. The savings story is indirect: better utilization of fewer, right-sized VMs behind the LB, fewer emergency scale-ups from uneven backends, and fewer incidents that cause human overtime. Pair LB metrics (backend latency, unhealthy host count) with MIG autoscaler signals so you scale on user-visible pain, not CPU alone.
 
 ### Load Balancer Types
 
@@ -522,6 +690,10 @@ gcloud compute instance-groups managed set-named-ports web-mig-eu \
 
 Storage policy should match workload behavior, because disks are not interchangeable once you are in steady production. Logs and backups tolerate latency more than metadata-heavy databases, and that distinction affects whether `pd-balanced` is enough or `pd-ssd` is required. Treat disk selection as part of the same design conversation as machine type, or you may optimize compute and lose at the storage layer.
 
+Persistent disks are **network-attached block devices**: they survive VM stop/start, can be snapshotted for backup, and can be resized in many cases without rebuilding the instance. Local SSDs are **physically colocated** with the host: they deliver lower latency for scratch, shuffle, or cache layers, but data is ephemeral relative to host maintenance and Spot preemption rules. A classic cost mistake is putting terabytes of cold logs on `pd-ssd` because "databases use SSD"—those logs belong on `pd-standard` or Nearline/Archive in Cloud Storage once they age out.
+
+Snapshots and snapshot schedules (shown earlier) are cheap insurance compared to rebuilding data. Remember snapshot storage bills separately; lifecycle policies that delete stale snapshots are part of FinOps hygiene. When you delete a VM but keep disks, you will still see disk line items—Recommender's idle persistent disk insights exist to catch exactly that pattern.
+
 | Disk Type | IOPS (Read) | Throughput | Use Case | Cost |
 | :--- | :--- | :--- | :--- | :--- |
 | **pd-standard** | 0.75 per GiB | 0.12 MiB/s per GiB | Bulk storage, logs | Lowest |
@@ -552,11 +724,38 @@ gcloud compute resource-policies create snapshot-schedule daily-snapshot \
   --daily-schedule
 ```
 
+### Hyperdisk and the Next Generation of Block Storage
+
+[Hyperdisk](https://cloud.google.com/compute/docs/disks/hyperdisks) is Google's recommended durable block storage for new Compute Engine workloads that need higher performance than classic Persistent Disk. Types include **Hyperdisk Balanced** (default for most apps), **Hyperdisk Extreme** (highest IOPS for databases), **Hyperdisk Throughput** (bandwidth-heavy analytics), and **Hyperdisk Balanced High Availability** (synchronous replication across two zones in a region). You provision IOPS and throughput explicitly on many Hyperdisk SKUs, which is powerful but also a **cost spike vector**: provisioned performance bills even when the VM is idle, and Hyperdisk is **not eligible for SUDs or resource-based CUDs** per Google's disk pricing docs.
+
+| Storage choice | Durability | Performance control | Cost caution |
+| :--- | :--- | :--- | :--- |
+| pd-balanced / pd-ssd | Zonal PD | Size-based IOPS curves | Cheaper idle; may bottleneck DBs |
+| Hyperdisk Balanced | Zonal/regional options | Provisioned IOPS + throughput | Pay for provisioned caps monthly |
+| local-ssd | Ephemeral on host | Lowest latency | Data lost on host maintenance; no Spot live migration |
+| Hyperdisk Balanced HA | Cross-zone sync replica | HA within region | ~2× storage cost vs single-zone Balanced |
+
+```bash
+# Create a Hyperdisk Balanced data volume (performance defaults scale with size)
+gcloud compute disks create orders-db-data \
+  --zone=us-central1-a \
+  --size=500GB \
+  --type=hyperdisk-balanced
+
+gcloud compute instances attach-disk app-db \
+  --zone=us-central1-a \
+  --disk=orders-db-data
+```
+
+Pair disk choice with machine series support: not every machine type accepts every Hyperdisk variant, and very large databases may need **Hyperdisk Extreme** or **pd-extreme** instead of balanced tiers. Right-sizing disks is as important as right-sizing vCPU—Recommender's idle disk insights exist precisely because orphaned volumes are a silent budget leak.
+
 ---
 
 ## Securing Access: OS Login and SSH Keys
 
 Historically, accessing a Linux VM involved generating an SSH key pair and pasting the public key into the project or instance metadata. This approach does not scale well: when an employee leaves, you must hunt down and remove their keys across all instances. It is exactly this manual cleanup burden that leads to stale keys and access drift as teams and environments grow.
+
+Project-wide SSH keys in metadata also complicate compliance: auditors cannot easily map a key fingerprint to a human identity, and break-glass keys tend to linger for years. OS Login stores keys in an identity-linked profile, rotates them automatically for `gcloud compute ssh` sessions, and respects IAM deny policies. For break-glass, use time-bound IAM grants plus logged IAP sessions instead of shared private keys in a ticket attachment.
 
 [OS Login solves this by linking SSH access to IAM (Identity and Access Management). Instead of managing individual SSH keys, you assign IAM roles (`roles/compute.osLogin` or `roles/compute.osAdminLogin`) to users or groups.](https://cloud.google.com/compute/docs/oslogin/set-up-oslogin)
 
@@ -572,6 +771,114 @@ gcloud projects add-iam-policy-binding my-project \
 ```
 
 When a user connects using `gcloud compute ssh`, GCP automatically generates a short-lived SSH key, pushes it to their OS Login profile, and allows them to log in. When IAM access is removed, future OS Login SSH connections are denied across VMs that use OS Login. For VMs that do not have external IPs, you combine OS Login with [Identity-Aware Proxy (IAP) TCP forwarding](https://cloud.google.com/iap/docs/using-tcp-forwarding) to securely tunnel SSH traffic without exposing ports to the internet.
+
+### Shielded VM, Confidential VM, and Defense in Depth
+
+**Shielded VMs** harden the boot chain with Secure Boot, virtual TPM (vTPM), and integrity monitoring so tampered bootloaders or kernels are detectable before they become persistent compromise. New Debian and many marketplace images ship Shielded-compatible; organizations can enforce Shielded creation via the `compute.requireShieldedVm` org policy. Shielded VM addresses **boot integrity**, not encryption of data while it is being processed in RAM.
+
+**Confidential VMs** add hardware memory encryption so data in use is protected from the hypervisor and other tenants on the host. They target regulated workloads and multi-tenant concerns about insider access to memory. Confidential VMs cannot run on sole-tenant node groups, so you choose isolation model upfront: physical sole-tenancy versus cryptographic confidentiality—not both on the same instance shape.
+
+```bash
+# Create a Shielded VM (secure boot + vTPM enabled on supported images)
+gcloud compute instances create hardened-api \
+  --zone=us-central1-a \
+  --image-family=debian-12 \
+  --image-project=debian-cloud \
+  --shielded-secure-boot \
+  --shielded-vtpm \
+  --shielded-integrity-monitoring
+
+# Create a Confidential VM (requires supported machine type + image)
+gcloud compute instances create conf-worker \
+  --zone=us-central1-a \
+  --machine-type=n2d-standard-4 \
+  --confidential-compute \
+  --maintenance-policy=TERMINATE \
+  --image-family=debian-12 \
+  --image-project=debian-cloud
+```
+
+For compliance-heavy platforms, the practical pattern is Shielded + OS Login + no external IP + IAP for admin access, adding Confidential VM only where contracts require encryption-in-use. Each layer adds operational constraints (maintenance policies, supported machine types, disk types), so document which tier each workload class must use before engineers freestyle instance flags.
+
+---
+
+## Patterns & Anti-Patterns
+
+Production Compute Engine designs succeed when templates, MIGs, and load balancers encode assumptions explicitly: stateless VMs, immutable templates, externalized durable state, and interruption-aware batch tiers. Weak designs treat VMs like pets, disable health checks to silence alerts, or buy three-year CUDs before rightsizing—then wonder why spend still climbs.
+
+| Pattern | When to use it | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| Template + regional MIG + global LB | Public HTTP APIs needing zone redundancy | Autoscaler adds zones with capacity; LB drains unhealthy backends | Set `min-num-replicas` ≥ 2 per active region |
+| Image family + rolling update | Frequent app releases | Canary flags limit blast radius; rollback is template pointer change | Keep old template until error budget recovers |
+| Spot worker pool + checkpointing | Batch/CI with restartable work | Up to 91% discount without 24h preemptible cap | Use MIG to recreate Spot VMs; handle metadata preemption signal |
+| OS Login + IAP, no external IP | Admin access to private tiers | Access tracks IAM lifecycle, not scattered SSH keys | Firewall allow IAP range only |
+| Custom machine type after metrics | Steady CPU/memory mismatch on N2 | Pay for shape you use; avoids oversized predefined types | Revisit when workload changes—rightsizing recommender helps |
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+| :--- | :--- | :--- | :--- |
+| Single-zone MIG for revenue APIs | Zone outage = full region down | Zonal MIG tutorials are shorter | Regional MIG + multi-zone distribution policy |
+| CUD before rightsizing | Pay for committed wrong size | Finance wants savings now | Run recommender; commit after 30–60 days stable |
+| Ignoring SUD on eligible cores | Over-buying CUD coverage | AWS habits don't transfer | Let SUD apply; CUD only on baseline above SUD |
+| Manual SSH keys in project metadata | Offboarding misses keys | Quick demo access | OS Login + IAM groups |
+| pd-standard boot disk on OLTP DB | Latency spikes under load | Cost table sorted by price | pd-ssd or Hyperdisk Balanced with measured IOPS |
+| Spot for jobs without checkpoint | Repeated full restarts | Spot price looks irresistible | Checkpoint to GCS or use standard VMs |
+
+---
+
+## Decision Framework
+
+Use the flows below when choosing machine family, pricing model, and MIG scope. They are not substitutes for benchmarking—they prevent obviously expensive mismatches early.
+
+```mermaid
+flowchart TD
+    Start["New Compute Engine workload"] --> Q1{"Latency-sensitive<br/>in-memory DB?"}
+    Q1 -->|Yes| M["M-series or custom high-mem N2"]
+    Q1 -->|No| Q2{"Needs GPU/TPU?"}
+    Q2 -->|Yes| A["A2/A3/G2 + check Spot/CUD rules"]
+    Q2 -->|No| Q3{"Steady web/API traffic?"}
+    Q3 -->|Yes| GP["E2 dev / N2 or N2D prod + regional MIG"]
+    Q3 -->|No| Q4{"Batch tolerant to loss?"}
+    Q4 -->|Yes| Spot["Spot VM or Spot MIG"]
+    Q4 -->|No| GP
+```
+
+### Machine family quick matrix
+
+| Signal | Lean toward | Avoid |
+| :--- | :--- | :--- |
+| Cost-sensitive dev/test | E2 shared-core or `e2-small` | N1 legacy, oversized custom types |
+| General production API | N2, N2D, or C3 after benchmark | Defaulting to M-series "just in case" |
+| GPU ML training | A3 + Spot if fault-tolerant | Standard VM without GPU quota planning |
+| License isolation | Sole-tenant node group | Sole-tenant for every app (cost) |
+
+### Spot vs CUD vs on-demand
+
+| Question | If mostly "yes" | Choose |
+| :--- | :--- | :--- |
+| Can the job restart from checkpoint without SLA breach? | Spot (or Spot MIG) |
+| Will vCPU/memory run >25% of month on N2/N2D/C2/M? | On-demand + automatic SUD first |
+| Is baseline core count stable 12+ months? | Add resource-based CUD on that baseline |
+| Does preemption break revenue path? | On-demand or CUD, not Spot |
+
+### Regional vs zonal MIG
+
+| Requirement | Regional MIG | Zonal MIG |
+| :--- | :--- | :--- |
+| Survive single zone failure | Preferred | Poor fit |
+| Lowest complexity lab | Acceptable overhead | Fine |
+| Stateful single-copy workload | Still need external HA design | May be forced, but plan outage |
+
+### End-to-end platform checklist
+
+Before declaring a Compute Engine slice production-ready, walk this checklist with your team. It ties together patterns, pricing, and security without introducing new tools.
+
+1. **Capacity** — Regional MIG, min replicas ≥ 2, autoscaling signal matches traffic shape (CPU, LB, or schedule), health checks reflect real readiness not just `sshd`.
+2. **Cost** — Rightsizing recommender reviewed; idle VM/disk recommendations addressed; Spot only on fault-tolerant tiers; CUD purchased only on measured baseline; SUD-eligible series used for always-on cores where appropriate.
+3. **Release** — Instance templates versioned; rolling update with surge and max-unavailable documented; canary percentage defined; rollback is template revert, not SSH surgery.
+4. **Data** — Boot vs data disks separated; snapshots scheduled; Hyperdisk provisioned performance matches measured p95; no orphaned disks after deletes.
+5. **Access** — OS Login enabled; external IPs removed where possible; IAP path tested; Shielded/Confidential requirements documented per tier.
+
+This checklist is deliberately boring—boring platforms survive traffic spikes without heroics, and FinOps reviews stop being archaeology on mystery disks.
 
 ---
 
@@ -591,14 +898,14 @@ When a user connects using `gcloud compute ssh`, GCP automatically generates a s
 
 | Mistake | Why It Happens | How to Fix It |
 | :--- | :--- | :--- |
-| Using N1 machines for new workloads | N1 appears first in old tutorials | Use N2, N2D, or E2---they offer better price-performance |
 | Not using Managed Instance Groups | Individual VMs seem simpler initially | Use MIGs for most production VM workloads; they provide autoscaling and self-healing |
 | Setting autoscaler min to 1 | Want to minimize cost | Min should be 2+ for high availability across zones |
 | Not configuring health checks | Assumed MIG "just knows" when VMs are unhealthy | Create HTTP health checks with appropriate thresholds |
 | Using external IPs on every VM | Easier to SSH directly | Use IAP tunneling; VMs should not have external IPs unless they serve public traffic |
-| Ignoring Sustained Use Discounts | Assuming CUDs are the only option | SUDs apply automatically; check billing reports to see your effective discount |
-| Choosing pd-standard for databases | It is the cheapest disk type | Use pd-ssd for any workload with latency requirements; pd-standard IOPS scales with disk size |
-| Not setting shutdown scripts on Spot VMs | Assuming preemption never happens | Implement graceful shutdown so Spot VMs can save state and deregister from services when interrupted |
+| Ignoring SUD or buying CUD too early | Treating GCP like "reservations first" clouds | Let automatic SUD apply on eligible cores; buy CUD only after rightsizing baseline |
+| Choosing pd-standard for databases | It is the cheapest disk type | Use pd-ssd or Hyperdisk with measured IOPS; pd-standard is for throughput-oriented bulk data |
+| Not setting shutdown scripts on Spot VMs | Assuming preemption never happens | Implement graceful shutdown; watch `preempted` metadata and use STOP vs DELETE deliberately |
+| Using N1 for new workloads | N1 appears first in older material | Default to N2, N2D, or E2; migrate N1 only when required |
 
 ---
 
@@ -646,6 +953,12 @@ You shouldn't worry because standard Compute Engine VMs benefit from a feature c
 When OS Login is enabled at the project level, Compute Engine completely bypasses local SSH key files like `~/.ssh/authorized_keys` and exclusively relies on IAM policies to authorize access. With OS Login, a user's ability to SSH into a VM is directly tied to their Google Cloud identity and IAM roles (like `roles/compute.osLogin`). Once the departed developer's Google Workspace account is suspended or their IAM role is revoked, their SSH access is typically cut off across all VMs in the project. This eliminates the operational nightmare of hunting down and deleting rogue public keys scattered across individual instances.
 </details>
 
+<details>
+<summary>8. Your FinOps lead sees rising Hyperdisk bills after a database migration, even though query latency improved. The disks show high provisioned IOPS but average observed IOPS stayed flat. What likely happened, and what would you change first?</summary>
+
+Hyperdisk Balanced and Extreme bill for **provisioned** IOPS and throughput caps, not just allocated size. During migration someone probably set provisioned performance generously to de-risk cutover, which is rational for a weekend—but expensive if left in place once steady state returns. Because Hyperdisk does not receive sustained-use or resource-based CUD discounts, those provisioned caps become pure monthly cost until you tune them. First step is compare provisioned versus observed performance in Monitoring, then step down IOPS/throughput to headroom above p95, or revert to pd-ssd if requirements do not justify Hyperdisk. Rightsizing disks is the same discipline as rightsizing machine types: measure, then dial knobs down.
+</details>
+
 ---
 
 ## Hands-On Exercise: Globally Load-Balanced App Across Two Regions
@@ -653,6 +966,10 @@ When OS Login is enabled at the project level, Compute Engine completely bypasse
 ### Objective
 
 Build a production-like architecture with MIGs in two regions behind a global HTTPS load balancer. Use this exercise to connect the concepts from this module: template-driven instances, regional redundancy, autoscaling policy, and endpoint load distribution through a single global IP. The goal is to complete a repeatable rollout that you can adapt into a real environment when your test and verification steps are in place.
+
+As you work, notice how **each layer assumes the one below is boring**: the VPC and firewall rules must allow health check ranges; templates must expose `/health`; MIGs must pass health checks before backends go green; the URL map must point at the correct backend service. A failure at any layer looks like "load balancer broken," but the root cause is often a missing named port or an autoscaler still at zero in one region. That dependency chain is exactly how production platforms are debugged—from the edge inward, not by restarting random VMs.
+
+**Hypothetical scenario:** During Task 5 you see only one hostname in responses despite four healthy backends. Before blaming the load balancer, verify backend balancing mode, named ports, and that each VM returns distinct metadata in its HTML—otherwise you may be caching at a browser or hitting a single zone because firewall rules blocked three subnets.
 
 ### Prerequisites
 
@@ -932,6 +1249,8 @@ echo "Cleanup complete."
 
 Next up: **[Module 2.4: Cloud Storage (GCS)](../module-2.4-gcs/)** --- Master storage classes, lifecycle management, versioning, signed URLs, and the gsutil/gcloud commands you will use every day.
 
+You now have the vocabulary to read a GCP architecture diagram critically: which tier is stateless behind a MIG, which disks are ephemeral versus durable, whether Spot or CUD economics match the SLA, and whether SSH access is governed by IAM instead of scattered keys. Carry that lens into storage and networking modules—compute choices echo through egress, snapshot, and identity bills long after the VM boots. Revisit this module when you design autoscaling policies or FinOps reviews; the tradeoffs compound quickly at scale, and small template mistakes replicate across every zone in a regional MIG during the next incident, major product launch, or your team's next quarterly cost review.
+
 ## Sources
 
 - [cloud.google.com: general purpose machines](https://cloud.google.com/compute/docs/general-purpose-machines) — Google Cloud's general-purpose machine-family documentation is the primary source for these series characteristics.
@@ -947,3 +1266,11 @@ Next up: **[Module 2.4: Cloud Storage (GCS)](../module-2.4-gcs/)** --- Master st
 - [cloud.google.com: live migration process](https://cloud.google.com/compute/docs/instances/live-migration-process) — The live migration process documentation directly states that disruption is typically much less than one second.
 - [cloud.google.com: setting vm host options](https://cloud.google.com/compute/docs/instances/setting-vm-host-options) — The host maintenance policy documentation is the primary source for default maintenance behavior.
 - [Application Load Balancer overview](https://cloud.google.com/load-balancing/docs/application-load-balancer) — This gives the current product model for Google Cloud application load balancers and their global and regional modes.
+- [cloud.google.com: sustained use discounts](https://cloud.google.com/compute/docs/sustained-use-discounts) — Documents automatic 25–100% monthly thresholds and up to 30% net SUD on eligible machine families.
+- [cloud.google.com: hyperdisks](https://cloud.google.com/compute/docs/disks/hyperdisks) — Hyperdisk types, provisioned performance, and SUD/CUD ineligibility.
+- [cloud.google.com: scaling schedules](https://cloud.google.com/compute/docs/autoscaler/scaling-schedules) — Cron-based MIG capacity schedules and `update-autoscaling` flags.
+- [cloud.google.com: idle VM recommendations](https://cloud.google.com/compute/docs/instances/idle-vm-recommendations-overview) — How Recommender classifies low CPU/network VMs over 1–14 days.
+- [cloud.google.com: machine type recommendations](https://cloud.google.com/compute/docs/instances/apply-machine-type-recommendations-for-instances) — Rightsizing recommender behavior and gcloud apply flow.
+- [cloud.google.com: shielded VM](https://cloud.google.com/compute/shielded-vm/docs/shielded-vm) — Secure Boot, vTPM, and integrity monitoring features.
+- [cloud.google.com: about confidential VM](https://cloud.google.com/compute/docs/about-confidential-vm) — Encryption-in-use model and operational constraints.
+- [cloud.google.com: recommender catalog](https://cloud.google.com/recommender/docs/recommenders) — IDs for idle VM, idle disk, and MIG machine-type recommenders.

--- a/src/content/docs/cloud/gcp-essentials/module-2.3-compute.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.3-compute.md
@@ -44,8 +44,8 @@ When you evaluate a family, collect three numbers from a representative week: p9
 ```mermaid
 flowchart TD
     subgraph "Machine Families"
-        A["<b>General Purpose</b><br/>E2, N2, N2D, T2D, N1<br/><i>Web servers, Dev/test, microservices</i>"]
-        B["<b>Compute Optimized</b><br/>C2, C2D, C3, H3<br/><i>HPC, gaming, batch jobs, scientific simulations</i>"]
+        A["<b>General Purpose</b><br/>E2, N2, N2D, T2D, C3, C3D, N1<br/><i>Web servers, Dev/test, microservices</i>"]
+        B["<b>Compute Optimized</b><br/>C2, C2D, H3<br/><i>HPC, gaming, batch jobs, scientific simulations</i>"]
         C["<b>Memory Optimized</b><br/>M2, M3<br/><i>SAP HANA, in-memory databases</i>"]
         D["<b>Accelerator Optimized</b><br/>A2, A3, G2<br/><i>ML training, inference, video transcoding</i>"]
     end
@@ -58,7 +58,7 @@ General-purpose series are where most teams should start and often stay. **E2** 
 | Series | CPU | vCPU:Memory Ratio | Best For | Notes |
 | :--- | :--- | :--- | :--- | :--- |
 | **E2** | Intel/AMD (automatic) | 1:4 (0.25 to 32 vCPUs) | Cost-sensitive, dev/test | Cheapest, shared-core options (e2-micro: 0.25 vCPU) |
-| **N2** | Intel Cascade Lake/Ice Lake | 1:4 (2 to 128 vCPUs) | General production | Good balance, use CUDs for savings (no SUDs) |
+| **N2** | Intel Cascade Lake/Ice Lake | 1:4 (2 to 128 vCPUs) | General production | Good balance; SUD-eligible (~20%), layer CUD on stable baseline |
 | **N2D** | AMD EPYC | 1:4 (series-specific limits) | General production workloads | Compare current N2D and N2 pricing in your region |
 | **T2D** | AMD EPYC | 1:4 | Scale-out workloads | Evaluate against current workload benchmarks |
 | **N1** | Intel Skylake/older | 1:3.75 | Legacy (avoid for new) | Still supported but outdated |
@@ -124,18 +124,19 @@ For lightweight workloads that do not need a full vCPU, E2 offers shared-core op
 
 ### Compute-Optimized, Memory-Optimized, and Accelerator Families
 
-Beyond general-purpose shapes, production platforms routinely land on specialized families when a single dimension—CPU throughput, RAM, or accelerators—dominates the bottleneck. The compute-optimized **C2**, **C2D**, and newer **C3** / **C3D** series target HPC, gaming backends, and numeric batch jobs where you want high vCPU performance per dollar rather than the widest memory envelope. Memory-optimized **M1**, **M2**, and **M3** machines exist for in-memory databases and SAP-scale footprints; Google documents M3 configurations up to very large vCPU and memory counts for workloads that cannot shard cheaply. Accelerator-optimized **A2**, **A3**, and **G2** families attach NVIDIA GPUs for ML training and inference; Spot pricing extends to GPUs, but preemption and maintenance behavior differ from standard VMs, so treat GPU pools as interruption-aware capacity.
+Beyond general-purpose shapes, production platforms routinely land on specialized families when a single dimension—CPU throughput, RAM, or accelerators—dominates the bottleneck. The compute-optimized **C2**, **C2D**, and **H3** series target HPC, gaming backends, and numeric batch jobs where you want high vCPU performance per dollar rather than the widest memory envelope. **C3** and **C3D** are classified as general-purpose in Google Cloud documentation (the `gcloud` CLI may still label C3 "Compute-optimized"—a historical quirk); benchmark them against N2/N2D before assuming an HPC tier. Memory-optimized **M1**, **M2**, and **M3** machines exist for in-memory databases and SAP-scale footprints; Google documents M3 configurations up to very large vCPU and memory counts for workloads that cannot shard cheaply. Accelerator-optimized **A2**, **A3**, and **G2** families attach NVIDIA GPUs for ML training and inference; Spot pricing extends to GPUs, but preemption and maintenance behavior differ from standard VMs, so treat GPU pools as interruption-aware capacity.
 
 | Series | Processor / accelerator | Typical workload | Cost note |
 | :--- | :--- | :--- | :--- |
-| **C3 / C3D** | Intel / AMD latest gen | Latency-sensitive APIs, simulation | Compare against N2/N2D in-region; CUDs may apply where SUDs do not |
+| **C3 / C3D** | Intel / AMD latest gen | General-purpose latency-sensitive APIs, simulation | General-purpose family; compare against N2/N2D in-region; CUDs may apply where SUDs do not |
+| **C2 / C2D / H3** | Intel / AMD HPC-oriented | HPC, gaming, numeric batch | Compare against N2/N2D when CPU-bound; CUDs may apply where SUDs do not |
 | **M2 / M3** | High memory per vCPU | SAP HANA, large caches | Hourly rates are high—justify with residency needs, not default choice |
 | **A2 / A3 / G2** | NVIDIA GPUs | Training, inference, video | Spot can discount GPU hours; live migration not available on Spot |
 | **T2D / T2A** | AMD / Arm | Scale-out Linux fleets | Good when software stack is Arm-ready; benchmark before mass migration |
 
 ### Custom Machine Types and Sole-Tenant Nodes
 
-Custom machine types let you pick vCPU and memory independently within a series, which is how you stop paying for RAM you never touch or vCPUs that sit idle while memory is pegged. Extended-memory custom shapes cost more per GB above the standard ratio for that series, so the billing signal should push you back toward predefined types when you are only slightly off-size. **Sole-tenant nodes** dedicate physical hosts to your project—useful for license compliance, noisy-neighbor isolation, or colocation-style placement. You pay for the entire node capacity, so sole-tenant is a deliberate premium unless regulation or performance isolation demands it; it is not a default cost-optimization path.
+Custom machine types let you pick vCPU and memory independently within a series, which is how you stop paying for RAM you never touch or vCPUs that sit idle while memory is pegged. Extended-memory custom shapes cost more per GB above the standard ratio for that series, so the billing signal should push you back toward predefined types when you are only slightly off-size. **Sole-tenant nodes** dedicate physical hosts to your project—useful for license compliance, noisy-neighbor isolation, or colocation-style placement. You pay for the entire node capacity, so sole-tenant is a deliberate premium unless regulation or performance isolation demands it; it is not a default cost-optimization path. Node type names are region-specific—run `gcloud compute sole-tenancy node-types list --zone=ZONE` before creating a group.
 
 ```bash
 # List sole-tenant node types available in a zone
@@ -143,7 +144,7 @@ gcloud compute sole-tenancy node-types list --zone=us-central1-a
 
 # Create a node group (reserves physical capacity)
 gcloud compute sole-tenancy node-groups create analytics-hosts \
-  --node-type=n2-node-96-240 \
+  --node-type=n2-node-80-640 \
   --node-count=1 \
   --zone=us-central1-a
 
@@ -167,7 +168,7 @@ GCP offers three pricing tiers for the same hardware, and each tier optimizes a 
 | Tier | Discount vs On-Demand | Max Lifetime | Guarantee | Use Case |
 | :--- | :--- | :--- | :--- | :--- |
 | **On-Demand** | 0% (baseline) | Unlimited | Will not be preempted | Production, stateful workloads |
-| **Committed Use (CUD)** | 28-52% | 1 or 3 year term | Will not be preempted | Steady-state production |
+| **Committed Use (CUD)** | ~37% (1yr) / ~55% (3yr) for general-purpose | 1 or 3 year term | Will not be preempted | Steady-state production |
 | **Spot** | 60-91% | None (no 24h limit) | Can be preempted anytime | Batch, CI/CD, fault-tolerant |
 | **Preemptible (legacy)** | 60-91% | 24 hours max | Preempted at 24h, or earlier | Use Spot instead (superset) |
 
@@ -254,7 +255,7 @@ Sustained Use Discounts (SUDs) apply automatically to eligible machine families-
 
 ### GCP Compute Cost Model (and How It Differs from "Buy a Reservation First")
 
-Understanding GCP pricing starts with what happens **without** anyone filing a purchase order. For eligible N1/N2/N2D/C2/M-series vCPU and memory—and some sole-tenant premium components—[sustained-use discounts](https://cloud.google.com/compute/docs/sustained-use-discounts) accrue automatically once a resource runs more than 25% of a billing month. Discounts step at 25%, 50%, 75%, and 100% utilization thresholds, reaching up to **30% net discount** on many N-family shapes and up to **20%** on several C2 resources. SUDs do **not** apply to E2, nor to usage already covered by committed-use discounts, which is why FinOps reviews often show E2 for bursty tiers and N2/N2D for always-on cores.
+Understanding GCP pricing starts with what happens **without** anyone filing a purchase order. For eligible N1/N2/N2D/C2/M1/M2 vCPU and memory—and some sole-tenant premium components—[sustained-use discounts](https://cloud.google.com/compute/docs/sustained-use-discounts) accrue automatically once a resource runs more than 25% of a billing month. Discounts step at 25%, 50%, 75%, and 100% utilization thresholds, reaching up to **30%** for N1/M1/M2 and up to **20%** for N2/N2D/C2. SUDs do **not** apply to E2, nor to usage already covered by committed-use discounts, which is why FinOps reviews often show E2 for bursty tiers and N2/N2D for always-on cores.
 
 Committed-use discounts (CUDs) are the deliberate mirror image: you commit to vCPU, memory, or spend for one or three years and receive lower rates in exchange for forecast risk. Resource-based CUDs attach to machine families; spend-based CUDs attach to billing-account spend. A common mistake is buying a three-year CUD for a fleet you plan to migrate to a different series next quarter—commitment savings evaporate if the workload moves off eligible SKUs. Spot VMs sit at the opposite end of the flexibility spectrum: [up to 91% off on-demand](https://cloud.google.com/compute/docs/instances/spot) for many machine types, no minimum or maximum runtime (unlike legacy preemptible's 24-hour cap), but preemption can happen anytime with as little as a 30-second shutdown window by default.
 
@@ -459,7 +460,7 @@ gcloud compute instance-groups managed set-autoscaling web-mig \
   --target-cpu-utilization=0.6 \
   --cool-down-period=120
 
-# Scale based on HTTP load balancing utilization
+# Scale based on custom load-balancing request-count metric (Cloud Monitoring)
 gcloud compute instance-groups managed set-autoscaling web-mig \
   --region=us-central1 \
   --min-num-replicas=2 \
@@ -847,16 +848,16 @@ flowchart TD
 | Signal | Lean toward | Avoid |
 | :--- | :--- | :--- |
 | Cost-sensitive dev/test | E2 shared-core or `e2-small` | N1 legacy, oversized custom types |
-| General production API | N2, N2D, or C3 after benchmark | Defaulting to M-series "just in case" |
+| General production API | N2, N2D, or C3/C3D after benchmark | Defaulting to M-series "just in case" |
 | GPU ML training | A3 + Spot if fault-tolerant | Standard VM without GPU quota planning |
 | License isolation | Sole-tenant node group | Sole-tenant for every app (cost) |
 
 ### Spot vs CUD vs on-demand
 
-| Question | If mostly "yes" | Choose |
-| :--- | :--- | :--- |
+| Question | Choose |
+| :--- | :--- |
 | Can the job restart from checkpoint without SLA breach? | Spot (or Spot MIG) |
-| Will vCPU/memory run >25% of month on N2/N2D/C2/M? | On-demand + automatic SUD first |
+| Will vCPU/memory run >25% of month on N2/N2D/C2/M1/M2? | On-demand + automatic SUD first |
 | Is baseline core count stable 12+ months? | Add resource-based CUD on that baseline |
 | Does preemption break revenue path? | On-demand or CUD, not Spot |
 
@@ -890,7 +891,7 @@ This checklist is deliberately boring—boring platforms survive traffic spikes 
 
 3. **Live migration is a GCP superpower that most users never notice**. [When Google needs to perform host maintenance, your VMs are transparently migrated to another physical host with no reboot and typically less than a second of degraded performance.](https://cloud.google.com/compute/docs/instances/live-migration-process) [This is enabled by default on all standard VMs. Preemptible/Spot VMs do not support live migration---they are terminated instead.](https://cloud.google.com/compute/docs/instances/setting-vm-host-options)
 
-4. **You can create a VM with up to 416 vCPUs and 12 TB of memory** using the M3 machine family. These ultra-high-memory machines are designed for SAP HANA, large in-memory databases, and genomics workloads. These ultra-high-memory machines are expensive on an hourly basis, but they can still be attractive when you need short-term capacity without buying hardware.
+4. **You can create a VM with up to 416 vCPUs and 12 TB of memory** using the M2 machine family (`m2-ultramem-416`). These ultra-high-memory machines are designed for SAP HANA, large in-memory databases, and genomics workloads. M3 tops out at lower maximums (128 vCPUs / 4 TB)—check current machine-type limits before sizing.
 
 ---
 
@@ -914,7 +915,7 @@ This checklist is deliberately boring—boring platforms survive traffic spikes 
 <details>
 <summary>1. Your team is running a batch processing workload that takes 30 hours to complete. A junior engineer suggests using Preemptible VMs to save money. How would you explain to them why Spot VMs are a better choice for this specific scenario?</summary>
 
-Preemptible VMs have a hard limitation: GCP will always terminate them after exactly 24 hours of uptime, regardless of whether there is available capacity in the zone. Because your workload takes 30 hours to complete, it would never finish on a Preemptible VM without being interrupted. Spot VMs are the modern successor to Preemptible VMs and remove this 24-hour maximum lifetime restriction. While Spot VMs can still be preempted at any time if GCP needs the capacity, they are allowed to run indefinitely during periods of low demand, making them the only viable low-cost option for uninterrupted jobs longer than 24 hours.
+Preemptible VMs have a hard limitation: GCP will always terminate them after exactly 24 hours of uptime, regardless of whether there is available capacity in the zone. Spot VMs are the modern successor and remove the 24-hour cap, but **Spot does not guarantee uninterrupted runtime**—GCP can preempt them anytime with as little as a 30-second warning. For a 30-hour batch job that cannot restart from scratch, neither Preemptible nor Spot is appropriate unless the workload checkpoints progress; use on-demand or committed-use capacity instead. Spot suits long jobs **only when they tolerate interruption and resume from checkpoints**; the 24-hour Preemptible limit makes Spot strictly better than legacy Preemptible, not a guarantee of continuous execution.
 </details>
 
 <details>
@@ -1101,7 +1102,6 @@ gcloud compute instance-groups managed set-named-ports web-mig-eu \
 
 # Add autoscaling
 for MIG_REGION in $REGION_US $REGION_EU; do
-  MIG_NAME="web-mig-$(echo $MIG_REGION | cut -d- -f1)"
   [ "$MIG_REGION" = "$REGION_US" ] && MIG_NAME="web-mig-us"
   [ "$MIG_REGION" = "$REGION_EU" ] && MIG_NAME="web-mig-eu"
 
@@ -1179,7 +1179,7 @@ echo "Load balancer will be available at http://$WEB_IP in 3-5 minutes"
 echo "Waiting for backends to become healthy..."
 while true; do
   STATUS=$(gcloud compute backend-services get-health web-backend-svc --global 2>&1)
-  HEALTHY=$(echo "$STATUS" | grep -c "HEALTHY" || true)
+  HEALTHY=$(echo "$STATUS" | grep -c "healthState: HEALTHY" || true)
   echo "Healthy backends: $HEALTHY"
   if [ "$HEALTHY" -ge 4 ]; then
     echo "All backends healthy!"


### PR DESCRIPTION
## Cloud track — GCP Essentials Wave 6a (expand-to-floor + cross-family review)

First GCP Essentials wave (curriculum order, after AWS Essentials + EKS Deep Dive completed). All three
below the 5000-word floor → expanded, cross-family reviewed (opus 4.8), ground-checked/web-verified, finalized.

| Module | Action | Author | Reviewer | Tier (after fixes) |
|---|---|---|---|---|
| 2.1 GCP IAM | expand 2.1k→5.0k | cursor | opus 4.8 | T0 (5012w, 15 src) |
| 2.2 GCP VPC | expand 1.6k→5.1k | deepseek | opus 4.8 | T0 (5129w, 13 src) |
| 2.3 Compute Engine | expand 2.1k→5.0k | cursor | opus 4.8 | T0 (5037w, 21 src) |

### Expansions
- **2.1**: resource hierarchy + deny policies, basic/predefined/custom roles, service accounts + Workload Identity Federation, IAM Conditions/Recommender, Patterns/Anti-Patterns + Decision Framework + cost lens.
- **2.2**: GLOBAL-VPC-vs-AWS contrast, firewall rules, Cloud NAT, Shared VPC vs peering, PGA/PSC, LB families, Patterns/Anti-Patterns + Decision Framework + cost lens.
- **2.3**: machine families + custom types, sustained-use vs committed-use discounts + Spot VMs, MIGs (autoscaling/autohealing/regional), Patterns/Anti-Patterns + Decision Framework + cost lens.

### Review fixes (ground-checked / web-verified by opus)
- **2.1**: `gcloud add-iam-binding`×9 → `add-iam-policy-binding` (non-existent verb); `asset get-effective-iam-policy`/`analyze-iam-policy` → `--scope`; IAM-Condition split flags → composite `--condition`; org-policy v1/v2 mix → consistent v2.
- **2.2**: fabricated incident opener → hypothetical; **fabricated "Flow Logs aggregation levels" feature** (a non-existent GCP capability) → real `--logging-aggregation-interval`/`--logging-flow-sampling`/`--logging-metadata`; route precedence corrected (longest-prefix then priority; default route priority 1000); **PGA VIPs swapped** (private=199.36.153.8/30, restricted=.4/30); `--secondary-ranges`→`--secondary-range`.
- **2.3**: **N2 wrongly marked "(no SUDs)"** → SUD-eligible (contradicted the module's own thesis); DYK "416 vCPU/12TB via M3" → **M2** (M3 maxes 128/4TB); SUD % split (30% N1/M1/M2, 20% N2/N2D/C2); C3/C3D → general-purpose (CLI-label quirk noted); malformed table; `grep "HEALTHY"` matched UNHEALTHY (lab broke) → `healthState: HEALTHY`; invalid sole-tenant node type; Spot-uninterrupted caveat.

All three pass `verify_module.py` (T0); incident-dedup gate PASS; no gutter/fused-fence defects.

## Learner check

> GCP offers two VPC modes, but in practice you should always use Custom Mode.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
