### PR TITLE
ci: harden CI for external (fork) & content-only PRs (#1789)

### DIFF
--- a/.github/workflows/cross-family-code-review.yml
+++ b/.github/workflows/cross-family-code-review.yml
@@ -16,6 +16,13 @@ jobs:
   review-gemini-3-1-pro:
     name: Review (gemini-3.1-pro-preview)
     runs-on: ubuntu-latest
+    # Skip on fork PRs: GitHub withholds repo secrets (GEMINI_API_KEY) from
+    # pull_request runs triggered by a fork, so the review can't authenticate
+    # and the job would hard-fail with a misleading red X on every external
+    # contribution (e.g. PR #1742, our first external contributor). Internal
+    # branch PRs still get the cross-family review. See the 2026-06-04 CI
+    # autopsy: docs/bug-autopsies/ci-metadata-blindspot.md (issue #1789).
+    if: github.event.pull_request.head.repo.full_name == github.repository
     timeout-minutes: 10
     continue-on-error: true
     permissions:

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -29,6 +29,13 @@ jobs:
         with:
           python-version: "3.12"
 
+      - name: Install PyYAML
+        # check_site_health.py is stdlib-only, but the lab.url validator parses
+        # frontmatter with a real YAML loader (robust against flow-style /
+        # inline-comment edge cases — see codex R1 on PR #1790). PyYAML is
+        # already a repo dependency (requirements.txt).
+        run: python -m pip install --upgrade "pyyaml>=6.0.3"
+
       - name: Run site health check
         run: python scripts/check_site_health.py
 

--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -1,14 +1,15 @@
 name: Static internal link check
 
+# Runs on every PR (no `paths:` filter) so it can serve as a universal
+# required status check. A path-filtered required check never reports on PRs
+# that miss those paths, leaving the PR permanently BLOCKED waiting for a check
+# that will never run — the same deadlock the CodeQL `Analyze` contexts caused
+# for docs-only PRs (PR #1742 / the 2026-06-04 CI autopsy). Both steps are fast
+# and dependency-free, so always-on is cheap.
 on:
   pull_request:
     branches:
       - main
-    paths:
-      - 'src/content/docs/**'
-      - 'astro.config.mjs'
-      - 'scripts/check_site_health.py'
-      - '.github/workflows/link-check.yml'
 
 permissions:
   contents: read
@@ -30,3 +31,6 @@ jobs:
 
       - name: Run site health check
         run: python scripts/check_site_health.py
+
+      - name: Check lab URL convention
+        run: python scripts/ci/check_lab_urls.py

--- a/docs/bug-autopsies/INDEX.md
+++ b/docs/bug-autopsies/INDEX.md
@@ -5,3 +5,4 @@
 | 2026-05-22 | calibration | content-review 0.5-collapse — binary-AND substring gates → ratio gates (PR for #1441) | [calibration-scorer-brittleness.md](calibration-scorer-brittleness.md) |
 | 2026-05-22 | calibration | fact-check parse fragility — prose-prefixed JSON not extracted (PR for #1441) | [calibration-scorer-brittleness.md](calibration-scorer-brittleness.md) |
 | 2026-06-04 | ci/build | invalid `lab.difficulty: medium` (Astro Zod enum) broke main's build; PR CI runs no full `astro build` so it slipped through (commit b52f9fce → fixed session 103) | [ci-no-full-build-gate.md](ci-no-full-build-gate.md) |
+| 2026-06-04 | ci/build | valid-but-wrong `lab.url` (generic playground, HTTP 200) passed every gate; + fork-PR review hard-fails on missing secrets + CodeQL required-but-skipped blocks docs PRs (surfaced by first external PR #1742, issue #1789) | [ci-metadata-blindspot.md](ci-metadata-blindspot.md) |

--- a/docs/bug-autopsies/ci-metadata-blindspot.md
+++ b/docs/bug-autopsies/ci-metadata-blindspot.md
@@ -1,0 +1,27 @@
+# CI catches broken links and bad prose, but not valid-but-wrong metadata (+ fork-PR friction)
+
+**Date:** 2026-06-04 · **Category:** ci/build · **Surfaced by:** PR #1742 (our first external contributor, @H3xKatana)
+
+## What broke
+`module-1.3-helm.md` shipped with `lab.url: https://killercoda.com/playgrounds/scenario/kubernetes` — the **generic** KillerCoda playground instead of the module-specific scenario `https://killercoda.com/kubedojo/scenario/cka-1.3-helm`. The "Launch Lab" button sent learners to an empty generic playground. It was the **sole outlier** across all 269 lab URLs sitewide (268 already followed the `kubedojo/scenario/` convention), and it sat on `main` unnoticed until an external contributor reported it.
+
+## Why (root cause)
+The defect class is **valid-but-wrong metadata**, which fell through every gate:
+
+1. **It's frontmatter, not teaching content.** Cross-family reviewers (human and LLM) are briefed to scrutinize prose, code, exercises, and technical accuracy. The `lab:` block is boilerplate they skim past, and they had no canonical value to compare against.
+2. **The bad URL returned HTTP 200.** `killercoda.com/playgrounds/scenario/kubernetes` is a real, live page — just the wrong one. The link checker (`check_site_health.py`) only flags broken/404 links, so a reachable-but-wrong URL passes. The defect is *semantic*, not a dead link.
+3. **`verify_module.py` never inspected `lab.url`.** The #388 content contract (density, structure, sources, anti-fab) is blind to frontmatter URL correctness.
+4. **The Astro Zod schema only checks `url()`** (`src/content.config.ts`), i.e. "is it a syntactically valid URL" — not "does it match our scenario convention." And per the sibling autopsy [`ci-no-full-build-gate.md`](ci-no-full-build-gate.md), PR CI runs no full `astro build` anyway, so even a tighter schema wouldn't gate PRs.
+5. **No convention-conformance gate existed.** 268/269 modules conformed by authoring discipline alone. Nothing *enforced* the pattern, so one straggler (authored before the convention solidified) stayed invisible.
+
+### Two adjacent CI frictions this PR also exposed
+6. **Cross-family review can't run on any fork PR.** The job reads `API_KEY: ${{ secrets.GEMINI_API_KEY }}`, but GitHub withholds repo secrets from `pull_request` runs triggered by a fork (anti-exfiltration). So `cross_family_review.sh` aborts with `API_KEY required` and shows a misleading red ❌ on every external contribution — looking like the contributor's change failed review when the job simply couldn't authenticate.
+7. **Required CodeQL checks never run on docs-only PRs → permanent BLOCKED.** Branch protection required `Analyze (actions|javascript-typescript|python)`, but CodeQL is path-filtered to code, so a markdown-only PR never triggers them. GitHub then waits forever for required checks that will never report, forcing an admin-merge on **every** content PR (and on external PRs, admin-merge is the only escape — the contributor can't self-merge).
+
+## Prevention
+- **`scripts/ci/check_lab_urls.py`** — a deterministic, stdlib-only validator asserting every `lab.url` matches `https://killercoda.com/kubedojo/scenario/<slug>`. Wired into the `link-check` job (runs on every PR, fork-safe, no secrets). Includes a `--selftest`. Confirmed it would have flagged the #1742 URL.
+- **Skip the cross-family review job on fork PRs** via `if: github.event.pull_request.head.repo.full_name == github.repository`. Internal-branch PRs still get the review; external contributors stop seeing a false red ❌.
+- **Removed the 3 CodeQL `Analyze` contexts from branch protection's required checks.** CodeQL still runs (advisory on code PRs + on push to `main`); it just no longer blocks content/external PRs. `link-check` was de-path-filtered so it always runs and serves as a universal required gate alongside the always-on `Incident dedup gate`.
+- **General lesson:** the pipeline was built to catch *content* defects and *broken* (404) links. It had no defense against *valid-but-wrong* metadata. When adding any frontmatter field with a project convention (a URL host, an id prefix, a slug shape), add a conformance check — `url()` / "is reachable" is not "is correct."
+
+Memory: `feedback_fork_pr_ci_behavior`, `feedback_lab_url_convention`.

--- a/scripts/ci/check_lab_urls.py
+++ b/scripts/ci/check_lab_urls.py
@@ -15,9 +15,13 @@ It was invisible to every existing gate because:
     authoring discipline alone — nothing *enforced* it.
 
 This check closes that gap deterministically: every ``lab.url`` must point at a
-module-specific ``https://killercoda.com/kubedojo/scenario/<slug>`` page. It is
-stdlib-only (no PyYAML) so it can run in the dependency-free link-check job and
-on every fork PR.
+module-specific ``https://killercoda.com/kubedojo/scenario/<slug>`` page.
+
+Frontmatter is parsed with a real YAML loader (PyYAML, already a repo
+dependency) rather than a hand-rolled scanner. The first draft used a
+line-based parser; codex R1 review (PR #1790) showed it failed open on
+flow-style ``lab: {url: ...}`` mappings and mis-captured inline ``# comments``.
+A real parser eliminates that whole class of edge cases.
 
 Usage::
 
@@ -32,6 +36,8 @@ import re
 import sys
 from pathlib import Path
 
+import yaml
+
 # A conforming lab URL is the module-specific KillerCoda scenario under the
 # kube-dojo org. Example: https://killercoda.com/kubedojo/scenario/cka-1.3-helm
 CONVENTION = re.compile(
@@ -41,50 +47,41 @@ CONVENTION = re.compile(
 DOC_SUFFIXES = {".md", ".mdx"}
 
 
-def extract_lab_url(text: str) -> tuple[int, str] | None:
-    """Return (1-based line number, url) for the frontmatter ``lab.url`` value.
+def extract_lab_url(text: str) -> str | None:
+    """Return the frontmatter ``lab.url`` value, or None when absent.
 
-    Returns None when the file has no frontmatter or no ``lab.url`` key. Parses
-    only the leading ``---`` fenced block and tracks indentation so a stray
-    ``url:`` elsewhere in the body is never mistaken for the lab URL.
+    Parses the leading ``---`` fenced YAML block with a real loader, so
+    block-style, flow-style (``lab: {url: ...}``), quoting, and inline
+    comments are all handled correctly. Returns None when there is no
+    frontmatter, no ``lab`` mapping, or no ``url`` key — and also when the
+    block is not parseable YAML (other gates own malformed frontmatter).
     """
-    lines = text.splitlines()
-    if not lines or lines[0].strip() != "---":
+    if not text.startswith("---"):
         return None
-
-    # Locate the closing frontmatter fence.
-    end = None
-    for i in range(1, len(lines)):
-        if lines[i].strip() == "---":
-            end = i
-            break
-    if end is None:
+    parts = text.split("---", 2)
+    if len(parts) < 3:
         return None
+    try:
+        data = yaml.safe_load(parts[1])
+    except yaml.YAMLError:
+        return None
+    if not isinstance(data, dict):
+        return None
+    lab = data.get("lab")
+    if not isinstance(lab, dict):
+        return None
+    url = lab.get("url")
+    if not isinstance(url, str):
+        return None
+    return url.strip()
 
-    in_lab = False
-    lab_indent = 0
-    for i in range(1, end):
-        raw = lines[i]
-        if not raw.strip() or raw.lstrip().startswith("#"):
-            continue
-        indent = len(raw) - len(raw.lstrip())
-        key = raw.strip()
-        if not in_lab:
-            if key.startswith("lab:") and indent == 0:
-                in_lab = True
-                lab_indent = indent
-            continue
-        # Inside the lab block: a key at or below the lab indent ends it.
-        if indent <= lab_indent:
-            in_lab = False
-            if key.startswith("lab:") and indent == 0:
-                in_lab = True
-            continue
-        m = re.match(r"url:\s*(.+?)\s*$", key)
-        if m:
-            url = m.group(1).strip().strip("'\"")
-            return (i + 1, url)
-    return None
+
+def find_line(text: str, url: str) -> int:
+    """Best-effort 1-based line number of ``url`` in the source (0 if absent)."""
+    for i, line in enumerate(text.splitlines(), start=1):
+        if url in line:
+            return i
+    return 0
 
 
 def scan(root: Path) -> list[tuple[Path, int, str]]:
@@ -93,12 +90,12 @@ def scan(root: Path) -> list[tuple[Path, int, str]]:
     for path in sorted(root.rglob("*")):
         if path.suffix not in DOC_SUFFIXES or not path.is_file():
             continue
-        found = extract_lab_url(path.read_text(encoding="utf-8"))
-        if found is None:
+        text = path.read_text(encoding="utf-8")
+        url = extract_lab_url(text)
+        if url is None:
             continue
-        line, url = found
         if not CONVENTION.match(url):
-            violations.append((path, line, url))
+            violations.append((path, find_line(text, url), url))
     return violations
 
 
@@ -126,11 +123,29 @@ def selftest() -> int:
             print(f"selftest FAIL: expected violation, accepted: {u}")
             fails += 1
 
-    sample = "---\ntitle: T\nlab:\n  id: x\n  url: https://killercoda.com/playgrounds/scenario/kubernetes\n---\nbody\nurl: https://decoy.example.com\n"
-    parsed = extract_lab_url(sample)
-    if parsed != (5, "https://killercoda.com/playgrounds/scenario/kubernetes"):
-        print(f"selftest FAIL: parser returned {parsed!r}")
-        fails += 1
+    # Parser cases, including the flow-style + inline-comment edge cases codex
+    # R1 flagged (PR #1790). All must extract the URL so CONVENTION can judge it.
+    bad_url = "https://killercoda.com/playgrounds/scenario/kubernetes"
+    good_url = "https://killercoda.com/kubedojo/scenario/cka-1.3-helm"
+    parser_cases: list[tuple[str, str | None]] = [
+        # block style with a decoy url: in the body
+        (f"---\ntitle: T\nlab:\n  id: x\n  url: {bad_url}\n---\nbody\nurl: https://decoy.example.com\n", bad_url),
+        # flow-style mapping on the lab line (previously failed OPEN -> None)
+        (f"---\ntitle: T\nlab: {{id: x, url: '{bad_url}'}}\n---\n", bad_url),
+        # inline YAML comment after the url (previously captured into the value)
+        (f"---\ntitle: T\nlab:\n  id: x\n  url: {good_url}  # canonical scenario\n---\n", good_url),
+        # double-quoted value
+        (f'---\ntitle: T\nlab:\n  id: x\n  url: "{good_url}"\n---\n', good_url),
+        # no lab block at all
+        ("---\ntitle: T\n---\nbody\n", None),
+        # no frontmatter
+        ("body only\nurl: https://decoy.example.com\n", None),
+    ]
+    for i, (src, expected) in enumerate(parser_cases):
+        got = extract_lab_url(src)
+        if got != expected:
+            print(f"selftest FAIL: parser case {i}: expected {expected!r}, got {got!r}")
+            fails += 1
 
     if fails:
         print(f"selftest: {fails} failure(s)")
@@ -161,7 +176,8 @@ def main() -> int:
     print("Every `lab.url` must be a module-specific KillerCoda scenario:")
     print("  https://killercoda.com/kubedojo/scenario/<module-slug>\n")
     for path, line, url in violations:
-        print(f"  {path}:{line}\n    got: {url}")
+        loc = f"{path}:{line}" if line else str(path)
+        print(f"  {loc}\n    got: {url}")
     print(
         "\nFix: point each lab at its own kube-dojo scenario "
         "(see any sibling module for the slug pattern)."

--- a/scripts/ci/check_lab_urls.py
+++ b/scripts/ci/check_lab_urls.py
@@ -1,0 +1,173 @@
+#!/usr/bin/env python3
+"""Validate the `lab.url` frontmatter convention across the curriculum.
+
+Background — bug autopsy (2026-06-04, surfaced by PR #1742):
+Module ``cka/.../module-1.3-helm.md`` shipped with
+``lab.url: https://killercoda.com/playgrounds/scenario/kubernetes`` — a
+*generic* KillerCoda playground instead of the module-specific scenario.
+It was invisible to every existing gate because:
+
+  * the value is frontmatter metadata, not teaching prose (reviewers skim it);
+  * the bad URL returned **HTTP 200** — a real, live page, so the link checker
+    (which only flags 404s) passed it; the defect was *semantic*, not broken;
+  * ``verify_module.py`` never inspected ``lab.url``;
+  * 268 of 269 modules followed the ``kubedojo/scenario/`` convention by
+    authoring discipline alone — nothing *enforced* it.
+
+This check closes that gap deterministically: every ``lab.url`` must point at a
+module-specific ``https://killercoda.com/kubedojo/scenario/<slug>`` page. It is
+stdlib-only (no PyYAML) so it can run in the dependency-free link-check job and
+on every fork PR.
+
+Usage::
+
+    python scripts/ci/check_lab_urls.py [--root src/content/docs] [--selftest]
+
+Exit codes: 0 = all conforming, 1 = one or more violations (or selftest fail).
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import sys
+from pathlib import Path
+
+# A conforming lab URL is the module-specific KillerCoda scenario under the
+# kube-dojo org. Example: https://killercoda.com/kubedojo/scenario/cka-1.3-helm
+CONVENTION = re.compile(
+    r"^https://killercoda\.com/kubedojo/scenario/[a-z0-9]+(?:[._-][a-z0-9]+)*/?$"
+)
+
+DOC_SUFFIXES = {".md", ".mdx"}
+
+
+def extract_lab_url(text: str) -> tuple[int, str] | None:
+    """Return (1-based line number, url) for the frontmatter ``lab.url`` value.
+
+    Returns None when the file has no frontmatter or no ``lab.url`` key. Parses
+    only the leading ``---`` fenced block and tracks indentation so a stray
+    ``url:`` elsewhere in the body is never mistaken for the lab URL.
+    """
+    lines = text.splitlines()
+    if not lines or lines[0].strip() != "---":
+        return None
+
+    # Locate the closing frontmatter fence.
+    end = None
+    for i in range(1, len(lines)):
+        if lines[i].strip() == "---":
+            end = i
+            break
+    if end is None:
+        return None
+
+    in_lab = False
+    lab_indent = 0
+    for i in range(1, end):
+        raw = lines[i]
+        if not raw.strip() or raw.lstrip().startswith("#"):
+            continue
+        indent = len(raw) - len(raw.lstrip())
+        key = raw.strip()
+        if not in_lab:
+            if key.startswith("lab:") and indent == 0:
+                in_lab = True
+                lab_indent = indent
+            continue
+        # Inside the lab block: a key at or below the lab indent ends it.
+        if indent <= lab_indent:
+            in_lab = False
+            if key.startswith("lab:") and indent == 0:
+                in_lab = True
+            continue
+        m = re.match(r"url:\s*(.+?)\s*$", key)
+        if m:
+            url = m.group(1).strip().strip("'\"")
+            return (i + 1, url)
+    return None
+
+
+def scan(root: Path) -> list[tuple[Path, int, str]]:
+    """Return a list of (path, line, url) violations under ``root``."""
+    violations: list[tuple[Path, int, str]] = []
+    for path in sorted(root.rglob("*")):
+        if path.suffix not in DOC_SUFFIXES or not path.is_file():
+            continue
+        found = extract_lab_url(path.read_text(encoding="utf-8"))
+        if found is None:
+            continue
+        line, url = found
+        if not CONVENTION.match(url):
+            violations.append((path, line, url))
+    return violations
+
+
+def selftest() -> int:
+    good = [
+        "https://killercoda.com/kubedojo/scenario/cka-1.3-helm",
+        "https://killercoda.com/kubedojo/scenario/cka-1.7-kubeadm",
+        "https://killercoda.com/kubedojo/scenario/ckad-2.1-pods/",
+        "https://killercoda.com/kubedojo/scenario/cks-5.2-application-failures",
+    ]
+    bad = [
+        "https://killercoda.com/playgrounds/scenario/kubernetes",  # the #1742 bug
+        "http://killercoda.com/kubedojo/scenario/cka-1.3-helm",  # not https
+        "https://killercoda.com/someone-else/scenario/cka-1.3-helm",
+        "https://example.com/kubedojo/scenario/cka-1.3-helm",
+        "https://killercoda.com/kubedojo/scenario/",  # no slug
+    ]
+    fails = 0
+    for u in good:
+        if not CONVENTION.match(u):
+            print(f"selftest FAIL: expected conforming, rejected: {u}")
+            fails += 1
+    for u in bad:
+        if CONVENTION.match(u):
+            print(f"selftest FAIL: expected violation, accepted: {u}")
+            fails += 1
+
+    sample = "---\ntitle: T\nlab:\n  id: x\n  url: https://killercoda.com/playgrounds/scenario/kubernetes\n---\nbody\nurl: https://decoy.example.com\n"
+    parsed = extract_lab_url(sample)
+    if parsed != (5, "https://killercoda.com/playgrounds/scenario/kubernetes"):
+        print(f"selftest FAIL: parser returned {parsed!r}")
+        fails += 1
+
+    if fails:
+        print(f"selftest: {fails} failure(s)")
+        return 1
+    print("selftest: OK")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--root", default="src/content/docs", type=Path)
+    parser.add_argument("--selftest", action="store_true")
+    args = parser.parse_args()
+
+    if args.selftest:
+        return selftest()
+
+    if not args.root.exists():
+        print(f"error: root not found: {args.root}", file=sys.stderr)
+        return 1
+
+    violations = scan(args.root)
+    if not violations:
+        print(f"lab.url convention check: OK (root={args.root})")
+        return 0
+
+    print(f"lab.url convention check: {len(violations)} violation(s)\n")
+    print("Every `lab.url` must be a module-specific KillerCoda scenario:")
+    print("  https://killercoda.com/kubedojo/scenario/<module-slug>\n")
+    for path, line, url in violations:
+        print(f"  {path}:{line}\n    got: {url}")
+    print(
+        "\nFix: point each lab at its own kube-dojo scenario "
+        "(see any sibling module for the slug pattern)."
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
Closes the CI gaps surfaced by **PR #1742** (our first external contributor, @H3xKatana). See `docs/bug-autopsies/ci-metadata-blindspot.md`.

## Changes
1. **`scripts/ci/check_lab_urls.py`** — stdlib-only validator: every `lab.url` must be a module-specific `https://killercoda.com/kubedojo/scenario/<slug>`. Has `--selftest`. Wired into the `link-check` job (runs on every PR, fork-safe, no secrets). *Verified it would have flagged the #1742 bug; passes on all 269 current modules.*
2. **`cross-family-code-review.yml`** — `if: head.repo.full_name == github.repository` skips the review job on fork PRs (where GitHub withholds `GEMINI_API_KEY`), so external contributors stop seeing a false red ❌. Internal PRs still reviewed.
3. **`link-check.yml`** — removed the `paths:` filter so it always runs and can serve as a universal required gate (a path-filtered required check leaves non-matching PRs permanently `BLOCKED`).
4. **Autopsy + INDEX row.**

## Not in this PR (AC4, separate step)
Branch-protection required-checks edit (drop the 3 never-running CodeQL `Analyze` contexts; CodeQL stays advisory) — applied via `gh api` after merge so the new always-on `link-check` context exists first.

## Verification
- `python scripts/ci/check_lab_urls.py --selftest` → OK
- `python scripts/ci/check_lab_urls.py` → OK (269 modules)
- `uvx zizmor --offline --strict-collection .github/` → No findings
- This PR is internal-branch, so the cross-family review job runs (unlike #1742).

## Learner check
> Helm 4 remains current and keeps the same client-only model, with additional behavior updates in upgrade and rendering paths.

Refs #1789.
