### PR TITLE
chore(content): module-9.5-caching ## References -> ## Sources

### DIFF
--- a/src/content/docs/cloud/managed-services/module-9.5-caching.md
+++ b/src/content/docs/cloud/managed-services/module-9.5-caching.md
@@ -1225,7 +1225,7 @@ kind delete cluster --name cache-lab
 
 ---
 
-## References
+## Sources
 
 - [Redis upstream repository](https://github.com/redis/redis) — Data structures and messaging/scripting capabilities
 - [Memcached upstream repository](https://github.com/memcached/memcached) — Multithreaded key/value cache store


### PR DESCRIPTION
## module-9.5-caching: `## References` → `## Sources`

Follow-up to PR #1786. 9.5 was finalized to T0 but the `/quality` board kept it
`needs_rewrite` because the heuristic rubric scorer requires an exact `## Sources`
heading (`^##\s+Sources\s*$`) to detect citations; 9.5 used `## References`, so
`has_citations=False` capped its score at 1.5. Rename aligns it with the scorer and the
curriculum-wide `## Sources` convention. Content unchanged otherwise; still T0.

## Learner check

> operate the cache as a deliberate reliability component rather than a mysterious fast database

(verbatim from `module-9.5-caching.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
