### PR TITLE
fix(security): resolve 2 high-severity CodeQL alerts in local_api.py (#1791)

### DIFF
--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -1418,7 +1418,14 @@ def build_module_state(repo_root: Path, module_key: str) -> dict[str, Any]:
     from status import _build_lab_summary, _extract_frontmatter, _git_head_for_file
     from translation_v2 import detect_module_state
 
-    normalized = module_key[:-3] if module_key.endswith(".md") else module_key
+    # Defense in depth: module_key reaches the filesystem below (en_path.exists(),
+    # _extract_frontmatter(en_path)). Both current callers pre-validate via
+    # _validate_module_key, but re-validate here so the function is safe
+    # regardless of caller and cannot be coerced into reading outside
+    # src/content/docs via "../" traversal (CodeQL py/path-injection, alert #32).
+    normalized = _validate_module_key(repo_root, module_key)
+    if normalized is None:
+        raise ValueError(f"unsafe or invalid module_key: {module_key!r}")
     en_path = repo_root / "src" / "content" / "docs" / f"{normalized}.md"
     uk_path = repo_root / "src" / "content" / "docs" / "uk" / f"{normalized}.md"
     frontmatter = _extract_frontmatter(en_path) if en_path.exists() else {}
@@ -5222,8 +5229,12 @@ def _html_fragment_to_text(fragment: str) -> str:
 
 def _strip_html_noncontent(text: str) -> str:
     text = re.sub(r"<!--.*?-->", " ", text, flags=re.DOTALL)
-    text = re.sub(r"<script\b[^>]*>.*?</script\s*>", " ", text, flags=re.IGNORECASE | re.DOTALL)
-    return re.sub(r"<style\b[^>]*>.*?</style\s*>", " ", text, flags=re.IGNORECASE | re.DOTALL)
+    # End-tag patterns use `</script\b[^>]*>` (not `</script\s*>`): browsers
+    # accept end tags with trailing junk like `</script\t\n bar>`, so the strict
+    # form would leave script/style content un-stripped (CodeQL py/bad-tag-filter,
+    # alert #31). `\b` keeps `</scriptx>` from matching a different tag name.
+    text = re.sub(r"<script\b[^>]*>.*?</script\b[^>]*>", " ", text, flags=re.IGNORECASE | re.DOTALL)
+    return re.sub(r"<style\b[^>]*>.*?</style\b[^>]*>", " ", text, flags=re.IGNORECASE | re.DOTALL)
 
 
 def _extract_html_h1(text: str) -> str | None:
@@ -7182,13 +7193,18 @@ def render_quality_module_page_html(repo_root: Path, module_key: str) -> str | N
     def _relative_path(raw_path: Any) -> str:
         if not raw_path:
             return ""
+        # raw_path is built as repo_root / src/content/docs / <validated key>.md,
+        # so it is already absolute under repo_root. Compute the display path
+        # purely lexically — no .resolve()/filesystem access on a request-derived
+        # value (CodeQL py/path-injection, alert #32) — and reject anything that
+        # escapes repo_root.
         try:
-            resolved = Path(raw_path).resolve()
-            return resolved.relative_to(repo_root).as_posix()
-        except (OSError, ValueError):
-            # Path doesn't exist or escapes repo_root; avoid reflecting arbitrary
-            # user-provided paths into generated HTML.
+            rel = Path(str(raw_path)).relative_to(repo_root)
+        except ValueError:
             return ""
+        if ".." in rel.parts:
+            return ""
+        return rel.as_posix()
 
     gate_items = []
     for item in diagnostics:

--- a/tests/test_local_api.py
+++ b/tests/test_local_api.py
@@ -1992,12 +1992,14 @@ def test_module_state_flags_missing_lab_and_ledger(tmp_path: Path) -> None:
     repo = tmp_path
     _init_repo(repo)
     _write(
-        repo / "src/content/docs/k8s/cka/module-X-stub.md",
+        repo / "src/content/docs/k8s/cka/module-x-stub.md",
         "---\ntitle: stub\n---\nbody\n",
     )
     _git(repo, "add", ".")
     _git(repo, "commit", "-m", "init")
-    state = local_api.build_module_state(repo, "k8s/cka/module-X-stub")
+    # Lowercase key: build_module_state now re-validates via _validate_module_key
+    # (lowercase-only slugs), matching the real curriculum (all 1504 keys lowercase).
+    state = local_api.build_module_state(repo, "k8s/cka/module-x-stub")
     codes = _diag_codes(state["diagnostics"])
     assert "no_lab" in codes
     assert "no_fact_ledger" in codes

--- a/tests/test_local_api_security.py
+++ b/tests/test_local_api_security.py
@@ -8,6 +8,8 @@ from pathlib import Path
 from threading import Thread
 from typing import Callable
 
+import pytest
+
 
 def _load_module():
     module_path = Path(__file__).resolve().parent.parent / "scripts" / "local_api.py"
@@ -122,6 +124,34 @@ def test_strip_html_noncontent_handles_script_with_trailing_space() -> None:
 
 def test_strip_html_noncontent_handles_style_with_trailing_space() -> None:
     assert "<x>" not in local_api._strip_html_noncontent("<style >x</style >")
+
+
+def test_strip_html_noncontent_handles_end_tag_with_trailing_junk() -> None:
+    # CodeQL py/bad-tag-filter (#31): browsers accept end tags with trailing
+    # whitespace + junk like `</script\t\n bar>`, so the strict `</script\s*>`
+    # form left the script/style body un-stripped.
+    assert "alert(1)" not in local_api._strip_html_noncontent(
+        "<script>alert(1)</script\t\n bar>tail"
+    )
+    assert "body{}" not in local_api._strip_html_noncontent(
+        "<style>body{}</style\n  junk>tail"
+    )
+
+
+def test_strip_html_noncontent_does_not_overmatch_different_tag_name() -> None:
+    # `</scriptx>` is a different (invalid) tag name, not a script close — the
+    # `\b` boundary must keep it from being treated as a script end tag, so
+    # surrounding real content is preserved.
+    out = local_api._strip_html_noncontent("<script>keep</scriptx><h1>Title</h1>")
+    assert "<h1>Title</h1>" in out
+
+
+def test_build_module_state_rejects_traversal_module_key(tmp_path: Path) -> None:
+    # CodeQL py/path-injection (#32): build_module_state re-validates module_key
+    # (defense in depth) so a "../" traversal raises before reaching the
+    # filesystem reads (en_path.exists() / frontmatter extraction) below it.
+    with pytest.raises(ValueError):
+        local_api.build_module_state(tmp_path, "../../../../etc/passwd")
 
 
 def test_relative_path_returns_empty_for_path_outside_repo_root(


### PR DESCRIPTION
Resolves the 2 open high-severity CodeQL alerts in `scripts/local_api.py`. Refs #1791.

## #32 `py/path-injection` (request-derived `module_key` → filesystem)
Two layers:
- **Source:** `build_module_state` now re-validates `module_key` via the existing `_validate_module_key` (raises `ValueError` on traversal). Previously only the *callers* validated — fragile, and protects the real arbitrary-read sink (`en_path.exists()` / `_extract_frontmatter(en_path)`).
- **Sink:** `_relative_path` computes the display path **lexically** (`Path.relative_to` + a `..`-in-parts guard) instead of `Path(raw_path).resolve()`, removing the FS-touching path expression CodeQL flagged at line 7186. Behaviour unchanged for valid inputs.

## #31 `py/bad-tag-filter` (script/style stripping)
`</script\s*>` → `</script\b[^>]*>` (and style). The strict form missed valid HTML end-tag variants like `</script\t\n bar>`, leaving content un-stripped; `\b` prevents over-matching `</scriptx>`.

## Verification
- `ruff check scripts/local_api.py` → clean
- `build_module_state('../../../../etc/passwd')` → raises ValueError (no FS read)
- real keys validate; `</script\t\n bar>`, `</style  junk>` now stripped; `</scriptx>` not over-matched
- CodeQL `Analyze (python)` runs on this PR (advisory); alerts confirmed cleared after merge re-scans `main`.
