### PR TITLE
chore(content): expand Azure Essentials 3.11/3.12 to 5000w floor + cross-family review fixes (+3.13 gate fix)

### DIFF
--- a/src/content/docs/cloud/azure-essentials/module-3.11-cicd.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.11-cicd.md
@@ -19,17 +19,23 @@ When you finish this module, you will be able to design, secure, and operate CI/
 
 ## Why This Module Matters
 
-Recent CI/CD security incidents have shown that when attackers compromise build infrastructure or workflow execution paths, they can steal pipeline secrets and use them to access downstream cloud environments. The operational lesson is the same: avoid long-lived credentials in pipelines and scope deployment identities as narrowly as possible.
+Hypothetical scenario: a platform team stores an Azure service principal client secret in a GitHub repository secret so nightly builds can push images to ACR. A contributor opens a pull request that modifies a workflow file. The workflow runs with elevated repository permissions, prints the secret to build logs, and an external scanner harvests the credential within minutes. The attacker now has Contributor access to a production resource group until someone notices the rotation calendar is three weeks overdue.
 
-This incident crystallized a lesson the industry had been learning the hard way: **the CI/CD pipeline is the most privileged part of your infrastructure, and it deserves the strongest security posture.** Your pipeline has the power to deploy code to production, access secrets, and modify infrastructure. If an attacker compromises your pipeline, they own your production environment. Static credentials stored in pipeline variables increase risk because they require manual rotation, are exposed to anyone who can administer or alter the pipeline, and can be exfiltrated if the pipeline or runner is compromised.
+That chain is not exotic. It is the predictable outcome when CI/CD authentication relies on long-lived passwords instead of short-lived, context-bound tokens. **The CI/CD pipeline is the most privileged part of your infrastructure, and it deserves the strongest security posture.** Your pipeline can deploy code to production, read Key Vault secrets, and modify infrastructure. If an attacker compromises the pipeline or the runner executing it, they inherit whatever RBAC roles you granted the deployment identity.
 
-In this module, you will learn how to build secure CI/CD pipelines targeting Azure using two platforms: Azure DevOps Pipelines and GitHub Actions. You will understand YAML pipeline syntax, how Service Connections and OIDC federation eliminate static credentials, and how to deploy to Azure Container Registry and Container Apps. By the end, you will build a complete GitHub Actions pipeline that authenticates to Azure using OIDC (zero secrets), builds a container image, pushes it to ACR, and deploys it to Container Apps.
+Recent CI/CD security incidents reinforce the same operational lesson across both GitHub Actions and Azure DevOps. When attackers compromise build infrastructure or workflow execution paths, they steal pipeline secrets and pivot into downstream cloud environments. Static credentials stored in pipeline variables increase risk because they require manual rotation. They are visible to anyone who can administer or alter the pipeline. They can be exfiltrated if the runner or logs are compromised.
+
+In this module, you will learn how to build secure CI/CD pipelines targeting Azure using two platforms: Azure DevOps Pipelines and GitHub Actions. You will understand YAML pipeline syntax, how Service Connections and OIDC federation eliminate static credentials, and how to deploy to Azure Container Registry, Container Apps, App Service, AKS, and infrastructure defined in Bicep or Terraform. By the end, you will build a complete GitHub Actions pipeline that authenticates to Azure using OIDC with zero stored passwords, builds a container image, pushes it to ACR, and deploys it to Container Apps.
 
 ---
 
 ## Azure DevOps Pipelines
 
-Azure DevOps is Microsoft's integrated DevOps platform providing [source control (Azure Repos), CI/CD (Azure Pipelines), project management (Boards), artifact management (Artifacts), and testing (Test Plans)](https://learn.microsoft.com/en-us/azure/devops/). Teams that already standardize on Microsoft tooling often choose Azure DevOps because source control, pipelines, and release management live in one project boundary, which simplifies permissions and audit trails compared with stitching together separate products.
+Azure DevOps is Microsoft's integrated DevOps platform providing [source control (Azure Repos), CI/CD (Azure Pipelines), project management (Boards), artifact management (Artifacts), and testing (Test Plans)](https://learn.microsoft.com/en-us/azure/devops/). Teams that already standardize on Microsoft tooling often choose Azure DevOps because source control, pipelines, and release management live in one project boundary. Permissions, audit logs, and work-item traceability stay inside a single organization instead of spanning separate vendors.
+
+Azure Pipelines excels when release managers need granular approval chains tied to Azure DevOps environments, when test results must gate promotions through built-in test plans, or when multiple product teams share a pool of self-hosted agents inside a corporate VNet. YAML pipelines are the modern default; classic release pipelines still exist but lack environment objects with the same YAML-first ergonomics described in this module.
+
+Understanding the stage/job/step hierarchy early prevents YAML that becomes impossible to reason about after the tenth microservice adds a deploy stage. Think of a **stage** as a phase gate in your release story, a **job** as a unit of parallel work that acquires an agent, and a **step** as one command or task executing on that agent. Deployment jobs are special: they bind to environments, emit deployment records, and support lifecycle strategies like `runOnce`, `rolling`, and `canary` depending on target type.
 
 ### Pipeline Basics
 
@@ -181,6 +187,56 @@ az role assignment create \
   --scope "/subscriptions/<sub-id>/resourceGroups/myRG"
 ```
 
+### Secure Authentication from CI to Azure
+
+Authentication is the highest-value security control in any Azure CI/CD design. Both GitHub Actions and Azure DevOps can reach Azure using a service principal and a client secret stored in the pipeline. Microsoft explicitly [discourages secret-based service connections](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/configure-app-secret?view=azure-devops) because secrets are long-lived, hard to rotate under pressure, and attractive to attackers who gain workflow edit access.
+
+The modern alternative is **OpenID Connect (OIDC) federation**, also called workload identity federation. The pipeline requests a short-lived JWT from its platform issuer. Entra ID validates the token's issuer, audience, and subject claim. It then issues an Azure access token scoped to the RBAC roles you assigned the service principal. No password crosses your YAML file or secret store.
+
+#### Why OIDC beats long-lived secrets
+
+Long-lived secrets fail in three predictable ways. First, rotation is manual and often deferred until an audit finding forces action. Second, anyone with permission to view or export pipeline secrets can copy them outside the pipeline boundary. Third, a compromised runner or malicious workflow step can echo secrets into logs that retention policies keep for months.
+
+OIDC addresses each failure mode. Tokens expire within minutes. The subject claim binds a token to a specific repository, branch, environment, or Azure DevOps service connection path. Entra ID refuses tokens whose claims do not match a federated credential you pre-registered. Even if an attacker exfiltrates one token, it cannot be replayed indefinitely and it cannot authenticate a workflow you did not authorize.
+
+#### GitHub Actions: `azure/login` with federated credentials
+
+GitHub Actions exposes OIDC through the [`permissions: id-token: write`](https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-azure) declaration at workflow or job scope. Without that permission, the runner cannot request a JWT from GitHub's issuer at `https://token.actions.githubusercontent.com`.
+
+The [`azure/login@v2`](https://github.com/marketplace/actions/azure-login) action exchanges that JWT for an Azure session. You store only three non-secret identifiers in GitHub: `AZURE_CLIENT_ID`, `AZURE_TENANT_ID`, and `AZURE_SUBSCRIPTION_ID`. The client secret field stays empty because federation handles proof of identity.
+
+Least-privilege design means creating **separate federated credentials per environment** rather than one credential for the entire repository. Match the `subject` claim to `repo:ORG/REPO:environment:production` for production deploy jobs and `repo:ORG/REPO:environment:staging` for staging. Assign the production service principal Contributor on the production resource group only. Assign the staging principal Contributor on the staging resource group only. A compromised staging workflow cannot mutate production infrastructure because Entra ID will not issue a production-scoped token for a staging subject.
+
+Pull-request workflows deserve tighter scopes than main-branch deploys. A federated credential with subject `repo:ORG/REPO:pull_request` can authenticate read-only tasks such as `terraform plan` or Bicep what-if against a sandbox subscription. Keep push and deploy permissions on branch and environment subjects that untrusted forks cannot satisfy.
+
+#### Azure DevOps: service connections with workload identity federation
+
+Azure DevOps authenticates to Azure through **service connections** referenced in tasks like `AzureContainerApps@1` or `AzureResourceManagerTemplateDeployment@3`. The UI path **Project Settings → Service connections → Azure Resource Manager → Workload Identity federation (automatic)** creates the Entra app registration, federated credential, and scoped RBAC assignment in one flow. Microsoft documents the manual equivalent in [Configure workload identity federation](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/configure-workload-identity?view=azure-devops).
+
+The federated credential issuer for Azure DevOps is `https://vstoken.dev.azure.com/{organizationId}`. The subject follows the pattern `sc://{organization}/{project}/{serviceConnectionName}`. That subject binding is why renaming a service connection after creation can break authentication until you update the federated credential.
+
+Legacy service connections that still use a client secret should be migrated during your next maintenance window. Secret rotation requires updating both Entra ID and the service connection. Federation removes that toil entirely. If you must keep a secret temporarily, store it in Azure Key Vault and reference it from the pipeline rather than embedding it in plain variables.
+
+#### Least-privilege RBAC for pipeline identities
+
+Contributor at subscription scope is the most common over-permission in Azure CI/CD. It is convenient during a hackathon and dangerous in production. Prefer scoped assignments:
+
+| Pipeline stage | Typical roles | Scope |
+| :--- | :--- | :--- |
+| Build and push image | `AcrPush` | ACR resource ID |
+| Deploy Container Apps | `Contributor` or custom role | Target resource group |
+| Deploy App Service slot | `Website Contributor` | Web app or resource group |
+| Deploy AKS manifest | `Azure Kubernetes Service RBAC Cluster Admin` or namespace-scoped role | AKS cluster or namespace |
+| Bicep/Terraform apply | `Contributor` on target RG; `User Access Administrator` only if the template assigns roles | Resource group or subscription per design |
+
+Use [custom role definitions](https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles) when built-in roles grant delete permissions your deployer should not have. A deployer that only updates container images rarely needs permission to delete the underlying App Service plan.
+
+#### Answering the OIDC session-length question
+
+> **Stop and think**: If an OIDC token is valid for only 10 minutes, how does a pipeline that takes 45 minutes to run maintain authentication to Azure?
+
+Each `azure/login` step performs a fresh token exchange at the start of the job that runs it. Long jobs should call `azure/login` again before lengthy operations if you approach token lifetime limits, or split work across jobs so each job re-authenticates independently. Azure DevOps service connections refresh tokens similarly per job. Design pipelines so no single shell step runs unattended for longer than the token lifetime without an explicit re-login.
+
 ---
 
 ## GitHub Actions Targeting Azure
@@ -292,6 +348,46 @@ jobs:
 
 This workflow separates concerns across three jobs: build produces and pushes the image (skipping push on pull requests so untrusted forks cannot publish to your registry), deploy-staging targets the staging environment, and deploy-production targets production only after staging succeeds. Associating deploy jobs with GitHub Environments (`staging`, `production`) lets you require reviewers before production steps run and scope environment-specific secrets so a staging job never sees production credentials.
 
+#### Workflow triggers and concurrency controls
+
+Beyond `push` and `pull_request`, production-grade workflows use **`workflow_dispatch`** for on-demand releases and **`schedule`** for nightly security scans. Combine triggers with **`paths` filters** so edits under `docs/` or `*.md` skip container builds. Without filters, a typo fix in README.md can launch a full matrix that burns minutes and queues behind more important builds.
+
+**Concurrency groups** cancel obsolete runs when new commits arrive on the same branch:
+
+```yaml
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+```
+
+This pattern prevents three overlapping deploys to staging when a developer pushes fix commits faster than the first workflow finishes. The latest commit wins; earlier runs stop before they mutate shared environments.
+
+**Job outputs** pass immutable identifiers between jobs. Capture the image digest or tag in the build job `outputs` block and reference it in deploy jobs with `needs.build.outputs.image-tag`. Avoid re-deriving tags in downstream jobs from `github.sha` alone when the build job might skip push on certain events—outputs make dependencies explicit in the Actions UI.
+
+#### Azure Pipelines equivalents: variable groups and template repositories
+
+Azure DevOps stores reusable configuration in **variable groups** and **library groups** linked to Key Vault secrets. Link a variable group to staging versus production pipelines so connection strings never cross environments. Mark secrets as secret type so logs mask values automatically.
+
+**Template repositories** let you maintain pipeline templates in a dedicated Git repo and reference them across projects:
+
+```yaml
+resources:
+  repositories:
+    - repository: templates
+      type: git
+      name: PlatformEngineering/pipeline-templates
+      ref: refs/tags/v2.1.0
+
+stages:
+  - template: container-build.yml@templates
+    parameters:
+      acrConnection: acr-prod-sc
+```
+
+Tag or SHA-pin template repositories exactly as you pin GitHub Actions. A floating `@main` template reference can introduce breaking changes without a consumer pipeline PR.
+
+**Pipeline artifacts** (`PublishPipelineArtifact` and `DownloadPipelineArtifact` tasks) carry non-container outputs—Bicep folders, Helm charts, test reports—between stages when you are not using a registry. Set meaningful artifact names with build IDs so rollback pipelines can fetch the same artifact bundle later.
+
 ### OIDC Setup for GitHub Actions
 
 The Azure CLI commands in this section create an app registration, service principal, and federated credentials that trust GitHub's OIDC issuer. You typically create one federated credential per branch, pull-request context, or environment subject so Entra ID only accepts tokens that match the workflow's actual execution context.
@@ -345,9 +441,228 @@ az role assignment create \
   --scope "/subscriptions/<sub-id>/resourceGroups/myRG"
 ```
 
-After the app registration and RBAC assignments exist, add three repository secrets so the `azure/login` action can locate your tenant and subscription: `AZURE_CLIENT_ID` (the application ID), `AZURE_TENANT_ID` (your Entra ID tenant), and `AZURE_SUBSCRIPTION_ID` (the target subscription). These values are identifiers, not passwords—OIDC handles authentication using short-lived tokens generated per workflow run, so you never store a client secret that an attacker could copy from the secrets store.
+After the app registration and RBAC assignments exist, add three repository secrets so the `azure/login` action can locate your tenant and subscription: `AZURE_CLIENT_ID` (the application ID), `AZURE_TENANT_ID` (your Entra ID tenant), and `AZURE_SUBSCRIPTION_ID` (the target subscription). These values are identifiers, not passwords. OIDC handles authentication using short-lived tokens generated per workflow run.
 
-> **Stop and think**: If an OIDC token is valid for only 10 minutes, how does a pipeline that takes 45 minutes to run maintain authentication to Azure?
+---
+
+## Pipeline Structure, Environments, and Promotion Gates
+
+Well-structured pipelines separate **build**, **validate**, and **promote** concerns. Mixing them in one job saves YAML lines but removes safety gates and makes rollback harder. Both GitHub Actions and Azure DevOps provide first-class environment objects where you attach approvals, branch filters, and secret scopes.
+
+### Azure DevOps: stages, templates, and environments
+
+Azure Pipelines organizes work into **stages** (logical phases), **jobs** (parallelizable units on an agent pool), and **steps** (individual tasks). A **deployment job** differs from a regular job because it targets a named [environment](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/environments?view=azure-devops) and records deployment history against that environment's resources.
+
+**YAML templates** reduce duplication across microservices. Store shared build steps in `templates/build.yml` and reference them with:
+
+```yaml
+stages:
+  - template: templates/build-and-push.yml
+    parameters:
+      acrServiceConnection: acr-service-connection
+      imageName: $(imageName)
+```
+
+Template parameters let one pipeline definition serve multiple services while keeping service-specific values in variable groups or pipeline variables.
+
+**Environments** in Azure DevOps represent logical targets such as Dev, Staging, and Production. When a deployment job sets `environment: production`, Azure DevOps evaluates [approvals and checks](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/approvals?view=azure-devops) configured on that environment. A release waiting for approval does not consume a parallel job slot, which matters when your organization has limited concurrency.
+
+**Deployment strategies** control how new bits reach users:
+
+| Strategy | Behavior | Azure DevOps mechanism | Best for |
+| :--- | :--- | :--- | :--- |
+| **Rolling / runOnce** | Replace instances sequentially or all at once | `strategy: runOnce` on deployment job | Simple web apps, Container Apps revisions |
+| **Blue-green** | Two full environments; switch traffic atomically | Two resource groups or App Service slots; swap after validation | Zero-downtime web tiers |
+| **Canary** | Route small traffic percentage to new version | App Service slot with routing rules; AKS service mesh weights | Risk-sensitive APIs |
+| **Ring-based** | Promote through internal → partner → broad audiences | Sequential stages with distinct environment names | Large SaaS with staged audiences |
+
+**Gated promotion** means no artifact reaches production without passing staging checks and human or automated approval. Configure branch filters so only `main` triggers production stages. Use `dependsOn` and `condition: succeeded()` so a failed smoke test blocks downstream stages automatically.
+
+### GitHub Actions: workflows, reusable workflows, and environments
+
+GitHub Actions uses **workflows** (YAML files under `.github/workflows/`), **jobs** (run on a runner), and **steps** (shell commands or actions). **Reusable workflows** (`workflow_call`) let a platform team publish a blessed deploy pattern:
+
+```yaml
+# .github/workflows/reusable-deploy.yml
+on:
+  workflow_call:
+    inputs:
+      environment:
+        required: true
+        type: string
+      image:
+        required: true
+        type: string
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: ${{ inputs.environment }}
+    steps:
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - uses: azure/container-apps-deploy-action@v2
+        with:
+          containerAppName: myapp-${{ inputs.environment }}
+          resourceGroup: rg-${{ inputs.environment }}
+          imageToDeploy: ${{ inputs.image }}
+```
+
+Calling repositories invoke the reusable workflow with `uses: org/repo/.github/workflows/reusable-deploy.yml@main` and pass inputs. Centralizing OIDC login and deploy actions prevents each team from inventing a slightly different—and slightly insecure—pattern.
+
+**GitHub Environments** (`environment: production` on a job) provide [protection rules](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment): required reviewers, wait timers, deployment branches, and environment-scoped secrets. Production secrets should live in the production environment, not repository-wide secrets, so a staging job cannot read them even if YAML is maliciously edited.
+
+For **gated promotion** in GitHub Actions, chain jobs with `needs:` and attach stricter environments to later jobs. Run automated smoke tests in the staging job before the production job becomes eligible. Use `workflow_dispatch` inputs when you want manual control over which version promotes without pushing a new commit.
+
+### Deployment strategies on Azure compute targets
+
+**Blue-green on App Service** uses deployment slots. Deploy the new build to a staging slot, warm it up, then swap slots so production traffic moves atomically. Rollback is another swap operation.
+
+**Canary on Container Apps** creates a new revision with a traffic weight below 100%. Monitor error rates and latency, then shift weight to the new revision or deactivate it. [Managing revisions](https://learn.microsoft.com/en-us/azure/container-apps/revisions-manage) is your rollback lever when a bad image ships.
+
+**Ring-based promotion** maps cleanly to sequential pipeline stages: `deploy-internal` → `deploy-partner` → `deploy-public`, each with its own environment approvals and monitoring dashboard. Fail fast in early rings before customer-facing rings receive the build.
+
+---
+
+## Deploying to Azure Targets
+
+Different Azure services expect different deploy mechanics. A pipeline that works for Container Apps will not drop cleanly onto AKS without manifest or Helm steps. Infrastructure pipelines differ again because they mutate control plane resources rather than application bits.
+
+### App Service
+
+[Deploy to App Service from GitHub Actions](https://learn.microsoft.com/en-us/azure/app-service/deploy-github-actions) typically uses `azure/webapps-deploy@v3` after `azure/login`. For containerized App Service, build and push to ACR first, then deploy the image reference:
+
+```yaml
+      - name: Deploy to App Service
+        uses: azure/webapps-deploy@v3
+        with:
+          app-name: my-webapp
+          images: ${{ env.ACR_NAME }}.azurecr.io/${{ env.IMAGE_NAME }}:${{ github.sha }}
+```
+
+Use **deployment slots** for staging. Point the staging slot at the candidate image, run smoke tests against the slot URL, then swap into production. Slot settings can stick to the slot or travel with the swap depending on configuration, which matters for connection strings that differ between staging and production.
+
+Azure Pipelines uses the `AzureWebAppContainer@1` task with the same image reference pattern and a service connection for authentication.
+
+### Azure Container Apps
+
+Container Apps deployments create a **new revision** when the template changes or the container image tag changes. The [`azure/container-apps-deploy-action`](https://learn.microsoft.com/en-us/azure/container-apps/github-actions) handles Dockerfile builds, source-to-cloud builds, or deploying a pre-built image tag.
+
+Best practices for Container Apps CI/CD:
+
+- Tag images with immutable identifiers such as the Git commit SHA, not only `latest`.
+- Configure the app to pull from ACR using **managed identity** with `AcrPull` rather than admin credentials.
+- Keep environment-specific values in Container Apps secrets or Key Vault references, not baked into the image.
+- Roll back by [activating a previous healthy revision](https://learn.microsoft.com/en-us/azure/container-apps/revisions-manage) rather than rebuilding old code under pressure.
+
+### AKS: build, push, deploy
+
+AKS pipelines follow a three-step rhythm: build container image, push to ACR, update the cluster workload. GitHub Actions and Azure DevOps both support this pattern with `azure/login`, `az acr build` or `docker build-push-action`, then `Azure/k8s-deploy` or `kubectl`/`helm` against the cluster.
+
+A minimal GitHub Actions fragment for manifest deploy:
+
+```yaml
+      - name: Build and push
+        run: |
+          az acr build --registry ${{ env.ACR_NAME }} \
+            --image myapp:${{ github.sha }} .
+
+      - name: Set AKS context
+        uses: azure/aks-set-context@v4
+        with:
+          cluster-name: my-aks
+          resource-group: my-rg
+
+      - name: Deploy manifests
+        uses: Azure/k8s-deploy@v5
+        with:
+          action: deploy
+          manifests: |
+            k8s/deployment.yaml
+            k8s/service.yaml
+          images: |
+            ${{ env.ACR_NAME }}.azurecr.io/myapp:${{ github.sha }}
+```
+
+For private AKS API servers, run agents inside the cluster VNet or use a self-hosted runner with network connectivity. Microsoft recommends self-hosted agents for [private cluster deployment jobs](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/environments?view=azure-devops).
+
+Use Helm when charts encapsulate environment-specific values files (`values-staging.yaml`, `values-production.yaml`). Pipeline parameters select the values file per stage.
+
+### Infrastructure: Bicep and Terraform with what-if
+
+Infrastructure pipelines should **preview before apply**. ARM/Bicep supports [`az deployment group what-if`](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deploy-what-if) to show creates, modifications, and deletes without changing resources. Terraform offers `terraform plan` with equivalent intent.
+
+Example Bicep gate in GitHub Actions:
+
+```yaml
+      - name: Bicep what-if
+        run: |
+          az deployment group what-if \
+            --resource-group ${{ env.RG }} \
+            --template-file infra/main.bicep \
+            --parameters @infra/main.parameters.json
+
+      - name: Bicep deploy
+        if: github.ref == 'refs/heads/main'
+        run: |
+          az deployment group create \
+            --resource-group ${{ env.RG }} \
+            --template-file infra/main.bicep \
+            --parameters @infra/main.parameters.json
+```
+
+Run what-if on every pull request. Run apply only from protected branches after approval. Store Terraform state in Azure Storage with blob locking. Never commit state files to Git.
+
+**Terraform on Azure** follows the same preview-then-apply rhythm. Configure the `azurerm` backend to use a storage account container with state locking. In GitHub Actions, run `terraform init`, `terraform plan -out=tfplan`, upload the plan artifact, and require a separate approved job for `terraform apply tfplan`. In Azure DevOps, split plan and apply stages; gate apply with an environment approval on production.
+
+Use **OIDC for Terraform** the same way as application deploys: configure `azure/login` or workload identity federation, then set ARM environment variables (`ARM_USE_OIDC=true`, `ARM_CLIENT_ID`, `ARM_TENANT_ID`, `ARM_SUBSCRIPTION_ID`) so the Terraform Azure provider acquires tokens without a client secret. Scope the identity to the resource groups Terraform manages, not the entire subscription, unless your modules genuinely require subscription-wide resources.
+
+When pipelines manage both Bicep and Terraform temporarily during migration, enforce a single source of truth per resource group. Running Bicep deploy and Terraform apply against the same scope causes state drift that what-if and plan output cannot reconcile without manual intervention.
+
+Separate **application pipelines** from **infrastructure pipelines** when lifecycles differ. Application teams may deploy daily; platform teams may apply Bicep weekly. Different identities and approval paths reduce the chance that an application deploy accidentally touches network or identity resources.
+
+### Artifacts, config, and rollback
+
+**Artifacts** carry build outputs between stages: container images in ACR, ZIP packages for App Service, Helm charts in ACR or Artifacts, Bicep modules in a Git tag. Pin artifact versions with immutable tags or digest SHAs so a production redeploy pulls the exact bits you tested in staging.
+
+**Environment-specific configuration** belongs in Azure App Configuration, Key Vault references, Container Apps secrets, or Kubernetes ConfigMaps and Secrets—not in the same artifact as code when values differ per environment. Inject config at deploy time so one image promotes across stages unchanged.
+
+**Rollback** is service-specific: swap App Service slots, shift Container Apps traffic to a prior revision, `helm rollback` on AKS, or redeploy a previous Bicep deployment from Git history. Document rollback in the pipeline README and test it quarterly. A rollback procedure you have never executed is a hope, not a plan.
+
+### Minimal OIDC workflow reference
+
+The workflow below consolidates login, ACR build, and Container Apps deploy in one file for labs and small services:
+
+```yaml
+name: OIDC Deploy
+on:
+  push:
+    branches: [main]
+permissions:
+  id-token: write
+  contents: read
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    environment: production
+    steps:
+      - uses: actions/checkout@v4
+      - uses: azure/login@v2
+        with:
+          client-id: ${{ secrets.AZURE_CLIENT_ID }}
+          tenant-id: ${{ secrets.AZURE_TENANT_ID }}
+          subscription-id: ${{ secrets.AZURE_SUBSCRIPTION_ID }}
+      - run: az acr build --registry $ACR --image app:${{ github.sha }} .
+        env:
+          ACR: ${{ secrets.ACR_NAME }}
+      - uses: azure/container-apps-deploy-action@v2
+        with:
+          resourceGroup: ${{ secrets.RESOURCE_GROUP }}
+          containerAppName: ${{ secrets.CONTAINER_APP_NAME }}
+          imageToDeploy: ${{ secrets.ACR_NAME }}.azurecr.io/app:${{ github.sha }}
+```
 
 ---
 
@@ -395,6 +710,12 @@ az vm create \
 
 Self-hosted runners introduce operational responsibility: you patch the OS, rotate registration tokens, and ensure one job cannot read another job's workspace artifacts. For production GitHub Actions scale-out, use the official **Actions Runner Controller (ARC)** on AKS, which [auto-scales runners based on pending jobs](https://github.com/actions/actions-runner-controller/blob/master/docs/automatically-scaling-runners.md) so you pay for capacity only while workflows are queued or running.
 
+When sizing self-hosted capacity, model peak concurrent jobs rather than average developer count. A team of fifteen engineers might run only three concurrent builds on a typical afternoon but spike to twelve when everyone merges before a release freeze. VM Scale Sets or ARC autoscaling policies should target queue depth, not CPU utilization alone, because idle runners still cost money while queued jobs delay releases.
+
+**Network placement** matters as much as CPU. Runners that deploy to private AKS clusters or pull from ACR via private endpoints must sit on subnets with routing to those endpoints. Document outbound allow lists if your security team restricts runner internet access—GitHub and Azure DevOps still need HTTPS to orchestration endpoints even when builds are otherwise internal.
+
+**Isolation between jobs** on the same runner prevents credential bleed. GitHub-hosted runners solve this by destroying the VM after each job. Self-hosted runners must clean workspaces aggressively, run ephemeral containers where possible, and avoid reusing Docker volumes that might retain `.azure` credential caches between jobs owned by different teams.
+
 > **Pause and predict**: Why might deploying a self-hosted runner inside your production virtual network introduce new security risks compared to using Microsoft-hosted runners?
 
 ---
@@ -426,7 +747,151 @@ flowchart TD
 
 If a repository can run or merge workflow changes without adequate review and a pipeline relies on long-lived cloud credentials, an attacker may be able to alter the workflow, expose those credentials, and use them against production resources. The practical defenses are to remove long-lived secrets, require approvals for protected environments, and enforce review on workflow changes.
 
+### Supply chain and workflow integrity
+
+Modern pipelines compose dozens of third-party actions and tasks. Treat each `uses:` reference and each Azure DevOps marketplace task as a dependency with supply-chain risk. Pin GitHub Actions to immutable commit SHAs for anything that touches credentials, production deploy paths, or forked pull-request workflows. Periodically bump SHAs through an automated pull request that runs your test suite before merge.
+
+Restrict **`pull_request_target`** workflows unless you fully understand the security model. That trigger runs in the base repository context with access to base secrets while checking out untrusted fork code—a dangerous combination when misconfigured. Prefer `pull_request` with OIDC subjects scoped to read-only sandbox subscriptions for external contributions.
+
+Enable **branch protection** on default branches and on `.github/workflows/**` path rules where GitHub supports it. Require CODEOWNERS review for workflow changes so a single compromised contributor account cannot silently alter production deploy steps. In Azure DevOps, restrict who can edit YAML pipelines and service connections through project-level permissions and audit streaming to Log Analytics or Sentinel.
+
+### Observability: correlating pipeline runs with Azure Activity Log
+
+When a production incident traces to a deployment, you need a fast answer to who deployed what and when. GitHub Actions retains workflow run history with commit SHA, actor, and job logs. Azure DevOps environments show deployment history with work-item links. On the Azure side, [Activity Log](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/activity-log) records resource modifications with caller identity and correlation IDs.
+
+Forward pipeline audit events to your SIEM. Alert on service principal logins from unexpected IP ranges, spikes in failed OIDC token exchanges, or deployment jobs that skip staging environments because someone edited YAML conditions. The goal is not to log every successful build—it is to detect anomalous promotion paths before they repeat.
+
 > **Stop and think**: If you use branch protection rules to require pull request reviews, how could an attacker with Contributor access to the repository still compromise the pipeline without merging a PR?
+
+---
+
+## Cost Lens: Runners, Minutes, and Parallel Jobs
+
+CI/CD cost surprises usually come from concurrency and trigger design, not from Azure resource consumption alone. Two billing models dominate this module: GitHub Actions minutes for hosted runners, and Azure DevOps parallel jobs for Microsoft-hosted agents.
+
+### GitHub Actions hosted runner economics
+
+For **private repositories**, GitHub includes a monthly minute allowance that depends on your plan. GitHub Free includes 2,000 minutes; GitHub Team includes 3,000; GitHub Enterprise Cloud includes 50,000 according to [GitHub Actions billing](https://docs.github.com/en/billing/managing-billing-for-github-actions/about-billing-for-github-actions). Minutes reset at the start of each billing cycle. Usage beyond the allowance bills per minute by runner SKU.
+
+Baseline per-minute rates for standard hosted runners (USD) from GitHub's billing documentation:
+
+| Runner SKU | Approximate per-minute rate |
+| :--- | :--- |
+| Linux 2-core (`actions_linux`) | $0.006 |
+| Windows 2-core (`actions_windows`) | $0.010 |
+| macOS (`actions_macos`) | $0.062 |
+
+**Public repositories** using standard GitHub-hosted runners do not consume billable minutes for those jobs. That is why open-source workflows can run extensive matrices without minute charges, while identical patterns in private repos accrue cost quickly.
+
+**Self-hosted runners** do not consume GitHub-hosted minutes. You pay for the Azure VMs, scale sets, or AKS nodes that run the agents instead. Self-hosted makes financial sense when you need sustained high concurrency, large runners, or long-running builds that would exhaust included minutes in days.
+
+Cost spikes on GitHub Actions often trace to:
+
+- **Matrix builds** that multiply jobs (`os × node-version × service` can turn one push into dozens of jobs).
+- **Chatty triggers** such as `on: push` without path filters, rebuilding on every documentation commit.
+- **Windows or macOS runners** when Linux would suffice (macOS is roughly ten times the Linux minute rate).
+- **Artifact and cache storage** billed hourly in GB-hours beyond included storage pools.
+
+Mitigations include path filters, concurrency groups to cancel superseded runs, caching dependencies with deterministic keys, and running expensive integration tests on a schedule rather than every push.
+
+### Azure DevOps parallel job economics
+
+Azure DevOps bills **parallel jobs**, not individual pipeline definitions. Each running job on a Microsoft-hosted agent consumes one parallel job from your organization's pool until it finishes. Private projects receive a limited free grant (commonly one parallel job up to 60 minutes per run and 1,800 minutes per month) as described in [Configure and pay for parallel jobs](https://learn.microsoft.com/en-us/azure/devops/pipelines/licensing/concurrent-jobs). Additional parallel jobs are purchased at the organization level and shared across all projects.
+
+Important consumption details:
+
+- A release **waiting for manual approval does not consume** a parallel job slot.
+- **Self-hosted agents** do not require paid Microsoft-hosted parallel jobs for the agent itself—you supply the machines.
+- Queued jobs indicate insufficient parallel capacity; purchasing another parallel job removes queue delay but increases monthly cost.
+
+Rule of thumb from Microsoft: estimate **one parallel job per four to five active developers** when many pipelines run concurrently. Teams with multiple products on one organization may need more.
+
+### Azure-side costs triggered by pipelines
+
+Pipelines also incur Azure service charges:
+
+- **ACR Tasks** and `az acr build` bill for build compute separately from GitHub or Azure DevOps minutes.
+- **Container Apps** create new revisions on deploy; idle revisions you forget to deactivate still consume resources if left active.
+- **Key Vault** operations and secret retrieval during deploy steps accrue per-transaction fees at scale.
+
+Treat pipeline cost as **platform minutes + Azure build/deploy resources + engineer time waiting in queues**. Right-sizing parallel jobs and using path filters often saves more than switching cloud SKUs.
+
+---
+
+## Patterns & Anti-Patterns
+
+These patterns reflect what mature Azure CI/CD teams repeat across GitHub Actions and Azure DevOps. They prioritize safe promotion, observable deploys, and identities that survive audits.
+
+| Pattern | When to Use | Why It Works | Scaling Note |
+| :--- | :--- | :--- | :--- |
+| **OIDC federation for every Azure deploy identity** | All new pipelines targeting Azure | Eliminates secret rotation toil and shrinks exfiltration value | Separate federated credentials per environment before repo count grows |
+| **Environment-scoped secrets and approvals** | Staging and production deploys | Staging jobs cannot read production secrets; humans gate prod | Map GitHub Environments or ADO environments to Azure resource groups |
+| **Immutable image tags per commit** | Container deploys to ACR, AKS, Container Apps | Rollback pulls a known artifact; `latest` hides what ran | Retention policies on ACR tags prevent unbounded storage cost |
+| **What-if / plan before infra apply** | Bicep, ARM, Terraform pipelines | Surprises surface in PR comments, not in production outages | Run plan on PR; apply only from default branch with approval |
+| **Reusable workflows or YAML templates** | Many repos with identical deploy shape | One security fix propagates everywhere | Version reusable workflows with tags or SHA pins |
+| **Path-filtered triggers** | Monorepos with docs, infra, and app folders | Docs edits skip multi-hour test matrices | Tune filters when new top-level folders appear |
+
+| Anti-Pattern | What Goes Wrong | Why Teams Fall Into It | Better Alternative |
+| :--- | :--- | :--- | :--- |
+| **One service principal for all environments** | Staging compromise becomes production compromise | Single OIDC setup is faster on day one | Separate apps, federated credentials, and RBAC scopes per environment |
+| **Contributor on the subscription for deployers** | Pipeline can delete unrelated resources | Broad role always "works" during debugging | Scope to resource group; use custom roles without delete |
+| **Deploy on every branch push to production targets** | Feature branches overwrite prod | Simple `on: push` trigger | Restrict production jobs to `main` and protected environments |
+| **Skipping smoke tests before approval gates** | Approvers click approve without signal | Pressure to ship fast | Automated HTTP or health checks in staging job outputs |
+| **Mutable `@v4` action tags only** | Tag hijack supply-chain risk | Tags are readable in reviews | Pin actions to full commit SHA; automate SHA bumps |
+| **Building on hosted runners then pushing huge contexts** | Slow uploads inflate minutes | Familiar Docker local workflow | ACR Tasks or `az acr build` builds inside Azure near the registry |
+| **No tested rollback** | Incidents extend while teams invent rollback | Rollback feels rare until it is not | Document slot swap, revision activate, or `helm rollback` and drill quarterly |
+
+---
+
+## Decision Framework: Platform, Auth, and Runners
+
+Choose CI/CD components based on where code lives, who must approve production change, and whether builds need private network access—not based on which logo your team prefers.
+
+```mermaid
+flowchart TD
+    A[Where does source code live?] --> B{Primarily GitHub?}
+    B -- Yes --> C{Need Azure DevOps Boards/Test Plans integration?}
+    C -- No --> D[GitHub Actions default]
+    C -- Yes --> E[Evaluate Azure DevOps Pipelines or dual remotes]
+    B -- No --> F{Already on Azure DevOps Repos?}
+    F -- Yes --> G[Azure DevOps Pipelines default]
+    F -- No --> H[Mirror repo or use GitHub Actions with Azure deploy]
+
+    D --> I{Authenticate to Azure how?}
+    G --> I
+    I -- Zero secrets --> J[OIDC / workload identity federation]
+    I -- Legacy integration --> K[Migrate to OIDC on schedule]
+
+    J --> L{Runner location?}
+    K --> L
+    L -- Public SaaS build --> M[Hosted runners / Microsoft-hosted agents]
+    L -- Private VNet resources --> N[Self-hosted runners / self-hosted agents]
+```
+
+| Decision | Choose GitHub Actions | Choose Azure DevOps Pipelines | Notes |
+| :--- | :--- | :--- | :--- |
+| Source of truth is GitHub.com | Default | Only if org mandates ADO for work tracking | Actions colocate workflows with code reviews |
+| Entire eng org on Azure DevOps | Possible via mirroring | Default | Service connections integrate natively |
+| OIDC to Azure | `azure/login` + federated credentials | Workload identity service connections | Both avoid client secrets when configured correctly |
+| Secret-based service principal | Migrate away | Migrate away | Acceptable only as temporary bridge |
+| Hosted runners | GitHub-hosted (minutes billing) | Microsoft-hosted (parallel jobs) | macOS builds are expensive on GitHub hosted |
+| Self-hosted | ARC on AKS or VMSS | VMSS or ACI agents in your VNet | You patch OS and isolate job workspaces |
+| Reusable pipeline logic | Reusable workflows | YAML templates + template repos | Pin versions to prevent drift |
+| Manual production gate | GitHub Environment reviewers | ADO environment approvals | Both support wait timers and branch filters |
+
+**Authentication decision:** Prefer OIDC unless a third-party tool literally cannot federate and you have a dated exception register entry. Secret-based connections require rotation evidence in audits.
+
+**Runner decision:** Start hosted until you hit one of three walls: private resource access, compliance requirement for tenant-isolated compute, or minute/job cost exceeding the VM fleet you would operate anyway. Then deploy self-hosted agents with autoscaling rather than a single pet VM.
+
+**Platform decision:** If developers already live in GitHub pull requests, GitHub Actions reduces context switching. If portfolio management, test plans, and pipelines must share Azure DevOps permissions boundaries, Azure DevOps Pipelines is the coherent default. Many enterprises run GitHub Actions for CI and Azure DevOps for release gates against the same ACR images—pick consciously and document which system owns production approval.
+
+### Applying the framework to a hybrid example
+
+Consider a product team with application code on GitHub and a platform team managing Bicep modules in Azure DevOps. A sensible split: GitHub Actions builds and pushes images to ACR on every merge to main using OIDC scoped to `AcrPush`. Azure DevOps YAML consumes the immutable tag as a pipeline resource, runs integration tests in a staging environment with automated checks, then waits for a release manager approval before a deployment job updates production Container Apps. Each system does what its permissions model handles best without sharing long-lived secrets across both.
+
+Document the handoff explicitly: which pipeline produces the canonical artifact tag, which environment name in each system maps to which Azure resource group, and which on-call rotation receives failed approval notifications. Ambiguity at that boundary causes double deploys or, worse, the assumption that "someone else already promoted to production."
+
+When evaluating a migration from secret-based service connections to OIDC, schedule the Entra work first, validate staging pipelines, then cut production over during a maintenance window with rollback credentials revoked immediately after success. Parallel secret and OIDC paths during migration are acceptable for days, not quarters—dual paths double audit findings and confuse on-call engineers about which identity actually deployed a failing revision.
 
 ---
 
@@ -495,6 +960,18 @@ You could have prevented this attack by referencing the third-party action using
 You should design a single workflow with three sequential jobs: a build job, a staging deploy job, and a production deploy job. The staging and production jobs must be associated with their respective GitHub Environments to leverage environment-specific variables and enforce the required manual approval gate on the production environment. For secure authentication, you should configure separate OIDC federated credentials in Entra ID for both the staging and production environments by matching the `subject` claims to those specific environments. This approach ensures the principle of least privilege, as the staging job will only receive an Azure token with Contributor access to the staging resource group. By scoping access at the environment level, you completely isolate the pipeline stages and prevent staging compromise from affecting production infrastructure.
 </details>
 
+<details>
+<summary>7. Your platform team runs Azure DevOps pipelines with Microsoft-hosted agents. Builds queue for 20+ minutes during business hours even though individual jobs finish in eight minutes. Parallel job settings show one Microsoft-hosted parallel job. What is the most likely cause, and what two changes address both wait time and cost?</summary>
+
+The organization is limited to a single Microsoft-hosted parallel job, so every job after the first waits in queue until the prior job releases the slot. Purchase or request additional parallel jobs for the organization so multiple pipelines can run concurrently during peak hours. Complement capacity with path filters, pipeline caching, and cancelling redundant runs so each consumed parallel job minute delivers more value. Self-hosted agents are an alternative when queue time remains unacceptable and you already operate a VM fleet with spare capacity.
+</details>
+
+<details>
+<summary>8. A developer proposes running `az deployment group create` directly from a laptop against production because "the pipeline what-if step is too slow." What risks does bypassing the pipeline introduce, and how should the team respond without blocking legitimate hotfixes?</summary>
+
+Manual CLI deploys bypass environment approvals, omit audit correlation with pull requests, and rely on whatever credential happens to be on the laptop—often over-privileged and unrotated. Respond by documenting an emergency break-glass pipeline triggered via `workflow_dispatch` or Azure DevOps manual run that still uses OIDC, requires two approvers, and writes to Activity Log. Hotfixes should change code in Git and flow through the expedited pipeline so the fix is reproducible and reviewable after the incident stabilizes.
+</details>
+
 ---
 
 ## Hands-On Exercise: GitHub Actions OIDC Auth to ACR Build and Container Apps Deploy
@@ -502,6 +979,14 @@ You should design a single workflow with three sequential jobs: a build job, a s
 In this exercise, you will set up OIDC authentication between GitHub Actions and Azure, build a container image with ACR Tasks, and deploy it to Container Apps. The sequence mirrors what many teams adopt in production: provision registry and runtime infrastructure, establish federated trust between GitHub and Entra ID, then wire a workflow that builds on every push to main without storing Azure passwords in GitHub.
 
 You need the Azure CLI, a GitHub repository, and optionally the `gh` CLI for setting repository secrets from your terminal. Work through the tasks in order because later steps reference resource names and object IDs created earlier.
+
+### Troubleshooting common lab failures
+
+If `azure/login` fails with an OIDC error, verify three items in order: the workflow declares `permissions: id-token: write`, the federated credential `subject` exactly matches your repository and branch or environment, and the three identifier secrets contain no trailing whitespace. Entra ID rejects tokens when the subject claim differs by even one character from the registered value.
+
+If `az acr build` succeeds but Container Apps still serves an old image, confirm the deploy step references the same tag the build pushed and that the app has permission to pull from ACR via managed identity or admin credentials configured earlier. Container Apps creates a new revision only when the template image reference changes; pushing `latest` without updating the app template may leave traffic on an older revision.
+
+If the GitHub workflow never triggers, check that the default branch name in `on.push.branches` matches your repository and that Actions is enabled under repository Settings. Organization policies can disable Actions for new repositories until an administrator allowlists them.
 
 ### Task 1: Create Azure Infrastructure
 
@@ -772,8 +1257,16 @@ az ad app delete --id "$APP_OBJECT_ID"
 - [learn.microsoft.com: yaml schema](https://learn.microsoft.com/en-us/azure/devops/pipelines/yaml-schema/?view=azure-pipelines) — The Azure Pipelines YAML schema and jobs documentation define pipelines, stages, jobs, and steps in these terms.
 - [learn.microsoft.com: configure app secret](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/configure-app-secret?view=azure-devops) — Microsoft Learn explicitly says secret-based ARM service connections are not recommended and that workload identity federation is the preferred credential type.
 - [learn.microsoft.com: approvals](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/approvals?view=azure-devops) — Microsoft Learn explicitly documents manual approval checks on environments that pause a stage until approval is granted.
-- [github.com: automatically scaling runners.md](https://github.com/actions/actions-runner-controller/blob/master/docs/automatically-scaling-runners.md) — The official ARC repository documents autoscaling using queued and in-progress workflow runs.
 - [learn.microsoft.com: caching](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/caching?view=azure-devops) — Microsoft Learn directly documents pipeline caching behavior and the Cache task model.
 - [learn.microsoft.com: container registry tasks overview](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-tasks-overview) — The ACR Tasks overview directly documents cloud-based builds and on-demand builds without a local Docker engine.
 - [learn.microsoft.com: revisions manage](https://learn.microsoft.com/en-us/azure/container-apps/revisions-manage) — Microsoft Learn directly documents activating and deactivating Container Apps revisions.
 - [Azure DevOps Workload Identity Service Connections](https://learn.microsoft.com/en-us/azure/devops/pipelines/release/configure-workload-identity?view=azure-devops) — Primary Microsoft guidance for Azure DevOps workload identity federation and service connection setup.
+- [learn.microsoft.com: environments](https://learn.microsoft.com/en-us/azure/devops/pipelines/process/environments?view=azure-devops) — Documents Azure DevOps environments, deployment history, and approval integration with deployment jobs.
+- [learn.microsoft.com: parallel jobs](https://learn.microsoft.com/en-us/azure/devops/pipelines/licensing/concurrent-jobs) — Explains Microsoft-hosted versus self-hosted parallel jobs, free tier limits, and purchasing additional capacity.
+- [learn.microsoft.com: Container Apps GitHub Actions](https://learn.microsoft.com/en-us/azure/container-apps/github-actions) — Official guidance for the azure/container-apps-deploy-action and revision-based deploy flows.
+- [learn.microsoft.com: deploy Bicep GitHub Actions](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deploy-github-actions) — Quickstart for OIDC-based Bicep deployment from GitHub Actions using azure/login and azure/arm-deploy.
+- [learn.microsoft.com: Bicep what-if](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deploy-what-if) — Documents az deployment group what-if preview behavior before infrastructure apply.
+- [learn.microsoft.com: App Service GitHub Actions](https://learn.microsoft.com/en-us/azure/app-service/deploy-github-actions) — Deploy web apps and container images to App Service from GitHub Actions workflows.
+- [learn.microsoft.com: custom roles](https://learn.microsoft.com/en-us/azure/role-based-access-control/custom-roles) — Reference for narrowing pipeline identity permissions below built-in Contributor scope.
+- [learn.microsoft.com: Activity Log](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/activity-log) — Azure platform log of subscription-level events including deployments and role assignments triggered by pipeline identities.
+- [github.com: automatically scaling runners.md](https://github.com/actions/actions-runner-controller/blob/master/docs/automatically-scaling-runners.md) — The official ARC repository documents autoscaling using queued and in-progress workflow runs.

--- a/src/content/docs/cloud/azure-essentials/module-3.11-cicd.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.11-cicd.md
@@ -167,12 +167,13 @@ To create a Workload Identity Federation service connection in Azure DevOps, use
 # Manual setup: Create app registration with federated credential for Azure DevOps
 az ad app create --display-name "azure-devops-cicd"
 APP_ID=$(az ad app list --display-name "azure-devops-cicd" --query '[0].appId' -o tsv)
+APP_OBJECT_ID=$(az ad app list --display-name "azure-devops-cicd" --query '[0].id' -o tsv)
 
 # Create service principal
 az ad sp create --id "$APP_ID"
 
 # Add federated credential for Azure DevOps
-az ad app federated-credential create --id "$APP_ID" --parameters '{
+az ad app federated-credential create --id "$APP_OBJECT_ID" --parameters '{
   "name": "azure-devops-federation",
   "issuer": "https://vstoken.dev.azure.com/YOUR_ORG_ID",
   "subject": "sc://YOUR_ORG/YOUR_PROJECT/YOUR_SERVICE_CONNECTION",
@@ -182,7 +183,8 @@ az ad app federated-credential create --id "$APP_ID" --parameters '{
 # Grant the service principal appropriate RBAC
 SP_OBJECT_ID=$(az ad sp show --id "$APP_ID" --query id -o tsv)
 az role assignment create \
-  --assignee "$SP_OBJECT_ID" \
+  --assignee-object-id "$SP_OBJECT_ID" \
+  --assignee-principal-type ServicePrincipal \
   --role Contributor \
   --scope "/subscriptions/<sub-id>/resourceGroups/myRG"
 ```
@@ -432,11 +434,16 @@ SP_OBJECT_ID=$(az ad sp show --id "$APP_ID" --query id -o tsv)
 
 # ACR push access
 ACR_ID=$(az acr show -n myacr --query id -o tsv)
-az role assignment create --assignee "$SP_OBJECT_ID" --role AcrPush --scope "$ACR_ID"
+az role assignment create \
+  --assignee-object-id "$SP_OBJECT_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --role AcrPush \
+  --scope "$ACR_ID"
 
 # Container Apps contributor access
 az role assignment create \
-  --assignee "$SP_OBJECT_ID" \
+  --assignee-object-id "$SP_OBJECT_ID" \
+  --assignee-principal-type ServicePrincipal \
   --role Contributor \
   --scope "/subscriptions/<sub-id>/resourceGroups/myRG"
 ```
@@ -978,13 +985,13 @@ Manual CLI deploys bypass environment approvals, omit audit correlation with pul
 
 In this exercise, you will set up OIDC authentication between GitHub Actions and Azure, build a container image with ACR Tasks, and deploy it to Container Apps. The sequence mirrors what many teams adopt in production: provision registry and runtime infrastructure, establish federated trust between GitHub and Entra ID, then wire a workflow that builds on every push to main without storing Azure passwords in GitHub.
 
-You need the Azure CLI, a GitHub repository, and optionally the `gh` CLI for setting repository secrets from your terminal. Work through the tasks in order because later steps reference resource names and object IDs created earlier.
+You need the Azure CLI, a GitHub repository, and optionally the `gh` CLI for setting repository secrets from your terminal. Install the Container Apps extension if needed: `az extension add --name containerapp`. Work through the tasks in order because later steps reference resource names and object IDs created earlier.
 
 ### Troubleshooting common lab failures
 
 If `azure/login` fails with an OIDC error, verify three items in order: the workflow declares `permissions: id-token: write`, the federated credential `subject` exactly matches your repository and branch or environment, and the three identifier secrets contain no trailing whitespace. Entra ID rejects tokens when the subject claim differs by even one character from the registered value.
 
-If `az acr build` succeeds but Container Apps still serves an old image, confirm the deploy step references the same tag the build pushed and that the app has permission to pull from ACR via managed identity or admin credentials configured earlier. Container Apps creates a new revision only when the template image reference changes; pushing `latest` without updating the app template may leave traffic on an older revision.
+If `az acr build` succeeds but Container Apps still serves an old image, confirm the deploy step references the same tag the build pushed and that the app has permission to pull from ACR via the managed identity configured in Task 1. Container Apps creates a new revision only when the template image reference changes; pushing `latest` without updating the app template may leave traffic on an older revision.
 
 If the GitHub workflow never triggers, check that the default branch name in `on.push.branches` matches your repository and that Actions is enabled under repository Settings. Organization policies can disable Actions for new repositories until an administrator allowlists them.
 
@@ -1014,6 +1021,15 @@ az containerapp create \
   --target-port 80 \
   --ingress external \
   --min-replicas 1
+
+# Give the Container App a system-assigned identity and let it pull from ACR
+az containerapp identity assign -g "$RG" -n "$APP_NAME" --system-assigned
+APP_MI_PRINCIPAL=$(az containerapp identity show -g "$RG" -n "$APP_NAME" --query principalId -o tsv)
+ACR_ID=$(az acr show -n "$ACR_NAME" --query id -o tsv)
+az role assignment create --assignee-object-id "$APP_MI_PRINCIPAL" \
+  --assignee-principal-type ServicePrincipal --role AcrPull --scope "$ACR_ID"
+az containerapp registry set -g "$RG" -n "$APP_NAME" \
+  --server "$ACR_NAME.azurecr.io" --identity system
 
 APP_URL=$(az containerapp show -g "$RG" -n "$APP_NAME" --query properties.configuration.ingress.fqdn -o tsv)
 echo "App URL: https://$APP_URL"
@@ -1052,11 +1068,19 @@ az ad app federated-credential create --id "$APP_OBJECT_ID" --parameters '{
 
 # Grant RBAC: ACR Push
 ACR_ID=$(az acr show -n "$ACR_NAME" --query id -o tsv)
-az role assignment create --assignee "$SP_OBJECT_ID" --role AcrPush --scope "$ACR_ID"
+az role assignment create \
+  --assignee-object-id "$SP_OBJECT_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --role AcrPush \
+  --scope "$ACR_ID"
 
 # Grant RBAC: Container Apps Contributor
 RG_ID=$(az group show -n "$RG" --query id -o tsv)
-az role assignment create --assignee "$SP_OBJECT_ID" --role Contributor --scope "$RG_ID"
+az role assignment create \
+  --assignee-object-id "$SP_OBJECT_ID" \
+  --assignee-principal-type ServicePrincipal \
+  --role Contributor \
+  --scope "$RG_ID"
 
 # Output the values you need for GitHub secrets
 TENANT_ID=$(az account show --query tenantId -o tsv)

--- a/src/content/docs/cloud/azure-essentials/module-3.12-bicep.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.12-bicep.md
@@ -17,9 +17,9 @@ This **[MEDIUM]**-complexity module takes about **1.5 hours** and builds on Modu
 
 ## Why This Module Matters
 
-Teams that build environments manually through the Azure portal often discover configuration drift only when they have to recreate the environment, and rebuilds can consume substantial engineering time because undocumented differences between the intended configuration and the actual deployment can easily break services. Once an environment is described in Bicep, provisioning the same infrastructure again usually becomes much faster and more repeatable, since the deployment can be rerun with different parameters instead of rediscovering settings from portal history or wiki pages.
+Hypothetical scenario: a platform team must rebuild a staging environment after a subscription migration. Portal clicks and wiki notes disagree on SKU choices, subnet sizes, and tag conventions. Engineers spend days reconciling drift before the environment is usable again. That failure mode is common when infrastructure lives outside version control.
 
-This is the fundamental promise of Infrastructure as Code (IaC): **your infrastructure is defined in version-controlled files, not in wiki pages, portal clicks, or tribal knowledge.** ARM templates have been Azure's native IaC format since the beginning, and Bicep is the modern, human-friendly language that compiles down to ARM. In this module, you will learn ARM template structure, Bicep syntax, modules, deployment scopes, and the what-if feature that previews changes before they are applied. By the end, you will refactor a CLI-based deployment script into a reusable Bicep template.
+Once an environment is described in Bicep, reprovisioning becomes faster and more repeatable. You rerun a deployment with different parameters instead of rediscovering settings from portal history. This is the fundamental promise of Infrastructure as Code (IaC): **your infrastructure is defined in version-controlled files, not in wiki pages, portal clicks, or tribal knowledge.** ARM templates have been Azure's native IaC format since the beginning. Bicep is the modern, human-friendly language that compiles down to ARM. In this module, you will learn ARM template structure, Bicep syntax, modules, deployment scopes, and the what-if feature that previews changes before they are applied. By the end, you will refactor a CLI-based deployment script into a reusable Bicep template.
 
 ---
 
@@ -88,17 +88,31 @@ classDiagram
     }
 ```
 
-The template above follows the canonical ARM shape: `parameters` accept deployment-time values, `variables` hold computed strings, `resources` declare what Azure should create, and `outputs` return useful values to callers or downstream pipelines. Because every property is explicit JSON, you can trace exactly what will deploy, but the syntax also makes even modest templates feel heavy compared with imperative CLI scripts.
+The template above follows the canonical ARM shape. `parameters` accept deployment-time values. `variables` hold computed strings. `resources` declare what Azure should create. `outputs` return useful values to callers or pipelines. Every property is explicit JSON, so you can trace exactly what will deploy. The syntax still makes modest templates feel heavy compared with imperative CLI scripts.
 
 > **Stop and think**: If an ARM template dynamically generates a storage account name using `[concat(parameters('env'), uniqueString(resourceGroup().id))]`, and the deployment fails because the name exceeds Azure's 24-character limit, how do you debug this? Since ARM templates do not support `print()` statements and the generation happens server-side, what steps must you take to discover the exact string that the ARM engine attempted to provision?
 
-ARM templates work, but they carry significant drawbacks that show up quickly on real teams. They are **verbose** (simple deployments require dozens of lines of JSON), **hard to read** when nested functions pile up, **comment-free** because JSON does not support inline documentation, and **awkward to modularize** because linked templates require externally hosted URIs. Microsoft introduced Bicep to preserve ARM's deployment engine while removing these ergonomics gaps, so you still deploy through Resource Manager but author templates in a language designed for infrastructure engineers rather than JSON editors.
+ARM templates work, but they carry significant drawbacks that show up quickly on real teams. They are **verbose** (simple deployments require dozens of lines of JSON). They are **hard to read** when nested functions pile up. JSON does not support inline comments, so intent disappears. **Modularization** via linked templates requires externally hosted URIs and extra deployment orchestration. Microsoft introduced Bicep to preserve ARM's deployment engine while removing these ergonomics gaps. You still deploy through Resource Manager. You author in a language designed for infrastructure engineers rather than JSON editors.
+
+### ARM functions and expressions (why Bicep feels lighter)
+
+ARM JSON uses a string-based expression language inside `[...]` brackets. Common functions include `resourceGroup()`, `subscription()`, `uniqueString()`, `format()`, and `reference()`. They are powerful but dense:
+
+```json
+"name": "[format('kubedojo{0}{1}', parameters('environment'), uniqueString(resourceGroup().id))]"
+```
+
+Bicep replaces many of these with native string interpolation: `'kubedojo${environment}${uniqueString(resourceGroup().id)}'`. The compiled output still uses ARM functions under the hood. Authors simply stop fighting JSON escaping. When you debug a failed deployment, `az deployment group show` and the portal deployment blade still expose ARM-level errors. Learning one expression style in Bicep is enough for Essentials; reach for ARM JSON function docs when decompiling legacy templates.
+
+### Linked templates vs Bicep modules (historical context)
+
+Before Bicep modules, large ARM solutions split into **linked templates** stored in storage accounts or template spec URIs. The parent template called children with `Microsoft.Resources/deployments` resources. That pattern works but adds moving parts: SAS tokens, URI versioning, and failure modes when a child URI is unreachable. Bicep's `module` keyword compiles to the same deployment resource type. The difference is developer ergonomics: relative paths, compile-time validation, and registry publishing. If you inherit linked-template estates, `az bicep decompile` and incremental module extraction are typical migration steps.
 
 ---
 
 ## Bicep: ARM Templates for Humans
 
-[Bicep is a domain-specific language (DSL) that compiles to ARM JSON.](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview) It provides the same deployment capabilities with dramatically better readability and tooling, because the Bicep CLI transpiles your source file into standard ARM JSON before Resource Manager ever sees it. That transparency matters in practice: you can mix Bicep modules with raw ARM JSON modules in one deployment, check compiled output into source control when a security scanner only accepts JSON, and still author day-to-day changes in the cleaner Bicep syntax.
+[Bicep is a domain-specific language (DSL) that compiles to ARM JSON.](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview) It provides the same deployment capabilities with better readability and tooling. The Bicep CLI transpiles your source file into standard ARM JSON before Resource Manager sees it. That transparency matters in practice. You can mix Bicep modules with raw ARM JSON modules in one deployment. You can check compiled output into source control when a scanner only accepts JSON. Day-to-day authoring stays in the cleaner Bicep syntax.
 
 ### Bicep vs ARM Template Comparison
 
@@ -144,11 +158,17 @@ Side by side, the language differences are stark enough that teams usually stand
 | **Compilation** | N/A (direct JSON) | Compiles to ARM JSON |
 | **Decompilation** | N/A | [Can decompile ARM to Bicep](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/decompile) |
 
-In day-to-day use, the biggest wins are comments, string interpolation, and first-class modules: you can explain non-obvious naming logic inline, compose `${environment}` strings naturally, and import a `./modules/storage.bicep` file without standing up a template hosting endpoint. When you need to bootstrap from an existing environment, `az bicep decompile` also gives you a starting Bicep file from exported ARM JSON, which is often faster than rewriting portal-created resources by hand.
+In day-to-day use, the biggest wins are comments, string interpolation, and first-class modules. You can explain non-obvious naming logic inline. You compose `${environment}` strings naturally. You import `./modules/storage.bicep` without a template hosting endpoint. When you bootstrap from an existing environment, `az bicep decompile` gives you a starting Bicep file from exported ARM JSON. That is often faster than rewriting portal-created resources by hand.
+
+### When teams still keep ARM JSON in repo
+
+Some regulated environments store only JSON in Git. The workflow is: author in Bicep locally, `az bicep build`, commit `main.json`, deploy JSON in CI. Other teams store Bicep only and compile in the pipeline. Both are valid. Pick one policy per repository and enforce it in code review. Mixing hand-edited JSON with Bicep sources in the same folder without ownership rules creates drift within the IaC layer itself.
 
 ### Bicep vs Terraform
 
-While Bicep is the native choice for Azure, Terraform remains a common option for teams that need multi-cloud IaC or already manage non-Azure resources with HashiCorp providers. The decision is less about syntax beauty and more about where state should live and how many clouds you must orchestrate from one toolchain.
+While Bicep is the native choice for Azure, Terraform remains a common option for multi-cloud IaC. Teams already managing Datadog, GitHub, or AWS with Terraform often keep Azure resources in the same state backend for operational consistency. The decision is less about syntax beauty and more about where state should live. It is also about how many clouds one pipeline must orchestrate.
+
+Terraform plans resemble Bicep what-if previews, but the mechanics differ. Terraform compares desired state in HCL against its state file. Bicep what-if compares template against live Azure without a separate state artifact. Hybrid organizations sometimes use Terraform for multi-cloud and Bicep for Azure-only landing zones. Document the boundary so engineers do not duplicate networking baselines in two languages.
 
 | Feature | Bicep | Terraform |
 | :--- | :--- | :--- |
@@ -157,11 +177,124 @@ While Bicep is the native choice for Azure, Terraform remains a common option fo
 | **Day 0 Support** | [Immediate support for new Azure features](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview) | Slight delay for provider updates |
 | **Integration** | Native to Azure CLI and Portal | Requires separate Terraform CLI |
 
-**Decision Framework**: Use Bicep if your organization is 100% Azure-native and you want to avoid managing state files, because Resource Manager itself holds the deployed resource graph. Use Terraform if you have a multi-cloud strategy or already use Terraform for other infrastructure (like GitHub, Datadog, or Kubernetes), since a shared state backend and provider ecosystem may outweigh Azure-native conveniences.
+The comparison tables above are a starting point. The full **Decision Framework** section later in this module walks through Bicep versus ARM JSON versus Terraform, incremental versus complete deployment mode, and local modules versus registry modules with explicit tradeoffs.
 
-### Bicep Key Concepts
+---
 
-Most production templates combine a small set of building blocks—parameters for environment variance, variables for derived names and tags, resource declarations with explicit API versions, optional `existing` references for out-of-scope dependencies, conditional and loop constructs for branching deployments, and outputs that downstream modules or pipelines consume. The example below shows each pattern in one file so you can see how they interact before splitting the file into modules.
+## Language & Authoring Model
+
+[Bicep is a transparent abstraction over ARM JSON.](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/overview) There is no separate Bicep runtime in Azure. The Bicep CLI transpiles your `.bicep` file into a standard ARM deployment template, and Resource Manager deploys that JSON. Every `resource` block maps one-to-one to an entry in the compiled `resources` array. That transparency matters when security scanners only accept JSON, when you need to diff compiled output in CI, or when you mix Bicep modules with legacy ARM JSON modules in one deployment.
+
+### File anatomy: params, vars, resources, modules, outputs
+
+A [Bicep file](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/file) is declarative. Element order does not change deployment behavior. The canonical sections are:
+
+| Section | Purpose | Typical use |
+| :--- | :--- | :--- |
+| `targetScope` | Where the deployment runs | Default `resourceGroup`; lift to `subscription` to create RGs |
+| `param` | Inputs at deploy time | Environment name, SKU, secrets (`@secure()`) |
+| `var` | Internal computed values | Naming prefixes, tag objects, derived CIDRs |
+| `resource` | Azure resources to create | One symbolic name per resource; pin `@api-version` |
+| `module` | Reusable nested deployments | Local path, registry `br:`, or template spec |
+| `output` | Values returned to callers | Endpoints, resource IDs, connection hints |
+
+Metadata, user-defined `type` blocks, and experimental `func` definitions extend the model for larger platforms. For most Essentials modules, parameters, variables, resources, modules, and outputs cover daily work.
+
+### Resource dependencies: implicit vs explicit
+
+[Resource Manager orders deployments using dependencies.](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/resource-dependencies) In Bicep, referencing another resource's symbolic name creates an **implicit** dependency. If `webApp` uses `appServicePlan.id`, ARM deploys the plan before the web app without a manual `dependsOn` array.
+
+You add **explicit** `dependsOn` when the link is not visible from property references alone. Examples include a deployment script that must run after a storage account exists, or extension resources that need ordering the compiler cannot infer. Prefer implicit dependencies because they stay readable and survive refactors.
+
+```bicep
+// Implicit: webApp waits for plan because of serverFarmId reference
+resource appServicePlan 'Microsoft.Web/serverfarms@2023-01-01' = {
+  name: 'kubedojo-plan'
+  location: resourceGroup().location
+  sku: { name: 'B1' }
+}
+
+resource webApp 'Microsoft.Web/sites@2023-01-01' = {
+  name: 'kubedojo-web'
+  location: resourceGroup().location
+  properties: {
+    serverFarmId: appServicePlan.id
+  }
+}
+
+// Explicit dependsOn when no property reference exists
+resource diagnosticSetting 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'send-to-log-analytics'
+  scope: webApp
+  properties: {
+    workspaceId: logAnalyticsWorkspace.id
+  }
+  dependsOn: [
+    webApp
+    logAnalyticsWorkspace
+  ]
+}
+```
+
+### Loops, conditions, and existing resources
+
+[Iterative loops](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/loops) use `[for item in collection: { ... }]`. You can loop resources, modules, variables, properties, and outputs. [Conditional deployments](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/conditional-resource-deployment) use `if (expression)` on a resource or module. Skipped resources are absent from the deployment, which affects outputs that reference them.
+
+[Existing resource references](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/existing-resource) let a template read resources deployed elsewhere without recreating them. You declare `existing` and optionally set `scope` to another resource group or subscription. Platform templates often reference a shared Key Vault, hub VNet, or Log Analytics workspace this way.
+
+### Small module example: network + compute wiring
+
+The snippet below is a realistic slice of a service template. It shows params, vars, implicit dependencies, a conditional dev-only storage account, and outputs for a pipeline.
+
+```bicep
+@description('Environment name')
+@allowed(['dev', 'staging', 'prod'])
+param environment string
+
+param location string = resourceGroup().location
+
+var prefix = 'kubedojo-${environment}'
+var tags = {
+  environment: environment
+  costCenter: 'platform-eng'
+  managedBy: 'bicep'
+}
+
+resource vnet 'Microsoft.Network/virtualNetworks@2023-04-01' = {
+  name: '${prefix}-vnet'
+  location: location
+  tags: tags
+  properties: {
+    addressSpace: { addressPrefixes: ['10.0.0.0/16'] }
+    subnets: [
+      { name: 'app', properties: { addressPrefix: '10.0.1.0/24' } }
+    ]
+  }
+}
+
+resource devStorage 'Microsoft.Storage/storageAccounts@2023-01-01' = if (environment == 'dev') {
+  name: '${replace(prefix, '-', '')}devstore'
+  location: location
+  tags: tags
+  sku: { name: 'Standard_LRS' }
+  kind: 'StorageV2'
+}
+
+output vnetResourceId string = vnet.id
+output devStorageName string = environment == 'dev' ? devStorage.name : ''
+```
+
+Compile locally before every PR: `az bicep build --file main.bicep` writes `main.json` so reviewers can inspect the ARM Resource Manager will execute.
+
+### Transpilation mental model (1:1 with ARM resources)
+
+When you declare `resource stg 'Microsoft.Storage/storageAccounts@2023-01-01' = { ... }`, the compiler emits one entry in the `resources` array of the ARM template. Module blocks emit nested `Microsoft.Resources/deployments` resources. Parameters become ARM `parameters`; variables become ARM `variables`. There is no hidden magic layer that changes SKU semantics. If a Bicep deployment creates an unexpected resource type, the compiled JSON is the ground truth artifact to inspect.
+
+Decompilation (`az bicep decompile --file exported.json`) is lossy for human readability but excellent for bootstrapping. Exported portal templates include noise and sometimes outdated API versions. Treat decompile output as a draft. Refactor into modules, parameters, and naming variables before merging to main.
+
+### Bicep building blocks in one file
+
+Most production templates combine parameters for environment variance, variables for derived names and tags, resource declarations with explicit API versions, optional `existing` references for out-of-scope dependencies, conditional and loop constructs for branching deployments, and outputs that downstream modules or pipelines consume. The example below shows each pattern in one file so you can see how they interact before splitting the file into modules.
 
 ```bicep
 // Parameters: Values provided at deployment time
@@ -242,11 +375,26 @@ output subnetIds array = [for subnet in vnet.properties.subnets: subnet.id]
 
 > **Pause and predict**: You define a resource using `if (environment == 'dev')` and subsequently expose its `id` as a template output. If you deploy this template to the 'prod' environment, the resource is skipped. What exactly happens at runtime when the ARM engine attempts to construct that output? How does Bicep handle conditional outputs when the underlying resource does not exist?
 
-Pay attention to API versions in each `resource` declaration: pinning `Microsoft.Storage/storageAccounts@2023-01-01` makes upgrades deliberate, while drifting to "latest" during a routine edit can change property schemas and break CI unexpectedly. Secure parameters (`@secure()`) also keep secrets out of deployment logs, which matters the moment you parameterize admin passwords or connection strings.
+Pay attention to API versions in each `resource` declaration. Pinning `Microsoft.Storage/storageAccounts@2023-01-01` makes upgrades deliberate. Drifting to "latest" during a routine edit can change property schemas and break CI unexpectedly. Secure parameters (`@secure()`) keep secrets out of deployment logs. That matters the moment you parameterize admin passwords or connection strings.
+
+### Conditional outputs and symbolic references
+
+When a resource is deployed with `if (environment == 'dev')`, outputs that reference it must handle absence in non-dev environments. Patterns include conditional outputs with ternary expressions (`environment == 'dev' ? devStorage.name : ''`) or separate outputs per environment tier. Quiz question 5 in this module probes the failure mode when outputs assume a resource always exists.
+
+Symbolic names are case-sensitive and cannot collide with parameter or variable names. Reference resources with their symbolic name (`storageAccount.name`), not the Azure resource name string, so renames propagate automatically.
 
 ### Deploying Bicep Templates
 
-Once a template compiles cleanly, deployment is a Resource Manager operation invoked through Azure CLI, PowerShell, or a pipeline task. The commands below show the usual progression—deploy with inline parameters, deploy with a parameter file, preview with what-if, validate without mutating resources, inspect history, and decompile exported JSON when migrating legacy ARM.
+Once a template compiles cleanly, deployment is a Resource Manager operation. You invoke it through Azure CLI, PowerShell, Azure DevOps, or GitHub Actions. The CLI commands below show the usual progression. Deploy with inline parameters when experimenting. Deploy with a parameter file when environments differ. Preview with what-if before shared environments. Validate without mutating resources in CI. Inspect history when debugging partial failures. Decompile exported JSON when migrating legacy ARM from portal exports.
+
+Understanding failure messages is part of safe deployment practice. Common classes include:
+
+- **Authorization** — `AuthorizationFailed` means the deploying identity lacks RBAC on the RG or resource type.
+- **Quota** — `QuotaExceeded` means subscription limits for cores, public IPs, or storage accounts.
+- **Invalid template** — Compile-time Bicep errors should be caught by `az bicep build`; ARM validation errors appear in `az deployment group validate`.
+- **Conflict** — Name collisions on globally unique resources such as storage accounts.
+
+When a nested module fails, open the child deployment in the portal or with `az deployment operation group list`. The parent deployment shows success while a child failed; do not assume the whole stack is healthy from the parent status alone.
 
 ```bash
 # Deploy a Bicep template to a resource group
@@ -284,7 +432,25 @@ az bicep decompile --file exported-template.json
 
 ## Bicep Modules: Composable Infrastructure
 
-Modules are the killer feature of Bicep because they let you break large templates into reusable components with explicit input parameters and typed outputs, much like functions in a programming language but still fully declarative. A `main.bicep` file orchestrates the environment while `./modules/*.bicep` files encapsulate networking, storage, compute, and observability concerns, and environment-specific `.bicepparam` files supply the only values that should change between dev, staging, and prod.
+Modules are the killer feature of Bicep. They let you break large templates into reusable components with explicit input parameters and typed outputs. Think of them like functions in a programming language, but fully declarative. A `main.bicep` file orchestrates the environment. `./modules/*.bicep` files encapsulate networking, storage, compute, and observability. Environment-specific `.bicepparam` files supply the only values that should change between dev, staging, and prod.
+
+### Module contracts: inputs, outputs, and deployment names
+
+Each module invocation creates a nested deployment with the `name` you provide. That name appears in deployment history and must be unique within the parent deployment. Use descriptive names (`storage-${environment}`) so operators correlate portal blades with Git modules.
+
+Module **params** are the public API. Treat breaking param renames like application API changes: semver your registry modules and document migrations. Module **outputs** are the integration surface for `main.bicep`. Export only what parents need (IDs, endpoints, names). Avoid leaking internal symbolic names.
+
+When a module fails, nested deployment errors bubble up with the child deployment name. Splitting modules by failure domain (network vs compute) shortens incident triage because you know which nested deployment to open first.
+
+### Orchestration patterns that scale
+
+Three patterns appear repeatedly in Azure platform engineering:
+
+- **Layered main** — `main.bicep` calls networking, then compute, then observability modules. Pass subnet IDs from network outputs into compute params. Dependencies stay implicit through output references.
+- **Environment router** — One `main.bicep`, many `.bicepparam` files. CI selects the parameter file by branch or pipeline stage. No template forks per environment.
+- **Platform base + product overlay** — Subscription template creates RG and policies. Product `main.bicep` deploys into the RG. Keeps guardrails centralized and application velocity high.
+
+Anti-pattern: circular output dependencies between modules A and B. Bicep compile fails early, but design reviews should catch logical cycles before merge.
 
 ```mermaid
 graph TD
@@ -414,7 +580,9 @@ output storageEndpoint string = storage.outputs.primaryEndpoint
 output appPlanId string = appPlan.outputs.id
 ```
 
-Notice how `main.bicep` references `storage.outputs.primaryEndpoint` and `appPlan.outputs.id` without re-declaring those resources, which is the compositional payoff: modules remain independently testable (`az bicep build` per file), while the root template describes the full environment graph.
+Notice how `main.bicep` references `storage.outputs.primaryEndpoint` and `appPlan.outputs.id` without re-declaring those resources. That is the compositional payoff. Modules remain independently testable with `az bicep build` per file. The root template describes the full environment graph. In code review, challenge modules that export ten outputs but only three are used. Unused outputs often signal unclear module boundaries.
+
+Testing strategy for modules: compile each module in isolation, run `az deployment group validate` with mock parameters in a lab RG, and only then integrate into `main.bicep`. For registry modules, add a consumer template in the module repository that pins the version under test.
 
 ### Bicep Parameters Files
 
@@ -436,6 +604,12 @@ az deployment group create \
   --parameters parameters/staging.bicepparam
 ```
 
+### User-defined types and secure parameters (advanced authoring)
+
+[Bicep user-defined types](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/user-defined-data-types) let you group related parameters into one structured object with compile-time validation. Instead of eight separate VM parameters, you define a `vmConfig` type and pass one object. That pattern scales when platform teams publish opinionated configs (backup policy bundles, monitoring baselines).
+
+Combine types with `@secure()` on secrets. Secure parameters are not logged in deployment history the same way plain strings are. They still exist in parameter files on disk, so protect `.bicepparam` with pipeline secret stores for passwords and keys. Prefer managed identities at runtime over embedding secrets in templates when the service supports it.
+
 ### Sharing Modules: Registries and Template Specs
 
 When modules graduate from a single repository to an organization-wide standard, you need a distribution mechanism that enforces versioning and access control. Azure provides two native ways to share IaC components without asking every team to clone the same Git repository.
@@ -455,9 +629,18 @@ az ts create \
 
 ---
 
-## Deployment Scopes
+## Deployment Scopes & Modularity
 
-[Bicep can deploy resources at four different scopes:](https://learn.microsoft.com/en-us/azure/azure-resource-manager/management/overview) tenant, management group, subscription, and resource group. Most day-to-day templates target a resource group (the default), but policies, budgets, role assignments, and greenfield resource group creation often require lifting `targetScope` so the template runs where the guardrail actually applies.
+[Bicep can deploy resources at four scopes.](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deploy-to-resource-group) Each scope defines what resource types you may declare and which Azure CLI command invokes the deployment. Choosing the wrong scope is a common review failure: a resource group template cannot create a subscription policy without changing `targetScope`.
+
+| Scope | `targetScope` value | Typical resources | CLI command |
+| :--- | :--- | :--- | :--- |
+| Resource group | `resourceGroup` (default) | Storage, VNets, AKS, Web Apps | `az deployment group create` |
+| Subscription | `subscription` | Resource groups, policies, budgets | `az deployment sub create` |
+| Management group | `managementGroup` | MG policies, RBAC at MG level | `az deployment mg create` |
+| Tenant | `tenant` | Tenant-wide policies, Entra artifacts | `az deployment tenant create` |
+
+Most application templates stay at resource group scope. Platform teams lift to subscription or management group when the template must create the resource group itself, assign Azure Policy, or wire role assignments before application resources land.
 
 ```mermaid
 graph TD
@@ -489,7 +672,7 @@ module resources 'main.bicep' = {
 }
 ```
 
-Subscription-scoped deployments are a common pattern for platform teams: create the resource group, then nest a module scoped to that group so application templates stay resource-group-local while the subscription template owns naming and placement policy.
+Subscription-scoped deployments are a common pattern for platform teams. The outer template creates the resource group. A nested module uses `scope: rg` so application templates stay resource-group-local while the subscription template owns naming and placement policy.
 
 ```bash
 # Resource group scope (default)
@@ -505,13 +688,42 @@ az deployment mg create --management-group-id myMG --location eastus2 -f mg.bice
 az deployment tenant create --location eastus2 -f tenant.bicep
 ```
 
+### Local modules vs registry modules vs template specs
+
+Three distribution patterns cover most enterprise Bicep reuse:
+
+1. **Local modules** (`module net './modules/network.bicep' = { ... }`) — fastest for a single repo; paths are relative; ideal for tightly coupled stacks reviewed together in one PR.
+2. **[Private Bicep registry on ACR](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/private-module-registry)** — publish versioned modules; consumers reference `br:myregistry.azurecr.io/bicep/modules/redis:v1`. Scales when many subscriptions need the same hardened baseline without copying Git subtrees.
+3. **[Template specs](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/template-specs)** — ARM templates stored as Azure resources with RBAC and versioning; portal-friendly for operators who do not edit Git daily.
+
+Registry modules trade local simplicity for governance. Template specs trade Bicep-native ergonomics for portal deploy buttons. Local modules trade enterprise scale for speed during early product development.
+
+```bicep
+// Registry module (requires prior publish to ACR)
+module redisCache 'br:contoso.azurecr.io/bicep/redis:v1' = {
+  name: 'redis-${environment}'
+  params: {
+    name: '${prefix}-cache'
+    location: location
+    sku: environment == 'prod' ? 'Premium' : 'Basic'
+  }
+}
+```
+
+Publish registry artifacts in CI after `az bicep build` succeeds. Pin versions in consumer templates so a floating `:latest` tag cannot change production SKUs overnight.
+
 ---
 
 ## Deployment Stacks: Managing Resource Lifecycles
 
-While Bicep modules organize your code, **Deployment Stacks** organize your deployed resources. A deployment stack is a native Azure resource that manages the lifecycle of a collection of resources as a single atomic unit. Those resources can span multiple resource groups or subscriptions, which closes the gap between "template compiles" and "production stays aligned with template."
+While Bicep modules organize your **code**, [deployment stacks](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deployment-stacks) organize **deployed resources**. A stack is a native Azure resource that tracks a set of resources deployed from a template. Stacks can span resource groups and subscriptions when platform boundaries require it.
 
-The key superpower of deployment stacks is **cleanup and protection** working together: [when you remove a resource from your Bicep file and update the stack, the stack can automatically delete or detach the unmanaged resource](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deployment-stacks), and [you can apply `DenySettings` to the stack, preventing anyone (even administrators) from manually modifying or deleting the managed resources via the portal or CLI](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deployment-stacks). That combination reduces both drift and panic-driven portal edits during incidents.
+Stacks address two production gaps that modules alone do not solve:
+
+- **Lifecycle cleanup** — When you remove a resource from the template and redeploy the stack, [actionOnUnmanage](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deployment-stacks) can delete or detach resources that are no longer managed. That is closer to "template is source of truth" than incremental mode alone.
+- **Drift protection** — [Deny settings](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deployment-stacks) can block portal or CLI deletes and modifications on managed resources. Use this when regulatory or SRE policy requires infrastructure changes to flow through Git, not break-glass portal edits.
+
+Deny settings are powerful. A misconfigured deny rule can block legitimate incident response. Pilot stacks on non-production scopes first. Document an escalation path before enabling `denyDelete` on data-plane resources.
 
 ```bash
 # Create a deployment stack with DenySettings to protect against drift
@@ -522,13 +734,43 @@ az stack group create \
   --deny-settings-mode denyDelete
 ```
 
+Stacks complement incremental deployments; they do not replace Git review. A stack tracks which resources belong to the managed set. Removing a resource from the template without updating the stack action can leave orphans or surprise deletes depending on `actionOnUnmanage`. Document whether your organization uses `deleteResources` or `detachResources` for non-production stacks. Detach is safer when experimenting. Delete enforces strict parity at the cost of data loss risk.
+
 ---
 
-## What-If Deployments: Preview Before You Apply
+## Operating Bicep in Shared Subscriptions
 
-The what-if operation is your safety net before any `az deployment group create` run touches production. [It shows what changes a deployment would make without actually making them](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-what-if), which gives reviewers a diff-like preview similar in spirit to `terraform plan` even though Bicep itself does not maintain a separate state file.
+Shared subscriptions multiply the impact of template mistakes. A staging deployment that targets the wrong resource group name can overwrite production if parameters are swapped. Guardrails that reduce that risk are cheap compared to incident hours.
+
+**Resource group targeting** — Always pass `-g` or `--resource-group` explicitly in scripts. Never rely on `az configure` defaults in CI agents. Pipeline variables should include subscription ID and resource group name per environment.
+
+**Parameter file review** — `.bicepparam` diffs should be as visible as `.bicep` diffs in pull requests. A one-line change from `eastus2` to `westeurope` can move data across regions with egress cost implications.
+
+**Deployment correlation** — Tag deployments with Git SHA in the deployment name or via `metadata` in Bicep. When finance asks why storage spend doubled, you need the deployment name that introduced `Standard_GRS`.
+
+**Cross-subscription modules** — Modules can set `scope` to resource groups in other subscriptions when RBAC allows. Hub-spoke networks often reference hub VNets with `existing` and peering resources in spoke templates. Draw scope diagrams in design docs so reviewers see subscription boundaries.
+
+**Kubernetes note for this curriculum** — When Bicep deploys AKS, cluster version should align with the KubeDojo target (Kubernetes 1.35). Pin `kubernetesVersion` in the AKS resource block rather than accepting portal defaults. Upgrades belong in planned template changes with what-if, not ad hoc portal bumps.
+
+### Drift detection without complete mode
+
+Incremental mode does not delete portal-created resources missing from the template. Teams run scheduled what-if jobs comparing Git main to live Azure. Any unexpected `+` or `~` triggers a ticket to backfill Bicep or remove manual resources. This pattern avoids complete mode while still surfacing drift within days instead of months.
+
+### Export and import workflows
+
+`az group export` and portal export generate ARM JSON for brownfield imports. Expect manual cleanup: exported templates include default properties and sometimes resources you no longer want. Workflow: export → decompile to Bicep → refactor modules → validate in lab RG → what-if against production RG read-only (if RBAC permits preview) → deploy incrementally.
+
+---
+
+## Safe Deployment Practices
+
+Production Bicep work is not only syntax. It is a pipeline of validate, lint, what-if, and controlled apply. [What-if](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-what-if) is your safety net before any `az deployment group create` touches shared environments. It predicts create, modify, and delete operations without changing resources. Bicep has no separate state file; what-if is how you see blast radius against live Azure.
 
 > **Pause and predict**: A colleague manually added a test subnet to your VNet via the Azure Portal. Your Bicep template defines the VNet but does not include this new subnet in its `subnets` array property. When you run a `what-if` deployment in Incremental mode, will the manual subnet be marked for deletion (-), modification (~), or ignored completely? What does this reveal about how Azure handles arrays during declarative updates?
+
+Incremental deployments often **do not remove** array elements that exist in Azure but are absent from the template definition. The manual subnet may survive with no delete marker in what-if. That behavior is why drift detection must include periodic template backfill, not only deployment-time previews. Complete mode is the mode that can remove resources not listed in the template; it is also the mode that deletes databases when misused.
+
+Array properties are not the only subtle case. Renaming a resource in Bicep usually creates a destroy-and-recreate plan because Azure resource names are often immutable. What-if shows delete plus create. Treat name changes as migration projects with data copy plans, not as casual refactors.
 
 ```bash
 # Preview changes
@@ -563,7 +805,49 @@ Scope: /subscriptions/xxx/resourceGroups/myRG
   + Microsoft.Web/serverfarms/kubedojo-staging-plan [2023-01-01]
 ```
 
-Running production deployments in complete mode can delete resources that were omitted from the template. The operational lesson is to review a what-if preview carefully and reserve deletion-oriented workflows for cases where the template really represents the whole environment.
+Running production deployments in [complete mode](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/deployment-modes) can delete resources omitted from the template. Incremental mode is the default and recommended path for most workloads. Complete mode exists when the template must represent the entire resource group and prune drift. Always pair complete mode with what-if and an explicit change ticket.
+
+### What-if change types and how to read them
+
+What-if output uses symbols documented on Learn. Train reviewers to treat `~ Modify` on SKU or redundancy properties as a cost signal, not only a technical diff.
+
+| Symbol | Meaning | Reviewer question |
+| :--- | :--- | :--- |
+| `+` | Create | Is this resource net-new spend? |
+| `~` | Modify | Does SKU, redundancy, or retention change monthly cost? |
+| `-` | Delete | Is data loss possible (storage, SQL, DNS)? |
+| `*` | No change | Confirms template matches live for that resource |
+| `!` | Ignore | Resource type not fully modeled in what-if |
+
+Array properties on resources such as subnets deserve extra care. Incremental deployments may not delete portal-added array elements that the template omits. What-if helps surface that class of drift before you assume parity.
+
+### CI integration: validate, build, what-if, deploy
+
+A minimal safe pipeline for pull requests:
+
+```yaml
+# Excerpt: GitHub Actions style — adapt to your runner auth (OIDC/federated credential)
+steps:
+  - name: Install Bicep CLI
+    run: az bicep install
+  - name: Build and lint
+    run: az bicep build --file infra/main.bicep
+  - name: Validate deployment
+    run: |
+      az deployment group validate \
+        --resource-group ${{ vars.RG_NAME }} \
+        --template-file infra/main.bicep \
+        --parameters @infra/parameters/ci.bicepparam
+  - name: What-if (required gate)
+    run: |
+      az deployment group what-if \
+        --resource-group ${{ vars.RG_NAME }} \
+        --template-file infra/main.bicep \
+        --parameters @infra/parameters/ci.bicepparam \
+        --result-format ResourceIdOnly
+```
+
+Promotion to production should require a human or break-glass approver on what-if output when the diff shows deletes or SKU changes on data services. Store deployment names in pipelines so `az deployment group list` correlates Git commits with Azure history.
 
 ```bash
 # Deployment modes
@@ -579,13 +863,145 @@ az deployment group what-if -g myRG -f main.bicep --mode Complete
 
 ---
 
+## Cost Lens: IaC Prevents Cost Surprises
+
+Bicep and ARM template deployments have **no per-deployment metered charge** from Microsoft for the deployment operation itself. The cost lever is what resources your template creates and how you operate deployments over time. Framing IaC as a cost-control discipline is accurate: templates make spend visible, reviewable, and repeatable.
+
+| Cost risk | How Bicep/ARM practice reduces it |
+| :--- | :--- |
+| Accidental SKU upgrade | What-if shows `~` on `sku` before apply; PR review catches `P` series in staging |
+| Complete-mode data loss | Deletes trigger re-create bills and downtime; incremental default avoids surprise `-` |
+| Untagged resources | `var tags` applied in template feeds Cost Management allocation |
+| Environment sprawl | Same `main.bicep` + different `.bicepparam` keeps dev cheap and prod right-sized |
+| Drift + emergency rebuild | Redeploy from Git is faster than forensic portal archaeology |
+
+**Knobs that change monthly spend** include App Service Plan SKU, storage redundancy (`LRS` vs `ZRS` vs `GRS`), AKS node pool VM size, and SQL tier. Encode those as parameters with `@allowed` sets so a typo cannot jump from `B1` to `P3v3` silently. Use environment maps (`envConfig[environment].appSku`) like the lab template so prod and dev diverge deliberately, not accidentally.
+
+**What makes cost spike unexpectedly** includes deploying to the wrong subscription (production parameters against a sandbox subscription that later bills centrally), enabling geo-redundant storage for dev workloads, and complete-mode deletes that force full reprovision with higher SKUs. Tag enforcement in Bicep is cheap insurance: a missing `costCenter` tag today becomes a finance escalation next quarter.
+
+Finance and engineering should agree on which parameters are **cost knobs** in each template. Document them in module README files or `metadata` descriptions. During review, diff those parameters first. A change from `Standard_LRS` to `Standard_GRS` is rarely "just a one-liner" for monthly storage bills.
+
+Hypothetical scenario: a pipeline promotes the production parameter file to a subscription that uses enterprise agreement discounts differently per region. The template deploys successfully. Cost Management shows a 40% month-over-month increase. Root cause is region and redundancy parameters, not a deployment failure. IaC did its job; parameter governance failed.
+
+---
+
+## Patterns & Anti-Patterns
+
+| Pattern | When to use it | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| Parameter files per environment | Same architecture, different SKUs and regions | Template stays single source; CI swaps only `.bicepparam` | Add a fourth environment by adding one file, not cloning templates |
+| Thin `main.bicep` + domain modules | Networking, data, and compute change at different rates | Reviewers scope diffs; modules compile independently | Publish mature modules to `br:` registry when 3+ teams consume them |
+| Mandatory what-if in CI | Every PR touching `*.bicep` | Surfaces blast radius before merge | Cache nothing that skips what-if on production paths |
+| `existing` for shared platform resources | Hub VNet, central Key Vault, Log Analytics | Avoids redeploying shared dependencies | Document scope and RBAC; cross-RG references need reader rights |
+| Pin API versions | Long-lived platforms | Prevents surprise schema breaks on "latest" drift | Schedule quarterly API version upgrades with test what-if |
+| Deployment stacks with deny on prod | Strict IaC-only estates | Blocks portal drift on managed resources | Pilot deny settings; keep break-glass runbook |
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+| :--- | :--- | :--- | :--- |
+| Monolithic 2,000-line `main.bicep` | Review fatigue; accidental cross-resource edits | "It worked in the demo" | Split modules by bounded context |
+| Floating registry tag (`:latest`) | Unreviewed SKU or security defaults change overnight | Fastest path to consume shared module | Pin `br:.../module:v1.4.2` |
+| Complete mode as "cleanup" | Deletes databases not listed in template | Misunderstanding incremental vs complete | Incremental + stack `deleteResources` policy |
+| Skipping what-if on "tiny" changes | Storage networking rules wiped with app SKU tweak | Late-night incident deploy | What-if even for one-property diffs |
+| Hardcoded production SKUs in template | Staging bills like prod; dev cannot shrink spend | Copy-paste from prod export | `envConfig` map or parameters |
+| Portal hotfix without backfill to Git | Next deployment overwrites or fights manual fix | Speed during incident | Backfill Bicep, then redeploy incrementally |
+
+---
+
+## Decision Framework
+
+Use these matrices when choosing tools and deployment modes. They complement the Bicep-vs-Terraform table earlier; they do not replace architecture review for multi-cloud estates.
+
+### IaC language: Bicep vs ARM JSON vs Terraform
+
+| Criterion | Bicep | ARM JSON | Terraform (AzureRM) |
+| :--- | :--- | :--- | :--- |
+| Azure-only greenfield | Preferred | Legacy maintenance | Viable if org standard |
+| Readability & modules | Native `module`, comments | Verbose linked templates | HCL modules + registry |
+| State management | Azure holds deployed graph | Same | Remote state required |
+| Day-0 new Azure APIs | Typically immediate via Bicep | Same underlying ARM | Provider lag possible |
+| Multi-cloud | No | No | Yes |
+| Security scan JSON-only | `az bicep build` → scan JSON | Direct | `terraform plan` JSON export |
+
+**Choose Bicep** when the team is Azure-native and wants transpiled ARM without maintaining JSON by hand. **Choose ARM JSON** when a regulated pipeline forbids `.bicep` in artifacts but allows compiled output. **Choose Terraform** when one pipeline must own AWS, Azure, and SaaS providers with shared state practices.
+
+### Deployment mode: incremental vs complete
+
+| Question | If "yes" → | If "no" → |
+| :--- | :--- | :--- |
+| Template lists every resource that must survive in the RG? | Consider complete with what-if | Stay incremental |
+| Drift from portal must be pruned automatically? | Stack + managed lifecycle, not ad hoc complete | Incremental + backfill Git |
+| Data services exist in the RG? | Avoid complete unless template owns them explicitly | Incremental |
+| Greenfield empty RG? | Either mode works; still run what-if | — |
+
+```mermaid
+flowchart TD
+  A[Need to deploy Bicep?] --> B{Template represents ALL resources in RG?}
+  B -->|No| C[Incremental mode + what-if]
+  B -->|Yes| D{Data services present?}
+  D -->|Yes| E[Complete only with what-if + approved change]
+  D -->|No| F[Complete acceptable with what-if]
+  C --> G{Need drift protection?}
+  G -->|Yes| H[Consider deployment stack + deny settings]
+  G -->|No| I[Modules + CI validate]
+```
+
+### Module distribution: local vs registry vs template spec
+
+| Factor | Local path | Bicep registry (`br:`) | Template spec |
+| :--- | :--- | :--- | :--- |
+| Team count | 1–2 teams in one repo | Many teams / subscriptions | Mixed dev + operator consumers |
+| Version discipline | Git tags / folders | Semver in registry | Template spec versions |
+| Portal deploy | No | No | Yes |
+| CI complexity | Lowest | Publish step to ACR | `az ts create` + RBAC |
+
+---
+
 ## Bicep Best Practices
 
-Good Bicep reads like a contract: names are predictable, lint rules catch unused parameters before CI, and validation runs on every pull request. The snippets below show two habits that prevent the most common template regressions—centralized naming maps and analyzer rules enforced through `bicepconfig.json`.
+Good Bicep reads like a contract. Names are predictable. Lint rules catch unused parameters before CI. Validation runs on every pull request. The snippets below show habits that prevent common template regressions: centralized naming maps and analyzer rules enforced through `bicepconfig.json`.
+
+### Deployment identity, RBAC, and pipeline auth
+
+Templates do not replace authorization. The identity running `az deployment group create` must have rights to create the resources declared. Common choices:
+
+- **Human operator** — `az login` with a user that has Contributor on the RG (acceptable for labs only).
+- **Pipeline service principal or federated workload identity** — Scoped Contributor or custom roles on target RGs; subscription Owner is rarely justified.
+- **Managed deployment scripts** — Deployment scripts run PowerShell or CLI inside Azure; they need their own managed identity and role assignments created in template or prerequisite.
+
+Role assignment in Azure CLI uses:
+
+```bash
+az role assignment create \
+  --assignee <principal-id-or-app-id> \
+  --role "Contributor" \
+  --scope /subscriptions/<sub-id>/resourceGroups/myRG
+```
+
+User-assigned managed identity creation is separate from system-assigned on resources:
+
+```bash
+az identity create -g myRG -n myPipelineIdentity -l eastus2
+```
+
+System-assigned identities are declared in the resource `identity` block (see AKS and Web App examples in certification modules). Match identity type to rotation and audit requirements.
+
+### Deployment naming and idempotency
+
+Set explicit deployment names in CI so reruns are traceable:
+
+```bash
+az deployment group create \
+  --resource-group myRG \
+  --name "main-$(Build.BuildId)" \
+  --template-file main.bicep \
+  --parameters @parameters/staging.bicepparam
+```
+
+Resource Manager deployments are idempotent for unchanged templates. Re-running the same parameters often yields `NoChange` on many resources in what-if. That behavior is useful for drift detection jobs that only alert when diffs appear.
 
 ### Naming Conventions
 
-Consistent naming makes cross-module references and operations dashboards easier to navigate, especially when storage accounts, Key Vaults, and virtual networks all share an environment prefix.
+Consistent naming makes cross-module references and operations dashboards easier to navigate. Storage accounts, Key Vaults, and virtual networks should share an environment prefix. Azure naming rules still apply: storage account names are globally unique and lowercase; many resources have length limits. Centralize naming in a `var naming = { ... }` object so modules receive computed names instead of inventing their own patterns.
 
 ```bicep
 // Use consistent, descriptive resource names
@@ -601,7 +1017,15 @@ var naming = {
 
 ### Linting and Validation
 
-Compile and lint before deploy. `az bicep build` catches syntax errors locally, analyzer rules in `bicepconfig.json` flag unused parameters and insecure defaults, and `az deployment group validate` confirms Resource Manager accepts the compiled template against your target subscription.
+Compile and lint before deploy. `az bicep build` catches syntax errors locally. Analyzer rules in `bicepconfig.json` flag unused parameters and insecure defaults. `az deployment group validate` confirms Resource Manager accepts the compiled template against your target subscription without creating resources.
+
+Extend validation in mature pipelines with:
+
+- **PSRule for Azure** or organizational policy-as-code on compiled JSON
+- **Resource Graph queries** post-deploy to assert tags and SKUs match expectations
+- **Cost estimation** workflows (manual spreadsheet or FinOps tooling) when SKUs change in what-if
+
+Linter rule `secure-parameter-default` blocking default values on secure params prevents accidentally committing `param password string = 'changeme'`. Treat linter warnings as merge blockers for platform repos.
 
 ```bash
 # Build (compile) Bicep to ARM JSON
@@ -631,6 +1055,26 @@ az deployment group validate -g myRG -f main.bicep -p environment=staging
 
 ---
 
+## Summary: From CLI Scripts to Governed IaC
+
+You started this module with ARM JSON as the foundation and Bicep as the authoring layer teams prefer for new Azure work. The through-line is simple: Resource Manager executes templates; your job is to make templates readable, modular, reviewable, and safe to apply.
+
+**Authoring** — Parameters express environment variance. Variables centralize naming and tags. Resources declare desired state with pinned API versions. Modules encapsulate domains. Outputs integrate layers without copy-paste. Loops and conditions remove template duplication. `existing` references connect to shared platform resources without redeploying them.
+
+**Scope and reuse** — Resource group scope covers most application resources. Subscription and management group scopes carry policies and guardrails. Local modules suit single-repo products. Registry modules scale security baselines. Template specs help operators who deploy from the portal under RBAC.
+
+**Safe apply** — Validate and build in CI. Require what-if on shared environments. Default to incremental mode. Treat complete mode and deployment stack delete actions as high-risk operations with approvals. Correlate deployment names to Git commits for audits.
+
+**Cost** — Deployments are not billed per template run; resources are. What-if catches SKU and redundancy changes. Tags in templates feed allocation. Parameter files prevent prod SKUs from landing in dev subscriptions by mistake.
+
+**Operations** — Drift happens in incremental mode when portal changes are not backfilled to Git. Scheduled what-if jobs surface drift early. Nested module failures require child deployment investigation. Export/decompile bootstraps brownfield; refactor before production apply.
+
+When you complete the hands-on lab, you will have practiced the same refactor sequence platform teams use: imperative CLI → modular Bicep → parameter files → what-if → incremental deploy → iterative what-if on child resource additions. That sequence is more valuable than memorizing every Bicep function. Functions are documented on Learn; workflow discipline wins interviews and on-call scenarios.
+
+Cross-family reviewers will ask whether your templates teach **why** a scope or mode was chosen, not only **how** to run CLI commands. Carry that standard into Module 3.13 networking modules, where Application Gateway and WAF resources also belong in version-controlled templates rather than portal-only configuration.
+
+---
+
 ## Did You Know?
 
 1. **Bicep is a transparent abstraction over ARM templates.** Every Bicep file compiles to a standard ARM JSON template. There is no "Bicep runtime" or "Bicep API"---Azure only sees ARM JSON. This means the important deployment artifact remains an ARM template, which reduces dependence on Bicep-specific tooling during deployment. You can even mix Bicep and ARM JSON in the same deployment using modules.
@@ -640,6 +1084,27 @@ az deployment group validate -g myRG -f main.bicep -p environment=staging
 3. Before deploying a template, what-if gives you a preview of the changes Azure Resource Manager expects to make, which makes it a useful safety check similar in spirit to Terraform plan.
 
 4. [**Bicep supports user-defined types** (since Bicep v0.12), allowing you to define structured parameter types.](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/user-defined-data-types) Instead of passing 8 separate parameters for a VM configuration, you define a `vmConfig` type with all properties, getting compile-time validation and IntelliSense. This moves Bicep closer to a full programming language while remaining declarative.
+
+The [Bicep linter](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/linter) runs during `az bicep build` and in the VS Code extension. Rules such as `no-unused-params` and `adminusername-should-not-be-literal` catch mistakes before deployment. Teams commit `bicepconfig.json` so every author shares the same severity levels.
+
+---
+
+## Review Checklist (self-assessment before Module 3.13)
+
+Use this checklist after the lab. It mirrors what cross-family reviewers verify on Azure Essentials expansions.
+
+- Can you draw the four deployment scopes and name one resource type each scope commonly deploys?
+- Can you explain implicit versus explicit `dependsOn` with an example from your lab `main.bicep`?
+- Can you describe when incremental mode leaves portal drift in place versus when complete mode or stacks remove it?
+- Did you run what-if before both deploy steps in the lab and interpret at least one `~` or `+` line?
+- Are cost knobs (SKU, redundancy, region) parameterized rather than hardcoded in your modules?
+- Can you articulate when you would choose registry modules over local paths for a shared Redis baseline?
+
+If any item is shaky, rerun Task 4 what-if against your lab resource group and read the deployment operations log for the nested module deployments. That five-minute investment prevents repeating the same debugging path in production.
+
+Optional stretch goal: publish your lab storage module to a private registry in a non-production ACR and consume it with a `br:` reference in a second `main.bicep`. You will feel the version-pinning and RBAC differences immediately. Most enterprises adopt registry modules only after local modules stabilize, but practicing both paths clarifies the Decision Framework tables above.
+
+Keep a personal cheat sheet of the CLI verbs you used: `group create`, `deployment group what-if`, `deployment group create`, `deployment group validate`, `bicep build`, and `bicep decompile`. Those six commands cover most Essentials labs and early production workflows. Add `stack group create` when you experiment with deployment stacks in a sandbox subscription. Record the resource group name and deployment name every time. Future you will need that correlation during incident review. The portal deployment history blade searches by deployment name, not by Git commit unless you encoded the commit in that name. This small habit separates ad hoc deploys from pipeline-driven deploys during audits and postmortems. Treat deployment names as operational metadata, not disposable labels, in every Azure environment.
 
 ---
 
@@ -693,14 +1158,30 @@ You construct a single, unified `main.bicep` template that utilizes parameters t
 <details>
 <summary>6. You are tasked with deploying an Azure Policy that restricts resource creation exclusively to the `eastus` region. You want this policy to automatically apply to all current and future resource groups within your project's subscription. Which deployment scope must you target in your Bicep file, and why would targeting the default Resource Group scope fail to achieve your goal?</summary>
 
-You must explicitly define `targetScope = 'subscription'` at the top of your Bicep file to deploy the policy at the Subscription scope. Targeting the default Resource Group scope would fail because a policy applied at the resource group level only restricts the resources provisioned within that specific group; any new resource group created outside of it would be completely unaffected by the restriction. By targeting the subscription, the policy cascades downwards, enforcing the region constraint across current and future resource groups under that subscription umbrella. This hierarchical inheritance and the need to manage top-level organizational guardrails are the primary reasons why Bicep supports distinct deployment scopes.
+You must explicitly define `targetScope = 'subscription'` at the top of your Bicep file to deploy the policy at the Subscription scope. Targeting the default Resource Group scope would fail because a policy applied at the resource group level only restricts resources in that group. Any new resource group created elsewhere would be unaffected. By targeting the subscription, the policy cascades downward and enforces the region constraint across current and future resource groups. Hierarchical inheritance is the primary reason Bicep supports distinct deployment scopes.
+</details>
+
+<details>
+<summary>7. Your pipeline compiles Bicep to JSON for a security scanner, then deploys with `az deployment group create` using the `.bicep` file directly. A reviewer asks why you do not deploy the JSON artifact. What is the correct explanation, and does Azure ever execute Bicep natively?</summary>
+
+Azure Resource Manager always executes ARM JSON templates. Bicep is an authoring layer that transpiles to that JSON. Deploying with `--template-file main.bicep` is valid because the CLI compiles Bicep before submission. Checking in compiled JSON satisfies scanners without changing the runtime engine. There is no separate Bicep runtime in Azure. The deployment history still records an ARM template deployment. Keeping Bicep as the source of truth while emitting JSON for policy gates is a common enterprise pattern.
+</details>
+
+<details>
+<summary>8. Scenario: a platform team publishes a hardened storage module to a private registry. A product team references `br:contoso.azurecr.io/bicep/storage:latest` and production storage suddenly enables geo-redundant SKU after an unpinned registry publish. What two practices prevent this class of cost and compliance surprise?</summary>
+
+Pin an explicit semantic version in the `br:` reference instead of a floating tag. Treat registry publishes like application releases with changelog review and CI what-if on consumer templates. Require module consumers to run `az deployment group what-if` when module version bumps merge. Registry modules are powerful because they centralize security defaults. They are risky when versions float because every team inherits changes without a PR in their own repository.
 </details>
 
 ---
 
 ## Hands-On Exercise: Refactor CLI Script to Bicep Template
 
-In this exercise, you will take a deployment that was done via Azure CLI commands and convert it into a reusable Bicep template with modules, then use what-if to preview changes before applying them incrementally. **Prerequisites**: Azure CLI with the Bicep extension installed (`az bicep install`) and permission to create a throwaway resource group in a subscription you use for labs.
+In this exercise, you will take a deployment that was done via Azure CLI commands and convert it into a reusable Bicep template with modules. You will run what-if to preview changes before applying them incrementally. The narrative mirrors how platform teams migrate click-ops or shell scripts: capture imperative steps, factor shared resources into modules, parameterize environment variance, then gate production on what-if output.
+
+Pay attention to **why each task exists**. Task 1 isolates storage so SKU and TLS policies are reviewable without App Service noise. Task 2 isolates compute so runtime and Always On rules stay in one module. Task 3 composes modules and shows environment maps instead of copy-pasted SKUs. Task 4 trains the what-if habit before spend. Task 5 applies incrementally. Task 6 shows how nested child resources (blob containers) change diffs.
+
+**Prerequisites**: Azure CLI with the Bicep extension installed (`az bicep install`) and permission to create a throwaway resource group in a subscription you use for labs. Run `az group create` before deployments; most resource operations assume an existing resource group per [Azure Resource Manager deployment flow](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-powershell).
 
 ### The Original CLI Script (What We Are Replacing)
 
@@ -1030,7 +1511,9 @@ rm -rf /tmp/bicep-lab
 
 [Module 3.13: Azure Application Gateway — Operator Path](../module-3.13-application-gateway/) --- Extend your Azure networking skills with WAF policies, TLS termination, AKS ingress integration, and diagnostics for application-layer load balancing.
 
-The skills you have built across the Azure Essentials modules---identity, networking, compute, storage, DNS, containers, serverless, secrets, monitoring, CI/CD, and infrastructure as code---are the foundation of every production Azure environment. The difference between a junior and senior engineer is not knowing more services; it is knowing how to combine these fundamentals into reliable, secure, and cost-effective architectures.
+The skills you have built across the Azure Essentials modules—identity, networking, compute, storage, DNS, containers, serverless, secrets, monitoring, CI/CD, and infrastructure as code—are the foundation of every production Azure environment. The difference between a junior and senior engineer is not knowing more services. It is knowing how to combine these fundamentals into reliable, secure, and cost-effective architectures. Bicep is the glue that keeps those combinations reproducible when subscriptions, regions, or teams change.
+
+Before moving on, confirm you can explain incremental versus complete mode to a teammate without looking at notes. Confirm you can run what-if and interpret `+` and `~` lines on a real lab resource group. Those two habits prevent more production pain than any single Bicep language feature.
 
 ## Sources
 
@@ -1045,3 +1528,9 @@ The skills you have built across the Azure Essentials modules---identity, networ
 - [learn.microsoft.com: deploy what if](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/deploy-what-if) — The what-if documentation explicitly says it predicts changes and does not make changes to existing resources.
 - [learn.microsoft.com: deployment modes](https://learn.microsoft.com/en-us/azure/azure-resource-manager/templates/deployment-modes) — The deployment modes documentation explicitly says incremental is the default and recommended mode, complete mode deletes absent resources, and what-if should be used before complete mode.
 - [learn.microsoft.com: user defined data types](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/user-defined-data-types) — The user-defined data types documentation explicitly says Bicep CLI version 0.12.x or higher is required.
+- [learn.microsoft.com: bicep file structure](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/file) — Documents params, vars, resources, modules, outputs, targetScope, and declarative ordering rules.
+- [learn.microsoft.com: resource dependencies](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/resource-dependencies) — Explains implicit dependencies via symbolic references and explicit dependsOn.
+- [learn.microsoft.com: deploy to resource group](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/deploy-to-resource-group) — Scope-specific deployment commands and targetScope values.
+- [learn.microsoft.com: conditional deployment](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/conditional-resource-deployment) — `if` expressions for resources and modules.
+- [learn.microsoft.com: existing resources](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/existing-resource) — Referencing resources deployed outside the current template scope.
+- [learn.microsoft.com: bicep linter](https://learn.microsoft.com/en-us/azure/azure-resource-manager/bicep/linter) — Core analyzer rules and bicepconfig.json configuration.

--- a/src/content/docs/cloud/azure-essentials/module-3.12-bicep.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.12-bicep.md
@@ -731,7 +731,9 @@ az stack group create \
   --name my-production-stack \
   --resource-group myRG \
   --template-file main.bicep \
-  --deny-settings-mode denyDelete
+  --action-on-unmanage detachAll \
+  --deny-settings-mode denyDelete \
+  --yes
 ```
 
 Stacks complement incremental deployments; they do not replace Git review. A stack tracks which resources belong to the managed set. Removing a resource from the template without updating the stack action can leave orphans or surprise deletes depending on `actionOnUnmanage`. Document whether your organization uses `deleteResources` or `detachResources` for non-production stacks. Detach is safer when experimenting. Delete enforces strict parity at the cost of data loss risk.
@@ -786,13 +788,15 @@ The what-if output uses color-coded symbols so you can scan a large deployment q
 What-If Results:
 
 + Create    (new resource will be created)
-~ Modify    (existing resource will be modified)
-- Delete    (resource will be removed, if using complete mode)
-* No change (resource exists and matches template)
-! Ignore    (resource type not supported for what-if)
+~ Modify    (existing resource properties will change)
+- Delete    (resource will be removed — complete mode or omitted from template)
+= NoChange  (resource exists and matches template; may redeploy without property changes)
+* Ignore    (resource exists but is not in the template, or what-if could not expand it)
+! Deploy    (ResourceIdOnly format — resource will redeploy; property changes unknown)
 
 Example output:
 Resource and property changes are indicated with these symbols:
+  - Delete
   + Create
   ~ Modify
 
@@ -816,8 +820,9 @@ What-if output uses symbols documented on Learn. Train reviewers to treat `~ Mod
 | `+` | Create | Is this resource net-new spend? |
 | `~` | Modify | Does SKU, redundancy, or retention change monthly cost? |
 | `-` | Delete | Is data loss possible (storage, SQL, DNS)? |
-| `*` | No change | Confirms template matches live for that resource |
-| `!` | Ignore | Resource type not fully modeled in what-if |
+| `=` | NoChange | Confirms template matches live for that resource |
+| `*` | Ignore | Resource not in template or what-if could not expand it |
+| `!` | Deploy | ResourceIdOnly format — redeploy expected; property diff unknown |
 
 Array properties on resources such as subnets deserve extra care. Incremental deployments may not delete portal-added array elements that the template omits. What-if helps surface that class of drift before you assume parity.
 
@@ -1327,13 +1332,16 @@ param location string = resourceGroup().location
 @description('Base name for resources')
 param baseName string = 'kubedojo'
 
+@description('Deployment timestamp tag')
+param deployedAt string = utcNow('yyyy-MM-dd')
+
 // Computed values
 var prefix = '${baseName}-${environment}'
 var tags = {
   environment: environment
   project: baseName
   managedBy: 'bicep'
-  deployedAt: utcNow('yyyy-MM-dd')
+  deployedAt: deployedAt
 }
 
 // Environment-specific configuration
@@ -1356,7 +1364,7 @@ var envConfig = {
 module storage 'modules/storage.bicep' = {
   name: 'storage-${environment}'
   params: {
-    name: '${replace(prefix, '-', '')}store'
+    name: take('${replace(prefix, '-', '')}st${uniqueString(resourceGroup().id)}', 24)
     location: location
     skuName: envConfig[environment].storageSku
     tags: tags
@@ -1367,8 +1375,8 @@ module storage 'modules/storage.bicep' = {
 module appService 'modules/appservice.bicep' = {
   name: 'appservice-${environment}'
   params: {
-    planName: '${prefix}-plan'
-    appName: '${prefix}-web'
+    planName: '${prefix}-plan-${uniqueString(resourceGroup().id)}'
+    appName: '${prefix}-web-${uniqueString(resourceGroup().id)}'
     location: location
     skuName: envConfig[environment].appSku
     tags: tags

--- a/src/content/docs/cloud/azure-essentials/module-3.13-application-gateway.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.13-application-gateway.md
@@ -17,6 +17,8 @@ After completing this module, you will be able to reason through the full reques
 - **Debug** Application Gateway failures by following a request through listener, WAF policy, routing rule, backend HTTP settings, probe, and backend pool.
 - **Design** a regional ingress pattern that uses the right boundary: Application Gateway, Front Door, AGIC, Application Gateway for Containers, or an in-cluster ingress controller.
 - **Evaluate** WAF, TLS, autoscaling, cost, logging, and migration choices before they become production incidents.
+- **Configure** WAF policies with managed and custom rules, narrow exclusions after log review, and a deliberate Detection-to-Prevention workflow.
+- **Implement** TLS termination with Key Vault-backed listener certificates and backend HTTP settings that stay aligned with health probe contracts.
 
 The emphasis is operational. You are not only learning which Azure resource to create; you are learning how to keep the resource understandable when many teams depend on it.
 
@@ -958,6 +960,54 @@ D. WAF CRS version
 <summary>Answer</summary>
 
 **Correct: B.** Certificate sync depends on secret access and the referenced secret ID. Backend replicas, MX records, and WAF rules do not explain the listener certificate.
+
+</details>
+
+### Question 5
+
+An architecture review must **design** a **regional** **ingress** pattern with an explicit traffic **boundary**. A global retail brand needs multi-region failover at the edge, WAF on private regional APIs inside hub-spoke VNets, and no managed Azure Layer-7 hop for an internal-only batch job in a single AKS cluster. Which pairing best matches those boundaries?
+
+A. Azure Front Door at the global edge, Application Gateway per region for private APIs, and in-cluster ingress only for the internal batch job
+B. Application Gateway only for global users and every backend, including the internal batch job
+C. Azure Load Balancer Standard as the sole public HTTPS entry with hostname-based routing to all workloads
+D. Azure API Management as the only edge for browser traffic, regional APIs, and Kubernetes workloads
+
+<details>
+<summary>Answer</summary>
+
+**Correct: A.** [Azure Front Door](https://learn.microsoft.com/en-us/azure/frontdoor/front-door-overview) fits the global edge and failover boundary; [Application Gateway](https://learn.microsoft.com/en-us/azure/application-gateway/overview) fits regional VNet-integrated WAF and private backends. An internal-only cluster service does not need a regional managed gateway when cluster ingress is enough. Load Balancer operates at Layer 4 and does not provide Application Gateway-style HTTP host routing. API Management is an API lifecycle and policy plane, not a substitute for a global CDN-style web edge plus regional private ingress.
+
+</details>
+
+### Question 6
+
+During application onboarding, `/checkout` POST bodies trip OWASP rule `942430` after the team moves a WAF policy to Prevention. Security asks you to **configure** the **WAF** **policy** with the narrowest defensible change. Firewall logs show one `RequestHeaderValues` selector on a legacy header. What should you do first?
+
+A. Disable the entire SQL injection managed rule group for all listeners
+B. Add a per-rule exclusion for rule `942430` scoped to that header selector after confirming the log evidence, then keep other SQLi rules active
+C. Detach the WAF policy from the Application Gateway
+D. Leave Prevention mode but stop collecting WAF logs to reduce noise
+
+<details>
+<summary>Answer</summary>
+
+**Correct: B.** The [WAF customization guidance](https://learn.microsoft.com/en-us/azure/web-application-firewall/ag/application-gateway-customize-waf-rules-portal) expects operators to tune with evidence: identify rule ID, match variable, and selector, then apply the smallest exclusion. Disabling a whole rule group weakens unrelated traffic. Removing WAF or ignoring logs removes the feedback loop you need before returning to a bounded Prevention posture.
+
+</details>
+
+### Question 7
+
+Pods show Ready in Kubernetes, but Application Gateway reports unhealthy backends. The application now exposes `/healthz`, while the gateway probe still calls `/ready` with a host header that does not match backend HTTP settings. As the operator responsible for how you **implement** **TLS** and probe contracts, what is the best next step?
+
+A. Increase autoscale `max_capacity` without touching probes or backend settings
+B. Update the probe path and host-header behavior to match the readiness contract, then revalidate listener TLS and backend HTTPS settings on the same route
+C. Disable health probes so traffic flows while the app team investigates
+D. Switch backends to HTTP-only on port 80 without updating documentation or certificates
+
+<details>
+<summary>Answer</summary>
+
+**Correct: B.** Probe contract drift is a common cause of false unhealthy backends when applications change readiness paths or host expectations. [Backend HTTP settings](https://learn.microsoft.com/en-us/azure/application-gateway/configuration-http-settings) and [TLS overview](https://learn.microsoft.com/en-us/azure/application-gateway/ssl-overview) should be validated together because hostname, SNI, protocol, and certificate behavior cross both hops. Scaling or disabling probes masks the mismatch and can send traffic to backends that the gateway correctly refuses.
 
 </details>
 


### PR DESCRIPTION
## Cloud track — Azure Essentials expand-to-floor (wave 4)

Below-floor → expand (cursor) → cross-family review (opus 4.8) → orchestrator web-verify → consolidated fix. Plus a verifier-gate fix for 3.13 (already review-done, was T3 on structural gates).

### Modules
| Module | body_words | tier |
|---|---|---|
| 3.11 Azure CI/CD (GitHub Actions + Pipelines) | 5097 | T0 PASS |
| 3.12 Bicep | 5000 | T0 PASS |
| 3.13 Application Gateway (gate fix only) | 5345 | T0 PASS |

### Review fixes (opus 4.8 R1)
**3.11** — P1: lab never granted the Container App ACR-pull permission (Task 4 private-image deploy would fail end-to-end; the troubleshooting note referenced a nonexistent step) → added system-assigned identity + `AcrPull` role + `az containerapp registry set --identity system`; P2: `--assignee`→`--assignee-object-id ... --assignee-principal-type ServicePrincipal` (Entra replication race).

**3.12** — P1: `utcNow()` inside a `var` is a Bicep compile error (broke the whole lab) → moved to a `param` default; P1: fixed `kubedojo` resource names → added `uniqueString(resourceGroup().id)` (global-name-collision; contradicted the module's own guidance); P2: `az stack group create` missing required `--action-on-unmanage`; P2: what-if symbol legend corrected.

**3.13** — verifier-gate fix only (quiz 4→7, learning outcomes 3→5, outcomes_aligned). Already `done` on the review axis; this clears its T3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)