### PR TITLE
fix(dispatch): cursor review class uses auto, not gpt-5.5

### DIFF
--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -197,7 +197,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",
             "gemini": "gemini-3.1-pro-preview",
-            "cursor": "gpt-5.5",
+            "cursor": "auto",
             "hermes": "claude-sonnet-4-6",
             "opencode": "openrouter/qwen/qwen3.7-max",
             "qwen": "qwen/qwen3.6-plus",


### PR DESCRIPTION
## Summary

Policy: cursor dispatches use **only composer-2.5 or auto** (per `feedback_cursor_model_auto_not_composer` + user directive 2026-06-04). The `review` task-class default routed `--agent cursor` to **gpt-5.5** — and the dispatch log shows 4 cursor/gpt-5.5 dispatches in the last 7 days that hit it. Changed to `auto` (self-selects, the preferred cursor model). The other cursor entries (`search`/`edit`/`draft`/`architect`) already use `composer-2.5(-fast)`.

## Test plan
- `dispatch_smart.py review --agent cursor --dry-run` → `model=auto` (was `gpt-5.5`).
- No other cursor entry changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)