### PR TITLE
chore(content): expand Azure Essentials 3.1/3.4/3.5 to 5000w floor + cross-family review fixes

### DIFF
--- a/src/content/docs/cloud/azure-essentials/module-3.1-entra-id.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.1-entra-id.md
@@ -96,7 +96,7 @@ flowchart TD
 | Level | Purpose | Key Facts |
 | :--- | :--- | :--- |
 | **Management Group** | Organize subscriptions into governance hierarchies | [Up to 6 levels deep (excluding root). Max 10,000 MGs per tenant.](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview) |
-| **Subscription** | Billing boundary and access control boundary | [Each subscription trusts exactly one Entra ID tenant.](https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/understand-billing-tenant-relationship) Max ~500 resource groups per sub (soft limit). |
+| **Subscription** | Billing boundary and access control boundary | [Each subscription trusts exactly one Entra ID tenant.](https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/understand-billing-tenant-relationship) Max 980 resource groups per sub. |
 | **Resource Group** | Logical container for related resources | Resources can only exist in one RG. Deleting RG deletes ALL resources inside. |
 | **Resource** | The actual thing (VM, database, storage account) | Inherits RBAC and policy from all levels above. |
 
@@ -228,7 +228,7 @@ az ad app federated-credential create --id "$APP_ID" --parameters '{
 }'
 ```
 
-**War Story**: Exposed client secrets in public repositories can be discovered quickly, and a high-privilege service principal can be abused for costly or destructive activity. The safer pattern is to avoid long-lived secrets by using Managed Identities for Azure workloads and federated workload identity for CI/CD.
+**Security note**: Exposed client secrets in public repositories can be discovered quickly, and a high-privilege service principal can be abused for costly or destructive activity. The safer pattern is to avoid long-lived secrets by using Managed Identities for Azure workloads and federated workload identity for CI/CD.
 
 ### Application Permissions vs Delegated Permissions
 
@@ -320,7 +320,7 @@ sequenceDiagram
     W->>Az: Call API with Bearer token
 ```
 
-For **AKS**, the supported pattern is [Azure Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity/overview). Enable the OIDC issuer on the cluster first. Create a user-assigned managed identity in the node resource group or a dedicated identity RG. Add a federated credential whose `issuer` is the cluster OIDC URL and whose `subject` is the Kubernetes service account (`system:serviceaccount:<namespace>:<name>`). Annotate the pod service account with `azure.workload.identity/client-id`. The pod receives Entra tokens like a VM managed identity, without mounting secrets. This curriculum targets Kubernetes **1.35**; workload identity is the modern replacement for the deprecated aad-pod-identity addon pattern.
+For **AKS**, the supported pattern is [Azure Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview). Enable the OIDC issuer on the cluster first. Create a user-assigned managed identity in the node resource group or a dedicated identity RG. Add a federated credential whose `issuer` is the cluster OIDC URL and whose `subject` is the Kubernetes service account (`system:serviceaccount:<namespace>:<name>`). Annotate the pod service account with `azure.workload.identity/client-id`. The pod receives Entra tokens like a VM managed identity, without mounting secrets. This curriculum targets Kubernetes **1.35**; workload identity is the modern replacement for the deprecated aad-pod-identity addon pattern.
 
 For **GitHub Actions**, you create a federated credential on the app registration (as shown earlier with `az ad app federated-credential create`) and use the `azure/login` action with `client-id`, `tenant-id`, and `subscription-id`—no `AZURE_CLIENT_SECRET`. Hypothetical scenario: a platform team runs twenty repositories; rotating twenty secrets quarterly is error-prone, but one federated trust per repo branch pattern scales with policy-as-code reviews.
 
@@ -778,17 +778,16 @@ You should see the resource group with `Succeeded` state.
 
 ### Task 2: Create a Custom RBAC Role (Storage Blob Lister)
 
-Create a custom role that can only list storage accounts and list blobs---but not read, write, or delete blob contents.
+Create a custom role that can list storage accounts and list and read blobs---but cannot write or delete blob contents.
 
 ```bash
 # Create the role definition file
 cat > /tmp/blob-lister-role.json << 'EOF'
 {
   "Name": "Storage Blob Lister",
-  "Description": "Can list storage accounts and enumerate blobs but cannot read or modify blob content",
+  "Description": "Can list storage accounts and enumerate and read blobs but cannot write or delete blob content",
   "Actions": [
     "Microsoft.Storage/storageAccounts/read",
-    "Microsoft.Storage/storageAccounts/listkeys/action",
     "Microsoft.Resources/subscriptions/resourceGroups/read"
   ],
   "DataActions": [
@@ -835,6 +834,15 @@ az storage account create \
   --resource-group "$RG_NAME" \
   --location "$LOCATION" \
   --sku Standard_LRS
+
+STORAGE_ID=$(az storage account show --name "$STORAGE_NAME" --resource-group "$RG_NAME" --query id -o tsv)
+
+# Owner/Contributor grant management-plane rights but NOT blob data access — assign a data role.
+ME=$(az ad signed-in-user show --query id -o tsv)
+az role assignment create --assignee "$ME" --role "Storage Blob Data Contributor" \
+  --scope "$STORAGE_ID"
+# wait ~30s for the role assignment to propagate before the data-plane ops below
+sleep 30
 
 # Create a container
 az storage container create \

--- a/src/content/docs/cloud/azure-essentials/module-3.1-entra-id.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.1-entra-id.md
@@ -19,15 +19,23 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-Misconfigured identity applications and forgotten credentials can expose large amounts of sensitive data for long periods if no one is inventorying app registrations, reviewing permissions, and rotating or eliminating secrets. In practice, risk tends to grow through small misses that are easy to ignore one day and expensive to unwind the next. This story illustrates a critical truth about Azure: **identity is not just security---it is the foundation of everything**. Every action in Azure, from creating a virtual machine to reading a blob in storage, flows through the identity layer. Unlike traditional on-premises environments where you might rely on network segmentation and firewall rules as your primary defense, Azure's control plane is entirely identity-driven, so if an attacker compromises a service principal with Contributor access to a subscription, no perimeter hardening alone can stop them from deleting databases.
+Hypothetical scenario: a platform team ships a new microservice with a client secret embedded in Helm values. Six months later, nobody remembers which pipeline created the app registration. The secret never rotated. An attacker with read access to the chart history now has Contributor on a production subscription. The breach is not a firewall failure. It is an identity lifecycle failure that compounded quietly.
 
-In this module, you will learn how Microsoft Entra ID (formerly Azure Active Directory) works as the identity backbone of Azure. You will understand the hierarchy of tenants, management groups, and subscriptions so you can reason clearly about where permission boundaries are enforced. You will learn the critical differences between Entra ID roles and Azure RBAC roles---a distinction that trips up even experienced engineers under pressure. By the end, you will be able to design an identity strategy that follows the principle of least privilege from the ground up and is easier to defend during security reviews.
+This pattern is common because Azure makes resource creation easy while identity cleanup stays manual. **Identity is not just security---it is the foundation of everything in Azure.** Every VM, storage account, and Kubernetes cluster call flows through Entra authentication and Azure RBAC authorization. Traditional on-premises defenses often lean on network segmentation first. Azure's control plane is identity-driven first. A compromised service principal with broad RBAC can delete data even when NSGs are perfect.
+
+In this module, you will learn how Microsoft Entra ID (formerly Azure Active Directory) works as the identity backbone of Azure. You will map tenants, management groups, and subscriptions to real permission boundaries. You will separate Entra directory roles from Azure resource roles---a distinction that still trips experienced engineers during incidents. You will also learn when managed identities beat secrets, and when workload identity federation beats both. By the end, you can design least-privilege access that survives audits and reduces licensing waste.
 
 ---
 
 ## Azure's Identity Backbone: Microsoft Entra ID
 
-Before you create a single resource in Azure, you need to understand the identity layer that governs everything. Microsoft Entra ID (still frequently called Azure AD in documentation, CLI tools, and everyday conversation) is a cloud-based identity and access management service. Think of it as the bouncer at every door in the Azure building. Every person, every application, every automated process must present credentials to Entra ID before Azure will do anything.
+Before you create a single resource in Azure, you need to understand the identity layer that governs everything. Microsoft Entra ID (still frequently called Azure AD in documentation, CLI tools, and everyday conversation) is a cloud-based identity and access management service. Think of it as the bouncer at every door in the Azure building. Every person, every application, and every automated process must present credentials to Entra ID before Azure will do anything.
+
+> **The Bouncer Analogy**
+>
+> A nightclub bouncer checks ID at the door—that is authentication. The wristband color determines which rooms you may enter—that is authorization. Entra ID issues wristbands (tokens). Azure RBAC decides which rooms (resources) each wristband may access. You need both checks; a forged ID at the door is useless if the wristband never gets issued, and a valid ID without the right wristband still cannot enter the VIP room.
+
+Cloud operators who internalize this analogy debug faster. Sign-in failures are bouncer problems (password, MFA, Conditional Access). Resource Manager `AuthorizationFailed` errors are wristband problems (missing RBAC, wrong scope, missing data-plane role, deny assignment). Mixing the two leads to futile password resets when the real issue is a missing `Storage Blob Data Contributor` assignment.
 
 ### What Entra ID Is (and What It Is Not)
 
@@ -94,6 +102,21 @@ flowchart TD
 
 A common mistake is treating subscriptions as purely a billing construct. They are also **security boundaries**, because a user with Owner on Subscription A has zero access to Subscription B by default, even if both subscriptions are in the same tenant. This is why large organizations use multiple subscriptions to isolate environments and teams: they want predictable blast-radius boundaries and cleaner privilege models before cost structures become a secondary consideration.
 
+### Enterprise Layout: Tenants, Management Groups, and Landing Zones
+
+Real enterprises rarely run "one subscription for everything." A common pattern is a **platform subscription** for shared services (logging, DNS hubs, identity automation) and **workload subscriptions** per product or environment (dev/test/prod). Management groups apply policies once—require tags, deny public IPs in production, inherit Azure Policy initiatives—while subscriptions keep billing and RBAC isolation crisp.
+
+| Pattern | Structure | Identity benefit |
+| :--- | :--- | :--- |
+| **Environment isolation** | MG `Production` / `NonProd` with separate subs | CA policies differ; prod Owners are fewer |
+| **Team isolation** | Subscription per product team | Blast radius contained to one sub |
+| **Platform hub** | Shared services sub with user-assigned MIs | Central MI for DNS/ACR/Key Vault access |
+| **Sandbox** | Low-privilege sub with Contributor for engineers | No standing Owner; PIM for exceptions |
+
+When designing landing zones, decide **where human access lives** (groups at MG or sub scope) versus **where workload identities live** (user-assigned MIs in the workload sub, federated CI/CD from GitHub). Hypothetical scenario: a company places all production apps in one subscription to "save money," then grants 40 engineers Contributor. Incident response becomes role-assignment archaeology. Splitting subscriptions costs little compared to one mistaken `az group delete`.
+
+Landing zone identity automation often uses infrastructure-as-code to create groups, assign RBAC, and register federated credentials. The operator still must understand scope strings. A role assignment scope of `/providers/Microsoft.Management/managementGroups/Production` affects every child subscription. A scope of `/subscriptions/{id}/resourceGroups/app-rg` affects only that group. Terraform `azurerm_role_assignment` and Bicep `Microsoft.Authorization/roleAssignments` must mirror the same paths you would type in `az role assignment create`.
+
 > **Pause and predict**: If you assign a user the 'Contributor' role at the Subscription level, but explicitly assign them the 'Reader' role at a specific Resource Group level within that subscription, what effective permissions do they have on the Resource Group?
 > *Answer: They have 'Contributor' access. Azure RBAC is an additive model. Permissions flow down the hierarchy, and a lower-level assignment cannot subtract or restrict permissions granted at a higher level (unless you use Azure Blueprints or explicit Deny Assignments, which are advanced and rare).*
 
@@ -147,6 +170,15 @@ Groups simplify access management. Instead of assigning roles to individual user
 
 Groups can have **assigned membership** (manually add/remove members) or **dynamic membership** (members are automatically added/removed based on user attributes like department or job title). [Dynamic groups require Entra ID P1 or P2 licensing.](https://learn.microsoft.com/en-us/entra/identity/users/groups-dynamic-membership)
 
+**Guest users (B2B collaboration)** invite external identities into your tenant as `userType: Guest`. Guests authenticate with their home organization but appear in your directory for RBAC and app access. Treat guests like employees for access reviews—contractors often retain group memberships after projects end. Assign RBAC to groups that include guests only when necessary; prefer app-scoped access or entitlement management for vendor scenarios.
+
+| Group strategy | Best for | RBAC tip |
+| :--- | :--- | :--- |
+| **Security group (assigned)** | Stable teams with manual onboarding | `Platform-Ops` group gets Contributor on `rg-platform` |
+| **Security group (dynamic)** | Department-based access at scale | Rule `department -eq "Engineering"`; needs P1 |
+| **Role-assignable group** | Nesting Entra directory roles | Limited to ~500 role-assignable groups per tenant |
+| **Microsoft 365 group** | Collaboration + optional RBAC | Extra M365 licensing surface; use security groups for pure RBAC |
+
 ```bash
 # Create a security group
 az ad group create \
@@ -197,6 +229,20 @@ az ad app federated-credential create --id "$APP_ID" --parameters '{
 ```
 
 **War Story**: Exposed client secrets in public repositories can be discovered quickly, and a high-privilege service principal can be abused for costly or destructive activity. The safer pattern is to avoid long-lived secrets by using Managed Identities for Azure workloads and federated workload identity for CI/CD.
+
+### Application Permissions vs Delegated Permissions
+
+App registrations declare **API permissions** in two flavors. **Delegated permissions** apply when a signed-in user is present—the app acts on behalf of that user within the consent boundary. **Application permissions** apply when the app calls APIs with its own identity (daemon jobs, unattended sync)—these are powerful and often require admin consent. [Microsoft Graph and Azure Resource Manager permissions are separate from Azure RBAC](https://learn.microsoft.com/en-us/entra/identity-platform/permissions-consent-overview): granting `Directory.Read.All` on Graph does not grant Reader on a subscription. Operators must track both planes during security reviews.
+
+A mature registration workflow documents: which secrets or federated credentials exist, which API permissions are granted, which enterprise application (service principal) holds Azure RBAC assignments, and who owns quarterly review. Hypothetical scenario: an inventory scanner holds Graph application permission and subscription Reader via RBAC. Removing Graph access does not remove storage enumeration if RBAC Reader remains—fix both or the scanner still exfiltrates metadata.
+
+```bash
+# List API permissions declared on an app registration
+az ad app show --id "$APP_ID" --query "requiredResourceAccess" -o json
+
+# Show service principal RBAC (Azure plane) vs Graph app roles (directory/API plane)
+az role assignment list --assignee "$SP_OBJECT_ID" --all -o table
+```
 
 ### Managed Identities: The Gold Standard
 
@@ -249,6 +295,48 @@ print(f"Secret value: {secret.value}")
 
 The `DefaultAzureCredential` class tries several credential types, and the exact chain depends on SDK version and configuration. In Azure, Managed Identity is one built-in option; on a developer machine, local credentials such as Azure CLI can be used instead.
 
+### How Managed Identities Obtain Tokens Without Secrets
+
+When code on an Azure resource calls the local **Instance Metadata Service (IMDS)** endpoint, Azure validates that the request originates from that resource and returns a Microsoft Entra access token for the managed identity's service principal. [No client secret or certificate is stored in your application configuration](https://learn.microsoft.com/en-us/entra/identity/managed-identities-azure-resources/overview); Azure rotates credentials on the platform side. This is why managed identities are the default recommendation for App Service, Azure Functions, VMs, and AKS pods that call Azure APIs: you grant RBAC on the identity's `principalId`, and the runtime handles token acquisition.
+
+The operator workflow is deliberately simple: create or enable the identity, assign roles at the narrowest scope, then let the SDK call `DefaultAzureCredential()` or `ManagedIdentityCredential()`. Propagation delays still apply after role assignment, so automated deployments should retry token acquisition for several minutes after `az role assignment create`.
+
+### Workload Identity Federation for AKS, GitHub Actions, and External Workloads
+
+Not every workload runs on Azure compute with IMDS available. CI/CD pipelines in GitHub Actions, pods on Amazon EKS or Google GKE, and legacy VMs outside Azure still need Entra tokens—but **client secrets expire, leak in logs, and resist rotation at scale**. [Workload identity federation lets a user-assigned managed identity or app registration trust tokens from an external identity provider (IdP)](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation) such as GitHub, Kubernetes OIDC issuers, or Google Cloud. You configure a **federated identity credential** with `issuer`, `subject`, and `audience` values that must case-sensitively match the external JWT; Microsoft identity platform validates the external token and issues an Entra access token with no long-lived secret.
+
+```mermaid
+sequenceDiagram
+    participant W as External workload
+    participant IdP as External IdP (GitHub/K8s)
+    participant Entra as Microsoft identity platform
+    participant Az as Azure resource API
+
+    W->>IdP: Request OIDC token
+    IdP->>W: JWT (subject matches federated credential)
+    W->>Entra: Exchange JWT for access token
+    Entra->>Entra: Validate trust on MI or app registration
+    Entra->>W: Entra access token
+    W->>Az: Call API with Bearer token
+```
+
+For **AKS**, the supported pattern is [Azure Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity/overview). Enable the OIDC issuer on the cluster first. Create a user-assigned managed identity in the node resource group or a dedicated identity RG. Add a federated credential whose `issuer` is the cluster OIDC URL and whose `subject` is the Kubernetes service account (`system:serviceaccount:<namespace>:<name>`). Annotate the pod service account with `azure.workload.identity/client-id`. The pod receives Entra tokens like a VM managed identity, without mounting secrets. This curriculum targets Kubernetes **1.35**; workload identity is the modern replacement for the deprecated aad-pod-identity addon pattern.
+
+For **GitHub Actions**, you create a federated credential on the app registration (as shown earlier with `az ad app federated-credential create`) and use the `azure/login` action with `client-id`, `tenant-id`, and `subscription-id`—no `AZURE_CLIENT_SECRET`. Hypothetical scenario: a platform team runs twenty repositories; rotating twenty secrets quarterly is error-prone, but one federated trust per repo branch pattern scales with policy-as-code reviews.
+
+**Important constraint**: [tokens issued by Microsoft Entra ID cannot be used as input to federated identity credential flows](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation)—the external IdP must be GitHub, your Kubernetes issuer, AWS Cognito, etc., not another Entra tenant token chained informally.
+
+```bash
+# Federated credential on a user-assigned managed identity (AKS-style issuer example)
+az identity federated-credential create \
+  --name "aks-federated-credential" \
+  --identity-name "app-identity" \
+  --resource-group myRG \
+  --issuer "https://oidc.prod.aks.azure.com/<tenant-id>/<cluster-id>/" \
+  --subject "system:serviceaccount:default:my-app-sa" \
+  --audience "api://AzureADTokenExchange"
+```
+
 ---
 
 ## Azure RBAC vs Entra ID Roles: The Great Confusion
@@ -257,13 +345,16 @@ This is the section that will save you hours of frustration. Azure has **two sep
 
 ### Entra ID Roles (Directory Roles)
 
-These roles control access to **Entra ID itself**---the directory. They govern who can create users, manage groups, register applications, configure Conditional Access policies, and perform other directory operations. In other words, Entra ID roles are about identity administration and tenant governance, not direct resource creation, deletion, or data plane operations.
+These roles control access to **Entra ID itself**---the directory. They govern who can create users, manage groups, register applications, configure Conditional Access policies, and perform other directory operations. In other words, Entra ID roles are about identity administration and tenant governance, not direct resource creation, deletion, or data plane operations. [Directory roles are assigned at tenant scope only](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/custom-overview); you cannot assign "User Administrator" on a single subscription because the directory is one flat namespace per tenant.
 
 Examples of core Entra ID directory roles are shown below:
 - **Global Administrator**: Full access to Entra ID and all Microsoft services (the "root" of your tenant)
 - **User Administrator**: Can create and manage users and groups
 - **Application Administrator**: Can manage app registrations and enterprise applications
 - **Security Reader**: Read-only access to security features
+- **Privileged Role Administrator**: Can manage role assignments for other Entra directory roles (high blast radius—often paired with PIM)
+
+When an engineer asks for "admin access," clarify **which plane** they need. Directory admins can reset passwords and create app registrations; they cannot deploy VMs until someone grants Azure RBAC. Resource owners can delete storage accounts but cannot invite guest users unless they also hold directory roles.
 
 ### Azure RBAC Roles (Resource Roles)
 
@@ -294,9 +385,27 @@ This is a critical detail: [a **Global Administrator** in Entra ID does **not** 
 > **Stop and think**: A new security engineer is granted the 'Global Administrator' role in Entra ID. When they log into the Azure portal, they cannot see any Virtual Machines or Storage Accounts. Why?
 > *Answer: Global Administrator is a directory role that grants control over Entra ID (users, groups, policies), not an Azure RBAC role. The engineer has no default access to Azure resources. They must explicitly elevate their access to gain the User Access Administrator role at the root scope before they can grant themselves permissions to view or manage Azure resources.*
 
+### Role Assignment Scope Hierarchy and `az role assignment create`
+
+Azure RBAC assignments attach a **role definition** to a **security principal** (user, group, service principal, or managed identity) at a **scope**. Scopes form a tree: management group → subscription → resource group → individual resource. [Permissions are additive as they inherit downward](https://learn.microsoft.com/en-us/azure/role-based-access-control/overview); a Contributor at subscription scope can modify every resource group underneath unless a **deny assignment** blocks specific actions.
+
+The CLI shape you will use daily is:
+
+```bash
+az role assignment create \
+  --assignee "<object-id-or-upn>" \
+  --role "<RoleName>" \
+  --scope "/subscriptions/<sub-id>/resourceGroups/<rg-name>"
+```
+
+Use the principal's **object ID** for service principals and managed identities (`principalId` from `az identity show` or `az ad sp show`). For users, UPN often works, but object ID avoids ambiguity when guest accounts share display names. Scope should be as narrow as the task allows: prefer resource group over subscription, and resource over resource group when the workload is single-purpose.
+
 ```bash
 # List Azure RBAC role assignments at subscription scope
 az role assignment list --scope "/subscriptions/<sub-id>" -o table
+
+# List assignments for one principal across the tenant (diagnostics)
+az role assignment list --assignee "$PRINCIPAL_ID" --all -o table
 
 # List all built-in Azure RBAC roles
 az role definition list --query "[?roleType=='BuiltInRole'].{Name:roleName, Description:description}" -o table
@@ -304,6 +413,14 @@ az role definition list --query "[?roleType=='BuiltInRole'].{Name:roleName, Desc
 # Show what a specific role can do
 az role definition list --name "Contributor" --query '[0].{Actions:permissions[0].actions, NotActions:permissions[0].notActions}'
 ```
+
+### Deny Assignments and the Least-Privilege Model
+
+Least privilege on Azure means granting the **minimum RBAC and directory roles** required for a task, at the **narrowest scope**, for the **shortest duration** practical. Groups should hold roles; humans should be members of groups. Standing Global Administrator or subscription Owner assignments should be rare and visible in access reviews.
+
+**Deny assignments** are the exception mechanism: they block specified control-plane or data-plane actions even when a role assignment would allow them. [You cannot create arbitrary deny assignments yourself in most tenants](https://learn.microsoft.com/en-us/azure/role-based-access-control/deny-assignments)—Azure creates them to protect platform resources, and deployment stacks can create deny settings to prevent deletion of managed resources. Operators still need to recognize deny assignments when troubleshooting "I have Contributor but the API returns AuthorizationFailed." List them in the portal under Access control (IAM) → Deny assignments, or query with appropriate `Microsoft.Authorization/denyAssignments/read` permission.
+
+Deny does not replace good role design. If teams rely on deny to compensate for excessive Contributor grants, the permission model is already unhealthy. The sustainable pattern is: built-in or custom roles scoped tightly, PIM for elevation, Conditional Access for sign-in risk, and access reviews to remove stale assignments.
 
 ### Custom RBAC Roles
 
@@ -347,11 +464,49 @@ az role definition list --custom-role-only true -o table
 
 An important distinction: **Actions** vs **DataActions**. [Actions control *management plane* operations (creating, deleting, configuring resources). DataActions control *data plane* operations (reading blobs in storage, sending messages to a queue). The role `Storage Blob Data Reader` uses DataActions, not Actions](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-definitions), because it grants access to the data inside storage, not to the storage account management operations.
 
+### Diagnosing "Access Denied" Across Entra ID and Azure RBAC
+
+When authentication succeeds but authorization fails, split the problem into **token issuance** (Entra sign-in, Conditional Access, app consent) versus **RBAC evaluation** (role assignments, scope, deny assignments, data-plane roles). The Azure portal's "Check access" blade on a resource is the fastest sanity check for RBAC. For directory tasks, verify Entra directory role assignments in Entra admin center roles and administrators.
+
+| Symptom | Likely plane | First checks |
+| :--- | :--- | :--- |
+| Cannot sign in to portal | Entra authentication / CA | Sign-in logs, CA report-only, MFA registration |
+| Sign-in works, cannot create RG | Azure RBAC | `az role assignment list --assignee`, scope too narrow |
+| Can create container, cannot upload blob | Data-plane RBAC | Missing `Storage Blob Data Contributor` or equivalent |
+| Global Admin cannot see VMs | Plane confusion | RBAC not granted; elevate access or assign Reader |
+| Contributor but delete blocked | Deny assignment / locks | Deny assignments tab, CanNotDelete lock on RG |
+| MI works locally, fails in Azure | Wrong credential chain | `DefaultAzureCredential` picking CLI instead of IMDS |
+
+Worked troubleshooting flow: confirm the principal's `objectId`, list all role assignments with `--all`, verify each assignment scope includes the target resource, confirm data-plane roles exist for storage/SQL/Key Vault data APIs, wait ten minutes for propagation, then inspect deny assignments. If the principal is a service principal, also verify API permissions and admin consent on the app registration—Graph consent gaps will not show up in `az role assignment list`.
+
+```bash
+# Effective permissions simulation (subscription scope example)
+az role assignment list --assignee "$PRINCIPAL_ID" --scope "/subscriptions/<sub-id>" -o table
+
+# Sign-in diagnostics for human users (requires appropriate Graph permissions)
+az rest --method GET \
+  --url "https://graph.microsoft.com/v1.0/auditLogs/signIns?\$top=5" \
+  --query "value[].{User:userPrincipalName, App:appDisplayName, Status:status.errorCode}" -o table
+```
+
 ---
 
 ## Conditional Access: Context-Aware Security
 
 Conditional Access policies are the enforcement engine of Entra ID. They evaluate conditions (who, where, what device, what app) and make access decisions (allow, block, require MFA). Think of them as programmable if/then rules for authentication that let you tighten control based on context instead of trying to secure every login with one static policy. In practice, this gives you better risk balance because you can keep the default experience lightweight while still protecting high-risk scenarios.
+
+### Policy Anatomy: Signals, Conditions, and Grant Controls
+
+Every Conditional Access policy is a pipeline. **Assignments** define who and what the policy applies to (users, groups, roles, cloud apps, or user actions such as registering security info). **Conditions** filter the sign-in context: client app type, device platform, location (IP ranges from **named locations**), sign-in risk level, or device compliance state. **Access controls** decide the outcome: block, grant with requirements (MFA, compliant device, approved app), or session controls (sign-in frequency, persistent browser session). [Policies evaluate in report-only mode first, then enforcement](https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-conditional-access-policy-common)—a practical rollout pattern that avoids locking out administrators on day one.
+
+| Policy stage | What you configure | Operator intent |
+| :--- | :--- | :--- |
+| **Assignments (WHO/WHAT)** | Users, groups, roles, cloud apps, user actions | Limit blast radius—start with admins, then expand |
+| **Conditions (signals)** | Locations, device state, risk, client apps | Tie controls to real risk (unknown geography, legacy auth) |
+| **Grant controls** | Require MFA, require compliant device, block | Enforce step-up only when context warrants it |
+| **Session controls** | Sign-in frequency, app-enforced restrictions | Reduce token lifetime for sensitive portals |
+
+**Named locations** are CIDR ranges or countries you label as trusted corporate networks versus "anywhere else." Pairing "Require MFA except from trusted locations" with "Block legacy authentication" closes common password-spray paths without punishing employees on VPN. [Risk-based Conditional Access (sign-in risk, user risk) requires Microsoft Entra ID Protection, which needs P2 licensing](https://learn.microsoft.com/en-us/entra/fundamentals/licensing).
 
 | Assignments (WHO) | Conditions (WHERE/WHEN/HOW) | Controls (THEN WHAT) |
 | :--- | :--- | :--- |
@@ -377,15 +532,27 @@ az rest --method GET \
   --query "value[].{Name:displayName, State:state}"
 ```
 
+### MFA Methods and Authentication Strength
+
+Multi-factor authentication is not a single technology. Entra supports Authenticator push/OTP, FIDO2 security keys, certificate-based auth, and telephony (where licensed). [Security defaults favor Microsoft Authenticator for all users](https://learn.microsoft.com/en-us/entra/fundamentals/licensing), while P1/P2 tenants can tune allowed methods per Conditional Access policy. Phishing-resistant MFA (FIDO2, Windows Hello for Business, certificate-based) should be required for Global Administrators and for PIM activations.
+
+Operators should align MFA policy with helpdesk capacity. If every CA policy demands FIDO2 on day one, contractors without enrolled keys will open tickets. A staged rollout—Authenticator first, FIDO2 for privileged roles—is usually sustainable. Pair MFA requirements with **named locations** so corporate VPN users are not challenged on every API call, while unknown locations always step up.
+
+[Break-glass emergency access accounts](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/security-emergency-access) should be cloud-only, excluded from routine Conditional Access, and monitored with alerts. Skipping this step causes painful lockouts during MFA migrations when administrators cannot sign in to fix policies.
+
 ---
 
 ## Privileged Identity Management (PIM) & Access Reviews
 
 Even with least privilege and Conditional Access, standing access is a massive security risk. Standing access means a user can hold a highly privileged role like Owner or Global Administrator continuously, even when they are not actively performing privileged tasks. If their account is compromised, the attacker can immediately inherit that privilege. This is why modern governance patterns treat privileged assignments as exceptions, not defaults.
 
-Microsoft Entra Privileged Identity Management (PIM) solves this by providing **Just-In-Time (JIT) access** that limits privileged exposure to specific windows. With PIM, users are made *eligible* for a role rather than being permanently assigned to it. When they need to perform a privileged task, they must *activate* the role and satisfy the controls defined in the policy, which is usually a lower-risk posture than indefinite standing rights. 
+Microsoft Entra Privileged Identity Management (PIM) solves this by providing **Just-In-Time (JIT) access** that limits privileged exposure to specific windows. With PIM, users are made *eligible* for a role rather than being permanently assigned to it. When they need to perform a privileged task, they must *activate* the role and satisfy the controls defined in the policy, which is usually a lower-risk posture than indefinite standing rights.
 
-The [Microsoft Entra PIM model](https://learn.microsoft.com/en-us/azure/role-based-access-control/pim-integration) exists so you can require evidence before granting temporary privilege, and it makes the access decision explicit instead of implicit.
+### Eligible vs Active Assignments
+
+An **active** assignment behaves like a classic standing role: the principal has the privilege until someone removes it. An **eligible** assignment means the principal *may* request activation; until activation succeeds, the effective permissions are not granted. [PIM applies to both Entra directory roles and Azure resource roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/pim-integration) when licensed appropriately—Global Administrator eligible assignments are directory-scoped, while subscription Owner eligible assignments are Azure RBAC-scoped. Activation creates a time-bound active assignment; when the window expires, the extra assignment disappears without a manual cleanup ticket.
+
+The [Microsoft Entra PIM model](https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-configure) exists so you can require evidence before granting temporary privilege, and it makes the access decision explicit instead of implicit.
 
 The activation process can require several controls before a role becomes active, and that sequence is where governance policies get enforced:
 - **Time-bounding**: The role automatically expires after a set period (e.g., 2 hours).
@@ -396,11 +563,108 @@ The activation process can require several controls before a role becomes active
 > **Stop and think**: An engineer is *eligible* for the Subscription Owner role via PIM. They activate the role, which requires approval. After approval, they try to delete a resource group but get an authorization error. 15 minutes later, the deletion succeeds. Why? 
 > *Answer: Azure RBAC role assignments can take up to 10 minutes to propagate across the globally distributed authorization system. PIM works by dynamically creating a temporary role assignment when activated, so the standard propagation delay applies. The user must simply wait a few minutes after activation for the permissions to take effect.*
 
-### Access Reviews
+### Access Reviews and Governance Cadence
 
-Over time, users accumulate permissions they no longer need—often from changing teams, temporary project assignments, or evolving org structures. **Access Reviews** automate cleanup by giving owners and reviewers a periodic checkpoint, which is far more reliable than relying on people to remember every stale permission. You can configure this process to ask users, managers, or resource owners on a cadence (for example, quarterly) whether specific access is still required. If the reviewer says "no" or fails to respond within the timeframe, Entra ID can automatically revoke access, which directly supports periodic governance evidence and least-privilege review processes. For this reason, Access Reviews are most effective when they are tied to clear ownership and realistic review cycles.
+Over time, users accumulate permissions they no longer need—often from changing teams, temporary project assignments, or evolving org structures. **Access Reviews** automate cleanup by giving owners and reviewers a periodic checkpoint, which is far more reliable than relying on people to remember every stale permission. You can configure this process to ask users, managers, or resource owners on a cadence (for example, quarterly) whether specific access is still required. If the reviewer says "no" or fails to respond within the timeframe, Entra ID can automatically revoke access, which directly supports periodic governance evidence and least-privilege review processes. [Deploy access reviews with explicit reviewers and auto-removal settings documented](https://learn.microsoft.com/en-us/entra/id-governance/deploy-access-reviews) so audit evidence is reproducible.
 
-*Note: PIM and Access Reviews are premium governance features, so check the current Microsoft Entra licensing requirements for your exact scenarios before rollout.*
+Access reviews complement PIM: PIM limits *how long* elevated access lasts during an incident window; access reviews prove *whether standing or eligible assignments should exist at all*. For this reason, Access Reviews are most effective when they are tied to clear ownership and realistic review cycles.
+
+### Entra ID Licensing: Free, P1, P2, and What Requires a Paid Seat
+
+[Microsoft Entra ID Free is included with Azure and Microsoft 365 subscriptions](https://learn.microsoft.com/en-us/entra/fundamentals/licensing) and covers basic directory features, security defaults with MFA for all users (with Authenticator as the primary method in defaults), and built-in Azure RBAC role usage. **Entra ID P1** adds Conditional Access, dynamic groups, self-service password reset with writeback, Entra Connect Health, and custom directory roles (each user with a custom role assignment needs P1). **Entra ID P2** adds Privileged Identity Management, Entra ID Protection (risk-based policies), and advanced access review capabilities bundled with governance scenarios.
+
+| Capability | Free | P1 | P2 |
+| :--- | :---: | :---: | :---: |
+| Security defaults / basic MFA | Yes | Yes | Yes |
+| Conditional Access policies | No | Yes | Yes |
+| Dynamic group membership | No | Yes | Yes |
+| Custom Entra directory roles | No | Yes (licensed assignees) | Yes |
+| Privileged Identity Management | No | No | Yes |
+| Risk-based Conditional Access | No | No | Yes (via ID Protection) |
+| Managed identities for Azure resources | Yes (no extra license) | Yes | Yes |
+
+Microsoft 365 E3 includes P1; Microsoft 365 E5 and EMS E5 include P2. Small-business **Microsoft 365 Business Premium** also bundles Conditional Access—check your exact SKU before buying standalone P1 seats.
+
+---
+
+## Patterns & Anti-Patterns
+
+| Pattern | When to use | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| **Group-based RBAC** | Any team larger than a handful of engineers | Role assignments on groups survive org churn; audit shows group membership changes | Use dynamic groups for department-based access; avoid nested group explosions |
+| **User-assigned managed identity shared across services** | Multiple Azure resources need the same downstream permissions | One `principalId`, one set of Key Vault or SQL role assignments | Pre-create identity in Terraform/Bicep before attaching to App Service, Functions, ACI |
+| **Workload identity federation for CI/CD** | GitHub Actions, GitLab, or non-Azure Kubernetes calling Azure APIs | No rotating client secrets in pipeline variables | One federated credential per repo/environment subject; review `issuer`/`subject` in PRs |
+| **Conditional Access baseline + report-only** | New tenant hardening | MFA for admins and block legacy auth stop most commodity attacks | Expand policies gradually; exclude break-glass accounts explicitly |
+| **PIM eligible for Owner/Global Admin** | Production subscriptions and tenant administration | Standing privilege window shrinks to activation duration | License every eligible user, approver, and reviewer (P2 or Governance) |
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+| :--- | :--- | :--- | :--- |
+| **Subscription Owner for all engineers** | One compromised laptop deletes entire environments | Speed during early cloud adoption | Contributor or custom roles at RG scope; PIM Owner when needed |
+| **Client secret in pipeline variables** | Secret leaks via logs, forks, or retired maintainers | Tutorials default to `AZURE_CLIENT_SECRET` | Federated credential + OIDC login action |
+| **System-assigned MI per microservice when permissions are identical** | N identities, N role assignments, N audit trails | Each tutorial enables `[system]` locally | One user-assigned MI attached to all components |
+| **Global Admin for day-to-day Azure portal work** | Directory and resource planes blurred; over-broad access | Confusion between Entra roles and RBAC | RBAC Reader/Contributor at scoped resources; PIM for elevation |
+| **Conditional Access without break-glass plan** | Lockout during MFA or location misconfiguration | "Secure everything" rush | Two cloud-only emergency accounts, excluded from CA, monitored |
+| **Ignoring deny assignments during RCA** | "Contributor" still fails mysteriously | Deny is invisible in simple IAM screenshots | Check Deny assignments tab; review deployment stack deny settings |
+
+---
+
+## Decision Framework: Workload Identity Choice
+
+Use this matrix when onboarding a new workload that needs Entra-authenticated access to Azure APIs. The goal is **no long-lived secrets** and **narrow RBAC scope**.
+
+| Workload context | Recommended identity | Why | Avoid |
+| :--- | :--- | :--- | :--- |
+| Single Azure VM, App Service, or Function | System-assigned managed identity | Lifecycle tied to resource; zero secret management | User-assigned unless you will share permissions |
+| Multiple Azure resources, same permissions | User-assigned managed identity | One principal, many attachments | Duplicate system-assigned identities |
+| AKS pod accessing Azure APIs | User-assigned MI + workload identity federation | OIDC trust to Kubernetes service account | Mounting service principal secrets into cluster |
+| GitHub Actions deploying to Azure | App registration + federated credential (OIDC) | Branch/repo-scoped trust, no secret rotation | Client secret in GitHub Secrets |
+| Third-party SaaS outside Azure | App registration + certificate or federation if supported | Explicit consent and scoped API permissions | Contributor role on subscription for the vendor |
+| Legacy app that cannot use OIDC/MI | Service principal + short-lived certificate | Certificates rotatable via Key Vault | Multi-year client secrets in config files |
+
+```mermaid
+flowchart TD
+    A[Workload needs Azure API access] --> B{Runs on Azure with IMDS?}
+    B -->|Yes, single resource| C[System-assigned managed identity]
+    B -->|Yes, multiple resources same perms| D[User-assigned managed identity]
+    B -->|No| E{External OIDC issuer available?}
+    E -->|Yes: GitHub/K8s/GCP/AWS| F[Federated credential on MI or app registration]
+    E -->|No| G{Can use certificate auth?}
+    G -->|Yes| H[App registration + cert from Key Vault]
+    G -->|No| I[Service principal secret - last resort, short TTL]
+    C --> J[Assign RBAC at narrowest scope]
+    D --> J
+    F --> J
+    H --> J
+    I --> J
+```
+
+---
+
+## Cost Lens: Entra Licensing and Over-Provisioning
+
+Identity licensing is a **per-user monthly line item** that is easy to overspend because it is invisible next to VM and storage bills. [Managed identities for Azure resources incur no additional Entra license charge](https://learn.microsoft.com/en-us/entra/fundamentals/licensing)—you pay for the Azure resources themselves, not per identity. The cost driver is **human and governance seats**: Conditional Access, dynamic groups, PIM activations, and access reviews each map to P1, P2, or Entra ID Governance licensing rules.
+
+**Free tier** covers directory basics and security defaults. If you only need cloud-only users, standard groups, and built-in RBAC on subscriptions, you may never buy P1—until you need Conditional Access for compliance, at which point every user **in scope of those policies** needs P1 (or a bundle like Microsoft 365 E3 that includes P1).
+
+**P1** is the enterprise baseline for policy-driven sign-in. Budget P1 (or E3) for employees subject to Conditional Access and for administrators who use custom Entra directory roles. A common over-licensing mistake is assigning P1 to every contractor when only employees hitting CA policies need it—use separate guest policies or scoped assignments.
+
+**P2** is required for PIM eligible/active role workflows, risk-based Conditional Access, and Entra ID Protection reports. [Microsoft documents that every user who is eligible for PIM, can approve activations, or participates in access reviews needs a P2 or Entra ID Governance license](https://learn.microsoft.com/en-us/entra/fundamentals/licensing). A team of five eligible Owners plus three approvers plus quarterly reviewers can require **more licensed identities than expected** because approvers and reviewers count too.
+
+**Cost spikes to watch**:
+- Buying standalone P2 when Microsoft 365 E5 already includes it for the same users (duplicate spend).
+- Leaving PIM eligible assignments on vendors or contractors who no longer need them—licenses still attach to identities in review scope.
+- Enabling advanced access review features without Entra ID Governance planning—some scenarios bill per reviewer and per reviewed user.
+- Using service principals with secrets instead of federation—no license savings, but incident cost dominates when secrets leak.
+
+**Knobs that reduce cost without weakening security**: use group-based licensing in Microsoft 365 admin center; align CA policies to groups rather than "all users" when possible; prefer managed identities (no license) over human service accounts; use PIM time bounds so fewer people need standing Owner; right-size P2 to identities in governance workflows only.
+
+Hypothetical scenario: a 200-person company buys 200 P2 licenses "for security," but only 15 administrators use PIM and 30 employees are in Conditional Access scope. A disciplined model might be 30 P1-equivalent (E3) plus 20 P2 for admins and reviewers—saving substantial monthly cost while keeping controls on the identities that actually touch privileged paths.
+
+**Licensing hygiene checklist** (quarterly): reconcile Microsoft 365 admin center group-based licensing with Entra group membership; remove P2 from users without eligible PIM roles; confirm contractors are guests with scoped access reviews; verify GitHub federated credentials still match active repos; audit app registrations with secrets older than 90 days.
+
+### Security Defaults vs Conditional Access
+
+Tenants without P1 historically relied on **security defaults**—tenant-wide baseline requiring MFA for admins and users, and blocking legacy authentication. [Security defaults are mutually exclusive with Conditional Access in many tenants](https://learn.microsoft.com/en-us/entra/fundamentals/security-defaults)—you choose a baseline path. Moving to Conditional Access means buying P1 (or bundled E3/Business Premium) and migrating policies deliberately. Do not disable security defaults until equivalent CA policies exist, or you temporarily weaken sign-in protections.
 
 ---
 
@@ -469,13 +733,27 @@ Assigning roles directly to individual users does not scale and creates a nightm
 A System-Assigned Managed Identity is inextricably tied to the specific lifecycle of the Azure resource it was created on. When you deleted the original VM, its managed identity (and all associated role assignments) was permanently destroyed by Azure. When you restored the VM, Azure generated a brand new System-Assigned Managed Identity with a completely different Principal ID. You must recreate the RBAC role assignments on the Key Vault for this new identity before the application can authenticate.
 </details>
 
+<details>
+<summary>7. Your security team wants GitHub Actions in `repo:contoso/deploy:environment:production` to deploy to Azure without storing `AZURE_CLIENT_SECRET`. The app registration already exists. What Entra feature do you configure, and what three fields must match the token GitHub sends?</summary>
+
+Configure a **federated identity credential** on the app registration (or on a user-assigned managed identity if the pipeline assumes that identity). The credential's **issuer** must match GitHub's OIDC issuer (`https://token.actions.githubusercontent.com`), the **subject** must match the workflow claim (for example `repo:contoso/deploy:environment:production`), and the **audience** must match what the login action expects (commonly `api://AzureADTokenExchange`). Microsoft identity platform rejects the exchange if any value differs by even case from the external JWT. This is workload identity federation: external OIDC token in, Entra access token out, with no client secret in GitHub.
+</details>
+
+<details>
+<summary>8. A contractor still appears as *eligible* for User Administrator in PIM, but your organization let their Microsoft 365 license expire last month. They attempt to activate the role and the portal blocks them. Which licensing lesson applies, and what should operations do?</summary>
+
+PIM requires **Microsoft Entra ID P2 or Entra ID Governance** licenses for users with eligible assignments, approvers, and reviewers—not merely an Azure subscription. Expired or missing P2/Governance licensing disables activation even if the eligible assignment row still exists. Operations should remove stale eligible assignments during offboarding, reconcile licenses in the Microsoft 365 admin center, and run access reviews so contractors do not remain in privileged eligibility after employment ends. This is why identity governance is both a security process and a licensing compliance process.
+</details>
+
 ---
 
 ## Hands-On Exercise: Custom RBAC Role + Managed Identity on a VM
 
-In this exercise, you will create a custom RBAC role, set up a VM with a Managed Identity, and verify that the identity can only perform the actions allowed by the custom role.
+In this exercise, you will create a custom RBAC role, set up a VM with a Managed Identity, and verify that the identity can only perform the actions allowed by the custom role. The lab stitches together three ideas from this module: **custom roles** narrow management and data actions, **system-assigned managed identities** remove secrets from the VM, and **scope-limited assignments** show least privilege in practice. You will see propagation delay in Task 5—build the wait into your scripts in production.
 
-**Prerequisites**: Azure CLI installed and authenticated (`az login`), a resource group to work in, and SSH access to a temporary VM for identity verification.
+The exercise intentionally uses **DataActions** with **NotDataActions** so listing and reading blobs succeed while delete fails. That mirrors real application needs: telemetry agents that read inputs but must not wipe archives. If you only granted Contributor, the VM could delete containers even when blob delete should be forbidden—another reminder that management-plane roles do not imply data-plane rights.
+
+**Prerequisites**: Azure CLI installed and authenticated (`az login`), a resource group to work in, and SSH access to a temporary VM for identity verification. Use a sandbox subscription; the VM is a small `Standard_B1s` burstable size. Delete the resource group in Cleanup to avoid ongoing compute charges.
 
 ### Task 1: Create a Resource Group for the Exercise
 
@@ -693,6 +971,8 @@ az group delete --name "$RG_NAME" --yes --no-wait
 az role definition delete --name "Storage Blob Lister"
 ```
 
+After cleanup, confirm the custom role no longer appears in `az role definition list --custom-role-only true`. If the role definition delete fails because assignments still exist, remove assignments first with `az role assignment delete`. Labs that skip cleanup leave custom roles and storage accounts billing quietly in sandbox subscriptions. Document your principal IDs during the lab—they help when comparing audit logs and exported Azure RBAC role assignment lists later.
+
 ### Success Criteria
 
 - [ ] Custom RBAC role "Storage Blob Lister" created with specific actions and data actions
@@ -724,3 +1004,13 @@ az role definition delete --name "Storage Blob Lister"
 - [learn.microsoft.com: deploy access reviews](https://learn.microsoft.com/en-us/azure/active-directory/governance/deploy-access-reviews) — Microsoft's access reviews deployment guidance documents recurring reviews and auto-apply removal behavior.
 - [learn.microsoft.com: new name](https://learn.microsoft.com/en-us/entra/fundamentals/new-name) — The official rename guidance states the July 2023 announcement and that existing login URLs, APIs, and PowerShell cmdlets stayed the same.
 - [learn.microsoft.com: ad](https://learn.microsoft.com/en-us/cli/azure/ad?view=azure-cli-lts) — The Azure CLI reference page still documents the az ad command group for Microsoft Entra entities.
+- [learn.microsoft.com: licensing](https://learn.microsoft.com/en-us/entra/fundamentals/licensing) — Documents Free, P1, and P2 feature matrices, Conditional Access and PIM license requirements, and managed identity licensing (none).
+- [learn.microsoft.com: workload identity federation](https://learn.microsoft.com/en-us/entra/workload-id/workload-identity-federation) — Explains federated credentials, supported external IdPs, and the OIDC token exchange flow without secrets.
+- [learn.microsoft.com: deny assignments](https://learn.microsoft.com/en-us/azure/role-based-access-control/deny-assignments) — Describes how deny assignments block actions despite role grants and that operators cannot create arbitrary deny assignments.
+- [learn.microsoft.com: rbac overview](https://learn.microsoft.com/en-us/azure/role-based-access-control/overview) — Scope hierarchy, inheritance, and role assignment fundamentals for management groups through resources.
+- [learn.microsoft.com: custom roles overview](https://learn.microsoft.com/en-us/entra/identity/role-based-access-control/custom-overview) — Entra directory roles versus Azure RBAC and tenant-scoped directory role assignments.
+- [learn.microsoft.com: workload identity overview](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview) — AKS OIDC issuer and Kubernetes service account federation to user-assigned managed identities.
+- [learn.microsoft.com: conditional access common policies](https://learn.microsoft.com/en-us/entra/identity/conditional-access/concept-conditional-access-policy-common) — Policy structure: assignments, conditions, grant controls, and report-only rollout.
+- [learn.microsoft.com: pim configure](https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-configure) — Eligible versus active role assignments and activation settings for directory and Azure roles.
+- [learn.microsoft.com: permissions consent overview](https://learn.microsoft.com/en-us/entra/identity-platform/permissions-consent-overview) — Delegated versus application API permissions and admin consent boundaries separate from Azure RBAC.
+- [learn.microsoft.com: security defaults](https://learn.microsoft.com/en-us/entra/fundamentals/security-defaults) — Baseline MFA and legacy auth blocks for tenants not yet on Conditional Access.

--- a/src/content/docs/cloud/azure-essentials/module-3.4-blob.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.4-blob.md
@@ -4,7 +4,7 @@ slug: cloud/azure-essentials/module-3.4-blob
 sidebar:
   order: 5
 ---
-**Complexity**: [QUICK] | **Time to Complete**: 1.5h | **Prerequisites**: Module 3.1 (Entra ID & RBAC). You should be comfortable assigning Entra ID RBAC roles and running `az` commands with `--auth-mode login` before starting.
+**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Module 3.1 (Entra ID & RBAC). You should be comfortable assigning Entra ID RBAC roles and running `az` commands with `--auth-mode login` before starting.
 
 ## What You'll Be Able to Do
 
@@ -19,11 +19,11 @@ After completing this module, you will be able to apply the patterns below in pr
 
 ## Why This Module Matters
 
-Poor tiering and missing lifecycle policies can quietly drive Azure storage bills far above expectations when large volumes of logs and intermediate data remain in hot storage for months.
+Poor tiering and missing lifecycle policies can quietly drive Azure storage bills far above expectations. Large volumes of logs and intermediate data often remain in Hot tier for months without anyone noticing.
 
-Azure Blob Storage is the foundation of data storage in Azure. It handles everything from serving website assets and storing application logs to backing enterprise data lakes and machine learning datasets. It is deceptively simple on the surface---you create a storage account, upload files, and they are stored. But beneath that simplicity lies a system with multiple access tiers, sophisticated access control mechanisms, replication options, and lifecycle management that can mean the difference between a reasonable bill and a financial disaster.
+Azure Blob Storage is the foundation of data storage in Azure. It serves website assets, application logs, enterprise data lakes, and machine learning datasets. The surface API looks simple: create a storage account, upload files, and read them back. Under that simplicity sits a layered system of access tiers, replication SKUs, authorization models, and lifecycle automation. Operators who ignore those layers often discover the cost impact only after a finance review.
 
-In this module, you will learn how Azure Storage Accounts work, how to choose the right access tier for your data, how SAS tokens and identity-based access control secure your blobs, and how Azure Data Lake Storage Gen2 extends Blob Storage for big data workloads. By the end, you will understand how to design a storage strategy that balances cost, performance, and security.
+In this module, you will learn how storage accounts scope redundancy and default tiers. You will choose access tiers and lifecycle rules that match real access patterns. You will apply SAS tokens, Entra ID RBAC, and network controls without falling back to account keys. You will also see how Data Lake Storage Gen2 extends Blob Storage for analytics workloads. By the end, you can design storage that balances cost, durability, and security deliberately rather than by accident.
 
 ---
 
@@ -41,6 +41,10 @@ A **Storage Account** is the top-level resource for Azure Storage. It provides a
 | **Premium page blobs** | Page blobs only | Premium (SSD-backed) | VM disk storage (unmanaged disks---legacy) |
 
 For the vast majority of workloads, **Standard general-purpose v2** is the right choice. Premium accounts are for specialized scenarios where you need consistently low latency or very high transaction rates.
+
+**Performance tier** (Standard vs Premium) is separate from **access tier** (Hot/Cool/Cold/Archive). Standard accounts store blob data on HDD-backed media unless you choose Premium block blob accounts for SSD-backed block blobs. Premium block blob (`BlockBlobStorage` kind) does not support the same lifecycle tiering to Archive as general-purpose v2. [Premium block blob accounts support LRS and ZRS in select regions](https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy). Plan premium accounts for IOPS-sensitive workloads, not for cheap long-term archive.
+
+**Naming and limits** matter at scale. Storage account names are globally unique, 3–24 characters, lowercase letters and numbers only. A single account can hold up to [5 PiB by default](https://learn.microsoft.com/en-us/azure/storage/common/scalability-targets-standard-account) with high request rates when partitioned well. Many teams use one account per environment (dev/stage/prod) or per data domain (media, logs, analytics) so firewall rules, private endpoints, and lifecycle policies stay understandable.
 
 To translate this theory into practice, here is how you would provision both a standard and a premium storage account using the Azure CLI, ensuring secure defaults are set from the start:
 
@@ -94,11 +98,35 @@ The table above shows durability tiers; the bullets below illustrate how redunda
 
 > **Stop and think**: If your primary region suffers a complete outage, how does your application know to read from the secondary region in an RA-GRS setup? (Hint: Azure provides a distinct secondary endpoint URL, appended with `-secondary`, that your application logic must actively switch to during a failover event.)
 
+### Redundancy in depth: blast radius, durability, and failover
+
+[Microsoft documents six redundancy options for storage accounts](https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy). Each option trades monthly storage cost against the failures it can survive. Think in three layers: disk or server failure inside one datacenter, loss of an entire datacenter or availability zone, and loss of an entire Azure region.
+
+**Locally redundant storage (LRS)** keeps three synchronous copies inside one physical datacenter in your chosen region. LRS targets at least **99.999999999% (11 nines)** annual durability for objects. It protects against drive, rack, and server failures. It does not protect against a datacenter-wide disaster such as fire or flooding. LRS is the lowest-cost option and the narrowest blast-radius protection.
+
+**Zone-redundant storage (ZRS)** spreads three synchronous copies across separate availability zones in the primary region. Each zone has independent power, cooling, and networking. ZRS targets at least **99.9999999999% (12 nines)** durability. Writes return success only after all available zones acknowledge the data. ZRS is Microsoft's recommended default for high availability within a single region, including [Data Lake workloads](https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy).
+
+**Geo-redundant storage (GRS)** and **geo-zone-redundant storage (GZRS)** add asynchronous replication to a paired secondary region hundreds of miles away. GRS uses LRS in the primary region; GZRS uses ZRS in the primary. The secondary region always uses LRS internally. Both GRS and GZRS target at least **99.99999999999999% (16 nines)** durability. Replication is asynchronous, so the secondary can lag the primary during heavy write load. That lag defines your **recovery point objective (RPO)** if the primary region fails.
+
+**Read-access geo-redundant storage (RA-GRS)** and **read-access geo-zone-redundant storage (RA-GZRS)** are the same geo-replicated configurations with read access to the secondary endpoint enabled before failover. Your application can read from `accountname-secondary.blob.core.windows.net` while the primary is healthy. That pattern supports warm DR testing and read-heavy DR architectures. [Azure Files does not support RA-GRS or RA-GZRS](https://learn.microsoft.com/en-us/azure/storage/common/storage-redundancy).
+
+The **RA** distinction matters operationally. Standard GRS and GZRS keep the secondary write-only until you fail over. RA variants let you serve read traffic from the secondary during a primary outage without waiting for DNS failover to complete. You still need application logic—or Traffic Manager, Front Door, or custom routing—to send writes to whichever endpoint is primary after failover.
+
+**Failover and RPO** are separate concerns from durability on paper. [Customer-managed planned failover](https://learn.microsoft.com/en-us/azure/storage/common/storage-disaster-recovery-guidance) swaps primary and secondary when both regions are healthy. Microsoft expects **no data loss** during planned failover when endpoints stay available throughout the process. **Customer-managed unplanned failover** is for primary-region endpoint outages. It promotes the secondary and typically causes **some data loss** for writes not yet replicated. After unplanned failover, the account becomes **LRS** in the new primary until you re-enable geo-redundancy. Check the **Last Sync Time** property on the account to estimate how far behind the secondary was before you fail over.
+
+**Archive tier constraint**: [Archive tier is supported only on LRS, GRS, and RA-GRS accounts today](https://learn.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview). It is not supported on ZRS, GZRS, or RA-GZRS. If you plan heavy Archive use with zone redundancy in the primary region, validate redundancy and tier compatibility before you ingest petabytes.
+
+Hypothetical scenario: A team stores compliance archives in GRS with RA-GRS enabled. They rehearse quarterly reads from the secondary endpoint. When a regional outage blocks the primary blob endpoint, their app already points read paths at `-secondary`. Failover then becomes a controlled promotion rather than an improvised DNS change under incident pressure.
+
 ---
 
 ## Blob Storage: Containers and Blobs
 
 Blob (Binary Large Object) storage is organized into **containers** within a storage account. Think of containers as top-level directories. A critical architectural constraint to remember is that standard Blob Storage is [fundamentally flat---there are no actual subdirectories, only virtual prefixes](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-namespace).
+
+Containers also carry policy boundaries in mature estates. You attach **immutable policies** at container scope. **Private endpoints** can target the blob sub-resource for an entire account, but IAM assignments often narrow to specific containers for pipeline identities. **Lifecycle prefixMatch** filters almost always start from container name or a path prefix inside it (`logs/2024/`). Naming containers after workload and environment (`prod-exports`, `dev-exports`) keeps automation readable when dozens of rules accumulate.
+
+Hot paths for performance sometimes use **block blob size and partition key** strategies. Extremely high request rates may require spreading blobs across multiple accounts because throttling limits apply per account. [Scalability targets document per-second limits](https://learn.microsoft.com/en-us/azure/storage/blobs/scalability-targets). When telemetry shows throttling, split by container prefix into additional accounts before chasing Premium tier spend.
 
 ```mermaid
 graph TD
@@ -190,6 +218,12 @@ az storage blob download \
 
 Azure Blob Storage offers four access tiers with radically different cost profiles. The foundational economic principle of cloud storage applies here: **storage cost and access cost are inversely related**. The cheaper a gigabyte is to store, the more expensive it will be to read.
 
+Tier choice is a product decision, not only a storage admin task. Application owners should answer three questions before upload defaults are set: How often is this object read? How fast must first byte return? What happens financially if we delete early? Hot optimizes for frequent access. Cool and Cold trade lower capacity rates for higher read and transaction charges. Archive optimizes capacity cost at the price of offline data and rehydration delay.
+
+Block blobs support tiering; append and page blobs do not use these access tiers the same way. [Access tier settings apply to block blobs in general-purpose v2 and Blob Storage accounts](https://learn.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview). Page blobs backing legacy unmanaged disks follow different pricing models. When architects say "move logs to Cool," they mean block blobs in object containers, not VM disks.
+
+Availability SLAs differ slightly by tier. Hot targets higher read availability than Cool, Cold, or Archive on the same redundancy SKU. For many batch workloads the SLA difference does not matter. For customer-facing assets served directly from blob without CDN, Hot plus redundancy matching your uptime target is the usual starting point.
+
 | Tier | Storage Cost (per GB) | Read Cost (per 10K ops) | Min Retention | Access Latency | Best For |
 | :--- | :--- | :--- | :--- | :--- | :--- |
 | **Hot** | Highest storage cost | Lowest read cost | None | Milliseconds | Frequently accessed data |
@@ -271,6 +305,24 @@ az storage account management-policy create \
 
 This JSON policy instructs Azure's background services to evaluate the `logs/` prefix periodically after the policy takes effect. Blobs age smoothly into Cool tier, then Archive, and are ultimately purged from the system after a year---greatly reducing the chance that you end up as the subject of the financial disaster war story from the introduction.
 
+### Access tiers and lifecycle in depth
+
+[Hot, Cool, and Cold are online tiers](https://learn.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview). Applications can read and write them with millisecond latency. **Archive is offline**. Reads and writes against archived blobs fail until you rehydrate to an online tier. Archive is for data you rarely touch and can tolerate hours of latency.
+
+**Minimum retention and early deletion** apply when you tier down or delete too soon. Cool requires **30 days** minimum on general-purpose v2 accounts. Cold requires **90 days**. Archive requires **180 days**. If you delete or move a blob before the minimum elapses, Azure charges a **prorated early deletion fee** based on the remaining days at that tier's storage rate. Overwriting a blob via Put Blob, Put Block List, or Copy Blob within the window can also trigger the fee. With **soft delete** enabled, a blob counts as deleted only after the soft-delete retention expires, so soft-deleted blobs are not subject to early deletion penalties during the retention window.
+
+**Blob-level vs account-level tiering** solves different problems. Each storage account has a **default access tier** (Hot, Cool, or Cold—not Archive). New block blobs without an explicit tier inherit that default. The portal may label them **Hot (inferred)** or **Cool (inferred)** when the tier comes from the account setting. You can override tier per blob at upload or with `az storage blob set-tier`. Changing the account default tier re-prices every blob that still has an inferred tier. Moving the default to a cooler tier bills **write operations per 10,000** for those blobs. Moving the default warmer bills **read operations and per-GB retrieval** from the source tier. Set explicit tiers on long-lived datasets so a blanket account change does not surprise finance.
+
+**Lifecycle management** automates tier transitions and expirations with JSON rules. [Rules can filter by prefix, blob index tags, and blob type](https://learn.microsoft.com/en-us/azure/storage/blobs/lifecycle-management-overview). Conditions use **last modified time**, **creation time**, and optionally **last accessed time** when access tracking is enabled. Actions include tier-to-cool, tier-to-cold, tier-to-archive, and delete for base blobs, versions, and snapshots. Policy changes can take up to **24 hours** to apply; the first run may start after that delay. Lifecycle policies are **free**; you pay standard **Set Blob Tier** and delete operation charges. Lifecycle **cannot rehydrate** Archive to an online tier—you must use Set Blob Tier or Copy Blob for that path.
+
+**Last-accessed tracking** lets rules tier down idle data even when last-modified time stays old. Each last-access time update can bill as an **other operation** at most once per 24 hours per object. Enable tracking only when lifecycle rules actually use last-accessed conditions, or you pay tracking overhead without savings.
+
+**Rehydration from Archive** uses Standard or High priority. [Microsoft documents up to 15 hours for Standard priority](https://learn.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview). High priority is faster for urgent restores but costs more. While rehydration runs, capacity billing stays at Archive rates until the blob lands in the target online tier. Plan restore runbooks before auditors or regulators ask for immediate access to cold records.
+
+**Smart tier** (where enabled) automatically moves data among Hot, Cool, and Cold based on usage. It is a managed alternative to hand-tuned lifecycle rules for variable access patterns. Whether you use Smart tier or explicit lifecycle rules, the design question is the same: match tier to measured access frequency, not to how long ago the file was created.
+
+Objects smaller than **128 KiB** in Cool, Cold, or Archive may bill as **128 KiB** minimum objects on accounts created after Microsoft's staged rollout dates documented in the access tiers overview. Packaging tiny telemetry files into larger aggregate blobs before tiering down avoids silent minimum-size billing surprises.
+
 ---
 
 ## Data Protection and Compliance
@@ -287,6 +339,10 @@ Versioning automatically maintains previous states of a blob each time it is [mo
 Write-Once, Read-Many (WORM) policies ensure data cannot be modified or deleted by *anyone*---not even users with full administrative privileges or Microsoft support---for a user-specified interval. 
 *   **Time-based retention policies:** Lock data for a specific duration (e.g., 7 years for financial records).
 *   **Legal holds:** Lock data indefinitely until the hold is explicitly removed (used during litigation).
+
+Versioning and immutability interact with operations teams daily. Versioning preserves history when applications overwrite blobs. Immutability prevents tampering even when someone has Owner rights. Together they support ransomware recovery narratives: restore a known-good version, while locked containers block attacker encryption from replacing compliance evidence. Operators must still plan **storage growth**: each version is billable capacity until lifecycle deletes old versions. Immutable containers reject lifecycle delete actions on protected blobs, so retention policies need explicit owners and calendar reviews.
+
+Change feed, point-in-time restore, and object replication build on similar blob-change tracking primitives. If you enable those features for operational backup, read [disaster recovery guidance](https://learn.microsoft.com/en-us/azure/storage/common/storage-disaster-recovery-guidance) for failover caveats. Unplanned failover can reset earliest restore points and introduce consistency considerations when change feed is enabled.
 
 ```bash
 # Enable versioning on a storage account
@@ -391,6 +447,10 @@ When you build a SAS URI, combine permission flags to grant only what the client
 | `t` | Tags |
 | `x` | Execute |
 
+**Account SAS** spans multiple services in the account (blob, file, queue, table) when signed with account keys. **Service SAS** scopes to a single service (blob) but still uses account keys unless you switch to user delegation. Service SAS is common in legacy apps. **User delegation SAS** scopes to blob resources and ties to Entra ID. For new integrations, default to user delegation with `--auth-mode login --as-user` as shown earlier.
+
+Operational hygiene for SAS URLs: never log complete URLs in application logs; treat query strings as secrets. Prefer HTTPS only. When a vendor integration is decommissioned, revoke delegation keys if user delegation SAS might still circulate. For account-key SAS, rotation requires regenerating every outstanding token when keys roll.
+
 ### 3. Identity-Based Access (Recommended)
 
 The gold standard for authorization is using Entra ID identities combined with Azure Role-Based Access Control (RBAC). By leveraging Managed Identities, you completely eliminate the need to generate, rotate, or secure credentials in application code.
@@ -454,11 +514,35 @@ az network private-endpoint create \
 
 > **Stop and think**: If you disable public network access and rely exclusively on a Private Endpoint, how will developers working from their local laptops access the storage account to upload test data? (Hint: They will need a VPN connection to the VNet, Azure Bastion, or a carefully configured Storage Firewall exception for their specific IP addresses.)
 
+### Security and access control in depth
+
+Authorization and network isolation work together. **Who** may call the data plane is separate from **where** requests may originate. Production designs usually tighten both.
+
+**Account keys** remain full-power secrets. [Each storage account has two 512-bit keys](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-keys-manage). Either key grants complete control over blobs, queues, tables, and files in that account. Keys leak through logs, tickets, and backups. Prefer Entra ID, managed identities, and user delegation SAS for application access. Rotate keys only when legacy integrations still require them.
+
+**SAS types** differ by signing material. **Account SAS** and **service SAS** are signed with storage account keys. **User delegation SAS** is signed with a key obtained through Entra ID. Microsoft recommends user delegation SAS when possible. The signing identity needs a role that includes **Microsoft.Storage/storageAccounts/blobServices/generateUserDelegationKey**, such as **Storage Blob Data Contributor**. [User delegation keys are valid up to seven days](https://learn.microsoft.com/en-us/azure/storage/blobs/storage-blob-user-delegation-sas-create-cli). Set SAS expiry within that window even if you want a longer calendar lifetime. Revoke compromised delegation keys with `az storage account revoke-delegation-keys`; cache delays may apply before old SAS URLs fail.
+
+**Entra ID RBAC on the data plane** assigns roles at subscription, resource group, storage account, container, or blob scope. **Storage Blob Data Reader** covers read and list. **Storage Blob Data Contributor** adds write and delete. **Storage Blob Data Owner** adds ACL management needed for Data Lake Gen2 paths. **Storage Blob Delegator** allows generating user delegation SAS without broad data write rights. Scope assignments narrowly: a CI pipeline that uploads build artifacts needs Contributor on one container, not on the whole account.
+
+**Service endpoints vs private endpoints vs firewall rules** solve different network problems. [Storage firewall rules](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security) restrict which public IPs and which VNet subnets may reach the **public** storage endpoints. **Service endpoints** route traffic from your subnet to Azure Storage over the Microsoft backbone while the account still has a public endpoint. **Private endpoints** place a private IP in your VNet via Azure Private Link. Blob traffic then stays off the public internet for clients that resolve the private DNS name. Many production accounts combine **default-action Deny** on the firewall with selected subnet rules for PaaS services, plus private endpoints for application tiers inside the VNet. `--public-network-access Disabled` blocks the public endpoint entirely; only private endpoint paths remain.
+
+**Blob versioning** keeps prior versions when blobs are overwritten or deleted. Each version is a separate billable object until you delete it. Versioning pairs well with lifecycle rules that tier or delete **previous versions** on a schedule. Without lifecycle on versions, overwrite-heavy workloads can grow storage silently.
+
+**Soft delete** for blobs and containers retains deleted objects for **1 to 365 days** before permanent removal. Restore with undelete APIs during the window. Soft delete is cheap insurance against operator mistakes and buggy automation.
+
+**Immutability (WORM)** supports **time-based retention** and **legal holds** on containers. Locked policies prevent overwrite and delete even for administrators until retention expires or legal hold clears. Immutable containers block lifecycle **delete** actions on protected blobs. Plan immutability for audit logs and regulatory archives where tamper evidence matters more than day-to-day agility.
+
+Hypothetical scenario: An export service runs on AKS with a managed identity. It receives Contributor on `exports/` only. Partner downloads use one-hour user delegation SAS on individual blobs. The account denies public access and accepts traffic only from the cluster subnet and a private endpoint in the production VNet. Keys exist for break-glass only and rotate on a calendar owned by security.
+
 ---
 
 ## Azure Data Lake Storage Gen2
 
 Azure Data Lake Storage Gen2 (ADLS Gen2) is [not a separate physical service---it is an architectural capability built natively onto Blob Storage](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction). When you toggle the **hierarchical namespace** feature upon creation, you gain true directory semantics, POSIX-like access control lists (ACLs), and atomic directory operations. This capability transforms Blob Storage into an enterprise analytics engine tailored for tools like Apache Spark, Databricks, and Synapse Analytics.
+
+The **DFS endpoint** (`dfs.core.windows.net`) exposes file-system semantics that Spark and Synapse prefer. The **blob endpoint** still exists for tools that speak classic blob APIs. Permissions combine **RBAC** (coarse, Azure control plane aligned) with **POSIX ACLs** on paths (fine-grained for data lake folders). **Storage Blob Data Owner** is required when pipelines set ACLs programmatically. Misaligned ACLs are a common reason jobs can list a path but fail to write parquet files underneath.
+
+[Hierarchical namespace is enabled only at account creation](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-namespace). Upgrading a flat account later is not a casual toggle. If analytics is on the roadmap within 12 months, enabling HNS up front avoids painful migrations. If the workload is only object PUT/GET with no directory renames, flat blob storage remains simpler and fully sufficient.
 
 To utilize these big data features, you must enable the namespace during creation and interact via the file system (`fs`) commands rather than the `blob` commands:
 
@@ -501,6 +585,110 @@ Choosing between flat Blob Storage and ADLS Gen2 is not about price---both use t
 
 ---
 
+## Patterns and Anti-Patterns
+
+Blob storage patterns turn one-off console choices into repeatable architecture. The goal is not perfect storage on day one. The goal is to make expensive mistakes boring: tiers match access, keys stay out of code, redundancy matches blast radius, and lifecycle runs without a human spreadsheet.
+
+| Pattern | When to use it | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| Lifecycle rules on day one | Any container with logs, backups, or exports | Tier-down and delete happen automatically as data ages | Add prefix filters per team; cap rule count (10 prefixes per rule) |
+| Explicit blob tiers for long-lived datasets | Data with known access frequency | Account default changes do not surprise you with inference charges | Tag blobs in CMDB with tier and retention owner |
+| ZRS in primary for production app data | Workloads needing zone fault tolerance within a region | Survives single-zone loss without regional failover | Pair with GZRS when regional DR is required |
+| RA-GZRS plus tested secondary reads | Business-critical blobs with DR read paths | Secondary endpoint is readable before failover | Application must use `-secondary` hostname in DR tests |
+| User delegation SAS for external sharing | Partners need time-bound read without Entra accounts | Signing ties to Entra identity; revoke via delegation keys | Hours-long expiry, single-blob scope, read-only when possible |
+| Managed identity plus scoped RBAC | Azure-hosted apps (AKS, Functions, VMs) | No secrets in config; platform rotates credentials | Scope to container, not whole account |
+| Private endpoint plus firewall default Deny | Production data planes inside VNets | Removes broad internet exposure to public endpoint | Document break-glass IP rules for on-call engineers |
+| Soft delete plus versioning | User-facing or compliance-sensitive blobs | Accidental delete and overwrite are recoverable | Add lifecycle on previous versions to control version sprawl |
+| ADLS Gen2 at create time for analytics | Spark, Synapse, Databricks lakehouses | Atomic directory ops and POSIX ACLs | Cannot casually flip namespace later; plan up front |
+
+Anti-patterns look efficient until the first incident or invoice.
+
+| Anti-pattern | What goes wrong | Better alternative |
+| :--- | :--- | :--- |
+| Leaving everything in Hot tier | Storage GB-month dominates; finance asks why logs cost like databases | Lifecycle to Cool/Cold/Archive by prefix and age |
+| Frequent reads on Archive-tier data | Retrieval and rehydration charges exceed storage savings | Keep quarterly-access data in Cold; reserve Archive for true cold compliance |
+| Account keys in app settings or pipelines | One leak compromises entire account | Managed identity and RBAC, or user delegation SAS |
+| Year-long container SAS with full permissions | Stolen URL grants broad long-lived access | Short expiry, minimum permissions, blob-scoped user delegation SAS |
+| LRS for irreplaceable customer data | Datacenter loss means data loss | ZRS minimum; GRS/GZRS when regional DR is required |
+| GRS without failover runbooks | Team discovers RPO and DNS steps during outage | Planned failover tests; monitor Last Sync Time |
+| Public blob access for "quick sharing" | Anonymous internet reads and crawlers | Disable public access; share with SAS or Entra |
+| Enabling ADLS Gen2 for simple object upload apps | Extra complexity without analytics benefit | Flat blob namespace until directory semantics are required |
+| Immutability on dev containers | Deletes blocked; storage grows forever | Separate immutable production containers with named owners |
+| Disabling network rules because Private Link is "done" | Misconfigured DNS still exposes public path | Set `public-network-access` explicitly; test both paths |
+
+---
+
+## Decision Framework
+
+Use two decisions in sequence: **redundancy SKU** (how much failure to survive) and **access tier** (how often data is read). Cost and operations follow from those choices.
+
+```mermaid
+flowchart TD
+    A[New blob dataset] --> B{Can you recreate all data from upstream?}
+    B -->|Yes, cheaply| C[LRS or ZRS in one region]
+    B -->|No| D{Need survive full region loss?}
+    D -->|No| E[ZRS in primary region]
+    D -->|Yes| F{Need read from secondary before failover?}
+    F -->|No| G[GRS or GZRS]
+    F -->|Yes| H[RA-GRS or RA-GZRS]
+    A --> I{How often is data read?}
+    I -->|Daily or weekly| J[Hot tier]
+    I -->|Monthly| K[Cool tier]
+    I -->|Quarterly| L[Cold tier]
+    I -->|Rarely, hours OK| M[Archive tier]
+    M --> N{Archive on ZRS account?}
+    N -->|Yes| O[Use LRS/GRS account for archive path or split accounts]
+```
+
+### Redundancy decision matrix
+
+| Requirement | Choose | Avoid |
+| :--- | :--- | :--- |
+| Dev/test blobs, easy rebuild | LRS | GZRS for cost reasons only |
+| Production app blobs, zone tolerance | ZRS | LRS when SLA expects zone survival |
+| Must survive regional disaster | GRS or GZRS | LRS or ZRS alone |
+| DR app reads secondary during outage | RA-GRS or RA-GZRS | GRS without read access |
+| Heavy Archive + zone primary | Separate accounts or LRS/GRS for archive | Archive on ZRS/GZRS account |
+| Lowest monthly storage $/GB | LRS Hot | RA-GZRS when you never test secondary |
+
+### Access tier decision matrix
+
+| Access pattern | Tier | Watch-out |
+| :--- | :--- | :--- |
+| Active read/write | Hot | Highest $/GB-month, lowest read cost |
+| Touch about monthly | Cool | 30-day minimum; read charges higher than Hot |
+| Touch about quarterly | Cold | 90-day minimum; do not use Archive if reads are quarterly |
+| Compliance, years, rare restore | Archive | Rehydration hours; 180-day minimum; offline until rehydrated |
+| Unknown or bursty | Smart tier or lifecycle from Hot | Measure before locking Archive |
+
+Worked example: Application logs land in Hot for seven days, then lifecycle moves them to Cool at day 30, Cold at day 90, and Archive at day 180. The storage account uses **ZRS** because zone outage should not stop ingestion. Customer profile images use **Hot** with **LRS** in a separate account because they are CDN-backed and reproducible from the app database. Neither choice is "best" globally—they match blast radius and access frequency.
+
+---
+
+## Cost Lens
+
+Blob economics are four meters: **capacity (GB-month by tier)**, **transactions (per 10,000 operations)**, **data retrieval (per GB on cooler tiers)**, and **egress (per GB leaving the region)**. [Block blob pricing](https://azure.microsoft.com/en-us/pricing/details/storage/blobs/) varies by region and redundancy SKU. Always model your region and redundancy, not a generic blog estimate.
+
+**Capacity** drops as tiers get cooler. Hot costs the most per GB-month. Archive costs the least. Redundancy multiplies the storage line: ZRS costs more than LRS; GRS and GZRS cost more than single-region options. Geo-replication also adds **geo-replication vNet/data transfer** between regions on write-heavy accounts.
+
+**Transactions** rise as tiers get cooler. Listing and reading Cold or Archive data costs more per 10,000 operations than Hot. A telemetry pipeline that scans Archive blobs daily can spend more on reads than it saved on storage.
+
+**Retrieval charges** apply per GB when you read Cool, Cold, or Archive data. Archive adds **rehydration** priority charges. The surprise bill pattern is "cheap Archive storage" plus "frequent partial reads" from indexing or antivirus scans.
+
+**Early deletion** fees punish tier mistakes. Moving 50 TB to Archive and deleting it after 30 days still bills roughly **150 days** of Archive storage equivalent (180-day minimum minus 30 days held). Test retention assumptions on a pilot prefix before bulk tier changes.
+
+**Lifecycle** policy execution is free. You pay underlying Set Blob Tier and delete operations. [Last-accessed tracking](https://learn.microsoft.com/en-us/azure/storage/blobs/lifecycle-management-overview) can add other-operation charges when enabled. Disable tracking unless rules use last-accessed conditions.
+
+**Egress** to the internet or other regions is often the dominant cost for CDN-less public downloads. Put Azure CDN or Front Door in front of hot objects served globally. Keep bulk analytics ingress on private endpoints in the same region as compute when possible.
+
+**Cost control knobs** that actually work: lifecycle and prefix filters; right-sizing redundancy (do not use RA-GZRS for disposable logs); user delegation SAS instead of wide-open containers; monitoring **capacity by tier** in Cost Management; alerting on Archive read spikes; versioning lifecycle for overwrite-heavy apps; and reserving Hot only for data touched in the last week.
+
+Hypothetical scenario: A 20 TB log bucket stays in Hot for a year at roughly $360/month storage in East US (illustrative—verify current rates). The same data in Cool might land near $120/month storage but fails if operators run weekly grep jobs across all objects because retrieval and read operations climb. Lifecycle to Cold after 90 days without reads, plus blocking scans on archived prefixes, aligns spend with the original "write once, read never" intent.
+
+Monitor **Capacity** metrics in Azure Monitor and Cost Management views split by tier when available. Review those charts monthly with application owners. A sudden jump in Hot capacity after enabling versioning usually means overwrite-heavy apps without version lifecycle rules. A jump in Archive capacity with flat Hot often means lifecycle is working; a matching jump in transaction costs may mean something is reading archived data too often.
+
+---
+
 ## Did You Know?
 
 1. **A single Azure Storage Account can handle up to 20,000 requests per second** and store up to 5 PiB of data. If you need to serve a very popular file to many concurrent clients, put Azure CDN in front of the storage account instead of relying on the storage account alone.
@@ -513,15 +701,16 @@ Choosing between flat Blob Storage and ADLS Gen2 is not about price---both use t
 
 ---
 
+
 ## Common Mistakes
 
 | Mistake | Why It Happens | How to Fix It |
 | :--- | :--- | :--- |
-| Storing all data in Hot tier indefinitely | Hot is the default and "just works" | Implement lifecycle management policies on day one. Most logs and backups should move to Cool after 30 days. |
+| Storing all data in Hot tier indefinitely | Hot is the default and "just works" | Implement lifecycle management policies on day one. Most logs and backups should move to Cool after 30 days. Model egress if you serve large downloads without CDN. |
 | Using storage account keys in application code | Keys are the first thing shown in tutorials | Use Managed Identities and RBAC for Azure-hosted apps. Use SAS tokens with short expiry for external access. |
 | Creating SAS tokens with long expiry and broad permissions | Developers want tokens that "just work" without renewal | Generate SAS tokens scoped to specific containers/blobs with minimum permissions and short expiry (hours, not months). |
 | Not enabling soft delete on blob storage | It seems like an unnecessary precaution until someone deletes production data | Enable soft delete with a 14-30 day retention period. It costs almost nothing but saves you from accidental deletions. |
-| Choosing LRS for data that cannot be recreated | LRS is the cheapest option | Use ZRS minimum for any data that has no backup. Use GRS or RA-GRS for business-critical data like customer records. |
+| Choosing LRS for data that cannot be recreated | LRS is the cheapest option | Use ZRS minimum for any data that has no backup. Use GRS or RA-GRS for business-critical data like customer records. Rehearse reading from `-secondary` when using RA variants. |
 | Enabling public anonymous access on containers | Quick demos and testing leave public access enabled | Set `--allow-blob-public-access false` at the account level. Use SAS tokens or RBAC for legitimate sharing needs. |
 | Not planning the storage account naming scheme | Storage account names must be [globally unique and 3-24 characters](https://learn.microsoft.com/en-us/azure/storage/common/storage-account-overview) | Adopt a naming convention early: `<company><env><region><purpose>`, e.g., `acmeprodeus2data`. |
 | Using Blob Storage when Data Lake (hierarchical namespace) is needed | Teams start with blob storage and later discover they need Spark/Databricks compatibility | Decide upfront if you need analytics workloads, and review Azure's current upgrade guidance and compatibility impacts before enabling hierarchical namespace later. |
@@ -592,7 +781,11 @@ To satisfy the network security mandate, you must disable public network access 
 
 In this exercise, you will create a storage account, configure lifecycle management, upload blobs to different tiers, practice generating scoped SAS tokens, and provision a Data Lake Gen2 namespace for big data.
 
+Treat the lab as a miniature production rollout. After each task, note which cost meters you touched: capacity (containers and blobs), transactions (upload and list), and potential retrieval (if you tier down and read back). That habit makes Azure Cost Management charts readable when this account moves from sandbox to shared team use.
+
 **Prerequisites**: Install and authenticate the Azure CLI (`az login`), and ensure your signed-in identity has **Storage Blob Data Contributor** (or Owner) on the subscription or resource group you use for the lab.
+
+**Tip**: Run `az storage account show -n "$STORAGE_NAME" -g "$RG" --query '{sku:sku.name, tier:accessTier, publicAccess:publicNetworkAccess}' -o json` after Task 1. You will reuse those fields when explaining redundancy and default tier choices to reviewers.
 
 ### Task 1: Create a Storage Account
 *[Maps to Learning Outcome: Implement storage account security with private endpoints, SAS tokens, and Entra ID-based RBAC access]*
@@ -872,3 +1065,7 @@ az group delete --name "$RG" --yes --no-wait
 - [learn.microsoft.com: storage](https://learn.microsoft.com/en-us/azure/role-based-access-control/built-in-roles/storage) — The Azure built-in roles page is the authoritative source for these storage RBAC roles.
 - [learn.microsoft.com: storage private endpoints](https://learn.microsoft.com/en-us/azure/storage/common/storage-private-endpoints) — Microsoft Learn documents both the default public-endpoint model and private endpoint network path.
 - [learn.microsoft.com: data lake storage introduction](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction) — Azure's ADLS introduction directly describes Gen2 as Blob-based capabilities unlocked by hierarchical namespace.
+- [learn.microsoft.com: lifecycle management overview](https://learn.microsoft.com/en-us/azure/storage/blobs/lifecycle-management-overview) — Documents rule structure, billing for tier operations, last-accessed tracking, and policy execution delays.
+- [learn.microsoft.com: storage disaster recovery guidance](https://learn.microsoft.com/en-us/azure/storage/common/storage-disaster-recovery-guidance) — Covers planned vs unplanned failover, RPO, Last Sync Time, and post-failover redundancy state.
+- [learn.microsoft.com: storage network security](https://learn.microsoft.com/en-us/azure/storage/common/storage-network-security) — Explains firewall default action, virtual network rules, and public network access settings.
+- [learn.microsoft.com: grant limited access with SAS](https://learn.microsoft.com/en-us/azure/storage/common/storage-sas-overview) — Compares account, service, and user delegation SAS and Microsoft guidance to prefer Entra-backed SAS.

--- a/src/content/docs/cloud/azure-essentials/module-3.4-blob.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.4-blob.md
@@ -303,7 +303,7 @@ az storage account management-policy create \
   }'
 ```
 
-This JSON policy instructs Azure's background services to evaluate the `logs/` prefix periodically after the policy takes effect. Blobs age smoothly into Cool tier, then Archive, and are ultimately purged from the system after a year---greatly reducing the chance that you end up as the subject of the financial disaster war story from the introduction.
+This JSON policy instructs Azure's background services to evaluate the `logs/` prefix periodically after the policy takes effect. Blobs age smoothly into Cool tier, then Archive, and are ultimately purged from the system after a year---greatly reducing the chance that you end up as the subject of the surprise-bill scenario described in the introduction.
 
 ### Access tiers and lifecycle in depth
 
@@ -445,7 +445,8 @@ When you build a SAS URI, combine permission flags to grant only what the client
 | `d` | Delete |
 | `l` | List |
 | `t` | Tags |
-| `x` | Execute |
+| `x` | Delete version |
+| `e` | Execute (ADLS Gen2) |
 
 **Account SAS** spans multiple services in the account (blob, file, queue, table) when signed with account keys. **Service SAS** scopes to a single service (blob) but still uses account keys unless you switch to user delegation. Service SAS is common in legacy apps. **User delegation SAS** scopes to blob resources and ties to Entra ID. For new integrations, default to user delegation with `--auth-mode login --as-user` as shown earlier.
 
@@ -548,8 +549,9 @@ To utilize these big data features, you must enable the namespace during creatio
 
 ```bash
 # Create a storage account with hierarchical namespace (Data Lake)
+DATALAKE_NAME="kubedojodatalake$(openssl rand -hex 4)"
 az storage account create \
-  --name "kubedojodatalake$(openssl rand -hex 4)" \
+  --name "$DATALAKE_NAME" \
   --resource-group myRG \
   --location eastus2 \
   --sku Standard_LRS \
@@ -669,7 +671,7 @@ Worked example: Application logs land in Hot for seven days, then lifecycle move
 
 Blob economics are four meters: **capacity (GB-month by tier)**, **transactions (per 10,000 operations)**, **data retrieval (per GB on cooler tiers)**, and **egress (per GB leaving the region)**. [Block blob pricing](https://azure.microsoft.com/en-us/pricing/details/storage/blobs/) varies by region and redundancy SKU. Always model your region and redundancy, not a generic blog estimate.
 
-**Capacity** drops as tiers get cooler. Hot costs the most per GB-month. Archive costs the least. Redundancy multiplies the storage line: ZRS costs more than LRS; GRS and GZRS cost more than single-region options. Geo-replication also adds **geo-replication vNet/data transfer** between regions on write-heavy accounts.
+**Capacity** drops as tiers get cooler. Hot costs the most per GB-month. Archive costs the least. Redundancy multiplies the storage line: ZRS costs more than LRS; GRS and GZRS cost more than single-region options. Geo-replication also adds **geo-replication data transfer (egress between regions)** on write-heavy accounts.
 
 **Transactions** rise as tiers get cooler. Listing and reading Cold or Archive data costs more per 10,000 operations than Hot. A telemetry pipeline that scans Archive blobs daily can spend more on reads than it saved on storage.
 
@@ -724,7 +726,7 @@ Monitor **Capacity** metrics in Azure Monitor and Cost Management views split by
 
 *[Maps to Learning Outcome: Configure Azure Blob Storage with access tiers and lifecycle management policies]*
 
-They should be in Cold tier. Hot tier costs $0.018/GB/month, leading to $10,800/year, whereas Cold tier reduces this to $2,700/year, saving approximately $8,100 annually. Cool tier would also offer significant savings, but since the data is accessed only quarterly, Cold tier's 90-day minimum retention perfectly aligns with the access pattern. Archive tier would save even more on storage, but the steep $5 per 10,000 read operations and hours-long rehydration time make it operationally impractical for data that still requires guaranteed quarterly access.
+They should be in Cold tier. Hot tier costs $0.018/GB/month (illustrative), leading to $10,800/year, whereas Cold tier reduces this to $2,700/year (illustrative), saving approximately $8,100 annually. Cool tier would also offer significant savings, but since the data is accessed only quarterly, Cold tier's 90-day minimum retention perfectly aligns with the access pattern. Archive tier would save even more on storage, but the steep $5 per 10,000 read operations and hours-long rehydration time make it operationally impractical for data that still requires guaranteed quarterly access.
 </details>
 
 <details>
@@ -1014,7 +1016,7 @@ echo "data" > /tmp/data.csv
 az storage fs file upload --source /tmp/data.csv --path "2024/sales/report.csv" --file-system "analytics-raw" --account-name "$DL_NAME" --auth-mode login
 
 # Perform an atomic rename of the directory (not possible in standard blob storage without copying all files)
-az storage fs directory move --name "2024/sales" --new-directory "2024/archived-sales" --file-system "analytics-raw" --account-name "$DL_NAME" --auth-mode login
+az storage fs directory move --name "2024/sales" --new-directory "analytics-raw/2024/archived-sales" --file-system "analytics-raw" --account-name "$DL_NAME" --auth-mode login
 ```
 
 <details>

--- a/src/content/docs/cloud/azure-essentials/module-3.5-dns.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.5-dns.md
@@ -23,7 +23,13 @@ A multi-region application can still fail hard if DNS points directly to one reg
 
 DNS is the invisible infrastructure that underpins every internet interaction. When it works, nobody thinks about it. When it fails, nothing works. In Azure, DNS is not just about resolving names to IP addresses---it is a critical component of high availability, traffic routing, and hybrid cloud architecture. Azure DNS handles public-facing domain resolution, Private DNS Zones handle name resolution within your virtual networks, and Traffic Manager uses DNS-based routing to distribute traffic across regions and endpoints.
 
+Hypothetical scenario: your platform team ships a flawless multi-region deployment, but the public zone still points `app.example.com` at a single static A record tied to last month's load balancer IP. A routine redeploy changes that IP, certificate renewals break for users with cached answers, and failover never triggers because nothing monitors endpoint health at the DNS layer. The application code was fine; the name layer was the single point of failure.
+
 In this module, you will learn how Azure DNS zones work for both public and private scenarios, how Traffic Manager routes traffic using different algorithms, and how Azure Front Door provides a modern alternative with layer-7 capabilities. By the end, you will understand how to design a DNS architecture that keeps your applications reachable even when entire regions fail.
+
+> **The DNS Analogy**
+>
+> Think of DNS as the phone book and routing policy of the internet. A public zone is the published directory everyone can look up. A private zone is the internal extension list inside your building. Traffic Manager is the receptionist who answers "which office should I connect you to?" based on who is available. Front Door is the security desk that inspects every visitor, terminates their credentials at the lobby, and only then forwards them to the right floor.
 
 ---
 
@@ -34,6 +40,10 @@ Azure DNS allows you to host your DNS zones on [Azure's global anycast network o
 ### How DNS Zones Work
 
 A DNS zone is a container for all the DNS records for a specific domain. When you create a zone for `example.com` in Azure DNS, [Azure assigns four name servers](https://learn.microsoft.com/en-us/azure/dns/dns-delegate-domain-azure-dns) (in the format `ns1-XX.azure-dns.com`, `ns2-XX.azure-dns.net`, `ns3-XX.azure-dns.org`, `ns4-XX.azure-dns.info`).
+
+Public zones in Azure DNS are authoritative only for names you delegate to them. Azure does not automatically become registrar and DNS host in one step: registration at a registrar and hosting at Azure DNS are two relationships that must meet at the NS records. Many production incidents trace to a perfectly valid zone in Azure that the public internet never queries because the registrar still points at a previous provider's name servers from a migration that stopped halfway.
+
+Azure DNS uses anycast so the same four names resolve to different physical servers worldwide, minimizing latency for global clients. You manage record sets through the portal, ARM templates, Bicep, or `az network dns` commands; all paths converge on the same authoritative data that resolvers fetch when NS delegation is correct.
 
 ```bash
 # Create a DNS zone
@@ -49,6 +59,22 @@ az network dns zone show \
 ```
 
 After creating the zone, you must [update your domain registrar's NS records to point to the Azure name servers](https://learn.microsoft.com/en-us/azure/dns/dns-delegate-domain-azure-dns). Until you do this, DNS queries for your domain will not reach Azure.
+
+### Delegation and the NS Record Chain
+
+Delegation is the handoff of authority from a parent zone to a child zone. When you register `example.com` with a registrar, that registrar typically publishes NS records that tell the global DNS system who is authoritative for your domain. Creating a zone in Azure DNS does not automatically change the internet's view of your domain. Azure assigns four name servers to your zone, but the registrar must publish those four names as the NS record set at the zone apex.
+
+The NS and SOA record sets at the zone apex are [created automatically when you create a public zone](https://learn.microsoft.com/en-us/azure/dns/dns-zones-records). You cannot delete them separately, though you can add additional name servers for co-hosting scenarios where two DNS providers serve the same zone. Child zones use separate NS record sets that you manage freely, which is how you delegate `dev.example.com` to a different DNS provider while keeping `example.com` in Azure DNS.
+
+Verification should happen from outside your own resolver cache. Use `nslookup -type=NS example.com` against a public resolver, or query one of the Azure-assigned name servers directly. Propagation at the registrar can take minutes to hours depending on the registrar's workflow and any prior TTL on the old NS records.
+
+### Time-to-Live Tradeoffs
+
+Every record set carries a TTL value that tells resolvers how long they may cache the answer. [Azure DNS changes propagate to Azure's authoritative servers within about 60 seconds](https://learn.microsoft.com/en-us/azure/dns/dns-faq), but clients and intermediate resolvers honor TTL independently. A TTL of 3600 seconds means a laptop that resolved your app five minutes before an outage may keep using a stale IP for nearly an hour.
+
+Lower TTL increases query volume and therefore cost, but it shrinks the blast radius during failover. Traffic Manager profiles expose their own DNS TTL setting, which can range from 0 seconds up to the RFC maximum. For production failover designs, teams commonly choose 10 to 30 seconds on Traffic Manager and alias-backed apex records rather than the 300-second default that feels safe during steady state.
+
+The right TTL is a compromise between stability and agility. Steady-state marketing sites with rarely changing backends can tolerate higher TTL. Active/active or priority-based failover architectures should treat TTL as part of the recovery time objective, not as an afterthought configured once during initial setup.
 
 ### Common Record Types
 
@@ -95,9 +121,58 @@ az network dns record-set list \
   --zone-name example.com -o table
 ```
 
+[Azure DNS supports the common public record types](https://learn.microsoft.com/en-us/azure/dns/dns-zones-records): A, AAAA, CNAME, MX, TXT, SRV, CAA, NS, PTR, and SOA. SPF records are represented as TXT records. Understanding when to use each type prevents subtle production failures that no amount of application tuning can fix.
+
+**A and AAAA** map hostnames to IPv4 and IPv6 addresses. They are the default choice for pointing `www` or `api` subdomains at a known IP. The weakness is lifecycle: if the IP is tied to a resource that Azure may replace, you must update the record manually unless you use an alias record instead.
+
+**CNAME** maps one name to another canonical name. It works well for subdomains like `blog.example.com` pointing at a SaaS provider's hostname. RFC 1034 forbids CNAME at the zone apex, which is why teams hit errors when they try to point naked `example.com` at an external hostname.
+
+**MX** directs email to mail exchangers with a preference value. Lower preference numbers are tried first. Email deliverability depends on accurate MX and TXT records for SPF and DKIM, so DNS changes here affect security tooling as much as user-facing web traffic.
+
+**TXT** holds arbitrary text used for domain verification, SPF, DKIM, and DMARC policies. Multiple TXT records can coexist on the same name, which is why certificate authorities and Microsoft 365 both ask you to add verification strings without removing existing ones.
+
+**SRV** encodes service location with priority, weight, port, and target. In Azure DNS the service and protocol belong in the record set name, such as `_sip._tcp` for SIP over TCP. SRV is common for federated identity, VoIP, and some Kubernetes service discovery patterns that expect DNS-based lookup.
+
+**CAA** restricts which certificate authorities may issue certificates for your domain or subdomain. Publishing `issue "digicert.com"` on `example.com` tells compliant CAs they should not mint certificates unless authorized. CAA is a cheap defense-in-depth control against mis-issued public certificates.
+
+**NS** at the zone apex is managed by Azure for your primary delegation. Additional NS records at the apex support split authority across providers. NS records on child names delegate subdomains, such as pointing `partners.example.com` at a partner's name servers.
+
+**SOA** is created automatically at the zone apex and stores serial numbers and timing parameters resolvers use when refreshing zone data. You can adjust fields like refresh and expire intervals, but you cannot delete the SOA record set independently of the zone.
+
+```bash
+# CAA record: authorize a specific CA to issue certificates
+az network dns record-set caa add-record \
+  --resource-group myRG \
+  --zone-name example.com \
+  --record-set-name "@" \
+  --flags 0 \
+  --tag issue \
+  --value "digicert.com"
+
+# SRV record: locate a SIP service
+az network dns record-set srv add-record \
+  --resource-group myRG \
+  --zone-name example.com \
+  --record-set-name _sip._tcp \
+  --priority 10 \
+  --weight 5 \
+  --port 5060 \
+  --target sip.example.com
+```
+
 ### Alias Records
 
 Azure DNS supports **alias records**, which [point directly to an Azure resource](https://learn.microsoft.com/en-us/azure/dns/dns-alias) (like a Load Balancer, Traffic Manager profile, or CDN endpoint) instead of an IP address. The key advantage: when the resource's IP changes, the DNS record updates automatically.
+
+Alias record sets are supported for **A**, **AAAA**, and **CNAME** types. Supported targets include [Azure public IP addresses, Traffic Manager profiles, Azure CDN endpoints, and Azure Front Door profiles](https://learn.microsoft.com/en-us/azure/dns/dns-alias). There is no additional charge for alias records themselves; you pay normal zone and query costs. Alias records also provide **lifecycle tracking**: if the target resource is deleted, the alias stops resolving correctly rather than silently pointing at a reassigned IP that now belongs to someone else.
+
+**Why alias beats CNAME at the apex.** CNAME at `example.com` violates DNS rules because the apex must also host NS and SOA records. Alias records are implemented as qualifications on A or AAAA record sets. During resolution Azure follows the alias to the current target and returns A or AAAA answers to the client, so browsers and TLS clients see a normal address record.
+
+**Alias to Public IP** is the straightforward case for load balancers and application gateways with standard public IPs. When Azure replaces the underlying IP, the alias tracks the resource ID rather than a numeric literal you pasted into a spreadsheet.
+
+**Alias to Traffic Manager** lets the zone apex participate in global routing. You can point `contoso.com` at a Traffic Manager profile instead of chaining CNAME indirection. When aliasing A or AAAA directly to Traffic Manager, [the profile must use external endpoints with static IP addresses](https://learn.microsoft.com/en-us/azure/dns/dns-faq), not FQDN-only external targets, because the alias resolution path materializes concrete addresses for clients.
+
+**Alias to Azure CDN or Front Door** supports branded naked domains for static sites and global entry points. Static websites on storage plus CDN often need apex support so users can type `wideworldimports.com` without `www`. Front Door custom domains similarly benefit from apex alias records that track the Front Door profile rather than a volatile edge address you copied manually.
 
 ```bash
 # Create an alias record pointing to a Load Balancer public IP
@@ -108,6 +183,24 @@ az network dns record-set a create \
   --zone-name example.com \
   --name app \
   --target-resource "$LB_PIP_ID"
+
+# Alias apex to a Traffic Manager profile
+TM_PROFILE_ID=$(az network traffic-manager profile show -g myRG -n app-tm-profile --query id -o tsv)
+
+az network dns record-set a create \
+  --resource-group myRG \
+  --zone-name example.com \
+  --name "@" \
+  --target-resource "$TM_PROFILE_ID"
+
+# Alias to an Azure Front Door profile (Standard/Premium)
+AFD_PROFILE_ID=$(az afd profile show -g myRG -n app-frontdoor --query id -o tsv)
+
+az network dns record-set a create \
+  --resource-group myRG \
+  --zone-name example.com \
+  --name "@" \
+  --target-resource "$AFD_PROFILE_ID"
 ```
 
 ```mermaid
@@ -130,6 +223,81 @@ flowchart TD
 ## Azure Private DNS Zones
 
 Private DNS Zones [provide name resolution within your Virtual Networks without exposing records to the public internet](https://learn.microsoft.com/en-us/azure/dns/private-dns-privatednszone). This is essential for internal service discovery---your web servers need to find your database by name (`db.internal.example.com`), not by memorizing IP addresses that change when you redeploy.
+
+Private zones implement **split-horizon DNS** when paired with a public zone for the same brand domain. Public resolvers answer `api.example.com` with internet-facing addresses, while linked VNets resolve `db.internal.example.com` or private-link names only inside Azure. The same logical application can therefore publish different answers depending on where the query originates, which is how zero-trust designs keep administrative interfaces off the public internet without renaming everything.
+
+### Resolution Links vs Registration Links
+
+Every VNet link to a private zone is either **resolution-only** or **registration-enabled**. Resolution links allow VMs in that VNet to query records in the zone. Registration links additionally create and maintain A records for VMs based on their Azure resource names.
+
+Only **one registration-enabled link is allowed per VNet per zone** to prevent two zones from fighting over the same VM hostname. Hub VNets that host shared infrastructure commonly enable registration so databases and middleware register automatically. Spoke VNets that run stateless application tiers typically use resolution-only links so they can look up shared services without polluting the zone with ephemeral pod-like names.
+
+When a VNet uses **Azure-provided DNS** (the default), [linked private zones are consulted before Azure-provided recursive resolution](https://learn.microsoft.com/en-us/azure/dns/private-dns-privatednszone). If you configure **custom DNS servers** on the VNet or NIC, that automatic chain stops. Custom DNS must forward queries for private zones to Azure, usually via conditional forwarders to **168.63.129.16** or via Azure DNS Private Resolver inbound endpoints.
+
+### Azure-Provided DNS and 168.63.129.16
+
+Before Private Resolver existed, hybrid designs relied on the platform recursive resolver at **[168.63.129.16](https://learn.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16)**. This virtual IP is stable across Azure and provides filtered name resolution for Azure-provided hostnames and linked private zones when the VNet uses default DNS settings.
+
+Custom DNS servers on domain controllers or Linux BIND instances must still forward Azure-specific names to 168.63.129.16. Without that forwarder, VMs lose the ability to resolve peer VM hostnames, private link FQDNs, and other platform-managed names even though your corporate AD zones work fine. VPN and ExpressRoute designs that inject custom DNS at the VNet level should treat 168.63.129.16 as a required forwarder, not an optional optimization.
+
+168.63.129.16 is not a substitute for cross-network hybrid resolution by itself. It answers queries from Azure workloads, but on-premises DNS knows nothing about your private zones unless you add conditional forwarding or deploy Private Resolver inbound endpoints that on-premises can target.
+
+### Azure DNS Private Resolver
+
+[Azure DNS Private Resolver](https://learn.microsoft.com/en-us/azure/dns/dns-private-resolver-overview) is a managed hybrid DNS bridge. It replaces fragile VM-based DNS forwarders with dedicated inbound and outbound endpoints deployed into delegated subnets in your VNet.
+
+**Inbound endpoints** receive DNS queries from on-premises or other networks over VPN or ExpressRoute. You point on-premises conditional forwarders at the inbound IP addresses inside your private address space. Those queries can then resolve Azure private zones linked to the hub VNet, including auto-registered VM names and private endpoint records.
+
+**Outbound endpoints** send queries from Azure to external DNS systems. You attach **DNS forwarding rulesets** that map domain suffixes to target DNS servers, such as forwarding `corp.contoso.com` to on-premises Active Directory DNS or forwarding `malware.example` to a protective DNS service.
+
+```bash
+# Create a Private Resolver in the hub VNet (subnets must be delegated to Microsoft.Network/dnsResolvers)
+az network dns-resolver create \
+  --resource-group myRG \
+  --name hub-resolver \
+  --virtual-network hub-vnet \
+  --location eastus
+
+# Inbound endpoint for on-premises to query Azure private zones
+az network dns-resolver inbound-endpoint create \
+  --resource-group myRG \
+  --dns-resolver-name hub-resolver \
+  --name inbound \
+  --ip-configurations '[{"subnet":{"id":"/subscriptions/.../subnets/snet-inbound"},"privateIpAddress":"10.0.0.4"}]'
+
+# Outbound endpoint plus ruleset for conditional forwarding to on-premises
+az network dns-resolver outbound-endpoint create \
+  --resource-group myRG \
+  --dns-resolver-name hub-resolver \
+  --name outbound \
+  --ip-configurations '[{"subnet":{"id":"/subscriptions/.../subnets/snet-outbound"},"privateIpAddress":"10.0.0.20"}]'
+
+az network dns-resolver forwarding-ruleset create \
+  --resource-group myRG \
+  --name onprem-rules \
+  --dns-resolver-outbound-endpoints "[$(az network dns-resolver outbound-endpoint show -g myRG --dns-resolver-name hub-resolver -n outbound --query id -o tsv)]" \
+  --location eastus
+
+az network dns-resolver forwarding-rule create \
+  --resource-group myRG \
+  --ruleset-name onprem-rules \
+  --name corp-forward \
+  --domain-name corp.contoso.com. \
+  --target-dns-servers '[{"ipAddress":"192.168.1.2","port":53}]'
+
+# Link ruleset to spoke VNet so VMs forward corp.contoso.com via outbound endpoint
+az network dns-resolver vnet-link create \
+  --resource-group myRG \
+  --ruleset-name onprem-rules \
+  --name spoke1-link \
+  --virtual-network spoke1-vnet
+```
+
+Each resolver supports up to five inbound and five outbound endpoints per instance, with [10,000 queries per second per endpoint](https://learn.microsoft.com/en-us/azure/dns/dns-private-resolver-overview) under documented limits. Rulesets can hold up to 1,000 forwarding rules and link to hundreds of VNets in the same region, which makes hub-and-spoke designs practical without maintaining BIND clusters.
+
+Compare Private Resolver against legacy VM forwarders using total cost of ownership, not just hourly compute. Two small DNS VMs plus patching windows plus monitoring often exceed a single resolver pair in operational hours, even before counting the incident when a VM forwarder disk fills during a log spike. Resolver subnets must be dedicated `/28` or larger delegations with no other workloads; planning IPAM early avoids painful renumbering when hybrid DNS lands late in a migration program.
+
+Centralized DNS architecture guidance from Microsoft recommends placing resolver infrastructure in hub VNets that already host VPN or ExpressRoute gateways, then linking rulesets to spokes that need on-premises suffix resolution. Document which teams may create forwarding rules; unconstrained ruleset edits become shadow IT paths that bypass security filtering on port 53.
 
 ### How Private DNS Zones Work
 
@@ -185,6 +353,12 @@ az network private-dns record-set list \
 
 **Auto-registration** is a powerful feature: when enabled on a VNet link, [every VM created in that VNet automatically gets a DNS record in the private zone. When the VM is deleted, the record is automatically removed](https://learn.microsoft.com/en-us/azure/dns/private-dns-autoregistration). This eliminates the need to manually manage internal DNS records.
 
+Auto-registration tracks Azure NIC IP assignments, not arbitrary static changes inside the guest OS. If an administrator reconfigures a static IP inside Windows or Linux without updating Azure networking, the private zone can drift from reality until the NIC resource changes again. Treat auto-registration as a mirror of Azure's view of the machine, not as a DHCP server replacement for guest-level networking experiments.
+
+Peered VNets do not automatically inherit private zone links. Each spoke that must resolve `internal.example.com` needs its own link, even when routing to the hub is already established. Teams often configure connectivity correctly at the IP layer but forget DNS is a separate control plane that only sees linked VNets.
+
+Wildcard records are supported in private zones for most record types, which helps platform teams publish `*.apps.internal.example.com` patterns for dynamically named services. NS and SOA wildcards remain constrained because apex authority records follow different rules.
+
 > **Pause and predict**: You have a Private DNS Zone linked to a VNet with auto-registration enabled. You deploy a VM named `database-primary`. Later, an administrator logs into the VM's guest OS (Windows or Linux) and manually changes its IP address. What happens to the DNS record in the Private DNS Zone, and why?
 
 ### Private DNS and Private Endpoints
@@ -227,6 +401,10 @@ az network private-endpoint dns-zone-group create \
 
 After this setup, when a VM in hub-vnet resolves `yourstorage.blob.core.windows.net`, [the response is the private IP of the private endpoint (e.g., 10.0.5.4) instead of the public IP](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns). [Traffic stays entirely within Azure's backbone](https://learn.microsoft.com/en-us/azure/private-link/private-link-overview).
 
+Microsoft publishes [recommended private zone names per service](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns) (`privatelink.blob.core.windows.net`, `privatelink.database.windows.net`, and others). Using nonstandard zone names works technically but breaks copy-paste runbooks and automation that assume the official suffix. DNS zone groups on the private endpoint create the correct A record automatically and refresh it when the endpoint changes, which is preferable to manual A records that orphan when endpoints are rebuilt.
+
+Split-horizon effects appear during troubleshooting: a developer's laptop on the public internet resolves the storage FQDN to a public address, while a VM in the linked VNet resolves the same FQDN to `10.x.x.x`. Always test from the same network path production uses, not from a corporate laptop outside Azure.
+
 ---
 
 ## Azure Traffic Manager: DNS-Based Global Load Balancing
@@ -261,7 +439,19 @@ sequenceDiagram
 | **MultiValue** | Returns multiple healthy IPs (client chooses) | Increase availability with client-side retry |
 | **Subnet** | Routes based on client's source IP range | VIP customers, partner-specific endpoints |
 
+Each routing method encodes a different operations contract. **Priority** is the classic disaster recovery pattern: one hot region, one or more warm standbys. Operations teams tune probe intervals knowing failover time includes both detection and cached TTL on clients. **Weighted** distributes probabilistically, which suits canaries where you want roughly 10% of DNS answers to point at a new build without pulling a lever on every client individually.
+
+**Performance** uses latency measurements between probe vantage points and endpoints to approximate "closest" for each client geography. It does not measure live RTT from every user's ISP; it approximates using Microsoft's network view, which is usually good enough for consumer apps but may surprise you for niche peering paths. **Geographic** maps DNS answers to policy regions. It is not automatic cross-region disaster recovery unless you design explicit fallback endpoints or nested profiles that allow overflow when a geography is entirely offline.
+
+**MultiValue** returns multiple healthy IPs simultaneously, pushing retry decisions to the client stack. That helps some custom clients but confuses others that pick only the first answer. **Subnet** routing supports partner allowlists or migration windows where specific CIDR blocks should always reach a legacy endpoint until decommission day.
+
+Health probes originate from [published Azure Traffic Manager address ranges](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-monitoring). Backend NSGs must allow those sources on the probe port and path. A probe that receives HTTP 403 because a WAF blocks Microsoft probe IPs looks identical to a dead server from Traffic Manager's perspective.
+
 > **Stop and think**: A company uses Traffic Manager with Geographic routing to restrict data access: EU users are routed to Frankfurt, US users to Virginia. If the Virginia region suffers a total outage, what happens to the US traffic? Does it fail over to Frankfurt, or drop entirely?
+
+Geographic routing honors the policy map first. US clients mapped to Virginia endpoints do not automatically land in Frankfurt unless you configured a fallback endpoint for the US geography or a nested profile that escalates to a secondary region. Many compliance-driven designs accept hard failure rather than cross-border overflow, which is intentional but must be documented in runbooks so incident commanders do not assume Traffic Manager behaves like Priority routing across geographies.
+
+Nested profiles let platform teams compose policies: an outer Geographic profile sends EU queries to an inner Priority profile with two EU regions, while US queries hit a separate inner profile. [Nested profiles do not double-charge DNS queries](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-faqs) at both parent and child levels for the same lookup, though health checks still accrue per monitored endpoint in each profile.
 
 ```bash
 # Create a Traffic Manager profile with Priority routing
@@ -344,11 +534,47 @@ az network traffic-manager endpoint create \
 
 **Scenario**: With DNS-based regional failover, new DNS queries can be steered toward a healthier region when probes detect an endpoint problem, which can reduce downtime while the primary region recovers.
 
+### DNS Routing vs Layer-7 Load Balancing
+
+The boundary between DNS-based routing and application-layer load balancing is where many global architectures go wrong. **Traffic Manager** participates only in name resolution. It returns an IP address (or multiple addresses for MultiValue routing) and then exits the path. It cannot inspect HTTP paths, terminate TLS, cache static assets, or block SQL injection attempts because it never sees application bytes.
+
+**Azure Front Door** and **Application Gateway** sit in the data path for HTTP or HTTPS. Front Door is global; Application Gateway is regional but offers rich Layer-7 rules inside a VNet. Choose Traffic Manager when you need cheap protocol-agnostic steering to public IPs or external hostnames, especially for non-HTTP services or simple active/passive failover. Choose Front Door when user experience, security inspection, and edge caching matter more than minimizing DNS query bills.
+
+**Hypothetical scenario — The TTL That Outlasted the Region**
+
+Hypothetical scenario: a retail platform configures Traffic Manager Priority routing correctly and validates failover in staging with a 30-second TTL. Production promotion accidentally leaves the apex alias pointing at a Traffic Manager profile whose production template still specifies 300-second TTL from an older runbook. East US fails during a sale event. Traffic Manager begins returning West US addresses within two probe cycles, but millions of mobile clients keep hammering a dead IP because their resolvers cached the old answer. Revenue recovery waits on cache expiry, not on infrastructure repair alone. The lesson is that DNS failover completes only when both health detection and TTL allow clients to ask again.
+
+A common layered pattern uses alias records at the apex pointing to Front Door for web traffic, while internal APIs behind Traffic Manager Performance routing connect game clients or IoT devices that speak custom TCP protocols Front Door cannot proxy. Another pattern nests Traffic Manager beneath Front Door only when you understand double billing and double TTL effects; simpler designs pick one routing layer as the source of truth.
+
+Application Gateway remains the right regional choice when backends live on private IPs inside a VNet and you need WAF plus path-based routing without exposing origins publicly. DNS still matters because public clients must resolve a name that reaches the gateway's frontend, but the gateway performs health checks and request routing after the connection starts.
+
+```mermaid
+flowchart LR
+    subgraph DNSLayer [DNS-layer routing]
+        C1[Client] -->|query| TM[Traffic Manager]
+        TM -->|A record answer| C1
+        C1 -->|TCP/UDP/HTTP direct| EP[Regional endpoint IP]
+    end
+
+    subgraph L7Layer [Layer-7 routing]
+        C2[Client] -->|HTTPS| FD[Front Door PoP]
+        FD -->|HTTPS| ORG[Origin pool]
+    end
+```
+
+When Geographic routing sends EU users to Frankfurt and US users to Virginia, remember that Geographic policies enforce placement; they do not automatically fail over across geography unless you configure nested profiles or overlapping endpoints. A total Virginia outage does not silently redirect US users to Frankfurt unless your design explicitly allows that overflow path.
+
 ---
 
 ## Azure Front Door: The Modern Alternative
 
 Azure Front Door is a global, scalable entry point for web applications. Unlike Traffic Manager (DNS only), Front Door operates at Layer 7 (HTTP/HTTPS) and sits in the data path. It acts as a reverse proxy, [providing SSL termination, caching, WAF, and intelligent routing](https://learn.microsoft.com/en-us/azure/networking/load-balancer-content-delivery/load-balancing-content-delivery-overview).
+
+Front Door terminates client TLS at a nearby Point of Presence, which means certificate management shifts to the edge profile rather than every origin region. Origins can remain private inside VNets when paired with Private Link or secured public hostnames, while clients only ever see the Front Door hostname and certificate. Session affinity cookies, URL path patterns, and custom routing rules operate on HTTP semantics Traffic Manager cannot see.
+
+Caching static assets at the edge reduces origin load and latency for repeat visitors. WAF policies inspect request bodies and query strings before traffic reaches application code, which closes the gap when Traffic Manager would happily send clients to a compromised but still TCP-healthy origin. The tradeoff is cost and complexity: you pay for Front Door requests and egress, and misconfigured origin host headers or health probes can mark healthy Kubernetes ingress as down even when pods respond correctly inside the cluster.
+
+Application Gateway fills a complementary regional niche. It is not global like Front Door, but it excels at VNet-local Layer-7 routing to private backends, integrated WAF, and AKS ingress controllers that need direct regional control. A pattern for large enterprises uses Front Door as the global front door and Application Gateway per region as the regional reverse proxy behind it, with DNS alias records pointing public names at Front Door rather than at regional IPs directly.
 
 ```mermaid
 flowchart TD
@@ -448,6 +674,118 @@ Use **Azure Front Door** when:
 
 ---
 
+## Cost Lens
+
+DNS looks inexpensive until query volume, health probes, and hybrid resolver endpoints accumulate across dozens of zones and regions. Understanding the billing model early prevents surprise invoices and guides TTL and architecture choices.
+
+### Public and Private Zone Hosting
+
+[Azure DNS bills per hosted zone and per query](https://azure.microsoft.com/en-us/pricing/details/dns/). The first 25 zones in a subscription cost **$0.50 per zone per month**, with additional zones at **$0.10 per zone per month**, prorated daily. Public and private zones share the same hosted-zone pricing table. A microservice team that creates one private zone per VNet can accidentally spend more on zone fees than on the VMs inside those VNets.
+
+Queries for the first billion per month cost **$0.40 per million**, dropping to **$0.20 per million** beyond that threshold, aggregated at subscription scope. Private zone queries inside linked VNets count toward the same totals as public internet queries against your authoritative zones.
+
+### TTL and Query Volume
+
+TTL is a cost knob. Cutting TTL from 300 seconds to 30 seconds can multiply recurring lookups roughly tenfold for clients that stay active. Traffic Manager profiles with very low TTL plus alias apex records plus aggressive client retry logic can push you toward higher query tiers during marketing events or DDoS-induced retry storms. Raise TTL only when failover speed requirements allow it; lower TTL when RTO demands it, but model the query increase before change windows.
+
+### Private Resolver Endpoints
+
+Hybrid designs using [Azure DNS Private Resolver](https://azure.microsoft.com/en-us/pricing/details/dns/) pay **$180 per month per inbound endpoint** and **$180 per month per outbound endpoint**, prorated hourly, plus **$2.50 per month per forwarding ruleset**. A hub with one inbound and one outbound endpoint therefore starts near **$362.50/month** before VNet data transfer. That is often cheaper than operating highly available BIND pairs, but it is not free compared with simple conditional forwarders to 168.63.129.16 on a single custom DNS VM.
+
+Scale resolver endpoints when you approach the documented **10,000 QPS per endpoint** limit. Additional inbound endpoints add monthly fixed cost but increase headroom for on-premises forwarders during peak login storms.
+
+### Traffic Manager Charges
+
+[Traffic Manager pricing](https://azure.microsoft.com/en-us/pricing/details/traffic-manager/) includes **$0.54 per million DNS queries** for the first billion each month, then **$0.375 per million** above that. Endpoint health monitoring adds **$0.36 per Azure endpoint per month** or **$0.54 per external endpoint per month** for basic probes. Fast 10-second probing adds **$1.00 or $2.00 per endpoint per month** depending on endpoint type.
+
+A profile with four external endpoints on fast probing can exceed **$8/month in probe fees alone**, before counting millions of client DNS lookups during an launch. Nested profiles bill queries once at the parent level, which avoids double-charging DNS lookups but still bills health checks for child endpoints normally.
+
+### Front Door vs Traffic Manager Cost Shape
+
+Front Door charges base profile fees, request processing, and outbound data transfer per the [Front Door pricing page](https://learn.microsoft.com/en-us/azure/frontdoor/understanding-pricing). It typically costs more at low traffic than Traffic Manager alone, but bundles WAF, caching, and TLS offload that would otherwise require separate services. Compare total cost of ownership, not line-item DNS query rates, when HTTP workloads need edge security.
+
+| Cost driver | What increases spend | Mitigation |
+| :--- | :--- | :--- |
+| Hosted zones | Many private zones per team or environment | Consolidate shared private zones; link many VNets |
+| Authoritative queries | Low TTL, high user count, retry storms | Tune TTL; cache at app layer where safe |
+| Private Resolver | Extra inbound/outbound endpoints | Right-size QPS; one hub resolver per region |
+| Traffic Manager probes | Many endpoints, fast interval | Use fast probing only on critical profiles |
+| TM DNS queries | Popular alias apex names | Accept tradeoff or move HTTP to Front Door |
+
+---
+
+## Patterns & Anti-Patterns
+
+Operational DNS maturity shows up in patterns teams repeat on purpose and anti-patterns they accidentally normalize. The table below captures proven Azure DNS designs and the failure modes that trigger midnight pages.
+
+| Pattern | When to use it | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| Centralized private zone with hub registration | Shared services in hub, apps in spokes | One authoritative internal namespace | One registration-enabled link per VNet; many resolution links |
+| Alias apex to Traffic Manager or Front Door | Global entry with lifecycle-safe apex | Avoids static A records and CNAME apex violations | TM alias to A/AAAA requires static external endpoint IPs |
+| Private endpoint DNS zone groups | PaaS accessed via Private Link | Automatic A records track endpoint IPs | Use official `privatelink.*` zone names per service |
+| Hub Private Resolver with rulesets | Hybrid AD plus Azure private zones | Managed HA forwarders replace BIND clusters | Watch $180/endpoint/month and QPS limits |
+| Low TTL on TM plus Priority routing | Active/passive regional failover | Faster cache expiry after probe failure | Query volume rises; monitor DNS billing |
+| Split public/private zones for same brand | Different answers inside vs outside Azure | Split horizon without exposing internal names | Document which resolvers see which zone |
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+| :--- | :--- | :--- | :--- |
+| Static A record to load balancer IP | Outage after redeploy or IP swap | Copy/paste from portal feels fastest | Alias record to public IP or TM profile |
+| CNAME at zone apex | Violates DNS rules; broken apex resolution | SaaS docs show CNAME examples only | Alias to Front Door, CDN, or TM |
+| One private zone per VNet with same name | Fragmented records, inconsistent discovery | Team autonomy without platform guardrails | Shared zone with multiple VNet links |
+| Custom DNS without 168.63.129.16 forwarder | Private Link and VM names fail silently | AD team owns DNS and skips Azure forward | Conditional forward or Private Resolver inbound |
+| Traffic Manager for WAF/TLS needs | No inspection or termination at edge | TM is simpler to demo | Front Door or App Gateway in data path |
+| TTL 3600 on failover profile | Users stay on dead region for minutes | Default TTL looks "normal" | 10–30s TM TTL with measured query cost |
+| Geographic TM without overflow plan | Region outage drops traffic entirely | Compliance interpreted as hard isolation | Nested profiles or explicit fallback endpoints |
+
+---
+
+## Decision Framework
+
+Start with the question clients are asking: **where should this name resolve, and who needs to enforce policy on the connection after resolution?** DNS answers the first part. Layer-7 services answer the second.
+
+```mermaid
+flowchart TD
+    A[Name resolution requirement] --> B{Internet-facing authoritative zone?}
+    B -- Yes --> C{Need apex to Azure resource with lifecycle tracking?}
+    C -- Yes --> D[Public zone plus alias A/AAAA/CNAME]
+    C -- No --> E[Standard A/AAAA/CNAME/MX/TXT records]
+    B -- No --> F{Resolution inside linked VNets only?}
+    F -- Yes --> G[Private DNS zone plus VNet links]
+    G --> H{Hybrid/on-prem must query Azure private names?}
+    H -- Yes --> I[Private Resolver inbound endpoint]
+    H -- No --> J[Default Azure DNS 168.63.129.16 chain]
+    F -- No --> K[Custom DNS plus forwarders/rulesets]
+    A --> L{Global traffic steering after resolution?}
+    L -- DNS-only / non-HTTP --> M[Traffic Manager profile]
+    L -- HTTP/S plus WAF/cache/TLS --> N[Front Door or regional App Gateway]
+    D --> L
+```
+
+| Decision | Choose public zone | Choose private zone |
+| :--- | :--- | :--- |
+| Who queries | Internet resolvers and clients | Linked VNets (and hybrid via Resolver) |
+| Record exposure | Publicly enumerable if guessed | Hidden from internet |
+| Typical records | MX, TXT, apex alias to TM/FD | Internal service names, privatelink zones |
+| Cost shape | Zone fee plus public query volume | Zone fee plus internal query volume |
+
+| Decision | Choose alias record | Choose CNAME |
+| :--- | :--- | :--- |
+| Zone apex | Supported | Not supported |
+| Target type | Azure resource IDs | Any hostname |
+| IP lifecycle | Tracks Azure resource | Manual updates if target IP changes |
+| MX/TXT at same name | Allowed with alias A/AAAA | Forbidden with CNAME at node |
+
+| Decision | Choose Traffic Manager | Choose Front Door |
+| :--- | :--- | :--- |
+| Protocol | Any after DNS returns IP | HTTP/HTTPS only |
+| Data path | Not in path | Reverse proxy in path |
+| Failover speed | TTL and probe bound | Active probes plus connection draining |
+| Best fit | TCP/UDP apps, simple failover | Web apps needing WAF, cache, path routes |
+
+When both services appear viable for a web property, run a decision workshop with security and finance stakeholders. Traffic Manager wins when monthly query volume is predictable, origins already terminate TLS correctly, and you accept DNS cache as part of RTO. Front Door wins when you must block OWASP patterns at the edge, serve static content from PoPs, or rewrite URLs based on path. Document the chosen boundary in your architecture decision record so future teams do not stack redundant global entry points that confuse incident response during major outages.
+
+---
+
 ## Did You Know?
 
 1. **Azure DNS is a large-scale authoritative DNS service** that uses anycast networking so queries are answered by nearby DNS servers, which improves performance and availability.
@@ -510,16 +848,30 @@ The missing component is the integration between the Private Endpoint and an Azu
 <details>
 <summary>6. <strong>Scenario</strong>: A gaming company uses Traffic Manager with Performance routing to connect players to the lowest-latency game server. After a server in Tokyo goes offline, players in Japan complain they cannot connect for several minutes, even though a backup server in Seoul is available. You investigate and find the profile has a TTL of 300 seconds. What two specific configuration changes must you make to guarantee failover happens in under 60 seconds?</summary>
 
-First, you must reduce the DNS TTL from 300 seconds to a much lower value, such as 10 or 30 seconds, so client machines and ISP resolvers expire the stale IP address faster. Second, you must optimize the endpoint monitoring settings by reducing the probe interval (e.g., from 30 seconds to 10 seconds) and potentially lowering the tolerated number of failures (e.g., from 3 to 2). By combining a short TTL with aggressive health probing, Traffic Manager detects the Tokyo server failure faster and clients usually query for the new Seoul IP address within tens of seconds. This ensures that the total time for failure detection and cache expiration remains strictly under one minute to minimize disruption.
+First, reduce the DNS TTL from 300 seconds to 10 or 30 seconds so client and ISP caches expire stale Tokyo IPs faster. Second, tighten endpoint monitoring by lowering probe interval toward 10 seconds and reducing tolerated failures so Traffic Manager marks Tokyo unhealthy sooner. Failover time is always detection time plus cache time; both knobs must move together for sub-minute recovery during regional game server loss.
+</details>
+
+<details>
+<summary>7. <strong>Scenario</strong>: Your security team requires CAA records so only one public CA can issue certificates for `example.com`. Separately, platform engineering wants `_http._tcp.example.com` SRV records for a service mesh discovery experiment. Both record types must live in the same Azure public zone you already delegated from the registrar. What do you configure, and why do neither record type replace your NS delegation at the apex?</summary>
+
+Publish a CAA record set on `@` (or a subdomain scope if policy allows) with the `issue` tag pointing at the approved CA name, which tells compliant CAs they must respect your authorization policy. Create an SRV record set named `_http._tcp` with priority, weight, port, and target fields per Azure DNS conventions for SRV naming. Neither CAA nor SRV replaces apex NS records because NS and SOA record sets are created and managed automatically for zone authority. CAA constrains certificate issuance; SRV advertises service location; NS still tells the internet which name servers are authoritative for the zone.
+</details>
+
+<details>
+<summary>8. <strong>Scenario</strong>: A hybrid hub VNet uses custom Active Directory DNS at 10.0.0.4 as the VNet DNS server. Spoke VMs cannot resolve `privatelink.blob.core.windows.net` to private endpoint IPs even though the private zone is linked to the spoke. On-premises users also cannot resolve Azure private zone names. Which two Azure components address the spoke problem and the on-premises problem respectively, and why is 168.63.129.16 still relevant?</summary>
+
+For spokes using custom DNS, configure conditional forwarding on the custom DNS servers to 168.63.129.16 for Azure private zones, or deploy Azure DNS Private Resolver with outbound rulesets linked to spokes and inbound endpoints for cross-network access. On-premises resolution requires inbound Private Resolver endpoints (or VPN/ExpressRoute connectivity plus forwarders) so AD DNS can forward Azure private suffixes into Azure. Address 168.63.129.16 remains the platform recursive resolver that understands linked private zones when queries reach Azure DNS; custom DNS must forward to it or to Resolver endpoints that encapsulate the same resolution path.
 </details>
 
 ---
 
 ## Hands-On Exercise: Public DNS Zone with Traffic Manager Failover
 
-In this exercise, you will create a public DNS zone, set up a Traffic Manager profile with Priority routing and health probes, and simulate a failover.
+In this exercise, you will create a public DNS zone, set up a Traffic Manager profile with Priority routing and health probes, and simulate a failover. The lab intentionally uses the `trafficmanager.net` namespace so you can practice global routing without buying a domain or waiting for registrar delegation. If you extend the lab to a real zone, remember delegation: create the zone, copy Azure's four name servers, update the registrar, then verify with external `nslookup` before cutting over production traffic.
 
 **Prerequisites**: Azure CLI installed and authenticated. You do not need a real domain for this exercise---we will work entirely within the `trafficmanager.net` namespace.
+
+Understanding TTL in this lab matters for interpreting Task 5. With TTL set to 10 seconds, `sleep 15` is usually enough for a fresh lookup to see the secondary endpoint, but your local resolver may still cache longer if an upstream forwarder ignores low TTL. If failover appears stuck, query the Traffic Manager name servers directly or flush local cache before assuming the profile misconfigured.
 
 ### Task 1: Create the Resource Group and Two Simulated Endpoints
 
@@ -733,18 +1085,27 @@ az group delete --name "$RG" --yes --no-wait
 
 - [learn.microsoft.com: dns faq](https://learn.microsoft.com/en-us/azure/dns/dns-faq) — The Azure DNS FAQ directly states that Azure DNS uses Anycast on Azure's global DNS name server network for fast performance and high availability.
 - [learn.microsoft.com: dns delegate domain azure dns](https://learn.microsoft.com/en-us/azure/dns/dns-delegate-domain-azure-dns) — Microsoft's delegation tutorial shows Azure DNS assigning four nameservers with exactly these suffixes.
+- [learn.microsoft.com: dns zones records](https://learn.microsoft.com/en-us/azure/dns/dns-zones-records) — Record type reference for A, AAAA, CAA, CNAME, MX, NS, SOA, SRV, TXT, and apex NS/SOA behavior.
 - [learn.microsoft.com: dns alias](https://learn.microsoft.com/en-us/azure/dns/dns-alias) — The Azure DNS alias-record overview says alias records reference Azure resources and update dynamically during DNS resolution.
 - [learn.microsoft.com: private dns privatednszone](https://learn.microsoft.com/en-us/azure/dns/private-dns-privatednszone) — The Private DNS zone overview directly states that private-zone records are not resolvable from the Internet and work only from linked VNets.
 - [learn.microsoft.com: private dns autoregistration](https://learn.microsoft.com/en-us/azure/dns/private-dns-autoregistration) — Microsoft's autoregistration doc explicitly describes automatic creation and removal of VM A records.
+- [learn.microsoft.com: private dns records](https://learn.microsoft.com/en-us/azure/dns/dns-private-records) — Private zone record types, wildcard rules, and apex constraints for CNAME/SOA.
+- [learn.microsoft.com: dns private resolver overview](https://learn.microsoft.com/en-us/azure/dns/dns-private-resolver-overview) — Inbound/outbound endpoints, rulesets, and service limits including QPS per endpoint.
+- [learn.microsoft.com: dns private resolver get started](https://learn.microsoft.com/en-us/azure/dns/dns-private-resolver-get-started-portal) — Step-by-step hybrid forwarding and VNet link patterns for Private Resolver.
+- [learn.microsoft.com: what is ip address 168 63 129 16](https://learn.microsoft.com/en-us/azure/virtual-network/what-is-ip-address-168-63-129-16) — Platform recursive resolver role, filtering, and custom DNS forwarder requirements.
+- [learn.microsoft.com: virtual networks name resolution](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-networks-name-resolution-for-vms-and-role-instances) — Default Azure-provided DNS behavior and conditional forwarding to 168.63.129.16.
 - [learn.microsoft.com: private endpoint dns](https://learn.microsoft.com/en-us/azure/private-link/private-endpoint-dns) — The private-endpoint DNS guidance says public DNS resolution is overridden with a private DNS zone so the FQDN resolves to the private endpoint IP.
 - [learn.microsoft.com: private link overview](https://learn.microsoft.com/en-us/azure/private-link/private-link-overview) — The Azure Private Link overview directly states that traffic travels over the Microsoft backbone network and public exposure is unnecessary.
 - [learn.microsoft.com: traffic manager overview](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-overview) — The Traffic Manager overview directly describes the service as DNS-based routing for public-facing endpoints.
 - [learn.microsoft.com: traffic manager how it works](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-how-it-works) — Microsoft's how-it-works page explicitly says clients connect directly and Traffic Manager is not a proxy or gateway.
 - [learn.microsoft.com: traffic manager routing methods](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-routing-methods) — The Traffic Manager routing-methods documentation lists these six supported methods and their intended behaviors.
 - [learn.microsoft.com: load balancing content delivery overview](https://learn.microsoft.com/en-us/azure/networking/load-balancer-content-delivery/load-balancing-content-delivery-overview) — Microsoft's load-balancing overview describes Front Door as a Layer 7 application delivery network with SSL offload, path routing, caching, and WAF-related security.
-- [learn.microsoft.com: understanding pricing](https://learn.microsoft.com/en-us/azure/frontdoor/understanding-pricing) — General lesson point for an illustrative rewrite.
+- [learn.microsoft.com: understanding pricing](https://learn.microsoft.com/en-us/azure/frontdoor/understanding-pricing) — Front Door billing components for comparing edge proxy TCO against DNS-only routing.
 - [learn.microsoft.com: traffic manager monitoring](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-monitoring) — The endpoint-monitoring doc directly states that firewalls must allow Traffic Manager IPs and recommends the AzureTrafficManager service tag.
 - [learn.microsoft.com: edge locations by region](https://learn.microsoft.com/en-us/azure/frontdoor/edge-locations-by-region) — The current Microsoft Learn edge-location page explicitly gives these counts.
 - [learn.microsoft.com: traffic manager performance considerations](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-performance-considerations) — Microsoft's performance-considerations doc states the default TTL is 300 seconds and that longer caching delays traffic redirection away from failed endpoints.
+- [learn.microsoft.com: traffic manager faqs](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-faqs) — Nested profile billing, Traffic View charges, and fast probing guidance.
+- [azure.microsoft.com: dns pricing](https://azure.microsoft.com/en-us/pricing/details/dns/) — Hosted zone, query, and Private Resolver endpoint pricing tables.
+- [azure.microsoft.com: traffic manager pricing](https://azure.microsoft.com/en-us/pricing/details/traffic-manager/) — DNS query and health probe pricing for Traffic Manager profiles.
 - [rfc-editor.org: rfc1034.html](https://www.rfc-editor.org/rfc/rfc1034.html) — RFC 1034 states that if a CNAME is present at a node, no other data should be present.
 - [Azure Front Door Overview](https://learn.microsoft.com/en-us/azure/frontdoor/front-door-overview) — Best official overview of Front Door capabilities, edge network, SSL offload, caching, and security positioning.

--- a/src/content/docs/cloud/azure-essentials/module-3.5-dns.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.5-dns.md
@@ -211,8 +211,8 @@ flowchart TD
     end
 
     subgraph Alias [Alias Record]
-        A_DNS[app.example.com] -->|Alias Record| A_Res[Azure Resource ID\nweb-lb-pip]
-        A_Res -.->|Azure DNS automatically\nresolves current IP| A_IP[Current IP]
+        A_DNS[app.example.com] -->|Alias Record| A_Res[Azure Resource ID<br/>web-lb-pip]
+        A_Res -.->|Azure DNS automatically<br/>resolves current IP| A_IP[Current IP]
     end
 ```
 
@@ -230,7 +230,7 @@ Private zones implement **split-horizon DNS** when paired with a public zone for
 
 Every VNet link to a private zone is either **resolution-only** or **registration-enabled**. Resolution links allow VMs in that VNet to query records in the zone. Registration links additionally create and maintain A records for VMs based on their Azure resource names.
 
-Only **one registration-enabled link is allowed per VNet per zone** to prevent two zones from fighting over the same VM hostname. Hub VNets that host shared infrastructure commonly enable registration so databases and middleware register automatically. Spoke VNets that run stateless application tiers typically use resolution-only links so they can look up shared services without polluting the zone with ephemeral pod-like names.
+A VNet can have auto-registration enabled on **only one** private DNS zone; a single zone can accept auto-registration from many VNets. Hub VNets that host shared infrastructure commonly enable registration so databases and middleware register automatically. Spoke VNets that run stateless application tiers typically use resolution-only links so they can look up shared services without polluting the zone with ephemeral pod-like names.
 
 When a VNet uses **Azure-provided DNS** (the default), [linked private zones are consulted before Azure-provided recursive resolution](https://learn.microsoft.com/en-us/azure/dns/private-dns-privatednszone). If you configure **custom DNS servers** on the VNet or NIC, that automatic chain stops. Custom DNS must forward queries for private zones to Azure, usually via conditional forwarders to **168.63.129.16** or via Azure DNS Private Resolver inbound endpoints.
 
@@ -252,33 +252,33 @@ Custom DNS servers on domain controllers or Linux BIND instances must still forw
 
 ```bash
 # Create a Private Resolver in the hub VNet (subnets must be delegated to Microsoft.Network/dnsResolvers)
-az network dns-resolver create \
+az dns-resolver create \
   --resource-group myRG \
   --name hub-resolver \
-  --virtual-network hub-vnet \
+  --id "/subscriptions/<sub>/resourceGroups/myRG/providers/Microsoft.Network/virtualNetworks/hub-vnet" \
   --location eastus
 
 # Inbound endpoint for on-premises to query Azure private zones
-az network dns-resolver inbound-endpoint create \
+az dns-resolver inbound-endpoint create \
   --resource-group myRG \
   --dns-resolver-name hub-resolver \
   --name inbound \
   --ip-configurations '[{"subnet":{"id":"/subscriptions/.../subnets/snet-inbound"},"privateIpAddress":"10.0.0.4"}]'
 
 # Outbound endpoint plus ruleset for conditional forwarding to on-premises
-az network dns-resolver outbound-endpoint create \
+az dns-resolver outbound-endpoint create \
   --resource-group myRG \
   --dns-resolver-name hub-resolver \
   --name outbound \
   --ip-configurations '[{"subnet":{"id":"/subscriptions/.../subnets/snet-outbound"},"privateIpAddress":"10.0.0.20"}]'
 
-az network dns-resolver forwarding-ruleset create \
+az dns-resolver forwarding-ruleset create \
   --resource-group myRG \
   --name onprem-rules \
-  --dns-resolver-outbound-endpoints "[$(az network dns-resolver outbound-endpoint show -g myRG --dns-resolver-name hub-resolver -n outbound --query id -o tsv)]" \
+  --dns-resolver-outbound-endpoints "[$(az dns-resolver outbound-endpoint show -g myRG --dns-resolver-name hub-resolver -n outbound --query id -o tsv)]" \
   --location eastus
 
-az network dns-resolver forwarding-rule create \
+az dns-resolver forwarding-rule create \
   --resource-group myRG \
   --ruleset-name onprem-rules \
   --name corp-forward \
@@ -286,11 +286,11 @@ az network dns-resolver forwarding-rule create \
   --target-dns-servers '[{"ipAddress":"192.168.1.2","port":53}]'
 
 # Link ruleset to spoke VNet so VMs forward corp.contoso.com via outbound endpoint
-az network dns-resolver vnet-link create \
+az dns-resolver vnet-link create \
   --resource-group myRG \
   --ruleset-name onprem-rules \
   --name spoke1-link \
-  --virtual-network spoke1-vnet
+  --id "/subscriptions/<sub>/resourceGroups/myRG/providers/Microsoft.Network/virtualNetworks/spoke1-vnet"
 ```
 
 Each resolver supports up to five inbound and five outbound endpoints per instance, with [10,000 queries per second per endpoint](https://learn.microsoft.com/en-us/azure/dns/dns-private-resolver-overview) under documented limits. Rulesets can hold up to 1,000 forwarding rules and link to hundreds of VNets in the same region, which makes hub-and-spoke designs practical without maintaining BIND clusters.
@@ -304,16 +304,16 @@ Centralized DNS architecture guidance from Microsoft recommends placing resolver
 ```mermaid
 flowchart TD
     subgraph Zone [Private DNS Zone: internal.example.com]
-        Records[db → 10.0.2.10\ncache → 10.0.2.20\napi → 10.0.1.15]
+        Records[db → 10.0.2.10<br/>cache → 10.0.2.20<br/>api → 10.0.1.15]
     end
 
     Hub[hub-vnet] -- "Linked (Auto-registration ON)" --> Zone
     Spoke1[spoke1-vnet] -- "Linked (Resolution ONLY)" --> Zone
     Spoke2[spoke2-vnet] -- "Linked (Resolution ONLY)" --> Zone
 
-    HubVMs[VMs auto-register\nDNS names] -.-> Hub
-    SpokeVMs1[VMs can resolve\nbut do not register] -.-> Spoke1
-    SpokeVMs2[VMs can resolve\nbut do not register] -.-> Spoke2
+    HubVMs[VMs auto-register<br/>DNS names] -.-> Hub
+    SpokeVMs1[VMs can resolve<br/>but do not register] -.-> Spoke1
+    SpokeVMs2[VMs can resolve<br/>but do not register] -.-> Spoke2
 ```
 
 ```bash
@@ -409,7 +409,7 @@ Split-horizon effects appear during troubleshooting: a developer's laptop on the
 
 ## Azure Traffic Manager: DNS-Based Global Load Balancing
 
-[Traffic Manager is a DNS-based traffic routing service that distributes traffic across global endpoints](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-overview). It works at the DNS layer (Layer 7 of DNS, technically)---when a client resolves your domain, Traffic Manager returns the IP of the most appropriate endpoint based on the routing method you configure.
+[Traffic Manager is a DNS-based traffic routing service that distributes traffic across global endpoints](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-overview). It operates at the DNS / application layer---when a client resolves your domain, Traffic Manager returns the IP of the most appropriate endpoint based on the routing method you configure.
 
 ### How Traffic Manager Works
 
@@ -582,13 +582,13 @@ flowchart TD
         direction LR
         C1[Client] -- "1. DNS Query" --> T[Traffic Manager]
         T -- "2. Returns IP" --> C1
-        C1 -- "3. Direct Connect\n(Not in data path)" --> O1[Origin Server]
+        C1 -- "3. Direct Connect<br/>(Not in data path)" --> O1[Origin Server]
     end
 
     subgraph FD [Azure Front Door - Layer 7]
         direction LR
-        C2[Client] -- "HTTPS" --> F[Front Door PoP Edge\n- SSL Offload\n- WAF\n- Caching\n- Routing]
-        F -- "HTTPS\n(In data path)" --> O2[Origin Server]
+        C2[Client] -- "HTTPS" --> F[Front Door PoP Edge<br/>- SSL Offload<br/>- WAF<br/>- Caching<br/>- Routing]
+        F -- "HTTPS<br/>(In data path)" --> O2[Origin Server]
     end
 ```
 
@@ -690,7 +690,7 @@ TTL is a cost knob. Cutting TTL from 300 seconds to 30 seconds can multiply recu
 
 ### Private Resolver Endpoints
 
-Hybrid designs using [Azure DNS Private Resolver](https://azure.microsoft.com/en-us/pricing/details/dns/) pay **$180 per month per inbound endpoint** and **$180 per month per outbound endpoint**, prorated hourly, plus **$2.50 per month per forwarding ruleset**. A hub with one inbound and one outbound endpoint therefore starts near **$362.50/month** before VNet data transfer. That is often cheaper than operating highly available BIND pairs, but it is not free compared with simple conditional forwarders to 168.63.129.16 on a single custom DNS VM.
+Hybrid designs using [Azure DNS Private Resolver](https://azure.microsoft.com/en-us/pricing/details/dns/) pay **$180 per month per inbound endpoint** and **$180 per month per outbound endpoint**, prorated hourly, plus **$2.50 per month per forwarding ruleset** (verify current pricing on the Azure DNS pricing page). A hub with one inbound and one outbound endpoint therefore starts near **$362.50/month** before VNet data transfer. That is often cheaper than operating highly available BIND pairs, but it is not free compared with simple conditional forwarders to 168.63.129.16 on a single custom DNS VM.
 
 Scale resolver endpoints when you approach the documented **10,000 QPS per endpoint** limit. Additional inbound endpoints add monthly fixed cost but increase headroom for on-premises forwarders during peak login storms.
 
@@ -792,7 +792,7 @@ When both services appear viable for a web property, run a decision workshop wit
 
 2. **[Traffic Manager health probes come from specific well-known IP ranges](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-monitoring)** published by Microsoft. If your backend has IP-based firewall rules, you must whitelist these IPs or your health probes will fail and Traffic Manager will mark your endpoint as degraded. The IP ranges are published in the Azure IP Ranges JSON file, under the `AzureTrafficManager` service tag.
 
-3. **Azure Front Door has over [192 edge locations (Points of Presence)](https://learn.microsoft.com/en-us/azure/frontdoor/edge-locations-by-region)** across 109 metro areas worldwide as of 2025. When a user in Tokyo accesses your app through Front Door, the TLS handshake terminates at a Tokyo PoP. This can substantially reduce TLS setup latency for users by terminating TLS at a nearby edge location instead of at a distant origin. The PoP then maintains a persistent, optimized connection to your origin backend.
+3. **Azure Front Door has over [190+ edge locations (Points of Presence)](https://learn.microsoft.com/en-us/azure/frontdoor/edge-locations-by-region)** across 100+ metro areas worldwide as of 2025. When a user in Tokyo accesses your app through Front Door, the TLS handshake terminates at a Tokyo PoP. This can substantially reduce TLS setup latency for users by terminating TLS at a nearby edge location instead of at a distant origin. The PoP then maintains a persistent, optimized connection to your origin backend.
 
 4. **Private DNS Zone auto-registration has a limit of one registration-enabled link per VNet.** A VNet can be linked to multiple Private DNS Zones for resolution, but [only one zone can have auto-registration enabled](https://learn.microsoft.com/en-us/azure/dns/private-dns-autoregistration). This prevents conflicts where multiple zones try to register the same VM name. If you need records in multiple zones, use one zone for auto-registration and manually create records in the others.
 
@@ -824,7 +824,7 @@ A standard A record requires a static IP; recreating the Load Balancer would ass
 <details>
 <summary>2. <strong>Scenario</strong>: You are designing a hub-and-spoke network architecture with one hub VNet (containing shared databases) and two spoke VNets (containing web APIs). You create a Private DNS Zone `internal.corp` to resolve internal hostnames. If you enable auto-registration for the hub VNet, how should you configure the links for the spoke VNets, and why?</summary>
 
-You must link the Private DNS Zone to the spoke VNets with auto-registration disabled (resolution-only). Azure only allows one VNet to have auto-registration enabled per Private DNS Zone to prevent naming conflicts. By enabling auto-registration on the hub, the shared databases automatically register their DNS records. The resolution-only links on the spokes ensure the web APIs can successfully look up those database hostnames without attempting to register their own potentially conflicting names into the shared zone.
+You must link the Private DNS Zone to the spoke VNets with auto-registration disabled (resolution-only). A VNet can enable auto-registration on only one zone, and you don't want stateless spoke app-tier VMs polluting the shared-services zone with ephemeral names. By enabling auto-registration on the hub, the shared databases automatically register their DNS records. The resolution-only links on the spokes ensure the web APIs can successfully look up those database hostnames without attempting to register their own potentially conflicting names into the shared zone.
 </details>
 
 <details>
@@ -836,7 +836,7 @@ The customer could experience over 6 minutes of downtime. First, Traffic Manager
 <details>
 <summary>4. <strong>Scenario</strong>: A financial startup is launching a global trading platform. They need to ensure that European traffic stays in Europe, all connections enforce TLS 1.3, static assets like charts are cached at edge locations, and any malicious SQL injection attempts are blocked before reaching the application servers. Why is Traffic Manager insufficient for this architecture, and what service must they use instead?</summary>
 
-Traffic Manager operates strictly at the DNS layer (Layer 7 of DNS) and is not in the data path, meaning it cannot inspect or modify HTTP traffic. It cannot terminate TLS, cache content, or provide Web Application Firewall (WAF) protections against SQL injections. The startup must use Azure Front Door. Front Door acts as a Layer 7 global reverse proxy in the data path, terminating TLS at the edge, caching static assets at local Points of Presence (PoPs), and inspecting traffic with its built-in WAF before forwarding it to the backend.
+Traffic Manager operates at the DNS / application layer and is not in the data path, meaning it cannot inspect or modify HTTP traffic. It cannot terminate TLS, cache content, or provide Web Application Firewall (WAF) protections against SQL injections. The startup must use Azure Front Door. Front Door acts as a Layer 7 global reverse proxy in the data path, terminating TLS at the edge, caching static assets at local Points of Presence (PoPs), and inspecting traffic with its built-in WAF before forwarding it to the backend.
 </details>
 
 <details>


### PR DESCRIPTION
## Cloud track — Azure Essentials expand-to-floor (wave 1 of 4)

Continues the cloud expand-to-floor workstream (sessions 96/97: AWS+EKS+GCP+GKE). Each module was below the 5000-word prose floor → expanded to floor (cursor) → cross-family reviewed (opus 4.8, web-verifying every Azure fact) → orchestrator ground-checked → consolidated fix.

### Modules
| Module | body_words | tier |
|---|---|---|
| 3.1 Entra ID & Azure RBAC | 5000 | T0 PASS |
| 3.4 Blob Storage & Data Lake | 5002 | T0 PASS |
| 3.5 Azure DNS | 5005 | T0 PASS |

### Review fixes applied (cross-family R1, opus 4.8)
**3.1** — P1: lab Task 3 `--auth-mode login` fails for Owner (Owner/Contributor don't grant blob *data* access via Entra) → added `Storage Blob Data Contributor` self-assignment with explanatory note; P2: RG-per-sub limit ~500→**980** (ARM limit); P2: custom-role prose contradicted its own DataActions (read) → reworded; P2: removed unused `listkeys/action` that bypassed the least-privilege lesson.

**3.4** — P1: `az storage fs directory move --new-directory` requires `{filesystem}/{path}` → fixed the marquee ADLS rename lab; P2: SAS perm `x` mislabeled "Execute" → **Delete version** (`e`=Execute); P2: undefined `$DATALAKE_NAME` in a teaching snippet; P2: dangling war-story callback. (Reviewer's ground-check correctly preserved two real 2026 features: Smart tier GA, 128 KiB min billable size.)

**3.5** — P1: entire Private Resolver block used non-existent `az network dns-resolver` → corrected to the `az dns-resolver` extension + `--id` for VNet refs; P1: Quiz #2 taught a wrong auto-registration limit (it's per-VNet, not per-zone) → corrected; P2: mermaid `\n`→`<br/>`, pricing hedge, OSI-layer wording.

Authored by cursor; reviewed by opus 4.8 headless; facts web-verified by orchestrator. Density gates + structure verified locally (verify_module.py T0 PASS on all three).

🤖 Generated with [Claude Code](https://claude.com/claude-code)