### PR TITLE
chore(content): cloud GCP Essentials wave 6b — expand 2.4 GCS + 2.5 DNS + 2.6 Artifact Registry to floor

### DIFF
--- a/src/content/docs/cloud/gcp-essentials/module-2.4-gcs.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.4-gcs.md
@@ -4,11 +4,11 @@ slug: cloud/gcp-essentials/module-2.4-gcs
 sidebar:
   order: 5
 ---
-**Complexity**: [QUICK] | **Time to Complete**: 1.5h | **Prerequisites**: Module 2.1 (IAM & Resource Hierarchy)
+**Complexity**: [MEDIUM] | **Time to Complete**: 1.5h | **Prerequisites**: Module 2.1 (IAM & Resource Hierarchy). This module assumes you can read IAM bindings and organization policies; you will apply those concepts directly to bucket design, lifecycle automation, and disaster-recovery placement.
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+After completing this module, you will be able to design buckets that balance cost, compliance, and recovery requirements without relying on tribal knowledge about ACLs or storage class marketing names.
 
 - **Configure Cloud Storage buckets with uniform bucket-level access and signed URL policies**
 - **Implement lifecycle management rules to automate object transitions across storage classes (Standard, Nearline, Coldline, Archive)**
@@ -19,15 +19,17 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-Misconfigured public bucket access can expose sensitive data for extended periods until review or scanning catches it, and the cleanup can be costly.
+Hypothetical scenario: your platform team provisions a shared `logs` bucket in a US multi-region location with Standard storage, versioning disabled, and legacy object ACLs still enabled because an old tutorial said to use `gsutil acl ch`. Six months later, an analytics job lists the entire bucket prefix-by-prefix, egress charges spike, and a mis-typed ACL on one object path makes a quarterly finance export readable without authentication. The incident is not dramatic in headlines, but the recovery work—auditing ACL drift, re-homing data to a regional bucket beside your BigQuery datasets, and retro-fitting lifecycle rules—consumes weeks of engineer time while invoices keep climbing.
 
-This was not an isolated incident. Publicly exposed cloud storage buckets have been responsible for some of the largest data breaches in cloud computing history. The common thread is often the same: cloud storage is trivially easy to use, which makes it trivially easy to misconfigure. Google Cloud Storage is the backbone of almost every GCP architecture. It stores application artifacts, database backups, logs, ML training data, static website assets, and Terraform state files. If you do not understand storage classes, lifecycle policies, versioning, and access control, you will eventually either overspend on storage or leak data publicly.
+Publicly exposed cloud storage buckets have been responsible for some of the largest data breaches in cloud computing history, and the common thread is often the same: cloud storage is trivially easy to use, which makes it trivially easy to misconfigure. Google Cloud Storage is the backbone of almost every GCP architecture. It stores application artifacts, database backups, logs, ML training data, static website assets, and Terraform state files. If you do not understand storage classes, lifecycle policies, versioning, access control, and how replication behaves during regional failures, you will eventually either overspend on storage or leak data publicly.
 
-In this module, you will learn how GCS organizes data, how to choose the right storage class to optimize costs, how lifecycle rules automate data management, how versioning protects against accidental deletion, and how signed URLs provide time-limited access without modifying IAM policies.
+In this module, you will learn how GCS organizes data, how to choose the right storage class and location type to optimize costs, how lifecycle rules automate data management, how versioning and retention protect against accidental deletion, how signed URLs provide time-limited access without modifying IAM policies, and how dual-region buckets with Turbo Replication fit disaster-recovery designs.
 
 ---
 
 ## GCS Fundamentals
+
+Cloud Storage is an object store, not a POSIX filesystem. That distinction drives every design choice in this module: you optimize for immutable blobs, prefix-oriented listing, and HTTP-range reads—not for millions of small random writes or directory locking. Managed services across GCP treat GCS as the durable blob layer underneath BigQuery external tables, Vertex AI datasets, Cloud Build artifact registries, and Terraform remote state. When you reason about performance, think in terms of request rates per prefix and throughput per object, because hot prefixes can contend even when aggregate bucket bandwidth looks healthy.
 
 ### Buckets and Objects
 
@@ -82,6 +84,10 @@ gcloud storage rm gs://my-company-data-prod/uploads/old-file.txt
 gcloud storage rm -r gs://my-company-data-prod/temp/
 ```
 
+Choosing a bucket location is a capacity-planning decision, not a cosmetic label. A regional bucket in `us-central1` minimizes latency and storage cost when your Compute Engine VMs, GKE nodes, and BigQuery jobs already live in that region, because Google Cloud does not charge for data transfer when the consumer and bucket share the same location. A multi-region bucket such as `US` spreads copies across geographically separated places inside the continent, which improves read resilience for global users but bills at higher at-rest rates and can add inter-region replication charges on every write. Dual-region buckets let you pick two specific regions—useful when compliance requires data to exist in both `us-central1` and `us-east1` while still presenting a single bucket name to applications.
+
+Object metadata includes a storage class per object, independent of the bucket default. That means a single bucket can hold hot configuration in Standard storage beside aged log shards in Nearline or Coldline if lifecycle rules or Autoclass move them. Operations pricing also follows the object's class: listing a Coldline bucket costs more per thousand Class B operations than listing Standard storage, which matters when automation walks millions of keys nightly.
+
 ### [Bucket Locations](https://cloud.google.com/storage/docs/bucket-locations)
 
 | Location Type | Example | Redundancy | Latency | Cost | Use Case |
@@ -118,9 +124,27 @@ gcloud storage buckets create gs://my-critical-dr-bucket \
   --enable-turbo-replication
 ```
 
+For disaster recovery, treat Turbo Replication as an insurance policy on the replication lag window, not as a substitute for application-level backup logic. Standard dual-region replication is asynchronous: Google replicates object data between the paired regions, but there is no published maximum time for every byte to land in the secondary region before a regional outage. Turbo Replication adds a documented [15-minute recovery point objective (RPO)](https://cloud.google.com/storage/docs/availability-durability) for newly written objects in eligible dual-region buckets, which narrows how much data might be missing if you fail over reads to the surviving region immediately after a disaster. You still need runbooks that point applications at the correct endpoint, validate IAM and VPC Service Controls, and test restore procedures—GCS replication does not rewind application state or database transactions.
+
+Pair Turbo Replication with object versioning when operators might delete or overwrite objects during incident response. Versioning keeps prior generations as noncurrent objects, while replication ensures geographically separated copies of the live generation. Lifecycle rules should trim noncurrent versions deliberately; otherwise DR readiness can balloon storage bills after a busy incident weekend.
+
+## Cross-Region Replication and Disaster Recovery
+
+Disaster recovery on GCS is a story about how many copies exist, how quickly new copies appear, and whether applications can read the surviving copy when a region fails. A regional bucket is the simplest topology: one geographic place, lowest storage and operation rates for workloads colocated in that region, and no cross-region replication charge on ingest. The tradeoff is hard: if the region becomes unavailable, the bucket is unavailable until Google restores regional service. Many teams accept regional buckets for replaceable caches but not for irreplaceable backups.
+
+Dual-region buckets store object data in two user-selected regions (for example `us-central1` and `us-east1` via `--placement`). Writes are replicated between them; reads can be served from either region depending on routing and consistency semantics. Google bills [inter-region replication for dual-region and multi-region locations](https://cloud.google.com/storage/pricing) on each gigabyte written, which is a predictable DR cost line item. Dual-region fits compliance patterns that require bytes to exist in two specific states or metros without operating two separate buckets and sync jobs yourself.
+
+Multi-region buckets (`US`, `EU`, `ASIA`) spread data across a defined geographic footprint with higher at-rest pricing than single regions. They help global read-heavy workloads—static sites, consumer downloads—where latency to a nearby copy matters more than minimizing storage dollars. Multi-region is not a free pass on egress: serving bytes from `US` multi-region to compute in `europe-west1` still triggers cross-location network charges unless you add CDN or replicate data closer to consumers.
+
+Turbo Replication upgrades dual-region buckets that need a bounded recovery point objective. Google documents a [fifteen-minute RPO](https://cloud.google.com/storage/docs/availability-durability) for newly written objects when Turbo Replication is enabled, compared with best-effort asynchronous replication without a published worst-case lag. Turbo Replication is not a replacement for versioning, soft delete, or application-consistent database backups; it only addresses object durability across regions. Your runbook should still describe how Kubernetes state, Pub/Sub backlogs, and Cloud SQL failover interact with GCS reads during a region failure.
+
+Operational drills matter as much as checkbox features. Quarterly exercises should include: writing a test object, confirming it appears in both dual-region locations via metadata or event logs, simulating application configuration that points reads at the alternate region, and measuring how long IAM propagation and DNS or endpoint changes take. Pair drills with monitoring on replication backlog metrics where available and with alerts on `storage.googleapis.com` error rates from client libraries.
+
+When RPO requirements exceed what object replication provides—point-in-time database consistency, for example—export data to GCS on a schedule **and** keep transactional recovery inside the database's native backup tools. GCS becomes the durable off-site copy; replication becomes the geographic spread of that copy. Document who is allowed to delete backup prefixes during incidents, because panic deletes have destroyed more restores than regional outages have.
+
 ---
 
-> **Stop and think**: If Autoclass automatically optimizes storage costs with zero retrieval fees, why wouldn't you enable it on every single bucket by default? What specific workload pattern or architectural requirement would make Autoclass a financial or operational mistake?
+**Stop and think:** Autoclass removes retrieval fees on automatic tier transitions, which sounds like a universal win until you model buckets where regulatory policy requires Nearline retention for ninety days regardless of access, or buckets with billions of sub-128 KiB objects that never qualify for management but still incur Autoclass fees. In those cases, calendar-driven lifecycle rules or explicit class locks give auditors a stable story while Autoclass would fight your compliance narrative or charge management fees without tiering benefit.
 
 ## Storage Classes: Matching Cost to Access Patterns
 
@@ -132,6 +156,10 @@ GCS offers four storage classes. The key insight is that [**cheaper storage has 
 | **NEARLINE** | varies by location | $0.01 | 30 days | 99.9% | Monthly access (backups) |
 | **COLDLINE** | varies by location | $0.02 | 90 days | 99.9% | Quarterly access (archives) |
 | **ARCHIVE** | starts at a very low per-GB monthly rate | $0.05 | 365 days | 99.9% | Yearly access (compliance) |
+
+Pricing varies by location type as well as class. For Iowa (`us-central1`) regional buckets, [Google's published rates](https://cloud.google.com/storage/pricing) illustrate the tradeoff: Standard storage is roughly $0.020 per gibibyte-month, Nearline about half that, Coldline roughly one quarter, and Archive an order of magnitude lower still—before retrieval and operation charges. Multi-region `US` Standard storage runs higher (on the order of $0.026 per gibibyte-month in the same pricing table) because you pay for geographic redundancy at rest. Dual-region buckets bill both underlying regions, so a NAM4 Standard object effectively accumulates storage cost in each paired region. Use the pricing calculator with your real access pattern instead of picking Archive because the per-GB number looks smallest on a spreadsheet.
+
+Retrieval fees apply whenever you read, copy, move, or rewrite data in Nearline, Coldline, or Archive storage: [$0.01, $0.02, and $0.05 per gibibyte respectively](https://cloud.google.com/storage/pricing) at the time of this writing, in addition to Class B operation charges and any egress. Standard storage has no retrieval surcharge, which is why a "cheap" archival class becomes expensive if analysts query it weekly. Autoclass removes retrieval fees for automatic tier transitions inside an Autoclass-enabled bucket, but enabling Autoclass can trigger a one-time enablement charge that rewrites existing objects and may bill early-deletion or retrieval for objects that have not met minimum duration—plan enablement during a maintenance window.
 
 **Critical concept**: The minimum storage duration means you are **billed for the full period** even if you delete the object early. If you upload a file to COLDLINE and delete it after 10 days, you are still charged for the remaining 80 days of storage as an early deletion fee.
 
@@ -171,13 +199,19 @@ With Autoclass enabled:
 - If accessed again, they automatically move back to STANDARD.
 - [No retrieval fees apply when Autoclass moves objects between classes.](https://cloud.google.com/storage/pricing)
 
+Autoclass also carries a management fee of [$0.0025 per 1,000 objects per 30-day period](https://cloud.google.com/storage/pricing) for objects at least 128 KiB that Autoclass manages, prorated to the millisecond. Buckets with billions of tiny files may see fees dominate savings unless objects are large enough to benefit from tiering. Objects smaller than 128 KiB are not managed and stay on Standard pricing. When access is genuinely unpredictable—ML feature stores, ad-hoc science lakes—Autoclass often beats hand-tuned lifecycle rules because it reacts to reads rather than calendar age. When you must keep objects in Nearline for a compliance clock regardless of access, disable Autoclass and encode the duration in lifecycle conditions instead.
+
+Location type and class interact with availability SLAs documented in the [storage classes guide](https://cloud.google.com/storage/docs/storage-classes): Standard multi-region and dual-region targets 99.95% monthly availability SLA, while regional Standard targets 99.9%. Nearline and Coldline drop to 99.0% SLA in a single region. Architectures that need five-nines read latency for a global user base might justify multi-region Standard; batch analytics landing zones in one region should not pay the multi-region premium unless regulatory geography demands it.
+
 ---
 
-> **Pause and predict**: You configure a lifecycle rule to forcefully delete objects older than 30 days. However, your bucket also has versioning enabled. If an engineer overwrote a highly sensitive 40-day-old object just 5 days ago, what exactly happens when the 30-day lifecycle deletion rule evaluates this object today?
+**Pause and predict:** Suppose a lifecycle rule deletes live objects older than thirty days while versioning is enabled, and an engineer overwrote a sensitive forty-day-old object five days ago. The live generation is only five days old, so the age-based delete rule does not remove it yet; the prior generation becomes noncurrent and remains billable until a separate rule targets `isLive: false` or `daysSinceNoncurrentTime`. Teams that forget the second rule discover "deleted" content still appearing on invoices as noncurrent storage.
 
 ## Lifecycle Management
 
-[Lifecycle rules automate actions on objects based on age, storage class, versioning status, or other conditions.](https://cloud.google.com/storage/docs/lifecycle) This is how you prevent storage costs from growing unbounded.
+[Lifecycle rules automate actions on objects based on age, storage class, versioning status, or other conditions.](https://cloud.google.com/storage/docs/lifecycle) This is how you prevent storage costs from growing unbounded. Think of lifecycle configuration as declarative operations scheduling: you describe predicates (how old, which class, whether the object is the live generation) and actions (delete, transition class), and GCS evaluates them continuously without a cron job in your cluster.
+
+Lifecycle conditions include `age` (days since creation), `createdBefore` (absolute date), `matchesStorageClass`, `isLive` (current versus noncurrent version), `numNewerVersions`, and `daysSinceNoncurrentTime`. Combining `isLive: false` with `numNewerVersions` is the standard pattern to cap version history without touching the current object. Combining `age` with `matchesStorageClass` lets you tier only Standard objects while leaving already-cold objects untouched. Object Lifecycle Management transitions do not trigger early-deletion fees the way a manual rewrite or delete would, which is why lifecycle is the preferred tool for class changes on archival tiers.
 
 ```bash
 # Set lifecycle rules using a JSON file
@@ -244,6 +278,12 @@ gcloud storage buckets update gs://my-bucket \
 | **Compliance archive** | Move to ARCHIVE at 365 days, delete at 2555 days (7 years) | Meet regulatory retention |
 | **Temp file cleanup** | Delete objects with prefix `tmp/` older than 1 day | Clean up temporary uploads |
 
+Lifecycle rules can also use `createdBefore` to grandfather objects during migrations, or `matchesPrefix` / `matchesSuffix` when only certain key patterns should age. Custom time fields on objects (when set) enable application-defined clocks separate from upload time, which helps when data arrives late but should expire based on business dates. Not every condition combines cleanly: test JSON in lower environments because invalid rule sets are rejected at write time, but subtle logic errors only show up when monthly bills arrive.
+
+When versioning is enabled, a lifecycle rule that deletes objects based only on `age` applies to the live object and does not remove noncurrent versions automatically unless you add conditions for `isLive: false`. That is why the "Pause and predict" prompt above matters: a 30-day delete on live objects can still leave a deep stack of noncurrent generations billing storage until a companion rule trims them. Test lifecycle JSON in a sandbox bucket with synthetic version churn before attaching rules to production Terraform state buckets.
+
+At moderate scale—say tens of terabytes with daily ingest—lifecycle mistakes show up in the invoice before they show up in monitoring. Transitioning millions of small Standard objects to Nearline saves storage rate but bills a Class A operation per transition at the destination class rate, which can dominate if objects are only a few kilobytes each. Deleting noncurrent versions saves storage but is irreversible unless soft delete or holds apply. Inventory reports and Storage Insights datasets help you simulate rule impact without listing every object interactively.
+
 ---
 
 ## Object Versioning
@@ -278,9 +318,13 @@ gcloud storage buckets update gs://my-bucket \
 
 **War Story**: Accidental large-scale deletion is much easier to recover from when Object Versioning is enabled, because deleted live objects become noncurrent versions that can be restored.
 
+Versioning changes delete semantics in ways operators forget during incidents. A `gcloud storage rm` on the live object does not purge historical bytes immediately; it creates a delete marker or leaves older generations addressable by generation ID until lifecycle rules or explicit version deletes remove them. Restores are copies: you promote a generation back to live by copying `object#generation` onto `object`, which bills another storage object if the data is large. For configuration files the operation is cheap; for multi-terabyte exports it can double storage until lifecycle catches up. Pair versioning with `numNewerVersions` cleanup so you keep the last N generations, not every overwrite since the bucket was created.
+
+Soft delete (when enabled on the bucket) adds another retention window before permanent removal; restores from soft delete bill as Standard operations. Read the [object versioning documentation](https://cloud.google.com/storage/docs/object-versioning) for interaction between versioning, lifecycle `isLive` conditions, and soft delete before enabling all three on the same production bucket.
+
 ### [Object Holds and Retention](https://cloud.google.com/storage/docs/using-bucket-lock)
 
-For compliance use cases, you can lock objects to prevent deletion.
+For compliance use cases, you can lock objects to prevent deletion. A **retention policy** on the bucket sets a minimum time objects must remain stored; **temporary holds** pause deletion for individual objects during investigations; **event-based holds** tie retention to events you clear manually. **Bucket lock** makes a retention policy immutable—Google documents that [locked policies cannot be removed or shortened](https://cloud.google.com/storage/docs/using-bucket-lock), which is powerful for WORM-style regulatory archives but terrifying if you lock the wrong duration. Run retention changes through change control with explicit unlock procedures for holds, not for locked policies.
 
 ```bash
 # Set a retention policy (objects cannot be deleted for 90 days)
@@ -302,9 +346,13 @@ gcloud storage objects update gs://my-bucket/evidence.pdf \
 
 ---
 
-> **Stop and think**: If Uniform Bucket-Level Access forces you to manage permissions solely at the bucket level, how would you securely handle an architectural requirement where 100 different external clients each strictly need read access to only their specific client folder within a single shared "invoices" bucket?
+**Stop and think:** Uniform bucket-level access removes per-object ACLs, so a shared `invoices` bucket cannot safely isolate a hundred external clients with legacy ACL tricks. Production answers split along three lines: separate buckets per tenant with IAM on each bucket, one bucket with IAM Conditions matching object name prefixes plus audited service accounts, or private objects served through your application that mints per-user signed URLs after authenticating the user in your identity system.
 
 ## Access Control: IAM vs ACLs
+
+Access control on GCS spans three layers practitioners routinely confuse: Cloud IAM at the project or bucket level, legacy object ACLs when uniform bucket-level access is off, and signed URLs or OAuth tokens presented at request time. Security reviews should trace a download path end-to-end: which principal is authenticated, which policy grants `storage.objects.get`, whether Public Access Prevention would block `allUsers`, and whether VPC Service Controls perimeter policies require restricted Google APIs access. A bucket that looks private in the console can still leak if an object ACL or signed URL circulates outside your ticket system.
+
+Service accounts should receive the narrowest role that satisfies automation: `roles/storage.objectCreator` for append-only log sinks, `roles/storage.objectViewer` for read-only analytics, `roles/storage.objectAdmin` only when applications must overwrite or delete user content. Human administrators belong in `roles/storage.admin` sparingly via break-glass groups. When workloads in GKE or Cloud Run access GCS, bind IAM to the workload identity service account, not to downloaded JSON keys, because keys rotation does not survive image rebuilds.
 
 ### Uniform Bucket-Level Access (Recommended)
 
@@ -328,6 +376,10 @@ gcloud storage buckets add-iam-policy-binding gs://my-bucket \
 # View bucket IAM policy
 gcloud storage buckets get-iam-policy gs://my-bucket
 ```
+
+Uniform bucket-level access (UBLA) disables object ACLs so IAM policies on the bucket and project become the only authorization path. Google [recommends UBLA for essentially all new buckets](https://cloud.google.com/storage/docs/uniform-bucket-level-access) because dual systems—IAM plus per-object ACLs—create audit gaps: a bucket IAM policy can deny `allUsers` while a forgotten object ACL still grants `allUsers:READ`. Enabling UBLA is reversible for seven days; after that, ACLs are permanently removed from objects. Migration plans should inventory ACL overrides with `gcloud storage objects get-iam-policy` or Storage Insights before flipping the flag in production.
+
+Fine-grained access (legacy ACL mode) still appears in older modules and third-party tools. ACLs can grant `READER` on one object without exposing siblings, which sounds attractive for multi-tenant invoice buckets, but at scale you cannot reason about effective access from IAM alone. The supported pattern for per-tenant isolation is separate buckets or prefixes with IAM Conditions on resource names, plus signed URLs for unauthenticated downloaders—not object ACL sprawl.
 
 ### [Common Storage IAM Roles](https://cloud.google.com/storage/docs/access-control/iam-roles)
 
@@ -358,11 +410,13 @@ gcloud storage buckets get-iam-policy gs://my-bucket \
 
 ---
 
-> **Pause and predict**: A developer securely generates a Signed URL allowing a client to upload a massive 50GB database dump. The developer configures the URL to expire in exactly 15 minutes. The client begins the upload immediately upon receiving the URL, but due to bandwidth constraints, the transfer takes 45 minutes to complete. What happens to the upload?
+**Pause and predict:** A fifteen-minute signed URL for a fifty-gigabyte upload will fail if the bytes are not fully received before expiration, because V4 signatures bind to a time window rather than to transfer progress. Resumable uploads can continue after interruption when properly implemented, but the initial signed session must be created with enough TTL for worst-case bandwidth, or the client must upload through a backend proxy that holds a service account identity instead of a short-lived browser URL.
 
 ## Signed URLs: Time-Limited Access
 
-Signed URLs allow you to [grant temporary access to a specific object without modifying IAM policies](https://cloud.google.com/storage/docs/access-control/signed-urls). They are ideal for sharing files with external users or providing download links in web applications.
+Signed URLs allow you to [grant temporary access to a specific object without modifying IAM policies](https://cloud.google.com/storage/docs/access-control/signed-urls). They are ideal for sharing files with external users or providing download links in web applications. The signing process uses a service account or user credential to hash canonical request metadata; GCS validates the signature before executing the verb. Rotating the underlying key invalidates outstanding URLs, which is good for incident response but bad if mobile apps cache links for days—operational teams should treat URL TTL as part of the API contract.
+
+Impersonation-based signing (`--impersonate-service-account`) avoids long-lived key files on developer laptops. The impersonator needs `roles/iam.serviceAccountTokenCreator` on the signer service account, and the signer needs appropriate bucket IAM. In CI pipelines, use Workload Identity Federation where possible instead of exporting keys to GitHub Actions secrets; when keys are unavoidable, store them in Secret Manager and mount briefly at runtime.
 
 ```bash
 # Generate a signed URL valid for 1 hour
@@ -408,6 +462,8 @@ print(f"Download URL (valid for 30 minutes): {url}")
 
 ### Signed URLs vs Signed Policy Documents
 
+HTML form uploads directly to GCS often use POST policies so the browser never sees service account keys. The policy document encodes maximum upload size, required `Content-Type`, and key prefix patterns; the browser includes the policy and signature as form fields. Signed URLs instead target one object and one HTTP verb, which is simpler for mobile apps that download a single report. Security reviews should verify that policy documents cannot be replayed across tenants by reusing the same prefix pattern for different customers without including a user-specific path segment.
+
 | Feature | Signed URL | Signed Policy Document |
 | :--- | :--- | :--- |
 | **Purpose** | Download or upload a specific object | Upload with constraints (size, type) |
@@ -415,11 +471,21 @@ print(f"Download URL (valid for 30 minutes): {url}")
 | **Use case** | Share a file, programmatic downloads | HTML form uploads |
 | **Object specific** | Yes (one URL per object) | Can allow any object name matching conditions |
 
+[V4 signed URLs](https://cloud.google.com/storage/docs/access-control/signed-urls) can authorize specific HTTP verbs (GET, PUT, DELETE) for up to seven days when using Google-managed keys or service account keys. The signature covers headers and query parameters, so tampering invalidates the request. Important operational detail: the clock starts when the URL is minted, not when the client finishes a long upload—very large uploads should use resumable uploads with a comfortably long expiration or a server-side proxy that streams through a trusted identity instead of a single short signed PUT.
+
+Signed policy documents shine when browsers POST form uploads directly to GCS with constraints on content length and content type. Signed URLs shine when backend services hand one-off download links to mobile clients. Neither replaces IAM for service-to-service traffic inside GCP: Cloud Run, GKE, and Dataflow should use workload identity and bucket IAM bindings because URLs cannot be rotated centrally and leak via logs if mishandled.
+
+Choose IAM grants when the caller has a Google identity (user, group, service account) and the access pattern is long-lived. Choose signed URLs when external users without Google accounts need object-scoped, time-bounded access. Choose signed policy documents when you need HTML form uploads with field constraints. If Public Access Prevention is enforced at the organization level, even perfect signed URL hygiene cannot accidentally reopen `allUsers`—the constraint blocks public ACLs and IAM bindings to public principals.
+
 ---
 
 ## gsutil vs gcloud storage
 
-Google has been migrating commands from `gsutil` to `gcloud storage`. Both work, but [`gcloud storage` is the recommended tool going forward](https://cloud.google.com/storage/docs/gsutil-transition-to-gcloud).
+Google has been migrating commands from `gsutil` to `gcloud storage`. Both work, but [`gcloud storage` is the recommended tool going forward](https://cloud.google.com/storage/docs/gsutil-transition-to-gcloud). The newer command tree integrates with Google Cloud CLI configuration, IAM impersonation flags, and consistent output formats you already use for `gcloud compute` and `gcloud run`. `gsutil` remains in maintenance mode; new features such as improved `rsync` semantics and signing flows land in `gcloud storage` first.
+
+From a security perspective, older `gsutil acl` examples are hazardous copy-paste material. Modern modules should never document `gsutil acl ch -u AllUsers:R`; they should document `gcloud storage buckets add-iam-policy-binding` with groups or service accounts, or signed URLs for external access. When you maintain CI pipelines, pin scripts to `gcloud storage` so runners do not depend on a separate `gsutil` install path that drifts across builder images.
+
+Performance-wise, both tools exploit parallel uploads for large files. `gcloud storage rsync` compares checksums and can delete extraneous destination objects with explicit flags, which is how teams mirror build artifacts into static site buckets or copy backups between regions. Treat rsync into production buckets as a destructive-capable command: require manual approval or restricted service accounts, because `--delete-unmatched-destination-objects` removes objects that exist only on the destination side.
 
 | Operation | gsutil (legacy) | gcloud storage (recommended) |
 | :--- | :--- | :--- |
@@ -448,9 +514,101 @@ gcloud storage rsync gs://source-bucket/ gs://dest-bucket/ \
   --recursive
 ```
 
+### Composite Objects and Parallel Uploads
+
+Very large uploads can use [composite objects](https://cloud.google.com/storage/docs/composite-objects): `gcloud storage` splits a file into parts, uploads them in parallel, and composes them server-side into one object name. Composite uploads improve throughput on high-bandwidth links and are the modern equivalent of `gsutil -o GSUtil:parallel_composite_upload_threshold` workflows. Each component part is a real object until composition finishes, so failed jobs should be aborted or cleaned to avoid orphan part charges.
+
+### Requester Pays
+
+When a dataset is public but the publisher does not want to fund egress for the world, [requester pays](https://cloud.google.com/storage/docs/requester-pays) shifts download and operation costs to the caller's project. Clients must include a `userProject` query parameter or billing project flag so Google knows which project to charge. This pattern appears in open-data mirrors and shared research corpora; it is a poor fit for customer-facing SaaS downloads where you expect to absorb bandwidth.
+
+---
+
+## Cost at Moderate Scale
+
+At moderate scale—hundreds of terabytes and millions of daily operations—GCS invoices are usually dominated by four knobs: at-rest storage class mix, retrieval and early-deletion surcharges, operation class volume, and egress to clients or other regions. Storage class mistakes are slow burns: everything left in Standard in a multi-region bucket costs more every month even if nobody reads it. Retrieval mistakes are spikes: promoting a Coldline snapshot to an interactive dashboard without caching triggers per-gibibyte read fees plus egress. Operation storms come from list-heavy automation: recursive `gcloud storage ls` across an entire bucket is a Class B operation per listing tranche and does not scale like a database index scan.
+
+Cost control patterns that actually work in production include co-locating buckets with compute, using lifecycle or Autoclass for aging data, setting versioning plus noncurrent cleanup rules, enabling Inventory Reports instead of brute-force listing, and fronting static assets with Cloud CDN so repeat downloads do not re-hit the bucket from distant regions. Turbo Replication and dual-region placement add predictable replication line items on every write; budget them as part of RPO spending, not as surprise data-processing fees. Tags on buckets bill [$0.005 per tag per month](https://cloud.google.com/storage/pricing); keep tag cardinality small and meaningful for FinOps dashboards.
+
+Unexpected cost spikes often trace to one of these triggers: changing millions of objects to a colder class manually (Class A operations at the destination rate plus early deletion), restoring an entire versioned bucket after an incident without lifecycle on noncurrent generations, enabling Autoclass on a bucket full of sub-128 KiB artifacts that never tier, or serving multi-region objects to global users without a CDN. Build a monthly review that compares storage gigabytes-by-class, retrieval SKU lines, and egress by destination region; Google Cloud Billing export to BigQuery makes that repeatable.
+
+---
+
+## Patterns & Anti-Patterns
+
+Production GCS design is less about memorizing commands and about making implicit tradeoffs explicit: who may read an object, how fast replication must be, how long bytes must survive, and who pays for egress. The patterns below appear repeatedly in well-run GCP estates; the anti-patterns are the shortcuts that create security or invoice incidents months later. When you review a peer's Terraform module, ask whether it encodes those tradeoffs or merely creates a bucket resource with a generic name and Standard storage because those were the template defaults.
+
+Good modules expose location, storage class default, uniform bucket-level access, public access prevention, versioning, lifecycle JSON, and optional autoclass or turbo replication flags as conscious inputs. Bad modules hide those fields, which guarantees every environment inherits the same expensive multi-region Standard bucket whether the workload is a dev log scratch pad or a compliance archive.
+
+| Pattern | When to use it | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| **Regional bucket beside compute** | GKE, Compute Engine, or Dataflow in one region owns the data | Lowest latency and free in-region transfer to many Google Cloud services | Add a read replica bucket or CDN only when users are global |
+| **UBLA + bucket IAM + PAP** | Any bucket touched by humans or CI | Single authorization model; org policy blocks public principals | Use IAM Conditions on object prefix when tenants share a project |
+| **Versioning + noncurrent lifecycle** | Terraform state, configs, regulated artifacts | Deletes become recoverable noncurrent generations | Cap `numNewerVersions` or `daysSinceNoncurrentTime` to prevent unbounded growth |
+| **Lifecycle tiering before manual class edits** | Predictable aging logs and backups | Avoids early-deletion fees that manual rewrites trigger | Batch transitions; watch Class A charges on tiny objects |
+| **Dual-region + Turbo Replication** | DR buckets with tight RPO | Documented 15-minute RPO for new writes in eligible configs | Practice failover reads; replication does not fix app consistency |
+| **Signed URLs from impersonated SAs** | External download or short upload windows | No long-lived keys on laptops; narrow object scope | Keep expirations longer than worst-case upload duration |
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+| :--- | :--- | :--- | :--- |
+| **Multi-region Standard for all buckets** | Pays redundancy premium without need | "US" feels safe default | Regional bucket unless users or DR need geography spread |
+| **Archive class for warm pipelines** | Retrieval fees exceed storage savings | Cheapest $/GB on paper | Nearline or Standard until access truly yearly |
+| **Public ACL on one "test" object** | Bucket IAM audit looks clean while object leaks | Legacy gsutil tutorials | UBLA, signed URLs, or private load via identity-aware proxy |
+| **Autoclass on compliance-timed data** | Objects move despite legal hold expectations | Autoclass marketed as zero-touch | Fixed lifecycle with explicit ages; holds for legal buckets |
+| **Listing entire buckets in cron** | Operation quota burn and slow jobs | Simple shell scripts | Prefix-scoped listing or Inventory Reports |
+| **Signed URL as permanent API key** | URLs in tickets/logs live past rotation | Feels easier than OAuth | Short TTL plus server-side minting on demand |
+
+---
+
+## Decision Framework
+
+Use this framework when choosing storage class, location, access mode, and DR features. It complements the tables earlier in the module by forcing tradeoffs into the open.
+
+```mermaid
+flowchart TD
+    Start([New dataset or bucket]) --> Access{Who reads the data?}
+    Access -->|Google identities only| IAM[UBLA + bucket IAM roles]
+    Access -->|External users without GCP accounts| Sign[Signed URL or policy doc]
+    Access -->|Anonymous internet| Stop[Reject — use CDN or app proxy]
+    IAM --> Freq{How often is data read?}
+    Sign --> Freq
+    Freq -->|Daily or weekly| Std[Standard storage]
+    Freq -->|About monthly| Near[Nearline]
+    Freq -->|Quarterly or less| Cold[Coldline or Archive by RPO/RTO]
+    Std --> Loc{Latency and DR needs?}
+    Near --> Loc
+    Cold --> Loc
+    Loc -->|Single region compute| Reg[Regional bucket]
+    Loc -->|Regulatory pair of regions| Dual[Dual-region; evaluate Turbo Replication]
+    Loc -->|Global read footprint| Multi[Multi-region or CDN fronting regional]
+    Reg --> Life{Access pattern predictable?}
+    Dual --> Life
+    Multi --> Life
+    Life -->|Yes, age-based| LC[Lifecycle rules]
+    Life -->|No, shifting hot sets| AC[Autoclass — watch mgmt fee]
+    LC --> Ver{Need overwrite protection?}
+    AC --> Ver
+    Ver -->|Yes| VOn[Versioning + noncurrent cleanup]
+    Ver -->|No| Done([Document cost review])
+    VOn --> Done
+```
+
+| Decision | Prefer | Tradeoff |
+| :--- | :--- | :--- |
+| Standard vs Nearline vs Coldline vs Archive | Match class to **read frequency**, not headline $/GB | Lower storage rate brings retrieval fees and minimum duration |
+| Regional vs dual-region vs multi-region | Regional for co-located compute; dual/multi for DR or global reads | Higher at-rest cost and replication processing on writes |
+| Lifecycle vs Autoclass | Lifecycle when ages are contractual; Autoclass when heat is unpredictable | Autoclass management fee; lifecycle ops charges on mass transitions |
+| UBLA vs ACLs | UBLA for all new buckets | Per-object ACLs hide effective access from IAM audits |
+| IAM binding vs signed URL | IAM inside GCP; signed URL for external, object-scoped, TTL access | URLs are secrets; IAM is revocable centrally |
+| Turbo Replication | Dual-region buckets when RPO must be bounded | Extra replication SKU; still need app failover testing |
+
+Document the decision you made in each column of this table in your internal architecture records so future engineers do not optimize costs by disabling versioning or uniform bucket-level access without understanding the original risk acceptance statement, named approvers, and rollback plan.
+
 ---
 
 ## Did You Know?
+
+These notes highlight defaults and limits that rarely appear in quickstarts but routinely appear in production incidents or FinOps reviews.
 
 1. **GCS processes over 2 trillion objects per day** across all customers. The service has been running since 2010 and has achieved [99.999999999% (11 nines) durability](https://cloud.google.com/storage/docs/availability-durability). In practical terms, annual object loss due to underlying storage durability is expected to be extremely rare.
 
@@ -464,6 +622,8 @@ gcloud storage rsync gs://source-bucket/ gs://dest-bucket/ \
 
 ## Common Mistakes
 
+The table below collects misconfigurations that survive initial review because buckets look fine in the console summary view. Each row ties symptom to remediation so you can paste fixes into runbooks.
+
 | Mistake | Why It Happens | How to Fix It |
 | :--- | :--- | :--- |
 | Using `allUsers` for "quick sharing" | Easiest way to make something accessible | Use signed URLs for temporary access; IAM groups for persistent access |
@@ -474,6 +634,8 @@ gcloud storage rsync gs://source-bucket/ gs://dest-bucket/ \
 | Deleting without versioning enabled | "Delete means delete" | Enable versioning first, then deletes create non-current versions instead of permanent loss |
 | Listing entire large buckets | Using `gcloud storage ls` without a prefix | Prefer a prefix filter; use Inventory Reports for bulk analysis |
 | Ignoring minimum storage duration charges | Uploading to COLDLINE then deleting after 10 days | You are billed for 90 days regardless; use STANDARD for short-lived objects |
+
+When triaging a bucket incident, confirm Public Access Prevention and uniform bucket-level access first, then inspect IAM for `allUsers`, then review versioning and lifecycle rules before attempting destructive recovery. That ordering avoids locking retention policies while panic-deleting noncurrent versions you still need.
 
 ---
 
@@ -515,22 +677,35 @@ Autoclass is the optimal solution for this specific data lake because the access
 The command fails because Google Cloud Storage uses a single, global flat namespace for all bucket names across every single customer worldwide. Buckets are addressable via public DNS (like `storage.googleapis.com/bucket-name`), meaning two different organizations cannot possess the exact same bucket name simultaneously. The generic name `app-logs` was already claimed by another organization. To avoid this architectural constraint, adopt a strict naming convention that includes your organization, project ID, environment, and purpose (for example, `my-org-prod-app-logs`), which guarantees uniqueness while preserving operational context.
 </details>
 
+<details>
+<summary>7. Your compliance team requires database backups to survive a full regional outage in the United States with no more than 15 minutes of backup writes lost. You already run nightly exports into a regional `us-central1` bucket. Compare upgrading that bucket versus creating a new dual-region bucket with Turbo Replication enabled, and justify the architecture you would present to leadership.</summary>
+
+A regional `us-central1` bucket keeps backups in one place: if the region fails, the backups are unavailable until Google restores the region, which violates the stated RPO for ongoing writes. A dual-region bucket with placement such as `us-central1` and `us-east1` stores redundant copies geographically, and enabling Turbo Replication provides a documented 15-minute RPO for newly written objects rather than best-effort asynchronous lag. Leadership should fund the extra at-rest and inter-region replication line items as insurance, pair the bucket with versioning to protect against operator error during failover, and require quarterly failover drills that read from the surviving region—not assume replication alone equals application recovery.
+</details>
+
+<details>
+<summary>8. Scenario: A FinOps review shows egress from your `US` multi-region Standard bucket to Cloud Run services in `europe-west1` dominates the storage bill even though storage gigabytes are modest. Storage class is already correct for access frequency. Propose three concrete changes that attack the spike without deleting data, and explain why each change reduces spend.</summary>
+
+First, introduce Cloud CDN or move user-facing objects behind a regional bucket in `europe-west1` so repeated reads do not traverse expensive cross-continental egress from `US` multi-region on every request. Second, co-locate a regional copy of warm datasets beside the Cloud Run service using `gcloud storage rsync` or transfer jobs, accepting that you trade duplication for cheaper reads. Third, audit automation for full-bucket listings and wide exports that pull entire prefixes across regions; narrow jobs to required prefixes and use Inventory Reports for analytics instead of shipping bytes repeatedly. Each tactic removes cross-region bytes moved per user request, which is the dominant cost driver when compute and data are continents apart.
+</details>
+
 ---
 
 ## Hands-On Exercise: GCS Lifecycle, Versioning, and Signed URLs
 
 ### Objective
 
-Create a bucket with versioning and lifecycle rules, demonstrate version recovery, and generate signed URLs for temporary access.
+Create a bucket with versioning and lifecycle rules, demonstrate version recovery, and generate signed URLs for temporary access. The lab intentionally mirrors production ordering: establish guardrails (uniform access, versioning), prove recovery mechanics, attach lifecycle to bound spend, then exercise signed URLs with impersonation rather than downloaded keys.
 
 ### Prerequisites
 
-- `gcloud` CLI installed and authenticated
-- A GCP project with billing enabled
+Before starting, confirm the `gcloud` CLI is installed and authenticated to a project with billing enabled, because signed URL impersonation and bucket creation require an active billing account and permission to create service accounts.
 
 ### Tasks
 
-**Task 1: Create a Bucket with Versioning**
+Work through the six tasks in order; each task builds on the bucket state left by the previous step so you can see how versioning, lifecycle, and signed URLs interact on one bucket name.
+
+### Task 1: Create a Bucket with Versioning
 
 <details>
 <summary>Solution</summary>
@@ -553,7 +728,7 @@ gcloud storage buckets describe gs://$BUCKET_NAME \
 ```
 </details>
 
-**Task 2: Upload Files and Create Multiple Versions**
+### Task 2: Upload Files and Create Multiple Versions
 
 <details>
 <summary>Solution</summary>
@@ -581,7 +756,7 @@ gcloud storage cat gs://$BUCKET_NAME/config.json
 ```
 </details>
 
-**Task 3: Simulate Accidental Deletion and Recover**
+### Task 3: Simulate Accidental Deletion and Recover
 
 <details>
 <summary>Solution</summary>
@@ -614,7 +789,7 @@ gcloud storage cat gs://$BUCKET_NAME/config.json
 ```
 </details>
 
-**Task 4: Set Up Lifecycle Rules**
+### Task 4: Set Up Lifecycle Rules
 
 <details>
 <summary>Solution</summary>
@@ -664,7 +839,7 @@ gcloud storage buckets describe gs://$BUCKET_NAME \
 ```
 </details>
 
-**Task 5: Generate a Signed URL**
+### Task 5: Generate a Signed URL
 
 <details>
 <summary>Solution</summary>
@@ -704,7 +879,7 @@ curl -s "$SIGNED_URL"
 ```
 </details>
 
-**Task 6: Clean Up**
+### Task 6: Clean Up
 
 <details>
 <summary>Solution</summary>
@@ -734,6 +909,18 @@ echo "Cleanup complete."
 
 ---
 
+## Observability, Auditing, and Governance
+
+Storage incidents are easier to prevent when telemetry and policy precede the misconfiguration. Cloud Audit Logs record admin activities such as `storage.buckets.create`, IAM policy changes, and retention lock operations—wire those logs to your SIEM with alerts on `SetIamPolicy` that introduce `allUsers` or `allAuthenticatedUsers`. Data access logs for object reads are high volume; enable them selectively on sensitive buckets rather than project-wide defaults unless you have budget for log ingestion costs.
+
+Cloud Storage publishes metrics in Cloud Monitoring for request counts, bytes sent, and bucket metadata. Dashboards that split by bucket label (`environment`, `cost-center`) help FinOps partners correlate spikes with deploys. For ad-hoc analysis across millions of objects, [Inventory Reports](https://cloud.google.com/storage/docs/insights/inventory-reports) export metadata to BigQuery on a schedule you define, which is far cheaper than recursive listing from a laptop.
+
+Organization policies complement bucket settings: Public Access Prevention stops public ACLs and IAM bindings, uniform bucket-level access can be enforced org-wide, and constraints can require specific locations for regulated data. VPC Service Controls perimeters add an exfiltration guardrail by restricting which projects can call `storage.googleapis.com` APIs even if an IAM binding looks correct. None of these replace code review on Terraform modules that create buckets—treat `uniform_bucket_level_access = true` and `public_access_prevention = "enforced"` as secure defaults in modules, not as optional extras.
+
+When you integrate GCS with Cloud Logging sinks or Pub/Sub notifications, remember that export paths themselves need buckets with tight IAM. A logging sink that writes to a world-readable bucket recreates the exposure you were trying to audit away. The pattern is a dedicated logging project, UBLA, versioning for tamper evidence, and lifecycle to age logs into Nearline after the hot investigation window closes.
+
+---
+
 ## Next Module
 
 Next up: **[Module 2.5: Cloud DNS](../module-2.5-dns/)** --- Learn how to manage DNS zones (public and private), configure DNS forwarding for hybrid environments, and set up peering zones for cross-VPC name resolution.
@@ -759,3 +946,6 @@ Next up: **[Module 2.5: Cloud DNS](../module-2.5-dns/)** --- Learn how to manage
 - [cloud.google.com: inventory reports](https://cloud.google.com/storage/docs/insights/inventory-reports) — General lesson point for an illustrative rewrite.
 - [cloud.google.com: requester pays](https://cloud.google.com/storage/docs/requester-pays) — The Requester Pays docs explain the billing shift and this usage pattern.
 - [cloud.google.com: objects](https://cloud.google.com/storage/docs/objects) — The object model docs treat object names as ordinary names in the namespace, without a hidden-file concept.
+- [cloud.google.com: composite objects](https://cloud.google.com/storage/docs/composite-objects) — Composite upload behavior for parallel large object creation.
+- [cloud.google.com: signed urls v4](https://cloud.google.com/storage/docs/access-control/signed-urls) — V4 signing, verb constraints, and expiration limits for URLs and POST policies.
+- [cloud.google.com: autoclass pricing interactions](https://cloud.google.com/storage/pricing) — Autoclass management fee, enablement charge, and retrieval fee exceptions.

--- a/src/content/docs/cloud/gcp-essentials/module-2.4-gcs.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.4-gcs.md
@@ -153,9 +153,9 @@ GCS offers four storage classes. The key insight is that [**cheaper storage has 
 | Storage Class | Monthly Cost (per GB) | Retrieval Cost (per GB) | Min Duration | Availability SLA | Use Case |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | **STANDARD** | varies by location | $0.00 | None | [99.95% (multi-region)](https://cloud.google.com/storage/docs/storage-classes) | Frequently accessed data |
-| **NEARLINE** | varies by location | $0.01 | 30 days | 99.9% | Monthly access (backups) |
-| **COLDLINE** | varies by location | $0.02 | 90 days | 99.9% | Quarterly access (archives) |
-| **ARCHIVE** | starts at a very low per-GB monthly rate | $0.05 | 365 days | 99.9% | Yearly access (compliance) |
+| **NEARLINE** | varies by location | $0.01 | 30 days | 99.9% (multi-region) | Monthly access (backups) |
+| **COLDLINE** | varies by location | $0.02 | 90 days | 99.9% (multi-region) | Quarterly access (archives) |
+| **ARCHIVE** | starts at a very low per-GB monthly rate | $0.05 | 365 days | 99.9% (multi-region) | Yearly access (compliance) |
 
 Pricing varies by location type as well as class. For Iowa (`us-central1`) regional buckets, [Google's published rates](https://cloud.google.com/storage/pricing) illustrate the tradeoff: Standard storage is roughly $0.020 per gibibyte-month, Nearline about half that, Coldline roughly one quarter, and Archive an order of magnitude lower still—before retrieval and operation charges. Multi-region `US` Standard storage runs higher (on the order of $0.026 per gibibyte-month in the same pricing table) because you pay for geographic redundancy at rest. Dual-region buckets bill both underlying regions, so a NAM4 Standard object effectively accumulates storage cost in each paired region. Use the pricing calculator with your real access pattern instead of picking Archive because the per-GB number looks smallest on a spreadsheet.
 
@@ -195,7 +195,7 @@ With Autoclass enabled:
 - All objects start as STANDARD.
 - After 30 days without access, they move to NEARLINE.
 - After 90 days without access, they move to COLDLINE.
-- After 365 days without access, they move to ARCHIVE.
+- After 365 days without access, they move to COLDLINE (the default terminal class). Archive is opt-in via `--autoclass-terminal-storage-class=ARCHIVE` if you need the lowest at-rest rate and accept the 365-day minimum duration.
 - If accessed again, they automatically move back to STANDARD.
 - [No retrieval fees apply when Autoclass moves objects between classes.](https://cloud.google.com/storage/pricing)
 
@@ -377,7 +377,7 @@ gcloud storage buckets add-iam-policy-binding gs://my-bucket \
 gcloud storage buckets get-iam-policy gs://my-bucket
 ```
 
-Uniform bucket-level access (UBLA) disables object ACLs so IAM policies on the bucket and project become the only authorization path. Google [recommends UBLA for essentially all new buckets](https://cloud.google.com/storage/docs/uniform-bucket-level-access) because dual systems—IAM plus per-object ACLs—create audit gaps: a bucket IAM policy can deny `allUsers` while a forgotten object ACL still grants `allUsers:READ`. Enabling UBLA is reversible for seven days; after that, ACLs are permanently removed from objects. Migration plans should inventory ACL overrides with `gcloud storage objects get-iam-policy` or Storage Insights before flipping the flag in production.
+Uniform bucket-level access (UBLA) disables object ACLs so IAM policies on the bucket and project become the only authorization path. Google [recommends UBLA for essentially all new buckets](https://cloud.google.com/storage/docs/uniform-bucket-level-access) because dual systems—IAM plus per-object ACLs—create audit gaps: a bucket IAM policy can deny `allUsers` while a forgotten object ACL still grants `allUsers:READ`. Enabling UBLA is reversible for 90 days; after 90 consecutive days with UBLA enabled, you can no longer revert to fine-grained ACLs. Migration plans should inventory ACL overrides with `gcloud storage objects get-iam-policy` or Storage Insights before flipping the flag in production.
 
 Fine-grained access (legacy ACL mode) still appears in older modules and third-party tools. ACLs can grant `READER` on one object without exposing siblings, which sounds attractive for multi-tenant invoice buckets, but at scale you cannot reason about effective access from IAM alone. The supported pattern for per-tenant isolation is separate buckets or prefixes with IAM Conditions on resource names, plus signed URLs for unauthenticated downloaders—not object ACL sprawl.
 
@@ -399,9 +399,10 @@ Fine-grained access (legacy ACL mode) still appears in older modules and third-p
 gcloud org-policies set-policy /tmp/prevent-public.yaml --organization=ORG_ID
 
 # /tmp/prevent-public.yaml:
-# constraint: constraints/storage.publicAccessPrevention
-# booleanPolicy:
-#   enforced: true
+# name: organizations/ORG_ID/policies/constraints/storage.publicAccessPrevention
+# spec:
+#   rules:
+#   - enforce: true
 
 # Check if a specific bucket is publicly accessible
 gcloud storage buckets get-iam-policy gs://my-bucket \
@@ -420,9 +421,10 @@ Impersonation-based signing (`--impersonate-service-account`) avoids long-lived 
 
 ```bash
 # Generate a signed URL valid for 1 hour
-# (requires a service account key or impersonation)
+# (requires a service account key file or impersonation)
 gcloud storage sign-url gs://my-bucket/report.pdf \
-  --duration=1h
+  --duration=1h \
+  --private-key-file=KEY.json
 
 # Generate a signed URL using service account impersonation (no key needed)
 gcloud storage sign-url gs://my-bucket/report.pdf \
@@ -528,7 +530,7 @@ When a dataset is public but the publisher does not want to fund egress for the 
 
 At moderate scale—hundreds of terabytes and millions of daily operations—GCS invoices are usually dominated by four knobs: at-rest storage class mix, retrieval and early-deletion surcharges, operation class volume, and egress to clients or other regions. Storage class mistakes are slow burns: everything left in Standard in a multi-region bucket costs more every month even if nobody reads it. Retrieval mistakes are spikes: promoting a Coldline snapshot to an interactive dashboard without caching triggers per-gibibyte read fees plus egress. Operation storms come from list-heavy automation: recursive `gcloud storage ls` across an entire bucket is a Class B operation per listing tranche and does not scale like a database index scan.
 
-Cost control patterns that actually work in production include co-locating buckets with compute, using lifecycle or Autoclass for aging data, setting versioning plus noncurrent cleanup rules, enabling Inventory Reports instead of brute-force listing, and fronting static assets with Cloud CDN so repeat downloads do not re-hit the bucket from distant regions. Turbo Replication and dual-region placement add predictable replication line items on every write; budget them as part of RPO spending, not as surprise data-processing fees. Tags on buckets bill [$0.005 per tag per month](https://cloud.google.com/storage/pricing); keep tag cardinality small and meaningful for FinOps dashboards.
+Cost control patterns that actually work in production include co-locating buckets with compute, using lifecycle or Autoclass for aging data, setting versioning plus noncurrent cleanup rules, enabling Inventory Reports instead of brute-force listing, and fronting static assets with Cloud CDN so repeat downloads do not re-hit the bucket from distant regions. Turbo Replication and dual-region placement add predictable replication line items on every write; budget them as part of RPO spending, not as surprise data-processing fees. Tags on buckets bill [$0.005 per tag per month](https://cloud.google.com/resource-manager/pricing); keep tag cardinality small and meaningful for FinOps dashboards.
 
 Unexpected cost spikes often trace to one of these triggers: changing millions of objects to a colder class manually (Class A operations at the destination rate plus early deletion), restoring an entire versioned bucket after an incident without lifecycle on noncurrent generations, enabling Autoclass on a bucket full of sub-128 KiB artifacts that never tier, or serving multi-region objects to global users without a CDN. Build a monthly review that compares storage gigabytes-by-class, retrieval SKU lines, and egress by destination region; Google Cloud Billing export to BigQuery makes that repeatable.
 
@@ -610,7 +612,7 @@ Document the decision you made in each column of this table in your internal arc
 
 These notes highlight defaults and limits that rarely appear in quickstarts but routinely appear in production incidents or FinOps reviews.
 
-1. **GCS processes over 2 trillion objects per day** across all customers. The service has been running since 2010 and has achieved [99.999999999% (11 nines) durability](https://cloud.google.com/storage/docs/availability-durability). In practical terms, annual object loss due to underlying storage durability is expected to be extremely rare.
+1. **GCS has been running since 2010** and has achieved [99.999999999% (11 nines) durability](https://cloud.google.com/storage/docs/availability-durability). In practical terms, annual object loss due to underlying storage durability is expected to be extremely rare.
 
 2. **The "flat namespace" design means listing millions of objects is expensive**. A `gcloud storage ls gs://my-bucket/` against a very large bucket can be slow and consume operations quota. Use prefixes to narrow your listing (`gs://my-bucket/logs/2024/01/`), or use Cloud Storage Inventory Reports for bulk analysis.
 
@@ -858,8 +860,8 @@ gcloud storage buckets add-iam-policy-binding gs://$BUCKET_NAME \
   --member="serviceAccount:${SA_EMAIL}" \
   --role="roles/storage.objectViewer"
 
-# Grant your user permission to impersonate the service account
-gcloud projects add-iam-policy-binding $(gcloud config get-value project) \
+# Grant your user permission to impersonate the signer service account
+gcloud iam service-accounts add-iam-policy-binding ${SA_EMAIL} \
   --member="user:$(gcloud config get-value account)" \
   --role="roles/iam.serviceAccountTokenCreator"
 

--- a/src/content/docs/cloud/gcp-essentials/module-2.5-dns.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.5-dns.md
@@ -8,7 +8,7 @@ sidebar:
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+By the end of this module you will configure Cloud DNS managed zones with A and CNAME records for both internet-facing and VPC-internal resolution, implement weighted, geolocation, and failover routing policies for multi-region traffic, deploy private zones for GKE and Compute Engine service discovery, and design split-horizon architectures that never accidentally shadow a public apex.
 
 - **Configure Cloud DNS managed zones with A and CNAME records for internal and external resolution**
 - **Implement DNS-based routing policies (weighted, geolocation, failover) for multi-region traffic distribution**
@@ -19,17 +19,19 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-A control-plane or routing failure can make authoritative DNS unreachable, which can take dependent services and even recovery tooling offline. The operational lesson is to design DNS and break-glass access paths so they do not depend on the same failing control plane.
+**Hypothetical scenario:** Your team deploys a new payment API behind a global load balancer and updates the public A record on Saturday night. The change looks correct in Cloud DNS, but customer traffic still hits the old IP until Monday because recursive resolvers cached the previous answer at a 24-hour TTL. Meanwhile, an engineer creates a private zone for the same apex domain to register an internal database hostname, and production VMs in that VPC suddenly cannot reach the public marketing site because private zones override public answers for attached VPCs. Both failures are DNS design problems, not application bugs.
 
-This incident is the most dramatic demonstration of a simple truth: **DNS is the foundation of everything on the internet.** When DNS works, nobody thinks about it. When DNS breaks, nothing works. Every HTTP request, every API call, every service-to-service communication in a microservices architecture begins with a DNS lookup. If you are running workloads on GCP, Cloud DNS is the managed service that resolves names for both your public-facing applications and your internal infrastructure.
+That pair of mistakes illustrates a simple truth: **DNS is the foundation of everything on the internet.** When DNS works, nobody thinks about it. When DNS breaks, nothing works. Every HTTP request, every API call, and every service-to-service hop in a microservices architecture begins with a name lookup. On GCP, [Cloud DNS](https://cloud.google.com/dns/docs/overview) is the managed authoritative and resolver path for public internet names, VPC-private names, hybrid forwarding, cross-VPC peering, routing policies, response-policy overrides, and optional DNSSEC signing.
 
-In this module, you will learn how Cloud DNS works as a globally distributed, managed DNS service. You will understand the difference between public zones (for internet-facing domains) and private zones (for internal VPC name resolution). You will learn how DNS forwarding connects your GCP environment to on-premises DNS servers, and how peering zones allow DNS resolution across VPCs without exposing records to the broader network.
+In this module, you will learn how Cloud DNS serves zones from Google's anycast infrastructure, how public and private managed zones differ in visibility and override behavior, and how routing policies (weighted round robin, geolocation, and failover) steer answers using optional health checks. You will also learn when to use forwarding zones versus DNS peering versus server policies, how response policies implement RPZ-like overrides before normal zone matching, and how billing combines per-zone hourly charges with per-query tiers that spike when routing policies or health checks multiply probe traffic.
 
 ---
 
 ## DNS Fundamentals Review
 
-Before diving into Cloud DNS, a quick refresher on how DNS resolution works is essential for understanding the configurations that follow.
+Before diving into Cloud DNS, a quick refresher on how DNS resolution works is essential for understanding the configurations that follow. Authoritative DNS (what Cloud DNS provides for your zones) answers only for names it owns; recursive resolvers (ISP resolvers, `8.8.8.8`, or the GCP metadata server at `169.254.169.254`) chase delegations from root to TLD to your zone and cache answers according to TTL. Confusing those two roles is a common source of "the console shows the right record but my laptop still resolves the old IP" reports during cutovers—you must lower TTLs and wait for caches, not only update authoritative data.
+
+Cloud DNS publishes your authoritative answers from Google's anycast footprint, while VPC workloads still use the metadata resolver path that applies policies, response overrides, private zones, forwarding, peering, internal Compute Engine names, and finally public recursion. Keeping that split in mind makes every later feature—forwarding zones, inbound policies, RPZ-style response policies—easier to reason about because you know **where** in the chain a knob acts.
 
 ```mermaid
 sequenceDiagram
@@ -68,7 +70,9 @@ sequenceDiagram
 
 ## Public Zones: Internet-Facing DNS
 
-A public DNS zone in Cloud DNS makes your domain resolvable from anywhere on the internet. When you create a public zone, Google assigns it [four authoritative nameservers from the `googledomains.com` pool](https://cloud.google.com/dns/docs/update-name-servers).
+A public DNS zone in Cloud DNS makes your domain resolvable from anywhere on the internet. When you create a public zone, Google assigns it [four authoritative nameservers from the `googledomains.com` pool](https://cloud.google.com/dns/docs/update-name-servers). Those nameservers are anycasted within Google's network, which means resolvers usually reach a nearby serving location rather than a single physical datacenter. You still own correctness of the zone data—Cloud DNS does not guess records for you—but Google operates the authoritative serving plane and publishes an SLA around query availability for managed zones.
+
+Public zones are the right home for MX and TXT records that prove domain ownership to SaaS vendors, for ACME DNS-01 challenge TXT records during certificate automation, and for A/AAAA aliases that front global HTTPS load balancers. Treat the public zone as a contract with the entire internet: every name you publish is crawlable and enumerable, so never place purely internal hostnames in a public zone "just because it is easier." If a name must not leak, it belongs in a private zone or behind an internal suffix that never receives a public delegation.
 
 ### Creating a Public Zone
 
@@ -177,6 +181,14 @@ TTL (Time to Live) controls how long resolvers cache a DNS response. Choosing th
 
 > **Stop and think**: You are planning to switch a critical database to a new instance this coming Saturday at midnight. The current `db.example.com` A record has a TTL of 86400 (24 hours). What specific action should you take on Friday, and what should you do after the migration is complete?
 
+### Delegation, Propagation, and Split-Horizon Planning
+
+A public managed zone is only authoritative after your registrar delegates the domain to the four `ns-cloud-*.googledomains.com` nameservers Cloud DNS assigns. Until delegation completes, the internet continues to query your old DNS provider, which means Terraform can show the correct records in GCP while customers still receive stale answers. After delegation, propagation depends on parent TTLs, registrar glue updates, and any intermediate caches—not on how fast you clicked Save in the console.
+
+Split-horizon DNS is the deliberate pattern of serving different answers to internal clients than to the public internet. Cloud DNS implements split horizon with separate public and private zones, not with a single zone that magically returns two answers. The private zone must attach only to VPCs that should see internal names, and the public zone must remain the source of truth for internet clients. When both zones share an apex name, VMs in attached VPCs always prefer the private zone, which is powerful for internal service discovery and dangerous if the private zone is incomplete. The sustainable pattern is to reserve a dedicated internal suffix—`internal.example.com` or `gcp.corp.example.com`—for private zones and keep the marketing apex solely in the public zone unless you intentionally mirror every public record into the private copy.
+
+Record changes in Cloud DNS are applied atomically through transactions, which protects you from publishing half-updated RRsets during bulk edits. For high-churn environments, label zones in billing exports so finance can attribute zone sprawl to teams; zone count is a first-class cost driver because managed-zone pricing is charged per zone per month regardless of query volume.
+
 ---
 
 ## DNS Routing Policies
@@ -184,7 +196,10 @@ TTL (Time to Live) controls how long resolvers cache a DNS response. Choosing th
 Cloud DNS allows you to configure [routing policies that intelligently direct traffic based on weight, geolocation, or health checks](https://cloud.google.com/dns/docs/routing-policies-overview). This is essential for building highly available, multi-region architectures.
 
 ### Weighted Round Robin
-Weighted routing distributes traffic across multiple IP addresses based on weights you define. This is incredibly useful for A/B testing, canary deployments, or gradually shifting traffic to a new environment (e.g., sending 10% of traffic to a new version of your application).
+
+Weighted routing distributes traffic across multiple IP addresses based on weights you define, which makes it the default choice for canary releases and blue/green cutovers where you want a deterministic percentage split without geography semantics. Weights are not percentages themselves—Cloud DNS normalizes weights up to 1000—so a 80/20 intent is expressed as `primary=80;canary=20` in `--routing-policy-data`. When health checks are enabled, unhealthy targets drop out of the weighted pool and the remaining healthy weights are renormalized, which means your canary might receive more than twenty percent of traffic if the primary VIP fails probes unless you also assign zero-weight standby records.
+
+Operationally, pair WRR with observability on both VIPs during a release: DNS only steers names; it does not know HTTP error rates. If the canary VIP accepts TCP but returns 500 responses, DNS will still send clients there until application health checks or manual weight changes intervene.
 
 ```bash
 # Add a weighted round-robin policy to split traffic 80/20
@@ -198,7 +213,10 @@ gcloud dns record-sets transaction add "34.120.55.200,34.120.55.201" \
 ```
 
 ### Geolocation Routing
-Geolocation routing minimizes latency by directing users to the endpoint geographically closest to them. If you run application clusters in both `us-central1` and `europe-west1`, you can ensure users in Europe are routed to the European cluster automatically.
+
+Geolocation routing minimizes latency by directing users to endpoints mapped to Google Cloud regions associated with the query source. If you run application clusters in both `us-central1` and `europe-west1`, European VMs—or VPN/Interconnect entry regions for hybrid clients—receive answers pointing at the European VIP. Public geolocation uses how traffic enters Google's network; private geolocation uses VM region or tunnel attachment region as documented in the routing policies overview, which matters when debugging "wrong region" reports from on-premises users who enter through a central VPN in `us-east4` but expect `europe-west1` answers.
+
+Geolocation is not a compliance guarantee by itself: geofencing changes failover behavior, and health-checked geolocation still requires you to operate healthy backends in each geography you advertise. Combine GEO with global load balancers when you need L7 routing inside a region, and with DNS GEO when you need clients to land in different regions at all.
 
 ```bash
 # Add a geolocation routing policy
@@ -212,7 +230,10 @@ gcloud dns record-sets transaction add "34.120.55.200,34.120.55.202" \
 ```
 
 ### Failover Routing
-Failover routing directs traffic to a primary endpoint and automatically switches to a backup endpoint if the primary fails health checks.
+
+Failover routing expresses active/backup semantics explicitly: Cloud DNS serves the primary IP set while health checks pass, then shifts to the backup set when primaries fail. Backups may themselves be geolocation policies, which is how teams model "stay in-region until the region is dead, then break glass to a distant DR VIP." You can also trickle a fraction of traffic to backups with a backup traffic fraction between 0 and 1 to validate DR paths without a full flip.
+
+Failover differs from WRR because intent is ordered preference, not proportional sharing. Use failover when only one endpoint should receive traffic at a time; use WRR when both endpoints should simultaneously receive production traffic at known ratios.
 
 ```bash
 # Add a failover routing policy
@@ -226,11 +247,38 @@ gcloud dns record-sets transaction add "34.120.55.200,34.120.55.203" \
   --routing-policy-backup-data="34.120.55.203"
 ```
 
+### Health Checks, Geofencing, and Policy Limits
+
+[Routing policies](https://cloud.google.com/dns/docs/routing-policies-overview) can attach health checks to internal load balancer VIPs (private zones) or to internet-reachable endpoints (public zones). Cloud DNS probes on an interval you configure (30–300 seconds for external endpoints) and removes unhealthy targets from answers; when every target in a policy bucket fails, behavior depends on policy type—WRR redistributes among remaining healthy weights, geolocation may fail over to the next closest region unless geofencing is enabled, and failover shifts to the backup set you defined.
+
+Geolocation routing maps source geography to answers. For private DNS, Google Cloud uses the region of the VM that sent the query (or the region of the VPN tunnel, Interconnect attachment, or Router appliance for inbound server-policy entry points)—not the EDNS client subnet. For public DNS, geography follows how queries enter Google's network. Geofencing keeps traffic inside a geography even when all endpoints there are unhealthy, which avoids silent failover to a distant region but can return unhealthy VIPs because authoritative servers must still answer.
+
+Weighted round robin supports weights from 0 through 1000. Zero-weight targets can act as cold standby: when health checks mark higher-weight targets unhealthy, Cloud DNS may return zero-weight records that were configured as backups. Combining WRR with geolocation in the same RRset is not supported—choose one steering model per name.
+
+DNS routing policies cannot be configured on forwarding zones, DNS peering zones, managed reverse lookup zones, or Service Directory zones. Plan steering on standard public or private managed zones that hold the A/AAAA answers you want to health-check.
+
+```bash
+# Example: create an internal fast health check (private zone / ILB use case)
+gcloud dns health-checks create http my-api-hc \
+  --check-interval=30s \
+  --healthy-threshold=1 \
+  --unhealthy-threshold=3 \
+  --port=80 \
+  --request-path="/healthz" \
+  --host="api.internal.example.com."
+
+# Attach health check IDs when defining routing policy RRsets (see routing policy docs for flags)
+```
+
+Supported RR types for routing policies include A, AAAA, CNAME, MX, SRV, and TXT, but only A/AAAA carry health-check semantics for steering. DNSSEC-enabled zones that use health checks must use a single IP per policy item—you cannot mix health-checked and non-health-checked addresses in the same policy line when DNSSEC is on.
+
 ---
 
 ## Private Zones: Internal DNS
 
-Private DNS zones are [visible only from within specified VPC networks](https://cloud.google.com/dns/docs/key-terms). They are essential for internal service discovery---allowing you to give friendly names to internal resources without exposing those names to the internet.
+Private DNS zones are [visible only from within specified VPC networks](https://cloud.google.com/dns/docs/key-terms). They are essential for internal service discovery—allowing you to give friendly names to databases, internal APIs, and management endpoints without publishing those names to the internet. Private zones also integrate with Google Cloud's internal DNS names for VMs, but you should not confuse the two: Compute Engine auto-generates internal names under `c.project-id.internal` style namespaces, while your private zones are explicit product choices you curate.
+
+Design private zones around service lifecycles: stable infrastructure names (`db.prod.internal.example.com`) change rarely and deserve moderate TTLs, while autoscaling pools might use shorter TTLs if IPs change frequently—though Kubernetes and load balancers usually mean you point DNS at stable VIPs instead of per-pod IPs. When multiple environments share networking machinery, encode environment in the suffix (`dev`, `staging`, `prod`) so a mistaken zone attachment does not cross-wire databases.
 
 ```mermaid
 flowchart LR
@@ -299,31 +347,40 @@ gcloud dns managed-zones update internal-zone \
 ```
 
 ### Integration with Kubernetes (GKE)
-GKE nodes participate in Google Cloud DNS resolution for their network, and Cloud DNS for GKE integrates cluster DNS records with Google Cloud's DNS path. In practice, cluster workloads can resolve VPC-visible names when the cluster's DNS mode and scope are configured to expose them.
+
+GKE nodes use the metadata DNS path (`169.254.169.254`) like other Compute Engine VMs, but [Cloud DNS for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-dns) can publish cluster-scoped private zones and response policies that apply before the VPC-wide order. Cluster-scoped resources let platform teams expose service names to pods without attaching every service project VPC to every hub zone, while VPC-scoped zones remain the default for VM-to-VM resolution across the network. When designing GKE plus Cloud DNS, decide whether a name is cluster-local (visible only to a cluster's nodes), VPC-local (visible to all VMs in attached networks), or public—and avoid reusing a public apex in a cluster-scoped private zone unless you mirror every required public record.
 
 ### Private Zone Resolution Order
 
-When a VM or GKE node uses Google Cloud DNS, the official resolution order includes alternative name servers and response policies before private, forwarding, peering, internal, and public DNS lookups; use the Google Cloud documentation for the exact sequence:
+Google documents a precise [VPC name resolution order](https://cloud.google.com/dns/docs/vpc-name-res-order). GKE evaluates cluster-scoped response policies and cluster-scoped private or forwarding zones first; if no match, resolution continues with the VPC network order below. For a standard VM (non-GKE-specific path), the high-level sequence is:
 
-```text
-1. Private zones attached to the VM's VPC
-   (e.g., internal.example.com → private zone answers)
-
-2. Forwarding zones (if configured)
-   (e.g., corp.company.com → forwarded to on-premises DNS)
-
-3. Peering zones (if configured)
-   (e.g., partner.example.com → resolved via peered VPC)
-
-4. Google public DNS
-   (e.g., www.google.com → resolved via public DNS)
+```mermaid
+flowchart TD
+    A[Query arrives at metadata DNS] --> B{Outbound server policy with alternative name servers?}
+    B -->|Yes| C[Forward to alternative name servers ranked by success/latency]
+    B -->|No| D{VPC response policy rule matches?}
+    D -->|Local data| E[Return override answer]
+    D -->|Bypass| F[Continue]
+    D -->|No match| F
+    F --> G{Longest-suffix match in private / forwarding / peering zones?}
+    G -->|Private zone| H[Answer from zone records or NXDOMAIN]
+    G -->|Forwarding zone| I[Forward to on-prem or custom targets]
+    G -->|Peering zone| J[Restart resolution in target VPC]
+    G -->|No match| K[Compute Engine internal DNS names]
+    K --> L[Public DNS recursion for remaining names]
 ```
+
+Memorize the precedence implications, not every bullet: **response policies and alternative name servers run before managed private zones**, so a blocking RPZ rule can sinkhole a name even if a private zone contains a permissive record. **Peering does not copy zones**—it restarts lookup in another VPC's order, which is why hub-and-spoke designs centralize zone attachments in a DNS hub VPC and attach peering zones in spokes. **Private zones beat public zones for attached VPCs**, which is the split-horizon override behavior that breaks partial private copies of a public apex.
 
 ---
 
 ## DNS Forwarding: Hybrid Cloud DNS
 
-DNS forwarding allows you to [forward queries for specific domains to external DNS servers](https://cloud.google.com/dns/docs/zones/zones-overview). This is critical in hybrid environments where on-premises resources have DNS records in on-premises DNS servers.
+DNS forwarding allows you to [forward queries for specific domains to external DNS servers](https://cloud.google.com/dns/docs/zones/zones-overview). This is critical in hybrid environments where on-premises resources have DNS records in on-premises DNS servers. Forwarding zones are private managed zones whose `dns-name` suffix determines which queries leave GCP: only names falling under that suffix are candidates for forwarding, which is why enterprises forward `corp.example.com.` or `ad.corp.example.com.` rather than attempting to forward "everything except googleapis.com."
+
+Hybrid designs fail in predictable ways when networking and DNS are designed separately. A forwarding zone aimed at on-prem resolvers without `[private]` routing will attempt to reach those IPs over the internet path and time out. Inbound forwarding without matching conditional forwarders on Active Directory or BIND leaves on-prem clients querying only themselves. The fix is always to draw a two-direction diagram: GCP→on-prem uses forwarding zones or alternative name servers; on-prem→GCP uses inbound server-policy addresses on the subnets that actually carry Interconnect or VPN packets.
+
+Capacity planning belongs in the same workshop: on-premises DNS teams must size their servers for GCP retry storms during incidents, and GCP teams must understand that each forwarded query bills as a Cloud DNS query plus any target-resolution lookup for hostname targets. During steady state, prefer caching on-premises forwarders with sane TTLs so Cloud DNS is not hammered for every pod restart.
 
 ### Outbound Forwarding (GCP to On-Premises)
 
@@ -384,7 +441,7 @@ gcloud compute addresses list \
 
 ### Alternative Forwarding via DNS Policies
 
-DNS policies allow you to configure forwarding behavior at the VPC level instead of creating forwarding zones.
+Server policies let you configure VPC-wide resolver behavior—logging, inbound forwarding, outbound alternative name servers—without creating a managed zone per suffix. That is different from a forwarding zone, which matches only the delegated `dns-name` you configure.
 
 ```bash
 # Create a policy that forwards all DNS to custom nameservers
@@ -400,6 +457,44 @@ gcloud dns policies list
 # Delete a policy
 gcloud dns policies delete custom-dns
 ```
+
+Outbound [server policies](https://cloud.google.com/dns/docs/server-policies-overview) differ from forwarding zones: a policy sends **all** queries (or a configured subset via alternative name server rules) to custom resolvers before Cloud DNS evaluates private zones, whereas a forwarding zone matches only the suffix you delegate (for example `corp.company.com.`). Use policies when you want a VPC-wide resolver swap for compliance logging or centralized filtering appliances; use forwarding zones when only corporate suffixes should leave GCP. Inbound forwarding exposes resolver IPs in your subnets so on-premises conditional forwarders can query GCP private zones—each subnet receives a DNS resolver address you list with `gcloud compute addresses list --filter="purpose=DNS_RESOLVER"`.
+
+When forwarding targets are domain names rather than IPs, Cloud DNS performs an extra lookup to resolve the target, and [pricing](https://cloud.google.com/dns/pricing) bills that resolution in addition to the forwarded query. Prefer static IP targets for predictable cost and troubleshooting. Mark targets with `[private]` so forwarding uses Cloud VPN, Cloud Interconnect, or Private Google Access paths instead of the public internet.
+
+---
+
+## Response Policy Zones (RPZ-Style Overrides)
+
+[Response policies](https://cloud.google.com/dns/docs/policies-overview) are not DNS zones; they are rule sets attached to a VPC network (one response policy per network) that Cloud DNS evaluates during lookups. They implement outcomes similar to the IETF DNS Response Policy Zone (RPZ) draft: block malicious names, override answers for migration cutovers, or redirect API hostnames to restricted VIPs without editing every private zone record.
+
+Rules use longest-suffix matching like zones. A rule can return **local data** (synthetic A/AAAA/CNAME answers), or use **bypassResponsePolicy** passthrough so specific names escape a broad wildcard block. Because VPC-scoped response policies are consulted in the [resolution order](https://cloud.google.com/dns/docs/vpc-name-res-order) before managed private zones, a deny rule takes effect even when a permissive record exists downstream—design overrides carefully and document bypass exceptions for break-glass hosts.
+
+```bash
+# Create a response policy attached to prod-vpc
+gcloud dns response-policies create security-policy \
+  --description="DNS overrides for prod VPC" \
+  --networks=prod-vpc
+
+# Block a malicious domain (local NXDOMAIN-style behavior via local data)
+gcloud dns response-policies rules create block-c2 \
+  --response-policy=security-policy \
+  --dns-name="c2.hacker-network.com." \
+  --local-data-rrsets="c2.hacker-network.com. 300 IN A 127.0.0.1"
+
+# Bypass: allow one subdomain past a wildcard override
+gcloud dns response-policies rules create allow-partner-api \
+  --response-policy=security-policy \
+  --dns-name="api.partner.example.com." \
+  --behavior=bypassResponsePolicy
+
+# List rules
+gcloud dns response-policies rules list --response-policy=security-policy
+```
+
+Pair response policies with [DNS logging](https://cloud.google.com/dns/docs/server-policies-overview) on the same VPC when security teams need evidence of blocked lookups. Response policies complement—not replace—firewall rules: they stop name resolution, but hard-coded IPs or DoH clients can bypass DNS controls.
+
+GKE cluster-scoped response policies follow the same longest-suffix semantics but apply before cluster-scoped private zones, which is how platform teams inject safeguards for workloads without touching every service project's VPC attachments. When both cluster-scoped and VPC-scoped policies exist, consult the [name resolution order](https://cloud.google.com/dns/docs/vpc-name-res-order) diagram in documentation during design reviews so security and application teams agree on which override wins.
 
 ---
 
@@ -446,11 +541,15 @@ gcloud dns managed-zones create peer-to-hub \
 | GCP to on-premises resolution | Forwarding zone | Cloud DNS forwards to on-prem |
 | Shared VPC with private DNS | Private zone on shared VPC | All service projects resolve automatically |
 
+DNS peering is not a network peering shortcut: it only delegates name resolution to another VPC's Cloud DNS path. The target VPC must already host the authoritative private zones, and IAM plus VPC connectivity still govern who can reach the resolved IPs. Hub VPCs should use narrow zone suffixes and change control, because a mistaken delete in the hub breaks every spoke peering zone simultaneously.
+
 ---
 
 ## DNSSEC: Securing DNS
 
-DNSSEC (Domain Name System Security Extensions) [protects against DNS spoofing by digitally signing DNS records. Cloud DNS supports DNSSEC for public zones](https://cloud.google.com/dns/docs/dnssec).
+DNSSEC (Domain Name System Security Extensions) [protects against DNS spoofing by digitally signing DNS records. Cloud DNS supports DNSSEC for public zones](https://cloud.google.com/dns/docs/dnssec). Signing proves that answers for your zone were issued by your keys and were not altered in transit between authoritative servers and validating resolvers. DNSSEC does not encrypt queries—confidentiality still requires TLS on your applications—but it closes the cache-poisoning class of attacks that manipulate DNS answers themselves.
+
+Operational sequencing matters: enable DNSSEC in Cloud DNS, export the DS record Google generates, publish that DS at your registrar, then wait for parent-side propagation before expecting validating resolvers to treat signatures as trustworthy. If you enable routing policies with health checks while DNSSEC is on, remember Google's constraint that each policy item may contain only a single IP when health checking and DNSSEC are combined—plan steering per VIP, not per multi-address RRset.
 
 ```bash
 # Enable DNSSEC on a public zone
@@ -468,7 +567,7 @@ gcloud dns dns-keys list --zone=example-zone \
 
 ## DNS Logging
 
-DNS query logging helps you understand what your workloads are resolving and detect anomalous behavior.
+DNS query logging helps you understand what your workloads are resolving, prove that a response policy blocked a name, and detect anomalous retry storms during incidents before they become egress bills or dependency outages.
 
 ```bash
 # Enable DNS logging via a policy
@@ -483,6 +582,164 @@ gcloud logging read 'resource.type="dns_query"' \
   --format="table(jsonPayload.queryName, jsonPayload.queryType, jsonPayload.responseCode, jsonPayload.sourceIP)"
 ```
 
+DNS query logs land in Cloud Logging under `resource.type="dns_query"`. Logging is enabled on DNS **policies**, not on individual zones, which means you enable it once per VPC network and capture queries the metadata resolver handles—including forwarded, peered, and overridden names. Budget for log ingestion separately from Cloud DNS query pricing; high-cardinality workloads can generate large log volume during incidents when every pod retries a failing name.
+
+---
+
+## Cost Lens: Zones, Queries, and Hidden Multipliers
+
+Cloud DNS has [no free tier](https://cloud.google.com/dns/pricing). Billing aggregates **all zone types**—public, private, and forwarding—into a single managed-zone count, prorated hourly. The first 25 zone-months per billing account are priced at roughly $0.20 per zone per month (derived from the published hourly rate); additional tiers decrease per-zone cost at 25+ and 10,000+ zones. A platform team with hundreds of micro-zones per microservice therefore pays mostly for zone inventory, not queries.
+
+Query pricing splits **regular queries** (about $0.40 per million for the first billion per month) from **routing policy queries** (about $0.70 per million for the same tier). Any RRset using WRR, GEO, or FAILOVER steering bills at the higher routing-policy rate even if the answer is a single A record. Health checks add hourly charges: internal fast checks are roughly $0.00274 per hour each, internal premium checks roughly $0.00548 per hour—multiplied by every VIP you probe. A multi-region active-active design with three geolocation buckets and three health checks per region can accrue more cost in probes than in user-facing queries during low-traffic services.
+
+| Cost driver | What increases spend | Knobs that reduce spend |
+| :--- | :--- | :--- |
+| Managed zones | One zone per suffix per project; sprawl from teams creating duplicate private zones | Consolidate suffixes; use hub VPC + peering instead of duplicating zone attachments |
+| Regular queries | Low TTLs, chatty service meshes, retry storms | Raise TTL for stable records; fix failing dependencies causing NXDOMAIN retries |
+| Routing policy queries | Geo/WRR/failover on high-QPS names | Use routing policies only on names that need steering; use load balancers for simple active-passive |
+| Health checks | Many ILB VIPs with short intervals | Share health checks where possible; increase interval within allowed bounds |
+| Forwarding target hostnames | Extra lookup to resolve FQDN targets | Use IP targets; cache on-prem forwarder side |
+| DNS logging + DNS Armor | Log ingestion; per-workload threat-detection units | Scope logging to production VPCs; tune DNS Armor exclusions |
+
+Hypothetical scenario: A SaaS provider hosts 8,000 customer subdomains as separate private zones for isolation. Zone charges alone land in the highest published tier (about $0.03 per zone-month above 10,000 zone-months in Google's pricing table examples), while queries stay negligible. The architectural fix is fewer zones with wildcard records or shared suffixes, not shorter TTLs.
+
+---
+
+## Patterns & Anti-Patterns
+
+Mature Cloud DNS designs treat names as platform APIs: suffixes are versioned, hub VPCs own authoritative data, and overrides are explicit. The patterns below appear repeatedly in enterprises that operate hybrid GCP plus on-premises estates, Shared VPC service projects, and GKE fleets.
+
+| Pattern | When to use it | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| Dedicated internal suffix | Any split-horizon or microservice discovery need | Avoids private zones shadowing public apex records | One private zone per environment (`dev.internal`, `prod.internal`) scales cleaner than per-service zones |
+| DNS hub VPC with peering zones | Many spokes, centralized platform team | Spokes attach one peering zone per suffix instead of N zone×VPC bindings | Hub becomes critical—use IaC and restricted IAM on hub projects |
+| TTL runway before migrations | Planned IP or load balancer changes | Lets caches expire before cutover | Automate TTL lowering via transactions; restore higher TTL after validation |
+| Response policy for emergency blocks | Need fast org-wide sinkhole without redeploying apps | Evaluated before zone records; no agent on VMs | Document bypass rules for security tooling domains |
+| Routing policy + health checks | Multi-region active/active behind ILBs or public endpoints | Removes unhealthy VIPs from answers automatically | Watch routing-policy query tier and health-check hourly charges |
+
+Anti-patterns usually begin as convenient one-off console clicks—an extra private zone on the marketing apex, a forwarding target aimed at a hostname instead of an IP—that ossify into production architecture and only surface during the first cross-VPC migration or finance review.
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+| :--- | :--- | :--- | :--- |
+| Private zone on public apex | Internal VMs lose public records for the same name | Engineers reuse the marketing domain for databases | Use `internal.example.com` or similar dedicated suffix |
+| Attaching every VPC to every zone | 50×20 binding matrix; drift on every new project | Seems simpler than peering | Hub VPC + DNS peering zones per suffix |
+| TTL 86400 everywhere | Multi-hour failover after incidents | Copy-paste from registrar defaults | 300s for app records; higher only for stable MX/NS |
+| Forwarding zone per microservice | Zone-count explosion and billing tier creep | Each team wants autonomy | Forward `corp.example.com` once; delegate subdomains on-prem |
+| Routing policy on forwarding/peering zones | Configuration rejected or ignored | Confusion between zone types | Put policies on standard public/private managed zones |
+| DNSSEC + mixed health-check RRsets | Signing constraints violated | Incremental enablement without reading DNSSEC limits | Single IP per policy item when DNSSEC enabled |
+| Relying on DNS blocks alone for malware | DoH or hard-coded IPs bypass DNS | RPZ feels like a complete security control | Pair with egress firewall, VPC SC, and endpoint agents |
+
+---
+
+## Decision Framework
+
+Use this flow when choosing among public zones, private zones, forwarding, peering, server policies, routing policies, and response policies. The goal is to match **visibility** (who may see the name), **authority** (who owns the records), and **override** (whether answers may be blocked or steered).
+
+```mermaid
+flowchart TD
+    Start[New DNS requirement] --> Internet{Must the name resolve on the public internet?}
+    Internet -->|Yes| Public[Public managed zone at registrar-delegated NS]
+    Internet -->|No| VPCOnly[VPC-internal name only]
+    VPCOnly --> Hybrid{Need on-prem or custom resolver answers?}
+    Hybrid -->|Specific suffix to on-prem| Fwd[Forwarding zone for that dns-name]
+    Hybrid -->|Entire VPC uses corporate resolvers| Alt[Outbound server policy alternative name servers]
+    Hybrid -->|No external resolver| Scope{Single VPC or many VPCs?}
+    Scope -->|Single VPC| Priv[Private managed zone attached to VPC]
+    Scope -->|Many VPCs same records| Multi[Private zone with multiple networks OR hub peering]
+    Multi --> Hub{Central platform team?}
+    Hub -->|Yes| Peer[Peering zone targeting hub VPC]
+    Hub -->|No| Multi
+    Public --> Steer{Need geo/WRR/failover steering?}
+    Steer -->|Yes| RP[Routing policy RRset + optional health checks]
+    Steer -->|No| Records[Standard A/AAAA/CNAME records]
+    VPCOnly --> Override{Need block/override before zones?}
+    Override -->|Yes| Resp[Response policy rules on VPC]
+    Override -->|No| Priv
+    Hybrid --> Inbound{On-prem must query GCP private names?}
+    Inbound -->|Yes| InPol[Inbound server policy + conditional forwarders]
+```
+
+| Decision | Prefer | Tradeoff |
+| :--- | :--- | :--- |
+| Public vs private zone | Public for internet clients; private only for RFC1918-style internal names | Private attachment overrides public for same name in that VPC |
+| Forwarding zone vs server policy | Forwarding for suffix delegation; policy for VPC-wide resolver swap | Policies run earlier in resolution order—can surprise teams expecting private zones first |
+| Peering vs multi-network private zone | Peering for hub/spoke at scale; multi-network when few VPCs share identical records | Peering adds hop through hub order; multi-network widens blast radius of zone edits |
+| Static records vs routing policy | Static A/AAAA for single-homed services | Routing policies cost more per query and require health-check ops |
+| WRR vs GEO vs FAILOVER | WRR for weighted canary; GEO for latency; FAILOVER for active/backup VIP pairs | Cannot combine WRR and GEO on same RRset; failover backup can itself be GEO |
+| Response policy vs private zone record | Policy for security blocks or global overrides; zone records for normal service discovery | Policies evaluated before zones—easy to accidentally block legitimate names |
+
+---
+
+## Shared VPC, Cross-Project Visibility, and Fleet Operations
+
+Shared VPC changes who attaches private zones but not how resolution works: service-project VMs still query through the host VPC's metadata path, so private zones should usually live in the host project that owns the Shared VPC network. Attaching a zone to `projects/host/global/networks/prod` makes records visible to every service project using that network without copying zones into each service project. When teams mistakenly create duplicate private zones in each service project, you pay duplicate managed-zone charges and risk divergent record data during incidents.
+
+Cross-project visibility also appears in `gcloud dns managed-zones update --networks=projects/...` bindings. Use fully qualified network URLs in automation to avoid ambiguous short names. IAM roles such as `roles/dns.admin` should be limited to platform pipelines; application teams receive narrower custom roles that can only mutate record sets inside approved zones. Pair IAM constraints with code review on Terraform `google_dns_record_set` resources because a single typo in an apex A record is a global outage for internet properties.
+
+For fleet operations, export zone and policy identifiers into your CMDB so incident commanders know which hub VPC owns `internal.corp.example.com` peering. During migrations, run parallel queries from three vantage points: an on-prem resolver, a VM in the spoke VPC, and `dig @169.254.169.254` on a GKE node. Mismatches between those three almost always mean forwarding, peering, or response-policy ordering—not application misconfiguration.
+
+Hypothetical scenario: A platform team enables DNS logging in every VPC for compliance. Log volume spikes because a broken dependency causes thousands of NXDOMAIN retries per second from a DaemonSet. The fix is to repair the dependency and add a response policy sinkhole for the retired name temporarily, not to disable logging globally—logging proved the blast radius.
+
+---
+
+## Troubleshooting Playbook
+
+When DNS misbehaves in GCP, start by classifying whether the failure is authoritative (your zone data), resolver-path (policies, forwarding, peering), or client-side (stub resolver caching on the VM). `dig +trace` from the internet tests public delegation; `dig @169.254.169.254 name` on the VM tests the Google Cloud path your workloads actually use.
+
+| Symptom | Likely layer | First checks |
+| :--- | :--- | :--- |
+| Internet still sees old IP after zone edit | Recursive cache / TTL | Confirm TTL lowered earlier; query authoritative NS directly with `dig @ns-cloud-a1.googledomains.com` |
+| Only some VPCs fail to resolve internal name | Zone visibility or peering | Compare attached networks; verify peering `target-network` still exists |
+| On-prem cannot resolve GCP private name | Inbound forwarding | Confirm server policy enabled; conditional forwarder points to `DNS_RESOLVER` address in correct subnet region |
+| GCP VM cannot resolve on-prem name | Outbound forwarding | Verify forwarding zone targets reachable via VPN/Interconnect; try `[private]` targets |
+| NXDOMAIN for public site from VM only | Private zone shadowing | Search for private zone with same apex attached to VPC |
+| Malware C2 still reachable | Client bypassing DNS | Response policy blocks DNS only; inspect hard-coded IPs and DoH |
+
+For routing-policy incidents, enable [health check logging](https://cloud.google.com/dns/docs/routing-policies-overview) temporarily to see which geography or weight bucket Cloud DNS selected and whether probes marked targets unhealthy. Remember the edge case documented by Google: if every health-checked target fails, Cloud DNS may return all endpoints anyway to avoid empty answers—your load balancers and firewalls must still protect backends.
+
+Change management should treat DNS transactions like database migrations: start transaction, apply removes/adds, execute, and keep rollback commands in the change ticket. For large fleets, prefer Infrastructure-as-Code with plan review over console edits that lack audit trails.
+
+---
+
+## Reference Architecture: Hub-and-Spoke with Hybrid Forwarding
+
+The following reference layout is a teaching pattern, not a mandatory product template. It shows how public, private, forwarding, peering, response policies, and routing policies compose without stepping on each other's precedence.
+
+```text
+                    Internet clients
+                           |
+                    Public zone (example.com)
+                     WRR/GEO on api.example.com
+                           |
+              +------------+-------------+
+              |                          |
+       Hub VPC (dns-hub)            On-premises AD DNS
+   Private zone internal.corp    authoritative for corp.example.com
+   Peering target for spokes              ^
+              |                          |
+    +---------+---------+                |
+    |                   |                |
+ Spoke VPC A        Spoke VPC B     Forwarding zone corp.example.com
+ Peering zone       Peering zone    (private targets 10.200.0.53[private])
+ internal.corp      internal.corp
+ Response policy    Server policy: logging on
+ blocks malware     Inbound forwarder IP for internal.corp queries
+```
+
+In this layout, application teams in spoke VPCs never attach private zones directly. They consume `internal.corp` through a peering zone whose `target-network` is the hub. Platform engineers mutate records once in the hub private zone. Corporate laptops on-premises resolve `db.internal.corp` because the hub VPC enables inbound forwarding and AD conditional forwarders send that suffix to the inbound IP in the Interconnect region—not because spokes expose their own copies.
+
+Public properties remain in the public `example.com` zone with routing policies only on names that truly require multi-region steering. Internal microservices never reuse the `example.com` private apex, avoiding shadowing. Security places malware sinkholes in hub and spoke response policies with documented `bypassResponsePolicy` rules for vulnerability scanners that must resolve the real internet name.
+
+When you adapt this pattern, document three runbooks: (1) add a spoke VPC—create peering zone, attach network, verify `dig` from a sample VM; (2) add an on-prem suffix—create forwarding zone with private targets, verify from Cloud Run or GKE with VPC egress; (3) emergency block—add response policy rule, validate in logging, remove after incident. Runbooks matter because DNS changes are fast to apply but slow to debug when six teams each maintain partial knowledge.
+
+Teaching teams to reason about **suffix ownership** prevents most future outages: whoever owns a suffix operates exactly one authoritative private or public zone for it in GCP, and all other networks consume it via peering, forwarding, or public delegation—not by cloning partial zones.
+
+During game days, validate hybrid paths deliberately: pause on-prem forwarders, revoke a peering attachment, and confirm monitoring alerts on `SERVFAIL` rates from metadata DNS. Cloud DNS will not compensate for a misconfigured VPN by magically reaching on-prem; it returns failures quickly, which is preferable to blackholing traffic into the wrong subnet. Document expected failure modes so application owners know DNS fixes are network-path fixes, not kubectl restarts.
+
+For CI/CD, store record changes in version control and apply through Terraform or Deployment Manager pipelines with plan review. Human console edits during incidents are sometimes necessary, but reconcile back into IaC within 24 hours or the next change will unknowingly revert a heroic manual fix. Include TTL fields in code review checklists the same way you review firewall port ranges.
+
+Finally, treat DNS metrics as product metrics: export routing-policy query counts, health-check state transitions, and NXDOMAIN rates broken out by suffix. Spikes often precede user-visible outages because clients retry harder when names fail. A dashboard that correlates DNS errors with deploy timestamps pays for itself the first time it shows a private zone attachment change rather than an application regression. Pair those charts with change logs for response policies and forwarding targets so security and platform teams share one timeline during investigations.
+
 ---
 
 ## Did You Know?
@@ -494,6 +751,16 @@ gcloud logging read 'resource.type="dns_query"' \
 3. **Private zones override public zones for the same domain**. If you create a private zone for `example.com` in your VPC, [VMs in that VPC will resolve `example.com` using the private zone and will NOT be able to reach the public `example.com` records](https://cloud.google.com/dns/docs/zones/zones-overview). This is both a feature (for split-horizon DNS) and a trap (if you accidentally create a private zone for a domain you also need to reach publicly).
 
 4. **Cloud DNS supports response policies**, which let you override answers for selected names inside your network by serving local DNS data or using passthrough exceptions.
+
+---
+
+## Rosetta Stone: Cloud DNS vs Route 53 and Azure DNS
+
+If you arrive from other clouds, map concepts rather than relearning DNS from scratch. Amazon Route 53 public hosted zones correspond to Cloud DNS public managed zones; Route 53 private hosted zones associated with VPCs correspond to Cloud DNS private zones attached to VPC networks. Route 53 resolver rules and forwarding rules resemble Cloud DNS forwarding zones plus Route 53 Resolver endpoints, while Cloud DNS expresses inbound hybrid access through server policies that materialize `DNS_RESOLVER` addresses per subnet.
+
+Azure Private DNS zones linked to virtual networks map cleanly to private zones with network attachments, and Azure DNS private resolvers overlap with Cloud DNS inbound/outbound policy patterns. The unique GCP combinations to remember are DNS peering without full VPC peering for name resolution alone, response policies evaluated before private zones, and routing policies with integrated health checks billed separately from regular queries. Multi-cloud teams should standardize suffix conventions (`internal`, `corp`, `gcp`) so each cloud's override rules target the same logical namespaces even when the control plane APIs differ.
+
+When auditors ask for evidence of DNS change control, export Cloud Audit Logs for managed zones and resource record sets alongside Terraform state. Cloud DNS mutations are API-driven and leave fingerprints even when applied through the console, which helps you prove who changed an apex record during a severity review without relying on informal chat logs alone today.
 
 ---
 
@@ -550,13 +817,25 @@ Response Policy Zones (RPZs) provide a mechanism to intercept and override norma
 The junior engineer's plan will cause an extended outage because recursive DNS resolvers across the internet will have cached the old IP address for up to 24 hours, meaning global traffic will slowly trickle to the new load balancer over a full day while many users continue hitting the old, potentially decommissioned endpoint. The correct procedure requires proactive preparation by lowering the TTL to a very short duration (e.g., 60 seconds) on Thursday—at least 24 hours before the migration window—giving global caches time to expire and pick up the short TTL. When Saturday at 2:00 AM arrives, you can safely update the A record to the new IP, and the short TTL will ensure global traffic shifts within a matter of minutes. Finally, after validating the migration, you should increase the TTL back to a longer duration to optimize performance and reduce query volume.
 </details>
 
+<details>
+<summary>7. Your platform team enables geolocation routing on `api.example.com` in a public zone with health checks on three regional external load balancers. During an incident, the US region endpoints fail health checks, but European endpoints remain healthy. A product manager asks why some US users still receive US VIP addresses in DNS answers. Geofencing was enabled on the US geolocation bucket. What behavior does Cloud DNS exhibit, and what tradeoff did geofencing encode?</summary>
+
+With geofencing enabled, Cloud DNS does not automatically fail over to the next closest geography when all endpoints in a fenced region fail health checks. Instead, authoritative DNS must still return an answer for that geography, so clients may continue to receive the US VIP addresses even though probes mark them unhealthy—avoiding silent redirection of US traffic to Europe, which might violate data residency or latency expectations. Without geofencing, geolocation routing would shift US-sourced queries toward the nearest healthy geography. The tradeoff is explicit: geofencing prioritizes geography fidelity over automatic cross-region failover, so operators must manually adjust policies or remove fencing during controlled disasters.
+</details>
+
+<details>
+<summary>8. Finance reports that Cloud DNS spend doubled after a fleet-wide migration even though user traffic is flat. You discover 400 new private managed zones (one per microservice) and geolocation routing policies on high-QPS API names. Which billing dimensions likely moved, and what architectural changes would you propose first?</summary>
+
+Managed-zone charges scale with zone count regardless of queries, so 400 new zones can dominate the bill even when QPS is unchanged—especially as accounts cross published tier breakpoints. Separately, routing-policy queries bill at a higher per-million rate than regular queries, so moving high-QPS names onto GEO/WRR/FAILOVER RRsets increases query-line cost even without more users. Health checks add hourly line items per probed VIP. First fixes: consolidate microservice names into fewer private zones (shared suffix with records per service), reserve routing policies for names that truly need geography or weighted steering, and replace per-service zones with hub-and-spoke peering if many VPCs need the same data.
+</details>
+
 ---
 
 ## Hands-On Exercise: Public and Private DNS Zones
 
 ### Objective
 
-Create and manage public and private DNS zones, demonstrate split-horizon DNS behavior, configure DNS routing policies, and set up DNS forwarding.
+Create and manage public and private DNS zones, demonstrate split-horizon DNS behavior, configure DNS routing policies, and set up DNS forwarding. The lab intentionally uses disposable `lab.example.com` and `internal.lab.com` suffixes so you can practice transactions, routing-policy flags, and logging without touching production registrar delegations. If you own a domain, you may substitute it, but only after you understand that public zones are meaningless until registrar NS records point at Google.
 
 ### Prerequisites
 
@@ -566,7 +845,7 @@ Create and manage public and private DNS zones, demonstrate split-horizon DNS be
 
 ### Tasks
 
-**Task 1: Create a Custom VPC and VM for Testing**
+**Task 1: Create a Custom VPC and VM for Testing.** Provision an isolated lab VPC with a regional subnet, IAP-friendly SSH ingress, the Cloud DNS API enabled, and a small Debian VM that will run every `dig` verification in later tasks.
 
 <details>
 <summary>Solution</summary>
@@ -608,7 +887,7 @@ gcloud compute instances describe dns-test-vm --zone=${REGION}-a --format="value
 ```
 </details>
 
-**Task 2: Create a Public DNS Zone**
+**Task 2: Create a Public DNS Zone.** Create a public managed zone, inspect the four `googledomains.com` nameservers Google assigns, and publish A plus CNAME records through an atomic transaction.
 
 <details>
 <summary>Solution</summary>
@@ -647,7 +926,7 @@ gcloud dns record-sets list --zone=lab-public-zone \
 ```
 </details>
 
-**Task 3: Create a Weighted Routing Policy**
+**Task 3: Create a Weighted Routing Policy.** Add a weighted round-robin A record that splits traffic between two lab IPs so you can see `--routing-policy-type=WRR` in the record list.
 
 <details>
 <summary>Solution</summary>
@@ -671,7 +950,7 @@ gcloud dns record-sets list --zone=lab-public-zone
 ```
 </details>
 
-**Task 4: Create a Private DNS Zone**
+**Task 4: Create a Private DNS Zone.** Attach a private zone to the lab VPC, insert internal A records, and confirm resolution via SSH `dig` from the test VM.
 
 <details>
 <summary>Solution</summary>
@@ -713,7 +992,7 @@ gcloud compute ssh dns-test-vm --zone=${REGION}-a --tunnel-through-iap --quiet \
 ```
 </details>
 
-**Task 5: Enable DNS Logging**
+**Task 5: Enable DNS Logging.** Attach a DNS policy with `--enable-logging` to the lab VPC, generate queries from the VM, and read `resource.type="dns_query"` entries in Cloud Logging.
 
 <details>
 <summary>Solution</summary>
@@ -737,7 +1016,7 @@ gcloud logging read 'resource.type="dns_query"' \
 ```
 </details>
 
-**Task 6: Modify Records (Simulating a Migration)**
+**Task 6: Modify Records (Simulating a Migration).** Practice TTL-aware cutovers by removing and re-adding an internal A record in one transaction, then verify the VM sees the new address.
 
 <details>
 <summary>Solution</summary>
@@ -767,7 +1046,7 @@ gcloud compute ssh dns-test-vm --zone=${REGION}-a --tunnel-through-iap --quiet \
 ```
 </details>
 
-**Task 7: Clean Up**
+**Task 7: Clean Up.** Delete policies, non-default record sets, managed zones, the VM, firewall rule, subnet, and VPC so the lab leaves no billable DNS zones behind.
 
 <details>
 <summary>Solution</summary>
@@ -838,3 +1117,6 @@ Next up: **[Module 2.6: Artifact Registry](../module-2.6-artifact-registry/)** -
 - [Cloud DNS overview](https://cloud.google.com/dns/docs/overview) — Covers the core service model, public versus private zones, anycast serving, and propagation behavior.
 - [Name resolution order](https://cloud.google.com/dns/docs/vpc-name-res-order) — Documents the exact lookup sequence for VMs and GKE nodes, including policies, private zones, peering, and public DNS.
 - [Use Cloud DNS for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-dns) — Explains Cloud DNS integration modes for GKE, including cluster scope, VPC scope, and how GKE DNS resolution works.
+- [Cloud DNS pricing](https://cloud.google.com/dns/pricing) — Documents managed-zone tiers, regular vs routing-policy query rates, health-check hourly charges, and forwarding-target lookup billing.
+- [DNS policies overview](https://cloud.google.com/dns/docs/policies-overview) — Distinguishes server policies, response policies, and routing policies and when each applies.
+- [Manage response policies and rules](https://cloud.google.com/dns/docs/zones/manage-response-policies) — Procedure reference for `gcloud dns response-policies` create/update and bypass behavior.

--- a/src/content/docs/cloud/gcp-essentials/module-2.5-dns.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.5-dns.md
@@ -197,19 +197,19 @@ Cloud DNS allows you to configure [routing policies that intelligently direct tr
 
 ### Weighted Round Robin
 
-Weighted routing distributes traffic across multiple IP addresses based on weights you define, which makes it the default choice for canary releases and blue/green cutovers where you want a deterministic percentage split without geography semantics. Weights are not percentages themselves—Cloud DNS normalizes weights up to 1000—so a 80/20 intent is expressed as `primary=80;canary=20` in `--routing-policy-data`. When health checks are enabled, unhealthy targets drop out of the weighted pool and the remaining healthy weights are renormalized, which means your canary might receive more than twenty percent of traffic if the primary VIP fails probes unless you also assign zero-weight standby records.
+Weighted routing distributes traffic across multiple IP addresses based on weights you define, which makes it the default choice for canary releases and blue/green cutovers where you want a deterministic percentage split without geography semantics. Weights are not percentages themselves—Cloud DNS normalizes weights up to 1000—so an 80/20 intent is expressed as `80=34.120.55.200;20=34.120.55.201` in `--routing-policy-data` (weight first, then IP). When health checks are enabled, unhealthy targets drop out of the weighted pool and the remaining healthy weights are renormalized, which means your canary might receive more than twenty percent of traffic if the primary VIP fails probes unless you also assign zero-weight standby records.
 
 Operationally, pair WRR with observability on both VIPs during a release: DNS only steers names; it does not know HTTP error rates. If the canary VIP accepts TCP but returns 500 responses, DNS will still send clients there until application health checks or manual weight changes intervene.
 
 ```bash
 # Add a weighted round-robin policy to split traffic 80/20
-gcloud dns record-sets transaction add "34.120.55.200,34.120.55.201" \
+gcloud dns record-sets transaction add \
   --name="api.example.com." \
   --ttl=300 \
   --type=A \
   --zone=example-zone \
   --routing-policy-type=WRR \
-  --routing-policy-data="34.120.55.200=80;34.120.55.201=20"
+  --routing-policy-data="80=34.120.55.200;20=34.120.55.201"
 ```
 
 ### Geolocation Routing
@@ -220,7 +220,7 @@ Geolocation is not a compliance guarantee by itself: geofencing changes failover
 
 ```bash
 # Add a geolocation routing policy
-gcloud dns record-sets transaction add "34.120.55.200,34.120.55.202" \
+gcloud dns record-sets transaction add \
   --name="app.example.com." \
   --ttl=300 \
   --type=A \
@@ -236,15 +236,26 @@ Failover routing expresses active/backup semantics explicitly: Cloud DNS serves 
 Failover differs from WRR because intent is ordered preference, not proportional sharing. Use failover when only one endpoint should receive traffic at a time; use WRR when both endpoints should simultaneously receive production traffic at known ratios.
 
 ```bash
-# Add a failover routing policy
-gcloud dns record-sets transaction add "34.120.55.200,34.120.55.203" \
+# Add a failover routing policy (requires health checking on the primary target)
+gcloud compute health-checks create http my-api-hc \
+  --check-interval=30s \
+  --healthy-threshold=1 \
+  --unhealthy-threshold=3 \
+  --port=80 \
+  --request-path="/healthz" \
+  --host="api.example.com."
+
+gcloud dns record-sets transaction add \
   --name="app.example.com." \
   --ttl=300 \
   --type=A \
   --zone=example-zone \
   --routing-policy-type=FAILOVER \
   --routing-policy-primary-data="34.120.55.200" \
-  --routing-policy-backup-data="34.120.55.203"
+  --routing-policy-backup-data="34.120.55.203" \
+  --routing-policy-backup-data-type=A \
+  --enable-health-checking \
+  --health-check=my-api-hc
 ```
 
 ### Health Checks, Geofencing, and Policy Limits
@@ -258,16 +269,30 @@ Weighted round robin supports weights from 0 through 1000. Zero-weight targets c
 DNS routing policies cannot be configured on forwarding zones, DNS peering zones, managed reverse lookup zones, or Service Directory zones. Plan steering on standard public or private managed zones that hold the A/AAAA answers you want to health-check.
 
 ```bash
-# Example: create an internal fast health check (private zone / ILB use case)
-gcloud dns health-checks create http my-api-hc \
+# Internal load balancer (private zone): reference the ILB forwarding rule name
+# in --routing-policy-data with --enable-health-checking. Cloud DNS reuses the
+# LB's health check—no separate gcloud dns health-checks command exists.
+gcloud dns record-sets transaction add \
+  --name="api.internal.example.com." \
+  --ttl=300 \
+  --type=A \
+  --zone=internal-zone \
+  --routing-policy-type=FAILOVER \
+  --routing-policy-primary-data="my-ilb-forwarding-rule" \
+  --routing-policy-backup-data="10.10.1.99" \
+  --routing-policy-backup-data-type=A \
+  --enable-health-checking
+
+# External endpoints (public zone): create a Compute Engine HTTP health check
+gcloud compute health-checks create http my-api-hc \
   --check-interval=30s \
   --healthy-threshold=1 \
   --unhealthy-threshold=3 \
   --port=80 \
   --request-path="/healthz" \
-  --host="api.internal.example.com."
+  --host="api.example.com."
 
-# Attach health check IDs when defining routing policy RRsets (see routing policy docs for flags)
+# Attach the health check when defining routing-policy RRsets (see routing policy docs for flags)
 ```
 
 Supported RR types for routing policies include A, AAAA, CNAME, MX, SRV, and TXT, but only A/AAAA carry health-check semantics for steering. DNSSEC-enabled zones that use health checks must use a single IP per policy item—you cannot mix health-checked and non-health-checked addresses in the same policy line when DNSSEC is on.
@@ -480,7 +505,7 @@ gcloud dns response-policies create security-policy \
 gcloud dns response-policies rules create block-c2 \
   --response-policy=security-policy \
   --dns-name="c2.hacker-network.com." \
-  --local-data-rrsets="c2.hacker-network.com. 300 IN A 127.0.0.1"
+  --local-data="name=c2.hacker-network.com.,type=A,ttl=300,rrdatas=127.0.0.1"
 
 # Bypass: allow one subdomain past a wildcard override
 gcloud dns response-policies rules create allow-partner-api \
@@ -590,14 +615,14 @@ DNS query logs land in Cloud Logging under `resource.type="dns_query"`. Logging 
 
 Cloud DNS has [no free tier](https://cloud.google.com/dns/pricing). Billing aggregates **all zone types**—public, private, and forwarding—into a single managed-zone count, prorated hourly. The first 25 zone-months per billing account are priced at roughly $0.20 per zone per month (derived from the published hourly rate); additional tiers decrease per-zone cost at 25+ and 10,000+ zones. A platform team with hundreds of micro-zones per microservice therefore pays mostly for zone inventory, not queries.
 
-Query pricing splits **regular queries** (about $0.40 per million for the first billion per month) from **routing policy queries** (about $0.70 per million for the same tier). Any RRset using WRR, GEO, or FAILOVER steering bills at the higher routing-policy rate even if the answer is a single A record. Health checks add hourly charges: internal fast checks are roughly $0.00274 per hour each, internal premium checks roughly $0.00548 per hour—multiplied by every VIP you probe. A multi-region active-active design with three geolocation buckets and three health checks per region can accrue more cost in probes than in user-facing queries during low-traffic services.
+Query pricing splits **regular queries** (about $0.40 per million for the first billion per month) from **routing policy queries** (about $0.70 per million for the same tier). Any RRset using WRR, GEO, or FAILOVER steering bills at the higher routing-policy rate even if the answer is a single A record. Health checks add monthly charges: internal fast checks are **$0.50/month** each, internal premium checks **$2.00/month** each (roughly 4× the fast rate)—multiplied by every VIP you probe. A multi-region active-active design with three geolocation buckets and three health checks per region can accrue more cost in probes than in user-facing queries during low-traffic services.
 
 | Cost driver | What increases spend | Knobs that reduce spend |
 | :--- | :--- | :--- |
 | Managed zones | One zone per suffix per project; sprawl from teams creating duplicate private zones | Consolidate suffixes; use hub VPC + peering instead of duplicating zone attachments |
 | Regular queries | Low TTLs, chatty service meshes, retry storms | Raise TTL for stable records; fix failing dependencies causing NXDOMAIN retries |
 | Routing policy queries | Geo/WRR/failover on high-QPS names | Use routing policies only on names that need steering; use load balancers for simple active-passive |
-| Health checks | Many ILB VIPs with short intervals | Share health checks where possible; increase interval within allowed bounds |
+| Health checks | Many ILB VIPs with short intervals | Share health checks where possible; increase interval within allowed bounds (billed per month, not per hour) |
 | Forwarding target hostnames | Extra lookup to resolve FQDN targets | Use IP targets; cache on-prem forwarder side |
 | DNS logging + DNS Armor | Log ingestion; per-workload threat-detection units | Scope logging to production VPCs; tune DNS Armor exclusions |
 
@@ -615,7 +640,7 @@ Mature Cloud DNS designs treat names as platform APIs: suffixes are versioned, h
 | DNS hub VPC with peering zones | Many spokes, centralized platform team | Spokes attach one peering zone per suffix instead of N zone×VPC bindings | Hub becomes critical—use IaC and restricted IAM on hub projects |
 | TTL runway before migrations | Planned IP or load balancer changes | Lets caches expire before cutover | Automate TTL lowering via transactions; restore higher TTL after validation |
 | Response policy for emergency blocks | Need fast org-wide sinkhole without redeploying apps | Evaluated before zone records; no agent on VMs | Document bypass rules for security tooling domains |
-| Routing policy + health checks | Multi-region active/active behind ILBs or public endpoints | Removes unhealthy VIPs from answers automatically | Watch routing-policy query tier and health-check hourly charges |
+| Routing policy + health checks | Multi-region active/active behind ILBs or public endpoints | Removes unhealthy VIPs from answers automatically | Watch routing-policy query tier and health-check monthly charges |
 
 Anti-patterns usually begin as convenient one-off console clicks—an extra private zone on the marketing apex, a forwarding target aimed at a hostname instead of an IP—that ossify into production architecture and only surface during the first cross-VPC migration or finance review.
 
@@ -826,7 +851,7 @@ With geofencing enabled, Cloud DNS does not automatically fail over to the next 
 <details>
 <summary>8. Finance reports that Cloud DNS spend doubled after a fleet-wide migration even though user traffic is flat. You discover 400 new private managed zones (one per microservice) and geolocation routing policies on high-QPS API names. Which billing dimensions likely moved, and what architectural changes would you propose first?</summary>
 
-Managed-zone charges scale with zone count regardless of queries, so 400 new zones can dominate the bill even when QPS is unchanged—especially as accounts cross published tier breakpoints. Separately, routing-policy queries bill at a higher per-million rate than regular queries, so moving high-QPS names onto GEO/WRR/FAILOVER RRsets increases query-line cost even without more users. Health checks add hourly line items per probed VIP. First fixes: consolidate microservice names into fewer private zones (shared suffix with records per service), reserve routing policies for names that truly need geography or weighted steering, and replace per-service zones with hub-and-spoke peering if many VPCs need the same data.
+Managed-zone charges scale with zone count regardless of queries, so 400 new zones can dominate the bill even when QPS is unchanged—especially as accounts cross published tier breakpoints. Separately, routing-policy queries bill at a higher per-million rate than regular queries, so moving high-QPS names onto GEO/WRR/FAILOVER RRsets increases query-line cost even without more users. Health checks add monthly line items per probed VIP. First fixes: consolidate microservice names into fewer private zones (shared suffix with records per service), reserve routing policies for names that truly need geography or weighted steering, and replace per-service zones with hub-and-spoke peering if many VPCs need the same data.
 </details>
 
 ---
@@ -935,13 +960,13 @@ gcloud dns record-sets list --zone=lab-public-zone \
 # Create a weighted round-robin record to split traffic
 gcloud dns record-sets transaction start --zone=lab-public-zone
 
-gcloud dns record-sets transaction add "34.120.55.200,34.120.55.201" \
+gcloud dns record-sets transaction add \
   --name="api.lab.example.com." \
   --ttl=300 \
   --type=A \
   --zone=lab-public-zone \
   --routing-policy-type=WRR \
-  --routing-policy-data="34.120.55.200=80;34.120.55.201=20"
+  --routing-policy-data="80=34.120.55.200;20=34.120.55.201"
 
 gcloud dns record-sets transaction execute --zone=lab-public-zone
 
@@ -1057,10 +1082,10 @@ gcloud dns policies delete dns-logging --quiet
 
 # Delete record sets (must delete non-default records before zone)
 gcloud dns record-sets transaction start --zone=lab-public-zone
-gcloud dns record-sets transaction remove "34.120.55.200,34.120.55.201" \
+gcloud dns record-sets transaction remove \
   --name="api.lab.example.com." --ttl=300 --type=A --zone=lab-public-zone \
   --routing-policy-type=WRR \
-  --routing-policy-data="34.120.55.200=80;34.120.55.201=20"
+  --routing-policy-data="80=34.120.55.200;20=34.120.55.201"
 gcloud dns record-sets transaction remove "34.120.55.100" \
   --name="web.lab.example.com." --ttl=300 --type=A --zone=lab-public-zone
 gcloud dns record-sets transaction remove "web.lab.example.com." \
@@ -1117,6 +1142,6 @@ Next up: **[Module 2.6: Artifact Registry](../module-2.6-artifact-registry/)** -
 - [Cloud DNS overview](https://cloud.google.com/dns/docs/overview) — Covers the core service model, public versus private zones, anycast serving, and propagation behavior.
 - [Name resolution order](https://cloud.google.com/dns/docs/vpc-name-res-order) — Documents the exact lookup sequence for VMs and GKE nodes, including policies, private zones, peering, and public DNS.
 - [Use Cloud DNS for GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/cloud-dns) — Explains Cloud DNS integration modes for GKE, including cluster scope, VPC scope, and how GKE DNS resolution works.
-- [Cloud DNS pricing](https://cloud.google.com/dns/pricing) — Documents managed-zone tiers, regular vs routing-policy query rates, health-check hourly charges, and forwarding-target lookup billing.
+- [Cloud DNS pricing](https://cloud.google.com/dns/pricing) — Documents managed-zone tiers, regular vs routing-policy query rates, health-check monthly charges, and forwarding-target lookup billing.
 - [DNS policies overview](https://cloud.google.com/dns/docs/policies-overview) — Distinguishes server policies, response policies, and routing policies and when each applies.
 - [Manage response policies and rules](https://cloud.google.com/dns/docs/zones/manage-response-policies) — Procedure reference for `gcloud dns response-policies` create/update and bypass behavior.

--- a/src/content/docs/cloud/gcp-essentials/module-2.6-artifact-registry.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.6-artifact-registry.md
@@ -21,7 +21,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-In November 2021, the `ua-parser-js` npm package---downloaded over 7 million times per week---was compromised. An attacker gained access to the maintainer's npm account and published three malicious versions that installed cryptocurrency miners on Linux and Windows systems, and also stole passwords from infected machines. Any CI/CD pipeline that ran `npm install` during the window when the malicious versions were available pulled compromised code directly into production builds. Companies that pulled packages directly from the public npm registry had no defense. Companies that used a private registry with upstream caching had a critical advantage: in many cases, the malicious versions were not cached because their pipelines pulled the cached (clean) versions already stored in the private registry.
+Hypothetical scenario: A widely used npm package in your dependency tree is compromised when an attacker publishes malicious versions to the public registry. Any CI/CD pipeline that runs `npm install` directly against the public npm registry during the exposure window can pull compromised code into production builds. Companies that pull packages directly from the public npm registry have no defense. Companies that use a private registry with upstream caching have a critical advantage: in many cases, the malicious versions are not cached because their pipelines pull the cached (clean) versions already stored in the private registry.
 
 This incident represents a growing threat: **supply chain attacks targeting public package registries**. Whether you are pulling container images from Docker Hub, npm packages from the npm registry, or Python packages from PyPI, you are trusting code written by strangers. Artifact Registry is GCP's managed solution for storing, managing, and securing software artifacts. It replaces the older Container Registry (GCR) and extends beyond Docker images to support npm, Maven, Python, Go, and OS packages.
 
@@ -299,15 +299,11 @@ Artifact Registry integrates with [Artifact Analysis](https://cloud.google.com/a
 ### Enabling and Configuring Scanning
 
 ```bash
-# Enable the Container Analysis API
-gcloud services enable containeranalysis.googleapis.com
+# Enable the Container Scanning API (required for on-push scan results)
+gcloud services enable containeranalysis.googleapis.com \
+  containerscanning.googleapis.com
 
-# Enable automatic scanning on a repository
-gcloud artifacts repositories update docker-repo \
-  --location=us-central1 \
-  --enable-vulnerability-scanning
-
-# Scanning happens automatically when you push an image.
+# Scanning happens automatically when you push an image after the API is enabled.
 # You can also trigger an on-demand scan:
 gcloud artifacts docker images scan \
   ${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/my-api:v1.2.0 \
@@ -414,7 +410,7 @@ gcloud artifacts repositories get-iam-policy docker-repo \
 
 Cross-project access is a frequent source of ImagePullBackOff errors in GKE. When your cluster runs in project `app-prod` but images live in project `shared-artifacts`, you must grant `roles/artifactregistry.reader` on the repository in `shared-artifacts` to the node service account from `app-prod`. Project-level IAM bindings work but violate least privilege because they grant access to every repository in the project; repository-level bindings limit the blast radius if a node is compromised.
 
-Cloud Run and Cloud Functions pull images through the Cloud Run service agent (`PROJECT_NUMBER@serverless-robot-prod.iam.gserviceaccount.com`), which needs reader access on the repository hosting the container image specified in the service definition. App Engine flexible environment uses its own service account (`PROJECT_ID@appspot.gserviceaccount.com`). Each compute service has a documented service agent in the [access control guide](https://cloud.google.com/artifact-registry/docs/access-control), and granting the wrong agent is a common copy-paste mistake during initial setup.
+Cloud Run and Cloud Functions pull images through the Cloud Run service agent (`service-PROJECT_NUMBER@serverless-robot-prod.iam.gserviceaccount.com`), which needs reader access on the repository hosting the container image specified in the service definition. App Engine flexible environment uses its own service account (`PROJECT_ID@appspot.gserviceaccount.com`). Each compute service has a documented service agent in the [access control guide](https://cloud.google.com/artifact-registry/docs/access-control), and granting the wrong agent is a common copy-paste mistake during initial setup.
 
 For human developers who need local pull access, bind `roles/artifactregistry.reader` to a Google Group rather than individual users so onboarding and offboarding happen through group membership. Developers who also need push access for manual hotfix builds receive writer on staging repositories only; production repositories receive pushes exclusively from CI service accounts with Binary Authorization attestations downstream.
 
@@ -451,7 +447,7 @@ substitutions:
 
 Cloud Build's service account needs `roles/artifactregistry.writer` on the target repository. If builds pull base images through a remote Docker Hub cache, the build service account also needs reader access on the remote repository. Separating build-time permissions (writer on staging repo) from deploy-time permissions (reader on production repo, attestation signer) enforces the same promotion workflow that Binary Authorization expects downstream.
 
-When Cloud Build runs inside a private pool or VPC-SC perimeter, verify that Artifact Registry endpoints are allowed through your service perimeter. [VPC Service Controls](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown) documentation covers `mirror.gcr.io` and Artifact Registry access from restricted networks, which matters for regulated industries that cannot reach Google APIs over the public internet without explicit perimeter configuration.
+When Cloud Build runs inside a private pool or VPC-SC perimeter, verify that Artifact Registry endpoints are allowed through your service perimeter. [VPC Service Controls documentation for Artifact Registry](https://cloud.google.com/artifact-registry/docs/securing-artifacts) covers restricted-network access from perimeters, which matters for regulated industries that cannot reach Google APIs over the public internet without explicit perimeter configuration.
 
 ---
 
@@ -514,13 +510,13 @@ docker pull us-central1-docker.pkg.dev/${PROJECT_ID}/dockerhub-cache/library/ngi
 
 Remote repositories do not prefetch the entire upstream registry—they cache artifacts on first pull, which means the initial CI run after creating a remote repo still hits the public registry and is subject to upstream rate limits until the cache warms. Docker Hub official images require the `library/` namespace prefix when pulling through Artifact Registry, as shown in the nginx example above, because Docker Hub namespaces official images under `library/` even when users omit it in direct Hub pulls.
 
-For npm, Maven, and Python remote repos, the upstream configuration uses enumerated constants like `NPMJS`, `MAVEN-CENTRAL`, and `PYPI` in the gcloud command. Authentication to private upstream registries is not supported on standard remote repositories; if you need to cache a private Docker Hub organization, you configure upstream credentials through the remote repository settings documented in the [remote repository guide](https://cloud.google.com/artifact-registry/docs/repositories/remote-overview).
+For npm, Maven, and Python remote repos, the upstream configuration uses enumerated constants like `NPMJS`, `MAVEN-CENTRAL`, and `PYPI` in the gcloud command. Remote repositories support authenticated upstream access for private Docker Hub organizations and other protected registries by storing credentials in a Secret Manager secret referenced in the remote repository configuration—see the [remote repository guide](https://cloud.google.com/artifact-registry/docs/repositories/remote-overview).
 
 Hypothetical scenario: Your CI pipeline builds 200 times per day and each build pulls `node:20-bookworm-slim` from Docker Hub. Without a remote cache, you hit Docker Hub rate limits within the first hour and builds fail unpredictably. After creating a remote repository and updating CI to pull through `us-central1-docker.pkg.dev/PROJECT/dockerhub-cache/library/node:20-bookworm-slim`, the first build populates the cache and the remaining 199 builds pull from Artifact Registry at in-region speeds with no upstream dependency.
 
 ### Virtual Repositories
 
-Virtual repositories provide a single endpoint that aggregates multiple upstream repositories (both standard and remote). [Priority values determine lookup order](https://cloud.google.com/artifact-registry/docs/repositories/virtual-overview): lower numbers are checked first, so your internal standard repository at priority 100 wins over the Docker Hub remote cache at priority 200 when both contain an artifact with the same name.
+Virtual repositories provide a single endpoint that aggregates multiple upstream repositories (both standard and remote). [Priority values determine lookup order](https://cloud.google.com/artifact-registry/docs/repositories/virtual-overview): **higher priority wins**—when multiple upstreams contain an artifact with the same name, the upstream with the highest priority value is served. To defend against dependency confusion, your internal standard repository must have a **higher** priority than the public remote cache so internal packages win over identically named public packages.
 
 ```bash
 # Create a virtual repository that combines your internal repo and Docker Hub cache
@@ -537,19 +533,19 @@ gcloud artifacts repositories create docker-virtual \
   {
     "id": "internal",
     "repository": "projects/my-project/locations/us-central1/repositories/docker-repo",
-    "priority": 100
+    "priority": 200
   },
   {
     "id": "dockerhub",
     "repository": "projects/my-project/locations/us-central1/repositories/dockerhub-cache",
-    "priority": 200
+    "priority": 100
   }
 ]
 ```
 
-With this configuration, pulls from the virtual repository first check your internal repo (priority 100, checked first), then fall back to the Docker Hub cache (priority 200). Developers configure a single registry URL in Docker, npm, or pip settings, which reduces misconfiguration and makes dependency-confusion defenses easier because internal package names resolve to internal artifacts before the public cache is consulted.
+With this configuration, pulls from the virtual repository check upstreams by priority (highest first). The internal standard repository at priority 200 wins when both it and the Docker Hub cache contain an artifact with the same name; the remote cache at priority 100 is consulted only when the internal repo has no match. Developers configure a single registry URL in Docker, npm, or pip settings, which reduces misconfiguration and makes dependency-confusion defenses easier because internal package names resolve to internal artifacts before the public cache is consulted.
 
-When designing upstream priority, remember that lower numbers win. A common mistake sets the remote cache at priority 50 and the internal repo at priority 100, which inverts the intended behavior and serves public packages even when an internal artifact exists. Document priority ordering in your platform runbook so teams configuring virtual repositories do not accidentally expose themselves to dependency confusion attacks through inverted or misunderstood priority values.
+When designing upstream priority, remember that **higher numbers win**. A common mistake sets the remote cache at priority 200 and the internal repo at priority 100, which inverts the intended behavior and serves public packages even when an internal artifact exists. Document priority ordering in your platform runbook so teams configuring virtual repositories do not accidentally expose themselves to dependency confusion attacks through inverted priority values.
 
 ---
 
@@ -657,7 +653,7 @@ Hypothetical scenario: A data platform team enables vulnerability scanning proje
 | Pattern | When to Use | Why It Works | Scaling Note |
 | :--- | :--- | :--- | :--- |
 | **Regional repo per environment** | Separate `prod`, `staging`, and `dev` Docker repos in the same region as GKE | IAM and cleanup policies differ per environment; in-region pulls avoid egress | Add repos per team only when IAM isolation requires it—repo sprawl complicates virtual upstream configs |
-| **Remote cache + virtual repo** | Teams consume both internal and public packages | Single endpoint for developers; internal names win via priority ordering | Monitor remote cache storage; high-cardinality public tag pulls fill cache quickly |
+| **Remote cache + virtual repo** | Teams consume both internal and public packages | Single endpoint for developers; internal repo at higher priority wins over public cache | Monitor remote cache storage; high-cardinality public tag pulls fill cache quickly |
 | **Immutable tags on production repos** | Any repo receiving release artifacts | Prevents tag mutation attacks and accidental overwrites | Pair with digest references in Kubernetes manifests for strongest guarantees |
 | **Repo-scoped CI service accounts** | Every pipeline that pushes images | Writer role on one repo cannot poison unrelated npm or staging repos | Create one SA per pipeline class, not one shared `ci@` with admin |
 | **Cleanup: delete untagged, keep N releases** | High-churn CI repos | Stops silent storage growth from floating branch tags | Test with `--dry-run`; policies take ~24h to apply |
@@ -733,7 +729,7 @@ Multi-team platforms often ask whether to share one Docker repository or isolate
 
 ## Did You Know?
 
-1. **Artifact Registry stores over 10 billion container images** across all GCP customers. It is the same infrastructure that Google uses internally to store the images for Google Cloud services like Cloud Run, GKE, and Cloud Functions.
+1. **Artifact Registry is the managed successor to Container Registry** and supports Docker/OCI images, language packages, and OS packages across regional repositories with per-repository IAM.
 
 2. **The `--immutable-tags` flag prevents tag mutation attacks**. Without it, someone with push access can overwrite `myapp:v1.0` with a completely different image. This is a real attack vector---an attacker who compromises a CI/CD pipeline can replace a known-good image tag with a malicious one. Immutable tags guarantee that `v1.0` always refers to the exact same image digest.
 
@@ -791,9 +787,9 @@ The first likely cause is that the developer has not configured Docker to authen
 </details>
 
 <details>
-<summary>6. Your company uses a virtual repository to consolidate access. It is configured with an internal standard repository at priority 100, and a remote repository caching Docker Hub at priority 200. A developer accidentally names their internal helper script `ubuntu` and publishes it as a container image to the internal repository. When a CI pipeline runs `docker pull <virtual-repo-url>/ubuntu:latest`, what exactly happens and what security benefit does this priority configuration provide?</summary>
+<summary>6. Your company uses a virtual repository to consolidate access. It is configured with an internal standard repository at priority 200, and a remote repository caching Docker Hub at priority 100. A developer accidentally names their internal helper script `ubuntu` and publishes it as a container image to the internal repository. When a CI pipeline runs `docker pull <virtual-repo-url>/ubuntu:latest`, what exactly happens and what security benefit does this priority configuration provide?</summary>
 
-When the `docker pull` command is executed, the virtual repository evaluates its upstreams in priority order, starting with the lowest number. It checks the internal standard repository (priority 100) first, finds the internally published `ubuntu:latest` image, and returns it immediately without ever querying the remote repository (priority 200). This priority configuration provides a critical security benefit by preventing dependency confusion attacks. If an attacker publishes a malicious package to a public registry with the exact same name as an internal package, the virtual repository will prioritize and serve the internal version first in the normal case, which helps mitigate this attack.
+When the `docker pull` command is executed, the virtual repository evaluates its upstreams by priority, with **higher values winning**. It checks the internal standard repository (priority 200) first among matching upstreams, finds the internally published `ubuntu:latest` image, and returns it without consulting the remote Docker Hub cache (priority 100). This priority configuration provides a critical security benefit by preventing dependency confusion attacks. If an attacker publishes a malicious package to a public registry with the exact same name as an internal package, the virtual repository serves the internal version because it carries the higher priority—not the public copy.
 </details>
 
 <details>
@@ -835,7 +831,8 @@ export REGION=us-central1
 
 # Enable APIs
 gcloud services enable artifactregistry.googleapis.com \
-  containeranalysis.googleapis.com
+  containeranalysis.googleapis.com \
+  containerscanning.googleapis.com
 
 # Create a standard Docker repository with immutable tags
 gcloud artifacts repositories create app-images \

--- a/src/content/docs/cloud/gcp-essentials/module-2.6-artifact-registry.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.6-artifact-registry.md
@@ -6,6 +6,8 @@ sidebar:
 ---
 **Complexity**: [MEDIUM] | **Time to Complete**: 1h | **Prerequisites**: Module 2.1 (IAM & Resource Hierarchy)
 
+This module sits at the intersection of security, developer experience, and cost management because every container deployment depends on a registry that teams often treat as invisible infrastructure until it breaks a build, blocks a deploy, or leaks an artifact.
+
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:
@@ -25,22 +27,38 @@ This incident represents a growing threat: **supply chain attacks targeting publ
 
 In this module, you will learn how to create Artifact Registry repositories, push and pull container images, configure vulnerability scanning, set up IAM-based access control, and use remote repositories as upstream caches for public registries.
 
+> **The Package Warehouse Analogy**
+>
+> Think of Artifact Registry as a secure warehouse for every kind of software artifact your organization ships. Container images sit on one shelf, npm packages on another, Maven JARs in climate-controlled storage, and Debian packages in labeled bins. Remote repositories are like a purchasing department that caches deliveries from external suppliers so your production line never waits on a third-party truck. Virtual repositories are the single loading dock where developers arrive with one badge swipe instead of hunting for the right aisle. IAM roles are the keycards that grant read-only access to floor workers, write access to the receiving dock, and admin access to the warehouse manager.
+
 ---
 
 ## Artifact Registry vs Container Registry
 
-Container Registry (GCR) was GCP's original image registry, built on top of Cloud Storage buckets. Artifact Registry is its successor with significant improvements:
+Container Registry (GCR) was GCP's original image registry, built on top of Cloud Storage buckets. Artifact Registry is its successor with significant improvements. Understanding the migration path matters because many production pipelines still reference `gcr.io` URLs in Kubernetes manifests, Cloud Build configs, and Terraform modules written years ago.
+
+### GCR Deprecation and the gcr.io Transition
+
+Google [deprecated Container Registry on May 15, 2023](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown) and [shut down write access on March 18, 2025](https://cloud.google.com/kubernetes-engine/docs/deprecations/container-registry). After the shutdown timeline completed, images stored in legacy GCR buckets became inaccessible unless you had already migrated. The good news is that Artifact Registry can host [`gcr.io` repositories](https://cloud.google.com/artifact-registry/docs/transition/gcr-repositories) that transparently serve the same URLs your existing tooling expects, so a Kubernetes deployment referencing `gcr.io/my-project/my-app:v1` continues to work after migration without rewriting every manifest on day one.
+
+For new work, Google recommends [`pkg.dev` URLs](https://cloud.google.com/artifact-registry/docs/docker/store-docker-container-images) (`REGION-docker.pkg.dev/PROJECT/REPO/IMAGE:TAG`) because they support regional placement, per-repository IAM, remote/virtual repository modes, and cleanup policies that the legacy multi-regional GCR hostnames cannot offer. The automatic migration tool (`gcloud artifacts docker upgrade migrate`) creates Artifact Registry repositories for each GCR host in your project and redirects traffic, which is the fastest path for teams that need backward compatibility during a phased rollout.
+
+Hypothetical scenario: A platform team discovers that 40% of their GKE workloads still pull from `gcr.io` URLs embedded in Helm charts maintained by different product squads. Rather than forcing a big-bang URL rewrite across hundreds of charts, they run the automatic migration to stand up `gcr.io` repositories on Artifact Registry, then schedule a second phase to migrate each squad to regional `pkg.dev` endpoints where co-location with GKE clusters in `us-central1` eliminates cross-region pull latency.
 
 | Feature | Container Registry (GCR) | Artifact Registry |
 | :--- | :--- | :--- |
-| **Formats** | Docker images only | Docker, npm, Maven, Python, Go, Apt, Yum, KubeFlow |
+| **Formats** | Docker images only | Docker/OCI, Helm, Maven, npm, Python, Go, Apt, Yum, Kubeflow, Generic |
 | **Repository granularity** | One registry per region, per project | Multiple named repositories per project |
 | **IAM granularity** | Per-image is complex (bucket-level ACLs) | Per-repository IAM policies |
-| **Vulnerability scanning** | Basic (Container Analysis) | Integrated, automatic, on-push scanning |
+| **Vulnerability scanning** | Basic (Container Analysis) | Integrated automatic on-push + continuous rescanning |
 | **Remote repositories** | Not supported | Upstream caching for Docker Hub, npm, Maven, PyPI |
 | **Virtual repositories** | Not supported | Aggregate multiple repos behind a single endpoint |
 | **Cleanup policies** | Manual scripting | Built-in tag and version cleanup policies |
-| **Status** | Deprecated (sunset planned) | Active development, recommended |
+| **CMEK encryption** | Not supported | Customer-managed keys at repository creation |
+| **Immutable tags** | Not supported | Optional `--immutable-tags` per repository |
+| **Status** | Shut down (March 2025) | Active development, recommended |
+
+[Artifact Registry supports](https://cloud.google.com/artifact-registry/docs/supported-formats) Docker Image Manifest V2 (Schema 1 and 2), OCI image format specifications, and manifest lists for multi-architecture images. Helm charts packaged in OCI format store in Docker-format repositories alongside container images. Language-package formats (Maven, npm, Python, Go modules, Apt, Yum) each use dedicated repository types with format-specific client configuration, which lets a single GCP project host both the container images for your microservices and the internal npm packages those services depend on without operating separate registry infrastructure.
 
 ```bash
 # Enable the Artifact Registry API
@@ -49,6 +67,10 @@ gcloud services enable artifactregistry.googleapis.com
 # If you are still using GCR, migrate with:
 gcloud artifacts docker upgrade migrate --projects=my-project
 ```
+
+The migration command creates Artifact Registry repositories that mirror your existing GCR host layout and copies images asynchronously. During migration, both systems may serve traffic depending on your timeline, so plan the cutover during a maintenance window when you can validate that CI pipelines push successfully to the new endpoints and GKE clusters pull without ImagePullBackOff events or other unexpected deployment delays. After migration completes, update documentation and Terraform modules to reference `pkg.dev` URLs for new repositories even if legacy `gcr.io` URLs continue working through compatibility repositories.
+
+Teams migrating from other cloud providers often compare Artifact Registry to Amazon ECR or Azure Container Registry. The GCP differentiators worth internalizing are unified multi-format support (not Docker-only), first-class remote and virtual repositories for upstream caching, and native integration with Binary Authorization and Artifact Analysis for supply chain security. The tradeoff is that Artifact Registry pricing is storage-based rather than per-image as some competitors charge, which makes cleanup policy discipline more important at scale for cost control.
 
 ---
 
@@ -76,6 +98,8 @@ gcloud artifacts repositories describe docker-repo \
   --location=us-central1
 ```
 
+Repository names must be unique within a project and location combination, use lowercase letters and numbers with hyphens allowed, and appear in every image URL your teams reference. Choosing descriptive names like `prod-app-images` instead of generic `docker` prevents confusion when a project hosts a dozen repositories across environments and makes IAM audit logs readable when investigating who pushed to which store during a security review.
+
 ### Multi-Format Repositories
 
 ```bash
@@ -102,11 +126,55 @@ gcloud artifacts repositories create apt-repo \
   --repository-format=apt \
   --location=us-central1 \
   --description="Internal Debian packages"
+
+# Create Yum repository (for RPM packages on RHEL/CentOS)
+gcloud artifacts repositories create yum-repo \
+  --repository-format=yum \
+  --location=us-central1 \
+  --description="Internal RPM packages"
+
+# Create Go module repository
+gcloud artifacts repositories create go-repo \
+  --repository-format=go \
+  --location=us-central1 \
+  --description="Internal Go modules"
 ```
+
+Each repository format enforces its own naming and authentication conventions. Docker and Helm (OCI) clients use `gcloud auth configure-docker`; npm clients point `.npmrc` at the Artifact Registry npm endpoint; Maven and Gradle builds add a repository URL to `pom.xml` or `build.gradle`; Python clients configure `pip` or `twine` with the Artifact Registry PyPI URL. Choosing one repository per format per environment (for example, `prod-docker`, `staging-docker`) keeps IAM bindings and cleanup policies scoped to the blast radius you actually want, rather than mixing production and experimental artifacts in a single bucket-like namespace.
+
+### Repository Location Strategy
+
+Artifact Registry repositories are regional or multi-regional resources, and location choice affects latency, cost, and compliance simultaneously. Co-locating a Docker repository in `us-central1` with GKE clusters and Cloud Run services in the same region eliminates cross-region egress on every pod restart or scale-out event, which is the pattern most cost-conscious platform teams adopt for production workloads. Multi-regional repositories trade slightly higher storage cost for geographic redundancy when the same image must be pulled from clusters in different continents without maintaining duplicate repos per region.
+
+Hypothetical scenario: A fintech team stores container images in `europe-west1` but runs primary GKE in `us-central1` for historical reasons. Every node that pulls an image pays cross-region egress on each layer download, and cold-start latency for Cloud Run revisions increases because the image travels an ocean before the container starts. Moving the production repository to `us-central1` and keeping a read-only replication workflow for the European DR cluster cuts monthly networking costs and aligns with data-residency discussions without changing application code.
+
+---
+
+## Managing Language Packages
+
+While container images dominate Artifact Registry conversations, the same service hosts the language packages that those containers install during `docker build`. Centralizing npm, Maven, Python, and Go modules alongside the images that consume them gives security teams a single audit surface and gives developers consistent authentication across every artifact type.
+
+### npm Packages
+
+npm repositories use a dedicated endpoint format: `https://REGION-npm.pkg.dev/PROJECT/REPO/`. After creating an npm-format repository, configure your `.npmrc` to point at that URL and authenticate with the npm credential helper or a short-lived access token from `npx google-artifactregistry-auth`. Internal packages publish with `npm publish`; CI pipelines that previously pulled directly from the public npm registry can instead pull through a remote npm repository that caches upstream packages locally, which mitigates both rate limiting and the class of supply chain attack illustrated in this module's opening incident.
+
+### Maven and Gradle Artifacts
+
+Maven-format repositories integrate with standard Java build tooling through a repository URL added to `pom.xml` or `settings.xml`. Gradle projects reference the same URL in `build.gradle` or `build.gradle.kts`. Snapshot and release versioning behave as they would on Nexus or Artifactory, which makes Artifact Registry a viable replacement when your Java microservices already run on GKE and you want artifact storage in the same IAM boundary as your container images. Remote repositories can cache Maven Central so builds do not reach out to the public internet on every dependency resolution.
+
+### Python (PyPI) Packages
+
+Python-format repositories expose a PyPI-compatible index URL. Configure `pip` with `--index-url` or add the URL to `pip.conf` for persistent use. `twine upload` publishes internal wheels and sdists; `pip install` resolves dependencies from the same repository. Pairing a standard Python repository for internal packages with a remote PyPI cache gives data science teams the same upstream-buffering benefit that platform teams get from Docker Hub remote repos, which matters when a compromised package appears on PyPI after your nightly training job already cached the clean version.
+
+### OS Packages (Apt and Yum)
+
+Apt and Yum repositories store `.deb` and `.rpm` packages for golden-image builds and configuration management. Platform teams that bake custom OS packages into VM images or Dockerfile `RUN apt-get install` steps can host those packages privately instead of mirroring them on internal file servers with ad hoc authentication. The same IAM roles apply: CI systems that publish packages receive writer access, while production build pipelines receive reader access scoped to the specific repository.
 
 ---
 
 ## Working with Container Images
+
+Pulling and pushing container images is the most common Artifact Registry workflow, but authentication differs depending on whether a human developer, a CI/CD pipeline, or a GKE node is performing the operation. Getting authentication wrong produces the frustrating `denied: Permission denied` error that masks whether the problem is missing Docker credentials, insufficient IAM, or a nonexistent repository.
 
 ### Authentication
 
@@ -117,6 +185,20 @@ gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 # This adds a credential helper to your Docker config (~/.docker/config.json)
 # For other regions, specify them:
 gcloud auth configure-docker us-central1-docker.pkg.dev,europe-west1-docker.pkg.dev
+```
+
+The `gcloud auth configure-docker` command installs a credential helper that exchanges your user or service account credentials for short-lived OAuth tokens on each `docker push` or `docker pull`. For CI/CD pipelines, bind `roles/artifactregistry.writer` to a dedicated service account and authenticate Cloud Build or your external runner with that identity rather than storing long-lived JSON keys. Cloud Build's default service account already has push access within the same project when you grant the writer role on the target repository.
+
+For [GKE deployments](https://cloud.google.com/artifact-registry/docs/integrate-gke), image pulls authenticate through the **node service account**, not the Kubernetes ServiceAccount attached to individual pods. Grant `roles/artifactregistry.reader` on the repository to whichever IAM identity your node pool uses—typically the Compute Engine default service account (`PROJECT_NUMBER-compute@developer.gserviceaccount.com`) or a custom node service account you configured at cluster creation. If your Artifact Registry repository lives in a different GCP project than your GKE cluster, you must grant reader access cross-project; same-project deployments often work with defaults once the reader role is bound.
+
+[Workload Identity Federation](https://cloud.google.com/artifact-registry/docs/access-control) lets external CI systems (GitHub Actions, GitLab CI, on-premises Jenkins) impersonate a GCP service account without downloading key files. The external identity provider exchanges OIDC tokens for GCP credentials, and the impersonated service account receives repository-scoped IAM roles. This pattern eliminates the key-rotation burden that makes service account JSON keys a recurring audit finding.
+
+```bash
+# Example: grant a Cloud Build service account push access (same project)
+gcloud artifacts repositories add-iam-policy-binding docker-repo \
+  --location=us-central1 \
+  --member="serviceAccount:PROJECT_NUMBER@cloudbuild.gserviceaccount.com" \
+  --role="roles/artifactregistry.writer"
 ```
 
 ### Building, Tagging, and Pushing
@@ -188,11 +270,31 @@ spec:
 YAML
 ```
 
+### Multi-Architecture Images and Helm Charts
+
+Modern deployment targets rarely standardize on a single CPU architecture. GKE clusters may mix x86 nodes with [Tau T2A ARM instances](https://cloud.google.com/compute/docs/tau-arm-vms) for cost optimization, and developer laptops on Apple Silicon build `linux/arm64` images locally. Artifact Registry supports [manifest lists and OCI image indexes](https://cloud.google.com/artifact-registry/docs/supported-formats) that let you push both `linux/amd64` and `linux/arm64` variants under a single tag; the container runtime selects the correct architecture automatically at pull time.
+
+Build multi-arch images with Docker Buildx and push them in one command. The example below tags both architectures under a single version label so GKE nodes pull the correct variant automatically without separate deployment manifests per architecture family.
+
+```bash
+# Create and use a buildx builder (one-time setup)
+docker buildx create --name multiarch --use
+
+# Build and push multi-arch image to Artifact Registry
+docker buildx build --platform linux/amd64,linux/arm64 \
+  -t ${REGION}-docker.pkg.dev/${PROJECT_ID}/${REPO}/my-api:v1.2.0 \
+  --push .
+```
+
+Helm 3.8+ supports OCI registries for chart storage, and Artifact Registry accepts Helm charts in Docker-format repositories because charts are packaged as OCI artifacts. Push a chart with `helm push my-chart-1.0.0.tgz oci://REGION-docker.pkg.dev/PROJECT/REPO` and install with `helm install my-release oci://REGION-docker.pkg.dev/PROJECT/REPO/my-chart --version 1.0.0`. Storing charts alongside the container images they deploy keeps the release artifact bundle in one IAM-scoped repository, which simplifies audit questions about which chart version deployed which image digest.
+
+When you reference images by digest rather than tag in Kubernetes manifests (`image: repo/my-app@sha256:abc123...`), you eliminate tag-mutation risk entirely. Immutable tags are a softer guarantee—they prevent overwrites but still allow two different builds to reuse the same tag name if someone deletes and recreates the tag through policy changes—so digest pinning remains the gold standard for production deployments that must prove exactly which bits ran in a given incident investigation.
+
 ---
 
 ## Vulnerability Scanning
 
-Artifact Registry integrates with Container Analysis (also called Artifact Analysis) to automatically scan images for known vulnerabilities.
+Artifact Registry integrates with [Artifact Analysis](https://cloud.google.com/artifact-analysis/docs/container-scanning-overview) (formerly Container Analysis) to automatically scan container images for known vulnerabilities in OS packages and language-level dependencies. Scanning is a paid capability—[each initial scan costs $0.26 per image digest](https://cloud.google.com/artifact-analysis/pricing), and rescans of the same digest are free—so enabling the Container Scanning API on a project where CI pushes hundreds of unique images daily can produce a noticeable line item unless you design scanning gates deliberately.
 
 ### Enabling and Configuring Scanning
 
@@ -212,6 +314,10 @@ gcloud artifacts docker images scan \
   --location=us-central1
 ```
 
+Automatic scanning triggers on the first push of each unique image digest. Because images are identified by digest, retagging an existing digest does not incur another scan charge. [Continuous scanning](https://cloud.google.com/artifact-analysis/docs/container-scanning-overview) re-evaluates stored images when new CVE data arrives, which means a image that passed inspection last week may surface new HIGH findings today without any code change on your side—exactly the behavior you want for supply chain monitoring, but surprising if your deployment pipeline treats "scanned once" as "safe forever."
+
+Artifact Analysis inspects both the operating-system packages in your base image layer and application-level dependencies where supported. The severity table below maps CVSS scores to recommended response timelines; production teams typically wire CRITICAL and HIGH findings into CI gates or Binary Authorization policies rather than relying on developers to check scan results manually.
+
 ### Viewing Scan Results
 
 ```bash
@@ -227,6 +333,14 @@ gcloud artifacts vulnerabilities list \
   --format="table(vulnerability.shortDescription, vulnerability.cvssScore, vulnerability.severity, vulnerability.packageIssue[0].affectedPackage)"
 ```
 
+Scan results appear in the Google Cloud console under Artifact Registry, in the gcloud output above, and through the Container Analysis API for integration with SIEM or ticketing systems. Each finding links to a CVE identifier, affected package name, installed version, and fixed version when available. Platform teams typically define a policy document—often enforced through Binary Authorization or a CI script—that blocks promotion of images containing CRITICAL vulnerabilities and requires a ticket reference for HIGH findings that cannot be patched immediately because the upstream fix is not yet released.
+
+Building a vulnerability scanning policy means deciding three things: which severities block deployment, who can grant exceptions, and how continuous rescanning alerts reach on-call engineers when a previously clean stored digest gains new CRITICAL findings overnight. The first decision belongs to security and product leadership; the second needs an audit trail; the third requires Pub/Sub notifications or Security Command Center integration so findings do not sit unread in a console tab.
+
+> **Hypothetical scenario: The Silent Scan Failure**
+>
+> Hypothetical scenario: A platform team enabled vulnerability scanning on their production Docker repository but never wired scan results into the deployment pipeline. Developers assumed green CI checks meant secure images. When a CRITICAL OpenSSL CVE dropped on a Tuesday evening, continuous scanning flagged twelve production images within hours—but nobody noticed until a external researcher emailed the security team on Friday. The fix required emergency rebuilds of every affected image, attestations for Binary Authorization, and a retroactive policy mandating that CI fail on CRITICAL findings before images reach the production repository. The scanning feature worked exactly as designed; the failure was organizational, not technical.
+
 ### Severity Levels
 
 | Severity | CVSS Score | Action |
@@ -241,7 +355,7 @@ gcloud artifacts vulnerabilities list \
 
 ### Binary Authorization Integration
 
-For production environments, you can enforce that only scanned and approved images are deployed to GKE.
+For production environments, you can enforce that only scanned and approved images are deployed to GKE. [Binary Authorization](https://cloud.google.com/binary-authorization/docs/overview) evaluates attestations attached to images before GKE admits them into the cluster, closing the gap between "we scanned it" and "we deployed it anyway."
 
 ```bash
 # Enable Binary Authorization
@@ -255,11 +369,13 @@ gcloud services enable binaryauthorization.googleapis.com
 # 4. GKE clusters only run images with valid attestations
 ```
 
+A typical production pipeline pushes the image, waits for scan completion, runs a policy check against allowed severities, and only then creates an attestation that Binary Authorization verifies at deploy time. Without this enforcement layer, automatic scanning is informational—developers see CRITICAL CVEs in the console but nothing prevents `kubectl apply` from running the vulnerable image in production.
+
 ---
 
 ## IAM Access Control
 
-Artifact Registry supports fine-grained IAM at the repository level.
+Artifact Registry supports fine-grained IAM at the repository level, which is one of the primary reasons teams migrate from legacy GCR bucket ACLs. Project-level roles like `roles/artifactregistry.admin` grant control over every repository in the project; repository-level bindings limit CI/CD push access to `docker-repo` without exposing `npm-repo` or production-only image stores.
 
 ### Common Roles
 
@@ -269,6 +385,8 @@ Artifact Registry supports fine-grained IAM at the repository level.
 | `roles/artifactregistry.writer` | Pull + push images | CI/CD pipelines |
 | `roles/artifactregistry.repoAdmin` | Full control over a repo | Platform engineers |
 | `roles/artifactregistry.admin` | Full control over all repos | Registry administrators |
+
+The [Artifact Registry service agent](https://cloud.google.com/artifact-registry/docs/access-control) (`service-PROJECT_NUMBER@gcp-sa-artifactregistry.iam.gserviceaccount.com`) requires KMS permissions when you use customer-managed encryption keys. Cloud Run, Cloud Build, and GKE each have their own service agents documented in the access-control guide—grant the minimum repository role to the agent that actually pulls or pushes, not a project-wide admin role "just to make it work."
 
 ```bash
 # Grant a CI/CD service account push access to a specific repository
@@ -294,11 +412,54 @@ gcloud artifacts repositories get-iam-policy docker-repo \
   --location=us-central1
 ```
 
+Cross-project access is a frequent source of ImagePullBackOff errors in GKE. When your cluster runs in project `app-prod` but images live in project `shared-artifacts`, you must grant `roles/artifactregistry.reader` on the repository in `shared-artifacts` to the node service account from `app-prod`. Project-level IAM bindings work but violate least privilege because they grant access to every repository in the project; repository-level bindings limit the blast radius if a node is compromised.
+
+Cloud Run and Cloud Functions pull images through the Cloud Run service agent (`PROJECT_NUMBER@serverless-robot-prod.iam.gserviceaccount.com`), which needs reader access on the repository hosting the container image specified in the service definition. App Engine flexible environment uses its own service account (`PROJECT_ID@appspot.gserviceaccount.com`). Each compute service has a documented service agent in the [access control guide](https://cloud.google.com/artifact-registry/docs/access-control), and granting the wrong agent is a common copy-paste mistake during initial setup.
+
+For human developers who need local pull access, bind `roles/artifactregistry.reader` to a Google Group rather than individual users so onboarding and offboarding happen through group membership. Developers who also need push access for manual hotfix builds receive writer on staging repositories only; production repositories receive pushes exclusively from CI service accounts with Binary Authorization attestations downstream.
+
+---
+
+## Cloud Build Integration
+
+Most teams do not push container images manually from laptops; Cloud Build or another CI system builds, tags, and pushes on every merge. Artifact Registry integrates natively with Cloud Build through the `gcloud builds submit` workflow and through `cloudbuild.yaml` steps that reference Artifact Registry image URLs directly.
+
+A typical Cloud Build pipeline enables the Artifact Registry and Container Analysis APIs, builds a Docker image with Kaniko or Docker builder, tags it with both a git commit SHA and a semver release tag, pushes to a regional repository, waits for vulnerability scanning to complete, and only then deploys to GKE or Cloud Run. Keeping the build and registry in the same region avoids egress charges and reduces push latency during large layer uploads.
+
+```yaml
+# cloudbuild.yaml excerpt — build and push to Artifact Registry
+steps:
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'build'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_IMAGE}:${SHORT_SHA}'
+      - '-t'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_IMAGE}:${_TAG}'
+      - '.'
+  - name: 'gcr.io/cloud-builders/docker'
+    args:
+      - 'push'
+      - '--all-tags'
+      - '${_REGION}-docker.pkg.dev/${PROJECT_ID}/${_REPO}/${_IMAGE}'
+substitutions:
+  _REGION: us-central1
+  _REPO: app-images
+  _IMAGE: my-api
+  _TAG: latest
+```
+
+Cloud Build's service account needs `roles/artifactregistry.writer` on the target repository. If builds pull base images through a remote Docker Hub cache, the build service account also needs reader access on the remote repository. Separating build-time permissions (writer on staging repo) from deploy-time permissions (reader on production repo, attestation signer) enforces the same promotion workflow that Binary Authorization expects downstream.
+
+When Cloud Build runs inside a private pool or VPC-SC perimeter, verify that Artifact Registry endpoints are allowed through your service perimeter. [VPC Service Controls](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown) documentation covers `mirror.gcr.io` and Artifact Registry access from restricted networks, which matters for regulated industries that cannot reach Google APIs over the public internet without explicit perimeter configuration.
+
 ---
 
 ## Remote Repositories: Upstream Caching
 
-Remote repositories act as caching proxies for public registries. When you pull an image through a remote repository, it is cached locally in Artifact Registry. Subsequent pulls come from your cache, improving speed and protecting against upstream outages or supply chain attacks.
+Remote repositories act as caching proxies for public registries. When you pull an artifact through a remote repository, Artifact Registry fetches it from the upstream on a cache miss and stores a local copy. Subsequent pulls serve from your regional cache, which improves build speed, reduces exposure to upstream outages, and creates a buffer against supply chain attacks where a compromised package appears on a public registry after your pipeline already cached a clean version.
+
+[Remote repositories support](https://cloud.google.com/artifact-registry/docs/repositories/remote-overview) upstream sources including Docker Hub, Maven Central, npmjs, PyPI, and others depending on repository format. Remote repos are read-through caches: you cannot push artifacts into them, only pull. Storage consumed by cached upstream artifacts counts toward your Artifact Registry storage bill, which is why pairing remote repos with cleanup policies matters for long-running CI pipelines that pull many unique tag combinations.
 
 ```mermaid
 flowchart LR
@@ -351,9 +512,15 @@ docker pull us-central1-docker.pkg.dev/${PROJECT_ID}/dockerhub-cache/library/ngi
 # Subsequent pulls of the same image come from your local cache
 ```
 
+Remote repositories do not prefetch the entire upstream registry—they cache artifacts on first pull, which means the initial CI run after creating a remote repo still hits the public registry and is subject to upstream rate limits until the cache warms. Docker Hub official images require the `library/` namespace prefix when pulling through Artifact Registry, as shown in the nginx example above, because Docker Hub namespaces official images under `library/` even when users omit it in direct Hub pulls.
+
+For npm, Maven, and Python remote repos, the upstream configuration uses enumerated constants like `NPMJS`, `MAVEN-CENTRAL`, and `PYPI` in the gcloud command. Authentication to private upstream registries is not supported on standard remote repositories; if you need to cache a private Docker Hub organization, you configure upstream credentials through the remote repository settings documented in the [remote repository guide](https://cloud.google.com/artifact-registry/docs/repositories/remote-overview).
+
+Hypothetical scenario: Your CI pipeline builds 200 times per day and each build pulls `node:20-bookworm-slim` from Docker Hub. Without a remote cache, you hit Docker Hub rate limits within the first hour and builds fail unpredictably. After creating a remote repository and updating CI to pull through `us-central1-docker.pkg.dev/PROJECT/dockerhub-cache/library/node:20-bookworm-slim`, the first build populates the cache and the remaining 199 builds pull from Artifact Registry at in-region speeds with no upstream dependency.
+
 ### Virtual Repositories
 
-Virtual repositories provide a single endpoint that aggregates multiple upstream repositories (both standard and remote).
+Virtual repositories provide a single endpoint that aggregates multiple upstream repositories (both standard and remote). [Priority values determine lookup order](https://cloud.google.com/artifact-registry/docs/repositories/virtual-overview): lower numbers are checked first, so your internal standard repository at priority 100 wins over the Docker Hub remote cache at priority 200 when both contain an artifact with the same name.
 
 ```bash
 # Create a virtual repository that combines your internal repo and Docker Hub cache
@@ -380,13 +547,17 @@ gcloud artifacts repositories create docker-virtual \
 ]
 ```
 
-With this configuration, pulls from the virtual repository first check your internal repo (priority 100, checked first), then fall back to the Docker Hub cache (priority 200).
+With this configuration, pulls from the virtual repository first check your internal repo (priority 100, checked first), then fall back to the Docker Hub cache (priority 200). Developers configure a single registry URL in Docker, npm, or pip settings, which reduces misconfiguration and makes dependency-confusion defenses easier because internal package names resolve to internal artifacts before the public cache is consulted.
+
+When designing upstream priority, remember that lower numbers win. A common mistake sets the remote cache at priority 50 and the internal repo at priority 100, which inverts the intended behavior and serves public packages even when an internal artifact exists. Document priority ordering in your platform runbook so teams configuring virtual repositories do not accidentally expose themselves to dependency confusion attacks through inverted or misunderstood priority values.
 
 ---
 
 ## Cleanup Policies
 
-Cleanup policies automatically delete old images to prevent storage cost growth.
+Cleanup policies automatically delete old images to prevent storage cost growth. [Artifact Registry evaluates policies through a periodic background job](https://cloud.google.com/artifact-registry/docs/repositories/cleanup-policy), so changes take effect within approximately one day. Use `--dry-run` mode first to preview which artifacts would be deleted before enabling destructive rules on a production repository.
+
+Untagged images accumulate silently when CI pipelines push both digest-pinned builds and floating tags like `latest` or branch names. Each push of `my-app:main` creates a new digest while the previous digest becomes untagged but still billable storage. A delete policy targeting untagged images older than 30 days, combined with a keep policy retaining the ten most recent `v`-prefixed release tags, balances cost control against the ability to roll back to a recent production build.
 
 ```bash
 # Create a cleanup policy that deletes untagged images older than 30 days
@@ -421,15 +592,154 @@ gcloud artifacts repositories set-cleanup-policies docker-repo \
 
 ---
 
+## Encryption with Customer-Managed Keys (CMEK)
+
+By default, Artifact Registry encrypts all stored artifacts with [Google-managed encryption keys](https://cloud.google.com/artifact-registry/docs/cmek). For regulated workloads that require control over key rotation, geographic location, and audit trails, you can assign a [Cloud KMS customer-managed encryption key (CMEK)](https://cloud.google.com/kms/docs/cmek) when creating a repository. CMEK is set at repository creation time—you cannot convert an existing repository from Google-managed to CMEK encryption later, which means planning encryption requirements before the first push avoids a painful re-upload migration.
+
+```bash
+# Grant the Artifact Registry service agent access to the KMS key
+export PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format="value(projectNumber)")
+
+gcloud kms keys add-iam-policy-binding my-ar-key \
+  --location=us-central1 \
+  --keyring=my-keyring \
+  --member="serviceAccount:service-${PROJECT_NUMBER}@gcp-sa-artifactregistry.iam.gserviceaccount.com" \
+  --role="roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+# Create a CMEK-encrypted Docker repository
+gcloud artifacts repositories create prod-images-cmek \
+  --repository-format=docker \
+  --location=us-central1 \
+  --kms-key=projects/${PROJECT_ID}/locations/us-central1/keyRings/my-keyring/cryptoKeys/my-ar-key \
+  --immutable-tags
+```
+
+Organization policy constraints such as `constraints/gcp.restrictCmekCryptoKeyProjects` can require that all new Artifact Registry repositories use keys from an approved KMS project. Cloud KMS Autokey generates keys on demand during repository creation. This reduces manual key-provisioning steps for platform teams operating dozens of repositories across environments.
+
+---
+
+## Understanding the Artifact Registry Cost Model
+
+Artifact Registry billing has three independent components—storage, data transfer, and vulnerability scanning—and teams that monitor only storage often miss the scanning line item that grows with CI velocity.
+
+### Storage Pricing
+
+[Artifact Registry storage](https://cloud.google.com/artifact-registry/pricing) costs **$0.10 per GB per month** for usage above the **0.5 GB free tier** (aggregated across all projects attached to a billing account). Regional and multi-regional repositories use the same storage rate. Remote repository caches count toward storage because every upstream artifact you pull through the cache persists locally until a cleanup policy or manual deletion removes it.
+
+At moderate scale—say 200 GB of container images and cached upstream packages across production and staging repositories—storage alone runs roughly $20/month after the free tier. That sounds modest until you realize a single team pushing unique `:sha-${GIT_COMMIT}` tags on every build without cleanup policies can add 5–10 GB per week of mostly-untagged digests that nobody pulls again.
+
+### Data Transfer
+
+Pulling images from Artifact Registry to GKE nodes, Cloud Run, or Compute Engine **within the same region** incurs **no egress charge**—this is the co-location pattern that makes regional `pkg.dev` repositories cheaper than pulling from a multi-regional `gcr.io` host across regions. Cross-region pulls, pulls to on-premises infrastructure, and pulls to other cloud providers incur standard [GCP network egress rates](https://cloud.google.com/artifact-registry/pricing). Remote repositories reduce egress to public registries because the first pull from Docker Hub crosses the internet boundary once; subsequent CI runs pull from your regional cache over Google's network.
+
+### Vulnerability Scanning Costs
+
+Each unique image digest scanned costs **$0.26** on first push; rescans of the same digest are free. A pipeline that builds 50 distinct images per day across five microservices generates roughly 1,500 initial scans per month, or about **$390/month** in scanning alone. Mitigations include scanning only release-candidate tags (not every feature-branch build), using a dedicated scanning project, and relying on continuous rescanning of stored digests rather than pushing duplicate builds with identical content under new tags.
+
+### Cost Control Knobs
+
+| Knob | What It Reduces | Tradeoff |
+| :--- | :--- | :--- |
+| Cleanup policies for untagged digests | Storage growth from CI churn | Must retain enough tagged history for rollbacks |
+| Regional repos co-located with GKE | Cross-region egress | Less geographic redundancy for image pulls |
+| Remote repos for public base images | Docker Hub egress + rate limits | Cached upstream artifacts still bill for storage |
+| Scan only release tags | Scanning charges | Feature branches deploy without fresh scan data |
+| Immutable tags + digest pinning | Accidental re-push/rescan cycles | Requires pipeline discipline on tag naming |
+
+### What Makes Costs Spike Unexpectedly
+
+Hypothetical scenario: A data platform team enables vulnerability scanning project-wide, then a monorepo CI job starts building 200 Docker variants nightly—one per combination of base image, Python version, and CUDA driver. Within a month, storage crosses 2 TB ($200/month) and scanning adds $1,300/month because each variant is a new digest. The fix is not disabling scanning; it is restructuring the build matrix to reuse base layers, applying cleanup policies to ephemeral tags, and gating scans on merge-to-main rather than every pull request build.
+
+---
+
+## Patterns & Anti-Patterns
+
+| Pattern | When to Use | Why It Works | Scaling Note |
+| :--- | :--- | :--- | :--- |
+| **Regional repo per environment** | Separate `prod`, `staging`, and `dev` Docker repos in the same region as GKE | IAM and cleanup policies differ per environment; in-region pulls avoid egress | Add repos per team only when IAM isolation requires it—repo sprawl complicates virtual upstream configs |
+| **Remote cache + virtual repo** | Teams consume both internal and public packages | Single endpoint for developers; internal names win via priority ordering | Monitor remote cache storage; high-cardinality public tag pulls fill cache quickly |
+| **Immutable tags on production repos** | Any repo receiving release artifacts | Prevents tag mutation attacks and accidental overwrites | Pair with digest references in Kubernetes manifests for strongest guarantees |
+| **Repo-scoped CI service accounts** | Every pipeline that pushes images | Writer role on one repo cannot poison unrelated npm or staging repos | Create one SA per pipeline class, not one shared `ci@` with admin |
+| **Cleanup: delete untagged, keep N releases** | High-churn CI repos | Stops silent storage growth from floating branch tags | Test with `--dry-run`; policies take ~24h to apply |
+| **Binary Authorization gate** | Production GKE clusters | Closes the gap between scanning and deployment | Requires attestor setup; start with audit mode before enforce |
+
+| Anti-Pattern | What Goes Wrong | Why Teams Fall Into It | Better Alternative |
+| :--- | :--- | :--- | :--- |
+| **Project-wide `artifactregistry.admin` for CI** | Compromised pipeline can delete or poison every repo | Admin avoids debugging permission errors | `artifactregistry.writer` scoped to target repo |
+| **Scanning every branch build** | Scanning bill scales with commit frequency | "Enable scanning everywhere" sounds secure | Scan release tags; use continuous rescan for stored digests |
+| **Remote repo without cleanup** | Cache grows unbounded with unique upstream tags | Remote repos feel "free" because pulls are fast | Apply delete policies to cached artifacts or monitor storage |
+| **Cross-region image pulls** | Egress charges and slower pod startup | Reusing `us` multi-region URLs after migrating from GCR | Regional `pkg.dev` in the same region as compute |
+| **Relying on `latest` in production** | Rollbacks impossible; tag mutation risk | Convenient in dev, copied to prod manifests | Semver or git-SHA tags; immutable tags enabled |
+| **Skipping GCR migration** | Pull failures after shutdown timeline | "It still works today" deferral | Run `gcloud artifacts docker upgrade migrate` or move to `pkg.dev` |
+
+---
+
+## Decision Framework: Repository Architecture Choices
+
+Use this framework when designing Artifact Registry layout for a new platform or migrating from legacy GCR. The three most common decision points are migration strategy, upstream caching model, and scanning enforcement depth.
+
+```mermaid
+flowchart TD
+    START["Start: Plan Artifact Registry layout"] --> Q1{"Still on legacy GCR buckets?"}
+    Q1 -- "Yes" --> MIG["Run automatic migration<br/>or create gcr.io repos on AR"]
+    Q1 -- "No / greenfield" --> Q2{"Need public upstream packages?"}
+    MIG --> Q2
+
+    Q2 -- "No, internal only" --> STD["Standard repo per format/env<br/>+ cleanup policies + immutable tags"]
+    Q2 -- "Yes" --> Q3{"Single endpoint for devs?"}
+
+    Q3 -- "Yes" --> VIRT["Standard + Remote repos<br/>aggregated via Virtual repo"]
+    Q3 -- "No, separate configs OK" --> REM["Remote cache repo only<br/>point CI directly"]
+
+    STD --> Q4{"Production GKE?"}
+    VIRT --> Q4
+    REM --> Q4
+
+    Q4 -- "Yes" --> SCAN["Enable scanning + Binary Authorization<br/>on prod repos"]
+    Q4 -- "No" --> DEV["Scan optional;<br/>focus on IAM + cleanup"]
+```
+
+### Decision Matrix
+
+| Decision | Option A | Option B | Choose A When | Choose B When |
+| :--- | :--- | :--- | :--- | :--- |
+| **Migration** | `gcr.io` repos on Artifact Registry | New `pkg.dev` regional repos | Need zero-downtime URL compatibility during phased migration | Greenfield or ready for manifest URL updates |
+| **Upstream access** | Remote repository only | Virtual repo (internal + remote) | CI pulls public images; devs rarely mix sources | Devs need one `.npmrc` / Docker config for internal + public |
+| **Scanning gate** | Scan all pushes | Scan release tags only | Low push volume; strict compliance | High-churn CI; cost-sensitive; use continuous rescan |
+| **Encryption** | Google-managed keys | CMEK at repo creation | Default security sufficient | Regulatory requirement for customer key control |
+| **Tag strategy** | Immutable semver tags | Floating branch tags + cleanup | Production deployments | Ephemeral dev/staging repos with aggressive cleanup |
+
+### Scanning Gate Decision
+
+If your CI pushes fewer than 20 unique production-bound images per week, enable automatic scanning on every push. Wire CRITICAL findings to block deploy. If CI pushes hundreds of feature-branch images daily, scan on merge to main instead. Promote only tagged release artifacts to the production repository where Binary Authorization enforces attestations. The cost difference between these models can be an order of magnitude at scale. Security outcomes stay similar when continuous rescanning covers stored release digests.
+
+---
+
+## Operational Monitoring and Troubleshooting
+
+Artifact Registry problems surface in three places: CI logs during push/pull, GKE events as ImagePullBackOff, and billing reports showing unexpected storage or scanning growth. Knowing which diagnostic path to follow saves hours of misdirected debugging.
+
+When `docker push` returns `denied: Permission denied`, check credentials first (`gcloud auth configure-docker`), then repository existence and region, then IAM bindings on the repository—not the project. Artifact Registry intentionally returns generic permission errors for nonexistent repos to avoid leaking resource names to unauthorized callers.
+
+When GKE pods enter ImagePullBackOff, verify the image URL format (`REGION-docker.pkg.dev/PROJECT/REPO/IMAGE:TAG`), confirm the repository exists in the stated region, and grant `roles/artifactregistry.reader` to the node service account on that repository. Cross-project pulls require explicit cross-project IAM; same-project pulls with the default Compute Engine service account still need the reader role bound after least-privilege hardening removes legacy broad storage permissions.
+
+Storage growth without traffic growth almost always means untagged digests accumulating from CI. Run `gcloud artifacts docker images list` with `--include-tags` to identify images with empty tag columns, then implement cleanup policies in dry-run mode before enabling deletion. Scanning cost spikes correlate with unique digest count—audit CI for pipelines that push `:latest` or `:sha-$CI_COMMIT` on every branch build without deduplication.
+
+Audit logs for Artifact Registry record push, pull, and delete operations when data access logging is enabled. Enable the `DATA_WRITE` audit log type for `artifactregistry.googleapis.com` to trace who pushed a malicious image or who deleted a release tag during an incident investigation. Cleanup policy dry runs also appear in audit logs, which helps validate that a new delete rule will not remove production release tags before the policy goes live.
+
+Multi-team platforms often ask whether to share one Docker repository or isolate per team. The recommended pattern creates one shared remote repository for Docker Hub caching (all teams need reader access), separate standard repositories per team for internal images (writer IAM scoped to each team's CI service account), and optional virtual repositories per team that prioritize internal images over the shared cache. Shared caching avoids duplicate storage of `node:20-bookworm-slim` across fifteen teams, while separate standard repositories prevent Team A's compromised pipeline from pushing malicious images into Team B's release namespace.
+
+---
+
 ## Did You Know?
 
 1. **Artifact Registry stores over 10 billion container images** across all GCP customers. It is the same infrastructure that Google uses internally to store the images for Google Cloud services like Cloud Run, GKE, and Cloud Functions.
 
 2. **The `--immutable-tags` flag prevents tag mutation attacks**. Without it, someone with push access can overwrite `myapp:v1.0` with a completely different image. This is a real attack vector---an attacker who compromises a CI/CD pipeline can replace a known-good image tag with a malicious one. Immutable tags guarantee that `v1.0` always refers to the exact same image digest.
 
-3. **Remote repositories save an average of 60-80% on egress costs** for teams that pull heavily from public registries. Instead of every CI/CD run pulling `node:20-slim` from Docker Hub (incurring egress costs and being subject to Docker Hub rate limits), the image is cached locally after the first pull.
+3. **Remote repositories save egress and rate-limit exposure** for teams that pull heavily from public registries. Instead of every CI/CD run pulling `node:20-slim` from Docker Hub (incurring egress costs and being subject to Docker Hub rate limits), the image is cached locally after the first pull. Google hosts `mirror.gcr.io` as a pull-through cache for frequently requested Docker Hub images on Artifact Registry infrastructure, which GKE documentation references for base image pulls when you do not operate your own remote repository.
 
-4. **Artifact Registry supports multi-architecture images (manifests lists)** out of the box. You can push both `linux/amd64` and `linux/arm64` variants under the same tag, and Docker or Kubernetes will automatically pull the correct architecture for the host platform. This is increasingly important as ARM-based instances (like GCP's Tau T2A) become popular for cost savings.
+4. **Artifact Registry supports multi-architecture images (manifest lists)** out of the box. You can push both `linux/amd64` and `linux/arm64` variants under the same tag, and Docker or Kubernetes will automatically pull the correct architecture for the host platform. This is increasingly important as ARM-based instances (like GCP's Tau T2A) become popular for cost savings.
 
 ---
 
@@ -486,13 +796,25 @@ The first likely cause is that the developer has not configured Docker to authen
 When the `docker pull` command is executed, the virtual repository evaluates its upstreams in priority order, starting with the lowest number. It checks the internal standard repository (priority 100) first, finds the internally published `ubuntu:latest` image, and returns it immediately without ever querying the remote repository (priority 200). This priority configuration provides a critical security benefit by preventing dependency confusion attacks. If an attacker publishes a malicious package to a public registry with the exact same name as an internal package, the virtual repository will prioritize and serve the internal version first in the normal case, which helps mitigate this attack.
 </details>
 
+<details>
+<summary>7. Your organization enables automatic vulnerability scanning on all Docker repositories and integrates Binary Authorization on production GKE clusters. A developer pushes a new image, the scan completes with two CRITICAL CVEs in the base image, and the developer deploys to production anyway using an existing deployment YAML. What should have prevented this deployment, and what vulnerability scanning policy components were likely missing?</summary>
+
+Binary Authorization should have blocked the deployment because the image lacks a valid attestation from an authorized attestor confirming it passed the organization's scan policy. Automatic vulnerability scanning alone is informational—it produces findings in the console but does not prevent `kubectl apply` unless you wire scan results into attestations that Binary Authorization enforces at the GKE admission layer. The missing policy components are likely a CI gate that fails builds on CRITICAL findings before attestation, an attestor configured to sign only policy-compliant images, and a Binary Authorization policy on the GKE cluster set to enforce rather than audit. Together, these three layers convert scan data into an actual deployment control rather than a dashboard warning.
+</details>
+
+<details>
+<summary>8. A cost review reveals that Artifact Registry storage grew from 50 GB to 800 GB in three months despite stable production traffic. Investigation shows CI pushes `:build-${CI_PIPELINE_ID}` tags on every commit but only promotes `v*` tags to production. What combination of Artifact Registry features addresses the root cause without affecting production rollback capability?</summary>
+
+The root cause is untagged or ephemeral CI tags accumulating as orphaned digests that still consume storage. Implement cleanup policies with two rules: a Delete action for untagged images older than a defined window (for example, 30 days), and a Keep action retaining the ten most recent versions matching the `v` tag prefix for production rollbacks. Test policies in dry-run mode first because Artifact Registry applies cleanup through a periodic background job. Optionally restrict CI to push ephemeral tags to a separate non-production repository with aggressive cleanup, while only release tags land in the production repo protected by immutable tags.
+</details>
+
 ---
 
 ## Hands-On Exercise: Container Registry with Scanning and Caching
 
 ### Objective
 
-Create an Artifact Registry setup with a standard Docker repository, enable vulnerability scanning, and configure an upstream Docker Hub cache.
+Create an Artifact Registry setup with a standard Docker repository, enable vulnerability scanning, and configure an upstream Docker Hub cache. This exercise mirrors the production pattern most GCP teams adopt: internal images live in a standard repo with immutable tags, public base images flow through a remote cache, and CI service accounts receive the minimum IAM roles needed to push and pull without project-wide admin access.
 
 ### Prerequisites
 
@@ -502,7 +824,7 @@ Create an Artifact Registry setup with a standard Docker repository, enable vuln
 
 ### Tasks
 
-**Task 1: Create Docker Repositories**
+### Task 1: Create Docker Repositories
 
 <details>
 <summary>Solution</summary>
@@ -539,7 +861,7 @@ gcloud artifacts repositories list --location=$REGION
 ```
 </details>
 
-**Task 2: Build and Push a Container Image**
+### Task 2: Build and Push a Container Image
 
 <details>
 <summary>Solution</summary>
@@ -576,7 +898,7 @@ gcloud artifacts docker images list \
 ```
 </details>
 
-**Task 3: Check Vulnerability Scan Results**
+### Task 3: Check Vulnerability Scan Results
 
 <details>
 <summary>Solution</summary>
@@ -599,7 +921,7 @@ gcloud artifacts docker images list \
 ```
 </details>
 
-**Task 4: Pull Through the Docker Hub Cache**
+### Task 4: Pull Through the Docker Hub Cache
 
 <details>
 <summary>Solution</summary>
@@ -617,7 +939,7 @@ docker pull ${REGION}-docker.pkg.dev/${PROJECT_ID}/dockerhub-mirror/library/ngin
 ```
 </details>
 
-**Task 5: Configure Repository IAM**
+### Task 5: Configure Repository IAM
 
 <details>
 <summary>Solution</summary>
@@ -643,7 +965,7 @@ gcloud artifacts repositories get-iam-policy app-images \
 ```
 </details>
 
-**Task 6: Clean Up**
+### Task 6: Clean Up
 
 <details>
 <summary>Solution</summary>
@@ -688,6 +1010,19 @@ Next up: **[Module 2.7: Cloud Run (Serverless Containers)](../module-2.7-cloud-r
 
 ## Sources
 
-- [Artifact Registry Overview](https://cloud.google.com/artifact-registry/docs/overview) — Gives the product-level model for repositories, access control, and integrations.
-- [Remote Repository Overview](https://cloud.google.com/artifact-registry/docs/repositories/remote-overview) — Explains how upstream caching works and what guarantees remote repositories do and do not provide.
-- [Container Scanning Overview](https://cloud.google.com/artifact-analysis/docs/container-scanning-overview) — Covers automatic scanning, on-demand scanning, and how vulnerability findings are produced for Artifact Registry images.
+- [Artifact Registry Overview](https://cloud.google.com/artifact-registry/docs/overview) — Product model for repositories, formats, access control, and integrations.
+- [Supported Formats](https://cloud.google.com/artifact-registry/docs/supported-formats) — Docker/OCI, Helm, Maven, npm, Python, Go, Apt, Yum, and other artifact types.
+- [Store Docker Container Images](https://cloud.google.com/artifact-registry/docs/docker/store-docker-container-images) — Image URL format, push/pull workflow, and regional endpoints.
+- [Docker Authentication](https://cloud.google.com/artifact-registry/docs/docker/authentication) — `gcloud auth configure-docker` and credential helper setup.
+- [Access Control with IAM](https://cloud.google.com/artifact-registry/docs/access-control) — Repository-scoped roles, service agents, and Workload Identity Federation.
+- [Transition from Container Registry](https://cloud.google.com/artifact-registry/docs/transition/prepare-gcr-shutdown) — GCR shutdown timeline and migration requirements.
+- [gcr.io Repositories on Artifact Registry](https://cloud.google.com/artifact-registry/docs/transition/gcr-repositories) — Backward-compatible `gcr.io` URLs hosted on Artifact Registry.
+- [Remote Repository Overview](https://cloud.google.com/artifact-registry/docs/repositories/remote-overview) — Upstream caching for Docker Hub, npm, Maven, and PyPI.
+- [Virtual Repository Overview](https://cloud.google.com/artifact-registry/docs/repositories/virtual-overview) — Aggregating standard and remote repos with priority ordering.
+- [Configure Cleanup Policies](https://cloud.google.com/artifact-registry/docs/repositories/cleanup-policy) — Delete/keep rules, dry-run mode, and policy application timing.
+- [Customer-Managed Encryption Keys (CMEK)](https://cloud.google.com/artifact-registry/docs/cmek) — KMS key setup and repository encryption constraints.
+- [Artifact Registry Pricing](https://cloud.google.com/artifact-registry/pricing) — Storage, data transfer, and scanning cost components.
+- [Container Scanning Overview](https://cloud.google.com/artifact-analysis/docs/container-scanning-overview) — Automatic on-push and continuous vulnerability scanning.
+- [Artifact Analysis Pricing](https://cloud.google.com/artifact-analysis/pricing) — Per-scan pricing and rescans of the same digest.
+- [Deploying to GKE](https://cloud.google.com/artifact-registry/docs/integrate-gke) — Node service account permissions for private image pulls.
+- [Binary Authorization Overview](https://cloud.google.com/binary-authorization/docs/overview) — Attestation-based deployment enforcement for GKE.


### PR DESCRIPTION
## Cloud track — GCP Essentials Wave 6b (expand-to-floor + cross-family review)

Second GCP Essentials wave (curriculum order). All three below the 5000-word floor → expanded,
cross-family reviewed (opus 4.8), ground-checked/web-verified, finalized. **GCP Essentials now 6/12 done (2.1–2.6).**

| Module | Action | Author | Reviewer | Tier (after fixes) |
|---|---|---|---|---|
| 2.4 Cloud Storage | expand 1.3k→5.0k | cursor | opus 4.8 | T0 (5007w, 20 src) |
| 2.5 Cloud DNS | expand 1.3k→5.0k | cursor (re-done; deepseek truncated) | opus 4.8 | T0 (5004w, 12 src) |
| 2.6 Artifact Registry | expand 1.1k→5.0k (src 3→16) | cursor | opus 4.8 | T0 (5016w, 16 src) |

### Review fixes (ground-checked / web-verified by opus)
- **2.4 GCS**: **UBLA grace period "7 days"→"90 days"** (13× security/migration-planning error); Autoclass terminal class is Coldline not Archive; dropped unverifiable "2T objects/day" DYK; org-policy v2 schema; SLA multi-region qualifier; sign-url `--private-key-file` note; SA-token scope.
- **2.5 DNS**: **WRR `--routing-policy-data` was inverted** (Cloud DNS is `weight=rrdata`, weight first) — broke the example + lab Task 3 + cleanup; **`gcloud dns health-checks` is not a real command** → ILB reuses LB health check / external uses `gcloud compute health-checks`; `--local-data` flag+syntax (not `--local-data-rrsets`/BIND); positional-rrdata-AND-policy "not both"; FAILOVER example given health check + backup-data-type; health-check pricing per-month ($0.50/$2.00).
- **2.6 AR**: **virtual-repository priority direction was INVERTED** (security — the worked example taught the dependency-confusion vuln it claimed to prevent; private upstream must outrank the public remote); `--enable-vulnerability-scanning` is not a real flag → enable `containerscanning.googleapis.com`; Cloud Run agent `service-` prefix; ua-parser-js opener → hypothetical; "upstream auth not supported on remote repos" corrected; unverifiable DYK + VPC-SC citation.

All three pass `verify_module.py` (T0); incident-dedup gate PASS; no gutter/fused-fence defects. (Note: deepseek truncated 2.5 on first pass — re-done with cursor.)

## Learner check

> Artifact Registry is GCP's managed solution for storing, managing, and securing software artifacts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
