### PR TITLE
fix(dispatch): route grok via xai-oauth; harden agy default_model

### DIFF
--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -86,7 +86,9 @@ class AgyAdapter:
     """Adapter for the ``agy`` Antigravity CLI."""
 
     name: str = "agy"
-    default_model: str = os.environ.get("KUBEDOJO_AGY_MODEL", "gemini-3.5-flash-high")
+    default_model: str = (
+        os.environ.get("KUBEDOJO_AGY_MODEL") or "gemini-3.5-flash-high"
+    )
     supported_modes: frozenset[str] = frozenset(
         {"read-only", "workspace-write", "danger"}
     )

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -375,7 +375,10 @@ def _hermes_provider_for_model(model: str) -> str:
     if model.startswith("claude-"):
         return "anthropic"
     if model.startswith("grok-"):
-        return "xai"
+        # xAI is accessed via the OAuth subscription (`hermes login --provider
+        # xai-oauth`), NOT the metered XAI_API_KEY "xai" provider. Override with
+        # KUBEDOJO_HERMES_PROVIDER=xai if you have an API key instead.
+        return "xai-oauth"
     return "openrouter"
 
 


### PR DESCRIPTION
## Summary

Unblocks the grok lane through hermes and hardens the agy default, both validated live this session.

1. **`_hermes_provider_for_model`: `grok-*` → `xai-oauth`** (was `xai`). xAI is accessed via the OAuth **subscription** (`hermes login --provider xai-oauth`), not the metered `XAI_API_KEY` `xai` provider. Verified: `hermes -z -m grok-4.3 --provider xai-oauth` → clean `GROK_OK grok-4.3`; `--provider xai` → `no API key found`. Override with `KUBEDOJO_HERMES_PROVIDER=xai` if you have an API key instead.
2. **`AgyAdapter.default_model`: `os.environ.get(...) or "…"`** — a set-but-empty `KUBEDOJO_AGY_MODEL` previously yielded `""`, which would force the `--model` flag to be omitted on every dispatch. Caught by a **grok-build-0.1 code review** (its first ground-checked code finding).

## Validation
- 4/5 grok models smoke-pass via `xai-oauth` oneshot (grok-4.3, grok-4.20-0309-non-reasoning, grok-4.20-0309-reasoning, grok-build-0.1; grok-4.20-multi-agent needs agentic mode).
- `grok-4.20-0309-reasoning` content-reviewed module 4.3 → APPROVE 4.5/5 (calibrated to opus's known verdict; disciplined hedging, no fabrication).
- ruff clean; `pytest test_agy_adapter.py` → 9 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)