### PR TITLE
feat(dispatch): agy adapter honors --model selection (Antigravity 1.x)

### DIFF
--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -1,13 +1,19 @@
 """AgyAdapter - wraps Antigravity CLI (``agy``) for the agent runtime.
 
 Phase 1 of the Antigravity migration keeps this adapter alongside the
-existing Gemini CLI adapter. ``agy`` model selection is controlled by the
-interactive TUI and persists across ``agy -p`` invocations; there is no CLI
-model flag today, so the runtime's model value is audit-only.
+existing Gemini CLI adapter. Antigravity 1.x added a per-session ``--model``
+flag (``agy models`` lists the choices), so the runtime's model value is now
+mapped to the matching CLI display string and passed through — it is no
+longer audit-only.
 
 Known behavioral facts as of issue #1350:
 
 - Headless prompt mode is ``agy -p "<prompt>"``. Stdin prompts are ignored.
+- Per-invocation model is ``--model "<Display Name>"`` where the display name
+  is one of the strings printed by ``agy models`` (e.g. ``Gemini 3.1 Pro
+  (High)``). The runtime model slug (``gemini-3.1-pro-high``) and the display
+  string normalize to the same key, so callers may pass either form; an
+  unrecognized or empty value falls back to ``default_model``.
 - Resume/new conversation is ``--conversation=<uuid>``.
 - Write-capable modes use ``--dangerously-skip-permissions``. In addition,
   ``dispatch_smart.py`` forces ``mode="danger"`` for ``--agent agy``
@@ -24,6 +30,7 @@ accepts ``tool_config["mcp_server_names"]`` for API parity with
 ``GeminiAdapter`` but does not act on it today — wire ``agy plugin
 enable <name>`` here once we have concrete MCP servers to consume.
 """
+
 from __future__ import annotations
 
 import os
@@ -46,12 +53,43 @@ _RATE_LIMIT_PATTERNS = (
 _RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
 
 
+# Canonical model display strings accepted by ``agy --model`` (verbatim from
+# ``agy models``). The runtime passes a slug like ``gemini-3.1-pro-high``;
+# ``_normalize_model`` collapses both that slug and the display string to the
+# same key so either form maps here.
+_AGY_MODEL_NAMES: tuple[str, ...] = (
+    "Gemini 3.5 Flash (Medium)",
+    "Gemini 3.5 Flash (High)",
+    "Gemini 3.5 Flash (Low)",
+    "Gemini 3.1 Pro (Low)",
+    "Gemini 3.1 Pro (High)",
+    "Claude Sonnet 4.6 (Thinking)",
+    "Claude Opus 4.6 (Thinking)",
+    "GPT-OSS 120B (Medium)",
+)
+
+
+def _normalize_model(value: str) -> str:
+    """Collapse a model identifier to its alphanumeric-lowercase form so that a
+    slug (``gemini-3.1-pro-high``) and the CLI display string
+    (``Gemini 3.1 Pro (High)``) map to the same key."""
+    return re.sub(r"[^a-z0-9]", "", value.lower())
+
+
+# normalized identifier -> canonical ``agy --model`` display string
+_AGY_MODEL_BY_NORMALIZED: dict[str, str] = {
+    _normalize_model(name): name for name in _AGY_MODEL_NAMES
+}
+
+
 class AgyAdapter:
     """Adapter for the ``agy`` Antigravity CLI."""
 
     name: str = "agy"
     default_model: str = os.environ.get("KUBEDOJO_AGY_MODEL", "gemini-3.5-flash-high")
-    supported_modes: frozenset[str] = frozenset({"read-only", "workspace-write", "danger"})
+    supported_modes: frozenset[str] = frozenset(
+        {"read-only", "workspace-write", "danger"}
+    )
 
     def build_invocation(
         self,
@@ -66,8 +104,10 @@ class AgyAdapter:
     ) -> InvocationPlan:
         """Build the ``agy`` print-mode invocation.
 
-        ``model`` is intentionally not mapped to a CLI flag. The active model
-        is whichever model the operator selected in the ``agy`` TUI panel.
+        ``model`` is mapped to the matching ``agy --model "<Display Name>"``
+        flag (see :func:`_normalize_model`). An unrecognized or empty value
+        falls back to ``default_model``; if even that is unmappable the flag
+        is omitted and agy uses its TUI-selected model.
         """
         if mode not in self.supported_modes:
             raise ValueError(f"AgyAdapter: unsupported mode {mode!r}")
@@ -82,18 +122,18 @@ class AgyAdapter:
         # --agent agy so callers can't accidentally route around this.
         cmd: list[str] = [agy_bin, "-p", prompt, "--dangerously-skip-permissions"]
 
+        resolved_model = self._resolve_model_flag(model)
+        if resolved_model:
+            cmd += ["--model", resolved_model]
+
         if session_id:
             cmd.append(f"--conversation={session_id}")
 
         # Phase 2 follow-up: agy uses `agy plugin` for MCP configuration,
-        # not a per-invocation CLI flag like gemini-cli.
-        # `model` is intentionally unused — agy's model is TUI-selected and
-        # cannot be overridden per-invocation. The runtime records the
-        # caller-passed model in the JSONL audit row for informational
-        # provenance only.
+        # not a per-invocation CLI flag like gemini-cli. The adapter accepts
+        # tool_config for GeminiAdapter API parity but does not act on it yet.
         _ = tool_config
         _ = task_id
-        _ = model
 
         return InvocationPlan(
             cmd=cmd,
@@ -103,6 +143,23 @@ class AgyAdapter:
             env_overrides={},
             liveness_paths=(),
         )
+
+    def _resolve_model_flag(self, model: str | None) -> str | None:
+        """Map a runtime model slug (or display string) to the canonical
+        ``agy --model`` value.
+
+        Tries the caller's ``model`` first, then ``default_model``, so a stale
+        placeholder (e.g. the legacy ``"tui-controlled"``) or an empty value
+        degrades to the adapter default rather than passing an invalid flag.
+        Returns ``None`` only when neither maps, leaving the model unset so
+        agy uses its TUI-selected one.
+        """
+        for candidate in (model, self.default_model):
+            if candidate:
+                resolved = _AGY_MODEL_BY_NORMALIZED.get(_normalize_model(candidate))
+                if resolved:
+                    return resolved
+        return None
 
     def parse_response(
         self,

--- a/scripts/agent_runtime/tests/test_agy_adapter.py
+++ b/scripts/agent_runtime/tests/test_agy_adapter.py
@@ -1,4 +1,5 @@
 """Unit tests for the ``AgyAdapter`` Antigravity CLI integration."""
+
 from __future__ import annotations
 
 from pathlib import Path
@@ -36,10 +37,73 @@ def test_build_invocation_always_includes_dangerously_skip(monkeypatch) -> None:
 
     for mode in ("read-only", "workspace-write", "danger"):
         cmd = _build(mode)
-        assert cmd == ["agy", "-p", "p", "--dangerously-skip-permissions"], (
+        assert cmd == [
+            "agy",
+            "-p",
+            "p",
+            "--dangerously-skip-permissions",
+            "--model",
+            "Gemini 3.5 Flash (High)",
+        ], (
             f"mode={mode} must produce the same cmd because agy has no "
             f"mode-specific permission flag"
         )
+
+
+def test_build_invocation_maps_model_slug(monkeypatch) -> None:
+    """A runtime model slug is mapped to agy's `--model` display string."""
+    monkeypatch.setattr("agent_runtime.adapters.agy.shutil.which", lambda _: "agy")
+    adapter = AgyAdapter()
+
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode="workspace-write",
+        cwd=Path("/tmp"),
+        model="gemini-3.1-pro-high",
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    assert "--model" in plan.cmd
+    assert plan.cmd[plan.cmd.index("--model") + 1] == "Gemini 3.1 Pro (High)"
+
+
+def test_build_invocation_accepts_display_string(monkeypatch) -> None:
+    """Passing the canonical display string maps to itself (idempotent)."""
+    monkeypatch.setattr("agent_runtime.adapters.agy.shutil.which", lambda _: "agy")
+    adapter = AgyAdapter()
+
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode="workspace-write",
+        cwd=Path("/tmp"),
+        model="Gemini 3.1 Pro (High)",
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    assert plan.cmd[plan.cmd.index("--model") + 1] == "Gemini 3.1 Pro (High)"
+
+
+def test_build_invocation_unknown_model_falls_back_to_default(monkeypatch) -> None:
+    """A stale/unknown slug (e.g. legacy 'tui-controlled') degrades to the
+    adapter default rather than passing an invalid --model value."""
+    monkeypatch.setattr("agent_runtime.adapters.agy.shutil.which", lambda _: "agy")
+    adapter = AgyAdapter()
+
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode="read-only",
+        cwd=Path("/tmp"),
+        model="tui-controlled",
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+    assert plan.cmd[plan.cmd.index("--model") + 1] == "Gemini 3.5 Flash (High)"
 
 
 def test_build_invocation_with_session_id(monkeypatch) -> None:

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -68,6 +68,7 @@ body even if the live stream was truncated. The JSONL row's
 
 Reuse with --dry-run to print the chosen plan without firing.
 """
+
 from __future__ import annotations
 
 import argparse
@@ -131,18 +132,16 @@ class TaskClassConfig:
     codex_search: bool = False  # opt-in per class
 
 
-# Note on the "agy" model entries below: Antigravity CLI's model is selected
-# interactively in its TUI panel and cannot be overridden per-invocation
-# (no -m / --model flag as of agy 1.0.0). The string `tui-controlled`
-# is an informational placeholder — the actual model in flight is whatever
-# the operator last picked in `agy`'s panel and is reported in the model
-# self-identify probe (`agy -p 'what model are you?'`). The per-class
-# distinction is therefore meaningless for agy until Google adds a model
-# flag or config-file path.
+# Note on the "agy" model entries below: Antigravity 1.x added a per-session
+# `--model` flag (`agy models` lists the choices), so per-class selection now
+# works. The slugs below normalize to agy's display strings in AgyAdapter
+# (`gemini-3.1-pro-high` -> "Gemini 3.1 Pro (High)"). Cheap scans use Flash;
+# the writer/judgment classes use Gemini 3.1 Pro (High). Override per call with
+# `--model`. An unrecognized slug falls back to the adapter default.
 TASK_CLASSES: dict[str, TaskClassConfig] = {
     "search": TaskClassConfig(
         models={
-            "agy": "tui-controlled",
+            "agy": "gemini-3.5-flash-high",
             "claude": "claude-haiku-4-5-20251001",
             "codex": "gpt-5.4-mini",
             "deepseek": "deepseek-v4-flash",
@@ -159,7 +158,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
     ),
     "edit": TaskClassConfig(
         models={
-            "agy": "tui-controlled",
+            "agy": "gemini-3.1-pro-high",
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.3-codex-spark",
             "deepseek": "deepseek-v4-pro",
@@ -176,7 +175,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
     ),
     "draft": TaskClassConfig(
         models={
-            "agy": "tui-controlled",
+            "agy": "gemini-3.1-pro-high",
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",
@@ -193,7 +192,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
     ),
     "review": TaskClassConfig(
         models={
-            "agy": "tui-controlled",
+            "agy": "gemini-3.1-pro-high",
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",
@@ -210,7 +209,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
     ),
     "architect": TaskClassConfig(
         models={
-            "agy": "tui-controlled",
+            "agy": "gemini-3.1-pro-high",
             "claude": "claude-opus-4-8",
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",
@@ -254,7 +253,7 @@ def _load_skill_body(skill_name: str) -> tuple[str, Path] | None:
 def _wrap_prompt_with_skill(prompt: str, skill_body: str, skill_name: str) -> str:
     """Prepend the skill body to the prompt with a clear marker."""
     return (
-        f"<auto-loaded-skill name=\"{skill_name}\">\n"
+        f'<auto-loaded-skill name="{skill_name}">\n'
         f"{skill_body.rstrip()}\n"
         f"</auto-loaded-skill>\n\n"
         f"{prompt}"
@@ -287,8 +286,7 @@ def make_task_id(task_class: str, agent: str) -> str:
     return f"smart-{agent}-{task_class}-{int(time.time())}"
 
 
-def ensure_worktree(worktree: Path, new_branch: str | None,
-                    base: str = "main") -> None:
+def ensure_worktree(worktree: Path, new_branch: str | None, base: str = "main") -> None:
     """Create a worktree if it doesn't exist; reuse if it does.
 
     Caller is responsible for picking a sensible path under .worktrees/.
@@ -305,13 +303,13 @@ def ensure_worktree(worktree: Path, new_branch: str | None,
     primary_venv = PRIMARY_REPO / ".venv"
     worktree_venv = worktree / ".venv"
     if primary_venv.exists() and not (
-            worktree_venv.exists() or worktree_venv.is_symlink()
+        worktree_venv.exists() or worktree_venv.is_symlink()
     ):
         worktree_venv.symlink_to(primary_venv)
     primary_node_modules = PRIMARY_REPO / "node_modules"
     worktree_node_modules = worktree / "node_modules"
     if primary_node_modules.exists() and not (
-            worktree_node_modules.exists() or worktree_node_modules.is_symlink()
+        worktree_node_modules.exists() or worktree_node_modules.is_symlink()
     ):
         worktree_node_modules.symlink_to(primary_node_modules)
 
@@ -458,10 +456,21 @@ def _run_router_agent(
     return ok, response.strip(), stderr.strip()
 
 
-def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
-         worktree: Path | None, task_id: str, timeout_s: int) -> int:
-    print(f"[smart] agent={agent} task_class={task_class} model={model} "
-          f"mode={mode} timeout={timeout_s}s")
+def fire(
+    *,
+    agent: str,
+    task_class: str,
+    prompt: str,
+    mode: str,
+    model: str,
+    worktree: Path | None,
+    task_id: str,
+    timeout_s: int,
+) -> int:
+    print(
+        f"[smart] agent={agent} task_class={task_class} model={model} "
+        f"mode={mode} timeout={timeout_s}s"
+    )
     if worktree:
         print(f"[smart] cwd={worktree}")
     print(f"[smart] task_id={task_id}")
@@ -526,27 +535,28 @@ def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
     elapsed = time.time() - started
     response_path = persist_response(task_id, response, stderr_excerpt)
     rel_response_path = str(response_path.relative_to(PRIMARY_REPO))
-    append_log({
-        "ts": int(started),
-        "elapsed_s": round(elapsed, 1),
-        "task_id": task_id,
-        "agent": agent,
-        "task_class": task_class,
-        "model": model,
-        "mode": mode,
-        "cwd": str(worktree) if worktree else None,
-        "ok": ok,
-        "session_id": session_id,
-        "response_chars": len(response),
-        "response_path": rel_response_path,
-        "stderr_excerpt": stderr_excerpt[:400] if stderr_excerpt else None,
-    })
+    append_log(
+        {
+            "ts": int(started),
+            "elapsed_s": round(elapsed, 1),
+            "task_id": task_id,
+            "agent": agent,
+            "task_class": task_class,
+            "model": model,
+            "mode": mode,
+            "cwd": str(worktree) if worktree else None,
+            "ok": ok,
+            "session_id": session_id,
+            "response_chars": len(response),
+            "response_path": rel_response_path,
+            "stderr_excerpt": stderr_excerpt[:400] if stderr_excerpt else None,
+        }
+    )
 
     # Print response_path BEFORE the body so callers that truncate stdout
     # (tail -N, head -N) still see the path and can `cat` the full file.
     print("=" * 70)
-    print(f"OK: {ok}  |  elapsed: {elapsed:.0f}s  |  "
-          f"resp_chars: {len(response)}")
+    print(f"OK: {ok}  |  elapsed: {elapsed:.0f}s  |  resp_chars: {len(response)}")
     print(f"response_path: {rel_response_path}")
     print("=" * 70)
     if response:
@@ -560,35 +570,55 @@ def fire(*, agent: str, task_class: str, prompt: str, mode: str, model: str,
 def main() -> int:
     p = argparse.ArgumentParser(
         description="Dispatch a headless agent with a "
-                    "task-class-based model choice. Mirrors the AGENTS.md "
-                    "economical multi-agent policy across agents.",
+        "task-class-based model choice. Mirrors the AGENTS.md "
+        "economical multi-agent policy across agents.",
     )
-    p.add_argument("task_class", choices=sorted(TASK_CLASSES),
-                   help="Picks the model + default mode.")
-    p.add_argument("prompt", nargs="?", default=None,
-                   help="Prompt text. Pass `-` to read from stdin.")
-    p.add_argument("--agent", choices=SUPPORTED_AGENTS, default="claude",
-                   help="Which agent to dispatch (default: claude).")
-    p.add_argument("--worktree",
-                   help="Path to a git worktree under .worktrees/. "
-                        "Required for write modes.")
-    p.add_argument("--new-branch",
-                   help="If --worktree doesn't exist, create it on this "
-                        "branch off main.")
-    p.add_argument("--mode",
-                   choices=["read-only", "workspace-write", "danger"],
-                   help="Override task-class default mode. For opencode, "
-                        "hermes, and cursor this is advisory; their CLIs "
-                        "enforce their own sandbox behavior.")
-    p.add_argument("--model",
-                   help="Override task-class default model "
-                        "(rarely needed — let the class+agent pick).")
-    p.add_argument("--timeout", type=int,
-                   help="Override task-class default hard timeout (s).")
-    p.add_argument("--task-id",
-                   help="Override auto-generated task_id.")
-    p.add_argument("--dry-run", action="store_true",
-                   help="Print the resolved plan and exit without firing.")
+    p.add_argument(
+        "task_class",
+        choices=sorted(TASK_CLASSES),
+        help="Picks the model + default mode.",
+    )
+    p.add_argument(
+        "prompt",
+        nargs="?",
+        default=None,
+        help="Prompt text. Pass `-` to read from stdin.",
+    )
+    p.add_argument(
+        "--agent",
+        choices=SUPPORTED_AGENTS,
+        default="claude",
+        help="Which agent to dispatch (default: claude).",
+    )
+    p.add_argument(
+        "--worktree",
+        help="Path to a git worktree under .worktrees/. Required for write modes.",
+    )
+    p.add_argument(
+        "--new-branch",
+        help="If --worktree doesn't exist, create it on this branch off main.",
+    )
+    p.add_argument(
+        "--mode",
+        choices=["read-only", "workspace-write", "danger"],
+        help="Override task-class default mode. For opencode, "
+        "hermes, and cursor this is advisory; their CLIs "
+        "enforce their own sandbox behavior.",
+    )
+    p.add_argument(
+        "--model",
+        help="Override task-class default model "
+        "(rarely needed — let the class+agent pick).",
+    )
+    p.add_argument(
+        "--timeout", type=int, help="Override task-class default hard timeout (s)."
+    )
+    p.add_argument("--task-id", help="Override auto-generated task_id.")
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print the resolved plan and exit without firing.",
+    )
     p.add_argument(
         "--skill",
         default=None,
@@ -644,10 +674,10 @@ def main() -> int:
 
     # Read-only task classes for codex run in danger mode, but they do not
     # require a worktree.
-    codex_readonly_class = (
-        args.agent == "codex"
-        and args.task_class in {"review", "search"}
-    )
+    codex_readonly_class = args.agent == "codex" and args.task_class in {
+        "review",
+        "search",
+    }
 
     if args.prompt is None:
         sys.stderr.write("[smart] no prompt — pass as arg or `-` for stdin\n")
@@ -683,8 +713,7 @@ def main() -> int:
             prompt = _wrap_prompt_with_skill(prompt, skill_body, skill_to_load)
             rel = _display_path(source_path)
             print(
-                f"[dispatch_smart] auto-loaded skill: {skill_to_load} "
-                f"(from {rel})",
+                f"[dispatch_smart] auto-loaded skill: {skill_to_load} (from {rel})",
                 file=sys.stderr,
             )
 
@@ -714,8 +743,10 @@ def main() -> int:
         return 2
 
     if args.dry_run:
-        print(f"[dry-run] agent={args.agent} task_class={args.task_class} "
-              f"model={model} mode={mode} timeout={timeout_s}s")
+        print(
+            f"[dry-run] agent={args.agent} task_class={args.task_class} "
+            f"model={model} mode={mode} timeout={timeout_s}s"
+        )
         _wt_label = worktree or f"(none — {mode})"
         print(f"[dry-run] worktree={_wt_label}")
         print(f"[dry-run] task_id={task_id}")


### PR DESCRIPTION
## Summary

Antigravity 1.x added a per-session `--model` flag (`agy models` lists the choices), so the runtime no longer needs to treat agy's model as TUI-only / audit-only.

- **`AgyAdapter.build_invocation`** now maps the runtime model slug (e.g. `gemini-3.1-pro-high`) to the canonical `agy --model "Gemini 3.1 Pro (High)"` display string via an alphanumeric-normalized lookup, so callers may pass either the slug or the display string.
- Unrecognized/empty values (e.g. the legacy `"tui-controlled"` placeholder) degrade to `default_model`; if even that is unmappable the flag is omitted and agy falls back to its TUI-selected model.
- **`dispatch_smart.py`** replaces the 5 `"agy": "tui-controlled"` placeholders with real per-class slugs: **Flash (High)** for cheap `search`, **Gemini 3.1 Pro (High)** for `edit`/`draft`/`review`/`architect`. The `--model` override flows straight through (`args.model or cfg.models[args.agent]`).

This enables **agy (Gemini 3.1 Pro High) as a second Gemini writer lane**.

## Test plan
- 3 new `AgyAdapter` unit tests: slug→display mapping, display-string idempotence, unknown→`default_model` fallback.
- Updated the existing cmd assertion for the new `--model` flag.
- `ruff check` clean; `pytest scripts/agent_runtime/tests/test_agy_adapter.py` → 9 passed.
- Verified end-to-end with `dispatch_smart.py … --agent agy --dry-run` (no agy invocation): `draft`→`gemini-3.1-pro-high`, `search`→`gemini-3.5-flash-high`, `--model` override honored.

Note: the `dispatch_smart.py` diff includes incidental auto-formatter reflow (the repo formatter normalized the whole file); the semantic change is only the agy model entries + the comment block.

🤖 Generated with [Claude Code](https://claude.com/claude-code)