### PR TITLE
feat(content): NN Block B Wave 1 — PyTorch bridge + init + optimizers (refs #1793)

### DIFF
--- a/src/content/docs/ai-ml-engineering/deep-learning/index.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/index.md
@@ -20,8 +20,10 @@ sidebar:
 | 1.1.6 | [Backprop by Hand for Dense Nets](/ai-ml-engineering/deep-learning/module-1.1.6-backprop-by-hand-dense-nets/) |
 | 1.1.7 | [Tiny NumPy NN Lab: XOR to Fashion-MNIST](/ai-ml-engineering/deep-learning/module-1.1.7-tiny-numpy-nn-lab/) |
 | 1.1.8 | [Computational Graphs & Scalar Autograd](/ai-ml-engineering/deep-learning/module-1.1.8-computational-graphs-scalar-autograd/) |
-| 1.2 | [PyTorch Fundamentals](/ai-ml-engineering/deep-learning/module-1.2-pytorch-fundamentals/) |
+| 1.2 | [The PyTorch Bridge: From Your NumPy Engine to torch](/ai-ml-engineering/deep-learning/module-1.2-pytorch-fundamentals/) |
 | 1.3 | [Training Neural Networks](/ai-ml-engineering/deep-learning/module-1.3-training-neural-networks/) |
+| 1.3.1 | [Initialization & Signal Propagation](/ai-ml-engineering/deep-learning/module-1.3.1-initialization-signal-propagation/) |
+| 1.3.2 | [Optimizers & Learning-Rate Dynamics](/ai-ml-engineering/deep-learning/module-1.3.2-optimizers-lr-dynamics/) |
 | 1.4 | [Training Deep Networks: Normalization, Regularization & Optimization](/ai-ml-engineering/deep-learning/module-1.4-cnns-computer-vision/) |
 | 1.5 | [Convolutional Neural Networks & Computer Vision](/ai-ml-engineering/deep-learning/module-1.5-rnns-sequence-models/) |
 | 1.6 | [From Backpropagation to Transformers](/ai-ml-engineering/deep-learning/module-1.6-backpropagation-deep-dive/) |

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.2-pytorch-fundamentals.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.2-pytorch-fundamentals.md
@@ -1,1019 +1,696 @@
 ---
-title: "PyTorch Fundamentals"
+title: "The PyTorch Bridge: From Your NumPy Engine to torch"
 slug: ai-ml-engineering/deep-learning/module-1.2-pytorch-fundamentals
 sidebar:
   order: 1003
 ---
-> **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 6-8 Hours
 
-## The $500 Million Black Box: Why Understanding the Math Matters
+In 2019, the PyTorch team presented the framework to the systems community as a tool built around an unusually simple promise: write ordinary Python, run tensor operations eagerly, and let automatic differentiation record the graph as the program executes. That design choice matters for you because Block A just made the same promise at a smaller scale. You wrote NumPy arrays, cached intermediate activations, hand-derived vector-Jacobian products in A6, trained a Fashion-MNIST MLP in A7, and built a scalar `Value` autograd engine in A8. PyTorch is the production version of that work: the tensors are faster, the kernels can run on GPUs, and the graph engine handles tensor VJPs, but the training story is still forward pass, loss, backward pass, parameter update.
 
-In late 2021, the real estate giant Zillow announced it was shutting down its "Zillow Offers" division, a massive operation dedicated to algorithmically buying and selling homes. The cost of this failure? A staggering $500+ million write-down and the layoff of roughly 25% of the company's workforce. The catastrophic financial loss was directly tied to the failure of their predictive machine learning models.
-
-Zillow's models, which relied heavily on complex algorithmic architectures, had failed to accurately forecast housing prices during volatile market shifts caused by external economic events. The models kept aggressively buying houses at inflated prices even as the market began to cool. The engineers treating their predictive engines as infallible black boxes failed to diagnose the underlying distribution shifts and exploding error gradients in their financial risk metrics. They trusted the output without critically evaluating the internal loss landscapes and backpropagation dynamics of their architectures.
-
-When you use a modern deep learning framework like PyTorch, it is dangerously easy to abstract away the mathematics. You can build a multi-layer neural network with five lines of code. But when the model fails—when it silently memorizes noise, suffers from vanishing gradients, or collapses under real-world data drift—calling a simple `.fit()` method will not save you. This module bridges the gap between theoretical mathematics and modern implementation. By building a network from scratch, you will become the engineer who can diagnose catastrophic failures that cost companies millions.
+Think of this module as a bridge rather than a reset. We will not rebuild a neuron, re-derive softmax cross-entropy, or pretend `loss.backward()` is a new mathematical idea. Instead, each PyTorch primitive will be mapped to something you already built by hand. A `torch.Tensor` is your Block A NumPy array with device placement and autograd metadata. `nn.Linear` is your A7 `Layer` with battle-tested parameter registration. `torch.optim.SGD` is the `W -= lr * dW` loop you wrote by hand. `nn.CrossEntropyLoss` is the stable softmax-CE from A5 wrapped behind an API that expects logits and integer class labels. The magic is not new math; the magic is engineering scale.
 
 ## Learning Outcomes
 
 By the end of this module, you will be able to:
-- **Design** a multi-layer neural network architecture from first principles, understanding the mathematical role of every weight and bias matrix.
-- **Implement** forward and backward propagation algorithms from scratch using raw Python and NumPy to demystify underlying framework magic.
-- **Diagnose** vanishing and exploding gradient problems by analyzing activation function outputs and plotting loss curves.
-- **Evaluate** the PyTorch 2.11.0 ecosystem, selecting the correct CUDA targets and hardware compatibility libraries for modern infrastructure.
-- **Debug** failing model training loops by isolating and resolving errors in weight initialization, learning rates, or tensor shape mismatches.
 
-## The Day a Machine Learned to See: When Math Became Magic
+- Implement PyTorch tensor creation, shape inspection, dtype conversion, NumPy round-trips, broadcasting, indexing, and device movement while explaining how each operation maps back to the arrays and shape discipline from A1 through A3.
+- Debug a small differentiable PyTorch computation by comparing finite-difference gradients to `torch.autograd`, then explain why `loss.backward()` performs the same reverse topological walk your A8 `Value.backward()` implemented.
+- Construct an `nn.Module` and an equivalent `nn.Sequential` MLP, inspect registered parameters, and connect every `nn.Linear` weight and bias to the hand-rolled A7 `Layer` fields.
+- Execute the canonical optimizer step sequence, `zero_grad(set_to_none=True)` -> forward -> loss -> backward -> `step()`, and relate `torch.optim.SGD` to the manual `W -= lr * dW` update loop from A7.
+- Build a small `Dataset` and `DataLoader`, then translate the A7 Fashion-MNIST MLP into PyTorch using `nn.CrossEntropyLoss`, an SGD optimizer, mode toggles, and disciplined device placement.
 
-**Toronto. December 3, 2012. 4:47 PM.**
+## Why This Module Matters
 
-Geoffrey Hinton was staring at his computer screen, trying to process what he was seeing. For thirty years, he'd been a voice in the wilderness, insisting that neural networks could work if we just had enough data and computing power. His colleagues had called him stubborn. Funding agencies had called him delusional. The AI winters had frozen out most of his peers.
+Frameworks become dangerous when they make unfamiliar work look short. A learner who begins with PyTorch often sees five lines of code, trains a classifier, and concludes that deep learning is mostly API memorization. Block A deliberately denied you that shortcut. You saw that a dense layer is a matrix multiply plus a bias, that activation functions cache masks or nonlinear values, that cross-entropy should be computed from logits with numerical care, that gradients must flow in reverse order, and that parameters only improve after an explicit update step. Now that you know the machinery, PyTorch can become a force multiplier instead of a black box.
 
-But today was different.
+The bridge also protects you from the most common beginner failures. When `grad is None`, you will ask whether the tensor was connected to the loss instead of randomly changing the learning rate. When validation accuracy looks frozen, you will check whether gradients accumulated across batches because `zero_grad()` was missing. When a CUDA tensor meets a CPU tensor, you will recognize a device-placement bug rather than a mysterious framework failure. When `model.eval()` changes outputs, you will remember that some modules carry mode-dependent behavior. These are engineering habits, not abstract mathematical facts, and they are easier to learn when every PyTorch primitive has a Block A ancestor.
 
-The ImageNet Large Scale Visual Recognition Challenge results were in. Hinton's team—two graduate students, Alex Krizhevsky and Ilya Sutskever—had entered a neural network called "AlexNet." The best competing systems achieved error rates around 26%. AlexNet achieved 15.3%.
+The bridge analogy is literal. On one side is your NumPy micro-framework: transparent, small, slow, and excellent for learning. On the other side is PyTorch: optimized kernels, device backends, registered modules, optimizers, data pipelines, and a tensor autograd engine. The planks across the bridge are one-to-one mappings. If a plank does not connect to something you built, we will name the missing concept and defer it to a later Block B module instead of smuggling in a new abstraction too early.
 
-Hinton read the number again: **15.3%**.
+Here is the whole map before we cross it. Read it from left to right and notice how little new math appears. Most of the new vocabulary names ownership and scale: which object owns parameters, which object owns a batch, which object owns the update rule, and which device owns the memory.
 
-Not slightly better. Not incrementally improved. A single neural network had reduced the error rate by more than 10 percentage points—a jump so large that reviewers initially assumed it was a mistake.
-
-> "I remember thinking: this changes everything. The ideas we'd been developing for decades—they actually work. We just needed scale."
-> — Geoffrey Hinton, reflecting on the moment in 2017
-
-The phone started ringing. Colleagues who'd dismissed neural networks for years suddenly wanted to know more. Within months, Google acquired Hinton's startup for $44 million. Within a year, neural networks would be the dominant paradigm in AI. Within a decade, they would power everything from voice assistants to self-driving cars to ChatGPT.
-
-But here's the remarkable part: **the core algorithm that made AlexNet work was invented in 1986.** The math hadn't changed. The architecture was similar to networks from the 1990s. What changed was data (ImageNet providing millions of labeled images), compute (GPUs making training fast), and new techniques (like ReLU, dropout, and batch norm solving training issues).
-
-## Introduction: What IS a Neural Network?
-
-You have likely interacted with neural networks through sophisticated APIs. You have seen them generate human-like text, recognize complex images, and transcribe speech in real time. But what is actually happening inside the memory of the GPU? Stripped of the philosophical hype, a neural network is strictly a mathematical function.
-
-It is a highly complex, deeply nested, parameterized function that maps inputs to outputs. The entire process of "machine learning" is simply a continuous optimization problem: finding the exact correct parameters (numerical weights) that make the function cleanly approximate the relationship between your input data and your desired output labels.
-
-Imagine a massive soundboard in a recording studio with millions of individual sliders. Each slider is a parameter. When you train a neural network, an algorithm automatically adjusts all those sliders simultaneously based on mathematical feedback until the resulting audio sounds perfect. The physical architecture of the network determines how the sliders are wired together, but the calculus-based learning algorithm does all the heavy lifting.
-
-```
-Neural Network = f(x; θ)
-
-Where:
-  x = input (image, text, numbers)
-  θ = parameters (weights and biases)
-  f = the function we're learning
+```text
+Block A hand-built system                   PyTorch production primitive
+--------------------------------------------------------------------------------
+NumPy arrays with shapes and dtypes     ->  torch.Tensor with dtype and device
+Cached forward values in each Layer     ->  dynamic autograd graph nodes
+A6 dense-layer VJPs                     ->  tensor backward kernels
+A7 Layer(W, b, forward, backward)       ->  nn.Linear inside nn.Module
+A5 stable softmax cross-entropy         ->  nn.CrossEntropyLoss on logits
+Manual W -= lr * dW update              ->  torch.optim.SGD.step()
+Manual shuffled index mini-batches      ->  Dataset plus DataLoader
+Hand-written train/eval metric blocks   ->  B2's structured training loop
 ```
 
-Before we dive into how PyTorch automates this vast mathematical orchestration, we must understand the raw mechanics from the ground up.
+The right column is not superior because it hides the left column; it is superior because it preserves the left column while making the repetitive engineering reliable. PyTorch frees you from retyping the dense-layer backward formula, but it does not free you from checking that logits have shape `[batch, classes]`. It removes your hand-written softmax, but it does not remove the need to pass class-index labels. It gives you a `DataLoader`, but it does not decide whether your data should be shuffled, normalized, split, cached, or moved to a GPU. Treat the framework as a set of named replacements for work you understand, and the API surface becomes much smaller.
 
-### The Modern Framework: PyTorch 2.11.0 Context
+## Part 1: `torch.Tensor` Is the NumPy Array You Already Know
 
-While we will learn the math from scratch, it is critical to know where the industry stands today. As of March 23, 2026, the latest stable release of PyTorch is **2.11.0**. 
-
-You must navigate official documentation with technical skepticism: the PyTorch documentation version selector sometimes inconsistently advertises v2.9.0 as the stable release. However, we base our architectural decisions on the authoritative package metadata from PyPI and the official GitHub releases, both of which unequivocally confirm that 2.11.0 is the current stable truth.
-
-PyTorch 2.11.0 requires C++17 under the hood and supports Python versions from 3.10 through 3.14 (with 3.14t marked as experimental). It is officially supported on Linux (glibc>=2.17), macOS 10.15+, and Windows 7/Server 2008 R2+. The stable binary support covers CUDA 12.6, CUDA 12.8, and experimental CUDA 13.0 architectures. Crucially, PyTorch 2.11 dropped support for the older Volta (SM 7.0) architecture in the 12.8 and 12.9 pre-built binaries, while simultaneously expanding support for cutting-edge Blackwell hardware. By understanding the underlying NumPy mathematics in this module, you are learning the exact blueprint of what PyTorch's C++ and CUDA backend executes at blinding speeds.
-
-### The Tumultuous History of Neural Networks
-
-Neural networks are not a new concept; their history is defined by periods of intense hype followed by crushing technological winters. The first mathematical model of a neuron was proposed in 1943 by Warren McCulloch and Walter Pitts in their paper "A Logical Calculus of the Ideas Immanent in Nervous Activity," proposing to "show how neurons might be connected to perform logical operations." In 1958, Frank Rosenblatt built the Mark I Perceptron, generating massive but premature hype (with The New York Times claiming it would eventually "walk, talk, see, write, reproduce itself and be conscious of its existence"). In 1969, Marvin Minsky and Seymour Papert published a book titled *Perceptrons*, which mathematically proved that early single-layer neural networks could not solve non-linear problems like the XOR logic gate, famously concluding that the perceptron was "worthy of study despite (and even because of!) its severe limitations." This devastating critique starved the field of funding, plunging researchers into the first "AI Winter."
-
-The field lay dormant until 1986, when researchers including Geoffrey Hinton, David Rumelhart, and Ronald Williams published a landmark paper demonstrating that multi-layer networks could overcome this limitation using an algorithm called backpropagation (a solution actually discovered earlier by Paul Werbos in 1974 and David Parker in 1985). While this reignited interest, computers of the 1980s and 1990s were far too slow to train deep architectures. Support Vector Machines (SVMs) and Random Forests dominated the industry, triggering a second, milder AI Winter for neural networks, during which Hinton later noted he "was pretty much the only person in the world who still believed in neural networks."
-
-The watershed moment arrived in 2012. A team led by Alex Krizhevsky utilized consumer-grade NVIDIA GPUs to train a massive, deep Convolutional Neural Network called AlexNet. By parallelizing the matrix multiplications on graphics hardware, AlexNet shattered all existing records in the ImageNet computer vision competition. This breakthrough proved that deep networks were theoretically sound—they just needed the immense computational horsepower of the GPU era.
-
-> **Stop and think**: If a neural network is just a mathematical function $f(x; \theta)$, what does it mean when the model "hallucinates" or gives a confident but wrong answer? *It means the parameters $\theta$ have found a local minimum that satisfies the training data but fails to generalize to unseen inputs $x$.*
-
-## The Building Block: A Single Neuron
-
-To understand the massive architectures driving today's AI, we must start with the fundamental atomic unit: the artificial neuron.
-
-### The Biological Inspiration
-
-The biological neuron is a microscopic decision-making unit residing in the nervous system. It operates on a remarkably simple physical principle: accumulate chemical signals from neighbors, and if the total electrical potential crosses a specific threshold, transmit a new signal downstream.
-
-1. It receives chemical signals through its **dendrites**.
-2. If the combined electrical potential exceeds a strict threshold in the **cell body**, an action potential is triggered.
-3. The electrical spike travels down the **axon** to influence thousands of other connected neurons.
-
-```
-    Dendrites          Cell Body         Axon
-    (inputs)           (processing)      (output)
-
-    x₁ ─────┐
-            │
-    x₂ ─────┼──────► [ Σ + f ] ──────► y
-            │
-    x₃ ─────┘
-```
-
-### The Artificial Neuron
-
-An artificial neuron perfectly models this biological process using pure arithmetic and programmatic logic. It takes a series of numerical inputs, multiplies each by a specific weight (representing the strength of the synaptic connection), adds a bias (representing the inherent cellular threshold to fire), and passes the final result through an activation function.
+The first PyTorch object to demystify is `torch.Tensor`. In Block A, your data lived in NumPy arrays with shapes such as `(batch, features)`, `(784, 256)`, or `(batch, classes)`. A PyTorch tensor has the same core contract: it stores typed numeric data in a rectangular shape, supports vectorized operations, follows broadcasting rules, and can be indexed or reshaped without writing Python loops. The additional production concerns are dtype, device, and optional autograd metadata. Those extra fields are what let the same math run on CPU, CUDA, or Apple's MPS backend while remaining differentiable when needed.
 
 ```python
-def neuron(inputs, weights, bias):
-    # 1. Weighted sum of inputs
-    z = sum(x * w for x, w in zip(inputs, weights)) + bias
+import numpy as np
+import torch
 
-    # 2. Apply activation function
-    output = activation(z)
+# Two samples, three features, exactly like the small matrices from A1-A3.
+features_np = np.array(
+    [[1.0, 2.0, 3.0],
+     [4.0, 5.0, 6.0]],
+    dtype=np.float32,
+)
 
-    return output
+features = torch.from_numpy(features_np)  # shape: [2, 3], dtype: torch.float32
+bias = torch.tensor([0.1, -0.2, 0.3], dtype=torch.float32)  # shape: [3]
+
+centered = features - features.mean(dim=0, keepdim=True)  # shape: [2, 3]
+shifted = centered + bias  # broadcasting [3] across the batch dimension
+
+print(features.shape, features.dtype)
+print(shifted)
 ```
 
-Mathematically, this logic is expressed flawlessly as a vector dot product:
+This code should feel almost boring after A1. The batch axis is still axis 0. `mean(dim=0, keepdim=True)` preserves a `(1, 3)` row so subtraction broadcasts across both samples. Adding `bias` with shape `[3]` uses the same broadcasting idea you practiced with NumPy. PyTorch uses `dim` where NumPy often says `axis`, but the mental model is identical: reduce or index along a named dimension, keep dimensions when you need later broadcasting to remain explicit, and inspect shapes before blaming the optimizer.
 
-```
-z = w₁x₁ + w₂x₂ + ... + wₙxₙ + b = w·x + b
-y = f(z)
-```
+Indexing follows the same discipline. If `images` has shape `[batch, channels, height, width]`, then `images[:, 0, :, :]` selects the first channel for every sample, while `images[0]` selects one complete image and drops the batch dimension. That dimension drop is often correct for inspection and wrong for model input. A single image with shape `[1, 28, 28]` cannot feed a model expecting a batch unless you add the batch axis back with `unsqueeze(0)`, producing `[1, 1, 28, 28]`. This is the same shape reasoning you practiced in A3, now with the image convention explicit.
 
-Where:
-- **x** = inputs (the raw features of your data vector)
-- **w** = weights (the learned parameters defining connection strength)
-- **b** = bias (an offset shifting the activation threshold)
-- **f** = activation function (determining how the sum translates to an output signal)
-- **y** = output prediction
+The most common tensor debugging move is not printing the entire tensor; it is printing a compact shape and dtype trace at the boundary between components. Before a model call, log `xb.shape`, `xb.dtype`, `xb.device`, `yb.shape`, `yb.dtype`, and `yb.device`. Before a loss call, log `logits.shape` and `yb.shape`. If those facts are correct, many scary training failures become ordinary questions about optimization. If those facts are wrong, no optimizer or initialization trick can compensate for a broken contract.
 
-## Activation Functions: Introducing Non-Linearity
-
-If we only used weighted sums without any further processing, no matter how many billions of neurons we connected together, the entire network would collapse mathematically into a single, flat linear equation. The physical universe and complex data distributions are wildly non-linear. To learn complex, curving, abstract patterns, we must intentionally inject mathematical non-linearity into the system using activation functions.
-
-### Sigmoid (The Classic)
-Historically the most popular choice, it smoothly squashes any input value into a rigid range between 0 and 1. While it suffers from vanishing gradients for very large or small inputs (where the curve flattens out to zero), it remains strictly necessary for the final output layer of binary classification tasks.
-
-```
-σ(z) = 1 / (1 + e^(-z))
-```
-
-### Tanh (Hyperbolic Tangent)
-Tanh squashes outputs to a range between -1 and 1. Because it is zero-centered, it forces the data to maintain a mean close to zero, which helps gradient descent converge considerably faster than Sigmoid. However, it still suffers from vanishing gradients at extreme positive and negative inputs.
-
-```
-tanh(z) = (e^z - e^(-z)) / (e^z + e^(-z))
-```
-
-### ReLU (Rectified Linear Unit)
-The absolute workhorse of the modern deep learning revolution. It operates on a brutally simple conditional: it returns the exact input if it is positive, and purely zero if it is negative. It is computationally dirt cheap to execute and single-handedly solves the vanishing gradient problem for positive values, allowing deep networks to learn rapidly.
-
-```
-ReLU(z) = max(0, z)
-```
-
-### Leaky ReLU
-A modern variation of ReLU designed specifically to prevent "dead neurons"—neurons that get stuck receiving negative inputs and outputting zero forever, completely destroying their ability to update. Leaky ReLU allows a tiny, fractional non-zero gradient when the input is negative, keeping the neuron mathematically alive.
-
-```
-LeakyReLU(z) = z if z > 0 else 0.01 * z
-```
-
-Here is a visual intuition of how these mathematical functions drastically shape the signal output:
-
-```
-Visualization of Activation Functions:
-
-Sigmoid:                ReLU:
-    1 ─────────            │     ╱
-      │      ╱             │    ╱
-  0.5 │─────╱              │   ╱
-      │    ╱               │  ╱
-    0 ─────                └──────
-     -5    0    5         -2  0  2  4
-```
-
-> **Pause and predict**: If you use a ReLU activation function and initialize all your weights to large negative numbers, what will happen during the first forward pass? *The network will output pure zeros, the gradients will be zero, and the network will be effectively "dead" and unable to learn.*
-
-## Network Architecture: Stacking Neurons
-
-A single neuron sitting alone can only draw a straight, rigid line through a dataset. To learn complex conceptual representations, we must arrange thousands of neurons into interconnected architectural layers. This creates a Multi-Layer Perceptron (MLP), frequently referred to as a dense or fully-connected neural network.
-
-```
-Input Layer    Hidden Layer(s)    Output Layer
-    x₁ ─────┐
-            ├──► h₁ ─────┐
-    x₂ ─────┼            ├──► y₁
-            ├──► h₂ ─────┤
-    x₃ ─────┼            ├──► y₂
-            ├──► h₃ ─────┘
-    x₄ ─────┘
-
-    Features   Learned         Predictions
-               Representations
-```
-
-### Why This Architecture Matters
-
-Deep neural networks perform a process known as hierarchical feature extraction. They do not just blindly memorize data; they progressively decompose it into higher-level abstract concepts. The early layers learn simple geometric primitives, while deeper layers combine those basic geometries into rich semantic understanding.
-
-```
-Image Recognition Example:
-
-Layer 1: Edges and colors
-Layer 2: Textures and patterns
-Layer 3: Parts (eyes, wheels)
-Layer 4: Objects (faces, cars)
-```
-
-### Matrix Formulation
-
-In a production environment, we almost never use standard Python `for` loops to iterate over individual neurons. Modern hardware processing units (especially NVIDIA GPUs) are heavily optimized to perform massive, simultaneous matrix multiplications. We vectorize the operations mathematically to process entire batches of data concurrently.
+The NumPy bridge is also direct. `torch.from_numpy(array)` creates a tensor that shares memory with the NumPy array when possible, and `tensor.numpy()` returns a NumPy view for CPU tensors that do not require gradients. That shared-memory behavior is convenient but worth respecting: mutating one side can mutate the other side. For teaching experiments, it is useful because you can reuse the arrays from A7 without rewriting the data loader. For production code, explicit `.clone()` calls are often clearer when ownership matters.
 
 ```python
-# Single sample
-z = W @ x + b     # Linear transformation
-a = activation(z)  # Non-linearity
+features_np[0, 0] = 10.0
+print(features[0, 0].item())  # 10.0, because from_numpy shares CPU memory
 
-# Batch of samples
-Z = W @ X + b     # X is (features, batch_size)
-A = activation(Z)
+copy_for_training = torch.from_numpy(features_np).clone()
+round_trip_np = copy_for_training.numpy()
+print(type(round_trip_np), round_trip_np.shape)  # <class 'numpy.ndarray'>, (2, 3)
 ```
 
-When you call `torch.matmul(W, X)` in your Python script using PyTorch, the framework bypasses Python entirely, dispatching this exact matrix operation to highly tuned C++ and CUDA libraries running directly on the graphics card memory.
+Two dtype habits matter immediately. Model inputs are usually `torch.float32` unless you intentionally use mixed precision later. Class labels for `nn.CrossEntropyLoss` are integer class indices with dtype `torch.long`, not one-hot float matrices. In A5 you built softmax-CE from one-hot targets because it made the derivative `p - y` visible. In PyTorch, `nn.CrossEntropyLoss` expects raw logits of shape `[batch, classes]` and labels of shape `[batch]`, because it combines log-softmax and negative log-likelihood internally in a stable implementation.
 
-## Forward Propagation & The Loss Function
-
-Forward propagation is the sequential act of passing raw input data completely through the network architecture to generate a final prediction. We implement this structurally by stringing matrix multiplications together, layer by layer, carrying the activated outputs forward.
+This label change is a good example of "same math, different engineering contract." A5 used one-hot labels so the derivative could be written as a vector subtraction. PyTorch uses integer labels because the implementation can index the correct class directly and avoid storing a dense one-hot matrix for every batch. The gradient with respect to logits is still the same softmax-probability-minus-target idea; the target representation is simply more compact at the API boundary.
 
 ```python
-def forward(X, parameters):
-    """
-    Forward propagation through L layers.
+logits = torch.randn(4, 10, dtype=torch.float32)  # shape: [batch=4, classes=10]
+labels = torch.tensor([0, 3, 4, 9], dtype=torch.long)  # shape: [4]
 
-    Args:
-        X: Input data (n_features, m_samples)
-        parameters: Dict with W1, b1, W2, b2, ..., WL, bL
-
-    Returns:
-        AL: Final output
-        caches: Intermediate values (needed for backprop)
-    """
-    caches = []
-    A = X
-    L = len(parameters) // 2  # Number of layers
-
-    # Hidden layers (with ReLU)
-    for l in range(1, L):
-        A_prev = A
-        W = parameters[f'W{l}']
-        b = parameters[f'b{l}']
-
-        Z = W @ A_prev + b
-        A = relu(Z)
-
-        caches.append((A_prev, W, b, Z))
-
-    # Output layer (with sigmoid for binary classification)
-    W = parameters[f'W{L}']
-    b = parameters[f'b{L}']
-
-    Z = W @ A + b
-    AL = sigmoid(Z)
-
-    caches.append((A, W, b, Z))
-
-    return AL, caches
+loss_fn = torch.nn.CrossEntropyLoss()
+loss = loss_fn(logits, labels)
+print(loss.item())
 ```
 
-Consider the dimensionality of a standard 2-layer network processing a batch of `m` images:
-
-```
-Input: X (784 features - flattened 28x28 image)
-Hidden: 128 neurons with ReLU
-Output: 10 neurons with softmax (digits 0-9)
-
-Forward pass:
-1. Z1 = W1 @ X + b1      # (128, 784) @ (784, m) = (128, m)
-2. A1 = ReLU(Z1)         # (128, m)
-3. Z2 = W2 @ A1 + b2     # (10, 128) @ (128, m) = (10, m)
-4. A2 = softmax(Z2)      # (10, m) - probabilities for each class
-```
-
-### Measuring Failure: The Loss Function
-
-To actually learn from its mistakes, the network must possess a mathematical way to know exactly how wrong its final prediction was. We rigorously quantify this wrongness using a designated Loss Function (also known as a Cost Function).
-
-**Binary Cross-Entropy Loss**
-Strictly used for binary (yes/no) classification tasks. It heavily penalizes the network when it makes confident but completely incorrect predictions.
-
-```
-L(y, ŷ) = -[y * log(ŷ) + (1-y) * log(1-ŷ)]
-```
-
-When averaged over `m` total training samples in a batch, it scales cleanly:
-```
-J = -(1/m) * Σ[y * log(ŷ) + (1-y) * log(1-ŷ)]
-```
-
-**Intuition**:
-- If y=1 and ŷ=1: loss ≈ 0 (correct and confident)
-- If y=1 and ŷ=0: loss → ∞ (wrong and confident)
-
-
-**Categorical Cross-Entropy Loss**
-Used for multi-class classification tasks where only one correct category exists (like classifying digits 0 through 9).
-
-```
-L(y, ŷ) = -Σ yᵢ * log(ŷᵢ)
-```
-Where y is one-hot encoded (e.g., [0,0,1,0,0,0,0,0,0,0] for digit "2").
-
-
-**Mean Squared Error (MSE)**
-Primarily used for continuous regression tasks (predicting raw floating-point numbers, like forecasting regional housing prices).
-
-```
-J = (1/m) * Σ(y - ŷ)²
-```
-
-## Backpropagation: The Engine of Learning
-
-Forward propagation gives us a structural answer. The chosen loss function objectively tells us how wrong the answer is. **Backpropagation** is the miraculous mathematical engine that tells us exactly *who to blame* for the error.
-
-Backpropagation iteratively computes the gradient of the loss function with respect to the network's learnable numerical parameters. It calculates precisely how a microscopic, fractional change in one specific weight embedded deep inside a hidden layer would ultimately impact the final output error. 
-
-### The Chain Rule
-
-At its core, backpropagation is nothing more than the calculus chain rule applied iteratively and recursively backward through the network's computational graph.
-
-```
-dy/dx = dy/dg * dg/dx
-```
-
-Translated into neural network terminology, the derivatives flow in reverse:
-```
-Loss ← Output ← Hidden ← ... ← Input ← Parameters
-```
-
-To manually derive the analytical gradients for our 2-layer dense network, we work backward layer by layer from the final loss calculation.
-
-```
-Z1 = W1 @ X + b1
-A1 = ReLU(Z1)
-Z2 = W2 @ A1 + b2
-A2 = sigmoid(Z2)
-L = cross_entropy(Y, A2)
-```
-
-**1. Output Layer Gradients:**
-```
-dL/dZ2 = A2 - Y     # For sigmoid + cross-entropy
-```
-
-**2. Output Layer Parameters:**
-```
-dL/dW2 = (1/m) * dZ2 @ A1.T
-dL/db2 = (1/m) * sum(dZ2, axis=1)
-```
-
-**3. Hidden Layer Gradients:**
-```
-dL/dA1 = W2.T @ dZ2
-dL/dZ1 = dL/dA1 * ReLU'(Z1)    # Element-wise
-```
-
-**4. Hidden Layer Parameters:**
-```
-dL/dW1 = (1/m) * dZ1 @ X.T
-dL/db1 = (1/m) * sum(dZ1, axis=1)
-```
-
-### Implementing Backpropagation from Scratch
-
-This backward flowing algorithm is the foundational code that makes the entire field of deep learning possible. Notice carefully how the intermediate values (caches) strategically saved during the forward pass are rapidly utilized here to calculate the local derivatives.
+Device placement is the second new field. A tensor lives on exactly one device, and operations usually require all participating tensors to live on the same device. CPU tensors cannot be added to CUDA tensors. CUDA tensors cannot feed a model whose parameters remain on CPU. The fix is not complicated; it is discipline. Pick a device, move the model once, and move every mini-batch to that device inside the training loop.
 
 ```python
-def backward(AL, Y, caches):
-    """
-    Backward propagation through L layers.
+def best_device() -> torch.device:
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
 
-    Args:
-        AL: Final output from forward prop
-        Y: True labels
-        caches: Intermediate values from forward prop
 
-    Returns:
-        gradients: Dict with dW1, db1, dW2, db2, ..., dWL, dbL
-    """
-    gradients = {}
-    L = len(caches)
-    m = AL.shape[1]
+device = best_device()
 
-    # Output layer (sigmoid + cross-entropy)
-    dAL = -(Y / AL) + (1 - Y) / (1 - AL)
-
-    # For sigmoid: dZ = dA * sigmoid'(Z) = dA * A * (1 - A)
-    A_prev, W, b, Z = caches[L-1]
-    dZ = AL - Y  # Simplified for sigmoid + cross-entropy
-
-    gradients[f'dW{L}'] = (1/m) * dZ @ A_prev.T
-    gradients[f'db{L}'] = (1/m) * np.sum(dZ, axis=1, keepdims=True)
-    dA_prev = W.T @ dZ
-
-    # Hidden layers (ReLU)
-    for l in reversed(range(L-1)):
-        A_prev, W, b, Z = caches[l]
-
-        # ReLU derivative: 1 if Z > 0, else 0
-        dZ = dA_prev * (Z > 0)
-
-        gradients[f'dW{l+1}'] = (1/m) * dZ @ A_prev.T
-        gradients[f'db{l+1}'] = (1/m) * np.sum(dZ, axis=1, keepdims=True)
-
-        if l > 0:
-            dA_prev = W.T @ dZ
-
-    return gradients
+features = features.to(device)
+labels = labels.to(device)
+print(features.device, labels.device)
 ```
 
-Here is a visual representation of how the raw data flows forward to create the prediction, and how the critical error gradients flow backward to inform the weight updates:
+The practical rule is simple enough to tape beside your monitor: data, labels, and model parameters must be on the same device before the forward pass. In A7, this problem did not exist because every NumPy array lived in CPU memory. PyTorch adds acceleration, but acceleration means memory ownership now matters. Later modules will discuss profiling and mixed precision; for B1, the correct habit is to choose the device explicitly and keep every tensor in a training step on it.
 
-```
-Forward:  X ───► Z1 ───► A1 ───► Z2 ───► A2 ───► Loss
-                ↑        ↑        ↑        ↑
-               W1       ---      W2       ---
+Do not treat `.to(device)` as a harmless decoration. It usually returns a tensor on the requested device rather than mutating the original tensor in place, so forgetting assignment leaves the old tensor where it was. The model call `model.to(device)` mutates module parameters recursively and returns the module for convenience, which is why both `model.to(device)` and `model = model.to(device)` are common. Tensors and modules therefore look similar at the call site but differ in ownership details. A disciplined batch-transfer helper avoids relying on memory of those details during a late-night debugging session.
 
-Backward: dX ◄─── dZ1 ◄─── dA1 ◄─── dZ2 ◄─── dA2 ◄─── dLoss
-                  ↓               ↓
-                 dW1             dW2
-                 db1             db2
-```
+## Part 2: Autograd Is Your A8 Engine, Scaled to Tensors
 
-### The PyTorch Advantage: Autograd
+In A8, your scalar `Value` class built a computation graph during the forward pass. Each operation created a node, stored parent pointers, cached the local backward rule, and then `backward()` walked the graph in reverse topological order while accumulating gradients with `+=`. PyTorch autograd follows the same contract. The difference is that the nodes are tensor operations such as matrix multiply, addition, ReLU, indexing, and reduction, and the local VJPs are implemented in optimized C++ and backend kernels instead of handwritten Python closures.
 
-You have just witnessed the rigorous mathematics required to derive backpropagation for a minuscule two-layer network. Now, imagine attempting to do this exact calculus by hand for a modern Transformer model comprising 100 billion parameters distributed across 500 dynamic layers. It is mathematically intractable for human engineers to write and maintain error-free backpropagation code at that staggering scale.
+The graph is dynamic, which means ordinary Python control flow participates naturally. If an `if` statement chooses one branch during the forward pass, autograd records the operations that actually ran, not the operations that could have run. If a loop iterates ten times for one sequence and twelve times for another, the recorded graph for each forward pass reflects that execution. This is why the 2019 PyTorch paper emphasized imperative, eager execution: the user's Python program is the graph-building language. A8 gave you the same property at scalar scale because `Value` nodes appeared only when your Python operators executed.
 
-This specific bottleneck is why PyTorch exists and dominates modern research. PyTorch is built around a revolutionary core module called **Autograd**. As you perform standard Python math operations on PyTorch tensors, Autograd dynamically builds a highly detailed computational graph in the background memory. When you simply invoke the `.backward()` method on your final loss variable, PyTorch automatically traverses this graph in reverse and perfectly calculates the exact analytical gradients for millions of parameters, utilizing the precise chain rule principles you just learned.
+Leaf tensors deserve a precise definition. A leaf tensor is typically a tensor you created directly with `requires_grad=True`, such as a model parameter. Gradients are populated on leaf tensors by default because those are the values optimizers update. Intermediate tensors usually have a `grad_fn` instead of a populated `.grad`; they know how they were produced, but PyTorch does not retain their gradients unless you explicitly ask. This is why inspecting `parameter.grad` after backward is normal, while expecting every hidden activation to have `.grad` populated is a misunderstanding of the graph's memory policy.
 
-## Gradient Descent & The Training Loop
-
-With our mathematically precise gradients calculated, we know exactly how to alter our weights to reduce the network's error. The overarching process of iteratively applying these gradient updates to the parameters is called Gradient Descent.
+The smallest useful example is a differentiable scalar function where you can compare finite differences from A1 with autograd from PyTorch. Use float64 here because finite differences are a numerical audit, and the extra precision makes the comparison less noisy. This is not a training recommendation; normal neural-network training usually uses float32 or a deliberate mixed-precision policy.
 
 ```python
-def update_parameters(parameters, gradients, learning_rate):
-    """
-    Update parameters using gradient descent.
+import numpy as np
+import torch
 
-    θ = θ - α * ∂L/∂θ
-    """
-    L = len(parameters) // 2
+torch.manual_seed(0)
 
-    for l in range(1, L + 1):
-        parameters[f'W{l}'] -= learning_rate * gradients[f'dW{l}']
-        parameters[f'b{l}'] -= learning_rate * gradients[f'db{l}']
+x = torch.tensor([0.25, -0.50, 1.25], dtype=torch.float64, requires_grad=True)
+loss = (torch.sin(x) * x + x.pow(2)).sum()
+loss.backward()
 
-    return parameters
+print("autograd gradient:", x.grad)
+
+def f_numpy(v: np.ndarray) -> float:
+    return float(np.sum(np.sin(v) * v + v**2))
+
+
+eps = 1e-6
+x_np = x.detach().numpy().copy()
+finite_diff = np.zeros_like(x_np)
+
+for i in range(x_np.size):
+    plus = x_np.copy()
+    minus = x_np.copy()
+    plus[i] += eps
+    minus[i] -= eps
+    finite_diff[i] = (f_numpy(plus) - f_numpy(minus)) / (2 * eps)
+
+print("finite difference:", finite_diff)
+print("max abs error:", np.max(np.abs(finite_diff - x.grad.detach().numpy())))
 ```
 
-### Why Gradient Descent Works
+The call to `requires_grad=True` tells PyTorch to record operations that depend on `x`. The forward expression builds a graph. The final `.sum()` turns the vector expression into one scalar loss, which is the standard reverse-mode training shape. `loss.backward()` seeds `dloss/dloss = 1` and performs the same reverse graph walk as your A8 engine. The `.grad` field on `x` then contains the accumulated gradient of that scalar loss with respect to every element of `x`.
 
-Imagine you're blindfolded on a hilly landscape, trying to find the lowest point. You can't see anything, but you can feel the slope under your feet. Here's your strategy:
+The finite-difference comparison is slow because it perturbs one coordinate at a time and reruns the whole function for each coordinate. That slowness is exactly why reverse-mode autograd matters for training. A neural network may have millions of parameters but one scalar loss, so one reverse walk can compute all parameter gradients together. A finite-difference checker is still valuable as a microscope for a tiny custom operation, but it is not a training algorithm. You used it in A1 and A6 for trust-building; PyTorch uses analytic VJPs for actual learning.
 
-1. Feel the slope under your feet (compute gradient)
-2. Take a step downhill (update parameters)
-3. Repeat until you can't go lower
+There are two important boundary tools. `with torch.no_grad():` temporarily disables gradient tracking for operations inside the block, which is what you want during evaluation or manual parameter updates in a toy example. `.detach()` returns a tensor that shares the same data but is disconnected from the current autograd graph, which is useful for logging, NumPy conversion, or stopping gradients intentionally. Do not use either one casually inside a model's `forward()` method; they are graph surgery tools, and graph surgery changes what learning can optimize.
 
-The gradient always points "uphill," so going in the opposite direction takes you "downhill" toward lower loss. It's like water flowing downhill—it always finds the path of steepest descent, eventually settling in a valley.
-
-The remarkable thing is that this simple strategy works even in spaces with millions of dimensions. In a neural network with 10 million parameters, you're navigating a 10-million-dimensional landscape—far beyond human imagination—but the math doesn't care. Gradient descent still finds the way down.
-
-### Variants of Gradient Descent
-
-The function above outlines the raw concept of gradient descent, but in production, we must choose how much data to process before executing the update step.
-- **Batch Gradient Descent**: Uses the entire dataset to compute the gradient before updating the weights once. It provides a highly stable error gradient, but it is computationally paralyzing to hold millions of records in GPU memory simultaneously.
-- **Stochastic Gradient Descent (SGD)**: Computes the gradient and updates the weights for a single training example at a time. It is extremely fast, but the path to the mathematical minimum is incredibly noisy and erratic.
-- **Mini-Batch Gradient Descent**: The undisputed industry standard. We chunk the massive dataset into smaller batches (e.g., 32 or 64 samples). This perfectly leverages the highly parallel architecture of modern GPUs, processing the batch efficiently as a single matrix multiplication while offering a smooth and rapid convergence path.
-
-### Learning Rate Dynamics
-
-The learning rate scalar ($\alpha$) strictly defines the size of the mathematical step we take in the direction indicated by the gradient. Tuning this specific hyperparameter is the most critical aspect of training stabilization.
-
-```
-Too small: Slow convergence, may get stuck
-Too large: Overshooting, unstable training
-Just right: Smooth convergence to minimum
-
-Loss
-  │
-  │  ╲      Learning rate too large
-  │   ╲╱╲ (overshooting)
-  │      ╲
-  │       ───── Just right
-  │
-  └────────────── iterations
-```
-
-The underlying consequences of learning rate misconfiguration can be modeled as follows:
-
-```mermaid
-graph TD
-    subgraph Learning Rate Impact
-    A[Current Loss] --> B{Learning Rate Too Large?}
-    B -- Yes --> C[Overshooting: Loss bounces wildly and diverges]
-    B -- No --> D{Learning Rate Too Small?}
-    D -- Yes --> E[Stuck: Extremely slow convergence to local minima]
-    D -- No --> F[Just Right: Smooth, rapid convergence to global minimum]
-    end
-```
-
-### The Complete Training Loop
-
-Combining forward propagation, loss calculation, backward propagation, and iterative gradient descent gives us the finalized, autonomous training loop.
+The difference between `no_grad()` and `detach()` is mainly about scope. `no_grad()` is a temporary mode for a block of operations: all computations inside the block avoid graph recording. `detach()` is a tensor-level boundary: one tensor leaves the graph, and future operations built from that detached tensor are disconnected from the earlier history. Logging a loss with `loss.item()` is another boundary, because it extracts a Python number that cannot carry gradients. These tools are good when intentional and disastrous when used to silence an error you did not understand.
 
 ```python
-def train(X, Y, layer_dims, learning_rate=0.01, num_iterations=1000):
-    """
-    Train a neural network.
+w = torch.tensor(2.0, requires_grad=True)
 
-    Args:
-        X: Training data (n_features, m_samples)
-        Y: Labels (n_classes, m_samples)
-        layer_dims: List of layer sizes [n_x, n_h1, n_h2, ..., n_y]
-        learning_rate: Step size for gradient descent
-        num_iterations: Number of training iterations
+loss = (w - 5.0).pow(2)
+loss.backward()
+print("before update:", w.item(), "grad:", w.grad.item())  # grad is -6.0
 
-    Returns:
-        parameters: Trained weights and biases
-        costs: Loss history
-    """
-    # Initialize parameters
-    parameters = initialize_parameters(layer_dims)
-    costs = []
+with torch.no_grad():
+    w -= 0.1 * w.grad
 
-    for i in range(num_iterations):
-        # Forward propagation
-        AL, caches = forward(X, parameters)
-
-        # Compute cost
-        cost = compute_cost(AL, Y)
-        costs.append(cost)
-
-        # Backward propagation
-        gradients = backward(AL, Y, caches)
-
-        # Update parameters
-        parameters = update_parameters(parameters, gradients, learning_rate)
-
-        # Print progress
-        if i % 100 == 0:
-            print(f"Iteration {i}: cost = {cost:.4f}")
-
-    return parameters, costs
+w.grad = None
+print("after update:", w.item())  # 2.6
 ```
 
-## Practical Application: MNIST Digit Recognition
-
-To empirically prove that our ground-up network architecture works, we will train it on MNIST, the widely regarded "Hello World" dataset of machine learning consisting of handwritten numerical digits.
-
-### MNIST Trivia
-Before jumping into the code, it is worth understanding the legacy of this dataset. MNIST stands for Modified National Institute of Standards and Technology. AI pioneer Yann LeCun created the dataset in 1998 to rigorous test early Convolutional Neural Networks designed to automatically read bank checks. The dataset is an eclectic mix of high school students' and Census Bureau employees' handwriting. The raw images were size-normalized and explicitly anti-aliased into a 28x28 pixel bounding box, guaranteeing that the mathematical center of mass of the digit is perfectly aligned in the grid.
-
-```
-Training: 60,000 images
-Test:     10,000 images
-Size:     28x28 pixels (784 features when flattened)
-Classes:  10 (digits 0-9)
-
-Sample images:
-┌────────┐ ┌────────┐ ┌────────┐
-│   ██   │ │    █   │ │  ███   │
-│  █  █  │ │   ██   │ │     █  │
-│ █    █ │ │    █   │ │   ██   │
-│ █    █ │ │    █   │ │     █  │
-│  ████  │ │   ███  │ │  ███   │
-└────────┘ └────────┘ └────────┘
-    0          1          2
-```
-
-We conceptually flatten these 2D images into 1D vectors to feed them into our dense network architecture:
-
-```mermaid
-flowchart LR
-    subgraph "Image Flattening"
-        direction TB
-        A[28x28 Pixel Grid] -->|Flatten| B[784x1 Vector]
-    end
-    B --> C(Input Layer: 784 Neurons)
-    C --> D(Hidden Layer: 128 Neurons)
-    D --> E(Output Layer: 10 Probabilities)
-```
-
-### Why MNIST?
-
-1. **Small enough**: Can train on CPU in minutes
-2. **Hard enough**: Requires real learning
-3. **Well-understood**: Benchmark results available
-4. **Visual**: Easy to interpret results
-
-### The "Drosophila of Machine Learning"
-MNIST is often called the "fruit fly of machine learning" - a simple model organism for experimenting. Just as biologists use fruit flies to understand genetics, ML researchers use MNIST to test new ideas.
-
-### It's Actually Too Easy Now
-Modern techniques achieve >99.5% accuracy on MNIST. Researchers have moved on to harder datasets like:
-- **CIFAR-10**: 60,000 color images in 10 classes
-- **ImageNet**: 14 million images in 20,000+ classes
-- **Fashion-MNIST**: Harder clothing items (drop-in MNIST replacement)
-
-### Human Performance
-Humans achieve about 97.5% accuracy on MNIST (yes, some digits are ambiguous!). A well-tuned neural network can beat human performance.
-
-### Expected Accuracy Baselines
-
-Understanding baseline performance is critical before evaluating a model's success. 
-
-| Model | Accuracy |
-|-------|----------|
-| Random guessing | 10% |
-| Simple neural net (no hidden layers) | ~92% |
-| 2-layer neural net | ~97% |
-| CNN (state of art) | ~99.8% |
-
-## Critical Implementation Details
-
-If you attempt to write the theoretical math directly into a Python script, it will frequently crash due to the rigid numerical limits of physical computing architecture.
-
-### Weight Initialization
-
-Initializing all matrix weights purely to zero typically destroys the network's ability to learn useful distinct features. Because every neuron starts identically, they all calculate the exact same gradients during backpropagation, remaining identical forever. We utilize He Initialization specifically for ReLU networks to maintain statistical variance across deep layers.
+Gradient accumulation is the first autograd behavior that surprises learners. PyTorch adds into `.grad`; it does not overwrite it. That is the same `+=` rule you used inside A8 because a value may receive gradient contributions from several paths. Across training iterations, however, you usually want each mini-batch to compute a fresh gradient estimate. That is why optimizer steps begin with `optimizer.zero_grad(set_to_none=True)`.
 
 ```python
-# BAD: All zeros (all neurons learn the same thing)
-W = np.zeros((n_out, n_in))
+w = torch.tensor(2.0, requires_grad=True)
 
-# BAD: Large random (exploding activations)
-W = np.random.randn(n_out, n_in) * 100
+loss1 = w * w
+loss1.backward()
+print(w.grad.item())  # 4.0
 
-# GOOD: Xavier/Glorot initialization
-W = np.random.randn(n_out, n_in) * np.sqrt(1 / n_in)
+loss2 = 3.0 * w
+loss2.backward()
+print(w.grad.item())  # 7.0, because 4.0 + 3.0 accumulated
 
-# BETTER: He initialization (for ReLU)
-W = np.random.randn(n_out, n_in) * np.sqrt(2 / n_in)
+w.grad = None
 ```
 
-**Why He initialization?**
-- Keeps variance of activations roughly constant across layers
-- Prevents vanishing/exploding gradients
-- Named after **Kaiming He** (Microsoft Research, 2015)
+This behavior is not a bug; it is a feature that enables gradient accumulation across micro-batches when batch memory is limited. The bug is forgetting which behavior you intend. In normal B1 training, clear gradients once per optimizer step. In deliberate gradient accumulation, clear them only after several backward passes and scale the loss accordingly. B2 will turn this into a complete training-loop discipline, but the core reason already lives in your A8 graph engine.
 
+One final autograd habit: rebuild the graph every training iteration. In PyTorch, the graph created by a forward pass is normally freed after `backward()` because saved intermediates consume memory. If you compute one loss, call `backward()`, and then try to backward through the exact same graph again, PyTorch will complain unless you asked to retain the graph. The usual training loop does not need retention. It runs a fresh forward pass for the next mini-batch, creating a fresh graph that reflects the current parameters and inputs.
 
-### Numerical Stability
+## Part 3: `nn.Module` and `nn.Linear` Are Your A7 `Layer`
 
-Computing raw mathematical exponentials can rapidly overflow 64-bit float memory limits, resulting in catastrophic `NaN` errors. We must intentionally add mathematical safety clips to our functions.
+In A7, your `Layer` class owned a weight matrix `W`, a bias vector `b`, a forward method, cached activations, and gradient fields such as `dW` and `db`. PyTorch packages the same idea into `nn.Module`. A module owns parameters, defines `forward()`, can contain child modules, and exposes `parameters()` so optimizers can find what should be updated. `nn.Linear(in_features, out_features)` is the dense layer you wrote by hand, with weight shape `[out_features, in_features]` and bias shape `[out_features]`.
 
-```python
-# BAD: Can overflow/underflow
-def sigmoid(z):
-    return 1 / (1 + np.exp(-z))
-
-# GOOD: Numerically stable
-def sigmoid(z):
-    z = np.clip(z, -500, 500)  # Prevent overflow
-    return 1 / (1 + np.exp(-z))
-
-# Cross-entropy with stability
-def cross_entropy(y, y_hat):
-    epsilon = 1e-15
-    y_hat = np.clip(y_hat, epsilon, 1 - epsilon)
-    return -np.mean(y * np.log(y_hat) + (1 - y) * np.log(1 - y_hat))
-```
-
-```python
-def softmax(z):
-    """
-    Softmax function for multi-class classification.
-    Converts logits to probabilities that sum to 1.
-    """
-    # Subtract max for numerical stability
-    exp_z = np.exp(z - np.max(z, axis=0, keepdims=True))
-    return exp_z / np.sum(exp_z, axis=0, keepdims=True)
-```
-
-### Visualizing the Training Progress
-
-Visual diagnostics are often one of the fastest ways to assess training health. Always plot your loss curves over time.
-
-```python
-plt.plot(costs)
-plt.xlabel('Iteration')
-plt.ylabel('Loss')
-plt.title('Training Loss')
-```
-
-A healthy loss curve:
-```
-Loss
-  │
-2.0├───╲
-   │    ╲
-1.0├─────╲────
-   │       ╲──────
-0.5├───────────────
-   │
-   └─────────────────
-   0    500   1000  iterations
-```
-
-Translated into a sequence showing how data cascades iteratively through the loop components:
-
-```mermaid
-sequenceDiagram
-    participant Data as Training Data
-    participant Forward as Forward Pass
-    participant Loss as Loss Function
-    participant Back as Backpropagation
-    participant Opt as Optimizer
-
-    loop Every Iteration
-        Data->>Forward: X, Y
-        Forward->>Loss: Predictions (A)
-        Loss-->>Loss: Calculate Error vs Y
-        Loss->>Back: Error Gradients (dA)
-        Back-->>Back: Apply Chain Rule
-        Back->>Opt: Parameter Gradients (dW, db)
-        Opt-->>Opt: Update Weights (W = W - alpha*dW)
-    end
-```
-
-By heavily utilizing matplotlib, you can plot decision boundaries and inspect the actual learned weights:
-
-```python
-def plot_decision_boundary(model, X, Y):
-    # Create grid
-    x_min, x_max = X[0, :].min() - 0.5, X[0, :].max() + 0.5
-    y_min, y_max = X[1, :].min() - 0.5, X[1, :].max() + 0.5
-    xx, yy = np.meshgrid(np.arange(x_min, x_max, 0.01),
-                         np.arange(y_min, y_max, 0.01))
-
-    # Predict on grid
-    Z = model(np.c_[xx.ravel(), yy.ravel()].T)
-    Z = Z.reshape(xx.shape)
-
-    # Plot
-    plt.contourf(xx, yy, Z, alpha=0.8)
-    plt.scatter(X[0, :], X[1, :], c=Y, edgecolors='black')
-```
-
-For MNIST, first-layer weights can be visualized as 28x28 images:
-
-```python
-# Reshape and plot weights
-for i in range(10):
-    plt.subplot(2, 5, i+1)
-    plt.imshow(W1[i].reshape(28, 28), cmap='gray')
-    plt.axis('off')
-```
-
-## Practical Exercises
-
-Before advancing to pure framework development, you must conquer the fundamental architectural limitations that plagued early AI research. 
-
-### Exercise 1: Implement a Perceptron
-
-Build a single-layer perceptron that can learn:
-- AND gate
-- OR gate
-- (Show it fails on XOR)
-
-### Exercise 2: 2-Layer XOR Network
-
-```
-Exercise 2: 2-Layer XOR Network
-Input: [0,0] → Output: 0
-Input: [0,1] → Output: 1
-Input: [1,0] → Output: 1
-Input: [1,1] → Output: 0
-```
-*Goal: Successfully implement a NumPy network capable of perfectly learning the XOR function using a hidden layer, proving you have bypassed the fatal flaw identified in the 1969 Perceptrons book.*
-
-### Exercise 3: MNIST Classifier
-
-Build a network that achieves >95% accuracy on MNIST:
-- Architecture: 784 → 128 → 64 → 10
-- Activation: ReLU (hidden), Softmax (output)
-- Loss: Cross-entropy
-- Optimizer: Mini-batch gradient descent
-
-### Exercise 4: Hyperparameter Exploration
-
-Experiment with:
-- Learning rate: 0.001, 0.01, 0.1, 1.0
-- Hidden layer sizes: 32, 64, 128, 256
-- Number of layers: 1, 2, 3
-- Batch size: 16, 32, 64, 128
-
-## Did You Know? 
-
-1. **Conda Support Dropped:** The PyTorch 2.11 release fully drops official Conda publishing, a systemic decision formally announced back in the 2.6 release. Official installation guidance strictly recommends standard `pip` as the primary binary package manager across Linux, macOS, and Windows.
-2. **Ecosystem Fragmentation:** The PyTorch package ecosystem maintains highly asynchronous versioning. While PyTorch itself sits at 2.11.0, the Torchvision library (vital for image manipulation) tracks stable release v0.26. Torchaudio is currently at v2.10.0, and Torchtext sits at v0.18.0.
-3. **Universal Function Approximators:** A single neural network hidden layer theoretically has the mathematical power to approximate a wide range of continuous functions on bounded domains, according to the Universal Approximation Theorem rigorously proven by George Cybenko in 1989.
-   **So why go deep?**
-   - Deep networks are exponentially more efficient.
-   - A function that needs 2^n neurons in a shallow network might need only n layers.
-4. **The Lottery Ticket Hypothesis:** A revolutionary 2019 MIT paper by Jonathan Frankle and Michael Carlin demonstrated that massive deep neural networks contain tiny, sparsely connected subnetworks (the "winning tickets") that can independently match the exact accuracy of the giant model. We intentionally over-parameterize networks just to drastically improve the mathematical odds of randomly initializing one of these winning tickets!
-5. **The Vanishing Gradient Problem:** For decades, training deep networks was often very difficult because gradients could shrink exponentially as they propagated backward. The historical solutions that unlocked deep architectures included ReLU activations (2010), Batch Normalization (2015), and Skip Connections via ResNet (2015).
-
-## Common Mistakes
-
-| Mistake | Why It Happens | How To Fix It |
-|---------|----------------|---------------|
-| **All-Zero Initialization** | Assigning `np.zeros()` to weights. | All neurons compute identical gradients and learn the exact same features. Use He Initialization (`np.random.randn() * np.sqrt(2/n)`). |
-| **Exploding Gradients** | Using large random weights during initialization or a high learning rate. | Loss results in `NaN` (Not a Number) because values exceed 64-bit float limits. Clip gradients and lower the learning rate. |
-| **Dying ReLUs** | A large negative bias causes the neuron output to be permanently negative, meaning the ReLU gradient is permanently zero. | The neuron "dies" and stops learning. Use Leaky ReLU or lower the learning rate. |
-| **Shape Mismatch Errors** | Matrix multiplication rules violated: `(A, B) @ (C, D)` requires `B == C`. | Print `tensor.shape` relentlessly during forward passes. Transpose weight matrices carefully. |
-| **Using Softmax with BCE Loss** | Mixing multi-class activations with binary loss functions. | The math breaks down. Use Sigmoid with Binary Cross-Entropy, and Softmax with Categorical Cross-Entropy. |
-| **Forgetting to Zero Gradients** | In PyTorch, gradients accumulate by default. | If you don't call `.zero_grad()` before `.backward()`, your updates will combine errors from previous batches, ruining training. |
-| **Wrong CUDA Target** | Installing PyTorch with a CUDA version incompatible with the host driver (e.g., trying to use CUDA 13.0 on an older driver). | Verify driver with `nvidia-smi` and install the correct wheel. `pip install torch` defaults to 13.0 in PyTorch 2.11; override if needed. |
-
-## Quiz
-
-<details>
-<summary>1. Scenario: You are building a binary classifier to detect fraud. You use ReLU in the hidden layers and ReLU in the final output layer. During training, the loss refuses to converge and predictions wildly fluctuate. What is structurally wrong?</summary>
-
-The output layer for a binary classifier must output a calculated probability strictly bounded between 0 and 1. The ReLU function outputs an unbounded range of values from 0 to infinity. The required loss function (Binary Cross-Entropy) expects normalized inputs bound mathematically between [0, 1] and will fail drastically when fed arbitrarily large positive numbers from the terminal ReLU layer. You must immediately change the final layer activation to a Sigmoid function to restore architectural integrity.
-</details>
-
-<details>
-<summary>2. Scenario: Your training loss curve drops significantly for the first 10 iterations, then begins violently oscillating up and down, never settling at a low value. What is the most likely culprit?</summary>
-
-Your designated learning rate is excessively high for the current loss landscape. The gradient descent steps are so large that the mathematical optimizer is repeatedly "overshooting" the absolute minimum of the valley, bouncing violently back and forth on the steep walls. You should reduce the learning rate by a factor of 10, observe the stabilization of the curve, and try the training loop again.
-</details>
-
-<details>
-<summary>3. Scenario: You are tasked with building a deep neural network to predict complex housing market fluctuations. You design an architecture with 50 dense hidden layers to capture deep hierarchical patterns, but you intentionally decide to skip all activation functions to speed up tensor processing. After a week of training on a GPU cluster, your massive model performs exactly the same as a simple single-layer linear regression script. Why did your deep architecture fail to learn complex, curving patterns?</summary>
-
-Without non-linear activation functions injecting curves into the mathematical boundaries, the entire network—no matter how many deep layers it physically possesses—collapses algebraically into a single, flat linear transformation (`W*X + b`). The massive sequential matrix multiplications of 50 linear layers can be simplified structurally into one single equivalent weight matrix. The mathematical non-linearity is strictly required; it is the sole mechanism that allows the network to intricately bend and warp its decision boundaries to solve complex, real-world regression problems that simple linear models cannot possibly capture.
-</details>
-
-<details>
-<summary>4. Scenario: You have an input matrix X of shape (784, 32) and a weight matrix W1. You attempt to compute the forward pass `Z1 = W1 @ X + b1` but receive a matrix shape mismatch error. If your hidden layer is designed to have 128 neurons, what must the exact shape of W1 be to mathematically resolve this error, and why?</summary>
-
-The exact shape of W1 must be (128, 784). In matrix multiplication `W1 @ X`, the inner dimensions must match. Since X has 784 features as its rows (shape 784 x 32), W1 must have 784 columns to successfully compute the dot product. To satisfy the architectural design of 128 neurons in the hidden layer, W1 must output 128 rows. Therefore, the weight matrix must be dimensionally initialized as (128, 784).
-</details>
-
-<details>
-<summary>5. Scenario: Your engineering team is maintaining a legacy computer vision neural network written entirely in pure NumPy matrix operations. The model architecture needs to be updated weekly to include new dynamic branching, varying batch sizes, and experimental nested layers. However, every time an architectural change is made, a senior engineer has to spend three grueling days manually deriving and coding the calculus chain rule equations. How does migrating the codebase to PyTorch's "Autograd" module structurally eliminate this developmental bottleneck?</summary>
-
-The Autograd engine completely eliminates the painful necessity to manually derive, verify, and hardcode the backpropagation chain rule equations for every newly invented architecture. It dynamically and autonomously builds a highly detailed computational graph during the forward pass in real time, securely tracking every mathematical operation in memory. When `.backward()` is executed, Autograd automatically calculates analytical gradients for registered parameters, making rapid architectural prototyping and complex dynamic deep learning structurally possible and far less error-prone.
-</details>
-
-<details>
-<summary>6. Scenario: You inadvertently initialize all the individual weights in your multi-layer dense network to exactly `0.5` instead of utilizing a randomized distribution. What specific mathematical failure will occur during the training loop?</summary>
-
-The entire network architecture will suffer from an unrecoverable symmetry breaking failure. Because every single neuron situated in a given hidden layer starts with the exact same mathematical weights, they will all receive the exact same calculated gradient updates during the backpropagation pass. They will continuously evolve identically over time, effectively reducing the entire layer's immense representational power down to that of a single, highly redundant neuron.
-</details>
-
-## Hands-On Exercise: Math to PyTorch Implementation
-
-In this rigorous laboratory exercise, we will seamlessly transition from the pure foundational NumPy mathematics to utilizing robust PyTorch 2.11.0 tensors alongside the Autograd engine. We will manually implement a simple targeted computation and rigorously verify that PyTorch's automatic differentiation engine perfectly matches our hand-calculated mathematical derivatives.
-
-### Environment Setup
-Verify your terminal environment is executing Python 3.10+ and install the PyTorch 2.11.0 binary precisely via `pip` (the officially recommended binary package manager across all architectures).
-```bash
-python3 -m venv .venv && source .venv/bin/activate
-pip install torch==2.11.0
-```
-
-Start the Python interactive shell to execute the following tasks:
-
-```bash
-python3
-```
-
-### Task 1: Initialize Tensors with Gradients
-Create specific PyTorch tensors representing a single artificial neuron's raw inputs, operational weights, and specific bias. You must explicitly instruct the PyTorch framework to begin tracking gradient histories for the operational parameters.
-
-<details>
-<summary>Solution: Task 1</summary>
+That weight orientation surprises many NumPy-first learners because A7 may have stored weights as `[in_features, out_features]` and computed `X @ W + b`. PyTorch stores `Linear.weight` as `[out_features, in_features]` and computes the equivalent affine transform internally. You should not transpose it during normal use; just know the registered parameter's shape when inspecting it. The external contract remains simple: an input batch shaped `[batch, in_features]` becomes logits or activations shaped `[batch, out_features]`.
 
 ```python
 import torch
+from torch import nn
 
-# Inputs (no gradient tracking needed)
-x = torch.tensor([1.0, 2.0, 3.0])
 
-# Parameters (require gradients!)
-w = torch.tensor([0.5, 0.1, 0.2], requires_grad=True)
-b = torch.tensor(0.0, requires_grad=True)
+class TinyMLP(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.hidden = nn.Linear(4, 8)  # input features 4 -> hidden units 8
+        self.output = nn.Linear(8, 3)  # hidden units 8 -> class logits 3
 
-print("Tensors initialized successfully.")
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        h = torch.relu(self.hidden(x))
+        return self.output(h)
+
+
+model = TinyMLP()
+xb = torch.randn(5, 4)  # shape: [batch=5, features=4]
+logits = model(xb)     # shape: [5, 3]
+
+for name, parameter in model.named_parameters():
+    print(name, tuple(parameter.shape), parameter.requires_grad)
 ```
-</details>
 
-### Task 2: Implement the Forward Pass
-Calculate the preliminary pre-activation vector `z` by utilizing the mathematical dot product, and correctly apply a standard ReLU activation function to retrieve the final predicted output `y`.
+The output names are the first payoff: `hidden.weight`, `hidden.bias`, `output.weight`, and `output.bias` are registered automatically because they are parameters inside child modules assigned as attributes. You did that bookkeeping manually in A7 with a `parameters()` generator. PyTorch does it consistently across nested models, which is why optimizers can receive `model.parameters()` without you passing every matrix by hand.
 
-<details>
-<summary>Solution: Task 2</summary>
+Registration is the reason subclassing `nn.Module` correctly matters. If you store a raw tensor as `self.weight = torch.randn(...)`, PyTorch will not automatically treat it as a trainable parameter unless it is wrapped as `nn.Parameter`. If you store child layers in a plain Python list instead of `nn.ModuleList`, PyTorch may not discover their parameters recursively. The safest early habit is to use built-in modules as attributes, `nn.Sequential`, `nn.ModuleList`, or `nn.Parameter` only when you can explain why you need manual ownership.
+
+The conceptual mapping is tight enough to put in a table:
+
+| Block A object | PyTorch object | What changed |
+|---|---|---|
+| `np.ndarray` activation batch | `torch.Tensor` | Adds dtype, device, and optional autograd graph metadata |
+| `Layer.W` and `Layer.b` | `nn.Linear.weight` and `nn.Linear.bias` | Registered as trainable `nn.Parameter` objects |
+| `Layer.forward(X)` | `Module.forward(x)` | Called by `model(x)` so hooks and module machinery work |
+| `Layer.backward(G)` | `loss.backward()` through autograd | Dense-layer VJPs are generated and scheduled by the graph engine |
+| `model.parameters()` in A7 | `model.parameters()` in PyTorch | Same name, but recursive and standardized across modules |
+
+You will also see `nn.Sequential`, which is useful for simple feed-forward stacks. It is not less real than a custom class; it is just a compact container when the forward pass is a straight chain. Use a custom `nn.Module` when you need named subparts, multiple inputs, control flow, or extra helper methods. Use `nn.Sequential` when the architecture is genuinely linear.
 
 ```python
-# Weighted sum (dot product) + bias
-z = torch.dot(x, w) + b
+sequential_model = nn.Sequential(
+    nn.Linear(4, 8),
+    nn.ReLU(),
+    nn.Linear(8, 3),
+)
 
-# ReLU Activation
-y = torch.relu(z)
-
-print(f"Forward pass output: {y.item()}")
+logits = sequential_model(torch.randn(5, 4))
+print(logits.shape)  # torch.Size([5, 3])
 ```
-</details>
 
-### Task 3: Trigger Autograd
-Define an arbitrary dummy target scalar value, rapidly calculate the Mean Squared Error deviation loss, and immediately trigger PyTorch's internal backpropagation engine to resolve the graph.
-
-<details>
-<summary>Solution: Task 3</summary>
+For the A7 Fashion-MNIST MLP, the module translation is straightforward. A7 used flattened 28 by 28 images, one hidden dense layer with 256 units, ReLU, and a 10-class output head. In PyTorch, that becomes `nn.Flatten()`, `nn.Linear(784, 256)`, `nn.ReLU()`, and `nn.Linear(256, 10)`. Notice what is absent: no explicit cache fields, no hand-written backward method, and no one-hot target matrix for cross-entropy.
 
 ```python
-target = torch.tensor(1.0)
+class FashionMLP(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Flatten(),        # [batch, 1, 28, 28] -> [batch, 784]
+            nn.Linear(28 * 28, 256),
+            nn.ReLU(),
+            nn.Linear(256, 10),  # raw logits for 10 Fashion-MNIST classes
+        )
 
-# Mean Squared Error
-loss = (y - target) ** 2
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
 
-# Trigger backpropagation (this replaces our manual backward() function)
+
+model = FashionMLP()
+example_images = torch.randn(32, 1, 28, 28)
+example_logits = model(example_images)
+print(example_logits.shape)  # torch.Size([32, 10])
+```
+
+This is the same MLP skeleton as A7 with much less handwritten infrastructure. The dense math is still `X @ W.T + b`, the activation is still ReLU, and the output is still raw class logits. PyTorch simply owns the repetitive engineering: parameter registration, graph construction, dense-layer backward kernels, and optimizer integration.
+
+The `state_dict()` method is another ownership payoff. It returns a mapping from parameter and buffer names to tensors, which is what checkpointing uses later. B2 will handle checkpoint discipline, but the idea begins here: once modules own parameters with stable names, saving, loading, freezing, and inspecting models becomes systematic. Your A7 micro-framework could do this only if you wrote the naming and serialization conventions yourself.
+
+## Part 4: Optimizers Are the Manual `W -= lr * dW` Loop
+
+The canonical PyTorch training step has a fixed order. Clear stale gradients, run the forward pass, compute a scalar loss, call backward, then update parameters. Change that order only when you can explain the reason. In A7, you updated each layer by iterating over `(param, grad)` pairs and subtracting `lr * grad`. `torch.optim.SGD` performs the same operation over registered parameters, with optional extras such as momentum left for B4.
+
+The fixed order is a debugging tool. If loss is `nan`, inspect the forward and loss before backward. If gradients are missing, inspect the graph connection before `step()`. If parameters do not change, inspect `.grad` after backward and before the optimizer clears or steps. A training loop with the same order every time creates reliable observation points. A loop that sometimes clears gradients after forward, sometimes after step, and sometimes not at all makes every later failure harder to localize.
+
+```python
+import torch
+from torch import nn
+
+torch.manual_seed(7)
+
+model = nn.Sequential(
+    nn.Linear(4, 8),
+    nn.ReLU(),
+    nn.Linear(8, 3),
+)
+
+optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+loss_fn = nn.CrossEntropyLoss()
+
+xb = torch.randn(16, 4)                         # shape: [16, 4]
+yb = torch.randint(0, 3, size=(16,), dtype=torch.long)  # shape: [16]
+
+model.train()
+optimizer.zero_grad(set_to_none=True)
+logits = model(xb)               # shape: [16, 3]
+loss = loss_fn(logits, yb)        # scalar
+loss.backward()
+optimizer.step()
+
+print(loss.item())
+```
+
+The `zero_grad(set_to_none=True)` call is current PyTorch idiom and often avoids unnecessary memory writes compared with filling existing gradient tensors with zeros. After backward, each parameter's `.grad` field contains the gradient for the current mini-batch. `optimizer.step()` reads those gradients and mutates parameters under the hood. That mutation is why you should not call `step()` before `backward()`, and why stale gradients produce a different update than the one your current batch actually requested.
+
+It is legal to call `zero_grad()` after `step()` instead of before the next forward pass, and some codebases do. This module uses the before-forward pattern because it makes the invariant visible: at the start of each mini-batch, parameter gradients are empty. The exact placement is less important than consistency, but consistency matters more than style. When you later read unfamiliar code, identify where gradients become empty, where they become populated, and where the optimizer consumes them.
+
+If you want to see the connection to A7 explicitly, compare SGD to a manual update on a single parameter. This toy block is not how you should train modules in real code, but it reveals the same arithmetic.
+
+```python
+weight = torch.tensor([1.0, -2.0], requires_grad=True)
+loss = (weight * weight).sum()
 loss.backward()
 
-print(f"Loss: {loss.item()}")
+with torch.no_grad():
+    manual_updated = weight - 0.1 * weight.grad
+
+print(weight.grad)       # tensor([ 2., -4.])
+print(manual_updated)    # tensor([ 0.8000, -1.6000])
 ```
-</details>
 
-### Task 4: Verify the Gradients
-Rigorously inspect the generated calculated gradients stored directly within the `.grad` attribute of the weights and bias. Compare them conceptually and mathematically to what the standard calculus chain rule would produce by hand.
+That subtraction is all plain SGD does before you add variants. Adam, AdamW, schedulers, warmup, and learning-rate dynamics are important, but they are B4's topic. In B1, the goal is to establish that an optimizer object is a disciplined wrapper around parameter mutation after autograd has filled `.grad`.
 
-<details>
-<summary>Solution: Task 4</summary>
+`torch.optim.SGD` also owns optimizer state, even when plain SGD has almost none. Once momentum enters, the optimizer remembers velocity tensors for each parameter. Once AdamW enters, it remembers moving averages. That state is why optimizers are objects rather than single functions, and why checkpointing later saves both `model.state_dict()` and `optimizer.state_dict()`. For B1, remember only the basic relationship: autograd computes gradients; the optimizer decides how to use them to mutate parameters.
+
+## Part 5: `Dataset` and `DataLoader` Replace Hand-Sliced Mini-Batches
+
+A7 made you shuffle indices and slice arrays manually. PyTorch keeps the same mini-batch concept but standardizes the data pipeline with `Dataset` and `DataLoader`. A `Dataset` answers two questions: how many examples exist, and what is example `i`? A `DataLoader` handles batching, optional shuffling, collation, and worker processes. The training loop then receives tensors through the familiar `for xb, yb in loader:` idiom.
+
+Separate those responsibilities carefully. The `Dataset` should represent individual examples and deterministic transforms that belong to an example. The `DataLoader` should decide how examples are grouped into mini-batches and whether their order is shuffled. The model should not know whether a batch came from an in-memory tensor, an image folder, a parquet file, or a streaming source. That separation is the reason the same training step can work with a tiny synthetic dataset in B1 and a production input pipeline later.
 
 ```python
-print("Gradient of loss wrt weights (dL/dw):", w.grad)
-print("Gradient of loss wrt bias (dL/db):", b.grad)
+from torch.utils.data import Dataset, DataLoader
 
-# The chain rule manually:
-# dL/dy = 2 * (y - target)
-# dy/dz = 1 (since z was positive, ReLU derivative is 1)
-# dz/dw = x
-# Therefore dL/dw = 2 * (y - target) * x
-manual_grad = 2 * (y.item() - target.item()) * x
-print("Manual Gradient:", manual_grad)
 
-assert torch.allclose(w.grad, manual_grad), "Gradients do not match!"
+class TensorClassificationDataset(Dataset):
+    def __init__(self, x: torch.Tensor, y: torch.Tensor) -> None:
+        if x.shape[0] != y.shape[0]:
+            raise ValueError("features and labels must have the same first dimension")
+        self.x = x
+        self.y = y
+
+    def __len__(self) -> int:
+        return self.x.shape[0]
+
+    def __getitem__(self, index: int) -> tuple[torch.Tensor, torch.Tensor]:
+        return self.x[index], self.y[index]
+
+
+images = torch.rand(128, 1, 28, 28)                         # shape: [128, 1, 28, 28]
+labels = torch.randint(0, 10, size=(128,), dtype=torch.long)  # shape: [128]
+dataset = TensorClassificationDataset(images, labels)
+
+loader = DataLoader(dataset, batch_size=32, shuffle=True, num_workers=0)
+
+for xb, yb in loader:
+    print(xb.shape, yb.shape)  # torch.Size([32, 1, 28, 28]), torch.Size([32])
+    break
 ```
-</details>
 
-**Success Checklist:**
-- [ ] You have successfully installed the PyTorch 2.11.0 wheel explicitly via `pip`.
-- [ ] You flawlessly instantiated floating-point tensors equipped with `requires_grad=True`.
-- [ ] You successfully executed a structured forward pass using pure PyTorch mathematical primitives.
-- [ ] You executed the `.backward()` trigger and strictly verified the `.grad` computational properties populated correctly against manual calculations.
+The `num_workers` argument controls subprocesses used for loading and preprocessing data. In notebooks, small local scripts, and teaching snippets, `num_workers=0` is the least surprising setting because all loading happens in the main process. In production training scripts, increasing it can hide input-pipeline latency behind GPU work, but only after you measure the bottleneck. The Block A equivalent was not glamorous: a shuffled index array and slices like `X[batch_idx]`. The PyTorch version is a reusable contract that scales to files, images, streaming datasets, and distributed training later.
 
-## Deliverables
+Shuffling belongs in the training loader, not the validation loader. Training shuffling changes the order in which SGD sees examples, reducing order artifacts and giving each epoch a different sequence of mini-batches. Validation shuffling usually adds noise to debugging because metrics should be reproducible and independent of data order. This is the same reasoning as A7's train/validation split, now encoded as `shuffle=True` for training and `shuffle=False` for validation.
 
-To definitively complete this foundational module, you must submit the following functional artifacts directly to your assigned version control repository for code review:
+Batch collation is the quiet third job. When a dataset returns one image tensor and one label at a time, the `DataLoader` stacks those individual images into an `[batch, channels, height, width]` tensor and the labels into `[batch]`. That default collation works when examples have the same shape. Variable-length text or ragged sequences need a custom collate function, but that belongs in later sequence modules. For Fashion-MNIST images, the default collation is exactly what you want.
 
-1. **Neural Network Toolkit (Main Deliverable)**: A comprehensive Python script (`numpy_network.py`) properly implementing the complete pure-NumPy forward and backward propagation execution loops. Must include configurable architecture (any number of layers), support for multiple activations, model save/load functionality, performance benchmarks, and a CLI interface.
-2. **MNIST Classifier**: Train your custom NumPy network on the MNIST dataset (Exercise 3), achieving >95% accuracy. Visualize training progress and show misclassified examples.
-3. **PyTorch Autograd Notebook**: A documented Jupyter Notebook (`pytorch_autograd.ipynb`) containing all robust solutions to the PyTorch Hands-On Exercise, empirically verifying that your precise manual gradient math computations perfectly match PyTorch's `.grad` backend outputs utilizing `torch.allclose`.
-4. **Architecture Notes**: A brief, technically precise markdown report (`architecture_notes.md`) evaluating and explaining exactly how radically changing the scalar learning rate from `0.01` up to `10.0` violently affected your plotted loss curve.
+The `DataLoader` does not magically put batches on the GPU. It yields CPU tensors unless the dataset already returns tensors on another device, which is uncommon for ordinary datasets. Move each batch inside the training loop. That keeps data loading separate from device execution and avoids quietly storing an entire dataset in GPU memory.
 
-## Further Reading
+```python
+device = best_device()
+model = FashionMLP().to(device)
 
-To deepen your mathematical foundations and physical intuition before advancing, consult the following authoritative resources:
+for xb, yb in loader:
+    xb = xb.to(device)
+    yb = yb.to(device)
+    logits = model(xb)
+    print(logits.device, yb.device)
+    break
+```
 
-### Foundational Papers
-- [Backpropagation (Rumelhart et al., 1986)](https://www.nature.com/articles/323533a0)
-- [Gradient-Based Learning (LeCun et al., 1998)](http://yann.lecun.com/exdb/publis/pdf/lecun-98.pdf)
-- [Deep Learning (Hinton, 2006)](https://www.cs.toronto.edu/~hinton/absps/fastnc.pdf)
+This is the same separation you used in A7 between data preparation and training math. Dataset code answers "what are the examples?" Training code answers "where should this mini-batch execute?" Mixing those responsibilities is a reliable way to create memory leaks or device mismatch errors.
 
-### Books and Core Textbooks
-- "Neural Networks and Deep Learning" by Michael Nielsen (free online)
-- "Deep Learning" by Ian Goodfellow, Yoshua Bengio, and Aaron Courville. This is the definitive, industry-standard mathematical textbook explaining deep learning geometric fundamentals.
-- "Pattern Recognition and Machine Learning" by Christopher M. Bishop. An exceptionally robust resource outlining the deep probabilistic and statistical foundations of predictive machine learning models.
+The data bridge can be summarized in one sentence: A7 manually selected rows from arrays, while PyTorch asks a dataset for examples and asks a loader to assemble rows into batches. Once the batch exists, the model and optimizer do not care how it was assembled. That is the abstraction worth learning, because it lets you swap synthetic tensors, Fashion-MNIST files, or a cached feature store without rewriting the training step.
 
-### Video Lectures
-- "Neural Networks" Series by 3Blue1Brown (YouTube). An incredibly intuitive, visually stunning breakdown of the rigorous matrix calculus and backpropagation geometry powering these algorithms.
-- "Neural Networks: Zero to Hero" by Andrej Karpathy.
-- "CS231n: Convolutional Neural Networks for Visual Recognition" (Stanford University). Andrej Karpathy's world-class, foundational university lectures diving deep into visual recognition implementation.
+## Part 6: Rebuilding the A7 Fashion-MNIST MLP in PyTorch
+
+Now put the bridge together. A7 trained a `784 -> 256 -> 10` MLP on Fashion-MNIST using a hand-written `Layer`, stable softmax-CE, mini-batch SGD, and manual metric reporting. The PyTorch translation below uses the same shape contract and the same math, but removes most of the infrastructure you wrote for learning purposes. The example uses Fashion-MNIST-shaped tensors so the snippet runs without a network download; if you have the actual A7 arrays loaded, replace the synthetic `images` and `labels` tensors with `torch.from_numpy(X_train).reshape(-1, 1, 28, 28).float()` and `torch.from_numpy(y_train).long()`.
+
+The important thing to preserve from A7 is not the data-loading library; it is the contract. Each input image becomes 784 float features after flattening. Each target is one of ten clothing classes. The model produces ten logits per image. The loss compares those logits against integer labels. The optimizer updates the two dense layers. Whether the tensors came from A7's NumPy arrays, `torchvision.datasets.FashionMNIST`, or the synthetic shape check below, the training step is the same. Real data makes the metric meaningful; the shape check makes the code path auditable before download or preprocessing enters the story.
+
+For a real Fashion-MNIST run, the first sanity check from A7 still applies. With roughly balanced ten-class labels and logits near zero at initialization, cross-entropy starts near `ln(10)`, about `2.302`. You do not need the value to be exact, but a first loss around `50`, `nan`, or `0.01` should trigger a contract check before a long run. Inspect label dtype, output dimension, normalization, and whether you accidentally passed probabilities instead of logits. Framework code is shorter, but the debugging questions remain Block A questions.
+
+```python
+import torch
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset, random_split
+
+
+def best_device() -> torch.device:
+    if torch.cuda.is_available():
+        return torch.device("cuda")
+    if torch.backends.mps.is_available():
+        return torch.device("mps")
+    return torch.device("cpu")
+
+
+class FashionMLP(nn.Module):
+    def __init__(self) -> None:
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(28 * 28, 256),
+            nn.ReLU(),
+            nn.Linear(256, 10),
+        )
+
+    def forward(self, x: torch.Tensor) -> torch.Tensor:
+        return self.net(x)
+
+
+torch.manual_seed(42)
+
+# Replace these two tensors with real Fashion-MNIST tensors from A7 or torchvision.
+images = torch.rand(1024, 1, 28, 28)                         # shape: [N, 1, 28, 28]
+labels = torch.randint(0, 10, size=(1024,), dtype=torch.long)  # shape: [N]
+
+dataset = TensorDataset(images, labels)
+train_set, val_set = random_split(
+    dataset,
+    lengths=[900, 124],
+    generator=torch.Generator().manual_seed(42),
+)
+
+train_loader = DataLoader(train_set, batch_size=64, shuffle=True, num_workers=0)
+val_loader = DataLoader(val_set, batch_size=128, shuffle=False, num_workers=0)
+
+device = best_device()
+model = FashionMLP().to(device)
+loss_fn = nn.CrossEntropyLoss()
+optimizer = torch.optim.SGD(model.parameters(), lr=0.1)
+
+for epoch in range(3):
+    model.train()
+    train_loss = 0.0
+    train_correct = 0
+    train_seen = 0
+
+    for xb, yb in train_loader:
+        xb = xb.to(device)
+        yb = yb.to(device)
+
+        optimizer.zero_grad(set_to_none=True)
+        logits = model(xb)
+        loss = loss_fn(logits, yb)
+        loss.backward()
+        optimizer.step()
+
+        batch_size = xb.shape[0]
+        train_loss += loss.item() * batch_size
+        train_correct += (logits.argmax(dim=1) == yb).sum().item()
+        train_seen += batch_size
+
+    model.eval()
+    val_loss = 0.0
+    val_correct = 0
+    val_seen = 0
+
+    with torch.no_grad():
+        for xb, yb in val_loader:
+            xb = xb.to(device)
+            yb = yb.to(device)
+            logits = model(xb)
+            loss = loss_fn(logits, yb)
+
+            batch_size = xb.shape[0]
+            val_loss += loss.item() * batch_size
+            val_correct += (logits.argmax(dim=1) == yb).sum().item()
+            val_seen += batch_size
+
+    print(
+        f"epoch={epoch + 1} "
+        f"train_loss={train_loss / train_seen:.4f} "
+        f"train_acc={train_correct / train_seen:.3f} "
+        f"val_loss={val_loss / val_seen:.4f} "
+        f"val_acc={val_correct / val_seen:.3f}"
+    )
+```
+
+The synthetic data will not produce meaningful accuracy, and that is fine for a structural check. The purpose of this snippet is to verify that the model, loss, optimizer, DataLoader, device movement, and train/eval modes fit together with correct shapes. When you swap in real Fashion-MNIST tensors, the same code becomes the A7 experiment expressed in PyTorch. Compared with the A7 from-scratch version, this is roughly 10x less code for the same training skeleton because PyTorch replaces the hand-written `Layer`, backward methods, stable softmax-CE routine, parameter generator, and update loop with standard primitives.
+
+That 10x reduction should not be read as "ten times less understanding." It is ten times less scaffolding. In A7, the scaffolding was the point because you needed to see every moving part. In B1, the point is to keep the same moving parts while using the framework's reliable versions. The first time a model fails to learn, you should be able to expand the PyTorch line mentally: `loss.backward()` means graph walk, local VJPs, and gradient accumulation; `optimizer.step()` means parameter mutation; `DataLoader` means shuffled mini-batches; `CrossEntropyLoss` means stable log-softmax plus class-index negative log-likelihood.
+
+The math is identical. `nn.Linear(784, 256)` computes the dense affine transform from A3 and A7. `nn.ReLU()` applies the activation from A4. `nn.CrossEntropyLoss()` consumes logits and class labels while implementing the stable softmax-CE from A5. `loss.backward()` executes the reverse-mode VJPs from A6 and A8. `torch.optim.SGD` subtracts a scaled gradient from each parameter, just like your manual A7 update. The shorter code is valuable only because you can still explain each line in Block A terms.
+
+There is one deliberate boundary in the snippet: it does not introduce Adam, learning-rate schedules, regularization, initialization experiments, normalization layers, or mixed precision. Those topics are not optional in serious training, but they are not B1. This module's payoff is the bridge itself. Once the bridge is solid, later Block B modules can add one engineering concern at a time without forcing you to relearn the basic PyTorch object model.
+
+## Part 7: Mode and Device Discipline
+
+Two PyTorch habits deserve early attention because they produce confusing bugs in real training runs. First, modules have mode. `model.train()` tells modules they are in training mode; `model.eval()` tells them they are in evaluation mode. For the simple B1 MLP above, the outputs are the same either way because `Linear`, `ReLU`, and `Flatten` do not behave differently across modes. Later, dropout, batch normalization, and some other modules absolutely do behave differently. Calling the mode methods now builds the habit before the habit is expensive.
+
+Mode is state on the module, not state on the optimizer or the data. A common mistake is to put `model.eval()` around validation and then forget to call `model.train()` when training resumes for the next epoch. Another mistake is to assume `model.eval()` makes gradients impossible. It does not. It changes module behavior; `torch.no_grad()` changes graph recording. Keeping those two ideas separate prevents subtle bugs when B5 and B6 introduce dropout and normalization.
+
+```python
+model = FashionMLP().to(device)
+
+model.train()
+# Training loop: gradients enabled, optimizer.step() allowed after backward.
+
+model.eval()
+with torch.no_grad():
+    # Evaluation loop: no graph tracking, no optimizer step, lower memory use.
+    logits = model(torch.rand(8, 1, 28, 28, device=device))
+```
+
+Second, device placement must be consistent. The model's parameters live wherever you moved the model. Inputs and labels must move there too. Loss functions usually have no parameters, but any class weights or tensors used inside a custom loss must also be on the same device. The error message often mentions "Expected all tensors to be on the same device," and the fix is not to sprinkle `.to(device)` randomly; the fix is a clear policy.
+
+```python
+device = best_device()
+model = FashionMLP().to(device)
+loss_fn = nn.CrossEntropyLoss()
+
+xb = torch.rand(16, 1, 28, 28).to(device)
+yb = torch.randint(0, 10, size=(16,), dtype=torch.long).to(device)
+
+logits = model(xb)
+loss = loss_fn(logits, yb)
+print(loss.device)
+```
+
+Hypothetical scenario: a team trains on a GPU instance and evaluates in a scheduled CPU job. The training script calls `model.to("cuda")` near the top, then later loads a validation batch from disk without moving it. The first evaluation step crashes with a device mismatch, and a hurried patch moves only the images, not the labels used by the weighted loss. The real fix is a single `device` variable, one model move after construction, and a batch-transfer helper used consistently in train and eval loops. The lesson is small, but the bug class is common enough that every PyTorch engineer should recognize it instantly.
+
+Mode and device bugs often masquerade as "bad model" bugs because the code still looks like training code. A dropout model evaluated in training mode may produce noisy metrics. A batch-norm model trained with validation statistics leaking into the running estimates may look better during development than it will in deployment. A CPU tensor accidentally created inside a custom loss may work on a laptop and fail only on the GPU job. B1 cannot cover every future failure, but it can give you the habit of inspecting mode, graph tracking, and device before changing the architecture.
+
+B2 will go deeper on training-loop structure: checkpointing, validation cadence, early stopping, metric history, and failure recovery. B1 stops at the bridge. You now know what PyTorch objects replace the pieces you wrote by hand, and you have a minimal loop whose ordering is correct.
+
+## Did You Know?
+
+- **PyTorch 2.12 was released on May 13, 2026.** The release blog is useful context when a module mentions current stable behavior, but most code in this bridge uses long-standing APIs that are stable across recent PyTorch versions.
+- **`torch.from_numpy` usually shares CPU memory with the source array.** That makes A7-to-B1 migration convenient, but it also means mutation can cross the boundary unless you explicitly clone the tensor.
+- **Karpathy's micrograd is intentionally tiny because reverse-mode autodiff is a local-contract idea.** Your A8 `Value` engine and PyTorch autograd differ in scale, not in the need to cache parents, run local VJPs, and accumulate gradients.
+- **PyTorch records dynamic graphs as Python executes.** That is why ordinary control flow can participate in the forward pass, and why each training iteration builds a fresh graph for the specific batch and branch choices that actually occurred.
+
+## Common Mistakes
+
+| Mistake | Why it breaks | Better approach |
+|---|---|---|
+| Passing one-hot labels into `nn.CrossEntropyLoss` for ordinary class-index training | PyTorch's standard cross-entropy API expects logits shaped `[batch, classes]` and integer labels shaped `[batch]`, so one-hot targets change the contract. | Keep targets as `torch.long` class indices, and remember that the loss combines stable log-softmax with negative log-likelihood. |
+| Forgetting `optimizer.zero_grad(set_to_none=True)` before each step | Gradients accumulate across backward calls, so stale gradients from prior mini-batches corrupt the current update. | Clear gradients once per optimizer step unless you are deliberately accumulating micro-batches with a documented scaling policy. |
+| Calling `.numpy()` on a CUDA tensor or a tensor that still requires gradients | NumPy only views CPU memory, and tensors connected to autograd need an explicit graph boundary before conversion. | Use `tensor.detach().cpu().numpy()` for logging or analysis, and avoid feeding that detached result back into the differentiable path. |
+| Moving the model to GPU but leaving batches on CPU | PyTorch operations require participating tensors to live on compatible devices, and mixed CPU/CUDA operations fail before training can proceed. | Create one `device`, call `model.to(device)` once, and move `xb` plus `yb` inside every train and eval loop. |
+| Expecting `.eval()` to disable gradients by itself | Evaluation mode changes module behavior, but it does not turn off autograd recording for ordinary tensor operations. | Use both `model.eval()` and `with torch.no_grad():` during evaluation loops so behavior and graph tracking are both correct. |
+| Mutating tensors in-place without understanding autograd's saved values | Backward kernels may need forward intermediates, and in-place changes can invalidate those saved tensors or silently change intended math. | Prefer out-of-place operations while learning, and reserve in-place mutations for code paths where you understand the autograd contract. |
+
+## Quiz
+
+1. **How does `torch.Tensor` extend the NumPy arrays you used in A1 through A3?**
+
+   <details>
+   <summary>Answer</summary>
+
+   A PyTorch tensor keeps the familiar rectangular shape, dtype, broadcasting, indexing, and vectorized operation model from NumPy, but adds device placement and optional autograd metadata. Device placement lets the same operation run on CPU, CUDA, or MPS backends when supported. Autograd metadata lets PyTorch record operations during the forward pass so `loss.backward()` can compute gradients later. The core shape reasoning remains the same.
+
+   </details>
+
+2. **Why does `loss.backward()` feel similar to the A8 `Value.backward()` method even though PyTorch operates on tensors?**
+
+   <details>
+   <summary>Answer</summary>
+
+   Both systems build a graph during the forward pass, seed the scalar loss with gradient one, and walk the graph in reverse topological order. Each node applies a local VJP and accumulates contributions into parent gradients. PyTorch's nodes are tensor operations implemented by optimized kernels, while A8's nodes were scalar Python objects, but the reverse-mode contract is the same.
+
+   </details>
+
+3. **What is the correct order of a normal PyTorch SGD training step, and which A7 operation does `optimizer.step()` replace?**
+
+   <details>
+   <summary>Answer</summary>
+
+   The normal order is `optimizer.zero_grad(set_to_none=True)`, forward pass, scalar loss computation, `loss.backward()`, and `optimizer.step()`. The step call replaces the manual A7 loop that subtracted `lr * grad` from every trainable parameter. Clearing gradients first is essential because PyTorch accumulates into `.grad` rather than overwriting it.
+
+   </details>
+
+4. **A model returns logits with shape `[64, 10]`. What shape and dtype should labels have for `nn.CrossEntropyLoss`, and why should you not apply softmax first?**
+
+   <details>
+   <summary>Answer</summary>
+
+   Labels should have shape `[64]` and dtype `torch.long`, with each value holding the integer class index. You should pass raw logits because `nn.CrossEntropyLoss` internally applies a stable log-softmax plus negative log-likelihood. Applying softmax first can reduce numerical stability and changes the API contract away from the intended logits-based loss.
+
+   </details>
+
+5. **What does a `DataLoader` add beyond the manual A7 mini-batch slicing loop, and what does it not do automatically?**
+
+   <details>
+   <summary>Answer</summary>
+
+   A `DataLoader` asks the dataset for examples, batches them, optionally shuffles training order, and can use worker processes for loading. It replaces the manual shuffled-index slicing loop from A7 while preserving the same mini-batch idea. It does not automatically move tensors to the model's device, choose the right split policy, normalize inputs, or make validation metrics meaningful. Those remain explicit training-engineering decisions.
+
+   </details>
+
+6. **Why do we call both `model.eval()` and `with torch.no_grad():` during evaluation?**
+
+   <details>
+   <summary>Answer</summary>
+
+   `model.eval()` changes the behavior of mode-sensitive modules such as dropout and batch normalization, while `torch.no_grad()` disables graph recording for operations inside the block. They solve different problems. Evaluation should use inference behavior and avoid building unnecessary graphs, so robust eval loops use both together.
+
+   </details>
+
+7. **You receive an error saying tensors are on CPU and CUDA at the same time. What should you inspect first?**
+
+   <details>
+   <summary>Answer</summary>
+
+   Inspect the device of the model parameters, the input batch, the labels, and any tensors used inside the loss. A disciplined loop moves the model once with `model.to(device)` and moves every `xb` and `yb` to the same device inside the loop. Randomly adding `.to(device)` in one place often hides the next mismatch rather than fixing the policy.
+
+   </details>
+
+## Hands-On Exercise
+
+**Task:** Translate one small Block A-style training run into PyTorch and prove that autograd, the optimizer, the DataLoader, and mode/device discipline are all wired correctly before you touch a larger dataset.
+
+1. Create a tensor dataset with 512 synthetic Fashion-MNIST-shaped images using `torch.rand(512, 1, 28, 28)` and 512 integer labels using `torch.randint(0, 10, (512,), dtype=torch.long)`.
+2. Build the `FashionMLP` class from Part 6 and print every parameter name plus shape using `model.named_parameters()`, confirming that the dense layers correspond to `784 -> 256 -> 10`.
+3. Train for five epochs with `nn.CrossEntropyLoss`, `torch.optim.SGD(model.parameters(), lr=0.1)`, `optimizer.zero_grad(set_to_none=True)`, `loss.backward()`, and `optimizer.step()`.
+4. Add an evaluation loop that calls `model.eval()` and wraps the forward pass in `with torch.no_grad():`, then reports validation loss and accuracy.
+5. Run the same script on `cpu` and, if available, on `cuda` or `mps`; document the one helper function that keeps model, inputs, and labels on the same device.
+
+**Success criteria:**
+
+- [ ] The first printed batch has image shape `[batch, 1, 28, 28]`, label shape `[batch]`, and logits shape `[batch, 10]`.
+- [ ] Every optimizer step follows the exact order `zero_grad` -> forward -> loss -> backward -> step.
+- [ ] The evaluation loop uses both `model.eval()` and `torch.no_grad()`, with no optimizer step inside evaluation.
+- [ ] No device mismatch occurs when switching from CPU to another available backend.
+- [ ] You can point to the A7 line or concept replaced by `nn.Linear`, `nn.CrossEntropyLoss`, `loss.backward()`, and `torch.optim.SGD`.
+
+**Verification:**
+
+```python
+assert next(model.parameters()).device == device
+assert logits.shape[1] == 10
+assert labels.dtype == torch.long
+assert all(parameter.grad is not None for parameter in model.parameters())
+```
+
+Run those assertions immediately after a training backward pass and before `optimizer.zero_grad(set_to_none=True)` clears gradients for the next step. The final assertion should fail during evaluation under `torch.no_grad()`, which is exactly the point: evaluation should not populate gradients.
 
 ## Key Takeaways
 
-1. **A neural network is just a function.** Specifically, it's a parameterized function f(x; θ) where learning means finding good values for θ. All the magic is in the parameters.
+PyTorch is the Block A system made practical. A tensor is a NumPy-style array with dtype, device, and optional graph metadata. Autograd is your A8 reverse-mode engine operating on tensor operations and optimized VJPs. `nn.Module` and `nn.Linear` are the standardized form of your A7 model and `Layer` classes. `torch.optim.SGD` is the manual parameter update wrapped in a reliable optimizer object. `Dataset` and `DataLoader` replace hand-sliced mini-batches while preserving the same batch semantics.
 
-2. **Forward propagation is function composition.** Each layer transforms its input: Z = W @ A + b, then A = activation(Z). Stack enough layers, and you can approximate any function.
+The most important engineering habit is ordering. Move model and batches to the same device. Enter training mode for training and evaluation mode for evaluation. Clear stale gradients, run forward, compute loss from logits and integer labels, call backward once on the scalar loss, then step the optimizer. Use `with torch.no_grad():` when evaluating. If you can explain each line in terms of A6, A7, and A8, PyTorch has stopped being magic and started being leverage.
 
-3. **Loss functions measure wrongness.** Cross-entropy for classification, MSE for regression. The lower the loss, the better the predictions match reality.
+## Learner check
 
-4. **Backpropagation is just the chain rule.** It assigns credit and blame to each parameter by computing how much changing that parameter would change the loss. No magic, just calculus.
-
-5. **Gradient descent navigates the loss landscape.** By repeatedly moving in the direction that reduces loss most steeply, we find good parameter values—even in spaces with millions of dimensions.
-
-6. **Activation functions provide non-linearity.** Without them, stacking linear layers would just produce another linear function. ReLU is the modern standard because it avoids vanishing gradients.
-
-7. **Initialization matters.** He initialization keeps gradients flowing through deep networks. Bad initialization can kill training before it starts.
-
-8. **The core ideas are old; the results are new.** Backpropagation (1986), convolutions (1989), and gradient descent (centuries old) power modern AI. What changed was data, compute, and clever tricks.
-
-## Next Steps
-
-With the rigorous mathematical foundations securely locked in and fully verified against PyTorch's underlying C++ execution engine, you are completely ready to tackle [Module 1.3: Training Neural Networks](./module-1.3-training-neural-networks).
-
-In the subsequent module, we will stop building flat tensors manually and begin leveraging PyTorch's high-level `torch.nn` module, training loops, and optimization tooling to build and train models at practical scale. You have learned the mathematical foundations; now it is time to turn them into working systems.
+> | 1.2 | [The PyTorch Bridge: From Your NumPy Engine to torch](/ai-ml-engineering/deep-learning/module-1.2-pytorch-fundamentals/) |
 
 ## Sources
 
-- [PyTorch 2.11.0 Release Notes](https://github.com/pytorch/pytorch/releases/tag/v2.11.0) — This is the cleanest allowlisted source for the module's version-specific PyTorch packaging and CUDA claims.
-- [ImageNet Classification with Deep Convolutional Neural Networks](https://cacm.acm.org/research/imagenet-classification-with-deep-convolutional-neural-networks/) — This is the classic AlexNet paper and directly supports several of the historical and benchmark claims in the module.
-- [Delving Deep into Rectifiers](https://arxiv.org/abs/1502.01852) — This paper is directly relevant to the module's discussion of ReLU networks and He initialization.
+- PyTorch 2.12 release blog. https://pytorch.org/blog/pytorch-2-12-release-blog/
+- PyTorch tensor documentation. https://docs.pytorch.org/docs/2.12/tensors.html
+- PyTorch autograd documentation. https://docs.pytorch.org/docs/2.12/autograd.html
+- PyTorch autograd mechanics note. https://docs.pytorch.org/docs/2.12/notes/autograd.html
+- PyTorch `torch.nn.Module` documentation. https://docs.pytorch.org/docs/2.12/generated/torch.nn.Module.html
+- PyTorch `torch.nn.Linear` documentation. https://docs.pytorch.org/docs/2.12/generated/torch.nn.Linear.html
+- PyTorch `torch.nn.CrossEntropyLoss` documentation. https://docs.pytorch.org/docs/2.12/generated/torch.nn.CrossEntropyLoss.html
+- PyTorch `torch.optim.SGD` documentation. https://docs.pytorch.org/docs/2.12/generated/torch.optim.SGD.html
+- PyTorch data loading documentation. https://docs.pytorch.org/docs/2.12/data.html
+- Paszke et al., "PyTorch: An Imperative Style, High-Performance Deep Learning Library." https://papers.neurips.cc/paper_files/paper/2019/hash/bdbca288fee7f92f2bfa9f7012727740-Abstract.html
+- d2l.ai automatic differentiation chapter. https://d2l.ai/chapter_preliminaries/autograd.html
+- Karpathy micrograd repository. https://github.com/karpathy/micrograd
+
+## Next Module
+
+Continue to [The Training Loop](/ai-ml-engineering/deep-learning/module-1.3-training-neural-networks/).

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.3.1-initialization-signal-propagation.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.3.1-initialization-signal-propagation.md
@@ -1,0 +1,690 @@
+---
+title: "Initialization & Signal Propagation"
+slug: ai-ml-engineering/deep-learning/module-1.3.1-initialization-signal-propagation
+sidebar:
+  order: 1004.1
+---
+
+> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 4-5 hours
+>
+> **Prerequisites**: Block A modules A3 (Forward Propagation), A6 (Backprop by Hand), A7 (Tiny NumPy NN Lab), and A8 (Scalar Autograd). PyTorch fundamentals from module 1.2 are helpful but not strictly required.
+>
+> **Primary tools**: PyTorch 2.12, NumPy for cross-checks.
+
+---
+
+In 2010, Xavier Glorot and Yoshua Bengio published a paper at AISTATS titled "Understanding the difficulty of training deep feedforward neural networks." The paper opened with a puzzle that had frustrated practitioners for years: deep networks with more than a handful of hidden layers often failed to train at all, while shallow networks with the same total parameter count sometimes worked fine. The failure was not a bug in the optimizer or the loss function — it was a signal problem. Activations at the deepest layers were either vanishing toward zero or exploding toward infinity before the first gradient step completed, and the gradients flowing backward were distorted by the same compounding effect. Glorot and Bengio showed that the root cause was weight initialization: drawing weights from a distribution with unit variance, which seemed reasonable, actually multiplied activation variance by the fan-in at every layer. A ten-layer network with 512 units per layer could amplify variance by a factor of 512 ten times over — a number so large that floating-point arithmetic itself became the bottleneck.
+
+Their fix was not a new optimizer or a new activation function. It was a scaling rule: initialize each weight from a distribution whose variance depends on the layer's fan-in and fan-out so that signals — both activations forward and gradients backward — remain near unit variance across depth. Five years later, Kaiming He and colleagues refined the rule for ReLU networks, adding a factor of two that accounts for ReLU zeroing half the activations on average. Those two papers — Glorot & Bengio (2010) and He et al. (2015) — are the engineering foundation beneath every modern deep network's first training step. In Block A you built forward propagation (A3), derived backward-pass VJPs by hand (A6), and trained a tiny MLP with manually chosen weight scales (A7). This module shows why that scale mattered, derives the variance rules from first principles, and maps them directly onto PyTorch's `nn.init` API so that `torch.Tensor` and `nn.Linear` feel like the same objects you already engineered in NumPy — just with the initialization discipline built in.
+
+---
+
+## Learning Outcomes
+
+By the end of this module, you will be able to measure activation and gradient scale in deep PyTorch stacks, derive the variance propagation formulas that explain those measurements, and apply Xavier and He initialization correctly in production training code.
+
+- **Implement** layer-wise activation and gradient standard-deviation probes in PyTorch 2.12 that make vanishing and exploding signals visible in a deep network before any optimizer step runs.
+- **Derive** the forward-pass variance propagation formula `Var(out) = n_in · Var(W) · Var(in)` for a linear layer under zero-mean independence assumptions, and explain why preserving unit variance requires `Var(W) = 1/n_in`.
+- **Compare** Xavier/Glorot and He/Kaiming initialization schemes, including their uniform and normal parameterizations, and select the appropriate scheme for tanh versus ReLU-family activations; **evaluate** when orthogonal initialization, LSUV, or normalization layers (forward-point to module B6) supplement or replace variance-scaled random init.
+- **Apply** PyTorch initialization idioms — `nn.init.kaiming_normal_`, `nn.init.xavier_uniform_`, the `nonlinearity` and `gain` arguments, and the `model.apply(init_fn)` pattern — to debug training failures by inspecting weight statistics, layer-wise activation norms, and early gradient magnitudes rather than guessing at learning rates.
+
+---
+
+## Why This Module Matters
+
+Training a deep network is a chain of multiplications. Every layer takes an input vector, multiplies it by a weight matrix, adds a bias, and passes the result through a nonlinearity. If the weights are too small, each multiplication shrinks the signal; after twenty or fifty layers the activations are indistinguishable from zero, the nonlinearities sit in their linear region or at saturation, and the gradients that backpropagation sends upstream are equally tiny. The optimizer receives gradient vectors full of numerical noise and cannot move the weights meaningfully — training appears to "not work" even though the code runs without errors. If the weights are too large, the opposite happens: activations explode layer by layer, floating-point values overflow to `inf` or `nan`, and the loss becomes undefined before you finish the first epoch.
+
+This is not a hypothetical edge case. It is the default outcome when you stack many layers and initialize weights from `N(0, 1)` without scaling. The NumPy `Layer` class you built in A3 used He-style scaling (`std = sqrt(2/fan_in)`) almost incidentally — this module explains *why* that choice was necessary and what happens when you omit it. The backward-pass VJPs you derived in A6 propagate gradient variance through weight matrices transposed relative to the forward pass; a weight scale that preserves forward variance does not automatically preserve backward variance, which is why Xavier initialization compromises between fan-in and fan-out while He initialization targets the forward pass for ReLU nets where backward variance is less fragile.
+
+PyTorch's `nn.Linear` and `nn.Conv2d` layers ship with sensible defaults (Kaiming uniform for linear layers in PyTorch 2.12), but defaults are not guarantees. Transfer learning, custom architectures, RNNs, and transformer blocks all require you to choose or override initialization deliberately. Normalization layers (module B6) reduce sensitivity to initialization but do not eliminate the need for it — a network with batch normalization still benefits from reasonable starting weights, and many architectures (especially RNNs and early transformer variants) train without normalization at all. Optimizers and learning-rate schedules (module B4) cannot fix a network whose signal is already dead on arrival. Initialization is the first engineering decision in every training run, and it is the one decision that costs nothing at runtime yet determines whether everything downstream is possible.
+
+The engineering mindset here mirrors what you practiced in A6 when you finite-difference checked analytic gradients: treat a claim as untrusted until you measure it. Initialization theory gives you a formula; a ten-line PyTorch probe tells you whether that formula matches your actual architecture, activation choice, and layer widths. When someone reports that a fifty-layer MLP "will not learn," the first diagnostic is not "try Adam with lr=3e-4" — it is "print activation std at layer 25." If that number is `1e-9` or `1e6`, no optimizer rescues the run. This module gives you both the formula and the probe so you can classify the failure in minutes instead of burning GPU cycles on random hyperparameter sweeps.
+
+There is also a subtle interaction between initialization and batch size that practitioners rediscover painfully. Gradient variance scales inversely with batch size when the loss is averaged over samples, as you saw when the `1/N` factor in A6's mean-loss gradient had to match the optimizer step. Initialization sets the *activation* scale before batching enters the picture, but if activations are already near zero, dividing gradients by a large batch makes them even smaller relative to weight magnitudes. Conversely, if activations are huge, a small batch produces noisy but enormous gradient spikes. Healthy initialization puts you in the regime where batch-size and learning-rate tuning in B4 actually matter — it widens the basin of trainable hyperparameters rather than replacing those hyperparameters entirely.
+
+---
+
+## Part 1: Making the Problem Visible
+
+Before deriving formulas, run an experiment that prints numbers you can trust. The goal is to watch activation standard deviation at every layer of a deep stack and see it drift away from 1.0 — the healthy baseline for unit-variance inputs.
+
+### 1.1 A deep linear stack with `N(0, 1)` weights
+
+Consider a depth-`L` network of linear layers with no bias, each mapping `n` inputs to `n` outputs. Initialize every weight matrix with independent `N(0, 1)` entries. Feed in a batch of inputs where each feature has approximately unit variance:
+
+```python
+import torch
+
+def probe_forward_stds(depth: int, n: int, init_std: float, activation=None):
+    """Print activation std after each layer of a deep stack.
+
+    Args:
+        depth: number of weight layers
+        n: fan-in / fan-out (square layers)
+        init_std: standard deviation of weight initialization
+        activation: optional callable (e.g., torch.tanh); None = linear only
+    """
+    torch.manual_seed(0)
+    x = torch.randn(256, n)  # batch=256, features ~ N(0,1)
+    print(f"input  std = {x.std():.4f}")
+
+    for layer_idx in range(depth):
+        W = torch.randn(n, n) * init_std  # shape (n, n), N(0, init_std^2)
+        x = x @ W                         # (256, n) @ (n, n) -> (256, n)
+        if activation is not None:
+            x = activation(x)
+        print(f"layer {layer_idx + 1:2d} std = {x.std():.4f}")
+
+    return x
+
+print("=== Linear only, N(0,1) weights, depth=10, n=512 ===")
+probe_forward_stds(depth=10, n=512, init_std=1.0, activation=None)
+```
+
+On a typical run, the input std is near 1.0, layer 1 std jumps to roughly 22–23 (because `sqrt(512) ≈ 22.6`), layer 2 std exceeds 500, and by layer 10 the values are astronomical or overflow to `inf`. Each linear layer multiplies variance by approximately `n_in · Var(W) = 512 · 1 = 512`, so the standard deviation scales by `sqrt(512) ≈ 22.6` per layer. Over ten layers that is `22.6^10`, far beyond float32 range. This is **activation explosion**, and it happens before any training step — purely from initialization and forward propagation.
+
+Compare with a small init: `init_std=0.01`. Now each layer shrinks variance by roughly `512 × 0.01² = 0.0512`, so std shrinks by about `sqrt(0.0512) ≈ 0.23` per layer. After ten layers the activations are near zero — **activation vanishing**.
+
+### 1.2 The same stack with `tanh`
+
+Nonlinearities change the picture but do not eliminate the problem, because saturation and vanishing gradients replace raw variance explosion as the primary failure mode when activations are poorly scaled. Run the same probe with `tanh` inserted after each linear map:
+
+```python
+print("\n=== tanh activations, N(0,1) weights, depth=50, n=256 ===")
+probe_forward_stds(depth=50, n=256, init_std=1.0, activation=torch.tanh)
+```
+
+With large pre-activations, `tanh` saturates toward ±1, so activation std may appear stable near 0.7–0.8 in deeper layers — but this stability is deceptive. The saturated tanh outputs carry almost no usable gradient: `d tanh(z)/dz = 1 - tanh²(z) ≈ 0` when `|z|` is large. The forward signal looks fine while the backward signal is dead. This is the classic **vanishing gradient** problem that plagued deep tanh networks before ReLU and before proper initialization.
+
+### 1.3 Probing gradient magnitudes
+
+Forward std alone does not tell the whole story. Measure gradient std at each layer during a backward pass:
+
+```python
+import torch.nn as nn
+
+class DeepLinearTanh(nn.Module):
+    def __init__(self, depth, n, init_std):
+        super().__init__()
+        self.layers = nn.ModuleList([
+            nn.Linear(n, n, bias=False) for _ in range(depth)
+        ])
+        for layer in self.layers:
+            nn.init.normal_(layer.weight, mean=0.0, std=init_std)
+
+    def forward(self, x):
+        for layer in self.layers:
+            x = torch.tanh(layer(x))
+        return x
+
+def probe_gradient_stds(depth=20, n=256, init_std=1.0):
+    torch.manual_seed(1)
+    model = DeepLinearTanh(depth, n, init_std)
+    x = torch.randn(64, n, requires_grad=False)
+    y = model(x).sum()  # scalar loss
+    y.backward()
+
+    print(f"init_std={init_std}, depth={depth}, n={n}")
+    for i, layer in enumerate(model.layers):
+        gstd = layer.weight.grad.std().item()
+        print(f"  layer {i + 1:2d} weight grad std = {gstd:.6e}")
+
+print("=== Gradient probe: bad init ===")
+probe_gradient_stds(depth=20, n=256, init_std=1.0)
+```
+
+With `init_std=1.0`, gradient std typically **decreases** from the output layer toward the input — early layers receive tiny gradients and barely learn. With `init_std=0.01`, gradients may explode toward the input. The backward pass applies the same weight matrices transposed (exactly the VJP `dL_dX = dL_dY @ W.T` from A6), so variance preservation requires a *different* scaling constraint on `Var(W)` — one that involves fan-out rather than fan-in. Parts 2 and 3 derive both constraints and show how Xavier and He schemes reconcile them.
+
+The asymmetry between forward and backward variance is easy to miss because both directions use the same weight tensor. In the forward pass each output neuron aggregates `n_in` inputs; in the backward pass each input neuron receives gradient contributions from `n_out` outputs. A square layer with `n_in = n_out = 512` makes both constraints identical, which is why early experiments on symmetric architectures masked the problem. Modern networks are rarely square: a projection from 2048 to 512 has very different fan-in and fan-out, and a compromise formula like Xavier's becomes necessary rather than optional. When you read PyTorch's `mode='fan_in'` versus `mode='fan_out'` in `kaiming_*`, you are choosing which direction gets priority — most feed-forward ReLU nets prioritize forward activations because dead activations are harder to recover from than slightly noisy gradients.
+
+### 1.4 Connecting to Block A
+
+In A3 you computed `Z = X @ W + b` and cached `Z` and `A` for backprop. In A7 you initialized `W` with `rng.normal(0, np.sqrt(2.0 / d_in), size=(d_in, d_out))` — He scaling for ReLU. The experiment above is the same computation in PyTorch: `nn.Linear` stores `W` with shape `(out_features, in_features)` and computes `x @ W.T + b`. The variance story is identical; only the weight layout differs from your NumPy convention where `W` was `(d_in, d_out)`. When reading PyTorch docs, always check whether a formula uses fan-in (columns of the weight matrix in the `(out, in)` layout) or fan-out (rows).
+
+The connection to A8's scalar autograd is equally direct. When micrograd-style `Value` objects propagated local derivatives through a tiny graph, each `+` and `*` node had a backward rule that preserved the scale of the upstream gradient relative to the local partial derivative. A deep network with badly scaled weights is a graph where those local partial derivatives are uniformly too large or too small — `loss.backward()` still runs the correct VJP algebra from A6, but the numeric values flowing through the graph are unusable. Initialization is therefore the step that puts the computational graph in a numerically healthy regime before autograd executes. PyTorch does not rescale your weights for you; it faithfully differentiates whatever values you provide.
+
+### 1.5 Intuition: why depth multiplies the problem
+
+Shallow networks forgive bad init because there are few multiplication steps between input and output. A three-layer MLP with width 128 has at most three opportunities to amplify or shrink variance. A fifty-layer network compounds the per-layer factor fifty times — multiplicatively in variance, which means exponentially in standard deviation for linear stacks. This is the same compounding intuition you saw when XOR required only one hidden layer but deeper architectures in modern vision need dozens. Depth buys representational power at the cost of demanding disciplined signal engineering at every layer boundary. Initialization is how you pay that cost up front rather than discovering it through failed training runs.
+
+---
+
+## Part 2: Variance Propagation Mathematics
+
+We now derive the scaling rule that the experiment demonstrated empirically. The derivation assumes independent, zero-mean weights and inputs — approximations that hold well at initialization before correlations develop during training.
+
+### 2.1 One linear layer
+
+Consider a single linear output unit (one row of the weight matrix) computing `y = sum_{j=1}^{n_in} w_j x_j`. Assume `E[w_j] = E[x_j] = 0` and that all `w_j` and `x_j` are mutually independent. The variance of the sum of independent products is `Var(y) = sum_j Var(w_j x_j) = sum_j Var(w_j) Var(x_j) = n_in * Var(W) * Var(x)`, where the last step uses identical variances across inputs and weights. In plain language: **output variance equals fan-in times weight variance times input variance**. If you want `Var(y) = Var(x)` — keeping the signal at unit scale — you need `Var(W) = 1/n_in`. For a weight matrix where each of the `n_in × n_out` entries is drawn independently from the same distribution, set `std(W) = 1 / sqrt(n_in)`. This is the **forward-pass preservation rule**.
+
+The derivation is an approximation, not a law of nature. Once training begins, weights and activations become correlated: certain neurons co-activate, others compete, and the independence assumption breaks. That is acceptable because initialization only needs to produce a reasonable starting point for the first few hundred steps — not to predict activation statistics at epoch fifty. What the formula captures is the *multiplicative* nature of depth. Each layer applies the same scaling logic, so errors compound exponentially in the number of layers unless each layer's scale is carefully chosen. A network with five layers and unit-variance mistakes loses roughly five factors of scale; a network with fifty layers loses fifty. That is why shallow networks trained fine with naive init in the 1990s while deeper networks did not: depth turned a small per-layer error into a catastrophic global failure.
+
+In A3 notation with `Y = X @ W + b` where `X:(N, d_in)` and `W:(d_in, d_out)`, each output neuron sums over `d_in` products, so `n_in = d_in`. PyTorch's `nn.Linear(d_in, d_out)` stores weight with shape `(d_out, d_in)`, so fan-in is `weight.shape[1]`. When you inspect a checkpoint's `state_dict`, always read fan-in from the second dimension of `*.weight` tensors — confusing it with fan-out is one of the most common initialization bugs in ported code.
+
+### 2.2 Backward-pass variance
+
+During backpropagation, the gradient with respect to the layer input is (from A6) `dL/dX = (dL/dY) @ W.T`. Each row of `dL/dX` is a sum over `n_out` products of upstream gradients and weights. By the same independence argument, `Var(dL/dx_j) = n_out * Var(W) * Var(dL/dy_j)`. To preserve gradient variance backward requires `Var(W) = 1 / n_out`. Forward and backward cannot both be satisfied exactly with a single random matrix unless `n_in = n_out`. Real networks have rectangular layers, so initialization schemes **compromise** between the two constraints. When you derived `dL_dX = G @ W.T` in A6, you were computing exactly the operation whose variance scales with fan-out; that is why a weight scale that looks perfect in a forward-only probe can still produce dying gradients in the earliest layers during backprop.
+
+### 2.3 Effect of activations
+
+Nonlinearities modify variance in activation-dependent ways, as summarized in the table below. The factor of one-half for ReLU is critical: even if the linear pre-activation has unit variance, the ReLU output has half the variance because roughly half the entries are zeroed. He initialization compensates with a factor of 2 in the weight variance (Part 4). Tanh and sigmoid introduce a different failure mode — not variance explosion but **saturation**, where outputs cluster near plus or minus one and local derivatives approach zero, starving the backward pass regardless of how carefully you scaled the weights.
+
+### 2.4 Worked numeric example
+
+| Activation | Effect on forward variance | Gradient concern |
+|---|---|---|
+| Identity (linear) | Preserves variance exactly under the linear rule | Same as forward |
+| `tanh` / sigmoid | Saturates: large inputs produce outputs near plus or minus one, variance bounded | Gradients vanish when saturated |
+| ReLU | Zeros negative half: `Var(out)` is about half of `Var(pre_activation)` | Gradient is 0 or 1 — no shrinkage, but dead neurons |
+
+Suppose `n_in = 256`, inputs have `Var(x) = 1`, and weights are `N(0, 1)`. Then `Var(y) = 256`, so `std(y)` is about 16, and to target `std(y)` near 1 you need `Var(W) = 1/256`, giving `std(W) = 1/16 = 0.0625`. The following PyTorch snippet verifies this single-layer relationship before you trust it in a deep stack:
+
+```python
+n = 256
+x = torch.randn(10000, n)  # large batch for stable std estimate
+W_bad = torch.randn(n, n)           # std = 1.0
+W_good = torch.randn(n, n) / (n ** 0.5)  # std = 1/sqrt(n)
+
+y_bad = x @ W_bad
+y_good = x @ W_good
+
+print(f"std(x)      = {x.std():.4f}")       # ~1.0
+print(f"std(y_bad)  = {y_bad.std():.4f}")    # ~16
+print(f"std(y_good) = {y_good.std():.4f}")    # ~1.0
+```
+
+This single-layer check is the building block for deep stacks: if each layer preserves variance, a 50-layer network maintains stable activations throughout. Run it whenever you port a formula from a paper into PyTorch — a transposed weight layout or a mistaken fan-in dimension silently turns a correct equation into an incorrect scale, and this three-line probe catches that mistake before you build fifty layers on top of it.
+
+---
+
+## Part 3: Xavier / Glorot Initialization
+
+Xavier Glorot and Yoshua Bengio (2010) proposed initializing weights to balance forward and backward variance for symmetric activations like `tanh` and sigmoid, where the activation's derivative is largest near zero and gradients flow best when pre-activations stay in that region.
+
+### 3.1 The compromise formula
+
+Xavier initialization sets `Var(W) = 2 / (n_in + n_out)`. The factor of 2 accounts for the uniform distribution variant described below. For layers where `n_in` is approximately equal to `n_out`, this is close to both `1/n_in` and `1/n_out` simultaneously. The scheme keeps pre-activations in the linear region of `tanh` where gradients are near 1, avoiding both saturation and vanishing. When layer widths differ substantially — for example a bottleneck layer mapping 2048 units to 64 — the compromise lands closer to one constraint than the other, which is still far better than ignoring the mismatch entirely.
+
+### 3.2 Uniform and normal parameterizations
+
+PyTorch provides both forms via `nn.init.xavier_uniform_` and `nn.init.xavier_normal_`:
+
+| Distribution | Parameterization | PyTorch call |
+|---|---|---|
+| Uniform | `W ~ U(-a, a)` where `a = sqrt(6 / (n_in + n_out))` | `nn.init.xavier_uniform_(tensor, gain=1.0)` |
+| Normal | `W ~ N(0, 2 / (n_in + n_out))` | `nn.init.xavier_normal_(tensor, gain=1.0)` |
+
+The uniform bound `a` is chosen so that for uniform `U(-a,a)`, variance equals `a²/3`. Setting `a = sqrt(6/(n_in+n_out))` gives `Var(W) = 2/(n_in+n_out)`. The normal form uses `std = sqrt(2/(n_in+n_out))` directly. Both distributions are equally valid; uniform init was common in early TensorFlow examples while normal init is more common in PyTorch codebases today. The variance target is identical — only the tail behavior differs, which matters slightly for regularization but rarely changes training outcomes for large matrices where the central limit theorem applies across thousands of weight entries.
+
+```python
+import torch.nn as nn
+
+layer = nn.Linear(512, 512, bias=True)
+nn.init.xavier_uniform_(layer.weight)
+nn.init.zeros_(layer.bias)  # bias convention: start at 0
+
+print("weight std:", layer.weight.std().item())
+print("expected:  ", (2.0 / (512 + 512)) ** 0.5)
+```
+
+The `gain` argument scales the effective variance for activations that amplify or shrink signals. PyTorch's `nn.init.calculate_gain(nonlinearity)` returns recommended gains — for example `tanh` uses gain approximately 5/3 and ReLU uses `sqrt(2)`. When a paper specifies init for linear activations but your network uses ReLU, pass the matching `nonlinearity` string so PyTorch adjusts the gain automatically rather than applying a mismatched scale that would leave activations systematically far too large or far too small at the very first training step.
+
+### 3.3 When to use Xavier
+
+Use Xavier (Glorot) initialization when your hidden activations are **symmetric and saturating** — `tanh`, logistic sigmoid, or linear output layers in encoder-decoder architectures. It remains the standard for LSTM and GRU gates in many implementations, though LSTM-specific schemes exist. For ReLU-family activations, Xavier leaves activations slightly too small on average because it does not account for ReLU halving variance; use He initialization instead (Part 4).
+
+Historically, Xavier initialization unlocked training for deeper tanh networks in the early 2010s, contributing directly to the resurgence of deep learning after the long "AI winter" period when multilayer perceptrons were considered too fragile to stack. Before Glorot and Bengio's analysis, practitioners often used ad-hoc scales like `1/sqrt(n)` without understanding the forward-backward tradeoff, and hyperparameter search over init scale was common. The paper replaced guesswork with a single line you could compute from layer dimensions. When you encounter legacy code or academic reproductions that mention "Glorot uniform," they refer to the same scheme as "Xavier uniform" in PyTorch — the naming split is purely historical, not mathematical.
+
+---
+
+## Part 4: He / Kaiming Initialization for ReLU Networks
+
+Kaiming He, Xiangyu Zhang, Shaoqing Ren, and Jian Sun (2015) analyzed variance propagation through ReLU layers and showed that Xavier's compromise is suboptimal when half the activations are zeroed at every layer.
+
+### 4.1 Deriving the factor of 2
+
+For a pre-activation `z` with zero mean and unit variance, ReLU output is `a = max(0, z)`. Because ReLU zeros the negative half of the distribution, `Var(a) = 0.5 * Var(z)`, so the linear part must produce pre-activation variance 2 rather than 1 to maintain unit output variance after ReLU. Since `Var(pre) = n_in * Var(W) * Var(x_in)`, preserving unit output variance after ReLU requires `n_in * Var(W) * Var(x_in) = 2 * Var(x_in)`, which simplifies to `Var(W) = 2 / n_in`. Equivalently, `std(W) = sqrt(2 / n_in)`. This is the **He (Kaiming) initialization** — the default philosophy for modern convolutional and transformer feed-forward blocks using ReLU, GELU, or similar non-saturating activations. Compare to your A7 NumPy code: `W = rng.normal(0, np.sqrt(2.0 / d_in), ...)`. That line was He initialization. PyTorch's `nn.init.kaiming_normal_` computes the same scale.
+
+### 4.2 Uniform and normal forms
+
+| Distribution | Parameterization | PyTorch call |
+|---|---|---|
+| Normal | `W ~ N(0, 2/n_in)` with `mode='fan_in'` | `nn.init.kaiming_normal_(w, mode='fan_in', nonlinearity='relu')` |
+| Uniform | `W ~ U(-a, a)` where `a = sqrt(6/n_in)` | `nn.init.kaiming_uniform_(w, mode='fan_in', nonlinearity='relu')` |
+
+The `mode` argument selects whether fan-in (`'fan_in'`), fan-out (`'fan_out'`), or the average (`'fan_avg'`) appears in the denominator. Default for `'fan_in'` matches the derivation above. For convolutions, fan-in includes kernel size: `n_in = in_channels × kernel_h × kernel_w`.
+
+```python
+conv = nn.Conv2d(64, 128, kernel_size=3, padding=1)
+nn.init.kaiming_normal_(conv.weight, mode='fan_in', nonlinearity='relu')
+fan_in = 64 * 3 * 3
+expected_std = (2.0 / fan_in) ** 0.5
+print(f"conv weight std: {conv.weight.std():.5f}, expected: {expected_std:.5f}")
+```
+
+For `LeakyReLU` with negative slope `a`, PyTorch's `calculate_gain('leaky_relu', param=a)` adjusts the variance factor because fewer activations are zeroed.
+
+### 4.3 When to use He
+
+Use He (Kaiming) initialization for any network whose hidden layers use **ReLU, LeakyReLU, PReLU, or GELU** (GELU is often close enough that He init works well in practice). ResNet, VGG, and most vision backbones rely on this scheme. PyTorch 2.12 applies Kaiming uniform with `a=sqrt(5)` as the default for `nn.Linear` — slightly different from pure He for ReLU but within the same design family.
+
+The ResNet paper (He et al., 2016) demonstrated that with proper initialization and residual connections, networks with 100+ layers could train on ImageNet — a result that would have been unthinkable with `N(0,1)` init. Residual shortcuts provide an additional path for gradients to flow, but they do not remove the need for reasonable weight scales in the convolutional blocks themselves. When you initialize a modern vision transformer's MLP sublayers, you are still applying the same fan-in variance logic, even though the architecture looks nothing like a 2012 AlexNet. The activation changed from ReLU to GELU; the init philosophy remained variance preservation adapted to the nonlinearity.
+
+---
+
+## Part 5: Orthogonal Initialization and Other Schemes
+
+Variance-scaled random initialization is the default tool, but several alternatives address specific architectural needs when independence-based variance formulas are insufficient or when the same weight matrix is applied repeatedly across time or depth in ways that amplify small scaling errors.
+
+### 5.1 Orthogonal initialization
+
+An orthogonal matrix `Q` satisfies `Q Q^\top = I`. Initialized as a random orthogonal matrix via SVD of a Gaussian draw, weights preserve vector norms exactly: `||Qx|| = ||x||` when `Q` is square. This prevents both explosion and vanishing across depth for linear maps and helps recurrent networks maintain hidden state magnitude over many time steps (forward-point to RNN modules in section 1.5).
+
+```python
+nn.init.orthogonal_(layer.weight, gain=1.0)
+```
+
+Orthogonal init is common for RNN hidden-to-hidden weights where the same matrix is applied repeatedly across time steps, compounding variance errors that feed-forward networks experience only across depth. It is less common for standard CNN or transformer feed-forward layers where Kaiming init is simpler and performs equally well. PyTorch implements orthogonal initialization via `nn.init.orthogonal_(tensor, gain=1.0)`, which performs an SVD on a random Gaussian matrix and returns an orthogonal factor. The optional `gain` scales the singular values uniformly, letting you combine norm preservation with a desired output amplitude when the downstream nonlinearity expects a specific input scale.
+
+### 5.2 Layer-Sequential Unit-Variance (LSUV)
+
+LSUV (Mishkin & Matas, 2016) initializes with orthogonal matrices, then iteratively rescales each layer's weights so that empirical output variance on a sample batch equals 1. It is more expensive than closed-form rules but adapts to exotic activations or architectures where analytical variance formulas are messy. Use LSUV when standard rules fail and you have compute budget for a data-dependent init pass. The method bridges random init and normalization: it uses real data to calibrate scales layer by layer, which can rescue architectures where neither Xavier nor He assumptions hold cleanly, such as networks with custom activations or unusual connectivity patterns.
+
+### 5.3 Bias initialization
+
+Bias vectors are almost always initialized to **zero**. Non-zero bias shifts the pre-activation distribution away from the origin, which matters for ReLU (shifting how many units start active) and batch normalization (which expects zero-centered inputs at init in some formulations). Output-layer biases sometimes receive special treatment — for example, initializing a binary classification bias to `-log((1-π)/π)` where π is the prior positive rate — but hidden-layer biases stay at zero unless you have a specific reason.
+
+### 5.4 Normalization layers change the game — but do not remove init
+
+Batch normalization (module B6), layer normalization, and RMSNorm re-center and re-scale activations during training, dramatically reducing sensitivity to initialization scale. ResNet trains with BN partly because it can tolerate a wider range of initial weight scales. However:
+
+- Normalization does not help if the very first forward pass produces `nan` before BN statistics are computed.
+- Many architectures (RNNs without BN, early transformers, reinforcement-learning heads) still depend on good init.
+- Even with BN, better initialization leads to faster convergence and more stable early training curves.
+
+Treat normalization as a complement to initialization, not a replacement. Batch normalization (module B6) will re-scale activations during training, but the first forward pass still runs on uninitialized statistics, and layers without normalization remain sensitive to weight scale throughout training.
+
+### 5.5 Residual connections and init scale
+
+Residual networks add a skip connection `y = F(x) + x` that gives gradients a direct highway past the stacked layers. This architectural choice reduces effective depth for gradient flow but does not change the forward activation scale in the residual branch `F(x)`. If `F(x)` has exploding variance, the sum `F(x) + x` is dominated by `F(x)` and the skip connection stops helping. ResNet-style training therefore combines He initialization in convolutional blocks with careful scaling of the final batch-norm gamma in each residual branch (often initialized to zero in the last BN of a block so early training behaves like an identity). You do not need to master residual init patterns in this module, but you should recognize that architecture and initialization co-evolve — neither alone explains why modern deep nets train.
+
+---
+
+## Part 6: PyTorch Initialization in Practice
+
+PyTorch centralizes initialization in `torch.nn.init`. Every `nn.Module` with learnable parameters exposes `.weight` and `.bias` tensors you can initialize after construction or via a recursive apply function.
+
+### 6.1 Inspecting defaults
+
+When you construct `nn.Linear(256, 256)` without custom init, PyTorch calls `reset_parameters()` which uses Kaiming uniform scaling derived from the fan-in and the LeakyReLU parameter `a=sqrt(5)` in the default implementation:
+
+```python
+import math
+import torch.nn as nn
+
+layer = nn.Linear(256, 256)
+w = layer.weight
+print("default weight shape:", w.shape)          # (256, 256) = (out, in)
+print("default weight std:  ", w.std().item())
+# PyTorch default nn.Linear uses kaiming_uniform_(a=sqrt(5)) -> gain=sqrt(1/3),
+# so the uniform bound is 1/sqrt(fan_in). (sqrt(6/fan_in) would be the ReLU/gain=sqrt(2) bound.)
+fan_in = w.shape[1]
+bound = 1.0 / math.sqrt(fan_in)
+print("approx Kaiming uniform bound:", bound)
+```
+
+Always inspect rather than assume. Third-party modules, copied code, and `load_state_dict` from checkpoints may leave weights in arbitrary states. When you wrap a pretrained backbone and add a new classification head, the backbone weights come from someone else's init and training, while your head needs explicit init — leaving the head at PyTorch defaults is fine, but leaving it at whatever random state existed after a partial `load_state_dict` is not.
+
+### 6.5 Convolutional layers and fan-in
+
+For `nn.Conv2d(in_channels, out_channels, kernel_size=k)`, fan-in is `in_channels * k * k` (times kernel height and width for non-square kernels). Each output pixel is a sum over all input channels and kernel positions, so the variance formula uses the full receptive field size, not just channel count:
+
+```python
+conv = nn.Conv2d(3, 64, kernel_size=7, stride=2, padding=3)
+fan_in = 3 * 7 * 7  # 147
+he_std = (2.0 / fan_in) ** 0.5
+nn.init.kaiming_normal_(conv.weight, mode='fan_in', nonlinearity='relu')
+print(f"conv fan_in={fan_in}, he_std={he_std:.4f}, actual std={conv.weight.std():.4f}")
+```
+
+The same `model.apply(init_fn)` pattern handles both Linear and Conv2d by checking `isinstance`. For depthwise-separable convolutions, fan-in per group differs from standard conv — always compute fan-in from the actual weight tensor shape rather than memorizing a formula for one conv type.
+
+### 6.2 The `model.apply(init_fn)` pattern
+
+The idiomatic way to initialize an entire model is a recursive `apply` function that pattern-matches module types and assigns the correct scheme to each, rather than hand-initializing tensors after construction:
+
+```python
+def init_weights(m):
+    if isinstance(m, nn.Linear):
+        nn.init.kaiming_normal_(m.weight, mode='fan_in', nonlinearity='relu')
+        if m.bias is not None:
+            nn.init.zeros_(m.bias)
+    elif isinstance(m, nn.Conv2d):
+        nn.init.kaiming_normal_(m.weight, mode='fan_in', nonlinearity='relu')
+        if m.bias is not None:
+            nn.init.zeros_(m.bias)
+
+model = nn.Sequential(
+    nn.Linear(784, 256),
+    nn.ReLU(),
+    nn.Linear(256, 128),
+    nn.ReLU(),
+    nn.Linear(128, 10),
+)
+
+model.apply(init_weights)
+
+# Verify
+for name, param in model.named_parameters():
+    if 'weight' in name:
+        print(f"{name:30s} std={param.std():.5f}")
+```
+
+This pattern mirrors what you did manually in A7 — loop over layers, set scale per layer width — but delegates the variance math to `nn.init`.
+
+### 6.3 Mapping Block A concepts to PyTorch
+
+| Block A (NumPy) | PyTorch 2.12 | Notes |
+|---|---|---|
+| `W = rng.normal(0, sqrt(2/d_in), (d_in, d_out))` | `nn.init.kaiming_normal_(m.weight, mode='fan_in', nonlinearity='relu')` | Weight layout transposed: PyTorch stores `(out, in)` |
+| Manual `W -= lr * dW` | `optimizer.step()` after `loss.backward()` | A8 autograd maps to `torch.autograd` |
+| `Layer.forward` caching `Z`, `A` | `nn.Module` forward + autograd graph | Same VJPs, automated |
+| He scale in A3 Part 5 preview | Default `nn.Linear` reset | Same formula, built in |
+
+When porting NumPy init code, remember to transpose the shape convention or use PyTorch's fan-in based on `weight.shape[1]`.
+
+### 6.4 Custom initialization for specific layers
+
+Sometimes one layer needs different treatment — most commonly the output classification head, which may use Xavier scaling while hidden ReLU layers use He init:
+
+```python
+class MLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.hidden = nn.Linear(512, 512)
+        self.output = nn.Linear(512, 10)
+
+    def forward(self, x):
+        x = torch.relu(self.hidden(x))
+        return self.output(x)
+
+def init_mlp(m):
+    if isinstance(m, nn.Linear):
+        if m.out_features == 10:  # output head
+            nn.init.xavier_uniform_(m.weight, gain=1.0)
+        else:
+            nn.init.kaiming_normal_(m.weight, nonlinearity='relu')
+        if m.bias is not None:          # zero ALL biases (hidden + output); safe if bias=False
+            nn.init.zeros_(m.bias)
+
+mlp = MLP()
+mlp.apply(init_mlp)
+```
+
+Output layers with softmax plus cross-entropy (A5) often train fine with smaller Xavier-scaled weights because the loss gradient `p - y` is already well-scaled at the head. The hidden layers are where He init matters most. When you fine-tune a pretrained backbone, you typically leave backbone weights untouched and initialize only the new head — the same principle applies: match init scheme to activation and layer role, not a one-size-fits-all default across the entire module tree.
+
+### 6.6 Transfer learning and partial initialization
+
+Loading a pretrained checkpoint is not initialization in the random sense, but it interacts with init discipline. When you replace the final layer of a pretrained ResNet with a new ten-class head, PyTorch creates fresh `nn.Linear` weights with default Kaiming init while the backbone retains trained values. If you accidentally call `model.apply(init_weights)` after loading, you overwrite the pretrained backbone with random weights — a common bug in transfer-learning scripts. The safe pattern is: load checkpoint, then initialize only parameters that were not loaded (detect by missing keys or by module name prefix). Initialization thinking applies whenever weights first enter the training loop, whether from a random generator or from disk.
+
+---
+
+## Part 7: Closing the Loop — Verifying Stable Propagation
+
+Return to the Part 1 experiment and re-run with He initialization. The activation std should remain near 1.0 across all 50 layers:
+
+```python
+def probe_forward_stds_he(depth: int, n: int, activation=torch.tanh):
+    """Deep stack with He-scaled weights: std(W) = sqrt(2/n)."""
+    torch.manual_seed(0)
+    x = torch.randn(256, n)
+    print(f"input  std = {x.std():.4f}")
+
+    he_std = (2.0 / n) ** 0.5
+    for layer_idx in range(depth):
+        W = torch.randn(n, n) * he_std
+        x = x @ W
+        if activation is not None:
+            x = activation(x)
+        print(f"layer {layer_idx + 1:2d} std = {x.std():.4f}")
+
+print("=== tanh + He init, depth=50, n=256 ===")
+probe_forward_stds_he(depth=50, n=256, activation=torch.tanh)
+```
+
+For `tanh`, He init (designed for ReLU) is not the theoretically optimal choice — Xavier is — but it keeps pre-activations modest and avoids saturation far better than `N(0,1)`. For a ReLU stack, He init is the correct match:
+
+```python
+print("\n=== ReLU + He init, depth=50, n=256 ===")
+probe_forward_stds_he(depth=50, n=256, activation=torch.relu)
+```
+
+Layer-wise std values should cluster between 0.8 and 1.2 throughout depth. Re-run the gradient probe from Part 1.3 with `init_std=(2/n)**0.5`:
+
+```python
+print("\n=== Gradient probe: He init ===")
+probe_gradient_stds(depth=20, n=256, init_std=(2.0 / 256) ** 0.5)
+```
+
+Gradient std across layers should be same order of magnitude — not decaying by ten orders from output to input. This empirical closure confirms the math: correct initialization is a variance engineering problem you can measure before spending GPU hours on a doomed training run.
+
+When training a real model, add lightweight logging on the first batch so you capture activation scale before the optimizer has changed any weights:
+
+```python
+def log_activation_stats(model, x, tag=""):
+    with torch.no_grad():
+        activations = []
+        h = x
+        for module in model:
+            h = module(h)
+            if isinstance(h, torch.Tensor):
+                activations.append(h.std().item())
+    print(f"{tag} activation stds:", [f"{s:.3f}" for s in activations[:5]], "...")
+```
+
+If stds drift outside `[0.1, 10]` in the first forward pass, fix initialization before tuning the learning rate (module B4). If stds look healthy but loss still diverges, look next at normalization (B6) or optimizer settings — but init is always the first check.
+
+### 7.1 Building a reusable init diagnostic
+
+Production training code often wraps the probe into a hook or callback that runs once on the first batch:
+
+```python
+@torch.no_grad()
+def activation_stats(model, x):
+    # Forward hooks capture each layer's real output during one actual forward pass,
+    # so this works regardless of branching, residuals, or functional (torch.relu) activations.
+    stats, handles = [], []
+    def hook(module, inp, out):
+        stats.append((module.__class__.__name__, out.std().item()))
+    for m in model.modules():
+        if isinstance(m, (nn.Linear, nn.Conv2d)):
+            handles.append(m.register_forward_hook(hook))
+    try:
+        model(x)
+    finally:
+        for h in handles:
+            h.remove()
+    return stats
+```
+
+Call this before `optimizer.step()` on step zero. Log the stats to your experiment tracker. When a run fails at epoch 3, you can compare its step-zero stats against a known-good baseline and immediately know whether initialization drift (from a code change, a partial checkpoint reload, or a mistaken `reset_parameters` call) caused the regression. This is cheaper than re-running full training with five learning rates hoping one works.
+
+### 7.2 Forward pointers: normalization and optimizers
+
+This module stops at initialization because signal scale at step zero is a prerequisite for everything that follows, not because the other training-engineering tools are unimportant. Module B6 (normalization) attacks a related but distinct problem: even with good init, internal covariate shift during training can destabilize activations as weights update. Batch norm and layer norm re-standardize activations on the fly, reducing sensitivity to init scale — but they introduce their own engineering concerns (batch-size dependence, train/eval mode toggles, running-statistics lag). Module B4 (optimizers) determines how gradient information is accumulated and scaled over time; AdamW and learning-rate warmup can rescue some mildly bad inits but cannot reconstruct a signal that has already vanished to machine epsilon. The recommended diagnostic order when training fails is therefore: check init stats first, then normalization behavior, then optimizer and learning-rate schedule — the same order as the Block B module sequence.
+
+---
+
+## Did You Know?
+
+- **The name "Xavier"** comes from Xavier Glorot's first name — the scheme is also called **Glorot initialization** after the first author. Papers and frameworks use both names interchangeably; PyTorch prefers `xavier_*` in API names.
+- **He initialization was first published on arXiv** in February 2015 as "Delving Deep into Rectifiers" (arXiv:1502.01852) and helped enable training of 100+ layer ResNets that won ImageNet 2015. The same team later formalized the PReLU activation in the same paper.
+- **PyTorch's default Linear init is not exactly pure He** — it uses Kaiming uniform with `a=sqrt(5)` derived from the LeakyReLU parameterization in the original `reset_parameters` design. For strict ReLU networks, explicitly calling `kaiming_normal_(..., nonlinearity='relu')` is clearer and matches the textbook formula.
+- **Orthogonal initialization connects to linear algebra**, not probability: the set of orthogonal matrices has measure zero in the space of all matrices, but the SVD-based sampling algorithm produces a uniform distribution over the orthogonal group — a rare case where "random" also means "structure-preserving."
+
+---
+
+## Common Mistakes
+
+| Mistake | Problem | Solution |
+|---|---|---|
+| Using `N(0, 1)` weights in deep networks | Activations explode or vanish exponentially with depth; training never starts | Scale by `1/sqrt(fan_in)` at minimum; use He or Xavier formulas |
+| Applying Xavier init to ReLU hidden layers | Ignores ReLU halving variance; activations shrink layer by layer | Use `nn.init.kaiming_normal_(..., nonlinearity='relu')` for ReLU stacks |
+| Applying He init to `tanh` / sigmoid stacks | Pre-activations may be larger than Xavier targets; more saturation risk | Use `nn.init.xavier_uniform_` or `xavier_normal_` for symmetric activations |
+| Confusing NumPy `(d_in, d_out)` with PyTorch `(out, in)` layout | Correct formula applied to wrong dimension; init still wrong | Always use `weight.shape[1]` as fan-in for PyTorch `nn.Linear` |
+| Initializing biases to large random values | Shifts ReLU activation fraction; batch norm running stats start biased | Initialize all hidden biases to zero unless you have a domain-specific reason |
+| Assuming `nn.Linear` defaults save you after `load_state_dict` partial load | Missing or mismatched keys leave some layers randomly initialized | After any partial load, verify `named_parameters()` std values explicitly |
+| Tuning learning rate when loss is `nan` on batch 1 | Optimizer cannot fix overflow that happened in forward pass | Probe activation std first; fix init or add normalization (B6) |
+
+---
+
+## Quiz
+
+1. **Why does `Var(out) = n_in · Var(W) · Var(in)` require independence assumptions, and what breaks first during training?**
+
+   <details>
+   <summary>Answer</summary>
+
+   The formula treats each product `w_j x_j` as independent with zero mean so that cross-terms vanish in `Var(Σ w_j x_j)`. During training, weights and activations become correlated because the network learns structure — the formula describes initialization, not late training. What breaks first is usually saturation: even with correct init variance, updates can push activations into tanh/sigmoid flat regions where gradients vanish regardless of the independence assumption.
+
+   </details>
+
+2. **A linear layer has `n_in=1024`, `n_out=256`. What is the Xavier normal std and the He normal std (fan-in mode)?**
+
+   <details>
+   <summary>Answer</summary>
+
+   Xavier: `std = sqrt(2 / (n_in + n_out)) = sqrt(2 / 1280) ≈ 0.0395`.
+   He (fan-in): `std = sqrt(2 / n_in) = sqrt(2 / 1024) ≈ 0.0442`.
+   He allows slightly larger weights because ReLU will halve the forward variance afterward. For this rectangular layer, Xavier sits between the forward-only (`1/1024`) and backward-only (`1/256`) targets.
+
+   </details>
+
+3. **You stack 40 ReLU layers with He init and batch normalization after each layer. Activation std is stable but loss is flat. Is initialization the problem?**
+
+   <details>
+   <summary>Answer</summary>
+
+   Probably not. Batch normalization (B6) actively re-scales activations, so stable std confirms init and BN are doing their jobs. A flat loss with healthy activations points to optimizer dynamics (B4), learning rate, label issues, or a model capacity / task mismatch. Initialization was necessary but not sufficient — proceed to optimizer and data debugging.
+
+   </details>
+
+4. **How does `loss.backward()` in PyTorch relate to the hand-derived VJPs in A6?**
+
+   <details>
+   <summary>Answer</summary>
+
+   `loss.backward()` traverses the autograd graph in reverse topological order, applying the same VJP rules you derived: dense layers use `dL_dW = X.T @ G`, `dL_dX = G @ W.T`; ReLU multiplies by `(Z > 0)`. The scalar autograd engine in A8 records operations during forward; PyTorch's `torch.autograd` does the same at tensor scale. Initialization determines whether the numeric values flowing through those VJPs are well-scaled or dominated by rounding error.
+
+   </details>
+
+5. **When would orthogonal initialization be preferred over He or Xavier?**
+
+   <details>
+   <summary>Answer</summary>
+
+   Orthogonal init preserves norms exactly and is preferred for recurrent hidden-to-hidden weights applied across many time steps, where variance errors compound multiplicatively at each timestep. It is also useful in very deep linear or near-linear pathways (some normalizing-flow components). For standard feed-forward ReLU CNNs, He init is simpler and equally effective.
+
+   </details>
+
+6. **What printed output confirms that He initialization fixed the Part 1 explosion experiment?**
+
+   <details>
+   <summary>Answer</summary>
+
+   Layer-wise activation std values that stay roughly in `[0.5, 1.5]` across all 50 layers (instead of growing by 10× per layer or decaying toward 0), and gradient std values that do not drop by more than 1–2 orders of magnitude from the last layer to the first. The absolute numbers depend on batch size and seed, but stability across depth is the signature of correct init.
+
+   </details>
+
+---
+
+## Hands-On Exercise
+
+**Task**: Build a diagnostic script that compares three initialization strategies on the same deep MLP architecture and reports whether signal propagation is healthy. Follow the steps below to construct the model, apply each init scheme, probe forward activation standard deviation at several depths, run a backward pass to inspect gradient scale, and record which strategies show exploding, vanishing, or stable statistics. The starter skeleton below provides the class structure; you fill in the comparison loop and interpret the printed numbers against the variance rules derived in Part 2.
+
+```python
+import torch
+import torch.nn as nn
+
+class DeepMLP(nn.Module):
+    def __init__(self, depth=30, width=256, n_classes=10):
+        super().__init__()
+        layers = []
+        for _ in range(depth):
+            layers += [nn.Linear(width, width), nn.ReLU()]
+        layers.append(nn.Linear(width, n_classes))
+        self.net = nn.Sequential(*layers)
+
+    def forward(self, x):
+        return self.net(x)
+
+def apply_init(model, scheme: str):
+    for m in model.modules():
+        if isinstance(m, nn.Linear):
+            if scheme == "bad":
+                nn.init.normal_(m.weight, 0.0, 1.0)
+            elif scheme == "xavier":
+                nn.init.xavier_normal_(m.weight)
+            elif scheme == "he":
+                nn.init.kaiming_normal_(m.weight, nonlinearity='relu')
+            if m.bias is not None:
+                nn.init.zeros_(m.bias)
+
+def probe_model(model, x, layer_indices=(0, 18, 38, 58)):
+    """Probe std after selected Sequential indices (Linear+ReLU pairs)."""
+    activations = []
+    h = x
+    for i, module in enumerate(model.net):
+        h = module(h)
+        if i in layer_indices:
+            activations.append((i, h.std().item()))
+    return activations
+
+# Run for scheme in ["bad", "xavier", "he"] and compare
+```
+
+Your success criteria:
+
+- [ ] Bad init shows std changing by more than 10x between layer 1 and layer 30 in either direction.
+- [ ] He init keeps hidden-layer std within roughly `[0.3, 3.0]` across depth.
+- [ ] Gradient std for He init does not differ by more than 100x between first and last hidden layer.
+- [ ] You can explain in one sentence why He outperforms Xavier for this ReLU MLP.
+
+Verification requires no external dataset — random input suffices because initialization quality is a property of the untrained network's forward and backward pass geometry, not of the data distribution.
+
+---
+
+## Key Takeaways
+
+- Deep networks multiply variance at every layer: for a linear map, `Var(out) = n_in · Var(W) · Var(in)` under zero-mean independence; preserving unit signal requires `Var(W) = 1/n_in`.
+- Backward-pass gradient variance imposes a complementary constraint `Var(W) = 1/n_out`; Xavier initialization compromises with `Var(W) = 2/(n_in + n_out)` for tanh/sigmoid, while He initialization uses `Var(W) = 2/n_in` to account for ReLU halving variance.
+- PyTorch 2.12 exposes these rules through `nn.init.xavier_*`, `nn.init.kaiming_*`, and `nn.init.orthogonal_*`; the `model.apply(init_fn)` pattern initializes entire architectures consistently.
+- Always verify initialization empirically — print layer-wise activation and gradient std on the first forward-backward pass before tuning optimizers (B4) or adding normalization (B6).
+- Block A's manual weight scaling in A3/A7 was He initialization in disguise; PyTorch automates the same math that you previously wrote as `sqrt(2/d_in)`.
+
+---
+
+## Sources
+
+- Glorot, X., & Bengio, Y. (2010). Understanding the difficulty of training deep feedforward neural networks. *AISTATS*. http://proceedings.mlr.press/v9/glorot10a.html
+- He, K., Zhang, X., Ren, S., & Sun, J. (2015). Delving Deep into Rectifiers: Surpassing Human-Level Performance on ImageNet Classification. *arXiv:1502.01852*. https://arxiv.org/abs/1502.01852
+- PyTorch 2.12 documentation: `torch.nn.init`. https://pytorch.org/docs/stable/nn.init.html
+- PyTorch 2.12 documentation: `torch.nn.Linear` (default `reset_parameters`). https://pytorch.org/docs/stable/generated/torch.nn.Linear.html
+- Dive into Deep Learning — Numerical Stability and Initialization: https://d2l.ai/chapter_multilayer-perceptrons/numerical-stability-and-init.html
+- Stanford CS231n — Weight Initialization: https://cs231n.github.io/neural-networks-2/#init
+- Goodfellow, I., Bengio, Y., & Courville, A. (2016). *Deep Learning*, §6.5–6.6. https://www.deeplearningbook.org/contents/mlp.html
+- Mishkin, D., & Matas, J. (2016). All you need is a good init. *ICLR*. https://arxiv.org/abs/1511.07289
+- Karpathy, A. (2022). "A Recipe for Training Neural Networks." http://karpathy.github.io/2019/04/25/recipe/
+- Paszke, A., et al. (2019). PyTorch: An Imperative Style, High-Performance Deep Learning Library. *NeurIPS*. https://arxiv.org/abs/1912.01703
+
+---
+
+## Learner check
+
+> | 1.3.1 | [Initialization & Signal Propagation](/ai-ml-engineering/deep-learning/module-1.3.1-initialization-signal-propagation/) |
+
+---
+
+## Next Module
+
+Continue to [Optimizers & Learning-Rate Dynamics](/ai-ml-engineering/deep-learning/module-1.3.2-optimizers-lr-dynamics/) — where initialization meets the update rule, and you will learn why even perfectly scaled weights need momentum, adaptive learning rates, and warmup schedules to converge efficiently.

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.3.2-optimizers-lr-dynamics.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.3.2-optimizers-lr-dynamics.md
@@ -1,0 +1,797 @@
+---
+title: "Optimizers & Learning-Rate Dynamics"
+slug: ai-ml-engineering/deep-learning/module-1.3.2-optimizers-lr-dynamics
+sidebar:
+  order: 1004.2
+---
+
+> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 4-6 hours
+>
+> **Prerequisites**: Module 1.1.7 (Tiny NumPy NN Lab — wrote SGD by hand), Module 1.1.8 (Scalar Autograd — built a Value engine), Module 1.3 (Training Neural Networks — PyTorch training loop mechanics), Module 1.3.1 (Weight Initialization — parameter values at t=0).
+>
+> **Primary tools**: PyTorch 2.12, `torch.optim`, `torch.optim.lr_scheduler`, NumPy.
+
+---
+
+Hypothetical scenario: you inherit a training script that ran for 72 hours on eight GPUs. The loss curve looks like an EKG — sharp drops alternating with long, almost-flat plateaus. The final validation accuracy is 68.3%, two points worse than a smaller model trained with a budget a tenth the size. The author shrugs: "I tried a few learning rates. SGD just does that sometimes." You open the file and find `torch.optim.SGD(model.parameters(), lr=0.01)` — no momentum, no schedule, no thought about the loss landscape the optimizer is trying to navigate. The training did not fail because deep learning is hard; it failed because the optimizer was handed a pair of boots and asked to climb ice.
+
+The manual update rule you wrote in Module 1.1.7 — `layer.W -= lr * layer.dW` — is the ancestor of every modern optimizer. That single line of code is correct, complete, and mathematically sound. It is also, in a great many practical settings, too slow to converge, too sensitive to its hyperparameter, or outright incapable of reaching a good minimum. The 70 years of optimization research that separate Rosenblatt's perceptron from today's large-scale training are not about inventing fundamentally different mathematics; they are about engineering the update step so that scarce gradient information moves parameters as efficiently as possible.
+
+This module builds the complete modern optimizer stack on top of the one-line update you already understand. Every PyTorch optimizer you will meet — SGD, Momentum, Nesterov, AdaGrad, RMSProp, Adam, AdamW — is a direct refinement of `W -= lr * dW`. The refinements address three problems: direction (which way should I move?), step size (how far?), and schedule (when should I change those decisions?). When you finish this module, you will read `torch.optim.AdamW(model.parameters(), lr=3e-4)` and see inside it a chain of design choices, each solving a problem you can diagnose from a loss curve.
+
+---
+
+## Learning Outcomes
+
+By the end of this module, you will be able to:
+
+1. **Diagnose** SGD convergence failures — zig-zagging in ravines, stalling on plateaus, and diverging from noisy gradients — from loss-curve and gradient-norm evidence alone.
+2. **Implement** momentum and Nesterov accelerated gradient in both raw NumPy and PyTorch, and explain why the "heavy ball" mechanism damps oscillation while preserving consistent gradient direction.
+3. **Derive** the Adam update rule from its parent methods (momentum + RMSProp + bias correction), computing one complete step by hand with a toy parameter vector to verify understanding.
+4. **Explain** why weight decay and L2 regularization are not equivalent under Adam, and configure `torch.optim.AdamW` correctly because of that distinction.
+5. **Design** a learning-rate schedule — including warmup, cosine annealing, and step decay — that matches a given training budget and batch size, then **execute** a learning-rate range test to select a well-motivated LR for a new problem rather than guessing `3e-4`.
+
+---
+
+## Why This Module Matters
+
+A practitioner who can design a model architecture but cannot diagnose an optimizer is like a driver who can plan a route but cannot read the fuel gauge. The optimizer controls the only mechanism by which your model actually changes. Hyperparameter search — grid, random, Bayesian — can find decent settings if you have unlimited compute budget, but it cannot explain why one setting worked and another did not. When training diverges at step 53,201, or when a carefully constructed schedule produces worse results than no schedule at all, understanding the optimizer's internal state is the difference between a five-minute fix and a multi-day rerun.
+
+The optimizer is also the site where many assumptions about the loss landscape become visible. Gradient descent assumes a locally quadratic bowl; real loss surfaces contain ravines, saddle points, cliffs, and regions where the Hessian's condition number exceeds 1,000. Momentum, adaptive step sizes, and schedules are all responses to violations of the simple-bowl assumption. Each response comes with its own failure modes. Adam can overshoot when its second-moment estimate lags behind a suddenly steep gradient. Cosine annealing can produce a loss spike at the restart boundary if the warmup is too short. SGD with momentum still requires you to pick the momentum coefficient β, and the wrong choice can turn the optimizer into an undamped oscillator that bounces across the loss surface without settling.
+
+The learning rate is often called the single most important hyperparameter in deep learning. That statement is approximately true — but it obscures the deeper truth that the learning rate is not one number. It is a number that interacts with batch size, gradient noise, optimizer state, normalization layers, and weight initialization to produce an effective step size the practitioner never directly sets. This module teaches you to think about that effective step size, so you can see past the `lr=` argument to the dynamics it actually controls.
+
+---
+
+## Part 1: SGD, the Loss Landscape, and Why It Goes Wrong
+
+### 1.1 The Update Rule You Already Know
+
+In Module 1.1.7 you implemented the core training loop for a tiny NumPy neural network. After computing gradients via your hand-written backpropagation, you updated every parameter with a single line:
+
+```python
+layer.W -= lr * layer.dW
+layer.b -= lr * layer.db
+```
+
+This is stochastic gradient descent in its purest form. For a parameter vector θ, given a mini-batch estimate of the gradient g_t at step t, the update is:
+
+```
+θ_{t+1} = θ_t - η · g_t
+```
+
+where η is the learning rate. The PyTorch equivalent is:
+
+```python
+import torch
+import torch.optim as optim
+
+model = torch.nn.Linear(10, 2)
+optimizer = optim.SGD(model.parameters(), lr=0.01)
+
+# Inside the training loop:
+optimizer.zero_grad()
+loss.backward()
+optimizer.step()
+```
+
+The `.step()` call executes exactly `θ -= η · g` for every registered parameter. The one-line manual update from A7 and this three-step PyTorch pattern are identical in effect. The difference is that PyTorch handles parameter traversal, gradient accumulation, device movement, and state management — but the mathematics has not changed.
+
+### 1.2 The Geometry That Breaks SGD
+
+Pure SGD is correct, but correct does not mean fast. To understand why, we need to look at the loss surface itself.
+
+Imagine a narrow valley running diagonally across a plane. The valley floor slopes gently toward a minimum at the far end, but the walls on either side are steep. If you stand anywhere in this valley and compute the gradient, it points almost straight into the wall — perpendicular to the direction you actually want to travel. SGD responds by stepping down the steep wall, overshooting the valley floor because the gradient was large, landing on the opposite wall, and repeating. The result is a zig-zag path that makes progress toward the minimum only through the small diagonal component of each step.
+
+This is the **ravine problem**. It is not a pathological edge case; it arises whenever the Hessian (the matrix of second derivatives) has eigenvalues that differ substantially in magnitude — a condition called **ill-conditioning**. The condition number κ = λ_max / λ_min quantifies this. When κ ≫ 1, the loss surface is shaped like a long, narrow trench, and the gradient at any point is dominated by the steepest direction, regardless of where the minimum actually lies.
+
+```ascii
+   Steep wall
+      /\
+     /  \
+    /    \
+   /  o-> \       o = starting point
+  /   |    \      -> = gradient direction (into wall)
+ /    v     \     ... = SGD path (zig-zag toward minimum)
+/............*_____\___ Valley floor
+              * = minimum
+```
+
+The zig-zag behavior has a concrete cost. If the condition number is 100, each step moves you roughly 100 units sideways for every 1 unit of forward progress. At a fixed learning rate, convergence takes O(κ) iterations instead of the O(1) you would get in a perfectly spherical bowl. Worse, the learning rate is bounded by the steepest direction: set it too high, and the steps into the wall overshoot so badly that training diverges. Set it low enough to avoid divergence, and forward progress along the valley floor becomes glacial.
+
+A second failure mode is the **plateau problem**. When the surface has very low curvature in every direction — a flat region where the gradient is near zero — SGD takes tiny steps and can appear to stop entirely. The optimizer has no memory of how it arrived at the plateau, so it cannot use past momentum to coast through.
+
+A third is **noisy gradients**. Mini-batch SGD estimates the true gradient from a subset of the data, so every g_t contains sampling noise. Near a sharp minimum, that noise can kick the parameters out of the basin entirely. Near a saddle point — where one direction curves up, another curves down — the noise can actually help by pushing the optimizer off the flat ridge, but it can also destabilize convergence in the final stages of training.
+
+All three failure modes — ravines, plateaus, and noise — are addressed by the two families of improvements we will study: momentum (which adds a velocity term) and adaptivity (which gives each parameter its own learning rate).
+
+---
+
+## Part 2: Momentum and Nesterov Accelerated Gradient
+
+### 2.1 The Heavy-Ball Intuition
+
+Physical momentum smooths motion. Push a heavy ball across a bumpy surface, and it resists sudden changes in direction — it rolls past small divots and averages out high-frequency jitter while continuing in the general direction of the slope. Polyak's 1964 momentum method borrows exactly this idea for optimization.
+
+Instead of using the raw gradient to update parameters, momentum maintains a **velocity vector** v_t that accumulates gradients over time, damped by a coefficient μ (typically 0.9):
+
+```
+v_t = μ · v_{t-1} + g_t
+θ_{t+1} = θ_t - η · v_t
+```
+
+In the ravine scenario, the gradient alternates sign across the steep direction on every step: positive on one wall, negative on the other. The velocity sum v_t adds those opposite-sign contributions, so they partially cancel. Along the valley floor, the gradient consistently points the same way, so those contributions accumulate. The result: the zig-zag is damped, and forward progress accelerates.
+
+Work through one dimension of a ravine numerically. Suppose the gradient alternates between +10 and -9 in the steep direction while contributing +0.1 consistently along the valley. With μ = 0.9, η = 0.01, and starting from rest:
+
+| Step | Raw gradient g_t | v_t (μ=0.9) | Update η·v_t |
+|------|-------------------|--------------|---------------|
+| 1    | +10               | 10.0         | 0.100         |
+| 2    | -9                | 0.0          | 0.000         |
+| 3    | +10               | 10.0         | 0.100         |
+| 4    | -9                | 0.0          | 0.000         |
+
+In the steep direction, the velocity cancels completely every other step. Pure SGD would have oscillated between +0.10 and -0.09 each step, never settling. Now contrast the valley-direction contribution, assuming a consistent gradient of +0.1:
+
+| Step | Cumulative v_t (valley) | Cumulative displacement (η·Σv₁..t) |
+|------|--------------------------|-------------------------------------|
+| 1    | 0.10                     | 0.001                               |
+| 2    | 0.19                     | 0.003                               |
+| 3    | 0.27                     | 0.006                               |
+| 4    | 0.34                     | 0.009                               |
+| 10   | 0.65                     | 0.041                               |
+
+The accumulative effect means the optimizer accelerates along consistent gradient directions — exactly the behavior that pushes it through plateaus and along ravine floors. The cost: momentum introduces one new hyperparameter, μ (PyTorch calls it `momentum`). Values of 0.9, 0.99, and 0.999 are common starting points.
+
+In PyTorch, enabling momentum requires only the `momentum` argument on the SGD optimizer — the velocity buffer is created, maintained, and applied automatically. This single flag activates the entire heavy-ball mechanism:
+
+```python
+optimizer = optim.SGD(model.parameters(), lr=0.01, momentum=0.9)
+```
+
+That is the entire API change. The optimizer now maintains a velocity buffer for every parameter, updates it on each `.step()` call, and uses it to compute the actual parameter update. You can inspect the buffer:
+
+```python
+optimizer.step()
+# After step, the velocity is in the optimizer state dict:
+state = optimizer.state_dict()
+for param_id, param_state in state['state'].items():
+    if 'momentum_buffer' in param_state:
+        print(param_state['momentum_buffer'].shape)
+```
+
+### 2.2 Nesterov Accelerated Gradient: Look Before You Leap
+
+Standard momentum computes the gradient at the current position, then adds the velocity to decide where to go. Nesterov's insight, from his 1983 work on accelerated gradient methods, was to compute the gradient at the position you *would* reach after applying the velocity, rather than at the current position. In physical terms: look where the momentum is carrying you, then correct. In equations:
+
+```
+v_t = μ · v_{t-1} + g(θ_{t-1} − η·μ·v_{t-1})
+θ_t = θ_{t-1} − η · v_t
+```
+
+The difference is the gradient argument: it is evaluated at the look-ahead position `θ − η·μ·v` (one momentum step ahead in the descent direction) instead of at the current `θ`. This correction term allows Nesterov to react faster when the velocity is carrying it toward a region where the gradient changes rapidly — it "sees the curve coming" and begins decelerating before the overshoot.
+
+For convex optimization, Nesterov's method has a provably better convergence rate (O(1/t²) vs. O(1/t) for standard momentum). For non-convex deep-learning loss surfaces, the practical benefit is subtler: Nesterov often reduces the oscillation amplitude around sharp minima and can produce modestly better final performance, particularly when training with high momentum values (μ ≥ 0.9) and a decaying learning rate.
+
+PyTorch exposes Nesterov as a flag on the SGD optimizer:
+
+```python
+optimizer = optim.SGD(model.parameters(), lr=0.01, momentum=0.9, nesterov=True)
+```
+
+PyTorch uses an algebraically-equivalent *reformulation* that avoids the second forward pass; note that PyTorch's momentum/Nesterov convention differs subtly from the classical Sutskever formulation, so do not expect bit-identical trajectories to a textbook implementation — see the PyTorch `torch.optim.SGD` docs. The reformulation maps directly onto the corrected textbook rule above: with `nesterov=True`, PyTorch still accumulates velocity with the current gradient but applies the update using a look-ahead correction baked into the step. The modest benefit shows up most clearly when μ is high (≥ 0.9) and the learning rate is decaying — settings where standard momentum tends to overshoot sharp curvature near a minimum.
+
+A small worked check with a single scalar parameter confirms the behavior difference. The code below tracks two copies of the same scalar parameter, one updated with standard momentum and the other with Nesterov, under identical gradients from a simple quadratic loss:
+
+```python
+import torch
+
+# Standard momentum baseline
+p_m = torch.tensor([0.0], requires_grad=True)
+opt_m = torch.optim.SGD([p_m], lr=0.1, momentum=0.9, nesterov=False)
+
+# Nesterov
+p_n = torch.tensor([0.0], requires_grad=True)
+opt_n = torch.optim.SGD([p_n], lr=0.1, momentum=0.9, nesterov=True)
+
+# Simulate a few steps with a simple quadratic loss: loss = (p - 3)^2
+for step in range(5):
+    for name, p, opt in [('momentum', p_m, opt_m), ('nesterov', p_n, opt_n)]:
+        opt.zero_grad()
+        loss = (p - 3.0) ** 2   # minimum at p=3
+        loss.backward()
+        opt.step()
+    print(f"step {step}: momentum p={p_m.item():.4f}, nesterov p={p_n.item():.4f}")
+
+# Both converge to 3.0; Nesterov typically overshoots less on the initial approach
+```
+
+### 2.3 What Momentum Cannot Fix
+
+Momentum helps with ravines and plateaus by adding a directional memory. It does not help with the fact that every parameter shares the same global learning rate. In a deep network, different layers operate at different scales: the first convolutional layer may need tiny updates to avoid wrecking learned edge detectors, while the final classifier head may need large updates because its weights were just randomly initialized. A single η forces a compromise that satisfies neither. This is the problem that adaptive methods solve.
+
+---
+
+## Part 3: Adaptive Methods — One Learning Rate Per Parameter
+
+### 3.1 AdaGrad: The First Adaptive Optimizer
+
+AdaGrad (Duchi, Hazan & Singer, 2011) introduced the idea that each parameter should have its own effective learning rate, and that rate should be informed by the history of gradients seen for that parameter. The rule is elegantly simple:
+
+```
+r_t = r_{t-1} + g_t²          (accumulate squared gradients)
+θ_{t+1} = θ_t - (η / (√(r_t) + ε)) · g_t
+```
+
+where r_t is the sum of squared gradients for that parameter across all time, ε is a tiny constant (1e-8 or so) for numerical stability, and the division and square root are applied element-wise. PyTorch places ε outside the square root — the same convention used in Adam's update below. The effect: parameters that consistently receive large gradients (like the steep walls of a ravine) get their effective learning rate scaled down by 1/√(Σg²). Parameters that receive small, infrequent gradients (like those on a plateau) keep a relatively larger learning rate.
+
+This is a genuine breakthrough for sparse features and problems where different dimensions have vastly different gradient magnitudes. In natural language processing, for instance, rare words get few gradient updates; AdaGrad gives them larger steps when they do appear, allowing them to be learned despite their sparsity.
+
+The fatal flaw: the denominator r_t is a sum over the entire training history, so it grows monotonically and without bound. As training proceeds, the effective learning rate `η / √(r_t)` decays to zero for every parameter. The model eventually stops learning, even if it has not converged. For convex problems this is actually a feature — the vanishing rate guarantees convergence. For non-convex deep learning over many epochs, it is a showstopper.
+
+### 3.2 RMSProp: A Moving Average Fixes the Decay
+
+RMSProp (Tieleman & Hinton, 2012, from Hinton's Coursera lecture) replaces the cumulative sum with an exponentially weighted moving average (EMA) of squared gradients:
+
+```
+r_t = β₂ · r_{t-1} + (1 - β₂) · g_t²
+θ_{t+1} = θ_t - (η / (√(r_t) + ε)) · g_t
+```
+
+where the smoothing constant (PyTorch calls it `alpha`) is typically 0.9–0.99, with a default of 0.99 — distinct from Adam's β₂ = 0.999. Because the EMA forgets old gradient magnitudes at a rate controlled by this decay, the effective learning rate no longer decays to zero. It adapts to the *recent* gradient magnitudes, which is exactly what non-stationary deep-learning optimization needs.
+
+RMSProp is still in active use, particularly in reinforcement learning where its simpler second-moment tracking (no bias correction, no first moment) works well with the high-variance gradients typical of policy-gradient methods. PyTorch includes it directly:
+
+```python
+optimizer = optim.RMSprop(model.parameters(), lr=0.01, alpha=0.99)
+# alpha is the EMA coefficient (β₂ in our notation)
+```
+
+Much of the benefit of adaptive methods is already captured by RMSProp. It handles per-parameter scaling and does not suffer from the monotonic decay of AdaGrad. What it lacks — and what Adam adds — is momentum.
+
+### 3.3 Adam: Momentum + RMSProp + Bias Correction
+
+Adam (Kingma & Ba, 2015, "Adam: A Method for Stochastic Optimization") combines the two ideas: the momentum velocity (using an EMA of past gradients) and the RMSProp adaptive scaling (using an EMA of squared gradients). The algorithm maintains two buffers for each parameter:
+
+```
+m_t = β₁ · m_{t-1} + (1 - β₁) · g_t        (first moment estimate — momentum)
+v_t = β₂ · v_{t-1} + (1 - β₂) · g_t²       (second moment estimate — adaptive scaling)
+```
+
+The algorithm's default hyperparameters are set to values that Kingma and Ba found robust across a wide variety of tasks: β₁ = 0.9 controls the first-moment decay (how much past gradients influence the current momentum direction), β₂ = 0.999 controls the second-moment decay (how quickly the adaptive scaling responds to changing gradient magnitudes), and ε = 1e-8 prevents division by zero in the parameter update.
+
+At t = 0, both m₀ and v₀ are initialized to zero. This introduces a problem: in the first few steps, m_t and v_t are biased toward zero because the EMA starts from zero and has not yet accumulated enough signal. For example, at step 1:
+
+```
+m₁ = β₁·0 + (1-β₁)·g₁ = (1-β₁)·g₁
+```
+
+If β₁ = 0.9, then m₁ = 0.1·g₁ — the estimate is an order of magnitude too small. Adam corrects this with a **bias correction** term:
+
+```
+m̂_t = m_t / (1 - β₁ᵗ)
+v̂_t = v_t / (1 - β₂ᵗ)
+```
+
+This division exactly cancels the initialization bias. At t=1, 1-β₁ᵗ = 0.1, so m̂₁ = (0.1·g₁) / 0.1 = g₁ — the unbiased estimate. As t grows, β₁ᵗ → 0 fairly quickly (0.9²⁰ ≈ 0.12, so the correction is negligible after ~20 steps), so the bias correction matters most in the very early phase of training.
+
+The final parameter update is:
+
+```
+θ_{t+1} = θ_t - η · m̂_t / (√v̂_t + ε)
+```
+
+This is the full Adam update. Let us compute one step by hand for a single parameter to make it concrete.
+
+**Worked example — one Adam step by hand.** Suppose θ₀ = 0.5, and the first three gradients are g₁ = 0.3, g₂ = -0.1, g₃ = 0.2. Use η = 0.01, β₁ = 0.9, β₂ = 0.999, ε = 1e-8.
+
+**Step 1 (t=1, g₁=0.3):** m₁ = 0.9·0 + 0.1·0.3 = 0.03; v₁ = 0.999·0 + 0.001·(0.3)² = 0.00009; m̂₁ = 0.03 / (1 - 0.9¹) = 0.3; v̂₁ = 0.00009 / (1 - 0.999¹) = 0.09; θ₁ = 0.5 - 0.01 · 0.3 / (√0.09 + 1e-8) = 0.5 - 0.01 = **0.49**.
+
+**Step 2 (t=2, g₂=-0.1):** m₂ = 0.9·0.03 + 0.1·(-0.1) = 0.017; v₂ = 0.999·0.00009 + 0.001·(0.01) = 0.00009991; m̂₂ = 0.017 / (1 - 0.9²) ≈ 0.08947; v̂₂ = 0.00009991 / (1 - 0.999²) ≈ 0.04998; θ₂ = 0.49 - 0.01 · 0.08947 / (√0.04998 + ε) ≈ 0.49 - 0.00400 = **0.4860**.
+
+**Step 3 (t=3, g₃=0.2):** m₃ = 0.9·0.017 + 0.1·0.2 = 0.0353; v₃ = 0.999·0.00009991 + 0.001·(0.04) = 0.00013981; m̂₃ = 0.0353 / (1 - 0.9³) ≈ 0.1303; v̂₃ = 0.00013981 / (1 - 0.999³) ≈ 0.04665; θ₃ = 0.4860 - 0.01 · 0.1303 / (√0.04665 + ε) ≈ 0.4860 - 0.00603 = **0.4800**.
+
+The bias-correction divisors (1 - β₁ᵗ) and (1 - β₂ᵗ) are **smallest** in the first few steps — at t=1 they equal 0.1 and 0.001 — so the correction factors 1/(1−βᵗ) are **largest** then, and m̂ and v̂ are much larger than the raw m and v early on. The effective step size is amplified until the EMA buffers have accumulated enough history. By step 3, m̂₃ ≈ 3.7× m₃ and v̂₃ ≈ 334× v₃; after ~20 steps the first-moment correction fades, but the second-moment correction (β₂ = 0.999) persists for hundreds of steps. This is why warmup matters: it keeps η small while those early, correction-amplified updates would otherwise dominate.
+
+Notice how the effective step size is determined by the ratio m̂ / (√v̂ + ε) — not by η alone. When the gradient is consistently large, v̂ grows and scales the step down. When gradients oscillate, m̂ (the smoothed value) is small even while v̂ remains large, producing a very small step. This automatic per-parameter scaling is why Adam often works out of the box at its default learning rate of 1e-3 (or 3e-4, the popular convention) across a wide range of architectures.
+
+In PyTorch, Adam is instantiated with exactly the defaults described above — the only argument you normally provide beyond the parameters is the learning rate:
+
+```python
+optimizer = optim.Adam(model.parameters(), lr=3e-4, betas=(0.9, 0.999), eps=1e-8)
+```
+
+The `betas` tuple is (β₁, β₂). You rarely need to change these from their defaults. The `eps` value is increased in some mixed-precision settings (e.g., to 1e-7 or higher) to avoid division-by-zero when the second-moment estimate underflows in float16.
+
+```python
+# Verify the buffers
+optimizer.step()
+state = optimizer.state_dict()
+for param_id, s in state['state'].items():
+    print('exp_avg (m_t) shape:', s['exp_avg'].shape)
+    print('exp_avg_sq (v_t) shape:', s['exp_avg_sq'].shape)
+```
+
+The `exp_avg` buffer holds m_t; `exp_avg_sq` holds v_t. Both are tensors the same shape as the parameter and consume memory proportional to the model size — Adam stores two additional copies of every trainable parameter. For large models, this memory overhead is substantial (~3× the parameter memory, counting parameters + m + v), and it is one reason projects like Adafactor (which factorizes the second moment) exist.
+
+---
+
+## Part 4: AdamW and the Weight-Decay Subtlety
+
+### 4.1 The Equivalence That Isn't
+
+In classical optimization, L2 regularization adds a penalty term λ‖θ‖² to the loss:
+
+```
+L_reg(θ) = L(θ) + (λ/2) ‖θ‖²
+```
+
+The gradient of the penalty is λθ, so the SGD update becomes:
+
+```
+θ_{t+1} = θ_t - η·(g_t + λθ_t) = (1 - ηλ)·θ_t - η·g_t
+```
+
+This is L2 regularization implemented as weight decay: the parameter shrinks by a factor of (1-ηλ) before the gradient update. In plain SGD, L2 regularization and weight decay are exactly equivalent after a simple reparameterization.
+
+Under Adam, they are not. When the L2 penalty gradient λθ is folded into g_t, it passes through the Adam machinery — specifically, it is divided by √v̂_t. A parameter that has a large second-moment estimate v̂_t will have its weight-decay contribution scaled down, making the regularization *adaptive*. A parameter with small v̂_t gets relatively stronger regularization. This is almost certainly not what you intended: regularization strength should be uniform across parameters, not coupled to gradient magnitude history.
+
+The correct approach is **decoupled weight decay** (Loshchilov & Hutter, 2019). Instead of adding λθ to the gradient before the Adam update, apply the decay directly to the parameter, **decoupled from** (i.e., not routed through) the adaptive `m̂/√v̂` update:
+
+```
+θ_{t+1} = θ_t - η · m̂_t / (√v̂_t + ε) - η·λ·θ_t
+```
+
+The regularization term η·λ·θ_t is subtracted directly from the parameter, outside the adaptive scaling machinery. This is what `torch.optim.AdamW` does — and the distinction is not cosmetic. The Loshchilov & Hutter paper demonstrated that decoupled weight decay consistently outperforms L2 regularization under Adam across CIFAR-10 and ImageNet, often by margins of 1-2% absolute accuracy:
+
+```python
+optimizer = optim.AdamW(model.parameters(), lr=3e-4, weight_decay=0.01)
+```
+
+The `weight_decay` argument to AdamW is the λ above — a direct multiplicative decay applied to the parameter, decoupled from the gradient scaling. In `torch.optim.Adam`, the same `weight_decay` argument implements the old-style L2 penalty (added to the gradient before the adaptive update), which is why the two optimizers produce different trajectories for the same `weight_decay` value.
+
+A practical rule: if your model uses Adam and you want regularization, use AdamW with `weight_decay=0.01` (or 0.1 for some vision models). Do not fall back to Adam and assume the `weight_decay` argument means the same thing.
+
+```python
+# These two produce DIFFERENT training dynamics:
+opt_adam   = optim.Adam(   model.parameters(), lr=3e-4, weight_decay=0.01)
+opt_adamw  = optim.AdamW(  model.parameters(), lr=3e-4, weight_decay=0.01)
+# Prefer AdamW for any model where you want weight decay.
+```
+
+The distinction generalizes: any optimizer that uses adaptive per-parameter scaling (Adam, RMSProp, AdaGrad, Adamax, Nadam) should decouple weight decay from the gradient preprocessing. PyTorch provides `AdamW` as the primary implementation; `SGD` does not need this distinction because it has no adaptive scaling.
+
+---
+
+## Part 5: Learning-Rate Schedules
+
+### 5.1 Why a Constant Learning Rate Is Rarely Optimal
+
+Early in training, the loss surface is unexplored territory — the optimizer needs to move quickly to escape random-initialization basins and find a good region. Late in training, the optimizer is navigating fine structure near a minimum — large steps would bounce it out. A constant learning rate cannot be both aggressive enough early and gentle enough late.
+
+Schedules address this by varying η over time. The simplest is **step decay**: multiply η by a factor γ every S epochs:
+
+```python
+scheduler = optim.lr_scheduler.StepLR(optimizer, step_size=30, gamma=0.1)
+# Decays the LR by 10× (multiplies by γ=0.1) every 30 epochs:
+# epoch 0-29: η = 0.1
+# epoch 30-59: η = 0.01
+# epoch 60-89: η = 0.001
+```
+
+Multistep decay provides finer control by letting you specify exact epoch boundaries where the learning rate drops. This is especially useful when you have prior knowledge about the loss landscape — for example, when training ResNet on ImageNet, the canonical schedule drops the LR at epochs 30, 60, and 90:
+
+```python
+scheduler = optim.lr_scheduler.MultiStepLR(
+    optimizer, milestones=[60, 120, 160], gamma=0.2
+)
+```
+
+These schedules work well when you know roughly how many epochs the problem needs, but they introduce two new hyperparameters (step size and decay factor) and create abrupt transitions that can temporarily destabilize training.
+
+### 5.2 Cosine Annealing
+
+Cosine annealing (Loshchilov & Hutter, 2017, "SGDR: Stochastic Gradient Descent with Warm Restarts") replaces the step-function decay with a smooth cosine curve:
+
+```
+η_t = η_min + 0.5 · (η_max - η_min) · (1 + cos(π · t / T))
+```
+
+Starting at η_max, the learning rate follows a half-cosine down to η_min over T steps. The transition is smooth, so there is no moment where the optimizer suddenly receives much smaller updates. Cosine annealing has become a standard for vision models trained with SGD and for many transformer training recipes.
+
+```python
+scheduler = optim.lr_scheduler.CosineAnnealingLR(optimizer, T_max=200, eta_min=0)
+# η follows a half-cosine from initial LR to 0 over 200 epochs.
+```
+
+The warm-restart variant (CosineAnnealingWarmRestarts) divides training into multiple cosine cycles, resetting η to η_max at the start of each cycle. The period T_mult typically doubles each cycle so later cycles are longer:
+
+```python
+scheduler = optim.lr_scheduler.CosineAnnealingWarmRestarts(
+    optimizer, T_0=50, T_mult=2, eta_min=1e-6
+)
+# Cycle 1: 50 epochs, cycle 2: 100 epochs, cycle 3: 200 epochs
+```
+
+### 5.3 Warmup: Why the First Few Steps Need Kid Gloves
+
+The earliest steps of training have a problem that the optimizer's internal state makes worse. At initialization, the Adam buffers m₀ and v₀ are zero. The bias correction fixes the scale, but it cannot fix the quality: the early second-moment estimate v̂_t is computed from very few gradient samples and is therefore a noisy, unreliable divisor. Dividing by a noisy estimate can produce wild parameter updates in the first few hundred steps that push the model into a bad region from which it never fully recovers.
+
+Warmup addresses this by starting the learning rate at (or near) zero and linearly increasing it to the target value over a small number of steps (typically a few hundred to a few thousand). By the time the LR reaches full strength, the Adam buffers have accumulated enough signal to produce stable estimates.
+
+```python
+def warmup_lambda(step):
+    warmup_steps = 1000
+    if step < warmup_steps:
+        return step / warmup_steps
+    return 1.0  # constant LR after warmup
+
+warmup_scheduler = optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=warmup_lambda)
+```
+
+For a warmup followed by cosine decay — the standard recipe for transformer training since Vaswani et al. (2017) — PyTorch's `SequentialLR` composes the two schedules cleanly. The `milestones` argument specifies the step at which the active scheduler switches:
+
+```python
+warmup = optim.lr_scheduler.LinearLR(
+    optimizer, start_factor=0.01, total_iters=1000
+)
+cosine = optim.lr_scheduler.CosineAnnealingLR(
+    optimizer, T_max=10000, eta_min=1e-6
+)
+scheduler = optim.lr_scheduler.SequentialLR(
+    optimizer, schedulers=[warmup, cosine], milestones=[1000]
+)
+```
+
+After step 1000, the active scheduler switches from warmup to cosine automatically. This pattern — warmup then cosine — is the de facto standard for transformer training (Vaswani et al., 2017; GPT variants; ViT) and appears in almost every large-scale training recipe published since 2018.
+
+### 5.4 When to Call scheduler.step()
+
+When to call `scheduler.step()` is a source of persistent training bugs, and the distinction between epoch-level and step-level scheduling is not something PyTorch enforces — it trusts you to get it right. The convention is straightforward but unforgiving:
+
+- **Epoch-level schedules** (StepLR, MultiStepLR, CosineAnnealingLR): call `scheduler.step()` once per epoch, AFTER `optimizer.step()`.
+- **Step-level schedules** (LambdaLR with a step function, warmup): call `scheduler.step()` once per optimizer step (i.e., once per batch), AFTER `optimizer.step()`.
+
+Calling `scheduler.step()` before `optimizer.step()` gives you the LR for the *previous* step, which is usually not what you want. Calling it at the wrong frequency can silently produce a very different schedule than intended. The safe pattern:
+
+```python
+for epoch in range(num_epochs):
+    for batch in dataloader:
+        optimizer.zero_grad()
+        loss = model(batch).mean()
+        loss.backward()
+        optimizer.step()
+        # Step-level scheduler goes here (warmup, per-step LambdaLR)
+        if per_step_scheduler:
+            per_step_scheduler.step()
+    # Epoch-level scheduler goes here (StepLR, CosineAnnealingLR)
+    epoch_scheduler.step()
+```
+
+The per-step vs per-epoch distinction is the most common scheduler bug in production code. The runnable contrast below uses the same toy optimizer but two schedulers with identical `T_max=10` — one stepped every batch, one stepped every epoch over 2 epochs × 5 batches. The per-step scheduler completes its full cosine in 10 optimizer steps (LR 1.0 → eta_min). The per-epoch scheduler uses the SAME `T_max=10` but is called only twice (once per epoch boundary), so it advances just 2/10 of the cosine — the LR barely drops (≈1.0 → ≈0.976) and never approaches `eta_min`. Sizing `T_max` for per-step calls while stepping per epoch is exactly the bug:
+
+```python
+import torch
+import torch.optim as optim
+
+def demo_scheduler_placement():
+    # Per-step: T_max counts optimizer steps
+    opt_step = optim.SGD([torch.nn.Parameter(torch.tensor(1.0))], lr=1.0)
+    sched_step = optim.lr_scheduler.CosineAnnealingLR(opt_step, T_max=10, eta_min=0.0)
+    lrs_per_step = []
+    for epoch in range(2):
+        for batch in range(5):
+            opt_step.step()          # dummy optimizer step
+            sched_step.step()        # AFTER optimizer.step(), once per batch
+            lrs_per_step.append(opt_step.param_groups[0]['lr'])
+
+    # Per-epoch: T_max counts epoch boundaries
+    opt_epoch = optim.SGD([torch.nn.Parameter(torch.tensor(1.0))], lr=1.0)
+    sched_epoch = optim.lr_scheduler.CosineAnnealingLR(opt_epoch, T_max=10, eta_min=0.0)
+    lrs_per_epoch = []
+    for epoch in range(2):
+        for batch in range(5):
+            opt_epoch.step()
+            lrs_per_epoch.append(opt_epoch.param_groups[0]['lr'])
+        sched_epoch.step()           # AFTER all batches in the epoch
+
+    print("per-step LRs:", [round(x, 3) for x in lrs_per_step])
+    # Cosine drops across all 10 steps: 1.0 → ... → 0.0
+    print("per-epoch LRs:", [round(x, 3) for x in lrs_per_epoch])
+    # LR stays 1.0 for epoch 0, then drops once at epoch 1 boundary
+
+demo_scheduler_placement()
+```
+
+Match `T_max` to the unit you actually step on. Warmup schedulers composed via `SequentialLR` are almost always per-step; `StepLR` and `CosineAnnealingLR` in vision recipes are almost always per-epoch. Mixing them in one training loop without tracking which scheduler fires where is how you end up with warmup ending at step 1,000 but cosine annealing finishing at step 200.
+
+---
+
+## Part 6: The Learning-Rate Finder
+
+### 6.1 The Range Test
+
+In 2015 (updated 2017), Leslie Smith proposed a simple empirical method: instead of guessing a learning rate, run one epoch where the LR increases exponentially from a very small value (e.g., 1e-7) to a very large value (e.g., 10), and plot the loss. The loss typically does three things:
+
+1. **Flat or slowly decreasing** at very low LRs — the optimizer is barely moving.
+2. **Steeply decreasing** as the LR enters the productive range — this is where you want to train.
+3. **Diverging** (sharp increase) when the LR exceeds what the loss landscape can tolerate — the optimizer is overstepping.
+
+The "just before divergence" point gives you an upper bound. Smith recommends picking an LR one order of magnitude below that point, or roughly at the point where the loss is decreasing fastest (the steepest negative slope). For cyclical learning rates, the upper and lower bounds of the cycle bracket this region.
+
+A minimal but functionally complete implementation of the LR range test in PyTorch is shown below. The key design choice is the exponential LR multiplier: each step increases the LR by a constant factor so that the sweep covers several orders of magnitude smoothly. The early-stopping guard (loss exceeding 4× the recent average) prevents wasting time on diverged training after the LR has exceeded the usable range:
+
+```python
+import torch
+import torch.nn as nn
+import torch.optim as optim
+import numpy as np
+
+def lr_find(model, train_loader, criterion, device, start_lr=1e-7, end_lr=10, num_steps=200):
+    """Run one epoch with exponentially increasing LR, collect loss values."""
+    model.train()
+    lr_mult = (end_lr / start_lr) ** (1 / num_steps)
+    lr = start_lr
+    optimizer = optim.SGD(model.parameters(), lr=lr)
+
+    lrs, losses = [], []
+    data_iter = iter(train_loader)
+
+    for step in range(num_steps):
+        try:
+            batch = next(data_iter)
+        except StopIteration:
+            data_iter = iter(train_loader)
+            batch = next(data_iter)
+
+        inputs, targets = batch
+        inputs, targets = inputs.to(device), targets.to(device)
+
+        optimizer.zero_grad()
+        outputs = model(inputs)
+        loss = criterion(outputs, targets)
+        loss.backward()
+        optimizer.step()
+
+        lrs.append(lr)
+        losses.append(loss.item())
+
+        lr *= lr_mult
+        for pg in optimizer.param_groups:
+            pg['lr'] = lr
+
+        # Stop if loss explodes
+        if step > 5 and loss.item() > 4 * np.mean(losses[-5:-1]):
+            break
+
+    return lrs, losses
+
+# After running: plot losses vs lrs on a log scale.
+# Pick LR at the steepest descending point, or ~1/10 of the divergence point.
+```
+
+The range test is cheap — one epoch of training — and gives you an evidence-based starting LR for any new dataset, architecture, or optimizer. It does not replace tuning, but it prevents the most expensive failure mode: discovering after a full run that the learning rate was off by a factor of 10 or 100.
+
+### 6.2 Order-of-Magnitude Defaults
+
+When the range test is impractical (e.g., hyperparameter search over many configurations), these defaults serve as reasonable starting points, backed by the literature:
+
+| Optimizer | Typical LR range | Notes |
+|-----------|-----------------|-------|
+| SGD (no momentum) | 1e-2 to 1e-1 | Requires a schedule; sensitive to batch size |
+| SGD + momentum (0.9) | 1e-2 to 1e-1 | Cosine schedule typical; still common for vision |
+| Adam | 1e-4 to 1e-3 | Default 1e-3 from paper; 3e-4 is the popular convention |
+| AdamW | 1e-4 to 3e-3 | Often higher than Adam because weight decay is decoupled |
+| RMSProp | 1e-3 to 1e-2 | Common in RL; alpha=0.99 |
+
+These are starting points, not laws. The correct LR for your problem depends on batch size (larger batches → often higher LR, the "linear scaling rule"), model depth, normalization layers (BatchNorm and LayerNorm reduce LR sensitivity), and dataset difficulty. The range test remains your best tool for narrowing the search.
+
+---
+
+## Part 7: Choosing an Optimizer in Practice
+
+### 7.1 A Decision Framework, Not a Table
+
+The optimizer question is too often answered by habit: "I always use AdamW" or "SGD generalizes better, so I use SGD." Both statements capture real patterns, but both are incomplete. The right optimizer depends on at least four factors:
+
+**1. How much hyperparameter tuning budget do you have?** Adam and AdamW are more robust to the learning-rate choice — they work reasonably well at their defaults across a wide range of problems. SGD with momentum requires careful LR tuning (the range test helps) and almost always needs a schedule. If you are exploring a new architecture or dataset and want quick signal, start with AdamW. If you are squeezing the last half-percent of accuracy on a well-understood benchmark (e.g., ImageNet classification), the tuning investment in SGD + momentum + cosine may pay off.
+
+**2. Does your problem have sparse gradients?** Embedding layers, particularly in NLP and recommendation systems, produce very sparse gradient updates — most rows of an embedding matrix get zero gradient on any given batch. Adam handles this well because its per-parameter scaling gives infrequently updated parameters larger effective step sizes. AdaGrad was originally motivated by this very use case. If your model has large embedding tables, Adam or a dedicated sparse optimizer (e.g., Adagrad, FTRL) is a better default than SGD.
+
+**3. What is your memory budget?** SGD stores one buffer per parameter (the velocity if momentum is used). Adam stores two. For a 7B-parameter model in float32, each full-size buffer is 7×10⁹ × 4 bytes = 28 GB, so **Adam (params + m + v) ≈ 28 × 3 = 84 GB** versus **SGD-with-momentum (params + velocity) ≈ 28 × 2 = 56 GB**. For very large models, this gap dictates whether training fits in GPU memory at all. Techniques like 8-bit Adam (bitsandbytes), Adafactor (which factorizes v_t), or plain SGD become necessary purely for memory reasons.
+
+**4. The generalization-gap debate.** A persistent empirical finding, most thoroughly documented by Wilson et al. (2017, "The Marginal Value of Adaptive Gradient Methods in Machine Learning"), is that adaptive methods sometimes produce models that generalize slightly worse than well-tuned SGD with momentum — on the order of 1-3% absolute accuracy on image classification benchmarks. The hypothesized mechanism: adaptive methods find "sharper" minima (higher curvature), which are more sensitive to data perturbations than the "flatter" minima SGD tends to find. The effect is real but its magnitude varies substantially across architectures and tasks. In practice, the generalization gap is often closed by strong data augmentation, longer training, and modern regularization (dropout, weight decay, stochastic depth), so that AdamW and SGD converge to similar final performance on many modern benchmarks when both are well-tuned.
+
+### 7.2 Practical Defaults
+
+For new projects in 2025-2026, a reasonable default stack is:
+
+```
+AdamW, lr=3e-4, weight_decay=0.01, betas=(0.9, 0.999)
+ + CosineAnnealingLR with warmup (1-5% of total steps)
+ + Gradient clipping at 1.0 (module B6)
+```
+
+This combination handles most architectures — transformers, MLPs, CNNs — with minimal per-problem tuning. Exceptions: (a) very large vision models where SGD + momentum + cosine still holds state-of-the-art claims, (b) RL where RMSProp or specialized optimizers (PPO defaults) dominate, (c) memory-constrained settings requiring 8-bit or factorized optimizers.
+
+A complete PyTorch snippet that instantiates this recommended stack and runs a training loop is shown below. Note the use of `set_to_none=True` on `zero_grad()` — this is slightly more memory-efficient than zeroing the gradient tensor in place, and it avoids a class of subtle bugs where zero-valued gradient tensors are accidentally included in gradient-norm calculations:
+
+```python
+import torch
+import torch.optim as optim
+
+model = ...  # your nn.Module
+# compute_loss(model, batch) and batch come from your training setup
+
+optimizer = optim.AdamW(model.parameters(), lr=3e-4, weight_decay=0.01,
+                         betas=(0.9, 0.999), eps=1e-8)
+
+warmup_steps = 500
+total_steps = 10000
+
+scheduler1 = optim.lr_scheduler.LinearLR(
+    optimizer, start_factor=0.01, total_iters=warmup_steps
+)
+scheduler2 = optim.lr_scheduler.CosineAnnealingLR(
+    optimizer, T_max=total_steps - warmup_steps, eta_min=1e-6
+)
+scheduler = optim.lr_scheduler.SequentialLR(
+    optimizer, schedulers=[scheduler1, scheduler2], milestones=[warmup_steps]
+)
+
+# Training loop (per-step scheduler.step() — matches warmup + cosine T_max in steps)
+for step in range(total_steps):
+    batch = next_batch()  # your data iterator
+    optimizer.zero_grad(set_to_none=True)
+    loss = compute_loss(model, batch)
+    loss.backward()
+    torch.nn.utils.clip_grad_norm_(model.parameters(), 1.0)
+    optimizer.step()
+    scheduler.step()
+```
+
+The `set_to_none=True` argument on `zero_grad()` sets `.grad` fields to `None` instead of zeroing the tensor. This is slightly more memory-efficient (the gradient buffer is freed) and can avoid a class of subtle bugs where zero-valued gradient tensors are accidentally included in gradient-norm calculations.
+
+---
+
+## Did You Know?
+
+- **Where "Adam" comes from.** Kingma & Ba derived the name from **ada**ptive **m**oment estimation — the optimizer tracks the first moment (mean) and second moment (uncentered variance) of the gradients.
+
+- **Sutskever's 2013 paper on momentum** (the one that popularized Nesterov momentum for deep learning) reports that without momentum, a deep autoencoder failed to train at all on MNIST under the same architecture and learning rate. The addition of momentum made the difference between zero signal and successful convergence.
+
+- **The linear scaling rule** (Goyal et al., 2017, "Accurate, Large Minibatch SGD: Training ImageNet in 1 Hour") states that when you multiply the batch size by k, you should also multiply the learning rate by k. This holds because one large-batch update with learning rate k·η approximates the *net effect* of k consecutive small-batch SGD steps at learning rate η, **under the assumption that the gradient changes little across those k steps** — which is why the rule needs warmup early in training (when that assumption is weakest) and breaks down past batch sizes of ~8K on ImageNet.
+
+- **Adam's ε parameter has caused real production incidents.** With float16 mixed precision, the default ε = 1e-8 can underflow the second-moment estimate v̂ to zero, causing division-by-zero in the update. PyTorch's automatic mixed precision handles this, but custom AMP implementations have produced NaN-in-weight incidents that took teams days to diagnose. Raising ε to 1e-7 or 1e-5 in fp16 regimes is a cheap insurance policy.
+
+---
+
+## Common Mistakes
+
+| Mistake | Problem | Solution |
+|---------|---------|----------|
+| Calling `scheduler.step()` before `optimizer.step()` | The LR for step t is based on step t-1's schedule state; the first epoch runs at the wrong LR | Always call `scheduler.step()` after `optimizer.step()` |
+| Using `Adam.weight_decay` as if it were decoupled | The weight decay is passed through the adaptive scaling, making regularization strength parameter-dependent | Use `AdamW` for decoupled weight decay |
+| Forgetting to zero the momentum buffer when restarting training from a checkpoint | The optimizer state dict carries velocity, but if you change the LR or model, stale momentum can push parameters in wrong directions | If changing hyperparameters mid-training, reinitialize the optimizer or manually zero the momentum buffers |
+| Setting `lr=0.1` with Adam because it works for SGD | Adam's effective step size is roughly η / √v̂, which is much larger than η alone for parameters with small gradients; 0.1 with Adam typically diverges | Start at 1e-3 or 3e-4 for Adam; use the LR finder |
+| Using cosine annealing with `T_max` equal to total steps but calling `scheduler.step()` every epoch | The cosine curve completes in `T_max` scheduler calls; if `T_max` is sized for total steps but you call `scheduler.step()` once per epoch, after `num_epochs` calls it has advanced only `num_epochs/T_max` of the way — the schedule never finishes, so the LR stays near its initial value and barely anneals | Match the scheduler call frequency to T_max: set T_max = num_epochs for epoch-level calls, or T_max = total_steps for step-level calls |
+| Forgetting that `optimizer.step()` uses the gradients accumulated in `.grad`, not the loss itself | If you call `.backward()` twice without `zero_grad()` in between, the second backward's gradients are added to the first — the effective batch size has changed | One `zero_grad()` per step; if accumulating gradients intentionally, call `optimizer.step()` only after the last backward in the accumulation cycle |
+
+---
+
+## Quiz
+
+1. **Why does pure SGD zig-zag in ravines instead of moving directly toward the minimum?**
+
+   <details>
+   <summary>Answer</summary>
+   In an ill-conditioned loss surface (large condition number κ), the gradient is dominated by the direction of steepest curvature. In a narrow valley, the gradient points almost perpendicular to the valley floor — into the steep wall. SGD follows that gradient, overshoots, lands on the opposite wall, and repeats. The forward progress along the valley floor is only the small diagonal component of each step. The effective convergence rate degrades from O(1) to O(κ).
+   </details>
+
+2. **Adam's bias correction divides m_t by (1 - β₁ᵗ) and v_t by (1 - β₂ᵗ). Why are these corrections necessary, and roughly how many steps does it take for them to become negligible at β₁=0.9 and β₂=0.999?**
+
+   <details>
+   <summary>Answer</summary>
+   Both m₀ and v₀ are initialized to zero. The EMA update m_t = β₁·m_{t-1} + (1-β₁)·g_t therefore produces estimates biased toward zero in early steps — at t=1, m₁ = 0.1·g₁ rather than g₁. Dividing by (1-β₁ᵗ) exactly cancels this initialization bias. For β₁=0.9: after ~20 steps, 0.9²⁰ ≈ 0.12, so the divisor (1-0.12)=0.88 and the correction is modest. After ~50 steps the correction is negligible. For β₂=0.999: 0.999¹⁰⁰⁰≈0.368, so it takes roughly 1,000-2,000 steps before the bias correction on v_t becomes small. The second-moment correction matters much longer, which is one reason warmup helps — it prevents large effective step sizes while v̂_t is still unreliable.
+   </details>
+
+3. **Explain why `Adam.weight_decay` and `AdamW.weight_decay` produce different parameter trajectories even when all other hyperparameters are identical.**
+
+   <details>
+   <summary>Answer</summary>
+   In `Adam`, weight decay is implemented as L2 regularization: the penalty gradient λθ is added to g_t and then divided by √v̂_t (the adaptive scaling). This means parameters with larger second-moment estimates receive weaker regularization, and vice versa. In `AdamW`, weight decay is decoupled: the term η·λ·θ is subtracted from the parameter AFTER the adaptive Adam update, so all parameters receive uniform regularization independent of their gradient history. The practical effect is that AdamW provides more consistent regularization, which typically leads to better generalization, especially for models where different layers have very different gradient magnitudes (e.g., transformers with large embedding tables).
+   </details>
+
+4. **You train a model with AdamW, warmup for 1,000 steps, then switch to cosine annealing. The loss drops quickly during warmup, then rises sharply at step 1,001 and never fully recovers. What is the most likely cause?**
+
+   <details>
+   <summary>Answer</summary>
+   The most likely cause is that the `SequentialLR` transition between warmup and cosine did not preserve the learning-rate value at the boundary. If warmup ends at η=1e-3 but the cosine scheduler was initialized with a different starting LR (or `eta_max`), the LR jumps discontinuously at step 1,001. The abrupt change can destabilize training, especially if the jump is upward. The fix is to ensure `CosineAnnealingLR` starts from the same LR where warmup ends. With `LinearLR(start_factor=0.01)` and initial LR=3e-4, warmup ends at 3e-4; if cosine's initial LR was set to the optimizer's default before warmup (3e-4), the transition is smooth. Alternatively, use `LambdaLR` with a custom function that smoothly transitions.
+   </details>
+
+5. **What does an LR range-test loss plot look like when the initial LR is already in the productive range, and what does it look like when the initial LR is too low?**
+
+   <details>
+   <summary>Answer</summary>
+   When the initial LR is already productive, the loss decreases immediately from the first few steps — there is no flat region at the left of the plot. When the initial LR is too low, the loss remains flat or decreases extremely slowly for many steps (the left side of the U-shaped curve) before finally entering the productive range. The optimal LR to pick is near the steepest point of the descending curve, which usually lies an order of magnitude or two below the divergence point. If you never see a steep descent (the loss decreases gradually over the entire range), the upper bound of the test may not be high enough; extend `end_lr` upward. If the loss diverges almost immediately, the lower bound `start_lr` should be decreased.
+   </details>
+
+6. **You are training a large model with AdamW on 8 GPUs using DistributedDataParallel. Each GPU processes a batch of 32 samples. Should you adjust the learning rate relative to a single-GPU baseline with batch size 32, and if so, by how much?**
+
+   <details>
+   <summary>Answer</summary>
+   The effective global batch size is 8 × 32 = 256. By the linear scaling rule (Goyal et al., 2017), you should multiply the learning rate by the batch-size ratio: η_256 ≈ 8 × η_32. So if the well-tuned single-GPU LR is 3e-4, the 8-GPU training should start around 2.4e-3. In practice, the linear scaling rule holds well up to batch sizes of a few thousand for ImageNet-scale problems, but for very large batch sizes (>8K) the rule breaks down because gradient noise reduction saturates. Note that the linear scaling rule was originally demonstrated for SGD + momentum; under Adam/AdamW the relationship is similar but the effective scaling may differ slightly because the adaptive normalization already adjusts per-parameter step sizes. The range test remains the most reliable method for determining the correct LR at any batch size.
+   </details>
+
+---
+
+## Hands-On Exercise
+
+**Task**: Run the learning-rate range test on a small CNN (or MLP) with the Fashion-MNIST dataset, then compare the loss curves produced by SGD, SGD with momentum, and Adam at the LR suggested by the range test.
+
+Follow these numbered steps to complete the exercise, which walks you through infrastructure setup, the LR range test, comparative training, and analysis of the resulting loss curves:
+
+1. Set up a minimal training pipeline: a 3-layer CNN or 2-hidden-layer MLP, `CrossEntropyLoss`, and the Fashion-MNIST data loader (available via `torchvision.datasets.FashionMNIST`).
+
+2. Implement the LR range test (as shown in Part 6) with `torch.optim.SGD(model.parameters(), lr=1e-7)`, sweeping up to `lr=1.0` over 200 steps. Plot the loss against LR on a log scale. Identify: the LR at which loss decreases fastest, and the LR at which loss begins diverging.
+
+3. Train three short runs (5 epochs each) at the chosen LR:
+   - `optim.SGD(model.parameters(), lr=chosen_lr)`
+   - `optim.SGD(model.parameters(), lr=chosen_lr, momentum=0.9)`
+   - `optim.Adam(model.parameters(), lr=chosen_lr / 10)` (because Adam's effective step size is larger — the factor of 10 is a heuristic; the range test on Adam separately is more precise)
+
+4. Record the final training loss for each run and plot the loss curves on the same axes.
+
+When you have completed the training runs, verify each of the following observable outcomes. If any criterion fails, the most likely culprit is the learning-rate choice — rerun the range test and verify you selected the LR at the steepest point of descent, not the divergence point:
+
+- [ ] The range-test plot shows the characteristic three-region shape (flat → steep descent → divergence).
+- [ ] SGD with momentum converges faster (lower loss at a given epoch) than plain SGD at the same LR.
+- [ ] Adam achieves competitive or better loss than momentum SGD within 5 epochs, without manual LR tuning beyond the /10 heuristic.
+
+After training, use the following verification code to compare final losses. The expected ordering (sgdm < sgd, adam competitive with sgdm) confirms that both momentum and adaptivity improve over plain SGD on a real problem, validating the theoretical arguments of Parts 2 and 3:
+```python
+# After training, compare final losses
+print(f"SGD final loss: {sgd_losses[-1]:.4f}")
+print(f"SGD+momentum final loss: {sgdm_losses[-1]:.4f}")
+print(f"Adam final loss: {adam_losses[-1]:.4f}")
+# Expect: sgdm_losses[-1] < sgd_losses[-1], and adam_losses[-1] roughly competitive
+```
+
+---
+
+## Key Takeaways
+
+1. `torch.optim.SGD(lr=0.01)` is the exact equivalent of the `W -= lr * dW` loop you wrote by hand in Module 1.1.7. Its simplicity makes its failure modes — ravines, plateaus, noise sensitivity — directly visible.
+2. Momentum (μ ≈ 0.9) adds a velocity term that damps oscillation across steep directions and accelerates movement along consistent gradient directions. Nesterov momentum evaluates the gradient at the look-ahead position `θ − η·μ·v` (one descent step ahead), often reducing overshoot when μ is high and the LR is decaying.
+3. Adam combines momentum (first moment EMA) with per-parameter adaptive scaling (second moment EMA) plus bias correction for the zero-initialization of both buffers. It is the default optimizer for most deep-learning work because it tolerates a wide range of learning rates.
+4. Weight decay and L2 regularization are not equivalent under adaptive optimizers. Use `AdamW` to apply weight decay outside the gradient-scaling machinery.
+5. Learning-rate schedules — step decay, cosine annealing, warmup — are not optional polish. Warmup is functionally necessary for stable Adam training at scale, and cosine annealing often provides a free 0.5-2% improvement in final accuracy over constant LR.
+6. The LR range test costs one epoch and gives you an evidence-based learning rate for any new problem. Combined with the optimizer defaults in this module, it eliminates most of the guesswork from optimizer configuration.
+
+---
+
+## Sources
+
+- Kingma, D. P., & Ba, J. (2015). Adam: A Method for Stochastic Optimization. *arXiv:1412.6980*. https://arxiv.org/abs/1412.6980
+- Loshchilov, I., & Hutter, F. (2019). Decoupled Weight Decay Regularization. *arXiv:1711.05101*. https://arxiv.org/abs/1711.05101
+- Smith, L. N. (2017). Cyclical Learning Rates for Training Neural Networks. *arXiv:1506.01186*. https://arxiv.org/abs/1506.01186
+- Loshchilov, I., & Hutter, F. (2017). SGDR: Stochastic Gradient Descent with Warm Restarts. *arXiv:1608.03983*. https://arxiv.org/abs/1608.03983
+- Duchi, J., Hazan, E., & Singer, Y. (2011). Adaptive Subgradient Methods for Online Learning and Stochastic Optimization. *Journal of Machine Learning Research, 12*, 2121-2159. https://jmlr.org/papers/v12/duchi11a.html
+- Sutskever, I., Martens, J., Dahl, G., & Hinton, G. (2013). On the Importance of Initialization and Momentum in Deep Learning. *ICML 2013*. https://proceedings.mlr.press/v28/sutskever13.html
+- Wilson, A. C., Roelofs, R., Stern, M., Srebro, N., & Recht, B. (2017). The Marginal Value of Adaptive Gradient Methods in Machine Learning. *NeurIPS 2017*. https://arxiv.org/abs/1705.08292
+- Goyal, P., et al. (2017). Accurate, Large Minibatch SGD: Training ImageNet in 1 Hour. *arXiv:1706.02677*. https://arxiv.org/abs/1706.02677
+- PyTorch `torch.optim` documentation. https://pytorch.org/docs/stable/optim.html
+- PyTorch learning rate scheduler documentation. https://pytorch.org/docs/stable/optim.html#how-to-adjust-learning-rate
+- Zhang, A., Lipton, Z. C., Li, M., & Smola, A. J. (2023). *Dive into Deep Learning*, Chapter 12: Optimization Algorithms. https://d2l.ai/chapter_optimization/
+
+---
+
+## Next Module
+
+Continue to [Training Deep Networks: Normalization, Regularization & Optimization](/ai-ml-engineering/deep-learning/module-1.4-cnns-computer-vision/) — the practical training-stability toolkit that builds directly on optimizer and learning-rate choices.
+
+---
+
+## Learner check
+
+> | 1.3 | [Training Neural Networks](/ai-ml-engineering/deep-learning/module-1.3-training-neural-networks/) |


### PR DESCRIPTION
## NN Block B — Wave 1 (epic #1793, Phase 2)

"Training as engineering." First wave of Block B: the PyTorch bridge + the first two net-new training-engineering modules. All three T0, cross-family reviewed (different model family than author), every finding orchestrator-ground-checked, full `astro build` green (2147 pages, 0 schema errors).

| Module | Slug | Author | Cross-family review |
|--------|------|--------|---------------------|
| B1 PyTorch bridge (rescope `1.2`) | `module-1.2-pytorch-fundamentals` | codex gpt-5.5 | cursor — APPROVE_WITH_NITS (code executed clean on torch) |
| B3 Initialization & Signal Propagation | `module-1.3.1-...` (net-new) | cursor auto | agy/gemini-3.1-pro — 3 real findings fixed (incl. default-`nn.Linear`-bound math) |
| B4 Optimizers & LR Dynamics | `module-1.3.2-...` (net-new) | deepseek-v4-pro | codex R1 (14 findings) + R2 (3 expansion errors) — all fixed |

**Pedagogy spine:** Block B shows PyTorch is *not magic* — every primitive maps 1:1 to the from-scratch Block A code (`loss.backward()`↔A8 autograd engine, `nn.Linear`↔A7 `Layer`, `optim.SGD`↔A7 manual `W -= lr·dW`, `nn.CrossEntropyLoss`↔A5 stable softmax-CE). PyTorch pinned to **2.12** (stable 2026-05-13).

**Review rigor highlight:** B4's draft (deepseek) was error-dense — codex caught 14 real defects with **0 false positives** (wrong Nesterov sign, ε-misplacement, a 10×-off memory figure, 3 fabricated citations) that the T0 verifier passed blind; the heavy fix then introduced 3 new prose errors that R2 caught before merge.

`index.md` updated (1.2 retitled; 1.3.1/1.3.2 rows added). Next-module chain coherent. The mislabeled `1.4` will be gutted/redirected once B5/B6 land (later wave).

Refs #1793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
