### PR TITLE
chore(content): expand Azure Essentials 3.8/3.9/3.10 to 5000w floor + cross-family review fixes

### DIFF
--- a/src/content/docs/cloud/azure-essentials/module-3.10-monitor.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.10-monitor.md
@@ -19,9 +19,9 @@ After completing this module, you will be able to complete these practical outco
 
 ## Why This Module Matters
 
-In April 2023, a logistics company running a fleet management application on Azure noticed that their customer complaints had tripled over two weeks. Drivers were reporting slow load times and intermittent errors. The engineering team had no idea what was happening because they had not configured any monitoring beyond the default Azure portal metrics. When they finally investigated, they discovered that their SQL database had been running at 98% DTU utilization for 11 days. A new reporting query, deployed two weeks earlier as part of a routine release, was running every 5 minutes and consuming massive database resources. Two weeks of degraded customer experience, a 15% spike in customer churn, and an estimated $180,000 in lost contracts---all because nobody was watching the metrics and nobody had set up an alert for "database utilization exceeds 80%."
+Hypothetical scenario: a logistics company runs a fleet management application on Azure. Customer complaints triple over two weeks while drivers report slow load times and intermittent errors. The engineering team has not configured monitoring beyond default portal metrics. When someone finally investigates, they find an Azure SQL database at sustained high DTU utilization. A reporting query deployed with a routine release runs every five minutes and dominates database capacity. The outage was preventable: a metric alert on database utilization and a log query on slow queries would have surfaced the regression within hours instead of weeks.
 
-Observability is not a luxury. It is the difference between proactively fixing problems and reactively apologizing to customers. Azure Monitor is the platform's unified observability service, collecting metrics and logs from every Azure resource, virtual machine, container, and application. Log Analytics provides the query engine to make sense of that data. Alerts turn signals into actions. Application Insights traces requests through distributed systems.
+Observability is not a luxury. It is the difference between proactively fixing problems and reactively apologizing to customers. [Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/fundamentals/overview) is the platform's unified observability service, collecting metrics and logs from every Azure resource, virtual machine, container, and application. [Log Analytics](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs) provides the query engine to make sense of that data. [Alerts](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-overview) turn signals into actions. [Application Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview) traces requests through distributed systems.
 
 In this module, you will learn how Azure Monitor collects and organizes data, how to explore metrics in Metrics Explorer, how to write KQL (Kusto Query Language) queries against Log Analytics, how to create alerts with action groups, and how Application Insights provides end-to-end request tracing. By the end, you will deploy monitoring agents on a VM, ingest custom logs, write KQL queries, and create an alert that sends email when a threshold is breached.
 
@@ -29,7 +29,17 @@ In this module, you will learn how Azure Monitor collects and organizes data, ho
 
 ## Azure Monitor Architecture
 
-Azure Monitor is not a single service---it is a platform composed of several interconnected components that are designed to work together as a chain. Think of the platform as three layers: ingestion, storage/analysis, and action. First, data from resources, applications, and infrastructure is ingested and normalized; second, dashboards and queries help you interpret that data; and third, alerting and automation turn that interpretation into operational response.
+Azure Monitor is not a single service—it is a platform composed of interconnected components designed as a chain. Think of three layers: **ingestion** (agents, diagnostic settings, App Insights SDKs, platform pipelines), **storage and analysis** (metrics time-series store and Log Analytics tables), and **action** (alerts, autoscale, Logic Apps, webhooks). Data from subscriptions, regions, and on-premises Arc machines can funnel into shared workspaces so SRE sees one operational picture instead of fifty siloed portals.
+
+### Designing centralized monitoring
+
+Enterprise landing zones typically designate a **monitoring subscription** that hosts Log Analytics workspaces, action groups, and alert rules. Spoke subscriptions hold applications with diagnostic settings and DCR associations pointing at the hub workspace. [Azure Policy](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/policy-reference) can deploy diagnostic settings and AMA associations automatically so new resources do not ship without telemetry. Tag resources with `environment`, `cost-center`, and `owner` so KQL can filter `AzureActivity` and `AzureResourceGraph` results during incidents.
+
+Cross-subscription visibility does not require moving resources—only correct routing and RBAC. Readers need `Log Analytics Reader` on the workspace; alert rule authors need `Monitoring Contributor` on scopes they manage. Document which workspace holds production security data versus production application data before an incident forces ad-hoc merging.
+
+### Activity logs versus resource logs
+
+The **Azure Activity log** records control-plane operations (who created a VM, who deleted a resource group). It lands in the `AzureActivity` table when collected to a workspace. **Resource logs** (data plane) describe what happened inside the resource—SQL deadlocks, Key Vault access, App Service HTTP logs. Diagnostic settings control resource log flow. Confusing the two leads to gaps: Activity log alerts catch deletions but not query time-outs; SQL diagnostic logs catch slow queries but not RBAC assignments. Enable both for production data stores.
 
 ```mermaid
 flowchart TD
@@ -80,9 +90,59 @@ flowchart TD
 | **Latency** | Near real-time (~1 minute) | 2-5 minutes (ingestion delay) |
 | **Retention** | 93 days (free) | 31 days free, up to 12 years paid |
 | **Query language** | Simple (filter, aggregate) | KQL (powerful, SQL-like) |
-| **Cost** | Free (platform metrics) | $2.76/GB ingested |
+| **Cost** | Free (platform metrics) | Per-GB ingested (see [pricing](https://azure.microsoft.com/pricing/details/monitor/)) |
 | **Best for** | Dashboards, alerting on thresholds | Root cause analysis, auditing, forensics |
 | **Examples** | CPU %, memory %, request count, latency | Error messages, audit events, request traces |
+
+> **The observability funnel analogy**
+>
+> Metrics are the speedometer and fuel gauge on your dashboard—continuous numbers that tell you something is wrong in seconds. Logs are the flight recorder—richer, heavier, and essential after an incident to reconstruct decisions and errors. Diagnostic settings are the cables that connect each system to the recorder. Alerts are the seatbelt warning light: useless if nobody hears the chime.
+
+### The data planes in depth: metrics, logs, and diagnostic settings
+
+Azure Monitor splits telemetry into two complementary data platforms. [Metrics](https://learn.microsoft.com/en-us/azure/azure-monitor/metrics/data-platform-metrics) land in a regional time-series store optimized for numeric aggregation, charting, and fast threshold evaluation. [Logs](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs) land in a Log Analytics workspace as typed tables queried with Kusto Query Language (KQL). Neither plane replaces the other: metrics answer "is something wrong right now?" while logs answer "what exactly happened and who triggered it?"
+
+**Platform metrics** are emitted automatically by most Azure resources. They are multi-dimensional (you can slice by instance, region, or HTTP status code where the resource supports dimensions), near-real-time with about one-minute granularity for many resource types, and retained for roughly 93 days without ingestion charges for standard platform metrics. Metrics Explorer is the portal experience for ad-hoc charts; the same metric definitions power metric alerts and autoscale rules. Custom metrics (from your application or from the Azure Monitor Agent) follow the same pipeline but may incur charges depending on volume and configuration.
+
+**Log Analytics workspaces** are the central SaaS data store for log tables. One workspace can hold activity logs, resource diagnostic logs, VM agent data, container stdout, and Application Insights tables side by side. That consolidation is what makes cross-resource KQL possible: you can join a Key Vault audit event with an App Service request trace in one query instead of hunting across siloed tools. Workspace-level settings include default retention, daily ingestion cap, commitment tier pricing, and optional dedicated clusters for advanced scenarios such as customer-managed keys.
+
+**Table plans** control cost versus query power per table. The [Analytics plan](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs#table-plans) is the default for high-value operational data: full KQL, alerts, Insights, dashboards, and interactive retention (30 days by default, extendable with long-term retention). The **Basic** plan reduces ingestion cost for medium-touch troubleshooting data; you still run KQL on a single table (with lookup into Analytics tables), and simple log alerts are supported. The **Auxiliary** plan minimizes ingestion cost for verbose or compliance-oriented streams but is not optimized for real-time analysis or alerting. Choosing the wrong plan for a firehose table (for example, verbose debug logs on Analytics) is one of the fastest ways to inflate a bill without improving incident response.
+
+**Retention and archive** are layered. Interactive analytics retention applies while data is "hot" in the workspace. [Long-term retention](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-retention-archive) can extend total retention up to 12 years per table at a lower storage rate, with search jobs or restore operations when you need to query cold data. Deleting rows with the purge API does not reduce retention charges—you must lower retention settings on the workspace or table. Plan retention per compliance need, not "keep everything forever by default."
+
+**Diagnostic settings** are the routing pipe from Azure resources into destinations you control. A single diagnostic setting can send **resource logs** (formerly diagnostic logs) and optionally **metrics** to a Log Analytics workspace, an Azure Storage account, or an Event Hub. Sending to a workspace enables KQL, log alerts, and correlation with other tables. Storage is cheaper for long-term archive and compliance exports but is not queryable with KQL until you re-import or use external tools. Event Hub fits streaming to SIEM pipelines or custom processors. Many teams use workspace for operations and Storage or Event Hub for regulated archives. [Diagnostic settings](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-settings) are not enabled by default on every resource—treat them as day-one infrastructure, often enforced with Azure Policy.
+
+```bash
+# Route Key Vault audit logs and all metrics to a workspace (same pattern for SQL, Storage, etc.)
+WORKSPACE_ID=$(az monitor log-analytics workspace show -g myRG -n kubedojo-logs --query id -o tsv)
+
+az monitor diagnostic-settings create \
+  --name "audit-and-metrics-to-law" \
+  --resource "/subscriptions/<sub>/resourceGroups/myRG/providers/Microsoft.Sql/servers/myserver/databases/mydb" \
+  --workspace "$WORKSPACE_ID" \
+  --logs '[{"category":"SQLSecurityAuditEvents","enabled":true},{"category":"Errors","enabled":true}]' \
+  --metrics '[{"category":"AllMetrics","enabled":true}]'
+
+# Export the same categories to Storage for cheap long-term retention (archive path)
+STORAGE_ID=$(az storage account show -g myRG -n mymonitorarchive --query id -o tsv)
+az monitor diagnostic-settings create \
+  --name "sql-logs-to-storage" \
+  --resource "/subscriptions/<sub>/resourceGroups/myRG/providers/Microsoft.Sql/servers/myserver/databases/mydb" \
+  --storage-account "$STORAGE_ID" \
+  --logs '[{"category":"SQLSecurityAuditEvents","enabled":true}]'
+```
+
+When you design monitoring, draw two arrows from every critical resource: one to **metrics** for dashboards and fast alerts, one through **diagnostic settings** to the right log destination for forensics. Skipping diagnostic settings leaves you with platform metrics only—you will see that CPU spiked but not which query or principal caused it.
+
+### Network monitoring and high-volume logs
+
+Network Watcher [NSG flow logs](https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-overview) and [traffic analytics](https://learn.microsoft.com/en-us/azure/network-watcher/traffic-analytics) can generate very large log volume. Treat them as a deliberate cost decision: flow logs to Storage or Event Hub for security analytics, not always to Analytics tables unless security operations queries them daily. [Azure Monitor for networks](https://learn.microsoft.com/en-us/azure/azure-monitor/insights/network-insights-overview) provides curated views when NSG diagnostics and topology data are enabled.
+
+For Azure Kubernetes Service, control plane metrics remain platform-managed while workload telemetry flows through Container Insights or OpenTelemetry collectors. Align with your platform team on whether container stdout belongs in `ContainerLogV2` on Analytics or Auxiliary—verbose application logging from dozens of pods is a common reason production workspaces exceed ingestion forecasts.
+
+### Custom logs and the Logs Ingestion API
+
+Applications can send custom structured logs with the [Logs Ingestion API](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-ingestion-api-overview) and DCR-defined destinations. Prefer structured JSON with stable schemas so tables remain queryable and transformations can drop fields before billing. Custom logs without retention planning often become “forever Analytics tables” that dominate workspace cost.
 
 ---
 
@@ -119,7 +179,11 @@ az monitor metrics list \
   -o table
 ```
 
-Common metrics you should usually monitor are your first line of defense in day-two operations, and they are the baseline signals you should validate before deep dives into logs. In practice, teams tune these default thresholds during normal traffic periods, then revise them once they observe workload seasonality.
+Common metrics you should usually monitor are your first line of defense in day-two operations. Platform metrics appear in Metrics Explorer within about a minute for many resource types, which is why on-call starts charts before KQL during a sev-1. **Custom metrics** let applications emit business KPIs (orders queued, jobs failed) via the [Metrics REST API](https://learn.microsoft.com/en-us/azure/azure-monitor/metrics/custom-metrics) or OpenTelemetry—useful when infrastructure looks healthy but the business pipeline is stuck.
+
+**Multi-dimensional metrics** let one alert rule split on dimension values (for example HTTP status code on App Service). Each dimension value can become a billed time series in large scopes, so prefer focused scopes or fewer dimensions when cost matters. **Metric namespaces** separate platform metrics (`Microsoft.Compute/virtualMachines`) from guest OS and custom namespaces; verify you alert on the namespace that actually receives data after AMA or diagnostic settings are configured.
+
+Teams tune default thresholds during normal traffic periods, then revise after observing seasonality. Document baseline charts in a workbook so new engineers know what “healthy” looks like before they page the team for a expected nightly batch spike.
 
 | Resource | Critical Metrics | Alert Threshold (suggestion) |
 | :--- | :--- | :--- |
@@ -130,16 +194,31 @@ Common metrics you should usually monitor are your first line of defense in day-
 | **Container App** | Replica count, Request count, Response time | Response > 1s, Restarts > 3/hour |
 | **Key Vault** | Service API Latency, Availability | Latency > 1s, Availability < 99.9% |
 
+When building dashboards, pin the charts that on-call checks first—DTU for databases, `Percentage CPU` for VMs, `Http5xx` for App Service—then link each chart to the alert rule that protects the same signal. That pairing trains the team that a green dashboard and a silent alert channel are related, not redundant.
+
 ---
 
 ## Log Analytics Workspaces
 
-A Log Analytics workspace is the central repository for log data in Azure Monitor, and it is where all the logs your
-team wants to investigate eventually land. Logs from resources, VMs, containers, and applications can all be sent to the
-same place, which makes cross-resource troubleshooting possible without switching between dozens of views. In practice,
-you use the workspace not just to store data but to reason across it, because queries in one place can correlate events
-and identify patterns that are invisible when looked at one-by-one. This is the foundation that enables reliable alert
-forensics, compliance investigations, and platform-wide capacity analysis.
+A [Log Analytics workspace](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-workspace-overview) is the central repository for log data in Azure Monitor. Logs from resources, VMs, containers, and applications can all be sent to the same workspace, which makes cross-resource troubleshooting possible without switching between dozens of portal blades. You use the workspace not just to store data but to reason across it: one KQL query can correlate a Key Vault `AuditEvent`, an App Service `AppRequest`, and a SQL `AzureDiagnostics` row that share a time window and resource ID.
+
+### Workspace architecture across subscriptions
+
+Platform teams often deploy **one workspace per environment** (production, staging, development) rather than per application. Resources in any subscription can send data to a workspace in another subscription as long as RBAC and network rules allow it. That pattern supports centralized monitoring for enterprise landing zones: hub subscriptions host the workspace, spoke subscriptions host workloads with diagnostic settings pointed at the hub. Use [Azure Monitor scoped configuration](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/scoped-configurations) and workspace permissions so application teams query only their tables or resource sets.
+
+When Microsoft Sentinel or Defender for Cloud is enabled on a workspace, billing and data mix change—Sentinel charges apply to security tables, and operational data may need a separate workspace to avoid paying Sentinel rates on routine VM performance logs. The [workspace design guidance](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/workspace-design) documents tradeoffs between single workspace simplicity and multi-workspace isolation.
+
+### Data collection rules and ingestion pipeline
+
+Modern collection uses [Data Collection Rules (DCRs)](https://learn.microsoft.com/en-us/azure/azure-monitor/agents/data-collection-rule-overview) attached to Azure Monitor Agent on VMs, or platform-native diagnostic settings on PaaS resources. DCRs define streams (performance, syslog, Windows events), optional [transformations](https://learn.microsoft.com/en-us/azure/azure-monitor/data-collection/data-collection-transformations) that filter or reshape JSON before ingestion, and destinations (workspace, metrics, storage). Transformations are a cost control: drop DEBUG fields, strip PII, or route noisy tables to Basic plans before billable ingestion occurs.
+
+```bash
+# List tables in a workspace (discover what is actually ingesting)
+az monitor log-analytics workspace table list \
+  --resource-group myRG \
+  --workspace-name kubedojo-logs \
+  --query '[].{Name:name, Plan:plan}' -o table
+```
 
 ```bash
 # Create a Log Analytics workspace
@@ -181,6 +260,10 @@ az monitor diagnostic-settings create \
 | `AppRequests` | Application Insights | HTTP request traces |
 | `AppExceptions` | Application Insights | Exception traces |
 
+The `_ResourceId` and `_SubscriptionId` columns on many tables tie rows back to Azure Resource Manager IDs. Use them in `where` clauses to scope dashboards per team without separate workspaces: `where _ResourceId contains "/resourceGroups/prod-app/"`. The `_IsBillable` column marks rows excluded from ingestion charges—useful when reconciling usage reports with raw row counts.
+
+Querying Entra sign-in data requires the `SigninLogs` table (often via Microsoft Graph connector or Sentinel). Security investigations blend `SigninLogs`, `AzureActivity`, and `AuditLogs` depending on which diagnostic streams you enabled—document which table is authoritative for your tenant.
+
 ---
 
 ## KQL: Kusto Query Language
@@ -192,6 +275,10 @@ because you can run a broad query to find candidate events, then immediately pro
 without rewriting the whole statement.
 
 ### KQL Fundamentals
+
+Read KQL top to bottom as a pipeline: each pipe takes the result of the previous step. Start wide with a table and time filter, then narrow with `where`, shape with `project` or `extend`, aggregate with `summarize`, and present with `order` or `render`. The Log Analytics portal **Simple mode** helps beginners without syntax; **KQL mode** is what alert rules and workbooks store—learn both because on-call will paste alert queries into the editor during incidents.
+
+Time filters are non-negotiable for cost and speed. Tables are date-partitioned; `where TimeGenerated > ago(1h)` limits scanned data. Use `bin(TimeGenerated, 5m)` for trend charts so alert queries and dashboards share the same grain. When comparing weeks, use `ago(7d)` and `ago(14d)` in parallel queries rather than open-ended scans.
 
 ```kusto
 // Basic query structure: Table | operator1 | operator2 | ...
@@ -232,6 +319,31 @@ Perf
 | where AvgCPU > 80
 | order by AvgCPU desc
 ```
+
+### Joining infrastructure and application signals
+
+Production investigations rarely stay in one table. A failed checkout might require `AppRequests` joined to `AppDependencies` on `OperationId`, then cross-checked against `AzureDiagnostics` for SQL time-outs on the same `ResourceId`. Use `join kind=inner` when you need matching keys only; use `lookup` when enriching a large table with a small reference set (region map, service owner table) to avoid expensive full scans.
+
+```kusto
+// Correlate slow requests with SQL dependency failures (last hour)
+AppRequests
+| where TimeGenerated > ago(1h)
+| where DurationMs > 3000
+| project RequestTime = TimeGenerated, OperationId, RequestName = Name, RequestDuration = DurationMs
+| join kind=inner (
+    AppDependencies
+    | where TimeGenerated > ago(1h)
+    | where DependencyType == "SQL"
+    | where Success == false
+    | project OperationId, SqlTarget = Target, SqlResult = ResultCode
+) on OperationId
+| order by RequestTime desc
+| take 50
+```
+
+### Workbooks, dashboards, and Grafana
+
+[Azure Monitor workbooks](https://learn.microsoft.com/en-us/azure/azure-monitor/visualize/workbooks-overview) combine metrics, log queries, and text into shareable operational views. Pin single charts to Azure dashboards for executive summaries. [Azure Managed Grafana](https://learn.microsoft.com/en-us/azure/managed-grafana/overview) integrates with Monitor for teams that already standardized on Grafana dashboards—useful when you unify cloud and on-premises metrics in one pane.
 
 ### Essential KQL Operators
 
@@ -292,26 +404,44 @@ AppExceptions
 
 ## Alerts and Action Groups
 
-Alerts proactively notify you when conditions are met, and they only become useful when you connect signal detection to an
-response workflow. Think of an alert as a three-part contract: a **condition** defines what “failure” means for your service,
-a **severity** tells responders how urgent it is, and an **action group** maps conditions to people or systems that should
-take action. If a condition is clear but the action group is missing, the monitor simply reports that it crossed a boundary
-without helping anyone respond. In Azure, this is why reliable alert design is both a technical decision and an
-operational one.
+[Alerts](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-overview) connect signal detection to response. A durable alert design has four parts: the **signal** (metric, log query, or activity log), the **evaluation logic** (threshold, dynamic band, or KQL aggregation), the **severity** (0–4 in Azure Monitor), and an **action group** that notifies humans or triggers automation. Alerts without action groups are dashboard decorations—they change state in the portal while on-call engineers sleep through the incident.
 
-### Alert Types
+### Alert types and when to use each
 
 | Type | Monitors | Evaluation Frequency | Use Case |
 | :--- | :--- | :--- | :--- |
-| **Metric alert** | Metric thresholds | 1 min | CPU > 85%, Response time > 2s |
-| **Log alert** | KQL query results | 5-15 min | Error count > threshold, security events |
-| **Activity log alert** | Control plane events | Real-time | Resource deleted, role assigned |
-| **Smart detection** | AI-detected anomalies | Continuous | Unusual failure rate, performance degradation |
+| **Metric alert** | Numeric time-series | As low as 1 minute | CPU, DTU, latency, queue depth—fast, cheap signals |
+| **Log alert** (scheduled query) | KQL result count | 5–15 minutes typical | Error rates, security patterns, cross-table correlation |
+| **Activity log alert** | Control plane events | Near real-time | Deletes, RBAC changes, policy violations |
+| **Smart detection** | App Insights anomalies | Continuous | Failure-rate spikes, dependency degradation |
 
-### Multi-Resource and Dynamic Alerts
+**Metric alerts** excel when the condition is a single numeric threshold on platform or custom metrics. They evaluate frequently and cost less per evaluation than scanning gigabytes of logs. **Log alerts** excel when the condition requires text, joins, or business logic—“more than 5% of checkout requests returned HTTP 500 in the last 15 minutes” is natural KQL, awkward as a raw metric. Expect log alerts to run on a slower cadence because each evaluation scans workspace data.
 
-- **Multi-Resource Alerts**: You can apply a single metric alert rule across multiple resources of the same type within a resource group or subscription, drastically reducing management overhead.
-- **Dynamic Thresholds**: Instead of hardcoding static limits (e.g., CPU > 85%), dynamic thresholds use machine learning to continuously analyze metric patterns, establishing a baseline and triggering alerts only when behavior deviates significantly from the norm.
+**Dynamic thresholds** on metric alerts use machine learning to learn seasonal baselines instead of a fixed “CPU > 85%.” They help workloads with daily cycles (batch jobs, business-hours traffic) but still need tuning for brand-new services with little history. **Multi-resource metric alerts** apply one rule to many VMs or databases in a scope, which reduces rule sprawl when you operate fleet-wide SRE policies.
+
+### Action groups, suppression, and alert processing rules
+
+An [action group](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/action-groups) is a named set of notification channels: email, SMS, voice, webhook (PagerDuty, Slack, Teams), Azure Functions, Logic Apps, or ITSM connectors. Reuse action groups across rules so routing changes happen in one place. [Alert processing rules](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-action-rules) add schedule-based suppression (maintenance windows), deduplication behavior, or routing overrides—for example, suppress non-critical Sev 3 alerts during a planned change window while still allowing Sev 1 pages.
+
+### Log alert example: HTTP 500 error rate
+
+Log alerts should encode **why** the condition matters. This query fires when failed requests exceed 5% of traffic in a 15-minute window—actionable for customer-facing APIs:
+
+```kusto
+AppRequests
+| where TimeGenerated > ago(15m)
+| summarize
+    Total = count(),
+    Failed = countif(toint(ResultCode) >= 500)
+| extend FailRate = 100.0 * Failed / Total
+| where Total > 100 and FailRate > 5
+```
+
+The `Total > 100` guard prevents alerting during low-traffic periods when three errors look like 100% failure rate. Wire the scheduled query rule to the same action group as your CPU alerts so on-call sees correlated infrastructure and application signals.
+
+### Autoscale driven by metrics
+
+[Autoscale](https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-overview) uses the same metric platform as alerts but changes capacity instead of notifying humans. VM scale sets, App Service plans, and other scalable resources can add or remove instances when CPU, queue length, or custom metrics cross thresholds. Autoscale rules and metric alerts complement each other: autoscale handles predictable load (morning traffic), alerts catch misconfiguration (autoscale maxed out but latency still high). Test scale-out and scale-in cooldowns in staging—aggressive scale-in during a traffic spike causes flapping outages.
 
 ```bash
 # Create an action group (email + webhook)
@@ -361,15 +491,58 @@ az monitor activity-log alert create \
   --action-group "$ACTION_GROUP_ID"
 ```
 
+### Alert severity and on-call routing
+
+Azure Monitor alert severity runs from 0 (Critical) to 4 (Verbose). Map severities to response channels before go-live: Sev 0–1 pages on-call, Sev 2 opens a ticket, Sev 3–4 posts to chat or a dashboard only. Document runbooks linked from action group webhooks so recipients know whether to scale SQL, restart pods, or fail over. Test action groups quarterly—expired PagerDuty keys are a common reason real outages stay silent while portal shows “Fired.”
+
+| Severity | Typical signal | Suggested channel |
+| :--- | :--- | :--- |
+| 0–1 | Customer-facing outage, data loss risk | PagerDuty / phone / SMS |
+| 2 | Degraded SLO, capacity near limit | Email + ticket system |
+| 3 | Early warning, non-customer impact | Teams / Slack webhook |
+| 4 | Informational trend | Dashboard only, no page |
+
+---
+
+## Production monitoring checklist
+
+Before declaring an Azure workload production-ready, verify observability end to end. This checklist prevents the “metrics exist but nobody gets paged” failure mode from the module opener scenario.
+
+| Area | Minimum bar | Verification |
+| :--- | :--- | :--- |
+| Platform metrics | CPU, memory, disk, or service-specific SLO metrics charted | Metrics Explorer shows 24h baseline |
+| Diagnostic settings | Data-plane logs for SQL, KV, Storage, App Service | `AzureDiagnostics` or resource-specific tables receive rows |
+| Workspace | One workspace per environment, retention documented | `az monitor log-analytics workspace show` |
+| Agent / DCR | AMA on VMs, Container Insights on AKS if applicable | `Heartbeat` or `ContainerLogV2` rows in last 15m |
+| App Insights | Workspace-based component linked, sampling configured | `AppRequests` shows traffic after deploy |
+| Alerts | Metric alerts for capacity; log alert for error rate | Test fire to action group in lower environment |
+| Action groups | Routes per severity, no orphaned rules | Portal shows action on every enabled rule |
+| Cost guards | Table plans for verbose logs, no DEBUG fleet-wide | Usage blade reviewed weekly first month |
+| Runbooks | Link from alert payload or wiki | On-call drill completes in under 15 minutes |
+
+Hypothetical scenario: a team ships AKS without Container Insights but installs Prometheus only for their own squad. During an outage, platform engineers cannot see pod restart loops in the shared workspace while application engineers see healthy HTTP metrics on the ingress. The checklist forces shared visibility before merge to main.
+
 ---
 
 ## Application Insights: End-to-End Tracing
 
-Application Insights is a component of Azure Monitor focused on application performance monitoring (APM), and it adds the
-application-context layer that raw infrastructure telemetry usually cannot provide. It tracks requests across services, records
-where latency is introduced, and captures exceptions with enough context to debug production failures quickly. In practice, this
-makes it your primary tool when you need to move from “the system is slow” to “service X is the one adding 10 seconds to
-every checkout request.” The result is a direct path from distributed telemetry to user-impacting issue resolution.
+[Application Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview) is the APM layer of Azure Monitor. It adds application context that infrastructure metrics alone cannot provide: HTTP requests, dependency calls (SQL, HTTP APIs, Azure services), exceptions, traces, and custom events. When a user reports a slow checkout, App Insights lets you follow one **operation ID** across the API gateway, order service, and payment service instead of guessing which tier failed.
+
+### Workspace-based versus classic resources
+
+Modern Application Insights resources are **workspace-based**: telemetry is stored in tables such as `AppRequests`, `AppDependencies`, and `AppExceptions` inside a linked Log Analytics workspace. Billing for ingestion and retention follows the [workspace pricing model](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#application-insights-billing), including commitment tiers and table plans. **Classic** Application Insights resources still exist in older deployments; they bill ingestion separately and cannot use workspace commitment tiers. New designs should always create workspace-based components and link them explicitly to a production or non-production workspace per environment.
+
+### Distributed tracing, correlation, and the Application Map
+
+Application Insights implements distributed tracing using the W3C `traceparent` standard. Each incoming request receives an operation ID; outbound calls propagate that context so dependencies appear under the same end-to-end transaction. The **Application Map** visualizes services as nodes and calls as edges, highlighting failure rates and latency between components. **Live Metrics** streams near-real-time server health (request rate, failures, CPU) without waiting for full ingestion—useful during a deploy or load test, though it is not a substitute for retained logs.
+
+### Instrumentation: SDK, auto-instrumentation, and OpenTelemetry
+
+You have three common instrumentation paths. **Auto-instrumentation** (Azure App Service, Container Apps, Functions when you set `APPLICATIONINSIGHTS_CONNECTION_STRING`) captures requests and dependencies with minimal code changes. **Application Insights SDKs** (.NET, Java, Node.js, Python) give finer control over telemetry initializers, custom dimensions, and sampling configuration. **OpenTelemetry** with the [Azure Monitor OpenTelemetry Distro](https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry-overview) is the long-term standards-based path: export OTLP to the same workspace-backed tables without locking into a single vendor SDK. Use auto-instrumentation for speed in platform-hosted apps; use OpenTelemetry when you run polyglot microservices or need portable instrumentation across clouds.
+
+### Sampling and noise control
+
+High-traffic applications can generate enormous telemetry volume. [Adaptive sampling](https://learn.microsoft.com/en-us/azure/azure-monitor/app/sampling) reduces ingestion while preserving errors and slow requests. Fixed sampling drops a percentage of successful telemetry. Without sampling, verbose INFO logging plus full dependency tracking on every request can dominate workspace ingestion charges—especially when every pod in a large AKS fleet emits identical successful calls. Tune sampling in staging with realistic load before production cutover.
 
 ```mermaid
 sequenceDiagram
@@ -408,6 +581,8 @@ workflow, which makes correlation much easier than hand-built log markers. In th
 custom tracing first—you are standardizing on a shared context model and only then refining what to collect for your
 specific service behaviors.
 
+For Kubernetes, install the [OpenTelemetry Collector](https://learn.microsoft.com/en-us/azure/azure-monitor/app/kubernetes-codeless) or enable codeless attachment where supported so pod telemetry reaches the same workspace as VM and platform logs. Consistent `cloud_RoleName` and `cloud_RoleInstance` dimensions keep the Application Map readable when replica counts change during autoscale events.
+
 ```bash
 # Configure App Insights on a Container App
 az containerapp update \
@@ -415,6 +590,12 @@ az containerapp update \
   --name my-app \
   --set-env-vars "APPLICATIONINSIGHTS_CONNECTION_STRING=$APPINSIGHTS_CONN_STRING"
 ```
+
+### Availability tests and smart detection
+
+[Availability tests](https://learn.microsoft.com/en-us/azure/azure-monitor/app/availability-overview) probe public URLs or private endpoints from Azure regions on a schedule. They emit metrics and alerts when synthetic transactions fail—ideal for “can users reach the site?” checks that infrastructure metrics miss (DNS, TLS, CDN, third-party SaaS). Combine synthetic tests with server-side App Requests so you distinguish global network issues from application regressions.
+
+**Smart detection** rules in Application Insights use ML on failure rates, dependency duration, and performance anomalies. They complement explicit alert rules when you lack baseline history. Smart detection does not replace log-based error-rate alerts for contractual SLOs; it surfaces unknown-unknown patterns during early rollout.
 
 ### Useful App Insights KQL Queries
 
@@ -446,15 +627,21 @@ AppRequests
 | order by TimeGenerated asc
 ```
 
+### Failure analysis workflow
+
+When App Insights shows elevated failures, walk this sequence before scaling infrastructure blindly. First, open the Application Map to see which dependency turned red. Second, run `AppExceptions` grouped by `ProblemId` for stack signature. Third, filter `AppDependencies` where `Success == false` for the failing tier. Fourth, check platform metrics (SQL DTU, App Service CPU) for the same timestamp. Fifth, pull resource logs via `AzureDiagnostics` if the dependency is Azure PaaS. This order moves from user symptom to code path to infrastructure constraint without duplicating work across tools.
+
 ---
 
 ## Azure Monitor Agent (AMA)
 
-The Azure Monitor Agent replaces the legacy Log Analytics Agent (MMA/OMS), and it is the collection mechanism you should
-use going forward. It collects performance counters, syslog, Windows events, and custom logs from VMs, then forwards that data
-to Log Analytics in a policy-driven way. In practice, this shift matters because configuration can be centralized with
-Data Collection Rules instead of repeating per-VM tweaks, which reduces drift as your fleet grows. When you care about observability
-consistency across a hundred-plus machines, this is usually the difference between a working setup and a governance nightmare.
+The [Azure Monitor Agent](https://learn.microsoft.com/en-us/azure/azure-monitor/agents/azure-monitor-agent-overview) replaces the legacy Log Analytics Agent (MMA/OMS). It collects performance counters, syslog, Windows events, and custom logs from VMs, then forwards data according to Data Collection Rules. Configuration is policy-driven: security teams publish DCRs for auth syslog, platform teams publish DCRs for perf counters, and associations attach rules to VM scale sets, Arc-enabled servers, and standalone VMs without reinstalling agents.
+
+AMA supports **managed identity** for authentication to ingestion endpoints, **multiple destinations** (workspace plus metrics), and **transformations** at collection time. The legacy MMA agent cannot use modern table plans or transformations—migrate during any VM refresh project. On Azure Kubernetes Service, container logs often flow via Container Insights (`ContainerLogV2`) rather than per-node AMA, but node-level syslog and perf counters still use AMA on the underlying nodes when required for host-level debugging.
+
+### VM insights and Container Insights
+
+[VM insights](https://learn.microsoft.com/en-us/azure/azure-monitor/vm/vminsights-overview) adds curated performance, dependency, and health views for virtual machines when AMA and the right DCRs are associated. [Container Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-overview) monitors AKS and Arc-enabled Kubernetes with Prometheus metrics, container logs, and Kubernetes events funneled to the workspace. Enable these solutions when you operate fleets—raw tables alone overwhelm engineers who need opinionated dashboards during incidents.
 
 ```bash
 # Install Azure Monitor Agent on a Linux VM
@@ -509,11 +696,130 @@ az monitor data-collection rule association create \
   --rule-id "$DCR_ID"
 ```
 
+### AMA on scale sets and Arc
+
+For virtual machine scale sets, associate the DCR at the scale set resource so new instances inherit collection automatically. [Azure Arc-enabled servers](https://learn.microsoft.com/en-us/azure/azure-monitor/agents/azure-monitor-agent-install?tabs=CLI) outside Azure use the same AMA package with Arc connectivity—hybrid fleets benefit from one DCR model for on-premises and cloud. Test DCR changes on a canary instance before fleet-wide association; a misconfigured syslog facility can double ingestion overnight.
+
+---
+
+## Cost lens: ingestion, retention, and alert economics
+
+Monitoring spend is rarely a single line item. It accumulates across Log Analytics ingestion, retention beyond included periods, Application Insights telemetry, metric alert evaluations, and data you never meant to collect. Understanding the knobs prevents observability from becoming an unbounded tax.
+
+### Log Analytics ingestion and commitment tiers
+
+Log Analytics bills ingested data volume in gigabytes per workspace. Pay-as-you-go is the default; [commitment tiers](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs#commitment-tiers) commit to a daily ingestion volume (starting at 100 GB/day) at a lower per-GB rate when sustained volume justifies it. Billable size is based on the string representation of columns stored, not the raw JSON payload—Microsoft documents that billed volume is often substantially smaller than incoming event size for Analytics tables, but verbose custom fields still add up. Use the workspace **Usage and estimated costs** blade to compare pay-as-you-go versus commitment before you lock a 31-day commitment period.
+
+The first 5 GB per billing account per month are free for Log Analytics ingestion (regional pricing applies beyond that—check [Azure Monitor pricing](https://azure.microsoft.com/pricing/details/monitor/) for your region). Auxiliary and Basic table plans reduce ingestion cost for tables that do not need full interactive analytics; query charges apply when you scan Basic or Auxiliary data interactively.
+
+### Retention beyond interactive analytics
+
+Default interactive retention is commonly 30 days for many tables (90 days for some Microsoft Sentinel and Application Insights scenarios). [Extending retention](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-retention-archive) or using long-term retention adds monthly charges per GB retained. Purging data does not retroactively reduce retention billing—you must lower retention settings. Archive expensive verbose tables to Auxiliary with explicit total retention for compliance instead of keeping debug logs on Analytics for a year.
+
+### Application Insights and sampling as a cost control
+
+Workspace-based Application Insights stores all telemetry in linked workspace tables, so App Insights ingestion is workspace ingestion. Adaptive and fixed [sampling](https://learn.microsoft.com/en-us/azure/azure-monitor/app/sampling) is the primary cost lever for high-traffic apps: drop redundant successful requests while retaining errors and outliers. Live Metrics Stream does not add ingestion volume for retained data, but it does not replace historical analysis either.
+
+### Metric alerts, log alerts, and hidden volume drivers
+
+Metric alerts bill per rule and can bill per monitored time series when dimensions multiply scopes. Log alerts bill based on scanned data during each evaluation—wide time ranges and unfiltered tables increase cost and latency. The silent budget killer is **verbose logging**: DEBUG-level application logs, NSG flow logs on every rule, and full HTTP body logging can push a single VM from a few gigabytes per month to tens of gigabytes. Pair diagnostic settings with table plan selection and ingestion transforms to drop noise before it lands in Analytics tables.
+
+| Cost driver | What spikes the bill | Mitigation |
+| :--- | :--- | :--- |
+| Analytics ingestion | NSG flow logs, verbose app logs, all pods at DEBUG | Basic/Auxiliary plans, transforms, log level discipline |
+| Retention | 365+ day retention on high-volume tables | Per-table retention, long-term tier, export to Storage |
+| App Insights | High RPS without sampling | Adaptive sampling, filter health-check traffic |
+| Log alerts | Broad KQL every 5 minutes | Tight `TimeGenerated` filters, metric alerts where possible |
+| Metric alerts | Hundreds of dimensional time series | Consolidate multi-resource rules, reduce dimensions |
+| Daily cap misconfiguration | Ingestion stops silently when cap hit | Set caps only in dev/test; use alerts on usage meters in prod |
+
+### Estimating ingestion before enablement
+
+Use the workspace **Usage and estimated costs** view and [Analyze usage in a Log Analytics workspace](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/analyze-usage) to identify top tables before enabling NSG flow logs or DEBUG logging fleet-wide. Multiply per-VM estimates by instance count: a modest 2 GB/month per VM becomes 200 GB/month at 100 VMs. Commitment tiers help only when sustained volume is predictable—spiky debug logging does not fit a fixed daily commit.
+
+---
+
+## Decision Framework: metrics, logs, destinations, and alerts
+
+Operators need a decision path because “turn on monitoring” is too vague. Start from the question you must answer in an incident, then pick the data plane and destination.
+
+```text
+start
+  |
+  v
+Need sub-minute numeric threshold on a resource metric?
+  | yes -> Metric alert + Metrics Explorer
+  | no
+  v
+Need text, joins, or % error rate over requests?
+  | yes -> Log Analytics table + log alert (scheduled query)
+  | no
+  v
+Need who changed Azure control plane (delete, RBAC)?
+  | yes -> Activity log alert on AzureActivity
+  | no
+  v
+Need retained queryable ops data in one place?
+  | yes -> Diagnostic settings -> Log Analytics workspace
+  | no
+  v
+Need cheap multi-year archive or SIEM stream?
+  | yes -> Diagnostic settings -> Storage and/or Event Hub
+  | no -> Revisit requirement (metrics-only may suffice)
+```
+
+| Decision | Choose | Tradeoff |
+| :--- | :--- | :--- |
+| Fast threshold on CPU, DTU, latency | Metric alert | Misses log-only context; cheap evaluation |
+| “>5% HTTP 500 in 15m” with volume guard | Log alert on `AppRequests` | Slower cadence; scans workspace GB |
+| Compliance archive, not daily KQL | Diagnostic settings → Storage | Cheap retention; not interactive in Log Analytics |
+| Real-time export to Splunk/Sentinel | Diagnostic settings → Event Hub | Streaming cost + consumer ops |
+| High-volume debug logs | Auxiliary or Basic table plan | Lower ingest; query/alert limits on Auxiliary |
+| Fleet-wide CPU policy | Multi-resource metric alert | One rule; dimension explosion still costs |
+
+### Instrumentation choice
+
+| Signal need | First instrumentation | Why |
+| :--- | :--- | :--- |
+| App Service / Functions / ACA | Connection string auto-instrumentation | Fastest path to requests and dependencies |
+| Custom business events | SDK or OpenTelemetry custom spans | Dimensions you control |
+| Polyglot Kubernetes microservices | OpenTelemetry distro → workspace | Portable across languages |
+| VM syslog and perf counters | Azure Monitor Agent + DCR | Policy-driven, no legacy MMA |
+
+---
+
+## Patterns & Anti-Patterns
+
+| Pattern | When to use it | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| One workspace per environment | Dev, staging, prod separation | Cross-resource KQL without mixing blast radius | Use RBAC and table-level access for teams |
+| Diagnostic settings on day one | All critical data-plane resources | Metrics alone miss audit and query text | Enforce with Azure Policy at scale |
+| Metric alerts for SLO gates | Latency, availability, CPU, DTU | Sub-minute evaluation, predictable cost | Add dynamic thresholds for seasonal workloads |
+| Log alerts for error-rate logic | HTTP 5xx %, auth failures | Expresses business conditions | Always filter `TimeGenerated` and minimum volume |
+| Workspace-based App Insights | New applications | Unified billing and KQL across infra + apps | Link prod workspace only to prod components |
+| Adaptive sampling in production | High RPS services | Cuts ingest while keeping failures | Validate in load test before go-live |
+
+| Anti-pattern | What goes wrong | Better approach |
+| :--- | :--- | :--- |
+| DEBUG logging everywhere in production | Ingestion dominates cloud bill | INFO in prod; DEBUG only on sampled instances |
+| Log alert without time filter | Scans entire table history; slow and costly | Start every query with `where TimeGenerated > ago(...)` |
+| One workspace per resource | Cannot correlate App + SQL + KV in one KQL | Centralize per environment with RBAC |
+| Alerts with no action group | Incidents visible only in portal | Attach shared action group per severity tier |
+| Classic App Insights for new apps | Misses commitment tiers and table plans | Workspace-based component linked to LAW |
+| All diagnostics to Analytics only | Paying interactive ingest for archive-only data | Route verbose streams to Auxiliary or Storage |
+| Static CPU 50% on bursty VMs | Alert fatigue; ignored pages | Raise threshold, longer window, or dynamic band |
+
+### Governance with Azure Policy and automation
+
+At scale, manual portal configuration drifts. [Azure Policy initiatives for monitoring](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/policy-reference) deploy diagnostic settings, deploy AMA with DCR associations, and enforce tagging that KQL relies on. Pair policy with remediation tasks so existing resources backfill telemetry without a human opening each blade. Logic Apps triggered from action groups can open ServiceNow tickets, post to Teams, or run safe automation (scale out, restart app) when alerts fire—keep automation idempotent and bounded so flapping alerts do not loop scale operations.
+
+Export selected tables to Storage or Event Hub when compliance requires immutable copies outside the workspace. [Data export rules](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-data-export-rules) run continuously per table; test export filters so you do not duplicate entire workspace firehoses into storage accounts without lifecycle policies.
+
 ---
 
 ## Did You Know?
 
-1. **Log Analytics ingestion costs $2.76 per GB**, but the first 5 GB per billing account per month are free. A single VM running the Azure Monitor Agent with default performance counters and syslog collection generates approximately 1-3 GB of log data per month. However, enabling verbose application logging or NSG flow logs can push a single VM to 10+ GB per month. Always estimate your ingestion volume before enabling logging on production fleets.
+1. **Log Analytics ingestion is priced per GB ingested** (regional rates on the [Azure Monitor pricing page](https://azure.microsoft.com/pricing/details/monitor/)), but the first 5 GB per billing account per month are free. A single VM running the Azure Monitor Agent with default performance counters and syslog collection generates approximately 1-3 GB of log data per month. However, enabling verbose application logging or NSG flow logs can push a single VM to 10+ GB per month. Always estimate your ingestion volume before enabling logging on production fleets.
 
 2. **KQL was designed by the same team that built Azure Data Explorer** (Kusto), and it processes over 15 exabytes of data per day across Microsoft's internal telemetry systems. The same language is used in Microsoft Sentinel (SIEM), Azure Monitor, Azure Data Explorer, and Microsoft 365 Defender. Learning KQL is one of the highest-ROI skills for any Azure engineer.
 
@@ -541,9 +847,9 @@ az monitor data-collection rule association create \
 ## Quiz
 
 <details>
-<summary>1. Your team is building a new microservice and wants to be notified immediately if the HTTP 500 error rate exceeds 5% for more than a minute. They also want to be able to search the exact error messages and stack traces from those failing requests to find the root cause. How should you use Azure Monitor metrics and logs to satisfy both requirements?</summary>
+<summary>1. Your team is building a new microservice and wants to be notified when the HTTP 500 error rate exceeds 5% for fifteen minutes. They also need to search exact error messages and stack traces from failing requests. How should you use Azure Monitor metrics and logs together?</summary>
 
-You should use metrics for the alerting requirement and logs for the root cause analysis. Metrics are numeric time-series data points that are evaluated in near real-time (1-minute granularity), making them perfect for triggering fast, threshold-based alerts like a 5% error rate. Logs, on the other hand, contain rich semi-structured text data such as full stack traces and error messages, which are necessary for debugging. However, logs have a slight ingestion delay (2-5 minutes) and are more expensive to store, making them less ideal for instantaneous alerting but essential for deep investigation.
+Use a **log alert** (scheduled query) on `AppRequests` for the error-rate condition because percentage-of-traffic logic needs KQL, not a single platform metric. Include a minimum request count guard so low traffic does not false-positive. Evaluation every five to fifteen minutes matches log ingestion latency. For root cause, query the same workspace: `AppExceptions` for stack traces and `AppRequests | where Success == false` for URLs and result codes. Platform metrics (CPU, memory) complement App Insights when failures correlate with infrastructure saturation. Metric alerts remain appropriate for pure infrastructure thresholds (DTU, disk queue) where no log query is required.
 </details>
 
 <details>
@@ -591,17 +897,27 @@ You need to redesign the strategy to eliminate alert fatigue by adjusting both t
 Application Insights tracks the request across multiple services by implementing distributed tracing based on the W3C Trace Context standard. When the user clicks "Checkout", the first component (the frontend web app) generates a unique Operation ID for that specific transaction. This Operation ID is automatically injected into the HTTP headers (such as `traceparent`) of all subsequent outbound calls to the API gateway and backend microservices. Because every service logs its telemetry (requests, dependencies, exceptions) using that exact same Operation ID, you can query Application Insights for that ID to visualize the entire end-to-end transaction, instantly identifying which specific microservice took 10 seconds to respond.
 </details>
 
+<details>
+<summary>7. Your security team needs a seven-year audit trail of Key Vault access events for compliance, but the SRE team only queries those logs during incidents (a few times per month). Diagnostic settings can send logs to a Log Analytics workspace, Storage, or Event Hub. How do you balance cost and queryability?</summary>
+
+Send operational copies to a Log Analytics workspace on an appropriate table plan so SRE can run KQL during incidents—use Basic or Auxiliary for high-volume audit streams if interactive analytics are rare. Send a parallel export to Azure Storage via diagnostic settings for low-cost long-term retention that satisfies compliance archive requirements. Storage is cheaper for years of retained JSON but is not queryable with KQL until you rehydrate or use external tools. Event Hub is optional if a SIEM consumes the stream in real time. The mistake to avoid is keeping seven years of verbose audit data in Analytics tables with default interactive retention, which inflates both ingestion and retention charges without daily operational value.
+</details>
+
+<details>
+<summary>8. Production App Insights ingestion jumped 400% after a release even though traffic only rose 10%. Developers enabled verbose dependency tracking and DEBUG logging on every microservice. What three changes reduce cost without blinding on-call to real failures?</summary>
+
+First, enable adaptive or fixed sampling so successful high-volume requests are represented statistically while errors and slow dependencies are retained. Second, lower log verbosity to INFO in production and restrict DEBUG to short-lived troubleshooting on a single instance. Third, route verbose container stdout to Auxiliary tables (or filter with ingestion transforms) instead of Analytics tables used for alerting. Metric and log alerts on error rate and latency should remain on Analytics or AppRequests tables so customer-impacting failures still page on-call. Validate changes in staging under load so sampling does not hide rare failure modes.
+</details>
+
 ---
 
 ## Hands-On Exercise: Monitor Agent on VM with Custom Logs, KQL Query, and Email Alert
 
-In this exercise, you will deploy a VM with the Azure Monitor Agent, collect performance data and custom logs, write KQL queries,
-and create an email alert that proves a monitoring workflow can move from raw metrics to actionable notification. Start by
-standards-first: creating the workspace and VM so each subsequent command has a reliable target. Then connect collection rules and
-verification commands to confirm telemetry is arriving before configuring alerts. By the end, you will have implemented a
-small end-to-end monitoring pipeline and can reuse that same pattern for production resources with confidence.
+In this exercise, you deploy a VM with the Azure Monitor Agent, collect performance data and syslog, write KQL queries, and create a metric alert with an email action group. The lab mirrors production patterns: workspace first, agent second, DCR third, validation fourth, alerts last. Skipping validation and jumping straight to alerts is how teams learn the hard way that rules fired on empty data.
 
-**Prerequisites**: Azure CLI installed and authenticated. Confirm you are on the right subscription, in the correct tenant, and using a principal or identity with permission to create monitor resources, query diagnostics, and create action groups. If those controls are missing, the lab still works for concept learning, but your verification queries and alert resources will fail when executed.
+**Prerequisites**: Azure CLI installed and authenticated. Confirm subscription, tenant, and permissions to create resource groups, VMs, Log Analytics workspaces, DCRs, and action groups. Ingestion delay is typically three to eight minutes—budget time in Task 4. Use a disposable email in the action group or expect messages when the CPU stress test triggers the alert.
+
+**Conceptual mapping**: Task 1 establishes the Log Analytics workspace (logs plane). Task 2–3 configure AMA and DCR (ingestion pipe). Task 4 proves data in `Perf` and `Heartbeat`. Task 5 attaches a metric alert (action plane) separate from log queries in Task 6. In production you would add diagnostic settings on PaaS resources and workspace-based App Insights for applications; this lab isolates VM collection so each step stays visible.
 
 ### Task 1: Create Infrastructure
 
@@ -791,6 +1107,8 @@ az monitor metrics alert show -g "$RG" -n vm-high-cpu \
 
 ### Task 6: Run KQL Queries
 
+After data appears, practice the investigation pattern you will use in production: start with `Heartbeat` to prove the agent path, use `Perf` for resource saturation, then add application tables when App Insights is linked. Save useful queries as workspace **saved searches** or workbook steps so on-call does not rewrite KQL under stress.
+
 ```bash
 # Query 1: Average CPU over the last 10 minutes
 az monitor log-analytics query \
@@ -846,6 +1164,10 @@ az group delete --name "$RG" --yes --no-wait
 - [ ] KQL queries returning CPU, memory, and heartbeat data
 - [ ] Metric alert created with email action group
 
+### Extending the lab (optional)
+
+Link workspace-based Application Insights to the same workspace and deploy a sample web app with `APPLICATIONINSIGHTS_CONNECTION_STRING` set. Confirm `AppRequests` rows appear, then clone the HTTP 5xx log alert query from the Alerts section. Add a diagnostic setting on the lab storage account (if created) to practice routing audit logs to Storage while metrics stay in Metrics Explorer—mirroring the split destination pattern from the Decision Framework. These optional steps take another thirty to sixty minutes but cement the difference between metrics-only VM monitoring and full application observability in one workspace. Document the workspace ID, action group name, and alert rule names in your team runbook so the next engineer can extend the lab without rediscovering resource names from CLI history. When you tear down the resource group, confirm alert rules and action groups are gone so orphaned notifications do not fire against deleted VMs. That cleanup habit matters in shared lab subscriptions where forgotten alerts spam the whole team during the next teammate VM stress test in the lab.
+
 ---
 
 ## Next Module
@@ -854,6 +1176,25 @@ az group delete --name "$RG" --yes --no-wait
 
 ## Sources
 
-- [Azure Monitor Overview](https://learn.microsoft.com/en-us/azure/azure-monitor/fundamentals/overview) — Best primary starting point for how Azure Monitor fits metrics, logs, traces, and alerting into one monitoring platform.
-- [What Are Azure Monitor Alerts?](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-overview) — Explains alert rule structure, action groups, alert types, and how Azure Monitor handles alerting at scale.
-- [Introduction to Application Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview) — Good follow-on reading for Application Insights as Azure Monitor's APM feature and for the main investigation experiences it provides.
+- [Azure Monitor Overview](https://learn.microsoft.com/en-us/azure/azure-monitor/fundamentals/overview) — How metrics, logs, traces, and alerting fit together on the platform.
+- [Azure Monitor Metrics](https://learn.microsoft.com/en-us/azure/azure-monitor/metrics/data-platform-metrics) — Time-series metrics store, retention, and multi-dimensional platform metrics.
+- [Azure Monitor Logs overview](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-platform-logs) — Workspaces, table plans (Analytics, Basic, Auxiliary), and KQL consumption patterns.
+- [Cost calculations for Log Analytics](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs) — Ingestion, commitment tiers, retention, and Application Insights billing via workspace.
+- [Diagnostic settings in Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/diagnostic-settings) — Routing resource logs and metrics to workspace, Storage, or Event Hub.
+- [Manage data retention and archive](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/data-retention-archive) — Interactive retention, long-term retention, and cost implications.
+- [Azure Monitor alerts overview](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-overview) — Metric, log, and activity log alert types and evaluation model.
+- [Action groups](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/action-groups) — Notification channels and integrations for alert response.
+- [Alert processing rules](https://learn.microsoft.com/en-us/azure/azure-monitor/alerts/alerts-action-rules) — Suppression schedules and alert behavior overrides.
+- [Autoscale overview](https://learn.microsoft.com/en-us/azure/azure-monitor/autoscale/autoscale-overview) — Metric-driven capacity changes for scalable resources.
+- [Application Insights overview](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview) — APM scenarios, workspace-based resources, and investigation tools.
+- [OpenTelemetry with Azure Monitor](https://learn.microsoft.com/en-us/azure/azure-monitor/app/opentelemetry-overview) — Standards-based instrumentation to workspace-backed tables.
+- [Sampling in Application Insights](https://learn.microsoft.com/en-us/azure/azure-monitor/app/sampling) — Adaptive and fixed sampling to control telemetry volume.
+- [Azure Monitor pricing](https://azure.microsoft.com/pricing/details/monitor/) — Regional ingestion, retention, and alert pricing reference.
+- [Log Analytics workspace overview](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/log-analytics-workspace-overview) — Workspace resource model and management basics.
+- [Data Collection Rule overview](https://learn.microsoft.com/en-us/azure/azure-monitor/agents/data-collection-rule-overview) — AMA and platform collection configuration.
+- [VM insights](https://learn.microsoft.com/en-us/azure/azure-monitor/vm/vminsights-overview) — Curated VM monitoring experience atop AMA.
+- [Container Insights overview](https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-overview) — AKS and Kubernetes monitoring solution.
+- [Availability tests](https://learn.microsoft.com/en-us/azure/azure-monitor/app/availability-overview) — Synthetic URL monitoring and alerts.
+- [Azure Monitor policy samples](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/policy-reference) — Policy definitions for diagnostic settings and agents.
+- [Logs data export rules](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-data-export-rules) — Continuous export from workspace tables to Storage or Event Hub.
+- [Analyze workspace usage](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/analyze-usage) — Find top ingestion tables and cost drivers.

--- a/src/content/docs/cloud/azure-essentials/module-3.10-monitor.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.10-monitor.md
@@ -33,7 +33,7 @@ Azure Monitor is not a single service—it is a platform composed of interconnec
 
 ### Designing centralized monitoring
 
-Enterprise landing zones typically designate a **monitoring subscription** that hosts Log Analytics workspaces, action groups, and alert rules. Spoke subscriptions hold applications with diagnostic settings and DCR associations pointing at the hub workspace. [Azure Policy](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/policy-reference) can deploy diagnostic settings and AMA associations automatically so new resources do not ship without telemetry. Tag resources with `environment`, `cost-center`, and `owner` so KQL can filter `AzureActivity` and `AzureResourceGraph` results during incidents.
+Enterprise landing zones typically designate a **monitoring subscription** that hosts Log Analytics workspaces, action groups, and alert rules. Spoke subscriptions hold applications with diagnostic settings and DCR associations pointing at the hub workspace. [Azure Policy](https://learn.microsoft.com/en-us/azure/azure-monitor/policy-reference) can deploy diagnostic settings and AMA associations automatically so new resources do not ship without telemetry. Tag resources with `environment`, `cost-center`, and `owner` so KQL can filter `AzureActivity` and `AzureResourceGraph` results during incidents.
 
 Cross-subscription visibility does not require moving resources—only correct routing and RBAC. Readers need `Log Analytics Reader` on the workspace; alert rule authors need `Monitoring Contributor` on scopes they manage. Document which workspace holds production security data versus production application data before an incident forces ad-hoc merging.
 
@@ -136,7 +136,7 @@ When you design monitoring, draw two arrows from every critical resource: one to
 
 ### Network monitoring and high-volume logs
 
-Network Watcher [NSG flow logs](https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-overview) and [traffic analytics](https://learn.microsoft.com/en-us/azure/network-watcher/traffic-analytics) can generate very large log volume. Treat them as a deliberate cost decision: flow logs to Storage or Event Hub for security analytics, not always to Analytics tables unless security operations queries them daily. [Azure Monitor for networks](https://learn.microsoft.com/en-us/azure/azure-monitor/insights/network-insights-overview) provides curated views when NSG diagnostics and topology data are enabled.
+Network Watcher **[VNet flow logs](https://learn.microsoft.com/en-us/azure/virtual-network/virtual-network-flow-logs-overview)** are the current path for virtual-network traffic visibility. Legacy [NSG flow logs](https://learn.microsoft.com/en-us/azure/network-watcher/nsg-flow-logs-overview) retire **2027-09-30**, and **new NSG flow logs can no longer be created after 2025-06-30**—plan migrations to VNet flow logs. [Traffic analytics](https://learn.microsoft.com/en-us/azure/network-watcher/traffic-analytics) can generate very large log volume. Treat flow logging as a deliberate cost decision: flow logs to Storage or Event Hub for security analytics, not always to Analytics tables unless security operations queries them daily. [Azure Monitor for networks](https://learn.microsoft.com/en-us/azure/azure-monitor/insights/network-insights-overview) provides curated views when network diagnostics and topology data are enabled.
 
 For Azure Kubernetes Service, control plane metrics remain platform-managed while workload telemetry flows through Container Insights or OpenTelemetry collectors. Align with your platform team on whether container stdout belongs in `ContainerLogV2` on Analytics or Auxiliary—verbose application logging from dozens of pods is a common reason production workspaces exceed ingestion forecasts.
 
@@ -179,7 +179,7 @@ az monitor metrics list \
   -o table
 ```
 
-Common metrics you should usually monitor are your first line of defense in day-two operations. Platform metrics appear in Metrics Explorer within about a minute for many resource types, which is why on-call starts charts before KQL during a sev-1. **Custom metrics** let applications emit business KPIs (orders queued, jobs failed) via the [Metrics REST API](https://learn.microsoft.com/en-us/azure/azure-monitor/metrics/custom-metrics) or OpenTelemetry—useful when infrastructure looks healthy but the business pipeline is stuck.
+Common metrics you should usually monitor are your first line of defense in day-two operations. Platform metrics appear in Metrics Explorer within about a minute for many resource types, which is why on-call starts charts before KQL during a sev-1. **Custom metrics** let applications emit business KPIs (orders queued, jobs failed) via the [Metrics REST API](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/metrics-custom-overview) or OpenTelemetry—useful when infrastructure looks healthy but the business pipeline is stuck.
 
 **Multi-dimensional metrics** let one alert rule split on dimension values (for example HTTP status code on App Service). Each dimension value can become a billed time series in large scopes, so prefer focused scopes or fewer dimensions when cost matters. **Metric namespaces** separate platform metrics (`Microsoft.Compute/virtualMachines`) from guest OS and custom namespaces; verify you alert on the namespace that actually receives data after AMA or diagnostic settings are configured.
 
@@ -204,7 +204,7 @@ A [Log Analytics workspace](https://learn.microsoft.com/en-us/azure/azure-monito
 
 ### Workspace architecture across subscriptions
 
-Platform teams often deploy **one workspace per environment** (production, staging, development) rather than per application. Resources in any subscription can send data to a workspace in another subscription as long as RBAC and network rules allow it. That pattern supports centralized monitoring for enterprise landing zones: hub subscriptions host the workspace, spoke subscriptions host workloads with diagnostic settings pointed at the hub. Use [Azure Monitor scoped configuration](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/scoped-configurations) and workspace permissions so application teams query only their tables or resource sets.
+Platform teams often deploy **one workspace per environment** (production, staging, development) rather than per application. Resources in any subscription can send data to a workspace in another subscription as long as RBAC and network rules allow it. That pattern supports centralized monitoring for enterprise landing zones: hub subscriptions host the workspace, spoke subscriptions host workloads with diagnostic settings pointed at the hub. Use [Azure Monitor workspace access management](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/manage-access) and workspace permissions so application teams query only their tables or resource sets.
 
 When Microsoft Sentinel or Defender for Cloud is enabled on a workspace, billing and data mix change—Sentinel charges apply to security tables, and operational data may need a separate workspace to avoid paying Sentinel rates on routine VM performance logs. The [workspace design guidance](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/workspace-design) documents tradeoffs between single workspace simplicity and multi-workspace isolation.
 
@@ -476,8 +476,8 @@ az monitor scheduled-query create \
   --description "More than 10 errors in 15 minutes" \
   --severity 1 \
   --scopes "$WORKSPACE_ID" \
-  --condition "count 'AzureDiagnostics | where Category == \"AuditEvent\" | where ResultType == \"Failure\"' > 10" \
-  --condition-query "AzureDiagnostics | where Category == 'AuditEvent' | where ResultType == 'Failure'" \
+  --condition "count 'Failures' > 10 resource id _ResourceId at least 1 violations out of 1 aggregated points" \
+  --condition-query Failures="AzureDiagnostics | where Category == 'AuditEvent' | where ResultType == 'Failure'" \
   --window-size 15m \
   --evaluation-frequency 5m \
   --action-groups "$ACTION_GROUP_ID"
@@ -674,7 +674,7 @@ az monitor data-collection rule create \
       "samplingFrequencyInSeconds": 60,
       "counterSpecifiers": [
         "\\Processor(_Total)\\% Processor Time",
-        "\\Memory\\Available Bytes",
+        "\\Memory\\Available MBytes Memory",
         "\\LogicalDisk(_Total)\\% Free Space",
         "\\LogicalDisk(_Total)\\Disk Reads/sec",
         "\\LogicalDisk(_Total)\\Disk Writes/sec"
@@ -722,11 +722,11 @@ Workspace-based Application Insights stores all telemetry in linked workspace ta
 
 ### Metric alerts, log alerts, and hidden volume drivers
 
-Metric alerts bill per rule and can bill per monitored time series when dimensions multiply scopes. Log alerts bill based on scanned data during each evaluation—wide time ranges and unfiltered tables increase cost and latency. The silent budget killer is **verbose logging**: DEBUG-level application logs, NSG flow logs on every rule, and full HTTP body logging can push a single VM from a few gigabytes per month to tens of gigabytes. Pair diagnostic settings with table plan selection and ingestion transforms to drop noise before it lands in Analytics tables.
+Metric alerts bill per rule and can bill per monitored time series when dimensions multiply scopes. Log alerts bill based on scanned data during each evaluation—wide time ranges and unfiltered tables increase cost and latency. The silent budget killer is **verbose logging**: DEBUG-level application logs, legacy NSG flow logs (retiring 2027-09-30—prefer VNet flow logs), and full HTTP body logging can push a single VM from a few gigabytes per month to tens of gigabytes. Pair diagnostic settings with table plan selection and ingestion transforms to drop noise before it lands in Analytics tables.
 
 | Cost driver | What spikes the bill | Mitigation |
 | :--- | :--- | :--- |
-| Analytics ingestion | NSG flow logs, verbose app logs, all pods at DEBUG | Basic/Auxiliary plans, transforms, log level discipline |
+| Analytics ingestion | VNet/NSG flow logs, verbose app logs, all pods at DEBUG | Basic/Auxiliary plans, transforms, log level discipline |
 | Retention | 365+ day retention on high-volume tables | Per-table retention, long-term tier, export to Storage |
 | App Insights | High RPS without sampling | Adaptive sampling, filter health-check traffic |
 | Log alerts | Broad KQL every 5 minutes | Tight `TimeGenerated` filters, metric alerts where possible |
@@ -735,7 +735,7 @@ Metric alerts bill per rule and can bill per monitored time series when dimensio
 
 ### Estimating ingestion before enablement
 
-Use the workspace **Usage and estimated costs** view and [Analyze usage in a Log Analytics workspace](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/analyze-usage) to identify top tables before enabling NSG flow logs or DEBUG logging fleet-wide. Multiply per-VM estimates by instance count: a modest 2 GB/month per VM becomes 200 GB/month at 100 VMs. Commitment tiers help only when sustained volume is predictable—spiky debug logging does not fit a fixed daily commit.
+Use the workspace **Usage and estimated costs** view and [Analyze usage in a Log Analytics workspace](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/analyze-usage) to identify top tables before enabling VNet flow logs or DEBUG logging fleet-wide. Multiply per-VM estimates by instance count: a modest 2 GB/month per VM becomes 200 GB/month at 100 VMs. Commitment tiers help only when sustained volume is predictable—spiky debug logging does not fit a fixed daily commit.
 
 ---
 
@@ -811,7 +811,7 @@ Need cheap multi-year archive or SIEM stream?
 
 ### Governance with Azure Policy and automation
 
-At scale, manual portal configuration drifts. [Azure Policy initiatives for monitoring](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/policy-reference) deploy diagnostic settings, deploy AMA with DCR associations, and enforce tagging that KQL relies on. Pair policy with remediation tasks so existing resources backfill telemetry without a human opening each blade. Logic Apps triggered from action groups can open ServiceNow tickets, post to Teams, or run safe automation (scale out, restart app) when alerts fire—keep automation idempotent and bounded so flapping alerts do not loop scale operations.
+At scale, manual portal configuration drifts. [Azure Policy initiatives for monitoring](https://learn.microsoft.com/en-us/azure/azure-monitor/policy-reference) deploy diagnostic settings, deploy AMA with DCR associations, and enforce tagging that KQL relies on. Pair policy with remediation tasks so existing resources backfill telemetry without a human opening each blade. Logic Apps triggered from action groups can open ServiceNow tickets, post to Teams, or run safe automation (scale out, restart app) when alerts fire—keep automation idempotent and bounded so flapping alerts do not loop scale operations.
 
 Export selected tables to Storage or Event Hub when compliance requires immutable copies outside the workspace. [Data export rules](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-data-export-rules) run continuously per table; test export filters so you do not duplicate entire workspace firehoses into storage accounts without lifecycle policies.
 
@@ -825,7 +825,7 @@ Export selected tables to Storage or Event Hub when compliance requires immutabl
 
 3. **Azure Monitor can detect anomalies automatically using machine learning.** The `series_decompose_anomalies()` KQL function analyzes time-series data and flags data points that deviate significantly from the expected pattern. You do not need to set static thresholds---the model learns what "normal" looks like and alerts on deviations. This catches issues like "response time gradually increased 40% over 3 days" that static thresholds miss.
 
-4. **Application Insights sampling reduces data volume without losing visibility.** By default, adaptive sampling kicks in when your application generates more than 5 events per second per server. It intelligently drops redundant telemetry (like 1000 identical successful requests) while preserving anomalies (errors, slow requests). A team generating 100 GB of App Insights data per month reduced it to 8 GB with adaptive sampling, with zero loss in diagnostic capability.
+4. **Application Insights sampling reduces data volume without losing visibility.** By default, adaptive sampling kicks in when your application generates more than 5 events per second per server. It intelligently drops redundant telemetry (like 1000 identical successful requests) while preserving anomalies (errors, slow requests). High-traffic estates often cut App Insights ingestion by 80–90% with adaptive sampling while retaining errors and slow requests for diagnosis.
 
 ---
 
@@ -1009,7 +1009,7 @@ az monitor data-collection rule create \
       "samplingFrequencyInSeconds": 30,
       "counterSpecifiers": [
         "\\Processor(_Total)\\% Processor Time",
-        "\\Memory\\Available Bytes",
+        "\\Memory\\Available MBytes Memory",
         "\\Memory\\% Used Memory",
         "\\LogicalDisk(_Total)\\% Free Space"
       ]
@@ -1044,13 +1044,15 @@ az monitor data-collection rule association list --resource "$VM_ID" \
 ### Task 4: Generate Load and Wait for Data
 
 ```bash
-# Generate some CPU load on the VM
+# Generate CPU load (stress-ng is not preinstalled on Ubuntu 22.04 images)
 az vm run-command invoke -g "$RG" -n monitor-lab-vm \
   --command-id RunShellScript \
-  --scripts "stress-ng --cpu 2 --timeout 120 &" 2>/dev/null || \
+  --scripts "sudo apt-get update -qq && sudo apt-get install -y stress-ng && stress-ng --cpu 2 --timeout 120"
+
+# Fallback if apt fails: yes-loop CPU burn
 az vm run-command invoke -g "$RG" -n monitor-lab-vm \
   --command-id RunShellScript \
-  --scripts "for i in \$(seq 1 4); do yes > /dev/null & done; sleep 120; kill %1 %2 %3 %4 2>/dev/null"
+  --scripts "for i in \$(seq 1 4); do yes > /dev/null & done; sleep 120; kill \$(jobs -p) 2>/dev/null; true"
 
 echo "Generating CPU load... Waiting 5 minutes for data to appear in Log Analytics."
 echo "(Data ingestion typically takes 3-8 minutes)"
@@ -1195,6 +1197,6 @@ Link workspace-based Application Insights to the same workspace and deploy a sam
 - [VM insights](https://learn.microsoft.com/en-us/azure/azure-monitor/vm/vminsights-overview) — Curated VM monitoring experience atop AMA.
 - [Container Insights overview](https://learn.microsoft.com/en-us/azure/azure-monitor/containers/container-insights-overview) — AKS and Kubernetes monitoring solution.
 - [Availability tests](https://learn.microsoft.com/en-us/azure/azure-monitor/app/availability-overview) — Synthetic URL monitoring and alerts.
-- [Azure Monitor policy samples](https://learn.microsoft.com/en-us/azure/azure-monitor/platform/policy-reference) — Policy definitions for diagnostic settings and agents.
+- [Azure Monitor policy samples](https://learn.microsoft.com/en-us/azure/azure-monitor/policy-reference) — Policy definitions for diagnostic settings and agents.
 - [Logs data export rules](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/logs-data-export-rules) — Continuous export from workspace tables to Storage or Event Hub.
 - [Analyze workspace usage](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/analyze-usage) — Find top ingestion tables and cost drivers.

--- a/src/content/docs/cloud/azure-essentials/module-3.8-functions.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.8-functions.md
@@ -32,10 +32,10 @@ The hosting plan determines the scaling behavior, available resources, and prici
 
 | Feature | Consumption | Flex Consumption | Premium (EP) | Dedicated (ASP) |
 | :--- | :--- | :--- | :--- | :--- |
-| **Scaling** | 0 to 200 instances | 0 to 1000 instances | 1 to 100 instances | Manual or autoscale |
-| **Scale to zero** | Yes | Yes | Optional (min 1) | No |
+| **Scaling** | 0 to 100 instances (Linux; Windows 200) | 0 to 1000 instances | 1 to 100 instances | Manual or autoscale |
+| **Scale to zero** | Yes | Yes | No (always ≥1 warm instance) | No |
 | **Cold start** | Yes (1-10 seconds) | Reduced (pre-warmed) | No (always warm) | No (always running) |
-| **Max execution** | 5 min (default, 10 max) | 30 min | Unlimited | Unlimited |
+| **Max execution** | 5 min (default, 10 max) | Default 30 min / max unbounded | Unlimited | Unlimited |
 | **Memory** | 1.5 GB | Up to 4 GB | 3.5-14 GB | Plan-dependent |
 | **VNet integration** | No | Yes | Yes | Yes |
 | **Cost model** | Per execution + GB-s | Per execution + GB-s | Per instance hour | Per App Service Plan |
@@ -46,7 +46,7 @@ Microsoft now recommends **Flex Consumption** for new serverless function apps. 
 
 ### The Scale Controller and Instance Limits
 
-Behind every dynamically scaled plan sits the **Functions scale controller**, a component that watches trigger metrics—queue depth, Event Hub lag, HTTP request rate, timer schedules—and adds or removes worker instances to match load. On the legacy Consumption plan, scale-out is capped at **200 instances** per function app. Flex Consumption raises that ceiling to **1,000 instances** and scales faster because it keys off per-instance concurrency settings rather than treating every invocation as a potential new worker. Premium plans scale between your configured minimum and maximum burst count on pre-provisioned Elastic Premium SKUs (EP1, EP2, EP3), while Dedicated plans inherit App Service Plan autoscale rules you define yourself.
+Behind every dynamically scaled plan sits the **Functions scale controller**, a component that watches trigger metrics—queue depth, Event Hub lag, HTTP request rate, timer schedules—and adds or removes worker instances to match load. On the legacy Consumption plan, scale-out is capped at **100 instances per function app on Linux** (the runtime Python and Node use; Windows Consumption allows up to **200**). Flex Consumption raises that ceiling to **1,000 instances** and scales faster because it keys off per-instance concurrency settings rather than treating every invocation as a potential new worker. Premium plans scale between your configured minimum and maximum burst count on pre-provisioned Elastic Premium SKUs (EP1, EP2, EP3), while Dedicated plans inherit App Service Plan autoscale rules you define yourself.
 
 Understanding these limits prevents architectural surprises during load tests. A fan-out workflow that launches ten thousand parallel activity functions still executes on a bounded worker pool; the orchestrator queues work, but downstream services must tolerate the throughput your instance cap allows. If you need guaranteed headroom for a product launch, Premium **always-ready** instances or Flex **always-ready** baselines buy responsiveness upfront instead of waiting for the scale controller to react.
 
@@ -97,6 +97,7 @@ az functionapp plan create \
   --name kubedojo-premium-plan \
   --location eastus2 \
   --sku EP1 \
+  --is-linux true \
   --min-instances 1 \
   --max-burst 20
 
@@ -156,7 +157,7 @@ In many environments, total startup time is often around **3-8 seconds**, which 
 
 Cold starts stack several phases: the platform must **allocate a worker**, the **Functions host runtime** must start, your **language worker** (Python, Node, .NET isolated process) must boot, and any **module imports or dependency injection** in your startup path run before the trigger handler executes. Large container images, heavyweight ML libraries, or synchronous network calls during import multiply the delay. Premium and Flex always-ready instances keep a baseline warm so the first customer request skips most of that path, which is why payment and authentication webhooks often justify the fixed hourly component even when average traffic is low.
 
-**War Story**: A payment processing company chose the Consumption plan for their webhook handler. Most requests completed in 200ms. But once every 15-20 minutes, the function would cold start, adding 6 seconds of latency. Their payment provider interpreted these 6-second responses as timeouts and marked them as failed, triggering retry logic that created duplicate transactions. Switching to Premium plan with 1 minimum instance eliminated cold starts entirely, and the duplicate transaction problem vanished overnight.
+**Hypothetical scenario (War Story)**: A payment processing company chose the Consumption plan for their webhook handler. Most requests completed in 200ms. But once every 15-20 minutes, the function would cold start, adding 6 seconds of latency. Their payment provider interpreted these 6-second responses as timeouts and marked them as failed, triggering retry logic that created duplicate transactions. Switching to Premium plan with 1 minimum instance eliminated cold starts entirely, and the duplicate transaction problem vanished overnight.
 
 ---
 
@@ -592,7 +593,7 @@ You can optimize performance and control scaling behavior by configuring `host.j
 }
 ```
 
-**Dynamic concurrency** (when enabled) lets the runtime learn optimal per-trigger concurrency and persist snapshots between scale events, which helps queue-heavy workloads without manual tuning. Pair **`functionAppScaleLimit`** consciously: setting it too low protects downstream systems but creates artificial backlog during legitimate spikes; leaving it unlimited on Consumption without testing can hit the 200-instance ceiling and still saturate a fragile database. For Python CPU-bound handlers, **`FUNCTIONS_WORKER_PROCESS_COUNT`** launches multiple worker processes to sidestep GIL contention—each process consumes memory, so GB-second costs rise with process count even if executions stay flat.
+**Dynamic concurrency** (when enabled) lets the runtime learn optimal per-trigger concurrency and persist snapshots between scale events, which helps queue-heavy workloads without manual tuning. Pair **`functionAppScaleLimit`** consciously: setting it too low protects downstream systems but creates artificial backlog during legitimate spikes; leaving it unlimited on Linux Consumption without testing can hit the 100-instance ceiling and still saturate a fragile database. For Python CPU-bound handlers, **`FUNCTIONS_WORKER_PROCESS_COUNT`** launches multiple worker processes to sidestep GIL contention—each process consumes memory, so GB-second costs rise with process count even if executions stay flat.
 
 ### Authentication and Authorization
 
@@ -671,9 +672,9 @@ Need event-driven code with bindings and Durable Functions?
 | :--- | :--- | :--- | :--- | :--- |
 | Cold-start tolerance | Low–medium | Medium–high (with always-ready) | High | High |
 | VNet required | No | Yes | Yes | Yes |
-| Max scale-out | 200 | 1,000 | Configurable burst | Plan limit |
-| Scale to zero | Yes | Yes | Optional | No |
-| Max single execution | 5 min default (10 max) | 30 min | Unlimited | Unlimited |
+| Max scale-out | 100 (Linux; Windows 200) | 1,000 | Configurable burst | Plan limit |
+| Scale to zero | Yes | Yes | No (always ≥1 warm) | No |
+| Max single execution | 5 min default (10 max) | Default 30 min / max unbounded | Unlimited | Unlimited |
 | Best cost when | Legacy Windows sporadic jobs | New serverless apps | Steady low-latency APIs | Shared ASP already paid |
 
 When latency-sensitive HTTP meets private networking, **Flex with targeted always-ready instances** often beats **Premium with large minimum instances** because you pay baseline warmth only on entry functions while background queue processors stay on-demand. When executions routinely exceed Flex timeout limits or require more than 4 GB memory per instance, move activities to Premium or Container Apps rather than forcing monolithic functions.
@@ -712,7 +713,7 @@ Patterns capture what experienced teams repeat on purpose; anti-patterns capture
 
 1. **Azure Functions Consumption plan has processed trillions of executions** since its launch. The free grant of 1 million executions and 400,000 GB-seconds per month means that many small-to-medium applications run entirely for free. A function that executes 100,000 times per month at 128 MB memory and 200ms average duration uses only 2,560 GB-seconds---well within the free tier. Flex Consumption adds selectable instance memory (512 MB, 2,048 MB, or 4,096 MB); higher tiers increase GB-second totals but prevent timeouts for memory-heavy Python workloads.
 
-2. **Durable Functions can run for up to 7 days on the Consumption plan** (the orchestrator itself; individual activity functions still have the 5-10 minute limit). On Premium and Dedicated plans, they can run indefinitely. One retail company uses a Durable Function orchestration that runs for 30 days, managing a month-long A/B test lifecycle with periodic check-ins and automatic completion.
+2. **Durable Functions orchestrations can run for days, weeks, or months on any hosting plan** because the runtime checkpoints orchestrator state to storage and replays on wake—there is no separate 7-day orchestration cap on Consumption, Flex, Premium, or Dedicated. What *is* bounded is each **activity function execution**: on Consumption that is 5 minutes by default (10 minutes maximum); on Flex the default is 30 minutes with no enforced maximum execution timeout (the 230-second ceiling applies only to HTTP-trigger responses). Durable timers for Python, JavaScript, and PowerShell can schedule up to 6 days per timer, chainable for longer waits. **Hypothetical scenario:** a month-long A/B test orchestration might use periodic timer check-ins and automatic completion without holding a worker busy between intervals.
 
 3. **Blob triggers use a polling mechanism, not events.** When you use a Blob trigger, Azure Functions scans the blob container for changes every few seconds. This means there can be a delay of up to 60 seconds between a blob being uploaded and the function executing. For real-time processing, use an Event Grid trigger (which is event-driven and near-instant) that subscribes to the blob storage account's BlobCreated events.
 
@@ -1045,21 +1046,19 @@ az functionapp log tail -g "$RG" -n "$FUNC_NAME" --timeout 10 2>/dev/null || \
 <summary>Verify Task 5</summary>
 
 ```bash
-# Query Cosmos DB for the processed results
-az cosmosdb sql query \
-  --account-name "$COSMOS_NAME" \
-  --resource-group "$RG" \
-  --database-name "ProcessingDB" \
-  --container-name "results" \
-  --query-text "SELECT c.blobName, c.sizeBytes, c.extension, c.status, c.processedAt FROM c" \
-  -o table 2>/dev/null || \
+# Cosmos DB document reads are data-plane operations — az cosmosdb has no sql query subcommand.
+# Confirm the results container exists (control plane):
 az cosmosdb sql container show \
   --account-name "$COSMOS_NAME" -g "$RG" \
   --database-name "ProcessingDB" --name "results" \
-  --query resource.id -o tsv
+  --query '{Name:name, PartitionKey:resource.partitionKey.paths[0]}' -o table
+
+# Open Azure portal → Cosmos DB account → Data Explorer → ProcessingDB → results
+# Run: SELECT c.blobName, c.sizeBytes, c.extension, c.status, c.processedAt FROM c
+# Expect two documents after both uploads process.
 ```
 
-You should see two documents in Cosmos DB: one for test-data.json (with recordCount=2 and status=processed_with_analysis) and one for readme.txt (with status=processed).
+You should see two documents in the portal Data Explorer: one for `test-data.json` (with `recordCount=2` and `status=processed_with_analysis`) and one for `readme.txt` (with `status=processed`). The CLI commands above prove the container exists; document content verification requires the portal or the Cosmos DB REST/SDK data plane.
 </details>
 
 ### Cleanup
@@ -1074,8 +1073,8 @@ rm -rf /tmp/functions-lab /tmp/test-data.json /tmp/readme.txt
 - [ ] Storage account with uploads container created
 - [ ] Cosmos DB account with ProcessingDB database and results container created
 - [ ] Function App deployed with blob trigger and Cosmos DB output binding
-- [ ] JSON file uploaded and processed (metadata stored in Cosmos DB with record count)
-- [ ] Text file uploaded and processed (metadata stored in Cosmos DB)
+- [ ] JSON file uploaded; function logs show processing; `results` container exists in Cosmos DB
+- [ ] Text file uploaded; portal Data Explorer shows two result documents with expected `blobName` and `status` values
 - [ ] Function execution visible in logs or monitor
 
 After cleanup, capture one lesson in your runbook: which trigger type you used, how long polling delayed processing, and which hosting plan you would choose for a production deployment with VNet and latency requirements.

--- a/src/content/docs/cloud/azure-essentials/module-3.8-functions.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.8-functions.md
@@ -18,11 +18,11 @@ sidebar:
 
 ## Why This Module Matters
 
-In 2022, an e-commerce company was processing product image uploads. Their workflow was simple: a customer uploads an image, the application resizes it into three formats (thumbnail, medium, large), and stores the results. They ran this on a pair of D4s_v5 VMs behind a load balancer, running a Node.js process that polled an upload queue every 500 milliseconds. The two VMs cost $280/month. During business hours, they processed about 200 images per hour. Between midnight and 6 AM, they processed zero. On Black Friday, they processed 15,000 images per hour and the VMs could not keep up, causing a 3-hour backlog of unprocessed images. After migrating to Azure Functions with a Blob trigger, images were processed within 2 seconds of upload, regardless of volume. The Functions scaled automatically from zero to hundreds of concurrent executions during Black Friday, and back to zero at night. Their monthly bill dropped from $280 to $23---and the image processing backlog disappeared permanently.
+Hypothetical scenario: an e-commerce team processes product image uploads by resizing each file into three formats and storing the results. They run the workload on a pair of always-on VMs that poll an upload queue, paying for capacity around the clock even when no uploads arrive overnight. During a seasonal traffic spike, the fixed pool cannot keep up and a processing backlog grows for hours. After migrating to Azure Functions with an event-driven trigger, the same logic scales out on demand and scales toward zero when idle, so burst capacity appears only when work exists instead of being pre-provisioned all month.
 
-Azure Functions is Microsoft's function-as-a-service (FaaS) platform. You write a small piece of code---a function---that is triggered by an event (an HTTP request, a new blob, a queue message, or a timer). Azure handles everything else: provisioning infrastructure, scaling, patching, and monitoring, so you do not need to manage servers for the platform plumbing. You pay only for the compute time your code consumes, measured in gigabyte-seconds. This model is especially compelling when work arrives in bursts, because idle capacity is paid for only when code actually runs and not while nothing is happening.
+That shift captures why serverless compute matters for cloud-native teams. Azure Functions is Microsoft's function-as-a-service (FaaS) platform. You write a small piece of code—a function—that is triggered by an event such as an HTTP request, a new blob, a queue message, or a timer. Azure handles provisioning, scaling, patching, and monitoring so you do not manage servers for platform plumbing. You pay primarily for the compute time your code consumes, measured in gigabyte-seconds on consumption-based plans. This model is especially compelling when work arrives in bursts, because idle capacity is not billed while nothing is running.
 
-In this module, you will learn the three hosting plans for Functions, how triggers and bindings eliminate boilerplate integration code, and how Durable Functions orchestrate multi-step workflows. By the end, you will build a function triggered by a blob upload that processes data and writes results to Cosmos DB using output bindings. The through-line is that each decision—plan, trigger, and orchestration style—maps directly to one of three constraints: cost, responsiveness, and operational complexity.
+In this module, you will learn the hosting plans for Functions, how triggers and bindings eliminate boilerplate integration code, and how Durable Functions orchestrate multi-step workflows. By the end, you will build a function triggered by a blob upload that processes data and writes results to Cosmos DB using output bindings. The through-line is that each decision—plan, trigger, and orchestration style—maps directly to one of three constraints: cost, responsiveness, and operational complexity.
 
 ---
 
@@ -41,6 +41,26 @@ The hosting plan determines the scaling behavior, available resources, and prici
 | **Cost model** | Per execution + GB-s | Per execution + GB-s | Per instance hour | Per App Service Plan |
 | **Free grant** | 1M executions + 400K GB-s/month | Similar | None | None |
 | **Best for** | Event-driven, sporadic | Event-driven, predictable | Low latency, always ready | Existing ASP, long jobs |
+
+Microsoft now recommends **Flex Consumption** for new serverless function apps. The legacy Consumption plan remains available on Windows, but Linux Consumption is retiring and no longer receives new language versions—plan migrations before that deadline if you inherit older apps. Flex Consumption keeps pay-per-execution billing while adding VNet integration, selectable instance memory (512 MB, 2,048 MB, or 4,096 MB), and optional **always-ready** instances that reduce cold starts without abandoning scale-to-zero for the rest of the app.
+
+### The Scale Controller and Instance Limits
+
+Behind every dynamically scaled plan sits the **Functions scale controller**, a component that watches trigger metrics—queue depth, Event Hub lag, HTTP request rate, timer schedules—and adds or removes worker instances to match load. On the legacy Consumption plan, scale-out is capped at **200 instances** per function app. Flex Consumption raises that ceiling to **1,000 instances** and scales faster because it keys off per-instance concurrency settings rather than treating every invocation as a potential new worker. Premium plans scale between your configured minimum and maximum burst count on pre-provisioned Elastic Premium SKUs (EP1, EP2, EP3), while Dedicated plans inherit App Service Plan autoscale rules you define yourself.
+
+Understanding these limits prevents architectural surprises during load tests. A fan-out workflow that launches ten thousand parallel activity functions still executes on a bounded worker pool; the orchestrator queues work, but downstream services must tolerate the throughput your instance cap allows. If you need guaranteed headroom for a product launch, Premium **always-ready** instances or Flex **always-ready** baselines buy responsiveness upfront instead of waiting for the scale controller to react.
+
+Load tests should ramp gradually the first time you observe scale-out, because cold-start storms during instantaneous step loads can look like failures even when the controller is working as designed. Capture **Application Insights** metrics for **`Function Execution Count`**, **`Average Memory Working Set`**, and **`Server Response Time`** segmented by plan SKU so you can compare Flex on-demand versus always-ready baselines with evidence instead of assumptions.
+
+### Mapping Plans to Workloads
+
+| Workload shape | Recommended plan | Primary reason |
+| :--- | :--- | :--- |
+| Nightly batch job, minutes of runtime | Flex Consumption on-demand | Scale to zero between runs; VNet if databases are private |
+| Public webhook API with tight SLA | Premium or Flex with always-ready | Cold-start tail latency breaks external timeout budgets |
+| Long-running ML preprocessing (30+ min) | Premium or Dedicated | Consumption and Flex cap individual function executions |
+| Existing .NET Framework integration | Dedicated or Premium isolated worker | Legacy runtime support outside in-process model |
+| Internal admin tool, sporadic clicks | Flex Consumption on-demand | Free monthly grant often covers entire monthly usage |
 
 > **Stop and think**: If your company has a strict policy that all database traffic must route through a private VNet, but you want to avoid paying for instances when no traffic is hitting your function at night, which hosting plan is your only viable option?
 
@@ -108,6 +128,15 @@ az functionapp create \
   --storage-account "$STORAGE_NAME"
 ```
 
+Each command encodes plan-specific infrastructure. **Consumption** (`--consumption-plan-location`) creates a hidden Dynamic Y1 plan tied to the app. **Premium** requires an explicit **`az functionapp plan create`** with SKU EP1/EP2/EP3, **`--min-instances`** for always-warm baseline, and **`--max-burst`** to cap scale-out during runaway loops. **Flex Consumption** uses **`--flexconsumption-location`** and deploys from blob storage containers rather than Azure Files shares used by older plans—CI pipelines should follow Flex deployment guidance to avoid partial updates. VNet integration attaches the function app to a delegated subnet so outbound traffic reaches private endpoints for SQL, Cosmos DB, or internal APIs without traversing the public internet.
+
+After creation, verify plan SKU and runtime stack before publishing code:
+
+```bash
+az functionapp show -g myRG -n kubedojo-flex-func \
+  --query '{plan:appServicePlanId, kind:kind, runtime:siteConfig.linuxFxVersion}' -o json
+```
+
 ### Understanding Cold Start
 
 Cold start is the latency added when a function executes for the first time (or after an idle period). It happens because Azure needs to allocate a worker, load the runtime, and initialize your code before your handler receives traffic. If a function has been idle, the first call absorbs this startup work, so the same function can look slow even when business logic is tiny. In practice, this matters most for user-facing endpoints and webhook processors where first-request latency directly affects retry behavior and user perception.
@@ -125,6 +154,8 @@ In many environments, total startup time is often around **3-8 seconds**, which 
 3. Use Flex Consumption (pre-provisioned instances)
 4. Avoid heavy initialization in function startup
 
+Cold starts stack several phases: the platform must **allocate a worker**, the **Functions host runtime** must start, your **language worker** (Python, Node, .NET isolated process) must boot, and any **module imports or dependency injection** in your startup path run before the trigger handler executes. Large container images, heavyweight ML libraries, or synchronous network calls during import multiply the delay. Premium and Flex always-ready instances keep a baseline warm so the first customer request skips most of that path, which is why payment and authentication webhooks often justify the fixed hourly component even when average traffic is low.
+
 **War Story**: A payment processing company chose the Consumption plan for their webhook handler. Most requests completed in 200ms. But once every 15-20 minutes, the function would cold start, adding 6 seconds of latency. Their payment provider interpreted these 6-second responses as timeouts and marked them as failed, triggering retry logic that created duplicate transactions. Switching to Premium plan with 1 minimum instance eliminated cold starts entirely, and the duplicate transaction problem vanished overnight.
 
 ---
@@ -132,6 +163,45 @@ In many environments, total startup time is often around **3-8 seconds**, which 
 ## Triggers and Bindings: The Power of Declarative Integration
 
 Triggers and bindings are what make Azure Functions genuinely productive, because they let you focus on business logic instead of integration boilerplate. A **trigger** is the event that causes a function to execute, like an HTTP request, new blob, timer, or message. A **binding** is a declarative connection to another Azure service that handles the boilerplate of reading from or writing to that service. In practice, this separation reduces repeated SDK code, lowers integration bugs, and makes each function easier to reason about under pressure.
+
+### The Programming Model: One Trigger, Many Bindings
+
+Every function obeys a strict contract: **exactly one trigger** defines when the function runs, and **zero or more bindings** declare additional inputs and outputs. Input bindings inject data—blob content, Cosmos DB documents, table rows—into your handler parameters. Output bindings accept return values or `Out<T>` parameters and persist results without explicit SDK calls. The runtime resolves connection strings from application settings (preferably Key Vault references), handles retries at the extension layer for many services, and serializes payloads into native types.
+
+You can configure bindings **declaratively** through attributes in Python v2 programming model (`@app.queue_trigger`, `@app.cosmos_db_output`) or `function.json` in older projects. **Imperative** binding is still possible by constructing SDK clients inside your function, but you lose automatic batching, retry integration, and the concise signatures that make Functions readable in code review. Reach for imperative code only when a binding extension does not exist or when you need fine-grained transaction control that declarative bindings cannot express.
+
+```text
+                    ┌─────────────────────────────────────┐
+  Timer / HTTP /    │  Trigger (required, exactly one)    │
+  Queue / Blob ────►│  "When does this function run?"     │
+                    └─────────────────┬───────────────────┘
+                                      │
+                    ┌─────────────────▼───────────────────┐
+                    │  Function handler (your business      │
+                    │  logic only)                        │
+                    └─────────────────┬───────────────────┘
+                                      │
+         ┌────────────────────────────┼────────────────────────────┐
+         ▼                            ▼                            ▼
+   Input binding                 Output binding              Output binding
+   (Blob, Table)                 (Cosmos DB)                 (Queue, SendGrid)
+```
+
+### Isolated Worker vs In-Process Execution
+
+For **Python, Node.js, Java, and PowerShell**, the Functions runtime always runs your code in a **language worker process** separate from the host. The host receives trigger events, forwards them to the worker over gRPC, and applies binding extensions on either side depending on the trigger type. This isolation improves security boundaries and lets each language runtime evolve independently.
+
+**.NET** is the special case. The legacy **in-process** model runs your function inside the same process as the Functions host, supports only LTS releases ending with .NET 8, and **does not support Flex Consumption**. Microsoft ends full support for in-process on **November 10, 2026**; new apps should use the **isolated worker** model, where your .NET app is a standalone executable with `Program.cs`, standard dependency injection, middleware, and `Microsoft.Azure.Functions.Worker.Extensions.*` packages. Isolated worker supports current .NET versions, .NET Framework 4.8, Durable Functions, and Flex Consumption—the combination most greenfield .NET teams should standardize on.
+
+| Aspect | Isolated worker (.NET and other languages) | In-process (.NET legacy) |
+| :--- | :--- | :--- |
+| Process boundary | Separate worker process | Same process as host |
+| Flex Consumption | Supported (.NET isolated) | Not supported |
+| Middleware / DI | Full .NET DI and middleware | Limited compared to isolated |
+| Binding packages | `Microsoft.Azure.Functions.Worker.Extensions.*` | `Microsoft.Azure.WebJobs.Extensions.*` |
+| Support horizon | Current and future runtimes | Ends November 10, 2026 |
+
+Supported languages on Functions 4.x include C#, Java, JavaScript/TypeScript, Python, and PowerShell, with **custom handlers** available for any executable that speaks HTTP. Custom handlers trade binding convenience for language freedom—you implement the trigger protocol yourself while Azure still manages scaling and the hosting plan.
 
 ### Trigger Types
 
@@ -145,6 +215,10 @@ Triggers and bindings are what make Azure Functions genuinely productive, becaus
 | **Event Hub** | Streaming events | IoT, telemetry processing |
 | **Cosmos DB** | Document change feed | Real-time data synchronization |
 | **Event Grid** | Azure events | Resource change reactions |
+
+**Event Grid** triggers deserve special attention for blob processing. A storage **Blob trigger** polls the container on an interval, which can introduce tens of seconds of delay. An **Event Grid** subscription on `Microsoft.Storage.BlobCreated` pushes an event to your function within seconds, which is why profile-picture and document-ingestion pipelines often pair Event Grid with Functions instead of raw Blob triggers when latency matters.
+
+**Cosmos DB** triggers consume the change feed, giving you ordered, incremental reads of inserts and updates inside a container partition range. **Timer** triggers fire on NCRONTAB schedules and are deceptively expensive at scale—each scheduled execution bills even when there is nothing to clean up, so combine timers with cheap early-exit logic rather than chaining dozens of per-resource schedules.
 
 ### Input and Output Bindings
 
@@ -180,6 +254,12 @@ flowchart LR
 > **Pause and predict**: If you use an output binding to write a document to Cosmos DB, but the Cosmos DB service experiences a brief 2-second network blip while the function runs, do you need to write custom retry logic in your Python code?
 
 The key point is that the function runtime and binding layer can absorb many integration concerns, so your handler can stay concise while still remaining resilient. You still design your system for idempotent operations and observability, because retries and eventual consistency are often about system behavior, not only code structure.
+
+### Imperative Bindings and Connection Settings
+
+When declarative bindings are insufficient, the Functions app still reads **`AzureWebJobsStorage`** and named connection settings from application settings. Binding connections map to settings such as `StorageConnection` or `CosmosDBConnection` referenced in attribute `connection=` parameters. At runtime the host resolves those values, which is why Key Vault references and managed identity reduce rotation toil: the setting name stays stable while the secret value rotates in vault. For local development, `local.settings.json` holds the same keys but must never be committed to source control.
+
+Batch-oriented triggers expose tuning knobs that directly affect cost. Storage queue triggers pull messages in batches (`batchSize` in `host.json`); larger batches improve throughput but lengthen individual function executions and GB-second totals if each message triggers heavy work. Service Bus triggers honor **`maxConcurrentCalls`** and **`prefetchCount`**, trading memory for pipeline depth. HTTP triggers expose **`maxConcurrentRequests`** and **`maxOutstandingRequests`** to protect downstream databases from unbounded parallelism when scale-out adds instances during spikes.
 
 ### Python Function Examples
 
@@ -265,9 +345,17 @@ def process_service_bus(msg: func.ServiceBusMessage) -> None:
     logging.info(f"Processing Service Bus message: {msg.get_body().decode('utf-8')}")
 ```
 
+The examples above use the **Python v2 programming model** (`FunctionApp()` decorator style), which is the default for new Python projects. Each decorator registers a binding extension with the host. **`run_on_startup=False`** on timers prevents an immediate execution during deploy that could duplicate migrations or send duplicate emails. HTTP routes inherit the **`routePrefix`** from `host.json` (commonly `api`), so the orders endpoint is reachable at `/api/orders` unless you override the prefix globally.
+
+When binding to Cosmos DB, partition key paths in the container must align with document fields you write—mismatches surface as runtime errors after deploy, not during `func start`, if local emulator settings differ from cloud. Service Bus triggers should complete or abandon messages within lock duration; enable **`maxAutoRenewDuration`** when handlers legitimately run longer than the default lock, otherwise messages become visible again and a second worker may duplicate work unless idempotency guards exist.
+
 ### Deploying Functions
 
 Once your function code is in place, deployment becomes a predictable sequence of local verification and publish steps. The commands below include local run, direct publish, and zip deployment, which is important because teams often discover environment drift only when their deployment path and authentication mode differ. Choose the simplest path during initial validation, then adopt zip deploy when you need repeatable, scripted releases.
+
+Local **`func start`** uses the same host runtime as Azure, which catches binding misconfigurations before cloud deploy. **`func azure functionapp publish`** packages Python dependencies according to remote build settings; for production, many teams prefer **`--build remote`** so native wheels compile on Azure's build agents rather than on developer laptops with mismatched architectures. Zip deploy via **`az functionapp deployment source config-zip`** is ideal for CI/CD pipelines that produce immutable artifacts stored in a pipeline workspace—pair it with deployment slots on Premium and Dedicated plans for swap-based releases, or use Flex rolling update strategies when zero-downtime matters.
+
+Authentication during deploy typically flows through **`az login`** and RBAC on the function app resource. Service principals in pipelines need **`Website Contributor`** or tighter custom roles on the app scope plus permission to reach the backing storage account, because the host stores triggers and sync state in storage even when your business data lives elsewhere.
 
 ```bash
 # Initialize a new Function project locally
@@ -297,6 +385,14 @@ az functionapp deployment source config-zip \
 ## Durable Functions: Orchestrating Complex Workflows
 
 Regular Azure Functions are stateless---each execution is independent, and local variables disappear when execution ends. Durable Functions add state management, enabling you to write multi-step workflows, fan-out/fan-in patterns, and human interaction patterns that survive process boundaries. In practice, stateful orchestration means you can encode ordering, waiting, and failure behavior without building your own durable storage layer. That is especially useful for business workflows where one step may complete in minutes and the next cannot proceed until a separate approval or external event arrives.
+
+Durable Functions introduce three function **kinds** with distinct roles. **Orchestrator** functions coordinate workflow logic and must be deterministic—they call activities, wait for timers, and schedule external events, but they never perform I/O directly. **Activity** functions execute non-deterministic work such as database writes, HTTP calls, or file transforms. **Entity** functions (Durable Entities) model singleton state with serializable operations, useful for counters, locks, or lightweight state machines without standing up a database. The runtime persists orchestration history to Azure Storage (default), Azure Cosmos DB, or SQL Server depending on your task hub configuration.
+
+### Checkpoint, Replay, and Idempotency
+
+When an orchestrator awaits an activity, the Durable Task framework **checkpoints** orchestration state to storage and releases the worker. On the next wake-up—whether seconds or days later—the orchestrator **replays** from the beginning of the function, but prior completed steps return cached results instantly instead of re-executing side effects. That replay model is why orchestrator code must avoid random numbers, direct I/O, and `DateTime.Now`; non-deterministic work belongs in activities.
+
+Activities must be **idempotent** because retries are normal. If charging a credit card fails transiently, the orchestrator may invoke the charge activity twice; your implementation should use idempotency keys or check existing ledger entries before posting a duplicate charge. The same discipline applies to email notifications and inventory decrements—design activities so a second call with the same input produces the same outcome without double effect.
 
 ### Patterns
 
@@ -333,6 +429,44 @@ sequenceDiagram
     Client->>API: Poll Status URL
     API-->>Client: Status: Complete + Result
 ```
+
+**Pattern 4: Human Interaction** pauses the orchestrator until an external actor raises an event—typically an approval link handled by a separate HTTP function that calls `raise_event` on the orchestration instance. While waiting, the orchestrator consumes **no compute**; only storage retains history.
+
+**Pattern 5: Monitor** runs a recurring check (inventory level, certificate expiry) on a timer inside the orchestration, calling an activity each interval until a condition is met or a timeout fires. This replaces fragile cron-plus-database flag patterns with a single durable workflow you can inspect in the Durable Functions monitoring UI.
+
+```mermaid
+flowchart LR
+    Start[Orchestrator starts] --> Wait[Wait for external event]
+    Wait -->|Approval received| Continue[Resume workflow]
+    Wait -->|Timeout| Escalate[Escalation activity]
+```
+
+### Retry Policies and Dead-Lettering
+
+Transient failures in queue-driven Functions are handled at two layers. **Binding extensions** for Azure Storage queues and Service Bus honor `host.json` settings such as `maxRetryCount`, `retryStrategy` (`fixedDelay` or `exponentialBackoff`), and lock renewal duration for long-running handlers. After retries exhaust, Service Bus messages move to the **dead-letter subqueue** where operators can inspect poison payloads without blocking the main queue.
+
+Durable Functions add orchestration-level policies via `CallActivityWithRetryAsync` or retry options on individual activities, specifying backoff coefficients and maximum attempts independent of the trigger extension defaults. Combine both layers thoughtfully: a Service Bus trigger might retry delivery three times before dead-lettering, while the orchestrator retries the business activity twice with idempotent logic—without idempotency, stacked retries amplify duplicate side effects.
+
+```json
+{
+  "extensions": {
+    "queues": {
+      "maxPollingInterval": "00:00:02",
+      "visibilityTimeout": "00:00:30",
+      "batchSize": 16,
+      "maxDequeueCount": 5
+    },
+    "serviceBus": {
+      "messageHandlerOptions": {
+        "maxConcurrentCalls": 8,
+        "maxAutoRenewDuration": "00:05:00"
+      }
+    }
+  }
+}
+```
+
+On Consumption and Flex plans, individual **activity** executions remain subject to per-function timeout limits, while the **orchestrator** instance can run for days by checkpointing between activities. Premium and Dedicated remove practical duration ceilings for activities as well, which matters for large file transforms or long external API polls implemented inside activities rather than orchestrator waits.
 
 ```python
 # Durable Functions example: Image processing pipeline
@@ -396,9 +530,17 @@ async def start_pipeline(req: func.HttpRequest, client) -> func.HttpResponse:
 
 Durable Functions store their state in Azure Storage (tables and queues), enabling them to run for days, weeks, or even months. An orchestration can be paused (waiting for a human approval, for example) and resumed without consuming any compute.
 
+### Observability and Versioning
+
+Durable Functions emit **custom traces and structured logs** tied to **instance IDs**, which appear in Application Insights when telemetry is enabled. Operators search by instance ID to compare orchestration history, failed activities, and retry timelines in the **Durable Functions monitoring** blade. When deploying new orchestrator logic, treat orchestration code changes as **versioned contracts**: in-flight instances replay against the orchestrator definition that existed when they started unless you use explicit versioning APIs—surprise breaking changes mid-flight produce nondeterminism errors that surface as `OrchestrationRuntimeException` entries in logs.
+
+Entity functions complement orchestrators when you need strongly consistent counters or lease patterns without provisioning Redis or SQL solely for coordination. An entity receives operations sequentially per entity key, which gives you a lightweight alternative to external locks for throttling concurrent updates to the same customer account or inventory SKU.
+
 ---
 
 ## Function App Configuration and Security
+
+Production Function Apps rarely fail because Python syntax is wrong; they fail because **identity, secrets, and concurrency** were treated as afterthoughts. This section ties together settings that every plan shares, then highlights where Premium and Flex differ in networking defaults.
 
 ### Application Settings and Secrets
 
@@ -420,6 +562,8 @@ az functionapp config appsettings set \
 # Enable managed identity for Key Vault access
 az functionapp identity assign --resource-group myRG --name kubedojo-func-xxxx
 ```
+
+Grant the identity **`Key Vault Secrets User`** (or tighter custom role) on the vault scope, then replace plaintext secrets with **`@Microsoft.KeyVault(SecretUri=...)`** references. The platform resolves secrets at runtime and refreshes them on a cache interval, which means secret rotation does not require redeploying function code if URIs remain stable. For Cosmos DB and Storage, prefer **RBAC data-plane roles** (`Cosmos DB Built-in Data Contributor`, `Storage Blob Data Contributor`) over connection strings when bindings support token authentication—connection strings remain common in labs for speed, but RBAC reduces credential leakage blast radius in production.
 
 ### Performance and host.json Configuration
 
@@ -448,9 +592,15 @@ You can optimize performance and control scaling behavior by configuring `host.j
 }
 ```
 
+**Dynamic concurrency** (when enabled) lets the runtime learn optimal per-trigger concurrency and persist snapshots between scale events, which helps queue-heavy workloads without manual tuning. Pair **`functionAppScaleLimit`** consciously: setting it too low protects downstream systems but creates artificial backlog during legitimate spikes; leaving it unlimited on Consumption without testing can hit the 200-instance ceiling and still saturate a fragile database. For Python CPU-bound handlers, **`FUNCTIONS_WORKER_PROCESS_COUNT`** launches multiple worker processes to sidestep GIL contention—each process consumes memory, so GB-second costs rise with process count even if executions stay flat.
+
 ### Authentication and Authorization
 
 Authentication determines who can call your function and how trust is established, so treat it as architecture, not decoration. Function-level auth via `authLevel` is useful for learning and simple internal APIs, while app-level Entra ID integration centralizes identity and token validation at the platform edge. In production this split gives you better auditability and easier policy changes, because enforcement happens outside individual function handlers.
+
+**Function keys** (`authLevel=FUNCTION` or `ADMIN`) embed shared secrets in URLs or headers—fine for lab webhooks, poor for user-facing browsers where keys leak via logs and referrer headers. **Easy Auth** (`az webapp auth`) validates JWTs from Entra ID before requests reach your code, enabling **`AuthLevel.ANONYMOUS`** on HTTP triggers while still rejecting unauthenticated callers at the edge. Combine Easy Auth with **`@Microsoft.KeyVault`** secret references so neither database credentials nor function keys live in source control.
+
+For internal service-to-service calls inside a VNet, some teams terminate mTLS at Application Gateway or use **`x-functions-key`** rotation via Key Vault-backed settings. Whatever model you choose, document which layer validates identity (gateway, Easy Auth, or function key) so on-call engineers know where to inspect failures when callers receive 401 responses after a secret rotation event.
 
 ```bash
 # Function-level auth (API key in header or query string)
@@ -466,9 +616,101 @@ az webapp auth microsoft update \
 
 ---
 
+## Cost Lens: Plans, Triggers, and Surprise Bills
+
+Serverless pricing looks inexpensive until trigger choice and hosting plan interact badly with production traffic. On **legacy Consumption** and **Flex Consumption on-demand** billing, you pay for **executions** plus **GB-seconds**—gigabytes of memory multiplied by seconds of execution time. Azure rounds memory up to the nearest 128 MB (legacy Consumption caps at 1,536 MB per instance) and bills a minimum of **100 ms and 128 MB per execution** even when your handler finishes in milliseconds. Each subscription receives a monthly **free grant** of **1 million executions** and **400,000 GB-seconds** shared across all function apps in that subscription, which covers many labs and low-traffic internal tools entirely.
+
+Flex Consumption adds a second billing mode: **always-ready** instances provision baseline memory continuously to reduce cold starts. Always-ready billing charges GB-seconds for the provisioned baseline **even when no functions execute**, and **does not include the free grant**—teams enable always-ready selectively per trigger type or function rather than blanket-warming entire apps. Premium (Elastic Premium) bills **per vCPU-second and GB-second** for active instances plus the cost of configured minimum instances, which is predictable but never scales to zero. Dedicated plans charge the underlying **App Service Plan** hourly whether functions run or not—the right choice when the same plan already hosts web apps or when you need unlimited duration without Premium SKUs.
+
+Cost spikes usually trace to behavioral causes rather than mysterious platform bugs. A **Timer** trigger that fires every minute across hundreds of environments generates 43,200 executions per month per function before any useful work happens—multiplied across dev, test, and staging copies, that exhausts free grants quickly. **Blob triggers** that poll large containers can invoke functions repeatedly when many blobs exist even if only a few change, which is another reason Event Grid is cheaper at the latency layer when events are sparse but containers are huge. Chatty HTTP APIs on Consumption during sustained 24/7 traffic often exceed Premium baseline cost; model both using the [consumption cost estimation guidance](https://learn.microsoft.com/en-us/azure/azure-functions/functions-consumption-costs) before launch.
+
+| Cost driver | Typical symptom | Mitigation |
+| :--- | :--- | :--- |
+| High execution count | Timer or webhook retry storms | Widen timer intervals; fix upstream timeouts; use idempotent handlers |
+| High GB-seconds | Large memory footprint or slow imports | Right-size Flex memory; slim dependencies; move heavy init to activities |
+| Always-ready baseline | Warm instances 24/7 "just in case" | Scope always-ready to HTTP entrypoints only; use on-demand elsewhere |
+| Premium minimum instances | Steady traffic on EP1+ | Compare against Dedicated ASP; tune min/max burst |
+| Dead-letter neglect | Repeated poison processing | Alert on DLQ depth; fix root cause before replay |
+
+The cold-start versus cost tradeoff is explicit: Consumption and Flex on-demand minimize idle spend but tax the first requests after idle periods; Premium and Flex always-ready spend continuously to buy stable tail latency. Neither side is universally correct—payment webhooks justify warmth, nightly ETL jobs do not.
+
+**Premium plan math** differs from consumption meters: you pay for allocated vCPU and memory per pre-warmed instance hour, not just executed milliseconds. A single EP1 instance running 730 hours per month carries a predictable baseline even if HTTP traffic is zero, which is why 24/7 APIs with moderate traffic often land near Premium parity versus consumption GB-seconds. Elastic scale **`maxBurst`** prevents runaway bills when a bug fans out infinite Service Bus messages—treat burst caps as financial circuit breakers, not only performance knobs.
+
+**Dedicated (App Service) plan** Functions share the ASP with web apps and background jobs. If you already pay for a P1v3 plan hosting three APIs, adding Functions to the same plan avoids incremental hosting cost until CPU or memory saturation forces a SKU upgrade. The tradeoff is loss of independent scale-to-zero: the plan runs continuously.
+
+---
+
+## Decision Framework: Hosting Plan and Compute Choice
+
+Use the framework below after you know connectivity, duration, and latency requirements. The earlier flowchart in the Hosting Plans section is a quick filter; this matrix compares **Functions hosting plans** against **Container Apps** and **Logic Apps** when teams debate "serverless" broadly.
+
+```text
+Need visual workflow / SaaS connectors with minimal code?
+  yes -> Logic Apps (orchestration/integration)
+  no
+Need long-running containers, KEDA scale, TCP, or sidecars?
+  yes -> Azure Container Apps
+  no
+Need event-driven code with bindings and Durable Functions?
+  yes -> Azure Functions (pick plan below)
+```
+
+| Requirement | First choice | Why | Watch out |
+| :--- | :--- | :--- | :--- |
+| Sporadic events, no VNet, under 5–10 min | Flex Consumption on-demand | Scale to zero; free grant; recommended serverless path | Cold starts on first requests |
+| Private resources in VNet, bursty traffic | Flex Consumption | VNet integration with serverless billing | Configure subnets and DNS before deploy |
+| Sub-second API latency 24/7 | Premium or Flex always-ready | Pre-warmed workers; unlimited duration on Premium | Baseline hourly cost never reaches zero |
+| Existing App Service Plan capacity | Dedicated Functions on ASP | Share plan with web apps; predictable cost | Plan size must cover peak combined load |
+| Multi-step human approvals over days | Functions + Durable Functions | Checkpointed orchestration; zero compute while waiting | Activity idempotency is mandatory |
+| Low-code integration across SaaS | Logic Apps | Connector ecosystem; visual designer | Per-action pricing at high volume |
+| Custom container + HTTP/TCP + KEDA | Container Apps | Full container control; scale to zero option | You manage image and probes |
+
+### Hosting Plan Decision Matrix
+
+| Factor | Consumption (legacy) | Flex Consumption | Premium (EP) | Dedicated (ASP) |
+| :--- | :--- | :--- | :--- | :--- |
+| Cold-start tolerance | Low–medium | Medium–high (with always-ready) | High | High |
+| VNet required | No | Yes | Yes | Yes |
+| Max scale-out | 200 | 1,000 | Configurable burst | Plan limit |
+| Scale to zero | Yes | Yes | Optional | No |
+| Max single execution | 5 min default (10 max) | 30 min | Unlimited | Unlimited |
+| Best cost when | Legacy Windows sporadic jobs | New serverless apps | Steady low-latency APIs | Shared ASP already paid |
+
+When latency-sensitive HTTP meets private networking, **Flex with targeted always-ready instances** often beats **Premium with large minimum instances** because you pay baseline warmth only on entry functions while background queue processors stay on-demand. When executions routinely exceed Flex timeout limits or require more than 4 GB memory per instance, move activities to Premium or Container Apps rather than forcing monolithic functions.
+
+### Functions vs Container Apps vs Logic Apps
+
+Teams sometimes ask whether Functions is the wrong product entirely. **Logic Apps** excel when integrations are connector-heavy, approvals are visual, and custom code is minimal—think SaaS webhooks stitched together with built-in retries and enterprise connectors. **Azure Container Apps** excel when you need arbitrary containers, TCP listeners, sidecars, or KEDA scaling on custom metrics while still avoiding full cluster operations. **Azure Functions** sits in the middle: optimized for short event-driven code with first-class bindings and Durable Functions orchestration. A valid hybrid places HTTP entry on Functions or Container Apps, pushes long orchestrations to Durable Functions, and delegates cross-SaaS fan-out to Logic Apps when connector maintenance would otherwise dominate sprint time.
+
+---
+
+## Patterns & Anti-Patterns
+
+Patterns capture what experienced teams repeat on purpose; anti-patterns capture the shortcuts that look fine in demos and fail on the first Black Friday.
+
+| Pattern | When to use it | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| Event Grid → Function for blob events | User-facing uploads need sub-minute processing | Push delivery avoids Blob trigger polling delay | Filter subscriptions to specific containers/paths |
+| Queue trigger + poison DLQ | Async work with retry semantics | Service Bus or Storage queues isolate bursts | Monitor dead-letter depth; idempotent handlers |
+| Durable fan-out/fan-in | Parallel independent steps with aggregation | `task_all` concurrency without manual thread pools | Size activities small; respect downstream rate limits |
+| Flex always-ready on HTTP only | Webhooks with strict timeout budgets | Warm entrypoints without warming entire app | Assign always-ready per function, not globally |
+| Key Vault references + managed identity | Any production binding connection | Secrets rotate without redeploy; no plaintext in settings | Grant least-privilege RBAC on vault and data plane |
+| Output bindings for Cosmos/Queue | CRUD micro-operations from Functions | Removes SDK ceremony; runtime handles batching | Still validate payload size limits per service |
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better approach |
+| :--- | :--- | :--- | :--- |
+| Blob trigger for real-time UX | 10–60s polling delay | Blob trigger appears first in tutorials | Event Grid trigger on BlobCreated |
+| Monolithic 2,000-line function | Untestable, slow cold start | "Move the whole microservice" migration | Chain activities via Durable Functions |
+| Consumption for VNet SQL | Cannot reach private database | Consumption is default in samples | Flex Consumption with VNet integration |
+| Timer per customer/resource | Execution count explodes | Cron seems simpler than queue batching | Single timer batches work items from storage |
+| Ignoring orchestrator determinism | Duplicate side effects on replay | Copy-paste imperative code into orchestrator | I/O only in activities; pure logic in orchestrator |
+| Plaintext connection strings | Secret sprawl and audit failures | Fastest portal copy/paste | `@Microsoft.KeyVault(SecretUri=...)` + MI |
+
+---
+
 ## Did You Know?
 
-1. **Azure Functions Consumption plan has processed trillions of executions** since its launch. The free grant of 1 million executions and 400,000 GB-seconds per month means that many small-to-medium applications run entirely for free. A function that executes 100,000 times per month at 128 MB memory and 200ms average duration uses only 2,560 GB-seconds---well within the free tier.
+1. **Azure Functions Consumption plan has processed trillions of executions** since its launch. The free grant of 1 million executions and 400,000 GB-seconds per month means that many small-to-medium applications run entirely for free. A function that executes 100,000 times per month at 128 MB memory and 200ms average duration uses only 2,560 GB-seconds---well within the free tier. Flex Consumption adds selectable instance memory (512 MB, 2,048 MB, or 4,096 MB); higher tiers increase GB-second totals but prevent timeouts for memory-heavy Python workloads.
 
 2. **Durable Functions can run for up to 7 days on the Consumption plan** (the orchestrator itself; individual activity functions still have the 5-10 minute limit). On Premium and Dedicated plans, they can run indefinitely. One retail company uses a Durable Function orchestration that runs for 30 days, managing a month-long A/B test lifecycle with periodic check-ins and automatic completion.
 
@@ -531,15 +773,31 @@ On the Consumption plan, Azure manages scaling automatically by rapidly allocati
 You should use a Durable Functions orchestrator with four separate activity functions for validation, charging, inventory, and emailing. The orchestrator function calls each activity sequentially, maintaining the state of the entire workflow reliably. If a step fails, such as the inventory update, the orchestrator can natively implement compensation logic to call a refund activity and reverse the credit card charge. By using Durable Functions instead of chaining multiple independent functions via queue messages, you gain a single, readable source of truth for the workflow. This ensures that partial failures do not leave your system in an inconsistent state while providing built-in observability.
 </details>
 
+<details>
+<summary>7. Your platform team must deploy a new Python function app that calls a PostgreSQL database inside a private VNet and should scale to zero on weekends. Flex Consumption is available in your region. Which execution and hosting choices align with current Microsoft guidance?</summary>
+
+Deploy on **Flex Consumption** with the Python v2 programming model, which runs in the standard language worker process and supports VNet integration that legacy Consumption lacks. Configure VNet integration on the function app and route database traffic through the integrated subnet. Use on-demand billing for scale-to-zero on weekends, adding always-ready instances only if cold-start latency becomes a measured problem on HTTP entrypoints. Avoid legacy Linux Consumption for new apps because Microsoft directs new serverless workloads to Flex Consumption and is retiring Linux Consumption over time.
+</details>
+
+<details>
+<summary>8. A Service Bus queue-triggered function processes financial transactions. After three failures, messages should land in a dead-letter queue for manual review, and the handler must survive transient Cosmos DB throttling. Where do you configure retries, and what code property must your handler guarantee?</summary>
+
+Configure **Service Bus** `maxConcurrentCalls`, lock renewal, and dead-letter behavior through the Service Bus extension in `host.json` and queue/subscription settings on the broker. The function runtime retries delivery until `maxDeliveryCount` exhausts, then dead-letters the message. Implement **idempotent** transaction logic so a retried delivery does not double-post charges if the first attempt partially succeeded. For Durable orchestrations wrapping the same work, also use activity retry policies—but idempotency remains the developer's responsibility because replay and broker retries stack.
+</details>
+
 ---
 
 ## Hands-On Exercise: Blob Trigger to Process and Store in Cosmos DB
 
 In this exercise, you will create an Azure Function triggered by blob uploads that processes the file metadata and stores the result in Cosmos DB via an output binding. This lab walks through the same principles from earlier in the module by tying triggers, host configuration, and secret management into one coherent workflow. You will provision resources, deploy code, and then verify end-to-end behavior so each layer is checked before you move to the next one. This sequencing helps prevent the “it deployed but does not run” gap that appears when configuration is left implicit.
 
+The lab intentionally uses a **Blob trigger** rather than Event Grid so you experience polling delay firsthand—compare the 60-second wait in Task 5 against the Event Grid guidance earlier and articulate which production scenarios would justify the extra subscription setup. In production you would also replace connection-string settings with managed identity and RBAC, but connection strings keep the lab focused on bindings rather than Entra ID role assignments you practiced in Module 3.1.
+
 **Prerequisites**: Azure CLI, Azure Functions Core Tools (`func`), Python 3.11+. You should also have an active subscription with sufficient permissions for resource creation, storage, and Cosmos DB so the commands are safe to run end-to-end without environment churn.
 
 ### Task 1: Create Infrastructure
+
+Task 1 provisions the three Azure pillars this lab needs: **Storage** (function host state plus upload container), **Cosmos DB** (output binding destination), and the resource group boundary for cleanup. The storage account name must be globally unique, which is why the script generates random suffixes. Cosmos DB uses **`Session`** consistency as a balanced default for read-your-writes metadata indexing; production pipelines might choose stronger consistency only when downstream analytics require it.
 
 ```bash
 RG="kubedojo-functions-lab"
@@ -596,6 +854,8 @@ az cosmosdb sql container show \
 </details>
 
 ### Task 2: Create the Function App
+
+Task 2 creates a **Consumption plan** function app for simplicity. In a production migration you would likely choose **Flex Consumption** instead and add VNet integration before storing secrets—note how application settings map directly to binding `connection=` names used later in `function_app.py`. Mismatched setting names are the most common reason blob triggers never fire after a successful deploy.
 
 ```bash
 # Create a Consumption plan Function App
@@ -751,6 +1011,8 @@ You should see the `process_upload` function with a `blobTrigger`.
 
 ### Task 5: Test the Function by Uploading Blobs
 
+Task 5 demonstrates end-to-end behavior and the **Blob trigger polling delay** discussed throughout the module. If results do not appear immediately, resist the urge to redeploy—wait the full polling window, confirm the blob landed in the **`uploads`** container with correct path casing, and inspect **`StorageConnection`** settings if the trigger never fires at all. Event Grid would remove this wait in production, at the cost of an additional subscription resource and filter maintenance.
+
 ```bash
 # Upload a JSON file
 echo '[{"user": "alice", "action": "login"}, {"user": "bob", "action": "purchase"}]' > /tmp/test-data.json
@@ -816,6 +1078,8 @@ rm -rf /tmp/functions-lab /tmp/test-data.json /tmp/readme.txt
 - [ ] Text file uploaded and processed (metadata stored in Cosmos DB)
 - [ ] Function execution visible in logs or monitor
 
+After cleanup, capture one lesson in your runbook: which trigger type you used, how long polling delayed processing, and which hosting plan you would choose for a production deployment with VNet and latency requirements.
+
 ---
 
 ## Next Module
@@ -824,6 +1088,15 @@ rm -rf /tmp/functions-lab /tmp/test-data.json /tmp/readme.txt
 
 ## Sources
 
-- [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale) — This is the primary Microsoft comparison for Consumption, Flex Consumption, Premium, and Dedicated hosting behavior.
-- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings) — It explains the trigger and binding model that underpins most of the module's examples.
-- [Durable Functions overview](https://learn.microsoft.com/en-us/azure/azure-functions/durable-functions/durable-functions-overview) — It is the best starting point for orchestration patterns, checkpoints, and long-running workflow behavior.
+- [Azure Functions hosting options](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale) — Primary comparison for Consumption, Flex Consumption, Premium, and Dedicated hosting behavior, scale limits, and plan selection guidance.
+- [Azure Functions Flex Consumption plan](https://learn.microsoft.com/en-us/azure/azure-functions/flex-consumption-plan) — Details on always-ready instances, memory sizes, VNet integration, and Flex-specific billing modes.
+- [Estimating consumption-based costs](https://learn.microsoft.com/en-us/azure/azure-functions/functions-consumption-costs) — GB-second calculation, free grants, and always-ready baseline costs for Flex Consumption.
+- [Azure Functions pricing](https://azure.microsoft.com/en-us/pricing/details/functions/) — Current meter rates for execution time, executions, and Premium vCPU/GB pricing.
+- [Azure Functions triggers and bindings](https://learn.microsoft.com/en-us/azure/azure-functions/functions-triggers-bindings) — Trigger/binding programming model, extension concepts, and supported integrations.
+- [Azure Functions best practices](https://learn.microsoft.com/en-us/azure/azure-functions/functions-best-practices) — Cold-start mitigation, plan selection, deployment, and operational guidance.
+- [Durable Functions overview](https://learn.microsoft.com/en-us/azure/azure-functions/durable-functions/durable-functions-overview) — Orchestrator, activity, and entity concepts with checkpoint/replay semantics.
+- [Durable Functions patterns and technical overview](https://learn.microsoft.com/en-us/azure/azure-functions/durable/durable-functions-orchestration) — Function chaining, fan-out/fan-in, async HTTP, human interaction, and monitor patterns.
+- [Guide for running C# Functions in the isolated worker process](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-process-guide) — Isolated worker benefits, package model, and migration path from in-process.
+- [Differences between in-process and isolated worker .NET Functions](https://learn.microsoft.com/en-us/azure/azure-functions/dotnet-isolated-in-process-differences) — Feature matrix including Flex Consumption support and binding package naming.
+- [Azure Event Grid trigger for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-event-grid-trigger) — Event-driven blob and resource notifications as an alternative to polling Blob triggers.
+- [host.json reference for Azure Functions](https://learn.microsoft.com/en-us/azure/azure-functions/functions-host-json) — Concurrency, queue/Service Bus retry settings, and extension configuration.

--- a/src/content/docs/cloud/azure-essentials/module-3.9-key-vault.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.9-key-vault.md
@@ -15,19 +15,25 @@ After completing this module, you will be able to:
 - **Deploy Key Vault integration patterns for App Service, Azure Functions, AKS, and VM workloads**
 - **Design multi-region Key Vault architectures with soft delete, purge protection, and HSM-backed keys**
 
+These outcomes chain together in real designs: you cannot integrate AKS or Container Apps safely without RBAC and managed identity; you cannot claim disaster recovery without understanding soft delete versus regional vault pairs; you cannot control spend without transaction and HSM-key meters. The hands-on lab intentionally uses RBAC, user-assigned identity, and soft-delete recovery—the same primitives production templates encode in Bicep or Terraform modules.
+
 ---
 
 ## Why This Module Matters
 
-In December 2022, a widely-used password management company disclosed a major breach. Attackers had stolen encrypted vault data and the encryption keys needed to decrypt it. The root cause was traced back to a developer's home computer that had an old, vulnerable version of a media player installed. The attacker exploited the vulnerability, captured the developer's master credentials, and used them to access the company's cloud storage containing encrypted customer data. The breach affected millions of users and led to substantial legal, remediation, and reputational costs.
+**Hypothetical scenario:** A platform team ships a hotfix that embeds a production database connection string in a Git commit. A contractor’s laptop is compromised the next week. The attacker clones the repository, extracts the string, and pivots into customer data before anyone rotates credentials. Incident response spends days untangling which services still read the old password from config maps, environment variables, and stale deployment artifacts.
 
-This incident drives home a fundamental point: **secrets management is not optional, and it is not a problem you solve with environment variables.** Every application has secrets---database passwords, API keys, encryption keys, TLS certificates. How you store and access these secrets determines whether a single compromised developer laptop leads to a minor inconvenience or a company-ending breach.
+That pattern is common because **secrets management is not optional, and it is not a problem you solve with environment variables alone.** Every application has secrets—database passwords, API keys, encryption keys, TLS certificates. How you store, scope, rotate, and audit access to those objects determines whether one leaked credential becomes a contained rotation event or a prolonged breach.
 
-Azure Key Vault is a cloud service for [securely storing and managing secrets, encryption keys, and certificates](https://learn.microsoft.com/en-us/azure/key-vault/general/developers-guide). It supports HSM-protected keys and integrates with many Azure services, but the exact hardware validation level depends on the SKU and HSM platform. In this module, you will learn the three object types Key Vault manages, the two access control models (Access Policies vs RBAC), how soft delete and purge protection safeguard against accidental deletion, and how to integrate Key Vault with your applications using Managed Identities. By the end, you will store a database connection string in Key Vault and retrieve it from a Container App without any credentials in your code.
+Azure Key Vault is a cloud service for [securely storing and managing secrets, encryption keys, and certificates](https://learn.microsoft.com/en-us/azure/key-vault/general/developers-guide). It supports HSM-protected keys and integrates with many Azure services, but the exact hardware validation level depends on the SKU and HSM platform. In this module, you will learn the three object types Key Vault manages, the two access control models (Access Policies vs RBAC), how soft delete and purge protection safeguard against accidental deletion, and how to integrate Key Vault with your applications using Managed Identities. You will also compare Standard, Premium, and Managed HSM costs, and choose among SDK, platform reference, and CSI integration paths. By the end, you will store a database connection string in Key Vault and retrieve it from a Container App without any credentials in your code.
 
 ---
 
 ## Key Vault Fundamentals
+
+Azure Key Vault is the default **control plane for secrets, keys, and certificates** in Azure-native architectures. Other services (Managed HSM, dedicated HSM appliances) exist for specialized key-only regimes, but vaults remain the integration point for App Service, SQL, AKS CSI, Disk Encryption, and hundreds of resource providers that expect a `vault.azure.net` URI. Thinking in object types—not “a password store”—helps you pick the right API, RBAC role, and pricing meter for each credential.
+
+Every REST call to `https://<vault-name>.vault.azure.net` is authenticated with a bearer token from Microsoft Entra ID whose audience is `https://vault.azure.net`. The token carries the caller’s identity; authorization is evaluated separately via RBAC or access policies. That split is why you can grant a managed identity read access without sharing passwords, and why compromised tokens are revocable by disabling the identity or removing role assignments—there is no long-lived shared vault password to rotate globally.
 
 ### The Three Object Types
 
@@ -38,6 +44,16 @@ Key Vault manages three distinct categories of cryptographic and sensitive mater
 | **Secrets** | [Any string up to 25 KB](https://learn.microsoft.com/en-us/azure/key-vault/secrets/about-secrets) | DB passwords, API keys, connection strings, config values | [`https://myvault.vault.azure.net/secrets/`](https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates) |
 | **Keys** | [RSA or EC cryptographic keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys) | Data encryption, signing, wrapping other keys | `https://myvault.vault.azure.net/keys/` |
 | **Certificates** | [X.509 certificates + private keys](https://learn.microsoft.com/en-us/azure/key-vault/certificates/about-certificates) | TLS/SSL for web apps, code signing, mTLS | `https://myvault.vault.azure.net/certificates/` |
+
+Each object type has its own lifecycle semantics on the data plane. **Secrets** are opaque strings (up to 25 KB) with optional `nbf` (not-before), `exp` (expiry), and `enabled` attributes. Disabling a secret blocks new reads without deleting history—useful during incident response when you need to stop traffic immediately but preserve versions for forensics. **Keys** are JSON Web Key (JWK) objects; software-protected keys run in FIPS-validated software modules, while HSM-protected keys (`RSA-HSM`, `EC-HSM`) keep private material inside the HSM boundary for Premium vaults. **Certificates** bundle the public certificate, policy (issuer, subject, SANs, validity), and private key; Key Vault can [integrate with public CAs](https://learn.microsoft.com/en-us/azure/key-vault/certificates/about-certificates) (DigiCert, GlobalSign) for enrollment and renewal, or you can import PFX files you already own.
+
+Versioning applies uniformly: every `set` on a secret, `create`/`rotate` on a key, or certificate renewal produces a new version ID. Applications should pin to a version only when they must reproduce a specific ciphertext; otherwise they read the **current** version and tolerate rotation by refreshing on a schedule or on failure. Backup operations are special—Microsoft documents a [500-version cap per object for backup](https://learn.microsoft.com/en-us/azure/key-vault/general/service-limits); vaults with hundreds of versions per secret slow backup and can block restore planning.
+
+### Key Vault vaults vs Azure Managed HSM
+
+Most teams start with a **Key Vault vault** (`*.vault.azure.net`). [Standard tier](https://learn.microsoft.com/en-us/azure/key-vault/general/overview) encrypts data at rest with FIPS 140 Level 1 software modules and supports software-protected RSA/EC keys. **Premium tier** adds HSM-protected keys (FIPS 140-3 Level 3 on newer HSM platform keys per Microsoft’s [about keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys) documentation) and is the right default when regulations or customer contracts require keys that never leave the HSM for wrap/unwrap operations.
+
+**Azure Managed HSM** (`*.managedhsm.azure.net`) is a separate resource type: single-tenant pools for **HSM-protected keys only**—no secrets or certificates in the same resource. Microsoft positions it for high-value keys and strict compliance ([Managed HSM overview](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/overview)). You pay an hourly pool fee (pricing page lists Standard B1 pools) rather than per-transaction secret pricing. Choose Managed HSM when you need dedicated tenancy, higher key counts per pool, or symmetric `oct-HSM` keys; stay on a Premium vault when you want one control plane for secrets, certs, and HSM keys together.
 
 ```mermaid
 graph TD
@@ -110,9 +126,31 @@ az keyvault secret show \
   --version "abc123def456..."
 ```
 
+For rotation-friendly secrets, set `exp` when you create or update so Key Vault can emit [SecretNearExpiry events](https://learn.microsoft.com/en-us/azure/event-grid/event-schema-key-vault) to Event Grid. Operations teams often pair expiry metadata with an Azure Function that writes the next version after the downstream system (SQL login, API vendor key) has been updated—Key Vault stores the truth, but it does not change external systems by itself.
+
+```bash
+# Create a secret with activation and expiry (ISO 8601 duration/date)
+az keyvault secret set \
+  --vault-name kubedojo-vault \
+  --name "api-key-vendor" \
+  --value "vendor-key-v1" \
+  --expires "2026-12-31T23:59:59Z" \
+  --not-before "2026-06-01T00:00:00Z"
+
+# Disable without deleting (blocks new reads of current version)
+az keyvault secret set-attributes \
+  --vault-name kubedojo-vault \
+  --name "api-key-vendor" \
+  --enabled false
+```
+
 ### Keys: Encryption Without Exposing Key Material
 
 Key Vault keys are special: [for HSM-protected keys, the private key material stays inside the HSM](https://learn.microsoft.com/en-us/azure/key-vault/general/developers-guide). When you need to encrypt data, you send the data to Key Vault, and it returns the ciphertext. You never see the raw key.
+
+Software keys (`RSA`, `EC`) are cheaper per operation and sufficient for dev/test or low-risk signing. HSM keys (`RSA-HSM`, `EC-HSM`) require **Premium** SKU and bill a monthly **per active key version** charge when used in the prior 30 days, plus per-operation fees ([Azure Key Vault pricing](https://azure.microsoft.com/en-us/pricing/details/key-vault/)). Advanced sizes (3072/4096-bit RSA, non-2048 curves) use a higher operations meter ($0.15 per 10,000 transactions vs $0.03 for 2048-bit software keys on the public pricing page). Throttling also differs: [service limits](https://learn.microsoft.com/en-us/azure/key-vault/general/service-limits) allow fewer GETs per 10 seconds for larger HSM keys because limits are weighted—4096-bit HSM GETs consume the budget eight times faster than 2048-bit HSM GETs.
+
+For bulk data, applications use **envelope encryption**: generate a random AES data key locally, encrypt the payload with AES, then wrap the data key with Key Vault’s RSA-OAEP or AES-KW. Only the small wrapped key transits the network to Key Vault. Azure Disk Encryption, SQL TDE with customer-managed keys, and many PaaS integrations follow this pattern so multi-gigabyte objects never traverse the vault API.
 
 > **Stop and think**: If the raw key material for a Key Vault key never leaves the HSM, how does an application encrypt a 50 GB video file? Sending a 50 GB payload over the network to Key Vault for encryption would be incredibly slow and inefficient. What pattern might be used instead?
 
@@ -166,14 +204,16 @@ az keyvault certificate download \
   --encoding PEM
 ```
 
+Certificate **policies** define issuer (self-signed vs CA partner), key type, exportability, and lifetime actions. Auto-renewal triggers before expiry; each renewal is a billable **certificate renewal** operation on the pricing page (distinct from ordinary certificate API calls). Imported certificates skip CA integration but still benefit from centralized private-key storage and access logging. When App Service or Application Gateway consumes certs, they typically pull the current version via reference URI—rotation in Key Vault propagates only after the consuming service refreshes its binding.
+
 ---
 
 ## Automated Secret Rotation
 
-Storing secrets securely is only half the battle; secrets must be rotated regularly to limit the impact of a potential compromise. Azure Key Vault provides native rotation policies for Keys, and integrates with Event Grid to orchestrate rotation for Secrets.
+Storing secrets securely is only half the battle; secrets must be rotated regularly to limit the impact of a potential compromise. Rotation has three moving parts: **generate new material**, **update dependents** (databases, partners, apps), and **retire old versions** without breaking decrypt of historical data. Azure Key Vault owns the first and third for keys; secrets usually need your automation for the second.
 
 ### Key Vault Rotation Policies (Keys)
-For cryptographic keys, you can [define an automated rotation policy directly within Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/keys/how-to-configure-key-rotation). This instructs the HSM to generate new key material at a scheduled interval.
+For cryptographic keys, you can [define an automated rotation policy directly within Key Vault](https://learn.microsoft.com/en-us/azure/key-vault/keys/how-to-configure-key-rotation). This instructs the HSM to generate new key material at a scheduled interval. The policy JSON combines `lifetimeActions` (when to rotate) with `attributes.expiryTime` on the key. After rotation, old versions remain addressable by version ID—encrypted blobs, disks, or database columns written with the prior key still decrypt. Your application or service (SQL TDE, Storage CMK) must be configured to prefer the latest version for new encryption while retaining access to older versions until data is re-encrypted or no longer needed.
 
 ```bash
 # Create a rotation policy for a key (rotate 30 days before expiry)
@@ -206,6 +246,8 @@ az keyvault key rotation-policy update \
 ### Secret Rotation via Event Grid
 For secrets (like database passwords), Key Vault cannot magically change the password in the target system (e.g., Azure SQL). Instead, Key Vault [emits an Event Grid event 30 days before a secret expires](https://learn.microsoft.com/en-us/azure/event-grid/event-schema-key-vault). This event triggers an Azure Function, which connects to the database, generates a new password, updates the database user, and saves the new version to Key Vault.
 
+Event types you should wire in automation include **SecretNearExpiry**, **SecretExpired**, **KeyNearExpiry**, and certificate analogues—each maps to a schema version documented on the Event Grid page. Subscriptions can fan out to Functions, Logic Apps, or Service Bus so rotation does not run inline with user traffic. Idempotency matters: NearExpiry may fire more than once if clocks or retries overlap; your function should check the current secret version before writing.
+
 ```bash
 # Example flow for Secret Rotation:
 # 1. Secret approaches 'Expiration Date'
@@ -213,7 +255,14 @@ For secrets (like database passwords), Key Vault cannot magically change the pas
 # 3. Event Grid triggers an Azure Function
 # 4. Function connects to Azure SQL and changes the password
 # 5. Function writes the new password to Key Vault as a new version
+# 6. Function notifies app owners OR relies on app cache TTL to pick up new version
 ```
+
+**Human runbooks vs automation:** low-frequency secrets (annual vendor API keys) may stay manual with calendar reminders; high-frequency database credentials should be fully automated. In all cases, test rollback: keep the previous secret version enabled until all consumers confirm the new password, then disable the old version to prevent silent fallback.
+
+### Monitoring who touched secrets
+
+Key Vault integrates with Azure Monitor for auditability. Enable diagnostic settings to stream **AuditEvent** logs to Log Analytics or a storage account ([overview](https://learn.microsoft.com/en-us/azure/key-vault/general/overview) describes monitoring options). Security teams hunt for unusual `SecretGet` volumes, `Delete` after hours, or `Purge` attempts. Correlate vault logs with Entra ID sign-in logs for human operators; managed identities show as service principals with predictable application IDs. Alerts on 429 rates often precede credential stuffing or misconfigured loops more than external attackers.
 
 ---
 
@@ -223,7 +272,9 @@ Key Vault supports two access control models. You must choose one at creation ti
 
 ### Access Policies (Legacy)
 
-Access Policies are vault-level permissions granted to specific identities. Each policy specifies what operations (get, set, delete, list, etc.) an identity can perform on secrets, keys, and certificates.
+Access Policies are vault-level permissions granted to specific identities. Each policy specifies what operations (get, set, delete, list, etc.) an identity can perform on secrets, keys, and certificates. Permissions are not Azure RBAC roles—they are Key Vault-specific strings like `get`, `list`, `set`, `delete`, `recover`, `backup`, `restore`, `encrypt`, `decrypt`, `wrapKey`, `unwrapKey`, `sign`, and `verify` combined per object type. A single principal might have `secret-permissions get list` and `key-permissions get wrapKey unwrapKey` on the same vault, which still grants visibility to **every** secret name in that vault when `list` is allowed.
+
+Microsoft’s migration guidance maps common combinations to built-in RBAC roles, but automated scanners should flag any vault with `enableRbacAuthorization: false` for remediation. Access policies also do not participate in Entra Conditional Access or PIM—only RBAC assignments do—so human access via policies bypasses modern Zero Trust controls described in the [Key Vault overview](https://learn.microsoft.com/en-us/azure/key-vault/general/overview).
 
 ```bash
 # Create a vault with access policies (not recommended for new vaults)
@@ -309,15 +360,29 @@ graph TD
 
 **War Story**: With Access Policies, permissions are granted at vault scope, so a broad set of identities can end up with access to more secrets than they actually need. They could not scope Access Policies to individual secrets. After migrating to RBAC, they granted `Key Vault Secrets User` at the individual secret scope, reducing the blast radius of each identity to only the secrets it needed.
 
+### Why mixing access policies and RBAC fails
+
+A vault is created in **either** RBAC mode or access-policy mode (`enableRbacAuthorization`). Microsoft’s [RBAC vs access policy guide](https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-access-policy) recommends RBAC for new vaults because it aligns with Entra ID Conditional Access, Privileged Identity Management, and subscription-wide access reviews. **Do not grant vault access policies on an RBAC-enabled vault** “just to make it work”—that bypasses the governance model and creates dual paths auditors cannot reason about. Migration is a one-time switch: export policies, map to built-in roles (`Key Vault Secrets User`, `Key Vault Crypto User`, etc.), validate with a staging vault, then cut over.
+
+Data-plane roles are intentionally narrow. `Key Vault Secrets User` can read secret **values**; `Key Vault Reader` sees vault metadata only. Human break-glass should use PIM-eligible `Key Vault Secrets Officer` at the narrowest scope (single secret URI), not standing `Key Vault Administrator` on the subscription. Managed identities for workloads almost always need **Secrets User** or **Crypto User**—not Officer—because rotation and import remain pipeline responsibilities.
+
+Network controls stack on top of RBAC: `default-action Deny` on the vault firewall, subnet rules, optional [private endpoints](https://learn.microsoft.com/en-us/azure/key-vault/general/how-to-azure-key-vault-network-security), and “Allow trusted Microsoft services” when a PaaS resource must reach the vault without public IPs. RBAC alone does not stop a caller on an allowed network path; conversely, a perfect firewall does not help if the identity holds `Key Vault Administrator`. Design both layers.
+
+### Transaction throttling on the data plane
+
+Even authorized callers hit [service limits](https://learn.microsoft.com/en-us/azure/key-vault/general/service-limits). Secret GET operations share a **4,000 transactions per 10 seconds per vault per region** bucket (with a subscription-wide multiplier). Create/import bursts for secrets, certificates, and keys share a **300 per 10 seconds** collective cap. Exceeding limits returns HTTP **429**; clients must backoff and retry. Hot paths that call `get_secret` on every HTTP request will throttle during scale-out long before RBAC denies them—cache in memory and refresh on interval or after rotation events.
+
 ---
 
 ## Soft Delete and Purge Protection
 
-Key Vault has two safety nets against accidental or malicious deletion:
+Key Vault has two safety nets against accidental or malicious deletion. Together they implement a **recoverable delete** model that is very different from simply removing a row in a configuration database.
 
-**Soft Delete**: When you delete a secret, key, or certificate, it is not immediately destroyed. Instead, it enters a "soft-deleted" state and can be recovered during the [retention period (7-90 days)](https://learn.microsoft.com/en-us/azure/key-vault/general/soft-delete-overview). Soft delete is on by default for newly created key vaults.
+**Soft Delete**: When you delete a secret, key, or certificate, it is not immediately destroyed. Instead, it enters a "soft-deleted" state and can be recovered during the [retention period (7-90 days)](https://learn.microsoft.com/en-us/azure/key-vault/general/soft-delete-overview). Soft delete is on by default for newly created key vaults. During the retention window the name remains reserved—you cannot create a new secret with the same name until the old object is recovered or purged. Applications that read the live name will fail after delete, which is why operations runbooks should document recover steps alongside monitoring alerts on secret GET failures.
 
-**Purge Protection**: When enabled, even a soft-deleted object cannot be permanently destroyed (purged) until the retention period expires. When purge protection is enabled, a soft-deleted object cannot be purged until the retention period expires. This protects against a compromised admin account deliberately destroying secrets.
+**Purge Protection**: When enabled, even a soft-deleted object cannot be permanently destroyed (purged) until the retention period expires. This protects against a compromised admin account deliberately destroying secrets. Microsoft documents that **purge protection cannot be disabled** once enabled; plan retention length per environment (seven days for labs, longer for production) because every delete becomes a waiting game until scheduled purge date. Vault-level purge protection also prevents purging the entire vault until retention elapses—pair with break-glass procedures stored outside the vault.
+
+**Operational implications:** soft delete protects against oops moments; purge protection protects against malicious purge. Neither replaces backup: [backup/restore](https://learn.microsoft.com/en-us/azure/key-vault/general/backup) downloads encrypted blobs that only restore into the same subscription and geography. For regional disasters, rely on paired-region replication behavior plus your active-active vault pattern, not backup alone.
 
 ```bash
 # Delete a secret (soft delete)
@@ -352,13 +417,17 @@ stateDiagram-v2
 
 ## Multi-Region Architectures and Disaster Recovery
 
-For mission-critical applications deployed across multiple Azure regions (e.g., East US and West Europe), depending on a single Key Vault creates a single point of failure and introduces cross-region latency.
+For mission-critical applications deployed across multiple Azure regions (e.g., East US and West Europe), depending on a single Key Vault creates a single point of failure and introduces cross-region latency. Calls from West Europe to an East US vault add round-trip time on every cold start that touches Key Vault; at scale you will feel it in pod startup and autoscaling curves even when throttling is not triggered.
 
 ### High Availability within a Region
-Behind the scenes, Azure Key Vault automatically replicates its contents within the region and to a paired region (e.g., East US to West US). If a single node fails, traffic is transparently routed to a healthy node.
+Behind the scenes, Azure Key Vault automatically replicates its contents within the region and to a paired region (e.g., East US to West US). If a single node fails, traffic is transparently routed to a healthy node. You do not configure this replication—it is part of the managed service SLA story. Your responsibility is to place the vault in the same sovereignty boundary as the primary workload and to grant identities access via RBAC before failover events, because Entra ID tokens and DNS for `*.vault.azure.net` must still resolve during stress.
 
 ### The Active-Active Vault Pattern
-However, if an entire region goes down, the vault in the [paired region enters read-only mode](https://learn.microsoft.com/en-us/azure/reliability/reliability-key-vault). For active-active applications that need to *write* secrets or manage keys during a regional outage, you [must deploy independent Key Vaults in each region](https://learn.microsoft.com/en-us/azure/reliability/reliability-key-vault).
+However, if an entire region goes down, the vault in the [paired region enters read-only mode](https://learn.microsoft.com/en-us/azure/reliability/reliability-key-vault). For active-active applications that need to *write* secrets or manage keys during a regional outage, you [must deploy independent Key Vaults in each region](https://learn.microsoft.com/en-us/azure/reliability/reliability-key-vault). Reads may continue from the surviving regional endpoint for many scenarios, but secret rotation, new certificate issuance, or emergency key creation requires a writable vault in the active region.
+
+**Sync discipline:** treat regional vaults like regional databases. Global secrets (Stripe API key, shared HMAC) need identical values in both vaults via CI/CD or an approved sync function with idempotent writes and alerting on drift. Regional secrets (SQL login for `db-east` vs `db-west`) should exist only in the local vault to avoid wrong-region connections. Document which category each secret belongs to in your secret catalog; auditors will ask.
+
+**Failover testing:** quarterly exercises should include revoking a secret version, recovering via soft delete, and failing over application reads to the secondary regional vault URI. Teams that only test compute failover without Key Vault writes discover read-only mode when they attempt to rotate during an incident.
 
 ```mermaid
 graph TD
@@ -377,13 +446,25 @@ graph TD
 
 When using multiple vaults, your CI/CD pipeline or a dedicated synchronization function must ensure that identical secrets (like a third-party API key) are pushed to both vaults. For regional resources (like a region-specific database password), the local vault stores the local credential.
 
+**Latency budgeting:** cross-region secret reads add tens of milliseconds per call. If each pod startup performs five serial GETs across the continent, startup SLOs suffer before throttling appears. Co-locate vault and compute in the same region whenever possible; use regional vault pairs only for disaster tolerance, not for routine traffic.
+
+**Compliance copies:** some regimes require customer-managed keys in specific geographies. Document vault region, backup geography, and Entra tenant residency together—Key Vault does not override data residency choices made at subscription creation time.
+
 > **Stop and think**: If you use an Active-Active Vault pattern and rely on a CI/CD pipeline to push the same Stripe API key to `KV-East` and `KV-West`, what happens to your application if the pipeline partially fails, updating `KV-East` but failing to update `KV-West`?
 
 ---
 
 ## Integrating Key Vault with Applications
 
+Applications should treat Key Vault as an **upstream dependency** with latency, quotas, and availability characteristics—not as a local file. Plan retries, circuit breaking, and health checks that distinguish “vault unreachable” from “identity misconfigured.” For VMs without managed identity legacy paths, install the [Azure Instance Metadata Service identity endpoint](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview-for-developers) via VM extensions; ARM templates and `az vm identity assign` attach the same principals Container Apps use.
+
+**AKS workload identity (modern):** replaces pod identity with federated credentials to Entra ID; the CSI provider documentation aligns with managed identity client IDs. Whichever identity model you choose, the vault firewall must see the caller’s egress path and RBAC must reference the same principal ID you pass to `az role assignment create`.
+
 ### Pattern 1: Direct SDK Access (Application Code)
+
+Direct SDK access is the most portable pattern: it works on AKS, Container Apps, VMs, and developer laptops with the same code path. Authentication flows through [DefaultAzureCredential](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview-for-developers), which tries environment variables, managed identity endpoint, and Azure CLI login in order. Authorization is pure RBAC on the vault data plane—no magic strings in app settings beyond the vault URL.
+
+**Design checklist for SDK consumers:** (1) grant only `Key Vault Secrets User` (or Crypto User) to the workload identity; (2) use versionless secret names in production so operators can rotate without redeploying when the app reloads secrets; (3) implement exponential backoff on 429 responses per [throttling guidance](https://learn.microsoft.com/en-us/azure/key-vault/general/overview-throttling); (4) emit structured logs when secret refresh fails but do not log secret values; (5) separate read credentials from rotation credentials—rotation functions need Officer, apps need User.
 
 ```python
 from azure.identity import DefaultAzureCredential
@@ -407,6 +488,10 @@ for secret in client.list_properties_of_secrets():
 
 ### Pattern 2: Key Vault References in App Configuration
 
+Platform references trade flexibility for simplicity. Azure resolves the secret at runtime and injects it like a normal app setting, which means your code never imports the Key Vault SDK—great for legacy apps, but rotation requires the platform to refresh the binding and you lose fine-grained per-request audit in application logs (vault diagnostics still record access). References must use a fully qualified secret URI including version if you pin; versionless URIs track **current** automatically per [App Service Key Vault references](https://learn.microsoft.com/en-us/azure/app-service/app-service-key-vault-references).
+
+The identity performing resolution needs `get` on secrets—typically the App Service system-assigned identity with **Secrets User** on the vault. Misconfiguration shows up as startup errors referencing `@Microsoft.KeyVault(...)` syntax literally in environment dumps; never log resolved values.
+
 Azure App Service and Functions can use Key Vault references in app settings, and Container Apps can consume Key Vault-backed secrets without SDK code:
 
 ```bash
@@ -424,6 +509,10 @@ az functionapp config appsettings set \
 
 ### Pattern 3: Container Apps with Key Vault
 
+Container Apps treat Key Vault as a **secret provider** referenced at deploy time. The `keyvaultref:` and `identityref:` pair binds a secret name to a vault URI and the managed identity that authenticates. Environment variables then use `secretref:` indirection so the image stays free of vault URLs. Rotation requires revising the Container App secret definition or using an external pipeline to update revisions—there is no in-container SDK call unless you add one.
+
+Operational tip: user-assigned identities are clearer in multi-tenant platforms than system-assigned when several apps share automation templates. Grant **Secrets User** on the vault scope, not Contributor on the resource group, to avoid accidental resource deletion rights.
+
 ```bash
 # Create a Container App that reads secrets from Key Vault via Managed Identity
 az containerapp create \
@@ -437,7 +526,11 @@ az containerapp create \
 
 ### Pattern 4: Kubernetes Integration (CSI Driver)
 
-For AKS, the Azure Key Vault Provider for Secrets Store CSI Driver [mounts secrets as files in the pod](https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-driver):
+For AKS, the Azure Key Vault Provider for Secrets Store CSI Driver [mounts secrets as files in the pod](https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-driver). Pods see secrets as read-only files under `/mnt/secrets-store` (path depends on your `volumeMount`). Linux containers can `source` or read files directly; .NET and Java apps often map paths via configuration. Because the driver calls Key Vault on mount and on rotation intervals, cluster autoscaling that churns pods during traffic spikes can amplify transaction counts—pre-warm secrets in images only when they are non-sensitive config; never bake real secrets into layers.
+
+**Rotation and reload:** enabling rotation on the `SecretProviderClass` lets the driver pick up new versions without redeploying the entire Deployment, but application code may still cache old values until it re-reads files or receives SIGHUP. Document whether your framework watches the mount directory. When `secretObjects` sync to Kubernetes Secrets for env vars, rotation updates the mount first; synced Secrets may lag unless you enable auto-reload annotations supported in your cluster version.
+
+**Identity wiring:** `useVMManagedIdentity: "true"` uses the kubelet identity on the node pool unless you specify `userAssignedIdentityID` for a dedicated identity per workload class—prefer user-assigned identities per team so compromise of one pool does not unlock every vault in the subscription.
 
 ```yaml
 # SecretProviderClass for AKS
@@ -471,11 +564,32 @@ spec:
           key: STRIPE_KEY
 ```
 
+Mount the volume in the pod spec (`volumeMounts` + `volumes` referencing the `SecretProviderClass`). With `secretObjects`, the driver can [sync into a native Kubernetes Secret](https://learn.microsoft.com/en-us/azure/aks/csi-secrets-store-driver) for env-var injection—understand that copying to a K8s Secret widens the blast radius to anyone with `get secrets` in the namespace. Prefer file mounts for sensitive material when your runtime supports reading paths.
+
+**Rotation on AKS:** enable rotation/reload on the `SecretProviderClass` so the driver polls Key Vault and remounts files; pair with workload restarts or sidecars that signal the app when files change. Managed identity (system- or user-assigned) replaces deprecated pod identity; set `useVMManagedIdentity: "true"` and pass the identity’s client ID as in the manifest above.
+
+### Contrast: hardcoded connection strings
+
+| Approach | Credential in Git? | Audit trail | Rotation | Scale-out risk |
+| :--- | :--- | :--- | :--- | :--- |
+| Env var / `appsettings.json` | Often yes | None on read | Redeploy required | N/A |
+| SDK + Managed Identity | No | Key Vault diagnostic logs | Update secret version; app refresh | Throttling if uncached |
+| App Service / Container Apps Key Vault reference | No | Platform + vault logs | Update vault; platform resolves | Platform caches reference |
+| CSI file mount | No | Vault logs + K8s audit | Driver rotation + pod reload | Low if mount-on-start only |
+
+The anti-pattern this module prevents is treating Key Vault as a remote `.env` file fetched per request. Fetch at process start (or on rotation webhook), hold in protected memory, and respect 429 backoff.
+
 ---
 
 ## Key Vault Networking: Private and Secure
 
-By default, Key Vault is [accessible from the public internet (with authentication required)](https://learn.microsoft.com/fi-fi/azure/key-vault/general/how-to-azure-key-vault-network-security?tabs=azure-cli). For production, restrict network access:
+By default, Key Vault is [accessible from the public internet (with authentication required)](https://learn.microsoft.com/fi-fi/azure/key-vault/general/how-to-azure-key-vault-network-security?tabs=azure-cli). Authentication and authorization still apply on public endpoints—network openness is not the same as anonymous access—but production baselines should assume attackers probe `*.vault.azure.net` from anywhere.
+
+**Defense in depth layers:** (1) private endpoint on a dedicated subnet with DNS integration to the vault’s private link FQDN; (2) firewall `default-action Deny` with explicit VNet service endpoints or private endpoint subnets; (3) optional IP rules for break-glass operators; (4) `Allow trusted Microsoft services` when Azure Backup, App Service, or other Microsoft services must reach the vault without routing through your VNet. Each layer reduces exposure; combine with RBAC least privilege because an insider on an allowed subnet can still exfiltrate secrets if they hold **Secrets User**.
+
+**AKS note:** when the CSI driver or workload identity calls Key Vault, traffic egresses from the node pool or overlay network—ensure NSGs and firewall rules include those subnets, not only developer office IPs. Private Link without updating DNS in the cluster causes opaque TLS failures that look like “Key Vault is down.”
+
+For production, restrict network access:
 
 ```bash
 # Restrict to specific VNets and IPs
@@ -508,15 +622,97 @@ az network private-endpoint create \
 
 ---
 
+## Cost Lens: Transactions, Keys, Certificates, and Managed HSM
+
+Key Vault billing is **operation-centric** for vaults, not capacity-based. Microsoft’s [pricing page](https://azure.microsoft.com/en-us/pricing/details/key-vault/) charges **$0.03 per 10,000 transactions** for most secret, software key, and certificate API calls in both Standard and Premium. That sounds negligible until you multiply by microservice instance count and request rate.
+
+**Secrets hot path:** An API tier with 200 pods, each handling 50 requests/second, that calls `get_secret` once per request generates 100,000 secret GETs per second—orders of magnitude above the [4,000 GETs per 10 seconds](https://learn.microsoft.com/en-us/azure/key-vault/general/service-limits) limit. You pay twice: throttling outages plus billable operations if you somehow stayed under the cap. **Knobs that reduce cost:** in-memory cache with TTL (5–15 minutes is common), startup-only fetch, batching configuration reads, and fewer secrets per vault (reuse references, not duplicate copies).
+
+**Premium HSM keys:** Each active HSM key version can incur **$1/month (2048-bit RSA)** plus operations, with higher monthly charges for advanced key sizes on the pricing table. Idle versions you never use may avoid the monthly HSM key fee, but **each version counts separately** if it was used in the last 30 days—rotation without retiring old versions increases steady cost.
+
+**Certificates:** Ordinary certificate API operations bill like secrets; **renewal requests** bill **$3 per renewal** (not the $0.03/10k bucket). Automated TLS with frequent renewals across dozens of hostnames adds up—consolidate SAN certs where policy allows.
+
+**Automated key rotation policy:** Scheduled rotations on vault keys are **$1 per scheduled rotation** per the pricing page—cheaper than manual runbooks only if rotation frequency is sane.
+
+**Managed HSM pools:** Billed per **hour per HSM pool** (e.g., Standard B1 at $3.20/hour on the US pricing page at time of writing—verify region/currency in the calculator). Economical when you need many HSM operations on dedicated hardware; expensive for a handful of secrets—use a Premium **vault** instead.
+
+**Cost spike surprises:** Black Friday scale-out without cache; certificate auto-renewal storms; integration tests hitting production vaults; and backup jobs over objects with 500+ versions (slow, operation-heavy). Tag vaults by environment and alert on Key Vault metrics for **ServiceApiHit** throttling and transaction volume.
+
+---
+
+## Patterns & Anti-Patterns
+
+### Proven patterns
+
+| Pattern | When to use | Why it works | Scaling note |
+| :--- | :--- | :--- | :--- |
+| **One vault per app per environment** | Prod vs dev isolation | Blast radius and RBAC scope stay bounded; aligns with [Microsoft app guidance](https://learn.microsoft.com/en-us/azure/key-vault/general/apps-api-keys-secrets) | More vaults mean more RBAC assignments—automate with IaC |
+| **RBAC + least-privilege data-plane roles** | All new vaults | Entra ID governance, secret-level scope, PIM for humans | Use `Key Vault Secrets User` at `/secrets/<name>` URI |
+| **Startup cache + periodic refresh** | High QPS services | Avoids 429 throttling and cuts $0.03/10k charges | Refresh on rotation Event Grid events, not every HTTP call |
+| **CSI file mount for AKS** | Twelve-factor apps that read files | No secret in image; identity-based access | Enable rotation; limit K8s Secret sync |
+| **Envelope encryption for bulk data** | Large blobs, disks, SQL CMK | Key Vault wraps DEK only; data stays in service | Use HSM keys when policy requires |
+
+### Anti-patterns
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+| :--- | :--- | :--- | :--- |
+| **Per-request `get_secret`** | 429 throttling + high ops bill | “Always fresh” security myth | Cache + rotation hooks |
+| **Subscription-wide `Key Vault Administrator`** | Over-privileged humans/scripts | Easiest role to “make it work” | Scoped Officer/User + PIM |
+| **Mixing access policies on RBAC vaults** | Audit gaps, dual control paths | Legacy scripts during migration | Complete RBAC migration |
+| **Premium vault for secrets-only workloads** | Paying HSM key fees unnecessarily | One-size-fits-all platform standard | Standard vault for secrets; Premium only when using HSM keys |
+| **CSI sync to K8s Secret for everything** | Secret duplicated in etcd | Env vars need Secret objects | Mount files; sync only when required |
+| **No purge protection in production** | Attacker purges after delete | Faster “cleanup” in tests | Enable purge protection; shorter retention in dev |
+
+---
+
+## Decision Framework
+
+Use this matrix when choosing control plane, SKU, and integration path. Prices and limits change—confirm in [pricing](https://azure.microsoft.com/en-us/pricing/details/key-vault/) and [service limits](https://learn.microsoft.com/en-us/azure/key-vault/general/service-limits) before production sign-off.
+
+| Decision | Choose A | Choose B | Choose C |
+| :--- | :--- | :--- | :--- |
+| **Authorization** | **Azure RBAC** (new vaults) | Access policies (legacy only) | — |
+| **Vault SKU** | **Standard** — secrets + software keys | **Premium** — HSM keys + secrets/certs in one vault | **Managed HSM** — dedicated HSM keys only, highest isolation |
+| **App integration** | **SDK + Managed Identity** (full control, any host) | **Key Vault reference** (App Service/Functions/Container Apps) | **Secrets Store CSI** (AKS file mounts + optional K8s Secret sync) |
+
+```mermaid
+flowchart TD
+    Start([Need to store credentials or keys?]) --> Q1{Kubernetes workload?}
+    Q1 -->|Yes| Q2{Prefer files vs env vars?}
+    Q2 -->|Files / rotation| CSI[Secrets Store CSI + Azure provider]
+    Q2 -->|Env vars only| CSI2[CSI with secretObjects sync OR SDK]
+    Q1 -->|No| Q3{Azure PaaS with native reference?}
+    Q3 -->|Yes| Ref[Platform Key Vault reference]
+    Q3 -->|No| SDK[SDK + DefaultAzureCredential]
+    Start --> Q4{Only HSM keys, no secrets?}
+    Q4 -->|Yes| MHSM[Managed HSM pool]
+    Q4 -->|No| Q5{Need RSA-HSM / EC-HSM in vault?}
+    Q5 -->|Yes| Prem[Premium vault]
+    Q5 -->|No| Std[Standard vault]
+    Start --> Q6{Greenfield vault?}
+    Q6 -->|Yes| RBAC[enable-rbac-authorization true]
+    Q6 -->|Legacy| AP[Plan migration to RBAC]
+```
+
+**Tradeoffs in one glance:** RBAC wins governance; access policies only remain for untouchable legacy. Standard is cheapest for secrets-heavy platforms. Premium adds HSM key monthly + ops cost but keeps certs and secrets together. Managed HSM is hourly pool pricing—justify with compliance, not convenience. SDK offers maximum portability; references minimize code but hide rotation semantics; CSI is best for AKS-native secret delivery with file-based interfaces.
+
+### When Standard beats Premium (and when it does not)
+
+Choose **Standard** when the workload stores application secrets and software-protected RSA/EC keys only, and compliance does not mandate HSM-wrapped keys. Many microservice estates never call `wrapKey` on an HSM key—paying Premium’s per-key monthly fees would fund unused capability. Choose **Premium** when you require `RSA-HSM`/`EC-HSM` keys that stay inside validated HSM boundaries, or when auditors explicitly map controls to FIPS 140-3 Level 3 material described in Microsoft’s tier comparison. Choose **Managed HSM** when symmetric `oct-HSM` keys, dedicated tenancy, or pool-level scaling guidance from [Managed HSM scaling](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/scaling-guidance) dominates the architecture—accept that secrets and certificates will still live in a separate vault.
+
+Certificate-heavy platforms should model **renewal dollars** separately from API operation dollars: a fleet of fifty certs renewing monthly triggers fifty $3 renewal lines on the public pricing page even if API traffic stays low. Secrets-heavy platforms should model **GET volume** against the 4,000/10s limit before the first invoice arrives. FinOps dashboards that only track vault count miss the dominant cost driver—transactions and renewals scale with application behavior, not resource inventory. Tag each vault with `cost-center` and `environment` application tags for chargeback reports. Review monthly Cost Management filters grouped by Key Vault resource ID.
+
+---
+
 ## Did You Know?
 
-1. **Azure Key Vault handles a very large volume of requests** across Azure customers. It is one of the most heavily used services in Azure because virtually every Azure service that needs secrets, keys, or certificates uses Key Vault under the hood. Azure Disk Encryption, App Service certificates, SQL Transparent Data Encryption---they all store their keys in Key Vault.
+1. **Azure Key Vault handles a very large volume of requests** across Azure customers. It is one of the most heavily used services in Azure because virtually every Azure service that needs secrets, keys, or certificates uses Key Vault under the hood. Azure Disk Encryption, App Service certificates, SQL Transparent Data Encryption—they all store their keys in Key Vault. That ubiquity means Microsoft invests heavily in throttling fairness and regional replication; your misconfigured loop affects shared capacity, which is why 429 responses should trigger client backoff instead of tight retry storms.
 
-2. **Key Vault tiers differ in protection model and pricing**. Check the current Microsoft documentation and pricing page before making compliance or cost claims about a specific SKU.
+2. **Key Vault tiers differ in protection model and pricing**. Standard uses software-protected keys with FIPS 140 Level 1 modules; Premium adds HSM-protected keys with stronger validations on current HSM platforms. Managed HSM pools bill hourly and target key-only estates. Always reconcile architectural slides with the current [overview](https://learn.microsoft.com/en-us/azure/key-vault/general/overview) and [pricing](https://azure.microsoft.com/en-us/pricing/details/key-vault/) pages before contractual commitments.
 
-3. **Key Vault has a throttling limit of [4,000 transactions per vault per 10 seconds](https://learn.microsoft.com/en-us/azure/key-vault/general/service-limits)** for secret read operations. Large microservice rollouts can hit Key Vault throttling if every instance fetches multiple secrets at once. Cache secrets locally, refresh them on a sensible interval, and stagger large deployments.
+3. **Key Vault has a throttling limit of [4,000 transactions per vault per 10 seconds](https://learn.microsoft.com/en-us/azure/key-vault/general/service-limits)** for secret read operations. Large microservice rollouts can hit Key Vault throttling if every instance fetches multiple secrets at once. Cache secrets locally, refresh them on a sensible interval, and stagger large deployments. The same page documents weighted limits for large RSA HSM keys—capacity planning is not only about secrets.
 
-4. **Once purge protection is enabled on a vault, it cannot be disabled.** This is by design---it prevents an attacker who gains admin access from disabling the protection and then purging secrets. If you enable purge protection on a test vault with a long retention period, deleted objects can't be permanently purged until that retention window expires. Use a shorter retention period (such as 7 days) for most non-production vaults.
+4. **Once purge protection is enabled on a vault, it cannot be disabled.** This is by design—it prevents an attacker who gains admin access from disabling the protection and then purging secrets. If you enable purge protection on a test vault with a long retention period, deleted objects cannot be permanently purged until that retention window expires. Use a shorter retention period (such as 7 days) for most non-production vaults, and document scheduled purge dates in change tickets so operators know when names become reusable.
 
 ---
 
@@ -526,12 +722,14 @@ az network private-endpoint create \
 | :--- | :--- | :--- |
 | Storing secrets in environment variables, config files, or code | It is "faster" during development | Use Key Vault from day one. Local dev uses `DefaultAzureCredential` which falls back to Azure CLI login---no secret management needed locally. |
 | Creating one vault per secret | Misunderstanding of vault purpose | A vault is a logical grouping of related secrets. [Use one vault per application/environment](https://learn.microsoft.com/en-us/azure/key-vault/general/apps-api-keys-secrets) (e.g., `app-prod-vault`, `app-dev-vault`). |
-For new vaults, create them with `--enable-rbac-authorization true` unless you have a specific reason to use Access Policies. RBAC provides per-secret scoping and uses standard Azure role-assignment and privileged-access workflows. |
+| Using Access Policies on new vaults | Copying old tutorials | For new vaults, create them with `--enable-rbac-authorization true` unless you have a specific legacy reason. RBAC provides per-secret scoping and uses standard Azure role-assignment and privileged-access workflows. |
 | Not enabling purge protection on production vaults | It seems overly cautious | A compromised admin could delete and purge all secrets. Purge protection ensures deleted secrets can be recovered. Enable it on all production vaults. |
 | Reading secrets from Key Vault on every request | It seems like the "most secure" approach | Cache secrets in memory and refresh periodically (every 5-15 minutes). Key Vault has throttling limits, and each call adds network latency. |
 | Granting Key Vault Administrator when Key Vault Secrets User is sufficient | "Administrator" sounds like the right role for an admin | [Key Vault Administrator can create, delete, and manage ALL objects. Most applications only need Key Vault Secrets User (read secrets).](https://learn.microsoft.com/en-us/azure/key-vault/general/rbac-guide) |
 | Not rotating secrets | The initial secret "works fine" | Implement secret rotation. Use Key Vault rotation policies for keys, or Event Grid notifications to trigger custom secret-rotation logic. |
 | Forgetting to configure firewall rules on production vaults | The vault works from everywhere by default | Set `--default-action Deny` and add only the necessary VNet subnets and IPs. Use Private Endpoint for the strongest isolation. |
+
+**Governance habits that stick:** maintain a secret catalog (name, owner, rotation cadence, regional copy, RBAC assignees). Review **Key Vault Administrator** assignments quarterly. Export diagnostic logs to a workspace with retention matching your compliance regime, and alert when `SecretGet` anomalies exceed baselines. Treat emergency secret disable (`enabled: false`) as a break-glass action with ticket linkage, not as everyday rotation.
 
 ---
 
@@ -573,13 +771,27 @@ The outage occurred because Key Vault is designed as a secure storage repository
 Storing a password directly in an environment variable leaves the plaintext credential exposed in memory dumps, process listings, debugging logs, and the Azure Portal interface for anyone with read access to the App Service. It also provides no audit trail of who viewed the password, and requires a full application restart to rotate the credential. By moving the password to Azure Key Vault and using a Managed Identity, the credential is encrypted at rest in a hardware security module (HSM) and the application's identity is authenticated via Entra ID. This approach provides fine-grained RBAC scoping, generates an immutable audit log of every access attempt, and allows the secret to be rotated independently of the application deployment lifecycle.
 </details>
 
+<details>
+<summary>7. Your security architect must choose between a Premium Key Vault in East US and a Managed HSM pool for storing a single RSA-2048 key used by SQL transparent data encryption with customer-managed keys. The workload also needs fifty application secrets in the same project. Which resource type do you recommend and why?</summary>
+
+Use a **Premium Key Vault** for this combined workload. Managed HSM pools host **HSM-protected keys only** and do not store the application secrets SQL and microservices need in the same resource ([about keys](https://learn.microsoft.com/en-us/azure/key-vault/keys/about-keys) contrasts vaults vs Managed HSM). Premium vaults provide HSM-backed `RSA-HSM` keys for TDE while still centralizing secrets and certificates under one RBAC and networking model. Managed HSM is justified when keys are the sole high-value assets, tenancy isolation is mandatory, or symmetric `oct-HSM` keys are required—not when dozens of secrets share the operational plane with one CMK.
+</details>
+
+<details>
+<summary>8. Scenario: ACI tasks fetch three secrets from Key Vault on every container start, but your SRE sees rising monthly Key Vault charges after autoscaling to 500 tasks/day that each restart twice. The app is correct functionally. What change preserves security while addressing cost?</summary>
+
+Fetching on **every start** is appropriate; fetching on **every task iteration or health probe** is not. Ensure secrets load once per process lifetime into memory, not per job step. If restarts are excessive, fix orchestrator restart policy. For 500×2 starts/day, operations stay modest; charges spike when loops call Key Vault repeatedly. Add caching inside the container process, reuse the same vault URI with versionless GET for current secret, and verify diagnostic logs so only startup paths call `get_secret`. That preserves managed identity authentication while aligning with Microsoft’s throttling guidance for high-volume GETs.
+</details>
+
 ---
 
 ## Hands-On Exercise: DB Connection String in Key Vault, Retrieved by Container App via Managed Identity
 
-In this exercise, you will store a secret in Key Vault, create a Container App with a Managed Identity, grant the identity access to read the secret, and verify the integration.
+In this exercise, you will store a secret in Key Vault, create a Container App with a Managed Identity, grant the identity access to read the secret, and verify the integration. The flow mirrors production: **no secret in the container image**, Entra ID authenticates the identity, RBAC authorizes only `get`/`list` on secrets, and soft delete demonstrates recoverability. You use a disposable resource group so purge protection stays off for easy cleanup—do not copy that setting to production vaults.
 
-**Prerequisites**: Azure CLI installed and authenticated.
+**What you are proving:** (1) RBAC mode vaults reject anonymous access; (2) role assignments use `az role assignment create --assignee <principal> --role "Key Vault Secrets User" --scope <vault-id>` syntax; (3) user-assigned managed identity requires `AZURE_CLIENT_ID` when multiple identities exist on the same resource; (4) secret lifecycle commands (`set`, `delete`, `list-deleted`, `recover`) behave as documented in soft-delete overview.
+
+**Prerequisites**: Azure CLI installed and authenticated (`az login`). Sufficient subscription permissions to create resource groups, Key Vaults, managed identities, and Container Apps in `eastus2` (or change `LOCATION` consistently).
 
 ### Task 1: Create Key Vault with RBAC Authorization
 
@@ -831,3 +1043,9 @@ az group delete --name "$RG" --yes --no-wait
 - [learn.microsoft.com: how to azure key vault network security](https://learn.microsoft.com/fi-fi/azure/key-vault/general/how-to-azure-key-vault-network-security?tabs=azure-cli) — Microsoft's Key Vault networking documentation explicitly states that the firewall is disabled by default and clarifies that authentication and permissions still apply.
 - [learn.microsoft.com: service limits](https://learn.microsoft.com/en-us/azure/key-vault/general/service-limits) — Microsoft's service-limits page explicitly documents the 4,000 transactions per 10 seconds threshold.
 - [learn.microsoft.com: apps api keys secrets](https://learn.microsoft.com/en-us/azure/key-vault/general/apps-api-keys-secrets) — Microsoft's current application guidance explicitly recommends separate key vaults for different applications and environments.
+- [learn.microsoft.com: overview](https://learn.microsoft.com/en-us/azure/key-vault/general/overview) — Documents Standard vs Premium tiers, FIPS levels, and centralized secrets management rationale.
+- [learn.microsoft.com: managed hsm overview](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/overview) — Explains single-tenant Managed HSM pools vs multi-tenant vaults.
+- [learn.microsoft.com: key vault throttling guidance](https://learn.microsoft.com/en-us/azure/key-vault/general/overview-throttling) — Official backoff guidance when HTTP 429 occurs.
+- [azure.microsoft.com: key vault pricing](https://azure.microsoft.com/en-us/pricing/details/key-vault/) — Transaction, HSM key monthly, certificate renewal, rotation, and Managed HSM hourly rates.
+- [learn.microsoft.com: backup](https://learn.microsoft.com/en-us/azure/key-vault/general/backup) — Backup limits and restore geography constraints.
+- [learn.microsoft.com: managed hsm scaling guidance](https://learn.microsoft.com/en-us/azure/key-vault/managed-hsm/scaling-guidance) — Capacity planning for dedicated HSM pools.

--- a/src/content/docs/cloud/azure-essentials/module-3.9-key-vault.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.9-key-vault.md
@@ -62,7 +62,7 @@ graph TD
         K[Keys<br/>- data-encrypt<br/>- signing-key<br/>- wrapping-key]
         C[Certificates<br/>- api-tls<br/>- mtls-cert<br/>- code-sign]
     end
-    F[Features:<br/>• HSM-backed FIPS 140-2 Level 2<br/>• Versioned updates<br/>• Audit logged access<br/>• Soft delete & purge protection<br/>• Private endpoint support]
+    F[Features:<br/>• HSM-backed FIPS 140-2 L2 / 140-3 L3 (HSM Platform 2, current default)<br/>• Versioned updates<br/>• Audit logged access<br/>• Soft delete & purge protection<br/>• Private endpoint support]
     Azure Key Vault --- F
     style F text-align:left
 ```
@@ -164,17 +164,19 @@ az keyvault key create \
 
 # Encrypt data (the key never leaves Key Vault)
 echo -n "sensitive data" | base64 > /tmp/plaintext.b64
-az keyvault key encrypt \
+CIPHERTEXT=$(az keyvault key encrypt \
   --vault-name kubedojo-vault \
   --name "data-encryption-key" \
   --algorithm RSA-OAEP \
-  --value "$(cat /tmp/plaintext.b64)"
+  --value "$(cat /tmp/plaintext.b64)" \
+  -o tsv --query result)
 
 # Decrypt data
 az keyvault key decrypt \
   --vault-name kubedojo-vault \
   --name "data-encryption-key" \
   --algorithm RSA-OAEP \
+  --data-type base64 \
   --value "$CIPHERTEXT"
 ```
 
@@ -320,13 +322,16 @@ az keyvault create \
 # Grant read-only access to secrets for a managed identity
 VAULT_ID=$(az keyvault show -n kubedojo-vault --query id -o tsv)
 az role assignment create \
-  --assignee "$MANAGED_IDENTITY_PRINCIPAL_ID" \
+  --assignee-object-id "$MANAGED_IDENTITY_PRINCIPAL_ID" \
+  --assignee-principal-type ServicePrincipal \
   --role "Key Vault Secrets User" \
   --scope "$VAULT_ID"
 
 # Grant secret management access to a specific secret
+ALICE_OBJECT_ID="<alice-entra-object-id>"
 az role assignment create \
-  --assignee "alice@company.com" \
+  --assignee-object-id "$ALICE_OBJECT_ID" \
+  --assignee-principal-type User \
   --role "Key Vault Secrets Officer" \
   --scope "$VAULT_ID/secrets/db-password"
 ```
@@ -456,7 +461,7 @@ When using multiple vaults, your CI/CD pipeline or a dedicated synchronization f
 
 ## Integrating Key Vault with Applications
 
-Applications should treat Key Vault as an **upstream dependency** with latency, quotas, and availability characteristics—not as a local file. Plan retries, circuit breaking, and health checks that distinguish “vault unreachable” from “identity misconfigured.” For VMs without managed identity legacy paths, install the [Azure Instance Metadata Service identity endpoint](https://learn.microsoft.com/en-us/azure/active-directory/managed-identities-azure-resources/overview-for-developers) via VM extensions; ARM templates and `az vm identity assign` attach the same principals Container Apps use.
+Applications should treat Key Vault as an **upstream dependency** with latency, quotas, and availability characteristics—not as a local file. Plan retries, circuit breaking, and health checks that distinguish “vault unreachable” from “identity misconfigured.” Azure VMs reach managed identity tokens through the always-present **IMDS** endpoint at `169.254.169.254`; `az vm identity assign` attaches the identity—no VM extension is required. Container Apps and other PaaS hosts expose a different token endpoint via `IDENTITY_ENDPOINT` and `IDENTITY_HEADER` environment variables (see Task 5 in the lab).
 
 **AKS workload identity (modern):** replaces pod identity with federated credentials to Entra ID; the CSI provider documentation aligns with managed identity client IDs. Whichever identity model you choose, the vault firewall must see the caller’s egress path and RBAC must reference the same principal ID you pass to `az role assignment create`.
 
@@ -626,13 +631,13 @@ az network private-endpoint create \
 
 Key Vault billing is **operation-centric** for vaults, not capacity-based. Microsoft’s [pricing page](https://azure.microsoft.com/en-us/pricing/details/key-vault/) charges **$0.03 per 10,000 transactions** for most secret, software key, and certificate API calls in both Standard and Premium. That sounds negligible until you multiply by microservice instance count and request rate.
 
-**Secrets hot path:** An API tier with 200 pods, each handling 50 requests/second, that calls `get_secret` once per request generates 100,000 secret GETs per second—orders of magnitude above the [4,000 GETs per 10 seconds](https://learn.microsoft.com/en-us/azure/key-vault/general/service-limits) limit. You pay twice: throttling outages plus billable operations if you somehow stayed under the cap. **Knobs that reduce cost:** in-memory cache with TTL (5–15 minutes is common), startup-only fetch, batching configuration reads, and fewer secrets per vault (reuse references, not duplicate copies).
+**Secrets hot path:** An API tier with 200 pods, each handling 50 requests/second, that calls `get_secret` once per request generates **10,000** secret GETs per second—orders of magnitude above the [4,000 GETs per 10 seconds](https://learn.microsoft.com/en-us/azure/key-vault/general/service-limits) limit. You pay twice: throttling outages plus billable operations if you somehow stayed under the cap. **Knobs that reduce cost:** in-memory cache with TTL (5–15 minutes is common), startup-only fetch, batching configuration reads, and fewer secrets per vault (reuse references, not duplicate copies).
 
 **Premium HSM keys:** Each active HSM key version can incur **$1/month (2048-bit RSA)** plus operations, with higher monthly charges for advanced key sizes on the pricing table. Idle versions you never use may avoid the monthly HSM key fee, but **each version counts separately** if it was used in the last 30 days—rotation without retiring old versions increases steady cost.
 
 **Certificates:** Ordinary certificate API operations bill like secrets; **renewal requests** bill **$3 per renewal** (not the $0.03/10k bucket). Automated TLS with frequent renewals across dozens of hostnames adds up—consolidate SAN certs where policy allows.
 
-**Automated key rotation policy:** Scheduled rotations on vault keys are **$1 per scheduled rotation** per the pricing page—cheaper than manual runbooks only if rotation frequency is sane.
+**Automated key rotation policy:** Each rotation produces a new key **version**; you pay for active HSM key versions and the operations they generate—not a flat per-rotation fee. Keep rotation frequency sane so version sprawl does not inflate monthly HSM key charges.
 
 **Managed HSM pools:** Billed per **hour per HSM pool** (e.g., Standard B1 at $3.20/hour on the US pricing page at time of writing—verify region/currency in the calculator). Economical when you need many HSM operations on dedicated hardware; expensive for a handful of secrets—use a Premium **vault** instead.
 
@@ -814,7 +819,8 @@ az keyvault create \
 USER_ID=$(az ad signed-in-user show --query id -o tsv)
 VAULT_ID=$(az keyvault show -n "$VAULT_NAME" --query id -o tsv)
 az role assignment create \
-  --assignee "$USER_ID" \
+  --assignee-object-id "$USER_ID" \
+  --assignee-principal-type User \
   --role "Key Vault Secrets Officer" \
   --scope "$VAULT_ID"
 ```
@@ -872,7 +878,8 @@ IDENTITY_CLIENT=$(az identity show -g "$RG" -n "$IDENTITY_NAME" --query clientId
 
 # Grant the managed identity Key Vault Secrets User role
 az role assignment create \
-  --assignee "$IDENTITY_PRINCIPAL" \
+  --assignee-object-id "$IDENTITY_PRINCIPAL" \
+  --assignee-principal-type ServicePrincipal \
   --role "Key Vault Secrets User" \
   --scope "$VAULT_ID"
 
@@ -933,33 +940,25 @@ az containerapp show -g "$RG" -n secret-reader-app \
 You should see the user-assigned identity attached to the Container App.
 </details>
 
-### Task 5: Verify Secret Access from the Container App
+### Task 5: Verify Managed Identity Token from the Container App
 
 ```bash
-# Get the Container App's FQDN
-APP_FQDN=$(az containerapp show -g "$RG" -n secret-reader-app \
-  --query properties.configuration.ingress.fqdn -o tsv)
-echo "App URL: https://$APP_FQDN"
-
-# Test that the managed identity can read secrets using az CLI inside the container
-# (In a real app, you'd use the Azure SDK with DefaultAzureCredential)
+# Container Apps use IDENTITY_ENDPOINT + IDENTITY_HEADER — not the VM IMDS URL.
+# Request an Entra token for Key Vault using the user-assigned managed identity:
 az containerapp exec \
   --resource-group "$RG" \
   --name secret-reader-app \
-  --command "curl -s -H 'Metadata: true' 'http://169.254.169.254/metadata/identity/oauth2/token?api-version=2019-08-01&resource=https://vault.azure.net&client_id=$IDENTITY_CLIENT'" 2>/dev/null | head -1 || \
-echo "Note: exec may not be available on quickstart image. Testing via CLI instead."
-
-# Verify from outside: use Azure CLI to confirm the identity has access
-az keyvault secret show \
-  --vault-name "$VAULT_NAME" \
-  --name "db-connection-string" \
-  --query '{Name:name, Value:value}' -o table
+  --command 'curl -s "$IDENTITY_ENDPOINT?resource=https://vault.azure.net&api-version=2019-08-01&client_id=$AZURE_CLIENT_ID" -H "X-IDENTITY-HEADER: $IDENTITY_HEADER"' \
+  2>/dev/null | head -c 200 || \
+echo "Note: exec may not be available on the quickstart image. Use the SDK pattern in Verify Task 5 below."
 ```
 
 <details>
 <summary>Verify Task 5</summary>
 
-The secret should be readable. In a production scenario, your application code would use the Azure SDK:
+A successful response includes an `"access_token"` field—this proves the **managed identity** can authenticate to Key Vault. It does **not** use your signed-in user's RBAC.
+
+In production, your application code uses the Azure SDK with the same identity:
 
 ```python
 from azure.identity import DefaultAzureCredential
@@ -971,7 +970,7 @@ secret = client.get_secret("db-connection-string")
 # Use secret.value to configure your database connection
 ```
 
-The `AZURE_CLIENT_ID` environment variable tells `DefaultAzureCredential` which user-assigned managed identity to use.
+The `AZURE_CLIENT_ID` environment variable tells `DefaultAzureCredential` which user-assigned managed identity to use. To confirm secret **content** after SDK integration, log only the secret name—not the value—or query Key Vault audit logs for `SecretGet` from the identity's object ID.
 </details>
 
 ### Task 6: Test Soft Delete and Recovery
@@ -1014,7 +1013,7 @@ az group delete --name "$RG" --yes --no-wait
 - [ ] Two secrets stored (db-connection-string and api-key)
 - [ ] User-assigned Managed Identity created and granted Key Vault Secrets User role
 - [ ] Container App deployed with the managed identity attached
-- [ ] Verified that the identity can read secrets from Key Vault
+- [ ] Managed identity token request via Container Apps `IDENTITY_ENDPOINT` returns an `access_token` (or SDK path documented)
 - [ ] Soft delete tested: secret deleted, found in deleted list, and recovered
 
 ---


### PR DESCRIPTION
## Cloud track — Azure Essentials expand-to-floor (wave 3)

Below-floor → expand (cursor) → cross-family review (opus 4.8) → orchestrator web-verify → consolidated fix.

### Modules
| Module | body_words | tier |
|---|---|---|
| 3.8 Azure Functions | 5029 | T0 PASS |
| 3.9 Key Vault | 5032 | T0 PASS |
| 3.10 Azure Monitor | 5035 | T0 PASS |

### Review fixes (opus 4.8 R1; currency facts web-verified by orchestrator)
**3.8** — P1: DYK falsely claimed a "7-day Durable Functions cap on Consumption" (contradicted the body) → corrected (orchestrators checkpoint/replay, no plan cap); P1: dead `az cosmosdb sql query` lab verification → replaced; P2: Flex timeout 30 min→Unbounded; Premium never scales-to-zero; Premium plan missing `--is-linux`; Linux Consumption cap 200→**100**; unlabeled anecdotes.

**3.9** — P1: lab MI-retrieval used VM IMDS (`169.254.169.254`) instead of Container Apps `IDENTITY_ENDPOINT`/`X-IDENTITY-HEADER` (web-verified) → fixed so it actually proves the MI path; P2: throttling arithmetic 100k→10k; IMDS-not-"installed"; FIPS 140-3 L3 box; `--assignee-object-id` race; encrypt/decrypt var.

**3.10** — P1: malformed `az monitor scheduled-query create` (`--condition`/`--condition-query` placeholder binding) → fixed; P2: 3 dead citation URLs; **NSG flow logs retirement** (retire 2027-09-30, no new after 2025-06-30 → VNet flow logs, web-verified); stress-ng lab reliability; "zero loss" anecdote; Linux AMA counter name.

🤖 Generated with [Claude Code](https://claude.com/claude-code)