### PR TITLE
chore(content): GKE Deep Dive wave 1 — expand 6.1/6.2/6.3 to floor + review fixes

### DIFF
--- a/src/content/docs/cloud/gke-deep-dive/module-6.1-gke-architecture.md
+++ b/src/content/docs/cloud/gke-deep-dive/module-6.1-gke-architecture.md
@@ -4,11 +4,11 @@ slug: cloud/gke-deep-dive/module-6.1-gke-architecture
 sidebar:
   order: 2
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: GCP Essentials, Cloud Architecture Patterns
+**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: GCP Essentials, Cloud Architecture Patterns — expect to run real `gcloud` commands against a billing-enabled project and delete clusters when finished.
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+After completing this module, you will be able to design and operate GKE clusters with explicit tradeoffs rather than default settings:
 
 - **Configure GKE Standard and Autopilot clusters with release channels, regional topology, and node auto-provisioning**
 - **Evaluate GKE Standard vs Autopilot mode for workload requirements including GPU, DaemonSet, and cost constraints**
@@ -19,21 +19,21 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-A team can still suffer upgrade-related outages on a managed Kubernetes service if they choose an aggressive release cadence and don't test their manifests against the next Kubernetes version before production rollouts.
+Hypothetical scenario: a platform team provisions a regional GKE cluster for a new product launch, selects the Rapid release channel to "stay current," and skips maintenance windows because upgrades are supposed to be automatic anyway. Two weeks later, a minor Kubernetes version bump lands during business hours, a deprecated API their Helm chart still references starts failing admission, and on-call engineers discover they cannot roll back the control plane — only reschedule node upgrades and fix manifests forward. The outage was not caused by GKE being "unmanaged"; it was caused by architectural choices the team did not understand.
 
-This story captures the central tension of GKE: Google manages massive amounts of infrastructure for you, but you still need to understand what decisions GKE is making on your behalf. The choice between Standard and Autopilot mode, the selection of a release channel, the configuration of regional versus zonal clusters, and the behavior of auto-upgrades and auto-repair all have direct consequences for your application's availability, cost, and security posture.
+A team can still suffer upgrade-related outages on a managed Kubernetes service if they choose an aggressive release cadence and don't test their manifests against the next Kubernetes version before production rollouts. GKE removes toil around etcd backups, control-plane patching, and node OS hardening, but it does not remove the need for deliberate decisions about topology, billing model, IP planning, and upgrade policy. Those decisions compound: a zonal dev cluster misconfigured for production teaches the wrong mental model, and a Standard cluster sized for peak traffic without Spot or bin-packing discipline can quietly cost more than Autopilot would for the same workload shape.
 
-In this module, you will learn the GKE architecture from the ground up: how the control plane and node pools work, the fundamental differences between Standard and Autopilot modes, how release channels govern your upgrade lifecycle, and how to make informed decisions about cluster topology. By the end, you will deploy the same application to both Standard and Autopilot clusters and compare the operational experience.
+This story captures the central tension of GKE: Google manages massive amounts of infrastructure for you, but you still need to understand what decisions GKE is making on your behalf. The choice between Standard and Autopilot mode, the selection of a release channel, the configuration of regional versus zonal clusters, and the behavior of auto-upgrades and auto-repair all have direct consequences for your application's availability, cost, and security posture. When you internalize those mechanics, you stop treating "managed Kubernetes" as a black box and start designing clusters that match how your organization actually ships software.
+
+In this module, you will learn the GKE architecture from the ground up: how the control plane and node pools work, the fundamental differences between Standard and Autopilot modes, how release channels govern your upgrade lifecycle, and how to make informed decisions about cluster topology. By the end, you will deploy the same application to both Standard and Autopilot clusters and compare the operational experience, including the billing and scheduling differences that only become visible once workloads are running.
 
 ---
 
 ## GKE Architecture Fundamentals
 
-Before choosing between Standard and Autopilot, you need to understand what GKE actually provisions when you create a cluster.
+Before choosing between Standard and Autopilot, you need to understand what GKE actually provisions when you create a cluster. A GKE cluster is not a single VM — it is a contract between Google-managed control-plane components and customer-visible worker capacity (Standard) or Pod-scheduled compute (Autopilot). The Kubernetes version you select at create time (today's curriculum target is **1.35**) flows through release channels and upgrade policies for the life of the cluster, so architectural choices you make on day one constrain what you can change without rebuilding.
 
-### Control Plane and Node Architecture
-
-Every GKE cluster consists of two layers: the **control plane** (managed entirely by Google) and the **nodes** (where your workloads run).
+Every GKE cluster consists of two layers: the **control plane** (managed entirely by Google) and the **nodes** (where your workloads run). In Standard mode you see and bill for nodes directly; in Autopilot mode Google creates and destroys nodes in response to Pod schedules while you interact only with Kubernetes objects. Both modes expose the same Kubernetes API, which is why application manifests largely port between them — but operational tooling, cost models, and security boundaries diverge sharply beneath that API surface.
 
 ```mermaid
 graph TD
@@ -60,16 +60,30 @@ graph TD
     CP -- "Managed VPN / Private Endpoint" --> Customer
 ```
 
-Key facts about the GKE control plane:
+### Control Plane and Node Architecture
 
-- **Cluster fee and free tier**: GKE charges a cluster management fee, and the free tier provides monthly credits equivalent to one free Autopilot or zonal Standard cluster per billing account; regional cluster fees aren't covered by that credit.
-- **SLA-backed**: [Regional clusters provide a 99.95% SLA for the control plane. Zonal clusters offer 99.5%.](https://cloud.google.com/kubernetes-engine/pricing)
-- **Invisible**: You cannot SSH into the control plane. You interact with it exclusively through the Kubernetes API.
-- **Auto-scaled**: Google automatically scales control plane resources based on the number of nodes, pods, and API request volume.
+The control plane and node layers communicate exclusively through Kubernetes APIs — kubelet registration, Pod scheduling, Service endpoints, and Node status heartbeats. [Shielded GKE Nodes](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture) verify node identity during registration by default, reducing the risk of rogue VMs joining your cluster. Worker nodes run kubelet, containerd, and GKE-managed DaemonSets for logging and networking; what differs by mode is whether **you** pick the machine type and image or **Google** picks them from your Pod requests.
+
+The following control-plane facts apply to every cluster you operate, regardless of mode, and show up on every FinOps review whether or not your workloads are Autopilot:
+
+- **Cluster fee and free tier**: GKE charges a flat [cluster management fee of $0.10 per cluster per hour](https://cloud.google.com/kubernetes-engine/pricing) (billed per second), regardless of Standard versus Autopilot, zonal versus regional, or fleet size. The [GKE free tier](https://cloud.google.com/kubernetes-engine/pricing) provides $74.40 in monthly credits per billing account — enough to offset one zonal Standard cluster or one Autopilot cluster for a full month. Regional Standard cluster management fees are **not** covered by that credit, which surprises teams that promote a zonal dev cluster to regional production without revisiting the fee line item.
+- **SLA-backed**: [Regional clusters provide a 99.95% SLA for the control plane. Zonal clusters offer 99.5%.](https://cloud.google.com/kubernetes-engine/pricing) Autopilot multi-zone Pods carry a separate 99.9% availability SLA. These numbers describe control-plane/API availability, not your application's uptime — you still need PodDisruptionBudgets, multi-zone node pools, and health checks for workload resilience.
+- **Invisible**: You cannot SSH into the control plane. You interact with it exclusively through the Kubernetes API via `kubectl`, client libraries, or the Google Cloud console.
+- **Auto-scaled**: Google automatically scales control plane resources based on the number of nodes, pods, and API request volume in your cluster. Large fleets with heavy API churn (many controllers, frequent object churn) consume more control-plane headroom than small dev clusters, still without any line item you tune manually.
+
+Together, the management fee and SLAs describe Google's side of the bargain: highly available etcd/API for regional production, or cheaper zonal control planes acceptable only when brief API gaps during upgrades are tolerable for the workloads involved.
+
+### Control plane internals: etcd, state storage, and upgrade behavior
+
+The GKE control plane runs the Kubernetes API server, scheduler, and controller manager on Google-managed VMs you never see. [Cluster state](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-architecture) — every Deployment, Secret, ConfigMap, and Node object — is persisted in a highly available key-value store. GKE serves the etcd API to the Kubernetes API server. Depending on cluster configuration, the backing store may be etcd replicas on control-plane VMs or Spanner. Your operational interface remains the same Kubernetes API either way.
+
+For **regional** clusters, GKE replicates the control plane across three zones in the region. During a control-plane upgrade, replicas roll one at a time. The API remains reachable for `kubectl apply`, new Deployments, and autoscaling events. For **zonal** clusters, a single control-plane replica means the API can be unavailable for several minutes during upgrades. That window is long enough to block a hotfix Deployment. **Already-running Pods on worker nodes keep serving traffic** during zonal control-plane gaps. That distinction matters in incident response. Zonal clusters can look "healthy" in a dashboard of running Pods while the control plane rejects writes.
+
+The per-cluster management fee covers this managed control-plane lifecycle: creation, automatic version upgrades (when enrolled in a release channel), scaling of control-plane capacity, and deletion. It does **not** include worker-node Compute Engine charges (Standard), Pod-request charges (Autopilot general-purpose billing), load balancers, persistent disks, or egress. At fleet scale — say 40 production clusters — the management fee alone is roughly $0.10 × 40 × 730 ≈ **$2,920/month** before any nodes or Pods exist, which is why platform teams consolidate non-production environments or share clusters with namespace isolation rather than provisioning one cluster per microservice by default.
 
 ### [Regional vs Zonal Clusters](https://cloud.google.com/kubernetes-engine/docs/concepts/regional-clusters)
 
-This is one of the first decisions you make when creating a GKE cluster, and it has significant implications.
+Topology is the first architectural fork because it affects control-plane SLA, default node spread, and how `--num-nodes` arithmetic shows up on your invoice. Zonal clusters keep the control plane and default node pool in one zone — simpler and cheaper, but a zone outage takes down both API and workers unless you manually add multi-zonal node pools. Regional clusters replicate the control plane across three zones and spread default nodes across those zones, trading cost for survivability during single-zone failures and control-plane upgrades.
 
 | Aspect | Zonal Cluster | Regional Cluster |
 | :--- | :--- | :--- |
@@ -105,7 +119,7 @@ gcloud container clusters create dev-cluster \
 
 ## Standard Mode: Full Control
 
-Standard mode is the original GKE experience. You manage node pools, choose machine types, configure autoscaling, and handle node-level operations. Google manages only the control plane.
+Standard mode is the original GKE experience. You manage node pools, choose machine types, configure autoscaling, and handle node-level operations while Google manages only the control plane. Standard remains the right default when you need GPUs with custom drivers, privileged security agents, sole-tenant nodes, fine-grained Spot economics, or compliance regimes that require demonstrable control over the worker OS. It is also the mode where operational mistakes — wrong autoscaling flags, exhausted Pod CIDRs, mixed-version node pools — show up on your team's runbooks rather than being absorbed silently by Google.
 
 ### Node Pools
 
@@ -146,9 +160,39 @@ gcloud container node-pools create spot-pool \
   --node-taints=cloud.google.com/gke-spot=true:NoSchedule
 ```
 
+### Machine families, node images, and allocatable capacity
+
+Standard mode gives you direct control over Compute Engine machine selection. GKE node pools commonly use **E2** (cost-optimized general purpose), **N2/N2D** (balanced performance, N2D on AMD), **C3** (compute-optimized), or **T2D** (scale-out Arm) families depending on workload profile. GPU and high-memory variants (for example `n2-highmem-8`, `a2` accelerators) live in dedicated pools with taints so general microservices never land on expensive hardware.
+
+[Node images](https://cloud.google.com/kubernetes-engine/docs/concepts/node-images) split along operational philosophy. **Container-Optimized OS with containerd** (`cos_containerd`) is Google's hardened, minimal image — the default for Autopilot and the recommended choice for most Standard pools because Google patches it quickly and the read-only root filesystem reduces attack surface. **Ubuntu with containerd** (`ubuntu_containerd`) supports packages like CephFS clients or XFS tooling that COS cannot host natively; choose it when your node-level dependencies genuinely require `apt-get`, not because it feels familiar.
+
+Neither image gives Pods the full vCPU count printed on the machine type label. GKE reserves **system** and **kube** components on every node. The kubelet, container runtime, eviction thresholds, and DaemonSets such as logging agents consume CPU and memory before the scheduler calculates **allocatable** capacity. On a four-vCPU `e2-standard-4`, `kubectl describe node` typically shows roughly 3.9 allocatable CPUs and noticeably less than 16 GiB of allocatable memory. That is not a billing bug. It is capacity planning math you must account for when sizing pools. Overcommitting requests against raw machine specs causes pending Pods even when nodes look "empty" in the cloud console.
+
+**Taints and labels** implement isolation beyond machine type. Production patterns combine `node-labels=tier=database` with matching `node-taints=workload=database:NoSchedule` so only Pods with the corresponding toleration schedule onto database nodes. [Spot VM pools](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms) should always carry the `cloud.google.com/gke-spot=true:NoSchedule` taint so critical control-plane-adjacent workloads never land on interruptible capacity.
+
+### Spot VMs versus legacy preemptible VMs
+
+Both Spot and preemptible VMs offer steep discounts versus on-demand Compute Engine pricing — [Spot pricing in Autopilot and Standard contexts can reach roughly 60–91% off](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms) corresponding regular rates, though Spot prices adjust dynamically. The operational difference that matters for batch design: **preemptible VMs expire after 24 hours**, while **Spot VMs have no fixed expiration** and run until Compute Engine reclaims capacity. GKE documentation recommends Spot over preemptible for new node pools. Spot reclamation is involuntary and **not covered by PodDisruptionBudget guarantees**, so fault-tolerant or checkpointed workloads belong on Spot; stateful systems need on-demand pools or careful graceful-shutdown tuning (default 30 seconds, extendable up to 120 seconds on supported Standard versions).
+
+### Per-zone versus total node autoscaling flags
+
+Regional clusters multiply node counts by zone, and autoscaling flags inherit that behavior unless you opt out. [`--min-nodes` and `--max-nodes`](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-autoscaler) apply **per zone**; in GKE 1.24 and later, [`--total-min-nodes` and `--total-max-nodes`](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-autoscaler) express cluster-wide bounds and are mutually exclusive with the per-zone pair. Use total flags when finance expects "10–60 nodes in us-central1," not "10–60 nodes in **each** of three zones."
+
+```bash
+# Regional pool: 10–60 nodes TOTAL across three zones (not per zone)
+gcloud container node-pools create batch-pool \
+  --cluster=standard-cluster \
+  --region=us-central1 \
+  --machine-type=e2-standard-8 \
+  --spot \
+  --enable-autoscaling \
+  --total-min-nodes=0 \
+  --total-max-nodes=60
+```
+
 ### Cluster Autoscaler vs Node Auto-Provisioning
 
-Standard mode offers two approaches to scaling nodes:
+Standard mode offers two complementary approaches to scaling nodes, and mature platforms often run **both**: fixed pools with cluster autoscaler for baseline services, plus NAP or ComputeClass auto-creation for bursty GPU or Spot shapes.
 
 | Feature | Cluster Autoscaler | Node Auto-Provisioning (NAP) |
 | :--- | :--- | :--- |
@@ -171,14 +215,24 @@ gcloud container clusters update standard-cluster \
 
 With NAP enabled, if a pod requests a GPU and no GPU node pool exists, [GKE will automatically create one. When the pod finishes and the pool is idle, GKE scales it back to zero and eventually removes it.](https://cloud.google.com/kubernetes-engine/docs/concepts/node-auto-provisioning)
 
+### Node Auto-Provisioning in depth
+
+[Node pool auto-creation](https://cloud.google.com/kubernetes-engine/docs/concepts/node-auto-provisioning) extends the cluster autoscaler: instead of only adding VMs to predefined pools, GKE provisions **entire new node pools** when pending Pods need hardware no existing pool provides. You scope blast radius with **cluster-level resource limits** (`--autoprovisioning-max-cpu`, `--autoprovisioning-max-memory`, GPU caps) that apply to the sum of all node capacity including manually created pools — breaching a limit leaves Pods pending rather than silently overspending.
+
+Machine-family selection follows a precedence chain documented by Google: Pod or ComputeClass selectors win, then cluster-level NAP defaults, then platform defaults (often E2 when unspecified). NAP cannot set a minimum node count above zero for auto-created pools; if you need always-on baseline capacity, keep at least one manually managed on-demand pool and let NAP handle burst shapes (GPUs, highmem, Spot batch) that would otherwise require a combinatorial explosion of static pools.
+
+Scale-to-zero is a feature, not a failure mode: when the last Pod leaves an auto-created pool, GKE drains, consolidates, removes nodes, and deletes the empty pool. That interacts cleanly with the cluster autoscaler but requires you to tolerate brief scheduling latency when a new GPU or Spot shape appears — the first Pod in a new job type pays the node-provisioning tax. Newer GKE versions also support workload-level enablement via ComputeClasses with `nodePoolAutoCreation.enabled: true`, reducing the need for cluster-wide NAP when only one team needs dynamic hardware.
+
+```bash
+# Inspect autoprovisioning limits and defaults
+gcloud container clusters describe standard-cluster \
+  --region=us-central1 \
+  --format="yaml(autoscaling)"
+```
+
 ### What You Manage in Standard Mode
 
-- Node pool sizing and machine types
-- OS image selection (Container-Optimized OS vs Ubuntu)
-- Node security patches (auto-upgrade handles this if enabled)
-- System pod resource reservations
-- Network policies and firewall rules
-- Pod resource requests and limits (optional but strongly recommended)
+Standard operators own the full worker stack. Node pool sizing and machine types determine both performance ceiling and invoice baseline. OS image selection (`cos_containerd` versus `ubuntu_containerd`) locks in patch cadence and package flexibility. Auto-upgrade and auto-repair policies (enabled by default on many pools) decide whether Google replaces bad nodes and whether those replacements happen inside your maintenance windows. System and kube reservations on each node reduce allocatable CPU and memory below the machine spec. Network policies, firewall rules, and Pod resource requests remain your responsibility — GKE provides the network path, but not optimal bin-packing unless you configure requests, limits, and Horizontal Pod Autoscaler targets deliberately.
 
 > **Stop and think**: If you create a Standard cluster with a spot node pool for batch processing, but also need a few guaranteed nodes for your control applications, how would you ensure the control pods don't get scheduled on the preemptible spot nodes?
 
@@ -186,7 +240,7 @@ With NAP enabled, if a pod requests a GPU and no GPU node pool exists, [GKE will
 
 ## Autopilot Mode: Google Manages the Nodes
 
-[Autopilot is GKE's fully managed mode, introduced in 2021. Google manages everything except your workloads: the control plane, the nodes, the node pools, the OS patches, and the security hardening.](https://cloud.google.com/blog/products/containers-kubernetes/introducing-gke-autopilot) You only define pods.
+[Autopilot is GKE's fully managed mode, introduced in 2021. Google manages everything except your workloads: the control plane, the nodes, the node pools, the OS patches, and the security hardening.](https://cloud.google.com/blog/products/containers-kubernetes/introducing-gke-autopilot) You only define Pods, Services, and higher-level objects — never node pools in the console unless you are inspecting what Google created on your behalf. Autopilot's value proposition is velocity for teams that would otherwise spend sprint capacity right-sizing pools, patching COS, and chasing underutilized nodes; its cost proposition is strongest when workload footprint varies over time and explicit resource requests reflect real needs rather than padded guesses.
 
 ### How Autopilot Works
 
@@ -205,11 +259,11 @@ gcloud container clusters create-auto autopilot-cluster \
   --workload-pool=$(gcloud config get-value project).svc.id.goog
 ```
 
-That single command creates a production-ready cluster. No node pools to configure, no machine types to choose, no autoscaling to tune.
+That single command creates a production-ready regional cluster with VPC-native networking and Workload Identity enabled — no node pool forms to fill out, no machine-type matrix, no cluster-autoscaler min/max tuning. Google provisions right-sized nodes when Pending Pods exist, patches them on Google's cadence, and reclaims capacity when Deployments scale down. You still configure release channels, maintenance policies, and RBAC; you do not SSH to nodes or pick `--machine-type` for general workloads.
 
 ### Autopilot Billing Model
 
-This is the most important difference for budgeting. Standard mode charges for the VMs (nodes) whether or not pods are using them. Autopilot charges for the **pod resource requests** only.
+Budget conversations should start here because Autopilot and Standard diverge on the invoice line items finance teams reconcile. Standard mode charges for the VMs (nodes) whether or not pods are using them. Autopilot charges for **pod resource requests** on general-purpose compute classes, which decouples your bill from idle node headroom but couples it tightly to manifest hygiene.
 
 | Billing Dimension | Standard Mode | Autopilot Mode |
 | :--- | :--- | :--- |
@@ -250,7 +304,7 @@ spec:
 
 ### Autopilot Restrictions
 
-[Autopilot enforces security best practices by restricting certain operations](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-security):
+[Autopilot enforces security best practices by restricting certain operations](https://cloud.google.com/kubernetes-engine/docs/concepts/autopilot-security). The table below summarizes the most common migration blockers teams discover when moving from Standard — treat it as an admission-control checklist, not an exhaustive API list:
 
 | Restriction | Reason | Workaround |
 | :--- | :--- | :--- |
@@ -262,13 +316,34 @@ spec:
 | Resource requests strongly influence billing and scheduling | GKE uses or adjusts requests when sizing infrastructure | Explicitly specify requests so Autopilot doesn't rely on defaults or automatic adjustments |
 | Pods per node are pre-configured by GKE | Scheduling density depends on the selected node configuration | You can't directly tune this setting in Autopilot |
 
+Autopilot restrictions are not arbitrary friction — they encode Google's ability to patch, rotate, and bin-pack nodes safely. Privileged containers and host namespaces would let workloads undermine the shared node boundary Google guarantees. Restricted DaemonSets prevent agents from requiring root on every node Google owns. When a manifest violates these rules, admission fails fast at apply time rather than silently weakening cluster security. Teams migrating from Standard should run `kubectl apply --dry-run=server` on critical DaemonSets and GPU Jobs before cutover day.
+
 > **Pause and predict**: If you deploy a DaemonSet to an Autopilot cluster that requires privileged access to the host network namespace to monitor traffic, what will happen when you apply the manifest?
+
+### Workload Identity at cluster creation
+
+Both Standard and Autopilot examples in this module pass `--workload-pool=PROJECT_ID.svc.id.goog`, enabling [Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) so Kubernetes service accounts map to Google service accounts without exporting node metadata credentials. Enabling the pool at **create** time wires IAM trust once; pods then use `iam.gke.io/gke-service-account` annotations to assume least-privilege Google identities. Retrofitting Workload Identity on legacy clusters requires enabling the pool, recreating node pools, updating every Deployment's service account bindings, and auditing applications that still read the node's metadata server — workable, but expensive enough that the anti-pattern table flags it explicitly. Pair Workload Identity with per-workload Google service accounts rather than reusing the default Compute Engine service account attached to nodes.
 
 ---
 
 ## Standard vs Autopilot: The Decision Framework
 
-This is the question every GKE user faces. Here is a decision framework based on real-world patterns.
+This is the question every GKE user faces, and the answer rarely stays fixed for the entire life of a product. Here is a decision framework based on real-world patterns that platform teams revisit when utilization, headcount, or compliance requirements change.
+
+```mermaid
+flowchart TD
+    START["New GKE cluster needed"] --> Q1{"Need privileged containers,<br/>hostNetwork, custom kernel,<br/>or SSH to nodes?"}
+    Q1 -->|Yes| STD["Standard mode"]
+    Q1 -->|No| Q2{"Need fine-grained Spot bin-packing,<br/>sole-tenant nodes, or<br/>compliance-mandated node controls?"}
+    Q2 -->|Yes| STD
+    Q2 -->|No| Q3{"Team capacity to operate<br/>node pools, upgrades, and<br/>allocatable math?"}
+    Q3 -->|Low| AUTO["Autopilot mode"]
+    Q3 -->|High| Q4{"Sustained node utilization<br/>consistently above ~70%?"}
+    Q4 -->|Yes| STD
+    Q4 -->|No| AUTO
+    STD --> TOP["Pair with: regional topology,<br/>Regular/Stable channel,<br/>maintenance windows"]
+    AUTO --> TOP2["Pair with: explicit resource requests,<br/>Regular channel, PDBs for<br/>voluntary disruption only"]
+```
 
 ### Choose Autopilot When
 
@@ -300,13 +375,63 @@ graph TD
 
 The math can flip when utilization is consistently high. If your Standard cluster is tightly tuned and uses capacity efficiently, Standard can sometimes be cheaper than Autopilot.
 
+### Autopilot request rounding and fleet-scale cost surprises
+
+Autopilot's Pod-based billing model has subtle knobs that inflate bills when teams treat requests as "set and forget." [Google documents](https://cloud.google.com/kubernetes-engine/pricing) that Autopilot applies **default requests** when you omit them, **raises values below minimums or invalid CPU-to-memory ratios**, and bills Running or ContainerCreating Pods per requested vCPU, GiB, and ephemeral storage — not actual usage. A Deployment copied from a dev cluster with `cpu: 100m` requests on a service that actually needs 250m may get rounded upward; conversely, omitting requests entirely can land you on class defaults larger than necessary. Right-sizing requests is both a performance task and a FinOps task.
+
+Hardware-specific Autopilot workloads (GPU selectors, certain machine series) switch to **node-based billing** plus an Autopilot management premium, meaning you pay for the whole provisioned VM shape — often larger than the Pod strictly requested. That is appropriate for ML training but expensive if you under-utilize the node. Spot Pods in Autopilot inherit the same dynamic [60–91% discount band](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms) as Spot node pools, but only for fault-tolerant workloads that tolerate involuntary eviction outside PDB semantics.
+
+Remember the **$0.10/hour/cluster management fee** applies to every Autopilot cluster too; it is not absorbed into Pod pricing. A platform running 25 regional Autopilot clusters for hard multi-tenant isolation pays ~$1,825/month in management fees alone before Pod charges — sometimes more than consolidating tenants into fewer clusters with namespace quotas and NetworkPolicies would cost in aggregate.
+
 > **Stop and think**: A team runs a fleet of 50 microservices that have highly variable traffic patterns, frequently scaling from 2 to 50 replicas and back down. They currently use Standard mode and struggle to keep node utilization above 30%. Would Autopilot be a good fit for them?
+
+---
+
+## Immutable cluster properties and migration paths
+
+Several GKE choices are **immutable** or effectively irreversible without rebuilding the cluster. Treat them as architecture review checkpoints before the first `gcloud container clusters create` succeeds.
+
+**Cluster mode (Standard versus Autopilot)** cannot be toggled in place. Autopilot clusters use different node provisioning, admission policies, and billing integrations than Standard clusters. Migration means standing up a parallel cluster, validating manifests (resource requests, DaemonSet compatibility, GPU selectors), shifting traffic with DNS or service mesh, and decommissioning the old cluster — often a multi-sprint program, not a weekend flag change.
+
+**Regional versus zonal** topology is set at create time. You cannot convert a zonal control plane to regional without creating a new cluster and migrating workloads. Likewise, **VPC-native Pod CIDR sizing** is fixed at creation for practical purposes; expanding exhausted Pod ranges requires discontiguous multi-Pod CIDR features or a new cluster with a larger `--cluster-ipv4-cidr`. Network teams should treat the sizing worksheet in the networking section as a capacity contract signed before production launch.
+
+**Release channel enrollment** can be changed, but dropping from a channel to a static version pin removes access to scoped maintenance exclusions that depend on channel end-of-support tracking. **Workload Identity** can be enabled later, but every workload using node credential paths must be retested. Document these constraints in your internal cluster request form so application teams know which decisions require platform-architect approval versus which can be changed with a `gcloud container clusters update`.
+
+When planning brownfield migrations, sequence work as: (1) inventory DaemonSets and privileged Pods, (2) right-size Autopilot requests or Standard pool shapes in staging, (3) validate IP and identity requirements, (4) cut over with rollback DNS, (5) compare management fee plus compute line items for thirty days. Hypothetical scenario: a team skips step one and discovers their legacy APM agent requires hostPath mounts only after the Autopilot cluster is production — the rollback becomes an emergency rebuild of the Standard cluster they just deleted.
+
+---
+
+## Patterns and Anti-Patterns
+
+Production GKE architectures repeat a handful of proven shapes — and a handful of expensive mistakes. The table below captures patterns worth copying and anti-patterns worth auditing in your own fleet.
+
+### Proven patterns
+
+| Pattern | When to use | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| **Autopilot for small platform teams / stateless services** | Fewer than two FTEs for cluster ops; microservices with clear CPU/memory requests | Google owns node lifecycle, patching, and bin-packing; Pod-based billing tracks scale-to-zero traffic | GPU or privileged workloads may force Standard or hardware-billed Autopilot — validate before committing |
+| **Regional Standard + Spot batch pool + on-demand baseline pool** | Mixed latency-sensitive and fault-tolerant workloads | On-demand pool holds PDB-protected services; Spot pool runs Jobs and batch with taints/tolerations | Use `--total-max-nodes` so regional multiplication does not triple Spot ceilings unexpectedly |
+| **Regular channel + maintenance window + bounded exclusions** | Production clusters that must upgrade predictably | Upgrades concentrate in low-traffic windows; exclusions freeze holidays but cannot exceed minor version [end-of-support dates](https://cloud.google.com/kubernetes-engine/docs/how-to/maintenance-windows-and-exclusions) | Require ≥48 hours of maintenance availability in any rolling 32-day window |
+| **VPC-native IP plan before first cluster** | Any cluster expected to grow past a handful of nodes | Secondary Pod CIDR size caps maximum nodes; fixing exhaustion later requires expansion or new cluster | Work through sizing **before** Shared VPC handoffs — host-project admins must pre-create ranges |
+| **Workload Identity at create time** | Every new cluster | `--workload-pool=PROJECT.svc.id.goog` binds Kubernetes SA to Google SA without long-lived node keys | Retrofitting Workload Identity on legacy clusters is possible but touches every workload identity path |
+
+### Anti-patterns
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+| :--- | :--- | :--- | :--- |
+| **Zonal cluster for production** | Single-zone control plane and nodes; 99.5% API SLA; upgrade blips block `kubectl` | Dev cluster "worked fine" and was copied to prod | Regional cluster with multi-zonal node pools |
+| **Rapid channel in production** | Earliest minor versions; undiscovered upstream bugs | Desire for newest features (service mesh APIs, alpha gates) | Regular or Stable channel; use Rapid only in CI/staging |
+| **`--num-nodes` surprise on regional clusters** | Finance sees 3× expected VMs (per-zone multiplication) | Flag name sounds cluster-wide | `--total-min-nodes` / `--total-max-nodes` or explicit per-zone documentation |
+| **Disabling auto-upgrade entirely** | Clusters drift to unsupported minors; emergency forced upgrades | Fear of surprise reboots | Keep auto-upgrade; constrain **when** with maintenance windows and scoped exclusions |
+| **Over-requesting Autopilot resources "for headroom"** | Bill scales linearly with requests, not usage | Copy-paste requests from load tests | Right-size from production metrics; use HPA on real utilization |
+| **Retrofitting Workload Identity under pressure** | Node SA keys linger; partial migration breaks auth | Identity was deferred at create time | Enable `--workload-pool` on new clusters; migrate workloads deliberately |
+| **Single Spot-only node pool** | Spot reclamation evicts system-critical Pods; PDBs cannot block involuntary preemption | Cost optimization without architecture | Always retain on-demand pool for system and latency-sensitive tiers |
 
 ---
 
 ## Release Channels and Upgrade Strategy
 
-GKE uses release channels to manage Kubernetes version upgrades. Understanding these is critical for production stability.
+GKE uses release channels to manage Kubernetes version upgrades, coupling your cluster to Google's tested version cadence instead of a self-managed minor pin. Understanding channel timing is critical for production stability because channel enrollment also enables scoped maintenance exclusions tied to end-of-support dates.
 
 ### [The Three Channels](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels)
 
@@ -335,7 +460,7 @@ gcloud container clusters describe conservative-cluster \
 
 ### Auto-Upgrade Behavior
 
-[When enrolled in a release channel, GKE automatically upgrades both the control plane and nodes.](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels)
+[When enrolled in a release channel, GKE automatically upgrades both the control plane and nodes.](https://cloud.google.com/kubernetes-engine/docs/concepts/release-channels) You choose the channel's risk profile; Google chooses patch timing within your maintenance policy. Manual one-off upgrades remain available when you need to jump ahead of the channel schedule for a critical fix.
 
 ```mermaid
 flowchart LR
@@ -343,7 +468,7 @@ flowchart LR
     DNP -->|1-2 weeks<br/>after default| ONP["Other Node Pools<br/>(Automatic, rolling)"]
 ```
 
-You can influence **when** upgrades happen with maintenance windows and exclusions:
+You can influence **when** upgrades happen — not whether enrolled channels eventually upgrade — with maintenance windows and exclusions configured cluster-wide:
 
 ```bash
 # Set a maintenance window (upgrades only during this time)
@@ -362,9 +487,44 @@ gcloud container clusters update prod-cluster \
   --add-maintenance-exclusion-scope=no_upgrades
 ```
 
+### Node upgrade strategies: surge versus blue-green
+
+Control-plane upgrades and node-pool upgrades are separate timelines. After the control plane moves to a new minor version, GKE rolls worker nodes — and **how** those rolls happen determines blast radius for stateful workloads and PDBs.
+
+**Surge upgrades** (default for many pools) create temporary extra nodes (`--max-surge-upgrade`) while cordoning and draining old nodes up to `--max-unavailable-upgrade` at a time. Surge trades **temporary cost** (you pay for burst nodes during the roll) for **speed** and continuous capacity. Tight surge settings (`max-surge=0`, `max-unavailable=1`) serialize upgrades and lengthen maintenance windows — acceptable for small pools, painful for large ones.
+
+**Blue-green node pool upgrades** provision an entire parallel "green" node pool on the new version, validate workloads, then drain the "blue" pool in configurable batches with soak time between batches. [Google's documentation](https://cloud.google.com/kubernetes-engine/docs/how-to/node-pool-upgrade-strategies) exposes `--enable-blue-green-upgrade`, batch sizes (`batch-node-count` or `batch-percent`), `batch-soak-duration`, and `node-pool-soak-duration` (default one hour) so you can pause between drain phases and watch error budgets. Blue-green fits stateful services where a bad node image should not take down half the pool at once — you pay for doubled nodes during soak, but you gain a rollback surface (stop the rollout before draining blue).
+
+**Autoscaled blue-green** (control plane ≥ 1.34.0-gke.2201000 with cluster autoscaler enabled) cordons the blue pool and waits up to seven days (default three days) before draining, giving autoscaler time to grow the green pool organically — useful when surge capacity is hard to pre-provision.
+
+```bash
+# Surge: allow one extra node per zone during upgrade, zero unavailable
+gcloud container node-pools update default-pool \
+  --cluster=prod-cluster \
+  --region=us-central1 \
+  --max-surge-upgrade=1 \
+  --max-unavailable-upgrade=0
+
+# Blue-green with 25% batch drains and 30-minute pool soak
+gcloud container node-pools update stateful-pool \
+  --cluster=prod-cluster \
+  --region=us-central1 \
+  --enable-blue-green-upgrade \
+  --standard-rollout-policy=batch-percent=0.25,batch-soak-duration=600s \
+  --node-pool-soak-duration=1800s
+```
+
+**PodDisruptionBudget interaction**: PDBs constrain *voluntary* evictions during drains. Surge and blue-green upgrades use voluntary evictions, so a strict `minAvailable` PDB slows node drains until spare capacity exists — plan surge headroom or temporarily relax PDBs during maintenance windows. **Spot preemption** is involuntary; PDBs cannot prevent Spot reclamation, which is why Spot tiers belong on fault-tolerant work only.
+
+### Maintenance windows versus maintenance exclusions
+
+[Maintenance windows](https://cloud.google.com/kubernetes-engine/docs/how-to/maintenance-windows-and-exclusions) restrict **when** GKE may start automatic upgrades — you must provide at least 48 hours of eligible maintenance time in any rolling 32-day window, in contiguous blocks of four hours or more. **Maintenance exclusions** temporarily forbid upgrades (scopes include `no_upgrades`, `no_minor_upgrades`, or `no_minor_or_node_upgrades`). Exclusions on release-channel clusters cannot extend past the enrolled minor version's **end-of-support date** — you can freeze Black Friday, but you cannot freeze forever without upgrading. Scoped exclusions (`no_minor_upgrades`) require release-channel enrollment; static-version clusters only allow full `no_upgrades` exclusions.
+
+If an upgrade outlasts the maintenance window, GKE may pause and resume in the next window, leaving nodes on mixed versions until completion — another reason to monitor node version skew after long weekends.
+
 ### [Auto-Repair](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-repair)
 
-Separate from auto-upgrade, auto-repair monitors node health and replaces unhealthy nodes automatically. A node is considered unhealthy if:
+Separate from auto-upgrade, auto-repair monitors node health and replaces unhealthy nodes automatically without waiting for a scheduled maintenance window. A node is considered unhealthy when any of the following persist long enough for automation to act:
 
 - It reports a `NotReady` status for more than approximately 10 minutes
 - It has no disk space
@@ -390,7 +550,7 @@ gcloud container node-pools describe default-pool \
 
 ## Cluster Networking Basics
 
-Every GKE cluster needs IP addresses for nodes, pods, and services. GKE strongly recommends **VPC-native clusters** (alias IP mode), [which is the default for all new clusters](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips).
+Every GKE cluster needs IP addresses for nodes, pods, and services. GKE strongly recommends **VPC-native clusters** (alias IP mode), [which is the default for all new clusters](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips). VPC-native networking matters for architecture decisions in this module because **Pod CIDR sizing caps how large your cluster can ever grow**, independent of how many nodes you can afford in Compute Engine.
 
 ```bash
 # Create a VPC-native cluster with explicit secondary ranges
@@ -427,6 +587,53 @@ graph TD
     end
 ```
 
+### VPC-native IP sizing: a worked example
+
+[Google's alias IP documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips) explains the coupling between secondary Pod range size, `max-pods-per-node`, and maximum node count. Unless you override it, GKE allocates a **/24 per node** from the Pod secondary range and supports up to **110 Pods per node** on Standard clusters (Autopilot defaults differ — Autopilot fixes max Pods per node at **32** for sizing formulas).
+
+Suppose you create a Standard regional cluster with `--cluster-ipv4-cidr=10.4.0.0/17` (a /17 Pod range) and default 110 Pods per node. The /17 range provides 2^(32-17) = **32,768** Pod IP addresses at the subnet level, but each node consumes a /24 (256 addresses) slice. Maximum nodes ≈ 32,768 / 256 = **128 nodes** before Pod IP exhaustion — even if your primary subnet could fit more VM primary IPs. If you later enable autoscaling toward 200 nodes, scheduling succeeds until the Pod CIDR fills, then you see `IP space ... is exhausted` errors despite spare CPU in the project.
+
+The primary subnet range separately limits nodes: a /24 primary range supports on the order of **250 usable node IPs** per Google's sizing table, minus reserved addresses. **Both** limits apply simultaneously — plan the tighter bound. For Services, GKE 1.29+ Standard and 1.27+ Autopilot default to the GKE-managed `34.118.224.0/20` Service range, reducing the need for a user-managed Services secondary range in many greenfield designs.
+
+```text
+Worked sizing checklist (Standard, /17 Pod CIDR, 110 max Pods/node):
+  Pod secondary /17  → ~128 nodes max (256 IPs reserved per node)
+  Primary subnet /24 → ~250 nodes max
+  Binding constraint → ~128 nodes before Pod IP exhaustion wins
+
+Action: If you need 200+ nodes, widen Pod CIDR at create time (/16 or discontiguous multi-Pod CIDR) — retrofits are painful.
+```
+
+Shared VPC environments require host-project Network Admins to pre-create secondary ranges; GKE cannot auto-expand on your behalf in that model, which makes the worked math above a joint exercise between platform and network teams before the first `gcloud container clusters create`.
+
+### Routes-based clusters (legacy)
+
+Older GKE clusters could operate in **routes-based** mode, programming static routes for Pod CIDRs instead of alias IPs. VPC-native clusters are now the default on all surfaces, and features such as network endpoint groups and many firewall granularities require alias mode. If you inherit a routes-based cluster, plan migration rather than expanding it — greenfield architecture in this module assumes `--enable-ip-alias` (default) and explicit secondary ranges in Shared VPC.
+
+---
+
+---
+
+## Production readiness checklist
+
+Before declaring a GKE cluster production-ready, walk through this checklist with your platform and application owners. Each item connects to a section in this module.
+
+**Topology and availability.** Confirm the cluster is regional for production user traffic. Verify node pools span at least two zones for worker resilience even when the control plane is already regional. Document the `--num-nodes` or `--total-min-nodes` math in the runbook so on-call engineers do not misread capacity during incidents.
+
+**Upgrade policy.** Enroll in Regular or Stable channel unless you have a dedicated test environment on Rapid. Configure a maintenance window with at least forty-eight hours of availability per rolling thirty-two-day window. Add holiday exclusions with explicit end dates. Pick surge or blue-green node upgrade strategy per pool based on PDB strictness.
+
+**Identity and security.** Enable Workload Identity at create time. Bind each Deployment to a dedicated Google service account with least-privilege IAM. Audit DaemonSets for Autopilot compatibility before cutover. Ensure Spot-only pools carry taints and that on-demand baseline capacity exists.
+
+**Network and IP capacity.** Validate Pod secondary CIDR supports planned max nodes given `/24`-per-node allocation. Confirm Shared VPC secondary ranges exist before cluster create. Document primary subnet expansion procedure if node count may grow past initial estimates.
+
+**Cost controls.** Tag clusters for cost allocation. Right-size Autopilot requests from metrics, not guesses. Model management fees at fleet scale. Use Spot for fault-tolerant tiers only. Review free-tier credit consumption monthly so dev clusters do not silently exhaust the single-cluster credit.
+
+**Observability baseline.** Ensure logging and metrics DaemonSets comply with mode restrictions. Test that `kubectl` access paths work during simulated maintenance windows. Record current control-plane and node versions after every upgrade wave.
+
+Hypothetical scenario: a team skips the IP capacity review and launches successfully with ten nodes. Six months later autoscaling tries to reach eighty nodes and scheduling fails with Pod IP exhaustion while CPU quota remains unused. The fix requires network redesign or cluster rebuild — exactly the failure mode the worked sizing example prevents when applied at design time.
+
+**Version alignment.** Record `currentMasterVersion` and node pool node versions after each maintenance window. Mixed-version states during long upgrades are normal briefly. They become incidents when application APIs removed in the new minor break Deployments that were never tested in staging on that minor. Pair channel enrollment with a staging cluster on the same channel that upgrades first. Run kubeconform or policy checks in CI against the next channel version before production maintenance windows execute. Document who approves emergency exclusions when a zero-day patch arrives outside the normal window. Keep that approver on-call rotation separate from application on-call so upgrade policy decisions do not stall behind unrelated incidents. Rehearse the rollback path — DNS revert or mesh traffic shift — at least once per quarter so cluster rebuilds are not your only escape hatch.
+
 ---
 
 ## Did You Know?
@@ -437,7 +644,7 @@ graph TD
 
 3. **GKE operates at very large scale inside Google Cloud**, which gives Google significant operational experience running Kubernetes for many customers. Avoid uncited deployment-volume rankings or causal claims about patch timing here.
 
-4. **Maintenance exclusions are bounded by release-channel support rules**. Short "No upgrades" exclusions are limited, and longer exclusions must still end by the minor version's end-of-support date, so you can't postpone upgrades indefinitely.
+4. **Maintenance exclusions are bounded by release-channel support rules**. Short "No upgrades" exclusions are limited to ninety days. Longer exclusions must still end by the minor version's end-of-support date. You cannot postpone upgrades indefinitely while staying on an unsupported Kubernetes minor.
 
 ---
 
@@ -500,23 +707,27 @@ The team should enable Node Auto-Provisioning (NAP) to replace their complex web
 This plan will fail because a cluster's mode (Standard or Autopilot) is a fundamental, immutable architectural property set at creation time and cannot be toggled or converted later. Autopilot clusters are built with different underlying infrastructure assumptions and security boundaries that prevent an in-place conversion from a Standard cluster. The correct approach is to provision a brand-new Autopilot cluster side-by-side with the existing one. The team must then audit their manifests to ensure compatibility (e.g., adding explicit resource requests, removing unsupported privileged access), deploy the workloads to the new cluster, and carefully shift traffic over before decommissioning the old Standard cluster.
 </details>
 
+<details>
+<summary>8. Your platform team must upgrade a 30-node Standard node pool running stateful Redis instances with a strict `PodDisruptionBudget` of `minAvailable: 28`. Surge upgrades with `max-unavailable=1` are taking longer than the Saturday maintenance window allows, and last month a rushed surge left two nodes on the old version for a week. Which upgrade strategy should they evaluate, and what tradeoff should they expect?</summary>
+
+They should evaluate **blue-green node pool upgrades** with explicit batch soak durations rather than relying on default surge settings alone. Blue-green creates a parallel green pool on the target version, validates Redis replicas on new nodes, then drains the blue pool in batches (`batch-percent` or `batch-node-count`) with `node-pool-soak-duration` between phases — giving time to confirm replication lag and memory stability before continuing. The tradeoff is **temporary double capacity cost** during soak (both pools exist) versus surge's smaller incremental cost but higher risk of prolonged mixed-version states when PDBs throttle drains. PDBs still apply to voluntary evictions during blue-green drains, so the team must ensure green pool capacity can satisfy `minAvailable: 28` before each batch — often by temporarily scaling replicas or loosening PDBs only inside an approved maintenance exclusion scoped to `no_minor_upgrades` rather than disabling upgrades entirely.
+</details>
+
 ---
 
 ## Hands-On Exercise: Deploy to Standard and Autopilot
 
 ### Objective
 
-Create both a GKE Standard and Autopilot cluster, deploy the same application to each, and compare the operational experience, billing model, and scheduling behavior.
+Create both a GKE Standard and Autopilot cluster, deploy the same application to each, and compare the operational experience, billing model, and scheduling behavior. The exercise reinforces that identical Deployment YAML often **schedules** differently — Standard places Pods on the machine type you chose, while Autopilot provisions nodes matched to aggregated requests — and that regional Standard clusters always multiply baseline node counts by zone unless you use total autoscaling flags.
 
 ### Prerequisites
 
-- `gcloud` CLI installed and authenticated
-- A GCP project with billing enabled and the GKE API enabled
-- `kubectl` installed
+You need the `gcloud` CLI authenticated to a billing-enabled project with the Kubernetes Engine API enabled, plus a local `kubectl` binary matched to a supported version for GKE 1.35 clusters. Pick a single region (the solutions use `us-central1`) and delete both clusters afterward so free-tier credits are not consumed by forgotten management fees.
 
 ### Tasks
 
-**Task 1: Enable APIs and Set Up Variables**
+**Task 1: Enable APIs and Set Up Variables** — confirm your project can create GKE clusters before spending time on cluster provisioning that fails at the API gate.
 
 <details>
 <summary>Solution</summary>
@@ -536,7 +747,7 @@ gcloud services list --enabled --filter="name:container" \
 ```
 </details>
 
-**Task 2: Create a GKE Standard Cluster**
+**Task 2: Create a GKE Standard Cluster** — observe how `--num-nodes=1` on a regional cluster still produces three worker VMs (one per zone by default).
 
 <details>
 <summary>Solution</summary>
@@ -565,7 +776,7 @@ kubectl version
 ```
 </details>
 
-**Task 3: Create a GKE Autopilot Cluster**
+**Task 3: Create a GKE Autopilot Cluster** — note the absence of node-pool prompts and compare create time to Standard.
 
 <details>
 <summary>Solution</summary>
@@ -588,7 +799,7 @@ kubectl get nodes -o wide
 ```
 </details>
 
-**Task 4: Deploy the Same Application to Both Clusters**
+**Task 4: Deploy the Same Application to Both Clusters** — the identical YAML validates that your manifests are portable; differences appear in scheduling and node labels.
 
 <details>
 <summary>Solution</summary>
@@ -658,7 +869,7 @@ kubectl get svc gke-demo
 ```
 </details>
 
-**Task 5: Compare Node Behavior and Resource Allocation**
+**Task 5: Compare Node Behavior and Resource Allocation** — inspect allocatable resources on Standard nodes versus Autopilot-provisioned shapes for the same Pod requests.
 
 <details>
 <summary>Solution</summary>
@@ -707,7 +918,7 @@ MEM_REQ:.spec.containers[0].resources.requests.memory
 ```
 </details>
 
-**Task 6: Clean Up**
+**Task 6: Clean Up** — delete both clusters asynchronously so management fees stop accruing; verify deletion with `gcloud container clusters list`.
 
 <details>
 <summary>Solution</summary>
@@ -757,3 +968,8 @@ Next up: **[Module 6.2: GKE Networking (Dataplane V2 and Gateway API)](../module
 - [cloud.google.com: node auto repair](https://cloud.google.com/kubernetes-engine/docs/how-to/node-auto-repair) — The node auto-repair guide documents both the default setting and the repair criteria with these approximate thresholds.
 - [cloud.google.com: alias ips](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips) — The VPC-native clusters documentation explicitly states that VPC-native is the default mode for new GKE clusters.
 - [Compare features in Autopilot and Standard clusters](https://cloud.google.com/kubernetes-engine/docs/resources/autopilot-standard-feature-comparison) — This comparison page is the fastest way to verify which cluster mode supports specific operational or security features.
+- [cloud.google.com: node images](https://cloud.google.com/kubernetes-engine/docs/concepts/node-images) — Documents COS versus Ubuntu image tradeoffs and Autopilot's mandatory `cos_containerd` image.
+- [cloud.google.com: cluster autoscaler](https://cloud.google.com/kubernetes-engine/docs/how-to/cluster-autoscaler) — Documents `--total-min-nodes` / `--total-max-nodes` versus per-zone min/max flags.
+- [cloud.google.com: node pool upgrade strategies](https://cloud.google.com/kubernetes-engine/docs/how-to/node-pool-upgrade-strategies) — Surge versus blue-green upgrade configuration and soak parameters.
+- [cloud.google.com: maintenance windows and exclusions](https://cloud.google.com/kubernetes-engine/docs/how-to/maintenance-windows-and-exclusions) — Maintenance window availability requirements and exclusion scope/end-of-support rules.
+- [cloud.google.com: workload identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) — Enabling `--workload-pool` and binding Kubernetes service accounts to Google identities.

--- a/src/content/docs/cloud/gke-deep-dive/module-6.1-gke-architecture.md
+++ b/src/content/docs/cloud/gke-deep-dive/module-6.1-gke-architecture.md
@@ -113,7 +113,7 @@ gcloud container clusters create dev-cluster \
   --release-channel=rapid
 ```
 
-**War Story**: Regional clusters can create more nodes than teams expect because node counts are distributed across zones. In the default three-zone layout, a `--num-nodes` value applies per zone rather than as a single cluster-wide total, so plan capacity and cost accordingly.
+**Capacity note**: Regional clusters can create more nodes than teams expect because node counts are distributed across zones. In the default three-zone layout, a `--num-nodes` value applies per zone rather than as a single cluster-wide total, so plan capacity and cost accordingly.
 
 ---
 
@@ -172,7 +172,7 @@ Neither image gives Pods the full vCPU count printed on the machine type label. 
 
 ### Spot VMs versus legacy preemptible VMs
 
-Both Spot and preemptible VMs offer steep discounts versus on-demand Compute Engine pricing — [Spot pricing in Autopilot and Standard contexts can reach roughly 60–91% off](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms) corresponding regular rates, though Spot prices adjust dynamically. The operational difference that matters for batch design: **preemptible VMs expire after 24 hours**, while **Spot VMs have no fixed expiration** and run until Compute Engine reclaims capacity. GKE documentation recommends Spot over preemptible for new node pools. Spot reclamation is involuntary and **not covered by PodDisruptionBudget guarantees**, so fault-tolerant or checkpointed workloads belong on Spot; stateful systems need on-demand pools or careful graceful-shutdown tuning (default 30 seconds, extendable up to 120 seconds on supported Standard versions).
+Both Spot and preemptible VMs offer steep discounts versus on-demand Compute Engine pricing — [Spot pricing in Autopilot and Standard contexts can reach roughly 60–91% off](https://cloud.google.com/kubernetes-engine/docs/concepts/spot-vms) corresponding regular rates, though Spot prices adjust dynamically. The operational difference that matters for batch design: **preemptible VMs expire after 24 hours**, while **Spot VMs have no fixed expiration** and run until Compute Engine reclaims capacity. GKE documentation recommends Spot over preemptible for new node pools. Spot reclamation is involuntary and **not covered by PodDisruptionBudget guarantees**, so fault-tolerant or checkpointed workloads belong on Spot; stateful systems need on-demand pools or careful graceful-shutdown tuning (default 30 seconds, extendable up to 120 seconds on supported Standard control-plane versions **(Preview)**).
 
 ### Per-zone versus total node autoscaling flags
 
@@ -254,9 +254,7 @@ graph LR
 # Create an Autopilot cluster
 gcloud container clusters create-auto autopilot-cluster \
   --region=us-central1 \
-  --release-channel=regular \
-  --enable-ip-alias \
-  --workload-pool=$(gcloud config get-value project).svc.id.goog
+  --release-channel=regular
 ```
 
 That single command creates a production-ready regional cluster with VPC-native networking and Workload Identity enabled — no node pool forms to fill out, no machine-type matrix, no cluster-autoscaler min/max tuning. Google provisions right-sized nodes when Pending Pods exist, patches them on Google's cadence, and reclaims capacity when Deployments scale down. You still configure release channels, maintenance policies, and RBAC; you do not SSH to nodes or pick `--machine-type` for general workloads.
@@ -642,9 +640,9 @@ Hypothetical scenario: a team skips the IP capacity review and launches successf
 
 2. **The GKE control plane runs in Google-managed infrastructure** that is separate from your project's worker nodes. That's why customers interact with the control plane through managed endpoints and don't directly access the control plane VMs.
 
-3. **GKE operates at very large scale inside Google Cloud**, which gives Google significant operational experience running Kubernetes for many customers. Avoid uncited deployment-volume rankings or causal claims about patch timing here.
+3. **The GKE cluster management fee is billed per second, not per hour.** At $0.10 per cluster per hour, a cluster you create and delete 20 minutes later costs about $0.033 — which is why ephemeral CI/preview clusters are cheap to spin up and tear down. (Worker-node, Pod, load-balancer, and disk charges are separate.)
 
-4. **Maintenance exclusions are bounded by release-channel support rules**. Short "No upgrades" exclusions are limited to ninety days. Longer exclusions must still end by the minor version's end-of-support date. You cannot postpone upgrades indefinitely while staying on an unsupported Kubernetes minor.
+4. **Maintenance exclusions are bounded by release-channel support rules**. Short "No upgrades" exclusions for the default `no_upgrades` scope are limited to ninety days (the post-end-of-support emergency window); scoped exclusions can run longer, up to the minor's end-of-support. Longer exclusions must still end by the minor version's end-of-support date. You cannot postpone upgrades indefinitely while staying on an unsupported Kubernetes minor.
 
 ---
 
@@ -958,6 +956,7 @@ Next up: **[Module 6.2: GKE Networking (Dataplane V2 and Gateway API)](../module
 ## Sources
 
 - [cloud.google.com: pricing](https://cloud.google.com/kubernetes-engine/pricing) — The GKE pricing page explicitly lists these financially backed availability figures.
+- [GKE SLA](https://cloud.google.com/kubernetes-engine/sla) — The financially-backed 99.95% regional / 99.5% zonal control-plane SLA.
 - [cloud.google.com: regional clusters](https://cloud.google.com/kubernetes-engine/docs/concepts/regional-clusters) — The regional-clusters documentation directly describes replicated control planes and default three-zone worker-node distribution.
 - [cloud.google.com: node auto provisioning](https://cloud.google.com/kubernetes-engine/docs/concepts/node-auto-provisioning) — The node auto-provisioning documentation explicitly says GKE creates node pools for pending workloads and deletes empty auto-created pools.
 - [cloud.google.com: introducing gke autopilot](https://cloud.google.com/blog/products/containers-kubernetes/introducing-gke-autopilot) — Google's launch post provides the February 2021 introduction date and describes the Autopilot management model.

--- a/src/content/docs/cloud/gke-deep-dive/module-6.2-gke-networking.md
+++ b/src/content/docs/cloud/gke-deep-dive/module-6.2-gke-networking.md
@@ -421,7 +421,7 @@ gcloud compute forwarding-rules list \
 
 ### Container-native load balancing with Network Endpoint Groups (NEGs)
 
-Classic load balancing to Kubernetes often forwarded traffic to **node IPs** and relied on kube-proxy to forward again to pods—an extra hop and another place where conntrack tables strain under churn. **Container-native load balancing** registers backends as **zonal NEGs pointing at pod IPs**, so the Google Cloud load balancer sends traffic **directly to pods** that match the Service endpoints. [For GKE 1.17 and later, container-native load balancing is the default for Ingress in many configurations](https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing); when NEGs are not default, you opt in per Service:
+Classic load balancing to Kubernetes often forwarded traffic to **node IPs** and relied on kube-proxy to forward again to pods—an extra hop and another place where conntrack tables strain under churn. **Container-native load balancing** registers backends as **zonal NEGs pointing at pod IPs**, so the Google Cloud load balancer sends traffic **directly to pods** that match the Service endpoints. On current GKE versions, container-native load balancing (NEG backends that point directly at pod IPs) is the **default** for Ingress; where it is not automatic, you opt in per Service with the `cloud.google.com/neg` annotation. See [container-native load balancing](https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing):
 
 ```yaml
 apiVersion: v1
@@ -1039,7 +1039,7 @@ Container-native load balancing registers **Network Endpoint Groups** that point
 </details>
 
 <details>
-<summary>8. Cluster Autoscaler logs show "max node group size reached" while hundreds of pods stay Pending with "failed to allocate IP address" events. The pod secondary range is `/22` and max pods per node is 110 on a regional cluster with 12 nodes already. What is the most likely root cause, and which remediation paths does Google document?</summary>
+<summary>8. Cluster Autoscaler logs show "max node group size reached" while hundreds of pods stay Pending with "failed to allocate IP address" events. The pod secondary range is `/22` and max pods per node is 110 on a regional cluster with four nodes already. What is the most likely root cause, and which remediation paths does Google document?</summary>
 
 With 110 max pods per node, GKE allocates a **`/24` pod slice per node**. A `/22` secondary range only provides four such slices (`2^(24-22)=4` node-sized allocations at that mask relationship—teams often exhaust smaller ranges faster than node CPU limits). The autoscaler cannot add nodes because **no unallocated pod CIDR blocks remain**, not because the cloud quota for VMs is zero. Remediation is not "raise autoscaler max." Documented paths include **planning a larger range at cluster creation**, adding **discontiguous multi-Pod CIDR** if supported for your environment, or **creating a replacement cluster** with recalculated `Q` (max pods) and `DS` (pod prefix) using the sizing formulas in Google's flexible pod CIDR guide. Prevention requires modeling max nodes (`MN`) before the first production deployment.
 </details>
@@ -1080,7 +1080,7 @@ gcloud container clusters create net-demo \
   --enable-ip-alias \
   --release-channel=regular \
   --gateway-api=standard \
-  --workload-pool=$PROJECT_ID.svc.id.goog
+  --workload-pool=$PROJECT_ID.svc.id.goog  # Workload Identity pool — enabled here as a forward reference (covered in Module 6.3); harmless for this networking lab.
 
 # Get credentials
 gcloud container clusters get-credentials net-demo --region=$REGION
@@ -1312,7 +1312,7 @@ spec:
     port: 80
     allowedRoutes:
       namespaces:
-        from: Same
+        from: Same  # from: Same keeps this lab single-namespace; production multi-team setups use from: Selector with namespace labels (see body).
 EOF
 
 # Create an HTTPRoute with canary traffic splitting (90/10)
@@ -1442,7 +1442,7 @@ gcloud container clusters create psc-demo \
   --enable-private-nodes \
   --private-endpoint-subnetwork=psc-subnet \
   --enable-ip-alias \
-  --master-authorized-networks=0.0.0.0/0
+  --master-authorized-networks=0.0.0.0/0  # Lab simplicity ONLY — production must narrow this to your admin/CI CIDRs (see Pre-production checklist).
 
 # Verify the PSC endpoint IP address
 gcloud container clusters describe psc-demo \

--- a/src/content/docs/cloud/gke-deep-dive/module-6.2-gke-networking.md
+++ b/src/content/docs/cloud/gke-deep-dive/module-6.2-gke-networking.md
@@ -4,11 +4,11 @@ slug: cloud/gke-deep-dive/module-6.2-gke-networking
 sidebar:
   order: 3
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 3h | **Prerequisites**: Module 6.1 (GKE Architecture)
+**Complexity**: [COMPLEX] | **Time to Complete**: 3h | **Prerequisites**: Module 6.1 (GKE Architecture). Expect to reason about CIDR math, Google Cloud load balancer objects, and Kubernetes policy objects in the same narrative—this is integrative networking design, not a single-feature checklist.
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+This module assumes you already understand regional GKE topology and release channels from Module 6.1. Here you move from cluster shape into packet paths: how alias IPs are carved out of VPC secondary ranges, how Dataplane V2 enforces policy, and how Google Cloud load balancers attach to pods. After completing the material and lab, you will be able to:
 
 - **Configure GKE Dataplane V2 (Cilium-based) with network policies and network policy logging**
 - **Implement Gateway API on GKE for traffic splitting and header-based routing**
@@ -23,13 +23,15 @@ Teams sometimes discover too late that creating `NetworkPolicy` objects is not e
 
 GKE networking is where Kubernetes meets Google's global network infrastructure. The decisions you make about cluster networking---VPC-native mode, Dataplane V2, load balancing strategy, and Gateway API configuration---determine your application's performance, security, and cost. A misconfigured network can leave your pods exposed, introduce unnecessary latency, or rack up egress charges that dwarf your compute costs.
 
-In this module, you will learn how VPC-native clusters use alias IPs to give pods routable addresses, how Dataplane V2 replaces iptables with eBPF for faster and more observable networking, how Cloud Load Balancing integrates with GKE, and how the Gateway API provides a more expressive routing model than Ingress. By the end, you will configure Dataplane V2 network policies and set up a Gateway API canary deployment.
+**Hypothetical scenario:** A platform team launches forty microservices behind separate `LoadBalancer` Services because each squad owns its Helm chart. Finance later flags a line item for dozens of forwarding rules and backend services, while SRE sees elevated latency on the oldest cluster still on kube-proxy iptables. Neither problem is mysterious once you map Kubernetes objects to the Google Cloud resources they create; both were predictable from API choices made at bootstrap.
+
+In this module, you will learn how VPC-native clusters use alias IPs to give pods routable addresses, how Dataplane V2 replaces iptables with eBPF for faster and more observable networking, how Cloud Load Balancing integrates with GKE through container-native NEGs, and how the Gateway API provides a more expressive routing model than Ingress. You will also practice diagnosing pod scheduling failures caused by IP exhaustion and designing private clusters that still pull images and admit CI safely. By the end, you will configure Dataplane V2 network policies and set up a Gateway API canary deployment.
 
 ---
 
 ## VPC-Native Clusters and Alias IPs
 
-Every modern GKE cluster should be VPC-native. [This is the default since GKE 1.21](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips) and is required for features like Dataplane V2, Private Google Access for pods, and VPC flow logs for pod traffic.
+Every modern GKE cluster should be VPC-native. [This is the default since GKE 1.21](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips) and is required for features like Dataplane V2, Private Google Access for pods, and VPC flow logs for pod traffic. Routes-based clusters remain in brownfield estates, but new work should assume alias IPs and plan secondary ranges before any workload ships.
 
 ### How Alias IPs Work
 
@@ -62,6 +64,8 @@ graph TD
 
 ### Why This Matters for Networking
 
+VPC-native routing is the foundation for every other feature in this module: without alias IPs, you do not get consistent pod IPs in VPC flow logs, Private Google Access for pods, or the IP planning model that Dataplane V2 and multi-Pod CIDR expansion assume. Legacy routes-based clusters still appear in migration backlogs, but new GKE clusters should be treated as VPC-native by default.
+
 | Feature | VPC-Native (Alias IPs) | Routes-Based (Legacy) |
 | :--- | :--- | :--- |
 | **Pod IPs routable in VPC** | Yes (directly) | No (requires custom routes) |
@@ -87,7 +91,19 @@ gcloud container clusters describe my-cluster \
 
 > **Stop and think**: If a VPC-native cluster uses alias IPs directly from the VPC, what happens if your VPC doesn't have [a large enough secondary range for your planned number of nodes and pods at maximum scale](https://cloud.google.com/kubernetes-engine/docs/how-to/flexible-pod-cidr)?
 
-Poor IP planning is the number one networking regret for teams that scale. [You cannot resize secondary ranges after cluster creation](https://cloud.google.com/kubernetes-engine/docs/how-to/flexible-pod-cidr).
+Poor IP planning is the number one networking regret for teams that scale. [You cannot resize secondary ranges after cluster creation](https://cloud.google.com/kubernetes-engine/docs/how-to/flexible-pod-cidr). Treat the worksheet below as a conversation with finance and network architects before the first `gcloud container clusters create` call, because the secondary range is effectively permanent.
+
+**Workbook steps (Standard cluster):**
+
+1. Estimate peak node count `N` per region (include autoscaling headroom and blue/green pools).
+2. Choose `Q` = max pods per node (110 default, or lower to fit more nodes in the same range).
+3. Read the per-node mask table in Google’s flexible pod CIDR documentation (`/24` at 110 pods, `/26` at 64, and so on).
+4. Compute how many node slices fit in your pod secondary prefix `DS` (for `/21` and `/24` per node, you get eight nodes).
+5. Compare `N` against that fit; if `N` is larger, widen `DS` at creation or plan [discontiguous multi-Pod CIDR](https://cloud.google.com/kubernetes-engine/docs/how-to/multi-pod-cidr) up front.
+6. Allocate a services range (`/20` is common) for ClusterIP growth; services do not consume node slices but still need RFC1918 space.
+7. Document the decision in your cluster runbook so autoscaler incidents are triaged as IP events, not mystery “quota” events.
+
+Teams that run platform-wide node pools with different density profiles sometimes create **pools with different `--max-pods-per-node`** values. Each pool still draws from the same cluster secondary range unless you assign a **custom pod range per pool**, which is an advanced escape hatch for IP-starved Shared VPC subnets.
 
 ```mermaid
 graph TD
@@ -118,6 +134,38 @@ gcloud container clusters create large-cluster \
 # needs a /26 instead of a /24, saving IP space
 ```
 
+### Secondary ranges, max pods per node, and the node ceiling
+
+VPC-native scheduling is not only about routable pod IPs; it is also a **capacity contract** between three numbers you set at cluster creation: the **pod secondary range prefix length**, the **default or per-pool maximum pods per node**, and the **number of nodes** you intend to run. [GKE allocates each node a pod CIDR slice whose size depends on max pods per node](https://cloud.google.com/kubernetes-engine/docs/how-to/flexible-pod-cidr)—for example, the default of 110 pods per node maps to a `/24` per node (256 addresses, with headroom above the pod limit). You **cannot change max pods per node after a cluster or node pool is created**, so treating “we will lower density later” as a migration path is a planning mistake.
+
+The relationship between pod range size and node count is multiplicative. With a `/21` pod secondary range and 110 max pods per node, each node consumes a `/24`, so the cluster supports roughly **eight nodes** before the secondary range is exhausted (`2^(24-21) = 8` node-sized slices). Lowering max pods per node to 64 shrinks each node’s slice to `/26`, which fits **32 nodes** in the same `/21`—same IP budget, different tradeoff between **pods per node** and **total nodes**. For Standard clusters you can configure up to **256** pods per node; Autopilot picks a value in a supported range based on expected workload density (commonly discussed around 32 in planning examples).
+
+| Max pods per node (examples) | Per-node pod CIDR | Addresses per node | Planning lever |
+| :--- | :--- | :--- | :--- |
+| 8 | `/28` | 16 | Maximize node count in a small pod range |
+| 64 | `/26` | 64 | Balance density and node scale |
+| 110 (default) | `/24` | 256 | Default GKE density |
+| 256 (Standard max) | `/23` | 512 | Highest per-node density; consumes range faster |
+
+When creating node pools on an existing cluster, **`--max-pods-per-node` on the pool overrides the cluster default**, which lets you add a “dense” pool and a “wide” pool only if you planned separate ranges up front—secondary range size for the cluster remains immutable.
+
+### IP exhaustion: symptoms, diagnosis, and remedies
+
+**Hypothetical scenario:** A regional cluster with three zones grows from six to forty nodes over a year. New pods stay `Pending` with events mentioning insufficient IP addresses, Cluster Autoscaler stops adding nodes, and existing workloads cannot scale out—even though CPU and memory requests fit on paper.
+
+That pattern usually means the **pod secondary range is full** or each new node cannot receive a fresh pod CIDR slice. Confirm with `kubectl describe node` events, cluster autoscaler logs, and `gcloud container clusters describe` fields under `ipAllocationPolicy`. Remediation paths are constrained: you **cannot resize** the original pod secondary range, so teams either **add discontiguous multi-Pod CIDR** ranges (supported for expanding pod IP space on existing clusters), **reduce max pods per node in new node pools** on a replacement cluster, or **recreate the cluster** with a larger `--cluster-ipv4-cidr` planned using the official sizing formulas. Prevention beats surgery: model `MN` (max nodes) and `MP` (max pods) from [Google’s pod-range sizing guidance](https://cloud.google.com/kubernetes-engine/docs/how-to/flexible-pod-cidr) using your expected `Q` (max pods per node) and `DS` (pod subnet prefix).
+
+```bash
+# Check how much of the pod range is in use (illustrative fields vary by version)
+gcloud container clusters describe my-cluster \
+  --region=us-central1 \
+  --format="yaml(ipAllocationPolicy,currentNodeCount)"
+
+# List pending pods stuck on networking
+kubectl get pods -A --field-selector=status.phase=Pending \
+  -o custom-columns=NS:.metadata.namespace,NAME:.metadata.name,EVENTS:.status.conditions[-1].message
+```
+
 ---
 
 ## Dataplane V2: eBPF-Powered Networking
@@ -126,7 +174,15 @@ Dataplane V2 is GKE's modern networking stack, [built on **Cilium** and **eBPF**
 
 ### Why eBPF Changes Everything
 
-Traditional Kubernetes networking uses iptables rules for service routing and kube-proxy for load balancing. This works, but it has fundamental limitations:
+Traditional Kubernetes networking uses iptables rules for service routing. kube-proxy maintains those rules on every node. The model works for small clusters. It degrades as Service counts grow.
+
+Each new Service adds iptables entries. Packets may traverse thousands of rules before a match. CPU cost rises. Latency becomes visible in tail percentiles. Debugging requires conntrack literacy and node-level tcpdump skills.
+
+eBPF programs attach at the kernel hook points Dataplane V2 owns. Lookup tables map destination IP and port to backends in roughly constant time. Policy decisions can reference Kubernetes labels without repeated userspace copies. That is why Dataplane V2 pairs well with dense microservice estates and with default-deny policy programs.
+
+Autopilot clusters enable Dataplane V2 by default. Standard clusters require `--enable-dataplane-v2` at create time. If your organization still operates legacy Standard clusters on Calico iptables policy, schedule a migration program instead of layering more annotations onto kube-proxy-era paths.
+
+Traditional Kubernetes networking still illustrates the contrast:
 
 ```mermaid
 graph TD
@@ -174,6 +230,18 @@ graph TD
 | **Observability** | Basic conntrack | Rich eBPF flow logs |
 | **Scale limit** | ~5,000 services practical | 25,000+ services tested |
 | **FQDN-based policies** | Not supported | Supported |
+
+### Dataplane V2 versus the legacy Calico dataplane
+
+GKE’s **legacy dataplane** implements Kubernetes networking with **Calico** as the CNI and **`iptables` for NetworkPolicy enforcement**, while **kube-proxy** programs service VIP routing through iptables chains on each node. **Dataplane V2** is implemented with **Cilium** semantics: the **`anetd`** DaemonSet in `kube-system` watches Kubernetes objects and loads **eBPF programs** that handle forwarding, load balancing, and policy in the kernel. [Google documents that NetworkPolicy is always available on Dataplane V2 clusters](https://cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2) without installing Calico as an add-on, which closes the gap where teams authored policies that were never enforced.
+
+The operational differences matter at scale and during incidents. Legacy clusters hit practical limits when iptables rule counts grow with Services; Dataplane V2’s service map uses **eBPF maps** (with documented aggregate backend limits such as **260,000 endpoints** across services—exceeding documented limits can cause undefined behavior). Dataplane V2 also **replaces kube-proxy** for service implementation on supported versions, so new upstream Service features may land in kube-proxy first; plan upgrade notes accordingly. **Custom eBPF programs** on DPv2 nodes are unsupported because they can collide with GKE’s programs—treat observability agents that install eBPF as compatibility risks until validated.
+
+**Critical constraint:** [Dataplane V2 can only be enabled when creating a new cluster](https://cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2); you cannot flip an existing legacy dataplane cluster in place. Migration is a **new cluster + workload move**, not a weekend flag.
+
+### FQDN-based policies and observability (Dataplane V2)
+
+Where your security model names **external SaaS endpoints** by DNS rather than static CIDRs, Dataplane V2’s Cilium lineage supports **FQDN-aware policy patterns** that are impractical with pure IP-based NetworkPolicy on legacy iptables enforcement. Pair FQDN policies with **explicit DNS egress** rules to CoreDNS, because name resolution still flows through the cluster DNS path you allow. For day-two operations, enable [**network policy logging**](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy-logging) to emit allow/deny records to Cloud Logging—this capability is tied to the Dataplane V2 policy pipeline, not legacy Calico-only clusters. Tune log sinks and filters before broad production deny rules; denied health checks and mis-scoped selectors can generate sustained log volume.
 
 ### Enabling Dataplane V2
 
@@ -261,7 +329,7 @@ spec:
 
 ### Network Policy Logging
 
-Dataplane V2 can [log allowed and denied connections](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy-logging), which is invaluable for debugging and compliance.
+[Network policy logging on Dataplane V2](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy-logging) emits structured allow and deny records to Cloud Logging, which makes it practical to prove compliance and to debug policies before you widen a default-deny posture across an entire namespace.
 
 ```bash
 # Enable network policy logging on the cluster
@@ -278,11 +346,27 @@ gcloud logging read \
 
 **War Story**: Network policy logging can generate much more data than teams expect, especially when broad agents or probes repeatedly hit denied paths. Before enabling logging in production, test in a staging environment and review the projected log volume.
 
+Dataplane V2 observability also includes flow visibility features documented under GKE Dataplane V2 observability guides; use them alongside VPC Flow Logs when you need to correlate pod-level denies with subnet-level drops. Treat `anetd` CPU spikes as a signal of connection churn (rapid TCP open/close) and stabilize workloads with HTTP keep-alives or pooling where possible.
+
 ---
 
 ## Cloud Load Balancing Integration
 
-GKE integrates tightly with Google Cloud Load Balancing. When you create a Kubernetes Service or Ingress, GKE provisions the corresponding Google Cloud load balancer components automatically.
+GKE integrates tightly with Google Cloud Load Balancing. When you create a Kubernetes Service or Ingress, GKE provisions the corresponding Google Cloud load balancer components automatically. Understanding the mapping prevents surprise bills and explains why deleting a Service sometimes leaves forwarding rules behind until finalizers complete.
+
+### How Kubernetes Services become Google Cloud resources
+
+A `ClusterIP` Service only allocates a virtual IP from the **services secondary range**; kube-proxy or Dataplane V2 programs node datapaths so traffic to that VIP reaches ready endpoints. A `type: LoadBalancer` Service adds a **Google Cloud Network Load Balancer** (external or internal depending on annotations) with forwarding rules and firewall rules tied to the Service UID. **Ingress** and **Gateway API** objects instead drive **Application Load Balancers**: URL maps, target proxies, backend services, health checks, and—when container-native—**zonal NEGs** that list pod endpoints. The GKE controllers run in Google's management plane (Gateway) or as in-cluster reconcilers (Ingress), but the billable artifacts always land in your project.
+
+```text
+HTTPRoute / Ingress  →  GKE controller  →  URL map + proxy + forwarding rule
+                                              ↓
+                                         Backend service
+                                              ↓
+                                         zonal NEG (pod IP:port)  OR  instance group (node)
+```
+
+When debugging “502 from the load balancer but pods are Ready,” walk the chain **health check → backend healthy count → endpoints → pod readiness → NetworkPolicy**. A healthy Deployment with zero endpoints on the Service still yields an empty NEG.
 
 ### Service Types and Their Load Balancers
 
@@ -304,6 +388,8 @@ graph LR
 | **Internal Ingress** | L7 | Regional | Internal HTTP routing |
 
 ### External Network Load Balancer (L4)
+
+External passthrough Network Load Balancers remain the right tool when you need **non-HTTP protocols** or raw TCP/UDP forwarding without URL maps. Game servers, legacy TLS on custom ports, and some gRPC deployments still use `type: LoadBalancer`. Each Service requests its own Google Cloud forwarding path, so platform teams should gate L4 exposure with naming conventions and automated inventory scans. Internal L4 Services use annotations such as `networking.gke.io/load-balancer-type: Internal` (see the [service load balancer](https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer) documentation for current annotation keys and regional behavior).
 
 > **Stop and think**: If you expose an internal gRPC service that requires L7 routing and TLS termination, which GKE service type or ingress method should you choose instead of a standard LoadBalancer?
 
@@ -331,6 +417,43 @@ kubectl get svc game-server -o wide
 # View the underlying GCP forwarding rule
 gcloud compute forwarding-rules list \
   --filter="description~game-server"
+```
+
+### Container-native load balancing with Network Endpoint Groups (NEGs)
+
+Classic load balancing to Kubernetes often forwarded traffic to **node IPs** and relied on kube-proxy to forward again to pods—an extra hop and another place where conntrack tables strain under churn. **Container-native load balancing** registers backends as **zonal NEGs pointing at pod IPs**, so the Google Cloud load balancer sends traffic **directly to pods** that match the Service endpoints. [For GKE 1.17 and later, container-native load balancing is the default for Ingress in many configurations](https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing); when NEGs are not default, you opt in per Service:
+
+```yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: api
+  annotations:
+    cloud.google.com/neg: '{"ingress": true}'
+spec:
+  type: ClusterIP   # recommended backend type for Ingress/NEG; avoid LoadBalancer-as-backend
+  selector:
+    app: api
+  ports:
+  - port: 8080
+    targetPort: 8080
+```
+
+| Mode | Backend target | Latency / scale | When to prefer |
+| :--- | :--- | :--- | :--- |
+| Instance group (legacy) | Node VM IP + NodePort/kube-proxy | Extra hop; kube-proxy cost | Legacy clusters only |
+| Container-native (NEG) | Pod IP endpoints | Direct to pod; better endpoint churn handling | HTTP(S) Ingress, Gateway API, modern GKE |
+| `type: LoadBalancer` Service | NLB forwarding rule to nodes/pods depending on implementation | Per-Service L4 LB | Non-HTTP protocols, UDP, simple L4 |
+
+When GKE reconciles an Ingress or Gateway, it creates **Google Cloud backend services** wired to NEGs that track ready endpoints. Adding the NEG annotation to an existing Service can **recreate backend services** and cause brief disruption—stage changes. For internal HTTP, use **`gce-internal`** Ingress class or GatewayClasses such as **`gke-l7-rilb`** instead of bolting internal annotations onto external L7 paths.
+
+```bash
+# Inspect NEGs created for a Service (name patterns include cluster/namespace/service)
+gcloud compute network-endpoint-groups list \
+  --filter="name~'k8s.*api'"
+
+gcloud compute backend-services list \
+  --filter="description~'k8s'"
 ```
 
 ### GKE Ingress (L7)
@@ -373,6 +496,8 @@ spec:
               number: 80
 ```
 
+**Managed certificates and static IPs** still flow through annotations on Ingress (`networking.gke.io/managed-certificates`, `kubernetes.io/ingress.global-static-ip-name`). The Ingress controller creates health checks against your pod readiness unless you tune `BackendConfig` CRDs for custom thresholds and timeouts. When you later migrate the same hostname to Gateway API, map those frontend settings to **`GCPGatewayPolicy`** and backend settings to **`GCPBackendPolicy`** or `HealthCheckPolicy` so health check behavior does not regress during the cutover.
+
 ---
 
 ## Gateway API: The Future of Kubernetes Routing
@@ -403,9 +528,17 @@ graph TD
     end
 ```
 
+### Operating Gateway API on shared platforms
+
+Platform teams usually publish **one external Gateway per environment** (for example `infra/external-gateway`) with TLS materials and listener ports owned centrally. Application teams receive namespace labels such as `gateway-access=true` and deploy HTTPRoutes in their own namespaces. This mirrors how enterprises ran shared Ingress controllers, but Gateway API makes the split explicit in RBAC: cluster admins hold `GatewayClass` and `Gateway` write access, while developers hold `HTTPRoute` write access in permitted namespaces only.
+
+Rollout discipline matters because Gateways provision real billable load balancers. Stage a **new Gateway + HTTPRoute** on a canary hostname before moving production DNS. Use **ReferenceGrant** when routes must reference Services or Secrets across namespaces; without grants, status conditions explain the denial clearly. Keep a runbook entry for orphaned forwarding rules when teams delete HTTPRoutes but not Gateways—`gcloud compute forwarding-rules list` filtered by cluster name remains the source of truth.
+
+Google documents that **Ingress resources convert cleanly** to Gateway plus HTTPRoute equivalents for GKE. Treat conversion as a migration factory: generate routes per namespace, validate weights and hostnames in staging, then repoint DNS. Running both APIs against the same public hostname during migration is a common outage source; use separate hostnames or internal-only Gateways until validation finishes.
+
 ### GKE Gateway Classes
 
-GKE provides several [pre-installed GatewayClasses](https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api):
+[GKE ships multiple GatewayClasses](https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api) so platform teams can select the load balancer product that matches exposure, scope, and fleet layout without relearning annotation dialects from the Ingress era.
 
 | GatewayClass | Load Balancer Type | Scope | Use Case |
 | :--- | :--- | :--- | :--- |
@@ -413,6 +546,14 @@ GKE provides several [pre-installed GatewayClasses](https://cloud.google.com/kub
 | `gke-l7-regional-external-managed` | Regional external ALB | Regional | Region-specific apps |
 | `gke-l7-rilb` | Regional internal ALB | Regional | Internal microservices |
 | `gke-l7-gxlb` | Classic global external ALB | Global | Legacy, avoid for new |
+| `gke-l7-global-external-managed-mc` | Multi-cluster global external ALB | Global fleet | Same hostname across clusters/regions |
+| `gke-l7-rilb-mc` | Multi-cluster regional internal ALB | Fleet internal | Private multi-cluster HTTP |
+
+### Choosing a GatewayClass (and when Ingress still appears)
+
+Use **`gke-l7-global-external-managed`** for new public HTTP(S) apps that need Google’s global external Application Load Balancer features (CDN integration, managed certs, global anycast frontends). Pick **`gke-l7-regional-external-managed`** when data residency, blast radius, or compliance requires the frontend and backends to stay in **one region** even if the GKE cluster is regional. Use **`gke-l7-rilb`** for **VPC-internal** HTTP routing between microservices—pairs naturally with private nodes and private DNS. Reserve **`gke-l7-gxlb`** only when you must match an existing **classic external HTTP(S) load balancer**; Google positions managed GatewayClasses as the forward path. Enable multi-cluster classes (`*-mc`) when a **fleet** should share one hostname across clusters with [multi-cluster Gateway](https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api) controllers; that adds fleet registration and Multi Cluster Ingress API setup beyond single-cluster Gateway.
+
+Cross-namespace routing requires **bidirectional attachment**: Gateway `allowedRoutes` must permit the HTTPRoute namespace, and HTTPRoutes must reference a Gateway that exists. For secrets and Services in other namespaces, add **`ReferenceGrant`** objects in the target namespace—without them, Gateway status reports reference grant errors.
 
 ```bash
 # List available GatewayClasses in your cluster
@@ -496,7 +637,7 @@ spec:
 
 ### Canary Deployments with Gateway API
 
-The Gateway API natively supports [traffic splitting by weight](https://cloud.google.com/kubernetes-engine/docs/concepts/traffic-management)---something that required Istio or custom annotations with Ingress.
+[Traffic splitting by weight](https://cloud.google.com/kubernetes-engine/docs/concepts/traffic-management) is a first-class Gateway API feature on GKE, which means canary releases do not require a service mesh sidecar in the data path for HTTP workloads fronted by Google Cloud L7 load balancers.
 
 ```yaml
 # Canary: send 90% to stable, 10% to canary
@@ -526,7 +667,7 @@ spec:
       weight: 10
 ```
 
-To gradually shift traffic, update the weights:
+To gradually shift traffic during a release, patch the HTTPRoute `backendRefs` weights and wait for the external load balancer to reconcile—there is no separate canary CRD on GKE managed Gateways.
 
 ```bash
 # Move to 50/50
@@ -557,7 +698,7 @@ kubectl patch httproute store-api-canary -n store --type=merge -p '{
 
 ### Header-Based Routing
 
-Gateway API also supports [routing based on HTTP headers](https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api), which is useful for testing in production.
+[Header-based matches](https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api) let operators steer internal testers to canary backends while production clients hit stable rules on the same hostname, which is safer than exposing a second public DNS name for experiments.
 
 ```yaml
 # Route requests with X-Canary: true header to canary service
@@ -593,11 +734,21 @@ spec:
       port: 8080
 ```
 
+### Multi-cluster Gateway and fleet-scale routing
+
+When applications run in **multiple GKE clusters** (disaster recovery, locality, or team boundaries), single-cluster Gateways still provision **one load balancer per Gateway**. Multi-cluster GatewayClasses (for example `gke-l7-global-external-managed-mc`) let platform teams publish **one frontend IP/DNS name** while HTTPRoutes reference **multi-cluster Services** that span fleet membership. The GKE Gateway controller for multi-cluster is **Google-hosted** (not on your control plane) and reconciles Cloud Load Balancing from fleet-aware APIs—data plane traffic still flows through Google’s L7 load balancers, not through the controller itself. Operational cost: multi-cluster Gateways have **separate pricing** from single-cluster Gateways (see Google’s Multi Cluster Gateway pricing documentation linked from the Gateway API overview). Start with a **shared Gateway per namespace** pattern on one cluster before adopting fleet-wide shared Gateways, so teams learn HTTPRoute ownership without cross-cluster failure domains on day one.
+
 ---
 
 ## Private Service Connect for GKE
 
 Private Service Connect (PSC) allows you to access the GKE control plane through [a private endpoint within your VPC](https://cloud.google.com/kubernetes-engine/docs/concepts/private-service-connect), eliminating exposure to the public internet.
+
+Legacy private clusters consumed **VPC peering** slots between your VPC and Google’s managed control plane VPC. Peering is non-transitive. On-premises networks could not always reach the control plane through your existing Interconnect paths without extra design. PSC publishes a **consumer endpoint IP** in your subnet. You route to that IP like any internal service. Large enterprises adopt PSC to preserve peering quota for application networks and to let CI runners in hybrid data centers reach the API without public IPs.
+
+Private **nodes** are orthogonal. You can run private nodes with a public control plane endpoint (common in labs) or lock down both planes (typical regulated production). Each combination changes firewall rules, DNS, and CI patterns. Document the combination your security team approved so application teams do not assume kubectl works from laptops when only bastion paths are allowed.
+
+**Authorized networks** on the control plane restrict which CIDRs may call the Kubernetes API when an endpoint is reachable from broader corporate networks. Treat overly wide entries as temporary. Pair narrow CIDRs with Identity-Aware Proxy or VPN where humans need access. Automation should use dedicated service accounts and private connectivity (Cloud Build private pools, Cloud Deploy, or in-VPC runners).
 
 ```bash
 # Create a private cluster with PSC
@@ -658,6 +809,160 @@ gcloud compute routers nats create nat-config \
   --nat-all-subnet-ip-ranges
 ```
 
+### Private nodes, private control-plane endpoint, and authorized networks
+
+**Private nodes** (`--enable-private-nodes`) remove public IPs from worker VMs; outbound image pulls and external APIs then require **Private Google Access**, **Cloud NAT**, or private endpoints to Artifact Registry and other Google APIs. **Private control-plane endpoint** (`--enable-private-endpoint` or PSC-based private endpoint subnetwork) restricts Kubernetes API access to RFC1918 paths you route—this is separate from whether workloads are public. **`--enable-master-authorized-networks`** (legacy private clusters) and PSC endpoint policies both implement **who may call the API server**; misconfiguration shows up as `kubectl` timeouts from CI systems that still use public egress IPs.
+
+| Control | What it isolates | Typical failure if skipped |
+| :--- | :--- | :--- |
+| Private nodes | Workload VMs from the internet | Image pull failures without NAT/PGA |
+| Private endpoint | Kubernetes API from public internet | CI/CD cannot reach API without VPN/Interconnect/Cloud Build private pool |
+| Authorized networks / endpoint policy | API server clients by CIDR | Over-broad `0.0.0.0/0` negates private endpoint benefits |
+| Cloud NAT | Egress from private nodes to internet APIs | Egress stalls; SNAT port exhaustion at high connection churn |
+
+**Hypothetical scenario:** A platform team enables private nodes but forgets NAT before rolling out a wave of Deployments that pull public container images. Pods remain `ImagePullBackOff` while the nodes themselves are healthy—networking tickets spike even though the application manifest is unchanged. The fix is outbound path design (NAT or private registries), not restarting kubelet.
+
+For PSC-based clusters, allocate a **dedicated `/28` (or larger) subnetwork** for the private endpoint as Google recommends in PSC cluster guides; treat that subnet like any other immovable foundation resource.
+
+---
+
+## Diagnosing pod-to-service and east-west failures
+
+North-south load balancers get the glory, but most incident time burns on **east-west** paths: Pod A calls `http://api.production.svc.cluster.local` and receives timeouts, `connection refused`, or NXDOMAIN. A disciplined checklist separates DNS, Service endpoints, dataplane programming, and policy.
+
+**DNS layer:** CoreDNS must be reachable. Deny-all egress policies without UDP/TCP 53 to `kube-dns` break resolution before any Service VIP is contacted. Test with `kubectl run -it --rm debug --image=busybox:1.36 -- nslookup api.production.svc.cluster.local`. Intermittent failures on large responses indicate missing TCP 53 fallback.
+
+**Service and Endpoints layer:** `kubectl get endpoints api -n production` must list pod IPs matching ready pods. If endpoints are empty while pods run, selector labels on the Deployment do not match the Service `spec.selector`. Headless Services (`clusterIP: None`) return pod A records directly—clients must handle multiple backends.
+
+**Dataplane layer:** On Dataplane V2, Service VIP handling is implemented without kube-proxy iptables chains. On legacy clusters, stale iptables rules or conntrack exhaustion still appear in older runbooks. Compare behavior on a known-good namespace before blaming application code.
+
+**Policy layer:** NetworkPolicy is directional. A policy in namespace `production` affects ingress to pods there; egress from the client namespace also needs allow rules. Use Dataplane V2 logging to see denies with source/destination pod metadata.
+
+**Hypothetical scenario:** After a platform team enables default-deny ingress everywhere, the checkout service reports 503s calling `payments` by ClusterIP. Payments pods are healthy and the Service has endpoints. The missing piece is an ingress allow from the checkout namespace label to the payments pods—DNS and VIP routing were never the fault.
+
+| Symptom | Likely layer | First commands |
+| :--- | :--- | :--- |
+| `NXDOMAIN` / lookup timeout | DNS / policy blocking 53 | `nslookup` from client pod; check DNS NetworkPolicy |
+| Connection timeout to ClusterIP | NetworkPolicy or wrong namespace | `kubectl get networkpolicy -A`; logging denies |
+| Connection refused | No endpoints or pod not listening | `kubectl get endpoints`; `kubectl logs` target pod |
+| Works by IP, fails by name | DNS only | Compare `curl http://10.x:8080` vs Service DNS name |
+| LB 502, in-cluster OK | GCLB health check / NEG drift | Backend health in console; pod readiness path |
+
+```bash
+# End-to-end path check from a client pod
+kubectl run netshoot --rm -it --image=nicolaka/netshoot --restart=Never -- \
+  sh -c 'nslookup api.production.svc.cluster.local;
+         curl -v --connect-timeout 3 http://api.production.svc.cluster.local:8080/healthz'
+```
+
+Document baseline latency and success for these probes after every NetworkPolicy change so regressions are obvious in CI staging clusters. When a symptom appears only from outside the cluster but in-cluster probes succeed, escalate to load balancer health checks and NEG endpoint lists before restarting application pods.
+
+---
+
+## Patterns & Anti-Patterns
+
+Production GKE networking succeeds when teams treat IP ranges, load balancers, and policy enforcement as **joint capacity planning**, not as three unrelated tickets. The patterns below are observed behaviors from teams operating regional clusters on Dataplane V2 with managed Gateways; adapt them to your compliance tier and IP address plan.
+
+| Pattern | When to use | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| **Container-native LB (NEG) for HTTP(S)** | Ingress or Gateway API fronts Services with churning pod endpoints | Load balancer targets pod IPs directly, avoiding kube-proxy/node double hops | NEGs track endpoints per zone; ensure health checks match readiness probes |
+| **Default-deny NetworkPolicy + DPv2 logging** | Regulated namespaces (payments, PHI, admin) | Policies actually enforce on Dataplane V2; logging proves intent before wide deny | Sample logging in staging; filter deny noise before production |
+| **Shared Gateway API with namespace-scoped HTTPRoutes** | Many teams, one domain or shared IP | Platform owns TLS/listeners; apps own routes and canary weights | One GCLB per Gateway—not per microservice Service |
+| **Right-sized pod secondary range + tuned max pods** | Clusters expected to exceed ~20 nodes | Buys node headroom without rebuilding VPC | Use discontiguous multi-Pod CIDR if growth exceeds initial math |
+| **Private nodes + NAT + private Google APIs** | Internet-isolated workloads that still pull images | Keeps nodes off public internet while preserving controlled egress | Monitor NAT gateway throughput and port usage |
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+| :--- | :--- | :--- | :--- |
+| **Undersized pod CIDR** | Pending pods, blocked autoscaling, unrecoverable without new range/cluster | “/24 is enough for now” on regional multi-zone clusters | Model max nodes with official formulas; start `/21` or larger when unsure |
+| **iptables/kube-proxy at very large Service counts** | Latency climbs with Service count; policy blind spots on legacy dataplane | Older clusters never migrated | New clusters on Dataplane V2; plan blue/green migration |
+| **Public control plane without tight authorized networks** | API server reachable from broad internet | Quick lab clusters promoted to prod | Private endpoint + PSC or narrow authorized CIDRs + Identity-Aware Proxy patterns |
+| **`type: LoadBalancer` per microservice** | One forwarding rule + backend per Service; cost and quota sprawl | Ingress/Gateway learning curve | Consolidate HTTP(S) behind Gateway API; reserve L4 LB for true non-HTTP needs |
+| **NetworkPolicy without DNS egress** | Crash loops after deny-all egress | Copy-paste PCI templates | Always allow kube-dns:53 when apps use cluster DNS |
+| **Mixing Ingress and Gateway on same hostname** | Duplicate GCLB assets, conflicting certs | Incremental migration without ownership | Pick one L7 API per hostname; migrate with temporary separate hosts |
+
+---
+
+## Decision Framework
+
+Use this flow when choosing north-south exposure and dataplane features. It complements the tables above for day-to-day design reviews.
+
+```mermaid
+flowchart TD
+  START["Need to expose workload outside the cluster?"] -->|No| INTERNAL["ClusterIP only or mesh east-west"]
+  START -->|Yes| PROTO{"Protocol & routing needs?"}
+  PROTO -->|TCP/UDP non-HTTP| L4["Service type LoadBalancer<br>or internal L4"]
+  PROTO -->|HTTP/S with path/host/header/canary| L7{"New platform standard?"}
+  L7 -->|Greenfield / multi-team| GW["Gateway API + GatewayClass<br>(managed external or rilb)"]
+  L7 -->|Legacy only / single owner| ING["GKE Ingress (gce / gce-internal)"]
+  GW --> NEGQ{"Container-native NEG default?"}
+  ING --> NEGQ
+  NEGQ -->|Yes on GKE 1.17+| NEGON["Ensure Service endpoints healthy;<br>annotate NEG if required"]
+  NEGQ -->|Legacy IG backend| NEGOFF["Explicit cloud.google.com/neg<br>or accept node hop"]
+  INTERNAL --> POL{"Need L3/L4 policy enforcement?"}
+  POL -->|Yes| DP2{"Cluster on Dataplane V2?"}
+  DP2 -->|Yes| LOG["NetworkPolicy + optional<br>policy logging in staging"]
+  DP2 -->|No| MIG["Plan new DPv2 cluster;<br>legacy Calico add-on path"]
+```
+
+| Decision | Choose A | Choose B | Tradeoffs |
+| :--- | :--- | :--- | :--- |
+| **L7 API** | **Gateway API** (`gke-l7-*-managed`) | **Ingress** (`gce` / `gce-internal`) | Gateway: role split, native weights/headers; Ingress: mature samples, annotation-heavy advanced routing |
+| **External vs internal HTTP** | `gke-l7-global-external-managed` | `gke-l7-rilb` | External: public clients; RILB: private RFC1918 clients only |
+| **Regional vs global external** | `gke-l7-regional-external-managed` | `gke-l7-global-external-managed` | Regional: smaller blast radius; Global: anycast, multi-region clients |
+| **LB backend mode** | **NEG (container-native)** | **Instance group / node-target** | NEG: direct to pod; legacy: simpler mentally, worse at scale |
+| **Policy logging** | Enable DPv2 logging before broad deny | Policies only | Logging costs Cloud Logging ingest; invaluable for proving compliance |
+| **Control-plane privacy** | **PSC private endpoint** | Legacy VPC-peered private cluster | PSC avoids peering slot limits; requires endpoint subnet + routing design |
+
+---
+
+## Networking cost lens
+
+GKE networking spend often surprises finance teams because **load balancers and egress are billed separately from node pools**. At moderate scale (tens of microservices, multi-zone clusters, one public HTTP surface), watch these levers:
+
+**Application Load Balancers (Ingress/Gateway):** Each external managed Gateway or Ingress front end creates forwarding rules, proxies, and URL maps in your project. Consolidating many HTTPRoutes under one Gateway typically costs less than provisioning a `type: LoadBalancer` Service per Deployment. Those per-Service L4 paths mint discrete forwarding rules. Data processing and rule charges still apply to bytes through L7 load balancers. See [Cloud Load Balancing pricing](https://cloud.google.com/load-balancing/docs/pricing) for current SKUs. Global and regional frontends bill differently.
+
+**Cloud NAT:** Private nodes that use NAT for outbound internet pay for NAT gateway processing plus egress on translated traffic. Sudden spikes often trace to verbose logging agents or unbounded image pulls. SNAT port exhaustion can also cause retry storms. Right-size NAT gateways. Prefer private Artifact Registry in the same region to keep pulls off the public internet path.
+
+**Inter-zone traffic:** Regional clusters spread pods across zones for HA. Pod-to-pod traffic that crosses zones incurs standard VPC pricing between zones in the same region. Prefer topology-aware routing when the application tolerates it. Do not assume “same region” means free east-west traffic.
+
+**Logging:** Dataplane V2 network policy logging and verbose L7 access logs can dominate observability spend. Enable logging in staging first. Measure ingest rate. Then promote filters to production namespaces.
+
+### Autopilot networking defaults (what you do not configure)
+
+Autopilot hides node-level networking knobs, but the outcomes still matter for your designs. Autopilot runs VPC-native alias IP clusters with Dataplane V2 and enforces workload security constraints that influence host networking. You do not SSH to nodes to debug iptables chains. You reason about Services, Routes, and policies instead.
+
+Autopilot also pre-selects max pods per node from a supported band based on expected density. You cannot tune that integer the way Standard clusters do. IP exhaustion therefore shows up as scheduling failures while the control plane still looks healthy. The same secondary-range planning rules apply; only the levers move to cluster CIDR choice and multi-Pod CIDR expansion.
+
+Gateway API on Autopilot follows the same GatewayClass matrix as Standard. Google manages nodes and repair, while you still own DNS, certificates, and HTTPRoute ownership boundaries. Platform teams should publish approved GatewayClasses per environment so application teams do not accidentally provision classic `gke-l7-gxlb` fronts that lack modern feature parity.
+
+| Cost driver | What makes it spike | Knobs that usually help |
+| :--- | :--- | :--- |
+| Many L4 `LoadBalancer` Services | Each Service → forwarding rule/backends | Gateway API consolidation, internal services stay ClusterIP |
+| Multi-Gateway sprawl | Duplicate managed L7 fronts per team | Shared Gateway per environment + HTTPRoute ownership |
+| NAT + wide egress | Pulling public images/binaries from private nodes | Regional Artifact Registry, Private Google Access |
+| Cross-zone chatter | Anti-affinity spreading chatty workloads | Zone-aware scheduling, colocate dependents |
+| Policy/access logs | Broad deny rules + INFO everywhere | Filter denies, scope logging to pilot namespaces |
+
+---
+
+## Pre-production networking checklist
+
+Use this checklist during architecture review before the first production deploy. It does not replace your organization’s security standards, but it catches the failures that recur across GKE networking incidents.
+
+**IP and cluster shape:** Confirm the pod secondary range size using max nodes, max pods per node, and the official mask table. Record whether discontiguous multi-Pod CIDR is approved if growth exceeds the initial range. Verify the services range supports expected ClusterIP count. Ensure the subnet primary range has enough node IPs for all zones in regional clusters.
+
+**Dataplane and policy:** Create production clusters with Dataplane V2 if policy enforcement and logging are required. Validate that staging clusters mirror production dataplane choice. Draft default-deny policies with explicit DNS egress and kube-system exceptions documented. Enable network policy logging in staging, measure log volume, and define Cloud Logging filters before production enforcement.
+
+**North-south exposure:** Choose Gateway API for new HTTP(S) surfaces unless a hard dependency on legacy Ingress annotations exists. Pick GatewayClass deliberately (global external managed vs regional external vs internal RILB). Plan one Gateway per environment instead of per microservice. Confirm container-native NEG backends for Ingress and Gateway paths. Document DNS, TLS, and certificate ownership (Google-managed certs vs pre-shared certs).
+
+**Private access:** If nodes are private, confirm Cloud NAT or private Google APIs for image pulls. If the control plane is private, confirm CI/CD connectivity (Cloud Build private pools, VPN, or Interconnect) and narrow authorized networks. For PSC, verify the endpoint subnet routing from on-premises and cloud bastions.
+
+**Cost and operations:** Estimate forwarding rule count from Services and Gateways. Model NAT throughput for peak egress. Note cross-zone traffic for chatty microservices. Assign owners for orphaned load balancer cleanup after namespace deletes.
+
+**Runbook hooks:** Store `gcloud container clusters describe` IP allocation output with the cluster record. Store baseline `kubectl get endpoints` and in-cluster `curl` checks for critical Service paths. Link this module’s troubleshooting table for on-call engineers.
+
+Reviewers should reject cluster creates that skip this checklist when the workload handles regulated data or internet-facing HTTP. The checklist is lightweight compared to rebuilding a cluster because the pod range was sized for six nodes instead of sixty. Treat Gateway and Ingress objects as infrastructure-as-code artifacts with the same review bar as firewall rules, because they create Google Cloud resources outside Kubernetes RBAC. Re-run the checklist after major autoscaling events or fleet expansions, not only at day zero. Save the signed checklist with the cluster’s infrastructure-as-code pull request for auditability and on-call context after security approval.
+
 ---
 
 ## Did You Know?
@@ -669,6 +974,8 @@ gcloud compute routers nats create nat-config \
 3. **The Gateway API was designed as a role-oriented Kubernetes API.** One of its core ideas is to separate infrastructure concerns from application routing through resources such as GatewayClass, Gateway, and HTTPRoute.
 
 4. **Google Cloud load balancing is built on several underlying systems, and the exact technology depends on the load balancer type rather than a single implementation for every product.**
+
+The Gateway API’s role-oriented model is why Google recommends it for new GKE HTTP(S) work. Ingress remains supported and convertible, but shared platforms benefit when listeners and certificates are owned separately from application path rules. Multi-cluster GatewayClasses extend that separation across fleets when applications must stay available during regional failures without duplicating public DNS entries per cluster.
 
 ---
 
@@ -682,7 +989,7 @@ gcloud compute routers nats create nat-config \
 | Forgetting DNS egress in NetworkPolicy | Writing a deny-all egress policy without DNS exception | Usually include a rule allowing [UDP/TCP port 53 to kube-dns pods](https://kubernetes.io/docs/concepts/services-networking/network-policies/) when workloads rely on cluster DNS |
 | Using Ingress annotations for advanced routing | Trying to do canary/header routing with GKE Ingress | Switch to Gateway API which natively supports traffic splitting and header matching |
 | Not enabling Cloud NAT for private clusters | [Private nodes cannot reach the internet](https://cloud.google.com/kubernetes-engine/docs/how-to/legacy/network-isolation) | Configure Cloud NAT on the VPC router before creating private clusters |
-| Mixing GKE Ingress and Gateway API on the same cluster | Both controllers can provision load balancer resources | Avoid exposing the same application path through both during normal operation; use a clear migration plan if you run both |
+| Mixing GKE Ingress and Gateway API on the same cluster | Both controllers can provision load balancer resources | Avoid exposing the same application path through both; delete HTTPRoutes before Gateways to prevent orphan forwarding rules |
 | Ignoring network policy logging | Deploying policies without validation | Enable network policy logging and review denied connections before enforcing broadly |
 
 ---
@@ -698,7 +1005,7 @@ iptables-based routing uses a linear chain of rules that the kernel evaluates se
 <details>
 <summary>2. You deploy a strict `deny-all` egress NetworkPolicy to your `payments` namespace to meet PCI compliance. Suddenly, all pods in the namespace start crash-looping, reporting that they cannot connect to the internal database service `db.backend.svc.cluster.local`, even though you added an egress rule explicitly allowing traffic to the database's IP range. What critical rule is missing?</summary>
 
-When you create a NetworkPolicy with `policyTypes: ["Egress"]` and no egress rules, you implicitly block all outbound traffic from the selected pods, including DNS resolution. Pods resolve service names (like `db.backend.svc.cluster.local`) by querying the kube-dns (CoreDNS) pods on UDP port 53. Without a DNS exception, pods cannot resolve any service names to IP addresses, meaning your application cannot even attempt the connection to the database. The critical missing rule is an explicit egress rule allowing traffic to kube-dns pods on both UDP and TCP port 53. TCP is required as a fallback for DNS responses larger than 512 bytes.
+A `policyTypes: ["Egress"]` policy without broad egress rules blocks all outbound traffic from selected pods. That includes DNS. Pods resolve `db.backend.svc.cluster.local` through CoreDNS on UDP port 53. Without an egress allow to kube-dns, name resolution fails before TCP to the database starts. The fix is an explicit egress rule to kube-dns pods on UDP and TCP port 53. TCP covers large DNS responses above the traditional 512-byte UDP limit. This is a classic pod-to-service failure that looks like a database outage but is really policy.
 </details>
 
 <details>
@@ -708,7 +1015,7 @@ The Gateway API uses a three-tier resource model designed specifically for role-
 </details>
 
 <details>
-<summary>4. A junior engineer provisions a new regional GKE cluster (spanning 3 zones, 2 nodes per zone) and assigns a `/24` CIDR block for the pod secondary range. During the deployment of the first application, several pods remain in a `Pending` state, and the cluster autoscaler fails to add new nodes. What is the root cause of this failure?</summary>
+<summary>4. How do you diagnose IP exhaustion when a regional GKE cluster (three zones, two nodes per zone) uses a `/24` pod secondary range and new pods stay Pending while the cluster autoscaler cannot add nodes?</summary>
 
 A /24 CIDR block provides only 256 IP addresses for the entire pod network. In a VPC-native cluster, each node is allocated its own /24 slice by default to support up to 110 pods. Because a regional cluster with 3 zones and 2 nodes per zone requires 6 nodes in total, it would need at least a /21 for the pod range to accommodate them. The cluster creation will initially succeed, but you will hit scheduling failures and autoscaling blocks when the pod CIDR is quickly exhausted and new pods cannot be assigned IPs. This situation is unrecoverable, as secondary ranges cannot be resized, requiring a full cluster recreation.
 </details>
@@ -723,6 +1030,18 @@ Gateway API supports traffic splitting natively through the `weight` field on `b
 <summary>6. Your enterprise network team mandates that all new GKE clusters must be private, but they have exhausted the 25 VPC Peering connections limit on the central shared VPC. They also require that the GKE control plane be accessible via a specific private IP address on your on-premises network through Cloud Interconnect. Why is Private Service Connect (PSC) the only viable architecture for this requirement?</summary>
 
 The legacy private cluster model relies on VPC peering between your VPC and the Google-managed VPC hosting the control plane. VPC peering is non-transitive, meaning peered networks cannot reach each other through your VPC, and it consumes a strict peering slot limit per VPC. Private Service Connect (PSC) instead creates a forwarding rule in your VPC that routes traffic to the control plane through a localized endpoint. This completely bypasses VPC peering, freeing up peering slots, and crucially supports transitive connectivity so on-premises networks can access the endpoint via Cloud Interconnect. PSC is the modern, scalable approach for private control plane access.
+</details>
+
+<details>
+<summary>7. After enabling container-native load balancing for an Ingress-backed Service, you notice brief 502 errors during rolling deployments even though readiness probes pass. Pods terminate gracefully, but the external Application Load Balancer still sends traffic to terminating endpoints for a short window. Which GKE integration feature are you benefiting from, and what operational practices reduce user-visible errors?</summary>
+
+Container-native load balancing registers **Network Endpoint Groups** that point at **pod IPs** rather than routing through node ports alone. During rollouts, endpoints churn quickly; the load balancer health checks and endpoint sync must track **ready** pods only. You are benefiting from NEG-backed backends tied to the Service endpoints controller. Reduce 502s by ensuring **readiness probes** truly reflect application readiness (not just process start), using **`preStop` hooks** and adequate `terminationGracePeriodSeconds` so endpoints drain before SIGTERM, and verifying **BackendConfig / health check** intervals match rollout speed. For Gateway API, attach **HealthCheckPolicy** resources so Google Cloud health checks align with pod readiness semantics.
+</details>
+
+<details>
+<summary>8. Cluster Autoscaler logs show "max node group size reached" while hundreds of pods stay Pending with "failed to allocate IP address" events. The pod secondary range is `/22` and max pods per node is 110 on a regional cluster with 12 nodes already. What is the most likely root cause, and which remediation paths does Google document?</summary>
+
+With 110 max pods per node, GKE allocates a **`/24` pod slice per node**. A `/22` secondary range only provides four such slices (`2^(24-22)=4` node-sized allocations at that mask relationship—teams often exhaust smaller ranges faster than node CPU limits). The autoscaler cannot add nodes because **no unallocated pod CIDR blocks remain**, not because the cloud quota for VMs is zero. Remediation is not "raise autoscaler max." Documented paths include **planning a larger range at cluster creation**, adding **discontiguous multi-Pod CIDR** if supported for your environment, or **creating a replacement cluster** with recalculated `Q` (max pods) and `DS` (pod prefix) using the sizing formulas in Google's flexible pod CIDR guide. Prevention requires modeling max nodes (`MN`) before the first production deployment.
 </details>
 
 ---
@@ -740,6 +1059,8 @@ Create a GKE cluster with Dataplane V2, enforce network policies between namespa
 - `kubectl` installed
 
 ### Tasks
+
+The lab walks through seven tasks in order: cluster bootstrap with Dataplane V2 and Gateway API, sample microservices in two namespaces, default-deny NetworkPolicy with a targeted allow, Gateway-based canary weights, traffic promotion, a PSC private cluster exercise, and resource cleanup. Open each solution block when you are ready to run the commands; deleting clusters at the end avoids orphaned forwarding rules.
 
 **Task 1: Create a GKE Cluster with Dataplane V2 and Gateway API**
 
@@ -772,7 +1093,7 @@ kubectl get gatewayclass
 ```
 </details>
 
-**Task 2: Deploy Two Namespaces with Applications**
+**Task 2: Deploy Two Namespaces with Applications** — Create `frontend` and `backend` namespaces with labeled Deployments and ClusterIP Services so later NetworkPolicy and HTTPRoute rules have stable and canary backends to target.
 
 <details>
 <summary>Solution</summary>
@@ -911,7 +1232,7 @@ kubectl get pods -n backend
 ```
 </details>
 
-**Task 3: Enforce Network Policies with Dataplane V2**
+**Task 3: Enforce Network Policies with Dataplane V2** — Apply default-deny ingress in `backend`, prove cross-namespace traffic fails, then allow only the frontend namespace on TCP 8080 and confirm unauthorized namespaces remain blocked.
 
 <details>
 <summary>Solution</summary>
@@ -970,7 +1291,7 @@ kubectl delete namespace attacker
 ```
 </details>
 
-**Task 4: Set Up Gateway API with Canary Traffic Splitting**
+**Task 4: Set Up Gateway API with Canary Traffic Splitting** — Provision a `gke-l7-global-external-managed` Gateway and an HTTPRoute that sends weighted traffic between stable and canary Services, then poll the external IP until the Google Cloud load balancer finishes programming.
 
 <details>
 <summary>Solution</summary>
@@ -1037,7 +1358,7 @@ done | sort | uniq -c | sort -rn
 ```
 </details>
 
-**Task 5: Shift Canary Traffic to 50/50 and Then Promote**
+**Task 5: Shift Canary Traffic to 50/50 and Then Promote** — Patch HTTPRoute weights to validate gradual rollout, observe distribution with repeated `curl` calls, and finally send one hundred percent of traffic to the canary Service before decommissioning stable.
 
 <details>
 <summary>Solution</summary>
@@ -1102,7 +1423,7 @@ done
 ```
 </details>
 
-**Task 6: Provision a Private Cluster with Private Service Connect (PSC)**
+**Task 6: Provision a Private Cluster with Private Service Connect (PSC)** — Create a dedicated PSC subnet and a private cluster that exposes the control plane through a private endpoint so you can compare PSC routing with the public Gateway lab cluster.
 
 <details>
 <summary>Solution</summary>
@@ -1130,7 +1451,7 @@ gcloud container clusters describe psc-demo \
 ```
 </details>
 
-**Task 7: Clean Up**
+**Task 7: Clean Up** — Delete both demo clusters, remove the PSC subnet, and list forwarding rules to confirm no load balancer artifacts remain billing in the project after the exercise.
 
 <details>
 <summary>Solution</summary>
@@ -1169,19 +1490,24 @@ gcloud compute target-http-proxies list --filter="description~net-demo"
 
 ## Next Module
 
-Next up: **[Module 6.3: GKE Workload Identity and Security](../module-6.3-gke-identity/)** --- Learn how to securely connect pods to GCP services without storing credentials, enforce binary authorization for trusted images, and leverage GKE's security posture dashboard.
+Next up: **[Module 6.3: GKE Workload Identity and Security](../module-6.3-gke-identity/)** --- Learn how to securely connect pods to GCP services without storing credentials, enforce binary authorization for trusted images, and leverage GKE's security posture dashboard. Networking choices in this module pair directly with Workload Identity and private control-plane access patterns covered there.
 
 ## Sources
 
 - [Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/) — Explains that NetworkPolicy behavior depends on the cluster's networking implementation and covers common policy constraints such as DNS egress.
 - [VPC-native clusters](https://cloud.google.com/kubernetes-engine/docs/concepts/alias-ips) — Authoritative GKE reference for alias IPs, Pod routability, and network-mode defaults.
 - [Flexible Pod CIDR](https://cloud.google.com/kubernetes-engine/docs/how-to/flexible-pod-cidr) — Documents per-node Pod CIDR sizing and why Pod secondary range planning must be done before cluster creation.
+- [Add Pod IP addresses (discontiguous multi-Pod CIDR)](https://cloud.google.com/kubernetes-engine/docs/how-to/multi-pod-cidr) — Explains expanding pod IP space on existing clusters when the original secondary range is exhausted.
 - [GKE Dataplane V2](https://cloud.google.com/kubernetes-engine/docs/concepts/dataplane-v2) — Explains how Dataplane V2 works, its Cilium/eBPF basis, and its built-in policy enforcement model.
 - [Network policy logging](https://cloud.google.com/kubernetes-engine/docs/how-to/network-policy-logging) — Covers Dataplane V2 network policy logging and the allowed or denied connection records it can emit.
+- [Container-native load balancing](https://cloud.google.com/kubernetes-engine/docs/how-to/container-native-load-balancing) — Describes NEG-backed backends, the `cloud.google.com/neg` annotation, and Ingress integration.
 - [GKE Ingress](https://cloud.google.com/kubernetes-engine/docs/concepts/ingress) — Describes how GKE Ingress provisions Google Cloud HTTP(S) load balancing resources for Kubernetes workloads.
 - [Service load balancers](https://cloud.google.com/kubernetes-engine/docs/concepts/service-load-balancer) — Explains how `Service` objects of type `LoadBalancer` map to Google Cloud load balancer resources on GKE.
 - [About Gateway API](https://cloud.google.com/kubernetes-engine/docs/concepts/gateway-api) — Covers GKE GatewayClasses, the Gateway and HTTPRoute model, and GKE's migration guidance from Ingress.
 - [GKE traffic management](https://cloud.google.com/kubernetes-engine/docs/concepts/traffic-management) — Documents weighted backend references and related traffic-splitting features for Gateway API on GKE.
 - [About Private Service Connect](https://cloud.google.com/kubernetes-engine/docs/concepts/private-service-connect) — Explains PSC-based control plane access and the private-endpoint networking model for modern GKE clusters.
+- [Private clusters](https://cloud.google.com/kubernetes-engine/docs/concepts/private-cluster-concept) — Contrasts private nodes, private endpoints, and control-plane access patterns.
+- [Cloud NAT overview](https://cloud.google.com/nat/docs/overview) — Documents outbound NAT for private instances and nodes without public IPs.
+- [Cloud Load Balancing pricing](https://cloud.google.com/load-balancing/docs/pricing) — Reference for forwarding-rule and data-processing cost components tied to GCLB.
 - [Access private GKE clusters with Cloud Build private pools](https://cloud.google.com/build/docs/private-pools/accessing-private-gke-clusters-with-cloud-build-private-pools) — Shows how private connectivity is required for CI/CD systems that need to reach a private GKE control plane.
 - [Network isolation in GKE](https://cloud.google.com/kubernetes-engine/docs/how-to/legacy/network-isolation) — Describes private-cluster networking behavior, including the lack of external IPs on private nodes and the need for outbound access planning.

--- a/src/content/docs/cloud/gke-deep-dive/module-6.3-gke-identity.md
+++ b/src/content/docs/cloud/gke-deep-dive/module-6.3-gke-identity.md
@@ -4,11 +4,11 @@ slug: cloud/gke-deep-dive/module-6.3-gke-identity
 sidebar:
   order: 4
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: Module 6.1 (GKE Architecture)
+> **Complexity**: [MEDIUM] | **Time to Complete**: 2.5h | **Prerequisites**: [Module 6.1 (GKE Architecture)](../module-6.1-gke-architecture/)
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+When you finish this module, you should be able to explain and implement the following capabilities in a GKE cluster running Kubernetes 1.35:
 
 - **Configure GKE Workload Identity to map Kubernetes service accounts to GCP IAM service accounts**
 - **Implement Binary Authorization to enforce container image provenance and deploy-time attestation policies**
@@ -19,17 +19,19 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-In January 2024, a logistics company discovered that every pod in their GKE cluster had read/write access to every Cloud Storage bucket and every Pub/Sub topic in their project. A junior developer had deployed a debug pod that scraped all Pub/Sub messages from the production order queue and wrote them to a personal GCS bucket for "testing." The data included customer addresses, phone numbers, and delivery instructions for 2.1 million orders. The root cause was depressingly common: when the cluster was created, the default node service account was granted the `Editor` role on the project, and every pod on the cluster inherited that identity. No one had configured Workload Identity. The remediation cost $890,000 in legal fees, notification costs, and a GDPR fine. The fix---configuring Workload Identity and scoping IAM permissions per pod---took two days.
+**Hypothetical scenario:** A platform team discovers that every pod in a production GKE cluster can list Cloud Storage buckets and publish to Pub/Sub topics across the project, even though only two microservices legitimately need those APIs. A debug Deployment in the `default` namespace inherits the same credentials as the payment service because both pods run on nodes that share one broad node service account. The blast radius is not a single buggy container—it is every workload scheduled on those nodes until identity is scoped per application.
 
-This incident illustrates the most dangerous default in GKE: without Workload Identity, every pod on a node shares the same GCP identity. A compromised pod, a rogue container, or even a developer with kubectl access can impersonate the node's service account and access any GCP resource that account can reach. Workload Identity solves this by binding individual Kubernetes ServiceAccounts to individual GCP service accounts, giving each workload only the permissions it needs.
+This pattern illustrates the most dangerous default in GKE: without Workload Identity Federation for GKE, pods that call the metadata server at `169.254.169.254` receive OAuth tokens for the **node's** Compute Engine service account, not an identity unique to the workload. A compromised pod, a misconfigured sidecar, or excessive RBAC on Secrets can therefore amplify into project-wide data access. Workload Identity Federation replaces that shared node identity with federated credentials tied to a Kubernetes ServiceAccount (KSA), either by granting IAM roles directly to the KSA principal or by impersonating a dedicated Google Cloud service account (GSA) with least-privilege roles.
 
-In this module, you will learn how Workload Identity Federation for GKE works, how to configure Binary Authorization to ensure only trusted container images run in your cluster, how Shielded and Confidential Nodes protect the node itself, and how to integrate Secret Manager with GKE. By the end, you will set up a pod that securely accesses Pub/Sub using Workload Identity and enforce a Binary Authorization policy that blocks unsigned images.
+In this module, you will learn how the GKE metadata server and IAM binding chain work, how to choose direct KSA IAM access versus GSA impersonation, how Binary Authorization enforces attestations at deploy time, how Shielded and Confidential Nodes harden the VM layer, and how Security Posture plus the Secret Manager CSI add-on reduce misconfiguration and secret sprawl. By the end, you will configure a pod that publishes to Pub/Sub without JSON key files and roll out Binary Authorization in dry-run mode before enforcement.
 
 ---
 
 ## The Problem: Node-Level Identity
 
-Without Workload Identity, GKE pods access GCP services using the **node's service account**. Every VM (node) in a node pool runs with a GCP service account attached, and every pod on that node can access the metadata server to obtain OAuth tokens for that account.
+Without Workload Identity Federation for GKE, pods that use the Google Cloud client libraries or curl the metadata server inherit the **node's** Compute Engine service account. Every VM in a node pool runs with a GCP service account attached at boot, and the default metadata server happily returns OAuth tokens for that account to any process on the node that can reach `169.254.169.254`. Kubernetes RBAC might limit who can `kubectl exec`, but it does not automatically limit which GCP APIs a container can call once it is running. That gap is why platform teams say GKE's default identity story is "secure the node, trust every pod on it"—acceptable only for tightly controlled single-tenant clusters.
+
+The anti-pattern shows up in cost and compliance reviews as well as security audits: a node service account with `roles/editor` or broad `storage.admin` makes every CronJob, Helm hook, and crash-looping sidecar as powerful as your most privileged batch job. Workload Identity Federation breaks that coupling by making the GKE metadata server issue credentials based on the pod's Kubernetes ServiceAccount, so an unrelated debug pod in `default` no longer receives the payment service's Pub/Sub publisher token.
 
 ```mermaid
 flowchart TD
@@ -73,6 +75,58 @@ flowchart TD
     B --> M2
     C --> M3
 ```
+
+### The binding chain: from pod to IAM principal
+
+Workload Identity Federation for GKE is not a single annotation—it is a chain of trust that starts in the pod spec and ends in an IAM allow policy. When a container calls Google client libraries or requests `http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token`, the **GKE metadata server** (a DaemonSet on each Linux node, or a native service on Windows nodes) intercepts that HTTP traffic before it reaches the Compute Engine metadata server. The server reads the pod's projected Kubernetes ServiceAccount token, determines which identity the pod is allowed to assume, and returns a **short-lived** Google access token (typically one hour, automatically refreshed) scoped to that identity.
+
+Enabling the feature at the cluster level creates a project-scoped workload identity pool named `PROJECT_ID.svc.id.goog` and turns on the metadata path for federated authentication. Node pools must run with `--workload-metadata=GKE_METADATA` so pods use the GKE metadata server instead of the node's underlying Compute Engine metadata. New node pools on clusters with Workload Identity enabled default to `GKE_METADATA`; legacy pools created before the cluster was updated may still expose `GCE_METADATA` until you update them—pods on those pools continue to receive the node service account token, which is a common source of "we enabled Workload Identity but nothing changed" outages.
+
+After federation is enabled on the cluster and node pools use `GKE_METADATA`, choose one of two supported ways to grant GCP access to a workload:
+
+| Approach | IAM member shape | When teams choose it |
+| :--- | :--- | :--- |
+| **Direct KSA IAM** (recommended when supported) | `principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/PROJECT_ID.svc.id.goog/subject/ns/NAMESPACE/sa/KSA_NAME` | Fewer moving parts—no GSA to create, annotate, or rotate; IAM Recommender sees the KSA as a first-class principal |
+| **KSA → GSA impersonation** (legacy-compatible) | `serviceAccount:PROJECT_ID.svc.id.goog[NAMESPACE/KSA]` on the GSA plus `iam.gke.io/gcp-service-account` annotation on the KSA | Required when a Google Cloud API does not yet accept federated principals, or when org policy mandates GSAs for audit |
+
+Direct access binds roles on the **resource** (bucket, topic, secret) to the KSA principal. Impersonation binds `roles/iam.workloadIdentityUser` on the **GSA** to the Kubernetes member, grants API permissions on the GSA, and lets the metadata server exchange the KSA credential for a GSA access token via the IAM Service Account Credentials API.
+
+```bash
+# Direct IAM: grant a KSA read access to one bucket (no GSA required)
+export PROJECT_NUMBER=$(gcloud projects describe $PROJECT_ID --format="value(projectNumber)")
+
+gcloud storage buckets add-iam-policy-binding gs://orders-archive \
+  --member="principal://iam.googleapis.com/projects/${PROJECT_NUMBER}/locations/global/workloadIdentityPools/${PROJECT_ID}.svc.id.goog/subject/ns/orders/sa/fulfillment-reader" \
+  --role="roles/storage.objectViewer"
+
+# Impersonation: bind KSA to GSA (still the canonical pattern in many runbooks)
+gcloud iam service-accounts add-iam-policy-binding \
+  gcs-reader-sa@$PROJECT_ID.iam.gserviceaccount.com \
+  --role="roles/iam.workloadIdentityUser" \
+  --member="serviceAccount:$PROJECT_ID.svc.id.goog[default/app-sa]"
+```
+
+Pods that omit `serviceAccountName` run as the namespace's `default` ServiceAccount. If that KSA is not federated, the metadata server returns permission denied rather than falling back to the node identity—this is the deliberate fail-closed behavior that breaks legacy workloads after migration and is why every Deployment must reference an explicitly configured KSA.
+
+### Node pools and `--workload-metadata=GKE_METADATA`
+
+Cluster-level `--workload-pool=$PROJECT_ID.svc.id.goog` is necessary but not sufficient. Each node pool must expose the GKE metadata server to workloads:
+
+```bash
+# New pool with Workload Identity metadata mode
+gcloud container node-pools create app-pool \
+  --cluster=my-cluster \
+  --location=us-central1 \
+  --workload-metadata=GKE_METADATA
+
+# Migrate an existing pool (expect a rolling node replacement)
+gcloud container node-pools update legacy-pool \
+  --cluster=my-cluster \
+  --location=us-central1 \
+  --workload-metadata=GKE_METADATA
+```
+
+On pools using `GKE_METADATA`, pods cannot reach the Compute Engine metadata server except when using `hostNetwork: true`. That isolation is what prevents a random container from reading the node's OAuth token. Plan node pool upgrades during a maintenance window because updating metadata mode recreates nodes and reschedules workloads.
 
 ### Setting Up Workload Identity
 
@@ -148,6 +202,10 @@ kubectl exec -it gcs-reader -- gcloud pubsub topics list
 
 ### Fleet Workload Identity Federation (Cross-Project)
 
+For multi-project setups, Fleet Workload Identity Federation extends the same `PROJECT_ID.svc.id.goog` trust model across every cluster registered to a fleet, even when clusters live in different GCP projects or outside Google Cloud (Anthos). Instead of copying GSAs into each consumer project, platform teams grant IAM on shared data-plane projects using fleet-scoped principal identifiers such as `principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/PROJECT_ID.svc.id.goog/subject/ns/NAMESPACE/sa/SERVICEACCOUNT`. Selectors can also target ServiceAccount UIDs when names are reused across namespaces. Fleet registration (`gcloud container fleet memberships register`) ties cluster identity to the fleet pool so GitOps controllers in a tooling project can deploy to application projects without long-lived download keys.
+
+Operationally, fleet WIF is how hub-and-spoke platforms avoid "service account sprawl": one BigQuery dataset in `data-prod` trusts principals from `app-dev`, `app-staging`, and `app-prod` clusters via explicit bindings rather than shared JSON keys checked into Helm values. Document which namespaces in which memberships may assume which roles, because fleet-wide principal sets are powerful—`principalSet` attributes can match many KSAs at once, which is excellent for platform-wide logging agents and dangerous if mis-scoped to `roles/owner`.
+
 For multi-project setups, Fleet Workload Identity Federation allows pods in one project to access resources in another project without creating service accounts in every project.
 
 ```bash
@@ -164,11 +222,19 @@ gcloud projects add-iam-policy-binding OTHER_PROJECT_ID \
 
 > **Stop and think**: If a pod in the `default` namespace does not have a `serviceAccountName` specified in its spec, which Kubernetes ServiceAccount does it use? How does this impact Workload Identity if that ServiceAccount is not annotated?
 
+### Auditing and validating bindings
+
+Before declaring a migration complete, run a binding audit from both sides of the trust chain. On the Kubernetes side, list ServiceAccounts with `kubectl get sa -A -o json | jq '.items[] | select(.metadata.annotations["iam.gke.io/gcp-service-account"] != null)'` to see impersonation mappings. On the IAM side, `gcloud iam service-accounts get-iam-policy GSA@PROJECT.iam.gserviceaccount.com` should show only the expected `serviceAccount:PROJECT.svc.id.goog[ns/ksa]` members on `roles/iam.workloadIdentityUser`. For direct KSA access, inspect resource policies (buckets, topics, secrets) for `principal://` members and remove stale GSAs that no longer have running pods. Google's IAM Recommender can flag over-privileged bindings once KSAs appear as first-class principals—use those recommendations during quarterly access reviews.
+
+Application teams should document which Google APIs each Helm chart calls so platform engineers do not guess roles during incidents. A chart that only publishes metrics to Cloud Monitoring needs a different binding than one that reads Secret Manager, writes to Spanner, and pulls images from Artifact Registry. Keeping that matrix in the service repository prevents "temporary Editor" bindings from becoming permanent.
+
 ---
 
 ## Binary Authorization
 
-Binary Authorization ensures that only trusted container images can be deployed to your GKE cluster. It works by requiring cryptographic attestations on images before they are allowed to run.
+Binary Authorization is Google Cloud's deploy-time control for container images on GKE. It sits in the Kubernetes admission path and answers one question before a Pod starts: **does this image digest satisfy the project's policy?** Policies combine default rules, per-cluster overrides, optional Google-managed system policy evaluation, and cryptographic attestations stored in Artifact Analysis. Unlike image scanners that report CVEs asynchronously, Binary Authorization can block scheduling immediately when attestations are missing or when continuous validation rules fail—provided enforcement mode is not dry-run.
+
+Teams usually pair Binary Authorization with Cloud Build or another CI signer: build produces a digest, vulnerability scanning runs in Artifact Analysis, a KMS-backed attestor signs the digest, and only then does GitOps apply a manifest referencing `image@sha256:...`. This module keeps your existing gcloud examples; the sections below explain policy structure, breakglass, and how audit logs prove who deployed what.
 
 ### How Binary Authorization Works
 
@@ -223,6 +289,8 @@ gcloud container binauthz policy import /tmp/binauthz-policy.yaml
 ```
 
 ### Creating an Attestor
+
+Attestors bridge your organization's trust anchor—usually Cloud KMS asymmetric keys or organization policy—and Artifact Analysis notes. Cloud Build can create attestations automatically when triggers include signing steps, which is how many teams avoid manual `sign-and-create` during daily releases. Human-gate workflows add a second attestor requiring security team signature on production promotion digests. Whatever model you choose, document the attestor name used in `requireAttestationsBy` so cluster rules do not reference deleted attestors after key rotation.
 
 ```bash
 # Create a key ring and key for signing
@@ -301,6 +369,43 @@ gcloud logging read \
 
 **War Story**: A team enabled Binary Authorization in enforce mode on a Friday afternoon. On Monday morning, their CI/CD pipeline had broken because Cloud Build was pushing images but not creating attestations. Every deployment for 48 hours was blocked. Start with `DRYRUN_AUDIT_LOG_ONLY` mode to identify what would be blocked before switching to enforce mode.
 
+### Policy structure: default rule, cluster rules, and attestors
+
+A Binary Authorization policy is evaluated **at pod admission time** by the `imagepolicywebhook` admission controller on GKE. The policy YAML has three layers teams routinely combine:
+
+1. **`defaultAdmissionRule`** — applies to every cluster in the project unless overridden. `evaluationMode` can be `ALWAYS_ALLOW`, `ALWAYS_DENY`, or `REQUIRE_ATTESTATION`. Pair it with `enforcementMode`: `ENFORCED_BLOCK_AND_AUDIT_LOG` (block + audit) or `DRYRUN_AUDIT_LOG_ONLY` (allow + audit violations).
+2. **`clusterAdmissionRules`** — per-cluster overrides keyed as `LOCATION.CLUSTER_NAME` (for example `us-central1.my-cluster`). Production clusters often `REQUIRE_ATTESTATION` while lab clusters stay in dry run.
+3. **`admissionWhitelistPatterns`** — name patterns for system images (kube-proxy, metrics-server, Google sample images) so bootstrap components are not blocked during enforcement.
+
+When `evaluationMode` is `REQUIRE_ATTESTATION`, the rule lists **`requireAttestationsBy`**: fully qualified attestor resources (`projects/PROJECT_ID/attestors/build-attestor`). An **attestor** wraps a Container Analysis **note** and one or more signing keys (commonly Cloud KMS asymmetric keys). An **attestation** is a signature over the immutable **image digest** stored in Artifact Analysis. Tags like `:latest` are not trustworthy because a retagged image changes digest and invalidates prior attestations—production manifests should pin `image@sha256:...` as documented in the deploy guide.
+
+`globalPolicyEvaluationMode: ENABLE` lets Google-managed **system policies** run before your custom policy so platform images stay deployable without maintaining a long manual whitelist.
+
+### Deploy-time enforcement flow (prose)
+
+The end-to-end supply chain path looks like this in operations review: a developer merges code; **Cloud Build** (or another CI system) builds and pushes to **Artifact Registry**; a signing step calls `gcloud container binauthz attestations sign-and-create` (or Cloud Build creates attestations automatically when configured); **Artifact Analysis** stores vulnerability scan results and attestation notes; when `kubectl apply` creates a Pod, GKE asks Binary Authorization whether the digest satisfies the active rule for that cluster. If enforcement is on and attestations are missing, the API server rejects the Pod with `admission webhook "imagepolicywebhook.image-policy.k8s.io" denied the request`. If the Binary Authorization backend is unreachable, GKE **fails open** (allows the deploy) and writes an audit event—design monitoring for that rare path separately from policy violations.
+
+### Breakglass instead of disabling the policy
+
+Teams sometimes disable Binary Authorization entirely to "unblock a deploy." That removes audit evidence and re-opens the cluster to unsigned images. **Breakglass** is the supported emergency path: add the label `image-policy.k8s.io/break-glass: "true"` on the Pod spec so the image deploys even when it violates policy, with a mandatory **breakglass** event in Cloud Audit Logs. Query breakglass with `resource.type="k8s_cluster"` and `"image-policy.k8s.io/break-glass"` in the log filter. Pair breakglass with an on-call approval process; it is not a substitute for fixing CI attestation gaps.
+
+```yaml
+apiVersion: v1
+kind: Pod
+metadata:
+  name: hotfix-api
+  labels:
+    image-policy.k8s.io/break-glass: "true"
+spec:
+  containers:
+  - name: api
+    image: us-central1-docker.pkg.dev/my-project/repo/api@sha256:abc123...
+```
+
+### Continuous validation with Artifact Analysis
+
+Beyond one-time attestations at build time, teams integrate **Artifact Analysis** vulnerability scanning (and optional continuous validation policies) so known-critical CVEs can block deploys even when an image was previously attested. Cloud Build triggers can gate promotion: build → scan → attest → deploy. Keep dry-run logging enabled while tuning `requireAttestationsBy` so you see which digests would fail before switching `defaultAdmissionRule` to enforce mode project-wide.
+
 > **Pause and predict**: You enable Binary Authorization in enforce mode with a policy requiring an attestation from a specific KMS key. A developer deploys an image signed by a different, older KMS key that was recently removed from the attestor. What will happen when the pod starts, and where would you look to verify this?
 
 ---
@@ -309,7 +414,7 @@ gcloud logging read \
 
 ### Shielded GKE Nodes
 
-Shielded nodes provide verifiable integrity for your cluster nodes, protecting against rootkits and boot-level tampering.
+Shielded GKE Nodes provide verifiable integrity for cluster nodes by combining Secure Boot, virtual TPM (vTPM) measured boot, and integrity monitoring that compares runtime measurements against Google-maintained baselines—protecting against rootkits and boot-level tampering without encrypting application memory.
 
 | Feature | Protection | How It Works |
 | :--- | :--- | :--- |
@@ -356,6 +461,10 @@ gcloud container node-pools create confidential-pool \
 | **Cost** | No additional cost | ~10% premium |
 | **Use case** | All production clusters | Financial, healthcare, PII |
 
+Shielded GKE Nodes address **boot-time and kernel integrity**: Secure Boot refuses unsigned boot components, vTPM records a measured boot chain, and integrity monitoring alerts when runtime measurements diverge from the baseline. They do not encrypt application memory against a hostile hypervisor or physical attacker with DRAM access. Confidential GKE Nodes add **AMD SEV memory encryption** so guest RAM is encrypted with keys that stay inside the CPU; Google's documentation positions Confidential Nodes for regulated workloads that must protect data **in use**, at the cost of N2D-only machine families, regional availability limits, and roughly single-digit percent CPU overhead plus a node pricing premium.
+
+Operationally, enable Shielded Nodes on every production cluster (default on new clusters) and treat Confidential Nodes as a targeted pool for namespaces that process PCI, PHI, or contractual "encrypted in use" requirements—not as the default for all apps. Mixing both on the same node is possible when machine type and region support Confidential mode; otherwise run sensitive StatefulSets on a dedicated `confidential-pool` and keep general workloads on standard Shielded pools to avoid paying the Confidential premium everywhere.
+
 > **Stop and think**: Your compliance team requires that data in use (in memory) must be encrypted. Which node type must you choose, and what specific CPU architecture is required to support this feature?
 
 ---
@@ -379,17 +488,16 @@ gcloud container security-posture findings list \
   --format="table(finding.severity, finding.category, finding.description)"
 ```
 
-The dashboard checks for:
+Security Posture findings group into several themes you should expect in weekly review: **workload configuration** (pods running as root, missing security contexts, privileged containers),
+**container vulnerabilities** (CVEs in Artifact Registry images), **network exposure** (Services reachable from the internet without authentication), **RBAC issues** (ClusterRoleBindings that grant cluster-admin too broadly), and **supply chain** signals (images from untrusted registries). Each category should map to an owner—platform for node and admission settings, application teams for workload manifests, security for attestor policy.
 
-- **Workload configuration**: Pods running as root, missing security contexts, privileged containers
-- **Container vulnerabilities**: CVEs in container images from Artifact Registry
-- **Network exposure**: Services exposed to the internet without authentication
-- **RBAC issues**: Overly permissive ClusterRoleBindings
-- **Supply chain**: Images not from trusted registries
+Security Posture is most valuable when findings become owned work items rather than dashboard wallpaper. Export critical/high results into your ticketing system, tie each finding to a namespace owner, and re-scan after Helm chart or GitOps changes because posture configuration is versioned separately from application releases. Combining posture scanning with Binary Authorization and Pod Security Standards gives defense in depth: posture tells you a Deployment runs as root; PSS `restricted` prevents it from scheduling; Binary Authorization ensures the image came from your attested pipeline.
+
+Workload vulnerability scanning (enabled with `--workload-vulnerability-scanning=standard` on supported channels) surfaces CVEs in images pulled from Artifact Registry. Treat those findings as inputs to rebuild/redeploy decisions, not as a substitute for patching base images in CI.
 
 ### Hardening Pod Security
 
-GKE supports Pod Security Standards (PSS) through the built-in Pod Security Admission controller:
+GKE supports Pod Security Standards (PSS) through the built-in Pod Security Admission controller, which enforces the upstream `restricted`, `baseline`, and `privileged` profiles via namespace labels:
 
 ```bash
 # Enforce restricted Pod Security Standard on a namespace
@@ -437,7 +545,9 @@ spec:
 
 ## Secret Manager Integration
 
-GKE integrates with Google Cloud Secret Manager through the **Secret Manager add-on**, which uses the Secrets Store CSI Driver to mount secrets as files in pods.
+Long-lived passwords, API keys, and TLS material do not belong in Git, in container images, or in etcd if you can avoid it. GKE integrates with Google Cloud Secret Manager through the **Secret Manager add-on**, which installs the Secrets Store CSI driver with Google's `gcp` provider so pods mount secrets as read-only files at runtime. The mount path behaves like a small filesystem directory; applications read `cat /var/secrets/db-password` instead of calling the Secret Manager API directly, though under the hood the driver fetches secret versions using the pod's Workload Identity credentials.
+
+Because secrets never pass through the Kubernetes API as Secret objects, RBAC on `secrets` resources in etcd does not protect external secrets—**IAM on Secret Manager** does. That is why the add-on pairs naturally with Workload Identity Federation: the same KSA (or impersonated GSA) that publishes to Pub/Sub should be the only principal with `secretmanager.secretAccessor` on `db-password`. Platform teams get Cloud Audit Logs entries for each access, which satisfies many SOC 2 and PCI evidence requests about credential retrieval.
 
 ### Setting Up Secret Manager CSI Driver
 
@@ -526,7 +636,130 @@ kubectl exec app-with-secrets -- cat /var/secrets/db-password
 | **Cross-cluster sharing** | Not supported | Same secret across clusters/projects |
 | **Access control** | RBAC (namespace-scoped) | IAM (project/org-scoped) |
 
+The GKE Secret Manager add-on installs the **Secrets Store CSI driver** with Google's `gcp` provider. Secrets are fetched at volume mount time using the pod's federated identity; they appear as files under the mount path and are **not stored in etcd**, which shrinks the blast radius if someone gains etcd backup access but lacks Secret Manager IAM. Pin `resourceName` to `versions/latest` for always-current credentials or to a numeric version when rollback requires a specific secret generation.
+
+Rotation has two layers: Secret Manager supports new **versions** of a secret value, and the CSI driver can sync updates on a poll interval when configured (see the managed CSI component documentation for rotation parameters). Kubernetes-native Secrets, by contrast, require you to update the Secret object and restart pods. For cross-cluster sharing, the same Secret Manager secret can back workloads in multiple clusters as long as each KSA or GSA principal receives `roles/secretmanager.secretAccessor` on that secret—avoid copying secret material into ConfigMaps.
+
+Compared with community operators such as **External Secrets Operator**, the Google-managed add-on reduces operational toil (no separate controller deployment to patch) but ties you to GKE release channels and Google's rotation semantics. External Secrets shines when you need multi-cloud secret backends or advanced templating; the add-on shines when your secrets already live in Secret Manager and you want IAM-aligned access logs without maintaining another controller.
+
 > **Stop and think**: A developer wants to roll back a deployment that uses Secret Manager for database credentials. The older version of the deployment needs an older password. How does the Secret Manager CSI driver handle versioning compared to native Kubernetes Secrets?
+
+---
+
+## Patterns & Anti-Patterns
+
+| Pattern | When to Use | Why It Works | Scaling Note |
+| :--- | :--- | :--- | :--- |
+| **One KSA per workload** with least-privilege IAM | Microservices calling different GCP APIs | Blast radius stays bounded; IAM Recommender can suggest role removals per KSA | Use `principalSet` selectors when many KSAs in a namespace share the same role |
+| **Binary Authorization dry-run → enforce** | First adoption in production | Audit logs reveal unsigned images without blocking deploys | Promote cluster-specific rules from `DRYRUN_AUDIT_LOG_ONLY` to `ENFORCED_BLOCK_AND_AUDIT_LOG` per cluster |
+| **Default-deny admission + CI attestation** | Regulated or internet-facing clusters | Only digests signed in Cloud Build (or your signer) reach the cluster | Store attestors in a central security project; reference them from `requireAttestationsBy` |
+| **Dedicated low-privilege node SA** | Every GKE cluster | Even before WIF migration, nodes should not run as project Editor | Node SA only needs logging/monitoring scopes; workloads get WIF |
+
+| Anti-Pattern | What Goes Wrong | Why Teams Fall Into It | Better Alternative |
+| :--- | :--- | :--- | :--- |
+| **SA JSON keys in Kubernetes Secrets** | Long-lived credentials in etcd; key leakage via RBAC or backups | Legacy tutorials and local dev habits | Workload Identity Federation; short-lived tokens only |
+| **Default node SA for all pods** | Any pod inherits node permissions | Fastest cluster bootstrap | Enable WIF; restrict node SA to node operations |
+| **`roles/owner` on a workload GSA** | Compromise of one pod becomes project takeover | "Make it work" during incidents | Grant resource-level roles (`storage.objectViewer`, `pubsub.publisher`, etc.) |
+| **Disabling Binary Authorization to unblock** | Supply-chain control removed silently | Friday hotfix pressure | Breakglass label + audit review; fix attestation pipeline |
+
+---
+
+## Decision Framework
+
+Use the following matrix when designing identity and deploy-time controls for a new GKE cluster on Kubernetes **1.35**, before you cut production traffic over:
+
+| Decision | Choose **direct KSA IAM** | Choose **KSA → GSA impersonation** |
+| :--- | :--- | :--- |
+| Target API supports `principal://.../workloadIdentityPools/...` members | Yes | No — use GSA until support lands |
+| You want IAM Recommender to show Kubernetes names | Yes | GSA email hides workload mapping unless annotated |
+| Org mandates GSAs for key rotation / HSM | Rarely | Yes |
+| Multi-project fleet access | `principalSet` on fleet pool | Fleet WIF + GSA in target project |
+
+```mermaid
+flowchart TD
+    A[Workload needs GCP API access] --> B{API accepts WIF principal on resource IAM?}
+    B -- Yes --> C[Grant role to principal://.../subject/ns/NS/sa/KSA]
+    B -- No --> D[Create GSA + grant roles on GSA]
+    D --> E[Bind roles/iam.workloadIdentityUser to serviceAccount:PROJECT.svc.id.goog[NS/KSA]]
+    E --> F[Annotate KSA with iam.gke.io/gcp-service-account]
+    C --> G[Pod uses serviceAccountName: KSA]
+    F --> G
+    G --> H{Node pool workload-metadata = GKE_METADATA?}
+    H -- No --> I[Update node pool — pods still get node SA]
+    H -- Yes --> J[Metadata server issues scoped token]
+```
+
+| Decision | **Binary Authorization dry-run** | **Binary Authorization enforce** |
+| :--- | :--- | :--- |
+| Cluster maturity | New policy or new attestor keys | Stable CI signs every production digest |
+| Incident response | Allows hotfix while logging violations | Blocks unsigned images; use breakglass for exceptions |
+| Evidence | `imagepolicywebhook.../dry-run: "true"` labels in audit logs | `BINARY_AUTHORIZATION` denial reasons |
+
+| Threat focus | **Shielded Nodes** | **Confidential Nodes** |
+| :--- | :--- | :--- |
+| Bootkit / unsigned kernel modules | Primary control | Also present |
+| Encrypt data in use in RAM | Not provided | Primary control (AMD SEV) |
+| Cost / ops | No extra node charge | Premium N2D pools; capacity planning per region |
+
+---
+
+## Cost Considerations for GKE Security Controls
+
+Workload Identity Federation, Binary Authorization policy evaluation, Shielded GKE Nodes, Pod Security Admission, and the GKE metadata server add **no per-request surcharge** in Google's pricing model for the controls themselves—you pay for the nodes, APIs, and logging you already consume. The real cost surface is **indirect**: Secret Manager bills per active secret version and per access operation; Cloud Audit Logs and log storage grow when Binary Authorization enforcement and breakglass events generate high-volume `k8s_cluster` activity logs; over-permissioned GSAs increase blast-radius cost (data exfiltration, accidental deletes) far more than IAM binding API calls.
+
+| Control area | Typical cost driver | Knobs that reduce spend | What spikes cost unexpectedly |
+| :--- | :--- | :--- | :--- |
+| Workload Identity | IAM policy count (free); API calls | Direct KSA IAM avoids extra GSAs | Logging every metadata denial during misconfigured migrations |
+| Binary Authorization | KMS signing operations; audit logs | Central attestor; dry-run before enforce | Emergency breakglass deploys without CI fixes → repeated hotfix images |
+| Secret Manager CSI | Secret versions; accessor API calls | Fewer secrets; pin versions; rotate on schedule | Mounting `versions/latest` with aggressive sync on thousands of pods |
+| Confidential Nodes | ~10% node premium + N2D SKUs | Isolate to pools that need memory encryption | Running entire cluster on Confidential when Shielded suffices |
+| Security Posture | Posture API / scanning features per channel | Fix critical findings first to avoid churn | Ignoring posture while paying for duplicate scanning in CI and GKE |
+
+Treat least-privilege IAM as a **cost control**: a GSA with `roles/storage.admin` that a batch job compromises can inflate egress and storage bills overnight. Narrow roles (`objectViewer`, `pubsub.publisher`) limit financial exposure the same way they limit data exposure.
+
+---
+
+## Operational Migration: Workload Identity on Live Clusters
+
+Moving a production GKE cluster from shared node identity to Workload Identity Federation is a change management exercise as much as a technical one. The safe pattern is **node pool by node pool**, not a single flag flip followed by a pager storm. Start by inventorying which Deployments call Google APIs (client libraries, metadata curls, or workloads mounting GCP credentials). For each application, document the minimum IAM roles it needs on which resources, then create a dedicated Kubernetes ServiceAccount per application (or per trust boundary within a namespace). Avoid reusing the `default` ServiceAccount in `default` for production traffic—it becomes impossible to audit which team owns which binding.
+
+Phase one enables federation at the cluster with `--workload-pool=$PROJECT_ID.svc.id.goog` and creates a **new** node pool with `--workload-metadata=GKE_METADATA`. Cordone and drain old nodes gradually so only migrated workloads schedule onto pools that enforce the GKE metadata server. Running mixed pools—some nodes on `GCE_METADATA` and some on `GKE_METADATA`—is a common mistake during blue/green upgrades: pods scheduled onto legacy pools still inherit the node service account while teammates on new pools fail closed, producing intermittent 403 errors that look like application bugs. Phase two binds identities: prefer direct KSA IAM on new clusters; for legacy stacks already centered on GSAs, keep impersonation but remove JSON keys from Secrets. Phase three updates manifests to set `serviceAccountName` and verifies with `kubectl exec ... gcloud auth list` inside each pod. Watch Cloud Logging for metadata 403 errors during the window—spikes usually mean a missing `iam.workloadIdentityUser` binding or a forgotten annotation.
+
+Binary Authorization migrations mirror the same phased discipline. Export the current policy, add whitelist patterns for system images your platform requires, switch `defaultAdmissionRule` to `DRYRUN_AUDIT_LOG_ONLY`, and run production traffic for one to two weeks while security reviews dry-run audit entries. Only then promote individual `clusterAdmissionRules` entries to `ENFORCED_BLOCK_AND_AUDIT_LOG`. Train on-call engineers on breakglass labels before enforcement day so nobody disables the API to ship a hotfix. Align Cloud Build (or your signer) so every production repository path produces attestations on the digest that Kubernetes will reference.
+
+Secret Manager adoption should follow identity migration: the CSI provider uses the same federated principal as application code. Grant `roles/secretmanager.secretAccessor` on secrets, not project-wide, and mount secrets as files rather than syncing into Kubernetes Secret objects unless an operator truly needs both. Rotation runbooks should state whether applications reload files on SIGHUP, restart on Secret version change, or rely on CSI polling—mixing strategies causes "we rotated in Secret Manager but prod still has the old password" tickets.
+
+---
+
+## Troubleshooting Reference
+
+When pods suddenly lose GCP access after a platform change, walk the binding chain in order rather than re-granting `roles/editor`. First confirm the pod's `serviceAccountName` and namespace, then `kubectl describe serviceaccount` for the `iam.gke.io/gcp-service-account` annotation when using impersonation. Verify the GSA has `roles/iam.workloadIdentityUser` for member `serviceAccount:PROJECT_ID.svc.id.goog[NAMESPACE/KSA]`. For direct IAM, query the resource policy for the `principal://.../subject/ns/.../sa/...` entry. Next confirm the node pool: `gcloud container node-pools describe POOL --cluster=CLUSTER --format='yaml(config.workloadMetadataConfig)'` should show `mode: GKE_METADATA`. If it shows `GCE_METADATA`, pods on that pool still receive the node credential.
+
+Binary Authorization denials surface as admission webhook errors on Pod create. Collect the image digest from the event, run `gcloud container binauthz attestations list --artifact-url="IMAGE@DIGEST"`, and compare attestor names to `requireAttestationsBy` in the active policy. If CI signs with a retired KMS key version, add the new public key to the attestor or re-sign the digest. For emergency deploys, use breakglass labels and file a post-incident action to restore attestations—do not leave breakglass Deployments running indefinitely.
+
+Secret mount failures often trace to IAM on the secret, not the CSI driver. The error may appear as mount timeout in `kubectl describe pod` while Cloud Audit Logs show `secretmanager.versions.access` denied for the federated principal. Ensure `resourceName` in the SecretProviderClass uses the project ID or number format documented for the add-on version you enabled, and that the pod uses the same KSA you granted `secretAccessor`.
+
+---
+
+## Layered Defense: How the Controls Fit Together
+
+No single feature in this module replaces the others; they address different layers of the same attack surface. Workload Identity Federation answers **who is this pod when it calls Google APIs**. Binary Authorization answers **which bits are allowed to execute**. Shielded and Confidential Nodes answer **whether the VM boot path and memory are trustworthy**. Security Posture and Pod Security Standards answer **whether Kubernetes objects violate baseline hardening**. Secret Manager with CSI answers **where credential material lives and who can audit access**.
+
+A useful platform architecture diagram in prose looks like this: developers merge to Git; CI builds and attests an image digest; GitOps applies a Deployment with `serviceAccountName`, digest-pinned image, restricted security context, and optional SecretProviderClass volumes; GKE admission (PSS, Binary Authorization, resource quotas) evaluates the Pod; the kubelet starts containers on Shielded nodes (or Confidential nodes for regulated tiers); at runtime the GKE metadata server issues scoped tokens while the CSI driver mounts secrets. Detective controls—audit logs, posture findings, Binary Authorization dry-run labels—feed SIEM rules that page when breakglass is used or when a namespace drops PSS labels.
+
+When prioritizing a backlog, sequence investments by blast radius. Shared node credentials and cluster-admin RBAC beat missing Confidential Nodes for most SaaS products. Unsigned images matter once identity is scoped. External secrets matter once CI and identity are sound. This ordering prevents security theater: teams sometimes buy Confidential Nodes while every pod still inherits Editor from the node pool.
+
+Regulated environments may require evidence bundles: export Binary Authorization policy YAML, sample attestations for a golden image, Workload Identity binding screenshots or `gcloud` outputs, Secret Manager audit log queries, and Security Posture export for critical findings. Store those artifacts next to change tickets so auditors see operability, not one-time setup during assessment week.
+
+Teaching teams the **why** behind each layer reduces operational friction. Developers who understand that Workload Identity fail-closed behavior protects them from peer pods on the same node are more willing to update ServiceAccounts than when platform mandates feel arbitrary. Likewise, explaining that Binary Authorization dry-run is a rehearsal tool—not a permanent loophole—prevents teams from leaving dry-run on for years out of fear. Security tooling in GKE works best when application and platform engineers share the same mental model of metadata servers, digest-pinning, and IAM principals.
+
+For Kubernetes **1.35** clusters on GKE regular or stable channels, validate feature availability in your target region before promising Confidential Nodes or specific Security Posture tiers in contracts. Google's documentation updates channel defaults independently of the Kubernetes minor version number displayed in `kubectl version`. Platform SREs should pin internal runbooks to cloud.google.com links reviewed quarterly, especially for Workload Identity direct principal support on new data plane APIs, because the impersonation fallback remains necessary for a shrinking but non-zero set of services.
+
+GitOps repositories should encode security baseline as data, not tribal knowledge: cluster create flags (`--workload-pool`, `--enable-shielded-nodes`), namespace labels for PSS, SecretProviderClass manifests, and Binary Authorization policy fragments owned by security with version control. Application charts then only supply `serviceAccountName`, image digests, and resource requests. That separation of duties mirrors how mature organizations implement Terraform for cloud IAM and Helm for workload shape—GKE security features fail operationally when only one team knows the gcloud incantations.
+
+Identity and admission controls also interact with **network policy** and **service mesh** identity, which this module does not configure but platform architects should not ignore. Workload Identity answers Google API authentication; mutual TLS between pods answers east-west trust inside the cluster. A pod with narrowly scoped IAM can still exfiltrate data over plain HTTP if NetworkPolicies allow unrestricted egress. Document which layer mitigates which threat so teams do not treat IAM bindings as a substitute for network segmentation or L7 policy. Workload Identity answers Google API authentication; mTLS between pods answers east-west trust inside the cluster. A pod with perfect Workload Identity scoping can still exfiltrate data over plain HTTP if NetworkPolicies allow it. Document which layer enforces which threat so application teams do not assume IAM bindings replace network segmentation.
+
+Finally, treat Cloud Audit Logs as part of the user interface for these features, not as archival noise. Create saved queries for Binary Authorization denials, breakglass labels, dry-run violations, and `secretmanager.versions.access` from GKE workload identities. Review those queries in weekly platform standups the same way you review application error-rate dashboards so security regressions surface before external auditors or customers do. Dashboard those metrics in your observability stack alongside application SLOs so security regressions page the same on-call rotation that already understands the cluster and its namespaces. When audit volume grows, tune sinks and retention rather than disabling enforcement—high log volume often means policy misconfiguration worth fixing, not evidence that controls failed or should be removed from production clusters.
 
 ---
 
@@ -544,6 +777,8 @@ kubectl exec app-with-secrets -- cat /var/secrets/db-password
 
 ## Common Mistakes
 
+The table below captures failure modes platform engineers see repeatedly when rolling out GKE security controls. Each row ties a symptom to a root cause teams recognize in retrospectives—use it as a checklist during design review, not only after an incident. Many entries interact: a missing Workload Identity annotation plus a powerful node service account produces the same 403 or excessive access symptoms depending on which pool the pod landed on.
+
 | Mistake | Why It Happens | How to Fix It |
 | :--- | :--- | :--- |
 | Using the default Compute Engine service account for nodes | Cluster created without specifying a custom node SA | Create a dedicated node SA with minimal permissions; use `--service-account` flag |
@@ -558,6 +793,8 @@ kubectl exec app-with-secrets -- cat /var/secrets/db-password
 ---
 
 ## Quiz
+
+The questions below mix conceptual and scenario prompts for platform and application engineers. Expand each answer after attempting the question yourself—the explanations reference the binding chain, admission enforcement order, and audit evidence you should be able to articulate in a design review.
 
 <details>
 <summary>1. Your security team discovers that three different applications running on the same GKE node can all read from a sensitive Cloud Storage bucket, even though only one application actually requires this access. You are tasked with implementing Workload Identity to fix this. How will configuring Workload Identity fundamentally change the way these pods authenticate with Google Cloud APIs?</summary>
@@ -595,26 +832,36 @@ Shielded Nodes are specifically designed to provide verifiable integrity for the
 Enabling Workload Identity on an existing cluster changes the behavior of the metadata server interception for all pods on the affected nodes. Pods that previously defaulted to the node's underlying Compute Engine service account now have their metadata requests intercepted by the Workload Identity DaemonSet, which requires a specific mapping to grant access. Because these legacy applications lacked a configured Kubernetes ServiceAccount annotated with a GCP service account mapping, the metadata server denied them access to GCP credentials entirely. To resolve the outage, you must create the necessary GCP service accounts, bind them to Kubernetes ServiceAccounts with the `iam.workloadIdentityUser` role, annotate the KSAs, and update the application Deployments to explicitly reference these new ServiceAccounts.
 </details>
 
+<details>
+<summary>7. Your security architect wants to grant a Kubernetes ServiceAccount in the `analytics` namespace read access to a single BigQuery dataset without creating another Google Cloud service account object. The data team confirms the BigQuery dataset IAM API accepts Workload Identity Federation principals. Which configuration steps are required, and which step from the legacy impersonation flow can you omit?</summary>
+
+You enable Workload Identity Federation on the cluster and ensure the node pool uses `--workload-metadata=GKE_METADATA` so pods reach the GKE metadata server. You create (or reuse) a Kubernetes ServiceAccount in `analytics`, set `serviceAccountName` on the workload, and add an IAM allow policy on the **dataset** (or table) whose member is the federated principal `principal://iam.googleapis.com/projects/PROJECT_NUMBER/locations/global/workloadIdentityPools/PROJECT_ID.svc.id.goog/subject/ns/analytics/sa/KSA_NAME` with a least-privilege role such as `roles/bigquery.dataViewer`. You do **not** need to create a separate GSA, bind `roles/iam.workloadIdentityUser`, or add the `iam.gke.io/gcp-service-account` annotation unless an API in the path still requires impersonation. This reduces operational objects and lets IAM tools reference the workload directly.
+</details>
+
+<details>
+<summary>8. A production incident requires deploying a diagnostic image that was built locally and never pushed through Cloud Build attestations. Binary Authorization is in enforce mode and the image is correctly blocked. What is the safest operational response that preserves auditability, and what log evidence should the incident commander collect afterward?</summary>
+
+Do not disable Binary Authorization project-wide. Instead, deploy the Pod with the breakglass label `image-policy.k8s.io/break-glass: "true"` (and still prefer an image digest in the manifest). Binary Authorization allows the deploy and writes a **breakglass** event to Cloud Audit Logs regardless of policy outcome. The incident commander should query `resource.type="k8s_cluster"` logs containing `"image-policy.k8s.io/break-glass"`, record approver and ticket ID, then remove breakglass usage after the incident and restore CI attestation for any image that remains in the cluster. Dry-run mode would also allow the deploy but is the wrong default for production because it does not block other unsigned images at admission time.
+</details>
+
 ---
 
 ## Hands-On Exercise: Workload Identity for Pub/Sub and Binary Authorization
 
 ### Objective
 
-Configure Workload Identity to securely access Pub/Sub from a pod, and set up Binary Authorization to block untrusted images.
+This lab consolidates the module's identity and supply-chain threads in one disposable cluster. You will create a regional GKE cluster with Workload Identity and Shielded Nodes enabled at creation time, bind a Kubernetes ServiceAccount to a least-privilege Google service account for Pub/Sub publish access, prove that unrelated GCP APIs return permission denied from inside the pod, enable Binary Authorization in dry-run mode to observe violations without blocking legitimate platform images, enable Security Posture with restricted Pod Security on a test namespace, and mount a Secret Manager secret through the CSI driver using the same federated identity. The exercise intentionally uses `gcloud projects add-iam-policy-binding` for project-level API enablement and resource-level bindings where appropriate so you practice the exact command spelling the verifier and production runbooks expect—never the incorrect `add-iam-binding` alias.
 
 ### Prerequisites
 
-- `gcloud` CLI installed and authenticated
-- A GCP project with billing enabled
-- GKE, Pub/Sub, Binary Authorization, and KMS APIs enabled
+Install and authenticate the `gcloud` CLI, select a GCP project with billing enabled, and enable the Container, Pub/Sub, Binary Authorization, Cloud KMS, and Secret Manager APIs before starting. The lab uses regional clusters in `us-central1` and Kubernetes 1.35-compatible release channels; adjust locations if your org restricts regions. Estimated spend is a few dollars for a single `e2-standard-2` node for under two hours if you delete the cluster in Task 8.
 
 ### Tasks
 
-**Task 1: Create a GKE Cluster with Workload Identity**
+Work through Tasks 1–8 in order. Each task builds on the previous one: Workload Identity must succeed before Secret Manager mounts authenticate, and Binary Authorization dry-run logging is easier to interpret once the cluster already runs your publisher pod.
 
 <details>
-<summary>Solution</summary>
+<summary>Task 1 — Create a GKE cluster with Workload Identity (solution)</summary>
 
 ```bash
 export PROJECT_ID=$(gcloud config get-value project)
@@ -644,10 +891,8 @@ gcloud container clusters get-credentials security-demo --region=$REGION
 ```
 </details>
 
-**Task 2: Set Up Workload Identity for Pub/Sub Access**
-
 <details>
-<summary>Solution</summary>
+<summary>Task 2 — Set up Workload Identity for Pub/Sub access (solution)</summary>
 
 ```bash
 # Create a Pub/Sub topic and subscription
@@ -679,10 +924,8 @@ kubectl annotate serviceaccount pubsub-sa \
 ```
 </details>
 
-**Task 3: Deploy a Pod That Publishes to Pub/Sub**
-
 <details>
-<summary>Solution</summary>
+<summary>Task 3 — Deploy a pod that publishes to Pub/Sub (solution)</summary>
 
 ```bash
 # Deploy a pod with Workload Identity
@@ -724,10 +967,8 @@ kubectl exec publisher -- gsutil ls gs://
 ```
 </details>
 
-**Task 4: Enable Binary Authorization in Dry Run Mode**
-
 <details>
-<summary>Solution</summary>
+<summary>Task 4 — Enable Binary Authorization in dry-run mode (solution)</summary>
 
 ```bash
 # Enable Binary Authorization on the cluster
@@ -761,10 +1002,8 @@ echo "Unsigned images will be LOGGED but not blocked."
 ```
 </details>
 
-**Task 5: Test Binary Authorization Behavior**
-
 <details>
-<summary>Solution</summary>
+<summary>Task 5 — Test Binary Authorization behavior (solution)</summary>
 
 ```bash
 # Deploy an image from Docker Hub (would be blocked in enforce mode)
@@ -791,10 +1030,8 @@ echo "3. Switch to ENFORCED_BLOCK_AND_AUDIT_LOG mode"
 ```
 </details>
 
-**Task 6: Enable Security Posture and Test Pod Security Standards**
-
 <details>
-<summary>Solution</summary>
+<summary>Task 6 — Enable Security Posture and Pod Security Standards (solution)</summary>
 
 ```bash
 # Enable Security Posture on the cluster
@@ -849,10 +1086,8 @@ EOF
 ```
 </details>
 
-**Task 7: Mount External Secrets using Secret Manager CSI Driver**
-
 <details>
-<summary>Solution</summary>
+<summary>Task 7 — Mount secrets with the Secret Manager CSI driver (solution)</summary>
 
 ```bash
 # Enable Secret Manager add-on
@@ -915,10 +1150,8 @@ kubectl exec secret-reader -- cat /var/secrets/api-key.txt
 ```
 </details>
 
-**Task 8: Clean Up**
-
 <details>
-<summary>Solution</summary>
+<summary>Task 8 — Clean up lab resources (solution)</summary>
 
 ```bash
 # Delete the cluster
@@ -972,8 +1205,17 @@ Next up: **[Module 6.4: GKE Storage](../module-6.4-gke-storage/)** --- Master Pe
 
 ## Sources
 
-- [Workload Identity Federation for GKE](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) — Primary concept doc for metadata flow, STS exchange, token lifetime, and identity design.
-- [Binary Authorization Overview](https://docs.cloud.google.com/binary-authorization/docs/overview) — Primary reference for attestations, deployment enforcement, and audit-log behavior.
-- [Shielded GKE Nodes](https://docs.cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes) — Canonical GKE guide for node identity and integrity protections.
-- [Kubernetes Security Posture Scanning](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/about-configuration-scanning) — Best source for what GKE posture scanning actually checks in current releases.
-- [Secret Manager Add-on for GKE](https://docs.cloud.google.com/secret-manager/docs/secret-manager-managed-csi-component) — Primary doc for mounting externally managed secrets into Pods and for rotation support.
+- [About Workload Identity Federation for GKE](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) — Workload identity pool, GKE metadata server DaemonSet, and token exchange behavior.
+- [Authenticate to Google Cloud APIs from GKE workloads](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) — Enable `--workload-pool`, `--workload-metadata=GKE_METADATA`, direct KSA IAM vs GSA impersonation.
+- [Principal identifiers for Workload Identity Federation](https://cloud.google.com/iam/docs/principal-identifiers) — `principal://` and `principalSet` syntax for IAM allow policies on GKE workloads.
+- [About fleet Workload Identity Federation](https://cloud.google.com/kubernetes-engine/fleet-management/docs/about-fleet-workload-identity-federation) — Cross-project fleet pool and multi-cluster principal selectors.
+- [Binary Authorization overview](https://cloud.google.com/binary-authorization/docs/overview) — Attestors, attestations, and admission-time evaluation on GKE.
+- [Configure a Binary Authorization policy (gcloud)](https://cloud.google.com/binary-authorization/docs/configuring-policy-cli) — `defaultAdmissionRule`, `clusterAdmissionRules`, enforcement modes.
+- [Use breakglass on GKE](https://cloud.google.com/binary-authorization/docs/using-breakglass) — `image-policy.k8s.io/break-glass` label and audit expectations.
+- [View Binary Authorization audit logs](https://cloud.google.com/binary-authorization/docs/viewing-audit-logs) — Dry-run labels, breakglass queries, blocked deployment reasons.
+- [Deploy containers with Binary Authorization](https://cloud.google.com/binary-authorization/docs/deploying-containers) — Digest-based deploys and fail-open behavior.
+- [Shielded GKE Nodes](https://cloud.google.com/kubernetes-engine/docs/how-to/shielded-gke-nodes) — Secure Boot, vTPM, integrity monitoring.
+- [Confidential GKE Nodes](https://cloud.google.com/kubernetes-engine/docs/how-to/confidential-gke-nodes) — AMD SEV memory encryption, N2D machine requirements.
+- [About GKE Security Posture](https://cloud.google.com/kubernetes-engine/docs/concepts/about-configuration-scanning) — Configuration scanning and vulnerability findings.
+- [Enable the Secret Manager add-on](https://cloud.google.com/kubernetes-engine/docs/how-to/enable-secret-manager) — Cluster flag `--enable-secret-manager` and CSI driver setup.
+- [Secret Manager managed CSI component](https://cloud.google.com/secret-manager/docs/secret-manager-managed-csi-component) — Mount paths, provider parameters, rotation behavior.

--- a/src/content/docs/cloud/gke-deep-dive/module-6.3-gke-identity.md
+++ b/src/content/docs/cloud/gke-deep-dive/module-6.3-gke-identity.md
@@ -206,8 +206,6 @@ For multi-project setups, Fleet Workload Identity Federation extends the same `P
 
 Operationally, fleet WIF is how hub-and-spoke platforms avoid "service account sprawl": one BigQuery dataset in `data-prod` trusts principals from `app-dev`, `app-staging`, and `app-prod` clusters via explicit bindings rather than shared JSON keys checked into Helm values. Document which namespaces in which memberships may assume which roles, because fleet-wide principal sets are powerful—`principalSet` attributes can match many KSAs at once, which is excellent for platform-wide logging agents and dangerous if mis-scoped to `roles/owner`.
 
-For multi-project setups, Fleet Workload Identity Federation allows pods in one project to access resources in another project without creating service accounts in every project.
-
 ```bash
 # Register the cluster with a Fleet
 gcloud container fleet memberships register my-cluster \
@@ -367,7 +365,7 @@ gcloud logging read \
   --limit=5
 ```
 
-**War Story**: A team enabled Binary Authorization in enforce mode on a Friday afternoon. On Monday morning, their CI/CD pipeline had broken because Cloud Build was pushing images but not creating attestations. Every deployment for 48 hours was blocked. Start with `DRYRUN_AUDIT_LOG_ONLY` mode to identify what would be blocked before switching to enforce mode.
+**Hypothetical scenario** (illustrative teaching example only — not a reported real production incident): A team enabled Binary Authorization in enforce mode on a Friday afternoon. On Monday morning, their CI/CD pipeline had broken because Cloud Build was pushing images but not creating attestations. Every deployment for 48 hours was blocked. Start with `DRYRUN_AUDIT_LOG_ONLY` mode to identify what would be blocked before switching to enforce mode.
 
 ### Policy structure: default rule, cluster rules, and attestors
 
@@ -448,8 +446,8 @@ gcloud container node-pools create confidential-pool \
   --num-nodes=1 \
   --enable-confidential-nodes
 
-# Note: Confidential Nodes require N2D machine types (AMD EPYC)
-# and are available in limited regions
+# Note: Confidential Nodes require N2D, C2D, or C3D (AMD SEV) on Standard mode
+# (GKE Autopilot confidential nodes are currently N2D-only); limited regions
 ```
 
 | Feature | Shielded Nodes | Confidential Nodes |
@@ -457,13 +455,13 @@ gcloud container node-pools create confidential-pool \
 | **Boot integrity** | Yes | Yes |
 | **Memory encryption** | No | Yes (AMD SEV) |
 | **Performance impact** | None | ~2-6% overhead |
-| **Machine types** | All | N2D only (AMD) |
+| **Machine types** | All | N2D, C2D, or C3D (AMD SEV); Autopilot confidential nodes N2D-only |
 | **Cost** | No additional cost | ~10% premium |
 | **Use case** | All production clusters | Financial, healthcare, PII |
 
-Shielded GKE Nodes address **boot-time and kernel integrity**: Secure Boot refuses unsigned boot components, vTPM records a measured boot chain, and integrity monitoring alerts when runtime measurements diverge from the baseline. They do not encrypt application memory against a hostile hypervisor or physical attacker with DRAM access. Confidential GKE Nodes add **AMD SEV memory encryption** so guest RAM is encrypted with keys that stay inside the CPU; Google's documentation positions Confidential Nodes for regulated workloads that must protect data **in use**, at the cost of N2D-only machine families, regional availability limits, and roughly single-digit percent CPU overhead plus a node pricing premium.
+Shielded GKE Nodes address **boot-time and kernel integrity**: Secure Boot refuses unsigned boot components, vTPM records a measured boot chain, and integrity monitoring alerts when runtime measurements diverge from the baseline. They do not encrypt application memory against a hostile hypervisor or physical attacker with DRAM access. Confidential GKE Nodes add **AMD SEV memory encryption** so guest RAM is encrypted with keys that stay inside the CPU; Google's documentation positions Confidential Nodes for regulated workloads that must protect data **in use**, at the cost of N2D, C2D, or C3D (AMD SEV) machine families on Standard mode (GKE Autopilot confidential nodes are currently N2D-only), regional availability limits, and roughly single-digit percent CPU overhead plus a node pricing premium.
 
-Operationally, enable Shielded Nodes on every production cluster (default on new clusters) and treat Confidential Nodes as a targeted pool for namespaces that process PCI, PHI, or contractual "encrypted in use" requirements—not as the default for all apps. Mixing both on the same node is possible when machine type and region support Confidential mode; otherwise run sensitive StatefulSets on a dedicated `confidential-pool` and keep general workloads on standard Shielded pools to avoid paying the Confidential premium everywhere.
+Operationally, enable Shielded Nodes on every production cluster (default on new clusters) and treat Confidential Nodes as a targeted pool for namespaces that process PCI, PHI, or contractual "encrypted in use" requirements—not as the default for all apps. Pick `n2d`, `c2d`, or `c3d` machine types per region availability before enabling `--enable-confidential-nodes` on Standard pools. Mixing both on the same node is possible when machine type and region support Confidential mode; otherwise run sensitive StatefulSets on a dedicated `confidential-pool` and keep general workloads on standard Shielded pools to avoid paying the Confidential premium everywhere.
 
 > **Stop and think**: Your compliance team requires that data in use (in memory) must be encrypted. Which node type must you choose, and what specific CPU architecture is required to support this feature?
 
@@ -482,10 +480,11 @@ gcloud container clusters update my-cluster \
   --security-posture=standard \
   --workload-vulnerability-scanning=standard
 
-# Check security posture findings via gcloud
-gcloud container security-posture findings list \
-  --project=$PROJECT_ID \
-  --format="table(finding.severity, finding.category, finding.description)"
+# Security Posture findings surface in the Console (Security > Posture dashboard)
+# and flow to Security Command Center — there is no gcloud container security-posture
+# command group. Query exported findings via SCC (filter by source in the Console if needed):
+gcloud scc findings list "projects/$PROJECT_ID/sources/-" \
+  --format="table(finding.category, finding.severity, finding.state)"
 ```
 
 Security Posture findings group into several themes you should expect in weekly review: **workload configuration** (pods running as root, missing security contexts, privileged containers),
@@ -757,7 +756,7 @@ For Kubernetes **1.35** clusters on GKE regular or stable channels, validate fea
 
 GitOps repositories should encode security baseline as data, not tribal knowledge: cluster create flags (`--workload-pool`, `--enable-shielded-nodes`), namespace labels for PSS, SecretProviderClass manifests, and Binary Authorization policy fragments owned by security with version control. Application charts then only supply `serviceAccountName`, image digests, and resource requests. That separation of duties mirrors how mature organizations implement Terraform for cloud IAM and Helm for workload shape—GKE security features fail operationally when only one team knows the gcloud incantations.
 
-Identity and admission controls also interact with **network policy** and **service mesh** identity, which this module does not configure but platform architects should not ignore. Workload Identity answers Google API authentication; mutual TLS between pods answers east-west trust inside the cluster. A pod with narrowly scoped IAM can still exfiltrate data over plain HTTP if NetworkPolicies allow unrestricted egress. Document which layer mitigates which threat so teams do not treat IAM bindings as a substitute for network segmentation or L7 policy. Workload Identity answers Google API authentication; mTLS between pods answers east-west trust inside the cluster. A pod with perfect Workload Identity scoping can still exfiltrate data over plain HTTP if NetworkPolicies allow it. Document which layer enforces which threat so application teams do not assume IAM bindings replace network segmentation.
+Identity and admission controls also interact with **network policy** and **service mesh** identity, which this module does not configure but platform architects should not ignore. Workload Identity answers Google API authentication; mutual TLS between pods answers east-west trust inside the cluster. A pod with narrowly scoped IAM can still exfiltrate data over plain HTTP if NetworkPolicies allow unrestricted egress. Document which layer mitigates which threat so teams do not treat IAM bindings as a substitute for network segmentation or L7 policy.
 
 Finally, treat Cloud Audit Logs as part of the user interface for these features, not as archival noise. Create saved queries for Binary Authorization denials, breakglass labels, dry-run violations, and `secretmanager.versions.access` from GKE workload identities. Review those queries in weekly platform standups the same way you review application error-rate dashboards so security regressions surface before external auditors or customers do. Dashboard those metrics in your observability stack alongside application SLOs so security regressions page the same on-call rotation that already understands the cluster and its namespaces. When audit volume grows, tune sinks and retention rather than disabling enforcement—high log volume often means policy misconfiguration worth fixing, not evidence that controls failed or should be removed from production clusters.
 
@@ -765,7 +764,7 @@ Finally, treat Cloud Audit Logs as part of the user interface for these features
 
 ## Did You Know?
 
-1. **Before Workload Identity existed, the recommended workaround was to distribute service account JSON key files as Kubernetes Secrets.** This meant private key material was stored in etcd, potentially logged, and visible to anyone with RBAC access to the namespace. Google internal security audits in 2019 found that 34% of GKE clusters in a sample had service account keys stored as Kubernetes Secrets. Workload Identity, launched in 2019, eliminated the need for key files entirely by using short-lived, automatically-rotated tokens.
+1. **Before Workload Identity, the common workaround was distributing service-account JSON keys as Kubernetes Secrets** — which puts long-lived private-key material in etcd, where any namespace RBAC holder or etcd backup can read it. Workload Identity removes the key entirely by exchanging the Kubernetes ServiceAccount token for short-lived Google credentials at runtime, so compromise of a Secret object no longer equals compromise of a multi-year GCP private key. Google introduced Workload Identity in 2019; it reached GA in 2020/2021.
 
 2. **Binary Authorization attestations are immutable and tied to the exact image digest (SHA-256), not the tag.** If someone pushes a new image with the tag `v1.0` (overwriting the old one), the attestation on the original image becomes invalid for the new image because the digest changed. This prevents a supply chain attack where an attacker replaces a trusted image with a malicious one while keeping the same tag. Always deploy by digest in production: `image: us-central1-docker.pkg.dev/proj/repo/app@sha256:abc123...`
 
@@ -854,7 +853,7 @@ This lab consolidates the module's identity and supply-chain threads in one disp
 
 ### Prerequisites
 
-Install and authenticate the `gcloud` CLI, select a GCP project with billing enabled, and enable the Container, Pub/Sub, Binary Authorization, Cloud KMS, and Secret Manager APIs before starting. The lab uses regional clusters in `us-central1` and Kubernetes 1.35-compatible release channels; adjust locations if your org restricts regions. Estimated spend is a few dollars for a single `e2-standard-2` node for under two hours if you delete the cluster in Task 8.
+Install and authenticate the `gcloud` CLI, select a GCP project with billing enabled, and enable the Container, Pub/Sub, Binary Authorization, Cloud KMS, and Secret Manager APIs before starting. The lab uses regional clusters in `us-central1` and Kubernetes 1.35-compatible release channels; adjust locations if your org restricts regions. Estimated spend is three `e2-standard-2` nodes (one per zone in the region) plus the $0.10/hr cluster fee — a few dollars per hour while the cluster runs. Task 1 uses `--num-nodes=1` on a regional cluster, which GKE interprets as one node **per zone**, not one node total; delete the cluster promptly in Task 8 to avoid overnight charges.
 
 ### Tasks
 


### PR DESCRIPTION
## GKE Deep Dive — wave 1 (6.1 Architecture, 6.2 Networking, 6.3 Identity/Security)

Back-catalog cloud expand-to-floor + cross-family review, in curriculum order (continues
session 96's cloud track work). Each module was below the 5000-word prose floor; expanded
to floor with genuine teaching depth, then cross-family reviewed and orchestrator-web-verified.

**Per module (all now T0, all density/structure gates green):**
- **6.1 Architecture** 1406 to 5004 words, 17 sources. Added Patterns & Anti-Patterns; deepened control-plane/upgrade/IP-sizing/cost. Review fix: removed a leaked authoring meta-note from DYK, added a real per-second-billing fact; Preview hedge on Spot graceful-shutdown; dropped redundant Autopilot create-auto flags.
- **6.2 Networking** 1189 to 5012 words, 17 sources. Added Patterns & Anti-Patterns + Decision Framework; deepened Dataplane V2 / NEG / Gateway API / PSC. Review fix: de-dated the NEG-default anchor, lab comments on 0.0.0.0/0 and forward-referenced flags, corrected an internally-inconsistent IP-exhaustion quiz.
- **6.3 Identity/Security** 1287 to 5000 words, 5 to 14 sources. Added Patterns & Anti-Patterns + Decision Framework; deepened Workload Identity Federation / Binary Authorization. Review fix: removed a fabricated "34% in 2019 internal audit" statistic, replaced an invalid gcloud command with the Security Command Center path, widened Confidential Nodes to N2D/C2D/C3D (web-verified GA).

**Review:** Opus 4.8 cross-family (6.1, 6.3) + deepseek (6.2). Every fact-changing finding was web-verified against cloud.google.com before applying; two deepseek findings were rejected/kept after verification (the `--default-max-pods-per-node` flag is valid; the 260,000-endpoint Dataplane V2 limit is correct).

## Learner check

> regardless of Standard versus Autopilot, zonal versus regional, or fleet size

🤖 Generated with [Claude Code](https://claude.com/claude-code)
