### PR TITLE
chore(content): cloud GCP Essentials wave 6d — 2.10 Ops + 2.11 Cloud Build + 2.12 Patterns (completes GCP Essentials)

### DIFF
--- a/src/content/docs/cloud/gcp-essentials/module-2.10-operations.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.10-operations.md
@@ -27,6 +27,23 @@ In this module, you will learn how Cloud Logging's architecture works (the log r
 
 ---
 
+## The Cloud Operations Suite at a Glance
+
+Google Cloud Observability bundles the services you use to answer three questions in production: **Is the system healthy?** **Why did it fail?** **Where is time being spent?** The suite is not a monolith you install once—it is a set of managed APIs and consoles that managed GCP services feed automatically, while Compute Engine and custom workloads connect through the [Ops Agent](https://cloud.google.com/monitoring/agent/ops-agent) or OpenTelemetry exporters.
+
+| Service | Primary question | Typical data source |
+| :--- | :--- | :--- |
+| **Cloud Monitoring** | Are metrics within SLO? | Platform metrics, custom metrics, log-based metrics, uptime checks |
+| **Cloud Logging** | What happened, in detail? | Platform logs, stdout/stderr, audit logs, Ops Agent file logs |
+| **Cloud Trace** | Which hop added latency? | HTTP spans from managed runtimes, OpenTelemetry instrumentation |
+| **Cloud Profiler** | Which function consumed CPU/heap? | Continuous sampling in Go, Java, Node.js, Python |
+| **Error Reporting** | What new exceptions appeared? | Stack traces in logs or the Error Reporting API |
+| **Managed Service for Prometheus (GMP)** | Can we keep PromQL and lose the Prometheus server? | Prometheus exporters, GKE managed collection, OTLP |
+
+Managed services such as Cloud Run, GKE, Cloud Functions, and Cloud SQL emit platform logs and metrics without extra agents. That integration is why teams often discover observability gaps only after they deploy custom code on Compute Engine: without the Ops Agent or equivalent instrumentation, you get infrastructure metrics but miss application logs, Prometheus scrapes, and trace context propagation. The sections below walk through each layer with enough depth to design a production observability stack—not merely enable default dashboards.
+
+---
+
 ## Cloud Logging Architecture
 
 ### The Log Router
@@ -82,6 +99,30 @@ flowchart LR
 | **System Event** | Yes (always on) | Free | 400 days | Live migration, auto-scaling |
 | **Platform Logs** | Yes | Paid | 30 days (default) | Cloud Run requests, GKE events |
 | **Application Logs** | Yes (stdout/stderr) | Paid | 30 days (default) | Your application output |
+
+### Log Buckets, Views, and Log Analytics
+
+Ingestion charges apply when log entries are **stored in a log bucket**, not when they merely pass through the Log Router. The `_Default` bucket in each project receives most platform and application logs; the `_Required` bucket stores Admin Activity and System Event logs that Google manages with fixed retention and **no storage charge** for the bucket itself. You can create **user-defined log buckets** with custom retention (for example 90 days for security review) and **log views** that restrict which entries analysts in a given role may read—useful when a central security team owns long-retention buckets but application teams need read-only access to their service logs.
+
+[Log Analytics](https://cloud.google.com/logging/docs/analyze/query-link) lets you run SQL against linked log buckets through BigQuery's engine without exporting every line to a dataset first. That matters for ad hoc investigations ("show me distinct `error_type` values last Tuesday") where Log Explorer's line-by-line UI becomes tedious. Queries issued through Log Explorer and Log Analytics are not separately billed by Cloud Logging; you pay for the underlying log storage that makes the data available. When compliance requires multi-year retention, the usual pattern is a **sink to Cloud Storage** or BigQuery with lifecycle rules, not an infinitely growing `_Default` bucket—object storage and BigQuery long-term tiers are typically cheaper than retaining high-volume DEBUG traffic in Logging past 30 days.
+
+```bash
+# Create a user-defined log bucket with 90-day retention
+gcloud logging buckets create security-audit \
+  --location=global \
+  --retention-days=90 \
+  --description="Extended retention for security review"
+
+# List buckets and their retention
+gcloud logging buckets list --location=global \
+  --format="table(name, retentionDays, lifecycleState)"
+
+# Link a bucket to Log Analytics (enables SQL queries in console)
+gcloud logging links create security-analytics-link \
+  --location=global \
+  --bucket=security-audit \
+  --description="Analytics link for security bucket"
+```
 
 ### Querying Logs
 
@@ -144,6 +185,10 @@ labels."compute.googleapis.com/resource_name"="my-vm"
 
 Sinks route copies of log entries to destinations outside the default Cloud Logging storage, which is essential for long-term retention, security analytics, and compliance archives that outlive the default 30-day platform retention. Each sink has its own filter and a **writer identity** service account that must be granted permission on the destination bucket, dataset, or topic—creating the sink is only half the job. Sinks operate independently of exclusions: a log can be excluded from expensive default ingestion while still being copied to BigQuery or Cloud Storage for audit teams.
 
+Think of sinks as **parallel export pipes** evaluated by the Log Router for every matching entry. A common enterprise pattern uses three sinks: (1) all Admin Activity and Data Access audit logs to a BigQuery dataset for SIEM queries; (2) `severity>=ERROR` platform logs to a Cloud Storage archive bucket with 7-year lifecycle; (3) a Pub/Sub topic streaming critical security events to a real-time processor. Each sink filter should be as narrow as compliance allows—exporting `severity>=INFO` from a busy GKE cluster to BigQuery can dwarf the cost of the cluster itself because BigQuery storage and analysis charges apply downstream.
+
+When granting the sink writer identity, use least privilege: `roles/storage.objectCreator` on a prefix, `roles/bigquery.dataEditor` on a dataset, or `roles/pubsub.publisher` on a topic. Terraform and Deployment Manager templates should output the writer email (`serviceAccount:...`) so security teams can audit bindings. If logs stop appearing at the destination, the first check is almost always IAM on the destination—not the sink filter—because the router silently drops failed writes after retries.
+
 ```bash
 # Create a sink to Cloud Storage (long-term archival)
 gcloud logging sinks create archive-all-logs \
@@ -205,6 +250,26 @@ gcloud logging exclusions list
 
 Writing structured (JSON) logs instead of plain text enables powerful querying and log-based metrics because Cloud Logging maps well-formed JSON objects into `jsonPayload` fields you can filter with the same precision as built-in `httpRequest` attributes. When you emit `latency_ms`, `user_id`, or `error_type` as top-level JSON keys, you can build distribution metrics and dashboards without fragile regex on `textPayload`, and you can alert on thresholds that reflect application semantics rather than substring matches. Plain `print()` output still lands in logs, but it forfeits that structured field model—so production services on Cloud Run should treat JSON logging as the default, not an optimization.
 
+Cloud Logging recognizes several **severity** conventions automatically. For JSON logs, include a `severity` field with values such as `INFO`, `WARNING`, `ERROR`, and `CRITICAL` so Log Explorer color-codes entries and severity filters behave predictably. The special field `message` (or `msg`) populates the summary line in the console. For HTTP services behind Cloud Run or load balancers, Cloud Logging also captures **`httpRequest`** metadata—method, URL, status, latency—when the platform generates request logs; your application JSON should complement, not duplicate, those fields unless you need business context the platform cannot infer.
+
+Design a **stable schema** per service: document required keys in your team's runbook (`service`, `trace_id`, `latency_ms`, `status_code`, `error_type`) and avoid renaming fields between releases without updating log-based metrics. Breaking renames silently starve dashboards because filters stop matching overnight. For correlation with Trace, log the trace ID from the incoming `X-Cloud-Trace-Context` header so Log Explorer queries can jump to the waterfall view for the same request.
+
+```text
+# Recommended jsonPayload shape for API services
+{
+  "severity": "ERROR",
+  "message": "Payment authorization failed",
+  "service": "checkout-api",
+  "trace_id": "projects/my-proj/traces/abc123",
+  "latency_ms": 842,
+  "status_code": 502,
+  "error_type": "GatewayTimeout",
+  "order_id": "ord-9981"
+}
+```
+
+When logs must never contain secrets, enforce redaction in the formatter—mask PAN fragments, tokens, and password fields before serialization. Structured logging makes redaction easier because you target known keys instead of regex over free-form strings.
+
 ### Python Structured Logging for Cloud Run
 
 ```python
@@ -262,6 +327,12 @@ Use these filters in Log Explorer during incidents, then promote the same expres
 
 Log-based metrics are the bridge between logging and monitoring: they evaluate filters as entries flow through the log router and expose matching traffic as Cloud Monitoring time series you can chart, combine with infrastructure metrics, and attach to alerting policies. **Counter** metrics increment when a filter matches (ideal for error counts and auth failures), while **distribution** metrics sample numeric fields such as latency so you can compute percentiles instead of only knowing that "something slow happened." The commands in the next two subsections show both patterns for Cloud Run workloads.
 
+Because evaluation happens **at ingestion time**, log-based metrics are not retroactive: creating a metric today does not backfill yesterday's errors. Plan metrics before launch for SLO-critical signals (5xx counts, payment failures, auth denials). Each log-based metric becomes a **chargeable custom metric** in Cloud Monitoring—budget for cardinality. User-defined log-based metrics share the custom-metric byte allotment (150 MiB free per billing account per month on the standard pricing page); high-volume broad filters can consume that allotment quickly.
+
+Label extractors add dimensions—for example grouping error counts by `resource.labels.service_name` or a `jsonPayload.error_type` field—so one metric serves many services on a dashboard. Too many unique label combinations, however, explode time-series cardinality and cost the same way high-cardinality Prometheus labels do. Prefer a small set of business-meaningful labels (`error_type`, `region`) over per-user dimensions unless you truly page on individual users.
+
+When a platform metric already exists (`run.googleapis.com/request_count` with `response_code_class`), use it instead of duplicating a log-based counter—the platform metric is non-chargeable and maintained by Google. Reach for log-based metrics when the signal lives only in application JSON (`jsonPayload.event="inventory_shortfall"`) or when you need a distribution from a field Cloud Run does not expose as a native histogram.
+
 ### Counter Metrics
 
 ```bash
@@ -300,6 +371,8 @@ gcloud logging metrics create api_latency \
 ---
 
 ## Cloud Monitoring: Dashboards and Metrics
+
+Cloud Monitoring is the time-series layer where platform metrics, custom metrics, log-based metrics, uptime check results, and SLO burn rates converge. Dashboards are your incident "single pane"—but only if they chart **symptoms** (request latency percentiles, error rates, saturation) alongside **causes** you investigate after paging (CPU, memory, instance count). A dashboard that shows only infrastructure graphs reproduces the November 2022 blind spot from the opener: healthy CPU while customers fail checkout.
 
 ### Built-in Metrics
 
@@ -396,6 +469,25 @@ gcloud monitoring dashboards create --config-from-file=/tmp/dashboard.json
 gcloud monitoring dashboards list --format="table(displayName, name)"
 ```
 
+Treat dashboard JSON as infrastructure: store definitions in Git, review changes in PRs, and name dashboards after services or user journeys (`checkout-api prod`, `data pipeline batch`) rather than engineer names. During incidents, pin the top three charts—request rate by response class, p99 latency, and your primary log-based error metric—so new responders do not hunt for widgets.
+
+### Notification Channels and On-Call Routing
+
+Before alert policies fire into the void, wire **notification channels**—email, Slack, PagerDuty, SMS, webhooks—to the teams that can act. Channels are reusable objects; policies reference them by ID. Separate **page-worthy** channels from **informational** ones so backup-job CPU warnings land in Slack while SLO burn-rate violations wake an on-call rotation. Include runbook URLs in policy documentation fields; Cloud Monitoring surfaces that text in notifications and reduces mean time to remediate when the recipient is not the engineer who authored the alert six months ago.
+
+```bash
+# Create a PagerDuty channel (token stored as channel label — use Secret Manager in prod pipelines)
+gcloud monitoring channels create \
+  --display-name="Checkout On-Call PagerDuty" \
+  --type=pagerduty \
+  --channel-labels="service_key=YOUR_INTEGRATION_KEY"
+
+# Verify channel before attaching to critical policies
+gcloud monitoring channels describe CHANNEL_ID --format=json
+```
+
+Review channels when on-call rotations change—stale Slack webhooks are a common reason "the alert definitely fired but nobody saw it" during postmortems.
+
 ### PromQL in Cloud Monitoring
 
 Cloud Monitoring natively supports PromQL for teams that already think in Prometheus rate/histogram queries, which lowers migration friction when you adopt GCP but keep Grafana-style mental models. Metric names are translated to the `*_googleapis_com:*` form, and you can express error rates as ratios of labeled request counters or pull latency quantiles from histogram buckets. PromQL is optional—MQL and console builders work too—but it is valuable when your runbooks already reference PromQL snippets from open-source stacks.
@@ -420,6 +512,18 @@ compute_googleapis_com:instance_cpu_utilization{instance_name=~"web-.*"} > 0.8
 ---
 
 ## Alerting Policies
+
+Alerting policies in Cloud Monitoring evaluate conditions on a schedule and open incidents when thresholds breach for a configured duration. Understanding **condition types** prevents mismatched alerts: a metric threshold on `run.googleapis.com/request_count` with `response_code_class="5xx"` measures error volume, while a PromQL ratio divides 5xx rate by total rate for a true error **percentage**. **SLO burn-rate conditions** (covered earlier) use `select_slo_burn_rate` and tie pages to error budgets. **Uptime check conditions** consume the `monitoring.googleapis.com/uptime_check/check_passed` metric. **Log-based metric conditions** behave like any custom metric once the log-based metric exists.
+
+| Condition style | Best for | Caution |
+| :--- | :--- | :--- |
+| **Metric threshold** | Single metric vs static threshold (CPU, queue depth) | Noisy if metric is a cause not a symptom |
+| **Metric absent** | Expected heartbeat metrics that stop arriving | False positives during deploys unless suppressed |
+| **PromQL / MQL ratio** | Error rate %, saturation ratios | Query cost counts toward alerting policy billing |
+| **SLO burn rate** | Customer-facing reliability | Requires upfront SLO definition |
+| **Uptime check failure** | External availability | Regional flaps—require multi-region failure |
+
+Policies also incur ongoing cost when they reference chargeable metrics: Google bills for **metric references active** in alerting policies and for **points returned** when conditions evaluate complex queries—another reason to delete orphaned policies during quarterly hygiene reviews.
 
 ### Creating Alert Policies
 
@@ -509,6 +613,10 @@ gcloud monitoring policies update POLICY_ID \
 
 Uptime checks monitor the availability of your public endpoints from Google's global probe network, which catches failures that internal metrics miss—expired TLS certificates, DNS misconfigurations, VPC egress rules blocking external clients, or regional routing issues that still leave instances "healthy" behind a load balancer. Probes run HTTP/HTTPS (or TCP) checks on a schedule you define, record per-region pass/fail time series, and integrate with alerting policies so pages fire when multiple regions agree a user-visible path is down.
 
+Google operates checkers in multiple geographic regions; configuring alerts to require failures from **two or more regions** reduces false positives when a single probe path has transient packet loss. Uptime checks bill per execution according to the [Observability pricing page](https://cloud.google.com/products/observability/pricing)—consolidate checks on user-journey URLs (`/health` on the public API gateway) rather than creating one check per internal microservice that customers never call directly. For private services, uptime checks cannot reach RFC 1918 addresses; use **private synthetic monitoring** patterns (Cloud Run job with VPC egress, or third-party probes inside your network) instead of expecting public checkers to hit internal load balancers.
+
+Authenticated endpoints require custom headers or OAuth tokens in advanced configurations; keep health endpoints unauthenticated but non-sensitive so probes stay simple. Pair uptime alerts with log-based error metrics: external "down" with flat error logs often implicates DNS or TLS, while uptime failure plus rising 5xx logs implicates application regression.
+
 ```bash
 # Create an HTTP uptime check
 gcloud monitoring uptime create my-api-uptime \
@@ -566,11 +674,28 @@ While logs and metrics tell you *that* a service is slow or experiencing high lo
 
 ### Cloud Trace
 
-Cloud Trace is a distributed tracing system that collects latency data from your applications and displays it in the GCP Console. When a request enters your system, Trace assigns it a unique trace ID; as the request crosses a load balancer, Cloud Run revision, Cloud SQL query, and external HTTP dependency, each hop emits a **span** with start time, duration, and parent/child relationships. That waterfall view answers *where* wall-clock time went, which is invaluable when p99 latency spikes but CPU stays flat because the service is waiting on I/O. Managed runtimes often capture baseline HTTP spans automatically, and you add OpenTelemetry instrumentation when you need custom spans around business logic or database calls.
+[Cloud Trace](https://cloud.google.com/trace/docs) is a distributed tracing system that collects latency data from your applications and displays it in the GCP Console. When a request enters your system, Trace assigns it a unique trace ID; as the request crosses a load balancer, Cloud Run revision, Cloud SQL query, and external HTTP dependency, each hop emits a **span** with start time, duration, and parent/child relationships. That waterfall view answers *where* wall-clock time went, which is invaluable when p99 latency spikes but CPU stays flat because the service is waiting on I/O. Managed runtimes often capture baseline HTTP spans automatically, and you add OpenTelemetry instrumentation when you need custom spans around business logic or database calls.
+
+Trace sampling is worth configuring deliberately: at very high QPS, storing every span can become expensive and noisy, while sampling too aggressively hides rare tail-latency paths. Cloud Run and GKE can propagate the `X-Cloud-Trace-Context` header so downstream services join the same trace without custom glue code. When you instrument manually, ensure outbound HTTP clients forward that header (or W3C `traceparent`) so a slow payment gateway appears as a child span instead of an unexplained gap.
+
+```bash
+# List recent traces for a Cloud Run service (REST via gcloud)
+gcloud trace list-traces \
+  --filter='rootSpanName:"GET /checkout"' \
+  --limit=5 \
+  --format="table(traceId, startTime, latency)"
+
+# In application code (Python + OpenTelemetry), a custom span around DB work:
+#   with tracer.start_as_current_span("fetch_inventory"):
+#       rows = db.execute("SELECT ...")
+# Cloud Trace picks up OTLP exports when the Ops Agent or collector is configured.
+```
 
 ### Cloud Profiler
 
-Cloud Profiler provides continuous CPU and heap profiling for applications running on GCP with statistical sampling overhead typically under 1%, producing flame graphs that highlight hot functions rather than single slow requests. Reach for Profiler when you have evidence of high CPU or memory churn in a specific binary and need to know which methods dominate—after Trace has already ruled out external waits. Agents exist for Go, Java, Node.js, and Python; you import the library and start the profiler at process boot so production profiles accumulate without manual capture sessions.
+[Cloud Profiler](https://cloud.google.com/profiler/docs) provides continuous CPU and heap profiling for applications running on GCP with statistical sampling overhead typically under 1%, producing flame graphs that highlight hot functions rather than single slow requests. Reach for Profiler when you have evidence of high CPU or memory churn in a specific binary and need to know which methods dominate—after Trace has already ruled out external waits. Agents exist for Go, Java, Node.js, and Python; you import the library and start the profiler at process boot so production profiles accumulate without manual capture sessions.
+
+Profiler complements Trace rather than replacing it: Trace shows that 8 seconds elapsed between "authorize payment" and "commit order," while Profiler shows that 70% of CPU time inside the payment service is spent in JSON serialization after you ruled out network waits. For Cloud Run, enable Profiler in the container image and ensure the service account has `roles/cloudprofiler.agent` (or the broader Monitoring agent role bundles that include it). Profiles appear in the console within minutes of traffic; compare profiles before and after a deploy to spot regressions in hot paths.
 
 > **Stop and think**: If users report that clicking "Checkout" takes 10 seconds, but your system CPU utilization is hovering at a very healthy 20%, which tool should you reach for first to diagnose the issue: Cloud Trace or Cloud Profiler? Why?
 
@@ -585,6 +710,219 @@ In a real-world GCP organization, resources are rarely confined to a single proj
 A **Metrics Scope** allows you to view and manage monitoring data from multiple GCP projects through a single pane of glass. You designate one **scoping project**—often a shared observability or platform project—and attach **monitored projects** whose metrics become visible in that scope. Dashboards in the scoping project can chart resources from any attached project side by side, which is how platform teams compare error rates across microservices without console project hopping. Alert policies defined in the scoping project can evaluate conditions globally (for example, any Cloud SQL instance above a CPU threshold), and IAM on the scoping project alone can grant SREs read access to organizational health without handing them Owner on every application project.
 
 > **Pause and predict**: If you have 10 separate production microservice projects, should you manage alert policies in each project separately, or centrally within a single metrics scoping project?
+
+---
+
+## Ops Agent: Unified Collection on Compute Engine
+
+Cloud Run and GKE collect stdout and platform metrics automatically, but **Compute Engine VMs** need an agent unless your application pushes telemetry directly to Cloud Logging and Cloud Monitoring APIs. The [Ops Agent](https://cloud.google.com/monitoring/agent/ops-agent) is the preferred replacement for the legacy separate Logging and Monitoring agents: one package, one YAML configuration file, Fluent Bit for high-throughput logs, and the OpenTelemetry Collector for metrics and traces.
+
+By default the Ops Agent collects `/var/log/syslog` (or `/var/log/messages`) and host metrics such as CPU, memory, and disk without custom configuration. Production setups extend receivers to scrape **Prometheus endpoints** on localhost, tail application log files under `/var/log/myapp/`, and accept **OTLP** metrics and traces from in-process OpenTelemetry SDKs. Configuration merges user overrides from `/etc/google-cloud-ops-agent/config.yaml` with a built-in baseline at agent restart— you never edit the built-in file directly.
+
+```bash
+# Install Ops Agent on a Debian/Ubuntu VM (run on the instance)
+curl -sSO https://dl.google.com/cloudagents/add-google-cloud-ops-agent-repo.sh
+sudo bash add-google-cloud-ops-agent-repo.sh --also-install
+
+# Verify agent status
+sudo systemctl status google-cloud-ops-agent
+
+# Example override: scrape a local Prometheus metrics endpoint
+sudo tee /etc/google-cloud-ops-agent/config.yaml << 'EOF'
+metrics:
+  receivers:
+    prometheus:
+      type: prometheus
+      config:
+        scrape_configs:
+          - job_name: 'my-app'
+            scrape_interval: 60s
+            static_configs:
+              - targets: ['localhost:9090']
+  service:
+    pipelines:
+      prometheus_pipeline:
+        receivers: [prometheus]
+EOF
+
+sudo systemctl restart google-cloud-ops-agent
+```
+
+Grant the VM's service account `roles/logging.logWriter` and `roles/monitoring.metricWriter` (or a custom role bundle your platform team publishes). Without those bindings, the agent buffers locally and you lose data silently during incidents—the classic "we thought logs were flowing" failure mode. For Windows VMs, paths and service names differ, but the receivers/processors/pipelines model is the same.
+
+---
+
+## Managed Service for Prometheus (GMP)
+
+Teams running Kubernetes often standardize on **Prometheus** for application metrics—histograms, RED metrics, custom business counters—but operating Prometheus at scale (retention, HA, remote write, cardinality explosions) consumes platform engineering time. [Google Cloud Managed Service for Prometheus (GMP)](https://cloud.google.com/managed-prometheus) is a fully managed, Prometheus-compatible backend built on the same Monarch datastore as Cloud Monitoring. You keep PromQL dashboards and alert rules; Google operates ingestion, retention (up to 24 months for Prometheus metrics), and global query fan-out.
+
+GMP supports **managed collection** on GKE (horizontal pod autoscaling collectors), self-deployed collectors, and OpenTelemetry pipelines on Cloud Run. Because GMP and native Cloud Monitoring metrics share a backend, you can chart `run.googleapis.com/request_count` beside `prometheus.googleapis.com/.../http_requests_total` in one dashboard and query both with PromQL in the console or Grafana. **Metering differs**: most Cloud Monitoring custom metrics bill by **bytes ingested** (scalar points count as 8 bytes each), while GMP bills by **samples ingested**—aligning with upstream Prometheus cost models and making high-cardinality label sets easier to attribute per namespace.
+
+```bash
+# Enable GMP API (if not already enabled with Monitoring)
+gcloud services enable monitoring.googleapis.com
+
+# List Prometheus targets in a GKE cluster with managed collection (console is often easier)
+# Metrics appear under prometheus.googleapis.com/* metric types in Metrics Explorer
+
+# Example PromQL mixing GMP and Cloud Run platform metrics:
+#   rate(run_googleapis_com:request_count{service_name="checkout"}[5m])
+#     /
+#   rate(prometheus.googleapis.com/.../http_requests_total{job="checkout"}[5m])
+```
+
+Use GMP when your organization already invested in Prometheus exporters and PromQL runbooks. Stay on native Cloud Monitoring custom metrics when you publish low-cardinality gauges from batch jobs via the Monitoring API and do not need PromQL portability. Many enterprises run both: platform metrics from GCP services, application RED metrics through GMP.
+
+---
+
+## Error Reporting
+
+[Error Reporting](https://cloud.google.com/error-reporting/docs) aggregates exceptions so responders see **grouped error events** instead of scrolling duplicate stack traces in Log Explorer. It is automatically enabled for supported runtimes: uncaught exceptions written to `stderr` on Cloud Run, Cloud Functions, GKE, and App Engine are parsed when log entries contain recognizable stack traces or formatted `ReportedErrorEvent` payloads. The Error Groups page highlights new and frequent failures; you can wire notification channels when a fresh group appears.
+
+Error Reporting itself has no separate per-event charge, but log entries that carry stack traces still incur **Cloud Logging ingestion** if they land in a chargeable bucket. The service samples up to 1,000 errors per hour for display; beyond that, counts are estimated so the UI remains responsive during storms. For explicit reporting from code, use language client libraries or the `events:report` REST method—those paths also generate structured log entries under `projects/PROJECT_ID/logs/clouderrorreporting.googleapis.com%2Freported_errors`.
+
+```python
+# Python: client library reports an handled exception with context
+from google.cloud import error_reporting
+
+client = error_reporting.Client()
+try:
+    process_payment(order_id)
+except PaymentError as exc:
+    client.report_exception(user=user_id, http_context={"url": "/checkout"})
+    raise
+```
+
+Pair Error Reporting with log-based metrics on `severity>=ERROR` for paging, and with Trace for the request that triggered the exception. Error Reporting answers "what new bugs shipped?"; log-based metrics answer "how fast is the error rate rising?"
+
+---
+
+## SLO Monitoring and Burn-Rate Alerts
+
+Infrastructure metrics and log counts are necessary but not sufficient for user-facing reliability. **Service-level objectives (SLOs)** translate "good enough" into measurable targets—99.9% of checkout requests succeed within 500 ms over a 30-day window, for example. Cloud Monitoring's [SLO monitoring](https://cloud.google.com/stackdriver/docs/solutions/slo-monitoring) lets you define a **service**, choose a **service-level indicator (SLI)** from platform metrics (Cloud Run request latency, load balancer availability, custom metrics), set a **performance goal**, and track **error budget** consumption over a compliance period.
+
+An **error budget** is the allowed unreliability before you violate the SLO. If the objective is 99.9% availability in 30 days, the budget is roughly 43 minutes of bad events. **Burn rate** measures how fast you consume that budget relative to sustainable pace; a burn rate of 10 means you will exhaust the month's budget in three days if nothing changes. Google recommends **two alerting policies per critical SLO**: a **fast-burn** policy with a short lookback for sudden spikes, and a **slow-burn** policy with a longer lookback for gradual degradation—the same pattern described in the Google SRE Workbook.
+
+Console-created SLO alerts use the `select_slo_burn_rate(SLO_NAME, LOOKBACK_PERIOD)` time-series selector. You set a burn-rate threshold and lookback duration; when consumption exceeds the threshold long enough, the policy fires. This is strictly more actionable than alerting on raw CPU because it ties pages to customer impact and pre-agreed budgets.
+
+```bash
+# SLOs are commonly created in console or Terraform; API sketch for burn-rate alert condition:
+# filter: select_slo_burn_rate("projects/PROJECT_ID/services/SERVICE_ID/serviceLevelObjectives/SLO_ID", "3600s")
+# comparison: COMPARISON_GT
+# thresholdValue: 14.4   # example fast-burn multiplier — tune per SLO policy
+
+# List services with SLOs in a project (Monitoring API)
+gcloud monitoring services list --format="table(displayName, name)"
+```
+
+When error budget is nearly exhausted, the disciplined response is to freeze risky releases and focus on reliability work—not to raise the SLO target quietly. Dashboards in the microservice SLO view show remaining budget percentage, SLI current value, and firing alert ratio per service.
+
+---
+
+## Cost Lens: Observability Spend at Moderate Scale
+
+Observability bills surprise teams when volume scales faster than attention. At moderate scale—a few Cloud Run services, a GKE cluster, several Compute Engine VMs, and audit logging enabled on sensitive buckets—the dominant costs are usually **log ingestion**, **custom metric cardinality**, and **retention**, not the console UI itself.
+
+| Cost driver | What spikes spend | Knobs that reduce spend |
+| :--- | :--- | :--- |
+| **Log ingestion** | DEBUG in staging copied to prod projects, Data Access audit logs on hot buckets, VPC Flow Logs at full sampling | Exclusion filters on `_Default`; scope audit configs; sample flow logs; structured INFO default |
+| **Log retention** | Keeping everything 90+ days in Logging buckets | Sink to Cloud Storage/BigQuery with lifecycle; shorten bucket retention for non-audit logs |
+| **Log-based metrics** | Broad filters matching millions of entries | Tight filters; prefer platform metrics when available—they are non-chargeable |
+| **Custom metrics (bytes)** | High-cardinality labels (`user_id`, `request_id`) on Monitoring API writes | Aggregate dimensions; use distributions sparingly |
+| **GMP samples** | Unbounded label cardinality from auto-instrumentation | Drop labels in relabel configs; use managed collectors' defaults on GKE |
+| **Uptime checks / alerting** | One check per microservice × many regions; alert conditions evaluating huge metric sets | Consolidate checks on user-facing URLs; delete orphaned policies |
+
+Per [Google Cloud Observability pricing](https://cloud.google.com/products/observability/pricing) (verify current rates in your billing console before budgeting):
+
+- **Logging storage** in `_Default` and user-defined buckets: **$0.50/GiB** ingested after the first **50 GiB free per project per month** (includes 30 days storage in the bucket).
+- **Vended network logs** (VPC Flow, firewall, NAT): **$0.25/GiB** with **no** free tier—enabling flow logs on every subnet is a common bill shock.
+- **Retention beyond 30 days** in log buckets: **$0.01/GiB/month** for stored volume.
+- **Chargeable custom metrics** (including log-based metrics): billed by bytes after **150 MiB free per billing account per month**; distribution points cost more than scalars.
+- **GMP**: billed by **samples ingested** (Prometheus-style metering), not the same byte model as generic custom metrics.
+
+Hypothetical scenario: A platform team enables Data Access audit logs project-wide and turns on VPC Flow Logs for "visibility." Ingestion jumps from 60 GiB/month to 800 GiB/month. At roughly $0.50/GiB on application logs and $0.25/GiB on vended logs, monthly Logging spend moves from single digits to hundreds of dollars before any application growth. The fix is scoped audit policies, flow-log sampling, and exclusion filters—not disabling observability entirely.
+
+Cloud Logging does **not** charge for routing copies via sinks to Pub/Sub, Cloud Storage, or BigQuery; downstream services bill separately. That makes **sink + exclude** patterns cost-effective: drop noise from `_Default` ingestion while archiving compliance streams cheaply in object storage.
+
+---
+
+## Patterns & Anti-Patterns
+
+Production observability on GCP succeeds when teams treat logs, metrics, and traces as **product infrastructure** with owners, budgets, and review cadences—not as default toggles left on after a tutorial.
+
+| Pattern | When to use it | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| **Structured JSON logging from day one** | Any Cloud Run, GKE, or Functions service | Enables field filters, distribution metrics, and Log Analytics without regex fragility | Standardize field names (`severity`, `trace_id`, `latency_ms`) across services |
+| **Symptom-based alerting (SLO + log-based error rates)** | User-facing APIs and batch SLAs | Pages correlate with customer pain and error budgets | Pair fast- and slow-burn SLO policies per critical path |
+| **Log router exclusions + selective sinks** | High-volume staging or health-check noise | Cuts `_Default` ingestion while compliance logs still reach BigQuery/Storage | Review exclusions quarterly—services change |
+| **Metrics scope hub project** | 5+ production projects | Central dashboards and IAM for SRE without Owner on every app project | Hub project becomes critical—back Terraform state and access reviews |
+| **Ops Agent Prometheus receiver on VMs** | Legacy apps exposing `/metrics` | One agent for logs + scraped metrics; feeds GMP or Monitoring | Cap scrape frequency and label cardinality |
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+| :--- | :--- | :--- | :--- |
+| **Alert on CPU alone** | Pages during backups; misses I/O latency | CPU graphs are easy in console | Alert on latency, error rate, SLO burn, or log-based 5xx counters |
+| **Plain `print()` logging in production** | Cannot build precise metrics or Log Analytics SQL | Fastest local debug habit | JSON to stdout with stable field names |
+| **Project-wide Data Access audit logs** | Massive ingestion on busy Storage buckets | Compliance checkbox without scoping | Audit specific resources; sink to cheap long-term storage |
+| **Log-based metric with overly broad filter** | Expensive metric + alert noise | "Match anything with 'error' in text" | Narrow filters on `jsonPayload` fields and `severity` |
+| **Self-hosted Prometheus on GKE without capacity planning** | Cardinality explosions, missed SLAs on the monitoring stack | Fear of managed pricing | GMP with managed collectors; keep runbooks in PromQL |
+| **No uptime checks on public URLs** | Internal metrics green while users cannot connect | Assume load balancer health equals app health | HTTP checks on `/health` from multiple regions |
+| **Ignoring trace context propagation** | Disjoint spans; mystery gaps in Trace | New service added without header forwarding | Propagate `X-Cloud-Trace-Context` or W3C traceparent |
+| **Retention in `_Default` for years** | Retention surcharges and query slowdown | Simplest button in console | Sink to Storage; keep `_Default` at 30 days |
+
+---
+
+## Decision Framework
+
+Use this framework when choosing among log-based metrics, Monitoring API custom metrics, alerting condition types, and GMP versus native Monitoring ingestion.
+
+```mermaid
+flowchart TD
+    Start[Need a new observability signal] --> Source{Where does the data live?}
+    Source -->|Already in logs| LogMetric{Need percentiles or just counts?}
+    LogMetric -->|Counts / rates| LBC[Log-based counter metric]
+    LogMetric -->|Percentiles / histogram| LBD[Log-based distribution metric]
+    Source -->|Not in logs yet| Push{Prometheus / OTLP already?}
+    Push -->|Yes, PromQL runbooks| GMP[Managed Service for Prometheus]
+    Push -->|No, simple gauge from app| CM[Cloud Monitoring custom metric API]
+    LBC --> Alert{Page humans?}
+    LBD --> Alert
+    CM --> Alert
+    GMP --> Alert
+    Alert -->|User impact / SLO| SLO[SLO burn-rate alert]
+    Alert -->|Threshold on metric| Cond{Condition type?}
+    Cond -->|Single metric threshold| TH[Metric threshold condition]
+    Cond -->|Ratio e.g. 5xx rate| MQL[PromQL or MQL ratio]
+    Cond -->|External reachability| UP[Uptime check + alert]
+    SLO --> Notify[Notification channel + runbook link]
+    TH --> Notify
+    MQL --> Notify
+    UP --> Notify
+```
+
+| Decision | Prefer | Tradeoff |
+| :--- | :--- | :--- |
+| **Log-based counter vs distribution** | Counter for "how many errors"; distribution when magnitude matters (latency ms) | Distributions cost more as chargeable custom metrics; require numeric fields in structured logs |
+| **Log-based vs Monitoring API custom metric** | Log-based when event already logged; API when emitting real-time gauge without log line | Log-based metrics are not retroactive; API metrics need client library or agent |
+| **GMP vs native custom metrics** | GMP for K8s/Prometheus ecosystems; native API for low-cardinality app gauges | Different metering (samples vs bytes); PromQL parity has minor differences from upstream |
+| **Metric threshold vs SLO burn alert** | SLO for customer-facing reliability targets; raw threshold for capacity signals | SLO setup requires service definition and SLI choice upfront |
+| **Uptime check vs internal health metric** | Uptime for user-visible URL; internal metric for dependency depth | Uptime checks bill per execution; catch DNS/TLS issues external probes see |
+| **Exclude vs sink-only routing** | Exclude to drop `_Default` cost; sink when destination must retain copy | Exclusions do not block sinks—design both intentionally |
+
+Revisit decisions after the first month of production traffic: log volume dashboards in the Logs Storage page, GMP ingestion by namespace (if enabled), and alert policy incident counts reveal whether your filters are too loose or too tight.
+
+---
+
+## Building an Observability Baseline for a New Service
+
+When a team launches a new Cloud Run service or GKE deployment, observability should ship in the same PR as the Dockerfile—not as a follow-up ticket. A practical **baseline checklist** covers emission, aggregation, external proof, and cost guardrails without boiling the ocean on day one.
+
+First, **emit structured logs** to stdout with severity, request identifiers, and latency fields your log-based metrics will need later. Second, confirm **platform metrics** appear in Metrics Explorer (`run.googleapis.com/request_count`, `request_latencies`) before writing custom instrumentation—many alerts need only platform data. Third, create at least one **log-based counter** for application-specific failures your platform metrics cannot see (for example `jsonPayload.error_type="RateLimitExceeded"`). Fourth, add an **uptime check** on the public health URL if the service has external consumers. Fifth, define an **SLO** if the service is on the critical path— even a simple availability SLI on HTTP 5xx rate beats debating whether 3% errors is "bad enough" during an outage.
+
+For Compute Engine workloads, install the **Ops Agent** in the golden image, verify IAM roles on the VM service account, and test that logs appear in Log Explorer before autoscaling the fleet. For Kubernetes, decide early whether application metrics flow through **GMP managed collection** or a self-managed Prometheus sidecar; switching later is doable but rewrites dashboards and alert rules.
+
+Hypothetical scenario: A team ships a new internal admin API with DEBUG logging enabled "temporarily" and no exclusion filter. Staging and production share a project; ingestion adds 200 GiB/month at $0.50/GiB after the free tier—roughly $75/month in logging alone for a low-traffic admin tool. The baseline fix is INFO default, DEBUG only via feature flag in non-prod, and an exclusion for known-noisy health probes—not removing logging entirely.
+
+Document the baseline in the service README: dashboard link, primary alert policy names, SLO target, and which log fields are stable contracts for downstream metrics. The next engineer onboarding during a 2 AM incident will thank you.
 
 ---
 
@@ -945,5 +1283,15 @@ Next up: **[Module 2.11: Cloud Build & CI/CD](../module-2.11-cloud-build/)** ---
 
 - [Route Log Entries](https://cloud.google.com/logging/docs/routing/overview) — Best primary reference for the Log Router, sinks, exclusions, and routing behavior.
 - [Log-Based Metrics Overview](https://cloud.google.com/logging/docs/logs-based-metrics) — Explains counter and distribution metrics, alerting integration, and non-retroactive behavior.
+- [Log Analytics](https://cloud.google.com/logging/docs/analyze/query-link) — SQL analysis over linked log buckets without full BigQuery export.
+- [Google Cloud Observability Pricing](https://cloud.google.com/products/observability/pricing) — Logging ingestion ($/GiB), retention, custom metrics, GMP samples, uptime checks.
+- [Ops Agent Overview](https://cloud.google.com/monitoring/agent/ops-agent) — Unified logging, metrics, Prometheus scrape, and OTLP on Compute Engine.
+- [Managed Service for Prometheus](https://cloud.google.com/managed-prometheus) — PromQL-compatible managed backend, GKE collection, sample-based metering.
+- [PromQL for Cloud Monitoring](https://cloud.google.com/stackdriver/docs/managed-prometheus/promql) — Querying platform, custom, and GMP metrics with PromQL.
+- [Error Reporting Overview](https://cloud.google.com/error-reporting/docs/grouping-errors) — Error grouping, sampling limits, and log-based detection.
+- [SLO Monitoring](https://cloud.google.com/stackdriver/docs/solutions/slo-monitoring) — Services, SLIs, error budgets, and microservice dashboards.
+- [Alerting on Burn Rate](https://cloud.google.com/stackdriver/docs/solutions/slo-monitoring/alerting-on-budget-burn-rate) — Fast-burn and slow-burn SLO alert patterns.
+- [Cloud Trace Documentation](https://cloud.google.com/trace/docs) — Distributed tracing, span model, and instrumentation.
+- [Cloud Profiler Documentation](https://cloud.google.com/profiler/docs) — Continuous CPU and heap profiling.
 - [Metrics Scopes Overview](https://cloud.google.com/monitoring/settings) — Covers scoping projects, multi-project monitoring, and centralized dashboards and alerts.
 - [Create Public Uptime Checks](https://cloud.google.com/monitoring/uptime-checks) — Authoritative guide for checker locations, regional behavior, and uptime-check configuration.

--- a/src/content/docs/cloud/gcp-essentials/module-2.10-operations.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.10-operations.md
@@ -19,7 +19,7 @@ By the end of this module, you will have practiced the observability patterns pr
 
 ## Why This Module Matters
 
-In November 2022, a fintech company's payment processing service began failing intermittently. Customers reported that approximately 5% of transactions were being declined with a generic "server error." The on-call engineer checked the Cloud Run dashboard and saw that CPU and memory utilization were normal. Request count looked steady. Everything appeared healthy from the infrastructure layer. The issue persisted for 4 hours before a senior engineer noticed an anomaly in the application logs: a third-party payment gateway was returning HTTP 429 (rate limit exceeded) for requests from a specific IP range. This log signal was buried in 2 million log lines per hour because the team had no log-based metrics, no alerting on error rates, and no structured logging. They were flying blind in a sea of unstructured text. The 4-hour delay in diagnosis cost them $340,000 in failed transactions and a significant hit to customer trust.
+**Hypothetical scenario:** In November 2022, a fintech company's payment processing service began failing intermittently. Customers reported that approximately 5% of transactions were being declined with a generic "server error." The on-call engineer checked the Cloud Run dashboard and saw that CPU and memory utilization were normal. Request count looked steady. Everything appeared healthy from the infrastructure layer. The issue persisted for 4 hours before a senior engineer noticed an anomaly in the application logs: a third-party payment gateway was returning HTTP 429 (rate limit exceeded) for requests from a specific IP range. This log signal was buried in 2 million log lines per hour because the team had no log-based metrics, no alerting on error rates, and no structured logging. They were flying blind in a sea of unstructured text. The 4-hour delay in diagnosis cost them $340,000 in failed transactions and a significant hit to customer trust.
 
 This incident demonstrates a truth that every platform engineer learns the hard way: **metrics tell you that something is wrong; logs tell you why.** You need both, and you need them working together. Cloud Operations (formerly Stackdriver) is GCP's integrated suite for monitoring, logging, and alerting. It is not a separate product you bolt on---it is deeply integrated into every GCP service. Cloud Logging automatically captures logs from managed services like Cloud Run, GKE, and Cloud Functions. Compute Engine instances require the Cloud Ops Agent for application and OS log collection. Cloud Monitoring automatically collects metrics from all GCP resources.
 
@@ -107,10 +107,11 @@ Ingestion charges apply when log entries are **stored in a log bucket**, not whe
 [Log Analytics](https://cloud.google.com/logging/docs/analyze/query-link) lets you run SQL against linked log buckets through BigQuery's engine without exporting every line to a dataset first. That matters for ad hoc investigations ("show me distinct `error_type` values last Tuesday") where Log Explorer's line-by-line UI becomes tedious. Queries issued through Log Explorer and Log Analytics are not separately billed by Cloud Logging; you pay for the underlying log storage that makes the data available. When compliance requires multi-year retention, the usual pattern is a **sink to Cloud Storage** or BigQuery with lifecycle rules, not an infinitely growing `_Default` bucket—object storage and BigQuery long-term tiers are typically cheaper than retaining high-volume DEBUG traffic in Logging past 30 days.
 
 ```bash
-# Create a user-defined log bucket with 90-day retention
+# Create a user-defined log bucket with 90-day retention and Log Analytics enabled
 gcloud logging buckets create security-audit \
   --location=global \
   --retention-days=90 \
+  --enable-analytics \
   --description="Extended retention for security review"
 
 # List buckets and their retention
@@ -372,7 +373,7 @@ gcloud logging metrics create api_latency \
 
 ## Cloud Monitoring: Dashboards and Metrics
 
-Cloud Monitoring is the time-series layer where platform metrics, custom metrics, log-based metrics, uptime check results, and SLO burn rates converge. Dashboards are your incident "single pane"—but only if they chart **symptoms** (request latency percentiles, error rates, saturation) alongside **causes** you investigate after paging (CPU, memory, instance count). A dashboard that shows only infrastructure graphs reproduces the November 2022 blind spot from the opener: healthy CPU while customers fail checkout.
+Cloud Monitoring is the time-series layer where platform metrics, custom metrics, log-based metrics, uptime check results, and SLO burn rates converge. Dashboards are your incident "single pane"—but only if they chart **symptoms** (request latency percentiles, error rates, saturation) alongside **causes** you investigate after paging (CPU, memory, instance count). A dashboard that shows only infrastructure graphs reproduces the blind spot from the opening scenario: healthy CPU while customers fail checkout.
 
 ### Built-in Metrics
 
@@ -396,7 +397,7 @@ gcloud monitoring metrics-descriptors list \
 # Query a specific metric (requires Monitoring Query Language - MQL)
 gcloud monitoring time-series list \
   --filter='metric.type="run.googleapis.com/request_count" AND resource.labels.service_name="my-api"' \
-  --interval-start-time=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ) \
+  --interval-start-time=$(date -u -v-1H +%Y-%m-%dT%H:%M:%SZ 2>/dev/null || date -u -d "1 hour ago" +%Y-%m-%dT%H:%M:%SZ) \
   --format=json
 ```
 
@@ -613,21 +614,19 @@ gcloud monitoring policies update POLICY_ID \
 
 Uptime checks monitor the availability of your public endpoints from Google's global probe network, which catches failures that internal metrics miss—expired TLS certificates, DNS misconfigurations, VPC egress rules blocking external clients, or regional routing issues that still leave instances "healthy" behind a load balancer. Probes run HTTP/HTTPS (or TCP) checks on a schedule you define, record per-region pass/fail time series, and integrate with alerting policies so pages fire when multiple regions agree a user-visible path is down.
 
-Google operates checkers in multiple geographic regions; configuring alerts to require failures from **two or more regions** reduces false positives when a single probe path has transient packet loss. Uptime checks bill per execution according to the [Observability pricing page](https://cloud.google.com/products/observability/pricing)—consolidate checks on user-journey URLs (`/health` on the public API gateway) rather than creating one check per internal microservice that customers never call directly. For private services, uptime checks cannot reach RFC 1918 addresses; use **private synthetic monitoring** patterns (Cloud Run job with VPC egress, or third-party probes inside your network) instead of expecting public checkers to hit internal load balancers.
+Google operates checkers in multiple geographic regions; configuring alerts to require failures from **two or more regions** reduces false positives when a single probe path has transient packet loss. Uptime checks bill per execution according to the [Observability pricing page](https://cloud.google.com/products/observability/pricing)—consolidate checks on user-journey URLs (`/health` on the public API gateway) rather than creating one check per internal microservice that customers never call directly. **Public** uptime checks (the default checker type) cannot reach RFC 1918 addresses on the public internet; for internal endpoints, use **VPC uptime checks** (`VPC_CHECKERS`) or other **private synthetic monitoring** patterns (Cloud Run job with VPC egress, or third-party probes inside your network) instead of expecting public checkers to hit internal load balancers.
 
 Authenticated endpoints require custom headers or OAuth tokens in advanced configurations; keep health endpoints unauthenticated but non-sensitive so probes stay simple. Pair uptime alerts with log-based error metrics: external "down" with flat error logs often implicates DNS or TLS, while uptime failure plus rising 5xx logs implicates application regression.
 
 ```bash
-# Create an HTTP uptime check
+# Create an HTTP uptime check (DISPLAY_NAME is the positional arg; period is in minutes: 1, 5, 10, or 15)
 gcloud monitoring uptime create my-api-uptime \
-  --display-name="My API Health Check" \
   --resource-type=uptime-url \
-  --monitored-resource="host=my-api-abc123-uc.a.run.app,project_id=my-project" \
-  --http-check-path="/health" \
-  --http-check-port=443 \
-  --period=60 \
-  --timeout=10 \
-  --checker-type=STATIC_IP_CHECKERS
+  --resource-labels="host=my-api-abc123-uc.a.run.app,project_id=my-project" \
+  --path=/health \
+  --protocol=https \
+  --period=5 \
+  --timeout=10
 
 # List uptime checks
 gcloud monitoring uptime list-configs \
@@ -928,11 +927,11 @@ Document the baseline in the service README: dashboard link, primary alert polic
 
 ## Did You Know?
 
-1. **Cloud Logging ingests over 150 petabytes of log data per month** across all GCP customers. The log router processes over 50 billion log entries per day. Despite this scale, the median query response time in the Log Explorer is under 3 seconds for queries spanning a 1-hour time window.
+1. **Cloud Logging operates at multi-petabyte scale** across GCP—enough volume that the Log Router, retention tiers, and query paths are engineered for massive throughput rather than single-tenant assumptions.
 
 2. **Log-based metrics are evaluated in real-time as logs flow through the log router**, not after they are stored. This means you can create an alert based on a log-based metric and receive a notification within 60-90 seconds of the triggering log entry being written---even before you could find it manually in the Log Explorer.
 
-3. **Cloud Monitoring's uptime checks run from 6 global regions simultaneously** (USA-Oregon, USA-Virginia, South America, Europe, Asia Pacific-1, Asia Pacific-2). A check is considered "failed" only when it fails from multiple regions, reducing false positives from network partitions. You can see the per-region results in the uptime check dashboard.
+3. **Cloud Monitoring's public uptime checks can run from multiple global checker regions** (for example USA-Oregon, USA-Iowa, USA-Virginia, Europe, South America, and Asia Pacific). A check is considered "failed" only when it fails from multiple regions, reducing false positives from network partitions. You can see the per-region results in the uptime check dashboard.
 
 4. **The Ops Agent (successor to the legacy Monitoring and Logging agents) supports both Prometheus metric scraping and fluent-bit log collection** in a single agent. If you are running custom metrics in Prometheus format on your VMs, the Ops Agent can scrape them and send them to Cloud Monitoring without running a separate Prometheus server.
 
@@ -1188,17 +1187,13 @@ gcloud logging metrics list \
 # Get the Cloud Run hostname
 SERVICE_HOST=$(echo $SERVICE_URL | sed 's|https://||')
 
-# Create an uptime check
-# Note: uptime checks via gcloud have limited support;
-# using the REST API is more reliable for complex configs
+# Create an uptime check (ops-lab-uptime is the display name; period is in minutes)
 gcloud monitoring uptime create ops-lab-uptime \
-  --display-name="Ops Lab API Health" \
   --resource-type=uptime-url \
   --resource-labels="host=$SERVICE_HOST,project_id=$PROJECT_ID" \
-  --http-check-path="/health" \
-  --http-check-port=443 \
-  --http-check-request-method=GET \
-  --period=60 \
+  --path=/health \
+  --protocol=https \
+  --period=5 \
   --timeout=10
 
 # List uptime checks

--- a/src/content/docs/cloud/gcp-essentials/module-2.11-cloud-build.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.11-cloud-build.md
@@ -172,6 +172,31 @@ gcloud builds submit --config=cloudbuild.yaml \
   --substitutions=_REGION=europe-west1,_SERVICE_NAME=my-api-eu
 ```
 
+### Step Orchestration & Build Options
+
+The simplicity of the `cloudbuild.yaml` format conceals substantial orchestration depth. Understanding the runtime knobs at your disposal transforms Cloud Build from a basic script runner into a high-performance build executor that can shrink pipeline durations from tens of minutes to single-digit minutes.
+
+**Parallelism via `waitFor`**: The `waitFor` field is not limited to the simple `['-']` (start immediately) pattern you have already seen. You can construct arbitrary directed acyclic graphs by referencing step `id` values. A step that specifies `waitFor: ['compile-go', 'compile-python']` will remain pending until both compilation steps complete successfully, enabling fan-in patterns where independent language builds converge before integration testing begins. Cloud Build enforces that no circular dependencies exist in your graph --- if you accidentally create a cycle (Step A waits for B, which waits for A), the build fails immediately at the scheduling stage rather than hanging indefinitely.
+
+**Machine Types**: The default `e2-medium` machine (2 vCPUs, 4 GB RAM) is appropriate for lightweight builds such as simple `npm install && npm test` pipelines. For compute-intensive workloads, you can request larger machine types through the `options.machineType` field. The `E2_HIGHCPU_8` type (8 vCPUs) is a common sweet spot for Docker image builds with many layers. For Go monorepo compilation, C++ builds, or large Java/Kotlin projects with Gradle, stepping up to `E2_HIGHCPU_32` (32 vCPUs) can cut compilation time by 60-80% compared to the default. The cost scales proportionally with vCPU count, and you are billed per build-second on the selected machine type. A machine that is twice as fast but costs twice as much per minute produces the same total cost while delivering faster feedback to developers --- an almost always worthwhile tradeoff.
+
+**Logging Modes**: The `options.logging` field controls where build output is stored. `CLOUD_LOGGING_ONLY` (the recommended default) streams live logs to Cloud Logging, making them searchable and available for alerting. `GCS_ONLY` writes logs to a Cloud Storage bucket, useful when you need long-term archival beyond Cloud Logging's retention period. The legacy `LEGACY` mode stores logs in Cloud Storage under a predefined bucket naming convention. Most teams standardize on `CLOUD_LOGGING_ONLY` and forward critical error patterns to monitoring dashboards.
+
+**Build Timeouts**: The default build timeout is 10 minutes (600 seconds). This is deliberately short to prevent runaway builds from consuming quota indefinitely. For larger projects, you can override this in the `timeout` field using Go duration syntax: `timeout: '1800s'` for 30 minutes, or up to the maximum of 24 hours (`'86400s'`). A timeout that is too generous masks real problems --- if your build suddenly jumps from 8 minutes to 45 minutes, a shorter timeout surfaces the regression faster by hard-failing the build rather than silently consuming budget.
+
+**Build Artifacts**: Beyond the `images` field for container images, Cloud Build can persist arbitrary build outputs to Cloud Storage using the `artifacts` field. This is essential when your pipeline produces binaries, test reports, or code coverage HTML that downstream systems need to consume. Artifacts are saved after all steps complete, and they support glob patterns to select files from the `/workspace` volume:
+
+```yaml
+artifacts:
+  objects:
+    location: 'gs://my-build-outputs/$BUILD_ID/'
+    paths:
+      - 'build/binaries/*'
+      - 'test-reports/coverage.html'
+```
+
+The `$BUILD_ID` substitution in the path ensures every build writes to a unique location, preventing collisions between concurrent pipeline executions. This pattern is widely used to publish test result summaries that CI dashboards can aggregate across builds.
+
 ## Builders: The Tools in Your Pipeline
 
 ### Google-Provided Builders
@@ -468,6 +493,90 @@ gcloud builds list --limit=10 \
 gcloud builds log BUILD_ID
 ```
 
+### Trigger File Filtering
+
+Not every source change warrants a full pipeline execution. A documentation update to `README.md` does not need to trigger a container build, and a change limited to the `frontend/` directory should not kick off the backend test suite. Cloud Build supports two complementary filtering directives on every trigger: `includedFiles` and `ignoredFiles`.
+
+When you specify `includedFiles`, the trigger fires only if at least one changed file matches one of the patterns. The `ignoredFiles` directive inverts the logic: the trigger fires unless every changed file matches an ignore pattern. These patterns accept glob syntax (`**` for recursive directory matching, `*` for single-level wildcards) and are evaluated against the list of files modified in the triggering commit. This distinction matters:
+
+```bash
+# Trigger only when frontend source files change
+gcloud builds triggers create github \
+  --name="frontend-ci" \
+  --repo-name="my-repo" \
+  --repo-owner="my-org" \
+  --branch-pattern="^main$" \
+  --build-config="cloudbuild-frontend.yaml" \
+  --included-files="frontend/**,package.json"
+
+# Trigger on everything EXCEPT documentation changes
+gcloud builds triggers create github \
+  --name="skip-docs" \
+  --repo-name="my-repo" \
+  --repo-owner="my-org" \
+  --branch-pattern="^main$" \
+  --build-config="cloudbuild.yaml" \
+  --ignored-files="docs/**,*.md,*.adoc"
+```
+
+The second example above is a common optimization in monorepos: it prevents the main pipeline from burning build minutes on pure documentation commits while still reacting to every source-code change. Teams that skip this optimization frequently discover, at the end of the month, that 30-40% of their build minutes went to verifying that README formatting is still correct.
+
+### Pub/Sub Triggers
+
+For event-driven workflows that extend beyond Git, Cloud Build can subscribe to Pub/Sub topics. A Pub/Sub trigger fires whenever a message is published to the specified topic, enabling pipelines that react to events such as: a new security vulnerability scan completing, a scheduled Cloud Scheduler job publishing a nightly-build message, or a BigQuery data pipeline signaling that fresh data is ready for model retraining.
+
+```bash
+# Create a Pub/Sub trigger
+gcloud builds triggers create pubsub \
+  --name="nightly-scan" \
+  --topic="projects/my-project/topics/nightly-scan-trigger" \
+  --build-config="cloudbuild-nightly-scan.yaml"
+```
+
+The Pub/Sub message payload is accessible inside the build through the `$_PUBSUB_PAYLOAD` substitution variable, allowing the build steps to parse JSON event data and adapt their behavior dynamically. For example, a message containing `{"scan_type": "full", "target": "production"}` can route the pipeline into a comprehensive security audit path, while `{"scan_type": "quick"}` triggers a fast lint-only pass.
+
+### Webhook Triggers
+
+When neither the native GitHub/GitLab integrations nor Pub/Sub fit your workflow --- for example, when you use a self-hosted version control system, a custom internal tool, or a third-party service that fires generic HTTP callbacks --- Cloud Build provides webhook triggers. A webhook trigger exposes a unique HTTPS URL that accepts POST requests with an optional shared secret for HMAC-SHA256 signature verification:
+
+```bash
+# Create a webhook trigger with secret verification
+gcloud builds triggers create webhook \
+  --name="custom-callback" \
+  --secret="projects/my-project/secrets/webhook-secret/versions/latest" \
+  --build-config="cloudbuild.yaml"
+```
+
+The trigger URL is returned on creation. Any external system can then POST JSON payloads to that URL, and Cloud Build validates the `X-CloudBuild-Signature` header against the shared secret before executing the pipeline. This is the escape hatch that connects Cloud Build to essentially any automation system in your ecosystem.
+
+### Second-Generation Repository Connections
+
+The GitHub and GitLab trigger patterns earlier in this section use what Google calls "first-generation" connections. In 2023, Google introduced a second-generation integration model built on **Developer Connect**, a new service that establishes deeper, bidirectional links between Cloud Build and external repositories.
+
+Second-generation connections offer several advantages over the first-generation approach: they support Bitbucket Cloud and Bitbucket Data Center in addition to GitHub and GitLab Enterprise, they use fine-grained access tokens instead of broad OAuth scopes, and they integrate with Cloud Build repositories --- a resource type that decouples the trigger configuration from the connection setup. With 2nd-gen, you first create a connection to your Git provider, then link individual repositories, and finally attach triggers to those repository resources:
+
+```bash
+# Create a 2nd-gen GitHub connection
+gcloud builds connections create github my-github-conn \
+  --region=us-central1
+
+# Link a repository through the connection
+gcloud builds repositories create my-repo \
+  --connection=my-github-conn \
+  --region=us-central1 \
+  --remote-uri="https://github.com/my-org/my-repo.git"
+
+# Create a trigger on the linked repository
+gcloud builds triggers create github \
+  --name="deploy-prod-2g" \
+  --repository="projects/my-project/locations/us-central1/connections/my-github-conn/repositories/my-repo" \
+  --branch-pattern="^main$" \
+  --build-config="cloudbuild.yaml" \
+  --region=us-central1
+```
+
+The second-generation model is the recommended path for new projects as of 2024, though first-generation triggers continue to function and are not deprecated. If your organization already has a working first-generation setup, migration to 2nd-gen offers incremental security improvements but is not an emergency --- prioritize the migration when you next restructure your trigger inventory.
+
 ## Cloud Build Service Account
 
 A pipeline is fundamentally an automated process acting on behalf of your organization. When Cloud Build pushes an image to Artifact Registry or deploys a service to Cloud Run, it must authenticate and authorize those actions. It achieves this by assuming the identity of an IAM Service Account.
@@ -651,6 +760,187 @@ availableSecrets:
 ```
 
 In this configuration, the `availableSecrets` block references the highly secure cryptographic payload stored within Secret Manager. During execution, the Cloud Build engine utilizes its service account identity to request the decrypted payload from the API. The secret is then injected dynamically into the runtime environment of the executing Docker container via the `secretEnv` array. Crucially, the double-dollar sign `$$NPM_TOKEN` escapes the variable, ensuring it evaluates directly as a shell parameter inside the container instead of attempting a premature Cloud Build substitution evaluation, completely obscuring the secret from the visible logs and build output.
+
+## Private Worker Pools
+
+The default Cloud Build worker pool runs on Google-managed infrastructure provisioned from a shared pool of virtual machines. This is the ideal configuration for most workloads: zero maintenance, automatic scaling, and builds that only communicate with public internet endpoints. However, when your pipeline must interact with resources inside a VPC --- a private Artifact Registry repository with no public ingress, an internal database that only accepts connections from RFC 1918 addresses, or a CI-driven integration test that validates a service behind an internal load balancer --- the default pool cannot reach those resources, because its workers live outside your VPC boundary.
+
+Private worker pools solve this by running build workers inside your own VPC network. You define a `WorkerPool` resource that specifies the VPC network, subnet, and the machine configuration for the workers:
+
+```bash
+# Create a private worker pool
+gcloud builds worker-pools create private-pool \
+  --region=us-central1 \
+  --peered-network=projects/my-project/global/networks/my-vpc \
+  --worker-machine-type=e2-medium \
+  --worker-disk-size=100
+```
+
+Once created, your `cloudbuild.yaml` references the private pool in the `options` block:
+
+```yaml
+options:
+  pool:
+    name: 'projects/my-project/locations/us-central1/workerPools/private-pool'
+```
+
+Private pool workers are dedicated to your project --- they are not shared with other GCP customers. This provides not only network isolation but also a hard guarantee that your builds run on infrastructure that has never executed another organization's code. The tradeoff is that you are responsible for the worker lifecycle: private pool workers that sit idle still consume capacity until they are scaled down or deleted, and you pay for the underlying Compute Engine resources. Private pools are the correct choice when network isolation or dedicated-tenancy requirements are non-negotiable, but they add operational surface area that the default pool eliminates entirely.
+
+## SLSA Build Provenance & Binary Authorization
+
+Software supply chain security has moved from an academic concern to a board-level priority. When your build pipeline produces a container image that eventually runs in production, how do you prove --- cryptographically --- that the image was built from a specific commit on a specific repository by a specific build service, and that no intermediate step could have tampered with the artifact?
+
+Cloud Build addresses this through **SLSA Level 3 build provenance** (Supply-chain Levels for Software Artifacts). Whenever you use the `images` field in your `cloudbuild.yaml` to declare the output container images, Cloud Build automatically generates a signed provenance attestation that records the complete build metadata: the source repository, the commit SHA, the builder images used, the build steps executed, the substitution variables (except those marked as secrets), and the digest of every output image. This attestation is stored in the Artifact Analysis service alongside your container image.
+
+The provenance is verifiable. A downstream system can cryptographically validate that the attestation was signed by Cloud Build's private key, establishing an auditable chain of custody from source commit to deployed artifact. This becomes operationally powerful when paired with **Binary Authorization**, a GCP service that enforces deploy-time policies. Binary Authorization can be configured to reject any container image that does not carry a valid Cloud Build provenance attestation, ensuring that only images built through your approved pipeline ever reach your GKE or Cloud Run production environment:
+
+```
+Source Repo → Cloud Build → Provenance Attestation → Binary Authorization Gate → GKE/Cloud Run
+```
+
+Setting up Binary Authorization requires configuring an attestor that validates Cloud Build provenance, and then enabling the Binary Authorization enforcement policy on your GKE cluster or Cloud Run service. The initial configuration involves several steps --- creating a KMS key for the attestor, configuring the Binary Authorization policy, and enabling the enforcement mode --- but once in place, it closes the gap between "we believe this image came from CI" and "we have cryptographic proof that this image came from CI."
+
+This is especially important in regulated industries where auditors require evidence that production deployments follow an approved change management process. Rather than producing manual screenshots of CI dashboards, you point the auditor to the provenance attestation chain.
+
+## Patterns & Anti-Patterns
+
+Cloud Build's flexibility is both its greatest strength and the source of its most common failures. The patterns below represent proven configurations that teams converge on after operating Cloud Build in production for months or years. The anti-patterns are the mistakes those teams made on the way.
+
+### Proven Patterns
+
+**Pattern 1: Separate CI and CD Configurations**
+
+Maintain distinct `cloudbuild-ci.yaml` (pull requests) and `cloudbuild-cd.yaml` (main branch / tags) files. The CI configuration runs tests, linting, and security scans but never deploys or pushes to production registries. The CD configuration assumes CI has already passed and focuses on building release artifacts and executing deployments. This separation prevents a misconfigured PR trigger from accidentally deploying to production, and it keeps each configuration file focused on a single responsibility.
+
+*When to use*: Any project with more than one developer. The separation cost is zero --- two YAML files instead of one --- and the blast-radius reduction is substantial.
+
+*Scaling note*: As your test suite grows, the CI configuration may become the bottleneck while the CD configuration remains fast. Monitoring CI and CD durations separately allows you to optimize each independently.
+
+**Pattern 2: Immutable Tags via Commit SHA**
+
+Always tag container images with the full or short commit SHA (`$COMMIT_SHA` or `$SHORT_SHA`) as the primary identifier. The `latest` tag is a convenience pointer for development environments only. In staging and production, every deployed image must be traceable to an exact commit. When a production incident requires a rollback, you are not guessing which version of the code was running --- you look at the running image tag, find the corresponding commit, and know exactly what changed.
+
+*When to use*: Always. This is the single highest-leverage tagging discipline you can adopt.
+
+*Scaling note*: Artifact Registry's garbage collection policies should exempt images tagged with commit SHAs that correspond to active deployments. Coordinate this with your release retention policy.
+
+**Pattern 3: Pre-Built Custom Builder Images**
+
+Instead of running `apt-get install` or `pip install` inside every build step --- which downloads packages from the internet on every pipeline execution --- pre-build custom builder images that contain your full toolchain and store them in Artifact Registry. A step that references `us-central1-docker.pkg.dev/my-project/builders/python-tools:latest` starts executing in seconds because all dependencies are already baked into the image. This pattern also eliminates the risk that a public package registry outage blocks your pipeline.
+
+*When to use*: When any build step spends more than 30 seconds installing tools that change rarely (weekly or less). The upfront cost of maintaining a builder image CI pipeline pays for itself within a week of reduced build times.
+
+*Scaling note*: Tag builder images with a version scheme (`python-tools:v2`, not `:latest`) and promote them through environments alongside your application images. An application pinned to builder image `v2` should not silently pick up `v3` which might have a breaking toolchain change.
+
+**Pattern 4: Fan-Out Test Matrix**
+
+For projects with multiple test suites that can run independently --- unit tests, integration tests, end-to-end tests, performance benchmarks --- use `waitFor: ['-']` to launch all test suites in parallel, with a final convergence step that aggregates results. This pattern reduces total CI time from the sum of all test durations to the duration of the longest individual suite.
+
+*When to use*: When total sequential test time exceeds 10 minutes and test suites are truly independent (no shared mutable state).
+
+*Scaling note*: The convergence step should fail the build if any parallel test suite failed. Use a shared artifact (a JSON status file written to `/workspace`) or rely on Cloud Build's native step dependency propagation.
+
+### Anti-Patterns
+
+**Anti-Pattern 1: The Monolithic cloudbuild.yaml**
+
+A single `cloudbuild.yaml` that uses conditional logic (bash `if` statements checking `$BRANCH_NAME`) to decide whether to run tests, build, or deploy. This anti-pattern emerges when teams start with a simple pipeline and gradually bolt on behavior for different branches.
+
+*What goes wrong*: The configuration becomes a tangle of imperative shell scripts masquerading as a declarative pipeline. Debugging a failed build requires mentally executing bash conditionals to determine which code path was taken. Worse, a logic error in a conditional can cause a pull request trigger to execute the production deployment path.
+
+*Better approach*: Use separate trigger-specific configuration files (`cloudbuild-ci.yaml`, `cloudbuild-cd.yaml`, `cloudbuild-release.yaml`) and configure each trigger to point to the correct file. The branching logic moves from inside the YAML to the trigger configuration, where it is visible, auditable, and less error-prone.
+
+**Anti-Pattern 2: Ignoring Build Timeouts**
+
+Leaving the default 10-minute timeout in place indefinitely, even as the project grows.
+
+*What goes wrong*: One day a new dependency or a larger test suite pushes the build to 11 minutes. The pipeline starts failing with timeout errors. The team's first reaction is usually to assume something is broken, triggering a fire drill that wastes an afternoon before someone checks the timeout setting.
+
+*Better approach*: Set the timeout to a comfortable multiple of your observed build duration --- at least 2x, ideally 3x --- and monitor build duration trends. If the 90th percentile build time consistently exceeds half the timeout, increase the timeout proactively. A build that is genuinely stuck (infinite loop, hung network call) will still hit the timeout and fail, but a build that is merely growing with the codebase will not be prematurely killed.
+
+**Anti-Pattern 3: Secrets in Substitutions**
+
+Passing API tokens, database passwords, or private keys through the `--substitutions` flag or `substitutions` YAML block.
+
+*What goes wrong*: Substitution values are stored in plaintext in the Cloud Build database. Any principal with `cloudbuild.builds.get` permission can view the full substitution payload for any build, including past builds. A developer who hardcodes a staging database password as a substitution variable has effectively published that password to everyone in the project who can view build history.
+
+*Better approach*: Store all sensitive values in Secret Manager and reference them through `availableSecrets` with `secretEnv`. This keeps the plaintext value out of the build record entirely. The Secret Manager access log provides an independent audit trail of which build service account accessed which secret and when.
+
+**Anti-Pattern 4: Default Service Account for Everything**
+
+Using the default Cloud Build service account across all pipelines and environments.
+
+*What goes wrong*: A junior developer's experimental pipeline, running on a feature branch with a hastily written `cloudbuild.yaml`, inherits the same IAM permissions as the production deployment pipeline. If that experimental build contains a misconfiguration --- or worse, if the feature branch is compromised --- the blast radius includes the ability to push images to production registries, modify GKE clusters, or delete Cloud Run services.
+
+*Better approach*: Create dedicated service accounts per pipeline or per environment, granting only the exact roles each pipeline needs. A CI-only trigger that runs tests gets `roles/logging.logWriter` and nothing else. A CD trigger that deploys to staging gets `roles/run.admin` scoped to the staging project. The production deployer gets its own service account that is never used by any other trigger.
+
+## Decision Framework
+
+The choices you face when adopting Cloud Build are not purely technical --- they involve tradeoffs between operational simplicity, cost, security posture, and ecosystem fit. The following decision matrix and flowchart help you navigate the most common decision points.
+
+### Cloud Build vs. GitHub Actions vs. GitLab CI
+
+| Dimension | Cloud Build | GitHub Actions | GitLab CI |
+|-----------|-------------|----------------|-----------|
+| **Infrastructure** | Fully managed, serverless (default pool) or VPC-native (private pool) | GitHub-hosted runners or self-hosted | GitLab-hosted runners or self-hosted |
+| **GCP integration** | Native IAM, Artifact Registry auth, Cloud Deploy hand-off, Cloud Logging | Requires Workload Identity Federation setup | Requires Workload Identity Federation setup |
+| **Free tier** | 120 build-minutes/day (default machine) | 2,000 minutes/month (private repos), unlimited for public | 400 minutes/month (all tiers) |
+| **Pricing model** | Per build-minute by machine type | Per minute by runner tier (Linux/Windows/macOS) | Per minute by compute tier |
+| **Configuration** | Single `cloudbuild.yaml`, build steps as containers | `.github/workflows/*.yml`, job matrix, reusable workflows | `.gitlab-ci.yml`, stages, includes |
+| **Ecosystem** | Deepest GCP service integration, no third-party action marketplace | Largest marketplace (12,000+ actions), broadest third-party integration | Built-in container registry, Kubernetes integration |
+| **Best for** | Organizations standardizing on GCP, regulated environments needing provenance + Binary Authorization | Mixed-cloud or SaaS-heavy stacks, open-source projects | Self-hosted GitLab organizations, integrated DevSecOps |
+
+**Decision heuristic**: If your applications already run on GCP and your team manages infrastructure through GCP IAM, Cloud Build eliminates the complexity of federating external CI systems into your GCP identity model. If your stack spans AWS, Azure, and GCP equally, GitHub Actions' provider-agnostic marketplace may justify the additional identity federation setup. If you are a GitLab shop, GitLab CI's tight repository integration reduces the number of systems your team needs to context-switch between, and Cloud Build can still serve as the GCP-native deployment execution engine invoked from a GitLab CI pipeline.
+
+### Default Worker Pool vs. Private Worker Pool
+
+```mermaid
+flowchart TD
+    Q1{Does your build need to access\\nprivate VPC resources?}
+    Q1 -- No --> Q2{Do you have regulatory\\ndedicated-tenancy requirement?}
+    Q1 -- Yes --> Private
+    Q2 -- No --> Q3{Is build duration predictability\\ncritical (no cold starts)?}
+    Q2 -- Yes --> Private
+    Q3 -- No --> Default
+    Q3 -- Yes --> Private
+
+    Default["Default Pool\n(Google-managed, shared infrastructure)\n- Zero maintenance\n- Automatic scaling\n- Lower cost\n- Public internet only"]
+    Private["Private Pool\n(VPC-native, dedicated workers)\n- VPC access to private resources\n- Dedicated tenancy\n- Predictable warm-start performance\n- Higher cost + operational overhead"]
+```
+
+Most teams should start with the default pool and only migrate to a private pool when a concrete requirement (VPC access, dedicated tenancy, or predictable warm-start latency) makes the default pool insufficient. Private pools add operational surface area --- worker lifecycle management, capacity planning, and per-worker Compute Engine billing --- that the default pool absorbs on your behalf.
+
+### When to Add Cloud Deploy
+
+Cloud Deploy is not a replacement for Cloud Build; it is the CD half of the CI/CD pairing. Use Cloud Build alone when you are deploying to a single environment (or when your "staging" and "production" environments are separate projects with separate Cloud Build triggers). Introduce Cloud Deploy when:
+
+- You need formal approval gates between environments (dev → staging → production with a human approval at the production boundary).
+- You want canary deployments with automatic traffic splitting and metric-based verification, rather than all-at-once deployments.
+- You need a single view of the rollout status across all environments, with the ability to promote or roll back releases from one control plane.
+- Compliance requires an immutable audit trail of which release was deployed to which environment and when, with cryptographic provenance linking each deployment back to a specific build.
+
+For a simple project deploying to a single Cloud Run service on push to `main`, Cloud Build alone is sufficient and Cloud Deploy adds complexity without proportionate benefit. As soon as you introduce a staging environment that must be validated before production, Cloud Deploy's value begins to materialize.
+
+## Cost Lens: Build-Minute Economics
+
+Cloud Build's pricing model is transparent: you pay for build minutes consumed, measured from the moment the build VM starts provisioning until it is torn down. The rate depends on the machine type you select.
+
+The **free tier** provides 120 build-minutes per day on the default machine type (`e2-medium`), calculated per billing account. For a small team running 15 builds per day averaging 5 minutes each, this covers the first 75 minutes, leaving 45 minutes of buffer before any charges accrue. Many small-to-medium teams operate entirely within the free tier without ever receiving a Cloud Build invoice.
+
+When you exceed the free tier or use larger machine types, pricing scales with vCPU count. The default `e2-medium` (2 vCPUs) is the cheapest option. Stepping up to `E2_HIGHCPU_8` (8 vCPUs, approximately 4x the per-minute rate) makes sense when the faster execution unblocks developers waiting for CI feedback. The economic calculation is not "how much does the build cost" but "how much does a developer waiting 15 minutes instead of 5 cost the organization." At typical engineering fully-loaded costs, the larger machine pays for itself if it saves even a few minutes per build across a team running dozens of builds daily.
+
+**Cost optimization levers**:
+
+- **File filtering on triggers**: The fastest build minute is the one you never consume. Use `ignoredFiles` to skip builds for documentation-only commits. For monorepos, use `includedFiles` to trigger only the relevant sub-pipeline.
+- **Caching**: Use Kaniko with Artifact Registry layer caching for Docker builds. A cached build that skips 80% of its layers might complete in 90 seconds instead of 8 minutes.
+- **Timeout discipline**: A build that hangs for 10 minutes before the timeout kills it consumes 10 billable minutes of zero-value execution. Set timeouts that are generous enough for normal operation but tight enough to catch hangs quickly.
+- **Right-size machine types**: Run your build on the default machine and measure the wall-clock time. If it is acceptable, stay on the default. If developers complain about CI latency, benchmark on `E2_HIGHCPU_8` and compare the cost-per-build against the developer-productivity gain.
+
+**What makes cost spike unexpectedly**:
+
+- **High-frequency trigger loops**: A trigger configured on `push` to a branch where an automated process also pushes commits (such as a version-bumping bot) can create infinite build loops. Each iteration consumes build minutes. Always pair automated commit bots with a commit author filter or a trigger condition that breaks the loop.
+- **Forked-repository abuse on public projects**: If you enable Cloud Build triggers for external contributors on a public repository, a malicious actor can submit pull requests that consume your build minutes by triggering builds in a loop. Mitigate this with `--comment-control=COMMENTS_ENABLED_FOR_EXTERNAL_CONTRIBUTORS_ONLY` or by requiring a maintainer to explicitly trigger CI on external PRs.
+- **Large private pool clusters left idle**: Private pool workers that are provisioned but not building still consume Compute Engine resources. If you create a private pool with a minimum of 5 workers and your team only runs builds during business hours, those workers sit idle for 16 hours a day at full Compute Engine pricing. Schedule private pool scale-down during off-hours or use a minimum worker count of zero with autoscaling.
 
 ## Did You Know?
 
@@ -1022,3 +1312,12 @@ Now that you have established a reliable and immutable pathway for releasing cod
 - [Cloud Build Overview](https://cloud.google.com/build/docs/overview) — Covers the core execution model, build steps, pools, and security concepts behind Cloud Build.
 - [Cloud Deploy Overview](https://cloud.google.com/deploy/docs/overview) — Explains delivery pipelines, targets, releases, promotions, approvals, and rollouts.
 - [Use Secrets from Secret Manager](https://cloud.google.com/build/docs/securing-builds/use-secrets) — Shows the supported pattern for handling build-time secrets safely in Cloud Build.
+- [Cloud Build Pricing](https://cloud.google.com/build/pricing) — Build-minute pricing by machine type, free tier details, and private pool cost model.
+- [Build Configuration Schema](https://cloud.google.com/build/docs/build-config-file-schema) — Complete reference for the `cloudbuild.yaml` schema including `options`, `artifacts`, `timeout`, and `machineType`.
+- [Configuring Build Triggers](https://cloud.google.com/build/docs/automating-builds/create-manage-triggers) — Trigger types, branch/tag patterns, file filtering, and comment control for external contributors.
+- [Private Worker Pool Overview](https://cloud.google.com/build/docs/private-pools/private-pools-overview) — VPC-native build execution, worker pool lifecycle, and private pool configuration.
+- [View Build Provenance](https://cloud.google.com/build/docs/securing-builds/view-build-provenance) — SLSA Level 3 build provenance generation, attestation verification, and supply chain integrity.
+- [Binary Authorization Overview](https://cloud.google.com/binary-authorization/docs/overview) — Deploy-time security enforcement, attestor configuration, and policy setup for GKE and Cloud Run.
+- [Cloud Build Service Account](https://cloud.google.com/build/docs/securing-builds/configure-build-sa) — Default and custom service account configuration, least-privilege patterns, and permission scoping.
+- [Connecting a Host via Developer Connect](https://cloud.google.com/build/docs/automating-builds/github/connect-repo-github) — Second-generation repository connections for GitHub, GitLab, and Bitbucket.
+- [Kaniko Cache in Cloud Build](https://cloud.google.com/build/docs/kaniko-cache) — Layer caching for Docker builds using Kaniko with Artifact Registry, reducing build times.

--- a/src/content/docs/cloud/gcp-essentials/module-2.11-cloud-build.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.11-cloud-build.md
@@ -182,7 +182,7 @@ The simplicity of the `cloudbuild.yaml` format conceals substantial orchestratio
 
 **Logging Modes**: The `options.logging` field controls where build output is stored. `CLOUD_LOGGING_ONLY` (the recommended default) streams live logs to Cloud Logging, making them searchable and available for alerting. `GCS_ONLY` writes logs to a Cloud Storage bucket, useful when you need long-term archival beyond Cloud Logging's retention period. The legacy `LEGACY` mode stores logs in Cloud Storage under a predefined bucket naming convention. Most teams standardize on `CLOUD_LOGGING_ONLY` and forward critical error patterns to monitoring dashboards.
 
-**Build Timeouts**: The default build timeout is 10 minutes (600 seconds). This is deliberately short to prevent runaway builds from consuming quota indefinitely. For larger projects, you can override this in the `timeout` field using Go duration syntax: `timeout: '1800s'` for 30 minutes, or up to the maximum of 24 hours (`'86400s'`). A timeout that is too generous masks real problems --- if your build suddenly jumps from 8 minutes to 45 minutes, a shorter timeout surfaces the regression faster by hard-failing the build rather than silently consuming budget.
+**Build Timeouts**: The default build timeout is **60 minutes (3600 seconds)**. For larger projects, you can override this in the `timeout` field using Go duration syntax: `timeout: '1800s'` for 30 minutes, or up to the maximum of **24 hours (`'86400s'`)**. Set the timeout to a comfortable multiple of your observed build duration—at least 2x, ideally 3x—so normal growth does not fail the build, while still catching genuinely hung steps (infinite loops, stuck network calls) before they burn a full day of quota.
 
 **Build Artifacts**: Beyond the `images` field for container images, Cloud Build can persist arbitrary build outputs to Cloud Storage using the `artifacts` field. This is essential when your pipeline produces binaries, test reports, or code coverage HTML that downstream systems need to consume. Artifacts are saved after all steps complete, and they support glob patterns to select files from the `/workspace` volume:
 
@@ -321,9 +321,9 @@ steps:
       - '--no-traffic'
       - '--tag=canary'
 
-  # Step 6: Run integration tests against staging
-  - name: 'curlimages/curl:latest'
-    entrypoint: 'sh'
+  # Step 6: Run integration tests against staging (cloud-sdk image includes gcloud)
+  - name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
+    entrypoint: 'bash'
     args:
       - '-c'
       - |
@@ -446,11 +446,13 @@ In this setup, a Pull Request trigger runs a subset of tasks defined in a separa
 For organizations operating enterprise instances of GitLab, Cloud Build facilitates seamless integration through the concept of "Connections." Rather than relying on a simple webhook, Cloud Build creates an authenticated, regional connection leveraging a Personal Access Token securely stored within Google Secret Manager.
 
 ```bash
-# Create a GitLab connection first
+# Create a GitLab connection (2nd-gen; three Secret Manager versions required)
 gcloud builds connections create gitlab my-gitlab-conn \
   --region=us-central1 \
   --host-uri="https://gitlab.com" \
-  --api-access-token-secret-version="projects/my-project/secrets/gitlab-token/versions/latest"
+  --authorizer-token-secret-version="projects/my-project/secrets/gitlab-api-pat/versions/latest" \
+  --read-authorizer-token-secret-version="projects/my-project/secrets/gitlab-read-pat/versions/latest" \
+  --webhook-secret-secret-version="projects/my-project/secrets/gitlab-webhook-secret/versions/latest"
 
 # Link a repository
 gcloud builds repositories create my-gitlab-repo \
@@ -458,13 +460,13 @@ gcloud builds repositories create my-gitlab-repo \
   --region=us-central1 \
   --remote-uri="https://gitlab.com/my-org/my-repo.git"
 
-# Create a trigger
-gcloud builds triggers create gitlab-enterprise \
+# Create a trigger on the linked repository
+gcloud builds triggers create gitlab \
   --name="deploy-from-gitlab" \
+  --region=us-central1 \
   --repository="projects/my-project/locations/us-central1/connections/my-gitlab-conn/repositories/my-gitlab-repo" \
   --branch-pattern="^main$" \
-  --build-config="cloudbuild.yaml" \
-  --region=us-central1
+  --build-config="cloudbuild.yaml"
 ```
 
 This configuration strategy anchors the repository metadata strictly within a designated Google Cloud region, ensuring compliance with data sovereignty and location requirements.
@@ -477,9 +479,9 @@ While automated triggers drive the day-to-day continuous integration loop, manua
 # Submit a build manually (from local source)
 gcloud builds submit --config=cloudbuild.yaml .
 
-# Submit with substitutions
+# Submit with substitutions (use a custom _TAG; do not override built-in SHORT_SHA)
 gcloud builds submit --config=cloudbuild.yaml \
-  --substitutions=_ENV=staging,SHORT_SHA=local123 .
+  --substitutions=_ENV=staging,_TAG=local123 .
 
 # Submit from a GCS archive
 gcloud builds submit --config=cloudbuild.yaml \
@@ -533,11 +535,11 @@ gcloud builds triggers create pubsub \
   --build-config="cloudbuild-nightly-scan.yaml"
 ```
 
-The Pub/Sub message payload is accessible inside the build through the `$_PUBSUB_PAYLOAD` substitution variable, allowing the build steps to parse JSON event data and adapt their behavior dynamically. For example, a message containing `{"scan_type": "full", "target": "production"}` can route the pipeline into a comprehensive security audit path, while `{"scan_type": "quick"}` triggers a fast lint-only pass.
+Bind fields from the Pub/Sub message on the trigger using **JSONPath substitution bindings** (not a built-in `$_PUBSUB_PAYLOAD` variable). For example, map `body.message.data` or attributes to custom substitutions such as `_DATA=$(body.message.data)` and `_EVENT=$(body.message.attributes.eventType)`, then reference `_DATA` and `_EVENT` in `cloudbuild.yaml` steps to route a comprehensive security audit versus a fast lint-only pass.
 
 ### Webhook Triggers
 
-When neither the native GitHub/GitLab integrations nor Pub/Sub fit your workflow --- for example, when you use a self-hosted version control system, a custom internal tool, or a third-party service that fires generic HTTP callbacks --- Cloud Build provides webhook triggers. A webhook trigger exposes a unique HTTPS URL that accepts POST requests with an optional shared secret for HMAC-SHA256 signature verification:
+When neither the native GitHub/GitLab integrations nor Pub/Sub fit your workflow --- for example, when you use a self-hosted version control system, a custom internal tool, or a third-party service that fires generic HTTP callbacks --- Cloud Build provides webhook triggers. A webhook trigger exposes a unique HTTPS URL; the shared secret is passed as **query parameters** on that URL (`?key=API_KEY&secret=SECRET`, with the secret value stored in Secret Manager), not as an HMAC header:
 
 ```bash
 # Create a webhook trigger with secret verification
@@ -547,7 +549,7 @@ gcloud builds triggers create webhook \
   --build-config="cloudbuild.yaml"
 ```
 
-The trigger URL is returned on creation. Any external system can then POST JSON payloads to that URL, and Cloud Build validates the `X-CloudBuild-Signature` header against the shared secret before executing the pipeline. This is the escape hatch that connects Cloud Build to essentially any automation system in your ecosystem.
+The trigger URL is returned on creation (including the `key` and `secret` query parameters your caller must supply). External systems POST to that URL; Cloud Build validates the secret as a query parameter before executing the pipeline. This is the escape hatch that connects Cloud Build to essentially any automation system in your ecosystem.
 
 ### Second-Generation Repository Connections
 
@@ -581,15 +583,15 @@ The second-generation model is the recommended path for new projects as of 2024,
 
 A pipeline is fundamentally an automated process acting on behalf of your organization. When Cloud Build pushes an image to Artifact Registry or deploys a service to Cloud Run, it must authenticate and authorize those actions. It achieves this by assuming the identity of an IAM Service Account.
 
-By default, Cloud Build historically leveraged a single, powerful "legacy" service account (`[PROJECT_NUMBER]@cloudbuild.gserviceaccount.com`) which possessed sweeping administrative privileges across the entire project. Relying on this default account violates the core security tenet of least privilege. A compromised pipeline configuration could theoretically be used to alter routing configurations, delete databases, or modify core infrastructure far beyond the scope of a simple deployment.
+Since the 2024 default change, **new projects** run Cloud Build as the **Compute Engine default service account** (`[PROJECT_NUMBER]-compute@developer.gserviceaccount.com`) unless you opt in to the legacy Cloud Build service account (`[PROJECT_NUMBER]@cloudbuild.gserviceaccount.com`). Either default can be broader than a single pipeline needs. Relying on project-wide defaults without scoping violates least privilege—a compromised `cloudbuild.yaml` could reach resources far beyond one deployment.
 
 Best practices dictate creating dedicated, custom service accounts explicitly tailored to the precise requirements of individual pipelines.
 
 ```bash
-# View the default Cloud Build service account
+# View which service accounts Cloud Build-related triggers may use
 gcloud projects get-iam-policy $PROJECT_ID \
   --flatten="bindings[].members" \
-  --filter="bindings.members:cloudbuild.gserviceaccount.com" \
+  --filter="bindings.members:compute@developer.gserviceaccount.com OR bindings.members:cloudbuild.gserviceaccount.com" \
   --format="table(bindings.role)"
 
 # Use a custom service account (recommended for production)
@@ -597,11 +599,11 @@ gcloud iam service-accounts create cloud-build-sa \
   --display-name="Custom Cloud Build SA"
 
 # Grant specific permissions
-gcloud projects add-iam-binding $PROJECT_ID \
+gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:cloud-build-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
   --role="roles/run.admin"
 
-gcloud projects add-iam-binding $PROJECT_ID \
+gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:cloud-build-sa@${PROJECT_ID}.iam.gserviceaccount.com" \
   --role="roles/artifactregistry.writer"
 
@@ -852,11 +854,11 @@ A single `cloudbuild.yaml` that uses conditional logic (bash `if` statements che
 
 **Anti-Pattern 2: Ignoring Build Timeouts**
 
-Leaving the default 10-minute timeout in place indefinitely, even as the project grows.
+Setting `timeout` far below your real pipeline duration—or never revisiting timeout after the test suite grows—while assuming the platform default will always fit.
 
-*What goes wrong*: One day a new dependency or a larger test suite pushes the build to 11 minutes. The pipeline starts failing with timeout errors. The team's first reaction is usually to assume something is broken, triggering a fire drill that wastes an afternoon before someone checks the timeout setting.
+*What goes wrong*: The default is **60 minutes (3600s)**, but an explicit `timeout: '600s'` in `cloudbuild.yaml` overrides it. Teams that copy a short timeout from a tutorial may see failures when integration tests expand, or they may set `timeout: '86400s'` everywhere and mask hung builds that burn quota for hours.
 
-*Better approach*: Set the timeout to a comfortable multiple of your observed build duration --- at least 2x, ideally 3x --- and monitor build duration trends. If the 90th percentile build time consistently exceeds half the timeout, increase the timeout proactively. A build that is genuinely stuck (infinite loop, hung network call) will still hit the timeout and fail, but a build that is merely growing with the codebase will not be prematurely killed.
+*Better approach*: Set `timeout` to a comfortable multiple of your observed build duration (at least 2x, ideally 3x) and monitor duration trends. If the 90th percentile build time consistently exceeds half your configured timeout, increase it proactively. A genuinely stuck build (infinite loop, hung network call) should still fail before 24 hours—the platform maximum.
 
 **Anti-Pattern 3: Secrets in Substitutions**
 
@@ -884,7 +886,7 @@ The choices you face when adopting Cloud Build are not purely technical --- they
 |-----------|-------------|----------------|-----------|
 | **Infrastructure** | Fully managed, serverless (default pool) or VPC-native (private pool) | GitHub-hosted runners or self-hosted | GitLab-hosted runners or self-hosted |
 | **GCP integration** | Native IAM, Artifact Registry auth, Cloud Deploy hand-off, Cloud Logging | Requires Workload Identity Federation setup | Requires Workload Identity Federation setup |
-| **Free tier** | 120 build-minutes/day (default machine) | 2,000 minutes/month (private repos), unlimited for public | 400 minutes/month (all tiers) |
+| **Free tier** | 120 build-minutes/day (default machine) | 2,000 minutes/month (private repos), unlimited for public | 400 compute-minutes/month on **free tier** (paid tiers include substantially more) |
 | **Pricing model** | Per build-minute by machine type | Per minute by runner tier (Linux/Windows/macOS) | Per minute by compute tier |
 | **Configuration** | Single `cloudbuild.yaml`, build steps as containers | `.github/workflows/*.yml`, job matrix, reusable workflows | `.gitlab-ci.yml`, stages, includes |
 | **Ecosystem** | Deepest GCP service integration, no third-party action marketplace | Largest marketplace (12,000+ actions), broadest third-party integration | Built-in container registry, Kubernetes integration |
@@ -933,7 +935,7 @@ When you exceed the free tier or use larger machine types, pricing scales with v
 
 - **File filtering on triggers**: The fastest build minute is the one you never consume. Use `ignoredFiles` to skip builds for documentation-only commits. For monorepos, use `includedFiles` to trigger only the relevant sub-pipeline.
 - **Caching**: Use Kaniko with Artifact Registry layer caching for Docker builds. A cached build that skips 80% of its layers might complete in 90 seconds instead of 8 minutes.
-- **Timeout discipline**: A build that hangs for 10 minutes before the timeout kills it consumes 10 billable minutes of zero-value execution. Set timeouts that are generous enough for normal operation but tight enough to catch hangs quickly.
+- **Timeout discipline**: A build that hangs until timeout consumes billable minutes of zero-value execution. Set timeouts generous enough for normal operation but well below the 24-hour maximum so hung jobs fail in minutes, not hours.
 - **Right-size machine types**: Run your build on the default machine and measure the wall-clock time. If it is acceptable, stay on the default. If developers complain about CI latency, benchmark on `E2_HIGHCPU_8` and compare the cost-per-build against the developer-productivity gain.
 
 **What makes cost spike unexpectedly**:
@@ -959,7 +961,7 @@ When you exceed the free tier or use larger machine types, pricing scales with v
 | Using the default Cloud Build SA for everything | Convenience; it has broad permissions | Create a custom SA per pipeline with minimal permissions |
 | Not using parallel steps | Steps run sequentially by default | Use `waitFor: ['-']` to run independent steps concurrently |
 | Hardcoding project IDs in cloudbuild.yaml | Works during initial development | Use `$PROJECT_ID` substitution for portability |
-| Not setting build timeouts | Default 10-minute timeout is too short for large builds | Set `timeout: '1800s'` (30 minutes) for complex pipelines |
+| Not setting build timeouts | Relying on a copied short timeout while the pipeline outgrows it | Set `timeout` to 2–3× observed duration (default platform max is 3600s unless you raise it to 86400s) |
 | Skipping tests in the CI pipeline | "We test locally" | Always run tests in CI; the pipeline is the source of truth |
 | Not using `images:` field for Docker pushes | Pushing images manually in steps | Use the `images:` field for automatic pushing and provenance |
 | Building everything on every commit | Simplest configuration | Use path filters in triggers to build only what changed |
@@ -988,7 +990,7 @@ You would configure two separate Cloud Build triggers using different Git matchi
 <details>
 <summary>4. A junior developer creates a basic Cloud Build pipeline that just runs `npm test` on a React frontend and outputs the results. During a security audit, you notice this pipeline is using the default Cloud Build service account. You immediately recommend switching it to a custom service account. What is the security risk of leaving it as the default?</summary>
 
-The risk lies in the violation of the principle of least privilege due to the default service account's broad, overly permissive roles. By default, the Cloud Build service account (`PROJECT_NUMBER@cloudbuild.gserviceaccount.com`) is granted the `Cloud Build Service Account` role, which includes permissions to push to Artifact Registry, deploy to Cloud Run, modify GKE clusters, and more. If a malicious actor compromises the React repository and alters the `cloudbuild.yaml` or a test script, they could use that pipeline's default credentials to deploy rogue containers or delete production infrastructure. A custom service account should be created with absolutely no permissions, and only the specific IAM roles required for that exact pipeline (e.g., just logging) should be granted.
+The risk lies in violating least privilege when triggers use a project-wide default identity with more permissions than the pipeline needs. On **new projects**, Cloud Build typically runs as the **Compute Engine default service account**; older projects may still use the legacy `PROJECT_NUMBER@cloudbuild.gserviceaccount.com` builder account if opted in—both can hold broad roles. If a malicious actor compromises the React repository and alters `cloudbuild.yaml` or a test script, they could abuse those credentials to push images, deploy services, or modify clusters. Create a dedicated service account per pipeline (or per environment) and grant only the roles that pipeline requires—for a CI-only job, logging and artifact read may be enough; omit deploy roles entirely.
 </details>
 
 <details>
@@ -1125,7 +1127,7 @@ steps:
     args:
       - 'build'
       - '-t'
-      - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_SERVICE}:${SHORT_SHA}'
+      - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_SERVICE}:${_TAG}'
       - '.'
 
   # Step 3: Push to Artifact Registry
@@ -1134,7 +1136,7 @@ steps:
     waitFor: ['build']
     args:
       - 'push'
-      - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_SERVICE}:${SHORT_SHA}'
+      - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_SERVICE}:${_TAG}'
 
   # Step 4: Deploy to Cloud Run
   - id: 'deploy'
@@ -1145,18 +1147,19 @@ steps:
       - 'run'
       - 'deploy'
       - '${_SERVICE}'
-      - '--image=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_SERVICE}:${SHORT_SHA}'
+      - '--image=${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_SERVICE}:${_TAG}'
       - '--region=${_REGION}'
       - '--allow-unauthenticated'
-      - '--set-env-vars=APP_VERSION=${SHORT_SHA}'
+      - '--set-env-vars=APP_VERSION=${_TAG}'
 
 substitutions:
   _REGION: 'us-central1'
   _REPO: 'cicd-lab'
   _SERVICE: 'cicd-lab-api'
+  _TAG: 'local'
 
 images:
-  - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_SERVICE}:${SHORT_SHA}'
+  - '${_REGION}-docker.pkg.dev/$PROJECT_ID/${_REPO}/${_SERVICE}:${_TAG}'
 
 options:
   logging: CLOUD_LOGGING_ONLY
@@ -1180,7 +1183,7 @@ cd /tmp/cicd-lab
 # Submit the build
 gcloud builds submit \
   --config=cloudbuild.yaml \
-  --substitutions=SHORT_SHA=manual01 \
+  --substitutions=_TAG=manual01 \
   .
 
 # Check build status
@@ -1232,7 +1235,7 @@ PYEOF
 # Build and deploy v2
 gcloud builds submit \
   --config=cloudbuild.yaml \
-  --substitutions=SHORT_SHA=manual02 \
+  --substitutions=_TAG=manual02 \
   .
 
 # Verify the new version
@@ -1250,7 +1253,7 @@ Audit your pipeline execution metadata locally using command-line filters to vis
 ```bash
 # List recent builds
 gcloud builds list --limit=5 \
-  --format="table(id, status, createTime, substitutions.SHORT_SHA)"
+  --format="table(id, status, createTime, substitutions._TAG)"
 
 # Get the latest build ID
 BUILD_ID=$(gcloud builds list --limit=1 --format="value(id)")

--- a/src/content/docs/cloud/gcp-essentials/module-2.12-patterns.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.12-patterns.md
@@ -5,9 +5,11 @@ sidebar:
   order: 13
 ---
 
+**Complexity**: [COMPLEX] | **Time to Complete**: 1.5 hours | **Prerequisites**: [Modules 2.1–2.11](../module-2.11-cloud-build/)
+
 ## What You'll Be Able to Do
 
-This **[COMPLEX]** capstone module takes about **1.5 hours** and assumes you have completed [Modules 1–11](../module-2.11-cloud-build/) in GCP DevOps Essentials. When you finish, you will be able to:
+This capstone module assumes you have completed the prior GCP DevOps Essentials modules. When you finish, you will be able to:
 
 - **Design** GCP architectures using Shared VPC, Private Service Connect, and hub-spoke network topologies to ensure secure, isolated communication.
 - **Evaluate** GCP-native patterns for microservices (Cloud Run, GKE, App Engine) and select the right compute tier based on workload requirements.
@@ -18,11 +20,41 @@ This **[COMPLEX]** capstone module takes about **1.5 hours** and assumes you hav
 
 ## Why This Module Matters
 
-In 2021, a rapidly growing healthcare analytics company named MedData Innovations had 6 GCP projects. By mid-2022, fueled by massive venture funding and unchecked hiring, they had 84 projects. Each project had been created manually by whichever engineer needed one, with no centralized naming convention, no consistent network configuration, and no centralized audit logging. When the security team was asked to produce a comprehensive audit report for a mandatory HIPAA compliance review, they discovered a fragmented nightmare: 23 projects had the default VPC still active and exposed, 11 had public Cloud Storage buckets containing sensitive patient telemetry, and 4 had long-lived service account keys that had not been rotated in over a year.
+**Hypothetical scenario:** A rapidly growing healthcare analytics company starts with six GCP projects. Within eighteen months, unchecked hiring and manual provisioning push that count past eighty. Each project was created by whichever engineer needed one, with no centralized naming convention, no consistent network configuration, and no centralized audit logging. When the security team prepares a mandatory HIPAA compliance review, they discover a fragmented environment: many projects still use the default VPC, several Cloud Storage buckets are publicly readable, and long-lived service account keys have not been rotated in over a year.
 
-The security engineer responsible for the audit spent six grueling weeks manually checking each project using raw CLI commands and spreadsheets. Inevitably, the compliance review failed. This failure resulted in a 90-day forced remediation period that halted all new feature development, cost the company over $850,000 in diverted engineering time and external consultant fees, and significantly delayed a major product launch, leading to the loss of a key enterprise client. 
+The security engineer responsible for the audit spends weeks manually checking each project using raw CLI commands and spreadsheets. The compliance review fails. Remediation halts new feature development, consumes substantial engineering time and consultant fees, and delays a major product launch. The failure is not a failure of individual GCP services. It is a complete absence of architectural discipline. Individual GCP services—IAM, VPCs, Compute Engine, Cloud Run—are merely raw building blocks. Architectural patterns are how you systematically assemble those blocks into a cohesive, governed system that scales, stays inherently secure, and remains manageable as your organization grows.
 
-This catastrophic failure was not a failure of individual GCP services, but a complete absence of architectural discipline. Individual GCP services---IAM, VPCs, Compute Engine, Cloud Run---are merely raw building blocks. Architectural patterns are how you systematically assemble those blocks into a cohesive, governed system that scales, stays inherently secure, and remains manageable as your organization grows. A project vending machine ensures every new project is born with an identical, secure configuration. A landing zone provides the organizational structure that actively prevents the chaos of ungoverned growth. In this module, you will master the foundational patterns that distinguish a robust, enterprise-grade GCP environment from an accidental, unmanageable one.
+A project vending machine ensures every new project is born with an identical, secure configuration. A landing zone provides the organizational structure that actively prevents the chaos of ungoverned growth. In this module, you will master the foundational patterns that distinguish a robust, enterprise-grade GCP environment from an accidental, unmanageable one.
+
+> **The Blueprint Analogy**
+>
+> Building a skyscraper from raw steel and concrete without architectural drawings produces a structure that might stand—for a while—but cannot pass inspection, cannot be expanded safely, and collapses under stress. GCP services are your steel and concrete. Landing zones, Shared VPC, organization policies, and reference patterns are the blueprints that turn raw materials into something you can operate at scale.
+
+---
+
+## Building Blocks from Prior Modules
+
+This capstone stitches together concepts you already practiced in earlier modules. Treat the list below as a checklist: if any item feels unfamiliar, revisit that module before you design production architecture.
+
+| Prior module | Capability you bring forward | Architectural role |
+| :--- | :--- | :--- |
+| [2.1 IAM](../module-2.1-iam/) | Organizations, folders, projects, IAM bindings, service accounts | Governance spine for landing zones and least-privilege access |
+| [2.2 VPC](../module-2.2-vpc/) | Global VPC, subnets, firewall rules, Shared VPC, Cloud NAT | Network perimeter every pattern below attaches to |
+| [2.3 Compute](../module-2.3-compute/) | MIGs, instance templates, autoscaling | Web and application tiers in classic three-tier designs |
+| [2.4 Cloud Storage](../module-2.4-gcs/) | Bucket classes, dual-region and multi-region storage | Static assets, backups, and log archives |
+| [2.5 Cloud DNS](../module-2.5-dns/) | Public and private zones, DNS policies | Name resolution for global load balancers and hybrid connectivity |
+| [2.6 Artifact Registry](../module-2.6-artifact-registry/) | Container and package repositories | Supply chain for Cloud Run, GKE, and Cloud Build |
+| [2.7 Cloud Run](../module-2.7-cloud-run/) | Serverless containers, VPC connectors | Default compute choice for stateless HTTP microservices |
+| [2.8 Cloud Functions](../module-2.8-cloud-functions/) | Event-driven functions | Lightweight triggers in serverless and pipeline patterns |
+| [2.9 Secret Manager](../module-2.9-secret-manager/) | Centralized secrets with audit trails | Credentials for CI/CD, databases, and runtime apps |
+| [2.10 Operations](../module-2.10-operations/) | Cloud Monitoring, Logging, alerting, SLOs | Observability layer every landing zone routes into |
+| [2.11 Cloud Build](../module-2.11-cloud-build/) | CI/CD pipelines, immutable artifacts | Delivery path from commit to running workload |
+
+Architectural maturity means you stop treating each service in isolation. A landing zone wires IAM inheritance from folders into Shared VPC attachments, log sinks into a central observability project, and organization policies that block the misconfigurations you saw in the opening scenario.
+
+When you sketch a new system, start from the outside in. Ask who must authenticate, which network segment the workload occupies, where logs must land for auditors, and how CI/CD from [Module 2.11](../module-2.11-cloud-build/) promotes artifacts into that segment. The capstone patterns below assume those prerequisites are already wired. Skipping them and jumping straight to a global load balancer produces the same compliance failure as the opening scenario—just with prettier diagrams.
+
+Platform engineers often maintain a "golden path" document that links each prior module lab to the production pattern it supports. That document is not bureaucracy. It is how you prevent teams from rediscovering that Cloud Run needs a VPC connector to reach private Cloud SQL, or that firewall rules in a Shared VPC host project affect every attached service project simultaneously.
 
 ---
 
@@ -30,9 +62,9 @@ This catastrophic failure was not a failure of individual GCP services, but a co
 
 ### The Problem of Manual Provisioning
 
-Manually creating GCP projects leads to severe operational bottlenecks and security risks because every team improvises its own baseline. Naming conventions drift across environments, the default VPC often remains active instead of being deleted, new projects become network islands that never attach to a shared security perimeter, and IAM is configured by hand in ways that grant overly broad roles while skipping centralized audit trails. None of these failures is exotic—they are the predictable outcome of scale without a factory.
+Manually creating GCP projects leads to severe operational bottlenecks and security risks because every team improvises its own baseline. Naming conventions drift across environments. The default VPC often remains active instead of being deleted. New projects become network islands that never attach to a shared security perimeter. IAM is configured by hand in ways that grant overly broad roles while skipping centralized audit trails. None of these failures is exotic—they are the predictable outcome of scale without a factory.
 
-> **Stop and think**: How many manual steps would it take to configure a VPC, delete the default network, enable 10 APIs, set up log sinks, and configure IAM for a single project? Now multiply that by 50 projects a year.
+> **Stop and think**: How many manual steps would it take to configure a VPC, delete the default network, enable ten APIs, set up log sinks, and configure IAM for a single project? Now multiply that by fifty projects a year.
 
 ### The Solution: Project Factory
 
@@ -43,6 +75,10 @@ flowchart TD
     Dev["Developer<br/>(via form, Terraform,<br/>or ServiceNow)"] -- "Request<br/>'I need a project for team-x-prod'" --> Factory["Project Factory<br/>(Terraform or Config Connector)"]
     Factory -- "Creates project with:" --> Config["Baseline Config<br/>- Standard naming<br/>- Billing linked<br/>- APIs enabled<br/>- Default VPC deleted<br/>- Shared VPC connected<br/>- Log sinks configured<br/>- IAM baseline<br/>- Org policies<br/>- Budget alerts"]
 ```
+
+At moderate scale—say twenty to forty new projects per year—the factory pays for itself in avoided audit rework alone. Each manually created project might skip budget alerts, forget to disable default service account keys, or attach to the wrong Shared VPC subnet. The factory makes those omissions impossible because the Terraform module or Config Connector manifest is the contract. Platform teams review that contract once; application teams consume it hundreds of times.
+
+Cost control starts at provisioning time. Link every factory-created project to a billing account, apply resource labels for cost center and team, and set budget alerts at creation. Unexpected spend often traces back to projects that nobody knew existed because they were created outside the factory.
 
 ### Implementing a Terraform Project Factory
 
@@ -139,7 +175,13 @@ terraform apply -var="team=payments" -var="env=prod" \
 
 > **Pause and predict**: If a developer creates a project outside of a structured landing zone folder hierarchy, what critical security controls might they inadvertently bypass?
 
-A landing zone is the foundational GCP environment your entire organization is built on: it defines resource hierarchy, network boundaries, security perimeters, and operational patterns that every later project must follow. In practice, an effective landing zone isolates distinct concerns into separate folders so organization policies and IAM controls inherit cleanly from the organization root down through production, non-production, and sandbox tiers instead of being renegotiated project by project.
+A landing zone is the foundational GCP environment your entire organization is built on. Google defines it as a modular, scalable configuration—also called a cloud foundation—that enables organizations to adopt Google Cloud securely. It defines resource hierarchy, network boundaries, security perimeters, and operational patterns that every later project must follow. In practice, an effective landing zone isolates distinct concerns into separate folders so organization policies and IAM controls inherit cleanly from the organization root down through production, non-production, and sandbox tiers instead of being renegotiated project by project.
+
+### Resource Hierarchy and Inheritance
+
+The hierarchy flows Organization → Folders → Projects → Resources. IAM bindings and organization policies inherit downward unless explicitly overridden. That inheritance is the governance superpower: set `constraints/iam.disableServiceAccountKeyCreation` at the organization root and every descendant project inherits it. Place production workloads under a `Production` folder with stricter region constraints than your `Sandbox` folder. Shared services—networking, logging, security tooling—live in dedicated projects under a `Shared Services` folder where platform engineers retain control.
+
+Folder design should mirror how your business thinks about risk, not how your org chart happens to look today. A common pattern separates `Shared Services`, `Production`, `Non-Production`, and `Sandbox`. Sandbox folders often carry auto-expiry policies or tighter service constraints so experiments cannot accidentally become production dependencies.
 
 ### The Three-Layer Architecture
 
@@ -186,6 +228,8 @@ flowchart TD
     FolderSandbox --> SB1
     FolderSandbox --> SB2
 ```
+
+Centralized logging deserves explicit mention because audit failures often start here. Route `cloudaudit.googleapis.com` logs from every service project to a `shared-logging` project with tamper-evident storage. Pair sinks with log-based metrics and alerting so public bucket changes or IAM policy edits surface within minutes, not during the next quarterly review.
 
 ### Organization Policies for the Landing Zone
 
@@ -243,9 +287,17 @@ EOF
 gcloud org-policies set-policy /tmp/allowed-services.yaml --folder=SANDBOX_FOLDER_ID
 ```
 
+Combine `constraints/storage.publicAccessPrevention` with uniform bucket-level access for defense in depth. Public bucket incidents are among the most common audit findings, and organization policies block them at the API layer regardless of developer intent.
+
+Identity onboarding belongs in the landing zone narrative as well. Most enterprises federate their corporate directory to Google Cloud through Cloud Identity or Workforce Identity Federation so human access inherits group membership used in IAM bindings. Service accounts created by the project factory should receive only the roles required for their workload, following the least-privilege patterns from [Module 2.1](../module-2.1-iam/). Long-lived JSON keys should remain disabled organization-wide; Workload Identity and attached service accounts cover machine authentication instead.
+
+Hybrid connectivity—Cloud VPN, Dedicated Interconnect, or Partner Interconnect—also lands in the shared-networking project rather than in individual application projects. That placement keeps routing, BGP sessions, and encryption domains under network team ownership while application teams consume subnets through Shared VPC attachment. Cross-Cloud Interconnect extends the same model when you must reach other cloud providers without hairpinning traffic through on-premises data centers.
+
+Google recommends building a landing zone before the first enterprise workload, but also acknowledges that landing zones are modular and evolve over time. Your first iteration might include folders, Shared VPC, centralized logging, and core organization policies while deferring VPC Service Controls perimeters until regulated data actually arrives. Document those deferrals explicitly so auditors understand what is planned versus what is missing.
+
 ### Google Cloud Foundation Toolkit
 
-Google provides the **Cloud Foundation Toolkit** (CFT), a set of deeply vetted Terraform modules that implement landing zone best practices right out of the box. Using these modules accelerates deployment and guarantees alignment with Google's own internal standards.
+Google provides the **Cloud Foundation Toolkit** (CFT), a set of deeply vetted Terraform modules that implement landing zone best practices. Using these modules can accelerate deployment and align you with Google's published reference architectures and example foundations rather than reinventing folder hierarchies from scratch.
 
 ```bash
 # The CFT includes these key modules:
@@ -267,42 +319,150 @@ cd terraform-example-foundation
 
 ## Network Architectures: Shared VPC, PSC, and Hub-Spoke
 
-Google Cloud networking is globally scoped, which simplifies routing compared with regional-only VPC models on other clouds; at enterprise scale you still need deliberate topologies so connectivity stays governable. **Shared VPC** is the usual starting point: a host project owns subnets, routes, and firewall rules while service projects attach VMs, GKE clusters, and VPC-connected Cloud Run services into those segments, so network administrators retain the perimeter and application teams cannot redefine it per project.
+Google Cloud networking is globally scoped, which simplifies routing compared with regional-only VPC models on other clouds. At enterprise scale you still need deliberate topologies so connectivity stays governable. **Shared VPC** is the usual starting point: a host project owns subnets, routes, and firewall rules while service projects attach VMs, GKE clusters, and VPC-connected Cloud Run services into those segments. Network administrators retain the perimeter, and application teams cannot redefine it per project.
+
+Shared VPC versus standalone VPC per project is one of the first landing-zone decisions. Standalone VPCs isolate teams completely but multiply NAT gateways, DNS zones, and firewall rule sets. Shared VPC centralizes those costs and policies while still giving each service project its own IAM boundary for compute resources. Most enterprises standardize on one Shared VPC per environment tier—production, non-production, sandbox—hosted in the shared-networking project from the landing zone diagram above.
 
 ### Hub-Spoke Network Topologies
 
-As your footprint expands, you often need multiple Shared VPCs—for example, strict isolation between a regulated production VPC and an ephemeral sandbox VPC. When those VPCs must talk to one another, teams historically used VPC Network Peering, but peering is **non-transitive**: if VPC A peers with B and B peers with C, A cannot reach C through B. Hub-spoke designs with **Network Connectivity Center (NCC)** attach every spoke VPC to a central hub that provides transitive routing, a natural place for inspection firewalls, and consistent policy for inter-VPC traffic.
+As your footprint expands, you often need multiple Shared VPCs—for example, strict isolation between a regulated production VPC and an ephemeral sandbox VPC. When those VPCs must talk to one another, teams historically used VPC Network Peering, but peering is **non-transitive**: if VPC A peers with B and B peers with C, A cannot reach C through B. At enterprise scale, organizations can use a hub-spoke design with **Network Connectivity Center (NCC)** to centrally orchestrate connectivity among attached VPC and hybrid spokes, then combine NCC with firewall policies or other inspection controls where policy requires it.
+
+```mermaid
+flowchart LR
+    Hub["NCC Hub"]
+    Prod["Production Shared VPC"]
+    Dev["Non-Prod Shared VPC"]
+    OnPrem["On-Prem via<br/>Cloud Interconnect"]
+    Hub --> Prod
+    Hub --> Dev
+    Hub --> OnPrem
+```
+
+NCC does not replace Shared VPC inside an environment tier. It connects tiers and hybrid endpoints after each tier already has a coherent internal design.
 
 ### Private Service Connect (PSC)
 
-Exposing internal services or consuming third-party managed offerings used to mean fragile peering meshes or public endpoints. **Private Service Connect (PSC)** publishes a producer service as an internal endpoint that you consume inside your own VPC, so you avoid coordinating non-overlapping CIDRs across organizations. Traffic stays on Google's backbone, NATs through the localized endpoint, and never needs a broad "trust the whole peered network" model—PSC is how you integrate SaaS and shared platform services without punching holes in your landing zone.
+Exposing internal services or consuming third-party managed offerings used to mean fragile peering meshes or public endpoints. **Private Service Connect (PSC)** publishes a producer service as an internal endpoint that you consume inside your own VPC, so you avoid coordinating non-overlapping CIDRs across organizations. Traffic stays on Google's backbone, NATs through the localized endpoint, and never needs a broad "trust the whole peered network" model. PSC is how you integrate SaaS and shared platform services without punching holes in your landing zone.
+
+Common PSC use cases include consuming managed services like Cloud SQL through private IP, publishing internal APIs to partner organizations, and accessing Google APIs through restricted VIP ranges when VPC Service Controls enforce a perimeter.
+
+Firewall policy objects complement Shared VPC at scale. Instead of hundreds of per-network firewall rules duplicated across environments, hierarchical firewall policies attach at the organization or folder level and express consistent allow/deny semantics. Pair those policies with VPC Flow Logs sampled to Cloud Logging so security teams can prove which rules actually fired during an incident review.
+
+DNS architecture also belongs in the network chapter because every reference pattern below assumes resolvable names. Private Cloud DNS zones attached to your Shared VPC resolve internal load balancer names for the application tier. Public Cloud DNS zones—or delegations from your registrar—point customer domains at global load balancer front ends. Split-horizon DNS mistakes are a frequent source of "works in staging, fails in prod" outages when private records leak or public records omit health-checked endpoints.
+
+When comparing Shared VPC to a pure hub-spoke design, remember they solve different problems. Shared VPC centralizes subnets inside one environment tier. NCC connects multiple tiers or clouds after each tier already has internal coherence. Teams sometimes conflate the two and attempt to peer every project individually, recreating the non-transitive peering maze that NCC was meant to simplify.
+
+---
+
+## Reference Architecture Patterns
+
+The patterns below are starting points, not copy-paste templates. Each maps landing-zone building blocks to a workload shape you will recognize from production systems.
+
+### Three-Tier Web Application (LB + MIG + Cloud SQL)
+
+The classic three-tier pattern separates web, application, and data layers behind distinct load balancers. Google's [External Application Load Balancer use cases](https://cloud.google.com/load-balancing/docs/https/use-cases) document how an external HTTPS load balancer fronts a web-tier Managed Instance Group, regional internal load balancers scale the application tier, and managed databases sit behind private connectivity.
+
+```
+                    Internet
+                       │
+                       ▼
+         ┌─────────────────────────┐
+         │ Global External HTTPS LB │
+         └────────────┬────────────┘
+                      │
+         ┌────────────▼────────────┐
+         │ Web tier (regional MIG)  │  ← autoscale on CPU/latency
+         └────────────┬────────────┘
+                      │
+         ┌────────────▼────────────┐
+         │ App tier (regional ILB)  │  ← business logic, no public IP
+         └────────────┬────────────┘
+                      │
+         ┌────────────▼────────────┐
+         │ Cloud SQL (HA primary)   │  ← synchronous standby in-region
+         └─────────────────────────┘
+```
+
+Design choices that matter at moderate scale: use regional MIGs across three zones for the web tier, keep the app tier on private subnets with egress through Cloud NAT, and enable Cloud SQL high availability so failover does not require application connection-string changes. Static assets belong in Cloud Storage behind a CDN rather than on web VMs. Secrets for database credentials flow through Secret Manager, not startup scripts checked into source control.
+
+Cost levers for this pattern include right-sizing MIG instance types, using committed use discounts on steady-state compute, choosing appropriate Cloud SQL tier and storage autoscaling limits, and fronting static content with Cloud CDN to reduce load balancer egress to origin.
+
+Health checks deserve explicit design attention because global load balancers remove unhealthy backends only when probes fail consistently. Configure HTTP health checks that validate application readiness—not merely TCP port open—and set appropriate thresholds so brief GC pauses do not drain an entire region during a rolling deploy. Pair health checks with graceful shutdown hooks on your web tier so in-flight requests complete before instances terminate.
+
+### Serverless Event-Driven (Cloud Run + Pub/Sub + Firestore)
+
+For spiky HTTP APIs and asynchronous workflows, a serverless stack reduces idle cost. Cloud Run services handle synchronous HTTP traffic and scale to zero between requests. Pub/Sub decouples producers from consumers when events must survive traffic bursts. Firestore or Cloud SQL provides persistence depending on query complexity and consistency requirements.
+
+```
+  Client ──HTTPS──► Cloud Run (API)
+                         │
+                         ├──► Pub/Sub topic ──► Cloud Run (worker)
+                         │
+                         └──► Firestore / Cloud SQL
+```
+
+Connect Cloud Run to private databases using Serverless VPC Access connectors into your Shared VPC subnets—exactly the pattern described in the [DeployStack three-tier tutorial](https://cloud.google.com/shell/docs/cloud-shell-tutorials/deploystack/three-tier-app) for Cloud Run talking to Cloud SQL and Memorystore privately. Store connection strings in Secret Manager and inject them at deploy time through Cloud Build, building on [Module 2.11](../module-2.11-cloud-build/).
+
+Serverless cost surprises usually come from always-on minimum instances, high Pub/Sub delivery volume, Firestore document read amplification, and VPC connector idle charges. Set min instances to zero for dev tiers, cap max instances in production, and monitor per-service billing labels.
+
+### Data Pipeline (Pub/Sub + Dataflow + BigQuery)
+
+Streaming analytics architectures ingest events through Pub/Sub, transform them in Dataflow, and land curated tables in BigQuery for dashboards and ML features. This pattern scales horizontally because each component is managed: Pub/Sub absorbs publish spikes, Dataflow autoscales workers within configured limits, and BigQuery separates storage from compute billing.
+
+Batch alternatives exist—scheduled Cloud Functions triggering extract jobs—but Dataflow is the default when event volume exceeds sporadic batch windows or when you need Apache Beam portability. Landing-zone considerations include VPC-SC perimeters around BigQuery datasets, Private Google Access for Dataflow workers without public IPs, and centralized log sinks capturing pipeline failures.
+
+Pipeline cost spikes when Dataflow max workers is unconstrained, when BigQuery on-demand scans full partitions repeatedly, or when raw events accumulate in Pub/Sub because downstream consumers lag. Apply BigQuery partitioning and clustering, use flex slots or reservations for predictable query load, and alert on Pub/Sub oldest-unacked-message age.
+
+Dead-letter topics and replay procedures belong in every pipeline design document. When Dataflow fails a record after retries, you need a quarantine path that preserves the payload for inspection without blocking the main stream. Reprocessing from dead-letter storage should be idempotent so duplicate inserts do not corrupt analytics tables. Operations teams that skip this step discover data gaps only when executives ask why dashboards flatlined three Tuesdays ago.
+
+Schema evolution is the other long-term pipeline cost. Pub/Sub messages are bytes until you enforce a contract. Use a schema registry or documented Avro/Protobuf definitions checked into the same repository as your Dataflow pipeline code. Breaking schema changes should trigger CI validation before deploy, the same way application API changes require contract tests.
+
+### Multi-Region High Availability and Disaster Recovery
+
+Highly available GCP architectures assume regions fail and design so users and batch jobs keep working anyway. The [multi-regional deployment guide](https://cloud.google.com/architecture/multiregional-vms) shows active-active stacks in two regions with regional MIGs behind a global load balancer.
+
+The **global external HTTPS load balancer** advertises one Anycast IP worldwide. Clients hit the nearest Google edge PoP, and the control plane sends traffic to healthy backends in the nearest region. When a region drops out, new sessions fail over without waiting for DNS TTLs to expire. Regional backends behind the same front end are the pattern you pair with stateless compute.
+
+**Regional failover** means running equivalent capacity in at least two regions—for example `us-central1` and `europe-west1`—behind that global front end, with Managed Instance Groups or GKE multi-cluster ingress shifting compute. The application tier must stay stateless or externalize session state so the surviving region can absorb a traffic spike without corrupting user data.
+
+**Data** is harder than compute. **Cloud Spanner** provides globally distributed SQL with TrueTime-backed external consistency and replication features designed for regional resilience. **Cloud SQL** uses cross-region read replicas you promote during disaster recovery; high-availability configurations within a region use synchronous standby instances. **Cloud Storage** dual-region and multi-region buckets keep object data durable across geography without custom replication jobs.
+
+DR testing is non-negotiable: run game days that fail over DNS-weighted backends, promote read replicas in a secondary region, and measure recovery time against business RTO targets. An architecture diagram that never gets exercised is a hypothesis, not a plan.
+
+Backup strategy sits adjacent to DR but serves a different purpose. DR keeps the business running when a region disappears; backup recovers from logical errors—accidental table drops, ransomware encryption, or bad deploy scripts. Cloud Storage object versioning, Cloud SQL automated backups, and BigQuery snapshot schedules each protect against different failure modes. Your landing zone should document retention periods and encryption requirements so application teams inherit backup defaults instead of inventing ad hoc cron jobs on VMs.
+
+Observability hooks belong in every reference pattern as well. Global load balancers export latency and error-rate metrics to Cloud Monitoring. MIG autoscalers consume those signals. Dataflow pipelines emit worker utilization and system lag metrics that predict pipeline backpressure before Pub/Sub backlogs explode. The [Operations module](../module-2.10-operations/) covered the tooling; this capstone shows where to attach it so on-call engineers see user-impacting degradation before customers open tickets.
 
 ---
 
 ## Compute & Microservices Evaluation
 
-Choosing a compute tier is a trade among operational overhead, cost, and control: start with the simplest managed option that still meets your workload constraints, and climb to Kubernetes only when you need APIs or scheduling features the simpler platforms cannot offer.
+Choosing a compute tier is a trade among operational overhead, cost, and control. Start with the simplest managed option that still meets your workload constraints, and climb to Kubernetes only when you need APIs or scheduling features the simpler platforms cannot offer.
 
 ### App Engine
 
-**App Engine** is Google's original serverless PaaS for HTTP-centric web and mobile backends. The **Standard** environment scales quickly—including to zero—and runs in a sandbox with supported language runtimes only, which keeps spiky traffic inexpensive. The **Flexible** environment runs your container on ordinary Compute Engine VMs behind the App Engine API; it supports arbitrary runtimes but scales more slowly, cannot scale to zero, and has largely been superseded by Cloud Run for new designs.
+**App Engine** is Google's original serverless PaaS for HTTP-centric web and mobile backends. The **Standard** environment runs applications in a sandboxed environment with specific language runtimes and supports automatic or basic scaling depending on configuration. It suits spiky HTTP workloads when you stay within supported runtimes. The **Flexible** environment runs your container on Compute Engine VMs behind the App Engine API. It supports custom runtimes but carries VM-based operational tradeoffs compared with lighter-weight serverless platforms like Cloud Run.
+
+For new designs, most teams default to Cloud Run unless they already operate App Engine Standard apps that benefit from its unique scaling profiles.
 
 ### Cloud Run
 
-**Cloud Run** is the default choice for most new stateless microservices. Built on Knative, it runs any container that speaks HTTP, scales to zero, bills per request millisecond while work is active, and multiplexes concurrent requests per instance so you are not paying for idle pods.
+**Cloud Run** is Google's fully managed platform for stateless HTTP services. It accepts container images, can scale to zero, supports configurable request concurrency, and bills in 100-millisecond increments for billed instance time while instances are allocated. Cloud Run services also support multiple containers—an ingress container plus sidecars—though without the full Kubernetes Pod scheduling model.
+
+Reach for Cloud Run when your service speaks HTTP, fits within request timeout limits, and does not need DaemonSets, arbitrary GPU node pools, or complex multi-pod scheduling.
 
 ### Google Kubernetes Engine (GKE)
 
-Reach for **GKE** when you need StatefulSets, persistent volumes, DaemonSets, GPU node pools, multi-container pods, custom scheduling, or long-running jobs beyond Cloud Run's timeout—patterns that still belong in Kubernetes even if Autopilot hides the nodes from you.
+Reach for **GKE** when you need StatefulSets, persistent volumes, DaemonSets, GPU node pools, multi-container pods with init containers, custom scheduling, or long-running jobs beyond Cloud Run's timeout—patterns that still belong in Kubernetes even if Autopilot hides the nodes from you.
 
 | Need | Why GKE | Cloud Run Alternative |
 | :--- | :--- | :--- |
 | **Stateful workloads** | Persistent volumes, StatefulSets | Not supported (stateless only) |
-| **Complex networking** | Service mesh, network policies | Limited VPC integration |
+| **Complex networking** | Service mesh, network policies | Limited compared with full Kubernetes |
 | **Custom scheduling** | DaemonSets, node affinity, GPU scheduling | Not supported |
-| **Multi-container pods** | Sidecar pattern, init containers | Single container per instance |
-| **Long-running processes** | Beyond 1-hour timeout | 60-minute max timeout |
-| **Full Kubernetes API** | CRDs, operators, Helm charts | Knative only |
+| **Multi-container pods** | Sidecar pattern, init containers | Multiple containers supported, without full Pod model |
+| **Long-running processes** | Beyond request timeout limits | Configurable timeout with upper bounds |
+| **Full Kubernetes API** | CRDs, operators, Helm charts | Knative subset only |
 
 ### GKE Modes
 
@@ -310,7 +470,7 @@ GKE ships in two operating modes that share the same control plane but differ in
 
 | Mode | Control Plane | Nodes | Use Case |
 | :--- | :--- | :--- | :--- |
-| **Autopilot** | Google-managed | Google-managed (pod-level billing) | Most workloads (recommended default) |
+| **Autopilot** | Google-managed | Google-managed infrastructure with pricing that varies by workload and hardware | Most workloads (recommended) |
 | **Standard** | Google-managed | You manage node pools | Custom node configurations, GPUs |
 
 ```bash
@@ -357,7 +517,7 @@ kubectl create serviceaccount my-app-ksa
 gcloud iam service-accounts create my-app-gsa
 
 # Bind them together
-gcloud iam service-accounts add-iam-binding my-app-gsa@my-project.iam.gserviceaccount.com \
+gcloud iam service-accounts add-iam-policy-binding my-app-gsa@my-project.iam.gserviceaccount.com \
   --role=roles/iam.workloadIdentityUser \
   --member="serviceAccount:my-project.svc.id.goog[default/my-app-ksa]"
 
@@ -367,6 +527,10 @@ kubectl annotate serviceaccount my-app-ksa \
 
 # Pods using my-app-ksa now automatically authenticate as my-app-gsa
 ```
+
+Migration sequencing matters when you operate multiple compute tiers simultaneously. Teams often lift-and-shift VMs first, containerize into Cloud Run second, and extract only the services that truly need Kubernetes into GKE third. That staircase controls cost and operational load. Attempting to land every team on GKE on day one spreads thin cluster admin expertise and hides the reality that many internal CRUD APIs fit comfortably on Cloud Run with a VPC connector and Secret Manager credentials.
+
+Binary Authorization and deploy-time policy checks integrate with the CI/CD patterns from [Module 2.11](../module-2.11-cloud-build/) to ensure only signed images from [Artifact Registry](../module-2.6-artifact-registry/) reach production clusters or Cloud Run services. Treat deploy gates as part of compute selection: serverless platforms still run your container bytes, and compromised build pipelines bypass whichever orchestrator sits at the end of the chain.
 
 ---
 
@@ -471,46 +635,84 @@ Beyond "is this user allowed," IAP can evaluate **context-aware access** policie
 
 ---
 
-## High Availability & Disaster Recovery
+## Google Cloud Well-Architected Framework
 
-Highly available GCP architectures assume regions fail and design so users and batch jobs keep working anyway. The **global external HTTPS load balancer** advertises one Anycast IP worldwide; clients hit the nearest Google edge PoP, and the control plane sends traffic to healthy backends in the nearest region. When a region drops out, new sessions fail over without waiting for DNS TTLs to expire—regional backends behind the same front end are the pattern you pair with stateless compute.
+Google publishes the [Well-Architected Framework](https://cloud.google.com/architecture/framework) to help teams design cloud topologies that are secure, efficient, resilient, high-performing, cost-effective, and sustainable. The framework organizes recommendations into pillars. Each pillar maps cleanly to decisions you make in this capstone.
 
-**Regional failover** means running equivalent capacity in at least two regions (for example `us-central1` and `europe-west1`) behind that global front end, with Managed Instance Groups or GKE multi-cluster ingress shifting compute. The application tier must stay stateless or externalize session state so the surviving region can absorb a traffic spike without corrupting user data.
+| Pillar | What it asks you to optimize | GCP capabilities you already used |
+| :--- | :--- | :--- |
+| **Operational excellence** | Deploy, operate, monitor, and manage workloads efficiently | Centralized logging ([2.10](../module-2.10-operations/)), Cloud Build CI/CD ([2.11](../module-2.11-cloud-build/)), project factory automation |
+| **Security, privacy, and compliance** | Protect data and meet regulatory obligations | Organization policies, IAP, Workload Identity, SCC, Secret Manager |
+| **Reliability** | Design for failure at zone, region, and dependency level | Global load balancing, regional MIGs, Cloud SQL HA, multi-region storage |
+| **Cost optimization** | Maximize business value per dollar spent | Budget alerts, labels, committed use discounts, serverless scale-to-zero |
+| **Performance optimization** | Tune resources for latency and throughput | Global Anycast front ends, appropriate machine types, CDN for static assets |
+| **Sustainability** | Reduce environmental impact of cloud consumption | Right-sizing, autoscaling, eliminating idle resources, region selection |
 
-**Data** is harder than compute. **Cloud Spanner** replicates SQL synchronously across regions with TrueTime-backed serializability, so a full regional loss is a routing problem rather than a restore-from-tape exercise. **Cloud SQL** uses asynchronous cross-region read replicas you promote during DR. **Cloud Storage** dual-region and multi-region buckets keep object data durable across geography without custom replication jobs.
+Use the framework as a review checklist before production launch. Walk each pillar with your architecture diagram in hand. Operational excellence fails when nobody owns runbooks for failover. Security fails when organization policies exist on paper but sandbox folders bypass them. Reliability fails when DR diagrams never get tested. Cost optimization fails when budgets alert finance but not the engineering team that can act on them.
+
+Cross-pillar perspectives—such as AI/ML and financial services—layer industry-specific guidance on top of these pillars without replacing them.
+
+Reliability pillar reviews should explicitly list dependencies and their failure modes: what happens when Cloud DNS is unavailable, when Identity Platform is degraded, or when a third-party SaaS accessed through PSC fails open versus closed. The framework does not replace architecture diagrams—it gives you vocabulary to stress-test them. Document accepted risks when you choose single-region deployment for a dev tier so stakeholders do not assume production-grade RTO where none was funded.
+
+Security pillar reviews should trace human and machine identities end to end. Humans reach admin consoles through IAP or Google identity with MFA enforced by your IdP. Machines use service accounts, Workload Identity, or federated credentials—not exported keys sitting in CI variables. Every arrow on your diagram should answer "which identity proves this call is authorized."
 
 ---
 
-## Anthos: Multi-Cloud and Hybrid
+## Cost Lens: Cross-Cutting Levers
+
+Architecture choices compound billing effects. The table below summarizes cost knobs from prior modules and this capstone's reference patterns.
+
+| Cost driver | What makes it spike | Mitigation |
+| :--- | :--- | :--- |
+| **Compute (MIG / GKE Standard)** | Over-provisioned instance types, unused node pools, missing autoscaling bounds | Right-size from metrics, use committed use discounts, prefer Autopilot or Cloud Run when ops overhead exceeds savings |
+| **Cloud Run / Functions** | Min instances left on, high concurrency misconfiguration, egress to internet instead of Private Google Access | Scale to zero in non-prod, cap max instances, route Google API traffic privately |
+| **Networking** | Multiple NAT gateways, inter-region egress, unused external IPs | Consolidate Shared VPC, keep workloads in same region as data, deny external IPs via org policy |
+| **Cloud SQL / Spanner** | HA + cross-region replicas on dev tiers, storage autoscaling without caps | Match tier to environment, use read replicas only where RPO requires them |
+| **Storage** | Multi-region buckets for dev assets, high-frequency small object operations | Use regional or nearline classes appropriately, lifecycle policies to archive |
+| **Observability** | Unfiltered log sinks to BigQuery, high-cardinality custom metrics | Filter sinks at source, sample debug logs, aggregate metrics |
+| **Security tooling** | SCC Premium on every sandbox project | Scope premium tiers to production folders |
+
+FinOps maturity pairs technical controls with organizational ones. Require cost-center labels at project creation through the factory. Review top ten billing SKUs monthly. Treat unexpected spend as an architecture smell—often an orphaned MIG, forgotten Cloud Run min instance, or Dataflow job without a worker cap.
+
+Reserved capacity and committed use discounts reward predictable baselines but punish over-commitment. Apply commitments only after six to twelve weeks of stable utilization data from Cloud Monitoring and billing export to BigQuery. For bursty analytics, flex slots or on-demand BigQuery may cost less than always-on reservations even at moderate query volume.
+
+Egress economics deserve explicit architecture review because they are silent budget killers. Serving user traffic from the same region as your object storage and compute avoids cross-region bandwidth charges. Calling Google APIs through Private Google Access avoids routing API traffic over the public internet and may reduce NAT processing. Publishing static assets through Cloud CDN collapses repeated downloads into cache hits at the edge instead of repeated origin fetches from Cloud Storage.
+
+Sandbox environments need cost guardrails too, not just production. Auto-delete projects in the sandbox folder after thirty days, cap machine types through organization policy, and alert when any sandbox project exceeds a small weekly spend threshold. Experiments that linger become shadow production systems with none of the controls you built into the landing zone.
+
+---
+
+## Multi-Cloud and Hybrid Operations
 
 > **Stop and think**: What operational challenges arise when a company runs Kubernetes on GCP, AWS, and their own on-premises data center simultaneously? How would you enforce a consistent security policy across all three?
 
-**Anthos** extends the GKE control model to VMware, bare metal, AWS, and Azure so platform teams can enforce Config Sync, Policy Controller, service mesh, and fleet management from a GCP-hosted management plane instead of maintaining four separate operational playbooks.
+Google Cloud's multi-cloud and hybrid Kubernetes story now spans products such as **GKE Multi-Cloud**, **GKE attached clusters**, and **Google Distributed Cloud**. These offerings provide centralized fleet management for clusters running on Google Cloud, other public clouds, and on-premises environments. Config Sync, Policy Controller, and service mesh capabilities extend from a GCP-hosted management plane so platform teams are not maintaining four separate operational playbooks.
 
 ```mermaid
 flowchart TD
-    subgraph GCP["Anthos Management Plane (GCP)"]
+    subgraph GCP["Fleet Management (GCP)"]
         direction LR
-        CM["Config Mgmt"]
-        SM["Service Mesh"]
+        CM["Config Sync"]
         PC["Policy Controller"]
-        FM["Fleet Mgmt"]
+        FM["Fleet Management"]
     end
     
     GKE["GKE Cluster<br/>(GCP)"]
-    VMware["Anthos on VMware<br/>(on-prem)"]
-    AWS["Anthos on AWS<br/>(EKS)"]
+    Attached["Attached Clusters<br/>(AWS / Azure)"]
+    OnPrem["Google Distributed Cloud<br/>(on-premises)"]
     
     GCP --> GKE
-    GCP --> VMware
-    GCP --> AWS
+    GCP --> Attached
+    GCP --> OnPrem
 ```
+
+Anthos branding still appears in older documentation, but new designs should follow current product names in Google's fleet management docs.
 
 ---
 
 ## Security Command Center
 
-**Security Command Center (SCC)** aggregates asset inventory, vulnerability findings, and misconfiguration signals across your organization so security teams can query active critical issues and resource exposure from one API instead of polling every project by hand—complementing the preventive guardrails you set in organization policies and landing zones.
+**Security Command Center (SCC)** aggregates asset inventory, vulnerability findings, and misconfiguration signals across your organization so security teams can query active critical issues and resource exposure from one API instead of polling every project by hand. It complements the preventive guardrails you set in organization policies and landing zones.
 
 ```bash
 # List active findings (requires Security Command Center Premium)
@@ -525,20 +727,97 @@ gcloud scc assets list organizations/ORG_ID \
   --format="table(asset.name, asset.securityCenterProperties.resourceType)"
 ```
 
+Enable SCC where the cost of a missed misconfiguration exceeds the licensing fee—typically production organization folders, not every sandbox experiment.
+
 ---
 
 ## Multi-Cloud Perspectives: AWS and Azure Equivalents
 
-If you already know AWS or Azure, map GCP patterns to familiar control planes so design reviews stay portable. **Hierarchy and governance**: Organizations, Folders, and Projects mirror AWS Organizations/OUs and Azure management groups/subscriptions; a CFT-driven landing zone plays the same role as AWS Control Tower. **Networking**: a single global VPC simplifies cross-region routing compared with per-region AWS VPCs; AWS Transit Gateway parallels Network Connectivity Center for hub-spoke, and AWS PrivateLink parallels Private Service Connect. **Compute and edge**: Cloud Run lines up with AWS App Runner for opinionated container hosting (Fargate is usually an EKS/ECS nodeless mode, not a direct Cloud Run equivalent), and GCP's global HTTPS load balancer resembles Azure Front Door for Anycast front doors.
+If you already know AWS or Azure, map GCP patterns to familiar control planes so design reviews stay portable. **Hierarchy and governance**: Organizations, Folders, and Projects mirror AWS Organizations/OUs and Azure management groups/subscriptions. A CFT-driven landing zone plays a similar role as AWS Control Tower. **Networking**: a single global VPC simplifies cross-region routing compared with per-region AWS VPCs. AWS Transit Gateway plays a similar hub-and-spoke role to GCP Network Connectivity Center in many multi-VPC designs. AWS PrivateLink and GCP Private Service Connect serve similar private service-consumption use cases, though implementation details differ. **Compute and edge**: GCP Cloud Run and AWS App Runner are both managed ways to run containerized applications, while AWS Fargate is serverless compute used with ECS or EKS. GCP's global HTTP(S) load balancing and Azure Front Door both offer global edge-routing patterns for internet-facing applications.
+
+---
+
+## Patterns & Anti-Patterns
+
+Production-grade GCP estates converge on a small set of repeatable patterns. The anti-patterns below are equally predictable—they appear whenever teams optimize for short-term speed without platform investment.
+
+Governance patterns succeed when they are easier to comply with than to bypass. A self-service portal that invokes the project factory with approved parameter sets beats a policy that says "do not create projects manually" while the console remains one click away. Likewise, default Shared VPC attachment in the factory beats documentation urging teams to "remember to ask networking for a subnet."
+
+Operational patterns succeed when observability and ownership are co-located. The team that deploys Cloud Run owns its SLO dashboards. The platform team owns centralized log retention and organization policies. Blurring that line produces either alert fatigue for platform on-call or blind spots where nobody watches application golden signals.
+
+| Pattern | When to Use | Why It Works | Scaling Note |
+| :--- | :--- | :--- | :--- |
+| **Project factory + Shared VPC** | Every new team or product needs an isolated project | Baseline security and networking are automatic; audit scope stays bounded | Add factory modules rather than one-off console projects as request volume grows |
+| **Folder-tiered landing zone** | Regulated org with prod / non-prod / sandbox separation | Organization policies inherit; blast radius stays folder-scoped | Split additional landing zones only when compliance requires hard isolation |
+| **Global LB + regional MIGs** | Internet-facing apps needing zone and region resilience | Anycast front end fails over without DNS churn; MIGs heal zone loss | Keep app tier stateless; externalize sessions to Memorystore or database |
+| **Cloud Run + Pub/Sub pipeline** | Event-driven workloads with variable traffic | Scale-to-zero saves idle cost; Pub/Sub buffers spikes | Cap max instances and monitor oldest-unacked-message age |
+| **Centralized audit log sink** | Any org subject to compliance audits | Tamper-evident trail in shared-logging project | Partition sinks by severity and retention tier to control storage cost |
+
+| Anti-Pattern | What Goes Wrong | Why Teams Fall Into It | Better Alternative |
+| :--- | :--- | :--- | :--- |
+| **Manual project creation** | Inconsistent IAM, default VPCs, missing budgets | Console clicks feel faster for "just one project" | Project factory from day one |
+| **Standalone VPC per team** | NAT/DNS/firewall sprawl, peering meshes | Teams want autonomy without platform standards | Shared VPC with service projects |
+| **VPN as primary access** | Broad network trust, lateral movement risk | VPNs are familiar | IAP for apps and SSH |
+| **GKE for every microservice** | Cluster ops cost exceeds app value | Kubernetes hype | Cloud Run first; GKE when API gaps appear |
+| **Public buckets "temporarily"** | Data exposure incidents | Quick sharing without IAM design | Uniform access + public access prevention org policies |
+| **Skipping DR exercises** | Failover runbooks fail under real pressure | DR feels expensive until outage | Quarterly game days with measured RTO |
+
+Review these anti-patterns during architecture walkthroughs, not only after incidents. Ask whether a new shortcut introduces manual project creation, bypasses Shared VPC, or stores credentials in source control. The table reads like a checklist because most production outages in cloud foundations trace back to one of those six habits rather than exotic zero-day exploits.
+
+When you adopt a pattern from the first table, write down the scaling trigger that would force you to revisit the decision. A Cloud Run service that consistently hits max instances during business hours may need a min instance for latency—or a move to GKE if you require sidecars the platform cannot express. Patterns are starting points with explicit exit criteria, not permanent tattoos. Revisit those triggers during quarterly architecture reviews so growth does not outpace your original assumptions silently without anyone noticing the drift.
+
+---
+
+## Decision Framework
+
+Use the flowchart below when choosing region, compute tier, and managed-versus-self-managed components. It complements the pattern tables above with explicit tradeoffs.
+
+```mermaid
+flowchart TD
+    Start[New workload design] --> Region{Data residency<br/>or latency constraint?}
+    Region -- Yes --> PickRegion[Choose allowed region(s)<br/>via org policy + user proximity]
+    Region -- No --> DefaultRegion[Default to single region<br/>with multi-region DR if RTO requires]
+    PickRegion --> Compute{Needs full Kubernetes API,<br/>GPU nodes, or StatefulSets?}
+    DefaultRegion --> Compute
+    Compute -- Yes --> GKE[GKE Autopilot or Standard]
+    Compute -- No --> HTTP{HTTP stateless service?}
+    HTTP -- Yes --> CloudRun[Cloud Run]
+    HTTP -- No --> Batch{Event-driven / short jobs?}
+    Batch -- Yes --> Functions[Cloud Functions or Cloud Run jobs]
+    Batch -- No --> MIG[Compute Engine MIG]
+    GKE --> Data{Database consistency needs?}
+    CloudRun --> Data
+    MIG --> Data
+    Functions --> Data
+    Data -- Strong global SQL --> Spanner[Cloud Spanner]
+    Data -- Relational HA --> CloudSQL[Cloud SQL HA]
+    Data -- Document / mobile --> Firestore[Firestore]
+    Data -- Analytics --> BigQuery[BigQuery + pipeline]
+```
+
+| Decision | Prefer | Tradeoff |
+| :--- | :--- | :--- |
+| **Region selection** | Single primary region aligned with users and data residency org policies | Multi-region adds replication cost; justify with explicit RTO/RPO |
+| **Managed vs self-managed database** | Cloud SQL, Spanner, Firestore for new apps | Self-managed on VMs only when license or feature gap requires it |
+| **Serverless vs VMs** | Cloud Run for HTTP; Functions for triggers | VMs when you need kernel-level control or legacy licensing |
+| **Shared VPC vs per-project VPC** | Shared VPC at enterprise scale | Per-project VPC only for hard isolation or acquisition integration |
+| **IAP vs VPN** | IAP for human access to specific apps/VMs | VPN or Interconnect for bulk hybrid network extension, not app-level auth |
+
+Document the decision record when you choose an option from this framework. Future engineers will otherwise re-open settled debates during every sprint planning session. A one-page architecture decision record capturing alternatives considered, tradeoffs accepted, and review date often saves more time than another whiteboard session.
+
+Regulated workloads may constrain the flowchart early— for example, data residency org policies eliminate multi-region active-active paths regardless of latency goals. Treat org policies as immovable inputs to the decision tree, not as afterthoughts applied during audit season.
 
 ---
 
 ## Did You Know?
 
-1. **Google's own internal infrastructure uses a project factory pattern** that has created over 4 million projects internally. The external Cloud Foundation Toolkit is inspired by the same principles Google uses to manage its own cloud environment at scale.
-2. **Identity-Aware Proxy handles over 500 million authentication decisions per day** across all GCP customers. It uses the same BeyondCorp infrastructure that Google built to eliminate VPNs for its own 150,000+ employees. Google employees access all internal tools through IAP without any VPN.
-3. **GKE Autopilot bills per pod, not per node**. This means you typically do not pay for unused node capacity. A pod requesting 0.5 vCPU and 1 GB RAM is billed for exactly that, even if the underlying node has 32 vCPUs. This can save 30-50% compared to Standard mode for workloads with variable resource requirements.
-4. **The GCP Cloud Foundation Toolkit Terraform modules have been downloaded over 20 million times** and are used by thousands of enterprises to set up their landing zones. Google Cloud Professional Services uses these same modules when helping customers design their GCP environments.
+1. **Large organizations often use automated project-provisioning patterns internally**, and Google publishes foundation tooling through the Cloud Foundation Toolkit that reflects similar governance principles for customers.
+
+2. **Identity-Aware Proxy and BeyondCorp reflect Google's long-running zero-trust approach**. Google publicly describes BeyondCorp as a replacement for traditional VPN-based access to internal resources.
+
+3. **For many general-purpose workloads, GKE Autopilot shifts operational responsibility toward Google and bills based on workload resource requests rather than requiring you to size node pools directly.**
+
+4. **The Cloud Foundation Toolkit and terraform-example-foundation repository are widely used starting points for building Google Cloud landing zones**, alongside Google's landing zone design documentation in the Architecture Center.
 
 ---
 
@@ -574,7 +853,7 @@ Replacing the VPN with IAP shifts the security model from network-centric trust 
 <details>
 <summary>3. A data science team needs to run a machine learning workload that requires specific NVIDIA GPUs and custom node taints to ensure only specific pods are scheduled on those expensive nodes. Meanwhile, the web backend team needs to deploy a standard stateless microservice that scales based on HTTP traffic. Which GKE operating mode should each team choose and why?</summary>
 
-The data science team should use GKE Standard, while the web backend team should use GKE Autopilot. GKE Standard is necessary for the data science team because they require custom node configurations, specific GPU accelerators, and node-level controls like taints and tolerations, which are fully managed by the user in Standard mode. In contrast, the web backend team should choose Autopilot because it completely removes the operational overhead of managing nodes and handles node auto-scaling automatically behind the scenes. Furthermore, Autopilot bills precisely per pod rather than per node, ensuring you only pay for exactly what the microservice consumes. This makes Autopilot the ideal choice for standard, scalable workloads where Google can manage the underlying infrastructure efficiency and reduce operational burden.
+The data science team should use GKE Standard, while the web backend team should use GKE Autopilot. GKE Standard is necessary for the data science team because they require custom node configurations, specific GPU accelerators, and node-level controls like taints and tolerations, which are fully managed by the user in Standard mode. In contrast, the web backend team should choose Autopilot because it completely removes the operational overhead of managing nodes and handles node auto-scaling automatically behind the scenes. Autopilot bills based on workload resource requests for many general-purpose pods, which makes it the ideal choice for standard, scalable workloads where Google can manage the underlying infrastructure efficiency and reduce operational burden.
 </details>
 
 <details>
@@ -595,13 +874,25 @@ The developer should use Workload Identity instead of a static service account k
 The platform team should have implemented an Organization Policy constraint specifically enforcing `constraints/storage.publicAccessPrevention` at the Organization or top-level Folder level. Organization Policies act as immutable, centrally managed guardrails that completely override any individual project or resource-level IAM permissions that a developer might attempt to set. If this specific policy had been in place within their landing zone, any developer attempting to grant public access to a bucket (or create a new publicly readable bucket) would be actively blocked by the GCP API at the moment of creation. Relying purely on documentation, training, or developer compliance is inevitably prone to human error at scale. In contrast, Organization Policies provide programmatic, foolproof enforcement of non-negotiable security baselines across the entire organizational resource hierarchy.
 </details>
 
+<details>
+<summary>7. Your ecommerce platform runs in us-central1 and europe-west1 behind a global external HTTPS load balancer with regional MIG backends. During a regional outage in us-central1, users report intermittent errors even though europe-west1 remains healthy. Autoscaling in the surviving region is slow to add capacity. Which architectural gaps most likely explain the incident, and what should you change?</summary>
+
+The architecture probably treats session state locally on web VMs or sizes the surviving region for normal traffic rather than failover traffic. Global load balancers route new connections to healthy backends, but existing sessions tied to failed instances still break unless the app is stateless or sessions are externalized to Memorystore or the database tier. Slow autoscaling in europe-west1 suggests max instance caps, conservative cooldown settings, or insufficient headroom for absorbing us-central1 traffic. Fix this by externalizing session state, pre-provisioning enough capacity in each active region to handle combined traffic during failover, tuning MIG autoscaling policies, and running regular DR game days that measure failover time against your RTO target.
+</details>
+
+<details>
+<summary>8. A platform team must choose between deploying a new internal API on Cloud Run versus GKE Autopilot. The API is stateless HTTP, integrates with Cloud SQL through a VPC connector, peaks at 500 requests per minute, and must scale to zero in development. No custom Kubernetes operators are required. Which option should they choose and why?</summary>
+
+They should choose Cloud Run. The workload is stateless HTTP with moderate traffic, needs scale-to-zero in non-production environments, and does not require Kubernetes-specific APIs like CRDs or DaemonSets. Cloud Run bills only for allocated instance time in 100-millisecond increments and removes node-pool operations entirely. GKE Autopilot would add cluster management overhead without providing features this API needs. Reserve GKE for workloads that require full Kubernetes scheduling, GPU node pools, or service mesh patterns Cloud Run cannot satisfy.
+</details>
+
 ---
 
 ## Hands-On Exercise: Landing Zone Foundations
 
 ### Objective
 
-Implement a simplified landing zone pattern with a shared services project, a workload project, centralized logging, and IAP-based SSH access.
+Implement a simplified landing zone pattern with a shared services project, a workload project, centralized logging, and IAP-based SSH access. Map each task to the Well-Architected pillars of security, operational excellence, and reliability.
 
 ### Prerequisites
 
@@ -673,11 +964,11 @@ gcloud iam service-accounts create workload-vm-sa \
 export VM_SA="workload-vm-sa@${PROJECT_ID}.iam.gserviceaccount.com"
 
 # Grant minimal permissions
-gcloud projects add-iam-binding $PROJECT_ID \
+gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:$VM_SA" \
   --role="roles/logging.logWriter"
 
-gcloud projects add-iam-binding $PROJECT_ID \
+gcloud projects add-iam-policy-binding $PROJECT_ID \
   --member="serviceAccount:$VM_SA" \
   --role="roles/monitoring.metricWriter"
 
@@ -840,11 +1131,12 @@ echo "Cleanup complete."
 - [ ] Dedicated service account with minimal permissions
 - [ ] Centralized log sink configured for audit logs
 - [ ] Firewall rules follow deny-all-ingress baseline
+- [ ] Architecture mapped to at least three Well-Architected pillars (security, operational excellence, reliability)
 - [ ] All resources cleaned up
 
 ---
 
-## Next Steps
+## Next Module
 
 Congratulations on completing the **GCP DevOps Essentials** track—you now have hands-on coverage of the core services every platform engineer touches. Continue with the **[Hyperscaler Rosetta Stone](/cloud/hyperscaler-rosetta-stone/)** to map GCP primitives to AWS and Azure, the **[Kubernetes certification tracks](/k8s/)** (CKA, CKAD, CKS, KCNA, KCSA), or the **[Platform Engineering track](/platform/)** for SRE, GitOps, DevSecOps, and MLOps depth.
 
@@ -852,6 +1144,19 @@ The patterns in this module are starting points, not copy-paste templates: every
 
 ## Sources
 
-- [terraform-example-foundation](https://github.com/terraform-google-modules/terraform-example-foundation) — Google's reference example for composing Cloud Foundation Toolkit modules into a governed cloud foundation.
-- [Shared VPC Overview](https://cloud.google.com/vpc/docs/shared-vpc) — Explains the host-project and service-project model that underpins the module's networking guidance.
-- [Identity-Aware Proxy Documentation](https://cloud.google.com/iap/docs) — Primary reference for IAP-secured web apps, TCP forwarding, and context-aware zero-trust access patterns.
+- [Landing zone design in Google Cloud](https://cloud.google.com/architecture/landing-zones) — Google's overview of landing zone elements, resource hierarchy, and deployment options.
+- [Google Cloud Well-Architected Framework](https://cloud.google.com/architecture/framework) — Pillars and perspectives for secure, reliable, cost-effective cloud design.
+- [terraform-example-foundation](https://github.com/terraform-google-modules/terraform-example-foundation) — Reference example for composing Cloud Foundation Toolkit modules into a governed foundation.
+- [Shared VPC Overview](https://cloud.google.com/vpc/docs/shared-vpc) — Host-project and service-project model for centralized network administration.
+- [VPC Network Peering](https://cloud.google.com/vpc/docs/vpc-peering) — Non-transitive peering behavior that motivates hub-spoke designs.
+- [Network Connectivity Center hub-and-spoke](https://cloud.google.com/network-connectivity/docs/network-connectivity-center/concepts/hub-and-spoke) — Central orchestration of connectivity among VPC and hybrid spokes.
+- [Private Service Connect](https://cloud.google.com/private-service-connect) — Private endpoints for consuming Google, partner, and producer services.
+- [External Application Load Balancer use cases](https://cloud.google.com/load-balancing/docs/https/use-cases) — Three-tier web service pattern with external and internal load balancers.
+- [Multi-regional deployment on Compute Engine](https://cloud.google.com/architecture/multiregional-vms) — Active-active multi-region architecture with global load balancing.
+- [Design reliable infrastructure](https://cloud.google.com/architecture/infra-reliability-guide/design) — Eliminating single points of failure across tiers.
+- [Cloud Run documentation](https://cloud.google.com/run/docs/overview) — Serverless container platform overview and scaling model.
+- [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) — Mapping Kubernetes service accounts to GCP identities without key files.
+- [Organization Policy overview](https://cloud.google.com/resource-manager/docs/organization-policy/overview) — Centralized constraints inherited through the resource hierarchy.
+- [Identity-Aware Proxy](https://cloud.google.com/iap/docs) — Zero-trust access to applications and VMs without VPN client software.
+- [Security Command Center overview](https://cloud.google.com/security-command-center/docs/security-command-center-overview) — Asset inventory and security findings across the organization.
+- [Dataflow overview](https://cloud.google.com/dataflow/docs/overview) — Managed stream and batch processing for analytics pipelines.

--- a/src/content/docs/cloud/gcp-essentials/module-2.12-patterns.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.12-patterns.md
@@ -122,23 +122,20 @@ module "project" {
   budget_amount = var.budget_amount
 }
 
-# Delete the default VPC
-resource "google_compute_network" "delete_default" {
-  name    = "default"
-  project = module.project.project_id
+# Default VPC: the project-factory module suppresses auto-created default networks
+# (auto_create_network=false). Do not declare a google_compute_network named "default"
+# here—that would create/manage a network instead of deleting the platform default.
 
-  lifecycle {
-    prevent_destroy = false
-  }
-}
-
-# Configure log sinks
+# Configure log sinks (unique_writer_identity grants a dedicated writer SA per sink)
 resource "google_logging_project_sink" "audit_to_central" {
-  name        = "audit-to-central-logging"
-  project     = module.project.project_id
-  destination = "logging.googleapis.com/projects/${var.central_logging_project}/locations/global/buckets/audit-logs"
-  filter      = "logName:\"cloudaudit.googleapis.com\""
+  name                   = "audit-to-central-logging"
+  project                = module.project.project_id
+  destination            = "logging.googleapis.com/projects/${var.central_logging_project}/locations/global/buckets/audit-logs"
+  filter                 = "logName:\"cloudaudit.googleapis.com\""
+  unique_writer_identity = true
 }
+# Grant roles/logging.bucketWriter (or equivalent) on the destination bucket to the
+# sink's writer_identity output—same IAM step as the gcloud lab in Task 4.
 
 # IAM baseline
 resource "google_project_iam_binding" "team_editors" {
@@ -181,7 +178,7 @@ A landing zone is the foundational GCP environment your entire organization is b
 
 The hierarchy flows Organization → Folders → Projects → Resources. IAM bindings and organization policies inherit downward unless explicitly overridden. That inheritance is the governance superpower: set `constraints/iam.disableServiceAccountKeyCreation` at the organization root and every descendant project inherits it. Place production workloads under a `Production` folder with stricter region constraints than your `Sandbox` folder. Shared services—networking, logging, security tooling—live in dedicated projects under a `Shared Services` folder where platform engineers retain control.
 
-Folder design should mirror how your business thinks about risk, not how your org chart happens to look today. A common pattern separates `Shared Services`, `Production`, `Non-Production`, and `Sandbox`. Sandbox folders often carry auto-expiry policies or tighter service constraints so experiments cannot accidentally become production dependencies.
+Folder design should mirror how your business thinks about risk, not how your org chart happens to look today. A common pattern separates `Shared Services`, `Production`, `Non-Production`, and `Sandbox`. Sandbox folders often pair **automated cleanup via tooling** (scheduled project deletion, budget caps) with tighter organization-policy constraints so experiments cannot accidentally become production dependencies—GCP has no native folder or project auto-expiry.
 
 ### The Three-Layer Architecture
 
@@ -204,7 +201,7 @@ flowchart TD
     NP2["payments-stg"]
     NP3["orders-dev"]
     
-    FolderSandbox["Folder: Sandbox (Auto-deleted after 30d)"]
+    FolderSandbox["Folder: Sandbox (auto-cleanup via tooling)"]
     SB1["sandbox-alice"]
     SB2["sandbox-bob"]
 
@@ -236,55 +233,64 @@ Centralized logging deserves explicit mention because audit failures often start
 Organization Policies are absolute, programmatic guardrails that cannot be overridden by individual developers, regardless of their local IAM roles. They enforce your security baseline across the entire organization or at specific folder levels.
 
 ```bash
+# Organization policies use the v2 policy file schema (name + spec.rules) with set-policy
+
 # Restrict which regions can be used (data residency)
 cat > /tmp/region-policy.yaml << 'EOF'
-constraint: constraints/gcp.resourceLocations
-listPolicy:
-  allowedValues:
-    - in:us-locations
-    - in:eu-locations
-  deniedValues:
-    - in:asia-locations
+name: organizations/ORG_ID/policies/gcp.resourceLocations
+spec:
+  rules:
+  - values:
+      allowedValues:
+      - in:us-locations
+      - in:eu-locations
+      deniedValues:
+      - in:asia-locations
 EOF
-gcloud org-policies set-policy /tmp/region-policy.yaml --organization=ORG_ID
+gcloud org-policies set-policy /tmp/region-policy.yaml
 
 # Disable service account key creation org-wide
 cat > /tmp/no-sa-keys.yaml << 'EOF'
-constraint: constraints/iam.disableServiceAccountKeyCreation
-booleanPolicy:
-  enforced: true
+name: organizations/ORG_ID/policies/iam.disableServiceAccountKeyCreation
+spec:
+  rules:
+  - enforce: true
 EOF
-gcloud org-policies set-policy /tmp/no-sa-keys.yaml --organization=ORG_ID
+gcloud org-policies set-policy /tmp/no-sa-keys.yaml
 
-# Restrict external IP addresses on VMs
+# Restrict external IP addresses on VMs (production folder)
 cat > /tmp/no-ext-ip.yaml << 'EOF'
-constraint: constraints/compute.vmExternalIpAccess
-listPolicy:
-  allValues: DENY
+name: folders/PROD_FOLDER_ID/policies/compute.vmExternalIpAccess
+spec:
+  rules:
+  - denyAll: true
 EOF
-gcloud org-policies set-policy /tmp/no-ext-ip.yaml --folder=PROD_FOLDER_ID
+gcloud org-policies set-policy /tmp/no-ext-ip.yaml
 
 # Enforce uniform bucket-level access
 cat > /tmp/uniform-access.yaml << 'EOF'
-constraint: constraints/storage.uniformBucketLevelAccess
-booleanPolicy:
-  enforced: true
+name: organizations/ORG_ID/policies/storage.uniformBucketLevelAccess
+spec:
+  rules:
+  - enforce: true
 EOF
-gcloud org-policies set-policy /tmp/uniform-access.yaml --organization=ORG_ID
+gcloud org-policies set-policy /tmp/uniform-access.yaml
 
-# Restrict which services can be used
+# Restrict which services can be used (sandbox folder)
 cat > /tmp/allowed-services.yaml << 'EOF'
-constraint: constraints/serviceuser.services
-listPolicy:
-  allowedValues:
-    - compute.googleapis.com
-    - container.googleapis.com
-    - run.googleapis.com
-    - storage.googleapis.com
-    - cloudbuild.googleapis.com
-    - secretmanager.googleapis.com
+name: folders/SANDBOX_FOLDER_ID/policies/serviceuser.services
+spec:
+  rules:
+  - values:
+      allowedValues:
+      - compute.googleapis.com
+      - container.googleapis.com
+      - run.googleapis.com
+      - storage.googleapis.com
+      - cloudbuild.googleapis.com
+      - secretmanager.googleapis.com
 EOF
-gcloud org-policies set-policy /tmp/allowed-services.yaml --folder=SANDBOX_FOLDER_ID
+gcloud org-policies set-policy /tmp/allowed-services.yaml
 ```
 
 Combine `constraints/storage.publicAccessPrevention` with uniform bucket-level access for defense in depth. Public bucket incidents are among the most common audit findings, and organization policies block them at the API layer regardless of developer intent.
@@ -678,7 +684,7 @@ Reserved capacity and committed use discounts reward predictable baselines but p
 
 Egress economics deserve explicit architecture review because they are silent budget killers. Serving user traffic from the same region as your object storage and compute avoids cross-region bandwidth charges. Calling Google APIs through Private Google Access avoids routing API traffic over the public internet and may reduce NAT processing. Publishing static assets through Cloud CDN collapses repeated downloads into cache hits at the edge instead of repeated origin fetches from Cloud Storage.
 
-Sandbox environments need cost guardrails too, not just production. Auto-delete projects in the sandbox folder after thirty days, cap machine types through organization policy, and alert when any sandbox project exceeds a small weekly spend threshold. Experiments that linger become shadow production systems with none of the controls you built into the landing zone.
+Sandbox environments need cost guardrails too, not just production. Use **tooling** (scheduled project deletion scripts, budget alerts, factory TTL labels) to retire sandbox projects—GCP does not auto-delete folders or projects after a fixed calendar period—cap machine types through organization policy, and alert when any sandbox project exceeds a small weekly spend threshold. Experiments that linger become shadow production systems with none of the controls you built into the landing zone.
 
 ---
 


### PR DESCRIPTION
## Cloud track — GCP Essentials Wave 6d (completes the sub-track)

Final GCP Essentials wave. **With this, GCP Essentials 2.1–2.12 is fully reviewed/done (12/12).**

| Module | Action | Author | Reviewer | Tier (after fixes) |
|---|---|---|---|---|
| 2.10 Cloud Operations | expand 2.1k→5.1k | cursor | opus 4.8 | T0 (5076w, 14 src) |
| 2.11 Cloud Build | expand 3.2k→6.5k | deepseek | opus 4.8 | T0 (6499w, 12 src) |
| 2.12 Architecture Patterns (capstone) | expand 1.9k→5.0k + structure rebuild | cursor | opus 4.8 | T0 (5030w, 16 src) |

### Review fixes (ground-checked / web-verified by opus)
- **2.10 Ops**: uptime-check lab/illustrative commands used non-existent flags (`--http-check-path/-port/-request-method`, `--period` in wrong units, `--monitored-resource`→`--resource-labels`) → corrected to the documented form; fabricated opener → hypothetical; DYK checker-region list (invented "Asia Pacific-1/-2", missing USA-Iowa) corrected; unsourced/inconsistent DYK stats softened; "uptime can't reach RFC 1918" → qualified to public checks (VPC checkers exist).
- **2.11 Cloud Build**: `add-iam-binding`×2 → `add-iam-policy-binding`; **default build timeout 10 min → 60 min** (rewrote the anti-pattern built on the wrong premise); `gcloud` run inside `curlimages/curl` → cloud-sdk builder; **fabricated `$_PUBSUB_PAYLOAD`** → real `body.message.*` payload bindings; **fabricated webhook HMAC `X-CloudBuild-Signature`** → real query-param secret; GitLab 2nd-gen connection multi-secret flags; built-in `SHORT_SHA` override → custom substitution; default builder SA 2024 change (Compute Engine default SA); GitLab CI "400 min (all tiers)" → Free tier only.
- **2.12 Patterns**: org-policies v1-schema/v2-command mismatch (all 5 failing) → consistent v2; "delete default VPC" Terraform that actually *created* a network → corrected; logging sink given `unique_writer_identity` + IAM-grant note; folder "auto-deleted 30d" label → "auto-cleanup via tooling".

All three pass `verify_module.py` (T0); incident-dedup gate PASS; no gutter/fused-fence defects.

## Learner check

> Cloud Logging automatically captures logs from managed services like Cloud Run, GKE, and Cloud Functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
