### PR TITLE
chore(content): Cloud Advanced Operations 8.1–8.10 expand-to-floor + cross-family review

### DIFF
--- a/src/content/docs/cloud/advanced-operations/module-8.1-multi-account.md
+++ b/src/content/docs/cloud/advanced-operations/module-8.1-multi-account.md
@@ -32,7 +32,47 @@ When production and non-production workloads share the same cloud account and ne
 
 The root cause of this catastrophic failure was not the load test itself, nor was it the junior developer's actions. The fundamental failure was the architecture—or rather, the complete lack of a defensive architectural strategy. When every resource, identity, and network component lives in a single cloud account, there are zero hard blast radius boundaries. IAM policies often become extremely complex and difficult to audit effectively. Cost attribution degrades into pure guesswork based on inconsistent resource tagging. Audit trails transform into a tangled mess of production operations interspersed with random development activity. Most dangerously, a single misconfiguration or resource exhaustion event in a non-critical environment can effortlessly cascade into a total production outage.
 
-This module teaches you how to systematically dismantle the single-account anti-pattern and design robust, scalable multi-account architectures across AWS, GCP, and Azure. You will learn to build organizational hierarchies that enforce complete isolation by default, centralize only what strictly needs to be shared (such as centralized logging, security scanning, and core networking), and keep everything else cryptographically separate. More importantly, you will understand how these foundational cloud boundary decisions directly dictate the operational posture of your Kubernetes clusters—determining exactly where they live, how they communicate across network boundaries, and who ultimately controls their lifecycle.
+This module teaches you how to systematically dismantle the single-account anti-pattern and design robust, scalable multi-account architectures across AWS, GCP, and Azure. You will learn to build organizational hierarchies that enforce complete isolation by default, centralize only what strictly needs to be shared (such as centralized logging, security scanning, and core networking), and keep everything else behind hard administrative boundaries. More importantly, you will understand how these foundational cloud boundary decisions directly dictate the operational posture of your Kubernetes clusters—determining exactly where they live, how they communicate across network boundaries, and who ultimately controls their lifecycle.
+
+---
+
+## The Landing Zone Concept
+
+Before you create your first additional cloud account, you need a landing zone: a pre-configured, multi-account foundation that provides a secure, compliant starting point for every new workload environment. Think of a landing zone as the factory floor—you do not build a factory around every new product line; you build the factory once, with power, ventilation, safety systems, and assembly lines already in place. Every new product plugs into that infrastructure from day one.
+
+### Why One Account Is Never Enough
+
+The landing zone is not just about scale. It is about **blast-radius isolation**: if a compromised developer credential or a runaway process brings down resources in one account, the boundary of an AWS account, GCP project, or Azure subscription means the damage stops there. Compare that to a single-account model where misbehavior in the staging namespace can exhaust shared API rate limits, fill shared log buckets, or worst of all, reach the production database through an overly broad IAM role.
+
+The landing zone also enforces **billing separation** by design. The moment your organization grows past a handful of engineers, you need to know how much Team Alpha spends versus Team Beta, and how much of that spend is production versus experimentation. Accounts and projects are natural billing containers; resource tags alone cannot provide the same hard guarantee because tagging is opt-in, often inconsistent, and never retroactive.
+
+**Quota isolation** is equally important. Cloud providers enforce service quotas per account or per project. If your development team spins up 50 GPU instances for a model training run and hits the regional quota ceiling in a shared account, the production pipeline blocked behind it has no recourse. Separating environments into distinct accounts gives each team its own quota pool.
+
+**Environment and team separation** closes the loop. A landing zone structured by environment (Production, Staging, Development, Sandbox) with workload accounts underneath allows you to attach a single Service Control Policy (AWS), Organization Policy constraint (GCP), or Azure Policy assignment to the Production Organizational Unit and know with certainty that every production account inherits it. Structure by team first and you will spend years writing per-account exception lists.
+
+### The Landing Zone Map Across Clouds
+
+| Concept | AWS | GCP | Azure |
+|---|---|---|---|
+| Automates org setup | Control Tower | Terraform landing-zone module / Fabric FAST | Azure Landing Zones (ALZ) |
+| Underlying hierarchy | AWS Organizations + OUs → Accounts | Resource Manager: Organization → Folder → Project | Entra ID tenant → Management Groups → Subscriptions |
+| Account factory | Account Factory (AFT) or Service Catalog | Project Factory (Terraform module + Cloud Build) | Subscription Vending (ARM/Bicep + EA/MCA) |
+| Baseline guardrails at creation | Preventive + detective guardrails applied on account birth | org-level constraints placed on folder, inherited by new projects | Azure Policy assignments at Management Group, inherited by new subscriptions |
+| Centralized logging | Org-wide CloudTrail + Config | Aggregated log sinks at org/folder level | Azure Activity Log + diagnostic settings |
+
+AWS Control Tower builds the landing zone on top of AWS Organizations, deploying a management account, a log archive account, and an audit account out of the box, then applies mandatory guardrails (preventive SCPs and detective AWS Config rules) that cannot be disabled by member accounts. GCP's equivalent is typically deployed through the open-source Terraform landing-zone module or the Google Cloud Foundation Toolkit, which creates a folder hierarchy, sets baseline Organization Policy constraints, and provisions a project factory. Azure's Cloud Adoption Framework (CAF) prescribes Azure Landing Zones: a set of Management Groups (like `Corp`, `Online`, `Sandbox`), subscription vending templates, and a policy-driven governance model.
+
+> **Hypothetical scenario**: A healthcare company migrates 200 workloads to the cloud without a landing zone. Each team manually creates accounts, skips CloudTrail configuration in 40% of them, and uses inconsistent naming. Six months later, an auditor requests proof that every account has logging enabled. The platform team spends three weeks writing one-off scripts to crawl accounts they did not know existed. The landing zone would have enforced organization-wide CloudTrail on every account from the moment of creation—audit proof would be a one-line AWS Config query.
+
+### Landing Zone and Kubernetes
+
+The landing zone shapes your Kubernetes posture before you provision a single cluster. With a landing zone in place, the platform team can pre-configure:
+
+- **Networking**: a shared VPC (GCP) or Transit Gateway (AWS) ready for new clusters to attach to (see Module 8.2 for the full transit-hub design).
+- **Identity**: an IAM Identity Center (AWS) / Workforce Identity Federation (GCP) / Entra ID (Azure) integration so that cluster RBAC maps to organizational SSO on day one.
+- **Logging**: a centralized log sink or organization trail so every new EKS/GKE/AKS cluster ships its audit events to the immutable archive without any per-cluster configuration.
+
+Without a landing zone, each of these integrations becomes a manual bootstrapping step performed by whoever happens to create the cluster—and almost certainly skipped the first time.
 
 ---
 
@@ -69,7 +109,7 @@ The compounding problems of this architecture are severe and unavoidable:
 - The monthly AWS cost report indicates a spend of "$84,000 this month," but tracing exactly which team or which experimental feature generated that cost can become extremely difficult because tagging enforcement is often manual and error-prone.
 - Security and compliance logs (like AWS CloudTrail) mix noisy developer experiments alongside critical production audit events, making real-time threat detection alerting virtually useless due to overwhelming false positives.
 
-The multi-account model systematically solves all of these inherent flaws by creating cryptographically hard boundaries. An AWS account, a GCP project, or an Azure subscription represents the absolute strongest isolation boundary that any cloud provider offers below the root organization level.
+The multi-account model systematically solves all of these inherent flaws by creating the strongest isolation boundary the provider offers. An AWS account, a GCP project, or an Azure subscription represents the absolute strongest isolation boundary that any cloud provider offers below the root organization level.
 
 ---
 
@@ -136,6 +176,69 @@ Understanding the subtle mechanical differences in how these providers enforce p
 There is one exceptionally critical nuance you must internalize: **[AWS Service Control Policies (SCPs) can only deny actions; they cannot explicitly grant permissions.](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html)** This means your entire SCP strategy must be based on establishing preventative guardrails rather than attempting to perform access grants. If an SCP allows an action, the IAM principal still requires an explicit `Allow` in their identity-based or resource-based policy to actually perform the action. 
 
 Conversely, GCP Organization Policies operate on a vastly different paradigm. They do not evaluate low-level IAM API actions; instead, they aggressively [constrain the actual configuration state of resources](https://cloud.google.com/resource-manager/docs/organization-policy/overview) (for instance, mandating that "Virtual Machines can only be created in specific geographic regions" or "Public IP addresses are strictly forbidden"). Azure Policy represents the most flexible hybrid of both worlds, possessing the capability to [explicitly deny deployments, seamlessly audit existing non-compliant resources, and even automatically remediate configurations on the fly](https://learn.microsoft.com/en-us/azure/governance/policy/concepts/effect-basics), which makes it incredibly powerful but correspondingly complex to reason about and debug.
+
+### Guardrails in Practice: Three Worked Examples
+
+**AWS SCP — Deny Public S3 Buckets Org-Wide.** An SCP is a deny-only permission boundary that applies to every IAM principal in the accounts under its scope. Suppose you want to prevent public-read ACLs on any S3 bucket across all production accounts:
+
+```json
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "DenyPublicS3ACL",
+      "Effect": "Deny",
+      "Action": ["s3:PutBucketAcl"],
+      "Resource": "*",
+      "Condition": {
+        "StringEquals": {
+          "s3:x-amz-acl": ["public-read", "public-read-write", "authenticated-read"]
+        }
+      }
+    }
+  ]
+}
+```
+
+This SCP, attached to the Production OU, blocks any `PutBucketAcl` call that attempts to set a public ACL. No per-account configuration needed—every current and future account in that OU inherits the restriction. Remember the golden rule: an SCP never grants permissions; it only narrows the maximum permissions a principal can exercise. The IAM principal still needs an explicit `Allow` for `s3:PutBucketAcl`.
+
+**GCP Organization Policy — Restrict VM External IPs.** GCP Organization Policies do not operate on IAM API actions. Instead, they enforce constraints on resource configurations. The `constraints/compute.vmExternalIpAccess` list constraint controls whether VMs can receive an external IP address:
+
+```bash
+# Apply the v2 org policy (target folder is encoded in the YAML name: field)
+gcloud org-policies set-policy policies/vm-external-ip-deny.yaml
+```
+
+The constraint definition (in YAML) specifies what is allowed. Because it is a deny-by-default list constraint, only the values you list explicitly in `allowedValues` are permitted:
+
+```yaml
+name: folders/123456789012/policies/compute.vmExternalIpAccess
+spec:
+  rules:
+  - values:
+      allowedValues:
+      - "projects/allowed-external-ips-project/zones/us-central1-a/instances/nat-gateway"
+```
+
+This means every VM across any project under that folder is blocked from obtaining an external IP—except the single NAT gateway instance that the networking team explicitly allows. The policy inherits downward to child folders and projects automatically.
+
+**Azure Policy — Deny Public IP on NICs.** Azure Policy assignments at a Management Group span all child management groups and subscriptions. The policy engine evaluates every create or update request against its rules:
+
+```json
+{
+  "if": {
+    "field": "type",
+    "equals": "Microsoft.Network/networkInterfaces"
+  },
+  "then": {
+    "effect": "deny"
+  }
+}
+```
+
+When this policy is assigned at the root management group with a more targeted condition (e.g., `field: "Microsoft.Network/publicIPAddresses"` not present in `properties.ipConfigurations[*].properties.publicIPAddress`), it blocks network interfaces from being created with a public IP. Alternatively, an `audit` effect would flag existing violations without blocking deployments—handy for brownfield environments where you need to understand the blast radius before enforcing.
+
+The key operational difference across the three clouds: AWS SCPs work exclusively through IAM action filtering (you can only deny what an IAM policy elsewhere allows). GCP constraints work through resource configuration gating at the API layer—the constraint checker inspects the resource definition in the API call itself. Azure Policy sits between the two, offering `deny`, `audit`, and `deployIfNotExists` (auto-remediation) effects that span both IAM and resource configuration.
 
 ---
 
@@ -273,9 +376,10 @@ WORKLOADS_FOLDER=$(gcloud resource-manager folders create \
   --format="value(name)")
 
 # Create environment sub-folders
-gcloud resource-manager folders create \
+PROD_FOLDER_ID=$(gcloud resource-manager folders create \
   --display-name="Production" \
-  --folder=$WORKLOADS_FOLDER
+  --folder=$WORKLOADS_FOLDER \
+  --format="value(name)")
 
 gcloud resource-manager folders create \
   --display-name="Staging" \
@@ -311,6 +415,77 @@ With AFT, engineers define an account request inside a centralized Terraform mod
 
 The account vending philosophy extends seamlessly into the modern Kubernetes lifecycle. Once the foundational cloud account is permanently established and secured, the exact same automated pipeline can transparently invoke secondary modules to deploy an EKS, GKE, or AKS cluster. By physically embedding the Kubernetes cluster provisioning inside the larger account vending logic, you mathematically guarantee that the cluster is automatically registered with your central ArgoCD or Flux instance, its audit logs are hard-wired to the immutable log archive account, and its inbound ingress controllers are correctly peered with the central network hub. This holistic pipeline can reduce environment setup from a multi-week manual effort to a far more repeatable and auditable automated process.
 
+### GCP Project Factory
+
+GCP's equivalent is the Project Factory—typically implemented through the open-source [Terraform project-factory module](https://github.com/terraform-google-modules/terraform-google-project-factory). The pattern is identical in spirit to AFT: a developer submits a structured request (a Terraform module call or a YAML manifest in a governance repository), and a CI/CD pipeline picks it up.
+
+```hcl
+# project-requests/team-a-prod.tf
+module "team-a-prod" {
+  source  = "terraform-google-modules/project-factory/google"
+  version = "~> 14.5"
+
+  name              = "team-a-prod"
+  org_id            = var.org_id
+  folder_id         = google_folder.production.id
+  billing_account   = var.billing_account
+  activate_apis     = [
+    "compute.googleapis.com",
+    "container.googleapis.com",
+    "logging.googleapis.com",
+    "monitoring.googleapis.com"
+  ]
+  disable_services_on_destroy = false
+
+  # Automatically apply baseline organization policies
+  enable_org_policy_data_access_logs = true
+  enable_org_policy_vm_external_ip   = false
+}
+```
+
+When this module is applied, the pipeline creates a project under the Production folder, enables the core APIs, and places it under the correct billing account—all before any cluster provisioning begins. Google's landing-zone blueprint (Fabric FAST) extends this further, pre-creating network host projects, log sink destinations, and shared VPC service projects in a deterministic order.
+
+### Azure Subscription Vending
+
+Azure subscription vending follows the same declarative model, typically powered by ARM templates or Bicep modules deployed through Azure DevOps or GitHub Actions. The Cloud Adoption Framework's [Azure Landing Zones](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/) accelerator provisions subscriptions under management groups with Azure Policy assignments pre-attached.
+
+A subscription vending request starts as a simple parameter file fed to a Bicep module that handles the orchestration:
+
+```bicep
+// subscription-vending.bicep — invoked per team/environment request
+param subscriptionName string = 'Team-A-Prod'
+param managementGroupId string = 'Production'
+param billingScope string = '/providers/Microsoft.Billing/billingAccounts/1234567/enrollmentAccounts/8901234'
+
+module subscription 'subscription.bicep' = {
+  name: '${subscriptionName}-create'
+  params: {
+    subscriptionName: subscriptionName
+    managementGroupId: managementGroupId
+    billingScope: billingScope
+  }
+}
+
+// Post-provisioning: apply baseline policies, configure networking, onboard to Log Analytics
+module baseline 'baseline.bicep' = {
+  name: '${subscriptionName}-baseline'
+  params: {
+    subscriptionId: subscription.outputs.subscriptionId
+    policyAssignments: [
+      'Deny-Public-IP',
+      'Audit-Diagnostic-Settings',
+      'Deploy-Log-Analytics-Agent'
+    ]
+    vnetHubResourceId: '/subscriptions/${networkHubSubscription}/resourceGroups/network-hub-rg/providers/Microsoft.Network/virtualNetworks/hub-vnet'
+  }
+  dependsOn: [subscription]
+}
+```
+
+The automation layer handles subscription creation, management group placement, and baseline onboarding in a single atomic pipeline stage. If the baseline step fails, the subscription is quarantined (moved to a `Pending` management group) until remediation.
+
+> **Key operational insight**: None of the three vending patterns (AFT, Project Factory, Subscription Vending) should require custom code. Each is a battle-tested open-source module maintained by the cloud provider or a major community. Your job is not to build the factory but to configure its parameters and wire it into your GitOps pipeline. If you find yourself writing a bespoke account-creation script, you have missed the entire point of the landing zone.
+
 ---
 
 ## Workload Isolation Patterns
@@ -331,11 +506,11 @@ The following matrix provides a clear framework for deciding when to share infra
 | Resource contention | High risk | Medium risk | Zero risk |
 | Operational overhead | Low | Medium | High |
 
-### The War Story: When Namespace Isolation Isn't Enough
+### Hypothetical Scenario: When Namespace Isolation Isn't Enough
 
-Teams that rely on namespace isolation alone can discover during a compliance review that a shared cluster does not provide the separation they assumed.
+Hypothetical scenario: A fintech company runs PCI- and non-PCI-grade workloads in the same Kubernetes cluster, separated only by namespaces and NetworkPolicies. During a compliance audit, the auditor asks a simple question: "Can a pod in the non-PCI namespace discover the existence of the PCI namespace and the pods inside it?"
 
-The shocking answer was yes. If cluster RBAC is overly broad, a tenant may be able to enumerate namespaces or other cluster-scoped resources unless you deliberately restrict those permissions. The auditor aggressively flagged this as a critical data leakage risk—not because actual financial data was directly exposed, but because the mere existence and infrastructure footprint of a PCI workload was easily discoverable by unauthorized internal tenants.
+The truthful answer is yes if your RBAC is not tightly scoped. cluster-scoped read access (on `namespaces`, `pods`, and `services` resources) can reveal the structure of the PCI environment. The auditor flagged this as a data leakage risk—not because actual cardholder data was exposed through the API, but because the existence and topology of the PCI infrastructure was discoverable by unauthorized internal tenants, violating the "need to know" principle.
 
 If teams build deeply around a shared-cluster model, moving later to hard isolation can become a long and disruptive migration.
 
@@ -376,6 +551,67 @@ flowchart LR
 ```
 
 The absolute golden rule of this architecture is that clusters are ephemeral cattle, never beloved pets. The Infrastructure as Code repository centralized in the Shared Services account possesses the capability to completely recreate any workload cluster from scratch in minutes. The critical strategic decision for platform teams is whether each individual development team physically manages their own cluster infrastructure configurations, or whether a centralized platform engineering team provisions the base clusters globally. As organizations grow, many teams adopt a model where a central platform group provisions base clusters and application teams own workload delivery through GitOps.
+
+### Workload Identity Across Account Boundaries
+
+Kubernetes pods live inside an account. But the cloud resources they need—databases, queues, object storage, secrets in a central vault—often live in different accounts. Hard-coding long-lived credentials into pods is a security anti-pattern with a body count. Instead, each cloud provider offers a mechanism for pods to assume a cloud identity without any stored credential, even when the target resource is in another account.
+
+**AWS: IRSA (IAM Roles for Service Accounts).** The pattern relies on an OIDC provider associated with the EKS cluster. A Kubernetes ServiceAccount annotated with an IAM role ARN allows pods using that ServiceAccount to obtain temporary AWS credentials through the STS `AssumeRoleWithWebIdentity` call. Crucially, the IAM role lives in whichever account the target resource is in. If Team A's EKS cluster is in account `111111111111` and their application needs to read from an S3 bucket in the shared-services account `222222222222`, the IAM role is created in `222222222222` with a trust policy that permits the EKS cluster's OIDC provider to assume it:
+
+```yaml
+# In the shared-services account (222222222222)
+# IAM role trust policy — allows any pod in Team-A's cluster with the right SA
+{
+  "Version": "2012-10-17",
+  "Statement": [{
+    "Effect": "Allow",
+    "Principal": {
+      "Federated": "arn:aws:iam::222222222222:oidc-provider/oidc.eks.us-east-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE"
+    },
+    "Action": "sts:AssumeRoleWithWebIdentity",
+    "Condition": {
+      "StringEquals": {
+        "oidc.eks.us-east-1.amazonaws.com/id/EXAMPLED539D4633E53DE1B71EXAMPLE:sub": "system:serviceaccount:team-a-app:inventory-reader"
+      }
+    }
+  }]
+}
+```
+
+The source cluster's OIDC provider must first be registered as an IAM identity provider in the shared-services account `222222222222` (per AWS [Authenticate to another account with IRSA](https://docs.aws.amazon.com/eks/latest/userguide/cross-account-access.html)); only then can a role in that account trust the federated principal ARN above.
+
+The pod's ServiceAccount is annotated with `eks.amazonaws.com/role-arn: arn:aws:iam::222222222222:role/inventory-reader`. No AWS credentials exist in the cluster. The EKS pod identity webhook injects the `AWS_WEB_IDENTITY_TOKEN_FILE` and `AWS_ROLE_ARN` environment variables, and the AWS SDK handles the rest.
+
+IRSA (above) is OIDC web-identity via `AssumeRoleWithWebIdentity`; EKS Pod Identity (`pods.eks.amazonaws.com`, Task 4) is a separate trust model—do not conflate them on the same workload.
+
+**GCP: Workload Identity Federation.** GKE clusters in one project can authenticate to resources in another project using workload identity federation. The cluster's workload identity pool is tied to a GCP service account in the target project:
+
+```bash
+# In the target project where the resource lives
+gcloud iam service-accounts add-iam-policy-binding \
+  sa-name@target-project.iam.gserviceaccount.com \
+  --member="principal://iam.googleapis.com/projects/CLUSTER_PROJECT_NUMBER/locations/global/workloadIdentityPools/CLUSTER_PROJECT_ID.svc.id.goog/subject/ns/team-a-app/sa/inventory-reader" \
+  --role="roles/iam.workloadIdentityUser"
+```
+
+The GKE Metadata Server running on each node intercepts credential requests from annotated pods and returns a federated token for the target service account. No key material touches the pod's filesystem.
+
+**Azure: Workload Identity.** AKS clusters using the workload identity mutating admission webhook (enabled with `az aks update --enable-oidc-issuer --enable-workload-identity`) project a federated credential into the pod's filesystem. A Microsoft Entra ID application registration with federated credentials allows the pod to authenticate as that identity:
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: inventory-reader
+  namespace: team-a-app
+  annotations:
+    azure.workload.identity/client-id: "00000000-0000-0000-0000-000000000000"
+    azure.workload.identity/tenant-id: "00000000-0000-0000-0000-000000000000"
+```
+
+The mutating webhook projects a signed token into `/var/run/secrets/azure/tokens/azure-identity-token`. The Azure SDK client libraries detect this file and exchange it for a Microsoft Entra ID access token scoped to the target resource—no client secrets, no connection strings, no ceremony.
+
+In all three models, the architecture is the same: the pod presents a signed identity token (from the cluster's trusted issuer) to the cloud IAM system, which validates it and returns short-lived credentials scoped to the cross-account role or service account. The blast radius stays small: even if a pod is compromised, the attacker gets only the permissions of that single cross-account role, not the cluster's node role or any human's access key.
 
 ---
 
@@ -453,7 +689,7 @@ aws organizations create-policy \
   --type SERVICE_CONTROL_POLICY \
   --content file://deny-cloudtrail-changes.json
 
-# Attach SCP to the root (applies to ALL accounts)
+# Attach SCP to the root (applies to all *member* accounts)
 aws organizations attach-policy \
   --policy-id p-1234567890 \
   --target-id $ROOT_ID
@@ -542,6 +778,20 @@ Use this framework when debating whether an architectural component should be co
 | Application deployment | | Yes | Teams own their deploy cadence |
 
 > **Stop and think**: Centralizing CI/CD pipelines in a shared services account establishes a single source of truth, but it also means the deployment runners require highly privileged cross-account access to modify production resources. How must you design the IAM trust boundaries so that a compromised runner cannot arbitrarily pivot and destroy resources across the entire organization?
+
+### Centralized Identity
+
+In a multi-account architecture without centralized identity, every account has its own set of local IAM users, groups, and roles. The result is a credential-management disaster: 50 accounts × N engineers = a combinatorial explosion of access keys, forgotten root credentials, and offboarding gaps where terminated employees retain access in forgotten corners of the organization.
+
+The fix is a single identity plane that all accounts trust:
+
+- **AWS IAM Identity Center** (formerly AWS SSO) integrates with an external identity provider (Okta, Entra ID, PingFederate, or IAM Identity Center's own directory) and maps organizational users and groups to permission sets in member accounts. An engineer logs in once through the AWS access portal and selects which account and role they need. The member accounts never contain any long-lived IAM users.
+
+- **GCP Cloud Identity / Workforce Identity Federation** provides the equivalent: a Google Workspace or Cloud Identity domain is the source of truth for users and groups. Workforce identity pools (for non-Google identity providers) allow SAML/OIDC federation, mapping external identities to GCP principals. Permissions are granted through IAM policy bindings at the folder or project level—never through per-project local user accounts.
+
+- **Azure Entra ID** (the identity plane for Azure) is already the tenant root. Every subscription is a child of the Entra ID tenant, so user and group objects are naturally shared. An engineer authenticates once to Entra ID and receives role-based access (e.g., `Contributor`, `Reader`) scoped to specific subscriptions or management groups. There is no concept of a "local IAM user" in Azure; all identities flow through Entra ID.
+
+The shared identity plane must be treated as a tier-0 asset. If the identity provider is compromised, every account in the organization is reachable. Protect it with phishing-resistant MFA (FIDO2 security keys or hardware tokens), emergency-access ("break-glass") accounts with full administrative access to the identity system itself, and conditional-access policies that block logins from untrusted locations. The identity plane is the one thing you cannot isolate per-account—by definition it spans the entire organization. Treat it accordingly.
 
 ### The Shared VPC Pattern (GCP)
 
@@ -686,6 +936,30 @@ aws organizations attach-policy \
   --target-id $WORKLOADS_OU
 ```
 
+### Consolidated Billing and Committed-Use Sharing
+
+A secondary payoff of the multi-account architecture that rarely gets mentioned in architecture diagrams: financial optimization. When all accounts roll up to a single payer (AWS management account, GCP billing account, Azure EA/MCA billing scope), the organization unlocks:
+
+- **Volume discount aggregation**: Reserved Instances, Savings Plans (AWS), Committed Use Discounts (GCP), and Azure Reserved VM Instances are purchased at the payer level. When a workload account consumes a matching resource, the discount applies—even if that account never purchased a commitment. Without consolidated billing, each team negotiates its own pricing, and combined purchasing power is forfeited.
+
+- **Pro tip: Coverage-first purchasing**: At the organization level, target 70–80% coverage on compute commitments (RIs, CUDs, Savings Plans) for predictable production workloads. Leave the remaining 20–30% as on-demand for elasticity and sandbox accounts. Purchasing 100% coverage locks you out of the flexibility the cloud is supposed to provide.
+
+### The Hidden Tax: Cross-Account Data Egress
+
+Multi-account isolation has a real financial tradeoff, and it is the one bill line item that catches every platform team off guard the first time: cross-account data transfer. The cloud providers generally treat traffic between accounts or projects as billable data egress if it crosses a regional or zonal boundary.
+
+| Transfer Type | AWS | GCP | Azure |
+|---|---|---|---|
+| Same region, same availability zone | Typically free (private IP) | Typically free | Typically free |
+| Same region, different AZ | $0.01/GB each direction | $0.01/GB (inter-zone) | $0.01/GB each direction |
+| Same region, cross-account/project/sub | Payer-to-payer, treated as inter-AZ or internet depending on routing | Billed at standard network egress rates if between projects | Billed per VNet peering pricing rules |
+| Cross-region | $0.02/GB (varies by region pair) | Internet egress rates ($0.12/GB typical) | $0.035/GB (varies) |
+| Cross-cloud (AWS to GCP, etc.) | Internet egress ($0.09/GB typical first 10TB) | Internet egress ($0.12/GB typical) | Internet egress (varies) |
+
+The upshot: multi-account isolation is not free. If you run heavy data pipelines that pull from S3 in a data-lake account into an EMR cluster in a compute account, every byte crossing that boundary incurs a transfer charge. This is where the landing-zone networking design (Module 8.2) becomes a cost decision, not just a connectivity decision: placing the compute cluster and the data lake in the same account and using VPC endpoints can eliminate egress charges entirely.
+
+> **Hypothetical scenario**: A machine-learning platform stores feature data in a centralized "data-lake" account (`us-east-1`) and runs training jobs in a separate "ml-compute" account (`us-west-2`). Each training epoch pulls 5 TB via cross-region S3 access and replication paths that bill at roughly $0.02/GB—about $100 in transfer per run. Over 200 training runs per month, that is $20,000 in egress charges that a same-account, same-region layout could largely avoid. The fix: align data locality with compute (same account and region where possible), or architect replication and endpoints deliberately. The landing zone should encode these data-locality rules—don't let workload teams discover them on the bill.
+
 ---
 
 ## Did You Know?
@@ -783,6 +1057,11 @@ touch shared/logging.tf
 
 Before writing a single line of automation code, you must forcefully define the target organizational state. You are actively building the deployment pipeline for a fictional analytics platform named "CloudBrew". The automated pipeline will deterministically generate the following logical structure based on configuration inputs. Deeply analyze the intended architectural state below.
 
+**Success Criteria**:
+- [ ] Identify the total number of accounts needed (security + infra + workload + sandbox)
+- [ ] Verify that the security OU accounts cannot be tampered with by workload accounts
+- [ ] Confirm that each team has production, staging, and development environments
+
 <details>
 <summary>Solution: Target Architecture Blueprint</summary>
 
@@ -816,7 +1095,7 @@ flowchart LR
     Stg --> S1["(mirror of prod accounts)"]
     Dev --> D1["(mirror of prod accounts)"]
 
-    SB --> SB1["(one per developer, auto-provisioned)<br/>(SCP: 72hr auto-nuke, $100/month budget, restricted regions)"]
+    SB --> SB1["(one per developer, auto-provisioned)<br/>(SCP: 72hr auto-nuke, $50/month budget, restricted regions)"]
 
     Susp --> Susp1["(SCP: deny all)"]
 ```
@@ -827,6 +1106,13 @@ Total accounts: 3 (security) + 3 (infra) + 18 (workloads: 6 teams x 3 envs) + N 
 ### Task 2: Implement the Baseline SCP
 
 Your automated account vending pipeline must programmatically attach a critical baseline Service Control Policy directly to the organization root to establish the primary boundary. Write the accurate JSON payload for this SCP in your `policies/baseline-scp.json` file. It must specifically deny any unauthorized tampering with CloudTrail, absolutely prevent accounts from leaving the organization, block users from disabling GuardDuty, and strictly restrict geographic regions to `us-east-1`, `us-west-2`, and `eu-west-1`.
+
+**Success Criteria**:
+- [ ] SCP denies `cloudtrail:StopLogging`, `cloudtrail:DeleteTrail`, `cloudtrail:UpdateTrail`
+- [ ] SCP denies `organizations:LeaveOrganization`
+- [ ] SCP denies `guardduty:DeleteDetector`, `guardduty:DisassociateFromMasterAccount`, `guardduty:UpdateDetector`
+- [ ] Region restriction condition uses `StringNotEquals` with `aws:RequestedRegion`
+- [ ] JSON validates with `jq . policies/baseline-scp.json`
 
 Validate your json syntax locally:
 ```bash
@@ -896,6 +1182,11 @@ jq . policies/baseline-scp.json
 
 Write an automation shell script inside `shared/ecr-policy.sh` that programmatically applies a robust ECR repository policy, ensuring that all dynamically created workload accounts can successfully pull container images. Your pipeline will automatically invoke this script when bootstrapping the central shared services account.
 
+**Success Criteria**:
+- [ ] ECR policy grants `ecr:GetDownloadUrlForLayer`, `ecr:BatchGetImage`, `ecr:BatchCheckLayerAvailability`
+- [ ] Organization-level condition (`aws:PrincipalOrgID`) is used instead of hard-coding account IDs
+- [ ] Script is idempotent (safe to run multiple times)
+
 <details>
 <summary>Solution: ECR Policy Automation</summary>
 
@@ -956,6 +1247,14 @@ The organization condition is generally superior because you typically do not ne
 ### Task 4: Codify Centralized Logging Infrastructure
 
 In the `shared/logging.tf` file, strictly define the complex Terraform resource blocks required to create the immutable S3 storage bucket designated for audit logs, alongside the specific IAM role that future workload accounts must assume to deposit log events.
+
+**Success Criteria**:
+- [ ] S3 bucket has `object_lock_enabled = true`
+- [ ] Object lock uses `GOVERNANCE` mode with 365-day retention
+- [ ] Bucket versioning is enabled
+- [ ] Bucket policy denies `s3:DeleteObject` and `s3:DeleteObjectVersion` for all principals
+- [ ] IAM role uses `pods.eks.amazonaws.com` as the trusted service principal type
+- [ ] `terraform validate` passes cleanly
 
 Verify the integrity of your Infrastructure as Code implementation locally:
 ```bash
@@ -1071,6 +1370,13 @@ resource "aws_iam_role_policy" "audit_log_writer" {
 
 Your advanced vending pipeline automatically assigns granular tags to all generated accounts. Using the simplified monthly cost data generated below, carefully calculate the true per-team costs, which must actively include a proportional distribution of all shared core infrastructure spend.
 
+**Success Criteria**:
+- [ ] Shared infrastructure total ($7,300) is correctly calculated
+- [ ] Proportional allocation uses direct workload spend as the distribution key
+- [ ] Team Alpha total = $18,780/month (60% share of shared costs)
+- [ ] Team Beta total = $12,520/month (40% share of shared costs)
+- [ ] Grand total ($31,300) reconciles with the sum of direct + shared spend
+
 | Account | Monthly Cost |
 |---|---|
 | Network Hub | $3,200 |
@@ -1123,3 +1429,5 @@ This specific proportional model is overwhelmingly the most common enterprise ap
 - [cloud.google.com: shared vpc](https://cloud.google.com/vpc/docs/shared-vpc) — Google's Shared VPC overview directly describes the host-project/service-project model and centralized control of network resources.
 - [docs.aws.amazon.com: orgs best practices mgmt acct.html](https://docs.aws.amazon.com/en_us/organizations/latest/userguide/orgs_best-practices_mgmt-acct.html) — AWS best-practices guidance explicitly recommends using the management account only for organization management and billing.
 - [docs.aws.amazon.com: manage acct closing.html](https://docs.aws.amazon.com/accounts/latest/reference/manage-acct-closing.html) — AWS Account Management documentation describes the 90-day post-closure period and reopening window.
+- [github.com: terraform-google-modules/terraform-google-project-factory](https://github.com/terraform-google-modules/terraform-google-project-factory) — Open-source Terraform module maintained by Google for declarative project creation with baseline configuration.
+- [learn.microsoft.com: Azure Landing Zones](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/) — Microsoft's Cloud Adoption Framework documentation for the Azure Landing Zone accelerator and subscription vending model.

--- a/src/content/docs/cloud/advanced-operations/module-8.10-iac-scale.md
+++ b/src/content/docs/cloud/advanced-operations/module-8.10-iac-scale.md
@@ -27,11 +27,15 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-A platform engineering team was operating a large AWS footprint from a single monolithic Terraform state file, and over time that state became a bottleneck. Routine `terraform plan` calls slowed enough to delay ordinary change approvals and made incident response feel painfully serialized. In that scenario, teams often lose the ability to keep pace with real-time production needs because every change has to cross the same large blast radius.
+Hypothetical scenario: a platform engineering team was operating a large AWS footprint from a single monolithic Terraform state file, and over time that state became a bottleneck. Routine `terraform plan` calls slowed enough to delay ordinary change approvals and made incident response feel painfully serialized. In that scenario, teams often lose the ability to keep pace with real-time production needs because every change has to cross the same large blast radius.
 
 That is why monolithic state becomes an incident amplifier: a slow refresh can push operators toward urgent console edits, and each manual change increases drift risk for the next automation run. When teams patch by hand, drift is no longer a rare corner case; it becomes the new normal and your IaC graph stops matching reality. The result is a destructive loop of urgent work followed by larger corrective applies.
 
-This module deconstructs scaling infrastructure as code into safe, composable practices. You will learn how to isolate failure domains by splitting state, design reusable Kubernetes-focused modules with explicit assumptions, and automate drift detection before it becomes an emergency. By the end, you can transition from brittle, serialized deployment pipelines to a resilient model using Terraform, Terratest, and Crossplane inside a GitOps posture that supports sustained scale.
+This module deconstructs scaling infrastructure as code into safe, composable practices. You will learn how to isolate failure domains by splitting state, design reusable Kubernetes-focused modules with explicit assumptions, and automate drift detection before it becomes an emergency. By the end, you can transition from brittle, serialized deployment pipelines to a resilient model using Terraform, OpenTofu, Terratest, and Crossplane inside a GitOps posture that supports sustained scale.
+
+The larger lesson is that enterprise IaC is not just scripts that create infrastructure. At scale, it becomes a reviewed, versioned product with owners, release notes, compatibility contracts, policy gates, cost controls, and incident procedures. AWS accounts, Google Cloud projects, and Azure subscriptions are not merely deployment targets; they are administrative boundaries where identity, billing, audit, and blast radius meet. A good IaC architecture makes those boundaries visible before a plan runs, not after a production apply surprises everyone.
+
+This is especially true for Kubernetes platform teams because clusters sit at the intersection of cloud networking, IAM, compute, storage, observability, and cost. A single EKS, GKE, or AKS cluster module may provision VPC or VNet attachments, workload identity bindings, private endpoints, logging sinks, autoscaling node pools, and backup hooks. If that module is treated as a pile of HCL rather than a product surface, every consumer gets a slightly different cluster and the platform team loses the ability to reason about the fleet.
 
 ---
 
@@ -58,6 +62,12 @@ A concrete analogy helps here. If an accountant wants to update a tiny marketing
 - Team members waiting idle to apply changes sequentially.
 - Intense temptation to bypass automation and make manual changes (resulting in drift).
 - Catastrophic state corruption from aborted or concurrent operations.
+
+The failure mode is not just "Terraform is slow." The deeper problem is that the state file has become the coordination point for too many independent lifecycles. A networking change, a node-pool change, an IAM role update, a database parameter edit, and an observability sink adjustment may all be logically unrelated, yet a monolithic root module forces them through the same refresh, lock, review queue, and rollback boundary. That is why a harmless tag update can become risky: it must evaluate the same global graph that also contains destructive database and cluster changes.
+
+AWS, GCP, and Azure all make this worse when the IaC graph crosses administrative boundaries. On AWS, the graph may span multiple accounts governed by [AWS Organizations service control policies](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html) and a [Control Tower landing zone](https://docs.aws.amazon.com/controltower/latest/userguide/what-is-control-tower.html). On Google Cloud, the same graph may cross organization, folder, and project boundaries in the [resource hierarchy](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy), with Org Policy constraints inherited through that hierarchy. On Azure, a plan may cross management groups, subscriptions, and resource groups organized through [management groups](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview) and Azure landing zones. If one root module needs credentials for every boundary, you have accidentally created a superuser deployment robot.
+
+For Kubernetes operations, the practical shift is to stop thinking in terms of "one repo equals one apply." Instead, think in stacks with separate ownership and release cadence: account vending or project vending, shared network, cluster foundation, node capacity, workload identity, add-ons, observability, and application-facing services. The platform team owns the product contract for each stack, while workload teams consume pinned versions and submit changes through review. That operating model preserves speed because a team can change its AKS node pool or GKE workload identity binding without taking a lock on unrelated AWS Transit Gateway or global DNS state.
 
 ### State Splitting Strategy
 
@@ -87,10 +97,15 @@ graph TD
     end
 ```
 
-By isolating these layers, you enforce a strict blast radius. A destructive change to the database tier cannot inadvertently delete the transit gateway routing tables.
 By isolating these layers, you enforce a strict blast radius and make ownership meaningful. A destructive change to the database tier cannot inadvertently delete the transit gateway routing tables, because those resources now live in a different execution boundary. That single architectural separation often removes the need for brittle manual coordination in CI and lets teams run in parallel with much lower contention.
 
 > **Stop and think**: In the split-state architecture shown below, if a syntax error breaks the `databases/` configuration, can the platform team still deploy updates to the EKS cluster or IAM roles? How does this impact deployment velocity during an incident?
+
+State segmentation should follow dependency direction, not just folder aesthetics. A lower-level state file should expose a small contract to higher-level consumers, while higher-level components should not reach back into the lower layer's implementation details. In a typical AWS layout, organization and account baselines sit at the bottom, VPC and shared networking come next, EKS cluster foundation follows, node pools and add-ons sit above that, and workload namespaces or managed services live at the edge. The same pattern maps cleanly to GCP projects and shared VPCs, and to Azure subscriptions, VNets, and AKS clusters.
+
+The segmentation rule is simple: split when ownership, lifecycle, credential scope, or blast radius changes. Production and staging should not share a state file because their approval and rollback requirements differ. Networking and cluster add-ons should not share a state file because a CoreDNS add-on change should not be able to modify a hub VNet. A central platform team and an application team should not share a state file because their access model is different. The split creates more directories, but it buys smaller plans, shorter locks, better audit trails, and less pressure to make emergency console changes.
+
+There is a cost dimension hiding inside this design choice. Poor state hygiene leaves behind orphaned resources because nobody is sure which state owns them, and cloud billing systems do not care whether an abandoned load balancer, NAT gateway, public IP address, disk, or snapshot was created by a clean module or by a failed migration. At moderate scale, a handful of forgotten per-environment resources can quietly turn into a recurring spend problem. A clean state boundary gives FinOps teams a way to map billed resources back to the module, team, environment, and cost center that created them.
 
 ---
 
@@ -227,6 +242,14 @@ terraform {
 #   --billing-mode PAY_PER_REQUEST
 ```
 
+Remote backend design is a multi-cloud operating decision, not just a Terraform syntax choice. Terraform's [S3 backend](https://developer.hashicorp.com/terraform/language/backend/s3) stores state in an S3 object and can use S3 lockfiles, while DynamoDB locking is now a legacy compatibility path that older estates still need to recognize during migrations. The [GCS backend](https://developer.hashicorp.com/terraform/language/backend/gcs) stores state in a Google Cloud Storage bucket prefix and supports locking, so the same segmentation idea maps to project and folder boundaries. The [azurerm backend](https://developer.hashicorp.com/terraform/language/backend/azurerm) stores state as a blob in Azure Storage and supports state locking with Azure Blob Storage capabilities.
+
+The backend should be provisioned before the infrastructure it manages, and it should be treated as a small, highly protected foundation service. Enable object versioning or equivalent recovery controls where the backend supports them, encrypt state at rest with organization-managed keys when policy requires it, and restrict access to the CI identities that actually need the state. The people who can read state may be able to read sensitive values, so state access belongs in the same review category as secret-store access rather than ordinary repository access.
+
+Locking protects the state file from concurrent writers, but it does not protect you from bad architecture. A lock on a monolithic state file can serialize a whole enterprise behind one slow apply, and a lock on a poorly scoped state file can still give the wrong team permission to change the wrong resources. The goal is therefore two-layer safety: small state files to reduce blast radius, plus backend locking to prevent simultaneous writes inside each boundary.
+
+When a lock gets stuck, the incident procedure should be boring and explicit. First, confirm whether a real apply is still running; second, inspect the CI job, terminal session, or pipeline logs that acquired the lock; third, back up the state before any manual unlock or recovery action; finally, document the reason in the change record. Manually deleting a lock because a plan is inconvenient is the IaC equivalent of force-removing a database transaction marker, and it can turn a slow deployment into a corrupted state recovery exercise.
+
 ### State File Organization Pattern
 
 State storage path design is not cosmetic; it is one of the highest-leverage controls for operational clarity. A robust directory hierarchy is essential to prevent confusion when dozens of teams are touching different environments, and the standard industry pattern aligns state keys with business-unit, environment, and region topology. When the path convention is obvious, runbooks become reliable, and on-call operators can recover faster because they can infer ownership from the key alone.
@@ -299,6 +322,12 @@ graph TD
 
 This specific key/path structure: `{env}/{region}/{component}/terraform.tfstate` matches the landing-zone foundations discussed in earlier architecture modules, and it maps cleanly onto isolated cloud accounts. In practice, it minimizes the blast radius of any individual apply operation while making governance easier in audits and incident retrospectives. You also gain a predictable place to enforce lifecycle rules around retention and encryption by component.
 
+Translate the pattern to each provider rather than copying S3 terminology everywhere. On AWS, the state key often includes organization unit, account alias, region, and component, because the account is the strongest operational boundary. On GCP, the equivalent path often includes folder, project, region, and component, because project ownership and billing are central to Google Cloud operations. On Azure, the path often includes management group lineage, subscription, region, and component, because subscriptions are common isolation and budget boundaries inside Azure landing zones.
+
+State outputs should be deliberately boring. Export stable identifiers such as VPC IDs, subnet IDs, project IDs, subscription IDs, cluster names, OIDC issuer URLs, and private DNS zone names, but avoid exporting internal implementation details that consumers should not depend on. If a downstream stack needs to know every route table ID, every private endpoint NIC, or every generated IAM policy fragment, the upstream module may not be exposing the right product interface yet.
+
+Drift becomes more dangerous after state is split because teams can start assuming their state file is the whole truth. It is only the truth for the resources it owns. A resource can drift because a human changed it in the console, because a controller reconciled it, because a provider default changed, or because another state file owns a dependency that moved. Mature teams therefore pair segmentation with scheduled drift checks, ownership tags, and policy gates that reject resources without `Environment`, `Team`, `CostCenter`, and lifecycle metadata.
+
 ---
 
 ## Designing Modules for Scale
@@ -308,6 +337,18 @@ Well-designed modules are the foundational building blocks for managing Kubernet
 > **Pause and predict**: If a module has 50 variables to account for every possible AWS configuration, how does that impact the readability of the root module consuming it? Is it actually better than writing raw resources?
 
 A common failure mode is creating "wrapper modules" that expose every underlying provider parameter and pretend abstraction exists where none is delivered. Such modules provide little architectural value because consumers still need deep platform knowledge to configure them safely. Instead, modules should encode your organization's specific security and compliance policies directly into baseline behavior, so the module can prevent unsafe defaults even when users are in a hurry.
+
+Terraform and OpenTofu modules are software interfaces. HashiCorp describes a [module](https://developer.hashicorp.com/terraform/language/modules) as a collection of resources managed together, and that definition matters because a module should have a cohesive reason to change. OpenTofu follows the same broad IaC workflow of writing configuration, planning changes, and applying approved operations across cloud and on-premises APIs, making it a practical vendor-neutral baseline for teams that need Terraform-compatible patterns while tracking the [OpenTofu](https://opentofu.org/docs/intro/) ecosystem. The point is not to debate brands; the point is to make module contracts explicit enough that either tool can operate safely.
+
+The cleanest large-scale layout is usually root-module-per-stack. A reusable module lives under `modules/`, but each real deployment has a small root module under `environments/`, `stacks/`, or a similar directory that wires provider aliases, backend configuration, input values, and data sources. That root module is where you express "production EKS in us-east-1" or "shared GKE networking in folder platform-prod." Keeping root modules thin makes review easier because reviewers can see whether the pull request changes product intent or reusable module behavior.
+
+Versioning is the difference between self-service and chaos. Publish reusable modules through a registry or controlled VCS source, pin consumers to explicit versions, and treat breaking changes as major-version events with migration notes. A platform team that updates a shared AKS, EKS, or GKE module without pinning can accidentally force every consumer to absorb a provider change at once. A platform team that publishes versioned modules lets each workload team plan, test, and roll forward on its own schedule.
+
+Do not use Terraform CLI workspaces as a substitute for architecture. The [workspaces documentation](https://developer.hashicorp.com/terraform/language/state/workspaces) is explicit that workspaces are not appropriate for system decomposition or deployments requiring separate credentials and access controls. Workspaces can be useful for lightweight duplication of a configuration, but they are a poor boundary for production versus staging, account versus account, or team versus team. If the blast radius or credential scope differs, use a separate root module and backend key.
+
+Orchestration tools help only after the state model is sound. Terragrunt can reduce backend and provider repetition across many root modules, while Terraform Stacks in HCP Terraform provide a component-based architecture for coordinating infrastructure across environments and deployments. [Terraform Stacks](https://developer.hashicorp.com/terraform/language/stacks) have documented product behavior and limits, so treat them as an orchestration layer rather than a magic substitute for good module design. The same caution applies to any in-house wrapper: it should make safe patterns easier, not hide dangerous coupling behind a friendlier command.
+
+Module review should include compatibility, security, operability, and cost. A cluster module should describe which Kubernetes version line it targets, how private control-plane access is handled, which workload identity model it supports, how add-ons are managed, what tags and labels are mandatory, and which cost-affecting resources it creates by default. For AWS, that may include IRSA or EKS Pod Identity decisions; for GCP, Workload Identity Federation for GKE; for Azure, Microsoft Entra Workload ID. These are part of the module contract because a workload team will build operational assumptions around them.
 
 ### EKS Cluster Module
 
@@ -540,6 +581,12 @@ module "eks" {
 }
 ```
 
+The root module consuming this EKS module should be small enough that a reviewer can understand its intent in a few minutes. If the root module contains hundreds of raw AWS resources alongside the module call, the abstraction is leaking and the team is back to building snowflakes. In a multi-cloud platform, the equivalent GKE and AKS root modules should have the same conceptual shape even though provider arguments differ: choose cluster name, region, private network, node-pool profile, identity mode, observability defaults, backup posture, and ownership tags.
+
+At enterprise scale, use separate release lanes for reusable modules and environment roots. A reusable module change should pass unit-style validation, static checks, policy checks, and at least one isolated integration test before consumers update. An environment root change should focus on version bump, input change, provider alias change, or data-source contract change. Keeping those lanes distinct makes rollback clearer: revert the root-module version pin to go back, or release a module patch when the reusable contract is wrong.
+
+Cost review belongs in the same pull request as the module change. Tools in the Infracost style can estimate cost impact from Terraform, CloudFormation, or CDK before deployment, which helps catch expensive resource class changes before they become invoices. The estimate is not a replacement for provider billing knowledge, because NAT, inter-zone traffic, cross-region replication, managed log ingestion, public IPs, and idle disks often depend on runtime traffic patterns. It is still valuable because it gives reviewers a cost diff when a module quietly adds three NAT gateways, a larger node-pool default, or a retained snapshot policy.
+
 ---
 
 ## IaC + GitOps: Crossplane vs. Terraform Operator
@@ -630,6 +677,14 @@ spec:
 | PR workflow | `terraform plan` in PR | `kubectl diff` in PR | `terraform plan` in PR |
 | Multi-cloud | Excellent | Good | Excellent |
 
+Crossplane is strongest when the platform team wants to expose a product API rather than expose raw cloud resources. A developer should not need to understand every RDS, Cloud SQL, or Azure Database for PostgreSQL parameter to request a compliant database; they should request a platform-defined class with size, retention, environment, and ownership fields. Crossplane compositions can turn that request into provider-specific managed resources while the controller watches for drift. That makes the platform API feel like Kubernetes, but it also means the platform team must operate Crossplane itself as a production control plane.
+
+The provider-native Kubernetes options follow the same reconciliation idea with different scope. Google [Config Connector](https://cloud.google.com/config-connector/docs/overview) manages Google Cloud resources as Kubernetes custom resources, AWS Controllers for Kubernetes ([ACK](https://aws-controllers-k8s.github.io/community/docs/community/overview/)) exposes AWS service resources through Kubernetes controllers, and [Azure Service Operator](https://azure.github.io/azure-service-operator/) manages Azure resources from within a Kubernetes cluster. These tools can be excellent when one cloud dominates the platform and Kubernetes is already the operational center. They can be awkward when a team needs one uniform abstraction across AWS, GCP, and Azure or when cluster outages must not block cloud recovery.
+
+The identity model must be part of the decision. AWS workloads can use [IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) or [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) to avoid static credentials in pods. GKE recommends [Workload Identity Federation for GKE](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) for fine-grained access to Google Cloud APIs without service account key files. AKS uses [Microsoft Entra Workload ID](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview), and new AKS designs should not use the older pod-managed identity pattern. If your infrastructure controller needs cloud credentials, the workload identity pattern is the line between a controlled platform and a cluster-wide secret with too much power.
+
+GitOps for infrastructure works best when the controller owns a narrow API surface. ArgoCD or Flux can sync Crossplane claims, Config Connector resources, ACK resources, or ASO resources from Git, while Atlantis or a Terraform/OpenTofu CI pipeline can run PR-driven plans for HCL. The decision is not "GitOps or Terraform"; it is whether reconciliation should happen continuously through the Kubernetes API or through reviewed plan/apply jobs. Continuous reconciliation is powerful for safe, repeatable services; explicit plan/apply is often better for rare, high-blast-radius changes such as account vending, hub networking, or region-scale migrations.
+
 ---
 
 ## Drift Detection and Testing
@@ -663,7 +718,7 @@ terraform plan -refresh-only
 # GitHub Actions example:
 ```
 
-A resilient pipeline runs this detection automatically using chron-based scheduled jobs.
+A resilient pipeline runs this detection automatically using cron-based scheduled jobs.
 
 ```yaml
 # .github/workflows/drift-detection.yml
@@ -676,6 +731,9 @@ on:
 jobs:
   detect-drift:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write   # Required for OIDC token minting (configure-aws-credentials)
+      contents: read
     strategy:
       matrix:
         component:
@@ -685,6 +743,8 @@ jobs:
           - iam
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: hashicorp/setup-terraform@v3
         with:
@@ -697,12 +757,12 @@ jobs:
           aws-region: us-east-1
 
       - name: Terraform Init
-        working-directory: terraform/prod/us-east-1/${{ matrix.component }}
+        working-directory: terraform/environments/prod/us-east-1/${{ matrix.component }}
         run: terraform init -input=false
 
       - name: Detect Drift
         id: drift
-        working-directory: terraform/prod/us-east-1/${{ matrix.component }}
+        working-directory: terraform/environments/prod/us-east-1/${{ matrix.component }}
         run: |
           terraform plan -refresh-only -detailed-exitcode -input=false 2>&1 | tee plan.txt
           EXIT_CODE=${PIPESTATUS[0]}
@@ -726,6 +786,18 @@ jobs:
               \"text\": \"DRIFT DETECTED in terraform/prod/us-east-1/${{ matrix.component }}\nRun terraform plan to see details.\"
             }"
 ```
+
+> **Production note**: Pin each `uses:` action to a full commit SHA per your org's supply-chain policy; version tags are shown here for readability.
+
+Drift detection should run at the same segmentation level as state ownership. If networking, clusters, databases, and IAM each have independent state, each deserves an independent scheduled plan with clear ownership and escalation. A single nightly job that runs every component serially may work for a small platform, but it becomes noisy at scale because failures hide in a long log and the owning team is unclear. A better model publishes a drift result per component, links to the exact plan output, and pages or tickets the team that owns the affected state.
+
+Multi-cloud drift signals have different personalities. AWS drift often appears as security group, IAM, route table, or autoscaling changes made during urgent response. GCP drift often appears around project IAM bindings, firewall rules, service enablement, or shared VPC attachments. Azure drift often appears in role assignments, policy exemptions, diagnostic settings, private endpoints, or AKS node-pool properties. The underlying lesson is the same: a manual console edit must either be reconciled back to code or deliberately imported into code, because leaving it invisible makes the next plan less trustworthy.
+
+Policy-as-code belongs before apply, not after an audit. OPA can evaluate structured Terraform plan JSON in CI, Sentinel can enforce policies in HashiCorp workflows, and tools such as Checkov can scan IaC for common misconfigurations before a provider API call happens. The important design principle is to gate the plan artifact, because the plan shows what will actually be created, changed, or destroyed after variables, modules, and data sources have resolved. Static HCL checks are useful, but the plan is where hidden module defaults become visible.
+
+Guardrails should express provider-specific risk in platform language. Reject public Kubernetes API endpoints unless an explicit exception is approved. Reject resources without ownership tags or labels. Reject NAT gateways, public IPs, or load balancers without a cost-center tag. Reject cross-region replication unless the module declares the DR reason. Reject Azure policy exemptions or AWS SCP workarounds without a ticket reference. These policies teach teams what "safe infrastructure" means in your environment, and they make the review process consistent across AWS, GCP, Azure, and Kubernetes.
+
+The cost lens matters during drift too. A manual console change may not break production, but it can create an expensive hidden path: traffic routed through a centralized NAT gateway, logs duplicated into a high-retention sink, snapshots retained forever, or cross-region replication enabled without lifecycle policy. AWS [NAT Gateway pricing guidance](https://docs.aws.amazon.com/vpc/latest/userguide/nat-gateway-pricing.html) includes gateway hours and processed data, and AWS recommends same-AZ placement or endpoints to reduce transfer costs. Google [Cloud NAT pricing](https://cloud.google.com/nat/pricing) includes gateway, processed data, IP address, and outbound transfer dimensions, while Google [network pricing](https://cloud.google.com/vpc/network-pricing) distinguishes same-zone, inter-zone, and inter-region data transfer. Azure [NAT Gateway documentation](https://learn.microsoft.com/en-us/azure/nat-gateway/nat-overview) points operators to pricing and SLA review before adoption. IaC review should catch those cost paths before they become normal.
 
 ### Terratest: Testing Infrastructure Code
 
@@ -788,7 +860,9 @@ func TestEksCluster(t *testing.T) {
 
     options := k8s.NewKubectlOptions("", kubeconfig, "default")
 
-    // Check that nodes are ready
+    // The module sets endpoint_public_access = false; k8s.GetNodes requires
+    // API reachability — run this test from a self-hosted runner inside the VPC,
+    // or override endpoint_public_access = true in CI-only test variables.
     nodes := k8s.GetNodes(t, options)
     require.GreaterOrEqual(t, len(nodes), 1)
 
@@ -813,6 +887,64 @@ go test -v -timeout 30m -run TestEksCluster
 
 ---
 
+## Patterns & Anti-Patterns
+
+The patterns below are deliberately operational rather than tool-branded. You can implement them with Terraform, OpenTofu, Pulumi, CloudFormation, Bicep, Crossplane, Config Connector, ACK, or ASO, but the same engineering tests apply: does the pattern reduce blast radius, make ownership visible, improve review quality, and keep cost tied to the team that creates it? If the answer is no, the tool choice is probably hiding an organizational problem.
+
+| Proven Pattern | When to Use | Why It Works | Scaling Note |
+|---|---|---|---|
+| Root module per stack | Use for each environment, region, account, project, subscription, or major component boundary. | Keeps state, credentials, reviews, and rollback scoped to a meaningful lifecycle. | Standardize naming so automation can discover stacks without a central spreadsheet. |
+| Versioned platform modules | Use when multiple teams consume a shared VPC, EKS, GKE, AKS, database, or observability module. | Turns infrastructure into a product contract with compatibility expectations and migration paths. | Pin versions in root modules and roll upgrades through rings rather than fleet-wide surprise changes. |
+| PR-driven plan with policy gates | Use when changes require human review, cost review, or high-blast-radius approval. | Reviewers see the resolved plan, policy engine results, and cost estimate before apply. | Run plans in parallel per state boundary, but serialize applies per backend lock. |
+| Kubernetes-native infrastructure API | Use when developers need self-service cloud resources through Kubernetes and platform abstractions. | Controllers continuously reconcile declared state and expose a familiar API to application teams. | Treat the controller cluster, provider credentials, and CRDs as production dependencies. |
+
+These patterns work because they separate responsibilities before automation runs. A networking team can own shared VPC or VNet state, a cluster team can own the EKS, GKE, or AKS foundation, and application teams can request higher-level services without inheriting every provider footgun. The platform team still provides paved roads, but the road is no longer one global apply queue.
+
+| Anti-Pattern | What Goes Wrong | Why Teams Fall Into It | Better Alternative |
+|---|---|---|---|
+| One global state file | Every change refreshes and locks unrelated resources, so slow plans and high blast radius become normal. | The first version was small, and nobody created a split rule before growth arrived. | Split by lifecycle, owner, credential scope, and blast radius before plan time becomes painful. |
+| Wrapper module with every provider argument | Consumers still need expert knowledge, but now debugging is harder because the abstraction hides raw resources. | Platform teams try to be flexible for every possible future use case. | Build opinionated modules for known product classes and add inputs only after repeated real demand. |
+| Console-first emergency fixes | The live environment diverges from code, and the next plan may undo or amplify the emergency change. | Incident pressure rewards immediate visible action over durable reconciliation. | Use break-glass with time-boxed exceptions, then reconcile through code, import, or deliberate rollback. |
+| Cost-blind module defaults | NAT gateways, public IPs, large node pools, snapshots, and log retention accumulate quietly. | Reviewers focus on functional correctness and assume billing will be caught elsewhere. | Add cost estimation, mandatory ownership tags, and provider-specific cost policies to CI. |
+
+The hardest anti-pattern to unwind is not technical; it is the habit of treating IaC as a private engineer convenience rather than a shared production interface. Once five teams depend on a module, changing it without versioning is the same kind of risk as changing a library API without a release process. Once a state file manages production, unlocking it without a recovery procedure is the same kind of risk as editing a database by hand.
+
+---
+
+## Decision Framework
+
+Use this framework when choosing how to manage a new piece of cloud infrastructure. Start with ownership and blast radius, then choose the execution model. Tool preference comes later, because a familiar tool used with the wrong boundary still produces fragile operations.
+
+```mermaid
+flowchart TD
+    A[New infrastructure capability] --> B{Does it cross account,<br/>project, subscription,<br/>or network boundaries?}
+    B -->|Yes| C[Use reviewed plan/apply<br/>with isolated state]
+    B -->|No| D{Is it a self-service<br/>developer-facing product?}
+    D -->|Yes| E{Is Kubernetes already<br/>the platform API?}
+    E -->|Yes| F[Use Crossplane or<br/>provider-native controllers]
+    E -->|No| G[Use versioned Terraform,<br/>OpenTofu, Pulumi, Bicep,<br/>or CloudFormation module]
+    D -->|No| H{Is continuous drift<br/>reconciliation required?}
+    H -->|Yes| F
+    H -->|No| C
+    C --> I[Add remote state,<br/>locking, policy, drift,<br/>and cost gates]
+    F --> J[Add GitOps sync,<br/>workload identity,<br/>controller SLOs,<br/>and break-glass policy]
+    G --> I
+```
+
+| Decision Axis | Prefer Plan/Apply IaC | Prefer Kubernetes-Native Controller | Watch the Tradeoff |
+|---|---|---|---|
+| Blast radius | Account vending, hub networking, global IAM, DNS, DR foundations | Namespaced self-service resources and repeatable managed services | Controllers can reconcile quickly, but they can also revert emergency console fixes quickly. |
+| Review model | Human-approved plans, cost diffs, and policy reports are mandatory | GitOps sync and admission policy are the main guardrails | Plan/apply is slower; reconciliation requires stronger controller observability. |
+| Team interface | Platform engineers are comfortable with HCL, Bicep, or provider IaC | Developers already use Kubernetes manifests and GitOps workflows | YAML self-service still needs product-level abstraction, not raw cloud resource exposure. |
+| State model | Remote backend with segmentation, locking, and explicit drift jobs | Kubernetes API state plus cloud provider reconciliation status | Kubernetes `etcd` and controller health become part of the infrastructure control plane. |
+| Cost control | Cost estimates and policy gates on the plan artifact | Admission policy, quotas, and controller-level defaults | Runtime traffic costs still need billing export and ownership tags in either model. |
+
+For AWS-heavy organizations, the default answer is often Terraform or OpenTofu for account, VPC, EKS, IAM, and shared-services foundations, then Crossplane or ACK for carefully bounded developer self-service. For GCP-heavy organizations, project and shared-VPC foundations often stay in Terraform/OpenTofu or Deployment Manager successors, while Config Connector can work well when Kubernetes is the platform API. For Azure-heavy organizations, landing-zone and subscription foundations often use Terraform or Bicep, while ASO can make sense for application-facing Azure resources that need to live beside Kubernetes workloads.
+
+The most important decision is where reconciliation should happen. If you need a human to read the exact plan before a production network or IAM boundary changes, use a PR-driven plan/apply workflow. If you need a product team to request a standard database, bucket, or queue and have the platform continuously keep it in policy, use a Kubernetes-native control-plane model. If you need both, use both, but draw the line explicitly and document which tool owns each resource.
+
+---
+
 ## Did You Know?
 
 1. **Terraform state handling is often the hardest operational part of Terraform at scale.** Teams commonly run into problems with concurrent changes, stuck locks, secret exposure, and backend mistakes, so state management deserves explicit design and review.
@@ -821,7 +953,7 @@ go test -v -timeout 30m -run TestEksCluster
 
 3. **Public Terraform modules often accumulate inputs that add complexity without delivering real abstraction value.** Module bloat is a common maintenance problem, so small, opinionated interfaces are usually easier to understand and operate.
 
-4. **[HashiCorp changed Terraform's license from Mozilla Public License 2.0 to Business Source License (BSL) in August 2023](https://www.hashicorp.com/ja/blog/hashicorp-adopts-business-source-license)**, which triggered the [creation of OpenTofu -- a community-maintained fork under the Linux Foundation](https://www.linuxfoundation.org/press/announcing-opentofu). Both Terraform and OpenTofu continue to evolve, but detailed feature and adoption comparisons should be checked against current primary sources before making specific claims.
+4. **[HashiCorp changed Terraform's license from Mozilla Public License 2.0 to Business Source License (BSL) in August 2023](https://discuss.hashicorp.com/t/hashicorp-projects-changing-license-to-business-source-license-v1-1/57106)**, which triggered the [creation of OpenTofu -- a community-maintained fork under the Linux Foundation](https://www.linuxfoundation.org/press/announcing-opentofu). Both Terraform and OpenTofu continue to evolve, but detailed feature and adoption comparisons should be checked against current primary sources before making specific claims.
 
 ---
 
@@ -835,7 +967,7 @@ go test -v -timeout 30m -run TestEksCluster
 | Writing modules that are too generic | "We'll configure everything through variables" | Write modules for YOUR use case. A module with 50 variables is worse than raw resources. Start specific, generalize only when you have three proven use cases. |
 | No automated drift detection | "We run terraform plan manually before changes" | Drift happens between planned changes. Schedule daily drift detection in CI. Alert on drift immediately -- it is often a security issue. |
 | Using `terraform taint` to force recreation | "The resource is broken, just recreate it" | `terraform taint` is deprecated in favor of `-replace`. Review the replacement impact in the plan before recreating infrastructure. |
-| Not testing modules before use | "It works on my machine" | Use Terratest or [`terraform test` (built-in since 1.6)](https://developer.hashicorp.com/terraform/language/tests%23example) to validate modules create functional infrastructure. Test in an isolated account to avoid production impact. |
+| Not testing modules before use | "It works on my machine" | Use Terratest or [`terraform test` (built-in since 1.6)](https://developer.hashicorp.com/terraform/language/tests) to validate modules create functional infrastructure. Test in an isolated account to avoid production impact. |
 | Manual state manipulation without backup | "I'll just terraform state rm this broken resource" | Back up state before manual changes, for example with `terraform state pull`, and treat state edits as high-risk recovery work rather than routine operations. |
 
 ---
@@ -876,6 +1008,18 @@ Committing state files to Git is dangerous because Terraform stores the plaintex
 <summary>6. Scenario: You maintain an EKS Terraform module used by 15 different product teams. One team requests a new feature that fundamentally changes how node groups are defined. How do you implement this change without breaking the module for the other 14 teams?</summary>
 
 You must treat the module as a versioned software artifact and implement the change using semantic versioning. Add the new feature by introducing optional variables with default values that strictly preserve the existing behavior for the 14 other teams. If the change is fundamentally breaking and cannot be made backward-compatible, you must release a new major version of the module (e.g., v2.0.0). The other teams will remain pinned to the v1 release and can plan their migration to the new architecture independently, ensuring that your feature addition causes zero operational disruption.
+</details>
+
+<details>
+<summary>7. Scenario: You need to implement modular IaC patterns with versioned components, workspace isolation, and strict policy-as-code validation before any Terraform or OpenTofu apply reaches AWS, GCP, or Azure. Where should the policy run, and why is the plan artifact more useful than raw HCL alone?</summary>
+
+The policy should run in CI against the resolved plan, before apply, because that is where module defaults, variables, provider data, and resource expansions are visible together. Raw HCL scanning is still valuable, but it can miss behavior hidden behind reusable modules or generated values. A plan-aware gate can reject the actual public endpoint, missing tag, or forbidden region that would be created. This makes the policy a release guardrail rather than a post-deployment audit finding.
+</details>
+
+<details>
+<summary>8. Scenario: You need to diagnose configuration drift across environments and deploy automated remediation pipelines for infrastructure managed by Terraform, OpenTofu, or CloudFormation. The platform wants continuous drift correction, but the network team wants human approval for hub routing changes. What mixed operating model fits both needs?</summary>
+
+Use PR-driven plan/apply for high-blast-radius foundation layers such as account, project, subscription, hub networking, and global IAM because humans need to inspect those plans before execution. Use Crossplane or provider-native Kubernetes controllers for bounded self-service products such as standard databases, queues, or buckets when the platform API is already Kubernetes-centered. The line between the two models should be documented by ownership and resource type, so no resource is managed by both systems. This gives developers a fast reconciled API while preserving deliberate approval for changes that can disrupt the whole platform.
 </details>
 
 ---
@@ -1085,13 +1229,22 @@ output "private_subnet_ids" {
 }
 
 # environments/prod/us-east-1/eks-cluster/data.tf
-# Read VPC info from the networking state
-data "terraform_remote_state" "networking" {
-  backend = "s3"
-  config = {
-    bucket = "company-terraform-state"
-    key    = "prod/us-east-1/networking/terraform.tfstate"
-    region = "us-east-1"
+# Query VPC and subnets via tags (loose coupling — no remote state dependency)
+data "aws_vpc" "main" {
+  tags = {
+    Name        = "production-vpc"
+    Environment = "production"
+  }
+}
+
+data "aws_subnets" "private" {
+  filter {
+    name   = "vpc-id"
+    values = [data.aws_vpc.main.id]
+  }
+
+  tags = {
+    Tier = "private"
   }
 }
 
@@ -1100,8 +1253,8 @@ module "eks" {
   source = "../../../../modules/eks-cluster"
 
   cluster_name = "prod-us-east-1"
-  vpc_id       = data.terraform_remote_state.networking.outputs.vpc_id
-  subnet_ids   = data.terraform_remote_state.networking.outputs.private_subnet_ids
+  vpc_id       = data.aws_vpc.main.id
+  subnet_ids   = data.aws_subnets.private.ids
 
   node_groups = {
     general = {
@@ -1291,9 +1444,39 @@ Return to the [Advanced Operations hub](/cloud/advanced-operations/) for a summa
 
 - [developer.hashicorp.com: remote state data](https://developer.hashicorp.com/terraform/language/state/remote-state-data) — HashiCorp's `terraform_remote_state` reference directly describes retrieving root module outputs from another state snapshot.
 - [developer.hashicorp.com: manage sensitive data](https://developer.hashicorp.com/terraform/language/manage-sensitive-data) — HashiCorp documentation explicitly says local state is plaintext and may contain secrets such as database passwords or API tokens.
+- [developer.hashicorp.com: S3 backend](https://developer.hashicorp.com/terraform/language/backend/s3) — HashiCorp documents S3 state storage, S3 lockfiles, and the deprecated DynamoDB locking compatibility path.
+- [developer.hashicorp.com: GCS backend](https://developer.hashicorp.com/terraform/language/backend/gcs) — HashiCorp documents Google Cloud Storage backend state storage and locking support.
+- [developer.hashicorp.com: azurerm backend](https://developer.hashicorp.com/terraform/language/backend/azurerm) — HashiCorp documents Azure Blob Storage state storage and AzureRM backend locking behavior.
+- [developer.hashicorp.com: modules](https://developer.hashicorp.com/terraform/language/modules) — HashiCorp defines module hierarchy, root modules, child modules, and module distribution patterns.
+- [developer.hashicorp.com: workspaces](https://developer.hashicorp.com/terraform/language/state/workspaces) — HashiCorp documents workspace behavior and warns against using workspaces for system decomposition or separate credential boundaries.
+- [developer.hashicorp.com: stacks](https://developer.hashicorp.com/terraform/language/stacks) — HashiCorp documents Terraform Stacks as a component-based architecture for coordinating deployments at scale.
+- [developer.hashicorp.com: tests](https://developer.hashicorp.com/terraform/language/tests) — HashiCorp documents Terraform's native testing framework and test-file structure.
+- [opentofu.org: getting started](https://opentofu.org/docs/intro/) — OpenTofu's documentation describes its IaC workflow and provider-based resource management model.
+- [docs.aws.amazon.com: AWS Organizations SCPs](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_scps.html) — AWS documents service control policies as organization-level permission guardrails.
+- [docs.aws.amazon.com: AWS Control Tower](https://docs.aws.amazon.com/controltower/latest/userguide/what-is-control-tower.html) — AWS documents Control Tower landing zones, account governance, and controls.
+- [cloud.google.com: resource hierarchy](https://cloud.google.com/resource-manager/docs/cloud-platform-resource-hierarchy) — Google Cloud documents organization, folder, and project hierarchy behavior and inherited policies.
+- [cloud.google.com: organization policy overview](https://cloud.google.com/resource-manager/docs/organization-policy/overview) — Google Cloud documents managed and custom organization policy constraints.
+- [learn.microsoft.com: Azure management groups](https://learn.microsoft.com/en-us/azure/governance/management-groups/overview) — Microsoft documents management group hierarchy, subscription organization, and inherited policy/RBAC behavior.
+- [learn.microsoft.com: Azure landing zones](https://learn.microsoft.com/en-us/azure/cloud-adoption-framework/ready/landing-zone/) — Microsoft documents Azure landing zone design, platform/application landing zones, and IaC implementation options.
+- [docs.aws.amazon.com: EKS IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) — AWS documents IAM roles for Kubernetes service accounts and OIDC-based pod credentials.
+- [docs.aws.amazon.com: EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) — AWS documents EKS Pod Identity associations between Kubernetes service accounts and IAM roles.
+- [cloud.google.com: Workload Identity Federation for GKE](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) — Google Cloud documents GKE workload identities for fine-grained access to Google Cloud APIs without service account key files.
+- [learn.microsoft.com: Microsoft Entra Workload ID for AKS](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview) — Microsoft documents AKS pod-to-Azure identity federation using Microsoft Entra Workload ID.
+- [learn.microsoft.com: Microsoft Entra pod-managed identity for AKS](https://learn.microsoft.com/en-us/azure/aks/use-azure-ad-pod-identity) — Microsoft documents the older AKS pod-managed identity approach referenced in the workload identity comparison.
+- [kubernetes.io: custom resources](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) — Kubernetes documents custom resources, custom controllers, and the declarative API model.
+- [cloud.google.com: Config Connector overview](https://cloud.google.com/config-connector/docs/overview) — Google Cloud documents Config Connector and its Kubernetes custom-resource approach for Google Cloud resources.
+- [aws-controllers-k8s.github.io: ACK overview](https://aws-controllers-k8s.github.io/community/docs/community/overview/) — ACK documentation describes defining and using AWS service resources directly from Kubernetes.
+- [azure.github.io: Azure Service Operator](https://azure.github.io/azure-service-operator/) — Azure Service Operator documentation describes managing Azure resources from a Kubernetes cluster.
+- [docs.crossplane.io: managed resources](https://docs.crossplane.io/latest/managed-resources/managed-resources/) — Crossplane documentation describes managed resources as Kubernetes representations of external resources.
+- [openpolicyagent.org: OPA Terraform](https://www.openpolicyagent.org/docs/terraform) — OPA documentation describes policy evaluation for Terraform plan data.
+- [developer.hashicorp.com: Sentinel](https://developer.hashicorp.com/sentinel/docs) — HashiCorp documents Sentinel as policy as code for proactive enforcement in HashiCorp workflows.
+- [infracost.io: get started](https://www.infracost.io/docs/) — Infracost documents pre-deployment cloud cost estimation for Terraform, CloudFormation, and AWS CDK workflows.
+- [docs.aws.amazon.com: NAT gateway pricing](https://docs.aws.amazon.com/vpc/latest/userguide/nat-gateway-pricing.html) — AWS documents NAT gateway hourly and per-GB processed-data cost surfaces and cost-reduction guidance.
+- [cloud.google.com: Cloud NAT pricing](https://cloud.google.com/nat/pricing) — Google Cloud documents Cloud NAT gateway, processed-data, external-IP, and data-transfer cost components.
+- [cloud.google.com: VPC network pricing](https://cloud.google.com/vpc/network-pricing) — Google Cloud documents intra-zone, inter-zone, inter-region, and product-to-product network data-transfer pricing behavior.
+- [learn.microsoft.com: Azure NAT Gateway overview](https://learn.microsoft.com/en-us/azure/nat-gateway/nat-overview) — Microsoft documents Azure NAT Gateway behavior and links operators to pricing and SLA guidance.
 - [github.com: provider terraform](https://github.com/crossplane-contrib/provider-terraform) — The provider-terraform README explicitly says it can run Terraform code and work with existing Terraform modules.
-- [hashicorp.com: hashicorp adopts business source license](https://www.hashicorp.com/ja/blog/hashicorp-adopts-business-source-license) — HashiCorp's August 10, 2023 announcement directly states the license change from MPL 2.0 to BSL v1.1.
+- [discuss.hashicorp.com: HashiCorp license change announcement](https://discuss.hashicorp.com/t/hashicorp-projects-changing-license-to-business-source-license-v1-1/57106) — HashiCorp's official announcement thread states the license change from MPL 2.0 to BSL v1.1.
 - [linuxfoundation.org: announcing opentofu](https://www.linuxfoundation.org/press/announcing-opentofu) — The Linux Foundation launch announcement explicitly describes OpenTofu as a response to Terraform's license change.
-- [developer.hashicorp.com: tests%23example](https://developer.hashicorp.com/terraform/language/tests%23example) — HashiCorp's testing documentation explicitly notes that the framework is available in Terraform v1.6.0 and later.
 - [Terraform State](https://developer.hashicorp.com/terraform/language/state) — This is the core reference for what state is, why Terraform needs it, and how state relates to infrastructure changes.
 - [Crossplane Repository](https://github.com/crossplane/crossplane) — This is the primary upstream project for the Kubernetes-native control-plane model discussed in the module's Crossplane section.

--- a/src/content/docs/cloud/advanced-operations/module-8.2-transit-hubs.md
+++ b/src/content/docs/cloud/advanced-operations/module-8.2-transit-hubs.md
@@ -19,8 +19,7 @@ After completing this module, you will be able to:
 - **Configure AWS Transit Gateway, GCP Cloud Interconnect, and Azure Virtual WAN for centralized network routing**
 - **Design hub-spoke network topologies that support transitive routing, traffic inspection, and cross-region connectivity**
 - **Implement network segmentation using route tables, firewall appliances, and centralized egress inspection points**
-- **Diagnose cross-region and cross-account routing failures in transit hub architectures using flow logs and route analysis**
-- **Evaluate cross-AZ and cross-region network topologies to mitigate hidden data transfer costs in high-throughput environments**
+- **Diagnose and optimize cross-AZ and cross-region transit topologies** — troubleshoot routing failures with flow logs and route analysis, and mitigate hidden data-transfer costs in high-throughput environments
 - **Debug overlapping CIDR conflicts and implement centralized IP Address Management (IPAM) strategies**
 
 ---
@@ -58,7 +57,7 @@ graph TD
 - 25 VPCs = 300 connections
 - 50 VPCs = 1,225 connections
 
-**Pros**: This pattern offers the lowest possible latency because traffic takes a direct path without intermediate hops. There is no central router to become a single point of failure, no bandwidth bottleneck, and crucially, no per-gigabyte data processing charges for the transit hop itself (in AWS, intra-region VPC peering is free for the connection). In tiny environments, these advantages can simplify troubleshooting because you can map traffic paths by manually tracing peering edges.
+**Pros**: This pattern offers the lowest possible latency because traffic takes a direct path without intermediate hops. There is no central router to become a single point of failure, no bandwidth bottleneck, and crucially, no per-gigabyte data processing charges for the transit hop itself (in AWS, intra-region VPC peering is free for the connection, though cross-AZ peering traffic still incurs roughly $0.01/GB each way). In tiny environments, these advantages can simplify troubleshooting because you can map traffic paths by manually tracing peering edges.
 
 **Cons**: The architecture scales quadratically. Route tables grow linearly per VPC, creating immense administrative burden. [VPC Peering explicitly denies transitive routing](https://docs.aws.amazon.com/whitepapers/latest/aws-vpc-connectivity-options/vpc-peering.html) (if VPC A peers with B, and B peers with C, VPC A cannot reach C through B). Furthermore, there is no centralized inspection point to enforce universal firewall policies.
 
@@ -120,7 +119,7 @@ graph TD
 >
 > <details>
 > <summary>Answer</summary>
-> Full mesh VPC Peering for 30 VPCs requires N*(N-1)/2 = 435 peering connections. Each peering connection requires route table entries in both VPCs. The route table limit is 200 entries per route table (can be raised to 1,000, but at a performance cost). Beyond the route table pressure, managing 435 connections is operationally complex: adding VPC #31 requires 30 new peering connections and 60 new route table entries. Transit Gateway reduces this to N connections (one per VPC) with centralized routing.
+> Full mesh VPC Peering for 30 VPCs requires N*(N-1)/2 = 435 peering connections. Each peering connection requires route table entries in both VPCs. The route table limit is 50 entries per route table (the default; adjustable to 1,000, with a performance caveat). Beyond the route table pressure, managing 435 connections is operationally complex: adding VPC #31 requires 30 new peering connections and 60 new route table entries. Transit Gateway reduces this to N connections (one per VPC) with centralized routing.
 > </details>
 
 ---
@@ -256,12 +255,25 @@ The traffic flow executes in a precise sequence:
 4. If allowed, the packet leaves the Firewall VPC and re-enters the TGW, but this time it is evaluated against the "Inspect" Route Table.
 5. The Inspect RT contains the specific route for VPC-B, delivering the packet successfully.
 
+Enable **appliance mode** on the inspection-VPC TGW attachment: without `appliance_mode_support = "enable"`, Transit Gateway hashes flows per-AZ and return traffic can land on a different AZ's firewall endpoint, breaking stateful inspection.
+
 This architecture introduces additional hop and inspection latency but provides major security benefits:
 - Centralized Intrusion Detection/Prevention (IDS/IPS) for internal traffic.
 - Consolidated logging of all inter-VPC flows in a single pane of glass.
 - Critical capability to block lateral movement by ransomware or compromised Kubernetes pods.
 
 ```hcl
+# Inspection-VPC attachment: appliance mode keeps ingress/return on the same AZ ENI
+resource "aws_ec2_transit_gateway_vpc_attachment" "firewall" {
+  subnet_ids                                      = [aws_subnet.firewall_a.id, aws_subnet.firewall_b.id]
+  transit_gateway_id                              = aws_ec2_transit_gateway.main.id
+  vpc_id                                          = aws_vpc.firewall.id
+  appliance_mode_support                          = "enable"
+  transit_gateway_default_route_table_association = false
+  transit_gateway_default_route_table_propagation = false
+  tags = { Name = "firewall-vpc-attachment" }
+}
+
 # Route all traffic from production to the firewall
 resource "aws_ec2_transit_gateway_route" "prod_default" {
   destination_cidr_block         = "0.0.0.0/0"
@@ -337,7 +349,8 @@ gcloud compute networks subnets create prod-subnet \
   --network=org-network \
   --region=us-central1 \
   --range=10.0.0.0/20 \
-  --secondary-range=pods=10.10.0.0/16,services=10.20.0.0/20
+  --secondary-range=pods=10.10.0.0/16,services=10.20.0.0/20 \
+  --secondary-range=pods-b=10.11.0.0/16
 
 # Grant GKE service account access to the shared subnet
 PROJECT_NUM=$(gcloud projects describe team-a-prod --format="value(projectNumber)")
@@ -356,6 +369,17 @@ gcloud container clusters create team-a-prod \
   --services-secondary-range-name=services \
   --enable-private-nodes \
   --master-ipv4-cidr=172.16.0.0/28
+
+# Second cluster in team-b-prod uses the pods-b secondary range (see diagram)
+gcloud container clusters create team-b-prod \
+  --project=team-b-prod \
+  --region=us-central1 \
+  --network=projects/network-hub-project/global/networks/org-network \
+  --subnetwork=projects/network-hub-project/regions/us-central1/subnetworks/prod-subnet \
+  --cluster-secondary-range-name=pods-b \
+  --services-secondary-range-name=services \
+  --enable-private-nodes \
+  --master-ipv4-cidr=172.16.0.16/28
 ```
 
 > **Stop and think**: In AWS, network segmentation is achieved by isolating workloads into separate VPCs and connecting them via a Transit Gateway with distinct route tables. In GCP's Shared VPC model, multiple environments might share the same VPC. How do you prevent workloads in a staging subnet from communicating with workloads in a production subnet?
@@ -714,7 +738,7 @@ Automated analysis does not remove human reasoning; it shortens the distance bet
 
 ## Did You Know?
 
-1. [**AWS Transit Gateway processes over 100 Gbps per attachment** and supports up to 5,000 attachments per gateway](https://docs.aws.amazon.com/vpc/latest/tgw/transit-gateway-quotas.html). Its release gave AWS customers a managed alternative to self-built transit VPC patterns.
+1. [**AWS Transit Gateway processes up to 100 Gbps per VPC attachment** and supports up to 5,000 attachments per gateway](https://docs.aws.amazon.com/vpc/latest/tgw/transit-gateway-quotas.html). Its release gave AWS customers a managed alternative to self-built transit VPC patterns.
 2. **GCP's Shared VPC is built for large multi-project environments.** Use host projects and shared subnets when multiple teams need centralized network control with delegated project ownership.
 3. **Azure Virtual WAN Standard automatically meshes hubs** within the same Virtual WAN, reducing manual inter-hub routing work over Microsoft's backbone.
 4. **Cross-AZ data transfer in AWS can become a major bill driver at scale.** Track it explicitly instead of assuming it is negligible.
@@ -747,7 +771,7 @@ In AWS, Transit Gateway connects separate VPCs (each with its own CIDR, route ta
 <details>
 <summary>2. Your EKS cluster spans 3 AZs and generates 50TB of cross-AZ traffic monthly. What are two strategies to reduce this cost?</summary>
 
-Strategy 1: Enable topology-aware routing in Kubernetes. Configure Services with `internalTrafficPolicy: Local` where possible, and use the `trafficDistribution: PreferClose` field in your Service spec so kube-proxy prefers endpoints in the same AZ. Strategy 2: Use pod topology spread constraints combined with service affinity to co-locate communicating services in the same AZ. For example, place the API server and its database cache in the same AZ. This requires understanding your service call graph. Together, these can reduce cross-AZ traffic by 40-70%, saving $500-$700/month on a 50TB workload.
+Strategy 1: Enable topology-aware routing in Kubernetes. Configure Services with `internalTrafficPolicy: Local` where possible — that setting is node-local and blackholes traffic if no endpoint exists on the same node, which is distinct from zone-aware `trafficDistribution`. Use `trafficDistribution: PreferSameZone` in your Service spec so kube-proxy prefers endpoints in the same AZ (`PreferClose` remains a deprecated alias as of Kubernetes 1.34). Strategy 2: Use pod topology spread constraints combined with service affinity to co-locate communicating services in the same AZ. For example, place the API server and its database cache in the same AZ. This requires understanding your service call graph. Together, these can reduce cross-AZ traffic by 40-70%, saving $500-$700/month on a 50TB workload.
 </details>
 
 <details>
@@ -771,14 +795,14 @@ Traffic from the 'web' VPC must hit a TGW attachment associated with a 'web' rou
 <details>
 <summary>6. A platform team deployed a multi-region Kubernetes v1.35 architecture. The application operates smoothly, but the monthly cloud bill displays exorbitant data transfer spikes. Upon investigation, they discover that front-end pods in `us-east-1a` are communicating with backend pods in `us-east-1b` and `us-east-1c` equally. How can this architecture be optimized to diminish these costs without sacrificing availability?</summary>
 
-The exorbitant costs stem directly from cross-AZ data transfer, which incurs financial penalties in both directions. The architecture can be deeply optimized by enabling topology-aware routing. By configuring Services with `trafficDistribution: PreferClose` (a feature introduced in Kubernetes 1.30 and fully stable in v1.35), `kube-proxy` actively prioritizes routing network traffic to application endpoints residing strictly within the same Availability Zone. This minimizes wasteful cross-AZ hops and vastly reduces the associated data transfer fees.
+The exorbitant costs stem directly from cross-AZ data transfer, which incurs financial penalties in both directions. The architecture can be deeply optimized by enabling topology-aware routing. By configuring Services with `trafficDistribution: PreferSameZone` (introduced as alpha in 1.30; the value is now `PreferSameZone` with `PreferClose` kept as a deprecated alias, beta and on by default as of 1.34), `kube-proxy` actively prioritizes routing network traffic to application endpoints residing strictly within the same Availability Zone. This minimizes wasteful cross-AZ hops and vastly reduces the associated data transfer fees.
 </details>
 
 ---
 
 ## Hands-On Exercise: Deploy an End-to-End Hub-and-Spoke Network
 
-In this exercise, you will deploy a fully executable hub-and-spoke network topology. You will provision the foundational infrastructure, architect the routing logic, apply the configuration via Terraform, and finalize the setup by deploying a stateful egress firewall. Each step builds toward a reproducible blueprint: first create stable primitives, then enforce segmentation, then validate behavior, then add defensive controls.
+In this exercise, you will deploy a guided hub-and-spoke network topology you can extend to complete end-to-end. You will provision the foundational infrastructure, architect the routing logic, apply the configuration via Terraform, and finalize the setup by deploying a stateful egress firewall. Each step builds toward a reproducible blueprint: first create stable primitives, then enforce segmentation, then validate behavior, then add defensive controls. Task 3 deliberately leaves TGW VPC attachment resources for you to add before apply.
 The exercise intentionally blends architecture, implementation, and validation so the same pattern can be reused in real teams. You are not only building a diagram that works once; you are building a repeatable sequence your team can standardize on. If this feels long in the first pass, it is by design: production-grade network work rewards patience and predictability over speed.
 
 ### Scenario
@@ -1019,7 +1043,7 @@ export LIVE_ACCOUNT=$(aws sts get-caller-identity --query Account --output text)
 export LIVE_VPC=$(terraform output -raw egress_vpc_id)
 export LIVE_SUBNET=$(terraform output -raw egress_subnet_id)
 ```
-Replace `ACCOUNT` with `$LIVE_ACCOUNT`, `vpc-egress123` with `$LIVE_VPC`, and `subnet-fw-az1` with `$LIVE_SUBNET` within the bash snippet below prior to running it.
+Replace `ACCOUNT` with `$LIVE_ACCOUNT`, `vpc-egress123` with `$LIVE_VPC`, and `subnet-fw-az1` with `$LIVE_SUBNET` within the bash snippet below prior to running it. The scaffold provisions one subnet per VPC (single-AZ lab); use only that mapping.
 
 <details>
 <summary>Solution</summary>
@@ -1072,7 +1096,7 @@ aws network-firewall create-firewall \
   --firewall-name "datastream-egress-fw" \
   --firewall-policy-arn "arn:aws:network-firewall:us-east-1:ACCOUNT:firewall-policy/datastream-egress-policy" \
   --vpc-id vpc-egress123 \
-  --subnet-mappings SubnetId=subnet-fw-az1 SubnetId=subnet-fw-az2
+  --subnet-mappings SubnetId=subnet-fw-az1
 ```
 </details>
 

--- a/src/content/docs/cloud/advanced-operations/module-8.3-cross-cluster-networking.md
+++ b/src/content/docs/cloud/advanced-operations/module-8.3-cross-cluster-networking.md
@@ -125,6 +125,19 @@ Choosing between these topologies is a foundational platform engineering decisio
 
 When this pattern appears during diligence, the highest-value move is to separate integration decisions from migration urgency. If you can define a long-lived network contract first, teams are less likely to make dangerous temporary exceptions just to satisfy timelines. The costliest mistakes usually occur when one team forces flat networking despite overlap constraints and then spends months papering over routing defects with manual service lists. In those cases, the architecture debt compounds because every workaround gets replicated across every future cluster purchase.
 
+## Patterns & Anti-Patterns
+
+| Pattern / Anti-Pattern | Problem | Better approach |
+|---|---|---|
+| **Pattern: Island + explicit gateways** | Overlapping pod CIDRs block flat routing | Treat each cluster as an island; expose only gateway-approved services |
+| **Pattern: Topology-aware Services** | Cross-AZ traffic inflates transfer bills | Set `trafficDistribution: PreferClose` and validate with flow telemetry |
+| **Anti-pattern: Forcing flat networking after M&A** | Overlapping `10.244.0.0/16` ranges break routing | Default to island networking until IPAM is reconciled |
+| **Anti-pattern: Hardcoded ClusterIPs** | ClusterIPs are local to one cluster | Use `*.svc.cluster.local`, MCS `*.svc.clusterset.local`, or Cilium global services |
+| **Anti-pattern: ClusterIP for cross-cluster** | No routable endpoint outside the cluster | Use LoadBalancer/NodePort, Cilium `service.cilium.io/global`, or MCS `ServiceExport` |
+| **Anti-pattern: Flat mesh without policies** | Any compromised pod can probe remote pods | Enforce `CiliumNetworkPolicy` / `NetworkPolicy` on cross-cluster paths |
+| **Anti-pattern: DNS-only failover without drills** | TTL caching delays regional cutover | Pair low TTLs with health checks, or use anycast (Global Accelerator / GCP global LB) |
+| **Anti-pattern: Ignoring split-brain** | Partitions cause duplicate writes | Run partition chaos tests; fail write probes and enter safe mode |
+
 ## Cilium Cluster Mesh
 
 Many teams adopt Cilium Cluster Mesh after they have already validated a flat-routing baseline and then discover that IP overlap, operational speed, and zero-change service discovery are the constraints that matter most. This is a practical evolution path because it lets teams preserve existing workload behavior while adding cross-cluster reach. In effect, you can stop treating network boundaries as application concerns and treat them as part of the platform substrate, which is exactly where transport abstractions should live in mature organizations.
@@ -220,8 +233,8 @@ metadata:
   namespace: payments
   annotations:
     # Optional: prefer local endpoints, use remote only as fallback
-    io.cilium/global-service: "true"
-    io.cilium/service-affinity: "local"
+    service.cilium.io/global: "true"
+    service.cilium.io/affinity: "local"
 spec:
   selector:
     app: fraud-detection
@@ -229,6 +242,8 @@ spec:
     - port: 8080
       targetPort: 8080
 ```
+
+> **Cilium 1.13+ annotations**: Cluster Mesh services use `service.cilium.io/global` and `service.cilium.io/affinity`. On Cilium releases before 1.13, the legacy spellings `io.cilium/global-service` and `io.cilium/service-affinity` are equivalent.
 
 By default, Cilium load-balances traffic globally. However, for latency-sensitive applications, maintaining local affinity is paramount. You can explicitly define service affinity rules to govern endpoint selection. In failure scenarios, those rules also give you a deterministic fallback strategy, because they control whether local capacity exhaustion will spill traffic to remote endpoints or prioritize consistency by reducing cross-cluster fan-out.
 
@@ -239,17 +254,17 @@ By default, Cilium load-balances traffic globally. However, for latency-sensitiv
 # "none"   - load-balance equally across all clusters (default)
 ```
 
-If you wish to prevent a service from being exposed to the global mesh entirely, you simply omit the `global-service` annotation. Use that boundary intentionally for internal-only APIs, especially when operational risk increases if a debugging pod in one cluster can resolve sensitive endpoints in another without explicit authorization policy.
+If you wish to prevent a service from being exposed to the global mesh entirely, you simply omit the `service.cilium.io/global` annotation. Use that boundary intentionally for internal-only APIs, especially when operational risk increases if a debugging pod in one cluster can resolve sensitive endpoints in another without explicit authorization policy.
 
 ```yaml
 # To make a service available ONLY to the local cluster
-# (not exported to cluster mesh), omit the global-service annotation
+# (not exported to cluster mesh), omit the service.cilium.io/global annotation
 apiVersion: v1
 kind: Service
 metadata:
   name: internal-cache
   namespace: payments
-  # No io.cilium/global-service annotation = local only
+  # No service.cilium.io/global annotation = local only
 spec:
   selector:
     app: redis-cache
@@ -257,7 +272,7 @@ spec:
     - port: 6379
 ```
 
-> **Pause and predict**: If you annotate a service with `io.cilium/service-affinity: "local"`, what happens when all local endpoints for that service crash? Will the requests fail, or will they route to the remote cluster?
+> **Pause and predict**: If you annotate a service with `service.cilium.io/affinity: "local"`, what happens when all local endpoints for that service crash? Will the requests fail, or will they route to the remote cluster?
 
 ### Network Policies Across Boundaries
 
@@ -439,6 +454,8 @@ Monitoring is the difference between “believing” and “proving” where you
 
 To truly optimize costs, you must possess the ability to actively monitor and quantify cross-AZ communication patterns using raw network flow telemetry. Cost optimization without telemetry is guessing, because traffic spikes can appear after a code deployment and remain invisible in coarse service metrics for hours. By instrumenting subnet-level flow analysis, you can distinguish application-driven growth from topology misconfiguration and choose the least risky mitigation with confidence.
 
+> **VPC Flow Logs limitation**: The optional `${az-id}` field records only the Availability Zone of the **logged ENI**, not the destination endpoint's AZ. Native flow logs do **not** expose a `dst_az_id` column. To classify true cross-AZ pod traffic in Athena, enrich records (for example via Amazon Data Firehose plus Lambda) with destination subnet/AZ metadata, or join `srcaddr`/`dstaddr` against your pod→node→subnet→AZ inventory table.
+
 ```bash
 # Use VPC Flow Logs to identify cross-AZ traffic patterns
 # Enable flow logs on each subnet
@@ -450,21 +467,20 @@ aws ec2 create-flow-logs \
   --log-destination arn:aws:s3:::vpc-flow-logs-bucket \
   --log-format '${az-id} ${srcaddr} ${dstaddr} ${bytes} ${flow-direction}'
 
-# Query with Athena to find top cross-AZ talkers
-# (assumes flow logs are partitioned in S3)
+# Query with Athena to rank high-volume pod CIDR flows (native fields only)
+# (assumes flow logs are partitioned in S3; join/enrich for true cross-AZ classification)
 cat <<'SQL'
 SELECT
+  az_id,
   srcaddr,
   dstaddr,
-  az_id,
   SUM(bytes) / 1073741824 AS gb_transferred,
   SUM(bytes) / 1073741824 * 0.01 AS estimated_cost_usd
 FROM vpc_flow_logs
 WHERE srcaddr LIKE '100.64.%'   -- pod CIDR
   AND dstaddr LIKE '100.64.%'   -- pod CIDR
-  AND az_id != dst_az_id         -- cross-AZ
   AND date = '2026-03-24'
-GROUP BY srcaddr, dstaddr, az_id
+GROUP BY az_id, srcaddr, dstaddr
 ORDER BY gb_transferred DESC
 LIMIT 20
 SQL
@@ -495,6 +511,16 @@ Different cloud providers employ drastically different technological approaches 
 - **GCP Ecosystem: Cloud Load Balancing (Global Tier)**
   - Google utilizes a uniquely powerful model providing [a single global Anycast IP address](https://cloud.google.com/load-balancing/docs/load-balancing-overview) that routes HTTP(S), TCP, and UDP traffic across the entire world.
   - It seamlessly features profound, native integration directly with GKE Network Endpoint Groups (NEGs).
+
+- **Azure Ecosystem: AKS networking + global front door**
+  - For cross-cluster east-west on AKS, teams commonly pair [Azure CNI Overlay](https://learn.microsoft.com/en-us/azure/aks/azure-cni-overlay) (overlapping pod space per cluster) with explicit gateways, or adopt [Azure CNI Powered by Cilium](https://learn.microsoft.com/en-us/azure/aks/azure-cni-powered-by-cilium) for Cilium Cluster Mesh–style global services.
+  - For multi-region user ingress, [Azure Front Door](https://learn.microsoft.com/en-us/azure/frontdoor/front-door-overview) (anycast edge + health probes) and [Traffic Manager](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-overview) (DNS-based latency/failover routing) mirror the AWS Global Accelerator / Route53 split.
+
+| Provider | Cross-cluster CNI / discovery | Multi-region external ingress |
+|---|---|---|
+| AWS | VPC CNI flat routes, MCS via fleet patterns | Route53 + Global Accelerator |
+| GCP | GKE MCS API, multi-cluster Gateway | Global external HTTP(S) LB + NEGs |
+| Azure | Azure CNI Overlay or Cilium on AKS | Azure Front Door + Traffic Manager |
 
 ### Provisioning GCP Global Load Balancers with Multi-Cluster Gateways
 
@@ -940,7 +966,7 @@ kind: Service
 metadata:
   name: rebel-base
   annotations:
-    io.cilium/global-service: "true"
+    service.cilium.io/global: "true"
 spec:
   selector:
     app: rebel-base
@@ -980,7 +1006,7 @@ kind: Service
 metadata:
   name: rebel-base
   annotations:
-    io.cilium/global-service: "true"
+    service.cilium.io/global: "true"
 spec:
   selector:
     app: rebel-base
@@ -1015,7 +1041,7 @@ kubectl --context kind-cluster-a run test-client \
 
 # Now test with local affinity
 kubectl --context kind-cluster-a annotate service rebel-base \
-  io.cilium/service-affinity=local --overwrite
+  service.cilium.io/affinity=local --overwrite
 
 # Run the test again - should strongly prefer Cluster A
 kubectl --context kind-cluster-a run test-client-2 \
@@ -1070,3 +1096,8 @@ Review these critical milestones prior to formally closing out your lab session 
 - [docs.aws.amazon.com: introduction how it works.html](https://docs.aws.amazon.com/global-accelerator/latest/dg/introduction-how-it-works.html) — AWS Global Accelerator docs directly state that its static IPs are anycast from the edge network and use the AWS global network.
 - [cloud.google.com: load balancing overview](https://cloud.google.com/load-balancing/docs/load-balancing-overview) — Google's load-balancing overview directly describes a single anycast IP and automatic multi-region failover.
 - [Kubernetes Topology Aware Routing](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/) — Explains the core zone-local routing concept and the older topology-hints model behind cost-aware service routing.
+- [docs.cilium.io: global service](https://docs.cilium.io/en/stable/network/clustermesh/global-service/) — Documents `service.cilium.io/global` and `service.cilium.io/affinity` for Cluster Mesh global services (Cilium 1.13+).
+- [docs.aws.amazon.com: flow logs](https://docs.aws.amazon.com/vpc/latest/userguide/flow-logs.html) — Defines native VPC Flow Log fields, including `${az-id}` for the logged ENI only.
+- [learn.microsoft.com: azure cni overlay](https://learn.microsoft.com/en-us/azure/aks/azure-cni-overlay) — Describes per-cluster overlapping pod CIDRs on AKS with overlay routing.
+- [learn.microsoft.com: azure cni powered by cilium](https://learn.microsoft.com/en-us/azure/aks/azure-cni-powered-by-cilium) — Covers AKS with Cilium datapath for advanced cross-cluster networking options.
+- [learn.microsoft.com: front door overview](https://learn.microsoft.com/en-us/azure/frontdoor/front-door-overview) — Azure Front Door anycast edge routing and health-based failover for multi-region ingress.

--- a/src/content/docs/cloud/advanced-operations/module-8.4-enterprise-identity.md
+++ b/src/content/docs/cloud/advanced-operations/module-8.4-enterprise-identity.md
@@ -64,6 +64,24 @@ To secure an enterprise environment, you must distinguish between three fundamen
 
 The critical insight for platform engineers: in a Kubernetes world, **workload identity is the most important identity type**. Pods need cloud credentials to access databases, secret stores, message queues, and cloud storage. How you securely provision those credentials determines your overall security posture.
 
+### Enterprise Identity Foundations: Humans, Machines, and Workloads
+
+Enterprise identity architecture starts with a single question: who or what is making this request, and who vouches for them? At scale, the answer spans three distinct identity classes that must never be conflated. Human identities represent engineers, auditors, and on-call responders who authenticate through an enterprise Identity Provider (IdP) such as [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/fundamentals/whatis), Okta, or Ping Identity. Machine identities represent cloud compute principals—EC2 instance profiles, GCE default service accounts attached to VMs, and Azure managed identities on nodes—that inherit credentials from the host. Workload identities represent application-level principals inside Kubernetes: a pod's ServiceAccount token, exchanged for cloud credentials through federation.
+
+The IdP is your organizational source of truth for human identity. It stores (or federates to) user records, group memberships, MFA enrollment, and lifecycle events such as hire, transfer, and termination. Cloud control planes and Kubernetes clusters should never maintain parallel user directories. Instead, they trust assertions from the IdP: SAML assertions for browser-based SSO, OIDC ID tokens for modern CLI and API flows, and SCIM (System for Cross-domain Identity Management) for automated provisioning and deprovisioning of users and groups into downstream systems.
+
+SSO via SAML or OIDC eliminates password sprawl across dozens of cloud consoles and cluster endpoints. When an engineer authenticates to Okta, Okta issues a signed assertion that AWS IAM Identity Center, GCP Workforce Identity Federation, or Azure Entra ID validates before granting a short-lived cloud session. [SCIM provisioning](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups) automates the mirror image: when HR offboards an employee in the IdP, SCIM deletes or disables their cloud accounts within minutes rather than waiting for a quarterly access review to discover orphaned access.
+
+The trust chain for human access follows a predictable pattern across all three hyperscalers. The user authenticates to the IdP. The IdP issues a federation token to the cloud identity layer. The cloud layer maps IdP groups to cloud permissions. For Kubernetes access, a final hop maps cloud-authenticated principals to in-cluster RBAC groups. Each hop must be auditable, time-bounded, and scoped to least privilege. A break anywhere in this chain—stale group membership, a misconfigured attribute mapping, or a ClusterRoleBinding that references the wrong OIDC group—creates either an outage (legitimate users locked out) or a breach path (former employees retaining cluster-admin).
+
+| Identity class | Primary authenticator | Typical lifetime | Federation protocol | Deprovisioning trigger |
+|---|---|---|---|---|
+| Human (workforce) | Enterprise IdP (Entra, Okta, Ping) | 1–12 hour SSO session | SAML 2.0 or OIDC | SCIM delete / IdP group removal |
+| Machine (cloud host) | Cloud metadata service (IMDS) | Instance lifetime | Platform-native (no external IdP) | Instance termination |
+| Workload (K8s pod) | Kubernetes ServiceAccount JWT | Pod lifetime (minutes to days) | OIDC token exchange (IRSA, Workload ID) | Pod deletion / SA rotation |
+
+Hypothetical scenario: A platform team provisions AWS, GCP, and Azure access for a new hire by creating native cloud user accounts in each provider. Six months later, the employee transfers to a non-technical role, but only the AWS account is disabled because GCP and Azure accounts were created manually and never linked to the IdP. The employee retains GKE cluster-admin through a stale Google Group membership. This is identity sprawl—the operational and security tax of maintaining parallel identity stores instead of federating everything through a single IdP with SCIM-driven lifecycle automation.
+
 ---
 
 ## Cross-Account Role Assumption (AWS)
@@ -141,12 +159,20 @@ aws iam put-role-policy \
         "Effect": "Allow",
         "Action": [
           "eks:DescribeCluster",
-          "eks:ListClusters",
           "eks:AccessKubernetesApi",
-          "eks:ListNodegroups",
-          "eks:DescribeNodegroup"
+          "eks:ListNodegroups"
         ],
         "Resource": "arn:aws:eks:*:222222222222:cluster/*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": "eks:ListClusters",
+        "Resource": "*"
+      },
+      {
+        "Effect": "Allow",
+        "Action": "eks:DescribeNodegroup",
+        "Resource": "arn:aws:eks:*:222222222222:nodegroup/*/*/*"
       }
     ]
   }'
@@ -184,6 +210,16 @@ aws eks update-kubeconfig --name prod-cluster --region us-east-1
 ```
 
 By heavily relying on `sts:AssumeRole`, we eliminate long-lived keys. If the developer's laptop is compromised, the credentials are only valid for a maximum of 3600 seconds.
+
+### Cross-Account and Cross-Project Equivalents (GCP and Azure)
+
+AWS popularized cross-account role assumption, but GCP and Azure solve the same organizational boundary problem with different primitives. Understanding all three prevents teams from building AWS-only runbooks that fail when a GKE or AKS cluster enters the portfolio.
+
+On GCP, cross-project access uses [service account impersonation](https://cloud.google.com/iam/docs/service-account-impersonation) rather than STS AssumeRole. A principal in Project A receives the `roles/iam.serviceAccountTokenCreator` role on a service account in Project B, then calls `gcloud auth print-access-token --impersonate-service-account=...` to obtain a short-lived token. For human engineers, Workforce Identity Federation tokens map to IAM bindings at the organization, folder, or project level—there is no separate "switch project" step because GCP IAM evaluates permissions across the resource hierarchy in a single evaluation.
+
+On Azure, cross-subscription access uses [Azure RBAC role assignments](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments) scoped to management groups, subscriptions, or resource groups. An Entra ID group receives `Azure Kubernetes Service Cluster Admin Role` at the management-group level, granting access to every AKS cluster beneath that scope without per-cluster configuration. [Azure Lighthouse](https://learn.microsoft.com/en-us/azure/lighthouse/overview) extends this model for managed service providers who administer customer tenants—delegated RBAC assignments that respect the customer's Entra ID policies while giving the MSP operational access.
+
+The Kubernetes implication is identical across clouds: human access should never require long-lived credentials stored on a laptop. Whether the mechanism is STS AssumeRole, GCP impersonation, or Azure RBAC at management-group scope, the session must be time-bounded, MFA-protected where possible, and fully logged in a centralized audit trail.
 
 ---
 
@@ -255,9 +291,13 @@ resource "aws_ssoadmin_permission_set_inline_policy" "prod_readonly_eks" {
     Statement = [
       {
         Effect = "Allow"
+        Action = ["eks:ListClusters"]
+        Resource = "*"
+      },
+      {
+        Effect = "Allow"
         Action = [
           "eks:DescribeCluster",
-          "eks:ListClusters",
           "eks:AccessKubernetesApi"
         ]
         Resource = "*"
@@ -287,6 +327,55 @@ resource "aws_ssoadmin_account_assignment" "sre_prod_admin" {
 ```
 
 Notice how `prod_admin` uses a highly restricted session duration (`PT1H`). Administrative tasks in production should be fast, deliberate, and fully audited.
+
+### Federating Your IdP into Every Cloud Control Plane
+
+IAM Identity Center is AWS's answer to the "one front door" problem, but GCP and Azure solve the same problem with different primitives. Understanding all three side by side prevents teams from building AWS-only identity patterns that fail the moment a GKE or AKS cluster enters the portfolio.
+
+On AWS, the federation path is: IdP (SAML/OIDC) → IAM Identity Center → Permission Sets → account-local IAM roles → (optional) EKS access entries. [Permission sets are templates](https://docs.aws.amazon.com/singlesignon/latest/userguide/permissionsetsconcept.html) that Identity Center materializes as IAM roles in each assigned account. SCIM sync from the IdP keeps users and groups current; when a user leaves the `platform-eng` group in Okta, their Identity Center assignments disappear on the next sync cycle.
+
+GCP offers two workforce paths. [Cloud Identity / Google Workspace](https://cloud.google.com/iam/docs/user-identities) with directory sync creates managed Google accounts that authenticate through your IdP—useful when teams need Gmail-style identities. [Workforce Identity Federation](https://cloud.google.com/iam/docs/workforce-identity-federation) is the syncless alternative: users authenticate directly through OIDC or SAML without creating Google accounts at all. Workforce pools use attribute mapping (`google.subject=assertion.sub`, `google.groups=assertion.groups`) and attribute conditions to translate IdP claims into IAM bindings. A condition like `assertion.groups.contains('gke-admins')` can restrict console access to a specific Entra ID group without provisioning individual Google identities.
+
+Azure centralizes human access through [Microsoft Entra ID](https://learn.microsoft.com/en-us/entra/fundamentals/whatis) groups mapped to [Azure RBAC role assignments](https://learn.microsoft.com/en-us/azure/role-based-access-control/role-assignments) at management group, subscription, or resource-group scope. Entra ID PIM (Privileged Identity Management) adds just-in-time activation for elevated roles—an engineer requests `Owner` on a production subscription, receives a time-limited assignment after approval, and the assignment auto-expires. For Kubernetes specifically, Entra groups become subjects in RoleBindings or feed the Entra ID authorization webhook for multi-cluster Azure RBAC governance.
+
+```mermaid
+flowchart TD
+    subgraph IdP [Enterprise IdP — Source of Truth]
+        Users[Users + Groups]
+        SCIM[SCIM Provisioning]
+    end
+
+    subgraph AWS [AWS Control Plane]
+        IC[IAM Identity Center]
+        PS[Permission Sets]
+        AcctRoles[Account IAM Roles]
+    end
+
+    subgraph GCP [GCP Control Plane]
+        WIF[Workforce Identity Federation]
+        CI[Cloud Identity / Workspace]
+        IAM[GCP IAM Bindings]
+    end
+
+    subgraph Azure [Azure Control Plane]
+        Entra[Microsoft Entra ID]
+        PIM[Entra PIM — JIT Roles]
+        AzRBAC[Azure RBAC Assignments]
+    end
+
+    Users -->|"SAML / OIDC SSO"| IC
+    Users -->|"OIDC / SAML"| WIF
+    Users -->|"OIDC / SAML"| CI
+    Users -->|"Native Entra auth"| Entra
+    SCIM --> IC
+    SCIM --> Entra
+    IC --> PS --> AcctRoles
+    WIF --> IAM
+    CI --> IAM
+    Entra --> PIM --> AzRBAC
+```
+
+The operational lesson across providers: never create standalone cloud-local user accounts for employees. Every human should enter through the IdP federation path, with SCIM or equivalent group sync driving provisioning and deprovisioning. Native cloud users should be reserved for break-glass emergencies and service automation—not daily engineering access.
 
 ---
 
@@ -414,7 +503,7 @@ OIDC_ISSUER=$(az aks show \
 az identity create \
   --name "team-a-keyvault-reader" \
   --resource-group identity-rg \
-  --subscription IDENTITY_SUB_ID
+  --subscription $IDENTITY_SUB_ID
 
 CLIENT_ID=$(az identity show \
   --name "team-a-keyvault-reader" \
@@ -449,6 +538,112 @@ metadata:
   labels:
     azure.workload.identity/use: "true"
 EOF
+```
+
+---
+
+## Mapping Enterprise IdP Groups to Kubernetes RBAC
+
+Cloud IAM gets an engineer to the cluster API server door. Kubernetes RBAC decides what they can do once inside. The mapping between enterprise groups and in-cluster permissions is where most multi-cloud identity architectures succeed or fail—and each provider offers a different integration point.
+
+### The OIDC Token Flow and Trust Chain
+
+Regardless of cloud provider, the Kubernetes authentication flow for human users follows the same abstract pattern. The user obtains an OIDC token from the enterprise IdP (directly or via a cloud federation layer). The cloud provider's identity bridge validates the token and maps it to a cloud principal. The Kubernetes API server receives the authenticated request with a username and group list. RBAC bindings match those groups to Roles or ClusterRoles. If any link in this chain is misconfigured, the user sees `Forbidden` errors that are painful to debug because the failure could be in the IdP, the cloud layer, or the cluster RBAC itself.
+
+```mermaid
+sequenceDiagram
+    participant User as Engineer
+    participant IdP as Enterprise IdP
+    participant Cloud as Cloud Identity Layer
+    participant K8s as Kubernetes API Server
+    participant RBAC as RBAC Authorizer
+
+    User->>IdP: Authenticate (SSO + MFA)
+    IdP->>User: OIDC ID token (groups claim)
+    User->>Cloud: Exchange token for cloud session
+    Cloud->>Cloud: Map IdP groups → cloud principal
+    User->>K8s: kubectl with cloud-authenticated identity
+    K8s->>Cloud: Validate token via webhook / authenticator
+    Cloud-->>K8s: Username + groups
+    K8s->>RBAC: Check RoleBinding for groups
+    RBAC-->>User: Allow or Forbidden
+```
+
+### EKS: Access Entries and IAM-to-RBAC Mapping
+
+Amazon EKS has migrated from the legacy `aws-auth` ConfigMap to [EKS access entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html) as the recommended authentication mode. Access entries map IAM principals (users or roles created by IAM Identity Center permission sets) to Kubernetes permissions through either AWS-managed EKS access policies or explicit Kubernetes group membership. When you assign the `AmazonEKSViewPolicy` access policy to an IAM role at namespace scope, the engineer gets view-only access without manually editing ConfigMaps or creating ClusterRoleBindings.
+
+For teams that need fine-grained, GitOps-managed RBAC, the Kubernetes groups approach remains available. You create an access entry with `--kubernetes-groups platform-eng` and then manage a `ClusterRoleBinding` that grants the `platform-eng` group a custom `ClusterRole`. [Access entries take precedence over ConfigMap entries](https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html) for the same IAM principal, so migration requires creating access entries before removing ConfigMap mappings.
+
+```bash
+# Map an IAM Identity Center permission-set role to a Kubernetes RBAC group
+aws eks create-access-entry \
+  --cluster-name prod-cluster \
+  --principal-arn arn:aws:iam::222222222222:role/aws-reserved/sso.amazonaws.com/us-east-1/AWSReservedSSO_ProdReadOnly_a1b2c3d4 \
+  --type STANDARD \
+  --kubernetes-groups platform-readonly
+
+# The ClusterRoleBinding (managed via GitOps) completes the chain:
+# Group "platform-readonly" → ClusterRole "view" (or custom role)
+```
+
+### GKE: Google Groups for RBAC
+
+GKE integrates enterprise group membership through [Google Groups for RBAC](https://cloud.google.com/kubernetes-engine/docs/how-to/google-groups-rbac). You create a required umbrella group named `gke-security-groups@yourdomain.com`, nest team groups (such as `platform-eng@yourdomain.com`) as members, and enable the feature on the cluster with `--security-group=gke-security-groups@yourdomain.com`. ClusterRoleBindings then reference team group emails as `kind: Group` subjects. Google Workspace administrators manage membership entirely outside GKE—when someone joins the platform team in Entra ID (synced to Google Groups via cloud identity federation), they automatically gain the corresponding cluster permissions.
+
+This pattern scales to multi-cluster fleets through the [Connect gateway](https://cloud.google.com/kubernetes-engine/enterprise/multicluster-management/gateway/setup-groups), which propagates group membership information across registered clusters. Instead of maintaining RBAC bindings per cluster per user, you maintain bindings per cluster per group—a reduction from O(users × clusters) to O(groups × clusters).
+
+### AKS: Entra ID Integration with Kubernetes RBAC
+
+AKS supports two complementary authorization models. [Kubernetes RBAC with Entra integration](https://learn.microsoft.com/en-us/azure/aks/azure-ad-rbac) authenticates users via Entra ID tokens and authorizes them through native Kubernetes RoleBindings where the subject is an Entra group object ID. [Entra ID authorization for the Kubernetes API](https://learn.microsoft.com/en-us/azure/aks/entra-id-authorization) delegates authorization to Azure RBAC at subscription or management-group scope—ideal when you need one role assignment to govern dozens of clusters without applying manifests to each one.
+
+For the Kubernetes RBAC path, the setup mirrors EKS access entries conceptually: enable Entra integration on the cluster, create a `Role` scoped to a namespace, and bind it to an Entra group:
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: appdev-namespace-access
+  namespace: development
+subjects:
+  - kind: Group
+    apiGroup: rbac.authorization.k8s.io
+    name: "aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee"  # Entra group object ID
+roleRef:
+  kind: Role
+  name: namespace-developer
+  apiGroup: rbac.authorization.k8s.io
+```
+
+Retrieve the group object ID with `az ad group show --group appdev --query id -o tsv`. Always use `--admin` sparingly: the cluster admin kubeconfig bypasses Entra authentication entirely, which defeats the purpose of enterprise identity integration.
+
+---
+
+## AWS Workload Identity: IRSA and EKS Pod Identity
+
+The Azure and GCP sections above cover workload identity for those platforms. AWS offers two mechanisms—IRSA and EKS Pod Identity—and choosing between them affects trust policy complexity, cross-account access, and operational ownership.
+
+[IRSA (IAM Roles for Service Accounts)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) uses the cluster's OIDC issuer. Each IAM role's trust policy must reference the OIDC provider and constrain the `sub` claim to a specific `system:serviceaccount:namespace:name` combination. The pod annotation `eks.amazonaws.com/role-arn` tells the AWS SDK which role to assume via `AssumeRoleWithWebIdentity`. IRSA supports direct cross-account access: a pod in Account A can assume a role in Account B if the trust policy permits the OIDC `sub` claim from Account A's cluster.
+
+[EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) simplifies the model by eliminating per-cluster OIDC provider setup. Associations between Kubernetes service accounts and IAM roles are managed through the EKS API (`aws eks create-pod-identity-association`), and a node-level Pod Identity Agent delivers credentials to pods. AWS [recommends Pod Identity for most new deployments](https://docs.aws.amazon.com/eks/latest/best-practices/identity-and-access-management.html) because it separates duties cleanly: EKS administrators manage associations, IAM administrators manage role permissions, and no one needs to touch OIDC provider configuration in every account.
+
+| Capability | IRSA | EKS Pod Identity |
+|---|---|---|
+| Requires OIDC provider per cluster | Yes | No |
+| Cross-account role assumption | Direct via `AssumeRoleWithWebIdentity` | Indirect via role chaining |
+| Trust policy management | Per-role, per-cluster OIDC conditions | Single EKS service principal |
+| ABAC session tags | No | Yes |
+| Annotation key | `eks.amazonaws.com/role-arn` | Association via EKS API (no annotation required) |
+
+Both mechanisms eliminate long-lived static credentials. Neither replaces Kubernetes RBAC: a pod's cloud identity determines what AWS APIs it can call, while Kubernetes RBAC determines what cluster resources the pod's ServiceAccount can access. Defense in depth requires configuring both layers independently.
+
+```bash
+# EKS Pod Identity: create association (replaces IRSA trust policy per cluster)
+aws eks create-pod-identity-association \
+  --cluster-name prod-cluster \
+  --namespace analytics \
+  --service-account s3-reader \
+  --role-arn arn:aws:iam::222222222222:role/pod-s3-reader
 ```
 
 ---
@@ -602,6 +797,14 @@ Here is an example of an EKS Audit log showing the mapped AWS identity. Notice h
 
 By querying your SIEM for `user.extra.sessionName = "alice-session"`, you can track Alice's actions across the cloud provider and inside the Kubernetes cluster seamlessly.
 
+### Multi-Cloud Audit Correlation
+
+Stitching identity events across AWS, GCP, and Azure requires a normalized schema in your SIEM because each provider uses different field names for the same concept. CloudTrail records `userIdentity.arn` and `userIdentity.sessionContext`; GCP Cloud Audit Logs record `authenticationInfo.principalEmail` and `authenticationInfo.serviceAccountKeyName`; Azure Activity Log records `caller` and `claims.appid`. Your correlation rule should map all three to a canonical `actor_id` field and join on timestamp windows when tracking cross-cloud pivot attacks.
+
+For Kubernetes audit logs, the `user.extra` fields differ by cloud authenticator. EKS embeds the AWS STS assumed-role ARN; GKE embeds the Google account or group email; AKS embeds the Entra object ID or UPN. Forward all cluster audit logs to the same immutable storage tier as cloud provider logs—splitting them by provider defeats the purpose of centralized identity forensics. Set alerts on high-risk verbs (`create secrets`, `delete namespace`, `patch clusterrolebinding`) combined with off-hours timestamps and principals that lack an active JIT approval record.
+
+Hypothetical scenario: An attacker compromises a CI/CD service account in a dev AWS account, assumes a cross-account role into production, and creates a privileged pod. Without correlated logging, the production CloudTrail entry shows a legitimate-looking `AssumeRole` from a known CI role—the dev-account compromise is invisible. With organization-wide CloudTrail, SIEM correlation on `sourceIPAddress`, `sessionName`, and the chain of `AssumeRole` events across accounts, the full attack path becomes reconstructable within minutes instead of days.
+
 ---
 
 ## Just-In-Time (JIT) Access
@@ -636,6 +839,24 @@ sequenceDiagram
 ### Implementing JIT with AWS SSO Permission Sets
 
 You can implement a basic JIT system using AWS SSO APIs combined with automation tools like ConductorOne or Indent.
+
+### JIT Access Across GCP and Azure
+
+AWS Identity Center permission set assignments are one JIT implementation, but GCP and Azure offer native equivalents that multi-cloud platform teams should configure in parallel rather than treating JIT as an AWS-only concern.
+
+On GCP, [IAM Conditions](https://cloud.google.com/iam/docs/conditions-overview) provide time-bound access without a separate JIT product. A binding with `request.time.getHours("America/New_York") >= 9 && request.time.getHours("America/New_York") <= 17` restricts cluster developer access to business hours. For stronger controls, integrate with [Entra PIM](https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-deployment-plan) or a third-party JIT platform that calls the GCP Resource Manager API to add and remove IAM bindings on a schedule. Privileged Access Manager (GCP's native JIT product, where available in your organization) provides approval workflows similar to Entra PIM with audit trails in Cloud Audit Logs.
+
+On Azure, [Entra Privileged Identity Management](https://learn.microsoft.com/en-us/entra/id-governance/privileged-identity-management/pim-deployment-plan) is the primary JIT mechanism. Eligible role assignments require activation with MFA, justification, and optional approver consent before the assignment becomes active. For AKS specifically, PIM-eligible `Azure Kubernetes Service Cluster Admin Role` assignments at subscription scope mean an engineer requests elevation, activates for two hours, performs the kubectl operation, and the role deactivates automatically—no CronJob cleanup required because Azure RBAC handles the lifecycle.
+
+The Kubernetes layer still needs its own JIT regardless of cloud provider. Even if cloud IAM access is time-bound, a stale ClusterRoleBinding with `cluster-admin` persists until something deletes it. Best practice: cloud JIT grants the cloud-authenticated identity; Kubernetes JIT (temporary RoleBinding with label-based expiry) grants the in-cluster permissions—both must expire together, orchestrated by the same approval ticket.
+
+```bash
+# GCP: time-bound IAM binding example (business-hours-only cluster access)
+gcloud projects add-iam-policy-binding team-a-prod \
+  --member="group:platform-eng@company.com" \
+  --role="roles/container.developer" \
+  --condition='expression=request.time.getHours("America/New_York") >= 9 && request.time.getHours("America/New_York") <= 17,title=business-hours-only'
+```
 
 ```bash
 # Create a "break-glass" permission set with short duration
@@ -725,6 +946,124 @@ spec:
 
 ---
 
+## Least Privilege at Enterprise Scale
+
+Temporary credentials and federation solve the "how do identities authenticate" problem. Least privilege at enterprise scale solves "what are they allowed to do once authenticated"—and this is where most organizations accumulate dangerous standing access over years of incremental role grants.
+
+**Permission boundaries** (AWS) and **organization policies** (GCP) / **Azure Policy** set guardrails that cap maximum permissions regardless of what individual role assignments grant. An AWS permissions boundary on a CI/CD role ensures that even if someone attaches `AdministratorAccess`, the effective permissions cannot exceed the boundary policy. This is essential when multiple teams can create IAM roles independently across dozens of accounts.
+
+**Just-in-time (JIT) access** eliminates standing admin privileges—the pattern covered earlier in this module with ConductorOne, Entra PIM, and Kubernetes CronJob cleanup. At enterprise scale, JIT must cover all three layers: cloud console/API access (Identity Center permission set assignments), cluster RBAC (temporary ClusterRoleBindings), and break-glass accounts (pre-provisioned emergency access with mandatory post-use review).
+
+**Break-glass accounts** are deliberately painful to use. They exist for scenarios where SSO, JIT tooling, or federation is unavailable—identity provider outage, network partition, or catastrophic misconfiguration. Store break-glass credentials in a physical safe or HSM-backed vault, require dual control to retrieve them, and alert the security team on every use. Break-glass accounts should never be the daily driver for platform engineers.
+
+**Separation of duties** prevents any single identity from both deploying code and approving its deployment. In a multi-cloud Kubernetes context, this means: the CI/CD pipeline service account can push images and apply manifests, but it cannot modify IAM roles, RBAC bindings, or network policies. Human admins who can modify RBAC cannot modify the CI/CD pipeline's service account permissions without a second approver. CloudTrail, Azure Activity Log, and GCP Cloud Audit Logs provide the evidence trail for periodic access reviews.
+
+**Audit of access** is not optional at enterprise scale. Every `AssumeRole`, every Entra PIM activation, every EKS access entry creation, and every Kubernetes RBAC binding change must flow to a centralized, immutable log store. Quarterly access reviews should compare IdP group membership against cloud role assignments and in-cluster RBAC bindings, flagging any principal that has access but no business justification. Orphaned service accounts—created for a decommissioned workload but never deleted—are a recurring finding in enterprise audits and represent both a security gap and an ongoing operational cost.
+
+| Control | AWS | GCP | Azure | Kubernetes (vendor-neutral) |
+|---|---|---|---|---|
+| Maximum permission cap | IAM Permissions Boundaries | Organization Policy constraints | Azure Policy deny effects | Admission controllers (OPA/Gatekeeper) |
+| JIT elevation | Identity Center + external JIT tool | IAM Conditions (time-based) | Entra PIM | Temporary ClusterRoleBinding + CronJob |
+| Break-glass | Root account + emergency IAM user | Org admin break-glass | Global admin (limited use) | `system:masters` cert (disable in prod) |
+| Separation of duties | SCPs blocking self-escalation | Deny policies on IAM admin actions | PIM approval workflows | OPA policies on RBAC mutations |
+| Access review evidence | CloudTrail + Access Analyzer | Policy Analyzer + audit logs | Entra access reviews + Activity Log | K8s audit logs + RBAC inventory tools |
+
+---
+
+## Operational and Cost Impact of Identity Sprawl
+
+Identity sprawl is the silent tax on multi-cloud operations. It does not appear on any single invoice line, but it inflates headcount, extends incident response times, and creates security liabilities that eventually surface as audit findings or breaches.
+
+**Operational cost of identity sprawl** manifests in several ways. Platform teams spend engineering hours maintaining parallel user directories across AWS IAM users, GCP service account keys, Azure local accounts, and Kubernetes RBAC bindings that reference individual email addresses instead of groups. Every new hire triggers a multi-day provisioning ticket across three clouds and N clusters. Every departure requires a manual checklist because SCIM sync was never configured for one provider. Access review cycles that should take days stretch into weeks when reviewers must reconcile IdP groups against cloud-native accounts that have no automated linkage.
+
+**Orphaned credentials** are both a security liability and a direct cost. An unused IAM user with access keys still counts against IAM quotas and generates CloudTrail events that your SIEM ingests and stores. A GCP service account key sitting in a forgotten Kubernetes Secret requires rotation workflows, vault licensing, and monitoring—even though no workload has mounted that Secret in months. Azure managed identities for decommissioned AKS node pools may retain role assignments on storage accounts and key vaults, creating invisible cross-subscription access paths. Each orphaned credential is a lottery ticket for an attacker and a recurring line item in your security tooling bill.
+
+**Cost knobs that reduce identity overhead** include federation (eliminate parallel user stores), workload identity (eliminate key rotation and Secrets Manager entries for cloud credentials), group-based RBAC (reduce binding count from O(users) to O(groups)), and centralized audit logging with automated anomaly detection (reduce mean-time-to-detect for credential abuse). The inverse—what makes identity cost spike unexpectedly—includes per-user-per-cluster RBAC bindings (GitOps repos balloon, review cycles lengthen), IRSA trust policies that hit the [4096-character IAM trust policy limit](https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_iam-quotas.html) across many clusters (forcing role proliferation), and SIEM ingestion of verbose authentication logs without sampling or filtering rules.
+
+Hypothetical scenario: A 40-cluster fleet uses individual user email addresses in RoleBindings instead of IdP groups. The GitOps repository contains 800 RoleBinding manifests. A reorganization merges two product teams, requiring an engineer two weeks to find and update every binding. During the transition window, former team members retain namespace-admin access in clusters they no longer support. The fix—migrating to group-based RBAC with SCIM-driven group sync—costs one sprint upfront but eliminates an entire class of recurring access-review toil.
+
+### Provider-Specific Cost Gotchas for Identity Infrastructure
+
+Network costs intersect with identity architecture in ways that surprise teams during their first multi-region, multi-account rollout. On AWS, every cross-AZ STS call and every IRSA token exchange that routes through a NAT Gateway incurs data processing charges—the identity layer is not free even when IAM itself has no per-request fee. A fleet of 50 clusters with pods constantly refreshing IRSA tokens can generate measurable NAT Gateway egress if clusters span three availability zones without VPC endpoints for STS. Mitigate with [VPC interface endpoints for STS and EKS](https://docs.aws.amazon.com/vpc/latest/privatelink/create-interface-endpoint.html) so token exchanges stay on the AWS backbone.
+
+On GCP, cross-project Workload Identity impersonation calls are free at the IAM layer, but logging every authentication event to Cloud Logging at full verbosity across 40 clusters can exceed the free tier quickly—especially when audit logs include token exchange metadata for thousands of pods. Apply log sinks with filters that route identity events to a dedicated, retention-tiered bucket rather than the default log bucket with short retention.
+
+On Azure, Entra ID PIM and Conditional Access are licensed capabilities—the identity cost is a per-user-per-month subscription line, not a usage meter. Factor PIM licensing into your platform budget when moving from standing admin access to eligible assignments for hundreds of engineers. The ROI typically justifies the license cost within one avoided incident, but finance teams need the line item forecasted upfront rather than discovered during the first renewal cycle.
+
+---
+
+## Patterns & Anti-Patterns
+
+| Pattern | When to Use | Why It Works | Scaling Note |
+|---|---|---|---|
+| Hub-and-spoke identity with IdP federation | Any org with 3+ cloud accounts | Single SSO front door; SCIM drives lifecycle | Identity Center / Workforce Identity Federation / Entra scale to thousands of accounts |
+| Group-based Kubernetes RBAC | All production clusters | O(groups × clusters) instead of O(users × clusters) | Requires IdP group sync; test group removal promptly |
+| Workload identity (IRSA / Pod Identity / Entra Workload ID) | Every pod that calls cloud APIs | Eliminates static credentials and rotation toil | Pod Identity reduces per-cluster OIDC setup on EKS |
+| EKS access entries over aws-auth ConfigMap | EKS 1.23+ clusters | API-managed, auditable, integrates with Identity Center | Migrate ConfigMap entries before switching to API-only mode |
+| Centralized immutable audit logging | All environments | Cross-account attack timeline reconstruction | S3 Object Lock / Azure immutable storage adds storage cost but prevents log tampering |
+
+| Anti-Pattern | What Goes Wrong | Why Teams Fall Into It | Better Alternative |
+|---|---|---|---|
+| Native cloud user accounts for employees | Offboarding gaps; no unified MFA policy | "It's faster than setting up SSO" | Federate through IdP on day one; no exceptions |
+| Shared Kubernetes ServiceAccount across microservices | One compromised pod exposes all cloud permissions | "One SA is easier in Helm charts" | Per-workload SA with dedicated cloud IAM binding |
+| Permanent cluster-admin for senior engineers | Stolen laptop = full cluster compromise | "Admins need access quickly" | JIT ClusterRoleBinding with auto-expiry |
+| IRSA trust policies per cluster per role at 50+ clusters | Hit IAM trust policy size limits; OIDC provider sprawl | "IRSA was the only option when we started" | Migrate to EKS Pod Identity associations |
+| Manual RBAC with individual user emails | Reorganization breaks access; audit nightmare | "Groups are hard to set up in our IdP" | Map IdP groups to RBAC `kind: Group` subjects |
+| Skipping SCIM deprovisioning | Former employees retain cloud access for months | "HR will tell us when someone leaves" | SCIM auto-delete with 24-hour max propagation SLA |
+
+---
+
+## Decision Framework: Choosing Your Identity Architecture
+
+Use this framework when designing or refactoring enterprise identity for a multi-cloud Kubernetes fleet. The goal is to pick the minimum-complexity path that satisfies your security requirements without creating operational bottlenecks.
+
+```mermaid
+flowchart TD
+    Start([New identity requirement]) --> Q1{Human or workload?}
+
+    Q1 -->|Human engineer| Q2{How many cloud providers?}
+    Q1 -->|Pod / automation| Q3{Which cloud hosts the cluster?}
+
+    Q2 -->|Single provider| Q2a[Federate IdP to native SSO:<br/>Identity Center / Workforce ID / Entra]
+    Q2 -->|Multi-provider| Q2b[Single IdP → federate to each cloud SSO layer<br/>SCIM sync groups everywhere]
+
+    Q2a --> Q4{Needs kubectl access?}
+    Q2b --> Q4
+
+    Q4 -->|Yes| Q5{Provider?}
+    Q4 -->|No — console/API only| Done1([Permission sets /<br/>IAM bindings /<br/>Azure RBAC])
+
+    Q5 -->|AWS EKS| Q5a[EKS access entries<br/>+ group-based RBAC]
+    Q5 -->|GCP GKE| Q5b[Google Groups for RBAC<br/>+ Connect gateway for fleets]
+    Q5 -->|Azure AKS| Q5c{Multi-cluster governance?}
+    Q5c -->|Yes| Q5d[Entra ID authorization<br/>Azure RBAC at subscription scope]
+    Q5c -->|No| Q5e[Entra + Kubernetes RBAC<br/>group RoleBindings]
+
+    Q3 -->|AWS| Q6{Cross-account<br/>cloud API access?}
+    Q3 -->|GCP| Q6a[Workload Identity:<br/>K8s SA → GCP SA binding]
+    Q3 -->|Azure| Q6b[Entra Workload ID:<br/>federated credential on Managed Identity]
+
+    Q6 -->|Yes, direct| Q6c[IRSA with cross-account<br/>trust policy]
+    Q6 -->|Same account| Q6d[EKS Pod Identity association<br/>preferred over IRSA]
+
+    Q5a --> Q7{Production admin access?}
+    Q5b --> Q7
+    Q5d --> Q7
+    Q5e --> Q7
+
+    Q7 -->|Yes| JIT([JIT access with<br/>auto-expiry + audit])
+    Q7 -->|Read-only| Done2([Standard SSO session<br/>with group-scoped RBAC])
+
+    Q6c --> Done3([Pod gets temporary<br/>cloud credentials])
+    Q6d --> Done3
+    Q6a --> Done3
+    Q6b --> Done3
+```
+
+**Tradeoff summary**: Federation adds upfront configuration cost but eliminates perpetual user-management toil. Group-based RBAC requires IdP hygiene but scales linearly instead of exponentially. IRSA offers cross-account flexibility at the cost of OIDC complexity; Pod Identity inverts that tradeoff. JIT access adds latency to emergency response but dramatically shrinks the blast radius of credential theft.
+
+---
+
 ## Did You Know?
 
 1. **AWS IAM evaluates authorization for a massive volume of requests across AWS services.** IAM decisions are designed to be fast enough that authorization does not become a practical bottleneck for normal service operations.
@@ -775,7 +1114,7 @@ RBAC assigns permissions based on static roles, meaning every new cluster requir
 <details>
 <summary>4. **Scenario:** A third-party SaaS monitoring tool asks you to create an IAM role in your AWS account that trusts their AWS account (`arn:aws:iam::999999999999:root`). You create the role and provide them the Role ARN. Six months later, another customer of that same SaaS tool successfully forces the SaaS platform to assume your role and read your S3 buckets. What attack just occurred, and how should you have prevented it?</summary>
 
-This is a classic "confused deputy" attack, where a service with cross-account permissions (the SaaS tool) is tricked into acting on behalf of an unauthorized party (the malicious customer). Because the trust policy only verified the SaaS provider's account ID, it couldn't distinguish between legitimate requests made on your behalf and requests the provider was tricked into making. You should have prevented this by adding `aws:ExternalId` or `aws:SourceAccount` conditions to the trust policy. These conditions ensure that the SaaS provider must supply a unique identifier tied specifically to your tenant when assuming the role, effectively verifying the original caller's identity, not just the immediate caller's identity.
+This is a classic "confused deputy" attack, where a service with cross-account permissions (the SaaS tool) is tricked into acting on behalf of an unauthorized party (the malicious customer). Because the trust policy only verified the SaaS provider's account ID, it couldn't distinguish between legitimate requests made on your behalf and requests the provider was tricked into making. You should have prevented this by adding `sts:ExternalId` or `aws:SourceAccount` conditions to the trust policy. These conditions ensure that the SaaS provider must supply a unique identifier tied specifically to your tenant when assuming the role, effectively verifying the original caller's identity, not just the immediate caller's identity.
 </details>
 
 <details>
@@ -788,6 +1127,18 @@ Sharing a single service account across multiple workloads fundamentally violate
 <summary>6. **Scenario:** An SRE's laptop is stolen while they are logged into their enterprise SSO portal. The attacker attempts to use the active SSO session to access the production EKS cluster and delete namespaces. However, the attacker finds they have only read-only permissions, despite the SRE being a senior admin. How did Just-In-Time (JIT) access architecture prevent this catastrophic breach?</summary>
 
 JIT access prevented the breach by eliminating standing privileges, meaning that even senior admins do not possess permanent administrative access to production by default. In a JIT system, elevated permissions are granted only when a specific, justified need arises (such as an active PagerDuty incident), and only for a limited duration (e.g., 2 hours) following an approval workflow. Because the SRE had not requested and been approved for an active JIT session at the time the laptop was stolen, their baseline credentials only provided safe, read-only access. The attacker would have needed to compromise the separate JIT approval workflow—which typically requires MFA or peer approval—to elevate their privileges, drastically shrinking the attack surface.
+</details>
+
+<details>
+<summary>7. **Scenario:** Your organization runs 30 EKS clusters across 10 AWS accounts. The platform team wants to migrate from the `aws-auth` ConfigMap to EKS access entries while integrating with IAM Identity Center. An engineer asks whether they can simply delete the ConfigMap after enabling access entries. What is the correct migration sequence, and why does order matter?</summary>
+
+You cannot simply delete the `aws-auth` ConfigMap because access entries and ConfigMap entries can coexist during migration, but access entries take precedence only for IAM principals that have a corresponding access entry. The correct sequence is: switch the cluster authentication mode to `API_AND_CONFIGMAP`, create access entries for every ConfigMap-mapped IAM principal (preserving the same username and Kubernetes groups), verify that affected users can authenticate and authorize correctly, then remove the ConfigMap entries and finally switch to `API`-only mode. Deleting the ConfigMap before creating access entries would break authentication for node groups and Fargate profiles that rely on ConfigMap entries created by EKS itself. Order matters because a gap in coverage locks out legitimate users or, worse, leaves stale ConfigMap entries that override intended access entry permissions for principals not yet migrated.
+</details>
+
+<details>
+<summary>8. **Scenario:** A cost review reveals your team spends $4,200/month on AWS Secrets Manager entries, most storing GCP service account JSON keys and Azure client secrets for Kubernetes workloads. Leadership asks why workload identity federation was not adopted earlier. Explain the security and cost case for migrating to IRSA, GKE Workload Identity, and Entra Workload ID, and identify one hidden operational cost of NOT migrating.</summary>
+
+Long-lived keys in Secrets Manager incur per-secret monthly charges plus API call costs for rotation Lambdas and pod mount operations. Workload identity eliminates these secrets entirely: pods receive short-lived tokens from the platform metadata layer without any stored credential material. The security case is equally strong—a leaked Secret Manager entry provides indefinite access until rotation, while a workload identity token expires with the pod lifetime (minutes to hours). The hidden operational cost of not migrating is engineering time spent on rotation runbooks, break-glass key recovery during outages, and access-review cycles that must inventory every static credential across every namespace. At 30 clusters with hundreds of workloads, this toil often exceeds one full-time platform engineer equivalent—far more expensive than the Secrets Manager line item alone.
 </details>
 
 ---
@@ -1080,3 +1431,12 @@ roleRef:
 - [docs.aws.amazon.com: howtosessionduration.html](https://docs.aws.amazon.com/singlesignon/latest/userguide/howtosessionduration.html) — AWS documents both the 1-hour default for new permission sets and the 12-hour maximum configured on the generated IAM roles.
 - [Delegate access across AWS accounts using IAM roles](https://docs.aws.amazon.com/IAM/latest/UserGuide/tutorial_cross-account-with-roles.html) — Good primary reference for STS role assumption and temporary credentials in cross-account AWS setups.
 - [About Workload Identity Federation for GKE](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) — Covers how GKE workload identity works, principal identifiers, and keyless access to Google Cloud APIs.
+- [EKS access entries](https://docs.aws.amazon.com/eks/latest/userguide/access-entries.html) — Documents the recommended API for mapping IAM principals to Kubernetes cluster access.
+- [Migrating aws-auth ConfigMap to access entries](https://docs.aws.amazon.com/eks/latest/userguide/migrating-access-entries.html) — Step-by-step migration path with precedence rules between ConfigMap and access entries.
+- [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) — AWS-recommended workload credential mechanism without per-cluster OIDC providers.
+- [GCP Workforce Identity Federation](https://cloud.google.com/iam/docs/workforce-identity-federation) — Syncless SSO from external IdPs to GCP using OIDC or SAML.
+- [Configure Google Groups for GKE RBAC](https://cloud.google.com/kubernetes-engine/docs/how-to/google-groups-rbac) — Enterprise group-based cluster authorization for GKE.
+- [AKS Entra ID authorization for Kubernetes API](https://learn.microsoft.com/en-us/azure/aks/entra-id-authorization) — Azure RBAC-based multi-cluster Kubernetes governance.
+- [AKS Kubernetes RBAC with Entra integration](https://learn.microsoft.com/en-us/azure/aks/azure-ad-rbac) — Native RoleBindings with Entra group subjects.
+- [Entra SCIM provisioning](https://learn.microsoft.com/en-us/entra/identity/app-provisioning/use-scim-to-provision-users-and-groups) — Automated user and group lifecycle sync from IdP to cloud applications.
+- [AWS IAM permissions boundaries](https://docs.aws.amazon.com/IAM/latest/UserGuide/access_policies_boundaries.html) — Maximum-permission caps for IAM entities in multi-team organizations.

--- a/src/content/docs/cloud/advanced-operations/module-8.5-disaster-recovery.md
+++ b/src/content/docs/cloud/advanced-operations/module-8.5-disaster-recovery.md
@@ -25,65 +25,85 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-The January 2017 GitLab loss event (see *What is a Terminal*) <!-- incident-xref: gitlab-2017-db1 --> shows that untested recovery procedures and unclear environment context can convert routine maintenance mistakes into high-impact data-loss incidents.
+Disaster recovery for Kubernetes is not a backup checkbox on a compliance spreadsheet. It is an engineering contract between the business and the platform team about how much downtime and data loss the organization will tolerate when an entire region, control plane, storage layer, or human process fails at the same time. Most teams discover the gap between that contract and reality during the first game day, not during architecture review, because backups that were never restored are indistinguishable from backups that never existed until someone tries to mount a volume in a secondary region at 3 a.m.
 
-The lesson is not "have backups." Every team has backups. The lesson is: **untested backups are not backups.** And in the Kubernetes world, the situation is even more complex. Your cluster state lives in etcd. Your application state lives in databases, PersistentVolumes, and external services. Your configuration lives in Git repos and Helm releases. A real disaster recovery plan must account for all of these, with tested procedures and clear targets for how fast you recover (RTO) and how much data you can afford to lose (RPO).
+In multi-cloud operations, the complexity compounds quickly. Your cluster state may live in a managed control plane you cannot snapshot directly. Your application state may live in RDS, Cloud SQL, or Azure Database with cross-region replication semantics you did not design. Your configuration may live in Git, Helm, Argo CD, and External Secrets Operator resources that must be restored in a specific order. Your traffic may still be flowing to a region that is technically up but functionally unusable. A credible DR plan names two governing numbers—RTO and RPO—and then traces every backup, replication path, DNS record, and runbook step back to those numbers with evidence from tested restores rather than slide-deck optimism.
+
+> **The Fireproof Safe Analogy**
+>
+> Backups are like documents in a fireproof safe in another city. Replication is like keeping a live duplicate ledger in that city. A DR strategy chooses how much of your business you keep running in the spare city before the fire, versus how fast you can rebuild after smoke clears. Kubernetes makes the safe heavier: you are protecting API objects, persistent data, secrets, ingress definitions, CRDs, and external dependencies that do not all fail or recover on the same timeline.
+
+For the extreme case where both regions serve production traffic simultaneously with near-zero RTO and RPO, see [Module 8.6: Multi-Region Active-Active Deployments](../module-8.6-active-active/). This module stops one step below that cliff: pilot light, warm standby, and backup-and-restore patterns that trade cost for recovery time while still meeting serious production requirements.
 
 ---
 
 ## RTO and RPO: The Two Numbers That Define Your DR Strategy
 
-Every disaster recovery plan starts with two numbers. Get these wrong, and everything downstream is wrong.
+Every disaster recovery plan starts with two numbers, and every downstream architectural argument should be traceable to them. If leadership says "we need five-nines availability" but finance approves only backup storage in a single region, the numbers were never aligned. Platform engineers translate business impact into measurable recovery targets, then choose replication, backup frequency, standby capacity, and DNS design to meet those targets with documented evidence from restore drills.
 
 ```mermaid
 flowchart LR
-    A[Last Backup or Snapshot] -->|RPO: Data Loss Window| B[Disaster Occurs]
-    B -->|RTO: Downtime Window| C[Service Restored]
+    A[Last durable commit or backup] -->|RPO window| B[Disaster occurs]
+    B -->|RTO window| C[Service restored and verified]
 ```
 
-**RPO (Recovery Point Objective):**
-"How much data can we afford to lose?"
-- RPO = 0: No data loss (synchronous replication)
-- RPO = 1 hour: Lose up to 1 hour of data (hourly backups)
-- RPO = 24 hours: Lose up to 1 day (daily backups)
+**Recovery Point Objective (RPO)** answers how much data the business can afford to lose, measured as maximum time or transaction volume between the last recoverable state and the failure event. An RPO of zero implies synchronous or quorum-acknowledged replication where a write is not considered committed until it exists in the DR location. An RPO of one hour implies you may lose up to one hour of writes if the primary disappears without warning. Backups alone do not set RPO; the backup schedule sets an upper bound, but replication lag, partial failures, and human detection delay determine what you actually lose.
 
-**RTO (Recovery Time Objective):**
-"How long can we be down?"
-- RTO = 0: No downtime (active-active, covered in Module 8.6)
-- RTO = 15 min: Quick failover (warm standby)
-- RTO = 4 hours: Cold standby or backup restore
-- RTO = 24 hours: Full rebuild from IaC
+**Recovery Time Objective (RTO)** answers how long the business can tolerate the service being unavailable or degraded before financial, regulatory, or reputational damage becomes unacceptable. RTO includes detection time, decision time, infrastructure provisioning, data promotion, Kubernetes reconciliation, DNS cutover, and verification—not merely the moment the first pod reaches Running. For near-zero RTO with simultaneous multi-region serving, you are in active-active territory documented in [Module 8.6](../module-8.6-active-active/); this module focuses on strategies where some downtime or controlled failover is expected.
 
-### Mapping RTO/RPO to DR Strategies
+### Worked example: deriving targets from business impact
 
-| Strategy | RTO | RPO | Cost | Complexity |
+Imagine a B2B payments API on EKS in `us-east-1` processing $12M per day, roughly $138 per second ($12M ÷ 86,400). Legal requires audit logs with no gaps, but the product owner accepts brief read-only mode during disasters if no captured payment is lost. Finance estimates $250K lost revenue and churn risk for each hour of hard outage during peak.
+
+| Business statement | Engineering translation |
+|---|---|
+| "We cannot lose confirmed payments" | RPO ≈ 0 for ledger data: synchronous or quorum replication, not nightly Velero alone |
+| "Thirty minutes of read-only is painful but survivable" | RTO ≈ 30 minutes for API availability if ledger integrity is preserved |
+| "Audit logs must be reconstructable" | Separate RPO for observability data; may be 15 minutes if shipped to multi-region object storage |
+
+The platform team maps workloads to tiers. Stateless API Deployments might target RTO 20 minutes via warm standby in `us-west-2`. PostgreSQL on RDS might use cross-region read replica with manual promotion for RPO near zero on committed transactions. Velero might capture cluster objects every four hours, which is insufficient for ledger RPO but still valuable for Kubernetes configuration recovery. The resulting architecture is hybrid by design, not a single DR pattern applied blindly.
+
+### The DR strategy ladder and cost posture
+
+AWS documents four classic patterns in [Disaster Recovery Options in the Cloud](https://docs.aws.amazon.com/whitepapers/latest/disaster-recovery-workloads-on-aws/disaster-recovery-options-in-the-cloud.html). The ladder below maps them to Kubernetes-heavy estates across AWS, GCP, and Azure. Costs are directional because they depend on data size, egress, instance families, and how much of the control plane you keep warm.
+
+| Strategy | Typical RTO | Typical RPO | Steady-state cost posture | Kubernetes interpretation |
 |---|---|---|---|---|
-| Backup & Restore | 4-24 hours | Hours to days | Low ($) | Low |
-| Pilot Light | 30-60 min | Minutes to hours | Medium ($$) | Medium |
-| Warm Standby | 5-15 min | Seconds to minutes | High ($$$) | High |
-| Active-Active | Near-zero | Near-zero | Very High ($$$$) | Very High |
+| Backup & restore | 4–24+ hours | Hours to days | Lowest: object storage, snapshots, minimal DR compute | DR cluster provisioned during incident; Velero restore + DB restore from backup |
+| Pilot light | 30–90 minutes | Minutes to hours | Low–medium: small DR cluster, DB replica, replicated backups | DR EKS/GKE/AKS with core addons; apps scaled up during failover |
+| Warm standby | 5–30 minutes | Seconds to minutes | High: partial production footprint always on | DR cluster runs reduced replicas; DB hot standby; DNS weighted or failover ready |
+| Active/active | Near zero | Near zero | Highest: full multi-region traffic and data path | See Module 8.6; not duplicated here |
 
-### The War Story: When RTO Doesn't Match Reality
+**Backup and restore** minimizes standing cost. You pay primarily for backup storage, snapshot storage, and cross-region replication of backup artifacts. Compute in the DR region is near zero until disaster. The RTO penalty is provisioning clusters, restoring volumes, rehydrating images, and waiting for controllers to reconcile thousands of objects under stress.
 
-A retail company set their RTO at 4 hours for their Kubernetes platform. During their annual DR test, the actual recovery took 11 hours. Why?
+**Pilot light** keeps a skeleton DR environment alive: small node pools, GitOps controllers, monitoring, and a database replica receiving asynchronous replication. You pay continuously for that skeleton plus inter-region replication. Failover is scale-out plus promotion rather than cold start from zero.
 
-- Restoring etcd from snapshot: 20 minutes (as expected)
-- Waiting for nodes to rejoin and pods to schedule: 45 minutes (expected 15)
-- Discovering that three CRDs were missing from the backup: 90 minutes to figure out
-- DNS propagation for the new cluster endpoint: 35 minutes
-- Discovering that PersistentVolume claims couldn't bind because the storage class didn't exist: 60 minutes
-- Application health checks failing because the database connection string pointed to the old cluster: 120 minutes
-- Load testing to verify the restored cluster could handle production traffic: 90 minutes
+**Warm standby** runs a meaningful fraction of production capacity in the DR region—often 30–50% of nodes and full application manifests at reduced replicas. You pay for duplicate compute and storage synchronization continuously. Failover is primarily traffic shift and scale-up, not application install from scratch.
 
-The lesson: your RTO should be based on tested recovery time, not theoretical recovery time. Add a 2x safety margin to your best-case test result.
-
-> **Pause and predict**: Your database performs asynchronous replication to a DR region with an average lag of 5 minutes. You also take full database snapshots every 12 hours. If your primary region completely fails and you promote the replica in the DR region, what is your actual RPO? If the replica also fails and you must restore from the last snapshot, how does your RPO change?
+> **Pause and predict**: Your database performs asynchronous replication to a DR region with average lag of five minutes. You also take full database snapshots every twelve hours. If the primary region fails and you promote the replica, what is the effective RPO? If the replica is also corrupt and you must restore from snapshot, how does the RPO change? Write both answers before reading the etcd section.
 
 ---
 
-## etcd Backup and Restore
+## Who Owns the Control Plane: etcd on Managed vs Self-Managed Clusters
 
-For self-managed Kubernetes clusters (kubeadm, kOps, Rancher), etcd is the single point of truth. Lose etcd, lose your cluster.
+The first DR design question on Kubernetes is whether you can snapshot etcd yourself. On **Amazon EKS**, **Google GKE**, and **Azure AKS**, the cloud provider operates the Kubernetes control plane, including etcd, API server availability, and control plane upgrades. AWS documents that it manages the etcd database as part of the EKS control plane under the shared responsibility model ([Security in Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/security.html)). GKE and AKS follow the same split: you do not SSH to control plane nodes for etcd snapshots on standard managed offerings.
+
+| Cluster type | etcd access | Primary cluster-state backup approach |
+|---|---|---|
+| Self-managed (kubeadm, kOps, Rancher) | You operate etcd | `etcdctl snapshot save` on control plane nodes |
+| Amazon EKS | AWS managed | Velero and/or [AWS Backup for EKS](https://docs.aws.amazon.com/eks/latest/userguide/integration-backup.html) |
+| Google GKE | Google managed | [Backup for GKE](https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke) and/or Velero |
+| Azure AKS | Microsoft managed | [Azure Backup for AKS](https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-backup-overview) and/or Velero |
+
+Velero remains the vendor-neutral lingua franca because it speaks the Kubernetes API: Deployments, Services, ConfigMaps, Ingresses, CRDs, and volume data via CSI snapshots or file-level node agents. Managed backup services integrate with cloud IAM, snapshot APIs, and policy engines at the expense of portability. Mature teams often run Velero for portability while enabling the managed service for compliance snapshots and centralized vault retention.
+
+What you still own on managed clusters is everything **in** the cluster and everything **around** it: node pools, add-ons, PersistentVolumes, external databases, secrets material, container images, DNS names, and GitOps state. A managed control plane recovery does not magically recreate your StorageClasses, missing CRDs, or a promoted database connection string pointing at the old region.
+
+---
+
+## etcd Backup and Restore (Self-Managed Clusters)
+
+For self-managed Kubernetes clusters (kubeadm, kOps, Rancher), etcd is the single point of truth for Kubernetes object state. Lose etcd without a durable snapshot and you lose the desired state of the entire fleet, even if worker nodes and container images still exist.
 
 ### etcd Snapshot Backup
 
@@ -105,6 +125,9 @@ ETCDCTL_API=3 etcdctl snapshot status /var/backups/etcd/snapshot-20260324-100000
 # +----------+----------+------------+------------+
 # | 3e6d0a12 | 15284032 |      12847 |    42 MB   |
 # +----------+----------+------------+------------+
+
+# On etcd 3.6+ (newer Kubernetes), use `etcdutl snapshot restore` and
+# `etcdutl snapshot status`; `snapshot save` remains in `etcdctl`.
 
 # Upload to S3 for off-site storage
 aws s3 cp /var/backups/etcd/snapshot-20260324-100000.db \
@@ -136,7 +159,7 @@ spec:
           tolerations:
             - key: node-role.kubernetes.io/control-plane
               effect: NoSchedule
-          containers:
+          initContainers:
             - name: etcd-backup
               image: registry.k8s.io/etcd:3.5.16-0
               command:
@@ -152,16 +175,26 @@ spec:
                     --key=/etc/kubernetes/pki/etcd/server.key
                   etcdctl snapshot status "$BACKUP_FILE" --write-out=json
                   echo "Backup complete: $BACKUP_FILE"
-                  # Upload to S3 (requires aws-cli)
-                  aws s3 cp "$BACKUP_FILE" \
-                    "s3://etcd-backups/prod/$(date +%Y/%m/%d)/" \
-                    --sse aws:kms
-                  # Retain only last 7 days locally
-                  find /backups -name "*.db" -mtime +7 -delete
               volumeMounts:
                 - name: etcd-certs
                   mountPath: /etc/kubernetes/pki/etcd
                   readOnly: true
+                - name: backup-dir
+                  mountPath: /backups
+          containers:
+            - name: upload-backup
+              image: amazon/aws-cli:2.15.0
+              command:
+                - /bin/sh
+                - -c
+                - |
+                  set -e
+                  BACKUP_FILE="$(ls -t /backups/snapshot-*.db | head -1)"
+                  aws s3 cp "$BACKUP_FILE" \
+                    "s3://etcd-backups/prod/$(date +%Y/%m/%d)/" \
+                    --sse aws:kms
+                  find /backups -name "*.db" -mtime +7 -delete
+              volumeMounts:
                 - name: backup-dir
                   mountPath: /backups
           volumes:
@@ -180,7 +213,7 @@ spec:
 # Stop all control plane components
 systemctl stop kubelet
 
-# Restore from snapshot
+# Restore from snapshot (etcd 3.6+: etcdutl snapshot restore / etcdutl snapshot status)
 ETCDCTL_API=3 etcdctl snapshot restore /var/backups/etcd/snapshot-20260324-100000.db \
   --name etcd-member-1 \
   --data-dir=/var/lib/etcd-restored \
@@ -204,7 +237,9 @@ kubectl get pods -A
 
 ## Velero: Kubernetes-Native Backup and Restore
 
-For managed Kubernetes (EKS, GKE, AKS) where you don't manage etcd directly, Velero is the standard tool for backing up and restoring Kubernetes resources and persistent volumes.
+For managed Kubernetes (EKS, GKE, AKS) where you do not manage etcd directly, Velero is the standard tool for backing up and restoring Kubernetes resources and persistent volumes at the API layer. Velero watches backup schedules, serializes selected API objects to object storage, coordinates volume snapshots through cloud plugins, and replays objects during restore with configurable namespace mappings and resource filters. It does not understand business transactions inside PostgreSQL unless you integrate database hooks; treat Velero as the **configuration and volume skeleton** layer of DR, not the ledger of record.
+
+Production Velero deployments separate concerns: a `BackupStorageLocation` for JSON manifests, a `VolumeSnapshotLocation` per cloud Region, IAM or Workload Identity with least privilege, encryption at rest on the bucket, and monitoring on `backup_failure_total` and `restore_failed_total` metrics. Version-pin the Velero server image and provider plugins together; upgrading Kubernetes to 1.35 without retesting plugins is a common source of partial backups that look successful in `velero backup describe` until restore time.
 
 ```mermaid
 flowchart TD
@@ -313,6 +348,82 @@ velero restore logs full-restore
 
 > **Stop and think**: You just ran a Velero restore of a critical namespace to a new cluster. The pods are starting, but they are all stuck in `Pending` state. The persistent volume claims (PVCs) remain unbound. What Kubernetes resource did you likely forget to include in your backup or pre-create in the new cluster, and how would you fix it?
 
+### Velero data movement: CSI snapshots vs node agent
+
+Velero can capture PersistentVolume data two ways. **Volume snapshots** use the cloud CSI driver to create EBS, GCE PD, or Azure Disk snapshots referenced in the Backup object. Restore creates new volumes from those snapshots in the target region if snapshots were copied or recreated there. **File-system backup** uses the Velero node agent (formerly restic integration) to read mounted volume data and upload objects to S3, GCS, or Azure Blob. File-system backup is slower for large databases but works when CSI snapshot APIs are unavailable or when you need portability across storage classes.
+
+Schedules should encode RPO intent explicitly. A `velero schedule` that runs every four hours with `--snapshot-volumes=true` implies you may lose up to four hours of volume data unless continuous replication also protects the database. Combine Velero for Kubernetes object recovery with database-native replication for low RPO on transactional data.
+
+```bash
+# Example: backup with CSI snapshots and labels for compliance scope
+velero backup create nightly-platform \
+  --include-cluster-resources=true \
+  --snapshot-volumes=true \
+  --selector disaster-recovery=included \
+  --ttl 720h0m0s
+
+# Copy Velero backup storage to DR region (AWS example — bucket replication)
+aws s3api put-bucket-replication \
+  --bucket velero-backups-prod-use1 \
+  --replication-configuration file://replication.json
+```
+
+---
+
+## Managed Kubernetes Backup Services (AWS, GCP, Azure)
+
+Each hyperscaler now offers a first-party backup path that complements Velero. Treat them as orchestration layers over snapshot APIs and Kubernetes API access, not as replacements for database replication.
+
+### AWS Backup for Amazon EKS
+
+[AWS Backup for EKS](https://docs.aws.amazon.com/eks/latest/userguide/integration-backup.html) creates composite recovery points for cluster resources and persistent storage attached via PVCs (EBS and EFS where configured). The cluster authorization mode must allow API access for backup operators. Restore can target a new cluster in another Region after you replicate recovery points. Pair AWS Backup policies for compliance retention with Velero for day-to-day namespace mobility and GitOps-adjacent workflows.
+
+### Backup for GKE
+
+[Backup for GKE](https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke) installs a Google-managed agent and stores backup artifacts in a BackupPlan location you choose. Backup plans support smart scheduling against a **target RPO in minutes** (minimum 60 minutes per [backup plan documentation](https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/how-to/backup-plan)) or cron schedules. Restores can target alternate clusters and regions; cross-location backup storage incurs outbound data transfer per GKE pricing. Backup for GKE captures Kubernetes resources and volume data but not node pool shape, container images, or external Cloud SQL state—those remain separate DR workstreams.
+
+### Azure Backup for AKS
+
+[Azure Backup for AKS](https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-backup-overview) requires the Backup extension in-cluster and a Backup vault with Trusted Access to the cluster. The **operational tier** supports RPO as low as four hours between backups with faster restores from snapshots and blob metadata in your tenant. The **vault tier** moves daily/weekly/monthly recovery points to vault-managed storage for longer retention and ransomware-resistant separation. Cross-region restore requires geo-redundant vault configuration documented in [AKS restore guidance](https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-cluster-restore).
+
+| Capability | Velero | AWS Backup (EKS) | Backup for GKE | Azure Backup (AKS) |
+|---|---|---|---|---|
+| Portability across clouds | Strong | AWS only | GCP only | Azure only |
+| Volume snapshots via CSI | Yes | Yes | Yes | Yes (Azure Disk/Files) |
+| Namespace-scoped policies | Yes | Via backup plans | BackupPlan selectors | Backup instance filters |
+| Central vault / compliance | DIY | AWS Backup vault | Google-managed storage | Azure Backup vault |
+
+---
+
+## Stateful Data DR: Cluster Objects vs Application Data
+
+Restoring Kubernetes objects is not the same as restoring application truth. A Velero restore might recreate a `StatefulSet`, `Service`, and `PersistentVolumeClaim`, but the database inside the volume is only as current as the snapshot or file backup captured. Operators routinely confuse **crash-consistent** volume snapshots—taken mid-write—with **application-consistent** snapshots that quiesce databases first.
+
+**Crash-consistent** snapshots are fast and default for CSI drivers. They are acceptable for many stateless caches and reproducible batch jobs. They are risky for busy OLTP databases unless the engine can recover from journal replay and you tolerate partial transactions.
+
+**Application-consistent** snapshots require cooperation: `preStop` hooks, database-native backup tools (`pg_basebackup`, MySQL Enterprise Backup, MongoDB Ops Manager), or cloud features like AWS RDS snapshots and Azure SQL automated backups. For Kubernetes, the durable pattern is often **database replication out of the cluster** plus Velero for configuration, not Velero alone for ledger data.
+
+Cross-region data paths differ by engine:
+
+- **Amazon RDS / Aurora**: cross-Region read replicas or Aurora global databases; promotion changes DNS endpoints.
+- **Google Cloud SQL**: read replicas in other regions; restore creates new instances from backups.
+- **Azure Database**: geo-redundant backup storage and failover groups for SQL; flexible server geo-restore options per SKU.
+
+PersistentVolumes follow storage replication rules. EBS snapshots copy to other Regions with [Amazon EBS snapshot copy](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-copy-snapshot.html). GCE supports snapshot schedules and multi-region storage policies. Azure Disk snapshots copy across regions via resource groups you designate during backup policy setup. Align PV restore zones with node availability zones or PVCs remain unbound.
+
+```mermaid
+flowchart TB
+    subgraph K8sRestore["Kubernetes restore path"]
+        V[Velero / managed backup] --> API[API objects restored]
+        API --> PVC[PVC recreated]
+    end
+    subgraph DataRestore["Data restore path"]
+        PVC --> SNAP[Volume snapshot or file backup]
+        SNAP --> DB[Database recovery / replication promotion]
+    end
+    API -.->|Does not replace| DB
+```
+
 ---
 
 ## Cross-Region Replication for DR
@@ -321,7 +432,9 @@ Backups are useless if they are destroyed in the same regional outage that took 
 
 ### Container Image Replication
 
-During a disaster, you must pull container images to your new DR cluster. If your primary registry (e.g., ECR in `us-east-1`) is down, your pods will fail with `ImagePullBackOff`. You must configure cross-region replication for your registries.
+During a disaster, you must pull container images to your new DR cluster. If your primary registry in the failed region is unreachable, restored Deployments will sit in `ImagePullBackOff` even when etcd and databases are healthy. Image DR is therefore part of RTO, not an optional packaging detail.
+
+On AWS, configure [Amazon ECR replication](https://docs.aws.amazon.com/AmazonECR/latest/userguide/replication.html) to push images to a secondary Region automatically. On GCP, replicate images across [Artifact Registry](https://cloud.google.com/artifact-registry/docs/repositories/copy-images) locations (multi-region buckets or copy-on-push to a DR region)—remote repositories are pull-through caches of an upstream and do not substitute for a copy in another region if that upstream is unreachable. On Azure, [Azure Container Registry geo-replication](https://learn.microsoft.com/en-us/azure/container-registry/container-registry-geo-replication) keeps registries warm in paired regions. Pin image digests in manifests when possible so a restored Deployment does not pull a newer mutable tag that changed between backup and restore.
 
 ```bash
 # AWS ECR Cross-Region Replication Example
@@ -337,22 +450,40 @@ aws ecr put-replication-configuration \
 
 ### Persistent Volume Replication
 
-While Velero can back up volume data to S3, this file-level copy is slow for large databases. For critical workloads, use storage-level replication (like AWS EBS snapshots or CSI volume replication) synced to your DR region.
+While Velero can back up volume data to S3, this file-level copy is slow for large databases. For block-level asynchronous replication, use the **csi-addons** [Volume Replication](https://github.com/csi-addons/kubernetes-csi-addons) API with a driver that implements mirroring (for example Ceph-CSI RBD mirroring). The EBS CSI driver does not implement `VolumeReplication`; pair this CRD with mirroring-capable storage, not generic EBS snapshots alone.
 
 ```yaml
-# Example: CSI VolumeReplication CRD (requires replication-capable CSI driver)
+# Example: VolumeReplication (csi-addons; mirroring-capable driver, e.g. Ceph-CSI)
 apiVersion: replication.storage.openshift.io/v1alpha1
 kind: VolumeReplication
 metadata:
   name: prod-db-replication
   namespace: data
 spec:
-  volumeSnapshotClass: ebs-csi-snapclass
+  volumeReplicationClass: rbd-volumereplicationclass   # driver-specific (e.g. Ceph-CSI)
   replicationState: primary
-  replicationSecretName: ebs-replication-secret
+  dataSource:
+    kind: PersistentVolumeClaim
+    name: prod-db-pvc
 ```
 
+### Multi-region restore mechanics by provider
+
+DR fails in details that diagrams hide: snapshot permissions, KMS keys, service quotas, and identity bindings do not travel with YAML.
+
+**AWS:** Provision the DR EKS cluster and node IAM roles first. Replicate or copy Velero backup buckets with S3 Cross-Region Replication; consider S3 Replication Time Control if backup RPO must be bounded ([S3 replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html)). Copy EBS snapshots to the DR Region or use AWS Backup copy actions. Restore with Velero `BackupStorageLocation` pointing at the DR bucket prefix. Promote RDS cross-Region replicas. Update Route 53 failover or weighted records (see DNS section). Verify security groups and VPC endpoints exist in the DR VPC—restore tests often fail because `sts` or `ecr.api` endpoints were never created there.
+
+**GCP:** Create the DR GKE cluster with Workload Identity pools and Backup for GKE `RestorePlan` targeting the alternate cluster ([restore guide](https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/how-to/restore)). Copy disk snapshots or use Backup for GKE storage in a multi-region or alternate region backup plan location. Promote Cloud SQL replicas or restore instance backups. Shift DNS using Cloud DNS routing policies or global load balancing frontends. Remember image pulls: replicate Artifact Registry or configure remote pulls to avoid `ImagePullBackOff` during regional outages.
+
+**Azure:** Install the Backup extension in the DR AKS cluster and enable Trusted Access from the geo-redundant Backup vault ([restore in secondary region](https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-cluster-restore)). Snapshot resource groups must exist in the target region. Promote Azure Database failover groups or restore flexible server backups. Use Azure Traffic Manager priority or weighted profiles, or Azure Front Door origin groups, for DNS/front-door cutover. Key Vault keys and managed identities must be replicated or recreated with identical names to avoid secret mount failures.
+
+---
+
 ## DR Patterns for Kubernetes
+
+Choosing a pattern is an economic and operational decision, not a badge of maturity. Teams sometimes implement warm standby for stateless APIs while keeping backup-and-restore for internal admin tools, because the revenue path justifies standing cost and the admin portal tolerates next-day recovery. Document the pattern per service tier in a service catalog so incident commanders do not debate architecture during outages.
+
+When mixing patterns, align **data plane** and **control plane** tiers. A warm standby Kubernetes cluster pointing at a database still on backup-and-restore RPO will violate leadership expectations even if pods start quickly. Conversely, synchronous database replication with cold Kubernetes restore shifts RTO to cluster build time—users see no data loss but long UI outages.
 
 ### Pattern 1: Backup & Restore (Cold DR)
 
@@ -373,11 +504,17 @@ flowchart LR
     S3_P -->|Cross-region replication<br/>RPO: 1 hour| S3_D
 ```
 
-**Cost**: Lowest. You pay only for S3 storage and cross-region replication in steady state. The DR cluster is provisioned only during a disaster.
+**Cost**: Lowest steady-state spend. You pay primarily for object storage, snapshot storage, and cross-region replication of backup artifacts while DR compute remains off.
 
-**Risk**: Longest recovery time. You are building infrastructure from scratch during the most stressful moment possible.
+**Risk**: Longest recovery time because humans or automation must provision clusters, restore volumes, re-establish identities, and warm caches during the incident. Runbooks and IaC modules must be pre-tested; otherwise theoretical four-hour RTO becomes eleven-hour reality.
 
 ### Pattern 2: Pilot Light
+
+Pilot light keeps the minimum viable platform alive in the DR region while application replicas stay scaled down. Typical components always running include a small EKS/GKE/AKS node pool, CoreDNS, CNI, GitOps controller, observability agents, service mesh control plane, and a database read replica ingesting changes from primary. Application Deployments may exist at zero replicas or a single canary pod to validate manifests each week.
+
+Failover steps are scale-out rather than greenfield: increase node groups, raise HPA minimums, promote database replica, flip DNS. RTO improves because you are not waiting for cluster creation APIs or addon installation during the incident. RPO is dominated by database replication lag plus any Kubernetes objects created since the last Velero backup if GitOps sync is disabled in DR.
+
+Cost is the standby tax: NAT gateways, control plane hours, minimal nodes, and replication bandwidth run 24/7. Finance should compare pilot light steady cost against revenue at risk for one hour of outage; that breakeven math often justifies pilot light for customer-facing tiers only.
 
 ```mermaid
 flowchart LR
@@ -397,6 +534,12 @@ flowchart LR
 
 ### Pattern 3: Warm Standby
 
+Warm standby runs a meaningful fraction of production capacity in the DR region continuously—often thirty to fifty percent of CPU and memory for stateless tiers, with databases in hot standby or low-lag synchronous modes where budgets allow. Ingress or Gateway API objects may already receive synthetic traffic or dark-canary requests to keep caches warm. Failover becomes primarily traffic shift, scale-up, and database role change rather than manifest installation.
+
+Operational complexity rises because you must prevent configuration drift between regions. GitOps with Kustomize overlays per region is the usual pattern: same base manifests, different replica counts, storage classes, and external URLs. Secrets and ConfigMaps must reference region-local endpoints even during normal operations, or failover introduces a thundering herd of manual edits.
+
+Warm standby is the highest DR tier before active-active covered in Module 8.6. If leadership demands sub-five-minute RTO for reads and writes globally without maintenance windows, you have outgrown warm standby—do not pretend DNS failover to a warm cluster satisfies active-active consistency requirements.
+
 ```mermaid
 flowchart LR
     subgraph Primary["Primary Region (us-east-1)"]
@@ -413,13 +556,29 @@ flowchart LR
     EKS_D -.->|On disaster:<br/>Scale to 6 nodes<br/>Route 100% traffic<br/>RTO: 5-10 mins| EKS_D
 ```
 
+> **Hypothetical scenario: The eleven-hour RTO surprise**
+>
+> A retail platform documented RTO of four hours for its Kubernetes estate. During the annual game day, engineers needed eleven hours to pass health checks. etcd restore on self-managed test clusters finished in twenty minutes, but managed production recovery was slower for different reasons: three CRDs installed by operators were missing from backups, PVCs could not bind because the DR StorageClass referenced a zone absent in the failover region, External Secrets Operator still referenced a primary-region Key Vault URL, and the database connection string in a ConfigMap still pointed at the failed region's endpoint. DNS with a 300-second TTL added thirty-five minutes of split-brain user traffic. The post-game-day rule: **RTO = 2 × measured game-day time** until two consecutive drills beat the target.
+
 ---
 
-## DNS Failover
+## DNS Failover Across AWS, GCP, and Azure
 
-DNS is the traffic director in any DR scenario. How you configure DNS failover determines whether your users experience a smooth transition or a prolonged outage.
+DNS is the traffic director in any DR scenario, and it is also the hidden RTO line item teams forget. Health checks may declare the primary unhealthy in under a minute, but resolvers worldwide cache your previous answers until TTL expires. Multi-cloud Kubernetes DR therefore pairs **low TTL on user-facing records** with **health-checked failover or weighted routing** at the provider edge.
 
-### Route53 Health Check + Failover
+### Amazon Route 53 (failover and ARC)
+
+Route 53 supports health-checked failover records between primary and secondary targets ([failover routing](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-failover.html)). For complex application recovery orchestration—scaling ASGs, invoking Lambda, updating records—**Route 53 Application Recovery Controller (ARC)** provides readiness checks and routing controls that integrate with cell-based architectures. ARC does not replace Velero; it coordinates traffic when your DR cluster is actually ready.
+
+### Google Cloud DNS
+
+Cloud DNS routing policies include weighted round robin and geo-based routing for steering users toward healthy regions. Pair DNS changes with [Cloud Load Balancing](https://cloud.google.com/load-balancing/docs) frontends that already health-check GKE Ingress or Gateway API backends. For global anycast-style entry, use external HTTP(S) load balancers with multi-region backend services rather than relying on DNS alone.
+
+### Azure Traffic Manager and Front Door
+
+[Azure Traffic Manager](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-overview) offers priority, weighted, performance, and geographic routing methods with endpoint health probes. **Azure Front Door** adds CDN-like global entry with origin groups per region; you can disable an origin during failover while keeping TLS and WAF policies consistent. AKS clusters behind AGIC or NGINX Ingress still need in-cluster health endpoints that reflect database readiness, not only `/healthz` on static pods.
+
+### Route 53 health check + failover (AWS reference implementation)
 
 ```bash
 # Create health check for primary region
@@ -450,7 +609,7 @@ aws route53 change-resource-record-sets \
           "SetIdentifier": "primary",
           "Failover": "PRIMARY",
           "AliasTarget": {
-            "HostedZoneId": "Z2FDTNDATAQYW2",
+            "HostedZoneId": "Z26RNL4JYFTOTI",
             "DNSName": "primary-nlb.elb.us-east-1.amazonaws.com",
             "EvaluateTargetHealth": true
           },
@@ -465,7 +624,7 @@ aws route53 change-resource-record-sets \
           "SetIdentifier": "secondary",
           "Failover": "SECONDARY",
           "AliasTarget": {
-            "HostedZoneId": "Z3AADJGX6KTTL2",
+            "HostedZoneId": "Z32O12XQLKSWN1",
             "DNSName": "dr-nlb.elb.eu-west-1.amazonaws.com",
             "EvaluateTargetHealth": true
           }
@@ -490,11 +649,35 @@ aws route53 change-resource-record-sets \
 
 **RECOMMENDATION:** Set TTL=60s for DR-critical records. Lower TTLs mean more DNS queries (more cost) but faster failover. TTL=30s is the practical minimum—below that, many resolvers ignore the TTL and cache for at least 30 seconds anyway.
 
+Include DNS propagation in runbook time budgets. Mobile carrier resolvers and corporate proxies cache longer than spec TTL. During game days, measure client-side resolution from multiple networks, not only `dig` from a bastion in the DR VPC.
+
+---
+
+## Kubernetes 1.35 Considerations for Backup and Restore
+
+Kubernetes 1.35 continues shifting storage and admission behavior in ways that affect DR. Container Storage Interface (CSI) snapshot APIs are the default path for volume backup in Velero and managed cloud backup services; in-tree volume plugins are legacy. Validate that `VolumeSnapshotClass` objects exist in every region where you might restore, and that snapshot classes reference the same driver names your DR cluster will use.
+
+Admission controllers and validating webhooks installed by policy engines (OPA Gatekeeper, Kyverno, Pod Security admission) must be restored before workloads or restores will fail with policy violations that did not exist when backups were taken. Back up cluster-scoped webhook configurations or document their Helm chart versions in Git.
+
+For service mesh and Gateway API resources, restore order matters: CRDs, GatewayClasses, Gateways, then HTTPRoutes. Velero hooks can annotate critical resources, but GitOps often replays them faster if repositories are authoritative.
+
+Node labels for topology spread constraints and zone-aware PVCs must exist in DR zones. If primary used `topology.kubernetes.io/zone: us-east-1a` and DR nodes only exist in `eu-west-1b`, StatefulSets with strict spread may pend until you adjust PVCs or node labels deliberately in the runbook.
+
+---
+
+## GitOps, Secrets, and Configuration Continuity
+
+Velero captures many in-cluster objects, but production platforms also depend on **Git repositories**, **Helm chart versions**, **Argo CD Application** sets, **Flux Kustomizations**, and secrets material from **External Secrets Operator**, **Secrets Store CSI Driver**, or cloud secret managers. DR plans must list which of these are authoritative and which are derivable.
+
+Git is usually authoritative for Deployment manifests and Ingress rules. If Git is available during a regional outage, you can redeploy application shape faster than full Velero restore for stateless tiers. Secrets are not authoritative in Git; they require replicated Key Vault, Secrets Manager, or Parameter Store with multi-region keys and identities that exist in the DR cluster before pods start. Sealed Secrets and SOPS-encrypted files need the decryption keys available in the DR region, not only on the primary HSM.
+
+Run a quarterly diff between a live cluster export (`kubectl get -A -o yaml` filtered) and GitOps desired state. Objects that exist only in the cluster—often CRDs installed by operators, validating webhook configurations, or storage classes created by hand—are restore surprises. Check them into Git or back them up with explicit Velero labels.
+
 ---
 
 ## IaC as Disaster Recovery
 
-The most powerful DR strategy for Kubernetes is often the simplest: **your entire infrastructure is defined in code, tested regularly, and can be recreated from scratch.**
+The most powerful DR strategy for Kubernetes is often the simplest: **your entire infrastructure is defined in code, tested regularly, and can be recreated from scratch.** Terraform, OpenTofu, Pulumi, and cloud Deployment Manager stacks recreate VPCs, node pools, IAM, and add-ons. GitOps recreates namespaces and workloads. Backups remain necessary for data that is not reconstructible from code: database files, uploaded user content, and volume snapshots.
 
 ```mermaid
 flowchart TD
@@ -596,15 +779,85 @@ kubectl top pods -A --sort-by=cpu
 
 ---
 
+## Implementing a Multi-Cloud DR Program End to End
+
+A DR program is more than tooling installation; it is a closed loop from business impact analysis through testing and finance review. Start by inventorying workloads on Kubernetes with their data classifications, external dependencies, and current backup coverage. For each workload, record actual RPO and RTO from last game day, not policy documents. Gaps become epics: enable volume snapshots, add cross-region replica, lower DNS TTL, or accept risk with executive sign-off.
+
+**Phase 1 — Discover and classify.** Export Velero schedules, managed backup policies, RDS/GCP/Azure database replication status, and registry replication rules. Flag namespaces without `snapshot-volumes` and databases without cross-region replicas. Identify operators that install cluster-scoped CRDs; these are frequent restore gaps.
+
+**Phase 2 — Design tiers.** Tier 0 (revenue critical) might require warm standby and database promotion runbooks under thirty minutes. Tier 2 (internal tools) might use backup-and-restore with twenty-four-hour RTO. Document which Kubernetes pattern applies per tier and which cloud services implement the data plane.
+
+**Phase 3 — Automate evidence.** Backup success metrics should page on failure, not on age alone. Track replication lag for databases and object storage. Store Terraform plans for DR regions in CI with periodic `terraform plan` to detect drift. Argo CD applications for DR should sync from the same Git revision policy as production.
+
+**Phase 4 — Exercise and recalibrate.** Quarterly game days measure wall-clock duration per runbook step. Update RTO targets to twice the best recent measurement until two consecutive drills beat the target. After major Kubernetes upgrades (for example 1.35 admission or CSI changes), rerun restore drills because webhook and storage behavior may change fail modes.
+
+**Phase 5 — Govern cost and risk.** Finance reviews DR spend quarterly: standby nodes, replication egress, snapshot storage, global load balancers. Engineering presents trade-offs explicitly: removing warm standby saves currency but adds RTO minutes; leadership must choose with data.
+
+Multi-cloud estates add coordination overhead: identity federation must work in the DR region, KMS keys must be replicated or dual-homed, and observability stacks must ingest metrics from the failover cluster without relying on the primary region's Prometheus. Standardize on OpenTelemetry export to a region-independent SaaS or dual-write collectors when possible.
+
+Compliance regimes (PCI, HIPAA, SOC 2) often mandate **immutable backups** and **restore testing evidence**. Managed vault tiers on Azure, AWS Backup Vault Lock, and GCS bucket retention policies satisfy immutability when configured deliberately. Auditors ask for restore logs, not backup job creation logs—game day artifacts are compliance deliverables.
+
+Finally, align DR with incident management. Severities should trigger pre-written communication templates and decision trees about failover versus failback. A DR architecture that requires heroics from one engineer who "was there in 2023" is fragile; runbooks must stand alone. When failover completes, schedule failback planning: split-brain writes happen if both regions accept traffic without a single writer of truth for data.
+
+Document dependencies outside Kubernetes explicitly: SaaS identity providers, payment gateways, certificate authorities, and artifact signing services must be reachable from the DR region or failover stops at the edge even when pods are healthy. These dependencies belong in the same service catalog tiering spreadsheet as RTO and RPO so incident commanders see the full blast radius before approving DNS cutover. Game-day scorecards should list each external dependency with pass or fail, not only Kubernetes API object counts restored by Velero into the secondary DR region target cluster.
+
+---
+
+## DR Runbooks, Game Days, and Restore Drills
+
+Untested backups are inventory, not disaster recovery. A runbook is a chronological program with prerequisites, commands, expected outputs, decision branches, and rollback steps—written for the engineer who did not build the system and accessed from infrastructure that survives the outage.
+
+Store runbooks **out of band** from the cluster they recover: a separate cloud object bucket with public-read blocked except via break-glass SSO, a printed binder for total cloud loss exercises, or a secondary provider static site. If the runbook lives only in Confluence backed by the same EKS cluster, you will repeat the classic failure mode where documentation and workloads disappear together.
+
+A credible runbook section list:
+
+1. **Declaration criteria** — when to fail over versus fail back, who approves, communication templates.
+2. **Pre-flight checks** — backup age, replication lag, CRD inventory diff, available IP space, quota headroom in DR region.
+3. **Infrastructure activation** — Terraform/Pulumi `dr_active=true`, node pool scale, Vault/Key replication status.
+4. **Data promotion** — database replica promotion commands with verification queries.
+5. **Kubernetes restore** — Velero or managed restore IDs, namespace order, storage class validation.
+6. **Traffic cutover** — DNS/TM/Front Door change with TTL math spelled out.
+7. **Verification** — synthetic transactions, error budget stop, observability dashboards.
+8. **Failback** — how to return primary without splitting writes.
+
+**Game days** exercise the runbook quarterly for tier-1 services. Tabletop the first hour, then execute a scoped restore into an isolated DR cluster or namespace. Measure wall-clock times per step; update RTO targets from measurements, not aspirations. Chaos experiments (node drains, zone failures) validate steady-state resilience but do not replace full restore drills—deleting a namespace locally does not prove cross-region database promotion works.
+
+---
+
+## Cost Lens: What Makes a DR Bill Spike
+
+DR is a subscription you hope never to cash out. Finance sees it as duplicate infrastructure; engineering should translate patterns into line items leadership can compare.
+
+| Cost driver | Backup & restore | Pilot light | Warm standby |
+|---|---|---|---|
+| DR compute (EKS/GKE/AKS nodes) | Near zero until event | Small always-on pool | Substantial always-on pool |
+| Database replication | Replica + storage IO | Replica + storage IO | Often sync or low-lag async |
+| Cross-region egress | Backup replication, snapshot copy | Continuous replication streams | Continuous + health-check traffic |
+| Snapshot / backup storage | Grows with retention × data size | Same + more frequent | Same + more frequent |
+| DNS / global load balancing | Low query volume at TTL 60s | Health check charges | Multi-region LB hourly fees |
+| Operational toil | High during incident | Medium | Lower incident time, higher steady run |
+
+**Cross-region replication egress** is the silent multiplier. Replicating 20 TiB of database changes and Velero object storage between `us-east-1` and `eu-west-1` can exceed compute cost during churn-heavy workloads. Use replication filters, compress backups, tier cold snapshots to archive storage classes, and avoid copying ephemeral cache data.
+
+**Standby capacity cost** scales with pod count and GPU/SSD SKUs even when idle. Pilot light clusters still pay for control plane hours, one node pool, NAT gateways, and observability agents. Warm standby duplicates load balancer hours and managed Prometheus scrapes.
+
+**Snapshot storage** accrues with CSI frequency. Hourly EBS snapshots of terabyte volumes without lifecycle policies have surprised finance teams when snapshots retained after workload deletion were never garbage-collected.
+
+Right-size DR to tiered RTO/RPO per application. Not every microservice needs warm standby; only the revenue path and its dependencies do. Document the cost of each ladder rung when proposing active-active in Module 8.6—leadership approves budgets when engineers show the invoice impact of each minute of RTO removed.
+
+Engineering leaders should publish a **DR balance sheet** annually: standby compute dollars, replication egress dollars, backup storage gigabytes, hours spent in game days, and minutes of customer outage avoided in the last drill. Without that balance sheet, teams either overspend on warm standby for low-value services or underspend until a regional outage converts theoretical RTO into career-defining weekends.
+
+---
+
 ## Did You Know?
 
-1. **Velero was originally called "Heptio Ark"** and was created by the team at Heptio (founded by two of Kubernetes' co-creators, Joe Beda and Craig McLuckie). When VMware acquired Heptio in 2018, the project was renamed to Velero (Latin for "sail") and donated to the CNCF. It is now the de facto standard for Kubernetes backup, with over 8,000 GitHub stars and production use at thousands of organizations.
+1. **Velero was originally called Heptio Ark** and was renamed from Heptio Ark to Velero under VMware, then donated to the CNCF Sandbox by Broadcom in 2026. The name change is not cosmetic: Ark backups are not compatible with modern Velero CRDs, so migration projects still encounter legacy objects in object storage buckets that were never lifecycle-expired.
 
-2. **etcd can handle a cluster state restore in under 60 seconds** for a typical cluster with 10,000-15,000 objects. The bottleneck is not the restore itself but the time for all controllers to reconcile state after the restore. The kube-controller-manager must re-evaluate every ReplicaSet, Deployment, and StatefulSet, which can take several minutes for large clusters. During this reconciliation window, some pods may be temporarily evicted and rescheduled.
+2. **etcd restore speed is rarely the long pole** on self-managed clusters. Restoring a snapshot of 10,000–15,000 Kubernetes objects can finish quickly, but controllers may spend many minutes reconciling Deployments, StatefulSets, and admission webhooks before the API server reflects a steady state users can trust.
 
-3. **AWS S3 Cross-Region Replication has a 99.99% SLA for replication within 15 minutes,** but the actual replication latency for most objects is under 30 seconds. This matters for Velero backups: if your primary region fails immediately after a backup completes, the backup files may not have replicated to the DR region yet. For critical RPO requirements, enable S3 Replication Time Control (RTC), which guarantees 99.99% of objects are replicated within 15 minutes.
+3. **S3 Cross-Region Replication is eventually consistent by default**, which means Velero backup objects may not exist in the DR bucket yet when the primary region fails seconds after `Backup` completion. For stricter backup RPO, AWS offers Replication Time Control with a documented 15-minute target for replicated objects ([S3 replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html)).
 
-4. **The GitLab 2017 data loss incident** was live-streamed on YouTube. The engineering team broadcast their recovery efforts in real-time, including the moments of panic when they discovered each backup method had failed. The video became one of the most-watched incident response recordings in tech history and directly inspired hundreds of companies to test their backup procedures. GitLab later published a detailed post-mortem that became a template for incident documentation.
+4. **Azure Backup for AKS operational tier advertises four-hour minimum RPO** between successful backups, while vault-tier copies support longer retention with ransomware-resistant separation ([AKS backup overview](https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-backup-overview)). That gap matters when leadership asks for "hourly backups" but only the operational policy is configured.
 
 ---
 
@@ -628,7 +881,7 @@ kubectl top pods -A --sort-by=cpu
 <details>
 <summary>1. You are meeting with the VP of Engineering to define the DR strategy for a new payment processing system. They state, "We cannot afford to lose a single transaction, but if the system goes down, we have 4 hours to bring it back online before we face compliance fines." How would you translate this into RTO and RPO metrics, and how do these two metrics influence your architectural choices for this system?</summary>
 
-The VP's requirements translate to an RPO (Recovery Point Objective) of zero and an RTO (Recovery Time Objective) of 4 hours. RPO dictates how much data you can afford to lose; an RPO of zero means you cannot rely on periodic backups and must implement synchronous replication across regions so data is committed in both places simultaneously before acknowledging the transaction. RTO dictates how long the system can be unavailable; an RTO of 4 hours means you do not need the expense of an active-active or warm standby setup. You can use a 'Pilot Light' or even a automated 'Backup & Restore' infrastructure provisioning process, as long as the data itself is synchronously replicated and protected.
+The VP's requirements translate to an RPO (Recovery Point Objective) of zero and an RTO (Recovery Time Objective) of 4 hours. RPO dictates how much data you can afford to lose; an RPO of zero means you cannot rely on periodic backups and must implement synchronous replication across regions so data is committed in both places simultaneously before acknowledging the transaction. RTO dictates how long the system can be unavailable; an RTO of 4 hours means you do not need the expense of an active-active or warm standby setup. You can use a 'Pilot Light' or even an automated 'Backup & Restore' infrastructure provisioning process, as long as the data itself is synchronously replicated and protected.
 </details>
 
 <details>
@@ -665,7 +918,9 @@ You must completely decouple your disaster recovery documentation from the infra
 
 ## Hands-On Exercise: Build and Test a DR Plan
 
-In this exercise, you will set up Velero backups, perform a simulated disaster, and verify recovery.
+In this exercise, you will set up Velero backups against local object storage, deploy a sample payments namespace, simulate total namespace loss, restore from backup, and draft a runbook section with explicit timing estimates. The exercise uses kind or minikube so you can practice restore mechanics without cloud spend; translate the same steps to your organization's Velero `BackupStorageLocation` and managed snapshot classes in production.
+
+Treat a successful local restore as necessary but not sufficient evidence of DR readiness. Production adds IAM boundaries, CRD admission webhooks, Pod Security admission, and storage classes that kind does not emulate. After this lab, schedule a game day in a non-production cloud region that exercises cross-region snapshot copy and database promotion, not only namespace delete in place.
 
 ### Prerequisites
 
@@ -959,7 +1214,17 @@ rm -f /tmp/velero-creds
 
 ## Sources
 
-- [GitLab 2017 Database Outage Postmortem](https://about.gitlab.com/blog/postmortem-of-database-outage-of-january-31/) — Primary incident record for the backup failures, live-streamed recovery, and operational lessons used in this module.
-- [Operating etcd Clusters for Kubernetes](https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/) — Upstream reference for etcd's role in Kubernetes and the supported backup and restore workflow.
-- [Disaster Recovery Options in the Cloud](https://docs.aws.amazon.com/whitepapers/latest/disaster-recovery-workloads-on-aws/disaster-recovery-options-in-the-cloud.html) — Maps backup-and-restore, pilot light, warm standby, and active-active patterns to RTO/RPO trade-offs.
-- [Route 53 Failover Record Values](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/resource-record-sets-values-failover.html) — Authoritative reference for failover-record TTL guidance in the DNS section.
+- [Operating etcd clusters for Kubernetes](https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/) — Supported etcd backup and restore concepts for self-managed clusters.
+- [Disaster Recovery Options in the Cloud (AWS)](https://docs.aws.amazon.com/whitepapers/latest/disaster-recovery-workloads-on-aws/disaster-recovery-options-in-the-cloud.html) — DR strategy ladder and RTO/RPO framing.
+- [Backup your EKS Clusters with AWS Backup](https://docs.aws.amazon.com/eks/latest/userguide/integration-backup.html) — Managed EKS backup integration and scope.
+- [Security in Amazon EKS (shared responsibility)](https://docs.aws.amazon.com/eks/latest/userguide/security.html) — AWS management of the control plane and etcd.
+- [Amazon EBS snapshot copy](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-copy-snapshot.html) — Cross-Region volume snapshot mechanics.
+- [Amazon S3 replication](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication.html) — Cross-Region backup object replication and RTC.
+- [Route 53 failover routing](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-failover.html) — DNS failover policies and health checks.
+- [Backup for GKE concepts](https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/concepts/backup-for-gke) — Managed GKE backup architecture.
+- [Backup for GKE backup plans](https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/how-to/backup-plan) — RPO scheduling and retention parameters.
+- [Backup for GKE restore](https://cloud.google.com/kubernetes-engine/docs/add-on/backup-for-gke/how-to/restore) — Cross-cluster and cross-location restore behavior.
+- [Azure Backup for AKS overview](https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-backup-overview) — Extension, vault tiers, and RPO characteristics.
+- [Restore AKS using Azure Backup](https://learn.microsoft.com/en-us/azure/backup/azure-kubernetes-service-cluster-restore) — Cross-region restore prerequisites.
+- [Azure Traffic Manager overview](https://learn.microsoft.com/en-us/azure/traffic-manager/traffic-manager-overview) — Multi-region DNS routing methods.
+- [Velero documentation](https://velero.io/docs/) — Backup, restore, schedules, and volume snapshot providers.

--- a/src/content/docs/cloud/advanced-operations/module-8.6-active-active.md
+++ b/src/content/docs/cloud/advanced-operations/module-8.6-active-active.md
@@ -26,13 +26,13 @@ When you finish this module, you will be able to design, route, replicate, and o
 
 ## Why This Module Matters
 
-In October 2021, a global food delivery platform processing roughly 34 million daily orders learned that warm standby disaster recovery is not the same as surviving partial regional degradation. The platform ran primarily in a single AWS region (us-east-1) with a warm standby in eu-west-1 for DR. At 14:22 UTC, an AWS networking issue caused elevated packet loss in us-east-1 for 23 minutes — not a full outage, but a sustained period where services were degraded rather than dead. The warm standby could not help because the primary was technically "up," just slow, and health checks passed because they tested reachability rather than latency. For those 23 minutes, order placement latency spiked from 200ms to 4.5 seconds, users abandoned carts, restaurants received stale orders, and delivery ETAs became meaningless.
+Hypothetical scenario: A global food delivery platform processing tens of millions of daily orders runs primarily in one AWS region with a warm standby in another region for disaster recovery. During a regional networking event that causes elevated packet loss for roughly twenty minutes — not a full outage, but sustained degradation — the warm standby cannot help. The primary region is technically up, just slow, and health checks pass on reachability rather than latency. Order placement latency spikes, users abandon carts, and a competitor running active-active across three regions sees no user-visible impact from the same underlying cloud impairment. Users who switch during the degradation window often do not return.
 
-The financial impact was $3.8 million in lost orders, but the strategic impact was larger: the company's biggest competitor, which ran active-active across three regions, experienced zero user-visible impact from the same AWS issue, and users who switched during those 23 minutes did not come back. That incident drove a six-month migration to active-active, during which the engineering team discovered that active-active is not "DR but better." It is a fundamentally different architecture that changes how you think about state, consistency, routing, and failure. This module teaches you how to design, implement, and operate multi-region active-active Kubernetes deployments — including the hard parts that architecture diagrams always skip.
+That gap drives a long migration where the engineering team discovers that active-active is not "DR but better." It is a fundamentally different architecture for state, consistency, routing, and failure. [Module 8.5](../module-8.5-disaster-recovery/) maps RTO and RPO to backup, pilot light, warm standby, and active-active on the DR ladder. This module assumes you already chose near-zero RTO for user-facing paths. It teaches how to design, implement, and operate multi-region active-active Kubernetes deployments across AWS, GCP, and Azure — including the hard parts that architecture diagrams skip.
 
 ---
 
-Before you read on, pause on this question: if both regions in an active-active setup can accept write requests simultaneously, what happens when two users try to buy the last remaining item in your inventory at the exact same millisecond from different regions? The answer depends entirely on which consistency strategy you chose, and that is why state management dominates active-active design.
+Before you read on, pause on this question: if both regions in an active-active setup can accept write requests simultaneously, what happens when two users try to buy the last remaining item in your inventory at the exact same millisecond from different regions? The answer depends entirely on which consistency strategy you chose, and that is why state management dominates active-active design. Keep that inventory question in mind as you read routing and idempotency sections — they are not separate topics, they are the same incident viewed from different layers.
 
 ## What Active-Active Actually Means
 
@@ -50,6 +50,8 @@ graph LR
 
 The difference from active-passive DR is not merely redundancy at rest; it is operational parallelism under normal conditions. In practice, active-active implies that both regions may write data (so state management becomes the hard problem), both regions must stay sufficiently in sync that users do not see arbitrary divergence (so replication lag is a design input, not an afterthought), routing must be intelligent rather than a blunt DNS failover, and every service must either tolerate multi-writer semantics or be explicitly partitioned so writers do not collide.
 
+Engineering leaders often ask for "zero downtime" and hear "active-active." Clarify the promise: you are buying **continuous service during many failure modes**, not immunity from bugs, bad deploys, or schema migrations. Schema changes still need expand/contract patterns or dual-write windows. Feature flags still need per-region kill switches when a new build misbehaves in only one geography. Security incidents still require coordinated key rotation across regions, which is harder when each cluster holds cached secrets. Treat active-active as a **product and operations program**, not a one-time infrastructure ticket closed after the second cluster goes green.
+
 ### The Active-Active Spectrum
 
 Not everything in a large platform needs to be active-active, and most organizations deliberately use a hybrid approach where only components with clear latency or availability ROI pay the coordination tax. The table below is a pragmatic starting point for classifying components before you commit engineering time to global write paths.
@@ -65,11 +67,21 @@ Not everything in a large platform needs to be active-active, and most organizat
 | Search index | Yes | Replicated index per region |
 | Message queues | Regional | Each region has its own queue, cross-region for specific flows |
 
+### Why Teams Choose Active-Active Over Warm Standby
+
+Warm standby and pilot light from [Module 8.5](../module-8.5-disaster-recovery/) optimize for **failover events**: traffic shifts when a region is declared unhealthy. Active-active optimizes for **continuous partial failure** and **latency under normal load**. You pay full compute in every participating region. You gain three properties warm standby cannot buy cheaply.
+
+First, **near-zero RTO for routing**: global load balancers and DNS health checks steer users away from a sick region without a manual promotion runbook. Second, **baseline latency**: European users hit European clusters instead of transatlantic round trips to a US-primary stack. Third, **no idle standby tax on revenue paths**: every region earns its keep during steady state, which helps finance teams accept duplicated infrastructure.
+
+The tradeoff is explicit on the DR ladder from Module 8.5. Active-active sits at the top for both RTO and RPO targets, and for cost and complexity. You inherit CAP constraints, replication lag, idempotency requirements, and multi-cloud egress bills that backup-and-restore never touches. Mature teams adopt active-active **selectively** on the spectrum table above — not as a default for every CronJob and batch exporter.
+
 ---
 
 ## Stateless Active-Active: The Easy Part
 
 Stateless services — APIs that do not maintain local session state between requests beyond what they read from shared stores — are the straightforward case for active-active. You deploy the same service in multiple regions, place a global load balancer in front, and route users to the nearest healthy endpoint by latency. The diagram below shows the common pattern: regional EKS clusters serving reads from local replicas while writes still funnel to a designated primary database, which is already a hint that "stateless" at the pod layer rarely means "stateless" for the whole system.
+
+On **AWS**, the usual path is Route 53 or Global Accelerator in front of an Application Load Balancer attached to an EKS Ingress or Gateway API implementation. Pull container images from a registry replicated per region (ECR replication rules or pull-through cache) so a regional outage does not block pod starts. On **GCP**, publish a global external IP from a multi-cluster Gateway and let Cloud CDN cache static responses where possible. On **Azure**, terminate TLS at Front Door and forward to a regional Application Gateway ingress controller so you do not expose every AKS API server to the public internet. In all three clouds, **PodDisruptionBudgets**, **topology spread constraints**, and **HorizontalPodAutoscaler** objects should be identical in intent but tuned per region for local peak hours — European evening traffic is not US morning traffic.
 
 ```mermaid
 graph TD
@@ -160,11 +172,32 @@ patches:
         value: "us-east-1"
 ```
 
+### Multi-Region Kubernetes: Independent Clusters, Not One Stretched Cluster
+
+Production active-active on Kubernetes means **one logically independent cluster per region** (or per availability zone stamp, depending on blast-radius goals), not a single control plane stretched across WAN links. EKS, GKE, and AKS all run regional control planes; etcd (managed by the cloud provider on these offerings) is not designed for cross-region quorum the way you might stretch VMware or bare-metal clusters.
+
+**Why stretched clusters are an anti-pattern:** WAN partitions split worker nodes from apiservers or split etcd members. Kubernetes expects low-latency control-plane traffic. A partition can orphan nodes, duplicate controllers, or leave workloads scheduled where storage no longer exists. The [Kubernetes documentation on clusters](https://kubernetes.io/docs/concepts/cluster-administration/) treats a cluster as a failure domain bounded by network reliability you control.
+
+**Preferred patterns:**
+
+| Pattern | What it gives you | Tradeoff |
+|---|---|---|
+| **GitOps per fleet** (Argo CD ApplicationSet, Flux Cluster API) | Identical manifests with Kustomize/Helm overlays per region | Drift detection and promotion pipelines become mandatory |
+| **Multi-cluster services / Gateway API** | Service discovery and LB across clusters (GKE multi-cluster Services, Submariner, Istio multi-cluster) | Mesh and gateway operational complexity |
+| **Global service mesh** (optional) | mTLS, traffic splitting, observability tags per region | Control plane overhead; avoid mesh-before-need |
+| **Regional data planes** | Postgres/Cosmos/Dynamo in-region; async replication between | Application must tolerate lag and conflicts |
+
+On **EKS 1.35**, use IRSA or EKS Pod Identity for AWS API calls from pods. On **GKE**, enable Workload Identity Federation. On **AKS**, use Microsoft Entra Workload ID federated credentials — legacy AAD Pod Identity is retired; plan Entra-based federation for new clusters ([AKS workload identity overview](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview)).
+
+ApplicationSet generators (shown above) should pin **image digests**, **resource requests**, and **topology spread** per region. Pair with external secrets managers replicated per landing zone from your multi-account architecture modules.
+
 ---
 
 ## Global State Management: The Hard Part
 
 The moment your active-active deployment needs to write durable data, everything gets complicated because networks are not instantaneous and failures are not rare. The CAP theorem still applies: in the presence of a network partition, you must choose between consistency and availability. Most active-active designs bias toward availability for user-facing paths, which means you must engineer for inconsistency windows rather than pretending replication is synchronous everywhere. The three strategies below — single-writer, geo-sharding, and CRDTs — are the workhorses you will see in production, often combined in the same company for different data types.
+
+CAP is not a license to ignore **PACELC** tradeoffs either. Even without a partition, extra latency appears when you choose consistency over latency on the write path. That is why Spanner commits wait on TrueTime uncertainty, and why DynamoDB MRSC rejects conflicting concurrent writers instead of merging silently. When you present architecture options to leadership, translate CAP into customer-visible behaviors: stale reads, duplicate charges, or slower checkouts — not academic vocabulary.
 
 ### Strategy 1: Single-Writer, Multi-Reader
 
@@ -193,6 +226,8 @@ graph LR
 ```
 
 When a user reads from eu-west-1, they typically see data that is on the order of ~100ms old relative to the primary, because asynchronous replication has not yet caught up. When that same user writes from eu-west-1, the application proxies the write to us-east-1, which adds roughly ~80ms of round-trip latency on top of ordinary query time. If us-east-1 fails entirely, you promote the eu-west-1 replica to primary — a process measured in minutes, not seconds — and you accept that some recent writes may be lost, meaning your effective RPO equals the replication lag at failure time.
+
+The same pattern appears on **Cloud SQL cross-region replicas**, **Azure Database for PostgreSQL read replicas**, and self-managed Postgres with logical replication on Kubernetes. Promotion runbooks must list DNS or connection string swaps, connection pool drains, and cache invalidation steps. Game-day scripts from Module 8.5 still apply, but active-active game days add **traffic weights** — you shift ten percent of real users, not only fail a cluster in isolation. Measure p95 checkout latency during the shift; if it spikes while error rates stay flat, your health checks are lying.
 
 ```yaml
 # Application config: route writes to primary, reads to local replica
@@ -236,6 +271,8 @@ graph TD
 
 The partition key is usually the user's home region, set at registration and changed rarely. The advantage is crisp: no write conflicts, because each region owns its partition. The disadvantage is that cross-region queries are slower because you must fan out or accept stale replicas — for example, when a user in Paris reads a US friend's profile, you either read from a US data replica in eu-west-1 (~100ms stale) or read from us-east-1 directly (adding ~80ms latency but returning fresh data).
 
+Geo-sharding interacts with **Kubernetes service discovery** when microservices assume colocated databases. If the `users` service in `eu-west-1` calls the `friends` service locally but the data lives in `us-east-1`, you have rebuilt a distributed monolith with extra network hops. Align **namespace per region**, **regional service DNS**, and **API gateway routing rules** so a regional request chain stays inside the same shard unless the use case explicitly requires cross-border reads. Document rare cross-shard operations as expensive APIs with rate limits, not as default GraphQL resolvers.
+
 ### Strategy 3: Conflict-Free Replicated Data Types (CRDTs)
 
 CRDTs are data structures that allow concurrent modifications in different regions and merge automatically without manual conflict resolution, which makes them attractive for shopping carts, counters, and social graphs where last-write-wins would destroy user trust. The sequence diagram below shows the intuition: during a partition, both regions accept updates independently, and when the network heals, merge rules produce a single converged state without operator intervention.
@@ -273,6 +310,29 @@ CRDTs work well when your domain tolerates commutative merges: counters (likes, 
 | Search results | Eventual (slightly stale OK) | Regional index, async update |
 | Chat messages | Causal (order matters per conversation) | Causal broadcast or geo-shard by conversation |
 
+### Multi-Primary Databases: What Each Cloud Actually Promises
+
+When both regions must accept writes, you are shopping for a **conflict model**, not a marketing label. The table below summarizes managed options. Verify SKU limits and preview status in your account before production cutover.
+
+| Platform | Multi-region write product | Conflict / consistency behavior | Kubernetes angle |
+|---|---|---|---|
+| **AWS** | DynamoDB global tables (MREC default; MRSC optional) | MREC: asynchronous replication, **last writer wins** per item using internal timestamps. MRSC: synchronous replication; concurrent writes can fail with `ReplicatedWriteConflictException` and retry. | Run apps on EKS; use IRSA or EKS Pod Identity for AWS API access. Data plane is DynamoDB, not etcd. |
+| **GCP** | Cloud Spanner multi-region instances | **External consistency** via TrueTime commit timestamps and commit-wait; behaves like a single logical database across regions. Cross-region writes pay latency for coordination. | GKE workloads use Workload Identity Federation; Spanner is external to the cluster control plane. |
+| **Azure** | Azure Cosmos DB accounts with multiple write regions | Container-level policy at **create time only**: Last-Writer-Wins on `_ts` or a custom numeric path, merge stored procedure (API for NoSQL), or manual conflict feed. | AKS apps use Microsoft Entra Workload ID; Cosmos is a separate regional service. |
+| **Vendor-neutral** | CockroachDB, YugabyteDB on Kubernetes | Serializable distributed SQL with Raft ranges; tunable survival goals and region locality. You operate the database; the cloud provides nodes and networking. | Often deployed as a StatefulSet or operator-managed cluster per region or stretched per vendor guidance. |
+
+**Precision matters.** DynamoDB global tables in multi-Region eventual consistency (MREC) do **not** give you cross-region strongly consistent reads. Spanner does **not** use last-writer-wins for financial-style invariants; it pays commit-wait latency instead. Cosmos DB conflict policies are **immutable after container creation** — wrong policy means rebuild, not a flag flip. None of these replace application idempotency for HTTP mutations; they only shrink the database conflict surface.
+
+#### Synchronous vs Asynchronous Replication in Practice
+
+**Synchronous** replication waits for a remote acknowledgment before acknowledging the client. RPO approaches zero for that write path, but write latency includes WAN RTT. Use it sparingly for ledgers, inventory locks, and entitlement tables where oversell is unacceptable.
+
+**Asynchronous** replication returns quickly and propagates changes in the background. RPO equals lag at failure time. It is the default for RDS cross-region read replicas, many object-store replication rules, and DynamoDB MREC global tables. Active-active user experiences depend on **read-your-own-writes** and **idempotency** because async is the economic default.
+
+#### CockroachDB and Other Self-Managed SQL
+
+Teams on EKS, GKE, or AKS sometimes deploy CockroachDB or YugabyteDB when they need PostgreSQL-flavored SQL with multi-region survivability goals. You define **survival goals** (how many region failures the cluster tolerates) and **regional by table** locality rules so rows live near their writers. This is not "free active-active": you still design partition keys, follow-the-workload patterns, and test regional isolation failures. Treat operator upgrades and cross-region networking as first-class operational work, not a sidecar experiment.
+
 ---
 
 Pause and predict before continuing: if network latency between the US and Europe is ~100ms, how long does it take for a database write in the US to become visible to a read request in Europe — is it just 100ms? Network RTT is only one component; WAL flush, shipping, and replay on the replica all add time, so reads often lag writes by more than the ping you measured.
@@ -280,6 +340,8 @@ Pause and predict before continuing: if network latency between the US and Europ
 ## Replication Lag: The Silent Killer
 
 In any multi-region deployment, replication lag is the interval between a write committing in one region and that write becoming visible to readers in another region. It is not a bug you can "fix" with more engineers — it is a physics and systems constraint you design around in application code, UX copy, and consistency mode selection. Raw network latency gives you a floor: within the same AZ you often see under 1ms, cross-AZ roughly 1–2ms, cross-region within the US roughly 20–40ms, US to Europe roughly 70–120ms, and US to Asia roughly 150–250ms. Actual database replication lag adds write-to-primary WAL time (~1ms), WAL shipping across the network, and replay on the replica (~1–5ms), so realistic end-to-end lag is often 5–20ms same-region, 100–500ms cross-region, and seconds under load when replicas fall behind.
+
+Managed services expose lag differently. **Amazon RDS** cross-region read replicas report `ReplicaLag` in CloudWatch — promotion RPO equals that lag at failover time per AWS guidance on read replica promotion. **Cloud Spanner** exposes replication metadata per instance configuration; cross-region instances trade higher write latency for tighter bounds. **Azure Cosmos DB** offers five consistency levels; session consistency gives read-your-own-writes within a session when clients honor region affinity, but not arbitrary cross-region strong reads without using the right consistency knob. Instrument lag at the application layer with write-then-read tests per region pair, not only cloud averages, because hot keys stall replication queues during sales events.
 
 ### The Read-Your-Own-Writes Problem
 
@@ -327,13 +389,62 @@ def read_user_profile(user_id):
 
 ---
 
+## Session Affinity, Split-Brain, and Stateful Tiers
+
+Stateless pods are only half the story. Browsers, mobile SDKs, WebSocket gateways, and OAuth session stores introduce **affinity** requirements. If you pin users to a region without planning data placement, you recreate single-region behavior behind a global hostname.
+
+**Session affinity** ties a client to an endpoint for a period. AWS Application Load Balancers support target group stickiness. GCP external Application Load Balancers support session affinity cookies. Azure Front Door can honor cookies or headers when routing rules allow. Affinity improves cache hit rates and simplifies debugging, but it fights active-active during failover: sticky users may keep hitting a degraded region until cookies expire. Document TTLs and force-refresh paths in runbooks.
+
+**Idempotency** (covered later in depth) is the safety net when affinity breaks mid-request. **Split-brain** appears when two regions both believe they own writes for the same shard — often after a network partition plus overly aggressive failover. Mitigations include:
+
+- **Quorum-based leadership** for stateful systems (etcd, ZooKeeper patterns, or database primaries with fencing).
+- **Fencing tokens** passed to storage so stale leaders cannot commit.
+- **Geo-sharding** so only one region owns a partition key at a time.
+- **Outbox patterns** for cross-region workflows instead of dual cron writers.
+
+For Kubernetes stateful tiers (StatefulSets, operators), prefer **one elected writer per shard** using coordination primitives (Lease API, external lock service) rather than distributed locks across WAN RTT on every request. Velero and managed backup APIs from Module 8.5 still matter for disaster rebuild, but they do not prevent split-brain during partial outages.
+
+---
+
 ## Traffic Routing for Active-Active
 
-Global traffic routing is how you turn multiple healthy regions into a single coherent service for users. DNS-based latency routing, weighted rollouts, and health-checked record sets let you steer clients to the nearest region under normal conditions while shifting load during incidents or canaries. The examples below use AWS Route 53, but the concepts transfer to Google Cloud Load Balancing, Azure Traffic Manager, and anycast frontends — the provider changes, the invariants do not.
+Global traffic routing turns multiple healthy regions into one coherent service. The control plane differs by cloud, but the invariants hold: **health signals must reflect user-visible quality**, not just TCP reachability; **DNS TTL and resolver caching** delay shifts; **anycast and edge proxies** can steer faster than DNS alone for long-lived TCP flows.
+
+### AWS: Route 53, Global Accelerator, and Regional Load Balancers
+
+**Amazon Route 53** offers latency-based, geolocation, weighted, and failover routing policies. Latency routing selects the record set associated with the lowest-latency AWS Region for each resolver, using measurements that change as internet paths shift ([latency-based routing](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-latency.html)). Pair routing policies with **Route 53 health checks** so unhealthy regions stop receiving answers.
+
+**AWS Global Accelerator** provides static anycast IPs that ingress traffic onto the AWS global network and forward to healthy endpoints in endpoint groups ([health checks for accelerators](https://docs.aws.amazon.com/global-accelerator/latest/dg/about-endpoint-groups-health-check-options.html)). Use Global Accelerator when you need fast regional failover for TCP/UDP workloads and consistent entry IPs. Use Route 53 when DNS-level steering and alias records to ALBs/NLBs are sufficient.
+
+Typical EKS active-active shape: Global Accelerator or Route 53 → regional ALB/NLB → Ingress/Gateway → pods. Evaluate target health on alias records when pointing DNS at accelerators or load balancers.
+
+### GCP: Cloud DNS and Global External Application Load Balancers
+
+On GKE, **multi-cluster Gateways** use the Kubernetes Gateway API with GatewayClasses such as `gke-l7-global-external-managed-mc` to provision a **global external Application Load Balancer** fronting pods across a fleet ([multi-cluster Gateways](https://cloud.google.com/kubernetes-engine/docs/concepts/multi-cluster-gateways)). Cloud DNS publishes A/AAAA records to the global VIP. Health checks run at the load balancer layer; unhealthy backends drain per Google Cloud probe configuration.
+
+Geo-distributed GKE fleets register clusters to a fleet, designate a **config cluster** for Gateway resources, and reference `ServiceImport` objects so HTTPRoutes reach backends in multiple regions. Anycast on global external load balancers attracts clients to the nearest Google edge PoP before forwarding to healthy regional backends.
+
+### Azure: Front Door, Traffic Manager, and Regional Application Gateway
+
+Microsoft documents multiple global load balancing options for AKS, including **Azure Front Door**, **Azure Traffic Manager**, cross-region load balancers, and Kubernetes Fleet Manager ([multi-region AKS models](https://learn.microsoft.com/en-us/azure/aks/reliability-multi-region-deployment-models)). The common enterprise pattern is **Front Door → regional Application Gateway → AKS ingress**, with Front Door performing Layer-7 routing, TLS termination at the edge, and origin health probes ([Front Door health probes](https://learn.microsoft.com/en-us/azure/frontdoor/health-probes)).
+
+Traffic Manager remains useful for DNS-level weighted or performance routing to regional endpoints, but Microsoft cautions against stacking redundant health probing on the same origins without design intent. Pick one primary global steering layer per hostname to avoid probe storms.
+
+### Health Checks That Survive Partial Degradation
+
+The Module 8.5 DR ladder assumes you can declare a region unhealthy. In active-active, **degraded is worse than down** because DNS may keep sending traffic to a "healthy" region with high latency or elevated error rates. Supplement liveness with:
+
+- Synthetic canaries that measure checkout latency end-to-end.
+- **Latency SLO burn** alerts that trigger weighted routing shifts.
+- Outlier detection on origin 5xx rates at the global load balancer.
+
+Route 53 health checks, Global Accelerator probes, GCP load balancer health checks, and Front Door probes all need paths that fail when the **application** is unhealthy — not when a static file returns 200 from a sidecar.
 
 ### Latency-Based Routing
 
 Latency-based routing answers the question "which region is fastest for this client right now?" by associating each regional endpoint with health checks and letting the DNS layer return the lowest-latency answer. Use it when your goal is steady-state performance rather than an intentional traffic split.
+
+**Geolocation routing** answers a different question: "which region should this country use by policy?" Regulated data residency sometimes overrides pure latency — a German user might be required to hit `eu-central-1` even if `us-east-1` measures faster in a lab test. **Weighted routing** answers rollout questions: send ten percent of DNS answers to a new region while watching error budgets. Combine weighted and latency policies carefully; not every DNS provider composes policies the same way, so prototype in a sandbox hosted zone or Cloud DNS test project before changing production apex records during peak season.
 
 ```bash
 # AWS Route53: Latency-based routing
@@ -427,6 +538,8 @@ Pause and predict again: if a customer clicks "Pay" and their network drops righ
 
 In an active-active deployment, requests are retried, duplicated, and rerouted between regions far more often than in a single-region monolith, because health checks flap, TCP sessions reset mid-request, and failover paths change mid-flight. Every write operation must therefore be idempotent: applying it twice must produce the same durable outcome as applying it once, usually by tracking a client-supplied idempotency key in a low-latency store replicated or reachable from all regions.
 
+The idempotency store itself becomes a multi-region design choice. A Redis cluster pinned to one region is fast but wrong during failover. **Amazon ElastiCache Global Datastore**, **GCP Memorystore cross-region**, or a Cosmos DB / DynamoDB table dedicated to idempotency metadata are common compromises. Keys should include tenant and operation type, expire after a business-safe window (24 hours for payments is typical), and return the **same HTTP status and body** on duplicates so clients stop retrying. Document that idempotency covers **at-least-once delivery**, not exactly-once side effects on downstream SaaS webhooks unless those partners also deduplicate.
+
 ```mermaid
 sequenceDiagram
     actor U as User
@@ -441,6 +554,8 @@ sequenceDiagram
 ```
 
 Without idempotency, the sequence diagram above ends with a user charged twice for one intent. With idempotency, the second request is recognized as a duplicate of the first and returns the original result, which is why payment and booking APIs treat idempotency keys as mandatory headers rather than optional niceties.
+
+Mobile clients and browser fetch retries amplify the problem. They do not know your regional failover story; they only know the TCP connection reset. Standardize header names (`Idempotency-Key` is common) and document TTL expectations in public API references. Backend frameworks should persist outcomes before returning `201 Created` so a crash after commit still yields a safe replay answer. Pair idempotency with **outbox tables** when you must emit Kafka or SNS events exactly once from the business perspective — the outbox row is the dedupe anchor, not the message broker alone.
 
 ### Implementing Idempotency Keys
 
@@ -539,7 +654,7 @@ Active-active is expensive in dollars and in cognitive load, and understanding t
 
 ### Active-Active Cost Breakdown
 
-Use the two tables below as a structured comparison: the first models a single-region baseline of roughly **$25,000/month**, and the second models an active-active footprint across two regions at roughly **$58,000/month (+132%)**.
+Use the two tables below as a structured comparison: the first models a single-region baseline of roughly **$15,000/month**, and the second models an active-active footprint across two regions at roughly **$38,000/month (+153%)**.
 
 | Component | Cost |
 |-----------|------|
@@ -565,6 +680,8 @@ Use the two tables below as a structured comparison: the first models a single-r
 | Additional operational cost | $3,000 | (NEW: multi-region ops) |
 
 Active-active is therefore not a clean 2× multiplier; it is commonly 2–3× because cross-region data replication, global load balancing, and increased operational complexity (monitoring, debugging, coordinated deploys) all add net-new spend on top of duplicated compute.
+
+Finance reviews should separate **structural duplication** (second cluster, second NAT path) from **traffic-shaped variables** (egress grows with success). A viral launch in one region can replicate logs, metrics, and changefeeds to another region even when user traffic stays local — observability pipelines are a common hidden multiplier. Tag every Deployment with `region`, `tier`, and `cost-center` so chargeback dashboards from Kubecost or OpenCost align with the executive story you told when approving active-active.
 
 ### Cost Optimization Strategies
 
@@ -592,21 +709,105 @@ The list below is how teams keep active-active financially defensible without pr
    - Application-level compression for event streams
    - Saves: $1,000-$2,000/month on data transfer
 
+### Multi-Cloud Cost Gotchas (AWS vs GCP vs Azure)
+
+Duplicating clusters is only the visible line item. **Egress and NAT** often dominate active-active bills:
+
+| Cost driver | AWS (typical pattern) | GCP (typical pattern) | Azure (typical pattern) |
+|---|---|---|---|
+| Internet egress | Data transfer out to internet per GB (verify current pricing in your region) | Premium tier egress from load balancers and VMs | Bandwidth meters on Front Door plus VM egress |
+| Cross-region replication | Inter-region data transfer between RDS replicas, S3 CRR, DynamoDB global tables | Inter-region egress between Spanner regions or GCS dual regions | Cosmos multi-region replication throughput plus RU charges |
+| NAT / outbound SNAT | NAT Gateway hourly plus per-GB processing for private subnet egress | Cloud NAT gateway and data processing charges | NAT Gateway or Azure Firewall SNAT paths for AKS outbound |
+| Cross-AZ traffic | Charges for traffic between AZs in the same region | Inter-zone egress within a region | Intra-region bandwidth still billable on some SKUs |
+| Global front door | Route 53 queries plus health checks; Global Accelerator hourly + DT premium | Global external ALB forwarding rules and egress | Front Door base fee plus per-GB outbound from edge |
+
+**Knobs that reduce surprise spikes:** keep object storage and CDN caches regional; batch cross-region changefeeds; use VPC endpoints / Private Service Connect / Azure Private Link to avoid hairpinning through NAT for cloud API traffic; right-size global load balancers so idle regions do not run peak node counts 24/7; tag spend by `region` and `cost-center` labels in Kubecost or OpenCost for in-cluster visibility.
+
+Hypothetical scenario: A team doubles EKS node counts for active-active but forgets cross-region Kafka mirroring. Their bill grows 2.4× instead of 2.0× because inter-region egress accrues on every message. FinOps reviews the NAT Gateway line item, not the cluster autoscaler.
+
+---
+
+## Patterns & Anti-Patterns
+
+### Proven Patterns
+
+| Pattern | When to use | Why it works | Scaling note |
+|---|---|---|---|
+| **Latency-first global routing** | User-facing APIs with regional clusters | Minimizes RTT for steady state; health checks remove bad regions | Combine DNS TTL reduction with accelerator/edge for TCP-heavy apps |
+| **Geo-sharded writes** | Social, ride-share, logistics with local interaction | Eliminates cross-region write conflicts by ownership | Rebalance shards with dual-write windows during migrations |
+| **Single-writer + regional read replicas** | Profiles, catalogs, read-heavy commerce | Simple semantics; predictable promotion runbooks | Add RYOW cache flags to hide replica lag for writers |
+| **Idempotent mutation APIs** | Payments, bookings, inventory holds | Survives retries during routing churn | Store keys in a low-latency cache with cross-region replication |
+| **GitOps ApplicationSet fleet** | EKS/GKE/AKS at 1.35 with identical baselines | One manifest pipeline, many clusters | Use progressive delivery per region, not big-bang sync |
+
+### Anti-Patterns
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+|---|---|---|---|
+| **Stretched Kubernetes across regions** | Split-brain scheduling; storage detach storms | Desire for "one cluster" simplicity | Independent regional clusters plus GitOps |
+| **Global distributed locks on hot paths** | 100–300ms added to every transaction | Fear of duplicate writes | Partition ownership; database-native consensus |
+| **Latency-blind health checks** | Traffic sticks to degraded region | Cheap `/healthz` without SLO tests | Synthetic transactions plus outlier routing |
+| **Dual-primary Postgres without CRDT discipline** | Silent data loss or manual merges | Misread "active-active" as symmetric RDS writes | Managed global tables/Spanner/Cosmos policies |
+| **Running cron in every region** | Triple reports, lock contention | Copy-paste manifests | Leader election or designated batch region |
+| **Ignoring cross-cloud egress** | 4×+ transfer cost vs single-cloud multi-region | Multi-cloud strategy without data gravity plan | Keep hot data path single-cloud; DR in second cloud cold |
+
+---
+
+## Decision Framework
+
+Use this flow when scoping a service for active-active. It complements the DR ladder in Module 8.5 — you should already know target RTO/RPO before arriving here.
+
+```mermaid
+flowchart TD
+    Start([Service needs multi-region?]) --> Q1{User-visible latency<br/>SLO under 150ms globally?}
+    Q1 -->|No| DR[Stay regional + Module 8.5 DR tier]
+    Q1 -->|Yes| Q2{Can workload be stateless<br/>or geo-sharded?}
+    Q2 -->|Yes| Route[Deploy per region + global LB/DNS]
+    Q2 -->|No| Q3{Strong invariants<br/>on every write?}
+    Q3 -->|Yes| SW[Single-writer or MRSC DB<br/>+ proxied writes]
+    Q3 -->|No| Q4{Conflicts mergeable<br/>with CRDT/LWW?}
+    Q4 -->|Yes| MP[Multi-primary store<br/>with explicit policy]
+    Q4 -->|No| Shard[Redesign partition key<br/>or shrink scope]
+    Route --> Idem[Require idempotency keys]
+    SW --> Idem
+    MP --> Idem
+    Shard --> Idem
+    Idem --> Cost{Finance accepts<br/>2-3x infra + egress?}
+    Cost -->|No| DR
+    Cost -->|Yes| Ship[GitOps fleet + game days]
+```
+
+| Decision | Choose A when | Choose B when | Tradeoff |
+|---|---|---|---|
+| **Routing** | DNS latency/weighted (Route 53, Cloud DNS, Traffic Manager) | Anycast edge (Global Accelerator, global external ALB, Front Door) | DNS cheaper; edge faster for TCP failover |
+| **Data** | Single-writer + async replicas | Multi-primary managed DB | Latency vs conflict surface |
+| **K8s topology** | 2–3 full regions at 70–100% capacity | 1 hot + 1 warm for noncritical tiers | Cost vs blast radius |
+| **Consistency test** | Monthly regional traffic shift with real users | Quarterly tabletop only | Confidence vs operational load |
+
+### Operating Active-Active in Production
+
+Shipping multi-region Kubernetes is the beginning, not the end. **Observability** must be comparable across regions: same golden signals (latency, traffic, errors, saturation) tagged by `region` and `cluster`. Use exemplar traces that include idempotency key, shard id, and database role (primary vs replica) so incident commanders do not guess why payments duplicate. **Deploy pipelines** should support regional waves — canary in `eu-west-1` before `us-east-1`, or parallel only when manifest diffs are overlays without shared ConfigMap surprises.
+
+**Configuration drift** is the silent killer. An ApplicationSet sync that updates image tags but leaves an old `DATABASE_WRITE_URL` in one overlay sends half of European traffic to a US primary unintentionally. Policy-as-code (OPA Gatekeeper, Kyverno, or cloud org policies) can require every Deployment to declare `REGION` and forbid public `LoadBalancer` Services on admin interfaces. **Backup scope** from Module 8.5 still includes etcd (managed by EKS/GKE/AKS control planes), Velero for namespace objects, and managed backup SKUs for databases — active-active does not remove backup; it raises the bar for restore drills because more regions mean more ways partial restores diverge.
+
+**Chaos and game days** should include DNS TTL wait periods, partial region degradation (latency injection, not only hard down), and datastore promotion with observability dashboards open. Hypothetical scenario: A team practices failing `us-east-1` pods but never shifts Route 53 weights, then declares RTO met while users still hit the degraded region via stale resolver caches. Practice the full user path, not only kube-apiserver availability.
+
 ---
 
 ## Did You Know?
 
-1. **Netflix runs active-active across three AWS regions** (us-east-1, us-west-2, eu-west-1) and has been doing so since 2012. Their "Zuul" gateway handles over 300 billion requests per day across these regions. The annual cost of their multi-region infrastructure is estimated at over $400 million, but a single hour of global downtime would cost approximately $16 million in lost revenue -- making active-active a clear business case.
+1. **Netflix runs active-active across three AWS regions** (us-east-1, us-west-2, eu-west-1) and has publicly described that architecture as part of its 2013 multi-region resiliency rollout. Its "Zuul" gateway is one of the routing layers that helps direct traffic across regions, making active-active a practical availability strategy rather than a purely theoretical pattern.
 
 2. **CockroachDB was specifically designed for multi-region active-active writes.** It implements a distributed consensus protocol (a variant of Raft) that can commit writes across regions with serializable isolation. The trade-off is write latency: a cross-region write requires a round-trip to achieve consensus, adding 100-250ms. For read-heavy workloads (which most web applications are), this trade-off is excellent.
 
-3. **The "read-your-own-writes" consistency problem** was formally defined by Doug Terry et al. at Microsoft Research in 1994. Thirty years later, it remains one of the most common bugs in distributed systems. Amazon's DynamoDB, Google's Spanner, and Azure's Cosmos DB all offer "session consistency" modes that guarantee read-your-own-writes, but only if the client maintains session affinity.
+3. **The "read-your-own-writes" consistency problem** was formally defined by Doug Terry et al. at Xerox PARC (the Bayou project) in 1994. Thirty years later, it remains one of the most common bugs in distributed systems. Amazon's DynamoDB, Google's Spanner, and Azure's Cosmos DB all offer "session consistency" modes that guarantee read-your-own-writes, but only if the client maintains session affinity.
 
-4. **Cross-region data transfer between AWS regions costs $0.02/GB**, but between AWS and GCP or Azure it costs $0.09/GB (standard internet egress rates). This 4.5x cost difference is one reason why multi-cloud active-active is significantly more expensive than multi-region active-active within a single cloud. Google's "cross-cloud interconnect" and AWS's "site-to-site VPN" reduce this somewhat, but typically not to intra-cloud rates.
+4. **Cross-region data transfer pricing differs by cloud and path** — inter-region replication within AWS, GCP, or Azure is usually far cheaper than hauling the same bytes over the public internet to another provider. Verify current rates in each vendor pricing page before modeling FinOps dashboards; list prices change and committed-use discounts reshape the story. Multi-cloud active-active for the same user-facing app is therefore uncommon unless regulatory or acquisition constraints force it; when required, keep authoritative data in one cloud and treat the other as DR or read-only analytics.
 
 ---
 
 ## Common Mistakes
+
+Active-active failures rarely look like mysterious kernel panics. They look like duplicate charges, empty shopping carts, or dashboards that disagree across regions. The table below collects mistakes platform teams repeat even after reading CAP theorem slides — use it as a pre-launch review checklist with your data owners and SRE leads.
 
 | Mistake | Why It Happens | How to Fix It |
 |---|---|---|
@@ -622,6 +823,8 @@ The list below is how teams keep active-active financially defensible without pr
 ---
 
 ## Quiz
+
+The questions below mix architecture judgment with operational detail you will need in design reviews and game days. Read each scenario fully before opening the answer — the distractors are plausible mistakes teams make during their first active-active migration. At least four items are scenario-based; use them to rehearse explanations you would give a principal engineer or CFO.
 
 <details>
 <summary>1. Your team wants to expand your primary application from `us-east-1` to `eu-west-1` to serve European customers better. A junior engineer suggests just deploying the exact same stateless manifests and pointing a Route53 weighted record at both. Why will this approach likely cause a massive incident if user databases are involved?</summary>
@@ -659,11 +862,27 @@ To justify the 2.3x cost multiplier, you must translate infrastructure expense d
 Batch operations are inherently single-instance processes that require coordination rather than geographic replication. By deploying the cron jobs to all regions identically, each region independently triggered its own execution of the jobs against the same shared database or notification service. To fix this, you must explicitly designate one region as the 'batch leader' or implement distributed leader election (e.g., via a Redis lock or Kubernetes lease) so that only one region holds the authority to run scheduled tasks at any given time. If the leader region fails, the lock expires and a healthy region automatically promotes itself to take over the batch processing.
 </details>
 
+<details>
+<summary>7. Your platform team proposes running a single GKE cluster with worker nodes in us-central1, europe-west1, and asia-southeast1 connected by a flat RFC1918 WAN to "simplify" active-active. What Kubernetes failure-domain guidance contradicts this design, and what should you recommend instead?</summary>
+
+Kubernetes assumes control-plane and etcd traffic stay within a reliable, low-latency failure domain. Stretching workers across continents does not create one healthy cluster; it creates correlated partition risk and storage attachment problems. The recommended approach is independent regional GKE clusters registered to a fleet, with multi-cluster Gateways or DNS steering for global traffic, and data tiers that declare their own replication semantics. GitOps ApplicationSets keep manifests aligned without pretending a single apiserver spans oceans.
+</details>
+
+<details>
+<summary>8. You enable DynamoDB global tables in multi-Region eventual consistency mode for a wallet balance table. Two regions concurrently debit the same item during a network partition. How does DynamoDB reconcile the item, and what application-level guardrail is still mandatory?</summary>
+
+DynamoDB MREC resolves concurrent updates per item using a last-writer-wins policy based on internal timestamps; replicas eventually converge to the winning version. That does not preserve business invariants like non-negative balances if both writes are valid numerically. Optimistic locking with version attributes does not behave like single-region DynamoDB across Regions. You still need idempotent APIs, conditional writes designed for your conflict model, or a single-writer/strong consistency mode (MRSC) for balances that cannot tolerate silent merges.
+</details>
+
 ---
 
 ## Hands-On Exercise: Design an Active-Active Architecture
 
 In this exercise, you will design an active-active architecture for a realistic application and implement the key patterns — classification, replication, read-your-own-writes, idempotent booking, and cost estimation — using the same decision framework the narrative sections introduced.
+
+Before you classify services, sketch three diagrams on paper: a **steady-state request path** from user to database per region, a **failover path** when health checks remove one region, and a **partition path** when networks split but both regions stay partially alive. If the partition diagram requires human judgment to avoid double charges, your design is not finished — add idempotency, shard ownership, or a stronger database mode before touching manifests.
+
+Document which global steering layer you chose per cloud (Route 53 vs Global Accelerator, Cloud DNS vs global external Gateway, Front Door vs Traffic Manager) and which health signal gates traffic shifts. Reviewers should challenge any design that only tests failover by scaling pods to zero — that validates Kubernetes, not user-visible routing.
 
 ### Scenario
 
@@ -741,7 +960,6 @@ Write the application code and Kubernetes configuration for the read-your-own-wr
 import redis
 import psycopg2
 import os
-import json
 
 REGION = os.environ["REGION"]
 RYOW_TTL = int(os.environ.get("RYOW_TTL_SECONDS", "5"))
@@ -839,6 +1057,7 @@ Write the idempotency key pattern for the booking service so duplicate submits d
 # booking_service.py - Idempotent booking
 import redis
 import json
+import os
 import uuid
 from datetime import datetime
 
@@ -974,6 +1193,15 @@ Break-even analysis:
 
 ## Sources
 
-- [Amazon Route 53 Latency-Based Routing](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-latency.html) — Direct vendor documentation for one of the routing patterns the module discusses.
-- [Promoting a Read Replica to Be a Standalone DB Instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.Promote.html) — Grounds the failover discussion around asynchronous replicas, promotion timing, and recovery tradeoffs.
-- [Azure Cosmos DB Consistency Levels](https://learn.microsoft.com/en-us/azure/cosmos-db/consistency-levels) — A clear primary source for session consistency and read-your-writes behavior in a real multi-region database product.
+- [Amazon Route 53 Latency-Based Routing](https://docs.aws.amazon.com/Route53/latest/DeveloperGuide/routing-policy-latency.html) — Latency routing policies and health-checked regional record sets.
+- [AWS Global Accelerator endpoint health checks](https://docs.aws.amazon.com/global-accelerator/latest/dg/about-endpoint-groups-health-check-options.html) — Anycast entry, probe behavior, and unhealthy endpoint draining.
+- [DynamoDB global tables — how it works](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/V2globaltables_HowItWorks.html) — MREC vs MRSC, last-writer-wins, and `ReplicatedWriteConflictException`.
+- [Promoting a Read Replica to Be a Standalone DB Instance](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_ReadRepl.Promote.html) — Async replica promotion, RPO, and failover timing on RDS.
+- [Cloud Spanner TrueTime and external consistency](https://cloud.google.com/spanner/docs/true-time-external-consistency) — Commit timestamps, external consistency, and cross-region reads.
+- [GKE multi-cluster Gateways](https://cloud.google.com/kubernetes-engine/docs/concepts/multi-cluster-gateways) — Global external Application Load Balancers across fleet clusters.
+- [AKS multi-region deployment models](https://learn.microsoft.com/en-us/azure/aks/reliability-multi-region-deployment-models) — Front Door, Traffic Manager, and active-active vs active-passive patterns.
+- [Azure Front Door health probes](https://learn.microsoft.com/en-us/azure/frontdoor/health-probes) — Origin probing, sample sizes, and degraded-origin behavior.
+- [Azure Cosmos DB conflict resolution policies](https://learn.microsoft.com/en-us/azure/cosmos-db/conflict-resolution-policies) — Last-writer-wins, custom merge procedures, and container immutability.
+- [Azure Cosmos DB multi-region writes](https://learn.microsoft.com/en-us/azure/cosmos-db/multi-region-writes) — Hub-region confirmation, conflict feeds, and write routing guidance.
+- [AKS workload identity overview](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview) — Microsoft Entra Workload ID for pod-to-Azure authentication.
+- [Kubernetes cluster administration concepts](https://kubernetes.io/docs/concepts/cluster-administration/) — Failure domains and operational boundaries for regional clusters.

--- a/src/content/docs/cloud/advanced-operations/module-8.7-stateful-migration.md
+++ b/src/content/docs/cloud/advanced-operations/module-8.7-stateful-migration.md
@@ -25,12 +25,11 @@ After completing this module, you will be able to:
 ## Why This Module Matters
 
 Stateful migration exposes a design fault line: if control planes diverge during topology shifts, consistency and write guarantees can become unreliable in minutes. This concept is further explored in [Advanced Merging](../../prerequisites/git-deep-dive/module-2-advanced-merging/).
-<!-- incident-xref: github-2018-10-split-brain -->
 <!-- incident-xref: github-2018-split-brain -->
 
-A similar scenario unfolded for a major streaming service in late 2022. The engineering team had successfully migrated their stateless microservices from on-premises virtual machines to Kubernetes. The remaining legacy footprint was a 12TB PostgreSQL database, a 3TB Elasticsearch cluster, a Redis cluster with 200GB of hot data, and a media processing service with 50TB of files on local network storage. Every migration attempt was estimated at two weeks of downtime, which the business flatly rejected. The database was simply too large for a standard dump-and-restore within the allowed maintenance window. 
+Hypothetical scenario: An engineering team has successfully migrated their stateless microservices from on-premises virtual machines to Kubernetes. The remaining legacy footprint is a 12TB PostgreSQL database, a 3TB Elasticsearch cluster, a Redis cluster with 200GB of hot data, and a media processing service with 50TB of files on local network storage. Every migration attempt is estimated at two weeks of downtime, which the business flatly rejects. The database is simply too large for a standard dump-and-restore within the allowed maintenance window.
 
-After months of delay, the streaming service engineers realized they were fighting "data gravity." Their 12TB database had grown to 16TB. Every day they waited, the mass of the data increased, pulling more dependencies into its orbit and making the eventual migration even more difficult. They eventually succeeded by combining Change Data Capture for the database, incremental synchronization for the media files, and the Strangler Fig pattern to route traffic incrementally. This module teaches you how to execute these exact patterns, allowing you to move massive stateful workloads without downtime while maintaining absolute data integrity.
+After months of delay, the engineers realize they were fighting "data gravity." Their 12TB database had grown to 16TB. Every day they waited, the mass of the data increased, pulling more dependencies into its orbit and making the eventual migration even more difficult. They eventually succeeded by combining Change Data Capture for the database, incremental synchronization for the media files, and the Strangler Fig pattern to route traffic incrementally. This module teaches you how to execute these exact patterns, allowing you to move massive stateful workloads without downtime while maintaining absolute data integrity.
 
 ## Understanding Data Gravity and Escape Velocity
 
@@ -74,6 +73,16 @@ To combat data gravity, engineers must decouple the applications from the data s
 
 > **Stop and think**: If you have a 5TB database that is accessed by 30 different microservices, what is the primary factor increasing its data gravity? Is it the size of the database, or the number of integrations? How would this impact your migration approach?
 
+### RPO, RTO, and the Cutover Window
+
+Every stateful migration is governed by two constraints that originate from the business, not the technology: Recovery Point Objective (RPO) and Recovery Time Objective (RTO). In a migration context, RPO measures how much data you can afford to lose — the maximum acceptable gap between the last write on the source and the first confirmed write on the target. RTO measures how long the application can be unavailable during the cutover. These two numbers dictate which migration strategy is viable.
+
+If the business says "RPO = 0 (no data loss) and RTO = 5 minutes," you cannot use a dump-and-restore approach, which requires locking the database for the entire extraction and restoration period. Instead, you need a replication-based strategy — logical replication, CDC, or managed DMS — that keeps the target synchronized within sub-second lag, reducing the cutover to a DNS switch. The replication lag at the moment of cutover is effectively your RPO: if the target is 2 seconds behind the source when you switch, you may lose up to 2 seconds of writes unless you implement a write-freeze window.
+
+If the business says "RPO = 1 hour and RTO = 4 hours," a dump-and-restore becomes viable because you can accept up to 1 hour of data loss and have 4 hours to complete extraction, transfer, and restoration. This dramatically simplifies the migration engineering — no replication pipeline to build or monitor, no Kafka cluster to manage, no CDC connector health checks.
+
+The distinction between stateless and stateful workloads sharpens here. A stateless Deployment can reschedule freely: terminate pods in one cluster, recreate them verbatim in another, and the application is immediately healthy because it carries no persistent data. A StatefulSet with a 10TB PersistentVolume reschedules with gravity — the data must physically move or be replicated before the pod can serve traffic in the new cluster. This is the fundamental asymmetry that makes stateful migration the hard case in any cloud migration program. The RPO/RTO conversation is the mechanism that translates business constraints into engineering decisions: tighter RPO means more sophisticated replication; tighter RTO means more automation in the cutover runbook and a more thoroughly tested rollback path.
+
 ## The Strangler Fig Pattern in Practice
 
 Named after the strangler fig tree that germinates in the canopy of a host tree and grows downwards until it eventually replaces the host entirely, this architectural pattern allows you to migrate monolithic services incrementally. Rather than attempting a high-risk big-bang cutover, you place a proxy router in front of the legacy system and selectively redirect specific API paths to newly modernized microservices running in Kubernetes.
@@ -115,6 +124,7 @@ metadata:
   name: strangler-fig-router
   namespace: migration
   annotations:
+    nginx.ingress.kubernetes.io/service-upstream: "true"
     nginx.ingress.kubernetes.io/upstream-vhost: "legacy.internal.company.com"
 spec:
   rules:
@@ -159,6 +169,10 @@ spec:
   type: ExternalName
   externalName: legacy.internal.company.com
 ```
+
+> **Controller support check**
+>
+> Verify this pattern against your exact Ingress controller before putting it in a migration runbook. `ExternalName` Services do not create normal `Endpoints`, so controllers that require endpoint objects may reject the backend, and ingress-nginx deployments commonly need explicit upstream and DNS resolver configuration in addition to the host-header annotation. If your controller cannot proxy `ExternalName` backends cleanly, use a small NGINX or Envoy proxy Service inside the cluster, a cloud-specific `BackendConfig`, or service-mesh egress for the legacy route.
 
 Beyond simple path-based routing, advanced ingress controllers and service meshes like Istio allow for percentage-based traffic splitting. This is essential for canary deployments during the migration phase. By sending only a small fraction of real user traffic to the new database-backed microservice, you can validate your data replication strategies under realistic workloads without jeopardizing the entire user base.
 
@@ -221,6 +235,18 @@ Lift-and-shift involves wrapping the existing binary in a container and mounting
 
 > **Stop and think**: You inherited a 10-year-old monolithic inventory application. The original developers left the company 5 years ago, and the business only requires it for compliance audits twice a year. Which migration strategy is most appropriate and why?
 
+### Dual-Write and Backfill: The Gradual Cutover
+
+When even minutes of downtime are unacceptable and the application architecture supports routing writes to two databases simultaneously, the dual-write pattern provides a migration path with effectively zero cutover window.
+
+**Phase 1: Backfill**. Run a one-time bulk copy of the existing data from the source to the target using the fastest available method — a parallel `pg_dump` and `pg_restore`, or a storage-level snapshot copy. During this bulk phase, which may take hours or days, the application continues writing exclusively to the source. The target is structurally complete but stale by the time the bulk copy finishes.
+
+**Phase 2: Dual-write with catch-up**. Modify the application's data-access layer to write every new transaction to both the source and target databases simultaneously. Simultaneously, run a backfill process that walks the source database row by row (ordered by primary key or timestamp) and inserts any rows that exist on the source but are missing on the target — these are the rows created during the bulk copy phase. The backfill is idempotent: it uses `INSERT ... ON CONFLICT DO NOTHING` (PostgreSQL) or `INSERT IGNORE` (MySQL) so that rows already written by the dual-write path are silently skipped.
+
+Once the backfill completes and the dual-write path has been running without errors for a burn-in period (24–72 hours), the cutover is a single code change: remove the write path to the source. The application now writes exclusively to the target. Read traffic can be migrated independently using the Strangler Fig pattern — route a percentage of reads to the target, compare results, and increase the percentage until all reads hit the target.
+
+**Cost and complexity**: Dual-write doubles the write load on the application and doubles the write throughput requirement on both database instances. Every write must handle partial failures: if the write to the target fails, should the source write be rolled back, or should the application log the discrepancy and continue? For most migrations, the pragmatic approach is to write to the source first, then to the target, and log any target failures for manual reconciliation. This tolerates transient target issues without impacting production availability.
+
 ## Infrastructure-Level Migration: CSI Volume Snapshots
 
 When dealing with stateful workloads already running in Kubernetes that need to be migrated to a different cluster or region, the Container Storage Interface (CSI) provides a powerful mechanism: Volume Snapshots. Rather than copying data through the application layer, CSI allows you to leverage the cloud provider's native block-storage snapshot capabilities. 
@@ -271,18 +297,50 @@ SNAPSHOT_ID=$(kubectl get volumesnapshot postgres-data-snapshot -n databases \
 EBS_SNAPSHOT=$(kubectl get volumesnapshotcontent $SNAPSHOT_ID \
   -o jsonpath='{.status.snapshotHandle}')
 
-# Copy to DR region
-aws ec2 copy-snapshot \
+# Copy to DR region and capture the destination-region snapshot ID
+DEST_EBS_SNAPSHOT=$(aws ec2 copy-snapshot \
   --source-region us-east-1 \
   --source-snapshot-id $EBS_SNAPSHOT \
   --destination-region eu-west-1 \
-  --description "Migration snapshot for postgres-data"
+  --description "Migration snapshot for postgres-data" \
+  --query SnapshotId \
+  --output text)
+
+aws ec2 wait snapshot-completed \
+  --region eu-west-1 \
+  --snapshot-ids "$DEST_EBS_SNAPSHOT"
 ```
 
-In the target cluster, provisioning a new persistent volume from the replicated snapshot is as simple as referencing the snapshot in the `dataSource` block of the new PVC definition. The CSI driver handles the allocation of the disk and the hydration of the block data prior to the pod starting.
+The copy step above creates an EBS snapshot in `eu-west-1`; it does not automatically create a Kubernetes `VolumeSnapshot` object in the destination cluster. Import the copied provider snapshot first by binding a `VolumeSnapshotContent` to a new destination-cluster `VolumeSnapshot`, then reference that imported snapshot from the PVC. The CSI driver handles the allocation of the disk and the hydration of the block data prior to the pod starting.
 
 ```yaml
-# Step 2: In the destination cluster, create a PVC from the snapshot
+# Step 2: In the destination cluster, import the copied EBS snapshot
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshotContent
+metadata:
+  name: imported-postgres-data-snapshot-content
+spec:
+  deletionPolicy: Retain
+  driver: ebs.csi.aws.com
+  source:
+    # Destination-region EBS snapshot ID returned by aws ec2 copy-snapshot.
+    snapshotHandle: snap-0abc123def4567890
+  volumeSnapshotClassName: ebs-csi-snapclass
+  volumeSnapshotRef:
+    name: postgres-data-snapshot-imported
+    namespace: databases
+---
+apiVersion: snapshot.storage.k8s.io/v1
+kind: VolumeSnapshot
+metadata:
+  name: postgres-data-snapshot-imported
+  namespace: databases
+spec:
+  volumeSnapshotClassName: ebs-csi-snapclass
+  source:
+    volumeSnapshotContentName: imported-postgres-data-snapshot-content
+---
+# Step 3: Create a PVC from the imported destination snapshot
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -291,7 +349,7 @@ metadata:
 spec:
   storageClassName: gp3
   dataSource:
-    name: postgres-data-snapshot
+    name: postgres-data-snapshot-imported
     kind: VolumeSnapshot
     apiGroup: snapshot.storage.k8s.io
   accessModes:
@@ -302,6 +360,88 @@ spec:
 ```
 
 > **Pause and predict**: You successfully created a volume snapshot in AWS `us-east-1` and copied it to `eu-west-1`. If the original source PV is 500Gi, will the new PVC in `eu-west-1` provision immediately, or do you need to wait for the data to copy into the new EBS volume before the pod can start?
+
+### GCP and Azure CSI Snapshots
+
+The CSI volume snapshot workflow demonstrated above uses AWS EBS, but the same pattern works across cloud providers with their respective CSI drivers.
+
+On Google Cloud, Persistent Disk snapshots are handled by the `pd.csi.storage.gke.io` driver. Creating a `VolumeSnapshot` triggers a PD snapshot — an instantaneous, differential resource. To materialize that snapshot in a target region, create a new disk from the global snapshot, for example `gcloud compute disks create postgres-data-restored --region=europe-west1 --replica-zones=europe-west1-b,europe-west1-c --source-snapshot=projects/PROJECT_ID/global/snapshots/postgres-data-snapshot --type=pd-ssd`. In the destination cluster, the restored PVC references the snapshot or disk through the CSI driver's supported pre-provisioning path. GCP PD snapshots are differential, meaning subsequent snapshots of the same disk capture only changed blocks, which reduces both creation time and storage cost.
+
+On Azure, Managed Disk snapshots are created through the `disk.csi.azure.com` driver. A `VolumeSnapshot` triggers a point-in-time snapshot of the underlying Azure Disk. Cross-region copy requires an incremental source snapshot and an explicit copy operation: `az snapshot create --resource-group target-rg --name migration-snap-westeurope --source /subscriptions/.../resourceGroups/source-rg/providers/Microsoft.Compute/snapshots/source-incremental-snap --location westeurope --incremental --copy-start`. The destination PVC references the snapshot through its ARM resource ID.
+
+While the Kubernetes abstraction is identical across providers, cross-region behavior and cost differ materially. AWS EBS snapshots are incremental and billed for the changed blocks retained by each snapshot copy, not the full provisioned volume size; the cross-region copy can still incur transfer charges. GCP PD snapshots store only diff blocks and are billed per-GB-month of actual storage consumed in each region. Azure incremental snapshots are billed per-GB-month plus outbound data transfer at standard inter-region rates.
+
+### Velero for Cross-Cluster and Cross-Provider PV Migration
+
+CSI volume snapshots work well for same-provider migrations, but real-world advanced operations often demand movement between clusters, regions, or cloud providers. Velero is the de facto open-source Kubernetes tool for backing up and restoring cluster resources — including PersistentVolume data — across boundaries. It is a CNCF project actively maintained to support Kubernetes versions through 1.35 and beyond.
+
+Velero handles volume data in two modes:
+
+**File-level backup (Restic/Kopia node-agent integration)**: Velero deploys a DaemonSet that backs up filesystem contents of selected volumes to an object store (S3, GCS, Azure Blob). This mode is provider-agnostic — the same backup can be restored to a different cloud provider because data is stored as files, not block snapshots. The file-level approach is slower than block snapshots and may not produce crash-consistent backups for databases with active writes without first quiescing the workload. For database workloads, pair file-level Velero backups with a database-native dump (`pg_dump`, `mysqldump`) and use Velero for the Kubernetes resource definitions (StatefulSets, Services, ConfigMaps).
+
+**Block-level backup (CSI snapshot integration)**: When the CSI driver supports snapshots, Velero delegates snapshot creation to the provider's storage API. This is faster and crash-consistent but provider-specific — an EBS snapshot cannot be restored as a GCP Persistent Disk. This mode is the best choice for same-provider DR and migration where performance matters most.
+
+A cross-provider migration workflow with Velero:
+
+```bash
+# On the source cluster (e.g., EKS): install Velero with node-agent
+velero install \
+  --provider aws \
+  --bucket velero-migrations \
+  --secret-file ./credentials-velero \
+  --use-node-agent \
+  --default-volumes-to-fs-backup \
+  --backup-location-config region=us-east-1
+
+# Back up the namespace including all PV data as files
+velero backup create migrate-payments \
+  --include-namespaces payments \
+  --default-volumes-to-fs-backup \
+  --snapshot-volumes=false
+
+# Verify backup completion
+velero backup describe migrate-payments --details
+
+# On the destination cluster (e.g., GKE): install Velero pointing to the same bucket,
+# then map source StorageClasses before restore.
+kubectl apply -f - <<'YAML'
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: change-storage-class-config
+  namespace: velero
+  labels:
+    velero.io/plugin-config: ""
+    velero.io/change-storage-class: RestoreItemAction
+data:
+  gp3: premium-rwo
+YAML
+
+velero restore create migrate-payments-restore --from-backup migrate-payments
+```
+
+Velero does not infer cross-cloud `StorageClass` names automatically. Configure `change-storage-class-config` before the restore, or use `--storage-class-mappings` where your Velero version and plugins support it, so an EBS-backed source PVC such as `gp3` becomes a GKE PVC such as `premium-rwo` intentionally rather than depending on a default.
+
+### Storage Class Differences Across Providers
+
+When migrating stateful workloads between clouds, storage class mapping is a common trip hazard. Each provider uses different StorageClass names, provisioner drivers, and performance characteristics:
+
+| Provider | StorageClass | Provisioner | fsType | Expand | Notes |
+|---|---|---|---|---|---|
+| AWS EKS | `gp3` | `ebs.csi.aws.com` | ext4 | Yes | 3000 IOPS / 125 MiB/s baseline; gp2 is legacy |
+| AWS EKS | `io2` | `ebs.csi.aws.com` | ext4 | Yes | Provisioned IOPS; io2 Block Express for >64K IOPS |
+| GCP GKE | `premium-rwo` | `pd.csi.storage.gke.io` | ext4 | Yes | SSD; regional PDs available for zonal HA |
+| GCP GKE | `standard-rwo` | `pd.csi.storage.gke.io` | ext4 | Yes | HDD; lowest cost, lowest throughput |
+| Azure AKS | `managed-csi-premium` | `disk.csi.azure.com` | ext4 | Yes | Premium SSD; low latency, high throughput |
+| Azure AKS | `managed-csi` | `disk.csi.azure.com` | ext4 | Yes | Standard SSD; cost-optimized, burstable |
+
+Key migration risks:
+
+- **Reclaim policy mismatch**: If the source uses `Retain` and the destination uses `Delete`, an accidental PVC removal in the destination destroys the underlying disk. Standardize both clusters on `Retain` during the migration window so data survives operator error.
+
+- **Access mode**: Most block storage (EBS, Persistent Disk, Azure Disk) supports only `ReadWriteOnce`. If your workload expects `ReadWriteMany`, you need a file-based storage class in the destination: EFS on AWS, Filestore on GCP, or Azure Files.
+
+- **StatefulSet identity**: StatefulSets assign stable pod names like `pod-0` and stable PVC names like `data-pod-0`. When restoring via Velero, the pod-to-PVC binding is preserved only if the StatefulSet name and namespace match the source exactly. Renaming either requires manual PVC relabeling or recreating the StatefulSet with matching PVC conventions.
 
 ## Database Replication Patterns
 
@@ -337,6 +477,14 @@ pg_restore \
 # For 5GB database: ~15-30 minutes total
 ```
 
+### Physical Replication (Supplemental)
+
+While logical replication and CDC are the primary tools for cloud migrations, physical replication deserves mention for specific use cases. Physical replication operates at the disk-block level, shipping Write-Ahead Log (WAL) segments from source to target. Unlike logical replication — which parses WAL into SQL statements and replays them — physical replication copies the raw block changes, making it significantly faster and lower-overhead on the source database.
+
+Physical replication is the default mechanism for PostgreSQL streaming replicas, MySQL group replication, and managed database read replicas (RDS read replicas, Cloud SQL read replicas). Its primary limitation for migration: it requires bit-for-bit identical database binaries and operating system architectures. You cannot use physical replication between PostgreSQL 14 and 16, between different operating systems, or between on-premises and a managed cloud service where the cloud provider abstracts the filesystem layer.
+
+When physical replication is viable — typically same-version, same-platform migrations where the target is self-managed — it offers the lowest replication lag and simplest setup of any method. For most cloud migrations to managed services, however, logical replication or CDC is required because the cloud provider controls the filesystem and only exposes the logical SQL interface.
+
 ### Pattern 2: Logical Replication (Medium Databases)
 
 Modern relational databases support logical replication, a mechanism where the database parses its own Write-Ahead Log (WAL) and streams discrete INSERT, UPDATE, and DELETE commands to a subscribed replica. Unlike physical replication, which requires bit-for-bit identical disk layouts, logical replication allows the target database to run on a different operating system, a different major version, or a managed cloud platform.
@@ -361,8 +509,10 @@ psql -h target-db.rds.amazonaws.com -U admin -d mydb <<'SQL'
 CREATE SUBSCRIPTION migration_sub
   CONNECTION 'host=source-db.internal port=5432 dbname=mydb user=replication_user password=xxx'
   PUBLICATION migration_pub;
+SQL
 
--- Monitor replication lag
+# On the SOURCE database: monitor publisher-side logical replication lag
+psql -h source-db.internal -U admin -d mydb <<'SQL'
 SELECT
   slot_name,
   pg_wal_lsn_diff(pg_current_wal_lsn(), confirmed_flush_lsn) AS lag_bytes
@@ -518,7 +668,113 @@ kubectl run pg-migration --rm -it --restart=Never \
   '
 ```
 
+### Pattern 5: Managed Cloud Database Migration Services
+
+When your migration target is a managed cloud database service, each major provider offers a purpose-built migration tool that handles the end-to-end pipeline (full load + ongoing CDC replication) without requiring you to deploy and operate a Kafka cluster or Debezium connectors.
+
+**AWS Database Migration Service (DMS)** supports homogeneous migrations (PostgreSQL to RDS PostgreSQL, MySQL to Aurora MySQL) and heterogeneous migrations (Oracle to Aurora PostgreSQL, SQL Server to RDS MySQL) through its companion Schema Conversion Tool (SCT). For homogeneous migrations, DMS handles schema and data copy automatically — you configure source and target endpoints, select the tables, and DMS runs the full load followed by ongoing CDC. DMS runs on a replication instance priced per hour based on instance class; you also pay for instance storage and cross-AZ/cross-region data transfer. The replication instance size should match the source database's change rate — under-provisioning causes replication lag to grow unbounded. DMS supports ongoing replication, keeping the target in sync for days or weeks until you are ready to cut over.
+
+**GCP Database Migration Service** provides serverless migrations for MySQL, PostgreSQL, Oracle (to Cloud SQL for PostgreSQL), and SQL Server. Unlike AWS DMS, there are no replication instances to manage — GCP DMS handles the initial snapshot, ongoing CDC, and cutover workflow through the GCP Console or `gcloud` CLI. For PostgreSQL homogeneous native paths, it uses logical replication under the hood, creating publications and subscriptions transparently, with no separate replication-instance hourly charge. Heterogeneous migrations are metered per GiB processed, and destination Cloud SQL resources plus any network egress still apply during the migration window. It supports source databases on-premises, on AWS RDS/Aurora, and on other Cloud SQL instances.
+
+**Azure Database Migration Service** supports migrations to Azure Database for PostgreSQL (Flexible Server), Azure SQL Database, and Azure Database for MySQL. It offers two operational modes: offline (with planned downtime) and online (with CDC-based continuous sync for zero-downtime cutovers). The online mode keeps the target in sync until you initiate the cutover from the Azure Portal or CLI. Azure DMS pricing is based on the compute tier (Standard or Premium) and the duration of the migration. For PostgreSQL-to-PostgreSQL migrations, native logical replication is also available directly between Azure Database for PostgreSQL Flexible Server instances.
+
+**When to use managed DMS vs. self-managed CDC**: Managed DMS reduces operational overhead — no Kafka cluster to run, no Debezium connectors to monitor, and built-in validation tooling. For standard migration paths (PostgreSQL → RDS PostgreSQL, MySQL → Cloud SQL MySQL), managed DMS is often the fastest path to a production cutover. The trade-off surfaces for complex migrations: managed DMS has limits on table count per task, maximum LOB column size, and transformation flexibility. For migrations involving custom data type mappings, complex filtering, or routing a single source to multiple heterogeneous targets, a self-managed CDC pipeline (Debezium + Kafka) provides the control that managed DMS abstracts away.
+
+### Schema and Version Compatibility
+
+Logical replication and CDC tools can replicate data between different database versions, but they cannot reconcile fundamentally incompatible data types or schema mismatches. Before starting any replication pipeline:
+
+- **Version gap**: PostgreSQL logical replication supports replicating from an older publisher to a newer subscriber (e.g., PG 14 → PG 16), but not the reverse. The subscriber must be at an equal or higher major version than the publisher.
+
+- **Data type mapping**: For heterogeneous migrations (Oracle → PostgreSQL, SQL Server → MySQL), the Schema Conversion Tool (AWS SCT) or an equivalent transformation layer must map every source type to a compatible target type. `NUMBER(38)` in Oracle maps to `NUMERIC(38)` in PostgreSQL; `DATETIME2` in SQL Server maps to `TIMESTAMP` in MySQL. An unmapped or incorrectly mapped type causes the CDC pipeline to fail silently or reject rows.
+
+- **Extension and plugin parity**: Source extensions (PostGIS, pg_partman, pg_cron) must exist on the target with compatible versions. Managed cloud databases often restrict which extensions are available — verify the target's supported extension list before the migration.
+
+- **Collation and encoding**: The source and target must use compatible collations and character encodings. A mismatch in `LC_COLLATE` or `LC_CTYPE` causes index corruption and incorrect sort order. Always set `ENCODING 'UTF8'` and matching `LC_COLLATE` on the target before starting replication.
+
 > **Stop and think**: You are migrating a 50TB PostgreSQL database with a strict SLA of zero downtime (read/write operations cannot be paused for more than 5 seconds). Would you choose logical replication or a CDC tool like Debezium? Why?
+
+## Patterns & Anti-Patterns
+
+Stateful workload migration rewards disciplined patterns and punishes shortcuts harshly. The difference between a smooth cutover and a multi-day outage often comes down to whether the team followed proven migration patterns or fell into well-known anti-pattern traps.
+
+### Proven Patterns
+
+**Pattern 1: CDC-buffered migration with a message queue**. Establish a CDC pipeline (Debezium + Kafka, or a managed equivalent) that tails the source database's transaction log and publishes change events to a durable message queue. Run the full-load copy independently, then let the CDC stream catch up. The message queue acts as a buffer: if the target database goes offline, no writes are lost — the events accumulate in Kafka. When the target recovers, it consumes the backlog and catches up. This pattern decouples the source from the target, eliminating the tight coupling that makes logical replication fragile over WAN links. Scaling note: Kafka topic partitioning must align with source table primary keys to preserve ordering within each entity.
+
+**Pattern 2: Strangler Fig with dual-write and read verification**. Route a percentage of production read traffic to the new system while the legacy system still handles all writes. Configure the application layer to dual-write to both databases (legacy and new) for the duration of the migration, then compare query results between the two systems for a subset of requests. This pattern catches discrepancies — schema mismatches, encoding issues, missing rows — before they affect users, because the legacy system remains authoritative. Once the new system's read results match the legacy system's for a sustained period (typically 24–72 hours), switch writes to the new system, then decommission the dual-write path. Scaling note: dual-write doubles write load and requires a transaction-outbox or CDC-based approach to handle cases where one write succeeds and the other fails.
+
+**Pattern 3: Velero-based PV migration for Kubernetes-native workloads**. For stateful workloads already on Kubernetes, use Velero with file-level backup (Restic/Kopia) to back up PV data to a provider-neutral object store. The backup captures both Kubernetes resources (StatefulSets, Services, ConfigMaps) and volume contents. Restore to the destination cluster with a single command. This works across cloud providers because the backup is stored as files, not provider-specific block snapshots. It is especially effective for CI/CD state, monitoring data, and application file stores where file-level crash consistency is acceptable. Scaling note: for databases with active writes, quiesce the workload or pair Velero with database-native backup tools (`pg_dump`, `mysqldump`).
+
+**Pattern 4: Re-platform via managed DMS for low-touch migrations**. When migrating a database to a managed cloud service (RDS, Cloud SQL, Azure Database), use the cloud provider's managed DMS to handle the end-to-end pipeline. This minimizes operational burden: no self-managed replication infrastructure, no connector health monitoring, and built-in validation tooling. The trade-off is reduced flexibility — you are limited to the source/target combinations and CDC behaviors the managed service supports. For standard migration paths, this is often the fastest path to a production cutover.
+
+### Anti-Patterns
+
+| Anti-Pattern | Why It Happens | The Damage | Better Approach |
+|---|---|---|---|
+| Big-bang cutover without replication proving | "Let's just do it over the weekend" — teams underestimate data transfer time and post-cutover issues | If the migration fails, you face an unbounded rollback window. The database may be in an inconsistent state with no fallback. | Use replication-based migration: keep source and target in sync for days/weeks before cutover. The cutover should be a DNS switch, not a data move. |
+| Running source + target long-term without a cost ceiling | "We'll keep the source running just in case" — then six months pass | Double infrastructure cost (compute, storage, backups, licensing). For a 16TB database cluster, this can exceed $15K/month in unnecessary spend. | Set a hard decommissioning deadline (14 days post-cutover). Tag resources with auto-shutdown policies. Take one final snapshot for archival, then terminate. |
+| Skipping schema and sequence validation before cutover | "The data replicated, so it must be consistent" — teams focus on row counts only | Auto-increment collisions, missing constraints, different collation behavior, stale statistics causing bad query plans on the target. | Run a comprehensive validation script that checks row counts, sequence values, constraint presence, index presence, collation settings, and checksums on critical tables. |
+| Using the same StorageClass name across providers without verifying behavior | "It's called 'standard' in both clusters, so it must be the same" | On EKS, `gp2` maps to SSD with burst credits; on GKE, `standard-rwo` is HDD. A workload tuned for SSD IOPS will degrade severely on HDD. | Explicitly map StorageClasses. Test the target PVC with `fio` or a database benchmark before cutting over. Override StorageClass in Velero restores or workload manifests. |
+| Migrating without a tested rollback plan | "The migration will succeed" — overconfidence or deadline pressure | If the target has a latent issue (networking, I/O throttling, connection limits), you are stuck with a degraded system and no quick path back. | Keep the source in read-only mode for 48 hours post-cutover. Document (and rehearse) the reverse replication path. Practice the rollback in a staging environment. |
+
+## Decision Framework
+
+Choosing the right migration strategy depends on four primary factors: data size, acceptable downtime budget, database engine compatibility, and team operational expertise. Use the decision matrix below to narrow your options, then apply the flowchart to confirm your choice.
+
+### Decision Matrix
+
+| Migration Profile | Data Size | Downtime Budget | Engine Change | Recommended Approach | Typical Timeline |
+|---|---|---|---|---|---|
+| Small, downtime-acceptable | < 1 TB | Hours | No | pg_dump/pg_restore or mysqldump | 1–2 days |
+| Medium, low-downtime | 1–10 TB | Minutes | No | Logical replication + cutover, or managed DMS | 1–2 weeks |
+| Large, zero-downtime | 10–100 TB | Seconds | No | CDC (Debezium/Kafka) or managed DMS with CDC | 2–6 weeks |
+| Massive, zero-downtime | 100+ TB | Seconds | No | Physical + CDC hybrid; consider offline data transfer appliance for bulk copy | 1–4 months |
+| Cross-engine migration | Any size | Varies | Yes (Oracle→PG, SQL Server→MySQL) | Managed DMS with SCT, or Debezium with custom transforms | 1–3 months |
+| K8s-native, same cloud | Any PV size | Minutes–hours | N/A | CSI snapshots + cross-region copy; fastest path | Hours–days |
+| K8s-native, cross-cloud | Any PV size | Minutes–hours | N/A | Velero with file-level backup; provider-agnostic | Days–weeks |
+
+### Decision Flowchart
+
+```mermaid
+graph TD
+    Start[Start: Stateful Workload Migration] --> K8sQ{Workload already<br/>on Kubernetes?}
+    
+    K8sQ -- "YES" --> SameCloud{Staying within<br/>same cloud provider?}
+    K8sQ -- "NO" --> LegacyQ{Database or<br/>file storage?}
+    
+    SameCloud -- "YES" --> CSI[CSI Volume Snapshots<br/>+ cross-region copy<br/>Fastest path, provider-native]
+    SameCloud -- "NO" --> Velero[Velero with file-level backup<br/>Provider-agnostic<br/>Restore to new StorageClass]
+    
+    LegacyQ -- "Database" --> DBEngine{Same database<br/>engine?}
+    LegacyQ -- "File storage" --> FileSize[Incremental sync:<br/>rsync/rclone for TB-scale<br/>Snowball/Transfer Appliance<br/>for 50TB+]
+    
+    DBEngine -- "YES" --> DBSize{Data size and<br/>downtime budget?}
+    DBEngine -- "NO" --> CrossEngine{Managed or<br/>self-managed?}
+    
+    DBSize -- "<1TB, hours OK" --> Dump[Dump-and-Restore<br/>Simple, deterministic]
+    DBSize -- "1-100TB, minutes OK" --> Logical[Logical Replication<br/>or Managed DMS<br/>Native CDC, low overhead]
+    DBSize -- ">100TB, seconds" --> CDC[CDC via Debezium + Kafka<br/>Decoupled, resilient<br/>or Managed DMS if supported]
+    
+    CrossEngine -- "Managed OK" --> ManagedDMS[Cloud DMS + Schema Conversion<br/>AWS DMS + SCT<br/>GCP DMS<br/>Azure DMS]
+    CrossEngine -- "Need full control" --> Debezium[Debezium + Kafka<br/>+ custom transforms<br/>Maximum flexibility]
+    
+    style CSI fill:#d4edda,stroke:#28a745,color:#000
+    style Velero fill:#d4edda,stroke:#28a745,color:#000
+    style Dump fill:#fff3cd,stroke:#ffc107,color:#000
+    style Logical fill:#d4edda,stroke:#28a745,color:#000
+    style CDC fill:#d4edda,stroke:#28a745,color:#000
+    style ManagedDMS fill:#d4edda,stroke:#28a745,color:#000
+    style Debezium fill:#fff3cd,stroke:#ffc107,color:#000
+```
+
+**Key trade-offs to weigh**:
+
+- **Cost vs. simplicity**: Managed DMS eliminates operational overhead but changes the cost model by provider: AWS DMS charges for the replication instance and related resources, while GCP DMS has no replication-instance hourly charge for homogeneous native migrations but meters heterogeneous processing per GiB. Self-managed Debezium + Kafka adds operational complexity but offers unlimited flexibility and no per-hour service charge.
+
+- **Speed vs. safety**: CSI snapshots are the fastest path for same-cloud migrations, but they don't validate data integrity at the application level. A dump-and-restore is slower but inherently validates schema integrity during restore.
+
+- **Provider lock-in**: Using CSI snapshots ties your DR/migration workflow to a specific cloud provider's storage API. Velero with file-level backup adds an abstraction layer that enables multi-cloud portability, at the cost of slower backup and restore performance.
 
 ## Zero-Downtime Cutover Runbooks and Verification
 
@@ -559,23 +815,98 @@ if [ "$MISMATCH" -eq 1 ]; then
   exit 1
 fi
 
-echo "Comparing sequences..."
-psql -h $SOURCE_HOST -U admin -d $DB_NAME -t -c \
-  "SELECT sequencename, last_value FROM pg_sequences WHERE schemaname = 'public'" | \
-while read -r SEQ_NAME SEQ_VAL; do
-  TARGET_VAL=$(psql -h $TARGET_HOST -U admin -d $DB_NAME -t -c \
-    "SELECT last_value FROM pg_sequences WHERE sequencename = '$SEQ_NAME'")
-  if [ "$SEQ_VAL" != "$TARGET_VAL" ]; then
-    echo "SEQUENCE MISMATCH: $SEQ_NAME - source=$SEQ_VAL target=$TARGET_VAL"
-  fi
-done
+echo "Inspecting target sequence state..."
+psql -h $TARGET_HOST -U admin -d $DB_NAME -c \
+  "SELECT sequencename, last_value FROM pg_sequences WHERE schemaname = 'public'"
+
+echo "Aligning target sequences to replicated table maxima..."
+psql -h $TARGET_HOST -U admin -d $DB_NAME -At -c "
+SELECT format(
+  'SELECT setval(%L, GREATEST(COALESCE((SELECT MAX(%I) FROM %I.%I), 0), 1), COALESCE((SELECT MAX(%I) FROM %I.%I), 0) > 0);',
+  pg_get_serial_sequence(format('%I.%I', table_schema, table_name), column_name),
+  column_name, table_schema, table_name,
+  column_name, table_schema, table_name
+)
+FROM information_schema.columns
+WHERE table_schema = 'public'
+  AND column_default LIKE 'nextval(%'
+  AND pg_get_serial_sequence(format('%I.%I', table_schema, table_name), column_name) IS NOT NULL;" | \
+psql -h $TARGET_HOST -U admin -d $DB_NAME
 
 echo "Verification complete."
 ```
 
+### DNS Switch and Connection Pool Caching
+
+After verification passes, the cutover itself is a connection-string change — updating a database endpoint from `source-db.internal` to `target-db.rds.amazonaws.com`. But in Kubernetes environments, this change is rarely instantaneous. Two caching layers delay the switch:
+
+**DNS caching**: Even with a low TTL (60 seconds or less), application pods may cache DNS lookups beyond the TTL. Java's `InetAddress` caching defaults to indefinite caching of successful lookups unless `-Dsun.net.inetaddr.ttl=60` is set explicitly. Node.js's `dns.lookup()` uses the OS resolver, which may or may not respect TTL depending on the operating system and `nscd` configuration. Go's `net` package respects TTL by default, but a long-lived connection pool won't trigger a re-resolution.
+
+**Connection pooling**: Database connection pools (HikariCP for Java, PgBouncer for PostgreSQL, `node-postgres` pool for Node.js) hold connections open for minutes or hours. Changing the DNS record doesn't migrate existing connections — they remain connected to the old database until the pool recycles them, which can take 30+ minutes for idle pools.
+
+The fix: after updating the DNS record or ConfigMap, perform a rolling restart of all application pods that connect to the database. For deployments with 50+ pods, a controlled rollout with `maxUnavailable: 1` and readiness gates minimizes disruption:
+
+```bash
+# Update the configuration
+kubectl create configmap db-config \
+  --from-literal=DATABASE_URL=postgres://target-db.rds.amazonaws.com:5432/mydb \
+  --dry-run=client -o yaml | kubectl apply -f -
+
+# Rolling restart — respects PodDisruptionBudget and readiness probes
+kubectl rollout restart deployment/payments-api deployment/orders-api deployment/inventory-api
+
+# Monitor progress
+kubectl rollout status deployment/payments-api --timeout=300s
+```
+
+### Rollback Planning
+
+Every cutover runbook must include a documented, tested rollback plan. The simplest and most reliable rollback: keep the source database running in read-only mode for at least 48 hours after cutover. If the target exhibits issues — latency spikes, connection limit exhaustion, unexpected query plans due to different PostgreSQL statistics — the rollback requires only a configuration change:
+
+1. Set the source database back to read-write mode: `ALTER DATABASE mydb SET default_transaction_read_only = false;`
+2. Update the ConfigMap to point back to the source.
+3. Rolling restart the application pods.
+4. Investigate the target issue before re-attempting the cutover.
+
+For zero-data-loss rollback — meaning any writes that landed on the target during the brief production window are preserved if you roll back — set up **reverse replication** before the final cutover. Create a publication on the target database and a subscription on the source. If a rollback is necessary, the target's writes flow back to the source. After the cutover is confirmed stable (48–72 hours with normal error rates and latency), drop both replication slots and decommission the source.
+
+### Pre-Cutover Testing
+
+A migration that hasn't been tested is a migration that will fail. Before production cutover:
+
+1. **Dry-run in staging**: Execute every step of the runbook against a staging copy of the database. Time each phase (full-load duration, replication catch-up time, verification script runtime, DNS propagation delay). Multiply all times by 1.5× when planning the production cutover window to account for larger data volumes and network variability.
+
+2. **Shadow traffic replay**: Use `pgbench` with production query logs, or a traffic mirroring setup (Envoy request mirroring, Istio traffic mirroring), to replay a sample of production reads and writes against the target database. Measure query latency, error rates, and connection pool behavior under realistic load.
+
+3. **Canary traffic routing**: If using the Strangler Fig pattern, route 1% of real production traffic to the new database-backed service for 24 hours, then 10%, then 50%, before the full cutover. Monitor error rates, latency percentiles (p50, p95, p99), and database resource utilization at each step. Roll back immediately if any percentile degrades by more than 20% from the baseline.
+
+4. **Cutover rehearsal**: Run the full cutover procedure at the same time of day and day of week as the planned production cutover (e.g., Sunday 02:00 UTC). Time every step precisely. Confirm the rollback procedure completes within your recovery time objective (RTO). The rehearsal should produce a timed runbook that the on-call team can follow during the actual cutover.
+
+### Cost Lens: What Stateful Migration Actually Costs
+
+Stateful migration is not free — and the costs are routinely underestimated. Understanding them upfront prevents budget surprises that can stall a migration mid-flight.
+
+**Double-running infrastructure**: During the migration window (2–6 weeks for large databases), you run both source and target systems simultaneously. For a production-grade database cluster (3-node primary + replica, 16 vCPU, 128 GB RAM, 1 TB SSD storage), approximate double-running costs:
+- AWS RDS for PostgreSQL (`db.r6g.4xlarge`, Multi-AZ): ~$1.50/hour per instance → ~$3,200/month for source + ~$3,200 for target = ~$6,400/month in compute alone.
+- GCP Cloud SQL for PostgreSQL (`db-custom-16-131072`, HA): ~$1.20/hour → ~$2,600/month each.
+- Azure Database for PostgreSQL Flexible Server (16 vCPU, 128 GB, HA): ~$1.40/hour → ~$3,000/month each.
+
+Add storage costs (typically $0.10–$0.20/GB-month for SSD), backup storage, and data transfer charges. Tag resources with a decommission date and set budget alerts to prevent these costs from persisting beyond the migration window.
+
+**Cross-region data transfer**: Copying a 10 TB database across regions for migration incurs egress charges that differ sharply by provider:
+- AWS: inter-region data transfer is ~$0.02/GB → ~$200 for 10 TB. However, if traffic traverses a NAT Gateway or crosses Availability Zones within the source region first, add ~$0.045/GB for NAT processing and ~$0.01/GB for cross-AZ data.
+- GCP: inter-region egress is ~$0.01–$0.12/GB, varying by source and destination region pair. A typical US-to-Europe transfer costs ~$0.08/GB → ~$800 for 10 TB.
+- Azure: inter-region data transfer is ~$0.02–$0.087/GB depending on zone/region pairing → ~$200–$870 for 10 TB.
+
+For 50+ TB datasets, data transfer charges alone can exceed $5,000 — which is why physical data transfer appliances (AWS Snowball Edge, GCP Transfer Appliance, Azure Data Box) become cost-competitive at this scale. These charge a flat per-device fee (~$200–$400) plus shipping, avoiding per-GB egress charges for the bulk data copy.
+
+**Snapshot storage**: During an active migration, CSI snapshots and database dumps stored in object storage incur monthly charges. At ~$0.02–$0.03/GB-month, a 10 TB snapshot costs ~$200–$300/month per copy. If you retain multiple snapshots (pre-migration baseline, mid-migration checkpoint, post-migration archival), costs multiply. Delete snapshots after confirming migration stability unless they serve a specific compliance or rollback purpose.
+
+**In-cluster cost visibility**: For teams running migration tooling inside Kubernetes (Velero, Debezium, Strimzi Kafka), tools like Kubecost or OpenCost provide real-time cost allocation by namespace, deployment, or custom label. Tag all migration resources with `migration=true` and `decommission-after=YYYY-MM-DD` to track the fully loaded migration cost separately from steady-state operations, and to prevent orphaned resources from accumulating charges after migration completes.
+
 ## Did You Know?
 
-1. **AWS Database Migration Service (DMS) has migrated millions of databases** since its launch in 2016. The most common migration path is Oracle-to-PostgreSQL, followed by SQL Server-to-Aurora. DMS handles schema conversion (via the Schema Conversion Tool) and ongoing CDC replication. For Kubernetes teams, DMS can replicate to an RDS instance that a K8s operator or application then connects to.
+1. **AWS Database Migration Service (DMS) is a common path for complex database migrations** because it can combine full-load copy, schema conversion support through the Schema Conversion Tool, and ongoing CDC replication. For Kubernetes teams, DMS can replicate to an RDS instance that a K8s operator or application then connects to.
 2. **The Strangler Fig pattern was coined by Martin Fowler in 2004**, inspired by the actual strangler fig trees he saw in Australia. These trees germinate in the canopy of a host tree, send roots down to the ground, and gradually envelop the host until the original tree dies. Fowler saw this as the perfect metaphor for gradually replacing a legacy system. The pattern has become the default migration strategy for monolith-to-microservices transitions.
 3. **Data transfer over the internet at 1 Gbps takes about 2.5 hours for 1TB of data.** For a 50TB database, that's over 5 days of continuous transfer -- assuming the network link is fully saturated, which it won't be. In practice, with network overhead and shared bandwidth, it often takes much longer. AWS Snowball Edge devices transfer 80TB via physical shipping and typically take 4-6 business days door-to-door, making physical transfer competitive or faster for datasets above ~50TB. GCP has Transfer Appliance and Azure has Data Box for the same purpose.
 4. **PostgreSQL's logical replication was introduced in version 10 (2017)** and significantly improved migration tooling. Before logical replication, the primary options for near-zero-downtime migration were: physical replication (requires same PG version and OS), third-party tools like Slony (complex, fragile), or CDC via trigger-based capture (high overhead). Logical replication made it possible to replicate between different PG versions, different platforms (on-prem to cloud), and even different schemas -- transforming database migration from a high-risk event to a routine operation.
@@ -951,3 +1282,13 @@ kind delete cluster --name migration-lab
 - [Kubernetes Volume Snapshots](https://kubernetes.io/docs/concepts/storage/volume-snapshots/) — Covers the CSI snapshot model, lifecycle objects, and restoration flow used in the infrastructure migration section.
 - [AWS Prescriptive Guidance: PostgreSQL Logical Replication](https://docs.aws.amazon.com/prescriptive-guidance/latest/migration-databases-postgresql-ec2/logical-replication.html) — Summarizes logical replication behavior and migration limitations, including sequences and schema constraints.
 - [Amazon EBS Snapshot Copy](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-copy-snapshot.html) — Directly supports the cross-Region snapshot-copy workflow used in the CSI snapshot migration example.
+- [Velero Documentation](https://velero.io/docs/main/) — Official documentation for Velero, covering backup and restore workflows for Kubernetes resources and PersistentVolumes, including file-level (Restic/Kopia) and CSI snapshot integration modes.
+- [AWS Database Migration Service User Guide](https://docs.aws.amazon.com/dms/latest/userguide/Welcome.html) — Covers DMS architecture, supported source/target combinations, Schema Conversion Tool usage, and ongoing replication (CDC) configuration.
+- [GCP Database Migration Service Documentation](https://cloud.google.com/database-migration/docs) — Details serverless migration workflows for MySQL, PostgreSQL, Oracle, and SQL Server to Cloud SQL, including CDC-based ongoing replication.
+- [Azure Database Migration Service Overview](https://learn.microsoft.com/en-us/azure/dms/dms-overview) — Covers offline and online migration modes, supported source/target pairs, and pricing tiers.
+- [GCP Persistent Disk Snapshots](https://cloud.google.com/compute/docs/disks/create-snapshots) — Documents PD snapshot creation, cross-region copy, and differential snapshot storage behavior.
+- [Azure Managed Disk Snapshots](https://learn.microsoft.com/en-us/azure/virtual-machines/snapshot-copy-managed-disk) — Covers snapshot creation, incremental snapshots, and cross-region copy for Azure Managed Disks.
+- [Kubernetes StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/) — Official Kubernetes documentation on StatefulSet identity (stable network IDs, ordered pod management, persistent storage) relevant to migration identity preservation.
+- [AWS EBS Snapshots](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-snapshots.html) — Documents EBS snapshot creation, incremental behavior, cross-region copy, and snapshot storage billing.
+- [GKE Persistent Volumes and Storage Classes](https://cloud.google.com/kubernetes-engine/docs/concepts/persistent-volumes) — Covers GKE storage classes, CSI driver configuration, and persistent disk provisioning for stateful workloads.
+- [AKS Storage Concepts](https://learn.microsoft.com/en-us/azure/aks/concepts-storage) — Documents AKS storage classes, CSI drivers for Azure Disk and Azure Files, and persistent volume provisioning.

--- a/src/content/docs/cloud/advanced-operations/module-8.8-cloud-cost.md
+++ b/src/content/docs/cloud/advanced-operations/module-8.8-cloud-cost.md
@@ -14,15 +14,47 @@ sidebar:
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to **Implement FinOps practices with cloud-native cost allocation tagging, showback, and chargeback mechanisms**, **Configure Kubernetes cost visibility using Kubecost, OpenCost, or cloud-native cost tools across multi-cluster environments**, **Optimize compute costs using reserved instances, committed use discounts, Spot/preemptible instances, and right-sizing**, and **Design automated cost anomaly detection and budget alerting pipelines that trigger remediation actions**.
+After completing this module, you will be able to:
+
+- **Implement** the FinOps operating model so engineering, finance, and product teams can make cost decisions from the same data.
+- **Enforce** cost allocation discipline with AWS tags, Google Cloud labels, Azure tags, and Kubernetes labels that survive multi-team platform scale.
+- **Allocate** Kubernetes cluster cost with OpenCost or Kubecost, including shared overhead, idle capacity, and namespace-level showback.
+- **Optimize** compute spend with rightsizing, bin-packing, node consolidation, commitments, and interruptible capacity across AWS, GCP, and Azure.
+- **Detect** cost anomalies with budgets, provider alerts, and unit economics that connect infrastructure spend to product value.
 
 ---
 
 ## Why This Module Matters
 
-A fast-growing company with a large cloud bill, and leadership realized cloud spend was growing faster than expected, but the organization still lacked workload-level cost visibility and could not answer basic ownership questions from provider billing alone.
+Hypothetical scenario: a platform team receives a sharply higher cloud bill after a quarter of product growth. Finance can see the provider, service, account, subscription, and project totals, but engineering cannot explain which tenants, namespaces, or features caused the increase. Product leaders want to know whether the spend bought more customer value or simply hid idle capacity, network transfer, and over-requested Kubernetes pods.
 
-Detailed cost reviews often uncover underutilized compute, steady workloads still billed at on-demand rates, orphaned storage, long-lived temporary environments, and overlooked network-transfer charges, so applying right-sizing, commitment discounts, workload-level cost allocation, and carefully chosen interruptible capacity can materially reduce cloud spend without requiring application rewrites.
+That gap is why cloud cost optimization is an engineering concern, not a monthly finance report. Engineers choose resource requests, load-balancer topology, log volume, storage classes, replication patterns, node pools, and traffic paths. Those decisions become billable usage within minutes, and no finance dashboard can recover intent after workloads were deployed without ownership metadata or operational guardrails.
+
+Detailed cost reviews often uncover underutilized compute, steady workloads still billed at on-demand rates, orphaned storage, long-lived temporary environments, and overlooked network-transfer charges. Applying right-sizing, commitment discounts, workload-level cost allocation, and carefully chosen interruptible capacity can materially reduce cloud spend without requiring application rewrites, but only when the team can tie every optimization to reliability and product impact.
+
+The trap is treating "save money" as the goal. A healthy FinOps practice asks a better question: are we buying the right amount of capacity, resilience, telemetry, and availability for the business outcome? Sometimes the correct answer is to spend more on redundancy or observability because the unit economics still work. Sometimes the correct answer is to delete unused environments because the spend has no owner and no measurable value.
+
+> **The Restaurant Kitchen Analogy**
+>
+> Cloud cost is like running a busy restaurant kitchen. Finance sees the supplier invoice, but the chefs decide how much food to prep, which dishes waste ingredients, when to keep extra staff on shift, and which stations share expensive equipment. A good kitchen does not merely yell "spend less"; it measures waste, assigns ownership, plans predictable demand, and keeps enough capacity for dinner rush without letting every prep table stay fully stocked overnight.
+
+---
+
+## The FinOps Operating Model
+
+The [FinOps Foundation describes FinOps](https://www.finops.org/framework/) as an operating model and cultural practice that creates shared accountability across engineering, finance, and business teams. In practical platform terms, FinOps is the feedback loop that turns cloud usage into decisions. It gives engineers timely cost signals, gives finance explainable forecasts, and gives product teams a way to compare infrastructure spend with customer value.
+
+The core loop is Inform, Optimize, and Operate. [The FinOps phases](https://www.finops.org/framework/phases/) are iterative, not a waterfall. A team may be mature in Inform for AWS compute, still immature for Kubernetes namespace allocation, and only beginning to operate anomaly response for AI inference spend. That uneven maturity is normal because different services expose different billing data, different owners, and different optimization levers.
+
+In the Inform phase, the goal is cost visibility and accountability. On AWS this means activated cost allocation tags, Cost and Usage Reports, Cost Explorer views, and budgets. On Google Cloud it means billing exports, labels, project hierarchy discipline, reports, and budgets. On Azure it means scopes, tags, Cost Management, cost allocation rules, and exports. Inside Kubernetes it means labels, namespaces, requests, usage metrics, and OpenCost or Kubecost allocation.
+
+In the Optimize phase, the team turns visibility into action. Optimization has two different layers that teams often confuse. Usage optimization reduces waste by right-sizing pod requests, scaling idle node pools down, removing orphaned volumes, cutting noisy logs, or keeping same-zone service traffic local. Rate optimization changes the price paid for unavoidable usage through AWS Savings Plans, Google Cloud Committed Use Discounts, Azure Reservations, and provider-specific spot capacity.
+
+In the Operate phase, cost controls become part of normal engineering work. Budgets and anomaly alerts route to owners, pull requests include cost impact when infrastructure changes, platform dashboards show unit cost, and teams review spend during operational planning. The operating phase is where FinOps becomes more than a cleanup project. It changes defaults, policy, ownership, and incident response so cost surprises become observable events.
+
+The reason this model matters in multi-cloud Kubernetes is that no single cloud bill knows your platform intent. AWS can tell you an EKS node, NAT Gateway, or load balancer cost money. Google Cloud can tell you a GKE cluster, Cloud NAT gateway, or logging bucket produced usage. Azure can show AKS, NAT Gateway, Load Balancer, and Log Analytics charges. None of them automatically knows that `tenant-a` owns the checkout namespace and `tenant-b` owns the recommendation workload unless you design that allocation path.
+
+FinOps also makes cost changes safer. A blanket mandate to reduce spend by 20 percent encourages risky behavior, such as lowering memory limits blindly or moving stateful systems to interruptible nodes. A FinOps operating model asks which spend is idle, which spend is inefficient, which spend is a negotiated rate problem, and which spend is necessary for reliability. That distinction protects learners from confusing cost cutting with cost engineering.
 
 ---
 
@@ -48,6 +80,39 @@ graph TD
     note[Implementation order: 1 --> 2 --> 3 --> 4<br/>You can't optimize what you can't see.]
     Optimization Process --> note
 ```
+
+---
+
+## Cost Allocation and Attribution
+
+Cost allocation answers "who caused this spend?" Cost attribution answers a slightly richer question: "which product, tenant, environment, feature, or platform service should be accountable for this spend?" A cloud bill without attribution is just a list of meters. A Kubernetes bill without attribution is even worse because many teams share the same nodes, load balancers, storage systems, logging pipelines, and network paths.
+
+The first allocation rule is boring but non-negotiable: every resource needs an owner. On AWS the usual control point is tags, and [user-defined cost allocation tags](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/custom-tags.html) must be activated for Billing and Cost Management before they become useful in cost reports. A tag that exists only on an EC2 instance but is not active for cost allocation will help inventory searches, but it will not reliably answer finance questions.
+
+On Google Cloud, labels are the familiar cost grouping mechanism for many resources, and billing reports can filter or group costs by labels after those labels exist on the usage. [Google Cloud's label documentation](https://cloud.google.com/resource-manager/docs/labels-overview) also makes an important distinction: labels are key-value metadata for organization and reporting, while tags serve different governance and policy use cases. FinOps teams should avoid mixing those terms because the wrong mechanism can make reports inconsistent.
+
+On Azure, tags and scopes are central to cost visibility. [Azure Cost Management cost allocation rules](https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/allocate-costs) can distribute shared service costs across subscriptions, resource groups, or tags for internal accountability, even though the underlying invoice responsibility does not change. Note: allocation requires Enterprise Agreement (EA) or Microsoft Customer Agreement (MCA) billing, reallocates Cost Management views only (not invoice responsibility), has processing delay, and excludes Reservation and Savings Plan purchases — see [current limitations](https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/allocate-costs#limitations).
+
+A practical tag taxonomy should be small, mandatory, and stable. Start with keys such as `owner`, `team`, `cost-center`, `application`, `environment`, `data-classification`, and `lifecycle`. Avoid keys with high-cardinality values such as build IDs, random ticket numbers, or temporary experiment names because they clutter reports and make aggregation hard. Use separate observability labels for high-cardinality debugging data.
+
+The hardest problem is untagged spend. Untagged resources become the default bucket for "we cannot tell who spent this," and that bucket grows whenever teams create emergency resources, managed services create supporting infrastructure, or automation skips metadata. A mature FinOps program treats untagged spend as operational debt. It has an owner, a weekly review, a threshold, and eventually a policy that prevents new untagged production resources.
+
+Showback and chargeback use the same allocation data but create different incentives. Showback reports spend to teams without directly moving budget, which makes it safer for early adoption because teams learn their cost shape before money is redistributed. Chargeback assigns the cost to the consuming team, which creates stronger incentives but also requires better data quality, exception handling, and executive agreement about shared platform costs.
+
+Shared cost allocation is where simplistic tagging breaks down. A platform security scanner, central logging workspace, shared ingress gateway, NAT Gateway, or multi-tenant database may support every product. Splitting those costs evenly is easy but often unfair. Splitting by revenue, request volume, namespace usage, allocated CPU, stored bytes, or tenant count can be fairer, but only if the driver is explainable and stable enough that teams trust it.
+
+The engineering pattern is to use a layered allocation model. Direct resource costs follow cloud tags, labels, projects, subscriptions, or accounts. Kubernetes workload costs follow namespace and workload labels. Shared cluster overhead is assigned by a documented rule, such as proportional requested CPU and memory, proportional actual usage, or a fixed platform tax. The rule will never be perfect, but it must be visible and consistently applied.
+
+| Allocation Surface | AWS Pattern | Google Cloud Pattern | Azure Pattern | Kubernetes Pattern |
+|---|---|---|---|---|
+| Business owner | Activated cost allocation tags such as `team` and `cost-center` | Labels on projects and resources, plus billing export fields | Tags on subscriptions, resource groups, and resources | Namespace and workload labels such as `team` and `app.kubernetes.io/part-of` |
+| Shared services | Cost categories, account structure, and tag-based reports | Billing export to BigQuery with allocation logic | Cost allocation rules and Cost Management exports | OpenCost or Kubecost shared cost policies |
+| Enforcement | Tag policies, IaC checks, and SCP-backed guardrails where appropriate | Organization policy, CI checks, and project factory defaults | Azure Policy, management groups, and landing-zone defaults | Admission policy with Kyverno, Gatekeeper, or ValidatingAdmissionPolicy |
+| Reporting cadence | Daily Cost Explorer or CUR-backed dashboards | Billing reports, BigQuery exports, and budgets | Cost Management views, exports, budgets, and workbooks | Namespace, controller, pod, label, and idle cost reports |
+
+Cost ownership also needs lifecycle ownership. Temporary environments should carry an expiry date. Development clusters should identify who can approve after-hours runtime. Persistent volumes should identify data owner and retention class. Load balancers should identify application owner and ingress purpose. These fields are not accounting decoration; they are the metadata that lets automation safely clean up resources without creating an outage.
+
+The best allocation systems are built into provisioning paths. Terraform modules, Crossplane compositions, project factories, account vending pipelines, and Helm charts should stamp required metadata by default. Admission controls should reject missing Kubernetes labels before the workload reaches production. Billing reviews should focus on exceptions and trends, not on asking humans to remember who created an unlabeled NAT gateway six weeks ago.
 
 ---
 
@@ -131,11 +196,29 @@ helm install opencost opencost/opencost \
   --set opencost.ui.enabled=true
 
 # Query the API for cost allocation
+# (assumes an existing port-forward — create one with:
+#   kubectl port-forward -n opencost svc/opencost 9003:9003)
 curl http://localhost:9003/allocation/compute \
   --data-urlencode "window=7d" \
   --data-urlencode "aggregate=namespace" \
   --data-urlencode "accumulate=true" | jq '.data[0]'
 ```
+
+OpenCost and Kubecost solve a problem that the provider bill cannot solve by itself. The cloud provider knows the node, disk, load balancer, and network meters. Kubernetes knows pods, namespaces, controllers, requests, labels, and actual usage. Cost visibility becomes useful only when those two worlds are joined, because the application owner usually thinks in workloads while finance usually receives infrastructure line items.
+
+[OpenCost's Allocation API](https://opencost.io/docs/integrations/api/) reports cost by Kubernetes concepts such as namespace, controller, pod, service, and label. That matters because Kubernetes scheduling is dynamic. A namespace that used 40 percent of one node yesterday might use 10 percent of three different nodes today. A static spreadsheet cannot follow that movement, but a cost model connected to metrics and billing data can attribute cost over time.
+
+The most important OpenCost or Kubecost number is often not the team total. It is idle cost. Idle cost is the portion of cluster spend that exists because capacity was provisioned but not consumed by workloads. Some idle capacity is healthy because clusters need headroom for bursts, rolling deployments, daemonsets, and node failures. Excessive idle capacity is waste because the scheduler is reserving nodes that no team actually uses.
+
+Idle cost should not be hidden inside a platform bucket forever. Early showback reports can place idle under the platform team so the platform group can tune autoscaling and node pool design. Mature reports often split idle proportionally across consuming teams, because over-requested pods and poor bin-packing create idle capacity even when the cluster autoscaler behaves correctly. The policy choice should be explicit because it changes incentives.
+
+Shared overhead needs similar care. System namespaces, CNI daemons, CSI drivers, metrics collectors, ingress controllers, service meshes, and security agents consume real resources. If you allocate only application pod cost, platform services look free and application teams underestimate the cost of high-cardinality telemetry, sidecars, and cross-cutting controls. If you allocate every shared cost by a blunt percentage, teams may distrust the report.
+
+A good in-cluster allocation model normally separates three buckets. Direct workload cost follows namespace, workload, and team labels. Shared cluster cost covers system components and platform add-ons, allocated by a policy such as proportional requested resources. Idle cost stays visible as its own line item so teams can see whether the waste came from oversized requests, autoscaler minimums, daemonset overhead, or deliberate resilience headroom.
+
+For multi-cluster environments, cluster identity is part of cost allocation. A production EKS cluster in `us-east-1`, a GKE cluster in `europe-west1`, and an AKS cluster in `westeurope` may all run the same product, but their network, logging, control-plane, and discount profiles differ. OpenCost labels should include cluster, provider, region, environment, and ownership so teams can compare like with like.
+
+The final allocation lesson is that cost visibility needs resource requests to be honest. Kubernetes schedules pods based on requested resources, and allocation engines often use requests, usage, or a blend of both. A team that requests 4 CPU for a pod that uses 400 millicores can create real node cost even if the workload looks idle in application metrics. FinOps and reliability share the same baseline data.
 
 ### Multi-Tenant Cost Allocation
 
@@ -198,9 +281,26 @@ spec:
             labels:
               team: "?*"
               cost-center: "?*"
-              environment: "production|staging|development"
+              environment: "production | staging | development"
+          spec:
+            template:
+              metadata:
+                labels:
+                  team: "?*"
+                  cost-center: "?*"
+                  environment: "production | staging | development"
 EOF
 ```
+
+Admission control is the Kubernetes side of FinOps governance. It does not replace cloud tag policies, project factories, or landing-zone controls, because many costs are created outside the cluster. It does prevent the most common in-cluster failure: a deployment reaches production with no durable owner, then appears in OpenCost as unattributed namespace spend after the bill has already landed.
+
+Use enforcement gradually. Start with audit mode in existing clusters so teams can see which workloads would fail. Move production namespaces to enforce mode once the platform has templates, examples, and a clear exception process. For brand-new clusters, enforce required labels from day one because retrofitting metadata after hundreds of workloads exist is slower and politically harder.
+
+Provider and Kubernetes metadata should align without becoming identical. AWS might use `cost-center`, Google Cloud might use `cost_center` because of label conventions, and Azure might inherit tags from a resource group. Kubernetes can still standardize on labels such as `platform.kubedojo.io/team` and `platform.kubedojo.io/cost-center`. The reporting pipeline can map those fields into a common business dimension.
+
+Showback should begin with education, not blame. A useful showback report says, "Your namespace spent roughly this much, this portion was idle, this portion came from shared overhead, and these three changes would reduce waste." A weak report says, "Your team is expensive." The first report creates engineering action. The second report creates arguments about accounting.
+
+Chargeback should wait until the allocation model is stable enough to survive disputes. Once budget actually moves, teams will challenge shared cost formulas, missing labels, and noisy workloads owned by other groups. This is healthy if the process is transparent. It becomes toxic if the platform team cannot explain why a cost was assigned or how a team can reduce it.
 
 ---
 
@@ -328,6 +428,32 @@ spec:
           averageUtilization: 75
 ```
 
+### Compute Cost Levers: Usage Before Rate
+
+Compute optimization starts with usage, not discounts. A one-year commitment on waste makes the waste cheaper, but it also makes the organization less willing to remove it. The safer sequence is to right-size requests, improve bin-packing, reduce idle node pools, and then buy commitments only for the stable baseline that remains after engineering cleanup.
+
+Kubernetes requests are the first lever because [the scheduler uses resource requests when placing pods](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/). If requests are inflated, the scheduler sees the cluster as full earlier than it should. Cluster autoscaler, Karpenter, and provider node provisioning then add nodes to satisfy artificial demand. The bill increases even when actual CPU and memory usage remain low.
+
+VPA recommendations are a low-risk way to make that invisible waste visible. [Kubernetes VPA stores recommendations in the VerticalPodAutoscaler status](https://kubernetes.io/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/), and recent Kubernetes documentation identifies `autoscaling.k8s.io/v1` as the stable API version. For production services, recommendation mode is often the right first step because it gives data without restarting pods or changing requests automatically.
+
+Rightsizing should be tied to service behavior. For memory-heavy workloads, lowering limits without understanding garbage collection, caches, or startup spikes can create OOM kills. For CPU-bound workloads, lower requests may increase pod density but also change HPA behavior because CPU utilization is calculated against requests. The goal is not the smallest number; it is the smallest request that preserves predictable scheduling and scaling behavior.
+
+Bin-packing is the second lever. A cluster with many oddly shaped pods can waste nodes even when individual requests look reasonable. One workload requests 3500 millicores and another requests 900 millicores, so two 4-vCPU nodes appear necessary even though actual usage might fit on one larger or different instance family. Node provisioning tools reduce this waste by choosing node shapes that better match pending pods.
+
+On AWS, Karpenter is commonly used with EKS to provision instances directly from pod requirements, diversify instance types, and consolidate empty or underutilized nodes. [AWS EKS cost optimization guidance](https://docs.aws.amazon.com/eks/latest/best-practices/cost-opt-compute.html) discusses bin packing, Spot, Savings Plans, Reserved Instances, and mixed capacity types. The important design choice is to let workloads express constraints while the provisioner selects economically sensible capacity.
+
+On Google Kubernetes Engine, cluster autoscaler and node auto-provisioning handle a similar shape of problem. [GKE cluster autoscaling documentation](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler) describes autoscaler behavior and notes that Spot VM node pools can be preferred when workloads allow it. [GKE cost optimization guidance](https://cloud.google.com/architecture/best-practices-for-running-cost-effective-kubernetes-applications-on-gke) also frames node auto-provisioning as a way to add node pools that match workload requirements.
+
+On Azure Kubernetes Service, [AKS cost optimization guidance](https://learn.microsoft.com/en-us/azure/aks/optimize-aks-costs) covers horizontal pod autoscaling, cluster right-sizing, cluster autoscaler, and node autoprovisioning. [AKS cluster autoscaler documentation](https://learn.microsoft.com/en-us/azure/aks/cluster-autoscaler-overview) emphasizes that the autoscaler watches for unschedulable pods and removes nodes without scheduled pods when scale-down conditions are met. That behavior turns honest requests into real cost control.
+
+Rate optimization comes after the baseline is understood. AWS Savings Plans fit predictable compute usage across compatible services and regions depending on plan type. Google Cloud Committed Use Discounts fit stable vCPU, memory, or resource commitments. Azure Reservations fit predictable VM and other resource usage over one-year or three-year terms. These tools reward predictability, so they are dangerous when purchased before cleanup.
+
+Interruptible capacity is different from a commitment. AWS Spot Instances, Google Cloud Spot VMs, and Azure Spot Virtual Machines can be much cheaper than on-demand capacity, but the provider can reclaim them. They fit stateless web replicas with enough redundancy, batch jobs with checkpoints, CI workers, render farms, and data processing that can restart. They do not fit single-replica stateful systems, quorum-critical databases, or workloads that cannot shut down inside the provider's notice window.
+
+The best production clusters mix capacity types. Critical system and stateful workloads use on-demand or reserved baseline capacity. Stateless burst workloads can prefer interruptible capacity with fallback. Batch queues can use mostly interruptible capacity and absorb evictions through retries. Development clusters can combine scheduled scale-down, small baselines, and spot pools because the recovery objective is different from production.
+
+The cost lever that surprises many teams is architecture. Moving a chatty service pair into the same zone, reducing verbose log fields, switching batch jobs to event-driven scale-to-zero patterns, or lowering cross-region replication frequency can save more than shaving a few percent from instance prices. FinOps engineers should therefore review topology, telemetry, and data movement before assuming compute commitments are the only meaningful lever.
+
 ---
 
 > **Pause and predict**: If your application traffic doubles every year, is it more cost-effective to buy 3-year Reserved Instances or stick to 1-year commitments?
@@ -341,26 +467,26 @@ graph TD
     classDef provider fill:#eceff1,stroke:#607d8b,stroke-width:2px;
     classDef strategy fill:#e3f2fd,stroke:#1565c0,stroke-width:2px;
 
-    subgraph AWS ["AWS (m7i.xlarge)"]
-        A1["On-Demand: $0.192/hr"]
-        A2["1yr Savings Plan: $0.121/hr (-37%)"]
-        A3["3yr Savings Plan: $0.077/hr (-60%)"]
-        A4["Spot: $0.058/hr (-70%, interruptible)"]
+    subgraph AWS ["AWS (m7i.xlarge, representative)"]
+        A1["On-Demand: ~$0.19/hr"]
+        A2["1yr Savings Plan: lower hourly commitment rate"]
+        A3["3yr Savings Plan: deeper commitment discount"]
+        A4["Spot: variable, interruptible, verify current pricing"]
     end:::provider
 
-    subgraph GCP ["GCP (n2-standard-4)"]
-        G1["On-Demand: $0.189/hr"]
-        G2["1yr CUD: $0.119/hr (-37%)"]
-        G3["3yr CUD: $0.085/hr (-55%)"]
-        G4["Spot: $0.057/hr (-70%)"]
-        G5["SUDs (automatic): $0.151/hr (-20%)"]
+    subgraph GCP ["GCP (n2-standard-4, representative)"]
+        G1["On-Demand: ~$0.19/hr"]
+        G2["1yr CUD: lower committed rate"]
+        G3["3yr CUD: deeper committed rate"]
+        G4["Spot: variable, preemptible"]
+        G5["SUDs: automatic where eligible"]
     end:::provider
 
-    subgraph Azure ["Azure (D4s v5)"]
-        Z1["On-Demand: $0.192/hr"]
-        Z2["1yr Reserved: $0.124/hr (-35%)"]
-        Z3["3yr Reserved: $0.079/hr (-59%)"]
-        Z4["Spot: ~$0.038/hr (-80%)"]
+    subgraph Azure ["Azure (D4s v5, representative)"]
+        Z1["On-Demand: ~$0.19/hr"]
+        Z2["1yr Reserved VM: lower committed rate"]
+        Z3["3yr Reserved VM: deeper committed rate"]
+        Z4["Spot: variable, eviction risk"]
     end:::provider
 
     subgraph STRATEGY ["Optimization Strategy"]
@@ -392,9 +518,23 @@ gcloud billing accounts describe BILLING_ACCOUNT_ID --format=json
 # Use the GCP Billing Console > Committed use discounts > Analysis
 ```
 
+Commitment sizing should use amortized cost and coverage, not raw monthly totals. If a workload runs 24 hours a day with stable demand, a one-year commitment may be reasonable after rightsizing. If a product is being redesigned, migrating regions, or moving from nodes to serverless, shorter commitments or lower coverage are safer. The highest discount is not always the best financial decision.
+
+[AWS Savings Plans](https://docs.aws.amazon.com/savingsplans/latest/userguide/what-is-savings-plans.html) commit to a consistent hourly spend in exchange for lower rates on eligible usage. Compute Savings Plans are flexible across services such as EC2, Fargate, and Lambda, while EC2 Instance Savings Plans are more specific. In EKS environments, the baseline node capacity is a candidate for commitments, while burst nodes and experimental workloads should usually remain on on-demand or Spot.
+
+[Google Cloud Committed Use Discounts](https://cloud.google.com/docs/cuds) reduce costs for committed resource usage, and [Compute Engine pricing documentation](https://cloud.google.com/compute/vm-instance-pricing) explains how on-demand, committed, sustained-use, and Spot pricing interact. GKE Standard clusters commonly combine commitments for predictable node pools with Spot node pools for fault-tolerant workloads. GKE Autopilot changes the calculation because teams pay according to Autopilot's billing model rather than manually managed node pools.
+
+[Azure Reservations](https://learn.microsoft.com/en-us/azure/cost-management-billing/reservations/) provide lower prices when you commit to one-year or three-year plans for eligible resources. [Azure Reserved VM Instance documentation](https://learn.microsoft.com/en-us/azure/cost-management-billing/manage/understand-vm-reservation-charges) explains that a reservation covers the compute portion of matching virtual machines. AKS node pools with predictable VM sizes are candidates, while workloads with uncertain region, SKU, or scale profiles need more flexibility.
+
+Spot capacity should be planned as an availability pattern, not a discount line. [AWS Spot Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-spot-instances.html), [Google Cloud Spot VMs](https://cloud.google.com/compute/docs/instances/spot), and [Azure Spot Virtual Machines](https://learn.microsoft.com/en-us/azure/virtual-machines/spot-vms) are all reclaimable capacity. The provider-specific semantics differ, but the engineering requirement is the same: graceful shutdown, retries, replicas, checkpoints, and fallback capacity.
+
+For Kubernetes, the clean pattern is multiple node pools or provisioner classes. Critical services run on on-demand or committed baseline capacity. Batch, CI, test, rendering, and stateless burst workloads tolerate taints or prefer labels that select interruptible nodes. PodDisruptionBudgets, topology spread, termination hooks, queue visibility, and application-level idempotency matter more than the discount percentage because they determine whether eviction becomes a controlled retry or an incident.
+
+Commitments also create a measurement problem. A team that buys a commitment and then right-sizes aggressively may show lower on-demand usage but still pay for the committed hourly baseline. FinOps dashboards should therefore report utilization, coverage, and effective savings together. A high coverage percentage with low utilization means the organization prepaid for capacity it no longer needs.
+
 ---
 
-> **Stop and think**: If Spot instances can be terminated at any time, what types of applications are completely unsuitable for them? Interruptible capacity on the major clouds can be substantially cheaper than on-demand pricing, but the exact discount and interruption behavior vary by provider, region, and instance type, so **Spot Instance Golden Rules** apply: because eviction notice windows are short and provider-specific, use Spot only for workloads that tolerate interruption, recover cleanly on other nodes, and do not depend on a single local-stateful replica.
+> **Stop and think**: If Spot instances can be terminated at any time, what types of applications are completely unsuitable for them? Interruptible capacity on the major clouds can be substantially cheaper than on-demand pricing, but the exact discount and interruption behavior vary by provider, region, and instance type. The **Spot Instance Golden Rules**: because eviction notice windows are short and provider-specific, use Spot only for workloads that tolerate interruption, recover cleanly on other nodes, and do not depend on a single local-stateful replica.
 
 ## Pillar 4: Spot Instance Lifecycle
 
@@ -468,10 +608,15 @@ spec:
                     operator: In
                     values:
                       - spot
-      # Tolerate Spot taints
+      # Tolerate per-provider Spot taints
+      # EKS:  eks.amazonaws.com/capacityType=SPOT:NoSchedule
+      # GKE:  cloud.google.com/gke-spot=true:NoSchedule
+      # AKS:  kubernetes.azure.com/scalesetpriority=spot:NoSchedule
+      # (this Deployment tolerates the EKS Spot taint — adjust for your provider)
       tolerations:
-        - key: "kubernetes.io/spot"
-          operator: "Exists"
+        - key: "eks.amazonaws.com/capacityType"
+          operator: "Equal"
+          value: "SPOT"
           effect: "NoSchedule"
       # Handle graceful shutdown on Spot interruption
       terminationGracePeriodSeconds: 120
@@ -531,6 +676,49 @@ spec:
     memory: "400Gi"
 ```
 
+Spot scheduling is provider-specific at the node layer but portable at the workload layer. The workload should declare whether it tolerates interruption, how long it needs for graceful shutdown, whether it can restart from checkpoints, and whether it has enough replicas elsewhere. The platform should translate those declarations into AWS Karpenter requirements, GKE Spot node pool labels, or AKS Spot node pool taints without forcing every application team to learn each provider's syntax.
+
+For GKE, Spot-backed nodes are labeled by GKE so pods can use affinity or tolerations to prefer them. For AKS, [Spot node pools](https://learn.microsoft.com/en-us/azure/aks/spot-node-pool) carry a Spot priority label and taint, and the cluster autoscaler should be enabled so capacity can return after evictions when it is still needed. For EKS, Karpenter or managed node groups can diversify instance types and capacity types so one unavailable Spot pool does not block every pending pod.
+
+The multi-cloud principle is the same: never make interruptible capacity the only path for a critical request. Use topology spread constraints, multiple replicas, retry queues, and fallbacks to on-demand capacity. A service that can tolerate one interrupted pod is not automatically safe when an entire node pool evaporates during a regional capacity shift.
+
+---
+
+## Hidden Costs That Surprise Teams
+
+The most painful cloud cost surprises rarely come from the biggest line item. Teams expect compute to cost money. They are less prepared for network processing, cross-zone transfer, logging ingestion, control-plane fees, and load balancer usage meters. These costs feel small in isolation, but they multiply quickly in Kubernetes because every replica, sidecar, retry, health check, and telemetry event can create billable traffic.
+
+Treat the following rates as representative examples, not procurement advice. They vary by region, currency, contract, service tier, and date. The correct FinOps habit is to verify current pricing before making a business case, then attach the pricing page or SKU export to the decision record so future reviewers know what assumption was used.
+
+| Hidden Cost | Representative Rate Shape | Why It Surprises Teams | Cost-Reduction Knob |
+|---|---|---|---|
+| NAT Gateway / Cloud NAT / Azure NAT Gateway | AWS and Google Cloud often have both hourly and per-GB processing components; Google Cloud Public NAT shows roughly `$0.045/GiB` data processing in common public examples, and AWS NAT Gateway examples often use roughly `$0.045/GB` plus hourly charges. | Private nodes pulling images, calling package mirrors, or reaching public APIs can send large traffic through NAT without application owners seeing it. | Keep egress same-AZ where possible, use VPC endpoints / Private Service Connect / Azure Private Link to bypass NAT for high-volume service traffic, deploy regional artifact mirrors and image caches, and apply egress allowlists. Note that per-AZ NAT (AWS HA pattern) is primarily a reliability and latency decision, not a cost reduction — it typically increases baseline NAT hourly charges. |
+| Cross-AZ / inter-zone transfer | AWS cross-AZ traffic is commonly modeled around roughly `$0.01/GB` in each charged direction; Google Cloud inter-zone transfer in the same region is listed around `$0.01/GiB`; Azure pricing differs and should be verified by bandwidth SKU. | Multi-zone resilience can turn chatty service calls, database traffic, or load balancer flows into transfer charges. | Keep chatty services zone-local where safe, use topology-aware routing, reduce retries, and place data stores near consumers. |
+| Cross-region replication | Often materially higher than same-zone transfer, with source, destination, and product-specific rates. | Backup, DR, analytics exports, and object replication can double data movement quietly. | Replicate only recovery-critical data, compress, deduplicate, tier retention, and test whether lower-frequency replication meets RPO. |
+| Load balancers and processing units | AWS ALB has hourly and LCU-style meters; Google Cloud and Azure load balancers have their own forwarding, data, or rule dimensions. | A test namespace with many `LoadBalancer` services can create many hourly charges even at low traffic. | Share ingress gateways, delete stale services, prefer internal routing when possible, and monitor per-service load balancer count. |
+| Managed Kubernetes control plane fees | EKS and GKE commonly publish roughly `$0.10/hour` cluster management examples; AKS has Free, Standard, and Premium management tiers. | Many small clusters can cost more in control-plane fees and shared overhead than teams expect. | Consolidate low-risk environments, use namespace tenancy where appropriate, and apply cluster lifecycle policies. |
+| Logging and metrics ingestion | CloudWatch Logs and Google Cloud Logging commonly publish around `$0.50/GB` or `$0.50/GiB` ingestion examples; Azure Monitor pricing depends on plan and region. | Debug logs, access logs, high-cardinality labels, and verbose sidecars scale with traffic, not with engineer attention. | Sample, drop noisy fields, set retention, use cheaper log plans for low-value data, and budget telemetry by service. |
+
+NAT cost is a classic Kubernetes surprise. Private clusters are a good security default, but private nodes still need outbound paths for image pulls, operating system updates, third-party APIs, and SaaS integrations. If every node in three zones uses one centralized NAT gateway, traffic can pay both NAT processing and avoidable cross-zone transfer. The engineering fix is not "avoid NAT"; it is to design outbound traffic intentionally.
+
+On AWS, [NAT Gateway pricing documentation](https://docs.aws.amazon.com/vpc/latest/userguide/nat-gateway-pricing.html) explicitly calls out hourly and per-gigabyte processing charges and recommends same-AZ placement or VPC endpoints for high-volume AWS service traffic. That recommendation matters for EKS because nodes often pull images from ECR, write logs, call STS, access S3, or use other AWS APIs. PrivateLink and gateway endpoints can keep some traffic off NAT paths.
+
+On Google Cloud, [Cloud NAT pricing](https://cloud.google.com/nat/pricing) includes hourly gateway cost, per-GiB processed traffic, IP address cost for Public NAT, and data transfer out costs when traffic leaves the network. GKE clusters that pull large images or send telemetry through public paths can therefore incur both NAT processing and egress costs. Private Google Access, artifact mirrors, and regional placement reduce the blast radius.
+
+On Azure, [Azure NAT Gateway pricing](https://azure.microsoft.com/en-us/pricing/details/azure-nat-gateway/) notes data processing and bandwidth considerations, while [Azure NAT Gateway documentation](https://learn.microsoft.com/en-us/azure/nat-gateway/nat-overview) explains that NAT Gateway becomes the explicit outbound path for subnet resources. AKS teams should review whether container registries, package mirrors, and telemetry exporters are using private connectivity or unnecessary public egress.
+
+Cross-zone traffic is the second common surprise because high availability can hide a metered data path. A service mesh retry, an internal load balancer, or a database client may send traffic from zone A to zone B even when a healthy local endpoint exists. [Kubernetes Topology Aware Routing](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/) can prefer same-zone endpoints when conditions are suitable, which can improve latency and may reduce cost.
+
+Topology-aware routing is not a universal cost switch. Kubernetes documents that it works best when traffic is reasonably balanced and there are enough endpoints per zone. If one zone sends most traffic or a service has too few replicas, forcing locality can overload local pods. The FinOps decision must therefore include reliability, latency, and failure-domain behavior, not only transfer pricing.
+
+Load balancer cost grows through both count and traffic. A team that creates one public load balancer per preview environment may pay hourly charges even when nobody uses those environments. A team that sends large response bodies through an Application Load Balancer may increase processing-unit usage. The platform pattern is shared ingress for common HTTP services, explicit approval for public exposure, and automatic cleanup for preview environments.
+
+Control-plane fees matter when teams create many clusters for isolation. One cluster per team can simplify ownership, but dozens of lightly used clusters multiply baseline fees, node overhead, monitoring agents, logging streams, and upgrade work. Namespace tenancy, virtual clusters, or scheduled development clusters can be cheaper, but they trade off blast-radius isolation. FinOps should make that tradeoff explicit instead of assuming either pattern is always cheaper.
+
+Telemetry spend deserves the same engineering rigor as compute spend. A high-traffic service that logs every request body, every retry, and every health check can spend more on ingestion than on the pod running the code. Metrics can have the same problem when labels include tenant IDs, request IDs, or user IDs. The fix is not to stop observing systems; it is to define telemetry value, retention, sampling, and cardinality budgets.
+
+The hidden-cost mindset changes architecture reviews. A design that looks cheap by instance price may be expensive after NAT processing, cross-region replication, load balancer meters, and log ingestion are included. Conversely, a slightly larger instance in the right zone, a shared ingress gateway, or a private endpoint can reduce total cost while improving reliability. FinOps is the discipline of seeing the whole cost path.
+
 ## Automated Budget Alerting and Anomaly Detection
 
 Visibility is only useful if it drives action, because relying on humans to check dashboards guarantees that cost spikes will go unnoticed until the end of the month, so you must implement automated budget alerting and anomaly detection pipelines. Kubecost can send alerts directly to Slack or Microsoft Teams when a namespace exceeds its daily budget or when spending anomalies occur.
@@ -559,7 +747,7 @@ kubecostProductConfigs:
 
 ### Cloud Provider Anomaly Remediation
 
-For cloud-native resources, you can use [AWS Budgets](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-controls.html) or [GCP Budgets](https://cloud.google.com/billing/docs/how-to/budgets) to trigger automated remediation (like shutting down a runaway dev environment) when a threshold is breached, and once the SNS topic receives the budget breach, it can trigger an AWS Lambda function that acts as a remediation pipeline—for example, automatically patching the cluster's node group `desiredCapacity` to `0` to halt further charges.
+For cloud-native resources, you can use [AWS Budgets](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-controls.html) or [GCP Budgets](https://cloud.google.com/billing/docs/how-to/budgets) to trigger automated remediation (like shutting down a runaway dev environment) when a threshold is breached. Once the SNS topic receives the budget breach, it can trigger an AWS Lambda function that acts as a remediation pipeline — for example, automatically patching the cluster's node group `desiredCapacity` to `0` to halt further charges. The Crossplane Stack below defines the budget and SNS subscription only; the Lambda, IAM role, and EKS/ASG API integration are omitted for brevity (a full implementation would wire the SNS topic to a Lambda with permissions to call `EKS:UpdateNodegroupConfig` or `ASG:UpdateAutoScalingGroup`).
 
 ```yaml
 # AWS Budget with an automated SNS action
@@ -590,6 +778,24 @@ spec:
                   - SubscriptionType: SNS
                     Address: "arn:aws:sns:us-east-1:123456789012:CostAlerts"
 ```
+
+Budgets are guardrails, not brakes. [AWS Budgets](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-managing-costs.html), [Google Cloud budgets](https://cloud.google.com/billing/docs/how-to/budgets), and [Azure Cost Management budgets](https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-acm-create-budgets) can alert when actual or forecasted spend crosses thresholds. They do not automatically make the architecture cheaper, and they may evaluate against delayed billing data, so they should trigger investigation and ownership workflows rather than replace runtime quotas.
+
+Anomaly detection fills a different gap. [AWS Cost Anomaly Detection](https://docs.aws.amazon.com/cost-management/latest/userguide/manage-ad.html) uses monitors and alert subscriptions to detect unusual spend patterns. [Azure Cost Management anomaly guidance](https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/analyze-unexpected-charges) helps teams investigate unexpected cost changes. Google Cloud budgets can publish programmatic notifications through Pub/Sub, which lets teams route cost events into automation, ticketing, or incident channels.
+
+The alerting design should match the allocation design. A provider-level budget alert sent only to a central finance mailbox is too slow for engineering action. A namespace budget in Kubecost sent to the owning team's channel is actionable because the team can inspect recent deploys, workload scale, log volume, and traffic. The platform team still needs a central view, but the first responder should be the team that can change the workload.
+
+Use multiple threshold types. A monthly budget alert at 50, 80, and 100 percent catches broad drift. A daily namespace or project budget catches runaway environments. A forecast threshold catches sustained growth before the end of the month. An anomaly alert catches sudden changes that do not fit historical patterns. These mechanisms overlap by design because billing data has delay and each signal catches a different failure mode.
+
+Automated remediation should be narrow and reversible. Turning off an entire production subscription because a forecast crossed a threshold is dangerous. Scaling a known development node pool to zero after hours, disabling a preview environment with an expired owner, or pausing a batch queue after it exceeds its daily budget can be reasonable. The automation should leave an audit trail and notify the owner before or immediately after action.
+
+Unit economics are the bridge between "cost went up" and "business got better." A platform that spends twice as much but handles four times as many paid requests may have improved. A platform that spends 20 percent less but doubles latency for premium tenants may have harmed the business. Useful units include dollars per request, dollars per tenant, dollars per successful workflow, dollars per training run, and dollars per gigabyte processed.
+
+Choose units that product and engineering can both influence. Dollars per request is useful for an API platform with stable request value. Dollars per tenant is useful for SaaS products with clear account boundaries. Dollars per batch job is useful for data pipelines. Dollars per cluster is usually too coarse because it hides tenant mix, workload efficiency, and traffic shape.
+
+Unit cost also prevents false optimization wins. Suppose a team cuts node cost by 25 percent but retry traffic doubles because pods throttle under peak load. The compute dashboard looks better, while dollars per successful request may get worse after load balancer, NAT, logging, and latency impact are counted. FinOps should therefore pair infrastructure metrics with service-level and product-level metrics.
+
+The operating review should be routine and short. A weekly FinOps review can examine untagged spend, top cost anomalies, idle cluster cost, commitment coverage, unit cost trend, and the status of agreed actions. This is not a blame meeting. It is a reliability-style operations review where cost is one of the signals that tells the team whether the platform is behaving as intended.
 
 ---
 
@@ -623,7 +829,8 @@ aws ec2 describe-addresses \
   --query 'Addresses[?AssociationId==null].{IP:PublicIp,AllocID:AllocationId}' \
   --output table
 
-# Find load balancers with no targets
+# Illustrative orphaned-load-balancer scan (not exhaustive — orphaned LBs can
+# still have target groups with no healthy targets; also check CloudWatch metrics)
 for LB_ARN in $(aws elbv2 describe-load-balancers --query 'LoadBalancers[*].LoadBalancerArn' --output text); do
   TG_COUNT=$(aws elbv2 describe-target-groups \
     --load-balancer-arn $LB_ARN \
@@ -688,6 +895,93 @@ spec:
 
 ---
 
+## Patterns & Anti-Patterns
+
+Cost optimization patterns work only when they preserve trust. If engineers believe cost reports are arbitrary, they will ignore them. If finance believes engineering optimizations are unverifiable, finance will keep using blunt budget cuts. The patterns below build a shared operating system for cost decisions, where ownership, measurement, and automation are visible enough to survive disagreement.
+
+| Pattern | When to Use It | Why It Works | Scaling Note |
+|---|---|---|---|
+| Allocation-first platform defaults | Use this for every new account, project, subscription, cluster, namespace, and workload path. | Required tags, labels, namespaces, and cost centers make spend explainable before it appears on a bill. | Bake metadata into Terraform modules, project factories, Helm charts, and admission policies so teams do not hand-type it. |
+| Usage optimization before commitments | Use this before buying Savings Plans, CUDs, or Reservations for a growing platform. | Rightsizing and consolidation reduce the baseline, so commitments cover real steady demand rather than waste. | Track coverage and utilization separately because a cheap unused commitment is still committed spend. |
+| Shared cost policy with visible idle | Use this when multiple teams share clusters, gateways, telemetry, NAT, or platform services. | Direct, shared, and idle costs are separated, so teams can debate the rule without losing the signal. | Revisit the allocation formula quarterly because tenant mix, platform overhead, and product economics change. |
+| Unit-cost SLOs | Use this when product usage is growing and absolute cloud spend is expected to rise. | Dollars per request, tenant, workflow, or gigabyte show whether spend is scaling better or worse than value. | Pair cost units with reliability units so teams do not reduce spend by harming latency or availability. |
+
+The allocation-first pattern is the foundation. It is tempting to begin with the largest optimization, but without ownership metadata the team cannot tell who should approve a change. A platform team can delete an unused load balancer only when it knows whether that load balancer belongs to a retired preview environment, a forgotten production path, or a security exception.
+
+The usage-before-commitments pattern protects future flexibility. A commitment should be the last mile of optimization for stable usage, not the first response to a large bill. This is especially important in Kubernetes because improved bin-packing can reduce node demand quickly. Buying a commitment before right-sizing can lock in the pre-optimization shape.
+
+The shared-cost policy pattern keeps platform economics honest. Shared ingress, telemetry, security, and networking costs are real costs of running production systems, but they should not become a black box. Teams need to see both their direct workload costs and the platform tax created by shared services. That visibility helps product teams choose whether a shared capability is worth its cost.
+
+Unit-cost SLOs keep optimization connected to value. A team serving more customers should not be punished for spending more in absolute terms if dollars per customer are improving. A team serving the same traffic at twice the logging cost should investigate even if total spend remains within budget. Unit economics turn cost into an engineering signal instead of a finance surprise.
+
+| Anti-Pattern | What Goes Wrong | Why Teams Fall Into It | Better Alternative |
+|---|---|---|---|
+| "Finance owns the cloud bill" | Engineering changes create spend faster than finance can explain it. | Traditional procurement models trained teams to treat cost as a back-office concern. | Give engineers daily cost visibility and make cost impact part of operational review. |
+| "Tag it later" | Untagged spend becomes impossible to allocate accurately after the fact. | Delivery pressure makes metadata look optional during incidents and launches. | Enforce required metadata in provisioning and admission paths, with explicit break-glass exceptions. |
+| "Move everything to Spot" | Critical workloads get evicted, state is lost, and availability drops. | The headline discount is easier to understand than interruption engineering. | Use Spot for fault-tolerant workloads with fallback, checkpointing, and clear scheduling rules. |
+| "Buy the biggest commitment" | The team pays for idle committed usage after migrations or rightsizing. | Discount percentages make aggressive commitments look like guaranteed savings. | Commit only to the stable baseline after usage optimization, then review coverage and utilization. |
+| "One cost dashboard for everyone" | Finance, platform, and application teams argue because each needs a different lens. | A single dashboard feels efficient during setup. | Build role-specific views from the same source data: executive trend, team showback, platform waste, and anomaly queue. |
+
+The "tag it later" anti-pattern is especially damaging because it compounds silently. A missing tag on one development VM is annoying. Missing metadata on a shared cluster, NAT gateway, or central logging workspace can obscure thousands of dollars and delay cleanup for months. Teams should treat tag coverage like test coverage for cost accountability.
+
+The "move everything to Spot" anti-pattern confuses price with architecture. Interruptible capacity is powerful when applications can restart, retry, or shift to on-demand nodes. It is reckless when the workload needs a single local disk, long graceful shutdown, or quorum stability. A good platform makes the cheap path easy for suitable workloads and the safe path obvious for critical ones.
+
+The "one dashboard" anti-pattern sounds harmless but often blocks adoption. Executives need trend and forecast. Finance needs amortization and budget. Platform engineers need idle cost, unallocated cost, and shared service spend. Application teams need namespace, workload, and unit-cost views. One source of truth does not mean one visualization.
+
+---
+
+## Decision Framework
+
+Cost decisions should move from visibility to action in a predictable order. The following framework is intentionally conservative because cloud cost changes can affect availability. Use it during architecture reviews, monthly FinOps reviews, or incident follow-ups when a cost spike needs remediation.
+
+```mermaid
+flowchart TD
+    A["Cost signal appears<br/>bill, budget, anomaly, or unit-cost drift"] --> B{"Is ownership known?"}
+    B -- "No" --> C["Fix attribution first<br/>tags, labels, namespace owner, cost center"]
+    C --> A
+    B -- "Yes" --> D{"Is the spend direct, shared, or idle?"}
+    D -- "Direct workload" --> E{"Is usage efficient?"}
+    D -- "Shared platform" --> F["Review allocation policy<br/>and platform service value"]
+    D -- "Idle capacity" --> G["Tune requests, autoscaler minimums,<br/>consolidation, and environment schedules"]
+    E -- "No" --> H["Right-size, scale, reduce logs,<br/>or change traffic topology"]
+    E -- "Yes" --> I{"Is baseline predictable?"}
+    I -- "Yes" --> J["Evaluate commitments<br/>Savings Plans, CUDs, Reservations"]
+    I -- "No" --> K{"Can workload tolerate interruption?"}
+    K -- "Yes" --> L["Use Spot capacity with fallback,<br/>checkpointing, and disruption controls"]
+    K -- "No" --> M["Use on-demand or reserved baseline<br/>and optimize architecture"]
+    F --> N["Measure unit economics<br/>and update showback"]
+    G --> N
+    H --> N
+    J --> N
+    L --> N
+    M --> N
+```
+
+Start with ownership because every other decision depends on it. If the spend cannot be assigned to a team, product, tenant, or platform service, optimization becomes guesswork. The first remediation may be a metadata fix, not a technical optimization. That can feel slow, but it prevents accidental deletion and makes future alerts actionable.
+
+Classify the spend as direct, shared, or idle. Direct workload cost belongs to a namespace, service, database, queue, or product. Shared platform cost supports multiple teams and needs an allocation rule. Idle cost indicates capacity that exists without corresponding workload usage. Each class has different owners and different fixes, so mixing them in one bucket hides the real action.
+
+For direct workload cost, ask whether usage is efficient before changing rate instruments. If a pod requests five times its observed memory need, a commitment does not solve the engineering problem. If traffic crosses zones unnecessarily, a cheaper instance does not fix the network bill. Rightsizing, topology, retention, and scaling are the first-order levers.
+
+For efficient and predictable baseline usage, evaluate commitments. The decision should include planned migrations, traffic forecasts, seasonality, product launches, and existing commitment utilization. A one-year commitment often keeps more optionality than a three-year commitment, while still reducing rate for stable capacity. A three-year commitment needs stronger confidence and executive awareness of opportunity cost.
+
+For variable and fault-tolerant workloads, evaluate interruptible capacity. The decision is not "Spot or no Spot"; it is "what percentage can be interrupted, how quickly can it recover, and what fallback exists?" A batch queue might run 90 percent on Spot and retry evictions. A customer-facing API might use Spot only for excess replicas above a reliable on-demand baseline.
+
+For shared platform cost, avoid reflexive cuts. A central observability platform, ingress gateway, service mesh, or security scanner may look expensive because it carries cost for many teams. The right question is whether the platform service creates value proportional to its usage and whether allocation encourages responsible consumption. Sometimes the fix is better sampling or retention, not deleting the platform capability.
+
+The final step is to measure unit economics after the change. If the cost action reduced total spend but increased error rate, latency, support tickets, or manual toil, it may not be a win. If total spend increased but dollars per tenant fell while reliability improved, the business may be healthier. FinOps decisions should close the loop with both cost and service outcomes.
+
+| Situation | First Question | Likely Lever | Avoid |
+|---|---|---|---|
+| Large untagged line item | Who owns it and why is metadata missing? | Tag enforcement and provisioning defaults | Guessing ownership from resource names |
+| High namespace cost | Is the cost direct, shared, or idle? | OpenCost/Kubecost allocation, request review, autoscaler tuning | Blaming the team without showing idle and overhead |
+| Stable 24/7 node baseline | Has usage already been optimized? | AWS Savings Plans, GCP CUDs, Azure Reservations | Committing to pre-rightsizing waste |
+| Bursty stateless workload | Can it tolerate eviction and retry? | Spot capacity with fallback and disruption controls | Running all replicas on interruptible nodes |
+| Network transfer spike | Which path produced bytes? | Same-zone routing, private endpoints, replication tuning | Looking only at compute instance cost |
+| Telemetry cost spike | Which logs or metrics create value? | Sampling, retention, field filtering, lower-cost plans | Disabling observability globally |
+
+---
+
 ## Did You Know?
 
 1. **Many Kubernetes environments run below their provisioned capacity.** Over-provisioned resource requests are a common source of waste, and recommendation tooling can help identify safer right-sizing opportunities before you change live workloads.
@@ -732,19 +1026,19 @@ If you use VPA in auto-update mode on an unpredictable workload, it will aggress
 <details>
 <summary>3. Your infrastructure currently incurs $10,000/month in on-demand EC2 usage for backend services that run 24/7. Your procurement manager suggests committing to a $10,000/month Compute Savings Plan to maximize discounts. Why is this a dangerous financial strategy?</summary>
 
-Committing to the full $10,000 is a mistake because Savings Plans lock you into a minimum hourly spend regardless of your actual usage. If your usage drops due to future right-sizing, architectural changes, or migration, you will still be forced to pay the fully committed amount for idle capacity. Instead, you should commit to only 60-70% of your current baseline to maintain flexibility for dynamic scaling and optimization. The remaining infrastructure can run on on-demand pricing, or ideally on Spot instances for fault-tolerant workloads, which provide deeper discounts without any long-term commitment.
+Committing to the full $10,000 is a mistake because Savings Plans lock you into a minimum hourly spend regardless of your actual usage. If your usage drops due to future right-sizing, architectural changes, or migration, you will still be forced to pay the committed amount even when matching usage disappears. Instead, commit conservatively to the stable baseline after optimization and keep enough flexible usage for scaling, migration, and architectural change. The remaining infrastructure can run on on-demand pricing or carefully selected Spot capacity for fault-tolerant workloads.
 </details>
 
 <details>
-<summary>4. Your team wants to migrate a legacy monolithic application to a Spot instance node group to save 70% on compute costs. The application takes 5 minutes to gracefully shut down, requires persistent local disk state, and runs as a single replica. Why will this migration result in a catastrophic production outage?</summary>
+<summary>4. Your team wants to migrate a legacy monolithic application to a Spot instance node group to chase a large compute discount. The application takes 5 minutes to gracefully shut down, requires persistent local disk state, and runs as a single replica. Why will this migration result in a catastrophic production outage?</summary>
 
-Spot instances can be reclaimed by the cloud provider with only a 2-minute interruption warning. Since the legacy monolith takes 5 minutes to shut down, it will be forcefully terminated before it finishes its shutdown sequence, leading to data corruption or incomplete transactions. Furthermore, because it relies on local disk state and runs as a single replica, the entire application will go offline and lose its state when the underlying node disappears. Spot instances are only safe for stateless, fault-tolerant workloads that can gracefully terminate within 2 minutes and have multiple replicas distributed across different nodes to ensure continuous availability during interruptions.
+Provider interruption semantics are short and provider-specific, and AWS EC2 Spot commonly uses an up-to-two-minute interruption notice. Since the legacy monolith takes 5 minutes to shut down, it can be terminated before it finishes its shutdown sequence, leading to data corruption or incomplete transactions. Furthermore, because it relies on local disk state and runs as a single replica, the entire application will go offline and lose its state when the underlying node disappears. Interruptible capacity is only safe for workloads that can recover cleanly, checkpoint progress, and maintain healthy replicas on other capacity.
 </details>
 
 <details>
 <summary>5. Your engineering team maintains a dedicated development EKS cluster that costs $3,000/month and is only actively used by developers Monday through Friday from 9 AM to 6 PM. How much could you realistically save, and what mechanisms would you use to achieve this?</summary>
 
-Because business hours represent roughly 45 hours out of a 168-hour week, leaving the cluster running 24/7 means you are paying for unused capacity 73% of the time. By implementing a scheduled auto-shutdown strategy that scales node groups down to zero outside of business hours, you can save approximately $2,190 per month. This can be achieved using tools like Karpenter with scheduled consolidation, custom CronJobs that manipulate node group sizes, or specialized downscaler controllers. Beyond compute nodes, you should also automate the suspension of NAT Gateways and LoadBalancers during these off-hours to eliminate all residual infrastructure costs.
+Because business hours represent roughly 45 hours out of a 168-hour week, leaving the cluster running 24/7 means you are paying for unused capacity 73% of the time. By implementing a scheduled auto-shutdown strategy that scales node groups down to zero outside of business hours, you can save approximately $2,190 per month. This can be achieved using tools like Karpenter with scheduled consolidation, custom CronJobs that manipulate node group sizes, or specialized downscaler controllers. NAT Gateways (AWS, GCP, Azure) bill hourly while provisioned and have no suspend/pause API — to eliminate residual charges outside business hours, tear down or avoid NAT for idle environments via ephemeral dev VPCs managed by IaC, delete unused `LoadBalancer` Services and orphaned LBs, and scale node pools to zero rather than trusting a non-existent suspend operation.
 </details>
 
 <details>
@@ -881,12 +1175,12 @@ echo "worker: 3 pods x 2Gi = 6Gi memory requested"
 echo ""
 echo "TOTAL REQUESTED: 13 CPU, 26Gi memory"
 echo ""
-echo "At m7i.xlarge pricing ($0.192/hr, 4 CPU, 16Gi):"
+echo "At representative m7i.xlarge pricing (~$0.192/hr, 4 CPU; verify current regional pricing):"
 echo "13 CPU / 4 CPU per node = 4 nodes needed (by CPU)"
 echo "26Gi / 16Gi per node = 2 nodes needed (by memory)"
 echo "Limiting factor: CPU (4 nodes)"
 echo ""
-echo "Cost: 4 nodes x $0.192/hr x 730 hours = $561/month"
+echo "Cost: 4 nodes x ~$0.192/hr x 730 hours = ~$561/month"
 echo ""
 echo "=== Actual Usage (nginx idle) ==="
 echo "Each nginx pod uses ~5m CPU and ~5Mi memory"
@@ -962,15 +1256,15 @@ Potential savings: $421/month ($5,052/year) -- 75% reduction
 
 ### 3. On-Demand Pricing (Impact: ~$50/month)
 - Workloads run 24/7, perfect for Savings Plans
-- With 1-year Compute Savings Plan: $140 * 0.63 = $88/month
-- Savings: $52/month
+- With a conservative 1-year Compute Savings Plan: estimate the post-commit monthly cost from the current AWS recommendation tool
+- Savings: depends on current region, instance family, payment option, and commitment coverage
 
 ## Recommended Actions (priority order)
 1. Apply right-sized resource requests (immediate, $421/month)
 2. Add HPA for api-server (1 day, ~$30/month additional)
 3. Purchase Savings Plan for baseline compute (1 week, ~$50/month)
 
-## Total Estimated Savings: $501/month ($6,012/year)
+## Total Estimated Savings: about $450-$500/month after validating current pricing
 ```
 </details>
 
@@ -996,17 +1290,56 @@ kind delete cluster --name cost-lab
 
 ## Sources
 
-- [cncf.io: opencost](https://www.cncf.io/projects/opencost/) — The CNCF project page directly states the acceptance and incubation dates.
-- [github.com: opencost](https://github.com/opencost/opencost) — The OpenCost repository states both its Kubecost origin and that it is a free, open-source distribution.
-- [docs.aws.amazon.com: budgets controls.html](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-controls.html) — AWS Budgets documentation explicitly describes automatic budget actions at thresholds.
-- [cloud.google.com: budgets](https://cloud.google.com/billing/docs/how-to/budgets) — Google Cloud Billing documentation directly says budgets can automate cost control responses using programmatic notifications.
-- [github.com: aws node termination handler](https://github.com/aws/aws-node-termination-handler) — The upstream README directly documents Spot interruption detection and cordon/drain behavior.
-- [docs.aws.amazon.com: ebs delete ebs volumes.html](https://docs.aws.amazon.com/prescriptive-guidance/latest/optimize-costs-microsoft-workloads/ebs-delete-ebs-volumes.html) — General lesson point for an illustrative rewrite.
-- [aws.amazon.com: pricing](https://aws.amazon.com/vpc/pricing/) — General lesson point for an illustrative rewrite.
-- [docs.aws.amazon.com: ebs snapshots.html](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-snapshots.html) — General lesson point for an illustrative rewrite.
-- [aws.amazon.com: pricing](https://aws.amazon.com/elasticloadbalancing/pricing//) — General lesson point for an illustrative rewrite.
-- [aws.amazon.com: backup](https://aws.amazon.com/rds/features/backup/) — General lesson point for an illustrative rewrite.
-- [docs.aws.amazon.com: get savings plans purchase recommendation.html](https://docs.aws.amazon.com/cli/latest/reference/ce/get-savings-plans-purchase-recommendation.html) — General lesson point for an illustrative rewrite.
-- [aws.amazon.com: pricing](https://aws.amazon.com/ec2/pricing/) — General lesson point for an illustrative rewrite.
-- [aws.amazon.com: applying spot to spot consolidation best practices with karpenter](https://aws.amazon.com/blogs/compute/applying-spot-to-spot-consolidation-best-practices-with-karpenter/) — General lesson point for an illustrative rewrite.
-- [Topology Aware Routing](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/) — Explains how Kubernetes prefers same-zone traffic, which is relevant when network-transfer pricing matters.
+- [FinOps Foundation: Framework overview](https://www.finops.org/framework/) — Defines FinOps as the operating model for cloud financial accountability.
+- [FinOps Foundation: Phases](https://www.finops.org/framework/phases/) — Describes the Inform, Optimize, and Operate phases used in this module.
+- [Microsoft Learn: FinOps Framework](https://learn.microsoft.com/en-us/cloud-computing/finops/framework/finops-framework) — Cross-checks the FinOps lifecycle and phase definitions.
+- [CNCF: OpenCost](https://www.cncf.io/projects/opencost/) — Confirms OpenCost project status and Kubernetes cost visibility scope.
+- [OpenCost API documentation](https://opencost.io/docs/integrations/api/) — Documents allocation reporting APIs for Kubernetes cost data.
+- [AWS Billing: user-defined cost allocation tags](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/custom-tags.html) — Documents activated cost allocation tags and billing reports.
+- [AWS EKS: compute and autoscaling cost optimization](https://docs.aws.amazon.com/eks/latest/best-practices/cost-opt-compute.html) — Documents EKS bin-packing, Spot, Savings Plans, and capacity-type guidance.
+- [AWS Savings Plans](https://docs.aws.amazon.com/savingsplans/latest/userguide/what-is-savings-plans.html) — Documents Savings Plans commitment behavior.
+- [AWS EC2 Spot Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-spot-instances.html) — Documents EC2 Spot capacity and interruption model.
+- [AWS Cost Explorer CLI recommendation](https://docs.aws.amazon.com/cli/latest/reference/ce/get-savings-plans-purchase-recommendation.html) — Documents the purchase recommendation command used in the lab.
+- [AWS Budgets actions](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-controls.html) — Documents budget actions and automated responses.
+- [AWS Budgets management](https://docs.aws.amazon.com/awsaccountbilling/latest/aboutv2/budgets-managing-costs.html) — Documents cost budget behavior and alerts.
+- [AWS Cost Anomaly Detection](https://docs.aws.amazon.com/cost-management/latest/userguide/manage-ad.html) — Documents anomaly monitors and alert subscriptions.
+- [AWS VPC NAT Gateway pricing](https://docs.aws.amazon.com/vpc/latest/userguide/nat-gateway-pricing.html) — Documents NAT Gateway hourly and data-processing cost dimensions.
+- [AWS VPC pricing](https://aws.amazon.com/vpc/pricing/) — Provides representative NAT Gateway and VPC pricing examples.
+- [AWS EKS pricing](https://aws.amazon.com/eks/pricing/) — Provides representative EKS cluster management pricing.
+- [AWS Elastic Load Balancing pricing](https://aws.amazon.com/elasticloadbalancing/pricing/) — Provides representative ALB hourly and LCU pricing examples.
+- [AWS CloudWatch pricing](https://aws.amazon.com/cloudwatch/pricing/) — Provides representative CloudWatch Logs ingestion pricing.
+- [AWS EBS delete unattached volumes guidance](https://docs.aws.amazon.com/prescriptive-guidance/latest/optimize-costs-microsoft-workloads/ebs-delete-ebs-volumes.html) — Documents unattached EBS volume cleanup as a cost practice.
+- [AWS EBS snapshots](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-snapshots.html) — Documents snapshot behavior for orphaned-resource cleanup discussions.
+- [Google Cloud labels overview](https://cloud.google.com/resource-manager/docs/labels-overview) — Documents labels as key-value metadata for organizing and reporting resources.
+- [Google Cloud Billing reports](https://cloud.google.com/billing/docs/how-to/reports) — Documents cost reporting by labels and billing dimensions.
+- [Google Cloud budgets](https://cloud.google.com/billing/docs/how-to/budgets) — Documents Cloud Billing budgets and alert behavior.
+- [Google Cloud budget notifications](https://cloud.google.com/billing/docs/how-to/notify) — Documents Pub/Sub programmatic notifications for budgets.
+- [Google Cloud committed use discounts](https://cloud.google.com/docs/cuds) — Documents one-year and three-year committed-use contracts.
+- [Google Cloud Compute pricing](https://cloud.google.com/compute/vm-instance-pricing) — Provides representative on-demand, committed, and Spot pricing context.
+- [Google Cloud Spot VMs](https://cloud.google.com/compute/docs/instances/spot) — Documents Spot VM preemption semantics.
+- [GKE cluster autoscaler](https://cloud.google.com/kubernetes-engine/docs/concepts/cluster-autoscaler) — Documents GKE autoscaler behavior and Spot node preferences.
+- [GKE cost optimization architecture guidance](https://cloud.google.com/architecture/best-practices-for-running-cost-effective-kubernetes-applications-on-gke) — Documents node auto-provisioning and cost-optimized GKE patterns.
+- [GKE pricing](https://cloud.google.com/kubernetes-engine/pricing) — Provides representative GKE cluster management pricing.
+- [Google Cloud NAT pricing](https://cloud.google.com/nat/pricing) — Documents Cloud NAT hourly, IP, data-processing, and transfer cost dimensions.
+- [Google Cloud VPC network pricing](https://cloud.google.com/vpc/network-pricing) — Documents inter-zone transfer pricing examples.
+- [Google Cloud Load Balancing pricing](https://cloud.google.com/load-balancing/pricing) — Documents load balancer pricing dimensions.
+- [Google Cloud Observability pricing](https://cloud.google.com/products/operations) — Provides representative Cloud Logging ingestion pricing.
+- [Azure Cost Management allocation](https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/allocate-costs) — Documents Azure cost allocation rules across scopes and tags.
+- [Azure Cost Management budgets](https://learn.microsoft.com/en-us/azure/cost-management-billing/costs/tutorial-acm-create-budgets) — Documents budget alerts and evaluation behavior.
+- [Azure cost anomaly guidance](https://learn.microsoft.com/en-us/azure/cost-management-billing/understand/analyze-unexpected-charges) — Documents unexpected charge and anomaly investigation.
+- [Azure Reservations](https://learn.microsoft.com/en-us/azure/cost-management-billing/reservations/) — Documents one-year and three-year Azure reservation plans.
+- [Azure Reserved VM Instance charges](https://learn.microsoft.com/en-us/azure/cost-management-billing/manage/understand-vm-reservation-charges) — Documents how VM reservation discounts apply.
+- [Azure Spot Virtual Machines](https://learn.microsoft.com/en-us/azure/virtual-machines/spot-vms) — Documents Azure Spot VM pricing and eviction behavior.
+- [AKS cost optimization](https://learn.microsoft.com/en-us/azure/aks/optimize-aks-costs) — Documents AKS autoscaling, right-sizing, and cost guidance.
+- [AKS cluster autoscaler](https://learn.microsoft.com/en-us/azure/aks/cluster-autoscaler-overview) — Documents AKS cluster autoscaler behavior.
+- [AKS Spot node pools](https://learn.microsoft.com/en-us/azure/aks/spot-node-pool) — Documents Spot node pool labels, taints, and autoscaler considerations.
+- [AKS cluster management tiers](https://learn.microsoft.com/en-us/azure/aks/free-standard-pricing-tiers) — Documents AKS Free, Standard, and Premium management tiers.
+- [Azure NAT Gateway overview](https://learn.microsoft.com/en-us/azure/nat-gateway/nat-overview) — Documents explicit outbound NAT behavior for subnets.
+- [Azure NAT Gateway pricing](https://azure.microsoft.com/en-us/pricing/details/azure-nat-gateway/) — Documents NAT Gateway data-processing and bandwidth pricing considerations.
+- [Azure Bandwidth pricing](https://azure.microsoft.com/en-us/pricing/details/bandwidth/) — Documents Azure data transfer pricing dimensions.
+- [Azure Load Balancer pricing](https://azure.microsoft.com/en-us/pricing/details/load-balancer/) — Documents Azure load balancer pricing dimensions.
+- [Azure Monitor cost and usage](https://learn.microsoft.com/en-us/azure/azure-monitor/cost-usage) — Documents Azure Monitor ingestion, retention, and export cost drivers.
+- [Azure Monitor pricing](https://azure.microsoft.com/en-us/pricing/details/monitor/) — Provides current Azure Monitor pricing dimensions.
+- [Kubernetes resource management](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) — Documents how requests guide scheduling and limits are enforced.
+- [Kubernetes Vertical Pod Autoscaling](https://kubernetes.io/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/) — Documents VPA recommendations and API behavior.
+- [Kubernetes Topology Aware Routing](https://kubernetes.io/docs/concepts/services-networking/topology-aware-routing/) — Documents same-zone routing behavior and limitations.

--- a/src/content/docs/cloud/advanced-operations/module-8.9-observability-scale.md
+++ b/src/content/docs/cloud/advanced-operations/module-8.9-observability-scale.md
@@ -27,11 +27,9 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-In August 2023, a rapidly growing global fintech platform, managing 14 Kubernetes clusters and over 2,800 active pods, experienced a catastrophic observability failure that cost the organization an estimated $2.5 million in strict service-level agreement (SLA) penalties. Their entire monitoring backbone relied on a single, massive Prometheus server. When their engineering teams deployed a major microservices expansion to handle new payment regions, the metric cardinality exploded to over 12 million unique time series within a matter of hours. The Prometheus instance's memory consumption rapidly climbed from 16GB to 64GB, query latency degraded to over 30 seconds, and the server began violently crash-looping with out-of-memory (OOM) errors every two days.
+**Hypothetical scenario:** A platform team operating fourteen Kubernetes clusters across three regions discovers that their single central Prometheus instance now holds more than twelve million active time series after a routine microservices rollout. Memory climbs from sixteen gigabytes to sixty-four gigabytes within hours, PromQL queries time out above thirty seconds, and the Prometheus pod begins crash-looping with out-of-memory errors every few days. The team responds by vertically scaling the pod to one hundred twenty-eight gigabytes of RAM, which briefly stabilizes ingestion until a restart forces a twenty-five-minute Write-Ahead Log replay. During that blind window, a payment gateway degrades while on-call engineers grep unstructured logs across hundreds of nodes because metrics, traces, and centralized dashboards are simultaneously unreliable.
 
-The platform engineering team attempted to mitigate the issue by vertically scaling the Prometheus pod, eventually allocating a staggering 128GB of RAM. While this temporarily stabilized the data ingestion, the architectural side-effects were devastating. Whenever the monolithic pod restarted, replaying the massive Write-Ahead Log (WAL) took upwards of 25 minutes. During one of these vulnerable WAL replay windows, a critical payment gateway service suffered a cascading failure. Because the primary monitoring system was effectively offline and recovering, the on-call engineers were flying completely blind. They were forced to manually parse unstructured text logs across hundreds of nodes using raw `grep` commands, transforming a routine infrastructure blip into a prolonged global outage.
-
-This incident underscores a fundamental truth about cloud-native infrastructure: observability data volume naturally grows at a much faster rate than the underlying applications. The real fix for the fintech company was not adding more RAM; it was a complete architectural overhaul. They needed to shard Prometheus across independent clusters, implement Thanos for long-term distributed queries, aggressively filter and route data using OpenTelemetry collectors, and enforce strict cardinality limits across all development teams. This module will teach you how to build exactly this kind of resilient, multi-cluster observability platform that gracefully handles millions of time series and terabytes of logs without ever becoming the bottleneck.
+This pattern underscores a fundamental truth about cloud-native infrastructure at enterprise scale: observability data volume naturally grows faster than the applications it monitors. The durable fix is rarely more RAM on a monolith. Teams need per-cluster Prometheus (or equivalent scrape agents), a vendor-neutral collection plane with OpenTelemetry, long-term metric storage with downsampling, log pipelines that sample before egress, and trace policies that keep errors without storing every span. On AWS that often means Amazon Managed Service for Prometheus (AMP) plus CloudWatch; on Google Cloud, Managed Service for Prometheus or Cloud Monitoring with Cloud Logging; on Azure, Azure Monitor managed Prometheus and Application Insights. This module teaches how to design that multi-cluster, multi-signal platform so telemetry remains trustworthy when clusters, tenants, and regions multiply.
 
 ---
 
@@ -58,9 +56,68 @@ As demonstrated in the table above, enterprise-scale telemetry demands tiered st
 
 ---
 
+## The Three Pillars at Multi-Cluster Scale
+
+Metrics, logs, and traces answer different questions, and each pillar fails in a predictable way when you treat a fleet of Kubernetes 1.35 clusters like a single laptop deployment. Metrics tell you *how much* and *how fast* through time-series aggregation; logs tell you *what happened in one place* with rich context; traces tell you *how a request moved* across services and regions. At small scale you can colocate all three in one namespace with default Helm charts. At large scale you must separate ingestion paths, retention tiers, and query planes so a logging storm cannot starve metric scrapes, and a cardinality explosion cannot take down trace backends.
+
+Naive single-cluster observability collapses for four structural reasons. First, **network and identity boundaries**: scraping every pod in every cluster from one Prometheus requires cross-VPC connectivity, long scrape intervals, or insecure metric endpoints exposed beyond the cluster perimeter. Second, **cardinality multiplication**: the same HTTP metric with a `pod` label across fifteen thousand pods creates orders of magnitude more series than the same metric aggregated at deployment scope. Third, **egress economics**: shipping raw logs and full-resolution metrics from eu-west-1 to a central us-east-1 store can dominate the observability bill because cloud providers price inter-region and NAT traversal differently on AWS, GCP, and Azure. Fourth, **blast radius**: one oversized ingester or compactor outage should not blank every region’s dashboards simultaneously.
+
+OpenTelemetry (OTel) is the vendor-neutral collection standard that keeps these pillars coherent. Applications and platform agents emit OTLP (OpenTelemetry Protocol) over gRPC or HTTP to an OTel Collector, which applies processors for batching, filtering, attribute enrichment, and sampling before exporting to backends. The Collector can scrape Prometheus endpoints, tail container logs via `filelog`, and receive traces from instrumented services using the same pipeline vocabulary. That uniformity matters when AWS teams standardize on AMP remote write, GCP teams on Google Cloud Managed Service for Prometheus, and Azure teams on Azure Monitor workspace ingestion, while still wanting identical pod labels and trace context in every cluster.
+
+```mermaid
+flowchart TB
+    subgraph Fleet["Many clusters / regions / tenants"]
+        C1[Cluster A metrics logs traces]
+        C2[Cluster B metrics logs traces]
+        C3[Cluster C metrics logs traces]
+    end
+
+    subgraph OTel["OTel Collector tier\nDaemonSet + optional central Deployment"]
+        Proc[Processors:\nfilter batch sample k8sattributes]
+    end
+
+    subgraph Backends["Purpose-built stores"]
+        M[Metrics:\nPrometheus Thanos Mimir AMP]
+        L[Logs:\nLoki Cloud Logging Azure Monitor]
+        T[Traces:\nTempo X-Ray Cloud Trace App Insights]
+    end
+
+    subgraph Consume["Consumption layer"]
+        G[Grafana / Cloud consoles]
+        SLO[SLO + alerting\nerror budgets]
+    end
+
+    C1 --> OTel
+    C2 --> OTel
+    C3 --> OTel
+    OTel --> M
+    OTel --> L
+    OTel --> T
+    M --> G
+    L --> G
+    T --> G
+    M --> SLO
+```
+
+The diagram is intentional: collectors are a **data plane**, backends are **storage/query engines**, and SLO tooling sits on metrics (often with exemplars linking into traces). Platform teams that skip the middle layer usually end up with fifteen different Fluent Bit configs and incompatible label names, which makes multi-cloud incident response painfully slow.
+
+| Pillar | Primary question | Typical failure at scale | Vendor-neutral anchor | AWS | GCP | Azure |
+| :--- | :--- | :--- | :--- | :--- | :--- | :--- |
+| **Metrics** | Is the system fast/healthy/right-sized? | OOM from label cardinality; slow PromQL | Prometheus + remote write / Thanos | AMP, CloudWatch metrics | Cloud Monitoring, GMP | Azure Monitor managed Prometheus |
+| **Logs** | What did this pod say when it failed? | Ingest quota blowout; expensive full-text index | Structured logs + label selectors | CloudWatch Logs | Cloud Logging | Log Analytics / Monitor logs |
+| **Traces** | Where did latency accumulate? | Storing 100% spans; broken context | W3C `traceparent` + tail sampling | X-Ray | Cloud Trace | Application Insights |
+
+> **Stop and think**: If your organization mandates Azure Monitor for corporate compliance but cluster teams prefer in-cluster Loki for developer self-service, which pillar needs the strictest write-path governance so you do not pay twice for the same log bytes?
+
+---
+
 ## Multi-Cluster Prometheus with Thanos
 
 Prometheus was originally designed for localized, single-cluster deployments. It utilizes a highly optimized local Time Series Database (TSDB) but lacks native capabilities for distributed querying, horizontal scaling, or seamless long-term object storage. When operating multiple clusters, you need a mechanism to query data across all of them globally, store historical data economically (beyond the brief retention period of local SSDs), and deduplicate incoming metrics from highly available (HA) Prometheus pairs.
+
+On Amazon EKS, the Prometheus Operator pattern remains the default starting point, with optional remote write to AMP when finance wants a managed control plane. On GKE, Google documents using Managed Service for Prometheus collectors or bringing your own Prometheus with consistent workload identity for scrape auth. On AKS, the Azure Monitor metrics addon can replace self-managed scrape infrastructure for teams that accept workspace-based governance. The Kubernetes version (1.35 in this curriculum) does not change these economics; it only shifts which kubelet/cAdvisor metrics appear and how autoscaling endpoints are labeled.
+
+Operational limits you should plan around—verify current numbers in vendor docs rather than memorizing quotas—include TSDB head block size, maximum recommended active series per Prometheus instance, ingester memory for Loki when stream counts spike, and tail-sampling buffer RAM in centralized Collectors. Exceeding any of these limits produces the same user-visible symptom: dashboards go blank during the exact moment leadership asks for a timeline.
 
 ### Thanos Architecture
 
@@ -114,7 +171,7 @@ spec:
     cluster: "prod-us-east-1"
     region: "us-east-1"
   thanos:
-    image: quay.io/thanos/thanos:v0.36.1
+    image: quay.io/thanos/thanos:v0.41.0
     objectStorageConfig:
       key: objstore.yml
       name: thanos-objstore-config
@@ -169,7 +226,7 @@ spec:
     spec:
       containers:
         - name: querier
-          image: quay.io/thanos/thanos:v0.36.1
+          image: quay.io/thanos/thanos:v0.41.0
           args:
             - query
             - --http-address=0.0.0.0:9090
@@ -207,7 +264,7 @@ spec:
     spec:
       containers:
         - name: store
-          image: quay.io/thanos/thanos:v0.36.1
+          image: quay.io/thanos/thanos:v0.41.0
           args:
             - store
             - --data-dir=/data
@@ -232,6 +289,25 @@ spec:
             storage: 20Gi  # Cache for frequently accessed blocks
 ```
 
+**Thanos Receive** (alternative to sidecar upload) accepts Prometheus remote write directly and writes to object storage without waiting for two-hour TSDB blocks. Receive fits burstier workloads and centralized agent models, but it shifts failure modes to the receive hash ring; operations teams must monitor replication factor and backlog queues. Many EKS/GKE/AKS fleets combine sidecar for clusters that already run Prometheus Operator, plus Receive for edge clusters that only run lightweight agents.
+
+Grafana Mimir (Cortex lineage) prefers remote write from the start. A minimal `remote_write` stanza in Prometheus or the OTel exporter points to Mimir distributors:
+
+```yaml
+# prometheus.yml fragment — remote_write to Mimir or AMP-compatible endpoint
+remote_write:
+  - url: https://mimir-distributor.monitoring.svc:8080/api/v1/push
+    headers:
+      X-Scope-OrgID: team-payments
+    queue_config:
+      capacity: 10000
+      max_shards: 50
+      min_shards: 1
+      max_samples_per_send: 5000
+```
+
+Tune `queue_config` when clusters flap during node drains; undersized queues cause sample drops that look like application outages in Grafana. Managed endpoints (AMP, Google Cloud Managed Service for Prometheus, Azure Monitor workspace) publish authentication and endpoint formats in their official docs—swap the URL and signing mechanism, keep the queue discipline.
+
 ### Thanos vs. Cortex vs. Mimir
 
 When architecting for scale, engineers typically weigh Thanos against push-based alternatives like Grafana Mimir. Both solve the long-term storage and global query problem, but they do so using fundamentally different topological designs. 
@@ -246,6 +322,24 @@ When architecting for scale, engineers typically weigh Thanos against push-based
 | Best for | Multi-cluster with existing Prometheus | Large multi-tenant platforms | Large multi-tenant platforms |
 | License | Apache 2.0 | Apache 2.0 | AGPL 3.0 |
 
+### Metrics at Scale: Remote Write, Federation, and Downsampling
+
+Prometheus remains the de facto metrics format on Kubernetes because `ServiceMonitor` objects, kube-state-metrics, and application `/metrics` endpoints already speak it. The core Prometheus project intentionally optimizes for **reliable local scraping** rather than horizontal sharding; when you outgrow one TSDB head, you choose an ecosystem pattern instead of a bigger single pod.
+
+**Remote write** pushes samples from Prometheus (or the OTel `prometheusremotewrite` exporter) to a centralized receiver. Grafana Mimir, Cortex, and Amazon Managed Service for Prometheus all ingest via Prometheus remote write APIs. This model centralizes query and compaction but shifts operational focus to ingestion quotas, per-tenant limits, and deduplication of HA pairs. AWS documents AMP pricing primarily around **samples ingested**, with additional charges for stored samples and query samples processed, which makes remote-write cardinality discipline an FinOps task, not only a reliability task.
+
+**Federation** (`/federate`) lets a global Prometheus pull aggregated series from regional Prometheus servers. Federation is simpler than Thanos for small multi-cluster footprints, but it still concentrates query load on the global instance and encourages up-sum-only workflows that break when labels differ across clusters. Most enterprises beyond roughly ten clusters adopt Thanos, Mimir, or a managed Prometheus-compatible service instead of a federation tree.
+
+**Recording rules** pre-compute expensive PromQL (rates, histogram quantiles, aggregations by deployment) into new lower-cardinality metrics. They are the cheapest performance win because dashboards query `$recording_rule` instead of `sum(rate(...[5m])) by (pod)` across thousands of pods.
+
+**Downsampling** (Thanos Compactor, Mimir/Cortex compaction, or managed retention policies) stores five-second resolution briefly, then one-minute or five-minute resolution for months. Compactor downsampling is how teams keep multi-year SLO history without paying full-resolution storage for every scrape interval.
+
+| Pattern | When it fits | AWS angle | GCP angle | Azure angle |
+| :--- | :--- | :--- | :--- | :--- |
+| Thanos sidecar + object store | Existing per-cluster Prometheus + S3/GCS/Azure Blob | Sidecar uploads to S3; querier in tooling cluster | GCS backend; multi-cluster GKE | Azure Blob + managed identities |
+| Mimir/Cortex remote write | Greenfield central TSDB + strong tenancy | AMP as managed remote-write target | Google Cloud Managed Service for Prometheus | Azure Monitor workspace for Prometheus metrics |
+| Federation only | Few clusters, coarse aggregates | Rare at EKS fleet scale | Rare beyond early GKE pilots | Possible for hub-spoke AKS |
+
 > **Stop and think**: If the Thanos Compactor goes down for 48 hours, what happens to your Grafana dashboards? Would you lose data, or just experience slower queries when looking at historical data from a week ago?
 
 ---
@@ -255,6 +349,10 @@ When architecting for scale, engineers typically weigh Thanos against push-based
 The OpenTelemetry (OTel) Collector acts as a vendor-agnostic ingestion pipeline, standardizing the receipt, processing, and exportation of all telemetry signals: metrics, logs, and distributed traces. At enterprise scale, the Collector becomes the single most critical data router in your architecture.
 
 Deploying OTel as a DaemonSet ensures that every Kubernetes node has a localized agent capable of collecting node-level metrics (from kubelet), intercepting standard out logs, and receiving application traces with minimal network latency.
+
+For fleets larger than a handful of clusters, introduce a **gateway tier**: DaemonSet collectors forward to a regional Deployment that runs tail sampling, sensitive attribute redaction, and rate limiting before remote write leaves the region. This mirrors how cloud providers structure their own pipelines—edge collection, regional aggregation, central query—and prevents every node from holding incomplete traces during `decision_wait`. On AWS, ADOT distributions package collectors with X-Ray exporters; on GCP and Azure, OpenTelemetry distributions target Cloud Trace and Application Insights respectively while still allowing OTLP export to Tempo for multi-cloud neutrality.
+
+When wiring exporters, treat TLS and identity as part of the data plane. Prometheus remote write to AMP or Azure Monitor workspaces should use workload identity (EKS Pod Identity or IRSA, GKE Workload Identity, Entra Workload ID on AKS) instead of long-lived keys embedded in ConfigMaps. The same identity pattern applies to Loki object storage and Thanos S3/GCS/Azure Blob uploads.
 
 ```mermaid
 flowchart LR
@@ -284,7 +382,7 @@ flowchart LR
         end
         subgraph Exporters
             E_Prom[prometheusremotewrite]
-            E_Loki[loki]
+            E_OTLPHTTP[otlphttp → Loki /otlp]
             E_OTLP[otlp to Tempo]
         end
         Receivers --> Processors --> Exporters
@@ -299,7 +397,7 @@ flowchart LR
     NodeExp --> R_Prom
     
     E_Prom --> Thanos[Thanos/Mimir\nmetrics]
-    E_Loki --> Loki[Loki/Elasticsearch\nlogs]
+    E_OTLPHTTP --> Loki[Loki/Elasticsearch\nlogs]
     E_OTLP --> Tempo[Tempo/Jaeger\ntraces]
 ```
 
@@ -397,8 +495,10 @@ spec:
         tls:
           insecure: true
 
-      loki:
-        endpoint: "http://loki-gateway:3100/loki/api/v1/push"
+      otlphttp/loki:
+        endpoint: "http://loki-gateway:3100/otlp"
+        tls:
+          insecure: true
 
       otlp/tempo:
         endpoint: "tempo-distributor:4317"
@@ -414,12 +514,14 @@ spec:
         logs:
           receivers: [filelog]
           processors: [memory_limiter, k8sattributes, batch]
-          exporters: [loki]
+          exporters: [otlphttp/loki]
         traces:
           receivers: [otlp]
           processors: [memory_limiter, k8sattributes, batch]
           exporters: [otlp/tempo]
 ```
+
+Loki 3.x ingests logs natively over OTLP (`/otlp`). The contrib `loki` exporter (`lokiexporter`, push to `/loki/api/v1/push`) was deprecated in 2024-07 and removed from current Collector builds—configs that still reference `exporters: loki` fail decode with `unknown type: loki`. Route log pipelines through `otlphttp` (or `otlp`) to the Loki OTLP endpoint instead.
 
 > **Pause and predict**: If you configure the `memory_limiter` processor in the OTel Collector to drop telemetry when it hits 90% memory, and there is a sudden spike in log volume, which signal (metrics, logs, or traces) gets dropped first? Or are they dropped equally?
 
@@ -462,6 +564,18 @@ flowchart TD
 ```
 
 This deliberate trade-off makes ingestion and long-term storage exponentially cheaper. When executing a search query, Loki quickly identifies the relevant compressed chunks using the label index and then brute-force scans (greps) through the chunk content in memory.
+
+### Structured Logging and Shipping Pipelines
+
+Unstructured printf-style logs force expensive parsing at query time and encourage operators to promote volatile fields (request IDs, user IDs) into labels, which repeats the cardinality mistake from metrics. **Structured logging** (JSON or logfmt with stable keys like `level`, `service`, `trace_id`, `http.route`) lets collectors enrich and filter without guessing. OpenTelemetry Logs Bridge maps existing log streams into OTLP so the same Collector pipeline can route to Loki, Google Cloud Logging, or Azure Monitor.
+
+At node scale, **Fluent Bit** and **Vector** remain the dominant shippers because they are lightweight, support Kubernetes metadata filters, and integrate with cloud-native sinks. A common enterprise pattern is DaemonSet shipper → regional OTel Collector (sampling + PII redaction) → central Loki or cloud logging API. On AWS, FireLens for EKS often fronts CloudWatch Logs; on GCP, logging agents target Cloud Logging with workload identity; on Azure, Container Insights and diagnostic settings feed Log Analytics. The architectural invariant is identical: **filter and sample before cross-region egress**, because log ingestion pricing is volume-based and surprises show up on the invoice before anyone tunes retention.
+
+| Tier | Retention | Query expectation | Cost driver |
+| :--- | :--- | :--- | :--- |
+| Hot | 1–7 days | Fast troubleshooting | In-memory ingesters / indexing |
+| Warm | 30 days | Namespace-scoped investigations | Object storage + compactor |
+| Cold / compliance | 1–7 years | Rare legal or audit pulls | Archive storage + export jobs |
 
 ### Loki Deployment for Multi-Cluster
 
@@ -516,6 +630,10 @@ data:
 
 At a massive scale, an unoptimized service blindly logging at the `DEBUG` level can single-handedly saturate a cluster's network interfaces and exhaust centralized storage budgets. OpenTelemetry allows you to assert authoritative control over log volumes before they ever leave the node.
 
+LogQL queries should mirror how operators actually troubleshoot: start with low-cardinality selectors (`{namespace="payments", app="ledger"}`), narrow time windows, then pipeline filters (`| json | level="error"`). Teaching engineers to search raw text globally without labels recreates Elasticsearch costs inside Loki. For security investigations that truly need full-text search, route a **copy** of specific audit streams to a purpose-built index rather than promoting all application logs to full-text infrastructure.
+
+When bridging clouds, normalize field names (`severity` vs `level`, `trace_id` vs `traceId`) in OTel `transform` processors so Grafana derived fields work across AKS, EKS, and GKE. Consistency beats having the perfect parser per language.
+
 ```yaml
 # OTel Collector: Filter noisy logs before they reach Loki
 processors:
@@ -532,10 +650,10 @@ processors:
           - key: k8s.namespace.name
             value: "kube-system"  # Drop kube-system logs
 
-  # Sample verbose logs (keep 10% of DEBUG logs)
+  # Sample a fixed percentage of log records (not severity-filtered by itself)
   probabilistic_sampler:
     sampling_percentage: 10
-    # Only applied to logs where severity == DEBUG
+  # To keep only DEBUG at 10%, add a filter processor on severity before the sampler
 
   # Transform: drop specific log fields to reduce size
   transform/logs:
@@ -554,6 +672,12 @@ processors:
 ## Cardinality and Cost Management
 
 In time-series databases, cardinality refers to the total number of unique time series actively being tracked. The cardinality of a single metric is determined by multiplying the number of unique values for each associated label. High-cardinality labels—such as explicit IP addresses, unique session tokens, or unsanitized HTTP request paths—are the primary culprits behind Prometheus OOM crashes.
+
+Cardinality is also how managed vendors meter your bill. Amazon Managed Service for Prometheus charges by metric samples ingested; Google Cloud and Azure publish analogous ingestion models for Prometheus metrics and log analytics. That means a label explosion is simultaneously a reliability incident and a procurement incident. FinOps dashboards should plot `prometheus_tsdb_head_series` (or cloud equivalents) alongside daily ingestion cost so product teams see feedback within days, not at quarter close.
+
+Platform engineering teams typically publish a **label contract**: allowed keys (`service`, `http_route_group`, `status_code`, `deployment`), forbidden keys (`user_id`, `email`, raw `url`), and guidance to put high-cardinality identifiers in exemplars, logs, or trace attributes. Enforcement layers include: (1) admission-time linting in CI for custom ServiceMonitors, (2) OTel `transform`/`filter` processors dropping labels at collection, (3) Prometheus `metric_relabel_configs` on scrape, and (4) hard per-tenant limits in Mimir or AMP workspaces. AWS documents cost optimization for AMP emphasizing ingestion control; the same discipline applies whether storage is S3 behind Thanos or a managed workspace.
+
+**Hypothetical scenario:** A team adds `customer_id` as a Prometheus label on an API with two million monthly active users. Even at one sample per minute, series multiplication overwhelms local TSDB RAM and can push remote-write pipelines into throttle. The remediation is not “buy bigger nodes forever”; it is migrate `customer_id` to trace attributes, aggregate counters by `customer_tier`, and add a recording rule for SLA-relevant aggregates only.
 
 ```mermaid
 flowchart TD
@@ -643,7 +767,17 @@ count by (pod) (http_requests_total)
 
 As architectures fracture into dozens of microservices deployed across disparate Kubernetes clusters, traditional single-service logging becomes insufficient for diagnosing systemic latency. Distributed tracing tracks the complete lifecycle of a single request as it traverses network boundaries, database calls, and inter-service HTTP requests. 
 
-This relies heavily on trace context propagation, where standard HTTP headers (such as the W3C standard `traceparent`) are seamlessly injected and extracted by each service.
+This relies heavily on trace context propagation, where standard HTTP headers (such as the W3C `traceparent` header defined in the W3C Trace Context recommendation) are injected at ingress and extracted by each downstream hop. If any service strips headers at a gateway or rewrites outbound calls without propagating context, traces fracture into orphan spans and on-call engineers see “mystery” latency inside the mesh. Service meshes (Istio, Linkerd, Cilium with Hubble) can automate propagation for HTTP/gRPC, but application-owned outbound clients still need explicit instrumentation or eBPF-based capture.
+
+**Head-based sampling** decides keep/drop at trace start (for example “keep 10% of all traces”). It is cheap and easy but statistically discards rare failures. **Tail-based sampling** buffers spans until the trace completes, then applies policies such as “keep all ERROR status” or “keep latency > 2s.” Tail sampling requires a centralized Collector Deployment with enough memory to hold incomplete traces during `decision_wait`, which is why DaemonSet collectors forward spans to a regional aggregator tier.
+
+**Exemplars** link histogram metrics to trace IDs so Grafana can jump from a latency spike in PromQL to the exact trace in Tempo or Jaeger. That bridge is how SLO dashboards become actionable during incidents instead of merely pretty.
+
+| Signal linkage | Mechanism | Operational payoff |
+| :--- | :--- | :--- |
+| Metrics → Traces | Exemplars on histograms | Click from SLO burn to slow trace |
+| Logs → Traces | `trace_id` field in JSON logs | Pivot from error line to waterfall |
+| Traces → Metrics | Span metrics derived in Collector | RED metrics from trace stream |
 
 ```mermaid
 flowchart TD
@@ -678,6 +812,8 @@ flowchart TD
 ### Tail-Based Sampling for Traces
 
 Ingesting and storing 100% of generated distributed traces is often financially unviable. Most systems implement sampling strategies. Standard "head-based" sampling makes a random drop-or-keep decision the moment a request starts. However, this means you will frequently drop traces for transactions that eventually fail later in the pipeline.
+
+For multi-region checkout flows, also verify **baggage and context propagation** across asynchronous boundaries (Kafka, SQS, Pub/Sub, Azure Service Bus). A trace that breaks when a message is enqueued will show a perfect frontend span and a disconnected consumer span, misleading latency analysis. OpenTelemetry propagators must be configured on producers and consumers with the same W3C headers; mesh ingress gateways should forward `traceparent` untouched. When vendors provide managed trace pipelines (X-Ray, Cloud Trace, Application Insights), confirm whether tail sampling happens in your Collector or in the cloud backend, because double-sampling can erase rare errors entirely.
 
 Tail-based sampling resolves this by holding all constituent spans of a trace in a temporary memory buffer until the entire request completes. Only then does it execute policy decisions, guaranteeing that any trace containing an error or exceeding latency thresholds is preserved.
 
@@ -736,17 +872,166 @@ spec:
           exporters: [otlp/tempo]
 ```
 
+### Managed Trace Backends
+
+Vendor-managed trace stores trade operational toil for ingestion pricing and retention limits. **AWS X-Ray** integrates with the CloudWatch agent and ADOT (AWS Distro for OpenTelemetry) collectors on EKS; sampling rules can be configured centrally while still exporting OTLP to self-hosted Tempo when needed. **Google Cloud Trace** accepts OTLP via OpenTelemetry and ties into Cloud Monitoring trace explorer views for GKE workloads. **Azure Application Insights** (workspace-based) ingests OpenTelemetry traces from AKS and links them to smart detection alerts, though teams should treat high-cardinality custom dimensions carefully because they affect both cost and query performance.
+
+---
+
+## Managed Observability: AWS, GCP, and Azure
+
+Build-versus-buy is not a one-time choice; it is a per-signal decision tied to compliance, staffing, and existing cloud commitments. Many enterprises run **open-source backends in-cluster** (kube-prometheus-stack, Loki, Tempo) for engineering velocity while using **managed ingestion and long-term stores** for production SLAs and IAM integration.
+
+| Capability | AWS (EKS-centric) | GCP (GKE-centric) | Azure (AKS-centric) | Kubernetes-neutral |
+| :--- | :--- | :--- | :--- | :--- |
+| Metrics | Amazon Managed Service for Prometheus, CloudWatch | Google Cloud Managed Service for Prometheus, Cloud Monitoring | Azure Monitor managed Prometheus metrics | Prometheus + Thanos/Mimir |
+| Logs | CloudWatch Logs, FireLens | Cloud Logging | Azure Monitor / Log Analytics | Loki, OTel → object store |
+| Traces | X-Ray, ADOT | Cloud Trace | Application Insights | Tempo, Jaeger |
+| Dashboards / SLO UI | Amazon Managed Grafana, CloudWatch | Cloud Monitoring dashboards | Azure Managed Grafana, Monitor workbooks | Grafana |
+| Cost visibility | Cost Explorer + CUR tags | Cloud Billing + labels | Cost Management + tags | Kubecost, OpenCost |
+
+**Amazon Managed Service for Prometheus** offers a Prometheus-compatible remote write endpoint with AWS IAM authentication and automatic scaling; AWS documents ingestion as the dominant cost driver, with tiered per-sample pricing and separate storage and query-sample charges. Teams on EKS often keep a local Prometheus for scraping and alerting while remote-writing to AMP for global query and retention.
+
+**Google Cloud Managed Service for Prometheus** and Cloud Monitoring collect Prometheus metrics from GKE with managed collectors and support PromQL-style querying in the Cloud Monitoring metrics explorer. Google documents metric ingestion and API read costs separately from logging, which matters when autoscaling clusters add kubelet/cAdvisor cardinality automatically.
+
+**Azure Monitor workspace for Prometheus metrics** (managed Prometheus on AKS) ingests Prometheus remote write data into a workspace integrated with Azure Monitor alerts and Grafana. Application Insights provides APM-style trace and dependency views; pairing it with OpenTelemetry SDKs is the supported path as legacy instrumentation agents retire.
+
+The managed path wins when you need **federated identity**, **private endpoints**, and **org-wide SLO reporting** without operating Compactor rings yourself. The self-hosted path wins when you need **multi-cloud identical configs**, **air-gapped regions**, or **aggressive custom sampling** that managed quotas resist.
+
+Hybrid designs are common and valid: scrape and alert locally with Prometheus on every cluster, remote-write long retention to AMP or Azure Monitor, mirror critical logs to Loki for LogQL, and export traces to Tempo plus Cloud Trace for teams that live in GCP consoles. The non-negotiable requirement is a written **telemetry routing policy** so you do not triple-pay for the same DEBUG log stream.
+
+---
+
+## SLOs, Error Budgets, and Symptom-Based Alerting
+
+Telemetry exists to support decisions, not to fill disks. **Service Level Indicators (SLIs)** are precise measurements (availability, latency, freshness) drawn primarily from metrics, with logs and traces as debugging lenses. **Service Level Objectives (SLOs)** set targets over rolling windows (for example 99.9% of checkout requests faster than 500 ms over thirty days). The **error budget** is the allowed unreliability before the SLO fails; when the budget burns quickly, feature work yields to reliability work.
+
+Symptom-based alerting pages humans on user-visible pain (SLO burn rate, failed synthetic probes, elevated 5xx rates) instead of every infrastructure twitch (single pod restart, node NotReady during drain). Multi-window, multi-burn-rate alerts (popularized in Google SRE practice) reduce false positives while still catching fast burns. Implementations typically use recording rules or Mimir/AMP ruler components to evaluate PromQL, then route through Alertmanager, PagerDuty, or cloud notification channels.
+
+**Alert fatigue** arrives when hundreds of threshold rules fire during partial outages, training on-call engineers to ignore pages. The fix is consolidation: one page per customer-facing service with clear severity, runbooks linked from annotations, and automatic silences for known maintenance windows. Multi-cluster environments should include `cluster` and `region` labels in alert templates so responders know which kubeconfig to use without reading a wiki. Managed clouds add native channels—Amazon SNS for CloudWatch alarms, Google Cloud alerting policies, Azure Monitor action groups—but the routing discipline remains the same: symptom first, infrastructure cause second.
+
+Recording rules for SLIs should be owned by the service team that owns the SLO, not only by central platform Prometheus. Central teams provide libraries (`slo:http_availability:ratio_rate5m`, `slo:http_latency:p99_rate5m`) and linting; product teams supply the `service` label selectors. That division prevents platform engineers from becoming bottlenecks every time a new deployment adds an HTTP route.
+
+| Alert type | Example signal | Why it scales |
+| :--- | :--- | :--- |
+| Symptom | `slo:burn_rate5m > 14` for checkout | Correlates to customer pain |
+| Cause | `KubeNodeNotReady` on one node | Useful after symptom fires |
+| Cardinality guard | `prometheus_tsdb_head_series` growth | Prevents observability outage |
+
+> **Pause and predict**: If you alert on CPU > 80% for every pod, but your SLO is latency-based, which alert will wake on-call during a thread-pool exhaustion incident that throttles checkout without high CPU?
+
+---
+
+## Cost Lens: Observability as a Top-3 Cloud Line Item
+
+Observability frequently lands in the top three non-compute cloud spends because pricing is **ingestion-linear**: every extra label value, log line, and span multiplies monthly cost more predictably than CPU throttling. FinOps teams that only right-size nodes while ignoring telemetry volume routinely save compute and still miss six-figure observability invoices.
+
+**Metrics costs** scale with samples ingested per month. High scrape frequency (10s vs 60s), HA duplication without deduplication, and unbounded labels (`user_id`, raw URL paths) explode sample counts. Managed Prometheus services on AWS, GCP, and Azure all document ingestion-tier pricing; verify current rates in official pricing pages because tiers change. Mitigations: increase scrape interval for infra metrics, drop expensive labels in OTel `transform` processors, use recording rules, enable downsampling, and enforce per-team quotas in Mimir or AMP workspace limits.
+
+**Logs costs** scale with gigabytes ingested and indexed. CloudWatch Logs charges ingestion and storage; Google Cloud Logging bills log volume; Azure Monitor log ingestion uses a pay-per-GB model in workspace analytics. Full-text search systems cost more than label-indexed Loki-style stores. Mitigations: structured logging at INFO in production, dynamic DEBUG only on targeted pods, tail sampling for verbose components, exclude health-check bodies, and tier retention (seven-day hot, thirty-day warm, archive for compliance).
+
+**Traces costs** scale with span count. Storing one hundred percent of traces for a high-QPS API is rarely economical; tail sampling that retains errors and slow traces while sampling routine success paths is the standard compromise. Cross-region export of spans mirrors NAT/egress surprises seen in metrics and logs.
+
+**Network costs** are the hidden multiplier. On AWS, NAT Gateway charges per gigabyte processed plus cross-AZ traffic; on GCP, Cloud NAT and inter-zone egress apply; on Azure, NAT Gateway and bandwidth meters add up. Centralizing all telemetry in one region from globally distributed clusters can cost more than the storage itself. Regional aggregation with summarized metrics and sampled logs/traces before cross-region transfer usually pays for itself.
+
+| Knob | Affects | Risk if misapplied |
+| :--- | :--- | :--- |
+| Scrape interval | Metric samples | Miss short incidents |
+| Label allow-lists | Cardinality | Blind spots in drill-down |
+| Log sampling | Log GB/month | Lose rare failure evidence |
+| Trace tail policies | Span storage | Over-retain routine traffic |
+| Retention downsampling | Long-term $ | Lose fine-grain historical queries |
+
+Kubecost and OpenCost attribute spend to namespaces and labels, but they do not replace cloud logging invoices. Use both: in-cluster attribution for engineering accountability, cloud billing exports for finance truth.
+
+### Provider-Specific Cost Gotchas
+
+**AWS:** NAT Gateway processing charges per gigabyte can exceed log storage when all DaemonSet shippers hairpin through a single NAT in a private subnet. Prefer VPC endpoints for S3 (Thanos/Loki blocks), AMP remote write endpoints, and CloudWatch Logs where available. Cross-AZ traffic between Prometheus replicas and ingesters also accrues silently during zone-balanced HA.
+
+**GCP:** Inter-zone egress within a region still carries cost at scale; placing Loki ingesters and GKE nodes in the same zone during labs is fine, but production should document zone spread versus telemetry egress explicitly. Cloud Logging charges log volume; exporting everything at DEBUG from GKE workloads is the most common surprise.
+
+**Azure:** NAT Gateway and bandwidth meters apply similarly to AWS patterns. Log Analytics ingestion bills per gigabyte ingested into a workspace; retaining verbose container stdout without transformation doubles both ingestion and retention cost.
+
+None of these replace fundamental telemetry discipline: fewer labels, shorter retention for noisy signals, and sampling before export.
+
+---
+
+## Patterns & Anti-Patterns
+
+| Pattern | When to Use | Why It Works | Scaling Note |
+| :--- | :--- | :--- | :--- |
+| Per-cluster Prometheus + global query | 3+ EKS/GKE/AKS clusters | Local scrape stays low-latency; global tier federates history | Add `cluster` external label on every write path |
+| OTel Collector DaemonSet + central sampler | Node logs + app OTLP | Distributes CPU; tail sampling needs aggregation tier | Separate memory limits per pipeline signal |
+| Recording rules + downsampling | Dashboards query heavy PromQL | Shrinks query cost and cardinality | Document rule ownership per team |
+| Symptom SLO alerts with multi-burn windows | On-call sustainability | Pages correlate to user pain | Pair with runbooks linking metrics → traces |
+| Regional telemetry aggregation | Multi-region active-active | Cuts NAT/egress before central store | Keep compliance data residency in region |
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+| :--- | :--- | :--- |
+| Central Prometheus scraping all clusters | OOM, cross-network scrape failures, security exposure | In-cluster Prometheus/Agent + Thanos/Mimir/AMP remote write |
+| High-cardinality labels on metrics | TSDB explosion, AMP/Mimir bill spike | Bound labels; put IDs in traces/logs |
+| `request_id` as Loki label | Ingester OOM, index blowout | Keep `request_id` in log line JSON field |
+| 100% trace retention | Span storage dominates budget | Tail sampling for errors/slow paths |
+| DEBUG logging fleet-wide | Log quota exhaustion | Dynamic log level + OTel filters |
+| Duplicate export to cloud + Loki ungoverned | Pay twice for same bytes | Policy: one primary log sink per environment |
+| CPU-threshold-only alerts | Miss latency SLO failures | Alert on SLI burn rates and synthetic checks |
+
+---
+
+## Decision Framework
+
+Use this flow when choosing observability architecture for a new fleet or region expansion. It assumes Kubernetes 1.35, multi-account or multi-project governance, and finance scrutiny on ingestion bills.
+
+```mermaid
+flowchart TD
+    Start[Fleet observability design] --> Clusters{How many clusters/regions?}
+    Clusters -->|1-2| Simple[In-cluster kube-prometheus + Loki single binary]
+    Clusters -->|3+| Global{Need single-pane global PromQL?}
+    Global -->|Yes| Store{Prefer self-hosted object store or managed Prometheus?}
+    Store -->|Self-hosted| Thanos[Thanos sidecar + querier + compactor]
+    Store -->|Managed| CloudMP[AMP / GMP / Azure Monitor workspace RW]
+    Global -->|No per-region only| Regional[Regional stacks + federated dashboards]
+    Clusters -->|Compliance multi-cloud| OTel[OTel Collector standard + dual export policy]
+    OTel --> Signals{Dominant pain today?}
+    Signals -->|Metrics cardinality| Card[Label governance + recording rules + downsampling]
+    Signals -->|Log cost| Log[Structured logs + sampling + retention tiers]
+    Signals -->|Trace volume| Trace[Tail sampling Deployment tier]
+    Card --> SLO[Define SLI/SLO + symptom alerts]
+    Log --> SLO
+    Trace --> SLO
+```
+
+| Decision input | Lean Thanos sidecar | Lean Mimir/AMP remote write | Lean managed logs (CloudWatch / Cloud Logging / Monitor) |
+| :--- | :--- | :--- | :--- |
+| Existing per-cluster Prometheus investment | High | Medium (agent mode) | N/A for metrics |
+| Multi-tenant hard limits required | Medium (label hacks) | High | High (cloud IAM boundaries) |
+| Team lacks TSDB operators | Low | Medium | High |
+| Strict data residency per region | High (region-scoped buckets) | Medium (regional workspaces) | High |
+| FinOps needs sample-level billing visibility | Medium | High on managed Prometheus | High on cloud logging |
+
+### Build vs Buy Summary
+
+| Requirement | Favor self-hosted (Thanos/Loki/Tempo) | Favor managed (AMP/GMP/Azure Monitor) |
+| :--- | :--- | :--- |
+| Identical config across AWS+GCP+Azure | Primary | Secondary (per-cloud workspaces) |
+| Small platform SRE team | Risky unless automated | Strong |
+| Enterprise IAM + PrivateLink | DIY with care | Strong |
+| Custom tail-sampling laws | Full control | Constrained by service limits |
+| Long-term cost at >1B samples/month | Tunable (object store tuning) | Tiered pricing—model before commit |
+
 ---
 
 ## Did You Know?
 
-1. **Prometheus was created at SoundCloud in 2012** and was the second project (after Kubernetes) to join the CNCF in 2016. It now monitors over 10 million Kubernetes clusters worldwide. Despite this ubiquity, Prometheus was never designed for multi-cluster or long-term storage -- those capabilities come from ecosystem projects like Thanos, Cortex, and Mimir. The Prometheus project maintainers have explicitly stated that horizontal scalability is not a goal of the core project.
+1. **Prometheus was created at SoundCloud in 2012** and was the second project (after Kubernetes) to join the CNCF in 2016. Despite this ubiquity, Prometheus was never designed for multi-cluster or long-term storage -- those capabilities come from ecosystem projects like Thanos, Cortex, and Mimir. The Prometheus project maintainers have explicitly stated that horizontal scalability is not a goal of the core project.
 
 2. **A single Kubernetes node generates approximately 500-800 metric time series** just from kubelet and cAdvisor metrics, before any application metrics. A 100-node cluster starts with 50,000-80,000 baseline time series. Application metrics typically add 3-10x on top of this. This means a 100-node cluster with microservices easily reaches 500K-1M time series -- the point where a single Prometheus instance starts struggling.
 
 3. **Grafana Loki's index is 10-100x smaller than Elasticsearch's** for the same log volume. Loki achieves this by indexing only labels (key-value metadata like namespace, pod name, and level), not the full text content. This means Loki is dramatically cheaper for storage but slower for full-text search queries. The design bet is that most log queries in Kubernetes filter by namespace and pod first, then grep through a small subset -- a bet that has proven correct for the majority of operational use cases.
 
-4. **OpenTelemetry became the second most active CNCF project** (after Kubernetes itself) in 2023 by contributor count. The project unified three competing standards: OpenTracing, OpenCensus, and the W3C Trace Context specification. The OTel Collector alone processes billions of telemetry signals per day across production deployments worldwide, making it arguably the most widely deployed data pipeline in cloud-native infrastructure.
+4. **OpenTelemetry became the second most active CNCF project** (after Kubernetes itself) in 2023 by contributor count. The project unified two competing projects, OpenTracing and OpenCensus, and standardized on W3C Trace Context for propagation. The OTel Collector alone processes billions of telemetry signals per day across production deployments worldwide, making it arguably the most widely deployed data pipeline in cloud-native infrastructure.
+
+Platform reviews should treat observability changes like capacity changes: every new label, log field, or span attribute needs an owner, a retention class, and a removal plan. That discipline keeps multi-cloud fleets understandable when AWS, GCP, and Azure invoices arrive in the same week. During incident retrospectives, ask whether missing telemetry caused slower mitigation; if yes, fund pipeline fixes before buying larger Prometheus pods. A one-page telemetry routing diagram prevents most observability gaps in production fleets across clouds.
 
 ---
 
@@ -803,11 +1088,25 @@ You implemented head-based sampling, which makes a randomized keep-or-drop decis
 To prevent a single runaway application from taking down your logging infrastructure, you must implement controls at multiple stages of the telemetry pipeline. First, establish strict log level configurations at the application level to ensure production services default to INFO or WARN, preventing DEBUG spam from ever being emitted. Second, deploy OpenTelemetry Collectors configured with filtering processors to drop known noisy patterns or truncate excessively large log bodies before they consume network bandwidth. Finally, configure tenant-based rate limiting and quota enforcement within Loki itself. This ensures that even if an application bypasses local filters, it will only exhaust its own isolated namespace quota without impacting the observability of other critical infrastructure.
 </details>
 
+<details>
+<summary>7. Your CFO asks why observability spend on AWS doubled after you connected six EKS clusters in eu-west-1 to a central AMP workspace in us-east-1. Prometheus samples look flat, but the bill spiked. Which cost dimensions should you investigate first, and what architectural change usually helps?</summary>
+
+Start with cross-region remote write and NAT egress, because shipping every sample and metadata field across regions can dominate the invoice even when series counts look stable. Next inspect AMP samples ingested (tiered per-sample pricing), duplicate HA pairs without deduplication, and shorter scrape intervals on infrastructure jobs. Query samples processed also accrue when global dashboards run heavy range queries during incidents. The usual architectural fix is regional AMP workspaces (or regional Thanos/Mimir cells) with aggregated recording rules exported globally, plus OTel filters that drop high-cardinality labels before remote write leaves the cluster region.
+</details>
+
+<details>
+<summary>8. Platform leadership wants one SLO dashboard for checkout across AKS, EKS, and GKE, but each cloud team exports metrics differently. What minimum contract should you standardize before picking Thanos versus managed Prometheus?</summary>
+
+Standardize external labels (`cluster`, `region`, `environment`, `team`), metric names for SLIs (availability and latency histograms), and alert labels before debating storage engines. Require OpenTelemetry or Prometheus exporters to expose the same histogram buckets and route through collectors that enforce label allow-lists. With that contract, Thanos or Mimir can federate self-hosted data, while AMP, Google Cloud Managed Service for Prometheus, and Azure Monitor workspaces can remote-write into Grafana with identical PromQL recording rules. Without the contract, any global backend becomes a label zoo and SLO math diverges per cloud.
+</details>
+
 ---
 
 ## Hands-On Exercise: Build a Multi-Cluster Monitoring Stack
 
-In this advanced exercise, you will manually provision and configure a robust monitoring stack featuring Prometheus, a simulated Thanos Sidecar arrangement, an OpenTelemetry Collector, Loki for log aggregation, and Grafana for visualization. 
+In this advanced exercise, you will manually provision and configure a robust monitoring stack featuring Prometheus, a simulated Thanos Sidecar arrangement, an OpenTelemetry Collector, Loki for log aggregation, and Grafana for visualization. The lab intentionally runs on a single kind cluster with Kubernetes 1.35 to keep resource usage manageable, but the configuration patterns mirror production multi-cluster designs: external labels for future federation, DaemonSet collectors for per-node logs, memory limiters to avoid OOM during bursts, and cardinality reports you should run weekly in real fleets.
+
+Before starting, internalize the production mapping: Task 1’s Prometheus external labels correspond to Thanos `cluster` labels; Task 2’s OTel→Loki path corresponds to regional aggregation before cloud logging export; Task 6’s cardinality report is the same PromQL you would paste into an incident channel when AMP ingestion spikes. If any step fails, check pod memory first—observability components are among the first to be starved when nodes are undersized. 
 
 ### Prerequisites
 
@@ -859,14 +1158,15 @@ Establish the log ingestion pathway. You will deploy Loki to store the logs and 
 helm repo add grafana https://grafana.github.io/helm-charts
 helm repo update
 
-# Install Loki in single-binary mode for the lab
+# Install Loki in monolithic mode for the lab (chart v12+ renamed SingleBinary → Monolithic)
 helm install loki grafana/loki \
   --namespace monitoring \
-  --set deploymentMode=SingleBinary \
+  --set deploymentMode=Monolithic \
+  --set loki.useTestSchema=true \
   --set loki.auth_enabled=false \
   --set loki.commonConfig.replication_factor=1 \
   --set loki.storage.type=filesystem \
-  --set singleBinary.replicas=1
+  --set monolithic.replicas=1
 
 # Install OpenTelemetry Operator/Collector
 helm repo add open-telemetry https://open-telemetry.github.io/opentelemetry-helm-charts
@@ -875,6 +1175,9 @@ helm repo update
 # Create OTel Collector values
 cat <<'EOF' > otel-values.yaml
 mode: daemonset
+presets:
+  logsCollection:
+    enabled: true
 config:
   receivers:
     filelog:
@@ -888,14 +1191,14 @@ config:
       send_batch_size: 10000
       timeout: 10s
   exporters:
-    loki:
-      endpoint: "http://loki:3100/loki/api/v1/push"
+    otlphttp:
+      endpoint: http://loki:3100/otlp
   service:
     pipelines:
       logs:
         receivers: [filelog]
         processors: [memory_limiter, batch]
-        exporters: [loki]
+        exporters: [otlphttp]
 EOF
 
 helm install otel-collector open-telemetry/opentelemetry-collector \
@@ -910,15 +1213,15 @@ echo "Loki and OTel Collector deployed successfully"
 ```
 </details>
 
-### Task 3: Deploy Sample Workloads with Metrics
+### Task 3: Deploy Sample Workloads for Log Collection
 
-To verify the ingestion engines are functioning properly, spin up a transient workload emitting standard Nginx metrics. Ensure that the namespace matches the pre-configured scraping annotations.
+Deploy a sample nginx workload so the OTel `filelog` receiver has container logs to ship. Plain `nginx:stable` serves HTTP on port 80 only (no `/metrics`); kube-prometheus-stack discovers targets via ServiceMonitor/PodMonitor, not `prometheus.io/*` pod annotations—this task validates **log** ingestion, not app metric scraping.
 
 <details>
 <summary>Solution</summary>
 
 ```bash
-# Deploy a sample app with Prometheus metrics
+# Deploy a sample app (stdout/stderr logs for filelog → Loki)
 kubectl create namespace sample-app
 
 kubectl apply -f - <<'EOF'
@@ -939,9 +1242,6 @@ spec:
       labels:
         app: web-server
         team: backend
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "80"
     spec:
       containers:
         - name: nginx
@@ -971,7 +1271,7 @@ kubectl wait --for=condition=Ready pod -l app=web-server -n sample-app --timeout
 
 ### Task 4: Query Cross-Cluster Metrics
 
-Execute direct PromQL requests using `curl` against the exposed Prometheus API to validate the existence of cluster external labels—a necessity for multi-cluster disambiguation.
+Execute direct PromQL requests using `curl` against the exposed Prometheus API. Confirm `external_labels` via the status config API—they are attached on federation, remote-write, and Alertmanager paths, not on every local instant-query series.
 
 <details>
 <summary>Solution</summary>
@@ -992,8 +1292,8 @@ curl -s 'http://localhost:9090/api/v1/query?query=count(kube_pod_info)%20by%20(n
 echo "=== Top CPU Consumers ==="
 curl -s 'http://localhost:9090/api/v1/query?query=topk(5,%20sum%20by%20(namespace,%20pod)%20(rate(container_cpu_usage_seconds_total{container!=""}[5m])))' | jq '.data.result[]'
 
-echo "=== Cluster Label (confirms external labels work) ==="
-curl -s 'http://localhost:9090/api/v1/query?query=up{job="kubelet"}' | jq '.data.result[0].metric.cluster'
+echo "=== External labels (configured on Prometheus) ==="
+curl -s 'http://localhost:9090/api/v1/status/config' | jq -r '.data.yaml' | grep -E 'external_labels|cluster:|region:'
 
 # Stop port-forward
 kill %1 2>/dev/null
@@ -1127,8 +1427,8 @@ kind delete cluster --name obs-lab
 
 - [ ] Prometheus correctly deployed with external labels injected (`cluster`, `region`).
 - [ ] Loki and OpenTelemetry Collector daemonsets deployed and streaming unstructured pod logs without crashing.
-- [ ] Sample Nginx workloads successfully scraped by Prometheus and their output logs retrieved by OTel.
-- [ ] Manual PromQL validation queries consistently return JSON results with cluster labels intact.
+- [ ] Sample nginx pods emit logs collected by OTel and queryable in Loki (no app `/metrics` scrape in this lab).
+- [ ] Manual PromQL validation queries return JSON; external labels verified via `/api/v1/status/config` (not on local `up` series).
 - [ ] Native LogQL queries cleanly return application logs from Loki's backend.
 - [ ] The automated cardinality report accurately identifies the specific top metrics driving series count bloat.
 - [ ] The main Grafana service is highly accessible over a secure port forward, with the correct Prometheus data source globally configured.
@@ -1141,5 +1441,19 @@ kind delete cluster --name obs-lab
 
 ## Sources
 
-- [Grafana Loki Overview](https://grafana.com/docs/loki/latest/get-started/overview/) — Covers Loki's label-based indexing model, storage design, and deployment modes for scalable logging.
-- [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) — Primary overview of the Collector's role as a vendor-agnostic telemetry ingestion, processing, and export pipeline.
+- [Amazon Managed Service for Prometheus](https://docs.aws.amazon.com/prometheus/latest/userguide/what-is-AMP.html) — Managed Prometheus-compatible metrics for container workloads on AWS.
+- [Understand and optimize costs in AMP](https://docs.aws.amazon.com/prometheus/latest/userguide/AMP-costs.html) — AWS guidance on ingestion-driven cost drivers and Cost Explorer usage.
+- [Amazon Managed Service for Prometheus pricing](https://aws.amazon.com/prometheus/pricing/) — Official sample-ingestion, storage, and query pricing tiers.
+- [CloudWatch Logs pricing](https://aws.amazon.com/cloudwatch/pricing/) — Ingestion and storage model for AWS log pipelines.
+- [AWS X-Ray developer guide](https://docs.aws.amazon.com/xray/latest/devguide/aws-xray.html) — Trace collection and service map concepts on AWS.
+- [Google Cloud Managed Service for Prometheus](https://cloud.google.com/stackdriver/docs/managed-prometheus) — GKE-oriented managed Prometheus metrics collection and querying.
+- [Cloud Logging pricing](https://cloud.google.com/stackdriver/pricing) — Log volume and retention cost factors on GCP.
+- [Cloud Trace documentation](https://cloud.google.com/trace/docs) — Distributed tracing on Google Cloud.
+- [Azure Monitor managed Prometheus metrics](https://learn.microsoft.com/en-us/azure/azure-monitor/essentials/prometheus-metrics-overview) — Managed Prometheus metrics workspaces for AKS and hybrid monitoring.
+- [Application Insights overview](https://learn.microsoft.com/en-us/azure/azure-monitor/app/app-insights-overview) — APM, traces, and telemetry for Azure workloads.
+- [Azure Monitor log ingestion and billing](https://learn.microsoft.com/en-us/azure/azure-monitor/logs/cost-logs) — Log Analytics ingestion cost guidance.
+- [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) — Vendor-neutral telemetry ingestion, processing, and export pipelines.
+- [Prometheus remote write](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#remote_write) — Remote storage integration contract used by AMP, Mimir, and Cortex.
+- [Thanos documentation](https://thanos.io/tip/thanos/getting-started.md/) — Multi-cluster long-term metric storage and global query architecture.
+- [Grafana Loki overview](https://grafana.com/docs/loki/latest/get-started/overview/) — Label-based indexing model and scalable logging deployment modes.
+- [Metrics for Kubernetes system components](https://kubernetes.io/docs/concepts/cluster-administration/system-metrics/) — Cluster-level metrics foundations for platform observability.


### PR DESCRIPTION
## Cloud / Advanced Operations — expand-to-floor + cross-family review (8.1–8.10)

Session 101. Continues the sessions 96–100 cloud workstream. Brings all 10 **Advanced
Operations** modules from `shipped_unreviewed` (sub-floor / unreviewed) to finalize-quality.

**What changed**
- 8 modules expanded to the 5,000-word teaching floor (scoped by `verify_module.py`
  `body_words`, not raw `wc` — code/tables/mermaid don't count); 2 already-dense modules
  (8.2, 8.3) got targeted gate/correctness fixes.
- Every module then went through an independent **cross-family review**, every finding
  was **ground-checked** by the orchestrator (web-verified against provider docs), and a
  fix-pass applied.
- All 10 now verify **T0 / PASS**. Incident-dedup gate: PASS.

**Per-module summary** (reviewer · key fixes)

| Module | Reviewer | Notable fixes (all ground-checked) |
|---|---|---|
| 8.1 multi-account | opus 4.8 | P1 cross-account IRSA trust ARN (wrong account); GCP inter-zone egress, Azure WI enable, GCP org-policy v2, `$PROD_FOLDER_ID` |
| 8.2 transit-hubs | opus 4.8 | route-table quota 200→50; `PreferClose`→`PreferSameZone` (KEP-3015); TGW `appliance_mode_support`; outcomes 6→5 |
| 8.3 cross-cluster-net | gemini-3.1-pro | sources 7→12; modern Cilium annotations; Athena `dst_az_id` enrichment note; brief Azure coverage |
| 8.4 enterprise-identity | gemini-3.1-pro | `eks:ListClusters`/`DescribeNodegroup` resource scoping; `aws:`→`sts:ExternalId` |
| 8.5 disaster-recovery | opus 4.8 | VolumeReplication CRD schema (csi-addons, not EBS); etcd backup upload image; etcdutl 3.6; Velero→CNCF/Broadcom |
| 8.6 active-active | opus 4.8 | cost prose↔tables; 1994 session-guarantees → Xerox PARC/Bayou; dropped fabricated Netflix figures |
| 8.7 stateful-migration | cursor | P1 PG lag host; cross-region CSI `VolumeSnapshotContent` import; `velero restore` name; GCP/Azure snapshot CLIs |
| 8.8 cloud-cost | cursor | P1 NAT-Gateway "suspension" myth; real Spot taints; Kyverno label scope; OpenCost port-forward |
| 8.9 observability-scale | opus 4.8 | P1 deprecated Loki exporter→OTLP; Loki `schemaConfig`; filelog mount; dropped fabricated "10M clusters" |
| 8.10 iac-scale | gemini-3.1-pro | duplicate paragraph; GHA `persist-credentials`/`id-token`; Terratest private-API; `environments/` path |

## Learner check

> RTO includes detection time, decision time, infrastructure provisioning, data promotion, Kubernetes reconciliation, DNS cutover, and verification

(verbatim from `module-8.5-disaster-recovery.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
