### PR TITLE
chore(content): Cloud Managed Services 9.1–9.10 expand-to-floor + cross-family review

### DIFF
--- a/src/content/docs/cloud/managed-services/module-9.1-databases.md
+++ b/src/content/docs/cloud/managed-services/module-9.1-databases.md
@@ -1,5 +1,5 @@
 ---
-title: "Module 9.1: Relational Database Integration (RDS / Cloud SQL / Flexible Server)"
+title: "Module 9.1: Managed Database Integration (RDS / Cloud SQL / Azure / NoSQL)"
 slug: cloud/managed-services/module-9.1-databases
 sidebar:
   order: 2
@@ -14,24 +14,75 @@ After completing this module, you will be able to:
 - **Implement connection pooling with PgBouncer or ProxySQL sidecars to optimize database connection management from pods**
 - **Deploy automated credential rotation for database secrets using cloud-native rotation with Kubernetes External Secrets Operator**
 - **Design high-availability database architectures with cross-AZ failover that Kubernetes workloads survive transparently**
+- **Compare relational, document, key-value, and globally distributed managed databases across AWS, GCP, and Azure and choose the right engine for a Kubernetes workload**
 
 ---
 
 ## Why This Module Matters
 
-Teams that run stateful databases on Kubernetes can hit painful outages when storage placement, scheduling, and availability-zone constraints are misaligned, which is one reason many production teams choose managed database services instead.
+Hypothetical scenario: a platform team runs PostgreSQL on Kubernetes with a StatefulSet backed by zone-local persistent volumes. During a regional AZ impairment, pods reschedule cleanly but the database volume remains pinned to the failed zone, and read traffic saturates cross-AZ links while failover scripts run manually. The incident is survivable, but the recovery path consumes senior database time that was supposed to go toward product features.
 
-The startup migrated to Amazon RDS the following Monday. Not because Kubernetes cannot run databases -- it absolutely can -- but because managed databases handle the hardest parts of database operations: automated failover, point-in-time recovery, patching, and cross-AZ replication. The real engineering challenge shifted from "keeping PostgreSQL alive" to "connecting Kubernetes workloads to managed databases securely, efficiently, and reliably."
+Many production teams reach the same conclusion without waiting for that outage: Kubernetes excels at stateless orchestration, while managed database services absorb the operational burden of automated failover, point-in-time recovery (PITR), engine patching, and cross-AZ or cross-region replication. The engineering challenge then shifts from "keeping PostgreSQL alive" to "connecting Kubernetes workloads to the right managed database securely, efficiently, and at predictable cost."
 
-This module teaches you the second part. You will learn how to connect Kubernetes pods to managed relational databases across all three major clouds using private networking, connection pooling, credential rotation, schema migrations in a GitOps workflow, and high-availability patterns that survive AZ failures without your on-call engineer losing sleep.
+This module teaches that integration layer across AWS, GCP, and Azure. You will connect pods through private networking, tame connection storms with pooling and managed proxies, rotate credentials without downtime, run schema migrations safely in GitOps pipelines, and design HA/DR topologies that survive AZ and regional failures. You will also learn when a relational engine, a document store, or a globally distributed database is the correct choice — and when an in-cluster operator still makes sense.
+
+---
+
+## Multi-Cloud Relational Database Landscape
+
+Relational managed databases remain the default for transactional applications: orders, ledgers, identity records, and anything that needs ACID guarantees with SQL ergonomics. Each cloud offers a spectrum from "lift-and-shift compatible" to "cloud-native rewrite," and Kubernetes integration patterns differ subtly across them.
+
+**AWS: RDS and Aurora.** [Amazon RDS](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/Welcome.html) supports PostgreSQL, MySQL, MariaDB, SQL Server, and Oracle as managed instances with familiar engines. RDS Multi-AZ maintains a synchronous standby in another Availability Zone; on primary failure, AWS promotes the standby and updates the endpoint DNS name, typically within about 60–120 seconds depending on workload and engine. Read replicas are asynchronous and scale read traffic — they are not automatic failover targets unless you promote one manually. For Kubernetes teams, RDS remains the default lift-and-shift path when your Helm charts already expect a PostgreSQL connection string and your ORM migration folder targets standard SQL dialect features without Spanner-style interleaved tables.
+
+[Aurora](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/CHAP_AuroraOverview.html) replicates storage at the volume layer across three AZs in a region. Storage durability is decoupled from compute. Aurora Serverless v2 autoscales Aurora Capacity Units (ACUs) based on load. You avoid picking a fixed instance size upfront for spiky Kubernetes microservices. [Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) adds up to 10 read-only secondary clusters in other regions. Replication latency is typically under one second. That supports regional DR and low-latency global reads from the writer endpoint in the primary region. When EKS spans multiple regions for latency, each regional cluster can read locally while writes funnel to the primary. Application code must tolerate write latency to the primary region or use Aurora write forwarding where supported.
+
+**GCP: Cloud SQL, AlloyDB, and Spanner.** [Cloud SQL](https://cloud.google.com/sql/docs) offers managed PostgreSQL, MySQL, and SQL Server with regional HA (primary + standby in another zone within the region) and optional cross-region read replicas for DR or migration. Private IP connectivity uses VPC peering to Google's managed services network, which is the pattern you use from GKE workloads that should never traverse the public internet to reach data. Cloud SQL Auth Proxy sidecars remain popular for local development parity even when production uses private IP, because the proxy handles TLS and IAM login consistently across environments.
+
+[AlloyDB for PostgreSQL](https://cloud.google.com/alloydb/docs/overview) targets PostgreSQL-compatible OLTP with a disaggregated storage/compute architecture and columnar acceleration for analytics-style queries without leaving the transactional engine. Choose AlloyDB when PostgreSQL compatibility matters but you need higher throughput than standard Cloud SQL tiers at moderate scale — for example, a GKE-hosted SaaS with heavy read/write contention on a single large tenant table where Cloud SQL CPU pegs during business hours.
+
+[Cloud Spanner](https://cloud.google.com/spanner/docs) is a different species: horizontally scalable, globally distributed, and externally consistent thanks to [TrueTime](https://cloud.google.com/spanner/docs/true-time-external-consistency). Spanner suits workloads that outgrow single-primary relational limits — global inventory, financial ledgers spanning regions — at the cost of Spanner-specific schema design and pricing. From Kubernetes, you connect like any external database using private IP or authorized networks, with client libraries that understand Spanner's SQL dialect and interleaved index patterns that differ from idiomatic PostgreSQL migrations.
+
+**Azure: SQL Database and Flexible Server.** [Azure SQL Database](https://learn.microsoft.com/en-us/azure/azure-sql/database/sql-database-paas-overview) offers DTU-based (bundled compute/storage/I/O) and vCore-based (transparent hardware choice) purchasing models. The [Hyperscale tier](https://learn.microsoft.com/en-us/azure/azure-sql/database/service-tier-hyperscale) separates compute from storage for very large databases with fast scale-out reads via replicas — think multi-terabyte SaaS tenants where storage growth outpaces CPU needs and AKS-hosted services must query without resharding application code.
+
+[Azure Database for PostgreSQL Flexible Server](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/overview) and the MySQL equivalent integrate directly into your VNet with private DNS (`privatelink.postgres.database.azure.com`), zone-redundant HA, and geo-replication via read replicas in other regions. This is the Azure counterpart to RDS/Cloud SQL for AKS workloads that speak standard PostgreSQL wire protocol, and it pairs naturally with Entra Workload ID for Key Vault–backed credentials synced through External Secrets Operator.
+
+| Dimension | AWS RDS/Aurora | GCP Cloud SQL / AlloyDB | Azure SQL / Flexible Server |
+|-----------|----------------|-------------------------|----------------------------|
+| Primary HA model | Multi-AZ sync standby; Aurora storage replication | Regional HA (primary + standby zone) | Zone-redundant HA option |
+| Read scaling | Read replicas (async); Aurora readers in cluster | Read replicas; AlloyDB read pools | Geo-replicas; Hyperscale secondaries |
+| Global distribution | Aurora Global Database (≤10 secondary regions) | Cross-region Cloud SQL replicas; Spanner natively global | Geo-replicated Flexible Server read replicas |
+| Typical K8s access | Private subnets + security groups; RDS Proxy optional | Private IP via VPC peering | VNet integration + private DNS |
+| Best fit | Broad engine support; mature ecosystem | PostgreSQL-heavy GCP estates | Microsoft stack + PostgreSQL/MySQL on Azure |
+
+---
+
+## NoSQL and Purpose-Built Managed Databases
+
+Not every Kubernetes workload belongs on PostgreSQL. Session stores, product catalogs with flexible schema, high-velocity telemetry keys, and globally replicated shopping carts each map to different data models — and each cloud ships purpose-built managed services that integrate with Kubernetes through private networking and workload identity rather than in-cluster StatefulSets. The decision is not "SQL vs NoSQL" in the abstract; it is whether your access patterns, consistency requirements, and operational budget align with a single-primary relational engine or a horizontally partitioned store designed for keyed lookups at planet scale.
+
+**Choosing relational vs document vs key-value vs wide-column.** Relational engines win when you need joins, constraints, and transactional updates across normalized tables — billing, accounts, reservations. Document stores ([Amazon DynamoDB](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/Introduction.html) items, [Firestore](https://firebase.google.com/docs/firestore) documents, [Azure Cosmos DB](https://learn.microsoft.com/en-us/azure/cosmos-db/introduction) JSON documents) excel when access patterns are keyed lookups with optional secondary indexes and schema flexibility matters more than ad-hoc joins. Key-value caches (often ElastiCache/Memorystore — see Module 9.5) sit in front of databases; wide-column stores like [Bigtable](https://cloud.google.com/bigtable/docs) target massive throughput time-series or analytics ingestion where single-row latency at billions of rows is the design center. Hybrid architectures are common: PostgreSQL as system of record, DynamoDB for high-velocity session state, and Bigtable for append-only telemetry — each accessed from the same Kubernetes namespace via distinct Services and IAM roles.
+
+**AWS DynamoDB.** DynamoDB offers on-demand capacity (pay per request) and provisioned capacity (predictable RCU/WCU with autoscaling). [Global tables](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GlobalTables.html) provide multi-region active-active replication for eventually consistent cross-region reads; design for idempotent writers because conflict resolution is last-writer-wins at the item level. From EKS, access DynamoDB through the AWS SDK with [IAM Roles for Service Accounts (IRSA)](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) or [EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) — no long-lived access keys in Secrets. Partition key design is the Kubernetes-adjacent lesson: hot partitions from a poorly chosen key hurt every pod equally, so load tests must include realistic shard distribution, not just pod count.
+
+**GCP Firestore and Bigtable.** Firestore (Native mode) is a serverless document database with real-time listeners — common for mobile/web backends called from services on GKE. Bigtable is a wide-column store for high-throughput, low-latency workloads (metrics, IoT, ML feature stores) where you design row keys carefully to avoid hot partitions. Both integrate via Google client libraries and [GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) for keyless authentication, which means your Deployment manifests reference a Kubernetes ServiceAccount while GCP IAM bindings enforce which tables or collections that workload may touch.
+
+**Azure Cosmos DB.** Cosmos DB exposes multiple APIs (SQL, MongoDB, Cassandra, Gremlin, Table) over a globally distributed storage engine. It offers [five consistency levels](https://learn.microsoft.com/en-us/azure/cosmos-db/consistency-levels) from strong to eventual, letting you trade latency for correctness per container. Critically, the [conflict resolution policy is immutable after container creation](https://learn.microsoft.com/en-us/azure/cosmos-db/conflict-resolution-policies) — choose last-writer-wins vs custom merge logic at design time, not after launch. Multi-region writes enable active-active patterns for globally distributed Kubernetes Deployments fronted by Traffic Manager or a global load balancer, but your microservices must implement compensating transactions when merge semantics reject conflicting updates.
+
+| Workload signal | Lean toward | Why |
+|-----------------|-------------|-----|
+| Multi-table ACID transactions | RDS / Cloud SQL / Flexible Server | Mature SQL + FK constraints |
+| Single-digit ms keyed lookups at huge scale | DynamoDB / Cosmos DB (partition key design) | Horizontal partition scaling |
+| Flexible nested JSON, mobile sync | Firestore | Document model + offline clients |
+| Billions of rows, scan-heavy analytics | Bigtable / DynamoDB streams + analytics | Wide-column throughput |
+| Global external consistency | Spanner / Cosmos DB (strong) | Coordinated cross-region commits |
 
 ---
 
 ## Private Network Connectivity
 
-The first rule of database connectivity from Kubernetes: **avoid exposing your database to the public internet whenever possible**. Every cloud provider offers private endpoint mechanisms that keep traffic on the provider's backbone network.
+The first rule of database connectivity from Kubernetes: **avoid exposing your database to the public internet whenever possible**. Every cloud provider offers private endpoint mechanisms that keep traffic on the provider's backbone network. Production clusters should treat a publicly reachable database endpoint as a temporary lab mistake. Private connectivity also simplifies compliance narratives. Auditors can draw a clear boundary: pods and databases communicate inside RFC1918 space or peered networks, not across the public internet.
 
-### Architecture: VPC-Native Connectivity
+**Architecture: VPC-native connectivity.** The diagram below shows the mental model every integration follows regardless of cloud: pods talk to a stable in-cluster DNS name, network policy and security groups enforce least privilege, and the managed database listens only on private addresses inside the peered VPC or VNet.
 
 ```mermaid
 flowchart LR
@@ -51,11 +102,9 @@ flowchart LR
     Svc -- VPC Peering/Private Endpoint ---> Primary
 ```
 
-> **Stop and think**: If your pod in `us-east-1a` queries a database in `us-east-1b`, the traffic is private and secure. However, what other consequence does crossing an Availability Zone boundary have? (Hint: Think about your cloud provider's monthly billing statement).
+> **Stop and think**: If your pod in `us-east-1a` queries a database in `us-east-1b`, the traffic is private and secure. However, what other consequence does crossing an Availability Zone boundary have? (Hint: Think about your cloud provider's monthly billing statement.)
 
-### AWS: RDS with VPC Private Subnets
-
-On AWS, your EKS cluster and RDS instance should share the same VPC or use VPC peering. [RDS instances deployed into private subnets are accessible from any resource within the VPC](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html).
+**AWS: RDS with VPC private subnets.** On AWS, your EKS cluster and RDS instance should share the same VPC or use VPC peering. [RDS instances deployed into private subnets are accessible from any resource within the VPC](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_VPC.WorkingWithRDSInstanceinaVPC.html). Security groups are the primary enforcement layer: allow TCP 5432 (or your engine port) only from the EKS node security group or pod security group if you use Security Groups for Pods, rather than opening the entire `10.0.0.0/8` supernet because it was faster during sprint planning.
 
 ```bash
 # Create a DB subnet group using private subnets
@@ -94,12 +143,12 @@ aws rds create-db-instance \
   --no-publicly-accessible
 ```
 
-The [`--manage-master-user-password` flag tells RDS to store the master password in AWS Secrets Manager automatically](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-secrets-manager.html). RDS generates and stores the password in Secrets Manager so you can avoid hardcoding or manually distributing it.
+The [`--manage-master-user-password` flag tells RDS to store the master password in AWS Secrets Manager automatically](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-secrets-manager.html). RDS generates and stores the password in Secrets Manager so you can avoid hardcoding or manually distributing it — a pattern that pairs directly with External Secrets Operator syncing credentials into Kubernetes Secrets for your Deployments.
 
-### GCP: Cloud SQL with Private IP Connectivity
+**GCP: Cloud SQL with private IP connectivity.** Cloud SQL private IP requires allocating a VPC peering range and connecting the servicenetworking API before the instance is created; skipping this ordering forces destructive recreation later. GKE nodes in the same VPC reach Cloud SQL private IPs without NAT, keeping latency predictable for east-west traffic inside the region.
 
 ```bash
-# Allocate IP range for Private Service Connect
+# Allocate IP range for Private Services Access
 gcloud compute addresses create google-managed-services \
   --global --purpose=VPC_PEERING \
   --addresses=10.100.0.0 --prefix-length=16 \
@@ -124,10 +173,10 @@ gcloud sql instances create app-postgres \
 
 # Get the private IP
 gcloud sql instances describe app-postgres \
-  --format='value(ipAddresses.filter("type=PRIVATE").ipAddress)'
+  --format='value(ipAddresses.filter(type:PRIVATE).ipAddress)'
 ```
 
-### Azure: Flexible Server with Private Access (VNet Integration)
+**Azure: Flexible Server with private access (VNet integration).** Azure Flexible Server injects the database into your VNet subnet and registers a private DNS zone so the FQDN resolves to internal addresses only. AKS pods resolve `app-postgres.privatelink.postgres.database.azure.com` the same way they resolve in-cluster Services, which keeps connection strings portable between local jump boxes and production pods.
 
 ```bash
 # Create a private DNS zone for PostgreSQL
@@ -152,9 +201,7 @@ az postgres flexible-server create \
   --high-availability ZoneRedundant
 ```
 
-### Kubernetes Service for Database Endpoints
-
-Regardless of cloud, create an ExternalName or headless Service so your application code uses a Kubernetes-native DNS name:
+**Kubernetes Service for database endpoints.** Regardless of cloud, create an ExternalName or headless Service so your application code uses a Kubernetes-native DNS name rather than embedding vendor-specific hostnames in twelve ConfigMaps spread across microservices.
 
 ```yaml
 apiVersion: v1
@@ -167,7 +214,7 @@ spec:
   externalName: app-postgres.abc123.us-east-1.rds.amazonaws.com
 ```
 
-Your application connects to `app-database.production.svc.cluster.local`. If you migrate from RDS to Cloud SQL, you change the Service -- not every application config.
+Your application connects to `app-database.production.svc.cluster.local`. If you migrate from RDS to Cloud SQL, you change the Service -- not every application config. Document the Service name in platform runbooks so teams never hardcode vendor hostnames in Helm values again.
 
 ---
 
@@ -175,11 +222,9 @@ Your application connects to `app-database.production.svc.cluster.local`. If you
 
 Every database connection consumes server memory, so large numbers of idle connections waste capacity. Kubernetes makes this worse because pods scale horizontally. If you have 20 replicas, each maintaining a pool of 10 connections, that is 200 connections. During a rolling deployment, both old and new pods exist simultaneously -- suddenly 400 connections.
 
-Managed databases have connection limits, and real performance usually degrades before you reach the configured maximum. The answer is connection pooling.
+Managed databases have connection limits. Real performance usually degrades before you reach the configured maximum. The answer is connection pooling. Pooling is not a single knob — it is an architecture choice among sidecars, centralized Deployments, and cloud-managed proxies. That choice must align with your failover and IAM strategy.
 
-### PgBouncer as a Sidecar
-
-The sidecar pattern places PgBouncer in the same pod as your application. Each pod gets its own pooler.
+**PgBouncer as a sidecar.** The sidecar pattern places PgBouncer in the same pod as your application so each pod maintains a small local pool that multiplexes onto shared backend connections without exposing the database to unbounded pod-level fan-out.
 
 ```yaml
 apiVersion: apps/v1
@@ -203,15 +248,15 @@ spec:
           ports:
             - containerPort: 8080
           env:
-            - name: DATABASE_URL
-              value: "postgresql://appuser:$(DB_PASSWORD)@localhost:6432/appdb?sslmode=require"
             - name: DB_PASSWORD
               valueFrom:
                 secretKeyRef:
                   name: db-credentials
                   key: password
+            - name: DATABASE_URL
+              value: "postgresql://appuser:$(DB_PASSWORD)@localhost:6432/appdb?sslmode=disable"
         - name: pgbouncer
-          image: bitnami/pgbouncer:1.23.0
+          image: bitnamilegacy/pgbouncer:1.23.0
           ports:
             - containerPort: 6432
           env:
@@ -246,9 +291,11 @@ spec:
               memory: 128Mi
 ```
 
-### PgBouncer as a Centralized Proxy
+> **Image note:** As of 2025-08-28, Broadcom moved versioned `docker.io/bitnami/*` tags to `docker.io/bitnamilegacy/*`; this module uses `bitnamilegacy/pgbouncer:1.23.0` so labs stay pullable. The legacy registry receives **no security updates** — production should use a maintained image such as [`edoburu/pgbouncer`](https://hub.docker.com/r/edoburu/pgbouncer) or Bitnami Secure.
 
-For larger clusters, a centralized PgBouncer Deployment is more efficient:
+The sidecar `DATABASE_URL` uses `sslmode=disable` because Bitnami PgBouncer does not enable TLS on port 6432 by default; use `sslmode=require` only after you configure TLS on PgBouncer and PostgreSQL.
+
+**PgBouncer as a centralized proxy.** For larger clusters, a centralized PgBouncer Deployment is more efficient because it amortizes pool state across hundreds of pods and gives platform engineers one place to tune `max_db_connections` in response to RDS CloudWatch `DatabaseConnections` metrics.
 
 ```yaml
 apiVersion: apps/v1
@@ -275,7 +322,7 @@ spec:
               app: pgbouncer
       containers:
         - name: pgbouncer
-          image: bitnami/pgbouncer:1.23.0
+          image: bitnamilegacy/pgbouncer:1.23.0
           ports:
             - containerPort: 6432
           env:
@@ -306,7 +353,7 @@ spec:
       targetPort: 6432
 ```
 
-### Pool Mode Decision Matrix
+**Pool mode decision matrix.** Transaction mode is the default recommendation for stateless HTTP services, but the matrix below captures why legacy session-oriented applications sometimes require session mode despite weaker multiplexing.
 
 | Pool Mode | How It Works | Best For | Watch Out |
 |-----------|-------------|----------|-----------|
@@ -318,15 +365,37 @@ spec:
 
 For many stateless web workloads, `transaction` mode is a strong default because it balances connection reuse with broad application compatibility.
 
+**Managed proxies: RDS Proxy and cloud equivalents.** In-cluster PgBouncer is powerful, but each cloud also offers managed connection proxies that understand failover semantics and IAM authentication — reducing operational toil when Lambda functions or bursty Deployments threaten to exhaust `max_connections`.
+
+[Amazon RDS Proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html) sits between your applications and RDS/Aurora, pooling and multiplexing connections while preserving sessions during Multi-AZ failover. It integrates with Secrets Manager and supports IAM authentication from clients to the proxy. RDS Proxy queues or throttles connection attempts when the pool is saturated rather than letting thousands of pods open raw PostgreSQL sessions simultaneously — the classic **thundering herd** after a cold start or deployment scale-up.
+
+On GCP, [Cloud SQL Auth Proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy) (sidecar or standalone) handles TLS and IAM-based login; for AlloyDB, the [AlloyDB Auth Proxy](https://cloud.google.com/alloydb/docs/auth-proxy/overview) plays a similar role. Azure Flexible Server supports private access patterns where connection pooling still typically lives in PgBouncer or application pools, though Hyperscale read replicas benefit from the same centralized pooler architecture.
+
+Hypothetical scenario: an e-commerce API scales from 10 to 200 pods during a flash sale. Each pod's ORM opens 20 connections on startup. Without a proxy, 4,000 connection attempts hit PostgreSQL within seconds — exceeding limits and causing cascading timeouts. A centralized PgBouncer Deployment capped at 150 backend connections, or RDS Proxy with a configured max connections percentage, absorbs the spike while pods wait milliseconds in a queue instead of failing authentication.
+
+```yaml
+# Example: annotate pods to use RDS Proxy endpoint instead of direct RDS hostname
+# Application DATABASE_URL points to the proxy endpoint in the same VPC as EKS.
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: api-database-config
+  namespace: production
+data:
+  DATABASE_HOST: "my-db-proxy.proxy-abc123.us-east-1.rds.amazonaws.com"
+  DATABASE_PORT: "5432"
+  POOL_MODE: "transaction"
+```
+
+When choosing sidecar vs centralized vs managed proxy, consider: sidecars isolate noisy neighbors but multiply pooler memory; centralized poolers maximize multiplexing but become a shared failure domain; managed proxies add cost per hour but handle failover pinning rules and IAM integration that self-managed PgBouncer does not.
+
 ---
 
 ## Credential Rotation
 
-Hardcoded database passwords in Kubernetes Secrets are a ticking time bomb. When you need to rotate them -- and you will -- you face a coordination problem: update the password in the database, update the Secret in Kubernetes, restart every pod that uses it, and do all of this without downtime.
+Hardcoded database passwords in Kubernetes Secrets are a ticking time bomb. When you need to rotate them — and you will — you face a coordination problem. You must update the password in the database, update the Secret in Kubernetes, and restart every pod that uses it. You must do all of this without downtime. Managed rotation plus External Secrets Operator turns that manual runbook into an automated loop. Cloud services remain the source of truth while Kubernetes reflects changes on a refresh interval you control.
 
-### External Secrets Operator (ESO) with Rotation
-
-ESO [syncs secrets from cloud provider secret managers into Kubernetes Secrets automatically](https://github.com/external-secrets/external-secrets).
+**External Secrets Operator (ESO) with rotation.** ESO [syncs secrets from cloud provider secret managers into Kubernetes Secrets automatically](https://github.com/external-secrets/external-secrets), which means your Deployments keep using familiar `secretKeyRef` env vars while the actual credential bytes live in Secrets Manager, Secret Manager, or Key Vault under audit logging and IAM policies.
 
 ```yaml
 apiVersion: external-secrets.io/v1
@@ -359,11 +428,11 @@ spec:
 
 When the secret rotates in Secrets Manager (via an AWS Lambda rotation function or equivalent), ESO picks up the new value within the `refreshInterval` window.
 
+Pair ESO with cloud workload identity so the operator itself never stores long-lived cloud credentials. On EKS, [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) or [Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) binds a Kubernetes ServiceAccount to an IAM role that can read Secrets Manager. On GKE, [Workload Identity Federation](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity) maps KSA → GSA for Secret Manager access. On AKS, [Microsoft Entra Workload ID](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview) achieves the same keyless pattern for Key Vault. The [Secrets Store CSI Driver](https://secrets-store-csi-driver.sigs.k8s.io/) complements ESO. It mounts secrets as volumes for applications that cannot read Kubernetes Secret objects directly.
+
 > **Stop and think**: How does the External Secrets Operator authenticate with AWS Secrets Manager without using hardcoded IAM user keys? (Hint: Think about Kubernetes Service Accounts and IAM OIDC Workload Identity.)
 
-### Dual-User Rotation Strategy
-
-The safest rotation pattern uses two database users, alternating between them:
+**Dual-user rotation strategy.** The safest rotation pattern uses two database users, alternating between them so one credential remains valid while pods roll onto the other during rotation windows — eliminating the race where old pods authenticate with passwords the database has already invalidated.
 
 ```mermaid
 sequenceDiagram
@@ -391,9 +460,9 @@ aws secretsmanager rotate-secret \
   --rotation-rules '{"AutomaticallyAfterDays": 30}'
 ```
 
-### Triggering Pod Restarts on Secret Change
+**Triggering pod restarts on secret change.** Kubernetes does not remount Secrets into running containers when the Secret object updates — a behavior that surprises teams the first time ESO syncs a new password while pods continue using stale env vars until restarted.
 
-Use Reloader or stakater/Reloader to [automatically trigger rolling restarts](https://github.com/stakater/Reloader):
+Use [stakater/Reloader](https://github.com/stakater/Reloader) to automatically trigger rolling restarts:
 
 ```yaml
 apiVersion: apps/v1
@@ -410,11 +479,9 @@ spec:
 
 ## Schema Migrations in GitOps
 
-Running `ALTER TABLE` in production is nerve-wracking enough. Doing it automatically through a GitOps pipeline requires careful design to avoid breaking running applications.
+Running `ALTER TABLE` in production is nerve-wracking enough. Doing it automatically through a GitOps pipeline requires careful design. You must avoid breaking running applications during rollouts. Kubernetes intentionally runs old and new code simultaneously. That is the exact condition that makes breaking DDL dangerous if you treat schema and binary as one atomic change.
 
-### The Expand-Contract Pattern
-
-Avoid making breaking schema changes in a single step. Instead:
+**The expand-contract pattern.** Avoid making breaking schema changes in a single step; instead, treat schema evolution like API versioning where multiple contract versions must coexist for the duration of a Deployment rollout.
 
 ```mermaid
 flowchart LR
@@ -428,7 +495,7 @@ flowchart LR
 | **2: MIGRATE** | `[ id | name | email ]`<br>*(Backfill script populates email)* | App v2: Writes both<br>Reads `[email]` |
 | **3: CONTRACT**| `[ id | email ]`<br>*(name column dropped)* | App v3: Writes `[email]` |
 
-### Kubernetes Job for Migrations
+**Kubernetes Job for migrations.** A dedicated Job — not an initContainer — guarantees exactly one migration attempt per sync wave regardless of how many replicas your Deployment scales to during a load test gone wrong.
 
 > **Stop and think**: Why is it dangerous to run database migrations as an `initContainer` within your application Deployment? Consider what happens when a Deployment horizontally scales from 2 to 10 replicas during an unexpected load spike.
 
@@ -463,9 +530,9 @@ spec:
       serviceAccountName: db-migrator
 ```
 
-The [`argocd.argoproj.io/hook: PreSync` annotation tells Argo CD to run this Job before deploying new application pods](https://argo-cd.readthedocs.io/en/latest/user-guide/sync-waves/). The migration runs, the schema updates, then the new application version rolls out.
+The [`argocd.argoproj.io/hook: PreSync` annotation tells Argo CD to run this Job before deploying new application pods](https://argo-cd.readthedocs.io/en/latest/user-guide/sync-waves/). The migration runs, the schema updates, then the new application version rolls out — preserving the invariant that the database schema is always compatible with the next wave of pods about to start.
 
-### Migration Safety Checklist
+**Migration safety checklist.** These rules apply equally whether the database runs under RDS, Cloud SQL, or an in-cluster operator; GitOps does not remove the need for lock timeouts and backward-compatible DDL.
 
 | Rule | Reason |
 |------|--------|
@@ -476,19 +543,36 @@ The [`argocd.argoproj.io/hook: PreSync` annotation tells Argo CD to run this Job
 | Test rollback before applying | `migrate down` should work for the rollback path you expect to use |
 
 ```sql
--- Safe migration example with timeout and lock
+-- Safe migration example: timeouts apply to ALTER TABLE, not index builds
 SET lock_timeout = '5s';
 SET statement_timeout = '30s';
 
 ALTER TABLE orders ADD COLUMN shipping_method VARCHAR(50) DEFAULT 'standard';
+```
+
+Run `CREATE INDEX CONCURRENTLY` as its own statement **outside** the `statement_timeout` scope above — concurrent index builds routinely exceed 30s and would be aborted, and `CONCURRENTLY` cannot run inside a transaction block.
+
+```sql
 CREATE INDEX CONCURRENTLY idx_orders_shipping ON orders(shipping_method);
 ```
 
 ---
 
-## High Availability and Read Replicas
+## High Availability, Disaster Recovery, and Read Replicas
 
-### Multi-AZ Architecture
+Understanding HA primitives precisely prevents expensive mistakes. Multi-AZ is about synchronous durability and automatic failover within a region. Read replicas scale reads asynchronously. Global or geo features address regional DR and latency. These capabilities are complementary, not interchangeable. Kubernetes does not heal applications that cache DNS forever. It also does not fix clients that open connections without TCP keepalive probes. HA design must include client retry semantics and observability, not just a checkbox on the RDS console.
+
+**Multi-AZ vs read replicas vs global topologies.** Teams frequently conflate these features because all three appear under "high availability" marketing pages, yet each solves a different failure mode with different RPO/RTO and billing implications.
+
+**Multi-AZ (same region):** AWS RDS Multi-AZ maintains a synchronous standby; writes commit on the primary before acknowledgment, and failover promotes the standby with an endpoint DNS update. GCP Cloud SQL **regional** instances keep a standby in another zone. Azure Flexible Server **zone-redundant HA** places primary and standby in different zones. RPO for these patterns is effectively zero for uncommitted transactions already acknowledged, and RTO is typically one to two minutes — but application connection pools must retry through DNS TTL caching (see Quiz question 4).
+
+**Read replicas (async):** Replicas lag the primary by seconds (or more under load). They scale read traffic and can serve DR after promotion, but they are not automatic failover targets unless you configure tools or runbooks. AWS RDS read replica endpoints (`-ro` suffix on cluster endpoints for Aurora), Cloud SQL read replicas, and Azure geo-replicas each expose separate hostnames — map them to `db-read` Services in Kubernetes.
+
+**Cross-region global:** [Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) replicates to up to 10 secondary regions with sub-second typical lag; [Cloud SQL cross-region replicas](https://cloud.google.com/sql/docs/postgres/replication/cross-region-replicas) support migration and DR; [Azure Flexible Server geo-replication](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-read-replicas-geo) provides read-only secondaries in paired regions. Regional loss requires explicit failover/switchover — test these runbooks quarterly with game days that measure how long your Kubernetes Deployments take to resume writes after DNS and connection pool drains complete.
+
+**Backups, PITR, and snapshots.** Automated backups plus PITR let you rewind to a timestamp before a bad migration — essential when a PreSync Job applies the wrong DDL. RDS and Cloud SQL retain backup windows and transaction logs; Azure Flexible Server offers PITR with configurable retention. Snapshots are user-initiated full copies for long-lived baselines or cross-account cloning. Backup storage often accrues cost separately from instance compute — verify retention policies so seven-year compliance requirements do not silently triple your storage bill while old snapshots linger after cluster teardown.
+
+**Multi-AZ architecture comparison.** The table below summarizes failover behavior differences that directly affect how you configure Kubernetes Services and application retry logic.
 
 All three clouds support Multi-AZ deployments for managed databases. The failover mechanics differ:
 
@@ -499,9 +583,7 @@ All three clouds support Multi-AZ deployments for managed databases. The failove
 | Cross-region | Separate feature (Read Replicas) | [Cross-region replicas](https://cloud.google.com/sql/docs/postgres/replication/cross-region-replicas) | [Geo-replication](https://learn.microsoft.com/en-us/azure/postgresql/flexible-server/concepts-read-replicas-geo) |
 | Endpoint changes on failover | No (DNS CNAME updated) | No (IP stays same) | No (DNS updated) |
 
-### Read Replica Routing in Kubernetes
-
-Create separate Services for read and write traffic:
+**Read replica routing in Kubernetes.** Create separate Services for read and write traffic so your application layer can enforce consistency rules in code rather than hoping a single DSN magically routes SELECTs to replicas without lag awareness.
 
 ```yaml
 # Write endpoint (primary)
@@ -525,7 +607,7 @@ spec:
   externalName: app-postgres-ro.abc123.us-east-1.rds.amazonaws.com
 ```
 
-Your application then uses two connection strings:
+Your application then uses two connection strings. The write Service targets the primary endpoint. The read Service targets replica endpoints when lag is acceptable.
 
 ```python
 # Application configuration
@@ -533,9 +615,9 @@ WRITE_DB = "postgresql://user:pass@db-write.production.svc:5432/appdb"
 READ_DB = "postgresql://user:pass@db-read.production.svc:5432/appdb"
 ```
 
-### Cross-AZ Traffic Costs
+Instrument replica lag before trusting read Services for user-facing queries. CloudWatch `ReplicaLag`, Cloud SQL replication status metrics, and Azure `pg_stat_replication` views can gate read routing. Disable read routing when lag exceeds your business tolerance — often one to five seconds for dashboards, zero for account balances.
 
-This catches many teams off guard. Cross-AZ data transfer costs money on every cloud:
+**Cross-AZ traffic costs.** This catches many teams off guard because intra-region traffic feels "local" until the finance dashboard shows bilateral per-GB charges on a chatty ORM.
 
 - **AWS**: [$0.01/GB per direction between AZs](https://aws.amazon.com/blogs/networking-and-content-delivery/optimizing-data-transfer-costs-when-using-aws-network-load-balancer/)
 - **GCP**: [$0.01/GB between zones in the same region](https://cloud.google.com/vpc/pricing)
@@ -551,15 +633,125 @@ If your application in AZ-a talks to a database in AZ-b, every query and respons
 
 ---
 
+## Kubernetes Integration: Managed Services vs In-Cluster Operators
+
+Running PostgreSQL inside the cluster with [CloudNativePG](https://cloudnative-pg.io/) or the [Zalando Postgres operator](https://github.com/zalando/postgres-operator) gives you GitOps-native manifests, custom extensions, and no per-vCPU cloud markup — but you inherit backup scheduling, failover testing, storage class tuning, and version upgrades. Managed databases invert that trade: higher monthly cost, lower operational surface area.
+
+Use managed when: your team lacks dedicated DBA capacity, compliance requires vendor-backed SLAs, you need cross-region HA without building it, or connection limits and patching cadence must be someone else's job. Use in-cluster operators when: you need specific extensions (PostGIS custom builds, logical decoding for CDC you control), air-gapped environments prohibit managed endpoints, or unit economics at sustained high throughput favor owned hardware over per-hour RDS charges.
+
+Access patterns from pods should always prefer private networking plus workload identity. Static username/password Secrets in etcd are acceptable for labs; production paths flow through External Secrets Operator syncing from Secrets Manager / Secret Manager / Key Vault, with database IAM authentication where supported (RDS IAM auth, Cloud SQL IAM login). NetworkPolicies restricting egress to database CIDRs and security groups allowing only node/pod CIDRs complete the zero-trust picture — the database never accepts `0.0.0.0/0`.
+
+For schema and data migrations, treat the managed endpoint like any external dependency: Jobs with PreSync hooks, expand-contract DDL, and advisory locks. Operators running inside the cluster do not remove migration discipline; they only colocate the process.
+
+---
+
+## Cost Lens for Managed Databases
+
+Managed database bills combine compute shape, storage, I/O, replication, backup retention, and network egress. Kubernetes autoscaling can amplify those charges if every new pod opens uncapped connections or runs chatty cross-AZ queries. Right-size from metrics, not from peak load-test fantasies.
+
+**Compute pricing models:** Provisioned instances (RDS `db.r6g.large`, Cloud SQL custom tier, Azure vCore) charge hourly whether or not queries run — simple to forecast but easy to over-provision "just in case." Serverless or autoscaling options ([Aurora Serverless v2 ACUs](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.how-it-works.html), DynamoDB on-demand, Cosmos DB serverless) shift cost toward usage but can spike during traffic bursts if minimum capacity floors are set too high. Right-size by observing CPU, freeable memory, and connection counts over a full business cycle, not just load-test peaks.
+
+**Storage and IOPS:** General-purpose SSD (gp3 on RDS, SSD on Cloud SQL) suits most OLTP; provisioned IOPS tiers matter when random write latency dominates. Storage grows monotonically unless you archive — autopilot/auto-increase features prevent fullness outages but not budget surprises. Cross-AZ synchronous replication (Multi-AZ) duplicates write I/O internally; you pay compute for the standby but not double storage in all engines — verify your provider's billing FAQ.
+
+**Replication and DR surcharges:** Read replicas bill as additional instances; cross-region replication adds inter-region egress (often ~$0.02/GB on AWS between regions — verify current rates). Aurora Global Database and Cosmos DB multi-region writes trade dollars for RTO/RPO improvements. Keep DR replicas in the minimum regions compliance requires, not "every region we might expand to someday."
+
+**Backup and PITR storage:** Retained automated backups and manual snapshots persist after instance deletion unless lifecycle policies delete them — a common source of orphaned charges after tearing down lab clusters.
+
+**Kubernetes-specific cost amplifiers:** Cross-AZ query chatter (quantified earlier), connection storms forcing larger instance sizes, and idle Dev clusters left running Multi-AZ production tiers over weekends. Mitigations: topology-aware routing, pooling/proxy layers, scheduled scale-down for non-prod namespaces, and separate smaller instances for preview environments.
+
+| Cost driver | What spikes the bill | Mitigation |
+|-------------|---------------------|------------|
+| Over-provisioned instance class | Always-on headroom "for peak" | Use autoscaling/serverless tiers; right-size from metrics |
+| Uncapped pod connections | ORM default pool × replica count | PgBouncer, RDS Proxy, lower per-pod pool sizes |
+| Cross-AZ / cross-region traffic | Pods and DB in different zones/regions | Co-locate or use regional endpoints + replicas |
+| Long backup retention | Compliance defaults on all envs | Tier retention: 7 days non-prod, 35+ prod |
+| Idle Multi-AZ standby | Dev databases with production HA | Single-AZ for dev; Multi-AZ only where RTO demands |
+
+---
+
+## Patterns & Anti-Patterns
+
+Production teams that integrate Kubernetes with managed databases converge on a small set of patterns — and repeat the same anti-patterns during their first migration.
+
+| Pattern | When to Use | Why It Works | Scaling Consideration |
+|---------|-------------|--------------|------------------------|
+| ExternalName / headless Service indirection | Any managed DB accessed from many Deployments | Swap endpoints without redeploying every microservice | Document DNS TTL behavior during failover drills |
+| Centralized PgBouncer or RDS Proxy | >20 pod replicas or serverless burst traffic | Multiplexes thousands of client sessions onto tens of DB connections | Run pooler replicas with topology spread across zones |
+| Dual-user rotation with ESO + Reloader | Compliance-mandated password rotation | Old and new credentials valid during rolling restart | Automate rotation Lambda / cloud-native rotators |
+| Expand-contract migrations via PreSync Job | GitOps-deployed schema changes | Old and new app versions coexist during rollout | Never retry failed migrations automatically (`backoffLimit: 0`) |
+| Read/write Service split | Read-heavy APIs with async replicas | Offloads SELECT traffic from primary | Monitor replica lag before routing critical reads |
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| Public database IP "temporarily" for debugging | Credential stuffing, data exfiltration | `kubectl port-forward` through a bastion pod; private IP only |
+| One giant shared database for all microservices | Blast radius, noisy neighbor schema locks | Database per bounded context; shared only when truly coupled |
+| ORM pool size × replica count without math | Hits `max_connections`, sudden outages | Calculate max backend connections; enforce via proxy |
+| Running migrations in app startup / initContainer | N replicas ⇒ N concurrent DDL attempts | Single PreSync Job with advisory locks |
+| Treating read replica as strongly consistent | Stale reads, double-spend bugs | Route only latency-tolerant reads; use primary for auth/billing |
+| Choosing Cosmos conflict policy after launch | Immutable policy locks wrong merge semantics | Design active-active conflict handling at container creation |
+| Skipping failover drills | Multi-AZ confidence without measured RTO | Quarterly forced failover tests with connection retry metrics |
+
+---
+
+## Decision Framework
+
+Choosing a managed database is a requirements exercise, not a brand loyalty exercise. Start from access patterns, consistency needs, and operational capacity — then map to engine and cloud.
+
+```mermaid
+flowchart TD
+    Start[New data store for K8s workload] --> ACID{Need multi-row ACID transactions?}
+    ACID -- Yes --> SQL{Scale beyond single primary?}
+    SQL -- No --> Relational[RDS / Cloud SQL / Flexible Server]
+    SQL -- Yes --> Global{Global low-latency writes?}
+    Global -- Yes --> SpannerOrCosmos[Spanner or Cosmos DB strong/multi-master]
+    Global -- No --> AuroraOrHyperscale[Aurora / Hyperscale / read replicas]
+    ACID -- No --> Access{Primary access pattern?}
+    Access -- Key-value / session --> KV[DynamoDB / Cosmos DB / Firestore]
+    Access -- Wide-column throughput --> Wide[Bigtable / Cassandra API]
+    Access -- Cache --> CacheModule[Module 9.5: ElastiCache / Memorystore]
+    Relational --> K8sIntegrate[Private VPC + pooler + ESO + workload identity]
+    KV --> K8sIntegrate
+```
+
+| Requirement | Prefer | Avoid |
+|-------------|--------|-------|
+| Complex joins + FK constraints | PostgreSQL-compatible managed (RDS, Cloud SQL, Flexible Server) | DynamoDB without denormalization plan |
+| Global external consistency | Cloud Spanner | Single-region RDS with app-level sync |
+| Active-active multi-region writes | Cosmos DB multi-region / DynamoDB global tables | Standard async read replica as write target |
+| Minimal ops, moderate scale | Managed relational + RDS Proxy/PgBouncer | Self-managed StatefulSet without DBA team |
+| Strict air-gap / custom extensions | In-cluster operator (CloudNativePG) | Public managed endpoint dependency |
+| Unpredictable spikey traffic | Aurora Serverless v2 / DynamoDB on-demand | Oversized fixed instance running 24/7 |
+| Existing Microsoft stack + .NET ORM | Azure SQL Hyperscale / Flexible Server | Forcing cross-cloud egress to AWS |
+
+Before committing, prototype three measurements from a representative Kubernetes Deployment. Measure p95 query latency through private networking. Count connections at max replica count. Estimate monthly cost at 50%, 100%, and 150% of expected load. If the prototype cannot survive a simulated AZ failover within your RTO target, fix networking and pool retry logic before production traffic — not during an outage.
+
+---
+
+## Observability and Resilience from Kubernetes
+
+Connecting pods to a managed database is only half the integration. The other half is knowing when connections fail silently, when replica lag makes your read Service lie, and when pool exhaustion precedes user-visible errors. Treat database connectivity as a first-class SLO alongside HTTP latency. Kubernetes control plane health can look green while every pod logs `FATAL: too many connections`.
+
+**Metrics that matter.** Export application-level database pool stats (active, idle, waiting clients) via Prometheus client libraries or sidecar exporters. Complement them with cloud metrics: RDS `DatabaseConnections`, `CPUUtilization`, and `FreeableMemory`; Cloud SQL `database/network/connections`; Azure Flexible Server `connections_failed` and `cpu_percent`. Alert on connection count approaching `max_connections` × 0.8, not at 100%. Recovery requires draining pools while traffic continues. Track PgBouncer `cl_waiting` or RDS Proxy queued client metrics to catch thundering herds during rollouts.
+
+**Logs and traces.** Enable slow query logs on the managed instance with thresholds aligned to your p95 SLO (often 200–500 ms for OLTP). Correlate Kubernetes pod names in application logs using the downward API `metadata.name` field. That helps trace which Deployment version issued expensive queries. OpenTelemetry database spans should include `db.system`, `server.address`, and pool wait time — not just statement text. On-call engineers can then distinguish network blips from missing indexes.
+
+**Failover testing from pods.** Schedule quarterly tests that run inside the cluster. A Job executes `aws rds reboot-db-instance --force-failover` (or cloud equivalent). A concurrent Deployment hammers the database Service with retry-enabled clients. Measure time-to-recovery at the application layer, not just RDS console "available" status. Configure connection pools with `maxLifetime` and `idleTimeout` shorter than typical DNS TTL mismatches. Stale connections recycle after Multi-AZ promotion.
+
+**NetworkPolicy and egress observability.** Even private databases benefit from explicit NetworkPolicies allowing egress only to database CIDRs and DNS. VPC Flow Logs on AWS and GCP, plus NSG flow logs on Azure, reveal unexpected cross-AZ chatter before the finance team does. When flow logs show pod CIDRs talking to database subnets on high port counts, you likely have connection leaks. ORMs that skip pool drain on SIGTERM during short preStop hooks are a common culprit.
+
+Hypothetical scenario: monitoring shows HTTP 200 responses but checkout success rate drops 3%. Database CPU is flat, yet RDS `DatabaseConnections` stair-steps upward each time HPA adds pods. Root cause: each new pod opens 30 connections on startup without a pooler. preStop does not drain the pool before SIGKILL. Fix: centralized PgBouncer with `terminationGracePeriodSeconds` aligned to pool drain time. Add HPA stabilization windows so connection count ramps smoothly instead of in spikes. Export a Grafana panel that overlays pod replica count and active DB connections. That makes this failure mode obvious before customers notice checkout errors.
+
+---
+
 ## Did You Know?
 
-1. **Amazon RDS operates at very large fleet scale**, which is one reason managed databases can absorb operational work that would otherwise fall on platform teams.
+1. **[Amazon Aurora Global Database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) supports up to 10 secondary read-only clusters in different AWS Regions**, with dedicated replication infrastructure that typically keeps lag under one second — enabling regional DR without rebuilding your Kubernetes manifests per region.
 
-2. **PostgreSQL connection capacity is constrained by server memory and per-connection process overhead**, so practical limits are often lower than the largest `max_connections` value you can configure.
+2. **PostgreSQL connection capacity is constrained by server memory and per-connection process overhead**, so practical limits are often lower than the largest `max_connections` value you can configure — which is why RDS documents connection limits per instance class and recommends proxies for serverless-style burst clients.
 
-3. **Cloud SQL now offers newer private connectivity patterns for multi-network topologies**, while older private-IP approaches had routing limitations that mattered in hub-and-spoke designs.
+3. **[Cloud Spanner's external consistency](https://cloud.google.com/spanner/docs/true-time-external-consistency) uses TrueTime to order transactions globally**, so a read after a committed write never observes a state where the write "hasn't happened yet" — stronger than default eventual consistency in many globally distributed stores.
 
-4. **Schema migrations are a common source of production risk**, especially when they take heavyweight locks or assume a deployment can change application code and database shape at the same instant.
+4. **Azure Cosmos DB conflict resolution policy cannot be changed after container creation**, so multi-region active-active Kubernetes workloads must choose last-writer-wins or custom merge logic at design time — not after discovering duplicate-key production incidents.
 
 ---
 
@@ -626,11 +818,15 @@ The downtime occurs because there is an unavoidable race condition: old pods sti
 
 ## Hands-On Exercise: Connect Kind Cluster to Local PostgreSQL
 
-Since managed databases require cloud accounts, we will simulate the architecture locally using Docker and kind.
+Since managed databases require cloud accounts, this exercise simulates the architecture locally using Docker and kind. You will practice the same patterns production uses — headless Services, centralized PgBouncer, migration Jobs, read/write endpoint split, and credential rotation — without provisioning RDS or Cloud SQL. Complete all six tasks in order; each builds on the previous networking and pooling setup.
+
+**Task 1 — Create an ExternalName Service.** Your first objective is to create a Kubernetes Service that points to the PostgreSQL container. Because ExternalName requires a DNS hostname rather than a raw IP, the lab uses a headless Service with manually maintained Endpoints — the same indirection pattern you use when wrapping RDS endpoints behind in-cluster DNS.
 
 ### Setup
 
 ```bash
+alias k=kubectl
+
 # Create a Docker network shared between kind and PostgreSQL
 docker network create db-lab
 
@@ -666,12 +862,8 @@ PG_IP=$(docker inspect lab-postgres \
 echo "PostgreSQL IP: $PG_IP"
 ```
 
-### Task 1: Create an ExternalName Service
-
-Create a Service that points to the PostgreSQL container.
-
 <details>
-<summary>Solution</summary>
+<summary>Task 1 Solution</summary>
 
 Since ExternalName requires a DNS name (not an IP), use a headless Service with Endpoints:
 
@@ -700,17 +892,15 @@ subsets:
 ```
 
 ```bash
-# Apply (replace PG_IP with actual value)
+# Save the YAML above as /tmp/db-service.yaml, then apply (replace PG_IP with actual value)
 sed "s/\${PG_IP}/$PG_IP/" /tmp/db-service.yaml | k apply -f -
 ```
 </details>
 
-### Task 2: Deploy PgBouncer as a Centralized Proxy
-
-Deploy a PgBouncer Deployment with 2 replicas and a ClusterIP Service.
+**Task 2 — Deploy PgBouncer as a centralized proxy.** Deploy a PgBouncer Deployment with two replicas and a ClusterIP Service in front of it. Centralized pooling mirrors the production pattern where platform teams operate shared database infrastructure while application teams consume a stable cluster DNS name.
 
 <details>
-<summary>Solution</summary>
+<summary>Task 2 Solution</summary>
 
 ```yaml
 apiVersion: v1
@@ -737,7 +927,7 @@ spec:
     spec:
       containers:
         - name: pgbouncer
-          image: bitnami/pgbouncer:1.23.0
+          image: bitnamilegacy/pgbouncer:1.23.0
           ports:
             - containerPort: 6432
           env:
@@ -785,12 +975,10 @@ k wait --for=condition=ready pod -l app=pgbouncer --timeout=60s
 ```
 </details>
 
-### Task 3: Test Connectivity Through PgBouncer
-
-Run a test pod that connects through PgBouncer and creates a table.
+**Task 3 — Test connectivity through PgBouncer.** Run a test pod that connects through PgBouncer and creates a table. Verify that the pooler forwards authentication to PostgreSQL and that connection counts on the database stay low even when multiple clients connect through the proxy Service.
 
 <details>
-<summary>Solution</summary>
+<summary>Task 3 Solution</summary>
 
 ```bash
 k run db-test --rm -it --image=postgres:16 --restart=Never -- \
@@ -801,12 +989,10 @@ k run db-test --rm -it --image=postgres:16 --restart=Never -- \
 ```
 </details>
 
-### Task 4: Simulate a Schema Migration Job
-
-Create a Kubernetes Job that runs a migration script.
+**Task 4 — Simulate a schema migration Job.** Create a Kubernetes Job that runs a migration script with `backoffLimit: 0`, matching the GitOps PreSync pattern from earlier in this module. The Job should create schema objects idempotently where possible so repeated lab runs do not fail on `already exists` errors.
 
 <details>
-<summary>Solution</summary>
+<summary>Task 4 Solution</summary>
 
 ```yaml
 apiVersion: batch/v1
@@ -847,12 +1033,10 @@ k logs job/migration-v1
 ```
 </details>
 
-### Task 5: Verify Read/Write Split
-
-Create a second endpoint Service simulating a read replica and test routing.
+**Task 5 — Verify read/write split.** Create a second endpoint Service simulating a read replica and test routing. In production this maps to separate `db-read` and `db-write` Services backed by different managed endpoints; here both point at the same PostgreSQL instance so you focus on DNS wiring rather than replication lag.
 
 <details>
-<summary>Solution</summary>
+<summary>Task 5 Solution</summary>
 
 ```bash
 # Create read-only Service (same PostgreSQL in this lab, but separate Service)
@@ -887,12 +1071,10 @@ k run read-test --rm -it --image=postgres:16 --restart=Never -- \
 ```
 </details>
 
-### Task 6: Simulate Credential Rotation
-
-Implement a manual credential rotation to see how workloads behave when secrets change.
+**Task 6 — Simulate credential rotation.** Implement a manual credential rotation to observe how workloads behave when Secrets change. Kubernetes does not hot-reload Secret env vars; you will see why Reloader or explicit rollouts are mandatory in production rotation runbooks.
 
 <details>
-<summary>Solution</summary>
+<summary>Task 6 Solution</summary>
 
 ```bash
 # 1. Create a dummy Deployment using the secret
@@ -960,7 +1142,9 @@ docker network rm db-lab
 
 ---
 
-**Next Module**: [Module 9.2: Managed Message Brokers & Event-Driven Kubernetes](../module-9.2-message-brokers/) -- Learn how to integrate SQS, Pub/Sub, and Service Bus with Kubernetes workloads, and use KEDA to autoscale consumers based on queue depth.
+## Next Module
+
+[Module 9.2: Managed Message Brokers & Event-Driven Kubernetes](../module-9.2-message-brokers/) — Learn how to integrate SQS, Pub/Sub, and Service Bus with Kubernetes workloads, and use KEDA to autoscale consumers based on queue depth.
 
 ## Sources
 
@@ -980,3 +1164,13 @@ docker network rm db-lab
 - [docs.aws.amazon.com: reboot db instance.html](https://docs.aws.amazon.com/cli/v1/reference/rds/reboot-db-instance.html) — The AWS CLI command reference explicitly documents the `--force-failover` option.
 - [Service | Kubernetes](https://kubernetes.io/docs/concepts/services-networking/service/) — Explains `ExternalName`, headless Services, and the DNS behavior the module relies on for stable database hostnames.
 - [Learn about using private IP | Cloud SQL](https://cloud.google.com/sql/docs/sqlserver/private-ip) — Clarifies Cloud SQL private IP connectivity and helps separate private services access from Private Service Connect.
+- [docs.aws.amazon.com: Aurora Serverless v2](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-serverless-v2.html) — Documents ACU-based autoscaling for Aurora Serverless v2.
+- [docs.aws.amazon.com: aurora global database](https://docs.aws.amazon.com/AmazonRDS/latest/AuroraUserGuide/aurora-global-database.html) — Defines Global Database topology, secondary region limits, and failover/switchover semantics.
+- [cloud.google.com: spanner true-time external consistency](https://cloud.google.com/spanner/docs/true-time-external-consistency) — Explains TrueTime and external consistency guarantees for global transactions.
+- [learn.microsoft.com: cosmos db consistency levels](https://learn.microsoft.com/en-us/azure/cosmos-db/consistency-levels) — Lists the five consistency levels and their latency/availability tradeoffs.
+- [learn.microsoft.com: cosmos db conflict resolution policies](https://learn.microsoft.com/en-us/azure/cosmos-db/conflict-resolution-policies) — States that conflict resolution policy is set at container creation and cannot be changed later.
+- [docs.aws.amazon.com: rds proxy](https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/rds-proxy.html) — Describes connection pooling, failover preservation, and IAM authentication for RDS Proxy.
+- [docs.aws.amazon.com: dynamodb global tables](https://docs.aws.amazon.com/amazondynamodb/latest/developerguide/GlobalTables.html) — Documents multi-region replication behavior for DynamoDB global tables.
+- [cloud.google.com: alloydb overview](https://cloud.google.com/alloydb/docs/overview) — Summarizes AlloyDB architecture and PostgreSQL compatibility positioning.
+- [learn.microsoft.com: azure sql hyperscale](https://learn.microsoft.com/en-us/azure/azure-sql/database/service-tier-hyperscale) — Explains Hyperscale tier storage/compute separation and read scale-out.
+- [cloudnative-pg.io](https://cloudnative-pg.io/) — Reference for the CloudNativePG operator when comparing in-cluster PostgreSQL to managed services.

--- a/src/content/docs/cloud/managed-services/module-9.10-analytics.md
+++ b/src/content/docs/cloud/managed-services/module-9.10-analytics.md
@@ -19,13 +19,44 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-In May 2024, a ride-sharing company processed 8 million trips per day. Their analytics pipeline was a tangle of CronJobs running on EKS: Python scripts that extracted data from PostgreSQL, transformed it in memory, and loaded it into BigQuery. Each CronJob ran on a dedicated pod with 16 GB of RAM to handle the largest tables. The pipeline consumed 12 always-on pods -- $6,800/month in compute -- and took 4 hours to complete the daily ETL. When a single CronJob failed (out-of-memory on a growing table), downstream analysts discovered the data gap 6 hours later when their dashboards showed zeros.
+Hypothetical scenario: a mobility platform processes millions of trips per day. Its analytics pipeline is a tangle of CronJobs on EKS: Python scripts extract data from PostgreSQL, transform it in memory, and load it into a managed warehouse. Each CronJob runs on a dedicated pod with 16 GB of RAM to handle the largest tables. The pipeline keeps twelve always-on pods even though the daily ETL window lasts only four hours, and a single out-of-memory failure on a growing table can leave analysts staring at empty dashboards hours later because nobody noticed the upstream gap.
 
 > **Stop and think**: If a CronJob is only running for 4 hours a day, why was the company paying for 12 always-on pods? What Kubernetes architectural choice leads to this?
 
 The data engineering team rebuilt the pipeline with Apache Airflow on Kubernetes. Airflow orchestrated the workflow as a DAG (Directed Acyclic Graph), with each task running as an ephemeral KubernetesPodOperator. Tasks requested only the resources they needed. The BigQuery load step used BigQuery's native LOAD command instead of streaming inserts, cutting costs by 90%. Ephemeral pods meant compute cost dropped to $1,200/month (pods only existed during the 4-hour window). Airflow's built-in retry logic and alerting caught failures within minutes. Same data, 82% less cost, faster incident detection.
 
-This module teaches you how to connect Kubernetes workloads to managed data warehouses (BigQuery, Redshift, Snowflake), orchestrate data pipelines with Airflow on Kubernetes, use ephemeral compute for analytics jobs, manage IAM for data access, and control costs in analytics workloads.
+Modern analytics is not a single product choice. Teams must decide whether they need a **data warehouse** for curated SQL, a **data lake** for cheap raw storage, or a **lakehouse** that adds ACID tables on object storage. They must choose between **serverless scan pricing** ([Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/pricing.html), [BigQuery on-demand](https://cloud.google.com/bigquery/pricing)) and **provisioned cluster hours** ([Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-usage-limits.html), [Azure Synapse dedicated pools](https://learn.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-overview-what-is)). Kubernetes sits in the middle as the orchestration plane: Airflow schedules ephemeral pods, Spark on Kubernetes transforms lake files, and workload identity connects pods to cloud warehouses without long-lived credentials.
+
+This module teaches you how to connect Kubernetes workloads to managed analytics platforms across AWS, GCP, and Azure; orchestrate ingest-to-BI pipelines; choose between warehouse, lake, and lakehouse patterns; and control the cost knobs that make analytics bills spike.
+
+---
+
+## Analytics Landscape: Warehouse, Lake, and Lakehouse
+
+Analytics workloads differ from transactional ones in almost every dimension that matters for architecture. **OLTP** (Online Transaction Processing) systems such as PostgreSQL, Cloud SQL, or Azure SQL optimize for short reads and writes on narrow rows: place an order, update inventory, authenticate a user. **OLAP** (Online Analytical Processing) systems optimize for scans and aggregations across billions of rows: revenue by region, funnel conversion, fraud pattern detection. Running heavy OLAP queries against your production OLTP database is one of the fastest ways to cause an outage, which is why mature teams **extract** operational data and **load** it into systems built for analytics.
+
+Three storage patterns dominate cloud analytics today, and each solves a different part of the problem. A **data warehouse** stores curated, schema-on-write tables optimized for SQL. Examples include [Amazon Redshift](https://docs.aws.amazon.com/redshift/latest/dg/welcome.html), [Google BigQuery](https://cloud.google.com/bigquery/docs/introduction), and [Azure Synapse dedicated SQL pools](https://learn.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-overview-what-is). A **data lake** stores raw or semi-structured files cheaply in object storage — [Amazon S3](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html), [Google Cloud Storage](https://cloud.google.com/storage/docs/introduction), or [Azure Data Lake Storage](https://learn.microsoft.com/en-us/azure/storage/blobs/data-lake-storage-introduction) — with schema applied at query time. A **lakehouse** adds open table formats such as [Apache Iceberg](https://iceberg.apache.org/docs/latest/), [Delta Lake](https://docs.delta.io/latest/index.html), or [Apache Hudi](https://hudi.apache.org/docs/overview) on top of the lake, giving you ACID transactions, time travel, and partition evolution without giving up cheap object storage.
+
+The processing model splits along another axis: **batch** versus **streaming**. Batch pipelines land daily or hourly files and rebuild aggregates overnight. Streaming pipelines consume events from [Amazon Kinesis](https://docs.aws.amazon.com/streams/latest/dev/introduction.html), [Google Pub/Sub](https://cloud.google.com/pubsub/docs/overview), or [Azure Event Hubs](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-about) and update metrics in near real time. Kubernetes is excellent at both: CronJobs and Airflow DAGs for batch, consumer Deployments with [KEDA](https://keda.sh/docs/latest/) scalers for streaming backpressure.
+
+Columnar file formats are the hidden performance lever behind almost every modern analytics stack. **Parquet** and **ORC** store values column-by-column rather than row-by-row, which means a query for `SUM(revenue)` reads only the revenue column instead of every field in every row. Combined with **compression** (Snappy, ZSTD, or GZIP) and **partitioning** (for example `year=2026/month=06/day=04/`), columnar storage can reduce scanned bytes by 90% or more compared with querying raw JSON in object storage. That reduction matters twice: queries finish faster, and on serverless engines you pay directly for scanned bytes.
+
+```text
+OLTP (production DB)          OLAP (warehouse / lake query)
+─────────────────────          ──────────────────────────────
+Short transactions             Wide scans & aggregations
+Row-oriented storage           Columnar storage (Parquet/ORC)
+Indexed point lookups          Partition pruning + column stats
+Must stay fast for users       Optimized for analyst concurrency
+```
+
+Pause and predict: if two teams store the same 10 TB dataset — one as newline-delimited JSON in a lake and one as partitioned Parquet in a warehouse — which team pays more for a `SELECT date, SUM(revenue)` query on a single day, and why? The JSON lake scan touches every byte of every record; the partitioned Parquet table reads one day's partition and only the `date` and `revenue` columns.
+
+### Compression, Partitioning, and File Layout
+
+Columnar formats achieve their cost advantage through three cooperating mechanisms. **Compression** reduces storage bytes and therefore scan bytes — Parquet with Snappy or ZSTD often shrinks textual CSV by 80% or more depending on column cardinality. **Partitioning** (`year/month/day` hive-style paths or BigQuery ingestion-time partitions) lets query engines skip entire directories when filters match partition keys. **File sizing** matters too: thousands of 1 MB files create metadata overhead and slow listing; compaction jobs (Spark `repartition`, Iceberg `rewrite_data_files`) target 128–512 MB objects as a common rule of thumb.
+
+For Kubernetes writers landing data to object storage, enforce partition paths in application code or Airflow templates (`s3://bucket/trips/dt=2025-11-15/part-000.parquet`) and reject uploads that omit partition keys. Athena and BigQuery external tables inherit layout mistakes instantly — there is no warehouse DBA to fix schema drift later.
 
 ---
 
@@ -33,17 +64,154 @@ This module teaches you how to connect Kubernetes workloads to managed data ware
 
 ### Managed Data Warehouses Compared
 
-| Feature | BigQuery (GCP) | Redshift (AWS) | Snowflake (Multi-cloud) |
-|---------|---------------|----------------|------------------------|
-| Pricing model | Per-query (on-demand) or slots (capacity) | Per-node-hour (provisioned) or Serverless | Per-credit (compute) + per-TB (storage) |
-| Separation of storage/compute | Yes (native) | Serverless only | Yes (native) |
-| Auto-scaling | Yes (on-demand) | Serverless: yes; Provisioned: manual | Yes (multi-cluster warehouse) |
-| K8s integration | Workload Identity, BQ API | IRSA, Redshift Data API | Snowflake Connector for Spark/Python |
-| Streaming ingestion | Storage Write API | Kinesis/MSK integration | Snowpipe |
-| Serverless option | Default (on-demand) | Redshift Serverless | Default |
-| Minimum cost | ~$0 (on-demand, pay per query) | ~$180/month (Serverless minimum) | ~$0 (pay per credit used) |
+| Feature | BigQuery (GCP) | Redshift (AWS) | Synapse Analytics (Azure) | Snowflake (Multi-cloud) |
+|---------|---------------|----------------|---------------------------|------------------------|
+| Pricing model | Per-query (on-demand) or slots (capacity) | Per-node-hour (provisioned) or Serverless RPU-hours | Dedicated SQL pool (DWU) or serverless SQL (per-TB scanned) | Per-credit (compute) + per-TB (storage) |
+| Separation of storage/compute | Yes (native) | Serverless: yes; Provisioned: coupled | Dedicated pools: coupled; Serverless endpoint: yes | Yes (native) |
+| Auto-scaling | Yes (on-demand) | Serverless: yes; Provisioned: manual resize | Serverless SQL autoscales; dedicated pools manual | Yes (multi-cluster warehouse) |
+| K8s integration | Workload Identity, BQ API | IRSA / EKS Pod Identity, Redshift Data API | Entra Workload ID, Synapse REST / ODBC | Snowflake Connector for Spark/Python |
+| Streaming ingestion | Storage Write API | Kinesis / MSK integration | Event Hubs, Spark Structured Streaming | Snowpipe |
+| Serverless option | Default (on-demand) | Redshift Serverless | Serverless SQL pool (built-in) | Default |
+| Minimum cost | ~$0 (on-demand, pay per query) | Serverless has usage-based minimums — verify current pricing | Serverless SQL charges per TB scanned | ~$0 (pay per credit used) |
+
+### Serverless Scan vs Provisioned Cluster Economics
+
+Not every "warehouse" bills the same way, and the pricing model should drive architecture as much as feature checklists. **Serverless scan engines** — [Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/what-is.html) querying S3, BigQuery on-demand, [Synapse serverless SQL](https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/on-demand-workspace-overview) querying ADLS — charge primarily for **data scanned** (or per-TiB processed). They shine for exploratory queries, irregular workloads, and teams that cannot predict nightly concurrency. The downside is unbounded scans: a `SELECT *` over years of unpartitioned JSON can generate a four-figure bill in minutes.
+
+**Provisioned cluster engines** — Redshift provisioned clusters, Synapse dedicated SQL pools, [Amazon EMR](https://docs.aws.amazon.com/emr/latest/ManagementGuide/emr-what-is-emr.html) or [Google Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) Spark clusters — charge for **capacity over time** (node-hours, DWUs, or cluster-hours). They shine when you run hundreds of concurrent dashboards, predictable nightly ETL, or Spark jobs that need local shuffle storage. The downside is idle cost: a cluster left running over a weekend still bills even if nobody queries it.
+
+| Workload shape | Favor serverless scan | Favor provisioned cluster |
+|----------------|----------------------|---------------------------|
+| Ad-hoc analyst SQL, unpredictable volume | Athena, BigQuery on-demand, Synapse serverless | — |
+| 24/7 BI dashboards with steady concurrency | — | Redshift provisioned, Synapse dedicated, BigQuery reservations |
+| Massive Spark transforms on lake files | Athena Spark (verify region availability) or Dataproc/EMR | EMR / Dataproc with autoscaling |
+| Startup with unknown scale | BigQuery on-demand (first 1 TiB/month free per billing account) | Start serverless; move to reserved capacity when spend stabilizes |
+
+At moderate scale — say 5–20 TB of curated analytics data and 50 daily analyst queries — teams often spend **$500–$3,000/month** on compute if they partition well and avoid full scans. The same data with no partitioning, CSV ingestion, and `SELECT *` habits can exceed **$10,000/month** on scan-priced engines. Storage is usually the smaller line item: S3 Standard, GCS Standard, and ADLS Hot tiers run roughly **$0.02–$0.03/GB-month** (verify current regional rates), while egress to the public internet or cross-region replication can exceed storage cost when BI tools pull large extracts outside the cloud region.
+
+### Managed Query and Processing Engines
+
+Beyond the core warehouses, each cloud offers specialized query and processing layers that sit on top of object storage rather than replacing it. Understanding when to query in place versus when to load into a warehouse is one of the highest-leverage architecture decisions in a data platform because it determines both latency and which billing meter dominates your monthly invoice.
+
+| Engine | Cloud | Model | Best for |
+|--------|-------|-------|----------|
+| [Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/what-is.html) | AWS | Serverless SQL over S3 via Glue Data Catalog | Ad-hoc lake queries, lightweight ETL |
+| [Redshift Spectrum](https://docs.aws.amazon.com/redshift/latest/dg/c-using-spectrum.html) | AWS | Redshift queries external S3 tables | Federated queries without copying all data into Redshift |
+| [BigQuery](https://cloud.google.com/bigquery/docs/introduction) | GCP | Serverless MPP warehouse + external tables over GCS | Default GCP analytics; federated GCS queries |
+| [Dataproc](https://cloud.google.com/dataproc/docs/concepts/overview) | GCP | Managed Spark/Hive clusters | Large Spark ETL, ML feature pipelines |
+| [Synapse serverless SQL](https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/on-demand-workspace-overview) | Azure | Pay-per-TB SQL over ADLS / Blob | Exploratory SQL without provisioning a pool |
+| [Synapse Spark](https://learn.microsoft.com/en-us/azure/synapse-analytics/spark/apache-spark-overview) | Azure | Managed Spark pools in Synapse workspace | Notebook-driven ETL, Delta Lake processing |
+| [Microsoft Fabric](https://learn.microsoft.com/en-us/fabric/get-started/microsoft-fabric-overview) | Azure | Unified SaaS analytics (OneLake, warehouse, Power BI) | Teams standardized on Microsoft 365 / Power BI |
+| [HDInsight](https://learn.microsoft.com/en-us/azure/hdinsight/hdinsight-overview) | Azure | Managed Hadoop/Spark/Kafka clusters | Legacy Hadoop estates migrating gradually |
+
+[Amazon Redshift Serverless](https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-usage-limits.html) blurs the line: it auto-scales RPU capacity and bills in RPU-hours rather than per scanned terabyte, behaving like a warehouse that wakes up on demand rather than a pure scan engine like Athena.
+
+Choosing between engines is not exclusive. Mature platforms combine them: Athena or Spectrum for ad-hoc lake exploration, a provisioned Redshift or Synapse pool for SLA dashboards, EMR or Dataproc for heavy Spark transforms, and BigQuery reservations when on-demand scan costs exceed ~$10K/month (rule of thumb — model with your actual query logs). The Kubernetes orchestrator sits above all of them, invoking the right API per task without forcing analysts to learn four different schedulers.
+
+---
+
+## The Analytics Pipeline: Ingest to BI
+
+Production analytics is rarely "one database." It is a pipeline of specialized services, and Kubernetes typically orchestrates the middle stages while managed cloud services handle durable storage and query serving.
+
+```mermaid
+graph LR
+    subgraph Ingest
+        A[Kinesis / Firehose<br/>AWS]
+        B[Pub/Sub<br/>GCP]
+        C[Event Hubs<br/>Azure]
+    end
+    subgraph Store
+        D[S3 / GCS / ADLS<br/>Data Lake]
+    end
+    subgraph Catalog
+        E[Glue Data Catalog<br/>AWS]
+        F[Dataplex<br/>GCP]
+        G[Microsoft Purview<br/>Azure]
+    end
+    subgraph Transform
+        H[Glue / EMR<br/>AWS]
+        I[Dataflow / Dataproc<br/>GCP]
+        J[Data Factory / Synapse Pipelines<br/>Azure]
+    end
+    subgraph Query
+        K[Athena / Redshift<br/>AWS]
+        L[BigQuery<br/>GCP]
+        M[Synapse / Fabric<br/>Azure]
+    end
+    subgraph BI
+        N[QuickSight]
+        O[Looker]
+        P[Power BI]
+    end
+    A --> D
+    B --> D
+    C --> D
+    D --> E
+    D --> F
+    D --> G
+    E --> H
+    F --> I
+    G --> J
+    H --> K
+    I --> L
+    J --> M
+    K --> N
+    L --> O
+    M --> P
+```
+
+**Ingest** moves events or files from operational systems into durable storage. [Amazon Kinesis Data Firehose](https://docs.aws.amazon.com/firehose/latest/dev/what-is-this-service.html) can land streaming records directly to S3 in Parquet. [Google Pub/Sub](https://cloud.google.com/pubsub/docs/overview) subscriptions can push to Cloud Storage or trigger Dataflow. [Azure Event Hubs](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-about) integrates with Stream Analytics or Spark on Synapse. Kubernetes producers often emit to these services via sidecars or SDK calls rather than writing directly to the lake, which decouples application uptime from storage write paths.
+
+**Catalog** services register schemas and partition locations so query engines know which S3 prefixes to read. [AWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/catalog-and-crawler.html) backs Athena and Redshift Spectrum. [Google Dataplex](https://cloud.google.com/dataplex/docs) governs lake zones and metadata. [Microsoft Purview](https://learn.microsoft.com/en-us/purview/purview) provides lineage and classification across Azure data assets. Without a catalog, you have a bucket of files; with a catalog, you have discoverable tables.
+
+**Transform** is where ETL or ELT happens. Managed options include [AWS Glue](https://docs.aws.amazon.com/glue/latest/dg/what-is-glue.html), [Google Cloud Dataflow](https://cloud.google.com/dataflow/docs/overview), and [Azure Data Factory](https://learn.microsoft.com/en-us/azure/data-factory/introduction). Many teams also run [dbt](https://docs.getdbt.com/docs/introduction) inside Kubernetes Jobs or Airflow pods to execute version-controlled SQL transforms against the warehouse. The Kubernetes angle: Airflow's KubernetesPodOperator runs each dbt model as an isolated pod with its own memory limit, preventing one heavy model from OOM-killing an entire shared worker.
+
+**Query and BI** expose data to humans. [Amazon QuickSight](https://docs.aws.amazon.com/quicksight/latest/user/welcome.html), [Looker](https://cloud.google.com/looker/docs), and [Power BI](https://learn.microsoft.com/en-us/power-bi/fundamentals/power-bi-overview) connect to warehouse endpoints. Keep BI tools pointed at OLAP systems, not at production PostgreSQL behind your checkout API.
+
+### Batch vs Near-Real-Time: Where Kubernetes Fits
+
+Not every dashboard needs sub-second freshness. **Batch analytics** — hourly or daily CronJobs, Airflow DAGs, or Spark sessions — remains the default for finance reporting, executive KPIs, and regulatory submissions because it is cheaper, easier to test, and tolerant of spot interruptions. **Near-real-time analytics** — streaming aggregations with five-minute or one-minute windows — suits operations dashboards, fraud scoring, and inventory alerts where stale data has immediate cost.
+
+The cloud-native streaming path differs by provider but follows the same shape. AWS teams often chain [Kinesis Data Streams](https://docs.aws.amazon.com/streams/latest/dev/introduction.html) → [Firehose](https://docs.aws.amazon.com/firehose/latest/dev/what-is-this-service.html) → S3 Parquet → Athena or Redshift COPY. GCP teams use [Pub/Sub](https://cloud.google.com/pubsub/docs/overview) → [Dataflow](https://cloud.google.com/dataflow/docs/overview) → BigQuery streaming inserts or storage write API. Azure teams use [Event Hubs](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-about) → [Stream Analytics](https://learn.microsoft.com/en-us/azure/stream-analytics/stream-analytics-introduction) or Spark Structured Streaming on Synapse → ADLS → Synapse SQL.
+
+Kubernetes participates at two points: **producers** (application pods emitting events through SDKs) and **processors** (Flink or Spark Structured Streaming deployments scaled by [KEDA](https://keda.sh/docs/latest/scalers/) on lag metrics). Managed stream processors reduce ops toil; in-cluster processors win when you need custom jars, GPU adjacency, or unified deployment with microservices on the same cluster. A practical hybrid keeps streaming aggregation in managed services and uses Kubernetes only for complex enrichment that changes weekly.
+
+When defining SLAs, write down acceptable staleness in minutes, not vague "real-time." A pipeline that lands data within fifteen minutes is near-real-time batch; calling it streaming sets wrong expectations for tooling cost and complexity.
+
+### Data Quality Gates in the Pipeline
+
+Analytics pipelines fail quietly more often than they fail loudly. A successful Job status with zero rows loaded is worse than a failed Job because dashboards show green infrastructure and wrong business numbers. Build validation as a first-class stage — the `validate` task in the Airflow DAG example checks minimum row counts before analysts wake up.
+
+Common checks implemented in Kubernetes validate pods include: row count within ±5% of trailing seven-day average, null rate below threshold for required columns, primary-key uniqueness, referential integrity against dimension tables, and freshness (`MAX(event_timestamp)` within SLA window). Store validation results in a metadata table or push metrics to Prometheus so Grafana alerts fire when `etl_rows_loaded` drops without a corresponding Job failure.
+
+Great Expectations, dbt tests, and Soda Core all run comfortably inside Kubernetes Jobs. The pattern is identical: mount expectations YAML from a ConfigMap, run the CLI against the warehouse connection using workload identity, exit non-zero on failure, and let Airflow retry or page on-call. Treat data quality failures as application incidents with the same severity as API error-rate spikes when executives consume the output.
+
+---
+
+## Lakehouse Table Formats on Object Storage
+
+Raw Parquet files in a lake are cheap but fragile: concurrent writers can corrupt partitions, schema changes break downstream jobs, and deleting rows requires rewriting entire directories. **Lakehouse formats** add database-like guarantees on object storage.
+
+[Apache Iceberg](https://iceberg.apache.org/docs/latest/) provides hidden partitioning, schema evolution, snapshot isolation, and time travel through metadata files stored alongside data. [Delta Lake](https://docs.delta.io/latest/index.html) adds ACID transactions and is deeply integrated with Spark and Synapse Spark. [Apache Hudi](https://hudi.apache.org/docs/overview) optimizes incremental upserts and change-data-capture workloads with record-level indexing.
+
+**Time travel** lets you query a table as-of an earlier snapshot without restoring backups from tape: finance replays end-of-quarter state, and engineers undo a bad MERGE by pointing SQL at the previous snapshot ID. Iceberg and Delta expose snapshots through metadata tables; Hudi uses timeline instants with comparable semantics but different SQL surface area per query engine. **ACID commits** prevent the classic lake failure mode where two ETL pods append to the same partition and analysts see interleaved files mid-write — the format serializes writes through a catalog ([Glue](https://docs.aws.amazon.com/glue/latest/dg/catalog-and-crawler.html), Hive Metastore, or Unity Catalog) so readers always resolve a single consistent manifest. Choosing among Iceberg, Delta, and Hudi is partly ecosystem fit: AWS teams optimizing for Athena and Redshift Spectrum often anchor on Iceberg in Glue, while Azure-heavy estates with Synapse Spark frequently standardize on Delta because MERGE and time travel are first-class in that stack.
+
+Engine support evolves quickly — verify current compatibility before committing — but the direction is clear: Spark, Trino/Presto, Flink, and major cloud warehouses increasingly read and write these formats natively. [BigQuery supports Iceberg tables](https://cloud.google.com/bigquery/docs/iceberg-tables) in its lakehouse offering. [Amazon Athena and EMR](https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html) query Iceberg tables registered in Glue. Running [Spark on Kubernetes with the Spark Operator](https://github.com/kubeflow/spark-operator) lets you compact small files, run MERGE upserts, and expire old snapshots on a schedule — work that is awkward in pure serverless SQL.
+
+When to adopt a lakehouse format: you need **mutating** fact tables (slowly changing dimensions), **time travel** for audit reproducibility, or **multiple engines** (Spark for ETL, Trino for federated SQL) over the same storage. When to skip it: append-only logs with immutable daily partitions and a single query engine may stay simpler as plain Parquet.
+
+### Engine Support Snapshot (verify before committing)
+
+Lakehouse adoption fails when the query engine you need does not support the format version you chose. As of 2026, check current compatibility matrices before standardizing: [Athena Iceberg support](https://docs.aws.amazon.com/athena/latest/ug/querying-iceberg.html), [BigQuery Iceberg tables](https://cloud.google.com/bigquery/docs/iceberg-tables), [Synapse Spark Delta Lake](https://learn.microsoft.com/en-us/azure/synapse-analytics/spark/apache-spark-overview), and [Trino Iceberg connector](https://trino.io/docs/current/connector/iceberg.html). Formats evolve quickly — a feature GA in one engine may still be preview in another, which matters when your ETL on Kubernetes writes snapshots that your BI tool cannot yet read.
+
+---
 
 ### Architecture: K8s to Data Warehouse
+
+The diagram below shows the canonical pattern: operational and streaming sources feed an orchestrator running on Kubernetes, which executes extract-transform-load-validate as isolated pods before committing curated datasets to a managed warehouse consumed by BI tools. The warehouse vendor varies by cloud — BigQuery on GCP, Redshift or Athena-curated tables on AWS, Synapse or Fabric on Azure — but the Kubernetes responsibilities (scheduling, identity, retries, resource isolation) stay constant.
+
+Each stage maps to different cloud APIs. Extract pods might call operational databases through read replicas, consume Kafka topics, or list new prefixes in object storage. Transform pods run Python, Spark, or dbt and write partitioned Parquet to a staging bucket. Load pods invoke native bulk-load commands so the warehouse reads columnar files in parallel rather than accepting row inserts over JDBC. Validate pods run row-count checks, null-rate thresholds, and schema assertions before marking the partition ready for analysts.
 
 ```mermaid
 graph TD
@@ -65,6 +233,10 @@ graph TD
 ---
 
 ## Connecting Kubernetes to Data Warehouses
+
+Kubernetes pods should never hold long-lived database passwords for analytics systems. The pattern across all three clouds is the same: bind a Kubernetes ServiceAccount to a cloud identity ([GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity), [EKS IRSA or Pod Identity](https://docs.aws.amazon.com/emr/latest/EMR-on-EKS-DevelopmentGuide/emr-eks-iam-roles.html), [AKS Workload Identity](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview)), grant that identity the minimum warehouse permissions, and let SDKs exchange tokens at runtime. For large loads, always prefer **bulk load APIs** (BigQuery Load Jobs, Redshift COPY, Synapse COPY INTO) over row-by-row inserts — warehouses are columnar MPP engines, not OLTP transaction processors.
+
+Private connectivity matters when compliance requires that traffic never traverse the public internet. [AWS PrivateLink for Redshift](https://docs.aws.amazon.com/redshift/latest/mgmt/enhanced-vpc-routing.html), [Private Service Connect for BigQuery](https://cloud.google.com/vpc/docs/private-service-connect), and [Private Link for Synapse](https://learn.microsoft.com/en-us/azure/synapse-analytics/security/synapse-private-link-hubs) let pods in your VPC reach managed endpoints without public IPs. The Kubernetes angle is unchanged: your pod still uses workload identity; only the network path differs.
 
 ### BigQuery from GKE
 
@@ -161,7 +333,9 @@ while True:
     time.sleep(5)
 
 if status['Status'] == 'FINISHED':
-    print(f"Loaded {status['ResultRows']} rows")
+    # Redshift Data API returns ResultRows=-1 for COPY/DDL statements.
+    # Query STL_LOAD_COMMITS (or SYS_LOAD_HISTORY on newer clusters) for rows loaded.
+    print(f"Statement {statement_id} finished — query STL_LOAD_COMMITS for row count")
 else:
     print(f"Failed: {status.get('Error', 'unknown')}")
 ```
@@ -196,11 +370,67 @@ result = cursor.fetchone()
 print(f"Loaded: {result}")
 ```
 
+### Azure Synapse from AKS
+
+Azure Synapse Analytics combines dedicated SQL pools, serverless SQL, Spark pools, and pipeline orchestration in one workspace ([overview](https://learn.microsoft.com/en-us/azure/synapse-analytics/overview-what-is)). From AKS, pods typically authenticate with [Entra Workload ID](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview) and load data through Azure Data Lake Storage Gen2 paths that Synapse can query.
+
+```yaml
+# ServiceAccount with Azure Workload Identity for Synapse / ADLS access
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: synapse-writer
+  namespace: data-pipeline
+  annotations:
+    azure.workload.identity/client-id: "00000000-0000-0000-0000-000000000000"
+  labels:
+    azure.workload.identity/use: "true"
+```
+
+```python
+# Load Parquet from ADLS into a Synapse dedicated pool via PolyBase COPY
+# Run from a Kubernetes Job pod with workload identity credentials
+import struct
+from azure.identity import DefaultAzureCredential
+import pyodbc
+
+credential = DefaultAzureCredential()
+# Connection string uses Azure AD token auth — no SQL password in the pod
+conn_str = (
+    "Driver={ODBC Driver 18 for SQL Server};"
+    "Server=tcp:myworkspace.sql.azuresynapse.net,1433;"
+    "Database=analytics;"
+    "Encrypt=yes;TrustServerCertificate=no;"
+)
+token = credential.get_token("https://database.windows.net/.default")
+# Token-based connection pattern — see Microsoft docs for full ODBC token injection
+
+sql = """
+COPY INTO dbo.trips
+FROM 'https://mystorageaccount.dfs.core.windows.net/staging/trips/2025-11-15/*.parquet'
+WITH (
+    FILE_TYPE = 'PARQUET',
+    CREDENTIAL = (IDENTITY = 'Managed Identity')
+);
+"""
+# Execute via pyodbc or synapseml connector from the pod
+```
+
+For bursty transform work, submit Spark jobs to a [Synapse Spark pool](https://learn.microsoft.com/en-us/azure/synapse-analytics/spark/apache-spark-overview) from an Airflow KubernetesPodOperator task rather than maintaining a permanent Spark cluster on AKS. For ad-hoc lake exploration without provisioning DWUs, point analysts at the [serverless SQL endpoint](https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/on-demand-workspace-overview), which scans ADLS files per terabyte like Athena scans S3.
+
+### Federated Query on Kubernetes: Spark and Trino
+
+Not every analytics workload belongs in a managed warehouse. Teams with strict data residency, existing Spark expertise, or multi-cloud storage may run query engines **on Kubernetes** and treat cloud storage as the persistence layer.
+
+The [Spark Operator](https://github.com/kubeflow/spark-operator) submits `SparkApplication` CRDs that spin up driver and executor pods (see the Ephemeral Spark example later in this module). [Trino](https://trino.io/docs/current/) (formerly PrestoSQL) runs as a Kubernetes Deployment and federates queries across Iceberg tables on S3, GCS, ADLS, and even external JDBC sources. Choose in-cluster engines when you need custom UDFs, tight network control, or unified batch/stream processing on the same cluster that runs your microservices. Choose managed warehouses when you want zero cluster tuning and predictable SaaS SLAs for BI consumers.
+
 ---
 
 ## Airflow on Kubernetes
 
-Apache Airflow is the standard orchestrator for data pipelines. Running it on Kubernetes gives you dynamic task execution with ephemeral pods.
+Apache Airflow is the standard orchestrator for data pipelines. Running it on Kubernetes gives you dynamic task execution with ephemeral pods instead of maintaining a fleet of always-on Celery workers that sit idle between scheduled runs. In multi-cloud estates, the same pattern works regardless of which warehouse receives the final load: extract pods pull from operational databases or object storage, transform pods write partitioned Parquet to the lake, and load pods invoke native bulk-load APIs on BigQuery, Redshift, or Synapse. The orchestrator owns retries, SLAs, and alerting; Kubernetes owns isolation and bin-packing.
+
+When evaluating Airflow on Kubernetes versus managed orchestrators such as [AWS Glue Workflows](https://docs.aws.amazon.com/glue/latest/dg/workflows_overview.html), [Google Cloud Composer](https://cloud.google.com/composer/docs/concepts/overview) (managed Airflow), or [Synapse Pipelines](https://learn.microsoft.com/en-us/azure/data-factory/concepts-pipelines-activities), the tradeoff is operational ownership. Self-managed Airflow on EKS/GKE/AKS gives maximum flexibility for custom Docker images, private network paths, and multi-cloud targets. Managed Composer or Synapse Pipelines reduce Day-2 toil at the cost of less control over executor internals and image patching cadence.
 
 ### Installing Airflow with Helm
 
@@ -238,14 +468,18 @@ graph TD
 
 Each task runs in its own pod with its own resource requests. When the task completes, the pod is deleted. You pay only for the compute you use.
 
+Production Airflow on Kubernetes also requires planning for **metadata durability** and **DAG delivery**. The Helm chart example enables git-sync so DAGs live in Git and mount into scheduler and webserver pods — the same GitOps discipline you apply to application manifests. The metadata database (typically PostgreSQL) should run as a managed RDS/Cloud SQL/Flexible Server instance rather than an in-cluster StatefulSet unless you have a dedicated DBA team. Task logs stream through Kubernetes logging; forward them to CloudWatch, Cloud Logging, or Azure Monitor so failed COPY commands are searchable alongside application logs.
+
+For cross-cloud warehouses such as Snowflake, the Kubernetes integration pattern shifts slightly: pods mount key-pair secrets (preferably via [External Secrets Operator](https://external-secrets.io/latest/)) and use the Snowflake Connector rather than cloud-native workload identity, because Snowflake lives outside any single cloud IAM boundary. Rotate keys on the same cadence as database passwords and scope each service user to one warehouse and schema.
+
 ### Airflow DAG with KubernetesPodOperator
 
 ```python
 # dags/daily_etl.py
 from airflow import DAG
 from airflow.providers.cncf.kubernetes.operators.pod import KubernetesPodOperator
-from airflow.utils.dates import days_ago
-from datetime import timedelta
+from datetime import datetime, timedelta, timezone
+from kubernetes.client import models as k8s
 
 default_args = {
     'owner': 'data-engineering',
@@ -257,8 +491,8 @@ default_args = {
 with DAG(
     'daily_trip_etl',
     default_args=default_args,
-    schedule_interval='0 6 * * *',  # Daily at 6 AM UTC
-    start_date=days_ago(1),
+    schedule='0 6 * * *',  # Daily at 6 AM UTC
+    start_date=datetime(2025, 11, 1, tzinfo=timezone.utc),
     catchup=False,
     tags=['analytics', 'production'],
 ) as dag:
@@ -271,10 +505,10 @@ with DAG(
         cmds=['python', 'extract.py'],
         arguments=['--date={{ ds }}', '--output=gs://staging/trips/{{ ds }}/'],
         service_account_name='bigquery-writer',
-        container_resources={
-            'requests': {'cpu': '500m', 'memory': '1Gi'},
-            'limits': {'cpu': '1', 'memory': '2Gi'},
-        },
+        container_resources=k8s.V1ResourceRequirements(
+            requests={'cpu': '500m', 'memory': '1Gi'},
+            limits={'cpu': '1', 'memory': '2Gi'},
+        ),
         is_delete_operator_pod=True,
         get_logs=True,
     )
@@ -287,10 +521,10 @@ with DAG(
         cmds=['python', 'transform.py'],
         arguments=['--input=gs://staging/trips/{{ ds }}/', '--output=gs://staging/trips-clean/{{ ds }}/'],
         service_account_name='bigquery-writer',
-        container_resources={
-            'requests': {'cpu': '2', 'memory': '8Gi'},
-            'limits': {'cpu': '4', 'memory': '16Gi'},
-        },
+        container_resources=k8s.V1ResourceRequirements(
+            requests={'cpu': '2', 'memory': '8Gi'},
+            limits={'cpu': '4', 'memory': '16Gi'},
+        ),
         is_delete_operator_pod=True,
         get_logs=True,
     )
@@ -303,10 +537,10 @@ with DAG(
         cmds=['python', 'load.py'],
         arguments=['--input=gs://staging/trips-clean/{{ ds }}/', '--table=analytics.trips'],
         service_account_name='bigquery-writer',
-        container_resources={
-            'requests': {'cpu': '500m', 'memory': '512Mi'},
-            'limits': {'cpu': '1', 'memory': '1Gi'},
-        },
+        container_resources=k8s.V1ResourceRequirements(
+            requests={'cpu': '500m', 'memory': '512Mi'},
+            limits={'cpu': '1', 'memory': '1Gi'},
+        ),
         is_delete_operator_pod=True,
         get_logs=True,
     )
@@ -319,9 +553,9 @@ with DAG(
         cmds=['python', 'validate.py'],
         arguments=['--table=analytics.trips', '--date={{ ds }}', '--min-rows=100000'],
         service_account_name='bigquery-writer',
-        container_resources={
-            'requests': {'cpu': '200m', 'memory': '256Mi'},
-        },
+        container_resources=k8s.V1ResourceRequirements(
+            requests={'cpu': '200m', 'memory': '256Mi'},
+        ),
         is_delete_operator_pod=True,
         get_logs=True,
     )
@@ -343,7 +577,11 @@ with DAG(
 
 ## Ephemeral Analytics Clusters
 
-Some analytics workloads need significant compute for a short time -- processing a month of data, retraining an ML model, or running a large backfill. Ephemeral clusters or node pools appear for the job and disappear after.
+Some analytics workloads need significant compute for a short time — processing a month of data, retraining an ML model, or running a large backfill. Provisioning permanent high-memory nodes for these bursts is one of the most common Kubernetes cost anti-patterns because the autoscaler cannot distinguish "waiting for next week's job" from "genuinely idle." Ephemeral node pools or cluster-autoscaler-driven scale-to-zero groups appear when Airflow or the Spark Operator schedules work, then drain after completion.
+
+The cloud-specific mechanics differ slightly but the Kubernetes scheduling contract is identical. On AWS, EKS managed node groups support `capacity-type SPOT` with `minSize=0` so the group scales to zero when no analytics pods are pending. On GCP, GKE spot node pools with `--num-nodes 0` and autoscaling achieve the same effect. On Azure, [AKS cluster autoscaler](https://learn.microsoft.com/en-us/azure/aks/cluster-autoscaler) with spot node pools and taints isolates analytics workloads from production application pools. In all cases, combine **taints and tolerations** with **node selectors** so a runaway Deployment cannot accidentally schedule onto expensive analytics hardware.
+
+Spot and preemptible instances add another 60–80% discount on top of ephemeral scheduling, with the caveat that interruptions happen. Airflow's retry logic and Spark's speculative execution make analytics batch workloads unusually tolerant of spot loss — unlike stateful web servers where an eviction mid-request becomes a user-visible 502. Size retry budgets and checkpoint intervals accordingly.
 
 ### Spot/Preemptible Node Pools for Analytics
 
@@ -384,15 +622,19 @@ analytics_task = KubernetesPodOperator(
         'value': 'true',
         'effect': 'NoSchedule'
     }],
-    container_resources={
-        'requests': {'cpu': '4', 'memory': '32Gi'},
-        'limits': {'cpu': '8', 'memory': '64Gi'},
-    },
+    container_resources=k8s.V1ResourceRequirements(
+        requests={'cpu': '4', 'memory': '32Gi'},
+        limits={'cpu': '8', 'memory': '64Gi'},
+    ),
     is_delete_operator_pod=True,
 )
 ```
 
 When this task runs, the cluster autoscaler detects pending pods that can only be scheduled on the analytics-spot node group, scales it up from 0 to the needed size, runs the task, and scales back to 0 after the pod completes. Total cost: the minutes of compute actually used.
+
+The Spark Operator pattern extends ephemeral compute to distributed frameworks. Instead of standing up a dedicated EMR or Dataproc cluster for a two-hour job, a `SparkApplication` CRD requests driver and executor pods directly on the analytics node pool. Executors shuffle intermediate data through local disks or spill to object storage depending on configuration. For jobs exceeding node-local disk, configure dynamic allocation and ensure S3A/GCS/HDFS committers support the object store — otherwise task failures during spot evictions can leave inconsistent output directories.
+
+Monitor Spark on Kubernetes with the Spark UI Service (often ClusterIP-only) and export metrics to Prometheus via the [Spark metrics servlet](https://spark.apache.org/docs/latest/monitoring.html). Airflow or Argo Workflows can wrap SparkApplication submission so retries and alerting match the rest of your pipeline estate.
 
 ### Ephemeral Spark on Kubernetes
 
@@ -447,12 +689,14 @@ Data warehouse access from Kubernetes should follow the same workload identity p
 
 ### Principle of Least Privilege for Analytics
 
-| Role | BigQuery Permission | Redshift Permission | What They Can Do |
-|------|-------------------|--------------------|--------------------|
-| ETL Writer | `bigquery.dataEditor` + `bigquery.jobUser` | `INSERT`, `COPY`, `CREATE TABLE` | Write data, run load jobs |
-| Analyst Reader | `bigquery.dataViewer` + `bigquery.jobUser` | `SELECT` on specific schemas | Read data, run queries |
-| Admin | `bigquery.admin` | Superuser | Everything (restrict to platform team) |
-| Dashboard Service | `bigquery.dataViewer` on specific datasets | `SELECT` on specific tables | Read only what dashboards need |
+Analytics IAM is more nuanced than "read/write" because the blast radius of a leaked ETL credential includes exfiltrating years of customer data, not just corrupting one row. Separate identities for extract, load, validate, and dashboard-read paths. On GCP, scope BigQuery roles to datasets rather than projects. On AWS, use Redshift datashares or schema-level grants instead of superuser for ETL roles. On Azure, map Entra groups to Synapse workspace roles and restrict ADLS ACLs to staging prefixes.
+
+| Role | BigQuery Permission | Redshift Permission | Synapse / ADLS Permission | What They Can Do |
+|------|-------------------|--------------------|-----------------------------|--------------------|
+| ETL Writer | `bigquery.dataEditor` + `bigquery.jobUser` | `INSERT`, `COPY`, `CREATE TABLE` | Storage Blob Data Contributor on staging container; SQL DDL on staging schema | Write data, run load jobs |
+| Analyst Reader | `bigquery.dataViewer` + `bigquery.jobUser` | `SELECT` on specific schemas | Serverless SQL read on curated views | Read data, run queries |
+| Admin | `bigquery.admin` | Superuser | Synapse SQL Admin + Owner on workspace | Everything (restrict to platform team) |
+| Dashboard Service | `bigquery.dataViewer` on specific datasets | `SELECT` on specific tables | Read-only on reporting views | Read only what dashboards need |
 
 ### Column-Level Security
 
@@ -486,25 +730,35 @@ RETURNS STRING ->
 ALTER TABLE trips MODIFY COLUMN rider_email SET MASKING POLICY email_mask;
 ```
 
+Data governance extends beyond RBAC into **lineage and retention**. [Google Dataplex](https://cloud.google.com/dataplex/docs) and [Microsoft Purview](https://learn.microsoft.com/en-us/purview/purview) track which Kubernetes pipeline wrote which table partition, simplifying GDPR deletes and audit responses. Set object lifecycle policies on staging buckets (delete raw extracts after 30 days, keep curated Parquet for seven years) and align warehouse table expiration with legal hold requirements. A staging prefix with overly broad IAM permissions is a common exfiltration path — treat it with the same sensitivity as production data because it often contains the same PII without masking policies applied yet.
+
 ---
 
 ## Cost Control for Analytics
 
-Analytics workloads can generate surprise bills quickly. A single bad query on BigQuery can scan petabytes. A misconfigured Redshift cluster can run 24/7 doing nothing.
+Analytics workloads can generate surprise bills quickly. A single bad query on BigQuery can scan petabytes. A misconfigured Redshift cluster can run 24/7 doing nothing. Understanding **which meter moves** — scanned bytes, slot-hours, RPU-hours, node-hours, or egress gigabytes — is the foundation of every cost review.
 
 > **Pause and predict**: If you forget to partition a BigQuery table, what happens to your querying costs as the table grows over several years?
 
-### BigQuery Cost Controls
+### Scan-Priced Engines: Athena and BigQuery
+
+[Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/pricing.html) bills per terabyte of data scanned by each query (verify current regional rate). [BigQuery on-demand](https://cloud.google.com/bigquery/pricing) bills at **$6.25/TiB** scanned (verify current rate) after the first **1 TiB free per month** per billing account. [Synapse serverless SQL](https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/on-demand-workspace-overview) uses a similar per-TB scanned model. The cost levers are:
+
+- **Partition filters** so queries touch one day instead of five years of history
+- **Column selection** — never `SELECT *` on wide fact tables when three columns suffice
+- **Columnar formats** (Parquet/ORC) so engines skip untouched columns entirely
+- **Clustering / sorting** (BigQuery clustering, Redshift sort keys) for high-cardinality filters
+- **`maximum_bytes_billed`** guardrails that abort queries before execution completes
 
 ```bash
-# Set project-level query quota (max 10 TB/day)
-bq update --project_id my-project \
-  --default_table_expiration 7776000 \
-  --max_bytes_billed 10995116277760  # 10 TB in bytes
+# Per-query byte cap on the bq CLI (this is a client-side guard, not a project quota)
+bq query \
+  --maximum_bytes_billed=10995116277760 \
+  'SELECT * FROM analytics.trips WHERE date = "2025-11-15"'
 
-# Set per-user quota
-bq update --project_id my-project \
-  --quota_per_user_bytes 1099511627776  # 1 TB per user per day
+# Project-level and per-user query quotas are configured via
+# the Google Cloud Console → IAM & Admin → Quotas, or the Service Usage API.
+# The bq CLI does not expose quota CRUD flags — use Console / gcloud alpha services quota.
 ```
 
 ```python
@@ -517,11 +771,20 @@ job_config = bigquery.QueryJobConfig(
     use_query_cache=True,
 )
 
-query = "SELECT * FROM analytics.trips WHERE date = '2025-11-15'"
+query = "SELECT trip_id, fare_amount FROM analytics.trips WHERE date = '2025-11-15'"
 result = client.query(query, job_config=job_config).result()
 ```
 
-### Redshift Cost Controls
+Hypothetical scenario: an analyst runs `SELECT *` on a 200 TB unpartitioned transactions table in BigQuery. At ~$6.25/TiB, that single query approaches **$1,250** before egress. Adding a `WHERE transaction_date = '2025-11-15'` partition filter on a daily-partitioned table might reduce scanned data to ~100 GB (~$0.60). The engineering work to partition at table creation pays for itself the first time someone forgets a WHERE clause.
+
+### Provisioned Cluster Costs: Redshift and Synapse Dedicated
+
+[Redshift provisioned clusters](https://docs.aws.amazon.com/redshift/latest/mgmt/working-with-clusters.html) bill per node-hour regardless of query activity. [Synapse dedicated SQL pools](https://learn.microsoft.com/en-us/azure/synapse-analytics/sql-data-warehouse/sql-data-warehouse-overview-what-is) bill in Data Warehouse Units (DWUs). Cost levers include:
+
+- **Pause / resume** schedules for dev/test clusters overnight and weekends
+- **Redshift Serverless** with [usage limits](https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-usage-limits.html) that deactivate compute when monthly RPU thresholds breach
+- **Right-sizing** — start smaller and resize after observing peak concurrency, not before
+- **Concurrency Scaling** (Redshift) for burst queries instead of permanently doubling node count
 
 ```bash
 # Use Redshift Serverless with usage limits
@@ -532,6 +795,12 @@ aws redshift-serverless create-usage-limit \
   --period monthly \
   --breach-action deactivate
 ```
+
+### Storage, Egress, and Hidden Line Items
+
+Object storage is cheap until it is not. Three buckets of **10 TB each** in S3 Standard cost roughly **$690/month** in storage alone (verify current pricing). Cross-region replication doubles storage. **Egress** to the internet or to another cloud can exceed compute: [S3 data transfer out](https://aws.amazon.com/s3/pricing/) to the internet starts around **$0.09/GB** (verify current tier). [GCS egress](https://cloud.google.com/storage/pricing) and [Azure bandwidth](https://azure.microsoft.com/pricing/details/bandwidth/) follow similar tiered models. Keep BI tools and Spark executors in the **same region** as the lake. [S3 same-Region reads are free](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html) when Athena, Redshift, or EMR in the same region query the bucket.
+
+Kubernetes compute for analytics adds another meter: even ephemeral Airflow task pods accrue CPU/memory charges on your node pool. Spot/preemptible node groups (covered later) reduce batch cost 60–80% when Airflow retries handle interruptions.
 
 ### Cost Monitoring Dashboard
 
@@ -570,17 +839,97 @@ spec:
 | BigQuery flat-rate (Editions) | 30-50% at scale | Predictable cost for >$10K/month spend |
 | Materialized views | 50-80% on repeated queries | Pre-compute common aggregations |
 
+Reserve **[BigQuery Editions / slot commitments](https://cloud.google.com/bigquery/docs/reservations-intro)** when monthly on-demand scan charges stabilize above the break-even point versus slot-hour pricing — typically when the same dashboards execute hundreds of times daily against similar datasets. For Redshift, use [Scheduled Actions](https://docs.aws.amazon.com/redshift/latest/mgmt/pause-resume-cluster.html) to pause provisioned clusters in dev accounts. Tag Kubernetes analytics namespaces with cost allocation labels (`team=data-platform`, `env=prod`) so FinOps can attribute spot node spend to the pipelines that requested it.
+
+---
+
+## Patterns & Anti-Patterns
+
+Analytics architecture fails in predictable ways. The patterns below appear repeatedly across AWS, GCP, and Azure estates because they align billing meters with workload shapes. Anti-patterns usually begin as reasonable shortcuts — querying the lake directly in production dashboards, skipping partitions "until we have more data," or sizing a Redshift cluster for peak Black Friday and leaving it there all year.
+
+| Pattern | When to Use | Why It Works | Scaling Consideration |
+|---------|-------------|--------------|-----------------------|
+| Lake ingest + warehouse serve | Raw events land in S3/GCS/ADLS; curated tables live in Redshift/BigQuery/Synapse | Decouples cheap storage from expensive compute; OLTP stays isolated | Compact small files in the lake; enforce partition conventions in CI |
+| Ephemeral K8s workers (Airflow KubernetesExecutor) | Batch ETL with variable task sizes | Pods request exact CPU/RAM per task; no 24/7 worker tax | Accept 10–30s pod startup; use spot nodes with retries |
+| Serverless scan for exploration, reserved capacity for BI | Unpredictable ad-hoc SQL early; steady dashboard load later | Athena/BigQuery on-demand has near-zero idle cost; reservations/slots reduce $/TiB at scale | Monitor scan bytes weekly; graduate hot tables to clustered warehouse tables |
+| Open lakehouse format (Iceberg/Delta/Hudi) | Multiple engines write/read the same tables; need MERGE/time travel | ACID on object storage without proprietary lock-in | Schedule compaction jobs on Kubernetes to merge small files |
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| Querying raw JSON in the lake with `SELECT *` | Every analyst scan touches every field and file; scan bills explode | Land Parquet with schema; partition by date; expose curated views |
+| No partitioning on time-series facts | Queries scan full history for one-day filters | Partition by `date` at creation; reject loads that omit partition keys |
+| Using the warehouse as OLTP | High-frequency row updates and point lookups degrade MPP performance | Keep mutations in OLTP; sync deltas via CDC into lake/warehouse |
+| Unbounded serverless scans without guardrails | One cross join can scan petabytes before anyone notices | `maximum_bytes_billed`, per-user quotas, cost alerts, mandatory partition filters |
+| Permanent oversized analytics node pools | EKS/GKE nodes sit at max size for a weekly 2-hour Spark job | Scale-to-zero spot pools with taints; Spark Operator or Airflow triggers scale-up |
+
+---
+
+## Decision Framework
+
+Choosing between warehouse, lake, lakehouse, serverless scan, and in-cluster Spark is a workload decision — not a vendor loyalty decision. Start with four questions: how fresh must data be, how predictable is query concurrency, how large are individual transforms, and who owns operational toil?
+
+```mermaid
+flowchart TD
+    Start[New analytics requirement] --> Fresh{Sub-hour freshness?}
+    Fresh -- Yes --> Stream[Streaming ingest<br/>Kinesis / Pub/Sub / Event Hubs]
+    Fresh -- No --> Volume{Transform size}
+    Stream --> Lake[Land in object storage<br/>+ streaming aggregates]
+    Volume -- Small SQL / exploration --> Scan[Serverless scan<br/>Athena / BQ on-demand / Synapse serverless]
+    Volume -- Large Spark / ML features --> SparkChoice{Managed Spark or K8s Spark?}
+    SparkChoice -- No cluster ops appetite --> ManagedSpark[EMR / Dataproc / Synapse Spark]
+    SparkChoice -- Existing K8s platform team --> K8sSpark[Spark Operator on spot nodes]
+    Volume -- Curated BI dashboards --> WH{Steady concurrency?}
+    WH -- Yes --> Provisioned[Redshift / Synapse dedicated / BQ reservations]
+    WH -- Sporadic --> ServerlessWH[Redshift Serverless / BQ on-demand]
+    Lake --> Format{Need updates / time travel?}
+    Format -- Yes --> Lakehouse[Iceberg / Delta / Hudi tables]
+    Format -- No --> RawParquet[Partitioned Parquet + catalog]
+    RawParquet --> Scan
+    Lakehouse --> Scan
+    Lakehouse --> K8sSpark
+```
+
+| Requirement | Prefer | Reason |
+|-------------|--------|--------|
+| Ad-hoc SQL on cold lake files | Athena, BigQuery external tables, Synapse serverless | No cluster to size; pay per scan |
+| 500 concurrent BI users, SLA dashboards | Redshift provisioned, Synapse dedicated pool, BigQuery capacity | Predictable slot/DWU capacity beats scan pricing |
+| Nightly 20 TB Spark aggregation | EMR/Dataproc or Spark on Kubernetes spot pool | MPP SQL engines are poor at heavy shuffles |
+| Multi-engine access (Spark + Trino + Athena) | Iceberg/Delta on S3/GCS/ADLS | One table format, many query engines |
+| Strict network isolation, custom UDFs | Trino/Spark on Kubernetes | Full control of network paths and libraries |
+
+For design reviews, require a **cost worksheet**: estimated daily ingest GB, partition strategy, expected scan bytes per top-10 query, cluster hours if provisioned, and egress paths to BI tools. If the worksheet cannot bound worst-case scan cost, the design is not ready for analyst self-service.
+
+### Microsoft Fabric and Unified Analytics (Azure)
+
+[Microsoft Fabric](https://learn.microsoft.com/en-us/fabric/get-started/microsoft-fabric-overview) consolidates data integration, lake storage ([OneLake](https://learn.microsoft.com/en-us/fabric/onelake/onelake-overview)), warehouse compute, and Power BI into a SaaS experience aimed at organizations already standardized on Azure AD and Microsoft 365. For Kubernetes teams, Fabric does not replace AKS orchestration — it replaces the sprawl of separately operated Synapse workspaces, ADF factories, and Power BI gateways when the business wants a single control plane.
+
+Typical integration: Kubernetes ETL pods land Parquet in ADLS paths that OneLake shortcuts reference; Fabric warehouse endpoints expose SQL to Power BI datasets; lineage flows through Purview automatically. The decision is organizational as much as technical: Fabric reduces tool count; self-managed Airflow on AKS plus Synapse serverless preserves fine-grained control for platform engineers who already invested in GitOps pipeline manifests.
+
+### Observability: Knowing the Pipeline Is Healthy
+
+Infrastructure metrics tell you pods ran; data metrics tell you the business can trust the output. Instrument both layers. Kubernetes-level signals include Airflow task duration, pod OOMKilled counts, spot interruption rates, and Job/CronJob failure counts in the `data-pipeline` namespace. Warehouse-level signals include bytes scanned per query (BigQuery `INFORMATION_SCHEMA.JOBS`, Athena query history), Redshift `STL_QUERY` duration, and Synapse DMVs for long-running SQL.
+
+Build dashboards that correlate **pipeline completion time** with **downstream row counts**. If the extract Job finishes on schedule but loaded rows drop 40% week-over-week, the problem is upstream data — not Kubernetes scheduling. Conversely, if row counts look stable but Job duration doubles, your transform pods may need more memory or the lake may have accumulated small files that need compaction.
+
+Alert on SLA misses, not only on pod crashes. A CronJob that succeeds with an empty extract because the source replica lagged is a silent data incident. The validate stage exists precisely to convert silent failures into hard failures that Airflow marks red and pages on-call.
+
+When triaging analytics incidents, walk the path in order: confirm the orchestrator task state in Airflow or Job status, inspect pod logs for COPY/load errors, verify object storage paths contain expected file counts and sizes, run a manual `SELECT COUNT(*)` against the target partition in the warehouse, and only then investigate BI layer caching. Skipping straight to "Tableau is broken" wastes hours when the root cause is an empty staging prefix because upstream replication lagged two hours.
+
+Document the expected runtime and row-count envelopes for each pipeline stage in runbooks attached to Airflow DAG docstrings or ConfigMap annotations. New engineers onboarding to on-call should not need to grep Python to learn that daily trips load should exceed 100,000 rows — the validate task encodes that invariant, and the runbook explains the business context behind the threshold.
+
+Export warehouse audit logs to the same SIEM that ingests Kubernetes audit events when compliance requires proving who queried PII columns. BigQuery audit logs, Redshift user activity logging, and Synapse SQL auditing each integrate with their cloud's logging backbone — wire those streams before auditors ask, not after a finding. Treat audit log retention with the same lifecycle discipline as the data itself. A query audit trail that expires before the compliance window defeats the purpose of enabling logging in the first place and can fail external audits outright.
+
 ---
 
 ## Did You Know?
 
-1. **BigQuery processes over 110 PB of data per day** across all customers. Its architecture separates storage (Colossus) from compute (Dremel), which means you can scale query processing to thousands of nodes for a single query without any cluster management. This serverless model inspired Snowflake and Redshift Serverless.
+1. **BigQuery processes over 110 PB of data per day** across all customers (as of ~2024 analyst briefings — verify current figure from Google Cloud's published benchmarks). Its architecture separates storage (Colossus) from compute (Dremel), which means you can scale query processing to thousands of nodes for a single query without any cluster management. This serverless model inspired Snowflake and Redshift Serverless.
 
 2. **Apache Airflow was created at Airbnb in 2014** by Maxime Beauchemin to orchestrate the company's growing data pipelines. It became an Apache top-level project in 2019 and is now used by over 10,000 organizations. The name "Airflow" was chosen because data flows through it like air -- invisibly and reliably (in theory).
 
-3. **Snowflake's multi-cluster warehouse feature automatically scales** from 1 to 10 clusters based on query queuing. A data warehouse that serves 5 analysts during the day and 500 during a quarterly review scales automatically without anyone touching the configuration. This is why Snowflake charges per-second of compute rather than per-node.
+3. **Snowflake's multi-cluster warehouse feature automatically scales** from 1 to up to ~300 clusters (verify current limits for your edition and warehouse size) based on query queuing. A data warehouse that serves 5 analysts during the day and 500 during a quarterly review scales automatically without anyone touching the configuration. This is why Snowflake charges per-second of compute rather than per-node.
 
-4. **The COPY command in Redshift is up to 1000x faster than INSERT statements** for bulk loading because it reads directly from S3 in parallel across all nodes. Each slice in a Redshift node reads a portion of the S3 files simultaneously. A 100 GB load that would take hours with INSERT completes in minutes with COPY.
+4. **The COPY command in Redshift can be dramatically faster than INSERT statements** for bulk loading (orders of magnitude less time in practice) because it reads directly from S3 in parallel across all nodes. Each slice in a Redshift node reads a portion of the S3 files simultaneously. A 100 GB load that would take hours with INSERT completes in minutes with COPY.
 
 ---
 
@@ -656,13 +1005,16 @@ EOF
 
 kind create cluster --name analytics-lab --config /tmp/kind-analytics.yaml
 
+# kubectl alias required for runnable k shorthand in this exercise
+alias k=kubectl
+
 # Create namespace for the data pipeline
 k create namespace data-pipeline
 ```
 
 ### Task 1: Deploy a Simple Airflow-Like Orchestrator
 
-Since full Airflow requires significant resources, we will simulate the pattern using Kubernetes Jobs with dependencies.
+Since a full Airflow deployment requires significant cluster resources for the scheduler, webserver, and metadata database, this lab simulates the core orchestration pattern using native Kubernetes Jobs with explicit sequencing. The pedagogical goal is identical: each pipeline stage runs in an isolated pod with its own resource limits, failures surface in Job status, and a parent orchestrator enforces ordering before the next stage starts.
 
 <details>
 <summary>Solution</summary>
@@ -693,7 +1045,7 @@ EOF
 
 ### Task 2: Create the Extract Job
 
-Build a Job that reads raw data and outputs cleaned JSON.
+Build a Kubernetes Job that reads raw CSV trip records from a ConfigMap volume and writes cleaned JSON to an ephemeral staging volume, mimicking the extract stage that in production would land Parquet files in S3, GCS, or ADLS through the AWS SDK, google-cloud-storage, or azure-storage-blob libraries.
 
 <details>
 <summary>Solution</summary>
@@ -759,11 +1111,12 @@ k apply -f /tmp/extract-job.yaml
 k wait --for=condition=complete job/etl-extract -n data-pipeline --timeout=60s
 k logs job/etl-extract -n data-pipeline
 ```
+> Save the manifest above to `/tmp/extract-job.yaml` before applying.
 </details>
 
 ### Task 3: Create the Transform Job
 
-Build a Job that aggregates trip data by region.
+Build a second Job that aggregates trip metrics by region — total distance, fare revenue, and average fare per kilometer — demonstrating the transform stage where Spark, dbt, or Python pandas would normalize schemas and compute business-ready facts before warehouse load.
 
 <details>
 <summary>Solution</summary>
@@ -841,14 +1194,17 @@ k apply -f /tmp/transform-job.yaml
 k wait --for=condition=complete job/etl-transform -n data-pipeline --timeout=60s
 k logs job/etl-transform -n data-pipeline
 ```
+> Save the manifest above to `/tmp/transform-job.yaml` before applying.
 </details>
 
 ### Task 4: Create a Pipeline Orchestrator
 
-Build a Job that runs extract, then transform, then validate in sequence (simulating Airflow).
+Build a coordinator Job that applies extract and transform manifests in sequence, waits for each Job to reach Complete status, and exits non-zero if any stage fails — the same contract Airflow's KubernetesPodOperator provides with `is_delete_operator_pod=True` and upstream/downstream dependencies.
 
 <details>
 <summary>Solution</summary>
+
+> **Image note:** `bitnamilegacy/kubectl` receives no security updates; production should use a maintained image such as `rancher/kubectl` or `alpine/k8s`.
 
 ```yaml
 apiVersion: batch/v1
@@ -864,7 +1220,7 @@ spec:
       serviceAccountName: pipeline-runner
       containers:
         - name: orchestrator
-          image: bitnami/kubectl:1.35
+          image: bitnamilegacy/kubectl:1.35
           command:
             - /bin/sh
             - -c
@@ -953,14 +1309,17 @@ k apply -f /tmp/orchestrator.yaml
 k wait --for=condition=complete job/pipeline-orchestrator -n data-pipeline --timeout=180s
 k logs job/pipeline-orchestrator -n data-pipeline
 ```
+> Save the orchestrator manifest above to `/tmp/orchestrator.yaml` before applying.
 </details>
 
 ### Task 5: Schedule the Pipeline as a CronJob
 
-Convert the orchestrator to run daily.
+Convert the orchestrator into a CronJob with `concurrencyPolicy: Forbid` so a slow run does not overlap the next scheduled execution, mirroring how production teams schedule nightly ETL windows before business hours in each timezone.
 
 <details>
 <summary>Solution</summary>
+
+> **Image note:** `bitnamilegacy/kubectl` receives no security updates; production should use a maintained image such as `rancher/kubectl` or `alpine/k8s`.
 
 ```yaml
 apiVersion: batch/v1
@@ -982,7 +1341,7 @@ spec:
           serviceAccountName: pipeline-runner
           containers:
             - name: orchestrator
-              image: bitnami/kubectl:1.35
+              image: bitnamilegacy/kubectl:1.35
               command:
                 - /bin/sh
                 - -c
@@ -1005,6 +1364,7 @@ k create job --from=cronjob/daily-etl-pipeline manual-test -n data-pipeline
 k wait --for=condition=complete job/manual-test -n data-pipeline --timeout=60s
 k logs job/manual-test -n data-pipeline
 ```
+> Save the CronJob manifest above to `/tmp/cronjob-pipeline.yaml` before applying.
 </details>
 
 ### Success Criteria
@@ -1023,10 +1383,23 @@ kind delete cluster --name analytics-lab
 
 ---
 
-**Next**: Return to the [Managed Services README]() for the complete module index and learning path recommendations.
+## Next Module
+
+You have completed the Managed Services track. Continue with [Advanced Cloud Operations](../advanced-operations/) for multi-account governance, disaster recovery, active-active architectures, and cost optimization at enterprise scale.
 
 ## Sources
 
 - [BigQuery Overview](https://cloud.google.com/bigquery/docs/introduction) — Grounds the module's BigQuery architecture claims in current vendor documentation.
-- [Airflow KubernetesExecutor](https://airflow.apache.org/docs/apache-airflow/2.2.4/executor/kubernetes.html) — Covers the executor behavior behind the module's Airflow-on-Kubernetes claims.
-- [Amazon Redshift Data API](https://docs.aws.amazon.com/redshift/latest/mgmt/data-api.html) — Supports the module's Redshift-from-Kubernetes pattern for connectionless SQL execution.
+- [BigQuery Pricing](https://cloud.google.com/bigquery/pricing) — On-demand per-TiB scan rates, slot capacity models, and free tier details.
+- [Amazon Athena](https://docs.aws.amazon.com/athena/latest/ug/what-is.html) — Serverless SQL over S3 and the Glue Data Catalog integration model.
+- [Amazon Athena Pricing](https://docs.aws.amazon.com/athena/latest/ug/pricing.html) — Per-TB scanned billing for SQL and Spark on Athena.
+- [Amazon Redshift Data API](https://docs.aws.amazon.com/redshift/latest/mgmt/data-api.html) — Connectionless SQL execution from Kubernetes pods via IAM.
+- [Amazon Redshift Serverless Usage Limits](https://docs.aws.amazon.com/redshift/latest/mgmt/serverless-usage-limits.html) — Cost guardrails for auto-scaling Redshift Serverless workgroups.
+- [AWS Glue Data Catalog](https://docs.aws.amazon.com/glue/latest/dg/catalog-and-crawler.html) — Metadata catalog backing Athena and Redshift Spectrum.
+- [Azure Synapse Analytics Overview](https://learn.microsoft.com/en-us/azure/synapse-analytics/overview-what-is) — Unified SQL, Spark, and pipeline workspace on Azure.
+- [Synapse Serverless SQL](https://learn.microsoft.com/en-us/azure/synapse-analytics/sql/on-demand-workspace-overview) — Pay-per-TB scanned queries over ADLS without dedicated pools.
+- [Apache Iceberg Documentation](https://iceberg.apache.org/docs/latest/) — Open table format specification for ACID lakehouse tables.
+- [Delta Lake Documentation](https://docs.delta.io/latest/index.html) — ACID transactions and time travel on object storage.
+- [Google Cloud Storage Introduction](https://cloud.google.com/storage/docs/introduction) — Object storage foundation for GCS-backed lakes and BigQuery external tables.
+- [Airflow KubernetesExecutor](https://airflow.apache.org/docs/apache-airflow/stable/executor/kubernetes.html) — Ephemeral pod-per-task orchestration on Kubernetes.
+- [Spark Operator](https://github.com/kubeflow/spark-operator) — Kubernetes-native Spark job submission via SparkApplication CRDs.

--- a/src/content/docs/cloud/managed-services/module-9.2-message-brokers.md
+++ b/src/content/docs/cloud/managed-services/module-9.2-message-brokers.md
@@ -10,7 +10,7 @@ sidebar:
 
 After completing this module, you will be able to:
 
-- **Configure Kubernetes workloads to consume from managed message brokers (Amazon MQ, Cloud Pub/Sub, Azure Service Bus)**
+- **Configure Kubernetes workloads to consume from managed message brokers (SQS/SNS, Cloud Pub/Sub, Azure Service Bus)**
 - **Implement event-driven autoscaling using KEDA with message queue depth as the scaling trigger**
 - **Deploy dead-letter queue patterns and retry logic for reliable message processing in Kubernetes applications**
 - **Compare managed message brokers across clouds and evaluate when to use self-hosted (RabbitMQ, NATS) alternatives on Kubernetes**
@@ -30,6 +30,30 @@ This module teaches you how to integrate managed message brokers -- SQS/SNS, Goo
 ## Messaging Fundamentals for Kubernetes Engineers
 
 Before diving into cloud services, let's establish the core messaging patterns that every integration uses.
+
+### The Three Messaging Shapes
+
+The first design choice is not "which cloud service should we use?" It is "what shape of communication does this workload need?" Managed messaging products overlap heavily in marketing names, but production systems usually need one of three shapes: a point-to-point queue, a publish-subscribe fan-out bus, or a durable log that can be replayed by independent consumers.
+
+A point-to-point queue is a work distributor. One message represents one unit of work, and one consumer instance should complete it. If ten Kubernetes pods poll the same SQS queue, Service Bus queue, or Pub/Sub subscription, they are not all supposed to see every message; they are competing to share the workload. This is the shape for order processing, image conversion, email sending, fraud review, and background tasks where the business wants completion rather than broadcast.
+
+A publish-subscribe system is an announcement channel. One producer publishes an event, and several independent consumers each need their own copy. AWS usually models that with SNS fan-out to SQS queues, EventBridge rules to targets, or SNS FIFO when ordered fan-out is required. Google Pub/Sub models fan-out directly with multiple subscriptions on one topic. Azure Service Bus uses topics and subscriptions for brokered pub/sub, while Event Grid handles event notifications to HTTP, Azure Functions, Service Bus, and other targets.
+
+A durable log or stream is different from both. Messages are appended to ordered partitions, retained for a configured time, and consumed by consumer groups that maintain offsets. Apache Kafka, Amazon MSK, Amazon Kinesis Data Streams, Google Pub/Sub used as a high-throughput event stream, and Azure Event Hubs all fit this mental model to varying degrees. This shape is useful when consumers need replay, windowed analytics, or independent progress through the same ordered history.
+
+Kubernetes does not remove those distinctions. A Deployment can poll a queue, subscribe to a topic, or run Kafka consumers, but the pod lifecycle adds new failure modes. Pods can be rescheduled while holding a message lease, rollouts can double the number of consumers for a short period, and autoscaling can amplify a backlog into sudden pressure on a downstream database. The broker gives you decoupling; Kubernetes decides how much compute attacks the backlog at any moment.
+
+AWS deliberately offers several products because each shape has a different operational contract. SQS is the simple queue for work distribution; SNS is the fan-out topic; EventBridge is an event bus with filtering, routing, retries, and many AWS service integrations; Amazon MQ is the managed broker for teams that need ActiveMQ or RabbitMQ protocols; MSK is managed Kafka; and Kinesis Data Streams is the AWS-native shard-based stream. Choosing among them is mostly about coupling, protocol, ordering, replay, and cost model.
+
+Google Cloud pushes most general messaging toward Pub/Sub, where a topic plus one subscription behaves like a queue and a topic plus many subscriptions behaves like fan-out. Pub/Sub Lite should now be treated as legacy migration material, not a new design target: Google's own documentation lists Pub/Sub Lite as deprecated with a June 30, 2026 turndown, and recommends migrating to Pub/Sub or Google Cloud Managed Service for Apache Kafka. That matters for architecture reviews because "reserved-capacity Pub/Sub Lite is cheaper" is no longer a safe forward-looking answer.
+
+Azure splits the same space into Service Bus, Event Grid, and Event Hubs. Service Bus is the enterprise broker for queues, topics, sessions, transactions, duplicate detection, and dead-lettering. Event Grid is the event distribution service for reactive notifications and CloudEvents-style routing. Event Hubs is the streaming ingestion service with partitions, consumer groups, retention, and Kafka-compatible endpoints for many Kafka clients. The names differ, but the design question remains queue, fan-out, or durable log.
+
+| Shape | AWS Fit | Google Cloud Fit | Azure Fit | Kubernetes Integration |
+|-------|---------|------------------|-----------|------------------------|
+| Point-to-point queue | SQS Standard or FIFO, Amazon MQ queue | Pub/Sub topic with one subscription | Service Bus queue | Deployment consumers, KEDA queue-depth scaler, workload identity |
+| Pub/sub fan-out | SNS to SQS, EventBridge rules, SNS FIFO | Pub/Sub topic with many subscriptions | Service Bus topic/subscriptions, Event Grid | One Deployment per subscription, independent DLQs, per-consumer scaling |
+| Durable log or stream | MSK, Kinesis Data Streams | Pub/Sub for event streams, Managed Service for Apache Kafka | Event Hubs, Event Hubs Kafka endpoint | Stateful consumer groups, KEDA Kafka/Event Hubs lag scalers, offset checkpoints |
 
 ### Point-to-Point vs Publish-Subscribe
 
@@ -58,6 +82,24 @@ graph TD
 | **Exactly-once** | Message delivered exactly 1 time | Higher latency, complexity | Kafka transactions, Pub/Sub with dedup |
 
 Most managed brokers provide **at-least-once** delivery by default. This means your consumer code must be **idempotent** -- processing the same message twice should produce the same result as processing it once.
+
+At-least-once is not a provider weakness; it is the normal contract for reliable distributed messaging. A broker can safely redeliver a message when it cannot prove that the previous consumer finished and committed all side effects. In Kubernetes, that uncertainty appears whenever a pod is killed during a rollout, a node loses network, a process crashes after writing to a database but before acknowledging the message, or an HTTP client times out while the broker may still process the acknowledgement.
+
+AWS SQS Standard queues give very high throughput and at-least-once delivery, but they do not promise strict ordering. SQS FIFO queues add ordering by `MessageGroupId` and deduplication through `MessageDeduplicationId` or content-based deduplication; AWS documents a 5-minute deduplication interval for duplicate suppression. That is powerful, but it is not a license to write non-idempotent consumers, because duplicate business actions can still come from producer retries with different IDs, downstream write retries, manual DLQ redrive, or a consumer bug.
+
+Google Pub/Sub defaults to at-least-once delivery, and a subscription is the unit that controls delivery state. A topic does not remember that "the inventory service" consumed a message; the inventory subscription does. Pub/Sub's exactly-once feature is more precise than a marketing slogan: Google documents it for pull subscriptions, within a cloud region, with successful acknowledgements preventing later redelivery. Your application still needs durable progress tracking because acknowledgement can fail, publisher-side retries can create separate publishes, and multi-region subscriber placement can weaken the guarantee.
+
+Azure Service Bus has a different vocabulary, but the same operational shape. A receiver usually uses peek-lock mode: it locks a message, processes it, and completes it when finished. If the lock expires or the receiver abandons the message, delivery count increases and the message can be retried until `MaxDeliveryCount` sends it to the dead-letter queue. Sessions add ordered processing for related message streams, while duplicate detection suppresses repeated sends with the same message ID during a configured detection window.
+
+Kafka-family systems move the guarantee boundary again. Kafka does not "delete" a message when a consumer finishes; it stores records in partitions and consumers commit offsets. Transactions and idempotent producers can provide exactly-once processing semantics when producers, consumers, and sinks participate correctly, but a Kubernetes consumer that writes to an ordinary database still needs an idempotency key or transactional outbox pattern. The broker can protect the log; it cannot automatically make every external side effect atomic.
+
+This is why message processing code should separate three facts: message receipt, business side effect, and acknowledgement. Receipt means the pod has a leased opportunity to work. The business side effect is the database write, API call, file upload, or notification the system actually cares about. The acknowledgement tells the broker that the message no longer needs delivery. If those three steps are blurred together, a crash can create either lost work or duplicate work.
+
+The practical safety pattern is to choose a stable idempotency key before the first consumer ships. For an order event, that might be `order_id` plus event type; for a payment command, it might be a gateway-provided idempotency key; for a telemetry event, it might be a producer ID plus sequence number. Store that key where the side effect happens, not only in memory inside the pod, because a restarted pod will not remember what the previous pod attempted.
+
+Dead-letter queues are part of the delivery guarantee, not an optional cleanup bin. AWS SQS redrive policy uses `maxReceiveCount`; Pub/Sub dead-letter topics use maximum delivery attempts; Azure Service Bus moves messages after maximum delivery count or explicit dead-letter operations. The DLQ gives operators a place to inspect poison messages without allowing one bad payload to consume every retry slot forever.
+
+The cost of stronger guarantees is usually paid in throughput and coordination. Ordering means fewer independent lanes: one SQS FIFO message group, one Pub/Sub ordering key, one Service Bus session, or one Kafka partition can only advance as fast as its slowest ordered sequence allows. Exactly-once-like features add acknowledgement tracking or transaction coordination. Use them when the business meaning requires them, not because the phrase sounds safer in an architecture diagram.
 
 ```python
 # BAD: Not idempotent -- double processing creates duplicate charges
@@ -101,6 +143,34 @@ When should you run your own broker (like RabbitMQ, Apache Kafka, or NATS) on Ku
 
 > **Stop and think**: Your company mandates that no customer PII (Personally Identifiable Information) can ever leave the physical boundary of your on-premises data center. Can you use AWS SQS for processing user registration events in this environment?
 > *Answer*: No. Managed cloud brokers like AWS SQS operate outside of your cluster on cloud provider infrastructure. Sending PII to SQS would violate the data locality mandate because the data leaves your physical data center. In this strict air-gapped or compliance-heavy scenario, you must use a self-hosted broker like RabbitMQ or NATS deployed directly within your local Kubernetes cluster.
+
+### Provider Fit by Workload
+
+For simple asynchronous work on AWS, start with SQS. It is pull-based, cheap to operate at low and moderate volume, easy to scale with KEDA, and does not force you to size broker nodes or partitions. Add SNS when one event must reach several queues, and add EventBridge when the event needs routing rules, SaaS or AWS service integrations, cross-account event buses, or target retry policies. Reach for Amazon MQ when application compatibility depends on AMQP, MQTT, STOMP, OpenWire, ActiveMQ, or RabbitMQ behavior.
+
+MSK and Kinesis are not "better SQS"; they solve a different problem. MSK is for Kafka applications that need partitioned logs, consumer groups, Kafka APIs, Connect, Streams, or ecosystem compatibility. Kinesis Data Streams is for shard-based AWS-native streaming where producers and consumers coordinate through partition keys and sequence numbers. Both services are good fits when replay and ordered history matter, but they add capacity planning that a simple queue hides.
+
+On Google Cloud, Pub/Sub is the default answer for most Kubernetes eventing unless you have a strong reason to use Kafka. A topic plus one subscription behaves like a work queue, while a topic plus many subscriptions creates fan-out. Because each subscription tracks its own backlog and acknowledgement state, separate Kubernetes Deployments can scale independently from the same topic. That is the cleanest way to let billing, inventory, analytics, and search indexing all react to `OrderCreated` without competing against each other.
+
+Pub/Sub Lite deserves special handling in legacy reviews. Before deprecation, it was attractive when teams wanted reserved capacity and lower predictable cost for very high, steady throughput. In 2026 curriculum work, that should be framed as a migration topic: identify any remaining Lite topics, decide whether standard Pub/Sub or managed Kafka is the target, and avoid teaching new designs that depend on a service scheduled for turndown. That single fact changes the decision matrix for Google messaging.
+
+Azure Service Bus is the strongest Azure fit for command-like messages with business value. Queues handle point-to-point work, topics and subscriptions handle fan-out, sessions preserve ordered processing for related streams, and duplicate detection helps suppress repeated sends during a configured window. These features make it a good match for orders, approvals, billing workflows, and integration workloads where a lost or duplicate command has direct business consequences.
+
+Azure Event Grid is better for notifications that something happened and for reactive glue between services. It pushes events to subscribers, retries delivery, can dead-letter undelivered events, and integrates deeply with Azure services. It is not a durable work queue where a Kubernetes consumer group pulls messages at its own pace. If your pod fleet needs to drain a backlog gradually while protecting a database, Event Grid is usually the wrong primary broker.
+
+Azure Event Hubs is the streaming choice. It uses partitions and consumer groups, supports AMQP and Kafka-compatible clients, and prices capacity around throughput units, processing units, or dedicated capacity depending on tier. Use it for telemetry, clickstreams, logs, IoT events, and analytics ingestion where the business wants time-ordered event history rather than one-and-done work dispatch. KEDA can scale Event Hubs or Kafka consumers by lag, but partition count remains a real ceiling for parallelism.
+
+The vendor-neutral Kubernetes answer is to keep broker ownership outside the application Deployment. Producers should know the topic or queue contract, not the number of consumer pods. Consumers should know how to process one message safely, not how to drain an entire incident backlog. KEDA, workload identity, External Secrets Operator, the Secrets Store CSI Driver, and broker operators are platform tools around the workload; they should not hide the core contract between producer, broker, and consumer.
+
+Hypothetical scenario: a team moves an order pipeline from SQS to Kafka because "streams are more scalable." The first demo looks successful because every order event is now retained and replayable. Two months later, the operations team discovers that a single `customer_id` partition key puts the largest enterprise customer on one hot partition, KEDA cannot scale consumers past useful partition parallelism, and replaying one bug fix competes with live order processing. The better design would have asked whether replay was truly required before trading a simple queue for partition-management work.
+
+| Workload Need | Prefer This Shape | AWS Starting Point | Google Starting Point | Azure Starting Point |
+|---------------|------------------|--------------------|-----------------------|----------------------|
+| One worker should complete each task | Queue | SQS Standard or FIFO | Pub/Sub topic with one subscription | Service Bus queue |
+| Several services need independent copies | Pub/sub fan-out | SNS to SQS or EventBridge | Pub/Sub topic with multiple subscriptions | Service Bus topic or Event Grid |
+| Consumers need replayable history | Durable log/stream | MSK or Kinesis | Pub/Sub or managed Kafka | Event Hubs |
+| Existing app requires broker protocol | Managed broker | Amazon MQ | Managed Kafka or self-hosted broker | Service Bus AMQP or self-hosted broker |
+| Strict ordered workflow per entity | Ordered queue/session/log | SQS FIFO message groups | Pub/Sub ordering keys or Kafka partitions | Service Bus sessions or Event Hubs partitions |
 
 ### AWS SQS/SNS: The Workhorse
 
@@ -165,7 +235,7 @@ az servicebus queue create \
   --name order-processing \
   --max-delivery-count 3 \
   --default-message-time-to-live P14D \
-  --dead-lettering-on-message-expiration true
+  --enable-dead-lettering-on-message-expiration true
 ```
 
 ---
@@ -228,7 +298,7 @@ spec:
 
 ### IAM for Queue Access (IRSA / Workload Identity)
 
-Pods should avoid using static credentials to access message brokers whenever cloud-native workload identity is available. Use cloud-native workload identity.
+Pods should avoid static credentials when cloud-native workload identity is available.
 
 ```yaml
 # AWS: IRSA ServiceAccount
@@ -263,6 +333,27 @@ metadata:
   annotations:
     iam.gke.io/gcp-service-account: pubsub-consumer@my-project.iam.gserviceaccount.com
 ```
+
+```yaml
+# Azure: Entra Workload ID
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: servicebus-consumer
+  namespace: processing
+  annotations:
+    azure.workload.identity/client-id: <client-id>
+```
+
+On AKS, pair this ServiceAccount with a federated identity credential that trusts the cluster OIDC issuer and maps the Kubernetes service account to the Entra application (client) ID shown in the annotation.
+
+Cloud workload identity is the preferred credential boundary for message consumers. On EKS, IRSA and newer EKS Pod Identity patterns connect a Kubernetes ServiceAccount to AWS IAM permissions so pods can receive SQS, SNS, EventBridge, MQ, MSK, or Kinesis permissions without static access keys. On GKE, Workload Identity Federation for GKE lets Kubernetes service accounts receive IAM authorization for Pub/Sub and other Google APIs without service account key files. On AKS, Microsoft Entra Workload ID federates Kubernetes service account tokens with Entra identities for Service Bus, Event Hubs, Event Grid, Key Vault, and other Azure resources.
+
+Static broker credentials still appear in real systems, especially with Amazon MQ, RabbitMQ, Kafka SASL users, legacy AMQP clients, or third-party SaaS brokers. When you cannot use cloud-native workload identity directly, use External Secrets Operator or the Secrets Store CSI Driver to pull credentials from AWS Secrets Manager, Google Secret Manager, Azure Key Vault, Vault, or a similar external store. Avoid pasting connection strings into manifests, because a Git diff then becomes a credential distribution mechanism.
+
+Self-hosted brokers on Kubernetes should be managed through operators only when you accept the operational ownership. Kubernetes documents the operator pattern as a controller plus custom resources that automate application-specific operations. That fits RabbitMQ or Kafka when you need protocol control, private data locality, or specialized topology, but it also means your platform team owns upgrades, persistent volume behavior, backup, restore, partition recovery, and broker-specific alerts.
+
+Networking is part of broker integration, not an afterthought. Managed brokers often support private endpoints, VPC/VNet integration, security groups, firewall rules, or private service connect equivalents, and those choices determine whether consumer traffic leaves private network paths. A pod with perfect IAM permissions still fails if egress policies, DNS, TLS trust, or endpoint routing are wrong. Treat identity, network path, and broker authorization as one design review.
 
 ---
 
@@ -312,7 +403,6 @@ spec:
         queueURL: https://sqs.us-east-1.amazonaws.com/123456789/order-processing
         queueLength: "100"
         awsRegion: us-east-1
-        identityOwner: operator
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -321,10 +411,14 @@ metadata:
   namespace: processing
 spec:
   podIdentity:
-    provider: aws-eks
+    provider: aws
 ```
 
+For KEDA 2.13 and later, use `provider: aws` in `TriggerAuthentication` and omit the deprecated `identityOwner: operator` field from the scaler metadata.
+
 The `queueLength: "100"` setting means KEDA will scale to ensure each pod handles at most 100 messages. If there are 1,500 messages in the queue, KEDA scales to 15 pods.
+
+KEDA's SQS scaler treats "messages that need capacity" as more than only visible backlog. Current KEDA documentation describes the default calculation as visible messages plus in-flight messages, because in-flight SQS messages still represent work consuming pods. That is usually correct for batch processors, but it can over-scale a workload with long-running tasks if every pod holds a message for minutes. Tune `queueLength`, max replicas, and visibility timeout together rather than treating them as separate settings.
 
 ### KEDA ScaledObject for Pub/Sub
 
@@ -346,6 +440,8 @@ spec:
         mode: "SubscriptionSize"
         value: "50"
 ```
+
+KEDA deprecated the older `subscriptionSize` parameter in favor of `mode` + `value`; the GCP Pub/Sub scaler itself is supported. Treat this example as the shape of a scaler, then verify the `mode` and `value` fields against the KEDA version running in your cluster.
 
 ### KEDA ScaledObject for Azure Service Bus
 
@@ -370,6 +466,8 @@ spec:
         name: azure-servicebus-auth
 ```
 
+The Azure Service Bus scaler follows the same principle as SQS: choose the target message count per pod from measured service capacity, not guesswork. If one pod can safely process 20 payment commands per minute without exhausting database connections, a target of 50 active messages per pod may already be too aggressive. KEDA can create consumers quickly, but it cannot make the downstream dependency accept more writes.
+
 ### Scale-to-Zero Considerations
 
 KEDA can scale to zero (`minReplicaCount: 0`), which saves costs when queues are empty. But there is a latency cost: when the first message arrives, KEDA must detect it, scale the workload up, and wait for the application to become ready before processing begins.
@@ -386,6 +484,58 @@ KEDA can scale to zero (`minReplicaCount: 0`), which saves costs when queues are
 
 > **Stop and think**: You configure a KEDA ScaledObject for a latency-sensitive fraud detection API queue with `minReplicaCount: 0`. During a low-traffic night, the queue empties and pods scale to zero. Suddenly, a high-priority transaction is flagged for review and enters the queue. What is the customer's experience for this specific transaction?
 > *Answer*: The transaction will likely experience noticeable cold-start delay. KEDA must first detect the message, scale the Deployment from 0 to 1, and Kubernetes must start the application before the message is processed. For latency-sensitive paths, usually keep `minReplicaCount: 1`.
+
+### Throughput, Backpressure, and Cost Lens
+
+Throughput planning starts with the broker's concurrency model. SQS Standard queues support a very high, nearly unlimited number of API calls per second per action, which makes them forgiving for bursty queue workloads. SQS FIFO queues trade some of that freedom for ordering and deduplication; the default non-high-throughput FIFO limits are commonly taught as 300 API actions per second or 3,000 messages per second with batches of ten. High-throughput FIFO can go higher, but the exact quota is region-specific and should be verified before a design review.
+
+Pub/Sub hides more partition math from you, but it does not remove quotas or cost. Publishers and subscribers consume regional quota, message storage grows with retention and unacknowledged backlog, and exactly-once subscriptions add latency and quota considerations. Pub/Sub pricing is based on published, delivered, and stored bytes, with data transfer costs when throughput crosses zone or region boundaries. Batching small messages matters because many pricing and throughput systems have minimum billable units or per-request overhead.
+
+Service Bus and Event Hubs make capacity choices more visible. Service Bus Basic and Standard expose operation-based pricing and fixed operations-per-second limits, while Premium uses Messaging Units and removes some fixed Standard-tier limits. Event Hubs Standard uses throughput units, where one throughput unit provides a published ingress capacity measured in megabytes or events per second and all event hubs in the namespace share the purchased capacity. Event Hubs auto-inflate can scale TUs up, but Azure's documentation says it does not automatically scale them back down.
+
+Kafka and Event Hubs consumers scale by partitions, not by wishful thinking. If a topic has ten partitions, only ten consumers in one consumer group can actively read at the same time unless the implementation allows idle consumers. KEDA's Kafka scaler documentation reflects that reality by defaulting replica count to the number of relevant partitions, nonzero-lag partitions, and `maxReplicaCount`. Setting `maxReplicaCount: 200` on a ten-partition topic may look bold, but most of those pods will sit idle.
+
+Backpressure is the art of slowing down before the dependent system fails. A queue backlog is not automatically bad; it is the buffer doing its job. The real question is whether the queue's age, retry count, and DLQ rate remain inside the business objective. If the consumer pods scale faster than the database, payment processor, or search index can absorb work, the system converts a broker backlog into a dependency outage. A mature KEDA design caps replicas from downstream capacity tests, not from the highest queue depth seen in a dashboard.
+
+High-frequency polling is a hidden cost and load multiplier. SQS charges per API request, and every empty receive still consumes an API call. AWS recommends long polling with wait times up to 20 seconds because it reduces empty responses and false empty responses. The same principle applies beyond SQS: prefer push delivery, streaming pulls, batching, or broker-native long polling when supported. A fleet of idle pods polling a quiet queue every second can spend money and produce noise while doing no business work.
+
+Provisioned capacity has the opposite failure mode. MSK broker-hours, Event Hubs throughput units, Service Bus Premium Messaging Units, and self-hosted Kafka nodes cost money even when the queue is empty. That can be the right trade when traffic is steady, latency is tight, or throughput is predictable. It is wasteful when a workload runs once per night and spends the rest of the day at zero. Match the capacity model to the traffic curve, not to the product that feels most sophisticated.
+
+Replication and region choices can dominate the bill at moderate scale. Cross-region event routing, multi-region consumers, geo-replication, inter-region Pub/Sub delivery, and internet egress can all add charges beyond the broker's headline request or throughput price. A common surprise is a fan-out topic where one business event creates five delivered copies, each copy is retained for retry, and two copies cross a region boundary for analytics. The architecture is correct only if the cost of that fan-out is intentional.
+
+The cheapest reliable message is often the one you do not send. Avoid tiny chatty events when a batch would preserve the same business meaning. Avoid publishing full documents when a stable object-storage pointer and checksum are enough. Avoid fan-out to every team "just in case" when consumers cannot name a specific action they perform. Event-driven architecture should make coupling explicit; it should not turn every state change into a permanent tax on every downstream system.
+
+Kubernetes gives you several control knobs around those costs. `minReplicaCount` controls idle compute spend and cold-start latency. `pollingInterval` controls how quickly KEDA sees backlog changes and how often it calls cloud APIs. `cooldownPeriod` controls whether consumers flap during lumpy traffic. `maxReplicaCount` protects dependencies from a thundering herd. Pod resource requests define cluster capacity consumed during a backlog. None of those values should be copied from a tutorial into production without a load test.
+
+For Kafka or Event Hubs compatible streams, scale on consumer lag rather than CPU. CPU can be low while a consumer waits on downstream I/O, and CPU can be high while lag is already stable. Lag tells you how far behind the consumer group is from the head of the log. A useful target says, "one pod should be responsible for roughly N records of lag," then caps replicas at a value the downstream sink can survive.
+
+```yaml
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: order-stream-consumer-scaler
+  namespace: processing
+spec:
+  scaleTargetRef:
+    name: order-stream-consumer
+  minReplicaCount: 1
+  maxReplicaCount: 12
+  pollingInterval: 30
+  cooldownPeriod: 180
+  triggers:
+    - type: kafka
+      metadata:
+        bootstrapServers: orders-kafka.kafka.svc:9092
+        consumerGroup: order-projector
+        topic: order-events
+        lagThreshold: "500"
+        activationLagThreshold: "50"
+        offsetResetPolicy: latest
+```
+
+This scaler says that one consumer pod should absorb about 500 records of lag, but it also refuses to create more than 12 replicas. If the topic only has eight partitions, a default KEDA Kafka configuration will not make more active consumers than partition ownership allows. That is the important stream lesson: capacity comes from partitions, consumer efficiency, and downstream throughput together, not from replica count alone.
+
+At moderate scale, a cost review should include five numbers. Count broker requests or billable operations, delivered bytes, retained backlog age, cross-zone or cross-region transfer, and idle provisioned capacity. Then connect those numbers to design knobs: batching, long polling, push delivery, retention, DLQ redrive velocity, partition count, replica caps, and per-consumer concurrency. That review usually finds cheaper reliability improvements than a service migration.
 
 ---
 
@@ -577,11 +727,87 @@ while True:
 
 ---
 
+## Patterns & Anti-Patterns
+
+Good messaging architectures make work ownership explicit. A producer owns the schema and meaning of the message, the broker owns durable delivery mechanics, the consumer owns idempotent side effects, and the platform owns safe scaling and credentials. Problems appear when one layer silently assumes another layer solved its part. A FIFO queue cannot fix a consumer that charges twice, and a perfect idempotency key cannot save a system that deletes messages before the database commit.
+
+The most reliable pattern is a dedicated queue or subscription per consumer capability. In AWS, that often means SNS fan-out to one SQS queue per downstream service. In Google Cloud, it means one Pub/Sub subscription per service. In Azure, it means one Service Bus subscription per service on a topic. Each consumer then gets independent backlog, retry policy, DLQ, KEDA scaler, alerting, and deployment cadence. One slow analytics consumer no longer blocks billing or inventory.
+
+Another proven pattern is "lease, process, commit, ack" with idempotency. The consumer receives or locks the message, performs the business write using a stable idempotency key, commits that write, and only then deletes or acknowledges the message. If the pod crashes before the acknowledgement, the broker may redeliver the message, but the idempotency record prevents duplicate business action. That pattern works across SQS visibility timeout, Pub/Sub ack deadlines, Service Bus locks, and Kafka offset commits.
+
+For streams, the mature pattern is lag-based autoscaling with partition-aware caps. KEDA can scale Kafka-compatible consumers from lag, but partition ownership limits useful concurrency. A design that pairs lag thresholds with `maxReplicaCount`, consumer batch size, database connection limits, and partition count behaves predictably during spikes. A design that simply says "scale to 100 pods when lag grows" often creates idle consumers or overloads the sink.
+
+| Pattern | When to Use | Why It Works | Scaling Consideration |
+|---------|-------------|--------------|-----------------------|
+| Dedicated queue or subscription per service | One event must feed independent services | Backlog, DLQ, retries, and deployment ownership stay separate | Scale each consumer from its own backlog rather than shared topic volume |
+| Idempotent consumer with ack-after-commit | Any at-least-once broker feeds business side effects | Redelivery becomes safe because duplicate work is recognized | Store idempotency state in the durable system that observes the side effect |
+| Fan-out topic plus per-service DLQ | Events must reach billing, inventory, analytics, and notifications | A poison message in one consumer does not block the others | Alert on each DLQ independently and throttle redrive by downstream capacity |
+| Lag-based stream consumers | Kafka, MSK, Event Hubs, or Kinesis-like workloads need replay | Consumer lag maps to stream progress better than CPU utilization | Partition count and sink capacity cap useful replicas |
+
+The queue-as-database anti-pattern is the most common failure mode. Teams leave business state only in a queue, assume retention is a database backup, and then discover that message expiry, DLQ moves, reprocessing, or purge operations erased the only copy of important state. Queues are excellent buffers and work distributors, but the durable system of record should be a database, object store, ledger, or event store designed for that role.
+
+Missing DLQs are usually a sign that the happy path was tested but failure was not. Developers often skip DLQs because they do not yet know what a poison message looks like, but that is exactly why the DLQ is needed. Without it, one schema mismatch can create endless retries, repeated pod crashes, and noisy alerts while healthy messages wait behind bad ones. A DLQ is not enough by itself; it needs monitoring, ownership, and a safe redrive procedure.
+
+Non-idempotent consumers are dangerous because they pass every local test. A single message enters the queue, one pod processes it, and the result looks correct. Production adds retries, rollout interruptions, duplicate publishes, network timeouts, DLQ replays, and partial downstream failures. If the consumer cannot recognize that it already processed `payment-123`, the broker will eventually expose the bug.
+
+Over-scaling from backlog is another trap. A queue depth of 100,000 messages looks like a compute problem, so a team raises `maxReplicaCount` from 20 to 200. The queue drains faster for a minute, then the database connection pool, third-party API quota, or search cluster collapses. The better answer is to scale up to the measured safe rate, preserve backlog as a buffer, and use age-of-oldest-message alerts to decide whether business objectives are at risk.
+
+| Anti-Pattern | What Goes Wrong | Why Teams Fall Into It | Better Alternative |
+|--------------|-----------------|------------------------|--------------------|
+| Queue as database | Message expiry, purge, or redrive changes destroy business state | The queue already looks durable during development | Store authoritative state in a database or event store and use the queue for delivery |
+| No DLQ or unmonitored DLQ | Poison messages retry forever or disappear into an ignored side channel | Failure payloads feel unlikely before launch | Configure DLQ, alert on depth and age, and document redrive ownership |
+| Non-idempotent consumer | Redelivery creates duplicate charges, emails, shipments, or ledger rows | Tests cover one delivery, not crashes between commit and ack | Use durable idempotency keys and commit before ack/delete |
+| One shared queue for many business services | Competing consumers steal messages from each other instead of all seeing events | A queue seems simpler than fan-out topology | Use a topic with one queue or subscription per service |
+| Autoscaling without downstream budget | KEDA turns broker backlog into database or API overload | Replica count is easier to change than dependency capacity | Cap replicas from load tests and throttle DLQ redrive |
+| Ordering everything globally | Throughput collapses behind one ordered lane | "Ordered" sounds safer than per-entity ordering | Order by entity key, session, message group, or partition only where needed |
+
+Hypothetical scenario: an e-commerce team publishes every checkout event to one shared queue and lets billing, warehouse, and email pods all poll it. In testing, it appears to work because the first pod to receive each event happens to run the expected logic. In production, billing consumes some email events, warehouse misses some billing commands, and retries create inconsistent order state. The fix is not a bigger broker; it is changing the topology to fan-out with one durable subscription per service.
+
+## Decision Framework
+
+Choosing between queue, pub/sub, and stream is a business-semantics decision first, then a provider decision. Ask whether one consumer should complete the work, several consumers need independent copies, or future consumers must replay history. Then ask whether ordering matters globally, per entity, or not at all. Only after those answers are clear should the team compare SQS, Pub/Sub, Service Bus, Event Grid, Event Hubs, MSK, Kinesis, or managed Kafka.
+
+```mermaid
+flowchart TD
+    Start[New message-driven workload] --> OneWorker{Should one worker complete each item?}
+    OneWorker -- Yes --> OrderedQueue{Need strict order?}
+    OrderedQueue -- Yes --> FIFO[Ordered queue/session<br>SQS FIFO, Pub/Sub ordering key,<br>Service Bus session]
+    OrderedQueue -- No --> Queue[Standard queue/subscription<br>SQS Standard, Pub/Sub subscription,<br>Service Bus queue]
+    OneWorker -- No --> ManyCopies{Do multiple services need every event?}
+    ManyCopies -- Yes --> Replay{Need replayable event history?}
+    ManyCopies -- No --> Reconsider[Recheck the requirement<br>maybe direct API or database trigger]
+    Replay -- No --> Fanout[Fan-out pub/sub<br>SNS to SQS, Pub/Sub subscriptions,<br>Service Bus topic, Event Grid]
+    Replay -- Yes --> Stream[Durable log or stream<br>MSK, Kinesis, Pub/Sub stream pattern,<br>Event Hubs]
+    FIFO --> K8s[KEDA scaler, idempotent consumer,<br>DLQ, workload identity]
+    Queue --> K8s
+    Fanout --> K8s
+    Stream --> K8sStream[KEDA lag scaler,<br>partition-aware replica cap,<br>offset checkpointing]
+```
+
+Use a standard queue when the business wants work completion and can tolerate duplicate delivery with idempotent consumers. That is the default for background processing, image conversion, order fulfilment commands, and async API offload. On AWS, SQS Standard is usually first. On Google Cloud, Pub/Sub with one subscription gives the same consumption shape. On Azure, Service Bus queues fit when enterprise broker features matter, while Azure Storage Queue may fit simpler Azure-native work not covered deeply in this module.
+
+Use ordered queues, sessions, ordering keys, or partitions only when the order has a named business entity. "All payments globally must be ordered" is usually impossible or unnecessary. "All events for order `O-12345` must be processed in order" is realistic. AWS uses FIFO message groups, Pub/Sub uses ordering keys, Azure Service Bus uses sessions, and Kafka/Event Hubs use partition keys. Each of those choices creates lanes of serialization, so pick the key that preserves correctness without sacrificing unrelated parallelism.
+
+Use pub/sub fan-out when each consumer is a separate business capability. Billing, inventory, email, analytics, and search indexing should not steal messages from one another. Give each service its own subscription or queue and its own DLQ. This adds resources, but it buys fault isolation. The cost of several subscriptions is usually lower than the operational cost of guessing which service failed to receive which event.
+
+Use a durable log or stream when replay is a product requirement, not just an appealing feature. Streams are excellent for analytics, audit trails, event-sourced projections, CDC pipelines, IoT telemetry, and ML feature generation. They are not automatically better for simple task queues. If no team can name who will replay events, how far back they need to replay, and what downstream sink can survive the replay rate, a simple queue is probably the more honest design.
+
+| Decision Question | Queue Answer | Pub/Sub Answer | Stream Answer |
+|-------------------|--------------|----------------|---------------|
+| Who should receive one message? | Exactly one competing consumer | Every subscription gets a copy | Every consumer group can read the retained log |
+| How is progress tracked? | Delete, complete, or acknowledge after processing | Per-subscription acknowledgement state | Consumer-group offsets or checkpoints |
+| What scales consumers? | Queue depth and message age | Subscription backlog and age | Consumer lag and partition ownership |
+| What limits throughput? | API quotas, FIFO groups, consumer capacity | Regional quotas, ack behavior, subscription backlog | Partition count, broker capacity, sink throughput |
+| What does replay mean? | Usually DLQ redrive or re-enqueue | Seek/snapshot features or republish depending on service | Native retained log replay by offsets |
+| What costs spike? | Empty polling, request count, redrive storms | Delivered bytes, storage, cross-region delivery | Broker hours, throughput units, partitions, retained storage |
+
+The decision framework should end with a runbook test. Create a poison message and prove it lands in the DLQ. Kill a pod after the database commit but before the ack and prove idempotency prevents a duplicate side effect. Fill the queue with enough messages to trigger KEDA and prove the database survives the replica cap. Redrive the DLQ slowly and prove dashboards show the recovery. If those tests are missing, the design is still a diagram.
+
 ## Did You Know?
 
-1. **Amazon SQS is one of AWS's earliest services** -- it has been around since the early days of AWS and remains widely used for decoupled messaging workloads.
+1. **SQS retention is bounded but generous** — AWS documents message retention from 1 minute up to 14 days (`MessageRetentionPeriod`), matching the comparison table above.
 
-2. **Google Pub/Sub is designed for very high-scale messaging** across Google's infrastructure and is used for event-driven communication patterns where producers and consumers need to stay decoupled.
+2. **Pub/Sub default retention is shorter than many teams assume** — Google documents 7-day default subscription message retention, with topic retention configurable up to 31 days per quota documentation.
 
 3. **KEDA supports many event sources beyond cloud queues** -- message brokers, databases, metrics backends, schedules, and CI/CD systems can all drive autoscaling.
 
@@ -665,6 +891,7 @@ This exercise uses a local kind cluster with a simulated queue (Redis acting as 
 ```bash
 # Create kind cluster
 kind create cluster --name event-lab
+alias k=kubectl
 
 # Install KEDA
 helm repo add kedacore https://kedacore.github.io/charts
@@ -673,19 +900,50 @@ helm install keda kedacore/keda --namespace keda --create-namespace
 k wait --for=condition=ready pod -l app.kubernetes.io/name=keda-operator \
   --namespace keda --timeout=120s
 
-# Install Redis (simulating a message queue)
-helm repo add bitnami https://charts.bitnami.com/bitnami
-helm install redis bitnami/redis --namespace messaging --create-namespace \
-  --set architecture=standalone \
-  --set auth.password=lab-redis-pass \
-  --set master.persistence.enabled=false
-k wait --for=condition=ready pod -l app.kubernetes.io/name=redis \
+# Install Redis (simulating a message queue) — plain Deployment, not Bitnami chart
+k create namespace messaging --dry-run=client -o yaml | k apply -f -
+k apply -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+  namespace: messaging
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis
+  template:
+    metadata:
+      labels:
+        app: redis
+    spec:
+      containers:
+        - name: redis
+          image: redis:7
+          args: ["--requirepass", "lab-redis-pass"]
+          ports:
+            - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+  namespace: messaging
+spec:
+  selector:
+    app: redis
+  ports:
+    - port: 6379
+      targetPort: 6379
+EOF
+k wait --for=condition=ready pod -l app=redis \
   --namespace messaging --timeout=120s
 ```
 
 ### Task 1: Deploy a Queue Consumer
 
-Create a Deployment that processes messages from a Redis list (simulating an SQS queue).
+Create a Deployment that processes messages from a Redis list, using Redis as a local stand-in for a cloud queue during the lab.
 
 <details>
 <summary>Solution</summary>
@@ -733,7 +991,7 @@ k apply -f /tmp/consumer.yaml
 
 ### Task 2: Configure KEDA ScaledObject for Redis
 
-Create a KEDA ScaledObject that scales the consumer based on Redis list length.
+Create a KEDA ScaledObject that scales the consumer from the Redis list length, mirroring the same backlog-driven pattern used with managed queues.
 
 <details>
 <summary>Solution</summary>
@@ -745,7 +1003,8 @@ metadata:
   name: redis-auth
   namespace: messaging
 stringData:
-  redis-url: redis://:lab-redis-pass@redis-master.messaging.svc:6379
+  redis-address: redis-master.messaging.svc:6379
+  redis-password: lab-redis-pass
 ---
 apiVersion: keda.sh/v1alpha1
 kind: TriggerAuthentication
@@ -756,7 +1015,10 @@ spec:
   secretTargetRef:
     - parameter: address
       name: redis-auth
-      key: redis-url
+      key: redis-address
+    - parameter: password
+      name: redis-auth
+      key: redis-password
 ---
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
@@ -786,7 +1048,7 @@ k apply -f /tmp/keda-scaledobject.yaml
 
 ### Task 3: Generate Load and Watch Scaling
 
-Push 200 messages into the queue and watch KEDA scale the consumer.
+Push 200 messages into the queue, then watch KEDA translate backlog into additional consumer pods while the list drains.
 
 <details>
 <summary>Solution</summary>
@@ -794,7 +1056,7 @@ Push 200 messages into the queue and watch KEDA scale the consumer.
 ```bash
 # Push 200 messages to the queue
 k run redis-producer --rm -it --image=redis:7 --namespace=messaging --restart=Never -- \
-  /bin/sh -c '
+  /bin/bash -c '
   for i in $(seq 1 200); do
     redis-cli -h redis-master -a lab-redis-pass LPUSH order-queue "{\"orderId\": \"order-$i\", \"amount\": $((RANDOM % 1000))}" > /dev/null 2>&1
   done
@@ -810,7 +1072,7 @@ k get pods -n messaging -l app=queue-consumer -w
 
 ### Task 4: Implement a Dead-Letter Queue Pattern
 
-Create a second Redis list as a DLQ and modify the consumer to move failed messages there.
+Create a second Redis list as a DLQ, then modify the consumer so repeated failures are quarantined instead of retried forever.
 
 <details>
 <summary>Solution</summary>
@@ -835,7 +1097,7 @@ spec:
         - name: consumer
           image: redis:7
           command:
-            - /bin/sh
+            - /bin/bash
             - -c
             - |
               RETRY_LIMIT=3
@@ -881,7 +1143,7 @@ k exec -n messaging deploy/queue-consumer-dlq -- \
 
 ### Task 5: Monitor DLQ with an Alert Consumer
 
-Deploy a monitoring pod that watches the DLQ length.
+Deploy a monitoring pod that watches DLQ length and prints an alert when failed messages exceed the configured threshold.
 
 <details>
 <summary>Solution</summary>
@@ -943,7 +1205,9 @@ kind delete cluster --name event-lab
 
 ---
 
-**Next Module**: [Module 9.3: Serverless Interoperability (Lambda / Cloud Functions / Knative)](../module-9.3-serverless/) -- Learn when to use serverless alongside Kubernetes, how to trigger cloud functions from K8s events, and how Knative brings the serverless model directly into your cluster.
+## Next Module
+
+[Module 9.3: Serverless Interoperability (Lambda / Cloud Functions / Knative)](../module-9.3-serverless/) -- Learn when to use serverless alongside Kubernetes, how to trigger cloud functions from K8s events, and how Knative brings the serverless model directly into your cluster.
 
 ## Sources
 
@@ -961,3 +1225,28 @@ kind delete cluster --name event-lab
 - [docs.aws.amazon.com: using messagegroupid property.html](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagegroupid-property.html) — AWS directly documents that strict ordering requires FIFO queues and that `MessageGroupId` defines ordered groups.
 - [Azure Service Bus queues, topics, and subscriptions](https://learn.microsoft.com/en-us/azure/service-bus-messaging/service-bus-queues-topics-subscriptions) — It gives the cleanest vendor overview of queue vs pub/sub semantics in Azure Service Bus.
 - [KEDA upstream repository](https://github.com/kedacore/keda) — Use this as the allowlisted starting point for KEDA concepts while the primary docs host remains off-list.
+- [Amazon SQS message quotas](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/quotas-messages.html) — AWS documents Standard queue throughput behavior, FIFO throughput limits, batching effects, and message retention bounds.
+- [Amazon SQS long polling best practices](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/best-practices-setting-up-long-polling.html) — AWS explains why long polling reduces empty receives and lists the maximum wait time.
+- [Amazon SQS exactly-once processing for FIFO queues](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/FIFO-queues-exactly-once-processing.html) — AWS documents FIFO deduplication behavior and the 5-minute deduplication interval.
+- [Amazon SQS message deduplication ID](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/using-messagededuplicationid-property.html) — AWS explains how `MessageDeduplicationId` prevents duplicate delivery within the deduplication window.
+- [Amazon MQ for ActiveMQ](https://docs.aws.amazon.com/amazon-mq/latest/developer-guide/working-with-activemq.html) — AWS documents Amazon MQ broker creation, supported protocols, and managed ActiveMQ behavior.
+- [Amazon MSK Developer Guide](https://docs.aws.amazon.com/msk/latest/developerguide/what-is-msk.html) — AWS documents Amazon MSK as managed Apache Kafka and explains broker, producer, consumer, and topic concepts.
+- [Amazon EventBridge retry policy](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-rule-retry-policy.html) — AWS documents EventBridge retry behavior, default retry duration, and DLQ guidance for undelivered events.
+- [Pub/Sub exactly-once delivery](https://cloud.google.com/pubsub/docs/exactly-once-delivery) — Google documents exactly-once delivery semantics, pull-subscription scope, and regional considerations.
+- [Choose Pub/Sub or Pub/Sub Lite](https://cloud.google.com/pubsub/docs/choosing-pubsub-or-lite) — Google documents Pub/Sub Lite deprecation and the June 30, 2026 turndown date.
+- [Pub/Sub pricing](https://cloud.google.com/pubsub/pricing) — Google documents throughput, storage, and data-transfer pricing behavior for Pub/Sub and Pub/Sub Lite.
+- [Choose between Azure messaging services](https://learn.microsoft.com/en-us/azure/service-bus-messaging/compare-messaging-services) — Microsoft compares Event Grid, Event Hubs, and Service Bus by messaging scenario.
+- [Azure Event Hubs overview](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-about) — Microsoft documents Event Hubs as a managed streaming platform with partitions, consumer groups, and Kafka compatibility.
+- [Azure Event Hubs scalability](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-scalability) — Microsoft documents throughput units, processing units, and auto-inflate scaling behavior.
+- [Azure Event Hubs Kafka configurations](https://learn.microsoft.com/en-us/azure/event-hubs/apache-kafka-configurations) — Microsoft documents the Kafka-compatible endpoint and configuration differences.
+- [Azure Event Grid delivery and retry](https://learn.microsoft.com/en-us/azure/event-grid/delivery-and-retry) — Microsoft documents Event Grid at-least-once delivery, retry policy, batching, and dead-letter behavior.
+- [KEDA AWS SQS scaler](https://keda.sh/docs/latest/scalers/aws-sqs/) — KEDA documents the `aws-sqs-queue` trigger, queue length target, and in-flight message scaling behavior.
+- [KEDA GCP Pub/Sub scaler](https://keda.sh/docs/latest/scalers/gcp-pub-sub/) — KEDA documents the GCP Pub/Sub scaler, `mode`, `value`, and parameter migration notes.
+- [KEDA Azure Service Bus scaler](https://keda.sh/docs/latest/scalers/azure-service-bus/) — KEDA documents queue and topic scaling for Azure Service Bus using active message count.
+- [KEDA Apache Kafka scaler](https://keda.sh/docs/latest/scalers/apache-kafka/) — KEDA documents Kafka lag scaling and partition-aware replica constraints.
+- [Kubernetes operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/) — Kubernetes documents operators as controllers built around custom resources and reconciliation loops.
+- [Secrets Store CSI Driver introduction](https://secrets-store-csi-driver.sigs.k8s.io/introduction) — The project documents mounting external secrets into Kubernetes pods through CSI volumes.
+- [Secrets Store CSI Driver providers](https://secrets-store-csi-driver.sigs.k8s.io/providers) — The project documents supported providers including AWS, Azure, GCP, Vault, and others.
+- [Amazon EKS IAM roles for service accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) — AWS documents IRSA as the mechanism for associating IAM roles with Kubernetes service accounts.
+- [GKE Workload Identity Federation](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) — Google documents Workload Identity Federation for granting GKE workloads access to Google Cloud APIs without service account key files.
+- [AKS Microsoft Entra Workload ID](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview) — Microsoft documents Workload ID federation from Kubernetes service accounts to Microsoft Entra identities.

--- a/src/content/docs/cloud/managed-services/module-9.3-serverless.md
+++ b/src/content/docs/cloud/managed-services/module-9.3-serverless.md
@@ -27,6 +27,40 @@ This module teaches you how to think about the serverless-Kubernetes boundary. Y
 
 ---
 
+## The Serverless Landscape: Two Flavors of Compute
+
+Before you can decide where to place a workload, you need to understand what "serverless" actually means across the three major clouds. The term has fractured into two distinct execution models, and confusing them leads to bad architecture decisions.
+
+### Function-as-a-Service (FaaS)
+
+FaaS is the original serverless model: you write a single function, upload the code, and the cloud runs it on demand. The function is the unit of deployment, not the container image or the pod. AWS Lambda pioneered this model in 2014, and it remains the most mature FaaS platform. Google Cloud Functions (2nd gen, built on Cloud Run infrastructure) and Azure Functions provide equivalent capabilities.
+
+With FaaS, the cloud provider manages every layer below your code: the OS, the runtime, the scaling, and the provisioning of compute capacity. You configure memory (and, indirectly, CPU — Lambda allocates CPU proportionally to memory), set a timeout, and decide how many concurrent instances you want running at most. You never see the VM, the container host, or the scheduler.
+
+FaaS functions have hard constraints. AWS Lambda caps execution at 15 minutes. Cloud Functions 2nd gen shares the same 60-minute ceiling as Cloud Run (since it runs on Cloud Run infrastructure). Azure Functions caps at 10 minutes on the Consumption plan, though Premium and Dedicated plans remove this limit. These constraints are not accidents — they enforce the stateless, short-lived execution model that makes FaaS scalable. If your function needs 20 minutes to complete, FaaS is the wrong tool regardless of what the timeout slider says on the premium tier.
+
+FaaS also imposes limits on deployment package size. Lambda allows 50 MB zipped, 250 MB unzipped (with container image support up to 10 GB for container-packaged functions). Azure Functions Consumption plan limits you to ~500 MB of temporary local storage (memory is capped separately, ~1.5 GB per instance). These numbers exist because the platform must be able to spin up a new instance of your function in a cold-start scenario — the larger the package, the longer the initialization.
+
+### Container-Serverless
+
+Container-serverless is the newer model. Instead of uploading code, you provide a container image. The cloud runs that container on demand, scaling it (potentially to zero) based on incoming requests. AWS App Runner and Fargate, Google Cloud Run, and Azure Container Apps are the flagship container-serverless offerings.
+
+The key difference from FaaS is control and generality. A container-serverless service can run any HTTP server, any language (even one with no official cloud runtime), and any framework — Flask, Express, Spring Boot, or a custom binary listening on a port. You are not limited to the provider's blessed runtimes or the event-source handshake protocols that FaaS requires. If your application is already packaged as a container, moving it to container-serverless requires no code changes beyond ensuring it listens on the `$PORT` environment variable and starts quickly.
+
+Cloud Run is particularly notable because it is built on Knative, the same open-source serverless layer you can deploy on any Kubernetes cluster. This means a Cloud Run service and a Knative Service on your GKE cluster use the same scaling model, the same revision management, and nearly the same YAML configuration. The portability argument is real: you can develop on Cloud Run and later move the workload to your own Knative installation without rewriting the application.
+
+The tradeoff is cold-start latency. Container-serverless cold starts are typically slower than FaaS cold starts because the platform must pull a container image (which may be hundreds of megabytes) and start a full user-space process rather than injecting your code into a pre-warmed runtime. AWS Fargate cold starts can take 30-60 seconds for a new pod, while Lambda cold starts are usually in the hundreds of milliseconds. Google Cloud Run mitigates this with aggressive image caching and a lightweight container runtime, starting many services in under 2 seconds cold, but large images or frameworks with heavy initialization (Spring Boot, Django with many middleware) will push this higher.
+
+### The Blurring Line
+
+The distinction between FaaS and container-serverless is eroding. AWS Lambda supports container images as a packaging format — you can build a container image and deploy it to Lambda, using the Lambda Runtime API to handle events. But this is still FaaS: Lambda manages the lifecycle, injects events through its Runtime API, and enforces the 15-minute timeout. The container is a packaging convenience, not a different execution model.
+
+Conversely, Google Cloud Functions 2nd gen runs on Cloud Run infrastructure. A Cloud Function (2nd gen) is effectively a Cloud Run service with a pre-configured buildpack that wraps your function code in a lightweight HTTP server. The underlying execution model is container-serverless, even though the developer experience is FaaS.
+
+What should you take from this? When evaluating where to place a workload, ask two questions: *Does this workload fit within a FaaS timeout and packaging constraint?* and *Does my team want to manage containers, or do we want the cloud to handle the runtime?* If the answer to the first question is yes and the second is "manage it for us," FaaS is the default. If either answer is no, container-serverless (or Kubernetes) is the better choice.
+
+---
+
 ## When Serverless vs When Kubernetes
 
 This is not a religious debate. It is a cost and operational decision matrix.
@@ -64,11 +98,34 @@ The exact crossover depends on execution time, memory, and provider pricing. But
 
 > **Stop and think**: If a service handles 5 million requests per month but each request takes 10 milliseconds and requires very little memory, would it still strictly follow the "Kubernetes wins above 2M requests" rule? Why might serverless still be cheaper here?
 
+### Decision Flowchart
+
+When you are staring at a new workload and need to decide where it runs, use the following flowchart. It captures the tradeoffs from the decision matrix in a sequence of elimination questions rather than a parallel comparison. Each "no" moves you closer to the right runtime; each "yes" narrows your options.
+
+```mermaid
+graph TD
+    Start["New workload"] --> Q1{"Runs continuously<br/>(24/7, steady traffic)?"}
+    Q1 -->|Yes| K8s["Kubernetes Deployment"]
+    Q1 -->|No| Q2{"Needs >15 min<br/>execution time?"}
+    Q2 -->|Yes| K8s
+    Q2 -->|No| Q3{"Requires GPU,<br/>large disk, or<br/>persistent conn?"}
+    Q3 -->|Yes| K8s
+    Q3 -->|No| Q4{"Already packaged as<br/>a container image?"}
+    Q4 -->|Yes| ContainerSL["Container-Serverless<br/>(Cloud Run / Fargate)"]
+    Q4 -->|No| Q5{"Language supported<br/>by FaaS runtime?"}
+    Q5 -->|Yes| FaaS["FaaS<br/>(Lambda / Cloud Functions)"]
+    Q5 -->|No| ContainerSL
+```
+
+This flowchart is a starting point, not a final answer. A workload might tick every container-serverless box and still be a better fit for Kubernetes if your team already operates a mature cluster, or if the workload shares a database with services that run on Kubernetes and you want to minimize cross-network latency. The flowchart eliminates obviously wrong choices; the remaining options should be weighed against team expertise, existing infrastructure, and cost.
+
 ---
 
 ## Triggering Cloud Functions from Kubernetes
 
-The most common pattern is using Kubernetes workloads as producers and cloud functions as async processors.
+The most common pattern is using Kubernetes workloads as producers and cloud functions as async processors. The Kubernetes pod runs as part of a Deployment or StatefulSet, handling the steady-state business logic, while the cloud function handles spiky, event-driven, or infrequent workloads that do not justify a permanently running container. The integration point between these two worlds is almost always a message broker (SQS, Pub/Sub, Event Hubs) or an event bus (EventBridge, Eventarc, Event Grid). Understanding why the message broker is the right integration point — rather than direct HTTP calls from pod to function — is essential for building reliable hybrid architectures.
+
+When a Kubernetes pod calls a Lambda function directly via HTTP, three things can go wrong: the function may be scaled to zero and start cold, introducing latency into the pod's request path; the function may be throttled (Lambda has account-level concurrent execution limits), causing the pod's request to fail; and if the pod itself crashes or restarts mid-call, there is no record of whether the function was invoked. A message broker solves all three: the pod writes a message and moves on, the broker buffers messages through traffic spikes, and the message persists until the function acknowledges successful processing. This decoupling is the foundation of every production-grade Kubernetes-to-serverless integration.
 
 ### Pattern 1: Queue-Triggered Functions
 
@@ -118,6 +175,8 @@ def request_report(user_id, report_type):
     )
 ```
 
+This queue-based pattern is the most robust integration between Kubernetes and serverless because it decouples the producer and consumer in both time and scale. The Kubernetes pod publishes a message and forgets about it, regardless of whether the serverless function is scaled to zero, throttled, or experiencing errors. If the function fails, the message remains in the queue (or moves to a dead-letter queue if you configure one). If traffic spikes 100x, the queue buffers the backlog while the serverless platform scales out. This is the architecture you want for any workload where delivery guarantees matter more than sub-second latency.
+
 ### Pattern 2: HTTP-Triggered Functions via API Gateway
 
 ```mermaid
@@ -133,12 +192,14 @@ aws apigatewayv2 create-api \
   --name hybrid-api \
   --protocol-type HTTP
 
-# Route /api/* to K8s ALB
+# Route /api/* to K8s ALB (private ALB requires a VPC link created first)
 aws apigatewayv2 create-integration \
   --api-id $API_ID \
   --integration-type HTTP_PROXY \
   --integration-uri arn:aws:elasticloadbalancing:us-east-1:123456789:listener/app/k8s-alb/abc123 \
-  --integration-method ANY
+  --integration-method ANY \
+  --connection-type VPC_LINK \
+  --connection-id $VPC_LINK_ID
 
 # Route /reports/* to Lambda
 aws apigatewayv2 create-integration \
@@ -197,7 +258,9 @@ spec:
 
 ## API Gateways: Bridging Both Worlds
 
-Cloud API Gateways sit in front of both Kubernetes services and serverless functions, providing a unified entry point.
+Cloud API Gateways sit in front of both Kubernetes services and serverless functions, providing a unified entry point. This is the architectural pattern that makes hybrid Kubernetes-serverless systems feel like a single application to external consumers. The API Gateway handles authentication, rate limiting, request validation, and response transformation at the edge — before any request reaches either a Kubernetes pod or a serverless function. This means your backend services, regardless of where they run, do not need to implement these cross-cutting concerns themselves.
+
+The routing logic at the API Gateway is what connects the two worlds. Typically, you define path-based routes: `/api/v1/orders` goes to the Kubernetes-hosted order service (steady traffic, database connections, complex business logic), while `/webhooks/stripe` goes to a Lambda function (spiky, stateless, third-party callback processing). Modern API Gateways support multiple integration types — HTTP proxy to any reachable endpoint, AWS Lambda proxy for direct function invocation without an intermediate HTTP layer, and mock integrations for testing. The key design decision is which routes belong on which backend, and that decision should flow from the traffic and cost analysis covered earlier in this module. A route that receives 10 requests per day does not need a permanently running Kubernetes pod; a route that receives 10,000 requests per minute should not pay per-invocation serverless pricing.
 
 ### Multi-Backend Architecture
 
@@ -268,6 +331,8 @@ graph TD
 ### Installing Knative
 
 ```bash
+alias k=kubectl
+
 # Install Knative Serving
 k apply -f https://github.com/knative/serving/releases/download/knative-v1.16.0/serving-crds.yaml
 k apply -f https://github.com/knative/serving/releases/download/knative-v1.16.0/serving-core.yaml
@@ -401,7 +466,11 @@ spec:
 
 ## Fargate vs Autopilot: Serverless Containers
 
-Fargate (AWS) and Autopilot (GCP) remove node management entirely. You define pods, and the cloud runs them without you provisioning or managing nodes.
+Fargate (AWS) and Autopilot (GCP) remove node management entirely. You define pods, and the cloud runs them without you provisioning or managing nodes. This is the container-serverless model applied to Kubernetes: you write standard Kubernetes manifests, but the control plane schedules your pods onto cloud-managed compute capacity rather than onto nodes you provisioned. You never SSH into a node, never patch a kernel, and never wonder whether your node group has enough capacity for the next deployment. The cloud handles all of that.
+
+This abstraction comes with a significant operational shift. On a standard Kubernetes cluster, you think in terms of nodes — how many you need, what instance types, whether to use spot or reserved. On Fargate or Autopilot, you think in terms of pods — how much CPU and memory each pod requests, and how many pods can run concurrently. The pod becomes the billing unit rather than the node. This changes how you reason about cost: instead of paying for a pool of compute that sits partially idle, you pay for exactly the resources each pod consumes, per second.
+
+The tradeoff is control. Fargate does not support privileged containers, host networking, or DaemonSets because those abstractions require node-level access, and Fargate provides no node to access. If your workload needs to mount a hostPath volume, run a log collection DaemonSet, or use a GPU with custom driver configuration, Fargate is not the right choice. Autopilot is more permissive — it supports DaemonSets and GPU workloads — but it still abstracts away the node, meaning you cannot SSH in to debug a kernel panic or inspect a container runtime issue. For teams that have invested in node-level observability and debugging workflows, this loss of visibility is a genuine operational cost that must be weighed against the reduction in node management toil.
 
 > **Pause and predict**: If you deploy a DaemonSet to a cluster using EKS Fargate for all its compute capacity, how many pods will the DaemonSet create? How does the Fargate architecture dictate this outcome?
 
@@ -412,7 +481,7 @@ Fargate (AWS) and Autopilot (GCP) remove node management entirely. You define po
 | Billing unit | Per pod (vCPU + memory per second) | Per pod (vCPU + memory per second) | Per container group (ACI pricing) |
 | DaemonSets | Not supported | Supported (since 2024) | Not supported |
 | GPUs | Supported (limited) | Supported | Not supported |
-| Persistent storage | EBS CSI (since 2024) | GCE PD | Azure Files |
+| Persistent storage | EFS CSI (static provisioning; EBS not supported on Fargate) | GCE PD | Azure Files |
 | Max pods per node | 1 pod = 1 "node" | Managed by GKE | Burstable |
 | Startup time | 30-60 seconds | Transparent | 15-30 seconds |
 | Best for | Batch, low-traffic services | Entire cluster, hands-off | Burst capacity |
@@ -467,7 +536,7 @@ Cold starts are the primary drawback of serverless. Here are practical mitigatio
 | **min-scale: 1** (Knative) | Keep one pod running | First request is usually warm |
 | **Warm-up endpoints** | Health check that loads dependencies | Reduces initialization overhead |
 | **Smaller images** | Alpine/distroless base images | Faster pull and startup |
-| **SnapStart** (Lambda Java) | Snapshot after init, restore on invocation | 90% reduction for JVM cold starts |
+| **SnapStart** (Lambda: Java, Python, .NET) | Snapshot after init, restore on invocation | 90% reduction for JVM cold starts |
 | **GraalVM native images** | Ahead-of-time compilation | 10-50ms startup for Java |
 
 ```bash
@@ -477,6 +546,20 @@ aws lambda put-provisioned-concurrency-config \
   --qualifier prod \
   --provisioned-concurrent-executions 5
 ```
+
+The cold-start problem deserves deeper treatment because it is the single most common reason teams reject serverless after an initial trial. Understanding *why* cold starts happen and *which* strategies apply to which runtimes is essential for making serverless work in production.
+
+**What causes a cold start?** When a serverless platform receives a request and no warm instance is available, it must create a new execution environment from scratch. For AWS Lambda, this means Firecracker — a purpose-built microVM — is provisioned, the runtime (Node.js, Python, Java, etc.) is loaded into the microVM, your code package is downloaded and extracted, and your initialization code (the code outside your handler function) runs. Only then can the platform invoke your handler with the incoming event. This entire chain — provisioning, runtime bootstrap, package load, init — is the cold start.
+
+The dominant cost in a cold start varies by runtime. For interpreted languages like Python and Node.js, the runtime bootstrap is fast (typically under 50 ms) and the dominant cost is initialization code — database connection pools, SDK client instantiation, framework setup. For JVM languages like Java and Kotlin, the JVM startup itself adds hundreds of milliseconds to seconds, which is why SnapStart and GraalVM native images are particularly valuable for the Java ecosystem. For Go, the compiled binary starts nearly instantly, so initialization code is again the dominant factor.
+
+**Provisioned concurrency** (Lambda) and **min instances** (Cloud Run) work by pre-allocating execution environments that sit idle, waiting for requests. These warm instances handle the first N concurrent requests without any cold start. The tradeoff is cost: you pay for the idle compute even when no requests arrive. For a latency-sensitive API with predictable baseline traffic, provisioning 2-3 warm instances may cost an extra $20-50 per month and eliminate the P99 latency spike that cold starts cause. For an unpredictable workload with zero traffic most of the time, provisioned concurrency wastes money.
+
+**SnapStart** (Lambda, for Java 11/17/21, plus Python and .NET) takes a different approach. Instead of keeping instances warm, Lambda snapshots the memory state of your function after initialization completes and persists that snapshot. When a cold start occurs, Lambda restores the snapshot instead of re-running initialization. The restore is fast (typically under 200 ms for JVM functions) because it is essentially a memory copy rather than a full JVM bootstrap and class-loading cycle. SnapStart does not eliminate cold starts entirely — it eliminates the initialization portion, leaving only the microVM provisioning and snapshot restore. It also introduces a constraint: any code that relies on uniqueness (random seeds, GUIDs generated during init, cached network connections) must be re-executed after restore, because the snapshot captures a frozen moment in time.
+
+**The container-serverless cold-start penalty.** Cloud Run and Fargate cold starts are typically longer than Lambda cold starts because the platform must pull a container image from a registry before starting it. Google mitigates this with aggressive caching of frequently used images and layers. AWS Fargate does not cache images across Fargate tasks — every new task pulls the image fresh, which is why Fargate cold starts are 30-60 seconds for typical images. If your container-serverless workload cannot tolerate this latency, you must either keep a minimum instance warm (Cloud Run `min-instances`) or use Kubernetes with pre-scaled pods instead.
+
+**KEDA and scale-to-zero on Kubernetes.** The Kubernetes ecosystem has its own answer to scale-to-zero: KEDA (Kubernetes Event-Driven Autoscaling). Unlike Knative, which is request-driven, KEDA scales based on event sources — queue depth, Kafka consumer lag, database query results, cron schedules. A KEDA-scaled deployment can scale to zero replicas when the event source is idle, and KEDA will scale it back up when events arrive. The cold-start latency on Kubernetes scale-to-zero is typically higher than on a managed FaaS platform because a Kubernetes pod must be scheduled onto a node, pull its image, and start — a process that can take 5-30 seconds depending on image size and cluster capacity. KEDA is the right choice when you need serverless-style scaling but cannot use a managed FaaS (compliance reasons, existing Kubernetes investment, or workload characteristics that exceed FaaS limits).
 
 ---
 
@@ -505,6 +588,82 @@ graph TD
 - **API pods on EKS**: Steady traffic, complex logic, persistent DB connections
 - **Webhook Lambda**: Spiky, unpredictable, stateless
 - **Report Lambda**: Infrequent, CPU-intensive for short bursts, output to S3
+
+---
+
+## Cost Lens: Serverless Economics
+
+Serverless pricing is seductive at low volume, but it can become punishing at scale if you do not understand the cost drivers. This section explains the mechanics, the traps, and the strategies for keeping serverless costs predictable.
+
+### How You Pay
+
+Every serverless compute platform bills on two dimensions: **invocations** (the number of times your function or service is called) and **duration** (how long each invocation runs, measured in GB-seconds or vCPU-seconds). AWS Lambda charges $0.20 per million requests plus $0.0000166667 per GB-second of execution time. Google Cloud Run charges per request ($0.40 per million) plus per vCPU-second and per GB-second of memory. Azure Functions Consumption plan charges $0.20 per million executions plus $0.000016 per GB-second.
+
+A lightweight function that runs for 100 ms with 256 MB of memory costs roughly $0.0000003 per invocation in compute — negligible at any reasonable scale. The invocation cost ($0.0000002 per call for Lambda) dominates for very short functions. But add memory and duration, and the GB-second charges grow linearly.
+
+At moderate scale — say, 10 million invocations per month, each running 500 ms with 1 GB of memory — Lambda costs roughly: 10M × $0.0000002 (invocation) = $2.00, plus 10M × 0.5 sec × 1 GB × $0.0000166667/GB-sec = $83.33. Total: ~$85/month. Compare this with the smallest always-on EKS node (a single t3.medium at ~$30/month reserved, plus control plane costs), and you can see why serverless wins at low-to-moderate volume.
+
+### The Cost Spike Scenarios
+
+Serverless costs spike in three predictable scenarios, and each has a mitigation.
+
+**Scenario 1: High sustained traffic.** At 100 million invocations per month with the same 500 ms / 1 GB profile, Lambda costs ~$853/month. Three always-on t3.medium nodes with reserved pricing cost ~$90/month and can handle significantly more throughput than a single Lambda instance. Above roughly 20-30 million invocations per month, Kubernetes becomes cheaper for any workload with steady traffic, because you pay for capacity rather than per-invocation. The mitigation is straightforward: identify the crossover point for your workload and move steady-state services to Kubernetes.
+
+**Scenario 2: Provisioned concurrency left on.** Provisioned concurrency eliminates cold starts by keeping instances warm, but you pay for those instances whether they handle requests or not. Five provisioned concurrent instances of a 1 GB Lambda function cost roughly $130/month in idle compute — more than the invocation and duration costs for many workloads. Teams often enable provisioned concurrency during launch, see improved latency, and forget to right-size it. A month later, the serverless bill is 3x the expected amount. The mitigation: use provisioned concurrency only for latency-sensitive paths, monitor the actual concurrent request count, and scale provisioned concurrency up and down with a schedule if traffic is predictable (lower it at night).
+
+**Scenario 3: Function-to-function chaining.** If a Lambda function calls another Lambda function synchronously and waits for the response, you pay for both functions' duration during the wait. A chain of three synchronous Lambda calls, each waiting 2 seconds for the next, bills for 6 seconds of compute per end-to-end request, even though the actual CPU work is minimal. This is the "chatty serverless" anti-pattern. The mitigation: use asynchronous patterns (SQS, EventBridge, Step Functions) for multi-step workflows. Step Functions let you orchestrate Lambda calls without paying for wait time — you pay per state transition (about $0.000025 per step) rather than per waiting second.
+
+### Free Tiers and Their Limits
+
+All three clouds offer generous free tiers that make experimentation essentially free, but each tier has hard limits that can catch teams off guard. AWS Lambda's free tier provides 1 million requests and 400,000 GB-seconds per month — enough to run a moderate production workload for free if your functions are short and lightweight. Cloud Run's free tier provides 2 million requests and 360,000 vCPU-seconds per month. Azure Functions offers 1 million executions and 400,000 GB-seconds. These tiers apply every month, not just during a trial period.
+
+The trap is that once you exceed the free tier, you pay for *all* usage, not just the excess. A service that runs at 1.1 million Lambda invocations per month pays for 1.1 million, not 100,000. Teams that grow gradually from the free tier into paid usage often miss this detail and are surprised by the first bill.
+
+---
+
+## Patterns & Anti-Patterns
+
+Serverless architecture has accumulated a body of proven patterns and well-known failure modes. The patterns below represent what works at scale across hundreds of production deployments. The anti-patterns are mistakes that teams make repeatedly, regardless of cloud provider or runtime.
+
+### Patterns
+
+**1. Async Queue Decoupling.** Place a message queue between your request producer and your serverless consumer. The producer (typically a Kubernetes pod or an API endpoint) writes a message to SQS, Pub/Sub, or Azure Service Bus and immediately returns a success response. The serverless function consumes from the queue, processes the message, and writes the result. This pattern absorbs traffic spikes, provides retry semantics (the message stays in the queue if processing fails), and allows the function to scale independently of the producer. It is the default integration pattern for any Kubernetes-to-serverless handoff.
+
+When to use it: whenever the caller does not need a synchronous response, or when the processing time is too variable to expose as an HTTP endpoint. Batch jobs, report generation, image processing, and email delivery are canonical use cases.
+
+**2. API Gateway Routing with Lambda Function URLs.** Instead of routing all traffic through a single Kubernetes ingress, split routes at the API Gateway layer: steady-state CRUD endpoints go to your Kubernetes services, while spiky or infrequent endpoints (webhooks, file upload processing, notification delivery) go directly to Lambda Function URLs or Cloud Run services. This reduces load on your Kubernetes cluster, eliminates the need to scale pods for low-traffic endpoints, and provides a unified authentication and rate-limiting layer at the API Gateway.
+
+When to use it: when migrating from a monolith to a hybrid architecture, or when adding new microservices that have dramatically different traffic patterns from the existing Kubernetes-hosted services.
+
+**3. Container-Serverless for Brownfield Migration.** When you have an existing containerized service that you want to run serverlessly without rewriting it, container-serverless (Cloud Run, Fargate, Azure Container Apps) is the path of least resistance. The service already listens on a port, already has health checks, and already packages as a container. Deploying it to Cloud Run requires no code changes — you push the image to Artifact Registry, create a Cloud Run service pointing at that image, and configure `min-instances` if you need warm starts. The migration from Kubernetes Deployment to Cloud Run service can take less than an hour for a simple HTTP service.
+
+When to use it: when you have containerized services with spiky or low-volume traffic, and your team lacks the bandwidth to refactor them into FaaS functions. Also the right choice when the service uses a language or framework not supported by FaaS runtimes.
+
+**4. Step Functions for Multi-Step Workflows.** Serverless functions should do one thing and do it quickly. Complex business logic that spans multiple steps — payment processing, order fulfillment, data pipeline orchestration — should be modeled as a state machine using AWS Step Functions, Google Cloud Workflows, or Azure Durable Functions. Each step is a separate function invocation, and the workflow engine handles retries, error routing, and parallelism. This keeps individual functions small and testable, avoids the function-to-function chaining anti-pattern, and provides visibility into workflow execution (each step is logged and traceable).
+
+When to use it: any workflow with more than two sequential steps that must complete in a specific order, or any workflow where failure in one step requires compensating actions in earlier steps.
+
+### Anti-Patterns
+
+**1. Serverless for Long-Running or Stateful Workloads.** Deploying a workload that runs for more than the FaaS timeout (15 minutes for Lambda, 60 for Cloud Run) to a serverless platform is a guaranteed failure. The platform terminates the execution, and any in-memory state is lost. Teams fall into this anti-pattern when they treat serverless as "cheap compute" without understanding the timeout constraints. A video transcoding pipeline that takes 45 minutes per file will never work on Lambda regardless of how much memory you allocate.
+
+Better approach: for long-running workloads, use Kubernetes Jobs or a container-serverless platform with a higher timeout (Cloud Run supports up to 60 minutes). For stateful workloads that need persistent connections (WebSocket servers, database connection pools that span requests), use Kubernetes Deployments with persistent pod identity.
+
+**2. Chatty Function-to-Function Synchronous Calls.** When a Lambda function calls another Lambda function via `Invoke` with `InvocationType: 'RequestResponse'` and waits, you pay for both functions' execution time simultaneously. A chain of five synchronous calls, each running 1 second, costs 5 seconds of billed duration per end-to-end request, even though the actual CPU time might total 500 ms. This pattern also introduces cascading latency: if the third function in the chain experiences a cold start, every upstream caller waits.
+
+Better approach: use an orchestrator service (Step Functions, Cloud Workflows) that invokes each function and waits at the orchestrator level, where you pay per state transition rather than per waiting second. Or restructure the workflow as an event-driven pipeline: each function publishes an event when it completes, and the next function subscribes to that event.
+
+**3. Cold Start on the User-Facing Path.** The first request a user makes should never pay a cold-start penalty. If your login endpoint or your product search endpoint is a Lambda function that scales to zero between uses, every user who visits after a quiet period experiences a multi-second delay. This is the fastest way to make users hate your serverless architecture, and it is completely avoidable.
+
+Better approach: identify every function that serves a synchronous user request (HTTP endpoints behind API Gateway, gRPC services) and either configure provisioned concurrency / min-instances for them, or move them to Kubernetes where pods stay warm. Reserve scale-to-zero for async, background, and batch workloads where latency is not user-visible.
+
+**4. Ignoring Execution Environment Reuse.** Serverless platforms reuse execution environments across invocations. If your function writes temporary files to `/tmp`, opens database connections during initialization, or caches data in global variables, those artifacts persist across invocations within the same warm instance — but they are NOT shared across instances and they disappear when the instance is recycled. Teams that rely on `/tmp` state between invocations (e.g., writing a file in invocation 1 and reading it in invocation 2) eventually hit an error when the second invocation lands on a different instance.
+
+Better approach: treat every invocation as if it runs in a fresh environment. Use external storage (S3, GCS, Blob) for any state that must survive beyond a single invocation. Use the execution context for performance optimization only (cached SDK clients, pre-loaded configuration), never for correctness.
+
+**5. Over-Provisioning Memory Without Understanding CPU Coupling.** AWS Lambda allocates CPU proportionally to memory: a 256 MB function gets roughly 0.16 vCPU, while a 1,792 MB function gets 1 full vCPU. Teams that set memory to 256 MB because "it's just a small function" and then wonder why it runs slowly are experiencing CPU throttling, not a platform defect. This also works in reverse: setting memory to 10 GB to get more CPU, even though the function only uses 200 MB of RAM, wastes money on unneeded memory allocation.
+
+Better approach: benchmark your function at different memory levels and find the sweet spot where execution time stops improving significantly. For CPU-bound functions, this is typically 1,792 MB (the point where a full vCPU is allocated). Above that, you get more vCPUs but pay proportionally for the memory.
 
 ---
 
@@ -573,6 +732,18 @@ With GKE Autopilot, the entire cluster is managed as a serverless container plat
 Knative solves this by handling traffic splitting at the networking and request routing layer, rather than relying on the ratio of running pod replicas. You simply update the Knative Service definition with a `traffic` block, explicitly mapping 95% to the v1 revision name and 5% to the v2 revision name. Knative configures the underlying ingress gateway (like Kourier or Istio) to route exactly 5% of incoming HTTP requests to the v2 pods, regardless of how many pods are currently running. This allows for precise, percentage-based canary rollouts even for services with very low request volumes or minimal replica counts.
 </details>
 
+<details>
+<summary>7. You notice your monthly Lambda bill jumped from $50 to $380 after enabling provisioned concurrency for a production API. The function runs with 1 GB of memory and you configured 10 provisioned concurrent instances. The function receives about 2 million invocations per month, each averaging 200 ms. Calculate the approximate monthly cost of the provisioned concurrency portion alone, and explain whether 10 instances is appropriate for this workload.</summary>
+
+Ten provisioned concurrent instances of a 1 GB Lambda function cost roughly: 10 instances × 1 GB × 730 hours/month × $0.0000041667 per GB-second (the provisioned concurrency rate, which is roughly 25% of the standard compute rate for the "always-on" portion) × 3,600 seconds/hour ≈ $109 per month in provisioned concurrency compute. Adding the invocation costs, the total bill increase to $380 suggests the provisioned concurrency is the dominant cost driver. For 2 million invocations per month at 200 ms each, the peak concurrency is likely well under 5 — meaning 10 provisioned instances are excessive. Reducing to 3 provisioned instances would still handle the steady-state traffic without cold starts while cutting the provisioned concurrency cost by ~70%.
+</details>
+
+<details>
+<summary>8. A platform team is comparing Cloud Run and Knative on GKE for a new service. The service is an HTTP API written in Go, packaged as a 12 MB distroless container, that needs to handle occasional traffic spikes but otherwise sits idle. The team already operates a GKE cluster. What are the decision factors between deploying to Cloud Run (managed) versus Knative on their existing GKE cluster?</summary>
+
+The decision hinges on three factors. First, operational overhead: Cloud Run eliminates the need to maintain the Knative installation, the Kourier/Istio networking layer, and the monitoring stack — Google manages all of it. On GKE, the team must install, upgrade, and troubleshoot Knative themselves, which adds ongoing maintenance cost. Second, cold-start latency: Cloud Run's managed infrastructure caches images aggressively and optimizes container startup, typically providing faster cold starts than a self-managed Knative installation where image pulls depend on cluster node disk and network conditions. Third, integration: if the service must communicate with other services on the same GKE cluster with very low latency, Knative on GKE keeps the traffic inside the cluster network; Cloud Run adds cross-network latency (typically low for same-region traffic, but non-zero). For a spiky, low-maintenance service, Cloud Run is usually the lower-total-cost option, but if the team values control over the serving layer and wants cluster-local networking, Knative on GKE is the right choice.
+</details>
+
 ---
 
 ## Hands-On Exercise: Knative Service with Scale-to-Zero
@@ -580,6 +751,8 @@ Knative solves this by handling traffic splitting at the networking and request 
 ### Setup
 
 ```bash
+alias k=kubectl
+
 # Create kind cluster with extra ports for Knative and explicitly target v1.35
 cat > /tmp/kind-knative.yaml << 'EOF'
 kind: Cluster
@@ -622,7 +795,7 @@ k patch configmap/config-domain \
 
 ### Task 1: Deploy a Knative Service
 
-Create a Knative Service that returns "Hello from Knative" and scales to zero.
+Deploy a Knative Service that responds to HTTP requests with a greeting message and is configured to scale down to zero replicas when idle, then verify it is ready to receive traffic.
 
 <details>
 <summary>Solution</summary>
@@ -664,7 +837,7 @@ k wait ksvc hello --for=condition=Ready --timeout=60s
 
 ### Task 2: Test Scale-to-Zero Behavior
 
-Verify the service scales to zero and then scales back up on request.
+Observe the Knative Service scaling down to zero replicas after an idle period, then trigger a request and confirm that the Activator component buffers the request and brings a new pod online to handle it.
 
 <details>
 <summary>Solution</summary>
@@ -695,7 +868,7 @@ k get pods -l serving.knative.dev/service=hello
 
 ### Task 3: Deploy a Second Revision and Split Traffic
 
-Update the service with a new environment variable and split traffic 80/20.
+Create a new revision of the Knative Service with an updated environment variable, then configure a traffic split that routes 80% of requests to the original revision and 20% to the new revision for canary testing.
 
 <details>
 <summary>Solution</summary>
@@ -750,7 +923,7 @@ done
 
 ### Task 4: Configure Knative Eventing with a PingSource
 
-Set up a cron-based event source that triggers the Knative service every minute.
+Install Knative Eventing components on the cluster, then create a PingSource that fires a CloudEvent on a cron schedule every minute and sends it to the Knative Service as a trigger target.
 
 <details>
 <summary>Solution</summary>
@@ -804,10 +977,21 @@ kind delete cluster --name knative-lab
 
 ---
 
-**Next Module**: [Module 9.4: Object Storage Patterns (S3 / GCS / Blob)](../module-9.4-object-storage/) -- Learn how to access cloud object storage from Kubernetes pods using CSI drivers, pre-signed URLs, and cross-region replication patterns.
+## Next Module
+
+[Module 9.4: Object Storage Patterns (S3 / GCS / Blob)](../module-9.4-object-storage/) — Learn how to access cloud object storage from Kubernetes pods using CSI drivers, pre-signed URLs, and cross-region replication patterns.
 
 ## Sources
 
 - [AWS Lambda asynchronous invocation](https://docs.aws.amazon.com/lambda/latest/dg/invocation-async.html) — Covers queueing behavior, async invocation semantics, and error-handling context for Kubernetes-to-Lambda handoff patterns.
 - [Knative Serving repository](https://github.com/knative/serving) — Good upstream entry point for Knative Serving concepts such as scale-to-zero, revisions, and request-driven compute.
 - [Google Kubernetes Engine pricing](https://cloud.google.com/kubernetes-engine/pricing) — Useful for understanding where Autopilot pricing follows Pod requests and where hardware-specific cases use different billing.
+- [AWS Lambda runtimes](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html) — Supported runtimes, runtime deprecation policy, and custom runtime configuration for Lambda.
+- [AWS Lambda SnapStart](https://docs.aws.amazon.com/lambda/latest/dg/snapstart.html) — SnapStart behavior, supported runtimes (Java 11/17/21, plus Python and .NET), runtime hooks, and pricing implications for JVM cold-start reduction.
+- [Google Cloud Run min instances](https://cloud.google.com/run/docs/configuring/min-instances) — Configuring minimum instances to eliminate cold starts on Cloud Run, including cost implications.
+- [AWS Fargate platform versions](https://docs.aws.amazon.com/eks/latest/userguide/fargate.html) — EKS Fargate capabilities, limitations (DaemonSets, privileged containers), and pod configuration.
+- [Azure Functions scale and hosting plans](https://learn.microsoft.com/en-us/azure/azure-functions/functions-scale) — Consumption, Premium, and Dedicated plan limits, cold-start behavior, and scaling decisions.
+- [KEDA documentation](https://keda.sh/docs/) — Event-driven autoscaling for Kubernetes, including scalers for cloud queue services (AWS SQS, GCP Pub/Sub, Azure Service Bus).
+- [AWS Step Functions pricing](https://aws.amazon.com/step-functions/pricing/) — Per-state-transition pricing model as an alternative to synchronous Lambda chaining.
+- [AWS Lambda provisioned concurrency](https://docs.aws.amazon.com/lambda/latest/dg/configuration-concurrency.html) — Reserved vs provisioned concurrency, pricing, and configuration for latency-sensitive workloads.
+- [CloudEvents specification](https://cloudevents.io/) — CNCF standard event format used by Knative Eventing for interoperable event routing.

--- a/src/content/docs/cloud/managed-services/module-9.4-object-storage.md
+++ b/src/content/docs/cloud/managed-services/module-9.4-object-storage.md
@@ -1,36 +1,117 @@
 ---
-revision_pending: true
 title: "Module 9.4: Object Storage Patterns (S3 / GCS / Blob)"
 slug: cloud/managed-services/module-9.4-object-storage
 sidebar:
   order: 5
 ---
-**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Module 9.1 (Databases), Kubernetes PersistentVolumes and CSI concepts
+**Complexity**: [MEDIUM] | **Time to Complete**: 2h | **Prerequisites**: Module 9.1 (Databases), Kubernetes PersistentVolumes and CSI concepts — you should understand when to use a PVC versus an HTTP API before choosing object storage patterns for pods.
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+After completing this module, you will be able to apply multi-cloud object storage patterns from Kubernetes workloads with correct security, cost, and durability tradeoffs:
 
-- **Implement CSI-based object storage mounting (Mountpoint for S3, GCS FUSE, Azure Blob CSI) for Kubernetes workloads**
-- **Configure lifecycle policies and intelligent tiering across S3, GCS, and Azure Blob for cost-optimized data pipelines**
-- **Deploy object storage access patterns using presigned URLs, workload identity, and IRSA/Workload Identity integration**
-- **Design object storage replication, versioning, and lifecycle strategies for robust data protection and disaster recovery**
+- **Compare object, block, and file storage and justify object storage for unstructured data, backups, and static assets on Kubernetes**
+- **Configure storage classes, lifecycle rules, and S3 Intelligent-Tiering across Amazon S3, Google Cloud Storage, and Azure Blob for cost-aware pipelines**
+- **Implement SDK access, CSI mounts, and pre-signed URLs from pods using IRSA, GKE Workload Identity, and Azure Workload Identity**
+- **Design versioning, cross-region replication, and Object Lock immutability for disaster recovery and compliance-aligned retention**
 
 ---
 
 ## Why This Module Matters
 
-A common object-storage cost win is discovering that most stored data is rarely read and then using lifecycle rules to move that cold data into cheaper tiers, which can cut monthly storage spend substantially.
+**Hypothetical scenario:** A platform team stores three years of application logs, ML feature files, and user-uploaded media in a single S3 Standard bucket because “one class is simpler.” Monthly storage grows linearly while read traffic stays flat; cross-AZ replication and millions of small PUT requests quietly dominate the bill. A lifecycle review moves cold prefixes to Standard-IA and Glacier Instant Retrieval, enables S3 Intelligent-Tiering on unpredictable prefixes, and routes hot avatar traffic through CloudFront with same-region origin reads. Storage spend drops without touching application code—only bucket policy, class selection, and CDN placement changed.
 
-Overly long-lived pre-signed URLs can turn a temporary sharing mechanism into a serious data-exposure problem if links are forwarded beyond the intended audience.
+Object storage feels deceptively simple—“just upload a file”—yet it underpins backups, data lakes, CI artifacts, static websites, and Velero disaster-recovery targets. From Kubernetes, integration is richer than mounting a PVC: workloads typically call cloud APIs through SDKs with workload identity, occasionally mount buckets through CSI drivers for legacy POSIX expectations, and often offload large uploads/downloads via pre-signed URLs so pods are not network proxies. The expensive mistakes are usually operational: wrong storage class for access pattern, public buckets from a single policy typo, CSI mounts backing databases, incomplete multipart uploads billing forever, or pre-signed URLs with reckless expiration.
 
-Object storage is deceptively simple -- "just upload a file." But from Kubernetes, the integration patterns are rich and the pitfalls are expensive. This module teaches you how to access S3, GCS, and Azure Blob from pods using workload identity, CSI drivers for filesystem-style access, pre-signed URLs for secure client-side access, lifecycle policies for cost optimization, cross-region replication for disaster recovery, and bucket security hardening.
+This module compares Amazon S3, Google Cloud Storage (GCS), and Azure Blob side by side—classes, lifecycle, durability, consistency, immutability, access control, CDN integration, and cost knobs—then maps each pattern to Kubernetes 1.35 workloads without collapsing to a single vendor story.
+
+---
+
+## Object, Block, and File Storage — Choosing the Right Abstraction
+
+Cloud storage is not one product. It is three families with different consistency, performance, and Kubernetes integration models. Block storage on Amazon EBS, Google Persistent Disk, or Azure Managed Disks presents a raw volume to an instance or pod. That model optimizes random I/O, fsync, and database page caches.
+
+File storage on Amazon EFS, Google Filestore, or Azure Files exposes a POSIX filesystem shared across many clients. Legacy applications that need directory semantics and file locking across nodes often choose file shares. Object storage stores opaque blobs keyed by name in a flat namespace. The pair of bucket plus key optimizes massive scale, HTTPS APIs, and immutability workflows such as versioning and legal hold.
+
+Unstructured data belongs in object storage in most designs. Logs, images, model checkpoints, Terraform state backups, and Helm chart tarballs fit the object model well. You pay per gigabyte-month and per request instead of provisioned IOPS you never use. Block volumes attached through PersistentVolumeClaims remain correct when the workload is PostgreSQL, etcd, or any engine that assumes local filesystem semantics.
+
+The Kubernetes documentation on [Volumes](https://kubernetes.io/docs/concepts/storage/volumes/) separates these concerns explicitly. Object stores are not first-class mount types for databases because clients access them over HTTP APIs rather than SCSI queues.
+
+| Dimension | Object (S3 / GCS / Blob) | Block (EBS / PD / Disk) | File (EFS / Filestore / Azure Files) |
+|-----------|--------------------------|-------------------------|--------------------------------------|
+| Unit of access | Key in bucket | LUN / volume | Path in share |
+| Typical K8s binding | SDK + optional CSI | PVC + CSI | PVC (RWX) |
+| Random rewrite in place | Poor (overwrite object) | Excellent | Good |
+| Share across many pods | Yes (read-mostly) | Usually RWO | Yes (RWX) |
+| Cost driver | GB-month + requests + egress | Provisioned GB + IOPS | Capacity + throughput tier |
+
+> **Stop and think:** Your data science team wants to train on a 2 TB image corpus stored in S3. They ask for a ReadWriteMany PVC backed by object storage so every node sees the same path. When is that reasonable, and when should they stream via SDK instead?
+
+---
+
+## Storage Classes, Lifecycle, and Intelligent Tiering
+
+Each hyperscaler maps the same economic idea to different class names. Hot data costs more per gigabyte because it must be instantly available without retrieval fees. You choose a class or transition rule based on access frequency, retrieval latency tolerance, and minimum storage duration penalties documented on each provider’s pricing page.
+
+One Zone-IA on AWS trades lower price for loss of zone-level redundancy within a region. That trade may be acceptable for reproducible ML shards but is a poor choice for sole-copy backups. GCS Nearline and Azure Cool tiers play the same infrequent-access role with different minimum billable durations—verify current numbers before modeling FinOps dashboards.
+
+### Amazon S3 storage classes
+
+[AWS documents multiple S3 storage classes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html) including S3 Standard for frequent access, S3 Standard-IA and S3 One Zone-IA for infrequent access at lower durability (single-AZ for One Zone-IA), S3 Glacier Instant Retrieval / Flexible Retrieval / Deep Archive for archive timelines, and S3 Intelligent-Tiering for objects with unknown or changing access patterns. Intelligent-Tiering automatically moves objects between frequent and infrequent access tiers without operational toil; [AWS notes monitoring and automation fees](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering.html) that you should weigh against manual lifecycle rules for predictable workloads.
+
+### Google Cloud Storage classes
+
+[GCS storage classes](https://cloud.google.com/storage/docs/storage-classes) include Standard (hot), Nearline (~monthly access), Coldline (~quarterly), and Archive (yearly). Buckets can be regional, dual-region, or multi-region; dual/multi-region options trade cost for geographic redundancy within a continent or globally. Lifecycle rules transition or delete objects by age, storage class, or prefix—similar mental model to S3 lifecycle JSON.
+
+### Azure Blob access tiers
+
+[Azure Blob access tiers](https://learn.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview) are Hot, Cool, Cold, and Archive, with automatic tiering available on storage accounts that support it. Archive tier retrieval is measured in hours, not milliseconds, which matters when operators expect “restore like Standard.”
+
+### Lifecycle rules — same pattern, three CLIs
+
+Lifecycle engines automate transition and expiration: move `videos/` to IA after 30 days, abort stale multipart uploads after one day, delete `tmp-uploads/` after seven days. The JSON and CLI examples later in this module for AWS, GCS, and Azure remain your operational templates; the design discipline is universal—**encode retention at bucket creation**, not in a quarterly spreadsheet.
+
+| Concern | AWS | GCP | Azure |
+|---------|-----|-----|-------|
+| Hot class | S3 Standard | Standard | Hot |
+| Infrequent | Standard-IA / One Zone-IA | Nearline | Cool |
+| Archive | Glacier tiers | Coldline / Archive | Cold / Archive |
+| Auto tiering | Intelligent-Tiering (objects ≥128 KB only) | Autoclass (where enabled) | Access tier auto |
+| Minimum billable days | Per class (verify current) | Per class | Per tier |
+
+> **Pause and predict:** You enable a lifecycle transition to Deep Archive after 90 days on a bucket with billions of 4 KB JSON metadata files. What cost might spike even if storage GB-month later falls?
+
+Per-object lifecycle transition charges can dwarf later storage savings when objects are only a few kilobytes each. On a separate track, S3 Intelligent-Tiering skips both the monitoring fee and automatic tier moves for objects smaller than 128 KB—they remain in the tier they were uploaded to.
+
+---
+
+## Durability, Consistency, and Regional Topology
+
+Managed object stores advertise extreme durability. AWS and GCS commonly cite eleven nines for object durability, meaning independent failures across racks, zones, and drives rarely lose an object. Durability is not the same as availability of your application path. A regional outage or misconfigured endpoint still blocks reads even when bits remain safe on disk.
+
+Design regional buckets when latency to a single Kubernetes cluster matters most. Use multi-region or dual-region buckets when users or clusters span geographies and you can tolerate higher storage charges plus replication lag measured in minutes or hours depending on options selected.
+
+Amazon S3 provides [strong read-after-write consistency](https://docs.aws.amazon.com/AmazonS3/latest/userguide/Welcome.html#ConsistencyModel) for new objects. Pipelines that write then immediately list or read from another pod rely on that guarantee during rolling deploys. GCS and Azure Blob document strong read-after-write consistency for objects in their service documentation. Still verify edge cases for list operations and delete markers during disaster-recovery drills because control-plane caches in applications may assume stronger list consistency than vendors provide.
+
+Cross-region replication on AWS, dual-region buckets on GCS, and geo-redundant storage on Azure add egress and replication PUT charges. AWS requires versioning on source and destination before replication rules apply per the [replication requirements guide](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-requirements.html). Kubernetes clusters in two regions should use region-local bucket endpoints in ConfigMaps or a global access abstraction like S3 Multi-Region Access Points documented later. Hardcoding one regional bucket in every manifest creates cross-ocean latency and egress invoices that FinOps will attribute to platform engineering.
+
+---
+
+## Data Protection — Versioning, Object Lock, and Immutability
+
+Accidental deletes, ransomware, and compliance retention push teams beyond “overwrite the key.” Versioning keeps prior object versions when keys are reused. Lifecycle rules can expire noncurrent versions after N days to cap storage multiplication while still allowing point-in-time recovery during the retention window.
+
+Object Lock on S3 offers governance mode for operations teams that need tamper-evident logs and compliance mode for records that regulators expect to be immutable for a fixed interval. Azure immutable Blob storage and GCS retention policies address the same control for multi-cloud portfolios. Pick one immutability story per dataset and document who can extend retention versus who can only read.
+
+Replication without versioning fails on AWS because replication rules require versioning on source and destination buckets. Delete marker replication choices change whether a delete in `us-east-1` hides objects in `eu-central-1`. Test bi-directional active-active media libraries with explicit delete-marker policies to avoid loops or ghost resurrections.
+
+MFA Delete on AWS adds friction to permanent deletes. That friction helps production data lakes but blocks automation in CI buckets. Platform teams often enable MFA Delete only on regulated buckets while CI roles lack `s3:DeleteObject` entirely on scratch prefixes.
 
 ---
 
 ## Pod-to-Storage Access Patterns
 
-There are three primary ways Kubernetes pods interact with object storage:
+Kubernetes pods interact with object storage in three primary ways, and mature platforms standardize on one default per workload type rather than mixing all three without documentation.
 
 ```mermaid
 graph TD
@@ -51,7 +132,9 @@ graph TD
 
 ### Pattern 1: SDK Access with Workload Identity
 
-The most common and flexible pattern. Your application uses the cloud SDK to interact with the storage API directly.
+The most common and flexible pattern uses the cloud SDK inside the application container. The SDK performs ranged reads, multipart uploads, conditional writes, and server-side encryption headers that FUSE mounts hide or approximate poorly. On EKS, IRSA annotates a Kubernetes ServiceAccount with an IAM role ARN. On GKE, Workload Identity binds a Kubernetes ServiceAccount to a Google service account. On AKS, Workload Identity federates Entra IDs to pods without storing client secrets in etcd.
+
+Rotate credentials by rotating cloud roles and trust policies, not by restarting pods to pick up static keys from Secrets. External Secrets Operator helps when applications still need small secrets, but object storage access should prefer keyless federation for every new service.
 
 ```yaml
 # AWS: Pod with IRSA for S3 access
@@ -61,7 +144,7 @@ metadata:
   name: storage-writer
   namespace: production
   annotations:
-    eks.amazonaws.com/role-arn: arn:aws:iam::123456789:role/S3WriterRole
+    eks.amazonaws.com/role-arn: arn:aws:iam::123456789012:role/S3WriterRole
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -93,7 +176,7 @@ spec:
               memory: 4Gi
 ```
 
-The IAM policy for the role:
+The IAM policy below scopes the IRSA role to a single bucket prefix. Least privilege means listing only when required and denying `s3:*` on unrelated ARNs.
 
 ```json
 {
@@ -158,10 +241,12 @@ metadata:
 ```bash
 # Create federated credential
 az identity federated-credential create \
+  --name k8s-blob-writer \
   --identity-name blob-writer-identity \
   --resource-group myRG \
   --issuer "$(az aks show -g myRG -n myAKSCluster --query 'oidcIssuerProfile.issuerUrl' -o tsv)" \
-  --subject system:serviceaccount:production:blob-writer
+  --subject system:serviceaccount:production:blob-writer \
+  --audiences "api://AzureADTokenExchange"
 
 # Assign Storage Blob Data Contributor role
 az role assignment create \
@@ -174,7 +259,9 @@ az role assignment create \
 
 ## CSI Drivers: Mounting Object Storage as a Filesystem
 
-Sometimes your application expects a filesystem path, not an SDK. CSI drivers bridge this gap by presenting object storage as a POSIX-like mount.
+Sometimes your application expects a filesystem path instead of an SDK. CSI drivers bridge that gap by presenting object storage as a POSIX-like mount under `/mnt/data` or similar paths. The illusion breaks down for databases, random writes inside large files, and file locking semantics that object APIs do not provide.
+
+Before choosing CSI, ask whether a two-week refactor to the SDK is cheaper than months of mysterious training job failures. If the workload is a one-off migration script, CSI may be perfect. If the workload is a stateful service, block storage wins.
 
 ### Mountpoint for Amazon S3 CSI Driver
 
@@ -183,24 +270,34 @@ Sometimes your application expects a filesystem path, not an SDK. CSI drivers br
 aws eks create-addon \
   --cluster-name my-cluster \
   --addon-name aws-mountpoint-s3-csi-driver \
-  --service-account-role-arn arn:aws:iam::123456789:role/S3CSIDriverRole
+  --service-account-role-arn arn:aws:iam::123456789012:role/S3CSIDriverRole
 ```
 
+Mountpoint for S3 CSI supports **static provisioning only**—it does not create buckets or provision volumes dynamically. Create the bucket out of band, then bind a manually defined `PersistentVolume` to a `PersistentVolumeClaim` with `storageClassName: ""` on both objects.
+
 ```yaml
-# StorageClass for S3
-apiVersion: storage.k8s.io/v1
-kind: StorageClass
+# Static PersistentVolume (bucket must already exist)
+apiVersion: v1
+kind: PersistentVolume
 metadata:
-  name: s3-storage
-provisioner: s3.csi.aws.com
-parameters:
-  bucketName: data-pipeline-prod
-mountOptions:
-  - allow-delete
-  - region us-east-1
-  - prefix data/
+  name: s3-pv-data-pipeline-prod
+spec:
+  capacity:
+    storage: 1Gi    # Required by the API; S3 capacity is not enforced
+  accessModes:
+    - ReadWriteMany
+  storageClassName: ""
+  mountOptions:
+    - allow-delete
+    - region us-east-1
+    - prefix data/
+  csi:
+    driver: s3.csi.aws.com
+    volumeHandle: data-pipeline-prod
+    volumeAttributes:
+      bucketName: data-pipeline-prod
 ---
-# PersistentVolumeClaim
+# PersistentVolumeClaim bound to the PV above
 apiVersion: v1
 kind: PersistentVolumeClaim
 metadata:
@@ -209,10 +306,11 @@ metadata:
 spec:
   accessModes:
     - ReadWriteMany
-  storageClassName: s3-storage
+  storageClassName: ""
+  volumeName: s3-pv-data-pipeline-prod
   resources:
     requests:
-      storage: 1Ti    # Not enforced -- S3 is unlimited, but required by K8s API
+      storage: 1Gi
 ---
 # Pod using the mount
 apiVersion: v1
@@ -256,17 +354,23 @@ spec:
 | File locking | Not supported | Not supported | Not supported |
 | Best for | Data pipelines, ML training data | Data analytics | Batch processing |
 
-**Critical warning**: Object storage CSI mounts are [NOT suitable for databases, caches, or any workload requiring random I/O, atomic operations, or POSIX compliance](https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/overview). Use them for read-heavy data pipelines and write-once-read-many workloads.
+**Critical warning**: Object storage CSI mounts are [NOT suitable for databases, caches, or any workload requiring random I/O, atomic operations, or POSIX compliance](https://cloud.google.com/storage/docs/cloud-storage-fuse/overview). Use them for read-heavy data pipelines and write-once-read-many workloads.
 
 > **Stop and think**: Your team is deploying a new PostgreSQL database to Kubernetes. A junior engineer suggests using the S3 CSI driver to store the data files "so we never run out of disk space." What is the technical reason you must reject this proposal, and what should you use instead?
 
+### Azure Blob CSI on AKS
+
+The Azure Blob CSI driver mounts block blobs as volumes for workloads that insist on file paths. Enable it at the cluster level, bind a managed identity or service principal with `Storage Blob Data Contributor` on the account, and mount with read-only flags when data is shared training corpora. Writes through FUSE still lack database-grade atomicity; treat mounts as convenience, not as a persistence layer for transactional state.
+
 ### GCS FUSE CSI Driver
 
-```yaml
-# GKE: Enable GCS FUSE on the cluster
-# gcloud container clusters update my-cluster \
-#   --update-addons GcsFuseCsiDriver=ENABLED
+```bash
+# GKE: enable the GCS FUSE CSI add-on on the cluster
+gcloud container clusters update my-cluster \
+  --update-addons GcsFuseCsiDriver=ENABLED
+```
 
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:
@@ -378,6 +482,14 @@ def generate_upload_url(filename, content_type):
     return url
 ```
 
+On GKE with Workload Identity, the pod’s federated token cannot sign URLs by itself. `generate_signed_url()` needs a service account key or a principal with `iam.serviceAccounts.signBlob` (or equivalent) to produce v4 signatures—plan for a dedicated signing identity or a small signing sidecar rather than assuming the workload token is enough.
+
+### Azure Blob shared access signatures
+
+Azure favors user delegation SAS and stored access policies tied to Entra-backed identities when pods mint short-lived URLs. The shape differs from AWS query-string v4 signatures, but the security goal matches: scope to one container, one blob, and a tight clock. Pair SAS generation with Workload Identity on AKS so the signing secret never lands in a Kubernetes Secret as a long-lived account key.
+
+When clients upload directly, place objects in a `quarantine/` prefix scanned by a ClamAV Deployment or a cloud malware API before promoting to `public/` or `processed/`. The promotion step should be a separate ServiceAccount with write access only to the clean prefix.
+
 ### Pre-Signed URL Security Best Practices
 
 | Practice | Why |
@@ -389,11 +501,29 @@ def generate_upload_url(filename, content_type):
 | Log all pre-signed URL generations | Audit trail for access tracking |
 | Never expose bucket credentials; only expose URLs | Pre-signed URLs are scoped and temporary |
 
+### CORS, content types, and upload integrity
+
+Browser-based uploads require CORS rules that whitelist only your application origins. Wildcard origins on sensitive buckets invite token theft combined with overly broad IAM. Bind `Content-Type` in pre-signed PUT parameters so clients cannot swap executables for images after the API mints a URL.
+
+Use checksum headers supported by your SDK where available. S3 supports additional checksum algorithms in modern APIs; validating on upload prevents corrupted objects from entering pipelines that only detect damage during expensive batch jobs hours later.
+
+### Monitoring pre-signed URL abuse
+
+Log every URL generation with principal, object key, and TTL. Ship logs to the same SIEM that processes authentication events. Anomalies—thousands of URLs for the same key, TTLs creeping upward in code review misses—often precede data exfiltration attempts.
+
 ---
 
 ## Lifecycle Policies for Cost Optimization
 
-For many object-storage workloads, the largest recurring charge is storing data over time, and moving rarely accessed data into colder tiers can reduce storage costs substantially.
+For many object-storage workloads, the largest recurring charge is storing data over time rather than serving it. Moving rarely accessed data into colder tiers reduces storage GB-month while trading retrieval latency and per-GB retrieval fees. Lifecycle policies express that trade as code: transition rules move objects after N days, expiration rules delete scratch prefixes, and incomplete multipart abort rules stop silent billing leaks.
+
+Operations teams should attach lifecycle JSON at bucket creation in Terraform or Crossplane, not during a quarterly FinOps fire drill. The same discipline applies on GCP with `gcloud storage buckets update --lifecycle-file` and on Azure with lifecycle management policies in the portal or ARM templates.
+
+### S3 Intelligent-Tiering versus fixed transitions
+
+When access patterns are unpredictable, fixed transitions guess wrong. S3 Intelligent-Tiering monitors access and moves objects between tiers automatically for objects **128 KB and larger**—smaller objects incur neither the monitoring fee nor automatic tier moves (they stay in the upload tier). AWS charges a small monitoring fee per eligible object in exchange for removing operator guesswork. When access is predictable—logs age daily, media becomes cold after 30 days—explicit transitions to Standard-IA, Nearline, or Cool tiers are cheaper than monitoring fees on billions of small objects.
+
+GCS Autoclass and Azure access tier automation play a similar role. Read each provider’s current pricing page before enabling automation account-wide. Pilot on one bucket, compare three months of invoices, then promote the pattern through your platform template library.
 
 ### Storage Tier Comparison
 
@@ -494,11 +624,23 @@ aws s3api list-multipart-uploads --bucket video-content-prod
 # You may be shocked at how many orphaned parts exist
 ```
 
+### Azure lifecycle example
+
+Azure Blob lifecycle management uses rules attached to storage accounts. A typical pattern transitions `logs/` blobs to Cool after 30 days and deletes `temp/` blobs after seven days. Express rules in ARM or Bicep alongside the storage account so AKS workload teams cannot create shadow accounts without lifecycle guardrails.
+
+### GCS dual-region and turbo replication
+
+When RPO requirements measure in minutes rather than hours, GCS dual-region buckets and turbo replication options reduce replication lag compared to manual cross-region copies. The spend is higher than single-region Standard storage. Finance should classify that line item as insurance, not “storage waste,” because the alternative is rebuilding datasets after regional loss.
+
+### Requester pays and egress discipline
+
+S3 Requester Pays shifts download costs to the requester account. That pattern suits shared datasets where consumers are other AWS accounts. It does not remove the need to think about Kubernetes egress from nodes. Pods downloading public buckets still incur cluster networking charges unless traffic stays inside the same region and VPC endpoint path documented by your cloud network team.
+
 ---
 
 ## Cross-Region Replication
 
-For disaster recovery or serving content from multiple regions, [cross-region replication copies objects automatically](https://aws.amazon.com/s3/features/replication/).
+Disaster recovery and multi-region serving both rely on copying objects automatically across buckets or regions. AWS documents this behavior in the [S3 Replication overview](https://aws.amazon.com/s3/features/replication/), and analogous features exist on GCS dual-region or multi-region buckets and on Azure geo-redundant storage when you design for geographic failure rather than single-cluster backup alone.
 
 ### AWS S3 Cross-Region Replication
 
@@ -517,7 +659,7 @@ aws s3api put-bucket-versioning \
 # Create replication configuration
 cat > /tmp/replication.json << 'EOF'
 {
-  "Role": "arn:aws:iam::123456789:role/S3ReplicationRole",
+  "Role": "arn:aws:iam::123456789012:role/S3ReplicationRole",
   "Rules": [
     {
       "ID": "dr-replication",
@@ -552,7 +694,7 @@ aws s3api put-bucket-replication \
 
 ### Multi-Region Access from Kubernetes
 
-When pods in different regions need the closest bucket:
+When pods in different regions need the closest bucket, avoid hardcoding one regional endpoint in every Deployment manifest. Use region-scoped configuration that tracks where the cluster runs.
 
 ```yaml
 # Region-specific ConfigMap
@@ -567,11 +709,11 @@ data:
   BUCKET_REGION: "us-east-1"
 ```
 
-For AWS, [S3 Multi-Region Access Points provide a single endpoint that automatically routes to the nearest bucket](https://docs.aws.amazon.com/AmazonS3/latest/userguide/MultiRegionAccessPointRequestRouting.html):
+On AWS, [S3 Multi-Region Access Points](https://docs.aws.amazon.com/AmazonS3/latest/userguide/MultiRegionAccessPointRequestRouting.html) expose one global endpoint that routes requests to the nearest replica bucket behind the scenes. That pattern reduces the need for per-region ConfigMap churn when the application SDK can target a single MRAP hostname.
 
 ```bash
 aws s3control create-multi-region-access-point \
-  --account-id 123456789 \
+  --account-id 123456789012 \
   --details '{
     "Name": "video-global",
     "Regions": [
@@ -580,6 +722,12 @@ aws s3control create-multi-region-access-point \
       {"Bucket": "video-content-ap"}
     ]
   }'
+
+# Creation is asynchronous — poll until Status is SUCCEEDED before using the MRAP
+aws s3control describe-multi-region-access-point \
+  --account-id 123456789012 \
+  --name arn:aws:s3::123456789012:accesspoint/video-global \
+  --query 'AccessPoint.Status'
 ```
 
 ---
@@ -587,6 +735,10 @@ aws s3control create-multi-region-access-point \
 ## Bucket Security Hardening
 
 ### Defense-in-Depth Configuration
+
+Bucket hardening should run in a fixed order so operators do not encrypt data that is still world-readable. Start with public access blocks, then default encryption, then logging, then versioning, then TLS-only policies. GCP and Azure mirror the sequence with uniform bucket-level access, customer-managed keys, diagnostic logs, and secure transfer required settings.
+
+Least-privilege IAM for Kubernetes means application ServiceAccounts can write only to intended prefixes. Platform CSI driver identities stay separate from application identities. A video processor role should not inherit ListAllMyBuckets because a developer copied a tutorial policy during incident response.
 
 ```bash
 # 1. Block all public access (do this first, always)
@@ -651,15 +803,224 @@ aws s3api put-bucket-policy --bucket video-content-prod \
 
 ---
 
+## Access Control, CDN Fronting, and Static Hosting
+
+Object storage access control stacks **identity policies** (IAM on AWS, IAM on GCP, Azure RBAC), **resource policies** (S3 bucket policy, GCS IAM conditions, Azure stored access policies), and **network constraints** (private endpoints, VPC service controls, storage firewalls). [AWS Block Public Access](https://aws.amazon.com/s3/features/block-public-access/) is account- and bucket-level guardrails that override naive `Principal: "*"` mistakes; enable it before any bucket policy work. GCP **uniform bucket-level access** disables object ACL sprawl; Azure disables anonymous access unless explicitly configured.
+
+**Pre-signed URLs** (S3), **signed URLs** (GCS v4), and **SAS tokens** (Azure) delegate time-limited capability without embedding long-lived keys in mobile apps—patterns covered earlier remain the Kubernetes-friendly default for large uploads. Pair short expirations with server-side encryption parameters in the signature so clients cannot downgrade protection.
+
+Static website hosting (S3 website endpoints, GCS website configuration, Azure static websites) is rarely the production pattern for public apps—teams front buckets with **Amazon CloudFront**, **Google Cloud CDN**, or **Azure Front Door / CDN** for TLS, caching, geographic edge, and WAF integration. A critical cost detail from [Amazon S3 pricing](https://aws.amazon.com/s3/pricing/): **data transfer for same-Region access to S3 from EC2 or CloudFront origin fetches in the same Region is generally free of charge** for the S3 side (verify current pricing pages before budgeting). Misplaced origins—CloudFront pulling from a bucket in another region—reintroduce cross-region egress that same-region design avoided.
+
+CORS configuration on buckets matters when browsers upload directly via pre-signed PUT; restrict allowed origins instead of `*` in production. For Kubernetes ingress of static assets, many teams bake assets into container images or use a CDN; object storage plus CDN remains superior for large, frequently changing media corpora.
+
+```bash
+# Example: Azure Blob CSI driver install context (AKS)
+# See https://learn.microsoft.com/en-us/azure/aks/azure-blob-csi-driver
+az aks update -g myRG -n myAKSCluster --enable-blob-driver
+```
+
+Legacy mount helpers (`s3fs`, `goofys`, Azure Blob FUSE) still appear in older runbooks; platform engineers on Kubernetes 1.35 should prefer **official CSI drivers** (Mountpoint for S3, GCS FUSE CSI, Azure Blob CSI) or **SDK access** because FUSE mounts inherit latency, partial POSIX support, and hard-to-debug caching behavior under concurrent pod churn.
+
+---
+
+## Cost Lens — Moderate Scale and Surprise Spikes
+
+At “moderate scale”—tens of terabytes, millions of objects, steady CI and user traffic—the object storage bill is usually **storage GB-month + request charges + retrieval penalties + egress**, not headline per-GB hot storage alone. A 50 TB Standard bucket sounds expensive until you realize **10 million LIST + GET** operations from a misconfigured indexer cost more than the storage itself. Conversely, moving cold telemetry to IA without measuring retrieval patterns can increase spend when analysts re-scan the dataset weekly.
+
+| Cost spike trigger | Mechanism | Mitigation |
+|--------------------|-----------|------------|
+| Wrong class for access pattern | Frequent reads on Archive tier | Lifecycle + class analytics; Intelligent-Tiering or Autoclass |
+| Cross-region egress | Pods in `eu-west-1` read `us-east-1` bucket | Regional buckets, MRAP, or CDN same-region origin |
+| Incomplete multipart uploads | Hidden parts bill silently | `AbortIncompleteMultipartUpload` lifecycle on every bucket |
+| Early deletion fee | IA/Glacier minimum storage duration | Match retention to class minimums |
+| Public internet egress | Clients download without CDN | CloudFront / Cloud CDN / Front Door |
+| Replication + RTC | 15-minute SLA replication metrics | Filter prefixes; destination class IA |
+
+**Knobs that reliably reduce cost:** lifecycle transition to colder classes, Intelligent-Tiering for unknown access, compressing objects before upload, batching small files into tar archives (trade listing granularity), using same-region workers and origins, and denying public egress paths you did not intend. **Knobs that increase cost but buy safety:** versioning, cross-region replication with replication time control ([AWS RTC targets 99.9% within 15 minutes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-time-control.html)), Object Lock compliance mode, and verbose access logging—budget these as insurance, not surprises.
+
+---
+
+## Kubernetes Backup Targets — Velero and SDK-First Design
+
+Cluster disaster recovery tools such as [Velero](https://velero.io/docs/) store backup objects in S3-compatible, GCS, or Azure Blob targets configured via `BackupStorageLocation`. That is object storage accessed through the Velero controller’s credentials—not a PVC—mirroring how application teams should treat large blob workflows: **grant the backup ServiceAccount cloud identity**, encrypt the backup bucket, block public access, and lifecycle noncurrent backup versions to Glacier/Coldline after N days.
+
+Application pods should default to **cloud SDKs inside the container** with workload identity (IRSA on EKS, GKE Workload Identity Federation, Azure Workload Identity on AKS) because SDK calls expose metadata operations, ranged reads, multipart uploads, and server-side encryption headers explicitly. CSI mounts remain appropriate for read-heavy ML datasets or legacy shell tools that only understand file paths—never for relational data directories. When you must mount, cap FUSE sidecar CPU/memory (GKE annotations shown earlier) and load-test concurrent writers; Mountpoint for S3 and peers improve sequential throughput but do not invent POSIX locks.
+
+EKS documents the [Mountpoint for Amazon S3 CSI driver](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi-driver.html) as an add-on; treat add-on IAM roles separately from application IRSA roles so a compromise in the app cannot mutate unrelated buckets through the driver’s broader policy.
+
+---
+
+## Multi-Cloud Object Storage Playbook
+
+The following playbook ties AWS, GCP, and Azure controls to the same operational questions platform teams ask during design review. It is not a product tutorial; it is a checklist you can run before any bucket backs production Kubernetes traffic.
+
+### Ingestion and multipart uploads
+
+Large objects should use multipart upload APIs on every cloud. Multipart improves reliability over flaky networks and lets controllers resume failed transfers. The downside is operational: failed parts remain billable until aborted. AWS documents automatic cleanup through lifecycle `AbortIncompleteMultipartUpload`. GCS and Azure have analogous compose and block-blob staging behaviors you must monitor in metrics, not only in storage dashboards.
+
+From Kubernetes, ingestion controllers should run near the bucket region. A pod in `eu-west-1` streaming uploads to `us-east-1` pays latency and cross-region charges on every part. For CI artifacts, many teams run regional buckets per cluster fleet and replicate only release artifacts to a central compliance bucket.
+
+### Listing, inventory, and metadata storms
+
+Object stores are not databases. Listing millions of keys with naive pagination can dominate request costs and throttle applications. S3 Inventory delivers CSV manifests of objects and metadata on a schedule. GCS provides storage insights and inventory reports. Azure offers blob inventory policies. Batch analytics should read inventory files instead of hammering `ListObjectsV2` from a nightly CronJob in the cluster.
+
+When you must list live, enforce prefix conventions. Structure keys like `tenantId/yyyy/mm/dd/objectId` so applications query narrow prefixes. A flat `uploads/` prefix with ten million keys is a self-inflicted outage during incident response.
+
+### Encryption and key management
+
+Encrypt data at rest by default on every bucket. AWS supports SSE-S3 and SSE-KMS with bucket keys to reduce KMS API costs. GCS offers Google-managed keys and customer-managed encryption keys. Azure supports Microsoft-managed and customer-managed keys in Key Vault. In transit, enforce HTTPS through bucket policies or Azure secure transfer required settings.
+
+Kubernetes does not replace key management. External Secrets Operator can sync secrets, but object encryption keys usually remain cloud KMS resources bound to workload identity. Document which ServiceAccounts may call `kms:Decrypt` versus `s3:PutObject` so audits do not confuse data-plane and control-plane permissions.
+
+### Event-driven pipelines
+
+Object uploads often trigger asynchronous processing. AWS can emit events to SNS, SQS, or EventBridge. GCS publishes to Pub/Sub. Azure emits Event Grid notifications. Kubernetes consumers scale on queue depth with KEDA scalers while functions or Deployments process new blobs.
+
+Design idempotency at the consumer. At-least-once delivery is common. A pod may see duplicate notifications after crashes. Store a processed-object index in a database or conditional write marker in object metadata rather than assuming exactly-once triggers.
+
+### Static assets and cache invalidation
+
+Serving user-facing media from object storage without a CDN shifts TLS termination and geographic latency onto a single regional endpoint. CloudFront, Cloud CDN, and Azure CDN integrate origin access controls so buckets stay private while edges cache public objects.
+
+Cache invalidation belongs in your deployment pipeline. When a ConfigMap changes, Kubernetes rolls pods; when a static asset changes, you must invalidate CDN paths or version filenames. Teams version assets with content hashes in filenames (`app.8f3a2.css`) to avoid wildcard invalidation storms.
+
+### Compliance prefixes and legal holds
+
+Regulated datasets need prefix isolation plus immutability. Separate `audit/` from `tmp/` buckets or prefixes at creation time. Applying Object Lock or immutable Blob policies to the entire bucket breaks CI cleanup on temporary keys. Narrow policies to compliance prefixes and automate lifecycle only on non-regulated prefixes.
+
+Legal holds pause deletion during investigations. Operations runbooks should state who may lift a hold and how Kubernetes backup jobs behave when holds block deletion of orphaned keys.
+
+### Testing DR and replication lag
+
+Replication is not backup unless you periodically restore. Schedule quarterly drills that list replicated prefixes, restore a sample object in a sandbox namespace, and verify checksums. Measure replication lag during peak write periods. RTC metrics on AWS help; on other clouds you infer lag by comparing object generation timestamps.
+
+Delete markers deserve explicit tests. If a user deletes an object in region A, determine whether region B should hide the object or retain a readable copy for active-active media libraries. The wrong delete-marker replication setting causes either data resurrection loops or silent user-visible loss.
+
+### Observability and chargeback
+
+Export storage metrics per bucket and per prefix where possible. Tag buckets with `team`, `cost-center`, and `data-classification` labels compatible with your FinOps tooling. In Kubernetes, annotate namespaces with the same labels so dashboards correlate pod counts to bucket spend.
+
+Alert on anomalous `4xx`/`5xx` rates from SDK metrics, not only on total bytes stored. A misconfigured policy that flips to public read often shows up as traffic spikes before security tools finish triage.
+
+### Azure Blob CSI and AKS notes
+
+AKS can enable the Blob CSI driver without treating blobs as POSIX-perfect disks. Mount read-only training data when the ML framework tolerates FUSE semantics. Write-heavy analytics should still prefer the Azure SDK with Workload Identity from the pod service account.
+
+Document mount options and subnet egress paths. Private clusters may require private endpoints to storage accounts before CSI mounts succeed from worker nodes without public internet routes.
+
+### GCS FUSE on GKE notes
+
+GKE’s GCS FUSE CSI driver injects sidecar resources for caching. Under-provisioned sidecars cause OOM kills that look like application instability. Load-test concurrent readers during model training peaks. Read-only mounts prevent accidental overwrite of shared corpora when multiple pods mount the same bucket prefix.
+
+### EKS Pod Identity and IRSA coexistence
+
+AWS now offers EKS Pod Identity alongside IRSA. Both remove long-lived keys from manifests. Standardize one mechanism per cluster generation and document trust policies in Git. Mixed clusters during migration should not duplicate broad `s3:*` policies on two parallel identity paths for the same Deployment.
+
+### MinIO and S3-compatible on-prem patterns
+
+Labs in this module use MinIO as an S3-compatible endpoint inside kind. On-prem S3-compatible stores follow the same SDK and pre-signed URL patterns. Differences appear in TLS trust chains, endpoint URLs, and lack of managed lifecycle unless you operate MinIO lifecycle APIs yourself. Treat compatibility testing as part of release gates when applications assume AWS-only headers.
+
+### Object key design for multi-tenant Kubernetes
+
+Tenant isolation belongs in key prefixes and IAM conditions, not in separate clusters per customer unless contracts require it. A prefix like `tenants/{tenantId}/objects/{uuid}` lets you attach IAM policies with `StringLike` on `s3:prefix`. GCS and Azure support parallel condition keys on service accounts and RBAC assignments.
+
+Avoid sequential IDs in public URLs when enumeration risks exist. Use opaque UUIDs in keys while authorization happens through pre-signed URLs or gateway checks. Listing APIs should never become the authorization layer.
+
+### Capacity planning worksheet
+
+Estimate monthly cost as storage GB-month in the active class plus request thousands times per-thousand price plus expected egress GB. Add replication multiplier when DR copies every object to a second region. Add versioning multiplier when noncurrent versions are not expired aggressively. Compare the total to block storage PVC costs only when workloads truly need POSIX semantics.
+
+Document assumptions in the service’s design doc. Finance reviews storage class choices faster when engineers show retrieval frequency evidence instead of guessing “cold after 90 days.”
+
+### Runbook prompts for on-call
+
+When pagers fire on object storage, ask five questions before diving into kubectl. Is the bucket regional and does the cluster match? Did a lifecycle rule recently transition objects to Archive? Are we listing huge prefixes without pagination? Did someone rotate IAM trust for IRSA or Workload Identity? Are CDN origins pointing cross-region?
+
+Answers usually implicate configuration drift rather than S3 outages. Keep Terraform state for buckets next to cluster state so rollback includes storage policies, not only Deployments.
+
+### Integrating with GitOps
+
+Bucket policies, lifecycle JSON, and encryption defaults belong in Git with the same review rigor as application manifests. Argo CD or Flux can reconcile Crossplane claims or Terraform Cloud runs that mint buckets per environment. Drift detection should flag buckets created manually in the console without lifecycle rules.
+
+Separate dev and prod accounts or projects at the organization level. CI clusters receive permissive scratch buckets with seven-day expiration. Production buckets require approval for public access changes and for deletion permissions on automation roles.
+
+### Performance expectations from pods
+
+Sequential read throughput from CSI mounts can match SDK performance for large files, but metadata-heavy workloads that stat thousands of paths per second will thrash against object API rate limits. Batch metadata operations with inventory files or prefix listing pagination instead of per-file stats in tight loops inside pods.
+
+Write-heavy pipelines should coalesce small objects. Thousands of 1 KB JSON files incur more request cost than fewer tar objects with the same total bytes, at the expense of partial read flexibility. Choose the object granularity deliberately when microservices emit telemetry from many pods.
+
+Platform reviewers should insist on a one-page storage diagram per service. The diagram lists bucket names, classes, retention, identity mechanism, and whether clients touch storage through SDK, CSI, or pre-signed URLs. That artifact prevents “temporary” public buckets from becoming permanent data lakes without owners. Review the diagram during major traffic launches and region expansions so storage policies stay aligned with cluster topology, FinOps chargeback tags remain accurate, and backup jobs still target only the intended production buckets.
+
+---
+
+## Patterns & Anti-Patterns
+
+| Pattern | When to Use | Why It Works | Scaling Consideration |
+|---------|-------------|--------------|------------------------|
+| SDK + workload identity as default | Microservices, controllers, Velero-style tools | Fine-grained IAM/RBAC, no FUSE cache surprises | Cache credentials via SDK; rotate via cloud identity, not static keys |
+| Pre-signed URLs for large client uploads | Mobile/web direct-to-bucket | Keeps pod network and CPU off the hot path | Short TTL + content-type binding + separate quarantine bucket |
+| Lifecycle at bucket creation | Any bucket living >30 days | Prevents “we will clean later” debt | Pair with Intelligent-Tiering only when access is unpredictable |
+| Versioning + replication for DR | Prod media, backups, audit logs | Point-in-time recovery across regions | Monitor replication lag metrics; test delete-marker behavior |
+| CDN same-region origin | Public static assets | Cuts latency and avoids cross-region S3 egress | Invalidate CDN on deploy; don’t bake secrets into public paths |
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| CSI mount for database files | Corruption, split-brain, failed locks | Block storage PVC (EBS/PD/Disk) |
+| One Standard class forever | Storage GB-month dominates as data ages | Prefix-based lifecycle + IA/Cool tiers |
+| 30-day pre-signed URLs | Leaked links become long-lived breach | 15–60 minutes upload, 1–4 hours download |
+| Static IAM user keys in Secrets | Keys sprawl; rotation pain | IRSA / Workload Identity / federated credentials |
+| Public bucket “just for testing” | Crawlers exfiltrate within hours | Account-level block public access + SCPs |
+| Ignoring request charges | LIST storms during misconfigured sync | Paginate; use inventory manifests; S3 Batch Operations |
+
+---
+
+## Decision Framework
+
+Use access pattern, compliance, and Kubernetes integration rather than vendor habit when you pick storage classes, replication, and mount strategies for a new bucket.
+
+```mermaid
+flowchart TD
+    Start[New dataset or bucket] --> Mutable{Need mutable POSIX writes in pod?}
+    Mutable -- Yes --> DBCheck{Database or cache?}
+    DBCheck -- Yes --> Block[Block PVC — not object CSI]
+    DBCheck -- No --> CSI[CSI mount read-heavy / legacy only]
+    Mutable -- No --> Access{Who reads/writes?}
+    Access -- Browser/mobile large files --> Presign[Pre-signed URL / SAS + quarantine bucket]
+    Access -- In-cluster service --> SDK[SDK + workload identity]
+    SDK --> Durability{Cross-region DR required?}
+    Durability -- Yes --> Repl[Versioning + replication / dual-region bucket]
+    Durability -- No --> Class{Access frequency known?}
+    Class -- Predictable --> Life[Lifecycle transitions to IA/Cool/Glacier]
+    Class -- Unpredictable --> Intel[Intelligent-Tiering / Autoclass]
+    Repl --> Lock{Regulatory immutability?}
+    Lock -- Yes --> WORM[Object Lock / immutable Blob policy]
+    Lock -- No --> Done[Encrypt + block public + logging]
+    Life --> Done
+    Intel --> Done
+    Presign --> Durability
+    CSI --> Done
+```
+
+| Requirement | Prefer | Tradeoff |
+|-------------|--------|----------|
+| Frequent random read/write in app | SDK against Standard class | CSI only if code cannot change |
+| Monthly analytics on logs | Lifecycle to IA/Nearline/Cool | Retrieval fees if accessed too often |
+| Legal hold / SEC-style retention | Object Lock compliance or Blob immutable | Deletes blocked for retention period |
+| Global low-latency reads | Multi-region bucket or MRAP + CDN | Higher storage + replication cost |
+| Ransomware recovery | Versioning + replication + restricted delete IAM | Storage multiplication; monitor noncurrent versions |
+
+---
+
 ## Did You Know?
 
-1. Amazon S3 operates at enormous scale and is designed for 99.999999999% durability (11 nines).
+1. Amazon S3 advertises 99.999999999% (11 nines) durability for objects stored in Standard across multiple facilities, though availability and regional endpoints remain separate design concerns you must still engineer around.
 
-2. Incomplete multipart uploads can become a hidden storage-cost problem because failed uploads leave billable parts behind until they are completed or aborted.
+2. Incomplete multipart uploads become a hidden storage-cost problem because failed uploads leave billable parts behind until operators complete, abort, or lifecycle-clean them—those parts do not always appear in console object counts.
 
-3. GCS FUSE can cache frequently read files locally, which can materially reduce repeat-read latency for ML training workloads that reuse the same dataset files.
+3. GCS FUSE can cache frequently read files locally, which materially reduces repeat-read latency for ML training workloads that reuse the same dataset shards across epochs on GKE nodes.
 
-4. Azure Blob Storage supports immutable storage with legal holds and time-based retention policies for WORM-style retention, and Microsoft documents it for regulated scenarios such as SEC 17a-4(f).
+4. Azure Blob Storage supports immutable storage with legal holds and time-based retention for WORM-style retention; Microsoft documents supported compliance postures including SEC 17a-4(f) style controls in the immutable storage overview linked in Sources.
 
 ---
 
@@ -695,7 +1056,7 @@ Object storage CSI drivers present a filesystem interface, but they fundamentall
 <details>
 <summary>3. After six months in production, your cloud bill shows S3 storage costs are double what the actual total size of your active objects should dictate. What silent mechanism likely caused this, and how do you permanently fix it?</summary>
 
-The hidden cost is almost certainly caused by incomplete multipart uploads. When large file uploads fail or are interrupted mid-transfer, the partial chunks remain stored in the bucket indefinitely but are completely invisible to standard list-objects API calls. Because they take up physical space, the cloud provider continues to charge you for them month over month. To fix this permanently, you must configure a bucket lifecycle rule such as AbortIncompleteMultipartUpload set to 1-7 days, which automatically purges any orphaned upload fragments.
+The hidden cost is almost certainly caused by incomplete multipart uploads. When large file uploads fail or are interrupted mid-transfer, the partial chunks remain stored in the bucket indefinitely but are completely invisible to standard list-objects API calls. Because they take up physical space, the cloud provider continues to charge you for them month over month. To fix this permanently, you must configure a bucket lifecycle rule such as `AbortIncompleteMultipartUpload` with `DaysAfterInitiation: 1` (AWS allows 1–7 days), which automatically purges any orphaned upload fragments.
 </details>
 
 <details>
@@ -716,15 +1077,29 @@ Without a Multi-Region Access Point (MRAP), your deployment manifests would need
 Relying solely on application configuration violates the principle of defense-in-depth, as a simple configuration drift, typo, or new tool (like an admin running a local script) could accidentally use HTTP. For example, if an engineer tests an endpoint using `curl` without HTTPS, the bucket policy will reject the insecure request. By enforcing TLS at the bucket policy level, you create an infrastructure-enforced guardrail that actively denies any unencrypted request regardless of the client's configuration. This guarantees data in transit is protected and satisfies strict compliance frameworks (like HIPAA or PCI-DSS) that require systemic, rather than application-level, enforcement of encryption.
 </details>
 
+<details>
+<summary>7. Your telemetry bucket stores 80 TB with unpredictable access: weekly incident replays spike reads, otherwise objects sit idle for months. Would you choose a fixed lifecycle to Glacier Deep Archive after 30 days, S3 Intelligent-Tiering, or stay on Standard—and why?</summary>
+
+Fixed Deep Archive after 30 days optimizes storage GB-month but punishes the weekly replay pattern with retrieval delays and per-GB retrieval fees that can exceed storage savings. Staying on Standard forever avoids retrieval surprises but wastes money on the long idle tail. S3 Intelligent-Tiering ([documented by AWS](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering.html)) fits unpredictable access: objects move between frequent and infrequent tiers automatically without rewriting lifecycle JSON each time analytics changes. Pair monitoring fees with a pilot bucket, and keep a lifecycle rule on `tmp/` prefixes for definite expiration regardless of tiering choice.
+</details>
+
+<details>
+<summary>8. A compliance officer requires WORM retention for 7 years on audit logs written by Kubernetes jobs. Which controls across AWS, GCP, and Azure satisfy immutability without mounting a CSI volume?</summary>
+
+Use SDK writes with workload identity into buckets protected by immutability features—not CSI mounts. On AWS, enable versioning and Object Lock in compliance mode for the audit prefix. On GCS, apply bucket retention policies or bucket lock matching the seven-year window. On Azure, configure [immutable Blob storage](https://learn.microsoft.com/en-us/azure/storage/blobs/immutable-storage-overview) with time-based retention or legal holds on the audit container. Kubernetes only needs a ServiceAccount with write-only scope to the audit prefix; Velero-style backup buckets may replicate to a second region, but immutability must be enforced at the bucket policy layer so even cluster-admin credentials cannot shorten retention during the hold.
+</details>
+
 ---
 
 ## Hands-On Exercise: Object Storage Access Patterns with MinIO
 
-This exercise uses MinIO (S3-compatible) running locally in a kind cluster to practice all three access patterns.
+This hands-on exercise uses MinIO as an S3-compatible API inside a kind cluster so you can practice SDK access, pre-signed URLs, lifecycle-style cleanup, and security checks without cloud spend.
 
 ### Setup
 
 ```bash
+alias k=kubectl
+
 # Create kind cluster
 kind create cluster --name storage-lab
 
@@ -736,8 +1111,7 @@ helm install minio minio/minio \
   --set persistence.enabled=false \
   --set rootUser=minioadmin \
   --set rootPassword=minioadmin123 \
-  --set resources.requests.memory=256Mi \
-  --set mode=standalone
+  --set resources.requests.memory=256Mi
 
 k wait --for=condition=ready pod -l app=minio -n storage --timeout=120s
 ```
@@ -804,7 +1178,7 @@ k logs s3-client -n storage
 
 ### Task 2: Generate Pre-Signed URLs
 
-Create a pod that generates pre-signed download URLs for the uploaded files.
+The second task deploys a short-lived pod that generates pre-signed download and upload URLs for objects already stored in the MinIO bucket, mirroring how a production API would delegate large transfers to clients.
 
 <details>
 <summary>Solution</summary>
@@ -880,12 +1254,13 @@ k logs url-generator -n storage
 
 ### Task 3: Implement Lifecycle-Like Cleanup
 
-Create a CronJob that cleans up files older than a specified age (simulating lifecycle policies).
+The third task installs a CronJob that deletes objects older than a configurable age threshold, simulating vendor lifecycle expiration rules you would otherwise express in S3, GCS, or Azure Blob JSON policies.
 
 <details>
 <summary>Solution</summary>
 
-```yaml
+```bash
+cat <<'EOF' > /tmp/cleanup-cronjob.yaml
 apiVersion: batch/v1
 kind: CronJob
 metadata:
@@ -932,16 +1307,15 @@ spec:
 
                   print(f"Cleanup complete: {deleted} objects deleted")
                   PYEOF
-```
+EOF
 
-```bash
 k apply -f /tmp/cleanup-cronjob.yaml
 ```
 </details>
 
 ### Task 4: Verify Bucket Security
 
-Write a script that checks bucket security settings.
+The fourth task runs an auditor pod that inspects versioning, encryption, and bucket policy presence so you can compare MinIO behavior to the defense-in-depth checklist used for cloud buckets.
 
 <details>
 <summary>Solution</summary>
@@ -1019,10 +1393,10 @@ k logs security-audit -n storage
 
 ### Success Criteria
 
-- [ ] S3 client pod creates bucket and uploads 11 files
-- [ ] Pre-signed URL generator produces valid download and upload URLs
-- [ ] CronJob runs and reports cleanup activity
-- [ ] Security audit pod reports versioning and encryption status
+- [ ] S3 client pod creates bucket and uploads 11 files using SDK-style CLI access
+- [ ] Pre-signed URL generator produces valid download and upload URLs with short expiration
+- [ ] Lifecycle-style CronJob deletes objects older than the configured age threshold
+- [ ] Security audit pod reports versioning and encryption status for the test bucket
 
 ### Cleanup
 
@@ -1032,12 +1406,14 @@ kind delete cluster --name storage-lab
 
 ---
 
-**Next Module**: [Module 9.5: Advanced Caching Services (ElastiCache / Memorystore)](../module-9.5-caching/) -- Learn Redis and Memcached architectures for Kubernetes workloads, caching strategies, cache stampede prevention, and using Envoy as a sidecar cache.
+## Next Module
+
+[Module 9.5: Advanced Caching Services (ElastiCache / Memorystore)](../module-9.5-caching/) — Redis and Memcached architectures for Kubernetes workloads, caching strategies, cache stampede prevention, and using Envoy as a sidecar cache.
 
 ## Sources
 
 - [aws.amazon.com: pricing](https://aws.amazon.com/s3/pricing/) — General lesson point for an illustrative rewrite.
-- [docs.cloud.google.com: overview](https://docs.cloud.google.com/storage/docs/cloud-storage-fuse/overview) — Google's Cloud Storage FUSE documentation explicitly says it is not POSIX compliant and should not back a database.
+- [cloud.google.com: overview](https://cloud.google.com/storage/docs/cloud-storage-fuse/overview) — Google's Cloud Storage FUSE documentation explicitly says it is not POSIX compliant and should not back a database.
 - [docs.aws.amazon.com: mpu abort incomplete mpu lifecycle config.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/mpu-abort-incomplete-mpu-lifecycle-config.html) — AWS documents both the billing behavior and the `AbortIncompleteMultipartUpload` lifecycle action.
 - [aws.amazon.com: replication](https://aws.amazon.com/s3/features/replication/) — AWS's S3 Replication overview explicitly describes automatic replication between buckets and across Regions.
 - [docs.aws.amazon.com: replication requirements.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/replication-requirements.html) — AWS states that both source and destination buckets must have versioning enabled for replication.
@@ -1045,5 +1421,13 @@ kind delete cluster --name storage-lab
 - [docs.aws.amazon.com: MultiRegionAccessPointRequestRouting.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/MultiRegionAccessPointRequestRouting.html) — AWS documents that Multi-Region Access Points route requests to the closest-proximity bucket.
 - [aws.amazon.com: block public access](https://aws.amazon.com/s3/features/block-public-access/) — AWS's Block Public Access documentation covers both the scopes and the default-on behavior for new buckets.
 - [AWS Presigned URL Best Practices](https://docs.aws.amazon.com/prescriptive-guidance/latest/presigned-url-best-practices/introduction.html) — Covers security guardrails and monitoring patterns for presigned URL workflows.
-- [Cloud Storage FUSE CSI Driver for GKE](https://docs.cloud.google.com/kubernetes-engine/docs/concepts/cloud-storage-fuse-csi-driver) — Explains how the GKE CSI integration works and where its filesystem semantics differ from traditional storage.
+- [Cloud Storage FUSE CSI Driver for GKE](https://cloud.google.com/kubernetes-engine/docs/concepts/cloud-storage-fuse-csi-driver) — Explains how the GKE CSI integration works and where its filesystem semantics differ from traditional storage.
 - [Azure Blob Immutable Storage Overview](https://learn.microsoft.com/en-us/azure/storage/blobs/immutable-storage-overview) — Explains legal holds, time-based retention, and compliance-oriented WORM behavior.
+- [Amazon S3 storage classes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html) — Official class definitions and use cases.
+- [S3 Intelligent-Tiering](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intelligent-tiering.html) — Automation fees and tier movement behavior.
+- [GCS storage classes](https://cloud.google.com/storage/docs/storage-classes) — Standard through Archive and regional options.
+- [Azure Blob access tiers](https://learn.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview) — Hot/Cool/Cold/Archive tradeoffs.
+- [Kubernetes Volumes concept](https://kubernetes.io/docs/concepts/storage/volumes/) — Clarifies when block/file PVCs apply versus API-backed object access.
+- [Velero documentation](https://velero.io/docs/) — Backup storage locations targeting object buckets.
+- [Mountpoint for Amazon S3 CSI on EKS](https://docs.aws.amazon.com/eks/latest/userguide/s3-csi-driver.html) — Add-on installation and IAM boundaries.
+- [Azure Blob CSI driver on AKS](https://learn.microsoft.com/en-us/azure/aks/azure-blob-csi-driver) — Enabling Blob CSI for AKS workloads.

--- a/src/content/docs/cloud/managed-services/module-9.5-caching.md
+++ b/src/content/docs/cloud/managed-services/module-9.5-caching.md
@@ -1,15 +1,14 @@
 ---
-revision_pending: true
-title: "Module 9.5: Advanced Caching Services (ElastiCache / Memorystore)"
+title: "Module 9.5: Advanced Caching Services (ElastiCache / Memorystore / Azure Cache)"
 slug: cloud/managed-services/module-9.5-caching
 sidebar:
   order: 6
 ---
-**Complexity**: [COMPLEX] | **Time to Complete**: 2h | **Prerequisites**: Module 9.1 (Databases), Module 9.4 (Object Storage), Redis fundamentals
+**Complexity**: [COMPLEX] | **Time to Complete**: 2h | **Prerequisites**: Module 9.1 (Databases), Module 9.4 (Object Storage), Redis fundamentals, and basic Kubernetes Service networking
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+After completing this module, you will be able to explain where a managed cache belongs in a multi-cloud Kubernetes architecture, choose an engine and deployment model, and operate the cache as a deliberate reliability component rather than a mysterious fast database.
 
 - **Configure Kubernetes pods to connect to managed caching services (ElastiCache, Memorystore, Azure Cache for Redis)**
 - **Implement cache-aside, write-through, and write-behind patterns for applications running on Kubernetes**
@@ -20,15 +19,29 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-A flash-sale traffic spike can overwhelm a relational database when each request fans out into multiple queries and every newly scaled pod opens more database connections.
+Hypothetical scenario: a flash-sale traffic spike can overwhelm a relational database when each request fans out into multiple queries and every newly scaled pod opens more database connections. The application might look healthy for the first few minutes because Horizontal Pod Autoscaler adds replicas, but each replica multiplies pressure on the same primary datastore. Without a cache, the scaling action that should protect users can become the action that pushes the database past its connection, CPU, or I/O ceiling.
 
-A self-managed cache with weak observability and poorly reviewed memory settings can silently evict data before peak traffic, pushing the full read load back onto the database.
+A self-managed cache with weak observability and poorly reviewed memory settings can silently evict data before peak traffic, pushing the full read load back onto the database. This is why caching is not just a performance trick. It is a load-shedding layer, a consistency tradeoff, and a cost control point that has to be designed with the same seriousness as the primary database.
 
-After moving to a managed Redis service with deliberate sizing, connection limits, and eviction monitoring, teams can dramatically reduce database load during later traffic spikes.
+After moving to a managed Redis service with deliberate sizing, connection limits, and eviction monitoring, teams can dramatically reduce database load during later traffic spikes. The managed provider absorbs patching, node replacement, failover orchestration, endpoint management, encryption plumbing, and routine monitoring integrations. The platform team still owns the architecture: choosing TTLs, protecting hot keys, separating cache data from durable state, and deciding how Kubernetes workloads authenticate to a private endpoint.
+
+The simplest way to visualize a cache is as a fast memory shelf in front of a slower warehouse. The warehouse is your source of truth, such as RDS, Aurora, Cloud SQL, AlloyDB, Azure SQL, Cosmos DB, or an API backed by one of those systems. The shelf is ElastiCache, Memorystore, Azure Cache for Redis, Azure Managed Redis, or a Redis-compatible service that keeps the most requested items close to the application. If the shelf is stocked with the right items, most users never wait for the warehouse trip. If the shelf is stale, empty, or stocked with the wrong items, every request walks back to the warehouse at once.
+
+In Kubernetes, the cache layer sits outside the cluster more often than beginners expect. Pods connect through private networking, DNS, workload identity, and a small amount of application configuration. That pattern is healthy because Redis and Memcached are stateful systems with failure modes that do not look like stateless Deployments. You can run Redis inside the cluster for labs, edge environments, and small internal tools, but production platform teams usually prefer managed caches when the application depends on predictable failover, snapshots, encryption, patch windows, and provider-backed availability.
+
+The multi-cloud decision is not "Redis everywhere" or "Memcached everywhere." AWS ElastiCache supports Valkey, Redis OSS, and Memcached engines; Google Memorystore offers Valkey, Redis, Redis Cluster, and Memcached services; Microsoft documents Azure Cache for Redis tiers and now points customers toward Azure Managed Redis for the future. Those offerings overlap, but they are not identical. Their replication models, scaling limits, version choices, billing meters, private connectivity options, and migration paths differ enough that a portable Kubernetes app still needs provider-specific infrastructure code and runbooks.
 
 ---
 
 ## Redis vs Memcached: Choosing Your Engine
+
+Redis, Valkey, and Memcached are all in-memory systems, but they optimize for different operational contracts. Memcached is intentionally simple: clients distribute keys across independent nodes, the server stores opaque values, and losing a node means losing the keys that hashed to that node. Redis and Valkey provide richer data structures, replication, clustering, Lua or function-style server-side logic depending on engine version, streams, sorted sets, pub/sub, and optional persistence. That power makes Redis-family engines more versatile, but it also creates more design choices that can hurt reliability if a team treats the cache like an ordinary database.
+
+The licensing history matters because it changed cloud provider roadmaps. Redis Ltd. changed Redis licensing in 2024, and the Linux Foundation announced Valkey as an open source alternative based on the Redis lineage. AWS now documents Valkey as a first-class ElastiCache engine, and Google documents Memorystore for Valkey alongside its Redis and Memcached offerings. Azure's current managed cache documentation remains Redis-branded, with Azure Cache for Redis tiers and Azure Managed Redis based on Redis Enterprise. The practical lesson is simple: choose the engine explicitly in Terraform, Pulumi, Crossplane, or CLI commands, and verify the provider's current default instead of assuming that "Redis" means the same thing everywhere.
+
+Redis-family engines are usually the right default for Kubernetes application platforms because platform teams rarely stop at plain key-value caching. Session state needs expiration and sometimes atomic updates. Rate limiting needs counters with TTLs. Leaderboards need sorted sets. Queue-like workloads might use lists or streams. Feature flags and API response caches need structured invalidation. Memcached can handle some of those by serializing application objects, but the application has to implement more behavior itself, and there is no built-in replication or persistence story to lean on when the workload becomes important.
+
+Memcached still has a serious place in architecture. It is a strong fit when values are disposable, the access pattern is simple, clients already implement consistent hashing, and horizontal scale matters more than engine features. Its model is also easier to reason about during incidents: if a node disappears, the cache is colder, but there is no replica election, cluster slot map, or persistence replay to debug. The cost of that simplicity is that the application must tolerate key loss and must not assume the cache can coordinate locks, sorted rankings, streams, or durable-ish sessions.
 
 ### Decision Matrix
 
@@ -46,6 +59,10 @@ After moving to a managed Redis service with deliberate sizing, connection limit
 
 **For many Kubernetes workloads, Redis is the more versatile choice.** Memcached is simpler but far less capable. Choose Memcached only when you need pure key-value caching at extremely high throughput with no need for data structures, persistence, or replication.
 
+When you hear "Redis is single-threaded," read that as a useful warning rather than an absolute limitation. Redis and Valkey can use background threads and I/O improvements depending on version and distribution, but command execution for many common operations is still shaped by a main execution path. That means one expensive command, one oversized value, one hot key, or one shard receiving a disproportionate share of traffic can dominate user-visible latency. Memcached's multi-threaded design can help with simple high-throughput reads, but it does not give you the richer data model that many modern application teams expect.
+
+Persistence is another source of confusion. Redis persistence through RDB snapshots or append-only files can reduce data loss in self-managed deployments, and managed providers expose some backup, snapshot, or persistence features depending on engine and tier. That does not turn a cache into the system of record. If your application cannot reconstruct the data from a database, object store, event stream, or authoritative API, you are no longer using a cache. You are operating a database with cache-oriented defaults, and the first eviction, flush, resize, or failed write-behind worker will expose the mismatch.
+
 ### Managed Service Comparison
 
 | Feature | AWS ElastiCache Redis | GCP Memorystore Redis | Azure Cache for Redis |
@@ -57,15 +74,27 @@ After moving to a managed Redis service with deliberate sizing, connection limit
 | Encryption in transit | TLS | TLS | TLS |
 | VPC integration | VPC subnets | VPC network | VNET injection |
 
+AWS gives you two broad ElastiCache deployment styles. Serverless caches reduce capacity planning and bill on stored data plus request processing, while node-based clusters bill by cache node hour and expose more of the familiar topology choices. For Valkey and Redis OSS, cluster mode disabled gives one shard with optional replicas and primary or reader endpoints, while cluster mode enabled partitions the keyspace across shards and requires cluster-aware clients. For Memcached, ElastiCache exposes independent nodes and relies on client-side distribution, which is why the application library choice becomes part of the architecture.
+
+Google Cloud splits the product family more visibly. Memorystore for Redis is the traditional standalone or highly available Redis service, Memorystore for Redis Cluster gives sharded Redis clusters with primaries and optional replicas per shard, Memorystore for Valkey is the Valkey-branded path, and Memorystore for Memcached provides a managed Memcached service where keys are distributed across nodes without replication. That separation is useful during design reviews because a GKE team can choose a simpler non-cluster Redis instance for a small service, a sharded Redis Cluster or Valkey instance for high-throughput shared platform use, or Memcached for disposable object caches.
+
+Azure has two names that learners must keep separate. Azure Cache for Redis is the long-running service with Basic, Standard, Premium, Enterprise, and Enterprise Flash tiers documented by Microsoft, while Azure Managed Redis is the newer Redis Enterprise based service that Microsoft recommends for future migrations. Basic and Standard are simpler choices for development or modest production needs, Premium adds features such as clustering and persistence, and Enterprise tiers bring Redis Enterprise capabilities such as modules and active geo-replication options. The provider's retirement and migration guidance matters for new designs because choosing the older SKU today can create planned migration work later.
+
+The Kubernetes integration shape is similar across providers even when the product names differ. The application should receive a private DNS name, port, TLS setting, authentication material, and a small connection-pool budget through Kubernetes configuration. Network reachability comes from VPC, VNet, Private Service Connect, Private Link, peering, or subnet placement. Credentials should come from cloud secret managers or workload identity rather than static values copied into manifests. Operators such as External Secrets Operator and the Secrets Store CSI Driver help pull credentials from AWS Secrets Manager, Google Secret Manager, Azure Key Vault, or compatible stores without making the Git repository the secret database.
+
 ---
 
 ## Caching Strategies
 
-The "right" caching strategy depends on your read/write ratio and consistency requirements.
+The "right" caching strategy depends on your read/write ratio, consistency requirements, tolerance for stale data, and the blast radius of a wrong answer. A cache for product descriptions can usually serve a value that is a few minutes old, while a cache for account balance, entitlements, or security decisions needs a much tighter contract. The strategy also determines who is responsible for invalidation: the application, a library, a background worker, the database change stream, or a scheduled refresh process.
+
+Start by naming the source of truth. For most cloud applications, the source of truth is a managed database such as Aurora, Cloud SQL, AlloyDB, Azure SQL, Cosmos DB, Spanner, DynamoDB, Firestore, or an API that owns durable state. The cache is a derived copy optimized for latency and read offload. Once the team agrees on that relationship, the design questions become sharper: how does data enter the cache, how does it leave, what happens when the cache is unavailable, and how stale can the answer be before the user experience or business process is wrong?
+
+In Kubernetes, the chosen strategy also affects rollout behavior. A Deployment with 50 pods can create a large number of simultaneous cache misses after a restart. A canary that changes serialization format can poison shared cache keys if it writes values older pods cannot read. A blue-green deployment can double connection usage during the overlap period. Good caching design therefore includes key versioning, connection budgets, readiness behavior, and explicit fallbacks, not only a `get` followed by a `setex`.
 
 ### Cache-Aside (Lazy Loading)
 
-The most common pattern. The application checks the cache first; on a miss, it reads from the database and populates the cache.
+The most common pattern is cache-aside, also called lazy loading. The application checks the cache first; on a miss, it reads from the database and populates the cache. This pattern keeps the cache focused on data that users actually request, which makes it cost-efficient for large catalogs, user profiles, permissions snapshots, and API response fragments where the full dataset is much larger than the hot working set.
 
 ```mermaid
 flowchart TD
@@ -98,12 +127,16 @@ def get_product(product_id):
     return product
 ```
 
-**Pros**: Only caches data that is actually requested. Simple to implement.
-**Cons**: Cache miss penalty (extra latency on first request). Data can become stale until TTL expires.
+**Pros**: Cache-aside only caches data that is actually requested, is simple to implement in any language, and gives the application direct control over TTL, serialization, fallback behavior, and negative caching for known-missing records.
+**Cons**: The first request after expiration pays the database latency, data can remain stale until TTL or invalidation, and a popular key can stampede the database if many pods miss at the same time.
+
+Cache-aside works well on AWS when EKS pods read from ElastiCache through a primary endpoint or cluster-aware client while the source of truth remains RDS, Aurora, DynamoDB, or another durable service. On GCP, GKE workloads commonly use Memorystore with Cloud SQL, AlloyDB, Spanner, or Firestore behind the cache. On Azure, AKS workloads can use Azure Cache for Redis or Azure Managed Redis in front of Azure SQL, Cosmos DB, or an internal API. The vendor-neutral rule is the same: a cache miss must have a bounded path back to authoritative data, and the application must survive a cache failure without corrupting that authoritative state.
+
+The main failure mode is accidental dependency inversion. Teams start with cache-aside, then gradually add data to Redis that has no database equivalent because Redis is convenient and fast. A feature flag, rate-limit counter, or session token might be acceptable in Redis if the business accepts loss or has a recovery path. A payment record, order confirmation, or entitlement grant is not. During design review, ask what happens after `FLUSHALL`, a failed resize, or a region evacuation. If the answer is "we lose customer state," the cache is no longer just a cache.
 
 ### Write-Through
 
-Every write goes to both the cache and the database simultaneously.
+In write-through caching, every write updates the database and the cache in the same application operation. The usual safe version writes the database first, confirms success, then refreshes or invalidates the cache key. Some libraries describe write-through as writing the cache first and letting the cache write the backing store, but that model is uncommon for managed Redis-family services in ordinary web applications because the cache is not the database transaction coordinator.
 
 ```mermaid
 flowchart TD
@@ -125,12 +158,16 @@ def update_product_price(product_id, new_price):
     return product
 ```
 
-**Pros**: Cache is typically consistent with the database. No stale reads after writes.
-**Cons**: Write latency increases (two writes per operation). Caches data that may never be read.
+**Pros**: The cache is typically consistent with the database immediately after the write path completes, which prevents confusing stale reads for users who update a profile, cart, preference, or session and then immediately refresh the page.
+**Cons**: Write latency increases because each operation touches two systems, the application must handle partial failure carefully, and the cache may store data that is rarely read again.
+
+The subtle part is the partial failure window. Suppose the database update succeeds but the cache update times out. Returning an error to the user may cause a retry that writes the database twice unless the operation is idempotent. Returning success may leave stale cache data until TTL or invalidation. The safer pattern is often "write database, delete cache key" rather than "write database, rewrite cache value," because the next reader can rebuild the value from the source of truth. For high-value workflows, pair this with versioned writes or database change events so a late cache writer cannot overwrite a newer value.
+
+Provider choice does not remove this application-level problem. ElastiCache Multi-AZ failover, Memorystore Standard tier automatic failover, or Azure Premium and Enterprise availability features can reduce infrastructure interruption, but they cannot make a two-system write magically atomic. If you need cross-resource transactions, keep the transaction in the database and treat the cache as invalidated derived state. If you need extremely fast reads after writes, keep TTL short, include a version field in the cached object, and make clients reject older versions when they appear.
 
 ### Write-Behind (Write-Back)
 
-Writes go to the cache immediately and are asynchronously flushed to the database.
+With write-behind, also called write-back, writes go to the cache immediately and are asynchronously flushed to the database. This is attractive for counters, telemetry rollups, game-like scoring, or analytics buffers because the user request can complete before the database absorbs the write. It is dangerous for critical business data because a cache crash, failed background worker, serialization bug, or region event can lose acknowledged writes.
 
 ```mermaid
 flowchart TD
@@ -139,8 +176,28 @@ flowchart TD
     B -. async, batched .-> D[Flush to Database]
 ```
 
-**Pros**: Extremely fast writes. Database load is smoothed by batching.
-**Cons**: Risk of data loss if cache fails before flush. Complex to implement correctly. Not suitable for critical data.
+**Pros**: Write-behind can make writes extremely fast from the user's perspective, smooth database load through batching, and absorb bursty updates that do not require immediate durable visibility.
+**Cons**: It creates a real risk of data loss if the cache fails before flush, requires replay and idempotency logic, and is usually unsuitable for critical data such as orders, payments, access grants, or inventory commitments.
+
+If you choose write-behind, pair it with an explicit queue or stream rather than relying on memory alone. On AWS, a safer design might write an event to SQS, Kinesis, MSK, or EventBridge and use Redis only for recent counters or deduplication. On GCP, Pub/Sub or a managed streaming system can hold the durable work while Memorystore serves fast reads. On Azure, Service Bus or Event Hubs can play the same role. Kubernetes workers can then scale with KEDA based on queue depth or Redis list and stream lag, but the durable queue remains the recovery mechanism if the cache disappears.
+
+The common beginner mistake is using write-behind for shopping carts because carts feel less formal than orders. That can be acceptable only if the business explicitly accepts cart loss and the user experience handles it. Many commerce teams treat carts as meaningful state because losing them reduces conversion and support trust. A safer design is write-through to the durable cart store, cache-aside for display reads, and short TTLs or event-driven invalidation for cart summaries.
+
+### Read-Through
+
+Read-through caching moves miss handling into a cache library, proxy, or data access layer. The application asks the cache abstraction for a key, and the abstraction knows how to load the missing value from the backing store. This keeps business code cleaner and can standardize TTLs, metrics, serialization, and stampede protection across services, but it also hides expensive database work behind a method that may look like a cheap cache read.
+
+In a multi-cloud Kubernetes platform, read-through is usually implemented in the application library or a sidecar rather than by ElastiCache, Memorystore, or Azure Cache itself. Those managed services provide the cache engine; they do not know how to query your product table, call your account API, or assemble a GraphQL response. The provider-neutral abstraction can still be valuable if every service emits the same metrics for cache hit rate, load latency, stale returns, and load errors. Without those metrics, read-through can make outages harder to understand because database pressure appears to come from "cache reads."
+
+Read-through fits shared platform libraries and domain services with consistent backing stores. It is weaker for one-off features where each key has unique loading rules, different authorization behavior, or user-specific filtering. Be careful with security boundaries: a read-through cache must include tenant, locale, role, and data-version information in the key when those attributes affect the answer. Otherwise one user's cached result can become another user's data leak.
+
+### Refresh-Ahead
+
+Refresh-ahead refreshes popular keys before users see an expiration. A background worker or request path checks the remaining TTL and reloads the value while the old value is still usable. This is a strong pattern for expensive read models, product pages, recommendation snapshots, pricing displays with accepted staleness, and configuration documents where the same keys are requested repeatedly throughout the day.
+
+The advantage is that refresh load can be smoothed instead of arriving at the exact expiration boundary. The risk is that refresh-ahead can waste money by refreshing values no one will read, and it can hide stale-data bugs when the refresh worker fails silently. On AWS, GCP, and Azure, the cost pattern is similar even though the meters differ: refresh-ahead consumes cache requests, database or API reads, and worker CPU whether users need the value or not. Use popularity thresholds, jitter, and refresh budgets so the warmer does not become a scheduled denial-of-service against the source of truth.
+
+Refresh-ahead also needs deployment discipline. When a new application version changes the cached JSON shape, a warmer running the old container image can repopulate keys with the old shape while new pods expect the new one. Use key namespaces such as `product:v3:{id}`, write migration readers that understand both formats, or drain old warmers before rolling out incompatible cache values. That problem is vendor-neutral and appears the same whether the cache endpoint is ElastiCache, Memorystore, Azure Cache, or an in-cluster Redis StatefulSet.
 
 ### Strategy Selection Guide
 
@@ -157,7 +214,57 @@ flowchart TD
 
 ---
 
+## Decision Framework
+
+Use this framework when a team asks, "Should we cache this?" The first decision is not the provider or engine; it is whether the application has a safe answer when the cached value is absent, stale, duplicated, or evicted. If the source of truth can rebuild the value and the user can tolerate bounded staleness, caching is a strong candidate. If losing the value means losing business state, treat the cache as an optimization around a durable store, not as the store itself.
+
+```mermaid
+flowchart TD
+    A[Need lower latency or datastore offload?] -->|No| B[Do not add a cache yet]
+    A -->|Yes| C{Can data be rebuilt from a source of truth?}
+    C -->|No| D[Use a durable database or queue first]
+    C -->|Yes| E{Simple opaque key-value data?}
+    E -->|Yes| F{Need replication, persistence, locks, streams, sorted sets, or pub/sub?}
+    E -->|No| G[Choose Redis-family engine: Valkey, Redis OSS, Azure Redis]
+    F -->|No| H[Consider Memcached for disposable object cache]
+    F -->|Yes| G
+    G --> I{Traffic predictable and steady?}
+    H --> I
+    I -->|Yes| J[Provision node-based managed cache sized for memory, CPU, and replicas]
+    I -->|No| K[Evaluate serverless or elastic tier where available]
+    J --> L{Kubernetes platform owns stateful ops?}
+    K --> L
+    L -->|No| M[Prefer managed cache with private endpoint and workload identity]
+    L -->|Yes, small or edge use case| N[In-cluster Redis/Memcached may be acceptable with explicit SLO limits]
+```
+
+| Decision | Prefer This | Tradeoff |
+|----------|-------------|----------|
+| Redis-family vs Memcached | Redis-family for data structures, replication, locks, streams, sorted sets, pub/sub, and richer operational controls | More features mean more configuration, more client behavior to understand, and more risk of treating cache state as durable state |
+| Memcached vs Redis-family | Memcached for simple disposable object caches with client-side sharding and no need for replication | Node loss means key loss, values are opaque, and advanced coordination patterns belong elsewhere |
+| Managed vs in-cluster | Managed cache for production dependencies, multi-AZ needs, patching, failover, encryption, backups, and provider support | Costs are visible as service charges, and platform teams must design private networking and identity integration |
+| In-cluster cache | In-cluster for local development, ephemeral preview environments, edge clusters, or workloads that can tolerate loss and manual recovery | Stateful Kubernetes operations, storage, failover, upgrades, and security become your team's responsibility |
+| Provisioned/node-based vs serverless | Provisioned nodes for predictable steady load and explicit capacity control; serverless for spiky load or teams that need reduced capacity planning | Serverless can spike on request-processing and storage meters, while provisioned nodes can waste money when idle |
+
+This matrix is deliberately conservative. A cache that saves 40 milliseconds on a low-traffic endpoint may not justify the new failure modes, IAM policies, dashboards, and runbooks. A cache that removes 80 percent of reads from a saturated database can be the difference between a stable release and a recurring incident. The decision is strongest when you can name the slow dependency, estimate the hot working set, bound staleness, and show how the system behaves during cache outage.
+
+For AWS, the "managed" branch usually points to ElastiCache Serverless or node-based ElastiCache for Valkey, Redis OSS, or Memcached in private subnets. For GCP, it points to Memorystore for Valkey, Redis, Redis Cluster, or Memcached connected to GKE through private networking. For Azure, it points to Azure Cache for Redis in existing estates or Azure Managed Redis for newer Redis Enterprise based designs. For vendor-neutral Kubernetes, it points to a Service abstraction, workload identity, external secret integration, and an application client that can fail fast, retry carefully, and degrade without corrupting the source of truth.
+
+The framework also gives reviewers a way to challenge over-caching. If a team cannot explain the invalidation rule, the expected hit rate, the cost at peak, and the fallback behavior, the design is not ready. Caching is most valuable when it is boring during normal operation and predictable during failure. It is least valuable when it becomes a hidden second database that no one owns.
+
+---
+
 ## Connecting Kubernetes to Managed Redis
+
+Kubernetes should see a managed cache as an external dependency with explicit contracts. The Deployment needs a stable hostname, port, TLS mode, authentication method, connection budget, timeout policy, and health behavior. The cluster needs network reachability through VPC or VNet routing, security groups or firewall rules, private service connectivity, DNS resolution, and a way to retrieve credentials. The platform team needs dashboards and alerts that combine provider metrics with application metrics, because a high cache hit rate with rising command latency still hurts users.
+
+The simplest DNS integration is a Kubernetes `ExternalName` Service that maps an internal service name to the provider's cache endpoint. That keeps application configuration Kubernetes-native, but it is not a load balancer and it does not proxy traffic. DNS clients still connect to the provider endpoint, and protocols with strict hostname expectations can care about the difference between the Kubernetes name and the target name. For Redis and Memcached, that is usually manageable, but TLS certificate validation and cluster-aware clients deserve testing before rollout.
+
+For production, many teams skip `ExternalName` and put the provider endpoint directly in a ConfigMap or secret-managed environment variable. That is less abstract, but it avoids hiding provider-specific endpoint behavior. ElastiCache cluster mode enabled clients need the configuration endpoint and must understand slot maps. Memorystore for Redis Cluster uses discovery behavior appropriate to clustered clients. Azure Redis clients may need TLS, access keys, or identity-based authentication depending on service and tier. The right abstraction is the one your client library can actually use.
+
+Workload identity is the cleanest direction for secret retrieval and cloud API access. On EKS, that means IAM Roles for Service Accounts or EKS Pod Identity where supported. On GKE, Workload Identity Federation for GKE lets Kubernetes service accounts receive Google Cloud permissions without static JSON keys. On AKS, Microsoft Entra Workload ID lets pods use Kubernetes service account tokens to access Azure resources such as Key Vault. The cache connection password or token may still be presented to the Redis client, but the path that fetches and rotates it should not depend on a long-lived cloud credential baked into a manifest.
+
+External Secrets Operator and Secrets Store CSI Driver solve related but different problems. External Secrets Operator synchronizes values from AWS Secrets Manager, Google Secret Manager, Azure Key Vault, and other backends into Kubernetes Secrets, which is convenient for environment variables and existing applications. Secrets Store CSI Driver mounts external secret values into pods as files through a CSI volume and can optionally sync them as Kubernetes Secrets. Either approach can work; the key decision is whether your application can reload rotated material without a restart and whether your security policy allows synchronized Kubernetes Secrets at rest.
 
 ### ElastiCache Redis from EKS
 
@@ -249,9 +356,29 @@ spec:
 
 ---
 
+### Managed Cache or In-Cluster Cache?
+
+Running Redis in Kubernetes is not wrong. It is a reasonable choice for a local lab, a preview environment, a single-node edge cluster, a throwaway integration test, or a small internal app where cache loss has almost no business impact. Helm charts, operators, and StatefulSets can create a working Redis deployment quickly, and the local lab in this module uses that model because it is portable. The problem starts when a team mistakes "works in a cluster" for "operates like a provider-backed managed service under production failure."
+
+An in-cluster Redis or Memcached deployment makes your Kubernetes platform responsible for stateful scheduling, persistent volumes if enabled, anti-affinity, backup policy, failover behavior, upgrades, TLS, authentication, memory fragmentation, eviction settings, and capacity planning. Operators can automate parts of that lifecycle, but they do not remove the need to test failure modes. If a node drain moves the primary, if a persistent volume attaches slowly, or if a replica lags during failover, the application still experiences the consequences.
+
+Managed services shift many infrastructure tasks to the provider. ElastiCache handles cache node replacement, managed endpoints, Multi-AZ options, encryption integration, and engine patching paths. Memorystore handles provisioning, replication, failover, monitoring integration, and private connectivity models inside Google Cloud. Azure Cache for Redis and Azure Managed Redis provide Azure-native monitoring, networking, and tier-based feature sets. The platform team still owns application correctness, but it no longer owns every Redis process, disk, and failover controller.
+
+There are also hybrid patterns. A service can use a tiny in-process or sidecar cache for a few seconds to absorb a hot key, a managed Redis-family cache for shared state across pods, and the database as the source of truth. That layered design is common for read-heavy APIs. The local cache reduces round trips for the hottest value, the managed cache reduces database reads across the fleet, and the database remains authoritative. Each layer must have a shorter or equal staleness budget than the layer behind it, or debugging becomes nearly impossible.
+
+### Provider-Specific Connectivity Notes
+
+On AWS, EKS pods typically connect to ElastiCache through private subnets and security groups. For cluster mode disabled Redis or Valkey, applications use the primary endpoint for writes and a reader endpoint or replica endpoints for read-heavy traffic where stale reads are acceptable. For cluster mode enabled, the client must be cluster-aware because keys are partitioned across slots and shards. ElastiCache Serverless changes capacity planning but does not remove the need for TLS settings, authentication, timeouts, and connection pooling.
+
+On GCP, GKE workloads must be in a network path that Memorystore supports, and the exact connectivity model depends on the Memorystore product. Traditional Memorystore for Redis exposes a simple endpoint for Basic or Standard tier instances, while Redis Cluster and Valkey products introduce sharded or newer connectivity choices. Memorystore for Memcached distributes keys across nodes and does not replicate them, so client auto-discovery and consistent hashing behavior matter more than they do with a single Redis endpoint.
+
+On Azure, AKS workloads connect through Azure networking constructs such as Private Link, VNet integration, firewall rules, and DNS resolution appropriate to the chosen cache service. Azure Cache for Redis tiers differ materially: Basic has no production SLA, Standard uses a replicated pair, Premium adds higher-end features such as clustering and persistence, and Enterprise tiers use Redis Enterprise capabilities. New designs should also account for Microsoft's Azure Cache retirement guidance and evaluate Azure Managed Redis when it fits the organization's migration timeline.
+
+Across all three clouds, the application should fail fast when the cache is unhealthy. A Redis command timeout of 30 seconds can hold request threads, exhaust connection pools, and trigger retries that amplify the outage. For most web APIs, a short connect timeout, a shorter command timeout than the user request timeout, bounded retries with jitter, and a circuit breaker are safer. If the cache is unavailable, the service should either query the source of truth directly, serve a known stale value, or return a controlled degraded response rather than piling up blocked requests.
+
 ## Cache Stampede Prevention
 
-A cache stampede (also called "thundering herd") happens when a popular cache key expires and hundreds of pods simultaneously query the database to rebuild it.
+A cache stampede, also called a thundering herd, happens when a popular cache key expires and hundreds of pods simultaneously query the database to rebuild it. Kubernetes makes this failure mode sharper because autoscaling, rolling deployments, and pod restarts can align many clients around the same cold cache. The cache is not the overloaded component during the first seconds of a stampede; the database, upstream API, or object store behind the cache takes the hit.
 
 ```mermaid
 flowchart LR
@@ -268,9 +395,11 @@ flowchart LR
 
 ### Prevention Strategies
 
+Stampede prevention is partly a cache technique and partly a capacity-management technique. Locks, early refresh, stale-while-revalidate, and request coalescing reduce duplicate rebuild work. Jittered TTLs prevent thousands of related keys from expiring on the same boundary. Background warming protects predictable hot keys before a launch or campaign. Database-side limits, circuit breakers, and queue-based rebuild workers keep the fallback path from exceeding the source of truth's safe operating envelope.
+
 #### 1. Probabilistic Early Expiration (PER)
 
-Refresh the cache before it expires, with a probability that increases as the TTL decreases:
+Refresh the cache before it expires, with a probability that increases as the TTL decreases. This keeps the cache warm without making every request refresh the value, and it spreads database work over time instead of concentrating it at the expiration instant:
 
 ```python
 import random
@@ -299,7 +428,7 @@ def refresh_cache(key, ttl):
 
 #### 2. Distributed Lock (Mutex)
 
-Only one pod rebuilds the cache; others wait or serve stale data:
+Only one pod rebuilds the cache; others wait or serve stale data. The lock must have a short expiry so a crashed pod does not block refresh forever, and the code should avoid deleting a lock that another pod acquired after the original lock expired:
 
 ```python
 def get_with_lock(key, ttl=300):
@@ -331,7 +460,7 @@ def get_with_lock(key, ttl=300):
 
 #### 3. Background Refresh (Never Expire)
 
-Cache entries never expire. A background process refreshes them on a schedule:
+Cache entries never expire from the user request path. A background process refreshes them on a schedule, and the application serves the last known value while tracking its age. This is powerful for read models with clear staleness budgets, but it requires monitoring so a failed warmer does not silently serve old data for hours:
 
 ```yaml
 apiVersion: batch/v1
@@ -369,6 +498,18 @@ spec:
 
 ---
 
+### Eviction Policy and Memory Pressure
+
+Eviction policy determines what Redis or Valkey does when new data would exceed the configured memory limit. For pure cache workloads, an eviction policy such as LRU, LFU, or TTL-based eviction lets the cache discard older or less useful keys and keep accepting writes. For workloads that should never lose values without application control, `noeviction` makes writes fail when memory is exhausted. That distinction is important because the same Redis command failure can be a healthy safety mechanism for durable-ish state and a production incident for cache-aside workloads.
+
+The safest default for a general application cache is often an all-keys policy such as `allkeys-lru` or `allkeys-lfu`, but the exact answer depends on access patterns. LRU favors recently used keys, which works well when traffic follows the common pattern where a small fraction of keys receive most reads. LFU favors frequently used keys, which can protect long-lived favorites even if they have not been read in the last few seconds. TTL-oriented policies only evict keys that have expiration metadata, which is useful when some keys should be protected but dangerous if developers forget TTLs and the eligible key set becomes too small.
+
+Managed providers expose eviction controls differently. In ElastiCache node-based Redis or Valkey, parameter groups are part of how teams manage engine settings, while serverless caches intentionally restrict many low-level parameters to preserve the managed abstraction. Memorystore and Azure cache tiers also limit or expose settings based on product type and tier. The portable habit is to record the intended eviction behavior in infrastructure code and then verify the live cache through provider metrics and `INFO` output where the service permits it.
+
+Memory pressure is not only the number of keys multiplied by average value size. Serialized JSON can be much larger than the database row it represents. Connection buffers, replication backlog, client output buffers, fragmentation, TLS overhead, and fork or snapshot behavior can all consume memory. Large values increase latency because they take longer to serialize, transfer, parse, and evict. A cache that is "only" 70 percent full by dataset estimates can still behave poorly if values are oversized, clients are slow, or replication and snapshot overhead were ignored.
+
+Set TTLs even when you also use explicit invalidation. TTL is the emergency brake for missed invalidation messages, failed deploy hooks, one-off scripts, and edge cases no one remembered. A cache key without TTL is a promise that the application will always invalidate it correctly. That promise usually fails as systems grow. Use longer TTLs for stable reference data, shorter TTLs for user-visible mutable state, and jitter so related keys do not expire together.
+
 ## Diagnosing Hot Key Distribution
 
 A "hot key" occurs when a single Redis key receives a disproportionate amount of traffic. Because Redis is single-threaded for command execution, a hot key on a clustered Redis setup will overwhelm a single shard, causing high CPU utilization on one node while other nodes remain idle.
@@ -384,13 +525,19 @@ A "hot key" occurs when a single Redis key receives a disproportionate amount of
 - **Local Caching**: Cache the hot key in the application's memory (e.g., using a local in-memory cache variable) for a few seconds to absorb the read spike before it hits Redis.
 - **Key Duplication**: Create copies of the key (e.g., `product:123:1`, `product:123:2`) and have clients randomly read from one of the copies to distribute load across multiple shards.
 
+Hot keys are often created by business success rather than bad code. A viral product page, a popular feature flag, a global configuration document, a home-page recommendation list, or a rate-limit counter for a large shared tenant can send a large fraction of traffic to one key. Adding more shards only helps if the traffic can be distributed across keys. Redis Cluster partitions by key hash slot, so one key still belongs to one shard no matter how many shards the cluster has.
+
+A good hot-key response starts with measurement. Provider metrics can show shard-level CPU, network, command latency, evictions, and connection behavior. Application metrics should show key families rather than raw full keys, because exporting every user-specific key as a label can destroy your monitoring system. Sampling, `redis-cli --hotkeys` where safe and supported, LFU frequency inspection, and client-side instrumentation can identify whether the issue is one exact key, one key prefix, or one expensive command pattern.
+
+Mitigation depends on semantics. For read-only values, duplicate the value across multiple keys and randomly select one on read, or add a tiny in-process cache with a five-to-ten-second TTL inside each pod. For counters, shard the counter into multiple keys and sum them asynchronously when exact real-time accuracy is not required. For locks, reduce lock scope and avoid a single global lock. For pub/sub, consider whether a managed streaming service is a better tool than forcing Redis to behave like a high-fanout event backbone.
+
 > **Stop and think**: If a celebrity tweets a link to a specific product, creating a sudden massive read spike on that single product's cache key, why won't simply adding more Redis cluster nodes solve the performance issue?
 
 ---
 
 ## Connection Limits and Pool Management
 
-Managed Redis instances have maximum connection limits based on instance size. Exceeding them causes connection refused errors.
+Managed Redis instances have maximum connection limits based on instance size. Exceeding them causes connection refused errors, but practical saturation can happen earlier because TLS, command volume, slow clients, and memory overhead all consume capacity. Connection planning is therefore a workload budget, not just a lookup in a provider table.
 
 ### Connection Budget
 
@@ -400,7 +547,11 @@ Managed Redis instances have maximum connection limits based on instance size. E
 | cache.r7g.xlarge | 65,000 | 1,000 | 64,000 |
 | cache.t4g.micro | 65,000 | 1,000 | 64,000 |
 
-Redis connection limits are generous, but the bottleneck is often on the client side. Each connection consumes memory and a file descriptor in the pod.
+Redis connection limits are generous in many managed tiers, but the bottleneck is often on the client side. Each connection consumes memory and a file descriptor in the pod, and every extra idle connection is still state the cache must track. A deployment with 200 pods and a default pool of 50 connections can reserve 10,000 potential connections before a single request is served. During a rolling update with `maxSurge`, that number can jump while old pods are still draining.
+
+Connection pools should be sized from concurrency, not copied from blog posts. If a pod handles 100 concurrent HTTP requests but only 10 percent of requests touch Redis, a pool of 10 to 20 may be plenty. If every request performs multiple cache operations and the latency budget is tight, a larger pool may be justified, but it must still fit the cache's connection limit during deployment surge and failure recovery. Use pool wait-time metrics, command latency, and rejected connection counts to tune this over time.
+
+The retry policy matters as much as pool size. When Redis is slow, unbounded retries can turn a small provider event into a database outage because cache misses and retry storms arrive together. Use bounded retries with exponential backoff and jitter, and prefer failing open to the source of truth for noncritical cache reads when the database can absorb it. For high-risk endpoints, a circuit breaker can temporarily stop cache calls and protect request threads while the cache recovers.
 
 ### Redis Connection Pooling
 
@@ -425,6 +576,8 @@ r = redis.Redis(connection_pool=pool)
 ```
 
 ### Monitoring Connection Usage
+
+Monitor from both sides of the connection. Provider dashboards show engine CPU, memory, evictions, replication lag, connection count, network throughput, command latency, and failover events. Application metrics show pool wait time, timeout rate, hit rate by key family, fallback database queries, and stale responses served. Those two views answer different questions: whether the cache is healthy, and whether the application is using it safely.
 
 ```yaml
 # PrometheusRule for Redis connection alerts
@@ -459,7 +612,31 @@ spec:
 
 ---
 
+## Cost Lens: What Caching Costs at Moderate Scale
+
+Caching saves money only when the avoided work is more expensive than the cache and the operational complexity around it. At moderate scale, the cache bill usually comes from memory capacity, node hours or serverless storage meters, request-processing meters where serverless is used, replica count, cross-zone or cross-region traffic, backups or persistence, and data transfer. The saved bill may appear in a different place: fewer database read replicas, lower database CPU, smaller API fleet, fewer timeouts, or less emergency overprovisioning before launches.
+
+AWS ElastiCache has two cost personalities. Node-based clusters charge for cache node usage by node type and time, so idle capacity still costs money, replicas increase the hourly footprint, and larger Graviton or memory-optimized nodes should be right-sized against real memory and CPU metrics. ElastiCache Serverless bills stored data in GB-hours and requests in ElastiCache Processing Units, so spiky workloads may benefit from reduced capacity planning while high steady request rates can make request processing a major line item. Cross-AZ traffic and global replication choices also matter because application nodes and cache nodes are not always in the same zone.
+
+Google Memorystore pricing depends on the selected product and provisioned capacity model. Traditional Memorystore for Redis bills provisioned capacity, while clustered and Valkey offerings introduce their own sizing and replication shapes. Read replicas, shards, and high-availability settings improve resilience and throughput, but they also multiply memory capacity. Memorystore for Memcached bills around node count and node resources, which means a large disposable cache can still be expensive if the working set is overestimated.
+
+Azure cost analysis starts with tier choice. Basic and Standard are cheaper but have fewer production features, Premium adds capabilities such as clustering and persistence, and Enterprise or Enterprise Flash tiers bring Redis Enterprise capabilities with different performance and storage characteristics. Azure Managed Redis introduces its own tiering and reservation options. The Azure design review should include not only hourly cache cost but also Private Link or networking charges where applicable, persistence storage, active geo-replication, and the migration cost if the organization is moving away from older Azure Cache SKUs.
+
+The easiest cache cost mistake is over-retention. Teams set long TTLs because misses are slow, then discover that memory grows until the cache needs a much larger tier. A better first move is to identify key families and assign TTLs by business value. Product details may live for minutes, feature flag snapshots for seconds, negative lookup results for a very short interval, and expensive reports behind an explicit refresh workflow. The goal is not maximum hit rate at any price; it is the lowest total cost that meets latency and correctness goals.
+
+The second mistake is ignoring value size. A 500-byte JSON object and a 50-KB rendered API response both count as one key in many dashboards, but they have very different memory, network, and request-processing costs. Compression can help large values, but it adds CPU and latency in the application. Storing smaller field-level values can reduce transfer, but it increases key count and command volume. Measure representative serialized values before choosing node size or serverless limits.
+
+The third mistake is forgetting the source-of-truth bill. If a cache with a 70 percent hit rate prevents an expensive database scale-up, it may be worth more than a cheaper cache with a 40 percent hit rate. If a cache costs more than the database reads it avoids, it is an architectural liability. Track avoided reads, database CPU reduction, API latency improvement, and cache cost in the same review. FinOps for caching is a system calculation, not a single service calculation.
+
+Knobs that reduce cost include shorter TTLs for low-value key families, jittered expiration to avoid overprovisioning for stampedes, right-sized connection pools, smaller serialized values, local short-lived caches for extreme hot keys, committed-use or reserved capacity for predictable steady workloads, and serverless only where the request and storage meters match the traffic shape. Knobs that make cost spike include cross-region replication, unnecessary replicas, high write amplification from refresh-ahead workers, cache warming that refreshes unused keys, large values, and retry storms during provider events.
+
 ## Envoy Sidecar Caching
+
+Not every caching layer has to live inside application code. HTTP responses can sometimes be cached by a proxy, gateway, CDN, service mesh extension, or sidecar. Envoy sidecar caching is useful when the application already emits correct HTTP cache headers or when the team needs a tactical read-offload layer for a legacy service that cannot be changed safely. It is not a replacement for domain-aware caching because Envoy does not know whether a product price, entitlement, or user-specific field is safe to share across callers unless headers and routing rules express that clearly.
+
+Sidecar caching is strongest for public or tenant-independent responses with simple invalidation rules. Static reference data, product category metadata, documentation fragments, and low-risk discovery APIs can work well. It is weaker for personalized responses because HTTP caches must vary on headers, cookies, authorization, locale, and other request attributes that affect the answer. If those vary rules are wrong, the cache can leak one user's response to another user. That is why application-level Redis caching remains common for domain objects with explicit keys and authorization-aware loading.
+
+Managed cloud caches and Envoy caches can also work together. An API server might use ElastiCache, Memorystore, or Azure Redis for shared product objects across all pods, while Envoy caches selected HTTP responses inside each pod for a few seconds. The sidecar absorbs repeated identical requests at the pod boundary; Redis absorbs repeated object reads across the fleet; the database remains authoritative. This layered design is powerful, but each layer needs its own TTL, metrics, and invalidation story.
 
 ### Architecture
 
@@ -531,7 +708,7 @@ data:
                           port_value: 8081
 ```
 
-Your application must return proper [`Cache-Control`](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/cache_filter) headers:
+Your application must return proper [`Cache-Control`](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/cache_filter) headers so Envoy can decide whether a response is cacheable, how long it can be retained, and whether it can be shared. Cache headers are part of the correctness contract, not decoration, because a proxy has no domain knowledge beyond the request and response metadata it receives:
 
 ```python
 from flask import Flask, jsonify
@@ -549,6 +726,42 @@ def get_product(product_id):
 > **Stop and think**: What HTTP headers are absolutely essential for the Envoy sidecar cache filter to know how long to retain a response?
 
 ---
+
+## Patterns & Anti-Patterns
+
+The best caching patterns are boring in production because they make failure behavior explicit. They say what data is cached, where the source of truth lives, how stale the value may be, what rebuilds it, how it is invalidated, and what happens when the cache is unavailable. The anti-patterns are usually attractive because they make the first implementation faster. They become expensive later because the team cannot reason about correctness, cost, or incident behavior.
+
+### Proven Patterns
+
+**Pattern 1: Cache-aside with TTL, jitter, and source-of-truth fallback.** Use this when reads dominate writes, the data can be rebuilt from a database or authoritative API, and bounded staleness is acceptable. The application checks ElastiCache, Memorystore, Azure Redis, or an in-cluster Redis service first, loads from the source of truth on miss, writes the value with a TTL, and adds jitter so related keys do not expire together. This scales well because the cache naturally concentrates memory on hot keys while the database remains authoritative.
+
+This pattern works for product catalogs, profile summaries, entitlement snapshots with short TTLs, feature flag documents, and expensive API response fragments. It fails when the application forgets TTLs, caches personalized data without including identity attributes in the key, or retries cache misses without stampede protection. At scale, pair it with key-family metrics, bounded connection pools, short command timeouts, and a database fallback budget so a cache outage does not become a database outage.
+
+**Pattern 2: Write database, then invalidate cache.** Use this when writes must be durable and post-write reads must not show old values for long. The application writes the source of truth first, then deletes or marks stale the affected cache keys. The next read rebuilds the cache from authoritative data. This is often safer than writing a freshly computed cache value because it avoids late writers overwriting newer values after concurrent updates.
+
+This pattern fits shopping carts, user settings, account profile changes, and administrative configuration. It scales when invalidation is narrow and key naming is predictable. It breaks when one database row affects many derived cache keys and the team has not mapped those dependencies. For complex read models, use an event stream or change-data-capture worker that rebuilds derived keys intentionally rather than scattering invalidation rules across many services.
+
+**Pattern 3: Hot-key shielding with local micro-TTL caches.** Use this when one or a few keys receive disproportionate read traffic and adding more Redis shards does not help. Each pod keeps a tiny in-memory copy for a few seconds, or the application duplicates one logical value across several physical cache keys. Redis or Valkey remains the shared cache, but the hottest read path no longer crosses the network for every request.
+
+This pattern is effective for global configuration, celebrity-linked product pages, public landing-page fragments, and other keys where a few seconds of staleness is acceptable. It fails when used for per-user authorization, inventory, or pricing decisions that require immediate precision. At scale, it should have a clear maximum local TTL, a way to force bypass during incidents, and metrics showing how much traffic was absorbed locally.
+
+**Pattern 4: Queue-backed write-behind for noncritical aggregates.** Use this when the user request should complete quickly, exact immediate durability is not required, and a durable queue can preserve work before the database update. Redis streams, lists, or counters may help shape recent state, while SQS, Pub/Sub, Service Bus, Event Hubs, Kinesis, or another durable stream protects recovery. KEDA can scale Kubernetes workers from queue depth or Redis list and stream metrics, but the data-loss boundary must be understood.
+
+This pattern fits analytics counters, approximate leaderboards, activity rollups, and deduplication windows. It fails for orders, payments, access grants, and anything where the user was promised a durable result. At scale, make every worker idempotent, expose lag metrics, cap retry age, and periodically reconcile aggregates against the source of truth.
+
+### Anti-Patterns
+
+**Anti-pattern 1: Caching everything because Redis is fast.** Teams fall into this when the first cache produces an impressive latency graph and every feature wants the same improvement. The cache fills with low-value keys, memory tiers grow, hit rate looks high but business value is unclear, and invalidation becomes impossible to audit. The better alternative is to cache named key families with explicit TTLs, expected hit rates, source-of-truth paths, and owners.
+
+**Anti-pattern 2: No TTL because manual invalidation exists.** Manual invalidation always misses some path eventually: a migration script, a replay worker, an admin panel, a bulk import, or a one-off support correction. Without TTL, stale data can survive indefinitely and learners often discover the bug only after a customer sees old state. The better alternative is TTL as a safety net plus explicit invalidation for faster freshness where needed.
+
+**Anti-pattern 3: Cache as system of record.** This happens when developers store sessions, carts, counters, locks, and business facts in the same Redis cluster because it is convenient. Eventually an eviction policy, resize, failover, flush, or bug removes values that no other system can rebuild. The better alternative is to classify each key family as disposable cache, recoverable derived state, or durable state, then move durable state to a database or queue designed for that responsibility.
+
+**Anti-pattern 4: No stampede protection.** A design can pass load tests while the cache is warm and still fail during deploys, region events, or campaign launches when many pods miss together. Teams fall into this because cache-aside examples are short and usually show one request at a time. The better alternative is jittered TTL, distributed locks for expensive rebuilds, request coalescing, stale-while-revalidate where acceptable, and fallback budgets for the source of truth.
+
+**Anti-pattern 5: Shared cache cluster for unrelated reliability classes.** A low-value page fragment cache, a session store, a rate limiter, and a queue-like stream have different eviction, persistence, and latency expectations. Putting them in one cluster saves setup time but couples their failures: a page-cache surge can evict session data, or a stream backlog can exhaust memory needed by rate limiting. The better alternative is separate caches or at least separate databases, key prefixes, maxmemory policies, alerts, and ownership boundaries where the provider supports them.
+
+**Anti-pattern 6: Ignoring cloud-specific lifecycle and migration signals.** The names look portable, but provider roadmaps differ. AWS has strong Valkey support in ElastiCache, Google offers Memorystore for Valkey and separate Redis products, and Microsoft documents migration guidance from Azure Cache for Redis toward Azure Managed Redis. Teams fall into this anti-pattern when they copy a multi-cloud table into an architecture decision record without checking the current provider docs. The better alternative is to pin engine, version, tier, and migration assumptions in infrastructure code and review them during platform upgrades.
 
 ## Did You Know?
 
@@ -622,41 +835,71 @@ The `noeviction` policy tells Redis to return an Out of Memory (OOM) error for a
 ### Setup
 
 ```bash
+alias k=kubectl
+
 # Create kind cluster
 kind create cluster --name cache-lab
 ```
 
 ### Task 1: Provision Managed Redis via CLI Simulation
 
-Before deploying the application, let's practice provisioning a managed Redis instance. While we use Helm for local testing, the command syntax mirrors cloud CLI tools.
+Before deploying the application, practice the shape of managed Redis provisioning and then simulate the service locally with a plain Redis Deployment. The local manifest is not a production recommendation; it gives the lab a Redis endpoint while preserving the same mental model you would use for ElastiCache, Memorystore, Azure Cache, or Azure Managed Redis.
 
 <details>
 <summary>Solution</summary>
 
 ```bash
-# In an AWS environment, you would use:
+# In an AWS environment, you would use (example only — consult
+# `aws elasticache create-replication-group --help`; use the Valkey engine where GA):
 # aws elasticache create-replication-group \
 #   --replication-group-id cache-lab-cluster \
 #   --engine redis --cache-node-type cache.t4g.micro \
 #   --num-cache-clusters 1
 
-# For our local Kubernetes lab, we simulate the managed service via Helm:
-helm repo add bitnami https://charts.bitnami.com/bitnami
-helm install redis bitnami/redis \
-  --namespace cache --create-namespace \
-  --set architecture=standalone \
-  --set auth.password=cache-lab-pass \
-  --set master.persistence.enabled=false \
-  --set master.resources.requests.memory=128Mi
+# For our local Kubernetes lab, simulate the managed service with plain Redis:
+k create namespace cache --dry-run=client -o yaml | k apply -f -
+cat <<'EOF' | k apply -n cache -f -
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: redis-master
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: redis-master
+  template:
+    metadata:
+      labels:
+        app: redis-master
+    spec:
+      containers:
+        - name: redis
+          image: redis:7
+          args: ["redis-server", "--requirepass", "cache-lab-pass"]
+          ports:
+            - containerPort: 6379
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis-master
+spec:
+  selector:
+    app: redis-master
+  ports:
+    - port: 6379
+      targetPort: 6379
+EOF
 
-k wait --for=condition=ready pod -l app.kubernetes.io/name=redis \
+k wait --for=condition=available deployment/redis-master \
   --namespace cache --timeout=120s
 ```
 </details>
 
 ### Task 2: Implement Cache-Aside Pattern
 
-Deploy a pod that demonstrates cache-aside with Redis.
+Deploy a pod that demonstrates cache-aside with Redis, including the difference between the first miss and later hits. Watch the output carefully because the lab shows the central promise of caching: repeated reads avoid simulated database latency only after the cache has been populated.
 
 <details>
 <summary>Solution</summary>
@@ -742,7 +985,7 @@ k logs cache-aside-demo -n cache
 
 ### Task 3: Demonstrate Cache Stampede
 
-Simulate a stampede by launching many concurrent requests after a cache key expires.
+Simulate a stampede by launching many concurrent requests after a cache key expires. The goal is not to benchmark Redis; it is to see how unprotected misses multiply database work and how a short distributed lock changes the number of simulated database queries.
 
 <details>
 <summary>Solution</summary>
@@ -851,7 +1094,7 @@ k logs stampede-demo -n cache
 
 ### Task 4: Monitor Redis Metrics
 
-Create a pod that reports Redis statistics.
+Create a pod that reports Redis statistics so the cache becomes observable instead of invisible infrastructure. The report focuses on memory, clients, hits, misses, evictions, and policy because those are the first signals you need during a cache-related production incident.
 
 <details>
 <summary>Solution</summary>
@@ -905,7 +1148,7 @@ k logs redis-monitor -n cache
 
 ### Task 5: Configure Eviction Policy
 
-Change the Redis eviction policy and demonstrate eviction behavior.
+Change the Redis eviction policy and demonstrate eviction behavior under a deliberately tiny memory limit. This task connects the earlier theory to a visible result: a cache can keep accepting writes only if its eviction policy is compatible with disposable cached data.
 
 <details>
 <summary>Solution</summary>
@@ -982,15 +1225,34 @@ kind delete cluster --name cache-lab
 
 ---
 
-**Next Module**: [Module 9.6: Search & Analytics Engines (OpenSearch / Elasticsearch)](../module-9.6-search/) -- Learn how to ingest Kubernetes logs into managed search engines, configure index lifecycle management, and optimize queries for operational analytics.
+## References
 
-## Sources
+- [Redis upstream repository](https://github.com/redis/redis) — Data structures and messaging/scripting capabilities
+- [Memcached upstream repository](https://github.com/memcached/memcached) — Multithreaded key/value cache store
+- [Amazon ElastiCache engine comparison](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/SelectEngine.html)
+- [Amazon ElastiCache engine versions](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/VersionManagement.html)
+- [Amazon ElastiCache pricing](https://aws.amazon.com/elasticache/pricing/?loc=ft)
+- [Amazon ElastiCache connection limits](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/TroubleshootingConnections.html) — Up to 65,000 simultaneous connections per node
+- [Managing clusters in ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/Clusters.html) — Shard limits, replication-group structure, and clustered Redis deployments
+- [Google Cloud Memorystore overview](https://cloud.google.com/memorystore/docs)
+- [Memorystore for Redis overview](https://cloud.google.com/memorystore/docs/redis/memorystore-for-redis-overview)
+- [Memorystore for Redis tier capabilities](https://cloud.google.com/memorystore/docs/redis/redis-tiers) — Basic and Standard tiers, read replicas, and failover
+- [Memorystore for Redis Cluster overview](https://cloud.google.com/memorystore/docs/cluster/memorystore-for-redis-cluster-overview)
+- [Memorystore for Memcached overview](https://cloud.google.com/memorystore/docs/memcached/memcached-overview)
+- [Azure Cache for Redis overview](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-overview)
+- [Azure Cache for Redis configuration and migration notice](https://learn.microsoft.com/en-us/azure/azure-cache-for-redis/cache-configure)
+- [Azure Managed Redis overview](https://learn.microsoft.com/en-us/azure/redis/overview)
+- [Redis key eviction policies](https://redis.io/docs/latest/develop/reference/eviction/)
+- [Redis licensing overview](https://redis.io/legal/licenses/)
+- [Linux Foundation Valkey announcement](https://www.linuxfoundation.org/press/linux-foundation-launches-open-source-valkey-community)
+- [Kubernetes Services and ExternalName](https://kubernetes.io/docs/concepts/services-networking/service/)
+- [KEDA Redis Lists scaler](https://keda.sh/docs/scalers/redis-lists/)
+- [KEDA Redis Streams scaler](https://keda.sh/docs/2.19/scalers/redis-streams/)
+- [Secrets Store CSI Driver usage](https://secrets-store-csi-driver.sigs.k8s.io/getting-started/usage.html)
+- [Envoy HTTP cache filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/cache_filter) — Freshness calculation and `Cache-Control` behavior
 
-- [github.com: redis](https://github.com/redis/redis) — The Redis upstream repository overview explicitly describes Redis data structures and messaging/scripting capabilities.
-- [github.com: memcached](https://github.com/memcached/memcached) — The upstream Memcached repository describes Memcached as a multithreaded key/value cache store.
-- [docs.aws.amazon.com: TroubleshootingConnections.html](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/TroubleshootingConnections.html) — AWS documents a hard limit of up to 65,000 simultaneous connections per ElastiCache node.
-- [envoyproxy.io: cache filter](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/cache_filter) — The Envoy cache-filter documentation explicitly describes freshness calculation and `Cache-Control` behavior.
-- [aws.amazon.com: pricing](https://aws.amazon.com/elasticache/pricing/?loc=ft) — General lesson point for an illustrative rewrite.
-- [Managing Clusters in ElastiCache](https://docs.aws.amazon.com/AmazonElastiCache/latest/dg/Clusters.html) — Covers shard limits, replication-group structure, and how AWS models clustered Redis deployments.
-- [Memorystore for Redis Tier Capabilities](https://cloud.google.com/memorystore/docs/redis/redis-tiers) — Explains the Basic and Standard tier behavior, read replicas, and failover model for non-cluster Memorystore.
-- [Memorystore for Redis Cluster Overview](https://cloud.google.com/memorystore/docs/cluster/memorystore-for-redis-cluster-overview) — Shows the separate clustered Redis product on Google Cloud and its shard-and-replica architecture.
+---
+
+## Next Module
+
+Continue to [Module 9.6: Search & Analytics Engines (OpenSearch / Elasticsearch)](../module-9.6-search/) to compare managed search services, Kubernetes log ingestion, and index lifecycle choices after you have seen how managed caches protect databases from repeated hot reads.

--- a/src/content/docs/cloud/managed-services/module-9.6-search.md
+++ b/src/content/docs/cloud/managed-services/module-9.6-search.md
@@ -10,22 +10,45 @@ sidebar:
 
 After completing this module, you will be able to:
 
-- **Deploy managed OpenSearch/Elasticsearch (Amazon OpenSearch, Elastic Cloud, Azure Cognitive Search) with Kubernetes ingestion pipelines**
-- **Configure Fluentd or Vector to ship Kubernetes logs to managed search clusters with index lifecycle management**
+- **Deploy managed search services (Amazon OpenSearch, Azure AI Search, Elastic Cloud) and self-hosted clusters (ECK operator) integrated with Kubernetes workloads**
+- **Configure Fluent Bit or Vector to ship Kubernetes logs to managed search clusters with index lifecycle management**
 - **Implement search-as-a-service patterns where Kubernetes applications query managed search indices via private endpoints**
-- **Optimize search cluster sizing, shard strategies, and index templates for Kubernetes log and application data volumes**
+- **Design index templates, shard strategies, and refresh policies for optimal query performance and cluster stability**
+- **Evaluate managed vs self-hosted search tradeoffs using cost, operational burden, and feature requirements**
 
 ---
 
 ## Why This Module Matters
 
-In August 2023, a SaaS company running 200 microservices on EKS generated 12 TB of logs per day. They ran a self-managed Elasticsearch cluster on Kubernetes -- 9 data nodes, 3 master nodes, each on i3.2xlarge instances with local NVMe storage. Total monthly cost: $22,000 for compute alone. The cluster required a dedicated engineer spending roughly 30% of their time on shard rebalancing, index lifecycle management, JVM tuning, and version upgrades. When they attempted an upgrade from Elasticsearch 7.x to 8.x, a mapping incompatibility brought down the cluster for 4 hours. During those 4 hours, the security team could not search logs to investigate an active incident.
+Hypothetical scenario: A platform team runs a self-managed Elasticsearch cluster on Kubernetes to serve two use cases — centralized logging for 200 microservices and a customer-facing product search feature. The cluster has 9 data nodes on i3.2xlarge instances with local NVMe storage. Total monthly compute cost runs around $22,000. A dedicated engineer spends roughly 30% of their time on shard rebalancing, index lifecycle management, JVM tuning, and version upgrades. When the team attempts an upgrade from Elasticsearch 7.x to 8.x, a mapping incompatibility brings down the entire cluster for 4 hours. During those 4 hours, the security team cannot search logs to investigate an active incident, and customers see 500 errors on product search.
 
-They migrated to Amazon OpenSearch Service (managed). The migration took three weeks. The managed service handles node replacement, automated snapshots, encryption, and version upgrades. The same engineer now spends 5% of their time on search operations. More importantly, the cluster has not had a single unplanned outage in 14 months. The lesson: running a distributed search cluster on Kubernetes is technically possible, but the operational overhead is enormous. Managed search services let you focus on what matters -- getting insights from your data.
+The team migrates to a managed service. The migration takes three weeks. The managed service handles node replacement, automated snapshots, encryption, and version upgrades. The same engineer now spends about 5% of their time on search operations. The cluster has not had a single unplanned outage in 14 months.
+
+The lesson is not that self-hosted search is wrong — it is that running a distributed search cluster demands deep operational knowledge. Managed search services absorb that operational burden so your team can focus on what matters: extracting insights from your data and building search experiences for your users. This module gives you the mental models to choose the right approach for your context and the hands-on skills to integrate search engines with Kubernetes in production.
+
+---
+
+## How Search Engines Work
+
+Before you deploy a search cluster, you need to understand what happens when you submit a query. The fundamental insight that separates a search engine from a database `LIKE '%keyword%'` scan is the inverted index — a data structure that maps every term to the list of documents containing it. This is why search engines answer queries in milliseconds against terabytes of data while a relational database scans rows linearly.
+
+### The Inverted Index
+
+Imagine a book index at the back of a textbook: instead of scanning every page to find "Kubernetes," you flip to the index, see that the term appears on pages 14, 87, and 203, and go directly to those pages. An inverted index works the same way. During indexing, the engine tokenizes each document into individual terms, normalizes them (lowercasing, removing punctuation), applies language-specific analyzers (stemming "running" to "run," removing stop words like "the" and "is"), and builds a sorted dictionary where each term points to a postings list — the documents and positions where the term appears. When you query for `level:error`, the engine does not scan documents. It looks up "error" in the dictionary, retrieves the postings list, and returns matching documents directly.
+
+### Relevance Scoring with BM25
+
+Not all matches are equally good. A search for "Kubernetes pod crash" returns documents where these words appear, but which document is most relevant? Modern search engines use BM25 (Best Match 25), an evolution of TF-IDF, to compute relevance scores. BM25 considers term frequency (how often a term appears in a document — but with diminishing returns, so a document repeating "error" 50 times does not completely dominate one mentioning it 5 times), inverse document frequency (rare terms like "OOMKilled" carry more signal than common terms like "container"), and field length normalization (a match in a short log line is more precise than a match buried in a 10 KB stack trace). The engine scores every matching document and returns them in relevance order, not insertion order. This ranking is what turns a grep into a search engine.
+
+### Facets, Aggregations, and Typo Tolerance
+
+Search engines do more than find documents. Aggregations compute real-time statistics over matching results — count errors per namespace, chart response times over the last hour, identify the top 10 slowest pods. These aggregations run against the inverted index structures and complete in milliseconds, even across billions of log lines. Typo tolerance uses fuzzy matching (Levenshtein distance) to catch misspellings — searching for "paymnts" still finds the "payments" namespace. Faceted search lets users drill down by applying filters interactively: show me errors, in the payments namespace, from the last 15 minutes, grouped by pod name. Every one of these capabilities is built on top of the inverted index, and understanding this foundation helps you reason about why certain queries are fast, certain mappings matter, and certain cluster configuration choices impact performance.
 
 ---
 
 ## Log Ingestion Architecture
+
+Getting Kubernetes logs into a search engine requires understanding the path each log line takes from a container's stdout to a queryable document. The architecture has four stages: collection (reading log files from node filesystems), enrichment (adding Kubernetes metadata like pod name, namespace, and labels), buffering (absorbing ingestion spikes), and indexing (writing to the search cluster). Each stage involves design decisions that affect reliability, cost, and queryability.
 
 ### The Kubernetes Logging Pipeline
 
@@ -40,9 +63,9 @@ flowchart TD
     B --> FS
     C --> FS
     FS["Node Filesystem: /var/log/containers/"] --> FB
-    FB["DaemonSet: Fluent Bit\n(one per node)"] --> BT
-    BT["Buffer/Transform\n(optional: Kafka, Kinesis)"] --> OS
-    OS["OpenSearch /\nElasticsearch"]
+    FB["DaemonSet: Fluent Bit<br/>(one per node)"] --> BT
+    BT["Buffer/Transform<br/>(optional: Kafka, Kinesis)"] --> OS
+    OS["OpenSearch /<br/>Elasticsearch"]
 ```
 
 ### Fluent Bit DaemonSet for Log Collection
@@ -161,7 +184,7 @@ data:
 
 ### Buffering with Kafka for Resilience
 
-For high-volume clusters, buffer logs through Kafka to prevent data loss when OpenSearch is slow or unavailable:
+For high-volume clusters, buffer logs through Kafka to prevent data loss when OpenSearch is slow or unavailable. The buffer acts as a shock absorber: Fluent Bit writes to Kafka at whatever rate the pods produce logs, and a separate Logstash or Vector consumer reads from Kafka into OpenSearch at whatever rate OpenSearch can handle. This decoupling is essential because OpenSearch ingestion throughput is not constant — it dips during heavy query loads, JVM garbage collection pauses, shard rebalancing, and snapshot operations. Without a buffer, those dips cause backpressure that propagates all the way to Fluent Bit's in-memory buffers on each node, which overflow and drop logs silently. Kafka's durability guarantees (configurable replication factor and minimum in-sync replicas) mean logs are safe on disk until OpenSearch recovers, and you can replay the topic if you ever need to re-index data with updated mappings.
 
 ```mermaid
 flowchart LR
@@ -189,13 +212,17 @@ flowchart LR
 
 ## Setting Up Managed Search
 
+Each major cloud provider offers a managed search service. They share the same architectural DNA — a distributed indexing and search engine — but differ in APIs, pricing models, and Kubernetes integration patterns.
+
 ### Amazon OpenSearch Service
+
+Amazon OpenSearch Service is the managed successor to Amazon Elasticsearch Service, running the open-source OpenSearch engine (forked from Elasticsearch 7.10.2). It supports two deployment modes: provisioned domains (you choose instance types and counts) and OpenSearch Serverless (capacity automatically scales, billed in OCUs — OpenSearch Compute Units). Provisioned domains give you direct control over instance family, EBS volume configuration, dedicated master nodes, and VPC placement. Serverless removes capacity planning entirely and charges separately for indexing and search workloads, which maps well to spiky log ingestion patterns where indexing bursts during deployments but querying is steady throughout the day.
 
 ```bash
 # Create an OpenSearch domain
 aws opensearch create-domain \
   --domain-name k8s-logs \
-  --engine-version OpenSearch_2.13 \
+  --engine-version OpenSearch_2.13 \  # pinned example; verify current supported versions via the AWS console/CLI
   --cluster-config '{
     "InstanceType": "r6g.large.search",
     "InstanceCount": 3,
@@ -228,7 +255,11 @@ aws opensearch create-domain \
   }'
 ```
 
-### GCP: Elastic Cloud on Google Cloud
+For Kubernetes integration, the External Secrets Operator can sync OpenSearch credentials into your cluster from AWS Secrets Manager, and IAM Roles for Service Accounts (IRSA) lets Fluent Bit pods assume an IAM role for keyless authentication to the OpenSearch domain. The endpoint is a private VPC endpoint when the domain is VPC-bound, meaning only workloads within the VPC — including your EKS nodes — can reach it.
+
+### GCP: Elastic Cloud and Vertex AI Search
+
+Google Cloud offers two paths for managed search. The first is Elastic Cloud, Elastic's own managed service available through the GCP Marketplace. You deploy Elasticsearch clusters via the Elastic Cloud console or API, and you get full Elastic Stack features — Kibana, machine learning jobs, alerting, and the Elastic Common Schema. The Elastic Cloud deployment runs in your GCP project's VPC through Private Service Connect, and billing flows through your GCP account. Fluent Bit connects using Elasticsearch's REST API over TLS with basic authentication or API keys.
 
 ```bash
 # Using Elastic Cloud (managed Elasticsearch) with GKE
@@ -236,6 +267,7 @@ aws opensearch create-domain \
 # Then configure Fluent Bit to point to the Elastic Cloud endpoint
 
 # Fluent Bit output for Elastic Cloud
+# Replace Host with your actual endpoint from the Elastic Cloud deployment dashboard.
 # [OUTPUT]
 #     Name  es
 #     Match kube.*
@@ -247,11 +279,67 @@ aws opensearch create-domain \
 #     Logstash_Format On
 ```
 
+The second path is Vertex AI Search (formerly Discovery AI / Enterprise Search), Google's fully-managed AI-powered search platform. Unlike Elastic Cloud, which is a general-purpose search engine you configure yourself, Vertex AI Search is an opinionated service designed for website search, document search, and retrieval-augmented generation (RAG). It handles ingestion pipelines, embedding generation for vector search, and relevance tuning automatically. For Kubernetes workloads, the primary integration pattern is through a REST API — your application sends search queries to Vertex AI Search and receives ranked results, bypassing the operational concerns of managing indices and clusters. It is ideal for product search and knowledge-base retrieval but is not a drop-in replacement for log analytics, which is better served by Elastic Cloud or self-hosted OpenSearch.
+
+### Azure AI Search
+
+Azure AI Search (formerly Azure Cognitive Search) is Microsoft's managed search platform. Unlike the OpenSearch/Elasticsearch ecosystem, Azure AI Search uses a different architecture: you define indexes with explicit field schemas, data sources (Azure Blob Storage, Cosmos DB, Azure SQL), and indexers that extract, transform, and load data on a schedule or via push APIs. The service supports full-text search with Lucene analyzers, vector search using Azure OpenAI embeddings or custom models, and hybrid search that combines BM25 lexical scoring with vector similarity using Reciprocal Rank Fusion. For Kubernetes integration, applications running on AKS query the service through its REST API (replace any lab placeholder with your actual endpoint from the Azure portal service dashboard), authenticating via Entra Workload ID (the Azure equivalent of IRSA) to avoid storing API keys in pods. The Azure portal provides a search explorer for ad-hoc queries. For operational Kubernetes logging, Azure's primary path is Azure Monitor + Log Analytics (with optional export to AI Search via diagnostic settings / Event Hubs for search-layer use cases); AI Search shines for application search, document/RAG, and hybrid retrieval rather than as a drop-in high-volume log-analytics store.
+
+---
+
+## ECK Operator — Self-Hosted on Kubernetes
+
+When a managed service does not fit — due to data residency requirements, cost at extreme scale, or the need for plugin customization — the Elastic Cloud on Kubernetes (ECK) operator provides a first-class Kubernetes-native deployment path. ECK is Elastic's official operator that manages the full lifecycle of Elasticsearch, Kibana, APM Server, and Beats on Kubernetes. It handles rolling upgrades, persistent volume provisioning, pod disruption budgets, and secure TLS between nodes — the same operational concerns you would otherwise script yourself with StatefulSets and init containers.
+
+The operator runs as a deployment in your cluster and watches custom resources. Deploying a production-grade Elasticsearch cluster becomes a matter of defining an Elasticsearch resource with node sets, version, and storage configuration. ECK creates the StatefulSets, provisions PersistentVolumeClaims per node, generates and rotates TLS certificates, and performs rolling upgrades when you change the version field. You can define multiple node sets with different roles: a set of master-eligible nodes with smaller instances for cluster coordination, a set of data nodes with fast local SSDs for indexing and search, and optionally coordinating-only nodes for query fan-out. The operator enforces anti-affinity by default, spreading nodes across Kubernetes zones for high availability.
+
+The tradeoff is that you regain operational control — and operational responsibility. You must monitor JVM heap pressure, manage snapshot repositories (S3, GCS, Azure Blob), tune the JVM heap size (no more than 50% of available memory, never above 30.5 GB due to compressed OOPs), and plan for version upgrades. For many teams, the ECK operator represents the sweet spot between the flexibility of self-hosted and the automation of managed: the operator handles the Kubernetes-native concerns (scheduling, storage, networking, certificates), but you still own the Elasticsearch-level concerns (index management, shard strategy, query performance).
+
+---
+
+## Vector and Semantic Search
+
+The most significant evolution in search engines over the past three years has been the addition of vector search — the ability to find documents by semantic meaning rather than exact keyword matches. Where a traditional lexical search for "application running out of memory" returns documents containing those exact words, a vector search understands that "OOMKilled container" and "heap exhaustion in the JVM" describe the same underlying problem, even though they share no keywords.
+
+Vector search works by converting text into dense numerical representations called embeddings. An embedding model (such as a sentence transformer or OpenAI's text-embedding models) maps each chunk of text to a vector — typically 384 to 1,536 floating-point numbers — in a high-dimensional space where semantically similar texts cluster together. At search time, the query is also converted to a vector, and the engine finds the nearest neighbors using approximate nearest neighbor (ANN) algorithms like HNSW (Hierarchical Navigable Small World graphs). Unlike exact kNN which compares the query vector against every document vector (O(n) complexity), ANN uses graph-based navigation to find close matches in logarithmic time, making vector search practical at scale.
+
+### Hybrid Search: The Best of Both Worlds
+
+Neither lexical nor vector search is universally better. Lexical search (BM25) excels at exact matches — finding a specific error code, a pod name, or a trace ID. Vector search excels at conceptual matches — finding "authentication failures" even when the logs say "401 Unauthorized" or "token expired." Hybrid search combines both: it runs a BM25 query and a vector ANN query in parallel, then merges the results using Reciprocal Rank Fusion (RRF), a formula that blends the ranked lists without requiring normalized scores. The practical result is a search experience that handles exact lookups and fuzzy semantic exploration in a single query.
+
+### Managed Vector Search Offerings
+
+All three major cloud search platforms now support vector search. Amazon OpenSearch Service added k-NN support starting with version 1.0 and has since added neural search plugins that handle embedding generation and ANN search natively — you define an ingest pipeline that calls an embedding model (Amazon Bedrock, SageMaker, or a custom model) to generate vectors for incoming documents, and searches automatically include vector similarity. Azure AI Search supports vector fields natively in index definitions, integrates with Azure OpenAI for embedding generation, and offers hybrid search with configurable RRF parameters through its REST API. Vertex AI Search on GCP abstracts vectors entirely — you upload documents and the service handles chunking, embedding, and hybrid retrieval automatically, though this comes with less control over the retrieval pipeline. For self-hosted deployments, Elasticsearch 8.x and OpenSearch 2.x both include k-NN plugins, and you can pair ECK-managed clusters with self-hosted embedding models from Hugging Face running as sidecar containers or separate inference services on Kubernetes.
+
+---
+
+## Indexing Pipeline Deep Dive
+
+Understanding what happens between a Fluent Bit `[OUTPUT]` directive and a queryable document helps you diagnose slow ingestion, high CPU, and stale search results. The indexing pipeline has four stages.
+
+### Ingest
+
+Raw documents arrive at the cluster's HTTP API as JSON payloads — a single document via the index API, or batches via the bulk API (which is far more efficient, amortizing network round-trips and index operations). The coordinating node routes each document to the appropriate primary shard based on a routing formula: `shard = hash(_routing) % number_of_primary_shards`. If no explicit routing key is provided, the document ID is used, meaning documents distribute evenly across shards by default. If you specify a routing key (for example, a tenant ID), all documents for that tenant land on the same shard, which can be useful for colocation but dangerous if it creates hot shards.
+
+### Analyze
+
+Before a document is written to the inverted index, its text fields pass through an analyzer pipeline. The analyzer performs character filtering (stripping HTML tags, normalizing Unicode), tokenization (splitting text into individual terms on whitespace and punctuation), and token filtering (lowercasing, removing stop words, applying stemming). For example, the sentence "Kubernetes pods are crashing" passes through the standard analyzer and becomes the tokens `[kubernetes, pod, crash]` — "are" is a stop word and removed, "pods" is stemmed to "pod," and "crashing" is stemmed to "crash." These tokens are what end up in the inverted index, which is why the same analyzer must be applied at query time to match the indexed terms. Mismatched analyzers are a common source of "my data is indexed but my queries return nothing" bugs.
+
+### Index
+
+After analysis, the engine writes the document to the transaction log (translog) for durability, then to an in-memory buffer. When the buffer fills or the refresh interval elapses (default: 1 second), the in-memory buffer is flushed to a new Lucene segment on disk, and the document becomes searchable. This is why OpenSearch and Elasticsearch are called near-real-time: there is up to a 1-second lag between indexing and searchability. The refresh interval is a critical tuning knob — set it to 30 seconds during bulk indexing to reduce segment creation overhead, then restore it to the default for normal query workloads. Each refresh creates a new Lucene segment, and having too many small segments degrades query performance; the engine periodically merges segments in the background to keep their count manageable.
+
+The index mapping defines the schema: which fields are `keyword` (exact match, aggregatable), which are `text` (full-text search, analyzed), which are `date`, `long`, or `geo_point`. Mappings constrain what queries are possible — you cannot run aggregations on a `text` field, and you cannot run full-text queries on a `keyword` field without a multi-field mapping. Defining explicit mappings before any data enters the index is a best practice because dynamic mapping, while convenient, often guesses wrong (mapping an ID field as `text` instead of `keyword`, for example) and the mapping cannot be changed for existing fields without reindexing.
+
+### Bulk Indexing
+
+For log ingestion, the bulk API is the only practical approach. Instead of sending one document per HTTP request, you batch documents into newline-delimited JSON (NDJSON) payloads and send them in a single POST. A well-tuned bulk pipeline uses batches of 500-2,000 documents or 5-15 MB per batch, whichever comes first — smaller batches waste network round-trips, larger batches risk timeouts and memory pressure on the coordinating node. The bulk response reports per-document success or failure, allowing the ingestion pipeline to retry individual failures without re-sending the entire batch.
+
 ---
 
 ## Index Lifecycle Management (ILM/ISM)
 
-Without lifecycle management, indices grow forever. A single day of logs for a 200-pod cluster can be 50 GB. After a month, you have 1.5 TB of indices, most of which nobody searches.
+Without lifecycle management, indices grow forever. A single day of logs for a 200-pod cluster can be 50 GB. After a month, you have 1.5 TB of indices, most of which nobody searches. Even worse, the cluster must maintain all those shards in memory, the coordinating node scans every index matching your wildcard patterns, and disk usage grows linearly until you hit a quota and ingestion stops. Index Lifecycle Management (ILM in Elasticsearch) or Index State Management (ISM in OpenSearch) solves this by defining automated policies that transition indices through phases — hot, warm, cold, and delete — based on age or size. Each phase trades query performance for storage cost, matching the resources consumed by an index to its actual access patterns over time.
 
 ### Lifecycle Phases
 
@@ -380,7 +468,7 @@ curl -XPUT "https://search-logs.us-east-1.es.amazonaws.com/_index_template/k8s-l
 
 ## Sharding and Replication Strategy
 
-Sharding determines how data is distributed across nodes. Getting it wrong causes hot spots, uneven disk usage, and query performance problems.
+Sharding determines how data is distributed across nodes, and getting it wrong causes hot spots, uneven disk usage, and query performance problems that are difficult to fix after the fact. A shard is OpenSearch's unit of parallelism — each shard is an independent Lucene index that can be placed on any data node, and a search query fans out to all shards in the target indices. The number of primary shards is set at index creation and cannot be changed without reindexing (you can split shards in newer versions, but this is a manual operation with downtime implications). This immutability makes the initial shard count one of the most consequential decisions in your search architecture.
 
 ### Shard Sizing Rules
 
@@ -430,7 +518,7 @@ Use a single index with a `namespace` field for filtering. Only create separate 
 
 ## Fine-Grained Access Control
 
-In a multi-team environment, different teams should only see logs from their own namespaces.
+In a multi-team environment, different teams should only see logs from their own namespaces — the frontend team has no business searching the payments namespace's error logs, and the platform SREs need full access across all namespaces. OpenSearch's security plugin provides role-based access control with two powerful dimensions: Document Level Security (DLS) filters which documents a role can see, and Field Level Security (FLS) which fields within those documents are visible. Combined with OIDC integration through your cloud provider's identity system (AWS IAM, GCP IAM, or Entra ID), you can map Kubernetes RBAC roles to OpenSearch roles, ensuring that a developer's access in kubectl matches their access in OpenSearch Dashboards.
 
 ### OpenSearch Security: Role-Based Access
 
@@ -481,7 +569,7 @@ curl -XPUT "https://search-logs.us-east-1.es.amazonaws.com/_plugins/_security/ap
 
 ## Query Optimization
 
-Search queries against log indices can be slow if not designed well. Here are patterns for efficient operational queries.
+Search queries against log indices can be slow if not designed well. The difference between a query that completes in 50 milliseconds and one that takes 15 seconds often comes down to three factors: whether the query uses filter context (cached, no scoring) versus query context (uncached, with scoring), whether the time range is narrow enough for OpenSearch to skip non-matching indices, and whether the field types in the query match the field types in the mapping. Below are patterns for efficient operational queries, organized around these principles. Each example targets a real operational workflow — finding recent errors, aggregating error distribution by workload, and returning lean results for dashboard consumption.
 
 ### Common Query Patterns
 
@@ -562,7 +650,7 @@ curl -XPOST "https://search-logs.us-east-1.es.amazonaws.com/k8s-logs-*/_search" 
 
 ## OpenSearch Dashboards from Kubernetes
 
-Deploy OpenSearch Dashboards (or Kibana) inside your cluster for log visualization.
+Deploy OpenSearch Dashboards (or Kibana) inside your Kubernetes cluster for log visualization and ad-hoc exploration. While managed search services provide the backend, your teams still need a UI to craft queries, build dashboards, and explore log patterns interactively. OpenSearch Dashboards is the visualization layer that connects to the managed domain — it runs as a stateless deployment in your cluster, and all data remains in the managed service. This architecture keeps the visualization close to your developers while the search engine benefits from managed operations. The deployment below configures two replicas for high availability and connects to the managed OpenSearch domain via the `OPENSEARCH_HOSTS` environment variable, using IAM-based authentication through IRSA when running on EKS.
 
 ```yaml
 apiVersion: apps/v1
@@ -609,6 +697,87 @@ spec:
     - port: 5601
       targetPort: 5601
 ```
+
+---
+
+## Cost Lens
+
+Managed search services charge along several dimensions, and understanding the cost levers helps you avoid bill shock while keeping search performance acceptable. The biggest cost drivers are instance-hours, storage volume, and data transfer.
+
+### Compute Costs
+
+Provisioned managed clusters (Amazon OpenSearch provisioned domains, Elastic Cloud) charge per instance-hour for each node. An `r6g.large.search` instance in us-east-1 costs roughly $0.17 per hour, so a 3-node data tier plus 3 dedicated master nodes runs approximately $750 per month for compute alone. Larger instance families, Graviton-based ARM instances (r6g, m6g), and reserved instances (1-year or 3-year commitments) can reduce the per-hour rate by 30-50%. OpenSearch Serverless uses OCUs (OpenSearch Compute Units), billed separately for indexing and search workloads; indexing OCUs scale with ingestion throughput, and search OCUs scale with query concurrency and data scanned. At moderate scale (100 GB/day ingestion, ~50 queries per minute), Serverless can be cheaper than provisioned instances, but at high query volumes the OCU cost can exceed provisioned pricing because you pay for every query.
+
+### Storage Costs
+
+EBS volumes in AWS OpenSearch are charged per GB-month. gp3 volumes cost ~$0.08 per GB-month, so 500 GB of storage adds $40 per month, but this grows linearly with retention. The ILM policy becomes your primary storage cost control: moving indices from hot (gp3 on the data nodes) to warm (gp3 with force-merge reducing size by 40-60%) to cold (ultrawarm or searchable snapshots, ~$0.024/GB-month) can reduce storage cost by 70% for older data. In OpenSearch Serverless, storage is included in the OCU rate, but you still pay for every GB-month regardless of access frequency, making ILM even more important for cost control.
+
+### What Makes Cost Spike
+
+Over-sharding is the most common hidden cost driver: every shard consumes JVM heap, and when heap pressure exceeds 75% the JVM enters aggressive garbage collection, slowing queries and ingestion. Teams respond by adding more nodes, which increases the monthly bill, when the root cause is simply too many shards. Cross-AZ data transfer for replication between availability zones is another silent cost — a 3-AZ deployment with 1 replica effectively triples the inter-AZ traffic for every indexed document, and while AWS does not charge for OpenSearch node-to-node traffic within a region, self-hosted clusters on EC2 do pay standard inter-AZ data transfer rates ($0.01/GB). In Azure, AI Search charges per search unit (a combined compute + storage measure), and you scale by adding replicas (for query throughput) or partitions (for index size). Elastic Cloud on GCP bills through the GCP Marketplace with instance-based pricing similar to AWS, and cross-zone traffic within a region is not charged.
+
+### Reducing Cost Without Sacrificing Searchability
+
+Set the refresh interval to 30 seconds or higher during bulk indexing to reduce segment merges and I/O. Use index rollover based on shard size (30 GB) rather than time (1 day) so that low-volume days do not create unnecessarily small shards. Force-merge warm indices to single segments, which reduces storage by up to 60% and accelerates queries since fewer segments need to be opened per search. For cold storage, use searchable snapshots — indices are stored in cheap object storage (S3, GCS, Azure Blob) and only the portions needed for queries are fetched into local cache, bringing storage costs down to ~$0.024/GB-month while retaining the ability to search.
+
+---
+
+## Patterns and Anti-Patterns
+
+### Proven Patterns
+
+**Pattern 1: Buffer Everything.** Always place a message queue (Kafka, Kinesis, Event Hubs) between log producers and the search cluster. This decouples ingestion spikes from OpenSearch's ability to index, prevents log loss during cluster maintenance or JVM pauses, and enables replay if you need to re-index data with updated mappings. The buffer also lets you perform streaming transformations — parsing unstructured logs, enriching with Kubernetes metadata, dropping sensitive fields — before they reach the search index, reducing the indexing load and improving data quality.
+
+**Pattern 2: Time-Based Index Rollover with ILM.** Design your index strategy around daily (or size-based) rollover with automated lifecycle management from day one. New indices are created by the rollover action, old indices transition through hot, warm, and cold phases on a schedule, and indices past retention are deleted automatically. Without this, you either accumulate unbounded storage costs or face a painful manual reindexing operation when you eventually need to clean up. The daily rollover also bounds shard count: you can predict exactly how many shards the cluster will hold at steady state and size nodes accordingly.
+
+**Pattern 3: Explicit Mappings Before Data.** Define index templates with explicit field types before any data flows into the cluster. Dynamic mapping guesses wrong often enough to cause real problems: an `order_id` field gets mapped as `text` (full-text search) when you need `keyword` (exact match and aggregatable), and changing the mapping for existing data requires a full reindex. Explicit mappings also let you disable indexing on fields you will never search (large log payloads, binary blobs) using `"index": false`, saving disk and memory.
+
+**Pattern 4: Separate Clusters by Workload Profile.** Logging workloads and application search workloads have fundamentally different access patterns. Logging is write-heavy, append-only, with most queries scanning recent time ranges. Application search is read-heavy with diverse query patterns and latency-sensitive users. Running both on the same cluster causes index contention, cache eviction, and unpredictable query latency. Operate two separate clusters (or two separate managed domains), sized independently for each workload profile.
+
+### Anti-Patterns
+
+| Anti-Pattern | Why Teams Fall Into It | Better Alternative |
+|---|---|---|
+| Using OpenSearch as a primary database | "We already have OpenSearch, why add PostgreSQL?" — OpenSearch is not ACID, does not support joins, and is not designed for transactional writes | Use a proper database for transactional data; push only searchable projections to OpenSearch via a CDC pipeline |
+| One index per namespace per day | Seems like good organizational hygiene — but 50 namespaces × 3 shards × 2 replicas × 90 days = 27,000 shards, which overwhelms cluster state | Use a single daily index with `namespace` as a keyword field and Document Level Security for access control |
+| No ILM policy before production | "We'll configure retention later" — after 6 months of unmanaged index growth, retroactively applying ILM requires reindexing terabytes | Define ISM/ILM policies and index templates before any data enters the cluster; validate them in staging |
+| Over-sharding for "future growth" | Fear of hitting a shard size ceiling leads teams to create 10-20 primary shards for a 30 GB/day index — each shard ends up at 2-3 GB, well below the 10 GB minimum | Target 30 GB per shard; the daily rollover is your natural point to increase shard count when volume actually grows |
+| Direct ingestion without Kafka | Simplicity bias — Fluent Bit → OpenSearch has fewer moving parts, until OpenSearch slows down and Fluent Bit's in-memory buffer overflows, dropping logs | Always buffer through Kafka or Kinesis; the buffer is your insurance policy against cluster unavailability |
+| Running force_merge on hot indices | "Let's optimize everything" — force_merge on an actively-written index creates new segments immediately after every merge, wasting CPU and I/O | Only force_merge on read-only warm/cold indices as part of ILM transitions |
+| Ignoring JVM heap pressure | "It's managed, so I don't need to worry" — managed services handle node replacement but do not tune your index strategy; over-sharding still causes heap pressure and GC pauses | Monitor JVMMemoryPressure (alert above 80%), count shards, and follow shard sizing guidelines regardless of deployment model |
+| No snapshot strategy | Relying on replicas as the only data redundancy — replicas protect against node failure but not against accidental index deletion, data corruption, or cluster-wide misconfiguration | Configure automated snapshots to S3/GCS/Azure Blob with retention matching your recovery point objective; test restore quarterly |
+
+---
+
+## Decision Framework
+
+Choosing how and where to run your search infrastructure depends on four factors: operational maturity, cost sensitivity, feature requirements, and data gravity. The flowchart below captures the primary decision path, but the tradeoffs deserve deeper discussion.
+
+```mermaid
+flowchart TD
+    START["Need search for Kubernetes workloads?"] --> Q1{"Primary use case?"}
+    Q1 -->|"Log analytics and observability"| Q2{"Team size and ops capacity?"}
+    Q1 -->|"Application search (product, docs, RAG)"| Q3{"Vector/semantic search needed?"}
+
+    Q2 -->|"Small team, low ops bandwidth"| MANAGED_LOG["Managed OpenSearch / Elastic Cloud\n- AWS OpenSearch\n- Elastic Cloud on GCP\n- Azure Monitor + Log Analytics (optional AI Search export for search-layer use)"]
+    Q2 -->|"Large team, dedicated SRE support"| Q4{"Data residency or extreme scale (>100TB)?"}
+    Q4 -->|"Yes"| ECK["ECK Operator on Kubernetes\n- Full control over config and plugins\n- Reuse existing K8s infra\n- Own the operational burden"]
+    Q4 -->|"No"| MANAGED_LOG
+
+    Q3 -->|"Yes"| Q5{"Prefer fully-managed AI pipeline?"}
+    Q5 -->|"Yes"| VERTEX["Vertex AI Search (GCP)\n- Automatic embedding and chunking\n- Minimal configuration\n- Higher per-query cost"]
+    Q5 -->|"No, want control"| Q6{"Cloud preference?"}
+    Q6 -->|"AWS"| AWS_VECTOR["Amazon OpenSearch Service\nwith neural search plugin\n+ Bedrock or SageMaker embeddings"]
+    Q6 -->|"Azure"| AZURE_VECTOR["Azure AI Search\n+ Azure OpenAI embeddings\n+ Hybrid search with RRF"]
+    Q6 -->|"Multi-cloud / self-hosted"| ECK_VECTOR["ECK Operator + OpenSearch 2.x\n+ self-hosted embedding model\n(Hugging Face, sentence-transformers)"]
+    Q3 -->|"No, lexical only"| Q7{"Compliance restricts managed services?"}
+    Q7 -->|"Yes"| ECK
+    Q7 -->|"No"| MANAGED_APP["Managed Elasticsearch / OpenSearch\n- Elastic Cloud\n- Amazon OpenSearch\n- Azure AI Search (lexical)"]
+```
+
+The core tension is between operational burden and control. Managed services absorb node management, patching, snapshot automation, and version upgrades — tasks that consume meaningful engineering time on self-hosted clusters. But managed services also impose limits: Amazon OpenSearch restricts certain APIs (no direct `_cluster/settings` modifications), Azure AI Search uses a different indexer model that does not support all Elasticsearch query DSL features, and Vertex AI Search abstracts the retrieval pipeline entirely. When your use case fits within the managed service's feature set, the operational savings typically outweigh the loss of control. When it does not — custom plugins, specific JVM tunings, niche hardware requirements — ECK on Kubernetes provides a production-grade self-hosted path without reinventing the StatefulSet and PVC management wheel.
+
+For teams straddling both worlds, a common strategy is to use a managed service for the logging cluster (where feature requirements are modest — search, aggregate, visualize — and data volume is high) and self-hosted ECK for the application search cluster (where custom relevance tuning, plugin integrations, and latency SLAs demand full control). This split lets you match the operational investment to the business criticality of each workload.
 
 ---
 
@@ -660,7 +829,7 @@ With 50 namespaces and 3 primary shards per index (plus 1 replica), a single day
 </details>
 
 <details>
-<summary>4. You have consolidated all logs into a single daily index to prevent shard explosion, but your security compliance team dictates that the frontend team must never be able to query logs from the payments namespace. How can Document Level Security (DLS) solve this requirement, and what performance trade-off it introduce?</summary>
+<summary>4. You have consolidated all logs into a single daily index to prevent shard explosion, but your security compliance team dictates that the frontend team must never be able to query logs from the payments namespace. How can Document Level Security (DLS) solve this requirement, and what performance trade-off does it introduce?</summary>
 
 DLS is an OpenSearch security feature that dynamically appends a filter query to every search request made by a specific user role. For example, assigning the frontend team a role with a DLS filter `{"match": {"kubernetes.namespace_name": "frontend"}}` ensures they only ever see their own documents, regardless of their actual search query. This satisfies the compliance requirement by providing multi-tenant security within a shared index without the overhead of maintaining separate physical indices. However, DLS adds a 5-15% performance overhead per query because the filter is evaluated on every single search request.
 </details>
@@ -677,15 +846,29 @@ In OpenSearch `bool` queries, `must` clauses calculate relevance scores for each
 Setting the primary shard count to 10 for 100 GB of data would result in shards of only 10 GB each, leading to over-sharding and unnecessary cluster state overhead. You should calculate shards based on a target size of 10-50 GB per shard. For 100 GB of daily logs, dividing by a conservative 30 GB target yields about 3 or 4 primary shards (e.g., ceil(100/30) = 4). You should not over-shard for hypothetical future growth because the daily rollover action in ISM/ILM creates a new index every day, giving you a natural point to seamlessly increase the shard count when your actual daily volume consistently exceeds the target shard size.
 </details>
 
+<details>
+<summary>7. You are evaluating whether to use Amazon OpenSearch Service (managed) versus running the ECK operator on EKS for a new Kubernetes logging pipeline. Your team has two SREs, and the cluster will ingest ~200 GB of logs per day with 30-day retention. Which approach would you recommend and what are the primary tradeoffs?</summary>
+
+For a team with only two SREs and a moderate ingestion volume, managed OpenSearch Service is the stronger choice. A 200 GB/day workload with 30-day retention means ~6 TB of total storage running on perhaps 6-9 data nodes — this is well within the operational envelope of a managed service. The two SREs would spend their time on JVM tuning, shard rebalancing, version upgrades, and snapshot management if self-hosted — time better spent on higher-leverage platform work. Managed OpenSearch handles node replacement, automated snapshots, encryption, and version upgrades. The tradeoff is cost: managed services charge a premium over raw EC2 instances, and you give up direct control over cluster settings and plugin installation. If the team grows to 5+ SREs and data volume exceeds 500 TB, the cost equation may tilt toward ECK plus reserved instances.
+</details>
+
+<details>
+<summary>8. Your application search feature uses BM25 lexical scoring, but users complain that searching for "login issues" does not return documents about "authentication failures" or "password reset errors." How would adding vector search to your cluster address this, and what changes would you need to make to your indexing pipeline?</summary>
+
+BM25 matches keywords exactly, so "login issues" only retrieves documents containing those words. Vector search converts queries and documents into dense embeddings in a high-dimensional space where semantically similar concepts cluster together. Adding vector search requires three changes to the indexing pipeline: first, deploy an embedding model (such as a sentence transformer running as a Kubernetes deployment) that generates a vector for each document at ingest time; second, add a `knn_vector` field to your index mapping with the embedding dimension and similarity metric (cosine or dot product); third, update the ingest pipeline to call the embedding service and populate the vector field. At query time, you run a hybrid search that executes both a BM25 query and a kNN vector query in parallel, then merges the ranked results using Reciprocal Rank Fusion so that documents matching conceptually or lexically both appear in the results.
+</details>
+
 ---
 
 ## Hands-On Exercise: Log Pipeline with OpenSearch
 
-This exercise uses OpenSearch running in kind to build a complete log ingestion and search pipeline.
+This exercise uses OpenSearch running in kind to build a complete log ingestion and search pipeline from scratch. You will deploy a single-node OpenSearch cluster, define an index template with explicit field mappings, ingest 500 simulated Kubernetes log entries using the bulk API, run aggregation queries to explore the data, and inspect cluster health metrics. Each task builds on the previous one, and the entire lab runs locally in a kind cluster that you tear down at the end. The concepts you practice here — explicit mappings, bulk ingestion, filter-based queries, and shard inspection — are the same ones you will use when operating production clusters at scale.
 
 ### Setup
 
 ```bash
+alias k=kubectl
+
 # Create kind cluster
 kind create cluster --name search-lab
 
@@ -698,6 +881,7 @@ helm install opensearch opensearch/opensearch \
   --set persistence.enabled=false \
   --set resources.requests.memory=1Gi \
   --set resources.limits.memory=1.5Gi \
+  # Backslash escapes a literal dot in the Helm values key segment (opensearch.yml).
   --set config.opensearch\\.yml."plugins.security.disabled"=true
 
 k wait --for=condition=ready pod -l app.kubernetes.io/name=opensearch \
@@ -712,7 +896,7 @@ helm install dashboards opensearch/opensearch-dashboards \
 
 ### Task 1: Create an Index Template
 
-Create an index template for Kubernetes logs with proper field mappings.
+Define an index template that will be applied to every new index matching the `k8s-logs-*` pattern. Your template must include explicit field mappings — `keyword` types for namespace, pod, container, and node fields (enabling exact-match queries and aggregations), `date` type for the timestamp (enabling range queries), and `text` type for the log message (enabling full-text search). The template should also configure index settings including the number of shards and the refresh interval.
 
 <details>
 <summary>Solution</summary>
@@ -751,7 +935,7 @@ k run opensearch-setup --rm -it --image=curlimages/curl -n search --restart=Neve
 
 ### Task 2: Ingest Sample Log Data
 
-Push simulated Kubernetes log entries into the index.
+Use a Python script running inside the kind cluster to push 500 simulated Kubernetes log entries into OpenSearch via the bulk API. The script should generate documents with varied `namespace` values (payments, frontend, api-gateway, checkout, analytics) and `level` values (info, warn, error) to create a realistic distribution. The bulk API batches all 500 documents into a single HTTP request using newline-delimited JSON (NDJSON) format — observe the response to confirm all documents were indexed successfully and verify the document count.
 
 <details>
 <summary>Solution</summary>
@@ -793,7 +977,7 @@ print(f\\\"Total documents: {count.get(\\\"count\\\", 0)}\\\")
 
 ### Task 3: Query for Errors by Namespace
 
-Search for error-level logs and aggregate by namespace.
+Craft an OpenSearch query that finds all error-level log entries across all indices and aggregates them by namespace. Use a `bool` query with a `filter` context for the level term (avoiding unnecessary relevance scoring) and a `terms` aggregation on the `kubernetes.namespace` field. Set `size` to 0 to suppress individual document hits and return only the aggregation results. Compare the error distribution across namespaces — does any single namespace dominate the error count?
 
 <details>
 <summary>Solution</summary>
@@ -822,13 +1006,12 @@ k run search-errors --rm -it --image=curlimages/curl -n search --restart=Never -
 
 ### Task 4: Check Index Health and Stats
 
-Query the cluster for index statistics and health.
+Inspect the cluster's operational state by querying three critical endpoints: the cluster health API (which reports status, node count, and shard allocation), the index stats API (which shows document count and storage size per index), and the cat shards API (which lists every shard with its current node assignment and size). Understanding how to read these endpoints is essential for troubleshooting in production — the cluster health status tells you whether all shards are allocated, the index stats confirm your data volume matches expectations, and the shard list reveals whether any shards are undersized or stuck in an unexpected state.
 
 <details>
 <summary>Solution</summary>
 
 ```bash
-# Index stats
 k run check-stats --rm -it --image=curlimages/curl -n search --restart=Never -- \
   sh -c '
   echo "=== Cluster Health ==="
@@ -860,10 +1043,21 @@ kind delete cluster --name search-lab
 
 ---
 
-**Next Module**: [Module 9.7: Streaming Data Pipelines (MSK / Confluent / Dataflow)](../module-9.7-streaming/) -- Learn how to build streaming data pipelines with managed Kafka, compare managed vs in-cluster Strimzi, and process real-time events from Kubernetes workloads.
-
 ## Sources
 
 - [Index State Management in Amazon OpenSearch Service](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/ism.html) — Primary AWS guide for lifecycle policies, rollover, and automated retention.
 - [Fine-grained access control in Amazon OpenSearch Service](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/fgac.html) — Covers document-level security, field-level security, roles, and mappings for shared clusters.
 - [Choosing the number of shards](https://docs.aws.amazon.com/opensearch-service/latest/developerguide/bp-sharding.html) — Provides AWS shard-sizing guidance and sizing tradeoffs directly relevant to logging workloads.
+- [Amazon OpenSearch Service pricing](https://aws.amazon.com/opensearch-service/pricing/) — Instance-hour, storage, and data transfer pricing for provisioned domains and Serverless OCU billing.
+- [Index templates in OpenSearch](https://opensearch.org/docs/latest/im-plugin/index-templates/) — Upstream OpenSearch documentation for composable index templates, component templates, and priority resolution.
+- [Elastic Cloud on Kubernetes (ECK) documentation](https://www.elastic.co/docs/deploy-manage/deploy/cloud-on-k8s) — Official Elastic operator documentation covering deployment, upgrades, node sets, and volume management.
+- [Azure AI Search documentation](https://learn.microsoft.com/en-us/azure/search/) — Overview of Azure's managed search service including indexers, vector search, hybrid retrieval, and AI enrichment pipelines.
+- [Vertex AI Search overview](https://cloud.google.com/vertex-ai-search/docs/overview) — GCP's fully-managed AI search platform covering website search, document search, and RAG retrieval capabilities.
+- [OpenSearch k-NN plugin](https://opensearch.org/docs/latest/search-plugins/knn/index/) — Documentation for approximate nearest neighbor search, including HNSW graphs, IVF, and Lucene-based ANN.
+- [External Secrets Operator](https://external-secrets.io/latest/) — Kubernetes operator for syncing secrets from AWS Secrets Manager, GCP Secret Manager, and Azure Key Vault into Kubernetes secrets.
+- [Fluent Bit Kubernetes filter](https://docs.fluentbit.io/manual/pipeline/filters/kubernetes) — Official documentation for the Kubernetes metadata enrichment filter used in the DaemonSet configuration.
+- [BM25 relevance scoring in Elasticsearch](https://www.elastic.co/blog/practical-bm25-part-2-the-bm25-algorithm-and-its-variables) — Elastic's technical deep-dive on the BM25 algorithm, its parameters (k1, b), and how they relate to term frequency saturation and field length normalization.
+
+## Next Module
+
+[Module 9.7: Streaming Data Pipelines (MSK / Confluent / Dataflow)](../module-9.7-streaming/) — Learn how to build streaming data pipelines with managed Kafka, compare managed vs in-cluster Strimzi, and process real-time events from Kubernetes workloads.

--- a/src/content/docs/cloud/managed-services/module-9.7-streaming.md
+++ b/src/content/docs/cloud/managed-services/module-9.7-streaming.md
@@ -10,28 +10,252 @@ sidebar:
 
 After completing this module, you will be able to:
 
-- **Configure Kubernetes consumers for managed streaming platforms (Amazon MSK, Confluent Cloud, [Azure Event Hubs with Kafka protocol](https://learn.microsoft.com/en-us/azure/event-hubs/azure-event-hubs-apache-kafka-overview))**
-- **Implement exactly-once processing patterns with Kafka transactions and Kubernetes StatefulSet consumer groups**
-- **Deploy stream processing applications (Kafka Streams, Flink) on Kubernetes with managed streaming backends**
-- **Design data pipeline architectures that combine managed streaming with Kubernetes batch and real-time processing workloads**
+- **Compare managed streaming platforms across AWS (Kinesis, MSK), GCP (Pub/Sub, Dataflow), and Azure (Event Hubs, Stream Analytics) and map Kafka concepts to each**
+- **Configure Kubernetes consumers and KEDA scalers for managed Kafka, Kinesis lag, and Pub/Sub backlog**
+- **Implement exactly-once processing patterns with Kafka transactions, idempotent consumers, and checkpointed stream processors on Kubernetes**
+- **Design data pipeline architectures that combine durable logs, stream processing, and batch sinks without treating a stream like a disposable queue**
 
 ---
 
 ## Why This Module Matters
 
-A team running a self-managed Kafka cluster on Kubernetes can spend significant engineering time on broker maintenance, storage operations, and version upgrades.
+Hypothetical scenario: your platform team runs order lifecycle events through a managed queue from [Module 9.2](../module-9.2-message-brokers/). Checkout works, but the data team cannot replay last Tuesday’s traffic to retrain a fraud model, and finance cannot rebuild a ledger view because messages were deleted after acknowledgment. The queue solved decoupling; it did not solve **history, ordering at scale, and parallel replay** — the problems a **durable event log** is built for.
 
-A broker or storage failure in a self-managed Kafka cluster can degrade producers and delay downstream processing if replication health drops and recovery is slow.
+A team running a self-managed Kafka cluster on Kubernetes can spend significant engineering time on broker maintenance, storage operations, and version upgrades. A broker or storage failure in a self-managed cluster can degrade producers and delay downstream processing if replication health drops and recovery is slow. Managed streaming services (MSK, Confluent Cloud, Kinesis, Pub/Sub, Event Hubs) trade line-item cost and some configuration freedom for control-plane operations, elastic capacity, and integrations your SREs would otherwise own. ZooKeeper is gone on modern Kafka paths ([MSK uses KRaft for new clusters](https://aws.amazon.com/about-aws/whats-new/2024/05/amazon-msk-kraft-mode-apache-kafka-clusters/)); the operational surface area shifted from ensemble tuning to partition economics, retention, and consumer lag.
 
-Managed Kafka services can materially reduce day-to-day operational work compared with self-managing brokers, but migration timelines and cost outcomes depend on workload, retention, region, and service choice. ZooKeeper is gone ([MSK uses KRaft since 2024](https://aws.amazon.com/about-aws/whats-new/2024/05/amazon-msk-kraft-mode-apache-kafka-clusters/)). The operational difference is transformative.
+This module teaches the **log model** that underpins event-driven architectures and CDC, how AWS, GCP, and Azure expose that model differently, when to choose Kinesis shards versus Kafka partitions versus Pub/Sub subscriptions, how delivery and processing semantics differ from queue “delete on read,” and how Kubernetes workloads (Deployments, StatefulSets, KEDA) attach to those backends without becoming part-time broker operators.
 
-This module teaches you when to use managed Kafka versus running Strimzi in-cluster, how partitioning and consumer groups work at scale, how exactly-once semantics prevent duplicate processing, how to monitor consumer lag and prevent data loss, how schema registries maintain data contracts, and how to build stream processing pipelines on Kubernetes.
+---
+
+## Event Streaming vs Message Queues vs Batch
+
+[Module 9.2](../module-9.2-message-brokers/) covers **queues and pub/sub brokers** where the primary contract is “deliver this message to a worker and move on.” Streaming adds a different contract: **append-only, partitioned logs** with **offsets**, **retention**, and **replay**. Consumers do not delete the log when they finish; they advance a cursor (offset or checkpoint) while the platform retains bytes for a policy window.
+
+| Pattern | Data shape | Consumer model | Best when |
+|---------|------------|----------------|-----------|
+| **Queue** (SQS, Service Bus queue) | Messages removed after ack | Competing consumers, DLQ | Task dispatch, job buffers |
+| **Pub/Sub fan-out** (SNS→SQS, topic subscriptions) | Copy per subscription | Independent subscriber groups | Notify many services once |
+| **Stream / log** (Kafka, Kinesis, Pub/Sub log, Event Hubs) | Immutable sequence per partition/shard | Consumer groups, replay, forked readers | CDC, analytics, audit, ML features |
+| **Batch** (S3, GCS, ADLS, Spark) | Files / tables | Scheduled jobs | Hourly reports, training sets |
+
+Batch pipelines tolerate minutes to hours of latency; streams target seconds or milliseconds for **continuous processing**. Many production systems are **lambda architectures**: stream for real-time path, batch for correction and heavy joins — Dataflow and Flink explicitly unify both.
+
+> **Cross-reference**: use queues when you need simple backpressure and poison-message isolation; use streams when **multiple teams must read the same history at different speeds** without republishing from a database.
+
+---
+
+## The Durable Log Model (Kafka Concepts Everywhere)
+
+Whether the product name is **topic**, **stream**, or **event hub**, the same primitives recur:
+
+```text
+Producer --(key)--> Partition/Shard 0 ── offset 0,1,2,...
+                 └─ Partition/Shard 1 ── offset 0,1,2,...
+Consumer Group A:  member-1 reads P0, member-2 reads P1
+Consumer Group B:  independent offsets on the same log
+```
+
+**Partition (Kafka) / shard (Kinesis) / partition key (Pub/Sub ordering)** is the unit of **parallelism** and, when keyed, **per-key ordering**. **Consumer groups** (Kafka, Kinesis enhanced fan-out consumers, Pub/Sub subscriptions with multiple subscribers) divide partitions among workers. **Retention** (hours to days by default, extendable) is what makes **replay** possible — and what you pay for in storage when you keep data “just in case.”
+
+**Change Data Capture (CDC)** connectors (Debezium, DMS, Datastream) treat database redo logs as stream sources; analytics and search indexes consume the same log as microservices, which is why streaming skills overlap with [Module 9.6](../module-9.6-search/) ingestion patterns.
+
+---
+
+## Multi-Cloud Managed Streaming Landscape
+
+| Concept | AWS | Google Cloud | Azure |
+|---------|-----|--------------|-------|
+| Native log / stream | [Kinesis Data Streams](https://docs.aws.amazon.com/streams/latest/dev/introduction.html), [MSK (Kafka)](https://docs.aws.amazon.com/msk/latest/developerguide/what-is-msk.html) | [Pub/Sub](https://cloud.google.com/pubsub/docs/overview) | [Event Hubs](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-about) |
+| Kafka-compatible endpoint | MSK, self-managed on EC2 | Pub/Sub + Kafka clients via REST/gRPC; BigQuery export | [Event Hubs Kafka protocol](https://learn.microsoft.com/en-us/azure/event-hubs/azure-event-hubs-apache-kafka-overview) |
+| Load to warehouse / lake | [Firehose](https://docs.aws.amazon.com/firehose/latest/dev/what-is-this-service.html) | [Dataflow](https://cloud.google.com/dataflow/docs/overview) → BigQuery, GCS | [Stream Analytics](https://learn.microsoft.com/en-us/azure/stream-analytics/stream-analytics-introduction), Event Hubs capture |
+| Managed stream processing | [Managed Service for Apache Flink](https://docs.aws.amazon.com/managed-flink/latest/java/what-is.html) | Dataflow (Beam) | Stream Analytics SQL |
+| Autoscale signal for K8s | Kinesis → [aws-kinesis-streams scaler](https://keda.sh/docs/latest/scalers/aws-kinesis-streams/); MSK → [kafka scaler](https://keda.sh/docs/latest/scalers/apache-kafka/) | [gcp-pubsub scaler](https://keda.sh/docs/latest/scalers/gcp-pubsub/) | [azure-eventhub scaler](https://keda.sh/docs/latest/scalers/azure-event-hub/) |
+
+**MSK / Confluent / Event Hubs (Kafka protocol)** expose topics, partitions, consumer groups, and transactions (where supported). **Kinesis** exposes streams and shards with a different client API but similar ordering rules per partition key. **Pub/Sub** is subscription-centric: throughput scales with topics and subscriptions; [ordering keys](https://cloud.google.com/pubsub/docs/ordering) give per-key sequence when you need it.
+
+---
+
+## Core Mechanics: Throughput, Ordering, and Replay
+
+### Producers and partition keys
+
+Producers choose a **key** (order ID, device ID, tenant) so all events for that key land in one partition/shard, preserving order for that entity. A **null key** round-robins for maximum spread — great for telemetry, dangerous when you assumed per-customer ordering.
+
+### Scaling units
+
+| Platform | Scale knob | Ordering scope | Notes |
+|----------|------------|----------------|-------|
+| Kafka / MSK | Partitions per topic | Per partition | Split/merge not automatic; plan headroom |
+| Kinesis (provisioned) | Shard count | Per shard | [Split/merge shards](https://docs.aws.amazon.com/streams/latest/dev/kinesis-using-sdk-java-resharding.html); 1 MB/s write, 2 MB/s read per shard baseline |
+| Kinesis (on-demand) | Automatic | Per shard | [On-demand Standard / Advantage](https://docs.aws.amazon.com/streams/latest/dev/how-do-i-size-a-stream.html) — pay per GB ingest/retrieve |
+| Pub/Sub | Topic + subscription throughput | Per ordering key | Quotas per project; [flow control](https://cloud.google.com/pubsub/docs/pull#flow_control) on subscribers |
+| Event Hubs | [Throughput units (Standard)](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-scalability) or Processing Units (Premium) | Per partition | Kafka clients use same partition model |
+
+### Retention and replay
+
+Kafka retention is topic-level (`retention.ms`). Kinesis defaults to 24 hours ([extendable](https://docs.aws.amazon.com/streams/latest/dev/kinesis-extended-retention.html)). Pub/Sub retains unacked messages per subscription policy ([up to 31 days on the topic](https://cloud.google.com/pubsub/docs/replay-overview) for replay features). Event Hubs supports [capture to ADLS](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-capture-overview) for cheap long-term replay.
+
+Replay is powerful and risky: resetting offsets or reprocessing a topic can **duplicate side effects** unless consumers are idempotent or you use transactional processing.
+
+### Delivery vs processing guarantees
+
+| Layer | Typical guarantee | What you must build |
+|-------|-------------------|---------------------|
+| Broker ingest | At-least-once to the log | Deduplicate on idempotent producer (Kafka) or accept duplicates |
+| Consumer read | At-least-once delivery | Idempotent handlers, idempotency keys in DB |
+| Stream processor | **Exactly-once processing (EOS)** within framework | Kafka transactions + EOS APIs; Flink checkpointing to durable store |
+| End-to-end | Rarely true EOS to external DB | Outbox pattern, or merge idempotent writes |
+
+[Pub/Sub exactly-once delivery](https://cloud.google.com/pubsub/docs/exactly-once-delivery) and [Kafka EOS design](https://kafka.apache.org/41/design/design/) narrow the window but do not remove the need for idempotent sinks.
+
+### Backpressure and lag
+
+When processing cannot keep up, **lag** grows (Kafka consumer lag, Kinesis iterator age, Pub/Sub oldest unacked age). CPU-based HPA often lies for I/O-bound consumers; **KEDA** scales on external metrics (see consumer group section below). Windowed aggregations (tumbling, session windows) in Flink/Dataflow need **watermarks** and bounded lateness — late events either go to side outputs or expand state cost.
+
+### Windowing, joins, and enrichment
+
+Stream processors answer questions like “count orders per minute per region” or “join clicks to purchases within five minutes.” **Tumbling windows** slice time into fixed buckets; **session windows** gap on inactivity; **sliding windows** overlap for moving averages. Event time — the timestamp embedded in the record — must drive windows, not `processingTime` only, or out-of-order mobile events will skew revenue dashboards.
+
+Stream-table joins attach a changelog topic to a **KTable** (Kafka Streams) or equivalent lookup store in Flink. Dimension data (product catalog, fraud rules) should be compacted topics or external stores with TTL; unbounded hash maps in pod memory eventually OOMKill under adversarial keys. For multi-cloud pipelines, the same join logic runs in Dataflow’s `ParDo` with stateful processing or in Azure Stream Analytics with reference data blobs — the mental model transfers even when the SQL surface differs.
+
+---
+
+## AWS: Kinesis, MSK, Firehose, and Flink
+
+### Kinesis Data Streams
+
+Kinesis is AWS’s **shard-based log**. Provisioned mode bills **per shard-hour** plus PUT payload; on-demand modes bill **per GB ingested and retrieved** plus optional per-stream hourly fees ([pricing](https://aws.amazon.com/kinesis/data-streams/pricing/)). Use Kinesis when you want tight AWS integration (Lambda, Firehose, CloudWatch) without operating Kafka brokers.
+
+```bash
+# Create an on-demand stream (capacity scales with usage)
+aws kinesis create-stream --stream-name order-events --stream-mode-details StreamMode=ON_DEMAND
+
+# Put a record with partition key for ordering
+aws kinesis put-record \
+  --stream-name order-events \
+  --partition-key "order-123" \
+  --data "$(echo -n '{"event":"created"}' | base64)"
+```
+
+**Firehose** is delivery, not processing: it batches stream records to S3, Redshift, OpenSearch, or Splunk with transformation Lambda optional ([Firehose docs](https://docs.aws.amazon.com/firehose/latest/dev/basic-deliver.html)). A common EKS pattern is microservices → Kinesis → Firehose → S3 tables queried by Athena, while a separate MSK topic feeds low-latency consumers on the cluster. That split keeps expensive replay storage off the Kafka retention bill.
+
+```bash
+# Example: delivery stream targeting S3 from a Kinesis data stream
+aws firehose create-delivery-stream \
+  --delivery-stream-name order-events-to-s3 \
+  --delivery-stream-type KinesisStreamAsSource \
+  --kinesis-stream-source-configuration KinesisStreamARN=arn:aws:kinesis:us-east-1:123456789012:stream/order-events,RoleARN=arn:aws:iam::123456789012:role/firehose-role \
+  --extended-s3-destination-configuration RoleARN=arn:aws:iam::123456789012:role/firehose-role,BucketARN=arn:aws:s3:::analytics-lake,Prefix=orders/
+```
+
+EKS workloads reading Kinesis use the AWS SDK or Kafka-compatible bridges; for IAM, prefer **Pod Identity** over static keys injected through Secrets. Iterator age metrics should appear on the same Grafana board as pod lag exporters.
+
+### Amazon MSK and Confluent Cloud
+
+MSK runs open-source Kafka with AWS patching and KRaft metadata ([MSK Serverless](https://docs.aws.amazon.com/msk/latest/developerguide/serverless.html) auto-scales brokers; provisioned clusters pick instance types and storage). Confluent Cloud adds enterprise tooling (Schema Registry, ksqlDB, Flink) with the same client protocol. Both fit teams standardizing on **Kafka clients** across clouds.
+
+### Managed Flink on AWS
+
+[Amazon Managed Service for Apache Flink](https://docs.aws.amazon.com/managed-flink/latest/java/what-is.html) runs SQL and DataStream jobs against Kinesis or MSK sources with managed checkpoints — alternative to self-managing Flink on Kubernetes (see Flink Operator section below).
+
+---
+
+## Google Cloud: Pub/Sub and Dataflow
+
+[Cloud Pub/Sub](https://cloud.google.com/pubsub/docs/overview) decouples publishers from subscribers: many subscriptions can read the same topic independently (fan-out), unlike a queue where one consumer group competes. Pull subscribers on GKE use workload identity to call the Pub/Sub API without long-lived keys ([GKE Workload Identity](https://cloud.google.com/kubernetes-engine/docs/how-to/workload-identity)).
+
+```bash
+# Publish with ordering key (ordering enabled on subscription)
+gcloud pubsub topics publish orders \
+  --message='{"event":"created"}' \
+  --ordering-key=order-123
+```
+
+[Dataflow](https://cloud.google.com/dataflow/docs/overview) executes Apache Beam pipelines — batch or streaming — with autoscaling workers; it is the managed answer to “Flink/Spark without patching JVM clusters.” Pair Pub/Sub → Dataflow → BigQuery for real-time analytics; use **templates** for operational guardrails.
+
+Pub/Sub pricing is driven by publish/deliver volume and retention of unacked messages ([Pub/Sub pricing](https://cloud.google.com/pubsub/pricing) — verify current SKUs). Subscriptions with many unchecked messages during outages can accumulate storage charges; dead-letter topics and max-delivery attempts mirror the DLQ patterns from Module 9.2. For GKE consumers, use gRPC pull with flow-control limits so a single slow pod does not hoard messages — the subscription backlog is shared, but effective throughput is only as fast as the slowest acking subscriber in some configurations.
+
+```yaml
+# Illustrative GKE consumer env (Workload Identity handles auth)
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: order-pubsub-consumer
+  namespace: streaming
+spec:
+  replicas: 4
+  template:
+    spec:
+      serviceAccountName: pubsub-consumer
+      containers:
+        - name: app
+          image: mycompany/order-consumer:1.4.0
+          env:
+            - name: PUBSUB_SUBSCRIPTION
+              value: projects/my-proj/subscriptions/order-processor
+            - name: FLOW_CONTROL_MAX_MESSAGES
+              value: "1000"
+```
+
+When you need Kafka client libraries on GCP without hosting brokers, some teams run Kafka protocol gateways or migrate to Pub/Sub-native clients; fighting the platform’s native API usually costs more in connectors than adopting Pub/Sub subscriptions with ordering keys.
+
+---
+
+## Azure: Event Hubs and Stream Analytics
+
+[Azure Event Hubs](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-about) is a Kafka-protocol-compatible log at the Premium and Standard tiers (with partition/TU limits per SKU). Producers can use native AMQP/HTTP or **Kafka client libraries** pointing at the Event Hubs bootstrap ([Kafka overview](https://learn.microsoft.com/en-us/azure/event-hubs/azure-event-hubs-apache-kafka-overview)).
+
+[Azure Stream Analytics](https://learn.microsoft.com/en-us/azure/stream-analytics/stream-analytics-introduction) provides SQL-over-stream jobs with inputs from Event Hubs, IoT Hub, or Blob — good for teams that want declarative windows without hosting Flink jars.
+
+Event Hubs **Capture** archives batches to ADLS for replay and batch correction — analogous to Firehose plus S3, and often the cost-effective way to retain years of history without holding everything in hot Kafka retention.
+
+Standard namespaces bill in **throughput units (TUs)**; Premium uses **processing units (PUs)** with isolated compute for predictable latency ([Event Hubs scalability](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-scalability)). Kafka-compatible clients still require you to size **partition count** up front — TU/PU limits cap how many megabytes per second the namespace accepts regardless of how many AKS pods you run.
+
+```properties
+# Kafka producer/consumer bootstrap for Event Hubs (example)
+bootstrap.servers=your-namespace.servicebus.windows.net:9093
+security.protocol=SASL_SSL
+sasl.mechanism=PLAIN
+sasl.jaas.config=org.apache.kafka.common.security.plain.PlainLoginModule required username="$ConnectionString" password="Endpoint=sb://...";
+```
+
+AKS workloads should use **Entra Workload ID** instead of embedding connection strings in manifests. Pair Stream Analytics for declarative aggregates (five-minute tumbling windows on telemetry) while microservices on AKS handle complex per-order state machines that SQL cannot express cleanly.
+
+---
+
+## Operational Runbooks: Capacity, Upgrades, and Failure Modes
+
+### Capacity planning worksheet
+
+Start from peak ingress MB/s, number of independent consumer groups, retention hours, and fan-out factor (how many distinct readers copy the same stream). For Kafka, multiply partitions by per-partition throughput ceiling on your SKU; for Kinesis, convert MB/s to shards or pick on-demand and model GB/month; for Pub/Sub, use quota dashboards plus backlog growth alerts; for Event Hubs, map TU/PU limits to partition throughput. Document the answer in the service repo so Kubernetes `maxReplicas` on KEDA objects cannot exceed the broker contract.
+
+### Upgrades and schema changes
+
+Broker upgrades on managed services are provider-driven — still schedule maintenance windows because client protocol versions and ACL formats change. Application upgrades are riskier: consumers on new code with old schemas fail deserialization. Roll out **schema registry changes** before binary deploys, deploy consumers with backward-compatible readers first, then producers. On Kubernetes, use canary Deployments (10% replicas) on a separate consumer group reading a shadow topic before cutting traffic.
+
+### Failure modes and mitigations
+
+| Symptom | Likely cause | Mitigation |
+|---------|--------------|------------|
+| Sudden lag spike, flat CPU | Downstream DB/API slow | Scale consumers only after fixing dependency; tune pool sizes |
+| Lag spike after deploy | Rebalance storm | Limit surge, use sticky assignor, increase session timeout carefully |
+| Repeated poison messages | Bad schema or corrupt payload | DLQ topic/subscription, quarantine bytes, alert on DLQ rate |
+| Throttling (Kinesis/Pub/Sub) | Hot key or shard/TU exhaustion | Reshard, increase TU/PU, or split topics |
+| ISR shrink / broker offline (Kafka) | AZ outage or disk | Managed failover; for Strimzi, verify rack awareness and RF |
+
+Hypothetical scenario: during a regional AZ impairment, MSK maintains quorum but clients on nodes in the impaired AZ timeout. Kubernetes may reschedule pods to healthy AZs faster than DNS caches refresh — pin consumers to topology spread constraints across zones and use broker bootstrap lists that include brokers in all AZs. For Pub/Sub and Kinesis, regional endpoints mean your mitigation is failover consumers in another region reading a replicated stream or accepting RPO>0 from capture files.
+
+### Security and compliance checkpoints
+
+Encrypt in transit (TLS/SASL) for every managed SKU, encrypt at rest with customer-managed keys where auditors require it, and scope IAM/Entra/GCP roles per topic/stream. Log access to administrative APIs (topic creation, subscription purge) through cloud audit logs. For PCI/PHI, keep cardholder or patient identifiers out of partition keys if logs echo keys in plaintext.
 
 ---
 
 ## Managed Kafka vs In-Cluster Strimzi
 
-### Decision Framework
+### Managed vs self-hosted comparison
+
+Teams routinely underestimate the **hidden cost** of operating brokers: JVM heap tuning across AZs, storage expansion during retention spikes, inter-broker TLS rotation, and incident bridges when a single slow disk stalls ISR. Managed offerings convert those hours into dollars per partition-hour or per GB, which is why the crossover in total cost of ownership often favors MSK once engineer salary is included — even when raw EC2 for Strimzi looks cheaper on a spreadsheet.
 
 | Factor | Managed (MSK/Confluent) | In-Cluster (Strimzi on K8s) |
 |--------|------------------------|-----------------------------|
@@ -46,31 +270,47 @@ This module teaches you when to use managed Kafka versus running Strimzi in-clus
 
 ### When to Choose Each
 
-**Choose managed Kafka when:**
-- Your team does not have Kafka expertise
-- You process more than 100 MB/s sustained
-- You need guaranteed durability (financial, healthcare)
-- You want to focus on producers/consumers, not broker operations
+**Choose managed Kafka (MSK, Confluent Cloud, Event Hubs with Kafka protocol)** when your team lacks dedicated broker SREs, sustained throughput exceeds what you can operate safely on StatefulSets, or regulatory durability requirements demand provider-managed replication and patching. Financial and healthcare telemetry often lands here because control-plane uptime and audit trails matter more than marginal per-partition savings from self-hosting.
 
-**Choose Strimzi when:**
-- Sub-millisecond latency matters (in-cluster communication)
-- You are on a tight budget with low volume
-- You need full control over Kafka configuration
-- You are running in environments without managed services (on-prem, edge)
+**Choose Strimzi (or bare-metal Kafka) on Kubernetes** when sub-millisecond producer-to-consumer latency inside the cluster is mandatory, traffic is low enough that broker operational cost exceeds managed SKUs, you must tune obscure broker configs (custom interceptors, authorizer plugins), or you deploy to environments without regional managed offerings (on-prem factories, edge sites, air-gapped enclaves). Budget for 24/7 paging when broker disks fail — managed services convert that risk into a line item.
 
 ### Strimzi Quick Setup (for comparison)
 
 ```yaml
-# Strimzi Kafka cluster in Kubernetes
+# Strimzi Kafka cluster in Kubernetes (KRaft, no ZooKeeper)
+apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: broker
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: event-cluster
+spec:
+  replicas: 3
+  roles: [controller, broker]
+  storage:
+    type: jbod
+    volumes:
+      - id: 0
+        type: persistent-claim
+        size: 500Gi
+        class: gp3-encrypted
+  resources:
+    requests:
+      memory: 4Gi
+      cpu: "2"
+---
 apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: event-cluster
   namespace: kafka
+  annotations:
+    strimzi.io/node-pools: enabled
+    strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 3.8.0
-    replicas: 3
+    version: 4.0.0
     listeners:
       - name: plain
         port: 9092
@@ -87,23 +327,6 @@ spec:
       default.replication.factor: 3
       min.insync.replicas: 2
       num.partitions: 12
-    storage:
-      type: jbod
-      volumes:
-        - id: 0
-          type: persistent-claim
-          size: 500Gi
-          class: gp3-encrypted
-    resources:
-      requests:
-        memory: 4Gi
-        cpu: "2"
-  zookeeper:
-    replicas: 3
-    storage:
-      type: persistent-claim
-      size: 50Gi
-      class: gp3-encrypted
   entityOperator:
     topicOperator: {}
     userOperator: {}
@@ -113,13 +336,15 @@ spec:
 
 ## Partitioning: The Foundation of Kafka Scalability
 
-A Kafka topic is divided into partitions. Partitions are the unit of parallelism -- more partitions means more consumers can process data concurrently.
+A Kafka topic is divided into partitions. Partitions are the unit of parallelism — more partitions means more consumers in the same group can process data concurrently, up to one consumer per partition. The same idea appears on other clouds under different names: Kinesis **shards**, Event Hubs **partitions**, and Pub/Sub **ordering keys** that map to ordered sequences. Misunderstanding this mapping is the most common reason streaming pipelines “scale out” in Kubernetes but fail to increase throughput.
+
+Planning partition count is a capacity exercise, not a guess. Too few partitions caps throughput and forces oversized pods; too many increases metadata overhead, rebalance time, and storage fragmentation on Kafka. For MSK and Event Hubs, changing partition counts later is possible but disruptive — consumers rebalance, and keys may land on new partitions, so ordering per key is preserved but historical locality is not. For Kinesis provisioned mode, you split or merge shards explicitly; on-demand modes hide shard management but you still pay for throughput and retention per actual usage.
 
 ### How Partitions Work
 
 ```mermaid
 graph TD
-    Prod[Producer] -->|key: order-123 --> hash%6 = P2| P2
+    Prod[Producer] -->|"key order-123, hash%6=P2"| P2
     subgraph Topic: order-events
         P0
         P1
@@ -179,16 +404,23 @@ def delivery_report(err, msg):
 ```
 
 **Common key strategies:**
-- **Customer ID**: All events for one customer in order
-- **Order ID**: All order lifecycle events in order
-- **Null key**: Round-robin across partitions (maximum throughput, no ordering)
-- **Tenant ID**: Multi-tenant isolation per partition
+
+- **Customer ID** — All events for one customer stay ordered, which matters for account-level fraud rules and support tooling that reconstructs timelines.
+- **Order ID** — Lifecycle events (created → paid → shipped) remain ordered without cross-order head-of-line blocking.
+- **Null key** — Round-robin across partitions maximizes throughput when order is irrelevant (metrics, clickstream without session stickiness).
+- **Tenant ID** — SaaS isolation: noisy tenants get their own partition subset when combined with topic-per-tenant or salted keys.
+
+Advanced teams implement **key-aware autoscaler hints**: if one tenant dominates traffic, observability tags `tenant_id` in metrics and routes that tenant to a dedicated topic rather than overheating a shared partition. On Kinesis, the partition key maps to a hash of the key modulo shard count; on Pub/Sub, ordering keys must be enabled on the subscription and producers must include the key on every publish.
 
 > **Pause and predict**: If you have a topic with 12 partitions and a consumer deployment with 15 replicas, what exactly happens to the last 3 pods? How will Kubernetes metrics report their status compared to their actual utility?
 
 ---
 
 ## Consumer Groups and Lag Monitoring
+
+Consumer groups are the bridge between **durable logs** and **Kubernetes scale**. Whether the broker is MSK, Event Hubs, or a Strimzi cluster inside the cluster, the rule holds: each partition is assigned to at most one consumer instance in a group at a time. Scaling replicas beyond partition count wastes CPU and memory; scaling below partition count leaves throughput on the table. Platform engineers should publish the **partition count as part of the topic contract** alongside schema version and retention, because application teams cannot HPA their way past a three-partition topic.
+
+Lag is the operational heartbeat. For Kafka, exporters surface `kafka_consumergroup_lag`; for Kinesis, **GetRecords.IteratorAgeMilliseconds** indicates how far behind the consumer is; for Pub/Sub, **oldest_unacked_message_age** plays the same role. Alert on lag growth rate, not instantaneous spikes during deploys, and correlate lag with downstream dependency latency (databases, payment APIs) before blaming the broker.
 
 ### Consumer Group Mechanics
 
@@ -217,7 +449,7 @@ graph TD
     P5 --> Pod3
 ```
 
-Each pod gets an equal share of partitions. Adding a 4th pod triggers rebalancing. [A 7th pod would be idle (6 partitions, 7 consumers)](https://kafka.apache.org/10/getting-started/introduction/).
+Each pod gets an equal share of partitions. Adding a 4th pod triggers rebalancing. [A 7th pod would be idle (6 partitions, 7 consumers)](https://kafka.apache.org/intro).
 
 ### Kubernetes Consumer Deployment
 
@@ -358,11 +590,19 @@ spec:
         offsetResetPolicy: earliest
 ```
 
+### Multi-cloud KEDA triggers (same pattern, different scalers)
+
+The ScaledObject above uses the Kafka scaler against MSK bootstrap servers. For Kinesis-backed consumers on EKS, swap the trigger for `aws-kinesis-stream` metadata (`streamName`, `awsRegion`, iterator age threshold). On GKE with Pub/Sub pull subscribers, use `gcp-pubsub` with the subscription ID and unacked message threshold. On AKS with Event Hubs, use `azure-eventhub` with connection strings or workload identity and the consumer group name. In every case, set `maxReplicaCount` ≤ partition/shard count and use **cooperative rebalancing** settings on Kafka clients to avoid stop-the-world partition moves during scale events.
+
+When lag clears, scale down slowly. Aggressive scale-in triggers rebalance storms that pause processing and can duplicate processing windows if commits were in flight. A `cooldownPeriod` and `pollingInterval` that match your P99 processing time are as important as the lag threshold itself.
+
 ---
 
 ## Exactly-Once Processing and Stateful Consumers
 
-For financial transactions or inventory updates, processing a message more than once (at-least-once semantics) or dropping it (at-most-once) is unacceptable. [Kafka achieves exactly-once semantics (EOS) through the combination of idempotent producers and transactional APIs.](https://kafka.apache.org/41/design/design/)
+For financial transactions or inventory updates, processing a message more than once (at-least-once semantics) or dropping it (at-most-once) is unacceptable for the business outcome even when the broker delivered correctly. [Kafka achieves exactly-once semantics (EOS) for read-process-write loops inside the Kafka ecosystem](https://kafka.apache.org/41/design/design/) through idempotent producers, transactions, and consumer offset commits that participate in the same transaction boundary. Flink and Beam (Dataflow) pursue a different but related guarantee: **exactly-once processing** relative to checkpoints stored in S3, GCS, or Azure Blob — failures roll back to the last successful checkpoint rather than re-reading unbounded history.
+
+Pub/Sub’s [exactly-once delivery](https://cloud.google.com/pubsub/docs/exactly-once-delivery) narrows duplicate delivery at the subscription layer when enabled, but your GKE handler must still write idempotently to Postgres or call external APIs with safe retries. Kinesis consumers achieve effectively-once by storing checkpoints in DynamoDB or by using Flink with managed checkpoints; there is no single “transaction” knob like Kafka’s `send_offsets_to_transaction`.
 
 ### The Transactional Pipeline
 
@@ -441,11 +681,43 @@ spec:
 
 By using a `StatefulSet`, `payment-aggregator-0` maintains its stable network identity and keeps its `state-store` volume across restarts. When the pod comes back up, its RocksDB cache is already populated, requiring only a minimal delta update before processing resumes.
 
+On Azure Event Hubs and GCP with Kafka-compatible bridges, the same transactional code paths apply only where the broker supports Kafka transactions; otherwise implement idempotent sinks and store checkpoints in an external store (Blob, DynamoDB, Firestore) with the same semantics you would expect from `commit_transaction()` in the Python example above.
+
+---
+
+## Kubernetes Integration for Streaming Workloads
+
+Running consumers on Kubernetes while brokers stay managed is the default healthy split: the data plane (Kafka, Kinesis, Pub/Sub, Event Hubs) lives in the cloud control plane, and the compute plane (your Deployments, StatefulSets, KEDA ScaledObjects) lives on the cluster. The integration work is authentication, network path, and observability — not running ZooKeeper pods.
+
+### Workload identity and keyless access
+
+Long-lived broker passwords in Secrets rot slowly and leak broadly when mounted into many namespaces. Prefer cloud-native workload identity: **EKS Pod Identity / IRSA** for MSK IAM authentication and Kinesis `PutRecord`, **GKE Workload Identity Federation** for Pub/Sub and Dataflow launchers, **Entra Workload ID** for Event Hubs and Azure Monitor exporters. The pod’s `ServiceAccount` maps to an IAM role or federated principal with least privilege — produce-only for ingest services, consume-only for read services, never cluster-admin for an app that only reads one topic.
+
+For secrets that must still exist (SASL passwords, registry API keys), use **External Secrets Operator** or **Secrets Store CSI** (covered in Module 9.8) so Kubernetes Secrets are short-lived projections of Secrets Manager, Secret Manager, or Key Vault. Rotate on the cloud side; pods pick up new versions on restart or via reload sidecars.
+
+### Networking and DNS
+
+MSK and Event Hubs often expose **private endpoints** inside your VPC/VNet. Consumers on Kubernetes need security groups / network policies that allow egress to broker ports (9092/9094/9098 depending on auth mode) and DNS resolution of broker bootstrap hostnames. For cross-cloud disaster recovery, avoid hard-coding a single bootstrap list in a ConfigMap without versioning — use ExternalName services or a small discovery Deployment that watches cluster metadata.
+
+Pub/Sub and Kinesis clients use HTTPS/gRPC to regional endpoints; ensure **egress NAT** and firewall rules allow those APIs from worker nodes, not only from a bastion. If you use service mesh mTLS between pods, remember the mesh terminates at the pod boundary — TLS to the broker is a separate hop configured in the Kafka client properties.
+
+### Observability beyond lag
+
+Export broker metrics (MSK open monitoring, Event Hubs metrics, Pub/Sub monitoring) into the same Prometheus/Grafana stack as application RED metrics. Dashboards should correlate **lag**, **process latency**, and **downstream error rate** on one row per consumer group. For Kubernetes, add pod labels `topic`, `consumer_group`, and `stream` so on-call engineers can trace from alert to Deployment in one click.
+
+Structured logs should include `partition`, `offset`, and `key_hash` (not raw PII keys) so replay debugging does not require turning on debug logging globally. Tracing (OpenTelemetry) across consume → process → produce chains helps find slow stages in Flink mini-batches and Kafka Streams punctuators alike.
+
+### Resource sizing and disruption budgets
+
+Consumers are often **memory-heavy** (deserialization buffers, RocksDB block cache) with modest CPU until compression or JSON parsing spikes. Set requests/limits from load tests with realistic message sizes — a 256 KB max message policy on the broker does not help if your app allocates multi-megabyte byte arrays per message.
+
+Use `PodDisruptionBudgets` on Stateful stream processors so node drains wait for checkpoint completion. For Deployments, pair `maxUnavailable: 1` with cooperative consumer protocols to limit rebalance churn during cluster upgrades.
+
 ---
 
 ## Schema Registry: Data Contracts for Events
 
-Without schema management, producers can change the event structure without warning, breaking consumers.
+Without schema management, producers can change the event structure without warning, breaking consumers in other namespaces or other companies’ microservices that share the topic.
 
 ### The Problem
 
@@ -547,13 +819,31 @@ curl -XPUT "http://schema-registry:8081/config/order-events-value" \
 | **FULL** | Both backward and forward | Only adding/removing optional fields with defaults |
 | **NONE** | No compatibility checking | Any change allowed (dangerous) |
 
-For many event pipelines, **BACKWARD** compatibility is a common default because it lets newer consumers read messages produced by older producers.
+For many event pipelines, **BACKWARD** compatibility is a common default because it lets newer consumers read messages produced by older producers. **FORWARD** compatibility protects old consumers reading new data — useful when producers upgrade first in a tightly coupled fleet. **FULL** is the safest default for widely shared topics but restricts schema evolution to additive optional fields with defaults.
+
+Confluent Schema Registry on Kubernetes (Deployment above) is one implementation; AWS Glue Schema Registry and Apicurio provide similar gates. The registry stores Avro, JSON Schema, or Protobuf definitions versioned per subject (`topic-value`). Producers embed schema IDs in the payload wire format; consumers fetch definitions before deserialize. When registration is rejected, the producer fails fast — far cheaper than poisoning a million-message topic.
+
+Operational tips for GKE/EKS/AKS: run registry behind internal ingress with mTLS, replicate read caching in consumers, and backup schema subjects before major merges. Pair with CI jobs that register schemas from `main` branches so application deploys cannot outrun contract publication.
 
 > **Stop and think**: Your team decides to deploy a new schema that changes an integer field `quantity` to a string field `quantity_str` to support formats like "1 dozen". If you are using BACKWARD compatibility, what will the schema registry do when the producer tries to register this schema?
 
 ---
 
+## CDC, Analytics, and the Stream–Batch Boundary
+
+Database **change data capture** feeds the same managed logs this module covers: Debezium reading MySQL binlog → Kafka/MSK, Datastream → Pub/Sub, or SQL Server CDC → Event Hubs. Kubernetes-hosted connectors (Strimzi KafkaConnect, custom Deployments) should run in isolated node pools because connector lag affects database source systems — long transactions on the OLTP side if binlog consumption stalls.
+
+The analytics path often forks: **hot** stream processors compute metrics for dashboards and fraud rules; **warm** Firehose or Event Hubs Capture lands Avro/Parquet in object storage; **cold** Spark or BigQuery batch jobs correct late data. Teach teams that replay from object storage is cheaper than infinite Kafka retention, but replay latency is higher — design retention for operational recovery (hours–days), not multi-year history unless compliance mandates it.
+
+Joining streams to **Kubernetes-served gRPC APIs** for enrichment is tempting; protect those APIs with bulkheads and circuit breakers so lag events do not retry-storm your catalog service. Cache enrichment keys in the processor state store where possible.
+
+---
+
 ## Stream Processing on Kubernetes
+
+Stream processing turns a passive log into derived streams, aggregates, and alerts. The deployment model splits into **libraries in your pods** (Kafka Streams), **operators managing clustered runtimes** (Flink Kubernetes Operator), and **fully managed cloud runners** (Dataflow, Managed Flink, Stream Analytics). Kubernetes is the natural home for the first two when you need custom JARs, GPU, or sidecars; managed runners win when checkpoint storage, autoscaler, and patch cadence should not live on your platform backlog.
+
+Windowed computation — tumbling counts per minute, session gaps for user activity, joins between order stream and payment stream — requires **event time** and **watermarks** in Flink/Beam, not just wall-clock processing time. Late events either update retractions (stream-table duality) or land in side outputs; skipping that design leads to silent under-counting during network delays.
 
 ### Architecture Options
 
@@ -562,7 +852,7 @@ For many event pipelines, **BACKWARD** compatibility is a common default because
 | Kafka Streams | Library (runs in your pods) | Simple transformations, joins | Low |
 | Apache Flink | Operator (FlinkDeployment) | Complex event processing, windows | High |
 | ksqlDB | Deployment | SQL-like stream processing | Medium |
-| [Google Dataflow](https://docs.cloud.google.com/dataflow/docs/overview) | Managed (GCP only) | Batch + stream unified | Medium |
+| [Google Dataflow](https://cloud.google.com/dataflow/docs/overview) | Managed (GCP only) | Batch + stream unified | Medium |
 
 ### Kafka Streams Application on Kubernetes
 
@@ -643,9 +933,21 @@ spec:
     upgradeMode: savepoint
 ```
 
+### Beam on Dataflow (GCP) from GKE producers
+
+GKE microservices publish to Pub/Sub; Dataflow jobs (template or classic) read the subscription with autoscaling workers. The Kubernetes cluster is not hosting the heavy workers — only the producers — which keeps cluster autoscaling simple. Use **shared VPC** and private Google access so traffic does not hairpin over the public internet. For Azure, Stream Analytics jobs ingest from Event Hubs while AKS consumers handle low-latency alerting paths in parallel.
+
+### When to keep processors on-cluster
+
+Choose Flink or Kafka Streams on Kubernetes when you need **custom operators**, on-prem hybrid, or strict data residency where managed Flink/Dataflow regions are unacceptable. Budget for StatefulSets, PVCs for RocksDB, and S3-compatible checkpoint buckets (`s3://`, `gs://`, `abfss://`) with lifecycle policies so failed job restarts do not replay from epoch zero.
+
 ---
 
 ## Setting Up Amazon MSK
+
+Provisioning MSK is the AWS-native path when you want Kafka protocol compatibility without operating brokers on EC2 or inside EKS. **Serverless** suits spiky dev/test and early production where partition-hour plus GB pricing tracks actual usage ([serverless guide](https://docs.aws.amazon.com/msk/latest/developerguide/serverless.html)). **Provisioned** clusters with `kafka.m7g` Graviton brokers suit steady high throughput where instance sizing is predictable. In both cases, clients on EKS authenticate with **IAM SASL** (`AWS_MSK_IAM`) via Pod Identity — the Deployment example in the consumer group section shows the environment variables; rotate away from long-lived SCRAM secrets when possible.
+
+Connect external systems with **MSK Connect** (managed Kafka Connect) for S3 sinks, Debezium CDC, or OpenSearch indexing without running Connect workers on your cluster. Each connector consumes worker capacity billed separately — model connector tasks in the same capacity worksheet as consumer lag. For cross-region disaster recovery, MSK replicator or MirrorMaker2 on a small Strimzi footprint can copy topics while primary processing stays on managed brokers in the active region.
 
 ```bash
 # Create MSK Serverless cluster (simplest option)
@@ -682,15 +984,99 @@ aws kafka create-cluster \
 
 ---
 
+## Cost Lens: Shards, Partitions, and Retention
+
+Streaming bills are rarely “one number per month.” They combine **ingress**, **egress/fan-out**, **storage/retention**, and **compute** for processors.
+
+| Cost driver | AWS | GCP | Azure | Mitigation |
+|-------------|-----|-----|-------|------------|
+| Throughput | Kinesis shard-hours or on-demand GB; MSK broker hours + storage | Pub/Sub publish/deliver GB; Dataflow worker hours | Event Hubs TU/PU; Stream Analytics SU | Right-size partitions; avoid over-sharding; on-demand Kinesis when spiky |
+| Fan-out | Kinesis enhanced fan-out per consumer-shard hour | Each subscription reads full stream | Multiple consumer groups / capture | Consolidate consumers; use capture + batch for cold paths |
+| Retention | Extended Kinesis retention per shard-hour; MSK EBS | Pub/Sub retention storage | Capture + ADLS (cheap) vs hot retention | Lower `retention.ms` after downstream compact; tier to object storage |
+| Over-provision | Idle provisioned shards at 1 MB/s each | High min subscribers pulling empty | Premium PU bought for peak | Switch to on-demand/autoscale modes; KEDA cap max replicas |
+| Egress | MSK cross-AZ replication; Firehose to other regions | Multi-region Pub/Sub | Geo-disaster recovery replication | Co-locate consumers in same region/AZ where possible |
+
+**Hypothetical scenario:** a team provisions 50 Kinesis shards for a 5 MB/s average ingest because “Black Friday might spike.” At roughly $0.015/shard-hour in provisioned mode (verify current [Kinesis pricing](https://aws.amazon.com/kinesis/data-streams/pricing/) in your region), idle shards dominate the bill while ingest stays flat. On-demand Standard or Advantage (when sustained ingest exceeds account minimums — see [mode selection guide](https://docs.aws.amazon.com/streams/latest/dev/how-do-i-size-a-stream.html)) aligns cost with actual GB. For Kafka, **empty partitions still cost metadata and rebalance overhead**; partition count should track **max parallel consumers**, not “future maybe.”
+
+MSK Serverless charges [per partition-hour and per GB](https://aws.amazon.com/msk/pricing/); provisioned MSK adds **broker instance + EBS**. Confluent Cloud bundles schema registry and connectors into SKU tiers. Always model **egress to analytics regions** — the stream is cheap until every event crosses continents three times.
+
+FinOps reviews should include **consumer fan-out**: a second consumer group reading the full topic doubles retrieve charges on Kinesis on-demand and increases Pub/Sub deliver billing. Prefer capture archives plus batch for historical reprocessing instead of cloning full-fan-out streaming paths unless latency requirements demand it. Tag Kubernetes namespaces with `stream_cost_center` labels so chargeback reports can tie EKS compute back to the topics driving retention and egress. Revisit those tags quarterly when product teams add new consumer groups or when retention policies change after compliance reviews, since both events shift streaming storage and egress costs materially.
+
+---
+
+## Patterns & Anti-Patterns
+
+### Proven patterns
+
+1. **Log + derived topics** — Raw events land in a compacted or long-retention topic; stream processors write curated “enriched” topics so consumers do not re-parse raw JSON. Analytics teams read derived topics without touching PII-heavy raw payloads, and replay after a bug fix reprocesses only the derived layer when raw bytes are unchanged.
+
+2. **Idempotent consumer + business key** — Store `event_id` or idempotency keys in the database so at-least-once delivery does not double-charge. Required for Pub/Sub, SQS-style bridges, and Kafka consumers alike; combine with outbox tables when the side effect is another database row rather than an external API.
+
+3. **KEDA on lag, not CPU** — Scale Kubernetes consumers from `kafka_consumergroup_lag`, Kinesis iterator age, or Pub/Sub backlog. Cap `maxReplicaCount` at partition/shard count and document the cap in the Helm chart README so application teams cannot override it blindly in values.yaml.
+
+4. **Schema registry as contract gate** — Register Avro/Protobuf/JSON schemas with BACKWARD compatibility so producers cannot silently break downstream deserializers on GKE. Pair registry rejection alerts with CI schema-diff jobs on pull requests that touch `.avsc` or `.proto` files.
+
+5. **Capture / Firehose cold path** — Hot stream for real-time; automatic archive to S3/GCS/ADLS for training and audit without paying multi-day broker retention for terabytes. Rehydrate cold data through batch Spark or BigQuery jobs when stream processors need historical correction, not through infinite Kafka retention.
+
+### Anti-patterns
+
+1. **Too few partitions** — Three partitions cap three parallel consumers forever; flash sales hit a ceiling while pods look “scaled.” Fix: increase partitions during design, accept one-time rebalance cost.
+2. **Hot partition from bad keys** — Using `country=US` as the key when 80% of traffic is US funnels all events through one partition. Fix: compound keys (`tenant+order`) or salt high-cardinality keys with a random suffix when order per key is not required.
+3. **Using a stream as a queue** — Deleting or compacting messages immediately after read defeats replay and multi-subscriber analytics. Fix: keep the log; use acknowledgment only in the consumer offset, not topic deletion.
+4. **Ignoring rebalance storms** — Rolling Deployments with `maxSurge: 100%` on Kafka consumers trigger constant partition reassignment. Fix: rolling update with limited surge, cooperative sticky assignors, or static membership where supported.
+5. **EOS without idempotent sinks** — Kafka transactions stop duplicate *internal* writes, but JDBC sinks still double-insert on retry. Fix: upsert keys, outbox table, or merge statements.
+6. **Unbounded state in Flink/Kafka Streams** — Session windows without retention on state stores fill disks. Fix: TTL, RocksDB tuning, incremental checkpoints to S3/GCS.
+
+---
+
+## Decision Framework: Picking a Streaming Platform
+
+```mermaid
+flowchart TD
+    Start([New event pipeline]) --> Q1{Need Kafka protocol<br/>and ecosystem?}
+    Q1 -->|Yes| Q2{Want zero broker ops?}
+    Q2 -->|Yes| MSK[MSK / Confluent / Event Hubs Kafka]
+    Q2 -->|No| Strimzi[Strimzi on Kubernetes<br/>or on-prem Kafka]
+    Q1 -->|No| Q3{Primary cloud?}
+    Q3 -->|AWS-native| Q4{Sub-second analytics<br/>on stream without Kafka?}
+    Q4 -->|Yes| Kinesis[Kinesis + Flink/Firehose]
+    Q4 -->|No| MSK
+    Q3 -->|GCP| PubSub[Pub/Sub + Dataflow]
+    Q3 -->|Azure| EH[Event Hubs + Stream Analytics / Capture]
+    MSK --> K8s[Consumers on GKE/EKS/AKS<br/>KEDA on lag]
+    Kinesis --> K8s
+    PubSub --> K8s
+    EH --> K8s
+```
+
+| If your priority is… | Lean toward… | Tradeoff |
+|---------------------|--------------|----------|
+| Maximum Kafka portability | MSK, Confluent, Event Hubs (Kafka) | Broker SKU complexity, partition planning |
+| Lowest ops on AWS, Lambda integration | Kinesis on-demand | Different client API than Kafka; shard/key discipline |
+| Unified batch + stream on GCP | Pub/Sub + Dataflow | Beam learning curve; GCP coupling |
+| SQL analytics without JVM ops | Azure Stream Analytics | Less flexible than Flink for custom state |
+| Air-gapped / full config control | Strimzi on Kubernetes | You own patching, storage, incidents |
+| Multi-cloud identical client | Confluent Cloud or self-managed Kafka | Cost vs managed regional services |
+
+**Kubernetes placement rule:** run **stateless consumers and stream processors** on the cluster; run **brokers** managed unless you have a dedicated data platform team. Strimzi shines when latency to pods matters and managed SKUs are unavailable (edge, regulated on-prem); MSK/Event Hubs shine when broker uptime is business-critical and team size is small.
+
+### Same workload, four clouds (design walkthrough)
+
+Imagine an order-events pipeline with 20 MB/s average, 80 MB/s peak, three consumer groups (fulfillment, analytics, fraud), and seven-day hot retention before archive. On **AWS**, MSK provisioned with ~24–36 partitions and three consumer Deployments on EKS is the default Kafka-native answer; Kinesis fits if you want native Firehose→S3 and Lambda consumers without Kafka ops. On **GCP**, Pub/Sub with three subscriptions plus Dataflow to BigQuery minimizes broker operations; ordering keys per `order_id` protect fulfillment sequencing. On **Azure**, Event Hubs Premium with Kafka clients on AKS plus Capture to ADLS mirrors the AWS split between hot consumers and cold lake. In all three, **KEDA** scales consumers on backlog, not CPU, and **capture/Firehose** holds long retention cheaply.
+
+The wrong choice is not “Kafka vs not Kafka” but **whether you need Kafka-protocol ecosystems** (Connect, ksqlDB, existing Java consumers) versus **cloud-native integration** (Pub/Sub push, Kinesis Lambda, Stream Analytics SQL). Teams already standardized on Kafka clients should not force Pub/Sub unless they budget connector maintenance; greenfield GCP workloads should not default to MSK on GKE cross-cloud unless compliance mandates AWS. Document the decision in an ADR referencing partition count, retention dollars, and expected engineer hours — those three numbers decide the SKU more often than feature checklists.
+
+---
+
 ## Did You Know?
 
-1. **Apache Kafka originated at LinkedIn and has been used there at very large scale**. Exact throughput, footprint, and adoption figures should be cited to current primary sources.
+1. **Amazon Kinesis Data Streams offers three capacity modes** — provisioned shards, [On-demand Standard, and On-demand Advantage](https://docs.aws.amazon.com/streams/latest/dev/how-do-i-size-a-stream.html) — so you can trade per-shard planning for per-GB billing when traffic is bursty (verify current pricing in your region).
 
-2. **Amazon MSK Serverless eliminates cluster capacity planning entirely**. You create a topic, produce and consume data, and [AWS automatically provisions and scales the underlying infrastructure](https://docs.aws.amazon.com/msk/latest/developerguide/serverless.html). [Pricing is per-partition-hour and per-GB of data](https://aws.amazon.com/msk/pricing/), which can be cost-effective for variable workloads compared with provisioned clusters, depending on usage patterns, retention, and region.
+2. **Amazon MSK Serverless automatically provisions and scales brokers** when you create topics and produce data ([developer guide](https://docs.aws.amazon.com/msk/latest/developerguide/serverless.html)); [pricing](https://aws.amazon.com/msk/pricing/) includes partition-hours and data volume rather than fixed broker sizes.
 
-3. **KRaft replaces ZooKeeper-based metadata management with a controller quorum inside Kafka**. Kafka's 3.x releases progressively moved production deployments toward KRaft and away from ZooKeeper.
+3. **Google Pub/Sub can deliver messages with exactly-once semantics** when subscribers use the feature and compatible client libraries ([exactly-once delivery](https://cloud.google.com/pubsub/docs/exactly-once-delivery)) — still pair with idempotent application writes to external systems.
 
-4. **Schema Registry compatibility checks help catch incompatible schema changes before producers publish data that downstream consumers cannot safely read**. The registry acts as a gatekeeper by rejecting incompatible schemas at registration time.
+4. **Azure Event Hubs exposes a Kafka-compatible endpoint** so many existing Kafka producers and consumers connect with a config change to bootstrap servers ([Kafka overview](https://learn.microsoft.com/en-us/azure/event-hubs/azure-event-hubs-apache-kafka-overview)), while capture archives events to ADLS for cheap replay.
 
 ---
 
@@ -702,10 +1088,10 @@ aws kafka create-cluster \
 | Not using a partition key when ordering matters | Null key gives best throughput | Use customer/order ID as key for ordered event processing |
 | Setting `auto.offset.reset=latest` in production | "We only want new messages" | Use an explicit offset strategy for your use case; `latest` can skip earlier data when no committed offset exists or when partitions are added |
 | Not monitoring consumer lag | "If messages are flowing, everything is fine" | Deploy kafka-exporter and alert on lag > threshold |
-| Skipping schema registry | "We will coordinate schema changes manually" | Manual coordination fails at scale; registry enforces compatibility |
-| Under-replicating topics (replication factor = 1) | Testing configuration leaked to production | [For most production topics, use replication factor >= 3 and `min.insync.replicas >= 2` where the cluster size supports it](https://kafka.apache.org/41/configuration/topic-configs/) |
+| Skipping schema registry or under-replicating topics | Test configs leak to prod (RF=1, no contracts) | Use RF≥3, `min.insync.replicas≥2`, and registry BACKWARD compatibility ([topic configs](https://kafka.apache.org/41/configuration/topic-configs/)) |
 | Running Kafka Streams without persistent state store volumes | Using `emptyDir` for state | State is lost on pod restart, causing full reprocessing; use PVCs for state stores |
 | Not setting producer `acks=all` for critical data | [Default was `acks=1` before Kafka 3.0](https://kafka.apache.org/42/streams/developer-guide/config-streams/) | Always set `acks=all` and `enable.idempotence=true` for data safety |
+| Hot partition from a weak global key | One Kinesis shard or Kafka partition takes most traffic | Use compound keys, salt when order is not required, or split topics by tenant |
 
 ---
 
@@ -747,13 +1133,29 @@ The CPU-based HPA failed because threads blocked on network I/O (waiting for a d
 The `acks=all` setting guarantees that the producer will wait for all *currently in-sync* replicas to acknowledge the write. However, because `min.insync.replicas` was set to 1, the cluster was perfectly willing to accept writes even when only a single broker (broker 1) was alive and in-sync. The producer received a success acknowledgment after writing solely to broker 1. When broker 1's disk failed, that un-replicated data was permanently lost. If `min.insync.replicas` had been configured to 2, the cluster would have proactively rejected the producer's write attempt once brokers 2 and 3 went down. The producer would have received an error instead of a false confirmation, allowing the application to safely retry or alert, thereby preserving data integrity at the cost of temporary unavailability.
 </details>
 
+<details>
+<summary>7. Your data platform publishes clickstream events to Google Pub/Sub with ordering keys set to `session_id`. A GKE Deployment scaled by CPU-based HPA sits at three replicas during normal traffic, but during a marketing campaign Pub/Sub delivery latency spikes while CPU stays at 30%. Analytics dashboards show growing `subscription/oldest_unacked_message_age`. What is failing, and how should Kubernetes scaling change?</summary>
+
+Pub/Sub is delivering faster than the consumers can ack because the pods are blocked on downstream BigQuery inserts or HTTP calls — classic I/O-bound backlog. CPU-based HPA sees healthy utilization and refuses to scale. The oldest-unacked-age metric proves messages are waiting in the subscription, not that the cluster lacks CPU. Replace or supplement HPA with KEDA’s `gcp-pubsub` scaler using a threshold on undelivered messages or oldest age, and ensure `maxReplicaCount` aligns with ordering-key cardinality (ordering limits parallel processing per key). Also verify flow-control settings on the pull subscriber so one pod does not starve others.
+</details>
+
+<details>
+<summary>8. An Azure team migrates on-prem Kafka producers to Event Hubs using the Kafka protocol. They create one partition and set `replicas: 10` on the consumer Deployment expecting 10× throughput. Throughput barely increases and lag remains high. What Kafka rule did they violate, and what should they change first?</summary>
+
+Kafka-style consumer groups assign at most one consumer per partition within a group. With one Event Hubs partition, only one consumer instance can actively read; the other nine pods idle. Throughput is partition-bound, not replica-bound. Increase partition count (or throughput units / PU on Premium) to match desired parallelism, then scale replicas up to that partition count. Also confirm Event Hubs namespace limits and KEDA `azure-eventhub` scaler caps so Kubernetes does not schedule useless pods.
+</details>
+
 ---
 
 ## Hands-On Exercise: Kafka Pipeline with Strimzi
 
+This lab uses Strimzi on a local kind cluster so you can touch partition assignment and lag without an AWS or GCP bill. The mechanics you observe — consumer group rebalancing, per-key ordering, replication — are identical on MSK, Event Hubs (Kafka protocol), and Confluent Cloud; only authentication and bootstrap DNS change when you move the consumers to production EKS/GKE/AKS.
+
 ### Setup
 
 ```bash
+alias k=kubectl
+
 # Create kind cluster with extra resources
 cat > /tmp/kind-kafka.yaml << 'EOF'
 kind: Cluster
@@ -777,21 +1179,36 @@ k wait --for=condition=ready pod -l name=strimzi-cluster-operator \
 
 ### Task 1: Create a Kafka Cluster
 
-Deploy a 3-broker Kafka cluster using Strimzi.
+Deploy a three-broker Kafka cluster using Strimzi so the lab mirrors production replication semantics (`default.replication.factor: 3`, `min.insync.replicas: 2`). Watch the Entity Operator create topic CRDs — that is the same GitOps pattern platform teams use for MSK topic provisioning via Terraform or CloudFormation in AWS accounts linked to EKS.
 
 <details>
 <summary>Solution</summary>
 
 ```yaml
 apiVersion: kafka.strimzi.io/v1beta2
+kind: KafkaNodePool
+metadata:
+  name: dual-role
+  namespace: kafka
+  labels:
+    strimzi.io/cluster: lab-cluster
+spec:
+  replicas: 3
+  roles: [controller, broker]
+  storage:
+    type: ephemeral
+---
+apiVersion: kafka.strimzi.io/v1beta2
 kind: Kafka
 metadata:
   name: lab-cluster
   namespace: kafka
+  annotations:
+    strimzi.io/node-pools: enabled
+    strimzi.io/kraft: enabled
 spec:
   kafka:
-    version: 3.8.0
-    replicas: 3
+    version: 4.0.0
     listeners:
       - name: plain
         port: 9092
@@ -803,21 +1220,6 @@ spec:
       transaction.state.log.min.isr: 2
       default.replication.factor: 3
       min.insync.replicas: 2
-      num.partitions: 6
-    storage:
-      type: ephemeral
-    resources:
-      requests:
-        memory: 1Gi
-        cpu: 500m
-  zookeeper:
-    replicas: 3
-    storage:
-      type: ephemeral
-    resources:
-      requests:
-        memory: 512Mi
-        cpu: 250m
   entityOperator:
     topicOperator: {}
 ```
@@ -831,7 +1233,7 @@ k wait kafka/lab-cluster --for=condition=Ready --timeout=300s -n kafka
 
 ### Task 2: Create a Topic and Produce Messages
 
-Create an `order-events` topic and publish messages.
+Create an `order-events` topic with six partitions and publish keyed messages so you can see how order lifecycle events for the same `order_id` land on one partition. This is the same discipline you use on MSK or Event Hubs when choosing a Kafka-compatible partition key for checkout flows.
 
 <details>
 <summary>Solution</summary>
@@ -856,7 +1258,7 @@ spec:
 k apply -f /tmp/topic.yaml
 
 # Produce messages
-k run kafka-producer --rm -it --image=quay.io/strimzi/kafka:0.44.0-kafka-3.8.0 \
+k run kafka-producer --rm -it --image=quay.io/strimzi/kafka:0.47.0-kafka-4.0.0 \
   -n kafka --restart=Never -- \
   bin/kafka-console-producer.sh \
   --broker-list lab-cluster-kafka-bootstrap:9092 \
@@ -879,7 +1281,7 @@ EOF
 
 ### Task 3: Deploy Consumer Group and Observe Partition Assignment
 
-Create a consumer Deployment with 3 replicas and verify partition distribution.
+Create a consumer Deployment with three replicas and verify that Strimzi’s built-in consumer group describes two partitions per pod — the live illustration of why you never scale consumers past partition count without first expanding the topic.
 
 <details>
 <summary>Solution</summary>
@@ -902,7 +1304,7 @@ spec:
     spec:
       containers:
         - name: consumer
-          image: quay.io/strimzi/kafka:0.44.0-kafka-3.8.0
+          image: quay.io/strimzi/kafka:0.47.0-kafka-4.0.0
           command:
             - /bin/sh
             - -c
@@ -925,7 +1327,7 @@ k apply -f /tmp/consumer-deployment.yaml
 sleep 15
 
 # Check consumer group partition assignments
-k run check-group --rm -it --image=quay.io/strimzi/kafka:0.44.0-kafka-3.8.0 \
+k run check-group --rm -it --image=quay.io/strimzi/kafka:0.47.0-kafka-4.0.0 \
   -n kafka --restart=Never -- \
   bin/kafka-consumer-groups.sh \
   --bootstrap-server lab-cluster-kafka-bootstrap:9092 \
@@ -935,18 +1337,18 @@ k run check-group --rm -it --image=quay.io/strimzi/kafka:0.44.0-kafka-3.8.0 \
 
 ### Task 4: Monitor Consumer Lag
 
-Produce more messages and observe lag building up.
+Produce a burst of one thousand messages and observe lag building in `kafka-consumer-groups.sh --describe`, then relate that metric to the Prometheus rules you would deploy against MSK or in-cluster Kafka exporters in production.
 
 <details>
 <summary>Solution</summary>
 
 ```bash
 # Produce 1000 messages rapidly
-k run bulk-producer --rm -it --image=quay.io/strimzi/kafka:0.44.0-kafka-3.8.0 \
+k run bulk-producer --rm -it --image=quay.io/strimzi/kafka:0.47.0-kafka-4.0.0 \
   -n kafka --restart=Never -- \
   /bin/sh -c '
   for i in $(seq 1 1000); do
-    echo "order-$((i % 100)):$(printf "{\"order_id\":\"%03d\",\"event\":\"created\",\"amount\":%d.%02d}" $i $((RANDOM % 100)) $((RANDOM % 100)))"
+    echo "order-$((i % 100)):$(printf "{\"order_id\":\"%03d\",\"event\":\"created\",\"amount\":%d.%02d}" $i $(( (i * 7) % 100 )) $(( (i * 7) % 100 )))"
   done | bin/kafka-console-producer.sh \
     --broker-list lab-cluster-kafka-bootstrap:9092 \
     --topic order-events \
@@ -956,7 +1358,7 @@ k run bulk-producer --rm -it --image=quay.io/strimzi/kafka:0.44.0-kafka-3.8.0 \
   '
 
 # Check lag
-k run check-lag --rm -it --image=quay.io/strimzi/kafka:0.44.0-kafka-3.8.0 \
+k run check-lag --rm -it --image=quay.io/strimzi/kafka:0.47.0-kafka-4.0.0 \
   -n kafka --restart=Never -- \
   bin/kafka-consumer-groups.sh \
   --bootstrap-server lab-cluster-kafka-bootstrap:9092 \
@@ -966,14 +1368,14 @@ k run check-lag --rm -it --image=quay.io/strimzi/kafka:0.44.0-kafka-3.8.0 \
 
 ### Task 5: Verify Ordering Within Partitions
 
-Confirm that messages with the same key always appear in order.
+Confirm that messages sharing a partition key appear with monotonically increasing offsets on a single partition, which is the ordering guarantee every managed streaming SKU inherits from the log model even when the control plane differs from Apache Kafka.
 
 <details>
 <summary>Solution</summary>
 
 ```bash
 # Consume from a specific partition to verify ordering
-k run partition-check --rm -it --image=quay.io/strimzi/kafka:0.44.0-kafka-3.8.0 \
+k run partition-check --rm -it --image=quay.io/strimzi/kafka:0.47.0-kafka-4.0.0 \
   -n kafka --restart=Never -- \
   bin/kafka-console-consumer.sh \
   --bootstrap-server lab-cluster-kafka-bootstrap:9092 \
@@ -1003,9 +1405,13 @@ k run partition-check --rm -it --image=quay.io/strimzi/kafka:0.44.0-kafka-3.8.0 
 kind delete cluster --name kafka-lab
 ```
 
+After cleanup, reflect on what would change if `lab-cluster` were MSK Serverless instead of Strimzi: authentication would move from plain internal listeners to SASL/IAM, bootstrap DNS would point to AWS, and KEDA would still scale on `kafka_consumergroup_lag` — only the scrape target and broker discovery change. The partition math you practiced is the constant across every managed SKU in this module.
+
 ---
 
-**Next Module**: [Module 9.8: Secrets Management Deep Dive](../module-9.8-secrets-deep/) -- Learn how External Secrets Operator, Secrets Store CSI, and HashiCorp Vault integrate with Kubernetes to manage dynamic secrets, TTLs, and credential rotation at scale.
+## Next Module
+
+[Module 9.8: Secrets Management Deep Dive](../module-9.8-secrets-deep/) — Learn how External Secrets Operator, Secrets Store CSI, and HashiCorp Vault integrate with Kubernetes to manage dynamic secrets, TTLs, and credential rotation at scale.
 
 ## Sources
 
@@ -1013,8 +1419,17 @@ kind delete cluster --name kafka-lab
 - [learn.microsoft.com: azure event hubs apache kafka overview](https://learn.microsoft.com/en-us/azure/event-hubs/azure-event-hubs-apache-kafka-overview) — Microsoft Learn explicitly documents Azure Event Hubs' Kafka endpoint and Kafka-protocol compatibility.
 - [kafka.apache.org: introduction](https://kafka.apache.org/intro) — Apache Kafka's introduction explains that partitions are exclusively assigned within a consumer group and that there cannot be more active consumer instances than partitions.
 - [kafka.apache.org: design](https://kafka.apache.org/41/design/design/) — Kafka's design documentation directly describes transactions, idempotence, and offset updates as the basis for exactly-once processing.
-- [docs.cloud.google.com: overview](https://docs.cloud.google.com/dataflow/docs/overview) — Google Cloud's Dataflow overview directly describes Dataflow as a managed service for unified stream and batch processing.
-- [docs.aws.amazon.com: serverless.html](https://docs.aws.amazon.com/msk/latest/developerguide/serverless.html) — The MSK Serverless developer guide explicitly says the service automatically provisions and scales capacity.
-- [aws.amazon.com: pricing](https://aws.amazon.com/msk/pricing/) — AWS pricing documentation directly lists partition-hour and per-GB pricing dimensions for MSK Serverless.
-- [kafka.apache.org: topic configs](https://kafka.apache.org/41/configuration/topic-configs/) — Apache Kafka topic configuration docs explicitly describe replication factor 3 plus `min.insync.replicas=2` with `acks=all` as a typical stronger-durability scenario.
-- [kafka.apache.org: config streams](https://kafka.apache.org/42/streams/developer-guide/config-streams/) — Kafka's Streams configuration guide explicitly notes that `acks=all` has been the default since the 3.0 release.
+- [cloud.google.com: dataflow overview](https://cloud.google.com/dataflow/docs/overview) — Google Cloud's Dataflow overview describes unified stream and batch processing.
+- [docs.aws.amazon.com: msk serverless](https://docs.aws.amazon.com/msk/latest/developerguide/serverless.html) — MSK Serverless automatically provisions and scales capacity.
+- [aws.amazon.com: msk pricing](https://aws.amazon.com/msk/pricing/) — Partition-hour and per-GB pricing dimensions for MSK Serverless.
+- [kafka.apache.org: topic configs](https://kafka.apache.org/41/configuration/topic-configs/) — Replication factor 3 plus `min.insync.replicas=2` with `acks=all` for stronger durability.
+- [kafka.apache.org: config streams](https://kafka.apache.org/42/streams/developer-guide/config-streams/) — `acks=all` default since Kafka 3.0.
+- [docs.aws.amazon.com: kinesis introduction](https://docs.aws.amazon.com/streams/latest/dev/introduction.html) — Kinesis Data Streams core concepts and shards.
+- [aws.amazon.com: kinesis data streams pricing](https://aws.amazon.com/kinesis/data-streams/pricing/) — Provisioned shard-hour vs on-demand GB pricing.
+- [docs.aws.amazon.com: kinesis capacity modes](https://docs.aws.amazon.com/streams/latest/dev/how-do-i-size-a-stream.html) — On-demand Standard vs Advantage selection.
+- [cloud.google.com: pub/sub overview](https://cloud.google.com/pubsub/docs/overview) — Pub/Sub messaging model and subscriptions.
+- [cloud.google.com: pub/sub exactly-once](https://cloud.google.com/pubsub/docs/exactly-once-delivery) — Exactly-once delivery requirements and scope.
+- [learn.microsoft.com: event hubs about](https://learn.microsoft.com/en-us/azure/event-hubs/event-hubs-about) — Event Hubs partitions and throughput units.
+- [learn.microsoft.com: stream analytics introduction](https://learn.microsoft.com/en-us/azure/stream-analytics/stream-analytics-introduction) — Stream Analytics job model.
+- [keda.sh: apache kafka scaler](https://keda.sh/docs/latest/scalers/apache-kafka/) — KEDA Kafka lag-based scaling.
+- [keda.sh: aws kinesis streams scaler](https://keda.sh/docs/latest/scalers/aws-kinesis-streams/) — KEDA Kinesis iterator age scaling.

--- a/src/content/docs/cloud/managed-services/module-9.8-secrets-deep.md
+++ b/src/content/docs/cloud/managed-services/module-9.8-secrets-deep.md
@@ -8,7 +8,7 @@ sidebar:
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+After completing this module, you will be able to make defensible design choices about secret storage, delivery, rotation, and Kubernetes integration:
 
 - **Implement External Secrets Operator to synchronize cloud secrets (AWS Secrets Manager, GCP Secret Manager, Azure Key Vault) into Kubernetes**
 - **Configure automatic secret rotation workflows that update Kubernetes secrets without pod restarts**
@@ -19,11 +19,27 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-In December 2023, a developer at a healthcare company committed a `.env` file containing an AWS access key to a public GitHub repository. An automated scanner (one of thousands operated by attackers) detected the key within 11 minutes. By the 14-minute mark, the attacker had used the key to enumerate S3 buckets, finding one containing patient records. By minute 22, they had exfiltrated 340,000 patient records. The breach cost the company $4.8 million in HIPAA fines, $1.2 million in incident response, and immeasurable reputation damage.
+Hypothetical scenario: a payments team ships a weekend hotfix and accidentally commits a `.env` file that contains a cloud access key, a database password, and a webhook signing secret. The repository is private, but the key is copied into a build log, a contractor's laptop has a stale clone, and an application container still exposes the password as an environment variable after the Git mistake is removed. The incident is no longer one secret in one file; it is a lifecycle failure across generation, storage, distribution, rotation, audit, and revocation.
 
-The root cause was not the developer's carelessness. It was an architecture that allowed long-lived, static credentials to exist in the first place. The access key had been active for 19 months. No one had rotated it. No one monitored its usage pattern. The secret was stored in a Kubernetes Secret (base64-encoded -- not encrypted) and also in a `.env` file on the developer's laptop.
+The root cause is not just developer carelessness. It is an architecture that lets long-lived static credentials exist in many places at once: source control, CI variables, local laptops, container images, Kubernetes Secret objects, application logs, and cloud consoles. A secret that is easy to copy is hard to revoke completely, because every consumer must be found, every cache must be refreshed, every dependent pod must reload, and every audit trail must prove that the old value stopped being used.
 
-Modern secrets management eliminates this entire class of vulnerability. Dynamic secrets have short TTLs and are generated on demand. External secret operators sync secrets from vaults without human access to plaintext. Sealed Secrets encrypt values so they are safe to commit to Git. This module teaches you the full spectrum of Kubernetes secrets management, from External Secrets Operator to Secrets Store CSI Driver to HashiCorp Vault, with honest comparisons so you can choose the right approach for your environment.
+Modern secrets management does not mean "put the password in a nicer box." It means designing a system where humans rarely see plaintext, workloads authenticate with short-lived identity instead of stored cloud keys, rotation is routine rather than heroic, and access can be audited after the fact. This module teaches the full Kubernetes integration path across AWS Secrets Manager, AWS Systems Manager Parameter Store, Google Secret Manager, Azure Key Vault, External Secrets Operator, Secrets Store CSI Driver, and HashiCorp Vault so you can defend the design in a real platform review.
+
+---
+
+## The Secret Lifecycle
+
+Secrets management is easiest to reason about as a lifecycle: generation, storage, distribution, rotation, audit, and revocation. Generation decides whether the secret is a random value, a database credential, a TLS private key, a cloud token, or a dynamic lease minted for one workload. Storage decides whether that value lives in AWS Secrets Manager, AWS Systems Manager Parameter Store, Google Secret Manager, Azure Key Vault, Vault, Kubernetes etcd, or Git as encrypted ciphertext. Distribution decides how the application sees the value: an environment variable, a mounted file, a native SDK call, or a dynamic credential broker.
+
+Rotation is where many otherwise polished designs fail. Changing the value in a cloud secret store is only the first step; the new value must reach Kubernetes, the application process must reload it, and the old credential must remain valid long enough for a safe transition or be revoked quickly enough to limit exposure. Audit answers a different question: not "is the secret encrypted," but "who or what accessed it, from where, under which identity, and was that access expected." Revocation closes the loop by disabling old versions, deleting temporary database users, removing unused IAM permissions, and proving that stale consumers are gone.
+
+The dangerous shortcut is to treat the secret object as the lifecycle. A Kubernetes Secret can store a password, and a cloud secret manager can store a password, but neither automatically gives you safe generation, distribution, rotation, audit, and revocation. AWS Secrets Manager gives you native rotation workflows for many secret types through Lambda-backed rotation or managed rotation, but your pods still need a reload path. Google Secret Manager gives strong versioning semantics and IAM-based access, but an application pinned to an old version will not magically move to a new alias unless you design for that. Azure Key Vault stores secrets, keys, and certificates with recoverability controls such as soft-delete, but a workload still needs Microsoft Entra-based access and a rotation propagation model.
+
+The Kubernetes angle is that cluster objects are excellent orchestration metadata and poor long-term secret repositories. GitOps wants declarative manifests, but plaintext secrets do not belong in Git. Pods want fast local access, but long-lived environment variables are copied into the process environment at start time and are awkward to rotate without restart. Operators want consistent workflows across EKS, GKE, and AKS, but each cloud has a different identity system, audit log surface, quota model, and pricing model. The practical answer is usually a layered design: cloud or Vault as the source of truth, workload identity for keyless access, ESO or CSI for Kubernetes delivery, and application reload mechanics for rotation.
+
+> **The Secrets Management Analogy**
+>
+> Think of a secret like a master key in a large building. Locking the key in a cabinet is storage; deciding who can open the cabinet is access control; replacing the lock on a schedule is rotation; checking the sign-out sheet is audit; and changing the doors so the old key stops working is revocation. A mature platform does all five, because a beautiful cabinet does not help if every contractor has a photocopy.
 
 ---
 
@@ -42,12 +58,15 @@ data:
   password: cDRzc3cwcmQ=    # base64("p4ssw0rd")
 ```
 
-Kubernetes Secrets are base64-encoded, **not encrypted**. Anyone with `kubectl get secret` access can decode them instantly:
+Kubernetes Secrets are base64-encoded, **not encrypted**, so the following example shows why encoded manifest data should never be treated as protected ciphertext:
 
 ```bash
+alias k=kubectl
 k get secret db-credentials -o jsonpath='{.data.password}' | base64 -d
 # Output: p4ssw0rd
 ```
+
+The base64 encoding exists because Kubernetes API objects are structured data and some secret values are binary. It is not a security boundary, and Kubernetes documentation explicitly warns that encoded values are only obscured. The more important default is that Secret objects are stored in the API server's backing data store, etcd, and they are unencrypted there unless the control plane is configured with encryption at rest. Anyone with direct etcd access, broad API permissions, or the ability to create pods that mount secrets in a namespace can potentially recover values.
 
 ### What Kubernetes Does and Does Not Provide
 
@@ -60,11 +79,41 @@ k get secret db-credentials -o jsonpath='{.data.password}' | base64 -d
 | Dynamic secrets | Not supported | Short-lived, auto-expiring credentials |
 | Git safety | Plaintext in manifests | Encrypted at rest in Git |
 
+This table should not make you dismiss Kubernetes Secrets entirely. They are still the native interface many workloads, Helm charts, and controllers expect, and the kubelet can project them into a pod as files with filesystem update semantics. The problem is treating a Kubernetes Secret as the source of truth. A safer model treats it as a local delivery artifact that can be recreated from an external source, restricted by namespace RBAC, protected by etcd encryption, and monitored through Kubernetes audit logs.
+
+The RBAC implication is subtle and important. Granting `get` on a Secret lets the subject retrieve a specific value; granting `list` or `watch` on secrets can expose every value in that scope because the API response includes secret data. Granting a developer permission to create arbitrary pods in a namespace can also be equivalent to granting indirect secret read access, because that pod can mount any Secret allowed in the namespace and print it. Production clusters therefore split duties: application teams can deploy workloads, but only platform-owned controllers and tightly scoped service accounts can read broad secret sets.
+
+Etcd encryption at rest is necessary but not sufficient. Kubernetes supports an `EncryptionConfiguration`, including KMS provider options, so the API server stores encrypted secret data instead of plaintext in etcd. That protects against a class of datastore compromise, but it does not protect against an authorized API read, an overbroad service account, a pod that echoes secrets to logs, or an application that loads secrets into environment variables forever. For Kubernetes 1.35 curriculum work, treat KMS-backed encryption, least-privilege RBAC, namespace isolation, audit logging, and external stores as the minimum baseline rather than optional hardening.
+
+Plain environment variables deserve special scrutiny. They are convenient, widely supported, and often required by legacy applications, but they are captured when the process starts and do not update just because the Kubernetes Secret changes. They can also appear in crash diagnostics, process inspection tools, or overly verbose debug output. Mounted files are usually easier to rotate because the application can watch a path, reopen the file, or reload configuration on a signal, but even file mounts require deliberate application behavior. Secrets management is therefore an application design topic, not just a cluster administration topic.
+
+---
+
+## Managed Secret Stores Across AWS, GCP, and Azure
+
+The three major clouds all provide managed secret stores, but they are not interchangeable in the details that matter during incidents. AWS Secrets Manager is designed for application secrets that need versioning, IAM policy control, CloudTrail audit events, KMS-backed envelope encryption, and rotation workflows. AWS Systems Manager Parameter Store can also hold encrypted `SecureString` parameters, and its standard tier has no additional charge, but it is a configuration and parameter service first. Use Parameter Store for low-change configuration values and simple encrypted parameters; use Secrets Manager when rotation workflow, secret lifecycle metadata, or application-secret semantics are central to the design.
+
+AWS Secrets Manager protects secret values with envelope encryption through AWS KMS. That distinction matters because the KMS key protects data keys, while Secrets Manager stores and serves the secret value through its own API. Automatic rotation commonly uses a Lambda function that performs staged steps such as creating a pending value, applying it to the backing service, testing it, and marking it current. The managed-service benefit is strong, but it introduces a dependency chain: the rotation Lambda needs network access to the database or service, permissions to update the target, and enough observability to troubleshoot failed rotation windows.
+
+Google Secret Manager models a secret as metadata plus one or more versions, and each version stores the actual payload. That version model is useful during rollback because workloads can reference a specific version, use aliases, or consume the latest enabled version depending on the operational pattern. Google encrypts secrets in transit and at rest by default and supports customer-managed encryption keys through Cloud KMS for teams with stronger key-control requirements. For GKE, Workload Identity Federation lets Kubernetes service accounts call Google Cloud APIs without long-lived service account key files, which is the keyless path you want for ESO controllers or applications that call Secret Manager directly.
+
+Azure Key Vault is broader than a password store. It manages secrets, cryptographic keys, and certificates, and it integrates with Microsoft Entra ID for authentication plus Azure RBAC or access policies for authorization. Soft-delete and purge protection are operationally important because accidental deletion of a vault, key, certificate, or secret should be recoverable instead of instantly permanent. For AKS, Microsoft Entra Workload ID uses projected service account tokens and OIDC federation so pods can access Azure resources such as Key Vault without embedding a client secret in the cluster.
+
+The encryption backing is conceptually similar across clouds even though the products differ. AWS Secrets Manager uses AWS KMS keys and envelope encryption; Google Secret Manager encrypts at rest by default and can use Cloud KMS customer-managed encryption keys; Azure Key Vault stores vault data encrypted at rest using keys protected by HSM-backed systems. In all three clouds, customer-managed keys improve control and separation of duties, but they also add failure modes. If a KMS key is disabled, access policy is broken, or a region-specific key is unavailable, the secret store can become unreachable even though the secret itself still exists.
+
+Cost at moderate scale is usually dominated by three knobs: number of stored objects or active versions, request volume, and optional premium features. AWS Secrets Manager charges per secret per month and per API calls, so a controller that polls thousands of secrets every few seconds can turn a simple platform pattern into measurable spend. Parameter Store standard parameters avoid additional storage charges within documented limits, while advanced parameters and higher-throughput usage add charges. Google Secret Manager bills active secret versions per location and access operations, so version sprawl and user-managed multi-location replication affect cost. Azure Key Vault pricing is operations-oriented for secrets and has separate considerations for keys, certificates, Premium tier, and Managed HSM usage.
+
+At platform scale, the cost lens changes design choices. A direct SDK call from every pod on every request is a poor pattern because it increases latency, quota pressure, and billable secret access operations. A short ESO refresh interval across many namespaces may feel safer, but it can create unnecessary API traffic when secrets rotate monthly or quarterly. A better design caches within the application or syncs through an operator at a reasonable interval, then uses explicit rollout triggers for urgent rotation. The target is not the lowest possible bill; it is a controlled bill where spending tracks risk reduction instead of accidental polling.
+
 ---
 
 ## External Secrets Operator (ESO): The Standard Approach
 
 ESO is the most widely adopted solution for syncing secrets from cloud secret managers into Kubernetes Secrets. It runs as an operator in your cluster and periodically fetches secrets from external sources.
+
+ESO fits GitOps because the manifest in Git describes *where* to fetch a secret and *how* to shape it, without storing the plaintext value. The source of truth stays in AWS Secrets Manager, Parameter Store, Google Secret Manager, Azure Key Vault, Vault, or another supported backend. The operator reconciles an `ExternalSecret` into a native Kubernetes Secret, which means existing Deployments, Helm charts, Ingress controllers, and applications can keep using familiar `secretKeyRef` and volume mounts. That compatibility is the reason ESO is the default answer for many platform teams.
+
+The tradeoff is that ESO deliberately creates a Kubernetes Secret. That means the synced value lands in etcd, is governed by Kubernetes RBAC, and is visible to anyone who can read that Secret in the namespace. This is acceptable when etcd encryption, namespace isolation, and RBAC are correctly configured; it is not acceptable when a compliance requirement says the secret must never be persisted in the cluster datastore. ESO is a synchronization pattern, not a magic bypass around Kubernetes secret exposure.
 
 ### Architecture
 
@@ -78,6 +127,8 @@ graph TD
 
 > **Pause and predict**: Given this architecture, what's a critical operational consideration for ESO concerning network connectivity and permissions? How would you secure the communication path between ESO and your cloud secret manager?
 
+The critical consideration is that ESO becomes a privileged bridge between Kubernetes and the external store. If it cannot reach the provider endpoint, rotations stop propagating. If its identity is too broad, a compromise of the ESO controller can read secrets for many applications. Production designs therefore use private endpoints where practical, network policies around the controller namespace, provider-side IAM scoped to exact secret paths, and separate `SecretStore` resources for teams that should not share blast radius.
+
 ### Installing ESO
 
 ```bash
@@ -90,6 +141,8 @@ helm install external-secrets external-secrets/external-secrets \
 ### ClusterSecretStore Configuration
 
 A ClusterSecretStore defines how ESO authenticates with the external secret provider. It is cluster-scoped, meaning any namespace can use it.
+
+Cluster-scoped stores are convenient for a central platform team, but they should not become a universal skeleton key. A `ClusterSecretStore` can be referenced across namespaces, so its provider credentials and access policy must be intentionally narrow or paired with admission policy that restricts who can reference it. A namespaced `SecretStore` is often better for tenant-owned applications because it keeps provider access, Kubernetes RBAC, and namespace ownership aligned. The decision is less about syntax and more about who owns the risk when a namespace is compromised.
 
 ```yaml
 # AWS Secrets Manager with IRSA
@@ -140,6 +193,10 @@ spec:
         namespace: external-secrets
 ```
 
+The provider authentication examples show the keyless direction. On EKS, IRSA and EKS Pod Identity map a Kubernetes service account to AWS IAM permissions so the ESO controller can call Secrets Manager without a static access key stored in Kubernetes. On GKE, Workload Identity Federation maps Kubernetes service accounts into Google IAM principals or service-account impersonation flows. On AKS, Microsoft Entra Workload ID uses service account token projection and OIDC federation to let the controller call Key Vault. The shared principle is that the cluster holds a projected workload identity token, not a long-lived cloud credential.
+
+This identity layer is also the right place to enforce separation between environments. A production ESO service account should not be able to read development secrets, and a development namespace should not be able to reference the production `ClusterSecretStore`. In AWS, that means IAM resource constraints and secret naming discipline. In GCP, that means IAM roles on specific Secret Manager resources or projects. In Azure, that means Key Vault access scoped through Azure RBAC or access policies. Kubernetes RBAC then limits which teams can create or modify `ExternalSecret` objects that reference those stores.
+
 ### ExternalSecret: Syncing Individual Secrets
 
 ```yaml
@@ -178,9 +235,11 @@ spec:
 
 > **Stop and think**: You have an existing application expecting secrets in a specific format, e.g., a single `config.json` file. How would you use ESO to fetch multiple individual secrets from AWS Secrets Manager and combine them into this single `config.json` within a Kubernetes Secret?
 
+The `refreshInterval` is a design decision, not boilerplate. ESO's periodic refresh means the operator updates the target Kubernetes Secret when the external value changes and the next reconciliation observes it. A five-minute interval is reasonable for many applications because most rotations are planned, but it is still a polling loop against a paid and quota-limited provider API. For emergency rotation, pair a sane interval with a manual refresh annotation, a rollout trigger, or an application reload controller rather than setting every `ExternalSecret` to an aggressive interval.
+
 ### ExternalSecret: Templating
 
-ESO can transform secret data using Go templates:
+ESO can transform secret data using Go templates, which is useful when the external store and the consuming application use different shapes:
 
 ```yaml
 apiVersion: external-secrets.io/v1
@@ -218,11 +277,17 @@ spec:
         property: dbname
 ```
 
+Templating is valuable because application configuration rarely matches provider storage exactly. A team may store username, password, host, port, and database name as separate JSON properties in AWS Secrets Manager, separate versions in Google Secret Manager, or separate Key Vault secrets in Azure. ESO can shape those inputs into a connection string, a `.dockerconfigjson`, or an application-specific config file. The risk is that templates can hide coupling; if a downstream app expects one generated string, every rotated field must remain compatible with that string format.
+
+For multi-cloud platforms, normalize conventions before you normalize tools. Decide whether secret paths include environment, application, region, and purpose; decide whether JSON objects are allowed or whether each key is a separate secret; decide who owns labels and tags; and decide how stale versions are disabled. ESO can talk to all three clouds, but it cannot make inconsistent naming and ownership models safe. The cleanest clusters usually have boring conventions such as `/prod/payments/api/database`, `projects/prod/secrets/payments-api-db`, or `https://platform-prod.vault.azure.net/secrets/payments-api-db`, mapped into a predictable Kubernetes Secret name.
+
 ---
 
 ## Secrets Store CSI Driver
 
 The Secrets Store CSI Driver mounts secrets directly from a vault as files in a pod, bypassing Kubernetes Secrets entirely. The secret exists only in the pod's filesystem and the vault -- in the standard CSI-only pattern, it does not land in etcd.
+
+CSI is the right mental model when the pod needs a file, not a Kubernetes API object. On Linux, the driver mounts secret content through an in-memory filesystem path and provider plugins retrieve values from AWS, Azure, GCP, Vault, or another supported backend. The pod references a `SecretProviderClass`, and the driver fetches the configured objects when the pod starts. If you enable sync as Kubernetes Secret, you regain compatibility with `secretKeyRef`, but you also reintroduce etcd persistence and the RBAC exposure that CSI-only designs were trying to avoid.
 
 ### Architecture Difference from ESO
 
@@ -234,6 +299,8 @@ graph TD
 ```
 
 > **Pause and predict**: If a secret never lands in etcd when using the CSI Driver, what are the primary security advantages and potential operational challenges compared to ESO? Consider auditability and secret rotation.
+
+The security advantage is smaller blast radius in the Kubernetes API. An attacker with `get secrets` permission cannot read a CSI-only value because there is no native Secret object to fetch. The operational challenge is that every pod mount becomes a provider access path, every node needs the driver and provider components healthy, and applications must read files rather than environment variables if you want rotation without restart. CSI reduces one exposure path, but it increases dependence on node-level plumbing and application reload behavior.
 
 ### Installing the CSI Driver
 
@@ -324,11 +391,31 @@ spec:
 
 **For most teams, ESO is the better choice.** It is simpler, more flexible, and works well with GitOps. Use Secrets Store CSI when your security requirements prohibit secrets from existing in etcd at all.
 
+That recommendation assumes the application can tolerate a Kubernetes Secret existing as a local delivery object. If the workload is an Ingress controller that needs TLS certificates, a database client that can read credentials from files, or a security-sensitive service in a regulated namespace, CSI may be a better fit. If the workload is a common Helm chart that expects `secretKeyRef`, an application that needs templated configuration, or a platform with many teams and GitOps workflows, ESO is usually easier to operate consistently. The best platform often supports both, with clear policy for when each is allowed.
+
+---
+
+## Rotation Propagation and Application Reloads
+
+Rotation has three separate clocks. The first clock is the cloud or Vault source of truth: AWS Secrets Manager may execute a Lambda-backed rotation schedule, Google Secret Manager may create a new enabled version and publish rotation notifications, Azure Key Vault may store a new secret version or renew a certificate, and Vault may issue a new dynamic lease. The second clock is Kubernetes delivery: ESO reconciles according to refresh policy and interval, while Secrets Store CSI can periodically republish mounted contents when rotation is enabled. The third clock is the application: a process might read a file on every request, cache credentials in a connection pool, or read an environment variable once at startup.
+
+Most rotation outages happen because teams update the first clock and forget the third. A rotated database password in AWS Secrets Manager does not update existing PostgreSQL connections. A new Google Secret Manager version does not make a Java process rebuild its connection pool. A Key Vault certificate renewal does not guarantee an Ingress controller has reloaded the file. A Vault dynamic credential may expire on schedule while the application still tries to reuse an old connection. The correct design includes a reload mechanism, not just a rotation mechanism.
+
+For ESO, propagation starts when the operator notices a changed remote value and updates the Kubernetes Secret. If the consuming pod mounts that Secret as a volume, Kubernetes updates the projected volume contents after the kubelet observes the change, and the application can watch the file path. If the consuming pod reads the Secret as environment variables, the process will not see the new value until the pod restarts. Teams commonly add a controller such as a reloader to trigger rolling restarts when selected Secrets change, but that should be a conscious availability decision because every rotation becomes a deployment event.
+
+For Secrets Store CSI Driver, mounted content can be updated when automatic rotation is enabled and the provider supports it. The driver documentation distinguishes file mounts, synced Kubernetes Secrets, and environment-variable consumption. File-reading applications still need to watch the mounted file or reload periodically. Environment-variable consumers still need restart even if CSI syncs a Kubernetes Secret. This is why CSI does not automatically solve the legacy-app problem; it gives you a better delivery path if the app can consume files or if you can wrap the app with a reloadable entrypoint.
+
+For Vault dynamic secrets, the lifecycle is lease-based rather than version-based. Vault can generate a unique database username and password for a role, attach a TTL, renew the lease, and revoke the credential when the lease expires or is explicitly revoked. That gives excellent blast-radius reduction, but it also means applications must renew leases or request new credentials before expiration. A short TTL is not automatically safer if the application cannot refresh connections gracefully; it can become an availability risk that looks like random database authentication failure.
+
+The pattern that works across AWS, GCP, Azure, and Vault is two-phase rotation. First, publish the new credential while the old one still works, then update or restart consumers in controlled waves, then revoke the old credential after telemetry shows the new one is in use. Some managed databases and rotation templates support alternating-user rotation so the old and new database users overlap safely. Where that is not available, you need a maintenance window, connection draining, or application code that can retry with refreshed credentials. Secret rotation is reliability engineering wearing a security badge.
+
 ---
 
 ## Dynamic Secrets with HashiCorp Vault
 
 Dynamic secrets are generated on-demand and automatically expire. Instead of a static database password that lives forever, Vault creates a temporary database user with a 1-hour TTL every time a pod requests credentials.
+
+Vault is different from the cloud-native managers because it can be both a secret store and a credential broker. A static secret store gives you a value that already exists; a dynamic secrets engine creates a value at request time, records a lease, and cleans it up later. For database credentials, that means Vault can create a real database user with role-specific privileges, return the username and password to the workload, and revoke the user when the lease expires. This is powerful because audit trails can map suspicious database activity to a specific lease and workload instead of one shared application password.
 
 ### Dynamic Secret Lifecycle
 
@@ -421,23 +508,33 @@ spec:
 
 > **Stop and think**: You need to provide different database credentials (read-only vs. read-write) to two different containers within the *same* pod based on their function. How would you modify the Vault Agent annotations and container configuration to achieve this isolation?
 
+### Cloud KMS Auto-Unseal for Vault HA
+
+A production Vault cluster should not depend on operators manually entering Shamir key shares every time a pod restarts, a node drains, or an HA standby takes over. Configure an auto-unseal `seal` stanza such as `seal "awskms"`, `seal "gcpckms"`, or `seal "azurekeyvault"` so Vault can ask the cloud KMS or Key Vault service to decrypt its root key material during startup. This keeps the unseal authority outside Vault storage while removing a human from the recovery path; in Kubernetes, the Vault server pod's workload identity must be authorized to call the KMS key with narrowly scoped permissions, or the pod may be healthy while Vault remains sealed.
+
+### Vault Secrets Operator for Native Secret Sync
+
+Vault Secrets Operator is the CRD-based Vault integration pattern for applications that expect native Kubernetes Secrets. Platform teams define connection and authentication resources such as `VaultConnection` and `VaultAuth`; application teams then use `VaultStaticSecret` for KV paths or `VaultDynamicSecret` for generated credentials, and the VSO controller syncs the result into a Kubernetes Secret. Contrast that with the Vault Agent Sidecar pattern above: the sidecar injects rendered files into the pod filesystem, while VSO syncs Vault data into a native Secret that existing `secretKeyRef`, volume, and Helm chart workflows can consume.
+
 ### Vault vs Cloud Secret Managers
 
 | Feature | HashiCorp Vault | AWS Secrets Manager | GCP Secret Manager | Azure Key Vault |
 |---------|----------------|--------------------|--------------------|-----------------|
-| Dynamic secrets | Yes (database, AWS, PKI) | No (static only) | No | No |
-| Secret rotation | Built-in (TTL + revocation) | Lambda-based rotation | Rotation with Cloud Functions | Auto-rotation (certificates) |
+| Dynamic secrets | Yes (database, AWS, PKI) | No dynamic leases; static secret values | No | No |
+| Secret rotation | Built-in (TTL + revocation) | Lambda-backed or managed rotation on a configurable schedule | Rotation with Cloud Functions | Auto-rotation (certificates) |
 | PKI/certificates | Yes (built-in CA) | Via ACM (separate service) | Via CAS | Via Key Vault certificates |
 | Multi-cloud | Yes | AWS only | GCP only | Azure only |
 | Self-hosted | Yes (or HCP Vault) | N/A (managed) | N/A (managed) | N/A (managed) |
 | Complexity | High (operate Vault cluster) | Low | Low | Medium |
-| Cost | Free (OSS) or ~$0.03/secret/month (HCP) | $0.40/secret/month | $0.06/secret version | $0.03/operation |
+| Pricing model | OSS or managed Vault subscription plus operations | Per stored secret and API calls | Per active version/location and access operations | Per operations, plus key/certificate/HSM dimensions |
 
-**Recommendation**:
+**Recommendation**: choose the simplest managed store that satisfies your lifecycle requirements, but move to Vault when dynamic credentials or cross-cloud control outweigh operational complexity.
 - Single cloud, simple needs: Use the cloud-native secret manager with ESO
 - Multi-cloud or dynamic secrets needed: Use Vault
 - Small team, few secrets: Cloud-native is easiest
 - Enterprise with strict compliance: Vault gives the most control
+
+Cloud-native secret managers usually win on operational simplicity because the provider runs the control plane, integrates with IAM, and exposes audit events in the same cloud account. Vault wins when the requirement is dynamic credentials, consistent multi-cloud policy, private PKI, or an abstraction layer that does not privilege one hyperscaler. The cost tradeoff is not just subscription or per-secret charges; it includes the human cost of operating Vault HA, unseal strategy, backup, disaster recovery, policy authoring, and plugin lifecycle. A self-hosted Vault outage can become an application outage if workloads depend on dynamic credentials and cannot renew leases.
 
 ---
 
@@ -582,17 +679,97 @@ graph TD
 | Runtime mount | Secrets Store CSI | Mount directly, bypassing etcd |
 | Rotation trigger | Reloader | Restart pods when secrets change |
 
+The complete architecture is intentionally layered because each layer handles a different failure mode. Git encryption tools protect repository workflows but do not rotate live application credentials. ESO gives existing Kubernetes-native workloads a familiar Secret object but does not prevent etcd exposure if the cluster is misconfigured. CSI avoids native Secret persistence in the CSI-only path but requires file-based consumption and node driver health. Vault dynamic secrets reduce credential lifetime but add lease-management complexity. Cloud secret managers centralize storage and audit, but they do not automatically teach applications how to reload.
+
+In a multi-cloud platform, the portable part is the control pattern, not the provider API. EKS workloads should use IRSA or EKS Pod Identity to avoid AWS access keys. GKE workloads should use Workload Identity Federation rather than service account key files. AKS workloads should use Microsoft Entra Workload ID instead of client secrets stored in Kubernetes. ESO and CSI then become delivery mechanisms that use those identities. KEDA scalers, database operators, Ingress controllers, and application Deployments should consume secrets through the same governed path instead of each team inventing a separate credential mount.
+
+The audit design should be explicit. Kubernetes audit logs should show who changed `ExternalSecret`, `SecretStore`, `ClusterSecretStore`, `SecretProviderClass`, and native Secret objects. Cloud audit logs should show which workload identity read which secret, and whether access came from the expected cluster identity. Vault audit devices should record lease issuance and revocation without exposing plaintext. Alerting should focus on abnormal access patterns: secrets read from a new namespace, a sudden increase in `GetSecretValue` calls, Key Vault operations from an unexpected identity, or Secret Manager access outside the deployment window.
+
+Cost and reliability are also part of the architecture. Use provider API calls to fetch or sync secrets at boundaries, not inside high-volume request paths. Keep ESO refresh intervals reasonable, use labels or annotations to trigger urgent syncs, and avoid one global `ClusterSecretStore` that every namespace can reference. Keep versions under control by destroying or disabling old GCP versions when rollback windows close, deleting unused AWS secrets rather than storing zombie values forever, and cleaning up Key Vault objects after retention and compliance rules allow. A secrets platform that nobody can afford to operate will eventually be bypassed.
+
+---
+
+## Patterns & Anti-Patterns
+
+### Proven Patterns
+
+**Pattern 1: external store as source of truth, Kubernetes as delivery plane.** Store canonical values in AWS Secrets Manager, Parameter Store, Google Secret Manager, Azure Key Vault, or Vault, then use ESO or CSI to deliver them to workloads. This scales because platform teams can centralize IAM, audit, rotation, and retention while application teams keep declarative manifests in Git. It works best when secret names, labels, paths, and ownership rules are standardized before hundreds of teams create their own conventions.
+
+**Pattern 2: keyless controller access through workload identity.** Run ESO, CSI providers, and applications under Kubernetes service accounts mapped to cloud identities rather than storing static cloud credentials in Kubernetes. On EKS, choose IRSA or EKS Pod Identity according to the cluster and organizational model. On GKE, use Workload Identity Federation. On AKS, use Microsoft Entra Workload ID. This pattern scales because credential issuance becomes short-lived and auditable, and the compromise of one namespace does not automatically expose a reusable cloud access key.
+
+**Pattern 3: rotation with reload choreography.** Treat every rotation as a rollout workflow that includes source update, Kubernetes propagation, application reload, telemetry confirmation, and old-secret revocation. ESO refresh or CSI rotation handles only the middle of that chain. Mature teams write runbooks that say whether an app watches files, restarts on Secret changes, refreshes SDK clients, drains database pools, or uses Vault lease renewal. This pattern scales because emergency rotation becomes a rehearsed operational motion instead of a Slack scramble.
+
+**Pattern 4: namespace-scoped blast-radius boundaries.** Use separate cloud secret paths, Key Vaults, IAM policies, `SecretStore` resources, and Kubernetes service accounts for environments and tenants that should not share risk. A production payments namespace should not reference the same store identity as a development analytics namespace. At small scale this feels repetitive, but it pays back when one service account is misconfigured or one namespace is compromised. The blast radius is bounded by design rather than by hope.
+
+**Pattern 5: file mounts for high-sensitivity values.** Prefer mounted secret files for applications that can reload configuration, especially when credentials are rotated regularly or when policy forbids environment-variable exposure. Files can be watched, reopened, and replaced without embedding values in process environment state. CSI-only mounts can also avoid native Kubernetes Secret persistence. This pattern scales when application frameworks agree on predictable file paths and reload signals.
+
+### Anti-Patterns
+
+**Anti-pattern 1: secrets in environment variables forever.** Teams fall into this because environment variables are easy, Twelve-Factor-style examples are everywhere, and many legacy applications only support them. The failure mode is stale values: a rotated Kubernetes Secret does not update a running process environment, so the application keeps using the old password until restart. The better alternative is file-based consumption with reload, native SDK retrieval with caching, or a controlled reloader that restarts pods when selected Secrets change.
+
+**Anti-pattern 2: one giant shared secret.** A team stores every credential for an application in one JSON blob because it is convenient to fetch and template. The failure mode is excessive blast radius: rotating one field forces every consumer to reload, access to one key implies access to all keys, and audit logs cannot easily distinguish which credential was needed. The better alternative is to group only values with the same owner, rotation cadence, and access policy, then template them at the edge when the application truly needs a combined file.
+
+**Anti-pattern 3: static cloud credentials for operators.** A platform team creates an AWS access key, GCP service account key, or Azure client secret and stores it in a Kubernetes Secret so ESO or a CSI provider can authenticate. This feels simple during a proof of concept, but it creates a high-value static credential inside the very cluster the tool is meant to protect. The better alternative is workload identity: IRSA or EKS Pod Identity, GKE Workload Identity Federation, and Microsoft Entra Workload ID.
+
+**Anti-pattern 4: no etcd encryption because secrets are external.** Teams assume ESO means "secrets live outside the cluster" and forget that ESO creates native Kubernetes Secrets by design. The failure mode is plaintext or weakly protected secret data in etcd, plus broad RBAC that lets too many subjects read those values. The better alternative is to enable KMS-backed encryption at rest, restrict `get`, `list`, and `watch` on Secrets, and use CSI-only mounts where policy forbids etcd persistence.
+
+**Anti-pattern 5: aggressive polling as a substitute for rotation design.** A team sets ESO refresh intervals to 15 or 30 seconds because faster feels safer. The failure mode is provider API cost, quota pressure, noisy reconciliation, and no guarantee that the application process actually reloads. The better alternative is a moderate refresh interval, explicit manual refresh for urgent changes, and application-level reload or restart automation.
+
+**Anti-pattern 6: Git encryption as the whole secrets platform.** SOPS and Sealed Secrets protect manifests at rest in Git, but they do not provide cloud audit logs, dynamic leases, provider-side rotation, or runtime access decisions. Teams fall into this pattern because encrypted YAML is easy to add to an existing GitOps repository. The better alternative is to use Git encryption for bootstrap or narrow exceptions, then move long-lived application secrets into managed stores or Vault with ESO/CSI delivery.
+
+---
+
+## Decision Framework
+
+Use this matrix when choosing the source of truth and the Kubernetes delivery path. The most common mistake is asking "which tool is best" without separating storage, identity, delivery, and reload. A team can choose AWS Secrets Manager as the source, EKS Pod Identity as authentication, ESO as delivery, and a reloader as propagation; another can choose Azure Key Vault, Entra Workload ID, CSI file mounts, and application file watches. The right answer is a composition.
+
+| Decision | Prefer This | When It Fits | Tradeoff |
+|----------|-------------|--------------|----------|
+| AWS static application secret with rotation | AWS Secrets Manager | You need rotation workflow, CloudTrail audit, KMS-backed encryption, and application-secret metadata | Higher per-secret/API cost than simple parameters |
+| AWS simple encrypted parameter | SSM Parameter Store `SecureString` | You need low-change config or simple secrets and can accept Parameter Store semantics | Standard tier lacks automatic rotation workflow and advanced features |
+| GCP application secret | Google Secret Manager | You want versioned secrets, IAM control, replication choices, and GKE Workload Identity Federation | Active versions and access operations affect cost |
+| Azure application secret/cert/key | Azure Key Vault | You need secrets plus keys or certificates, Microsoft Entra auth, soft-delete, and Azure-native audit | Operations pricing and vault access model require planning |
+| Multi-cloud dynamic credentials | HashiCorp Vault | You need database dynamic users, leases, revocation, PKI, or consistent multi-cloud policy | Higher operational complexity and availability responsibility |
+| Kubernetes delivery for most apps | ESO | Apps expect native Kubernetes Secrets, GitOps should hold only references, and templating is useful | Secret data lands in etcd and must be protected by RBAC/encryption |
+| Kubernetes delivery for strict no-etcd policy | Secrets Store CSI Driver | Apps can consume files and policy forbids native Secret persistence | Node driver/provider health and app reload behavior matter more |
+| Git-stored encrypted bootstrap values | SOPS or Sealed Secrets | You need to keep limited encrypted values in Git for bootstrap or disconnected workflows | Does not replace runtime rotation, audit, or dynamic credentials |
+
+```mermaid
+flowchart TD
+    A[Need to deliver a secret to a Kubernetes workload] --> B{Is the value dynamic or short-lived?}
+    B -- Yes --> C[Use Vault dynamic secrets or cloud-native temporary identity]
+    B -- No --> D{Single cloud source of truth?}
+    D -- AWS --> E{Need native rotation workflow?}
+    E -- Yes --> F[AWS Secrets Manager]
+    E -- No --> G[SSM Parameter Store SecureString]
+    D -- GCP --> H[Google Secret Manager]
+    D -- Azure --> I[Azure Key Vault]
+    D -- Multi-cloud --> J[Vault or per-cloud stores with consistent policy]
+    F --> K{Can the app consume mounted files?}
+    G --> K
+    H --> K
+    I --> K
+    J --> K
+    C --> K
+    K -- Yes, and no-etcd policy matters --> L[Secrets Store CSI Driver]
+    K -- No, app expects K8s Secret/env/template --> M[External Secrets Operator]
+    L --> N[Design file watch or restart path]
+    M --> O[Enable etcd encryption, RBAC, and reload automation]
+```
+
+The decision framework should be revisited whenever the consumer changes. A database password for a legacy app may start with ESO and a rolling restart because the app only reads environment variables. The same platform may use CSI-only mounts for TLS private keys on an Ingress controller, direct SDK calls for a service that can cache Google Secret Manager versions, and Vault dynamic credentials for administrative database jobs. Consistency matters, but forcing every workload through one delivery mechanism usually creates exceptions that are less safe than a documented two-tool policy.
+
 ---
 
 ## Did You Know?
 
-1. **GitHub scans every public commit for over 200 secret patterns** (API keys, tokens, passwords) through their Secret Scanning program. In 2024 alone, they detected and notified providers about over 15 million leaked secrets. Despite this, the median time between a secret being committed and an attacker exploiting it is under 30 minutes.
+1. **Kubernetes warns that Secrets are stored unencrypted in etcd by default** unless encryption at rest is explicitly configured. That is why a managed cloud cluster's convenience does not remove the need to understand the control-plane encryption model and RBAC boundaries.
 
-2. **HashiCorp Vault's dynamic database secrets feature creates and destroys** roughly 50 million ephemeral database credentials per day across its customer base. Each credential lives for an average of 45 minutes before automatic revocation -- compared to the industry average of 11 months for static database passwords.
+2. **Secrets Store CSI Driver rotation and ESO refresh solve different layers** of the same problem. ESO updates a Kubernetes Secret on reconciliation, while CSI rotation updates mounted content and optionally synced Secrets, but an environment-variable consumer still needs a pod restart.
 
-3. **Kubernetes Secrets are stored in etcd in plaintext by default.** Encryption at rest was added in Kubernetes 1.13 (2018) but must be explicitly configured. A 2024 survey by Wiz found that 38% of production Kubernetes clusters still had not enabled etcd encryption, meaning anyone with access to the etcd data directory could read all secrets.
+3. **Google Secret Manager bills active versions per location**, so forgotten old versions are not just operational clutter. Version retention should match rollback needs, and user-managed replication should be chosen deliberately because each selected location changes the cost model.
 
-4. **The External Secrets Operator (ESO) emerged from a consolidation** of four competing projects: Godaddy's kubernetes-external-secrets, Alibaba's external-secrets, ContainerSolutions's externalsecret-operator, and AWS's secrets-store-csi-driver. The ESO project unified them under the CNCF in 2021 and is now the standard.
+4. **Azure Key Vault soft-delete gives teams a recovery window for deleted vault objects**, but recovery is not the same as a complete restore of every dependent integration. Treat vault deletion and purge permissions as production-critical controls rather than ordinary cleanup permissions.
 
 ---
 
@@ -602,7 +779,7 @@ graph TD
 |---------|---------------|---------------|
 | Treating base64 as encryption | "The secret is encoded, so it is safe" | base64 is encoding, not encryption; anyone can decode it |
 | Storing secrets in ConfigMaps | Developer confusion between ConfigMap and Secret | Use Secrets (they get masked in logs and have RBAC separation) |
-| Not enabling etcd encryption at rest | Not configured by default | Enable `EncryptionConfiguration` with AES-CBC or KMS provider |
+| Not enabling etcd encryption at rest | Not configured by default | Enable `EncryptionConfiguration` with a KMS v2 provider; use `secretbox` only when local key storage is the accepted fallback |
 | Using the same secret across all environments | "Simpler to manage one secret" | Separate secrets per environment; use ESO with environment-specific paths |
 | Not monitoring secret access | "We have RBAC, that is enough" | Enable Kubernetes audit logging; alert on secret read events from unexpected sources |
 | Committing plaintext secrets to Git then deleting them | "I removed it, so it is gone" | Git history preserves everything; rotate the secret immediately, use git-filter-repo to purge |
@@ -616,7 +793,7 @@ graph TD
 <details>
 <summary>1. You are auditing a newly provisioned Kubernetes cluster and notice that the team is storing database passwords in standard Kubernetes Secret objects. The lead developer argues this is safe because the values are unreadable when viewed in the manifest. Why is this assumption dangerous, and what minimal configuration changes must you enforce to secure these secrets?</summary>
 
-The developer's assumption is dangerous because Kubernetes Secrets are merely base64-encoded, not encrypted, meaning anyone with `kubectl get secret` permissions can instantly decode them. Furthermore, these secrets are stored in plaintext within the etcd database by default. To secure these secrets minimally, you must enable etcd encryption at rest using an `EncryptionConfiguration` with AES-CBC or a KMS provider. You must also strictly restrict RBAC permissions to ensure only necessary ServiceAccounts and users can read the secrets, and enable Kubernetes API audit logging to track access. Finally, implementing an external secrets manager like ESO or the CSI driver means the true source of the secret remains external, even though ESO still syncs a Kubernetes Secret into etcd.
+The developer's assumption is dangerous because Kubernetes Secrets are merely base64-encoded, not encrypted, meaning anyone with `kubectl get secret` permissions can instantly decode them. Furthermore, these secrets are stored in plaintext within the etcd database by default. To secure these secrets minimally, enable etcd encryption at rest with an `EncryptionConfiguration`, preferably using a KMS v2 provider so key-encryption-key control stays outside the API server host; `secretbox` is the local-key fallback when a KMS plugin is not available. You must also strictly restrict RBAC permissions to ensure only necessary ServiceAccounts and users can read the secrets, and enable Kubernetes API audit logging to track access. Finally, implementing an external secrets manager like ESO or the CSI driver means the true source of the secret remains external, even though ESO still syncs a Kubernetes Secret into etcd.
 </details>
 
 <details>
@@ -659,6 +836,9 @@ No, the secret is absolutely not safe because Git is a version control system de
 # Create kind cluster
 kind create cluster --name secrets-lab
 
+# This module uses the standard Kubernetes shorthand in runnable blocks.
+alias k=kubectl
+
 # Install ESO
 helm repo add external-secrets https://charts.external-secrets.io
 helm install external-secrets external-secrets/external-secrets \
@@ -677,7 +857,7 @@ k wait --for=condition=ready pod -l app.kubernetes.io/name=sealed-secrets \
 
 ### Task 1: Create and Seal a Secret
 
-Use kubeseal to encrypt a secret that is safe to store in Git.
+Use kubeseal to encrypt a secret that is safe to store in Git, then verify that the cluster controller can decrypt it back into a native Kubernetes Secret.
 
 <details>
 <summary>Solution</summary>
@@ -716,7 +896,7 @@ echo ""
 
 ### Task 2: Set Up a Fake Secret Store with ESO
 
-Since we do not have a real cloud provider, use ESO's Fake provider to demonstrate the workflow.
+Since we do not have a real cloud provider in this lab, use ESO's Fake provider to demonstrate the reconciliation workflow without introducing static cloud credentials.
 
 <details>
 <summary>Solution</summary>
@@ -782,7 +962,7 @@ echo ""
 
 ### Task 3: Use ESO Templates to Generate a Connection String
 
-Create an ExternalSecret that templates multiple fields into a single connection string.
+Create an `ExternalSecret` that templates multiple fields into a single connection string, then inspect the generated Kubernetes Secret to confirm the expected shape.
 
 <details>
 <summary>Solution</summary>
@@ -835,7 +1015,7 @@ echo ""
 
 ### Task 4: Deploy a Pod That Uses the Synced Secret
 
-Deploy a pod that reads the ESO-managed secret as an environment variable.
+Deploy a pod that reads the ESO-managed secret as an environment variable, then consider why this convenient pattern still needs restart-based rotation handling.
 
 <details>
 <summary>Solution</summary>
@@ -893,7 +1073,11 @@ spec:
 
 ```bash
 k apply -f /tmp/secret-consumer.yaml
-k wait --for=condition=ready pod/secret-consumer --timeout=30s
+for i in {1..30}; do
+  k get pod/secret-consumer >/dev/null 2>&1 && break
+  sleep 1
+done
+k wait --for=condition=ready pod/secret-consumer --timeout=60s
 sleep 3
 k logs secret-consumer
 ```
@@ -901,7 +1085,7 @@ k logs secret-consumer
 
 ### Task 5: Verify Secret Status and Health
 
-Check the status of all ExternalSecrets and SealedSecrets.
+Check the status of all `ExternalSecret` and `SealedSecret` resources so you can distinguish successful reconciliation from objects that merely exist.
 
 <details>
 <summary>Solution</summary>
@@ -940,12 +1124,41 @@ kind delete cluster --name secrets-lab
 
 ---
 
-**Next Module**: [Module 9.9: Cloud-Native API Gateways & WAF](../module-9.9-api-gateways/) -- Learn how cloud API gateways compare to Kubernetes Gateway API, how to integrate WAF protection, and how to handle OAuth2/OIDC proxying for your services.
+## Next Module
+
+[Module 9.9: Cloud-Native API Gateways & WAF](../module-9.9-api-gateways/) -- Learn how cloud API gateways compare to Kubernetes Gateway API, how to integrate WAF protection, and how to handle OAuth2/OIDC proxying for your services.
 
 ## Sources
 
-- [Good practices for Kubernetes Secrets](https://kubernetes.io/docs/concepts/security/secrets-good-practices/) — Authoritative baseline for how Kubernetes Secret storage, access, and encryption-at-rest actually work.
-- [External Secrets Operator](https://github.com/external-secrets/external-secrets) — Primary upstream reference for ESO's role, supported providers, and high-level behavior.
-- [Secrets Store CSI Driver](https://github.com/kubernetes-sigs/secrets-store-csi-driver) — Primary upstream reference for CSI-based secret mounts and optional Kubernetes Secret sync behavior.
-- [Vault Database Secrets Engine](https://developer.hashicorp.com/vault/docs/secrets/databases) — Primary source for dynamic database credentials, leases, and revocation semantics in Vault.
-- [Flux Kustomization Decryption with SOPS](https://fluxcd.io/flux/components/kustomize/kustomizations/) — Useful current reference for SOPS-backed GitOps decryption workflows in Kubernetes.
+- [Kubernetes Secrets](https://kubernetes.io/docs/concepts/configuration/secret/) — Native Secret behavior, base64 encoding, default etcd storage warning, and size considerations.
+- [Good practices for Kubernetes Secrets](https://kubernetes.io/docs/concepts/security/secrets-good-practices/) — Kubernetes guidance for encryption at rest, RBAC, external stores, and access restrictions.
+- [Encrypting Confidential Data at Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) — Kubernetes `EncryptionConfiguration`, KMS provider, and encryption verification guidance.
+- [ExternalSecret API](https://external-secrets.io/latest/api/externalsecret/) — ESO refresh policy, refresh interval, target templating, and sync behavior.
+- [ClusterSecretStore API](https://external-secrets.io/latest/api/clustersecretstore/) — ESO cluster-scoped store behavior and provider configuration model.
+- [Secrets Store CSI Driver Concepts](https://secrets-store-csi-driver.sigs.k8s.io/concepts.html) — CSI mount flow, provider model, and security implications.
+- [Secrets Store CSI Driver Auto Rotation](https://secrets-store-csi-driver.sigs.k8s.io/topics/secret-auto-rotation.html) — Mounted-content rotation, synced Secret behavior, and environment-variable restart caveat.
+- [AWS Secrets Manager Encryption](https://docs.aws.amazon.com/secretsmanager/latest/userguide/security-encryption.html) — AWS KMS envelope encryption behavior for secret values.
+- [AWS Secrets Manager Rotation by Lambda](https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotate-secrets_lambda.html) — Lambda-backed rotation workflow and rotation steps.
+- [AWS Secrets Manager Rotation Schedules](https://docs.aws.amazon.com/secretsmanager/latest/userguide/rotate-secrets_schedule.html) — Rotation windows, rate expressions, and schedule constraints.
+- [AWS Secrets Manager Pricing](https://aws.amazon.com/secrets-manager/pricing/) — Current per-secret and API-call pricing model; verify region-specific pricing before estimating production spend.
+- [AWS Systems Manager Parameter Store Tiers](https://docs.aws.amazon.com/systems-manager/latest/userguide/parameter-store-advanced-parameters.html) — Standard versus Advanced parameter limits, size, policies, and cost distinction.
+- [AWS Parameter Store KMS SecureString](https://docs.aws.amazon.com/kms/latest/developerguide/services-parameter-store.html) — How `SecureString` parameters use AWS KMS.
+- [Amazon EKS Pod Identity](https://docs.aws.amazon.com/eks/latest/userguide/pod-identities.html) — EKS Pod Identity behavior, benefits, limits, and credential isolation.
+- [IAM Roles for Service Accounts](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) — IRSA behavior and OIDC-based temporary AWS credentials for pods.
+- [Google Secret Manager Overview](https://cloud.google.com/secret-manager/docs/overview) — Secret versions, IAM, replication, encryption, and CMEK behavior.
+- [Google Secret Manager Pricing](https://cloud.google.com/secret-manager/pricing) — Active version, replication-location, access-operation, and rotation-notification pricing model.
+- [Workload Identity Federation for GKE](https://cloud.google.com/kubernetes-engine/docs/concepts/workload-identity) — GKE workload identity behavior and keyless access to Google Cloud APIs.
+- [GKE Secret Manager Workload Identity Tutorial](https://cloud.google.com/kubernetes-engine/docs/tutorials/workload-identity-secrets) — Official GKE pattern for accessing Secret Manager without service account key files.
+- [Azure Key Vault Overview](https://learn.microsoft.com/en-us/azure/key-vault/general/overview) — Key Vault secrets, keys, certificates, encryption at rest, access control, and monitoring.
+- [Azure Key Vault Keys, Secrets, and Certificates](https://learn.microsoft.com/en-us/azure/key-vault/general/about-keys-secrets-certificates) — Object identifiers, versions, and supported object types.
+- [Azure Key Vault Soft-Delete](https://learn.microsoft.com/en-us/azure/key-vault/general/soft-delete-change) — Soft-delete and purge behavior for vaults and vault objects.
+- [Azure Key Vault Pricing](https://azure.microsoft.com/en-us/pricing/details/key-vault/) — Operations-oriented pricing model and billing definitions; verify current regional pricing before estimation.
+- [AKS Microsoft Entra Workload ID](https://learn.microsoft.com/en-us/azure/aks/workload-identity-overview) — AKS workload identity with projected service account tokens and OIDC federation.
+- [Vault Database Secrets Engine](https://developer.hashicorp.com/vault/docs/secrets/databases) — Dynamic database credentials, leases, static roles, and revocation semantics in Vault.
+- [Vault Lease Concepts](https://developer.hashicorp.com/vault/docs/concepts/lease) — Lease creation, renewal, and revocation behavior for dynamic secrets.
+- [Vault Secrets Operator](https://developer.hashicorp.com/vault/docs/deploy/kubernetes/vso/sources/vault) — VSO CRDs for Vault connection, authentication, static secrets, and dynamic secrets.
+- [Vault Seal Configuration](https://developer.hashicorp.com/vault/docs/configuration/seal) — Seal stanza behavior and Shamir fallback when no auto-unseal configuration exists.
+- [Vault AWS KMS Seal](https://developer.hashicorp.com/vault/docs/configuration/seal/awskms) — AWS KMS auto-unseal stanza and activation behavior.
+- [Vault GCP Cloud KMS Seal](https://developer.hashicorp.com/vault/docs/configuration/seal/gcpckms) — GCP Cloud KMS auto-unseal stanza and authentication model.
+- [Vault Azure Key Vault Seal](https://developer.hashicorp.com/vault/docs/configuration/seal/azurekeyvault) — Azure Key Vault auto-unseal stanza and activation behavior.
+- [Flux Kustomization Decryption with SOPS](https://fluxcd.io/flux/components/kustomize/kustomizations/) — Current reference for SOPS-backed GitOps decryption workflows in Kubernetes.

--- a/src/content/docs/cloud/managed-services/module-9.9-api-gateways.md
+++ b/src/content/docs/cloud/managed-services/module-9.9-api-gateways.md
@@ -19,7 +19,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-At 02:18 on a Monday morning, a marketplace company's checkout API began returning intermittent 502 errors during what should have been a routine campaign launch. The cluster autoscaler added nodes, the database pool expanded, and the NGINX Ingress controller showed no single client violating its per-IP limit. By sunrise, the support queue had hundreds of angry merchants, the promotion budget was wasted, and the post-incident review estimated six figures of lost gross merchandise value from carts that never completed.
+**Hypothetical scenario:** At 02:18 on a Monday morning, a marketplace company's checkout API began returning intermittent 502 errors during what should have been a routine campaign launch. The cluster autoscaler added nodes, the database pool expanded, and the NGINX Ingress controller showed no single client violating its per-IP limit. By sunrise, the support queue had hundreds of angry merchants, the promotion budget was wasted, and the post-incident review estimated six figures of lost gross merchandise value from carts that never completed.
 
 The uncomfortable discovery was that nothing "broke" in the simple routing layer. The attacker used residential proxies, rotated account tokens, and targeted one expensive endpoint with enough aggregate concurrency to exhaust the database before any one IP address looked suspicious. The team had confused an ingress controller with an API security boundary, so authentication, bot-aware filtering, quota management, and endpoint-level throttling all happened too late or not at all.
 
@@ -82,7 +82,7 @@ flowchart TD
 
 That role split is more than administrative neatness. In a shared cluster, the team running the ingress infrastructure should not need to edit every application route, and application teams should not be able to bind arbitrary hostnames or certificates without approval. Gateway API models this directly with `GatewayClass`, `Gateway`, `HTTPRoute`, `GRPCRoute`, and route attachment rules instead of expecting one overloaded Ingress object to express all relationships.
 
-The following manifest shows the platform team creating a shared HTTPS gateway, while application teams create routes in a namespace labeled for gateway access. The important detail is `allowedRoutes`, because it prevents an accidental or malicious route in an unrelated namespace from attaching itself to the production listener. Kubernetes version 1.35+ keeps these APIs stable for common HTTP routing, although individual implementations still differ in how they expose advanced policies.
+The following manifest shows the platform team creating a shared HTTPS gateway, while application teams create routes in a namespace labeled for gateway access. The important detail is `allowedRoutes`, because it prevents an accidental or malicious route in an unrelated namespace from attaching itself to the production listener. Gateway API v1.0+ keeps the core HTTP routing types stable; `GRPCRoute` is v1 since Gateway API v1.1, although individual implementations still differ in how they expose advanced policies.
 
 ```yaml
 # Platform team creates the Gateway
@@ -268,27 +268,34 @@ aws wafv2 create-web-acl \
 
 # Associate WAF with ALB (used by AWS Load Balancer Controller)
 aws wafv2 associate-web-acl \
-  --web-acl-arn arn:aws:wafv2:us-east-1:123456789:regional/webacl/k8s-api-protection/abc123 \
-  --resource-arn arn:aws:elasticloadbalancing:us-east-1:123456789:loadbalancer/app/k8s-alb/abc123
+  --web-acl-arn arn:aws:wafv2:us-east-1:123456789012:regional/webacl/k8s-api-protection/abc123 \
+  --resource-arn arn:aws:elasticloadbalancing:us-east-1:123456789012:loadbalancer/app/k8s-alb/abc123
 ```
 
 The rule set above combines managed common web protections, SQL injection detection, and a rate-based rule. In production, a team would usually start managed rule groups in count mode or with carefully scoped exceptions, review sampled requests, and then move to blocking after false positives are understood. That review process is not bureaucratic delay; it is how you avoid turning a WAF rollout into a customer-facing outage.
 
 ```yaml
 apiVersion: networking.k8s.io/v1
+kind: IngressClass
+metadata:
+  name: alb
+spec:
+  controller: ingress.k8s.aws/alb
+---
+apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: api-ingress
   namespace: production
   annotations:
-    kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/scheme: internet-facing
     alb.ingress.kubernetes.io/target-type: ip
-    alb.ingress.kubernetes.io/wafv2-acl-arn: arn:aws:wafv2:us-east-1:123456789:regional/webacl/k8s-api-protection/abc123
+    alb.ingress.kubernetes.io/wafv2-acl-arn: arn:aws:wafv2:us-east-1:123456789012:regional/webacl/k8s-api-protection/abc123
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
-    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:123456789:certificate/abc123
+    alb.ingress.kubernetes.io/certificate-arn: arn:aws:acm:us-east-1:123456789012:certificate/abc123
     alb.ingress.kubernetes.io/ssl-redirect: "443"
 spec:
+  ingressClassName: alb
   rules:
     - host: api.example.com
       http:
@@ -393,7 +400,7 @@ spec:
     spec:
       containers:
         - name: ratelimit
-          image: envoyproxy/ratelimit:master
+          image: envoyproxy/ratelimit:1e745fc8
           ports:
             - containerPort: 8080
             - containerPort: 8081
@@ -580,10 +587,10 @@ metadata:
   name: jwt-auth
   namespace: gateway-system
 spec:
-  targetRef:
-    group: gateway.networking.k8s.io
-    kind: HTTPRoute
-    name: api-routes
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: api-routes
   jwt:
     providers:
       - name: google
@@ -608,11 +615,12 @@ gRPC and WebSocket traffic expose assumptions that ordinary REST traffic often h
 | Gateway | gRPC Support | Configuration |
 |---------|-------------|---------------|
 | AWS ALB | Yes (HTTP/2) | Target group protocol: gRPC |
-| AWS API Gateway | Yes (HTTP API) | Integration type: HTTP_PROXY with gRPC |
+| AWS API Gateway | Limited — unary only via HTTP_PROXY passthrough; no streaming; not an officially supported gRPC path | HTTP API HTTP_PROXY integration |
 | GCP GCLB | Yes (HTTP/2) | Backend service protocol: HTTP2 |
-| Azure App Gateway v2 | Yes (HTTP/2) | Backend protocol: HTTP/2 |
+| Azure App Gateway v2 | No (backend is HTTP/1.1) | Classic v2 uses HTTP/2 client-side only; backends are HTTP/1.1 — use Application Gateway for Containers (AGC) for gRPC |
+| Azure Application Gateway for Containers (AGC) | Yes (HTTP/2) | gRPC route |
 | Envoy Gateway | Yes (native) | GRPCRoute resource |
-| NGINX Ingress | Yes | `nginx.org/grpc-services` annotation |
+| NGINX Ingress (community ingress-nginx) | Yes | `nginx.ingress.kubernetes.io/backend-protocol: "GRPC"` |
 
 The most common gRPC failure is a silent protocol downgrade. A gateway listener accepts TLS from the client, but the upstream connection to the service defaults to HTTP/1.1. The result can look like mysterious protocol errors, failed streams, or application-level timeouts even though the service is healthy. Fixing it means configuring the gateway to use gRPC or HTTP/2 on the backend connection, not just opening the right port.
 
@@ -623,11 +631,11 @@ kind: Ingress
 metadata:
   name: grpc-ingress
   annotations:
-    kubernetes.io/ingress.class: alb
     alb.ingress.kubernetes.io/backend-protocol-version: GRPC
     alb.ingress.kubernetes.io/listen-ports: '[{"HTTPS":443}]'
     alb.ingress.kubernetes.io/target-type: ip
 spec:
+  ingressClassName: alb
   rules:
     - host: grpc.example.com
       http:
@@ -709,7 +717,7 @@ Observability is the counterweight that keeps these layers understandable. Edge 
 
 A useful production request path carries one correlation value across all of those layers. The name can vary by organization, but the concept should not. If the WAF blocks a request, the security team should be able to find the request ID in edge logs. If the Kubernetes gateway returns a 503, the platform team should be able to find the route and backend service associated with the same ID. If the application returns a domain error, the service team should not have to guess which public API key or WAF rule was involved.
 
-War story: a platform team once spent a full incident bridge arguing about whether 401 responses came from the application, the OAuth2 proxy, or the cloud API gateway. Each layer logged a different generated request ID, and one layer stripped the incoming value during a rewrite. The fix was technically small but operationally important: the edge generated a canonical ID when missing, every gateway preserved it, and each service logged it without overwriting. The next incident was shorter because the team could follow one request across the entire path.
+Hypothetical scenario: a platform team once spent a full incident bridge arguing about whether 401 responses came from the application, the OAuth2 proxy, or the cloud API gateway. Each layer logged a different generated request ID, and one layer stripped the incoming value during a rewrite. The fix was technically small but operationally important: the edge generated a canonical ID when missing, every gateway preserved it, and each service logged it without overwriting. The next incident was shorter because the team could follow one request across the entire path.
 
 Metrics need similar discipline. A gateway success rate can look healthy while one backend route is burning down, because aggregate HTTP 200 rates hide expensive endpoints and low-volume customers. Track status codes and latency by route, backend, authentication result, WAF action, and rate limit descriptor. The labels should be low-cardinality enough for your metrics system, but specific enough to answer whether `/api/v1/checkout` is failing because of auth, routing, throttling, or application errors.
 
@@ -794,11 +802,11 @@ For production design reviews, require a request-path proof. The diagram should 
 
 ## Did You Know?
 
-1. **Managed WAF services process very large traffic volumes and provide managed rules for common web attacks such as SQL injection and XSS.** Exact fleet-wide request counts, attack-mix percentages, and update cadences should be cited from a dated primary source.
+1. **AWS WAF can inspect web requests at regional and CloudFront edge scopes** and ships managed rule groups for common attacks such as SQL injection and cross-site scripting, with sampled requests and CloudWatch metrics for tuning before blocking.
 
 2. **The Kubernetes Gateway API reached v1.0 (GA) on October 31, 2023** and is the successor to Ingress, whose API is frozen rather than removed. A key motivation was to reduce reliance on vendor-specific annotations by providing a more expressive standard API.
 
-3. **gRPC, introduced by Google, uses Protocol Buffers and HTTP/2-based transport.** Its performance characteristics depend on workload, payload shape, and implementation, so avoid universal speed multipliers or internal adoption percentages unless they are cited from a primary source.
+3. **gRPC uses Protocol Buffers over HTTP/2**, so gateways must preserve HTTP/2 semantics end to end; performance gains versus REST depend on payload size, streaming patterns, and client implementation rather than a fixed speed multiplier.
 
 4. **OAuth2 Proxy began as Bitly's `oauth2_proxy` project** and later moved to the community-maintained `oauth2-proxy/oauth2-proxy` project, which supports many providers including OIDC.
 
@@ -866,6 +874,7 @@ In this exercise, you will build a small Gateway API lab, route traffic between 
 ### Setup
 
 ```bash
+alias k=kubectl
 # Create kind cluster with extra ports
 cat > /tmp/kind-gateway.yaml << 'EOF'
 kind: Cluster
@@ -894,6 +903,8 @@ helm install eg oci://docker.io/envoyproxy/gateway-helm \
 k wait --for=condition=ready pod -l control-plane=envoy-gateway \
   --namespace envoy-gateway-system --timeout=120s
 ```
+
+On vanilla kind, Envoy Gateway's LoadBalancer Service stays `<pending>`, so `Gateway.status.addresses` is never populated. After Task 1 programs the gateway, port-forward the Envoy proxy Service (label `gateway.envoyproxy.io/owning-gateway-name=lab-gateway`) and use `http://localhost:8888` for all lab curls instead of a gateway IP.
 
 ### Task 1: Create a Gateway and Backend Services
 
@@ -995,9 +1006,16 @@ spec:
       port: 80
 ```
 
+Save the manifest above to `/tmp/gateway-setup.yaml`, then apply:
+
 ```bash
 k apply -f /tmp/gateway-setup.yaml
 k wait --for=condition=programmed gateway/lab-gateway --timeout=60s
+
+# kind: reach the Envoy proxy via port-forward (LoadBalancer stays pending)
+ENVOY_SVC=$(k get svc -n default -l gateway.envoyproxy.io/owning-gateway-name=lab-gateway -o jsonpath='{.items[0].metadata.name}')
+k port-forward -n default svc/"$ENVOY_SVC" 8888:80 &
+GATEWAY_URL=http://localhost:8888
 ```
 </details>
 
@@ -1031,17 +1049,18 @@ spec:
           weight: 20
 ```
 
+Save the manifest above to `/tmp/httproute.yaml`, then apply:
+
 ```bash
 k apply -f /tmp/httproute.yaml
 
-# Get the gateway's external address
-GW_IP=$(k get gateway lab-gateway -o jsonpath='{.status.addresses[0].value}')
-echo "Gateway IP: $GW_IP"
+# Use GATEWAY_URL from Task 1 port-forward (http://localhost:8888 on kind)
+echo "Gateway endpoint: $GATEWAY_URL"
 
 # Test traffic splitting (send 20 requests)
 for i in $(seq 1 20); do
-  k run curl-$i --rm -it --image=curlimages/curl --restart=Never -- \
-    curl -s http://$GW_IP/ 2>/dev/null
+  k run curl-$i --rm -i --image=curlimages/curl --restart=Never -- \
+    curl -s "$GATEWAY_URL/" 2>/dev/null
 done
 ```
 </details>
@@ -1085,14 +1104,14 @@ spec:
           weight: 20
 ```
 
+Save the manifest above to `/tmp/httproute-headers.yaml`, then apply:
+
 ```bash
 k apply -f /tmp/httproute-headers.yaml
 
-GW_IP=$(k get gateway lab-gateway -o jsonpath='{.status.addresses[0].value}')
-
-# Test header-based routing
-k run header-test --rm -it --image=curlimages/curl --restart=Never -- \
-  curl -s -H "X-Version: v2" http://$GW_IP/
+# Test header-based routing (GATEWAY_URL from Task 1)
+k run header-test --rm -i --image=curlimages/curl --restart=Never -- \
+  curl -s -H "X-Version: v2" "$GATEWAY_URL/"
 # Should always return "Hello from v2 (canary)"
 ```
 </details>
@@ -1105,35 +1124,35 @@ Configure an Envoy Extension Policy to limit requests sent through the Gateway. 
 <summary>Solution</summary>
 
 ```yaml
-# Apply Envoy Gateway ClientTrafficPolicy
+# Apply Envoy Gateway BackendTrafficPolicy (local rate limit — no Redis RLS)
 apiVersion: gateway.envoyproxy.io/v1alpha1
-kind: ClientTrafficPolicy
+kind: BackendTrafficPolicy
 metadata:
   name: rate-limit-policy
   namespace: default
 spec:
-  targetRef:
-    group: gateway.networking.k8s.io
-    kind: HTTPRoute
-    name: echo-route
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: echo-route
   rateLimit:
-    type: Global
-    global:
+    type: Local
+    local:
       rules:
         - limit:
             requests: 2
             unit: Second
 ```
 
+Save the manifest above to `/tmp/rate-limit.yaml`, then apply:
+
 ```bash
 k apply -f /tmp/rate-limit.yaml
 
-# Test the rate limit through the gateway
-GW_IP=$(k get gateway lab-gateway -o jsonpath='{.status.addresses[0].value}')
-
-echo "Sending 10 rapid requests to Gateway IP: $GW_IP..."
+# Test the rate limit through the gateway (GATEWAY_URL from Task 1)
+echo "Sending 10 rapid requests to $GATEWAY_URL..."
 for i in $(seq 1 10); do
-  STATUS=$(k run rate-test-$i --rm -i --image=curlimages/curl --restart=Never -- curl -s -o /dev/null -w '%{http_code}' http://$GW_IP/ 2>/dev/null)
+  STATUS=$(k run rate-test-$i --rm -i --image=curlimages/curl --restart=Never -- curl -s -o /dev/null -w '%{http_code}' "$GATEWAY_URL/" 2>/dev/null)
   echo "Request $i returned HTTP $STATUS"
 done
 # You should see HTTP 200 for the first few requests, followed by HTTP 429 (Too Many Requests)
@@ -1155,10 +1174,10 @@ metadata:
   name: jwt-auth
   namespace: default
 spec:
-  targetRef:
-    group: gateway.networking.k8s.io
-    kind: HTTPRoute
-    name: echo-route
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: echo-route
   jwt:
     providers:
       - name: example
@@ -1166,14 +1185,14 @@ spec:
           uri: https://raw.githubusercontent.com/envoyproxy/gateway/main/examples/kubernetes/jwt/jwks.json
 ```
 
+Save the manifest above to `/tmp/security-policy.yaml`, then apply:
+
 ```bash
 k apply -f /tmp/security-policy.yaml
 
-GW_IP=$(k get gateway lab-gateway -o jsonpath='{.status.addresses[0].value}')
-
-# Test without a token (should return 401 Unauthorized)
+# Test without a token (should return 401 Unauthorized; GATEWAY_URL from Task 1)
 k run auth-test --rm -i --image=curlimages/curl --restart=Never -- \
-  curl -s -o /dev/null -w '%{http_code}' http://$GW_IP/
+  curl -s -o /dev/null -w '%{http_code}' "$GATEWAY_URL/"
 ```
 </details>
 


### PR DESCRIPTION
## Cloud / Managed Services — expand-to-floor + cross-family review (9.1–9.10)

Session 102. Continues the cloud workstream. Brings all 10 **Managed Services** modules
from `shipped_unreviewed`/`needs_rewrite` to finalize-quality. **This wave also ran a
candidate-reviewer trial** (grok-via-hermes + agy with selectable models) alongside the
proven opus/cursor lanes — every candidate finding was orchestrator-ground-checked
(web-verified) before any fix shipped.

**What changed**
- 9 modules expanded to the 5,000-word teaching floor; 9.9 (already at floor) got a
  targeted gate + content fix.
- Every module went through an independent cross-family review (see table), every finding
  ground-checked, fix-pass applied. All 10 verify **T0 / PASS**. Incident-dedup gate: PASS.
- **Systemic catch:** the Broadcom **Bitnami → `bitnamilegacy`** image move (2025-08-28)
  broke labs in 9.1/9.2/9.5/9.10 (ImagePullBackOff) — all fixed (memory:
  `feedback_bitnami_images_moved_to_legacy`).

**Per-module summary** (reviewer · notable fixes — all ground-checked)

| Module | Reviewer | Notable fixes |
|---|---|---|
| 9.1 databases | opus 4.8 | P1 bitnami/pgbouncer→legacy; K8s env-var ordering; PSA≠PSC; CONCURRENTLY+timeout (opus reverse-saved Aurora-10-region / Cosmos / Azure-cross-AZ) |
| 9.2 message-brokers | **grok-build** + opus | merged: bitnami/redis→plain; Pub/Sub Lite June-30 (opus false-confirmed March-18); az `--enable-dead-lettering`; KEDA identityOwner; `$RANDOM`-in-dash |
| 9.3 serverless | **agy·Gemini-3.1-Pro** | Azure Functions 500MB-not-1.5GB; Fargate EFS-not-EBS; API GW VPC_LINK; SnapStart Java21/Python/.NET |
| 9.4 object-storage | **agy·Claude-Sonnet** | P1 S3 CSI static-only; az federated-credential `--name`; Intelligent-Tiering 128KB; GCS WI signing; MRAP async |
| 9.5 caching | **grok-4.20** | P1 bitnami/redis→plain (orchestrator-caught; grok-4.20 missed it); dedupe Next-Module |
| 9.6 search | **grok-build** | Azure AI Search is retrieval/RAG, NOT a direct AKS-log sink (→ Azure Monitor/Log Analytics) |
| 9.7 streaming | opus 4.8 | P1 Strimzi 0.46+ ZooKeeper removed → KRaft/KafkaNodePool (lab+body); Mermaid; `$RANDOM` |
| 9.8 secrets-deep | **agy·Claude-Opus** | P1 Azure CSS YAML indent; added VSO + KMS auto-unseal (promised, uncovered); etcd-encryption provider; wait race |
| 9.9 api-gateways | opus 4.8 | gate fix + P1 Envoy BackendTrafficPolicy+Local rate-limit; Azure/AWS/NGINX gRPC facts; kind port-forward; fabricated opener→Hypothetical |
| 9.10 analytics | **agy·Claude-Sonnet** | P1 fake `bq update` quota flags; KPO dict→`V1ResourceRequirements`×5; `days_ago` removed; bitnami/kubectl→legacy (agy·GPT-OSS review rejected as hallucinated) |

## Learner check

> The shared principle is that the cluster holds a projected workload identity token, not a long-lived cloud credential

(verbatim from `module-9.8-secrets-deep.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
