### PR TITLE
feat(content): NN Block B Wave 2 — training loop + regularization + normalization (refs #1793)

### DIFF
--- a/src/content/docs/ai-ml-engineering/deep-learning/index.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/index.md
@@ -21,9 +21,11 @@ sidebar:
 | 1.1.7 | [Tiny NumPy NN Lab: XOR to Fashion-MNIST](/ai-ml-engineering/deep-learning/module-1.1.7-tiny-numpy-nn-lab/) |
 | 1.1.8 | [Computational Graphs & Scalar Autograd](/ai-ml-engineering/deep-learning/module-1.1.8-computational-graphs-scalar-autograd/) |
 | 1.2 | [The PyTorch Bridge: From Your NumPy Engine to torch](/ai-ml-engineering/deep-learning/module-1.2-pytorch-fundamentals/) |
-| 1.3 | [Training Neural Networks](/ai-ml-engineering/deep-learning/module-1.3-training-neural-networks/) |
+| 1.3 | [The Training Loop: From One Step to a Reproducible Run](/ai-ml-engineering/deep-learning/module-1.3-training-neural-networks/) |
 | 1.3.1 | [Initialization & Signal Propagation](/ai-ml-engineering/deep-learning/module-1.3.1-initialization-signal-propagation/) |
 | 1.3.2 | [Optimizers & Learning-Rate Dynamics](/ai-ml-engineering/deep-learning/module-1.3.2-optimizers-lr-dynamics/) |
+| 1.3.3 | [Regularization & Generalization](/ai-ml-engineering/deep-learning/module-1.3.3-regularization-generalization/) |
+| 1.3.4 | [Normalization Layers](/ai-ml-engineering/deep-learning/module-1.3.4-normalization-layers/) |
 | 1.4 | [Training Deep Networks: Normalization, Regularization & Optimization](/ai-ml-engineering/deep-learning/module-1.4-cnns-computer-vision/) |
 | 1.5 | [Convolutional Neural Networks & Computer Vision](/ai-ml-engineering/deep-learning/module-1.5-rnns-sequence-models/) |
 | 1.6 | [From Backpropagation to Transformers](/ai-ml-engineering/deep-learning/module-1.6-backpropagation-deep-dive/) |

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.3-training-neural-networks.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.3-training-neural-networks.md
@@ -1,1133 +1,709 @@
 ---
-citations_verified: true
-title: "Training Neural Networks"
+title: "The Training Loop: From One Step to a Reproducible Run"
 slug: ai-ml-engineering/deep-learning/module-1.3-training-neural-networks
 sidebar:
   order: 1004
 ---
 
-> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 6-8 hours
->
-> **Prerequisites**: Python fundamentals, NumPy arrays, matrix multiplication, gradient descent, and the previous neural-network-from-scratch module.
->
-> **Primary tools**: PyTorch, TorchVision, NumPy, local virtual environments, optional CUDA-capable GPU.
+Hypothetical scenario: A model retraining job finishes without an exception, writes a checkpoint, and sends a neat metrics summary to the team channel. The training loss went down, so the run looks healthy at first glance. The next morning, validation accuracy is worse than the baseline, the resumed run uses a different learning rate than the interrupted run, and nobody can reproduce the "good" curve from yesterday because the random split changed. Nothing in that story requires a new derivative formula. It is a training-loop failure: the loop did not clearly separate training from validation, did not save enough state to resume, and did not make the experiment repeatable enough to debug.
 
----
+This module treats the training loop as an engineering object, not as boilerplate around the model. In Block A you wrote the NumPy loop yourself: mini-batches entered, logits came out, stable softmax cross-entropy produced a scalar, backprop filled gradients, and `W -= lr * dW` updated parameters. In B1 you crossed the bridge to PyTorch primitives: `torch.Tensor`, `torch.autograd`, `nn.Linear`, `nn.CrossEntropyLoss`, `DataLoader`, and `torch.optim.SGD`. B2 now asks the practical question: how do those primitives become a run you can trust, stop, resume, compare, and explain?
 
 ## Learning Outcomes
 
 By the end of this module, you will be able to:
 
-1. **Implement** PyTorch tensor, autograd, and `nn.Module` workflows that replace manual NumPy backpropagation without hiding the training mechanics.
-2. **Debug** common training-loop failures, including stale gradients, wrong loss functions, unregistered layers, device mismatches, and evaluation-mode errors.
-3. **Compare** CPU, GPU, mixed-precision, and compiled execution paths, then choose the path that fits a workload's memory, latency, and operational constraints.
-4. **Evaluate** whether a model training script is production-ready by inspecting data loading, checkpointing, validation, logging, reproducibility, and failure detection.
-5. **Design** a complete supervised training pipeline that includes data preparation, model definition, loss selection, optimizer setup, validation, checkpointing, and troubleshooting evidence.
-
----
+- Implement the canonical PyTorch training step in the correct order, then map each line back to the A7 manual NumPy update and B1's tensor, autograd, module, loss, and optimizer primitives.
+- Debug train/validation loop boundaries by verifying `.train()` mode during parameter updates, `.eval()` mode during validation, and `with torch.no_grad():` around evaluation-only forward passes.
+- Design checkpoint dictionaries that restore model parameters, optimizer state, scheduler state, epoch counters, and best validation metrics rather than only reloading weights.
+- Compare reproducibility controls, including Python, NumPy, PyTorch, `DataLoader` worker seeding, and deterministic-algorithm settings, while explaining why bit-identical results across hardware are not guaranteed.
+- Implement metric logging, overfit-one-batch sanity checks, gradient accumulation, and early-stopping hooks, then evaluate whether the resulting script can be interrupted, resumed, validated, and audited with enough evidence to explain a failed or successful run.
 
 ## Why This Module Matters
 
-At 03:12 on a Tuesday morning, a fraud-detection retraining job finishes successfully and ships a model whose predictions are almost random. The platform engineer on call sees no Kubernetes failures, no failed health checks, and no obvious Python exception. The training script printed reassuring loss values for hours, yet the model performs worse than yesterday's baseline because validation ran with dropout still enabled and gradients were silently accumulating across batches.
+The shortest PyTorch training loop is easy to memorize and easy to get subtly wrong. A single missing `optimizer.zero_grad(set_to_none=True)` changes the effective gradient from "this batch" to "this batch plus whatever came before." A single missing `model.eval()` makes validation depend on stochastic dropout masks and batch-normalization batch statistics. A checkpoint that saves only `model.state_dict()` can restart inference, but it cannot faithfully resume training because momentum buffers, adaptive optimizer moments, scheduler counters, and best-metric history are missing. The code still runs, which is why these bugs are more dangerous than syntax errors.
 
-That engineer does not need a definition of a tensor in that moment; she needs a mental model sharp enough to ask the right questions under pressure. Did the optimizer see the parameters? Did the labels match the loss function? Did the model switch from training behavior to inference behavior before validation? Did logging keep full computational graphs alive until the GPU ran out of memory? Those questions separate a person who has merely run a tutorial from a practitioner who can operate machine-learning systems responsibly.
+The loop is also where the Block A mental model becomes operational. `loss.backward()` is the same reverse graph walk your A8 scalar `Value.backward()` performed, except the nodes are tensor operations and PyTorch owns the vector-Jacobian products. `nn.CrossEntropyLoss` is the stable softmax cross-entropy from A5, except the API takes logits and integer class labels instead of an explicit one-hot target matrix. `torch.optim.SGD.step()` is the A7 line `W -= lr * dW`, except the optimizer discovers registered parameters from the `nn.Module` tree and applies the update consistently. PyTorch replaces your hand-written code line-for-line; it does not remove the need to know which line owns which responsibility.
 
-PyTorch makes deep learning accessible because [it lets engineers write ordinary Python while it handles automatic differentiation, device movement, layer registration, and optimizer updates](https://arxiv.org/abs/1912.01703). The accessibility can be dangerous when the learner treats the framework as a black box. This module teaches PyTorch as a set of inspectable mechanisms, so each convenience maps back to a concrete training responsibility that can be verified, debugged, and improved.
+Think of the training loop like a flight checklist. The engine design matters, but crews still use a fixed sequence because order prevents silent state mistakes. In a training step, the checklist is `zero_grad -> forward -> loss -> backward -> step`. In an epoch, the checklist is `train loop -> validation loop -> metrics -> checkpoint -> scheduler/early-stop decision`, with the exact scheduler placement depending on the scheduler type. In a reproducible run, the checklist starts before the first batch with seeds, dataset split policy, device choice, and run metadata. You are not adding ceremony for its own sake; you are making the run inspectable.
 
-The path through the module follows the way training systems actually fail. First you will map data into tensors with explicit shapes, dtypes, and devices. Then you will watch autograd build and clear computation graphs. After that you will construct registered modules, run complete training and evaluation loops, and add the operational controls that keep experiments reproducible and production jobs recoverable.
+This module deliberately avoids re-teaching autograd and `nn.Module`. B1 already covered the bridge, and Block A already made the math visible. Here the emphasis is training discipline: what happens to gradients between steps, what happens to mode-dependent modules between train and validation, what state is needed to continue a run, what numbers should be logged, and what small sanity check should happen before a long job consumes real compute. Optimizer internals belong to B4, initialization to B3, regularization to B5, normalization to B6, detailed diagnostics to B7, and precision to B8. B2 owns the loop that holds all of them together.
 
----
+## Part 1: The Canonical Training Step
 
-## Core Content
+The smallest trustworthy PyTorch training step has five operations in a strict order. First, clear gradients from the previous step. Second, run the model forward on the current mini-batch. Third, compute a scalar loss from model outputs and targets. Fourth, ask autograd to backpropagate through the computation graph. Fifth, ask the optimizer to update the parameters using the gradients that were just computed. This sequence is short, but every line has stateful consequences.
 
-### 1. From Manual Backpropagation to PyTorch Training
-
-The previous module asked you to build neural networks from lower-level pieces so that the chain rule, cached activations, and parameter updates were visible. That work matters because PyTorch does not remove those mechanics; it automates them behind a more reliable interface. When you call `loss.backward()`, PyTorch traverses a computation graph whose nodes correspond to the same intermediate values you cached manually.
-
-A training framework earns trust only when you can connect its abstractions to the work being done. A tensor is not just an array; in PyTorch it can also carry device placement, dtype, gradient-tracking state, and a link to the operation that produced it. A model is not just a Python class; as an `nn.Module`, it registers parameters so optimizers can discover them, save them, move them, and update them.
-
-The central training contract is compact: feed tensors into a registered model, compute a scalar loss, ask autograd for gradients, let an optimizer update registered parameters, and evaluate with behavior appropriate for inference. Most training bugs violate one part of that contract. The module therefore teaches PyTorch by repeatedly checking the contract rather than by listing API calls.
-
-```mermaid
-flowchart LR
-    Data[Input tensors<br>shape dtype device] --> Model[nn.Module<br>registered parameters]
-    Model --> Logits[Raw predictions<br>logits or values]
-    Logits --> Loss[Scalar loss<br>task-specific objective]
-    Loss --> Backward[loss.backward<br>autograd gradients]
-    Backward --> Optimizer[optimizer.step<br>parameter update]
-    Optimizer --> Model
-    Model --> Eval[model.eval plus no_grad<br>validation behavior]
+```text
+A7 NumPy loop                           B2 PyTorch training step
+--------------------------------------------------------------------------------
+dW, db = 0 for this batch            -> optimizer.zero_grad(set_to_none=True)
+logits = layer.forward(xb)           -> logits = model(inputs)
+loss = stable_softmax_ce(logits, y)  -> loss = loss_fn(logits, targets)
+backward cached VJPs through layers  -> loss.backward()
+W -= lr * dW; b -= lr * db           -> optimizer.step()
 ```
 
-| Training responsibility | Manual NumPy version | PyTorch version | Practitioner check |
-|---|---|---|---|
-| Store data in arrays | `np.ndarray` with manually managed shapes | `torch.Tensor` with shape, dtype, device, and gradient flags | Print `shape`, `dtype`, `device`, and `requires_grad` before blaming the model |
-| Track intermediate values | Custom caches inside forward functions | Dynamic computation graph built during tensor operations | Inspect whether tensors still have `grad_fn` when memory grows unexpectedly |
-| Compute gradients | Hand-written derivatives and chain-rule loops | `loss.backward()` over the recorded graph | Verify gradients are finite and reset at the intended time |
-| Update parameters | Manual subtraction using learning rate | `optimizer.step()` over registered parameters | Confirm `len(list(model.parameters()))` is not zero |
-| Move to accelerator | Separate GPU library or custom kernels | `.to(device)` on tensors and modules | Keep model, input tensors, and labels on the same device |
-| Save training state | Custom serialization of arrays and counters | `state_dict()` for model and optimizer | Save both model and optimizer when resuming training |
-
-A PyTorch tensor can represent a scalar loss, a vector of class labels, a matrix of tabular features, a batch of images, or a sequence of token embeddings. The framework does not know the business meaning of those values. It only knows dimensions, numeric types, storage location, and the graph of operations that transform one tensor into another.
-
-```mermaid
-graph TD
-    A[0D scalar<br>single loss value<br>shape: empty] --> B[1D vector<br>class labels or features<br>shape: batch]
-    B --> C[2D matrix<br>tabular batch<br>shape: batch x features]
-    C --> D[3D tensor<br>single image with channels<br>shape: channels x height x width]
-    D --> E[4D tensor<br>image batch<br>shape: batch x channels x height x width]
-    E --> F[5D tensor<br>video batch<br>shape: batch x frames x channels x height x width]
-```
-
-| Tensor rank | Common name | Example training object | Typical shape | Failure to watch for |
-|---|---|---|---|---|
-| 0 | Scalar | Loss value after reduction | `[]` | Calling `backward()` on a non-scalar without supplying a gradient |
-| 1 | Vector | Class labels for a batch | `[batch]` | Passing one-hot labels to `CrossEntropyLoss` when it expects class indices |
-| 2 | Matrix | Tabular features or flattened images | `[batch, features]` | Accidentally transposing batch and feature dimensions |
-| 3 | Tensor | One color image | `[channels, height, width]` | Mixing channel-first PyTorch format with channel-last image libraries |
-| 4 | Batch tensor | Batch of color images | `[batch, channels, height, width]` | Forgetting to flatten before a fully connected network |
-| 5 | Sequence batch | Batch of short video clips | `[batch, frames, channels, height, width]` | Applying image-only layers without deciding how time should be handled |
-
-The first debugging habit is to print tensor metadata before reading stack traces too deeply. Shape errors often look mysterious because the failing operation reports only the immediate mismatch, not the upstream decision that created it. When the network expects `[batch, 784]` and receives `[batch, 1, 28, 28]`, the fix is not inside the optimizer; it belongs at the boundary between the data loader and the model.
+The order matters because PyTorch gradients accumulate by default. Accumulation is useful for gradient accumulation, multi-loss objectives, and some distributed training patterns, but it is wrong for ordinary one-batch-one-step training unless you reset at the start of each step. The current PyTorch optimizer API defaults `zero_grad` to `set_to_none=True`, which sets `.grad` fields to `None` instead of allocating zero tensors. That saves memory and lets you detect parameters that received no gradient, but it also means manual gradient inspection must handle `None` explicitly.
 
 ```python
 import torch
+from torch import nn
 
-images = torch.randn(64, 1, 28, 28)
-labels = torch.randint(0, 10, (64,))
+w = nn.Parameter(torch.tensor([[0.5]]))  # shape: [1, 1]
+optimizer = torch.optim.SGD([w], lr=0.1)
+loss_fn = nn.MSELoss()
 
-print("images:", images.shape, images.dtype, images.device, images.requires_grad)
-print("labels:", labels.shape, labels.dtype, labels.device, labels.requires_grad)
+x = torch.tensor([[2.0]])      # shape: [batch=1, features=1]
+target = torch.tensor([[0.0]]) # shape: [batch=1, outputs=1]
 
-flattened = images.view(images.size(0), -1)
-print("flattened:", flattened.shape)
-```
-
-Active learning prompt: before running the snippet above, predict the shape of `flattened` and identify which dimension represents the batch. If your answer does not preserve the batch dimension, the model may still run for a single example but fail when real batches arrive.
-
-PyTorch and NumPy can share memory when tensors are created with `torch.from_numpy`. That sharing is efficient, but it can surprise you when preprocessing code mutates the original array after creating the tensor. In training code, accidental mutation is especially costly because a model may appear nondeterministic even though the randomness comes from shared storage.
-
-```python
-import numpy as np
-import torch
-
-array = np.array([1.0, 2.0, 3.0], dtype=np.float32)
-tensor = torch.from_numpy(array)
-
-array[0] = 99.0
-print(tensor)
-
-safe_copy = torch.tensor(array)
-array[1] = -5.0
-print("shared:", tensor)
-print("copied:", safe_copy)
-```
-
-Dtype choices also shape the training result. Floating-point tensors are used for model inputs, activations, weights, and losses because gradients require continuous values. Integer tensors are used for indices and class labels because classification losses such as `CrossEntropyLoss` expect each target to name a class, not a floating-point score.
-
-| Dtype | Typical use | Why it matters | Common mistake |
-|---|---|---|---|
-| `torch.float32` | Default model weights, activations, and losses | Good balance of precision and hardware support | Converting labels to float for a classification loss that expects integer indices |
-| `torch.float16` | Mixed-precision training on compatible GPUs | Lower memory use and faster tensor cores when used carefully | Running unstable operations in half precision without automatic scaling |
-| `torch.bfloat16` | Mixed precision on supported accelerators | Wider exponent range than float16 can reduce overflow risk | Assuming every GPU supports it equally well |
-| `torch.long` | Class labels and embedding indices | Many PyTorch indexing operations require 64-bit integer labels | One-hot encoding labels before passing them to `CrossEntropyLoss` |
-| `torch.uint8` | Raw image bytes before conversion | Efficient storage for images in the range 0 to 255 | Training directly on byte images without converting and normalizing |
-
-The second debugging habit is to treat device placement as part of the tensor's type. A CPU tensor and a CUDA tensor are not interchangeable, even if their shapes match. PyTorch will not secretly copy data across the PCIe bus inside a model call because that would hide expensive operations and create unpredictable performance.
-
-```python
-import torch
-
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-
-features = torch.randn(32, 128, device=device)
-weights = torch.randn(128, 10, device=device)
-logits = features @ weights
-
-print(logits.shape, logits.device)
-```
-
-When you create new tensors inside `forward`, use the incoming tensor's device or a registered buffer instead of assuming CPU. This matters in production because a script that works on a laptop can crash immediately when the same model moves to GPU. The pattern `torch.zeros_like(x)` is often safer than `torch.zeros(...)` because it inherits shape, dtype, and device from the tensor already flowing through the model.
-
-```python
-import torch
-
-x = torch.randn(8, 16)
-mask = torch.zeros_like(x)
-print(mask.shape, mask.dtype, mask.device)
-```
-
-### 2. Autograd: Turning Computation into Gradients
-
-Autograd is PyTorch's automatic differentiation system, and its core idea is simple enough to test with small tensors. When a tensor has `requires_grad=True`, PyTorch records operations that produce new tensors from it. When you call `backward()` on a scalar result, PyTorch walks that graph backward and accumulates partial derivatives into each leaf tensor's `.grad` field.
-
-```ascii
-+-------------------+       +-------------------+       +-------------------+
-| x requires_grad   | ----> | y = x * x         | ----> | loss = y.sum()    |
-| leaf tensor       |       | recorded op       |       | scalar output     |
-+-------------------+       +-------------------+       +-------------------+
-          ^                                                       |
-          |                                                       |
-          +---------------- gradients via backward ---------------+
-```
-
-The word "accumulates" is the detail that turns into real incidents. PyTorch adds new gradients to existing `.grad` values because some advanced training strategies intentionally combine gradients across multiple micro-batches. In ordinary training loops, you must clear old gradients before computing new ones, or each update is based on the current batch plus leftover information from previous batches.
-
-```python
-import torch
-
-x = torch.tensor([2.0], requires_grad=True)
-
-y = x * 3
-y.backward()
-print("after first backward:", x.grad.item())
-
-y = x * 5
-y.backward()
-print("after second backward:", x.grad.item())
-
-x.grad.zero_()
-y = x * 7
-y.backward()
-print("after reset:", x.grad.item())
-```
-
-Worked example: suppose a model starts with stable loss and then produces `NaN` after several hundred batches. A rushed engineer might blame the dataset or the learning rate. A more reliable investigation first checks whether the training loop calls `optimizer.zero_grad()` before `loss.backward()`, because missing that line causes gradient values to combine across all previous batches.
-
-```python
-import torch
-import torch.nn as nn
-import torch.optim as optim
-
-model = nn.Linear(4, 2)
-criterion = nn.CrossEntropyLoss()
-optimizer = optim.SGD(model.parameters(), lr=0.1)
-
-x = torch.randn(16, 4)
-y = torch.randint(0, 2, (16,))
-
-for step in range(3):
-    optimizer.zero_grad()
-    logits = model(x)
-    loss = criterion(logits, y)
-    loss.backward()
-
-    total_grad_norm = 0.0
-    for parameter in model.parameters():
-        total_grad_norm += parameter.grad.detach().norm().item()
-
-    optimizer.step()
-    print(f"step={step} loss={loss.item():.4f} grad_norm={total_grad_norm:.4f}")
-```
-
-This worked example demonstrates the healthy sequence: zero stale gradients, run the forward pass, compute a scalar loss, backpropagate, inspect gradients if needed, and only then update parameters. If the gradient norm is infinite, `NaN`, or wildly larger than expected, you have evidence before the optimizer changes the weights. That evidence is more useful than a final failed accuracy number because it points to the exact phase where training broke.
-
-Active learning prompt: remove `optimizer.zero_grad()` in a temporary copy of the script and predict what will happen to the printed gradient norm over repeated steps. Do not focus only on whether the script crashes; focus on whether the update represents one batch or a hidden mixture of many batches.
-
-Autograd records graphs dynamically, which means Python control flow works naturally. An `if` branch, a loop, or a conditional model path can produce a different graph on each forward pass. That flexibility made PyTorch popular for research, but it also means the graph lives only as long as the tensors that reference it.
-
-```python
-import torch
-
-def piecewise_loss(x):
-    if x.mean().item() > 0:
-        return (x ** 2).mean()
-    return (x.abs()).mean()
-
-x = torch.randn(10, requires_grad=True)
-loss = piecewise_loss(x)
+optimizer.zero_grad(set_to_none=True)
+prediction = x @ w             # 2.0 * 0.5 = 1.0
+loss = loss_fn(prediction, target)
 loss.backward()
 
-print("loss:", loss.item())
-print("gradient available:", x.grad is not None)
+print(f"loss before step: {loss.item():.1f}")
+print(f"gradient dloss/dw: {w.grad.item():.1f}")
+
+optimizer.step()
+print(f"w after step: {w.item():.1f}")
 ```
 
-Detaching is how you intentionally stop a value from participating in gradient computation. Metrics, logs, visualizations, and cached predictions usually should not preserve the graph. If you append a loss tensor to a Python list every batch, you keep the graph alive and memory grows with training history; if you append `loss.item()`, you keep only a plain Python number.
+The expected output is `loss before step: 1.0`, `gradient dloss/dw: 4.0`, and `w after step: 0.1`. The derivative is the same calculation you would do by hand: `loss = (2w - 0)^2`, so `dloss/dw = 2 * (2w) * 2 = 4` when `w = 0.5`. The SGD update is the A7 update rule with a registered parameter: `w = 0.5 - 0.1 * 4 = 0.1`. PyTorch did not invent a new rule; it recorded the operations and applied the chain rule you already implemented.
+
+A model-agnostic training step only needs to make batch movement and return values explicit. Notice that the function sets training mode before the forward pass, moves both inputs and targets to the same device as the model, clears gradients before building the graph, and returns detached Python numbers rather than live tensors. Returning live tensors from logging code can accidentally keep graphs alive and increase memory across an epoch.
 
 ```python
-import torch
+def train_step(model, batch, loss_fn, optimizer, device):
+    model.train()
 
-loss_history = []
+    inputs, targets = batch
+    inputs = inputs.to(device)
+    targets = targets.to(device)
 
-x = torch.randn(4, requires_grad=True)
-loss = (x ** 2).mean()
+    optimizer.zero_grad(set_to_none=True)
+    logits = model(inputs)
+    loss = loss_fn(logits, targets)
+    loss.backward()
+    optimizer.step()
 
-loss_history.append(loss.item())
-metric_tensor = loss.detach()
-
-print(type(loss_history[0]))
-print(metric_tensor.requires_grad)
+    batch_size = inputs.shape[0]
+    return loss.detach().item(), batch_size
 ```
 
-`torch.no_grad()` is the larger boundary you use around inference or validation. It tells PyTorch not to build graphs for the operations inside the block, saving memory and compute. It does not change dropout or batch normalization behavior; that is the job of `model.eval()`, which you will use with `no_grad()` during validation.
+The graph lifecycle is worth making concrete. The forward pass creates a dynamic graph because model parameters require gradients. The scalar loss points to the output of that graph. `loss.backward()` walks the graph backward, accumulates gradients into leaf parameters, and normally frees intermediate buffers that are no longer needed. `optimizer.step()` reads parameter `.grad` fields and mutates parameter values. If you call `backward()` twice on the same graph without retaining it, PyTorch complains because the temporary buffers were already released; if you retain every graph for logging, memory grows because you told the runtime not to clean up.
 
-```python
-import torch
-import torch.nn as nn
-
-model = nn.Sequential(nn.Linear(4, 8), nn.ReLU(), nn.Linear(8, 2))
-x = torch.randn(5, 4)
-
-model.eval()
-with torch.no_grad():
-    logits = model(x)
-    predictions = logits.argmax(dim=1)
-
-print(predictions)
+```text
+inputs + parameters
+        |
+        v
+   model forward  ---- dynamic graph records tensor ops
+        |
+        v
+   scalar loss    ---- one number that still points to the graph
+        |
+        v
+   backward()     ---- parameter.grad fields receive accumulated gradients
+        |
+        v
+   optimizer.step ---- parameters are mutated, graph is no longer needed
 ```
 
-| Situation | Use gradient tracking? | Use `model.train()`? | Use `model.eval()`? | Reason |
-|---|---|---|---|---|
-| Training a batch | Yes | Yes | No | Need gradients and training behavior for dropout or batch normalization |
-| Validating accuracy | No | No | Yes | Need deterministic inference behavior without graph allocation |
-| Logging scalar loss | No after extraction | Usually still training | No | Store `loss.item()` rather than the graph-backed tensor |
-| Freezing a pretrained encoder | Usually no for frozen part | Depends on full model | Depends on phase | Prevent unnecessary gradients through frozen parameters |
-| Computing adversarial examples | Yes for inputs | Often eval | Often yes | Need input gradients while keeping inference behavior stable |
-| Exporting predictions | No | No | Yes | Production inference should be deterministic and memory efficient |
+The common beginner reversal is to call `optimizer.step()` before `loss.backward()`. That step uses old gradients, `None` gradients, or gradients from a previous batch, depending on what happened earlier. Another common reversal is to call `zero_grad` after `backward()` and before `step()`, which erases exactly the gradients the optimizer was supposed to use. Some PyTorch tutorials clear gradients after `step()` so the next iteration starts clean; this module uses the equally valid and more checklist-friendly pattern of clearing before the forward pass. The invariant is the same: each optimizer step must consume exactly the gradients intended for that step.
 
-### 3. Building Models with `nn.Module`
+`nn.CrossEntropyLoss` deserves one boundary reminder because it is the loss most learners use first. It expects raw logits shaped `[batch, classes]` and class-index targets shaped `[batch]` with integer dtype. Do not apply `softmax` before passing logits to this loss. In A5 you wrote stable softmax cross-entropy manually to understand the math; in PyTorch the loss combines the stable log-softmax and negative-log-likelihood pieces internally, so passing probabilities instead of logits weakens numerical stability and changes gradient behavior.
 
-`nn.Module` is the foundation for trainable PyTorch models because it provides registration. Registration means PyTorch knows which tensors are parameters, which nested modules belong to the model, which buffers should move with the model, and which values belong in a checkpoint. A model that computes correct numbers but fails to register parameters will not train because the optimizer has nothing to update.
+The step also defines where it is safe to observe state. Before `backward()`, parameter gradients should usually be `None` because they were cleared and the current graph has not propagated anything yet. After `backward()`, gradients should be finite for parameters that participated in the loss; parameters with `None` gradients may be frozen, unused, detached, or behind a branch that did not execute. After `optimizer.step()`, parameter values should change if the learning rate is nonzero and the gradients are nonzero. These three checkpoints are the first debugging probes for a model that "runs but does not learn," and they are much cheaper than launching another full experiment.
 
-```python
-import torch
-import torch.nn as nn
+In A7 you could inspect `dW` arrays directly because every layer stored its own backward result. PyTorch centralizes that evidence in the `.grad` field of each leaf parameter. That is why a practical training-step smoke test often prints a small table of parameter names, gradient norms, and update norms for one batch. You do not need that table in every production run, but you should know how to produce it when loss is flat. If all gradient norms are zero or `None`, the problem is upstream of the optimizer. If gradients are finite and parameters still do not move, the problem is usually optimizer configuration, frozen parameters, or a learning rate of zero.
 
-class DigitClassifier(nn.Module):
-    def __init__(self, input_features=784, hidden_features=128, classes=10):
-        super().__init__()
-        self.fc1 = nn.Linear(input_features, hidden_features)
-        self.activation = nn.ReLU()
-        self.dropout = nn.Dropout(p=0.2)
-        self.fc2 = nn.Linear(hidden_features, classes)
+## Part 2: The Full Loop: Epochs, Batches, and Validation
 
-    def forward(self, x):
-        x = x.view(x.size(0), -1)
-        x = self.fc1(x)
-        x = self.activation(x)
-        x = self.dropout(x)
-        x = self.fc2(x)
-        return x
+A real training run wraps the training step in two loops: epochs over the dataset and mini-batches inside each epoch. The training `DataLoader` usually shuffles examples because mini-batch SGD relies on different stochastic estimates of the full-dataset gradient. The validation `DataLoader` usually does not need shuffling because validation is a measurement pass, not an optimization pass. A separate validation loop is not optional. If the same loop both updates parameters and reports "validation" metrics, you are measuring training behavior under a misleading name.
 
-model = DigitClassifier()
-print(model)
-print("parameter tensors:", len(list(model.parameters())))
-```
-
-The `super().__init__()` line initializes the machinery that makes registration work. Assigning `self.fc1 = nn.Linear(...)` after that call registers `fc1` as a submodule. If you omit the parent initializer or hide layers inside a plain Python list, the model may still run a forward pass, but optimizer construction can fail or silently exclude layers.
-
-```python
-import torch.nn as nn
-
-class RegisteredStack(nn.Module):
-    def __init__(self, width=32, depth=3):
-        super().__init__()
-        self.layers = nn.ModuleList(
-            [nn.Linear(width, width) for _ in range(depth)]
-        )
-
-    def forward(self, x):
-        for layer in self.layers:
-            x = layer(x).relu()
-        return x
-```
-
-A `ModuleList` is not a stylistic preference; it is the difference between trainable layers and ordinary Python objects. PyTorch recursively searches registered modules when you call `model.parameters()`, `model.to(device)`, `model.state_dict()`, and `model.eval()`. Layers in a regular list are invisible to those recursive operations.
-
-| Container pattern | Registered as trainable? | Moves with `.to(device)`? | Saved in `state_dict()`? | Appropriate use |
-|---|---|---|---|---|
-| `self.layer = nn.Linear(...)` | Yes | Yes | Yes | Fixed layer known during initialization |
-| `self.layers = nn.ModuleList([...])` | Yes | Yes | Yes | Dynamic number of layers iterated in `forward` |
-| `self.blocks = nn.ModuleDict({...})` | Yes | Yes | Yes | Named dynamic branches or configurable stacks |
-| `self.layers = [nn.Linear(...)]` | No | No | No | Avoid for trainable modules |
-| `self.scale = nn.Parameter(...)` | Yes | Yes | Yes | Custom trainable tensor not wrapped by a layer |
-| `self.register_buffer("mean", tensor)` | No optimizer update | Yes | Yes | Non-trainable state such as normalization statistics |
-
-Model output should match the loss function's expectations. For multi-class classification, `nn.CrossEntropyLoss` expects raw logits with shape `[batch, classes]` and labels with shape `[batch]` containing integer class indices. It applies log-softmax internally, so adding a final softmax layer before the loss weakens numerical stability and changes the gradient path.
-
-```python
-import torch
-import torch.nn as nn
-
-logits = torch.randn(32, 10)
-labels = torch.randint(0, 10, (32,))
-
-criterion = nn.CrossEntropyLoss()
-loss = criterion(logits, labels)
-
-print(loss.item())
-```
-
-For regression, the model usually outputs continuous values and the target tensor has a compatible floating-point shape. The loss function encodes what "wrong" means: squared error heavily penalizes large deviations, while absolute error is more robust to outliers. The right choice depends on the business cost of different errors, not on which loss appears first in a tutorial.
-
-| Task type | Model output | Target format | Common loss | Decision cue |
-|---|---|---|---|---|
-| Multi-class classification | Raw logits `[batch, classes]` | Integer labels `[batch]` | `nn.CrossEntropyLoss` | Exactly one class is correct for each example |
-| Binary classification with one output | Logit `[batch, 1]` or `[batch]` | Float labels with zeros and ones | `nn.BCEWithLogitsLoss` | Each example has a yes-or-no target |
-| Multi-label classification | Logits `[batch, labels]` | Float matrix of zeros and ones | `nn.BCEWithLogitsLoss` | Several labels may be true at once |
-| Regression | Continuous values | Continuous target values | `nn.MSELoss` or `nn.L1Loss` | Distance between numeric values matters |
-| Ranking or metric learning | Embeddings or scores | Pairwise or triplet structure | Margin or contrastive loss | Relative ordering matters more than absolute class |
-
-Active learning prompt: a teammate builds a two-class classifier with `nn.MSELoss` because there are only two classes. Predict two symptoms you might observe during training, then identify which target format and loss function would better match the task.
-
-Model inspection is not optional in professional work. Before running a long job, print the architecture, count parameters, and confirm that every expected layer appears in the parameter list. This catches missing `super().__init__()`, plain-list layers, and mismatched dimensions before expensive GPU time is wasted.
-
-```python
-import torch
-import torch.nn as nn
-
-model = DigitClassifier()
-total_parameters = sum(parameter.numel() for parameter in model.parameters())
-
-for name, parameter in model.named_parameters():
-    print(f"{name}: shape={tuple(parameter.shape)} trainable={parameter.requires_grad}")
-
-print(f"total parameters: {total_parameters}")
-```
-
-```mermaid
-flowchart TD
-    Input[Batch of images<br>64 x 1 x 28 x 28] --> Flatten[Flatten inside forward<br>64 x 784]
-    Flatten --> FC1[Linear 784 to 128<br>registered weights and bias]
-    FC1 --> Relu[ReLU activation<br>nonlinear transform]
-    Relu --> Dropout[Dropout during train<br>disabled during eval]
-    Dropout --> FC2[Linear 128 to 10<br>class logits]
-    FC2 --> Loss[CrossEntropyLoss<br>compares logits to labels]
-```
-
-`nn.Sequential` is useful when a model is a straight pipeline with no branching, reused outputs, or conditional logic. A custom class is better when you need named intermediate values, skip connections, multiple inputs, multiple outputs, or richer validation in `forward`. Senior engineers tend to choose the simplest structure that still makes debugging clear.
-
-```python
-import torch.nn as nn
-
-prototype = nn.Sequential(
-    nn.Flatten(),
-    nn.Linear(784, 128),
-    nn.ReLU(),
-    nn.Dropout(0.2),
-    nn.Linear(128, 10),
-)
-```
-
-### 4. Training, Validation, and Checkpointing Loops
-
-A training loop is a control system that repeatedly measures error and changes parameters. The five core steps are stable across many architectures: clear gradients, run the model, compute loss, backpropagate, and update. The surrounding details decide whether the loop is trustworthy: data shuffling, device movement, validation mode, checkpointing, metric logging, and failure checks.
-
-```mermaid
-flowchart TD
-    Start[Start epoch] --> TrainMode[model.train]
-    TrainMode --> Batch[Load batch]
-    Batch --> Device[Move data and labels to device]
-    Device --> Zero[optimizer.zero_grad]
-    Zero --> Forward[Forward pass]
-    Forward --> Loss[Compute loss]
-    Loss --> Backward[loss.backward]
-    Backward --> Step[optimizer.step]
-    Step --> More{More batches?}
-    More -- yes --> Batch
-    More -- no --> EvalMode[model.eval]
-    EvalMode --> NoGrad[Validation inside no_grad]
-    NoGrad --> Checkpoint[Save checkpoint if metric improves]
-```
-
-The following script is intentionally small but complete enough to run when PyTorch and TorchVision are installed. It uses MNIST because the dataset is familiar, downloads automatically, and trains quickly on CPU. The goal is not to chase leaderboard accuracy; the goal is to practice a loop whose mechanics can be transferred to larger projects.
+The complete skeleton below uses a synthetic classification problem so the code is runnable without downloading data. It is intentionally model-agnostic: replace `TinyClassifier` and the dataset with your own module and loaders, and the loop contract stays the same. The model itself is not the lesson; the lesson is the shape of the run. Inputs are `[batch, features]`, logits are `[batch, classes]`, and targets are `[batch]`, exactly the CrossEntropyLoss contract from B1 and A5.
 
 ```python
 import random
-from pathlib import Path
-
 import numpy as np
 import torch
-import torch.nn as nn
-import torch.optim as optim
-from torch.utils.data import DataLoader
-from torchvision import datasets, transforms
+from torch import nn
+from torch.utils.data import DataLoader, TensorDataset, random_split
 
 
-class DigitClassifier(nn.Module):
-    def __init__(self):
+class TinyClassifier(nn.Module):
+    def __init__(self, in_features=8, hidden=32, num_classes=3):
         super().__init__()
-        self.network = nn.Sequential(
-            nn.Flatten(),
-            nn.Linear(784, 128),
+        self.net = nn.Sequential(
+            nn.Linear(in_features, hidden),
             nn.ReLU(),
-            nn.Dropout(0.2),
-            nn.Linear(128, 10),
+            nn.Linear(hidden, num_classes),
         )
 
     def forward(self, x):
-        return self.network(x)
+        return self.net(x)
 
 
-def set_seed(seed=13):
+def make_synthetic_dataset(n=900, in_features=8, num_classes=3, seed=123):
+    generator = torch.Generator().manual_seed(seed)
+    x = torch.randn(n, in_features, generator=generator)
+    teacher = torch.randn(in_features, num_classes, generator=generator)
+    logits = x @ teacher
+    y = logits.argmax(dim=1)
+    return TensorDataset(x, y)
+
+
+def make_loaders(batch_size=64, seed=123):
+    dataset = make_synthetic_dataset(seed=seed)
+    split_generator = torch.Generator().manual_seed(seed)
+    train_ds, val_ds = random_split(dataset, [720, 180], generator=split_generator)
+
+    train_loader = DataLoader(train_ds, batch_size=batch_size, shuffle=True,
+                              generator=torch.Generator().manual_seed(seed))
+    val_loader = DataLoader(val_ds, batch_size=batch_size, shuffle=False)
+    return train_loader, val_loader
+
+
+def accuracy_from_logits(logits, targets):
+    predictions = logits.argmax(dim=1)
+    return (predictions == targets).sum().item()
+
+
+def train_one_epoch(model, loader, loss_fn, optimizer, device):
+    model.train()
+    total_loss = 0.0
+    total_correct = 0
+    total_examples = 0
+
+    for inputs, targets in loader:
+        inputs = inputs.to(device)
+        targets = targets.to(device)
+
+        optimizer.zero_grad(set_to_none=True)
+        logits = model(inputs)
+        loss = loss_fn(logits, targets)
+        loss.backward()
+        optimizer.step()
+
+        batch_size = inputs.shape[0]
+        total_loss += loss.detach().item() * batch_size
+        total_correct += accuracy_from_logits(logits.detach(), targets)
+        total_examples += batch_size
+
+    return {
+        "loss": total_loss / total_examples,
+        "accuracy": total_correct / total_examples,
+    }
+
+
+@torch.no_grad()
+def evaluate(model, loader, loss_fn, device):
+    model.eval()
+    total_loss = 0.0
+    total_correct = 0
+    total_examples = 0
+
+    for inputs, targets in loader:
+        inputs = inputs.to(device)
+        targets = targets.to(device)
+
+        logits = model(inputs)
+        loss = loss_fn(logits, targets)
+
+        batch_size = inputs.shape[0]
+        total_loss += loss.item() * batch_size
+        total_correct += accuracy_from_logits(logits, targets)
+        total_examples += batch_size
+
+    return {
+        "loss": total_loss / total_examples,
+        "accuracy": total_correct / total_examples,
+    }
+
+
+def fit(epochs=5, seed=123):
     random.seed(seed)
     np.random.seed(seed)
     torch.manual_seed(seed)
-    if torch.cuda.is_available():
-        torch.cuda.manual_seed_all(seed)
 
-
-def accuracy_from_logits(logits, labels):
-    predictions = logits.argmax(dim=1)
-    return (predictions == labels).float().mean().item()
-
-
-def main():
-    set_seed()
     device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-    data_dir = Path("data")
+    train_loader, val_loader = make_loaders(seed=seed)
 
-    transform = transforms.Compose(
-        [
-            transforms.ToTensor(),
-            transforms.Normalize((0.1307,), (0.3081,)),
-        ]
-    )
+    model = TinyClassifier().to(device)
+    loss_fn = nn.CrossEntropyLoss()
+    optimizer = torch.optim.SGD(model.parameters(), lr=0.2)
 
-    train_data = datasets.MNIST(data_dir, train=True, download=True, transform=transform)
-    test_data = datasets.MNIST(data_dir, train=False, download=True, transform=transform)
+    history = []
+    for epoch in range(1, epochs + 1):
+        train_metrics = train_one_epoch(model, train_loader, loss_fn, optimizer, device)
+        val_metrics = evaluate(model, val_loader, loss_fn, device)
 
-    train_loader = DataLoader(train_data, batch_size=128, shuffle=True)
-    test_loader = DataLoader(test_data, batch_size=512)
-
-    model = DigitClassifier().to(device)
-    criterion = nn.CrossEntropyLoss()
-    optimizer = optim.Adam(model.parameters(), lr=0.001)
-
-    best_accuracy = 0.0
-    checkpoint_path = Path("mnist-checkpoint.pt")
-
-    for epoch in range(3):
-        model.train()
-        running_loss = 0.0
-
-        for batch_index, (features, labels) in enumerate(train_loader):
-            features = features.to(device)
-            labels = labels.to(device)
-
-            optimizer.zero_grad()
-            logits = model(features)
-            loss = criterion(logits, labels)
-
-            if not torch.isfinite(loss):
-                raise RuntimeError(f"non-finite loss at epoch {epoch}, batch {batch_index}")
-
-            loss.backward()
-            optimizer.step()
-
-            running_loss += loss.item()
-
-        model.eval()
-        correct = 0
-        total = 0
-
-        with torch.no_grad():
-            for features, labels in test_loader:
-                features = features.to(device)
-                labels = labels.to(device)
-
-                logits = model(features)
-                predictions = logits.argmax(dim=1)
-                correct += (predictions == labels).sum().item()
-                total += labels.numel()
-
-        validation_accuracy = correct / total
-        average_loss = running_loss / len(train_loader)
-
+        row = {
+            "epoch": epoch,
+            "train_loss": train_metrics["loss"],
+            "train_acc": train_metrics["accuracy"],
+            "val_loss": val_metrics["loss"],
+            "val_acc": val_metrics["accuracy"],
+        }
+        history.append(row)
         print(
-            f"epoch={epoch} "
-            f"train_loss={average_loss:.4f} "
-            f"validation_accuracy={validation_accuracy:.4f}"
+            f"epoch={epoch:02d} "
+            f"train_loss={row['train_loss']:.4f} train_acc={row['train_acc']:.3f} "
+            f"val_loss={row['val_loss']:.4f} val_acc={row['val_acc']:.3f}"
         )
 
-        if validation_accuracy > best_accuracy:
-            best_accuracy = validation_accuracy
-            torch.save(
-                {
-                    "epoch": epoch,
-                    "model_state_dict": model.state_dict(),
-                    "optimizer_state_dict": optimizer.state_dict(),
-                    "validation_accuracy": validation_accuracy,
-                },
-                checkpoint_path,
-            )
-
-    print(f"best validation accuracy: {best_accuracy:.4f}")
+    return model, history
 
 
 if __name__ == "__main__":
-    main()
+    fit()
 ```
 
-Each line in the loop has a reason. `model.train()` enables training-time behavior for dropout and batch normalization. `optimizer.zero_grad()` clears stale gradient buffers. `loss.backward()` fills those buffers with derivatives for the current batch. `optimizer.step()` changes the parameters, and validation happens under `model.eval()` plus `torch.no_grad()` so the reported metric reflects inference behavior.
+The separation between `train_one_epoch` and `evaluate` is more than style. The training function mutates model parameters and therefore must build a graph, call `backward()`, and call `optimizer.step()`. The evaluation function measures the current model and therefore must not build a backward graph or mutate parameters. The `@torch.no_grad()` decorator is equivalent to wrapping the function body in `with torch.no_grad():`; it disables gradient recording for inference-style code and reduces memory use because PyTorch does not keep backward buffers.
 
-The order is not ceremonial. If you call `optimizer.step()` before `loss.backward()`, the optimizer updates using stale or missing gradients. If you forget `model.eval()`, dropout may randomly disable activations during validation. If you forget `torch.no_grad()`, validation may allocate graphs that are never needed, increasing memory use and slowing the job.
+The metric aggregation multiplies each batch loss by `batch_size` before averaging. That small detail matters whenever the last batch is smaller than the others. If you simply average per-batch losses, a final batch of 17 examples receives the same weight as a full batch of 64 examples. The difference may be small, but it is avoidable, and careful aggregation makes metrics easier to compare across batch sizes. Accuracy is counted as correct examples divided by total examples for the same reason.
 
-```mermaid
-sequenceDiagram
-    participant Loader as DataLoader
-    participant Model as nn.Module
-    participant Loss as Loss function
-    participant Auto as Autograd
-    participant Opt as Optimizer
-    Loader->>Model: batch tensors on selected device
-    Model->>Loss: logits or predictions
-    Loss->>Auto: scalar loss with graph
-    Auto->>Model: gradients stored on parameters
-    Opt->>Model: update registered parameters
-    Model->>Loader: next batch repeats the control loop
-```
+Validation is not the test set. The validation split is used repeatedly during development to choose checkpoints, tune early-stopping behavior, and decide whether the training run is improving. The test set should remain untouched until the model-selection process is finished. This module focuses on the train/validation loop because the test protocol depends on project policy, but the engineering rule is stable: do not update parameters on validation examples, and do not make repeated design decisions from the final test set.
 
-Data loading is part of training quality because slow or inconsistent input pipelines create misleading experiments. Shuffling training data reduces order effects, batching trades statistical noise against hardware efficiency, and parallel workers can hide preprocessing latency. Validation data is usually not shuffled because reproducible metric computation matters more than stochastic order.
+Scheduler placement depends on the scheduler. Some schedulers, such as `StepLR`, are commonly stepped once per epoch after the optimizer has completed that epoch. Others, such as `OneCycleLR`, are stepped every optimizer update. `ReduceLROnPlateau` is stepped after validation because it needs the validation metric. B4 will teach learning-rate dynamics in detail; for B2, the important habit is to state when the scheduler moves and to save its state so a resumed run does not repeat or skip scheduler history.
 
-| DataLoader setting | Training effect | Risk when misused | Practical starting point |
-|---|---|---|---|
-| `batch_size` | Controls examples per optimization step | Too large may exceed memory, too small may produce noisy updates | Start with a size that fits comfortably, then measure throughput |
-| `shuffle=True` | Randomizes training order each epoch | Forgetting it can overfit sequence artifacts in ordered datasets | Use for training unless order is meaningful |
-| `shuffle=False` | Keeps validation order stable | Using it for training may hide data-order bias | Use for validation and test loaders |
-| `num_workers` | Loads samples in parallel subprocesses | Too many workers can add overhead or file contention | Start with zero for debugging, then increase while measuring |
-| `pin_memory=True` | Speeds CPU-to-GPU transfer on CUDA systems | Adds little value on CPU-only runs | Enable for CUDA training after correctness is proven |
-| Custom dataset | Loads samples lazily from files or services | Bugs in `__getitem__` can corrupt labels silently | Add small sample visualizations or assertions |
+The epoch boundary is also the right place to make run-level decisions because it is the first moment when training evidence and validation evidence are both available for the same model state. If you save a checkpoint before validation, the checkpoint does not correspond to the validation metric you are about to report. If you update a scheduler from validation loss before writing the checkpoint, the saved scheduler state represents the next epoch rather than the state that produced the metric. Either policy can be valid when documented, but hidden ordering makes resumes confusing. A clean loop chooses an order and makes the checkpoint represent that order.
 
-Optimizers encode assumptions about the loss landscape. Stochastic gradient descent is simple and can generalize well when tuned, but it usually requires more learning-rate care. Adam adapts per-parameter update sizes and often works well early in experimentation. AdamW decouples weight decay from Adam's adaptive update and is a common choice for transformer-style architectures.
+For small local experiments, printing one formatted line per epoch is enough. For longer jobs, write structured records such as JSON Lines, TensorBoard events, or another metrics format your platform can ingest. The record should include epoch or step, train loss, validation loss, task metric, learning rate, checkpoint path, and whether the checkpoint became the new best. That small schema turns the loop into evidence. When a run fails, you can ask whether validation degraded before the learning-rate change, whether the best checkpoint was written, and whether the resumed run continued from the expected epoch.
 
-| Optimizer | Strength | Trade-off | Good use case |
-|---|---|---|---|
-| `SGD` | Simple, inspectable, strong baseline when tuned | Sensitive to learning rate and schedule | Vision models, controlled experiments, teaching gradient behavior |
-| `SGD` with momentum | Smooths noisy gradients | Momentum can overshoot when learning rate is high | Larger batches or losses with noisy local directions |
-| `Adam` | Adapts update size per parameter | Can hide poor scaling or overfit without regularization | Fast prototypes and many tabular or smaller neural networks |
-| `AdamW` | Handles decoupled weight decay cleanly | Still needs learning-rate and decay tuning | Transformers and models where weight decay matters |
-| Learning-rate scheduler | Changes step size over time | Misconfigured schedules can stop learning too early | Longer runs where early exploration and late refinement differ |
-| Gradient clipping | Limits extreme gradient norms | Can mask upstream instability if used blindly | Recurrent models, transformers, or jobs with occasional spikes |
+## Part 3: `.train()` and `.eval()` Mode Discipline
 
-Checkpointing should save enough state to resume training, not just enough state to run inference. Model weights are sufficient for deployment, but optimizer state contains momentum and adaptive statistics that affect future updates. If a long training job crashes and resumes with a fresh optimizer, the loss curve may jump even though the model weights loaded correctly.
+`model.train()` and `model.eval()` toggle the module's `training` flag recursively through child modules. They do not mean "compute gradients" and "do not compute gradients." Gradient recording is controlled by autograd context, such as normal execution, `with torch.no_grad():`, or inference-specific contexts. The mode toggle affects modules whose forward behavior changes between training and evaluation. The two most important examples are dropout and batch normalization, which B5 and B6 teach in depth. In B2, the key point is the mode bug: validation can be wrong even when gradients are disabled if the module remains in training mode.
+
+Dropout randomly zeroes activations during training and becomes an identity operation during evaluation. Batch normalization uses batch statistics during training and running statistics during evaluation when running statistics are tracked. Those behaviors are exactly why the validation loop calls both `model.eval()` and `torch.no_grad()`. The first line changes layer behavior; the second line changes graph recording. They solve different problems and both belong in evaluation code.
 
 ```python
 import torch
+from torch import nn
 
-def save_checkpoint(path, epoch, model, optimizer, validation_accuracy):
+torch.manual_seed(7)
+dropout = nn.Dropout(p=0.5)
+x = torch.ones(12)
+
+dropout.train()
+train_a = dropout(x)
+train_b = dropout(x)
+
+dropout.eval()
+eval_a = dropout(x)
+eval_b = dropout(x)
+
+print("training outputs differ:", not torch.equal(train_a, train_b))
+print("evaluation outputs equal:", torch.equal(eval_a, eval_b))
+print("evaluation is identity:", torch.equal(eval_a, x))
+```
+
+The exact training outputs depend on the random mask, but the pattern is stable: training mode samples masks, evaluation mode does not. If you forget `model.eval()` before validation, the validation metric becomes a noisy measurement of training-time behavior. If you forget `model.train()` after validation, the next epoch may train with dropout disabled and batch normalization frozen in evaluation behavior. Both mistakes can produce plausible metrics for a while, which is why the mode calls should be part of named functions rather than scattered across notebook cells.
+
+| Concern | `model.train()` / `model.eval()` | `with torch.no_grad():` |
+|---|---|---|
+| Primary job | Switch mode-dependent module behavior | Disable recording of backward graph |
+| Affects dropout | Yes, active in train and identity in eval | No, dropout follows module mode |
+| Affects BatchNorm | Yes, batch stats in train and running stats in eval | No, statistics behavior follows module mode |
+| Affects gradient computation | Not directly | Yes, operations stop tracking gradients |
+| Belongs in training loop | `model.train()` before train batches | Usually no, because training needs gradients |
+| Belongs in validation loop | `model.eval()` before validation batches | Yes, because validation does not call backward |
+
+The order inside validation is simple: set eval mode, enter no-grad, run forward passes, aggregate metrics, and leave the function. You do not need to set the model back to training mode at the end of `evaluate` if the next call to `train_one_epoch` always begins with `model.train()`. That style makes each function locally responsible for its required mode and avoids hidden dependence on what the previous function happened to do.
+
+One subtle point is that `model.eval()` changes behavior only for modules that implement mode-specific logic. A plain `nn.Linear` layer returns the same values in train and eval mode. That is why a mode bug may remain invisible in a small MLP and appear later when you add dropout in B5 or batch normalization in B6. Build the habit before the architecture needs it. It costs one line and prevents a class of failures that are painful to diagnose after a long run.
+
+## Part 4: Checkpointing and Resuming
+
+A checkpoint is not just a file with weights. It is a snapshot of the training state needed to continue the run with the same optimization trajectory. For inference, saving `model.state_dict()` is enough because you only need learned parameters and persistent buffers. For training, PyTorch's saving-and-loading guidance is explicit that a general checkpoint should save more than the model state: optimizer state matters because optimizers keep internal buffers and hyperparameter state while training. If you use a scheduler, its counter matters too. If you track "best validation loss," that metric matters because early stopping and best-checkpoint selection depend on it.
+
+The minimal training checkpoint for this module contains five fields: model state, optimizer state, scheduler state or `None`, epoch, and best metric. The scheduler is optional because not every run has one, but the key should still exist so load code has a stable shape. This pattern also leaves room for run metadata such as a seed, git SHA, dataset version, or hyperparameters, but avoid stuffing large datasets or arbitrary Python objects into the checkpoint. The file should restore training state, not become a hidden experiment database.
+
+```python
+from pathlib import Path
+import torch
+
+
+def save_checkpoint(path, model, optimizer, scheduler, epoch, best_metric):
+    path = Path(path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
     torch.save(
         {
-            "epoch": epoch,
             "model_state_dict": model.state_dict(),
             "optimizer_state_dict": optimizer.state_dict(),
-            "validation_accuracy": validation_accuracy,
+            "scheduler_state_dict": scheduler.state_dict() if scheduler is not None else None,
+            "epoch": epoch,
+            "best_metric": float(best_metric),
         },
         path,
     )
 
 
-def load_checkpoint(path, model, optimizer, device):
-    checkpoint = torch.load(path, map_location=device)
+def load_checkpoint(path, model, optimizer, scheduler, device):
+    checkpoint = torch.load(path, map_location=device, weights_only=True)
+
     model.load_state_dict(checkpoint["model_state_dict"])
     optimizer.load_state_dict(checkpoint["optimizer_state_dict"])
-    return checkpoint["epoch"], checkpoint["validation_accuracy"]
+
+    scheduler_state = checkpoint.get("scheduler_state_dict")
+    if scheduler is not None and scheduler_state is not None:
+        scheduler.load_state_dict(scheduler_state)
+
+    start_epoch = int(checkpoint["epoch"]) + 1
+    best_metric = float(checkpoint["best_metric"])
+    return start_epoch, best_metric
 ```
 
-For inference-only loading, create the architecture, load the model state dict, switch to evaluation mode, and run under `torch.no_grad()`. Avoid loading untrusted pickle-based model files because generic `torch.load` can deserialize Python objects. When publishing models across trust boundaries, prefer safer formats and documented model cards where the serving team can reproduce preprocessing and expected inputs.
+The load order assumes you have already reconstructed the model, moved it to the target device, constructed the optimizer from the model parameters, and constructed the scheduler from the optimizer. Construct the scheduler from the optimizer BEFORE loading any state, then load the saved `state_dict`s in order — model, optimizer, scheduler — and resume at `epoch + 1`. Most schedulers (e.g. `StepLR`) do not change the optimizer's learning rate at construction time; a few (e.g. `OneCycleLR`) set the initial LR when created, which is the specific case where construction order versus state-load order matters. Loading in the model → optimizer → scheduler order is the safe sequence in all cases.
 
 ```python
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+model = TinyClassifier().to(device)
+optimizer = torch.optim.SGD(model.parameters(), lr=0.2)
+scheduler = torch.optim.lr_scheduler.StepLR(optimizer, step_size=5, gamma=0.5)
+train_loader, val_loader = make_loaders(seed=123)
+loss_fn = nn.CrossEntropyLoss()
+
+save_checkpoint(
+    "checkpoints/best.pt",
+    model=model,
+    optimizer=optimizer,
+    scheduler=scheduler,
+    epoch=0,
+    best_metric=float("inf"),
+)
+
+start_epoch, best_val_loss = load_checkpoint(
+    "checkpoints/best.pt",
+    model=model,
+    optimizer=optimizer,
+    scheduler=scheduler,
+    device=device,
+)
+
+print(start_epoch, best_val_loss)
+```
+
+The common bug is saving the best model weights but not the optimizer or scheduler state, then calling that a resume checkpoint. That is a valid inference checkpoint and a weak training checkpoint. With SGD momentum, the optimizer's velocity buffers affect the next update. With Adam or AdamW, first and second moment estimates shape every update. With schedulers, the current learning rate may depend on how many steps or epochs have already happened. Reloading weights while resetting those states creates a new run that starts from old weights but follows a different trajectory.
+
+Best-checkpoint handling is a separate decision from periodic checkpointing. Periodic checkpoints answer "can I resume after interruption?" Best checkpoints answer "which model should I deploy or evaluate after training?" A robust run often writes both: a latest checkpoint every epoch or every fixed number of steps, and a best checkpoint only when validation improves. For small teaching runs a single best checkpoint is enough to learn the mechanism, but production jobs should choose a policy that matches failure risk and storage constraints.
+
+If exact stochastic replay matters, checkpointing gets more complicated because random-number-generator states and sampler positions matter. This module does not require an exact mid-epoch replay mechanism, and many production teams accept epoch-boundary resumes because they are simpler and reliable enough. Be honest about that boundary. A checkpoint that restores model, optimizer, scheduler, epoch, and best metric can resume training correctly at an epoch boundary. It does not guarantee bit-identical continuation of every augmentation, shuffle, and kernel choice unless you also control and restore those sources of randomness.
+
+Checkpoint files should be treated as write-once artifacts for a particular run state. If a process can be interrupted while writing, prefer writing to a temporary path and then renaming it into place so readers do not see a half-written file. If storage is remote, understand whether the rename operation is atomic for that storage backend before relying on it for failure recovery. This module stays local and uses `torch.save` directly, but the habit scales: checkpointing is part of the failure model of a training system, not a decorative line at the end of an epoch.
+
+The checkpoint should also be load-tested early. A run that saves checkpoints for six hours and only discovers a load error after interruption did not really have checkpointing. During development, save a checkpoint after a tiny epoch, create a fresh model, optimizer, and scheduler, load it, and run one more training step. That test catches mismatched model definitions, missing scheduler state, bad device mapping, and accidental dependence on in-memory variables. It is the checkpoint equivalent of overfitting one batch: prove the recovery path before you need it.
+
+## Part 5: Reproducibility Without False Promises
+
+Reproducibility starts before training. Set Python's `random` seed if your dataset, split code, or transforms use it. Set NumPy's seed if preprocessing or dataset code uses NumPy randomness. Set PyTorch's seed because model initialization, tensor sampling, dropout masks, and PyTorch samplers may use it. If you use a `DataLoader` with worker processes, seed the worker libraries and pass a `torch.Generator` so shuffling and worker base seeds are controlled. These steps do not make every run identical across all machines, but they remove avoidable randomness from the script.
+
+```python
+import random
+import numpy as np
 import torch
 
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-model = DigitClassifier().to(device)
 
-checkpoint = torch.load("mnist-checkpoint.pt", map_location=device)
-model.load_state_dict(checkpoint["model_state_dict"])
+def seed_everything(seed, deterministic=False):
+    random.seed(seed)
+    np.random.seed(seed)
+    torch.manual_seed(seed)
+
+    if torch.cuda.is_available():
+        torch.cuda.manual_seed_all(seed)
+
+    torch.use_deterministic_algorithms(deterministic)
+    if deterministic and torch.backends.cudnn.is_available():
+        torch.backends.cudnn.benchmark = False
+```
+
+PyTorch's reproducibility documentation is careful: completely reproducible results are not guaranteed across releases, commits, platforms, or even CPU versus GPU execution when the same seeds are used. That caveat is not legal fine print; it is a numerical reality. Floating-point reductions can happen in different orders, backend libraries can select different kernels, and deterministic alternatives may not exist for every operation. `torch.use_deterministic_algorithms(True)` asks PyTorch to use deterministic algorithms when available and to raise an error when only nondeterministic implementations are available, but PyTorch also notes that deterministic operations often run slower.
+
+The tradeoff is a policy decision. During debugging, deterministic algorithms can save hours because two runs with the same seed differ less, making regressions easier to isolate. During high-throughput training, strict determinism can reduce performance or block useful operations. A pragmatic workflow is to keep a deterministic debug mode for small reproductions, record seeds and versions for every serious run, and use multiple seeds for conclusions that depend on model quality rather than on debugging a specific failure.
+
+`DataLoader` worker seeding is the place where many "I set the seed" claims fail. Worker processes may call NumPy or Python randomness inside dataset code or transforms. PyTorch documents the pattern: derive a worker seed from `torch.initial_seed()`, use it to seed NumPy and Python in that worker, and pass a seeded `torch.Generator` to the loader. The generator controls random sampling and the worker base seed; the worker function aligns other libraries with that seed.
+
+```python
+def seed_worker(worker_id):
+    worker_seed = torch.initial_seed() % 2**32
+    np.random.seed(worker_seed)
+    random.seed(worker_seed)
+
+
+generator = torch.Generator()
+generator.manual_seed(123)
+
+train_loader = DataLoader(
+    make_synthetic_dataset(seed=123),
+    batch_size=64,
+    shuffle=True,
+    num_workers=2,
+    worker_init_fn=seed_worker,
+    generator=generator,
+)
+```
+
+Reproducibility also includes what you write down. A useful run record includes the seed, PyTorch version, device type, dataset version or split seed, model hyperparameters, optimizer settings, scheduler settings, and checkpoint path. If the run is part of a larger platform workflow, record the container image or environment lockfile and the git commit as well. KubeDojo will eventually connect this to platform-level training workflows, but the local habit starts here: a metric curve without run context is a story you cannot verify later.
+
+One more practical boundary: validation reproducibility depends on validation data order only if your metric aggregation is order-sensitive or your validation code has hidden state. For ordinary loss and accuracy, validation shuffling is unnecessary. Leaving it off makes metric traces easier to compare and removes one source of accidental variance. Training shuffling remains useful because the mini-batch sequence influences optimization, which is exactly why it should be seeded and recorded.
+
+Reproducibility is strongest when the dataset split is an artifact rather than an accident. A split created by `random_split(..., generator=seeded_generator)` is reproducible as long as the dataset order is stable, but a later dataset refresh can still change which examples land in validation. For serious experiments, record the dataset version and either persist the split indices or make the split rule deterministic from stable example identifiers. The seed answers "how did the random process run"; the data version answers "what did the random process run on." You need both to compare runs honestly.
+
+Do not confuse deterministic debugging with scientific confidence. A single deterministic seed can make a bug reproducible, but it can also hide the fact that a training recipe is fragile across seeds. Once the loop is correct, important claims about model quality should be checked across a small seed sweep when compute allows. That sweep belongs above the single-run loop, but the loop must expose the seed and write metrics consistently so the sweep can aggregate results without guessing which run produced which checkpoint.
+
+## Part 6: Metrics, Sanity Checks, Accumulation, and Stopping
+
+The training loop should report at least a training loss, a validation loss, and one task metric that a human can understand. For classification, accuracy is often a first metric, even when it is not sufficient for imbalanced datasets. For regression, mean absolute error may be more interpretable than mean squared error. The important engineering habit is to log both the objective the optimizer sees and a metric that reflects the task. A decreasing training loss with a flat validation metric is not automatically a bug, but it is evidence that needs interpretation.
+
+Logging should detach values from the graph. Use `loss.item()` for scalar losses and count metrics from detached logits or no-grad validation outputs. If you store `loss` tensors directly in a list during training, each tensor may keep references to the graph that produced it, and memory can grow across the epoch. This is the same graph-lifetime issue from Part 1, now expressed through logging. Python numbers, detached tensors, and no-grad validation outputs are safer metric artifacts than live graph-connected tensors.
+
+Before a long run, overfit one batch. This sanity check is old practical wisdom, popularized in modern neural-network debugging guides such as Karpathy's training recipe and echoed in CS231n: if a sufficiently expressive model cannot memorize a tiny batch with regularization disabled, the full training job is not worth starting. The failure usually points to a data/label mismatch, wrong loss contract, missing gradient, frozen parameter, impossible learning rate, or mode bug. B7 will turn this into a full diagnostic playbook; B2 uses it as the first smoke test for the loop.
+
+```python
+def overfit_one_batch(model, loader, loss_fn, optimizer, device, steps=200):
+    model.train()
+    inputs, targets = next(iter(loader))
+    inputs = inputs.to(device)
+    targets = targets.to(device)
+
+    losses = []
+    for _ in range(steps):
+        optimizer.zero_grad(set_to_none=True)
+        logits = model(inputs)
+        loss = loss_fn(logits, targets)
+        loss.backward()
+        optimizer.step()
+        losses.append(loss.detach().item())
+
+    return losses
+```
+
+Read this function as a contract test, not as a regular training method. It intentionally reuses the same batch for many updates because the question is whether gradients, labels, loss, and optimizer updates can cooperate on the easiest possible task. If your model includes dropout or heavy data augmentation, disable those influences for the check or use a model variant without them. If the one-batch loss cannot drop sharply, do not proceed to a full dataset and hope the problem disappears.
+
+Gradient accumulation is another loop mechanism that belongs here because it changes when `optimizer.step()` happens. Suppose GPU memory fits a micro-batch of 32 examples, but you want the gradient signal of an effective batch of 128 examples. You can run four forward/backward passes, divide each loss by four, accumulate gradients, then step once. Dividing by the accumulation count preserves the gradient scale you would get from a mean loss over the larger batch. Without that division, the effective gradient is four times larger, which also changes the effective learning rate. B4 will discuss learning-rate scaling; B2 gives you the loop pattern.
+
+```python
+def train_one_epoch_with_accumulation(
+    model,
+    loader,
+    loss_fn,
+    optimizer,
+    device,
+    accumulation_steps=4,
+):
+    model.train()
+    optimizer.zero_grad(set_to_none=True)
+
+    total_loss = 0.0
+    total_examples = 0
+
+    for batch_idx, (inputs, targets) in enumerate(loader):
+        inputs = inputs.to(device)
+        targets = targets.to(device)
+
+        logits = model(inputs)
+        loss = loss_fn(logits, targets) / accumulation_steps
+        loss.backward()
+
+        if (batch_idx + 1) % accumulation_steps == 0:
+            optimizer.step()
+            optimizer.zero_grad(set_to_none=True)
+
+        batch_size = inputs.shape[0]
+        total_loss += loss.detach().item() * accumulation_steps * batch_size
+        total_examples += batch_size
+
+    if len(loader) % accumulation_steps != 0:
+        optimizer.step()
+        optimizer.zero_grad(set_to_none=True)
+
+    return {"loss": total_loss / total_examples}
+```
+
+The leftover step at the end handles loaders whose length is not divisible by `accumulation_steps`, but it is slightly under-scaled because those leftover gradients were divided as if a full accumulation group existed. For production code, prefer `drop_last=True` when exact accumulation groups matter, or scale the last group by its actual size with a slightly more complex loop. That nuance is a perfect example of training engineering: a simple pattern is correct under stated assumptions, and those assumptions should be visible.
+
+Early stopping is a validation-driven loop hook. It watches a validation metric, counts how many consecutive checks have failed to improve by at least `min_delta`, and stops when that count reaches `patience`. B5 will cover the regularization interpretation; here the point is mechanism and checkpoint discipline. If you stop because validation stopped improving, restore the best checkpoint rather than leaving the model at the final, possibly worse epoch.
+
+```python
+class EarlyStopping:
+    def __init__(self, patience=3, min_delta=0.0):
+        self.patience = patience
+        self.min_delta = min_delta
+        self.best = float("inf")
+        self.bad_epochs = 0
+
+    def step(self, metric):
+        improved = metric < self.best - self.min_delta
+        if improved:
+            self.best = metric
+            self.bad_epochs = 0
+            return False, True
+
+        self.bad_epochs += 1
+        should_stop = self.bad_epochs >= self.patience
+        return should_stop, False
+```
+
+The hook returns two booleans because the loop has two separate jobs: save the best checkpoint when validation improves, and stop when patience is exhausted. In a real loop, the validation block would call `stopper.step(val_loss)`, save a best checkpoint on improvement, break on stop, and then load the best checkpoint before final evaluation. That design avoids a quiet mismatch between the reported best metric and the in-memory model left after training.
+
+```python
+stopper = EarlyStopping(patience=2, min_delta=1e-4)
+best_path = "checkpoints/best.pt"
+
+for epoch in range(start_epoch, 20):
+    train_metrics = train_one_epoch(model, train_loader, loss_fn, optimizer, device)
+    val_metrics = evaluate(model, val_loader, loss_fn, device)
+    scheduler.step()
+
+    should_stop, improved = stopper.step(val_metrics["loss"])
+    if improved:
+        save_checkpoint(best_path, model, optimizer, scheduler, epoch, stopper.best)
+
+    print(epoch, train_metrics, val_metrics, "best_val_loss", stopper.best)
+
+    if should_stop:
+        print(f"early stopping at epoch {epoch}")
+        break
+
+load_checkpoint(best_path, model, optimizer, scheduler, device)
 model.eval()
-
-with torch.no_grad():
-    sample = torch.randn(1, 1, 28, 28, device=device)
-    logits = model(sample)
-    prediction = logits.argmax(dim=1).item()
-
-print(prediction)
 ```
 
-### 5. Acceleration, Operations, and Senior-Level Debugging
+This snippet assumes an epoch-stepped scheduler such as `StepLR`; a metric-driven scheduler such as `ReduceLROnPlateau` would receive the validation loss instead, and a per-step scheduler would move inside the batch loop. The important point is not one universal scheduler location. The important point is that the training loop names the location, saves the scheduler state, and makes the stop/restore decision from validation evidence rather than from training loss alone.
 
-GPU acceleration changes the economics of training, but it does not change the training contract. The model, input tensors, labels, and any new tensors created during the forward pass must live on compatible devices. A script that moves only the model to CUDA is broken; a script that moves data every batch but creates CPU masks inside `forward` is also broken.
-
-```python
-import time
-import torch
-
-
-def benchmark_matrix_multiply(device, size=2048, iterations=20):
-    x = torch.randn(size, size, device=device)
-    y = torch.randn(size, size, device=device)
-
-    for _ in range(3):
-        _ = x @ y
-
-    if device.type == "cuda":
-        torch.cuda.synchronize()
-
-    start = time.perf_counter()
-
-    for _ in range(iterations):
-        _ = x @ y
-
-    if device.type == "cuda":
-        torch.cuda.synchronize()
-
-    return (time.perf_counter() - start) / iterations
-
-
-cpu_time = benchmark_matrix_multiply(torch.device("cpu"), size=1024, iterations=5)
-print(f"cpu_seconds_per_iteration={cpu_time:.6f}")
-
-if torch.cuda.is_available():
-    gpu_time = benchmark_matrix_multiply(torch.device("cuda"), size=1024, iterations=5)
-    print(f"gpu_seconds_per_iteration={gpu_time:.6f}")
-    print(f"speedup={cpu_time / gpu_time:.2f}")
-else:
-    print("cuda_available=false")
-```
-
-Small workloads may not benefit from a GPU because transfer overhead, kernel launch overhead, and underutilization can dominate. Large matrix multiplications and convolution-heavy models often benefit substantially because the GPU keeps many parallel arithmetic units busy. The senior-level decision is therefore not "GPU is faster"; it is "this workload is large enough, batched enough, and memory-efficient enough to justify GPU scheduling."
-
-```mermaid
-graph TD
-    Workload[Training workload] --> Size{Enough arithmetic per batch?}
-    Size -- no --> CPU[CPU may be simpler and cheaper]
-    Size -- yes --> Memory{Fits accelerator memory?}
-    Memory -- no --> Reduce[Reduce batch size<br>accumulate gradients<br>checkpoint activations]
-    Memory -- yes --> Transfer{Data pipeline keeps GPU busy?}
-    Transfer -- no --> Loader[Tune DataLoader<br>preprocess efficiently<br>use pinned memory]
-    Transfer -- yes --> GPU[Use CUDA path<br>measure throughput and cost]
-```
-
-| Execution path | Best fit | Watch for | Senior decision question |
-|---|---|---|---|
-| CPU training | Small models, debugging, CI smoke tests | Slow epochs on large tensor workloads | Is correctness still being established? |
-| Single GPU | Most local deep-learning experiments | Device mismatches and memory pressure | Is the batch large enough to use the device efficiently? |
-| Mixed precision | Large models on compatible accelerators | Overflow, underflow, and unsupported operations | Does automatic scaling preserve metrics while improving throughput? |
-| `torch.compile` | Stable models with repeated execution paths | Compile overhead and graph breaks | Is the model mature enough to optimize after debugging? |
-| Gradient accumulation | Effective large batch without fitting it at once | Forgetting when to call `optimizer.step()` | Does the accumulated gradient match the intended batch size? |
-| Distributed training | Large datasets or models across devices | Synchronization, reproducibility, and operational complexity | Has single-device training already been made correct and measurable? |
-
-[Mixed precision can reduce memory use and improve throughput on modern accelerators by using lower precision where it is safe. The safe part matters. PyTorch's automatic mixed precision chooses appropriate operations and gradient scaling helps avoid underflow](https://arxiv.org/abs/1710.03740), but the engineer still must compare validation metrics and inspect instability rather than assuming faster means equivalent.
-
-```python
-import torch
-import torch.nn as nn
-import torch.optim as optim
-
-device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
-model = nn.Sequential(nn.Linear(128, 256), nn.ReLU(), nn.Linear(256, 10)).to(device)
-criterion = nn.CrossEntropyLoss()
-optimizer = optim.AdamW(model.parameters(), lr=0.001)
-
-features = torch.randn(64, 128, device=device)
-labels = torch.randint(0, 10, (64,), device=device)
-
-if device.type == "cuda":
-    scaler = torch.cuda.amp.GradScaler()
-    optimizer.zero_grad()
-
-    with torch.cuda.amp.autocast():
-        logits = model(features)
-        loss = criterion(logits, labels)
-
-    scaler.scale(loss).backward()
-    scaler.step(optimizer)
-    scaler.update()
-else:
-    optimizer.zero_grad()
-    logits = model(features)
-    loss = criterion(logits, labels)
-    loss.backward()
-    optimizer.step()
-
-print(loss.item())
-```
-
-`torch.compile` is an optimization step, not a substitute for a correct model. Compile after the eager-mode model trains, validates, checkpoints, and debugs correctly. This order preserves PyTorch's developer-experience advantage: ordinary Python while you are learning and diagnosing, compilation only when the execution path is stable enough to optimize.
-
-```python
-import torch
-import torch.nn as nn
-
-model = nn.Sequential(nn.Linear(32, 64), nn.ReLU(), nn.Linear(64, 2))
-
-if hasattr(torch, "compile"):
-    model = torch.compile(model)
-
-x = torch.randn(8, 32)
-print(model(x).shape)
-```
-
-Production training also needs failure detection. A training script should fail fast when loss becomes non-finite, labels fall outside the expected class range, the optimizer has no parameters, a checkpoint cannot be written, or validation accuracy collapses relative to a baseline. These checks turn silent corruption into actionable errors.
-
-```python
-import math
-import torch
-
-def assert_training_batch(features, labels, num_classes):
-    if not torch.isfinite(features).all():
-        raise ValueError("features contain non-finite values")
-
-    if labels.dtype != torch.long:
-        raise TypeError(f"labels must be torch.long, received {labels.dtype}")
-
-    if labels.min().item() < 0 or labels.max().item() >= num_classes:
-        raise ValueError("labels contain a class index outside the expected range")
-
-
-def assert_loss_is_healthy(loss):
-    value = loss.item()
-    if not math.isfinite(value):
-        raise RuntimeError(f"loss is non-finite: {value}")
-```
-
-A senior debugging workflow narrows the problem by proving simpler claims before investigating complex ones. Can the model overfit one batch? Do gradients exist for every trainable layer? Does validation produce identical predictions twice in a row under `model.eval()` and `torch.no_grad()`? Does a checkpoint restore identical output for the same input? Each question isolates a layer of the training system.
-
-| Debugging probe | What it tests | Healthy signal | Likely issue when it fails |
-|---|---|---|---|
-| Overfit one small batch | Model capacity and training loop mechanics | Loss falls close to zero on the same batch | Wrong loss, missing gradients, bad labels, or no optimizer updates |
-| Print gradient norms | Gradient flow through layers | Non-zero finite gradients where expected | Dead activations, detached tensors, or unregistered parameters |
-| Count optimizer parameters | Registration and optimizer setup | Expected number of tensors in parameter groups | Plain Python lists, missing `super().__init__()`, or frozen parameters |
-| Run validation twice | Deterministic inference behavior | Same predictions for same inputs | Missing `model.eval()` or hidden randomness |
-| Save and reload checkpoint | Serialization and architecture match | Same output after reload for same input | Missing state, wrong architecture, or device loading error |
-| Compare CPU and GPU tiny run | Device-independent correctness | Similar losses within expected numerical tolerance | Device-specific tensor creation or precision assumptions |
-
-The "overfit one batch" test deserves special attention because it is the fastest way to separate data-scale problems from loop correctness problems. If a model cannot memorize a tiny fixed batch, adding more data will not fix it. The bug is usually in architecture wiring, loss-target mismatch, optimizer configuration, gradient flow, or preprocessing.
-
-```python
-import torch
-import torch.nn as nn
-import torch.optim as optim
-
-model = nn.Sequential(nn.Linear(4, 16), nn.ReLU(), nn.Linear(16, 3))
-criterion = nn.CrossEntropyLoss()
-optimizer = optim.Adam(model.parameters(), lr=0.05)
-
-features = torch.randn(12, 4)
-labels = torch.randint(0, 3, (12,))
-
-for step in range(200):
-    optimizer.zero_grad()
-    logits = model(features)
-    loss = criterion(logits, labels)
-    loss.backward()
-    optimizer.step()
-
-print(f"final_loss={loss.item():.6f}")
-```
-
-The economics of PyTorch are not only about faster syntax. Framework primitives reduce engineering time, but acceleration can increase infrastructure spend if jobs are poorly batched, frequently restarted, or run without checkpointing. A cheaper GPU hour can be more expensive than a CPU run if half the time is spent waiting for the data loader or repeating failed epochs.
-
-```mermaid
-graph LR
-    Task[Training task] --> Manual[Manual implementation]
-    Task --> Framework[PyTorch implementation]
-    Manual --> Risk1[Higher derivative-code risk]
-    Manual --> Risk2[Longer GPU integration path]
-    Framework --> Benefit1[Autograd and optimizers]
-    Framework --> Benefit2[DataLoader and checkpointing]
-    Framework --> Benefit3[Acceleration path after correctness]
-```
-
-| Cost driver | How PyTorch helps | Remaining engineering responsibility | Operational metric |
-|---|---|---|---|
-| Development time | Provides layers, autograd, losses, optimizers, and loaders | Choose correct abstractions and verify assumptions | Time from baseline idea to validated run |
-| Compute time | Enables GPU, mixed precision, and compilation | Measure utilization and avoid unnecessary graph allocation | Examples per second and cost per epoch |
-| Failure recovery | Supports checkpointing with state dicts | Save complete state and test restore paths | Lost work after interruption |
-| Debugging time | Exposes tensor metadata and gradients | Add assertions, probes, and reproducible seeds | Time to isolate a broken training phase |
-| Deployment risk | Provides eval mode, export paths, and ecosystem tools | Match preprocessing, trust model files, and validate outputs | Difference between validation and serving behavior |
-| Team learning | Uses readable Python and rich ecosystem examples | Teach mechanisms rather than copy patterns blindly | Review quality of training-code changes |
-
-Framework comparisons are useful when they focus on trade-offs rather than identity. PyTorch is a practical default for many teams because it combines readable eager execution with a broad ecosystem. TensorFlow remains important in many production and legacy environments. JAX is attractive for functional transformations, accelerator-oriented research, and workflows where compilation and transformation discipline are central.
-
-| Framework | Strength | Trade-off | Practical selection cue |
-|---|---|---|---|
-| PyTorch | Pythonic eager execution, broad research and application ecosystem | Production path still requires discipline around export, serving, and reproducibility | Choose when team productivity and debuggability are primary |
-| TensorFlow | Mature serving ecosystem and legacy production footprint | Older static-graph patterns can be harder for beginners to debug | Choose when existing platform investment already centers on it |
-| JAX | Powerful functional transformations and strong accelerator workflows | Steeper learning curve and different programming model | Choose when function transforms, compilation, or TPU-oriented work dominate |
-| Manual NumPy | Maximum educational transparency | Impractical for complex models and accelerators | Use for learning internals, not routine production training |
-| Higher-level wrappers | Less boilerplate for common training patterns | Can hide mechanics when learners are still building mental models | Add after the team can debug plain PyTorch loops |
-
-The final mental model is a layered one. Tensors describe numeric data and execution placement. Autograd records differentiable computation. Modules register parameters and organize forward logic. Losses turn predictions into scalar training signals. Optimizers mutate parameters using gradients. Operational controls make the loop repeatable, measurable, recoverable, and safe.
-
----
+The loop mechanisms in this part are intentionally modest, but together they create an engineering runbook. Metrics tell you whether training and validation are moving together or separating. The overfit-one-batch check tells you whether the model can learn at all under idealized conditions. Gradient accumulation tells you how to trade memory pressure for a larger effective batch without changing gradient scale by accident. Early stopping tells you when the validation evidence says to stop spending compute and which checkpoint should represent the run. None of these mechanisms replaces understanding the model, but each one narrows the search space when training does something surprising.
 
 ## Did You Know?
 
-1. [**Reverse-mode automatic differentiation predates modern deep learning**](https://en.wikipedia.org/wiki/Seppo_Linnainmaa): PyTorch's autograd uses ideas that were developed decades before today's large neural networks, and the reason it fits neural networks so well is that training usually has many parameters but one scalar loss.
-
-2. **Gradient accumulation is intentional behavior**: PyTorch adds gradients into `.grad` buffers instead of replacing them because accumulation supports larger effective batches, multi-loss training, and advanced optimization patterns.
-
-3. **`CrossEntropyLoss` expects raw logits**: The loss combines log-softmax with negative log likelihood internally, so adding softmax before it can reduce numerical stability and distort the gradient signal.
-
-4. **Pickle-based model loading is a trust boundary**: Generic PyTorch checkpoint loading can deserialize Python objects, so production teams should treat untrusted model files as executable input and prefer safer distribution formats when appropriate.
-
----
+- PyTorch 2.12 was announced by the PyTorch Foundation on May 13, 2026, and the current docs for this module's APIs are the 2.12 documentation set. That matters because API details move over time; for example, the modern mixed-precision documentation points users toward `torch.amp.autocast("cuda", ...)` instead of the deprecated `torch.cuda.amp.autocast(...)` form.
+- PyTorch's `zero_grad(set_to_none=True)` behavior is not merely cosmetic. Gradients set to `None` can reduce memory use and make it clear which parameters did not receive gradients, but optimizers can treat `None` differently from a zero tensor, so manual gradient code must be written with that distinction in mind.
+- `model.eval()` and `torch.no_grad()` are easy to confuse because both appear in validation code, but they control different systems. Evaluation mode changes layer behavior for modules such as dropout and BatchNorm, while no-grad changes autograd recording and memory use during forward passes.
+- Full reproducibility is an engineering target, not a single function call. PyTorch documents that results are not guaranteed to be reproducible across releases, platforms, or CPU/GPU executions, even with identical seeds, so serious run records should include seeds, versions, device details, and dataset split policy.
 
 ## Common Mistakes
 
-| Mistake | Scenario symptom | Root cause | Corrective action |
-|---|---|---|---|
-| Forgetting `optimizer.zero_grad()` | Loss starts plausible, then gradients grow until updates become unstable or non-finite | PyTorch accumulates gradients across backward calls by default | Clear gradients before each normal training step unless intentional accumulation is documented |
-| Calling softmax before `CrossEntropyLoss` | Classification training improves slowly or becomes numerically fragile | The loss already applies the stable log-softmax calculation internally | Return raw logits from the model and pass integer class labels directly |
-| Using a plain Python list for layers | `model.parameters()` is empty or missing expected tensors | `nn.Module` cannot register modules hidden in ordinary lists | Use `nn.ModuleList`, `nn.ModuleDict`, or direct module attributes |
-| Leaving validation in training mode | Validation metrics fluctuate on identical data, especially with dropout | Dropout and batch normalization keep training-time behavior active | Call `model.eval()` before validation and return to `model.train()` before training |
-| Building validation graphs | GPU memory grows during evaluation even though no learning happens | Inference loop runs without `torch.no_grad()` | Wrap validation and inference operations inside `with torch.no_grad():` |
-| Mixing CPU and GPU tensors | Runtime error reports tensors on different devices | Model, labels, inputs, or newly created tensors live on incompatible devices | Create a `device` variable and move every batch plus the model consistently |
-| Logging full tensors | Memory grows with the number of batches or logged metrics | Stored tensors keep references to computation graphs | Log `loss.item()` or `tensor.detach().cpu()` depending on the metric need |
-| Saving only model weights for resumable jobs | Training resumes but loss curve jumps or behaves differently | Optimizer momentum and adaptive state were discarded | Save model state, optimizer state, epoch, metric history, and configuration together |
-
----
+| Mistake | Problem | Better approach |
+|---|---|---|
+| Calling `optimizer.step()` before `loss.backward()` | The optimizer updates with stale, missing, or previous-batch gradients instead of the current batch's gradients. | Keep the step checklist fixed: zero gradients, forward, loss, backward, optimizer step. |
+| Forgetting `optimizer.zero_grad(set_to_none=True)` | Gradients accumulate across batches and silently change the effective update direction and magnitude. | Clear gradients once per intended optimizer update, usually before the forward pass. |
+| Validating without `model.eval()` | Dropout and BatchNorm behave as if the model is still training, so validation becomes noisy or biased. | Make `evaluate()` call `model.eval()` internally every time it runs. |
+| Validating without `torch.no_grad()` | PyTorch records graphs that will never be backpropagated, wasting memory and sometimes keeping tensors alive through logging. | Wrap validation in `with torch.no_grad():` or use `@torch.no_grad()` on the evaluation function. |
+| Saving only `model.state_dict()` for resume | The model weights reload, but optimizer buffers, scheduler counters, epoch, and best metric reset or disappear. | Save a checkpoint dictionary with model, optimizer, scheduler, epoch, and best validation metric. |
+| Averaging per-batch losses equally | A small final batch receives the same weight as a full batch, making epoch loss slightly wrong. | Multiply each batch loss by batch size, sum, and divide by total examples. |
+| Accumulating gradients without dividing the loss | The gradient is scaled by the number of micro-batches, which changes the effective learning rate. | Divide loss by `accumulation_steps` before `backward()` when using mean-reduced losses. |
+| Reporting training loss as model quality | Training loss can improve while validation quality degrades, especially once a model memorizes training data. | Track train loss, validation loss, and at least one task metric, then choose best checkpoints from validation evidence. |
 
 ## Quiz
 
-1. Your team trains a small image classifier and the training loss decreases, but validation accuracy changes every time you run validation on the same saved checkpoint and same validation set. The model contains dropout. What should you inspect first, and why?
+1. **Why does the canonical step clear gradients before the forward pass in this module?**
 
    <details>
    <summary>Answer</summary>
 
-   Inspect whether the validation loop calls `model.eval()` before inference and uses `torch.no_grad()` around the loop. Dropout remains active in training mode, so repeated validation passes can produce different predictions for the same inputs. `torch.no_grad()` is also appropriate because validation does not need computation graphs, although the nondeterministic metric symptom points most directly to the missing evaluation mode.
+   PyTorch accumulates gradients into parameter `.grad` fields. Clearing gradients before the forward pass makes the invariant obvious: the next `backward()` call should produce exactly the gradients for the current intended update. Clearing after `optimizer.step()` can also work if done consistently, but clearing between `backward()` and `step()` erases the gradients the optimizer needs.
+
    </details>
 
-2. A teammate writes `self.layers = [nn.Linear(128, 128), nn.Linear(128, 10)]` inside an `nn.Module`. The forward pass runs, but the optimizer reports an empty parameter list or the loss never changes. How do you fix the model and prove the fix worked?
+2. **What is the difference between `model.eval()` and `with torch.no_grad():` during validation?**
 
    <details>
    <summary>Answer</summary>
 
-   Replace the plain Python list with `nn.ModuleList` or assign the layers as direct module attributes, and make sure `super().__init__()` is called first. Then print `list(model.named_parameters())` or count `sum(p.numel() for p in model.parameters())` before training. A non-empty parameter list with the expected layer names proves PyTorch registered the trainable tensors.
+   `model.eval()` recursively changes the module's training flag, which affects mode-dependent layers such as dropout and BatchNorm. `torch.no_grad()` disables gradient recording, which reduces memory use and prevents construction of a backward graph during evaluation. Validation usually needs both because correct layer behavior and disabled graph recording are separate concerns.
+
    </details>
 
-3. A fraud model uses `nn.CrossEntropyLoss`, but the labels arrive as one-hot floating-point vectors because a preprocessing job was copied from a different framework. The script crashes or trains poorly after a quick workaround. What target format should the team provide, and why?
+3. **Why is a checkpoint with only `model.state_dict()` insufficient for resuming training?**
 
    <details>
    <summary>Answer</summary>
 
-   The team should provide integer class indices with dtype `torch.long` and shape `[batch]`, while the model returns raw logits with shape `[batch, classes]`. `CrossEntropyLoss` expects each target to name the correct class, not to provide a one-hot probability vector. Keeping logits raw also lets the loss use its numerically stable internal log-softmax path.
+   Model weights are only one part of training state. Optimizers keep momentum or adaptive moment buffers, schedulers keep counters and learning-rate history, and the loop needs the current epoch and best validation metric to make correct stop/save decisions. Loading only weights starts from the same parameters but not from the same optimization trajectory.
+
    </details>
 
-4. During validation, GPU memory usage increases batch after batch until the process fails, even though the script never calls `backward()` in validation. What code pattern is most likely missing, and what secondary logging mistake would you check?
+4. **A validation loop reports lower loss every epoch, but it never calls `torch.no_grad()`. Is the metric necessarily wrong?**
 
    <details>
    <summary>Answer</summary>
 
-   The validation loop is likely missing `with torch.no_grad():`, so PyTorch still builds computation graphs for each forward pass. As a secondary check, inspect whether the script appends graph-backed tensors such as `loss` or `logits` to a list for later reporting. Validation metrics should usually be stored as Python numbers via `.item()` or as detached CPU tensors when detailed analysis is required.
+   The numeric metric may still be correct if the model is in evaluation mode and no accidental mutation occurs, but the loop is wasteful and risky because PyTorch records graphs that are never used for backward. The memory overhead can hide until larger batches or longer validation runs. Correct validation uses no-grad because evaluation is a measurement pass, not a gradient-building pass.
+
    </details>
 
-5. A model trains successfully on CPU, but the first CUDA run fails with a device mismatch inside `forward`. The model and input batch were moved to CUDA. What hidden source of CPU tensors should you look for?
+5. **Why divide the loss by `accumulation_steps` during gradient accumulation?**
 
    <details>
    <summary>Answer</summary>
 
-   Look for tensors created inside `forward` with constructors such as `torch.zeros(...)`, `torch.arange(...)`, or `torch.tensor(...)` that do not specify the incoming tensor's device. Those tensors default to CPU and then collide with CUDA tensors during operations. Prefer `torch.zeros_like(x)`, pass `device=x.device`, or register persistent non-trainable tensors as buffers so they move with the model.
+   Most PyTorch losses default to a mean over the mini-batch. If four micro-batches are backpropagated and each mean loss is used directly, the accumulated gradient is roughly four times the gradient of one effective large batch. Dividing each micro-batch loss by four preserves the gradient scale and avoids accidentally changing the effective learning rate.
+
    </details>
 
-6. A long training job is interrupted after several hours. The engineer saved only `model.state_dict()` and restarts with a fresh Adam optimizer. The job resumes, but the loss curve shifts and convergence differs from the original run. What was missing from the checkpoint?
+6. **What does the overfit-one-batch sanity check prove, and what does it not prove?**
 
    <details>
    <summary>Answer</summary>
 
-   The checkpoint omitted optimizer state, and for Adam that state includes adaptive moment estimates that affect future updates. A resumable checkpoint should include the model state dict, optimizer state dict, epoch or step counters, validation metrics, and enough configuration to reconstruct the run. Model weights alone are appropriate for inference, not for an exact training resume.
+   It proves that the model, data, labels, loss, gradients, and optimizer can cooperate on an intentionally easy memorization task. It does not prove that the model generalizes, that the validation split is clean, or that hyperparameters are optimal. Passing the check is a gate before serious training; failing it is strong evidence of a loop, data, or contract bug.
+
    </details>
 
-7. Your team wants to enable mixed precision because GPU memory is tight. After enabling it, throughput improves but validation quality drops. How should you evaluate whether mixed precision is acceptable rather than assuming the faster run is better?
+7. **Which reproducibility controls belong in a serious PyTorch training run, and why is a seed alone not enough?**
 
    <details>
    <summary>Answer</summary>
 
-   Compare validation metrics, loss curves, and non-finite loss checks against a known float32 baseline using the same data split and seed where possible. Use automatic mixed precision and gradient scaling rather than manually converting every tensor to half precision. If quality drops, inspect numerically sensitive operations, learning rate, loss scaling behavior, and whether the target hardware supports the chosen lower-precision format well.
+   A serious run should record or set Python, NumPy, and PyTorch seeds, use a seeded `torch.Generator` for reproducible sampling, seed `DataLoader` workers when they call Python or NumPy randomness, record the dataset version or split indices, and document whether deterministic algorithms were enabled. A seed alone is not enough because dataset order, worker libraries, backend kernels, hardware, PyTorch versions, and nondeterministic operations can still change the observed result.
+
    </details>
-
-8. A new model cannot overfit a single tiny batch after hundreds of updates. The full dataset is large and noisy, but the one-batch experiment should be easy. What training components should you debug before changing the architecture?
-
-   <details>
-   <summary>Answer</summary>
-
-   Debug the basic training contract first: labels match the loss, model outputs have the expected shape, parameters are registered, gradients are finite and non-zero, `optimizer.zero_grad()` and `optimizer.step()` occur in the correct order, and preprocessing produces sensible inputs. If a model cannot memorize one fixed batch, adding more data or making the architecture more complex usually hides the underlying loop or data bug rather than solving it.
-   </details>
-
----
 
 ## Hands-On Exercise
 
-In this lab you will build a local PyTorch training workflow, introduce controlled failures, and document the evidence you used to diagnose them. The exercise intentionally withholds completed solution files because the goal is active problem-solving. Use the module content as your reference, and write down predictions before running each script.
+Take the synthetic training skeleton from Part 2 and turn it into a small experiment you can repeat. First run it as written for five epochs and record the final train and validation metrics. Then add a `StepLR` scheduler with `step_size=2` and `gamma=0.5`, save a checkpoint whenever validation loss improves, and reload the best checkpoint after training. Finally, run the same script twice with the same seed and confirm that the printed metrics are close enough for your local hardware and PyTorch build.
 
-### Step 1: Prepare a Local Workspace
+For the mode-discipline check, temporarily remove `model.eval()` from `evaluate()` and add `nn.Dropout(p=0.4)` after the ReLU in `TinyClassifier`. Run validation twice in a row without a training step between the two calls. If validation metrics differ noticeably, you have demonstrated why evaluation mode belongs inside the evaluation function. Restore `model.eval()` afterward and confirm that repeated validation is stable for the same model state.
 
-Create an isolated workspace and install the packages needed for the exercise. Use the explicit virtual-environment Python path when running scripts so the commands behave the same way in shells that have different global Python installations.
+For the checkpoint check, train for two epochs, save a latest checkpoint, create a fresh model/optimizer/scheduler trio, load the checkpoint, and continue training from the returned `start_epoch`. Print the learning rate before and after resume so you can see whether scheduler state survived. If the resumed run restarts the learning-rate schedule at the beginning, your checkpoint is missing scheduler state or loading it in the wrong place.
 
-```bash
-mkdir pytorch-training-lab
-cd pytorch-training-lab
-.venv/bin/python -m venv .venv
-.venv/bin/python -m pip install --upgrade pip
-.venv/bin/python -m pip install torch torchvision numpy
-.venv/bin/python -c "import torch; print(torch.__version__)"
-```
+Success criteria:
 
-- [ ] You created a `pytorch-training-lab` directory.
-- [ ] You created a local `.venv` inside that directory.
-- [ ] You installed `torch`, `torchvision`, and `numpy`.
-- [ ] You verified that importing `torch` prints a version instead of raising an exception.
+- [ ] The training script has separate `train_one_epoch` and `evaluate` functions, and each function owns its required module mode internally.
+- [ ] The checkpoint dictionary contains `model_state_dict`, `optimizer_state_dict`, `scheduler_state_dict`, `epoch`, and `best_metric`.
+- [ ] Repeated validation on the same model state does not change because dropout is disabled by evaluation mode and gradients are not recorded.
+- [ ] The best checkpoint is restored after early stopping or after the final epoch, so the in-memory model matches the best validation metric you report.
+- [ ] The run record includes the seed, PyTorch version, device type, dataset split policy, final metrics, and path to the best checkpoint.
 
-### Step 2: Explore Gradients and Accumulation
+## Key Takeaways
 
-Create `explore_gradients.py`. Your script should create `x = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)` and test four expressions independently: `x.sum()`, `(x ** 2).sum()`, `x.mean()`, and `x.max()`. Before each run, write a comment predicting the gradient, then verify the result with `backward()`.
+The PyTorch training step is the A7 NumPy update loop with better engineering around the same responsibilities. `zero_grad(set_to_none=True)` clears previous gradients, the forward pass builds the graph, the loss produces a scalar objective, `loss.backward()` runs the A8-style reverse graph walk at tensor scale, and `optimizer.step()` performs the parameter update that used to be `W -= lr * dW`.
 
-```python
-import torch
+The full training loop must separate mutation from measurement. Training mode plus gradient recording belongs in the train loop. Evaluation mode plus no-grad belongs in the validation loop. Checkpoints must save enough state to resume optimization, not merely enough weights to run inference. Reproducibility requires seeding multiple libraries, controlling `DataLoader` workers, recording run context, and being honest about hardware and backend limits.
 
-x = torch.tensor([1.0, 2.0, 3.0], requires_grad=True)
+The loop is also your first diagnostic surface. Log train loss, validation loss, and a task metric; overfit one batch before launching a long run; use gradient accumulation only when the loss scaling and step timing are explicit; and restore the best checkpoint when early stopping chooses a validation winner. Later Block B modules will tune initialization, optimizers, regularization, normalization, diagnostics, and precision, but every one of those tools enters through this loop.
 
-tests = [
-    ("sum", x.sum()),
-    ("squared_sum", (x ** 2).sum()),
-    ("mean", x.mean()),
-    ("max", x.max()),
-]
+## Learner check
 
-for name, expression in tests:
-    if x.grad is not None:
-        x.grad.zero_()
+The index row for this rescope is intentionally mirrored here so the module and section index stay tied together:
 
-    expression.backward(retain_graph=True)
-    print(name, x.grad)
-```
-
-Run it with:
-
-```bash
-.venv/bin/python explore_gradients.py
-```
-
-- [ ] You predicted each gradient before executing the script.
-- [ ] You reset gradients between tests or otherwise prevented accidental accumulation.
-- [ ] You explained why `x.max()` produces a sparse gradient for this input.
-- [ ] You modified the script once to demonstrate accumulation deliberately, then restored the correct reset behavior.
-
-### Step 3: Build a Complete MNIST Training Script
-
-Create `train_mnist.py` using the complete training-loop pattern from the module, but write the file yourself rather than pasting blindly. Include a registered `nn.Module`, `CrossEntropyLoss`, Adam or AdamW, train and validation loaders, `model.train()`, `model.eval()`, `torch.no_grad()`, finite-loss checks, and checkpoint saving when validation accuracy improves.
-
-```python
-# Fill this file from the module pattern rather than copying a hidden answer.
-# Required components:
-# - DigitClassifier class inheriting from nn.Module
-# - DataLoader objects for train and validation data
-# - CrossEntropyLoss with raw logits and integer labels
-# - optimizer.zero_grad() before loss.backward()
-# - model.eval() and torch.no_grad() during validation
-# - checkpoint dictionary with model and optimizer state
-```
-
-Run it with:
-
-```bash
-.venv/bin/python train_mnist.py
-```
-
-- [ ] The script downloads or reuses MNIST data successfully.
-- [ ] Training loss is printed at least once per epoch.
-- [ ] Validation accuracy is computed under evaluation mode.
-- [ ] A checkpoint file is written when validation accuracy improves.
-- [ ] Your model uses registered layers that appear in `named_parameters()`.
-
-### Step 4: Create and Fix a Broken Model
-
-Create `debug_model.py` with a deliberately broken model containing these issues: missing `super().__init__()`, layers stored in a plain Python list, `MSELoss` used for multi-class labels, missing `optimizer.zero_grad()`, and validation without evaluation mode or `no_grad()`. Then fix the file one bug at a time and record the symptom that led you to each fix.
-
-```python
-# Intentionally create the broken version first.
-# Then fix one issue at a time and keep a short debugging note for each fix.
-```
-
-Run it with:
-
-```bash
-.venv/bin/python debug_model.py
-```
-
-- [ ] You observed at least one failure before applying fixes.
-- [ ] You replaced the plain Python list with a PyTorch registration mechanism.
-- [ ] You changed the loss-target pair to a valid classification setup.
-- [ ] You added gradient reset in the correct part of the loop.
-- [ ] You used `model.eval()` and `torch.no_grad()` for validation.
-- [ ] You confirmed that the fixed script runs without crashing.
-
-### Step 5: Benchmark CPU and Optional GPU Execution
-
-Create `benchmark_devices.py` and compare matrix multiplication time on CPU and CUDA if CUDA is available. Use synchronization around CUDA timing so your measurements reflect completed work rather than queued kernels.
-
-```python
-import time
-import torch
-
-
-def benchmark(device, size, iterations):
-    x = torch.randn(size, size, device=device)
-    y = torch.randn(size, size, device=device)
-
-    for _ in range(3):
-        _ = x @ y
-
-    if device.type == "cuda":
-        torch.cuda.synchronize()
-
-    start = time.perf_counter()
-
-    for _ in range(iterations):
-        _ = x @ y
-
-    if device.type == "cuda":
-        torch.cuda.synchronize()
-
-    return (time.perf_counter() - start) / iterations
-
-
-for size in [512, 1024, 2048]:
-    cpu_time = benchmark(torch.device("cpu"), size=size, iterations=5)
-    print(f"size={size} cpu_seconds={cpu_time:.6f}")
-
-    if torch.cuda.is_available():
-        gpu_time = benchmark(torch.device("cuda"), size=size, iterations=5)
-        print(f"size={size} gpu_seconds={gpu_time:.6f} speedup={cpu_time / gpu_time:.2f}")
-    else:
-        print(f"size={size} cuda_available=false")
-```
-
-Run it with:
-
-```bash
-.venv/bin/python benchmark_devices.py
-```
-
-- [ ] The script prints timing information for all configured matrix sizes.
-- [ ] CUDA timing uses synchronization when a CUDA device is available.
-- [ ] You explain why small matrix sizes may show less impressive speedup than large sizes.
-- [ ] You connect the benchmark result to a training decision, such as batch size or device choice.
-
-### Step 6: Write a Training Readiness Note
-
-Create `training-readiness.md` summarizing whether your MNIST training script is ready for a longer experiment. Treat this as an engineering review, not a tutorial summary. Include evidence from your runs, the bugs you fixed, and any remaining risks you would address before productionizing the workflow.
-
-- [ ] The note identifies the selected model, loss, optimizer, and device path.
-- [ ] The note includes at least three concrete debugging checks you performed.
-- [ ] The note explains how validation differs from training in your script.
-- [ ] The note states what your checkpoint contains and whether it supports training resume.
-- [ ] The note names at least two risks that would matter for a larger dataset.
-- [ ] The note avoids copying module prose and uses your observed results.
-
----
-
-## Next Module
-
-Next: [Training Deep Networks: Normalization, Regularization & Optimization](/ai-ml-engineering/deep-learning/module-1.4-cnns-computer-vision/) goes deeper on keeping training stable and generalizing well — normalization layers, regularization, weight initialization, and learning-rate schedules — before [Convolutional Neural Networks & Computer Vision](/ai-ml-engineering/deep-learning/module-1.5-rnns-sequence-models/) introduces convolutional architectures and spatial feature learning.
-
----
+> | 1.3 | [The Training Loop: From One Step to a Reproducible Run](/ai-ml-engineering/deep-learning/module-1.3-training-neural-networks/) |
 
 ## Sources
 
-- [PyTorch: An Imperative Style, High-Performance Deep Learning Library](https://arxiv.org/abs/1912.01703) — Primary paper describing PyTorch's imperative execution model, autograd design, and performance goals.
-- [Seppo Linnainmaa](https://en.wikipedia.org/wiki/Seppo_Linnainmaa) — Background on Linnainmaa and the 1970 publication associated with reverse-mode automatic differentiation.
-- [Automatic differentiation](https://en.wikipedia.org/wiki/Automatic_differentiation) — Overview of forward-mode and reverse-mode automatic differentiation and their computational tradeoffs.
-- [Mixed Precision Training](https://arxiv.org/abs/1710.03740) — Primary reference for mixed-precision training, including speed and memory tradeoffs.
-- [Adam: A Method for Stochastic Optimization](https://arxiv.org/abs/1412.6980) — Original paper introducing the Adam optimizer discussed in the module.
+- PyTorch Foundation, "PyTorch 2.12 Release Blog" - https://pytorch.org/blog/pytorch-2-12-release-blog/
+- PyTorch Tutorials, "Training with PyTorch" - https://docs.pytorch.org/tutorials/beginner/introyt/trainingyt.html
+- PyTorch Tutorials, "Saving and Loading Models" - https://docs.pytorch.org/tutorials/beginner/saving_loading_models.html
+- PyTorch 2.12 documentation, `torch.optim.Optimizer.zero_grad` - https://docs.pytorch.org/docs/2.12/generated/torch.optim.Optimizer.zero_grad.html
+- PyTorch 2.12 documentation, `torch.nn.Module.eval` and module mode behavior - https://docs.pytorch.org/docs/2.12/generated/torch.nn.Module.html
+- PyTorch 2.12 documentation, `torch.no_grad` - https://docs.pytorch.org/docs/2.12/generated/torch.no_grad.html
+- PyTorch 2.12 documentation, reproducibility notes and `DataLoader` worker seeding - https://docs.pytorch.org/docs/2.12/notes/randomness.html
+- PyTorch 2.12 documentation, `torch.use_deterministic_algorithms` - https://docs.pytorch.org/docs/2.12/generated/torch.use_deterministic_algorithms.html
+- PyTorch 2.12 documentation, automatic mixed precision deprecation notes for `torch.cuda.amp` - https://docs.pytorch.org/docs/2.12/amp.html
+- Dive into Deep Learning, "Generalization in Deep Learning" - https://d2l.ai/chapter_multilayer-perceptrons/generalization-deep.html
+- Andrej Karpathy, "A Recipe for Training Neural Networks" - https://karpathy.github.io/2019/04/25/recipe/
+- Stanford CS231n, "Neural Networks Part 3: Learning and Evaluation" - https://cs231n.github.io/neural-networks-3/
+
+## Next Module
+
+Next: [Initialization & Signal Propagation](/ai-ml-engineering/deep-learning/module-1.3.1-initialization-signal-propagation/).

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.3.2-optimizers-lr-dynamics.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.3.2-optimizers-lr-dynamics.md
@@ -788,7 +788,7 @@ print(f"Adam final loss: {adam_losses[-1]:.4f}")
 
 ## Next Module
 
-Continue to [Training Deep Networks: Normalization, Regularization & Optimization](/ai-ml-engineering/deep-learning/module-1.4-cnns-computer-vision/) — the practical training-stability toolkit that builds directly on optimizer and learning-rate choices.
+Continue to [Regularization & Generalization](/ai-ml-engineering/deep-learning/module-1.3.3-regularization-generalization/) — dropout, weight decay, early stopping, and label smoothing: the toolkit for closing the gap between training and test performance, building directly on the optimizer and learning-rate choices from this module.
 
 ---
 

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.3.3-regularization-generalization.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.3.3-regularization-generalization.md
@@ -1,0 +1,582 @@
+---
+title: "Regularization & Generalization"
+slug: ai-ml-engineering/deep-learning/module-1.3.3-regularization-generalization
+sidebar:
+  order: 1004.3
+---
+
+> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 4-6 hours
+>
+> **Prerequisites**: Module 1.1.5 (Loss Functions — stable softmax cross-entropy), Module 1.1.7 (Tiny NumPy NN Lab — manual SGD loop), Module 1.3 (Training Neural Networks — PyTorch training loop, validation discipline), Module 1.3.1 (Initialization & Signal Propagation), Module 1.3.2 (Optimizers & Learning-Rate Dynamics — weight decay vs AdamW).
+>
+> **Primary tools**: PyTorch 2.12, `torch.nn`, `torch.optim`, NumPy, Matplotlib (optional plotting).
+
+---
+
+Hypothetical scenario: a computer-vision team ships a ResNet that achieves 99.8% training accuracy on a curated internal dataset of 2,000 labeled images. Demo day goes well. Two weeks later, the model is deployed against real warehouse footage and misclassifies roughly one in four frames — worse than a linear baseline trained on the same labels. Post-mortem review reveals the training script never held out a validation set, the model had twenty times more parameters than training examples, and dropout was accidentally left disabled during the final "evaluation" run that produced the 99.8% headline number. The team did not fail because regularization is mysterious; they failed because they never measured the gap between memorization and generalization, and they treated training accuracy as a proxy for production quality.
+
+That gap — the difference between performance on data the model has seen during optimization and performance on genuinely new data drawn from the same underlying distribution — is the central engineering problem of supervised deep learning. In Block A you derived cross-entropy by hand and watched a tiny NumPy network memorize XOR before generalizing to Fashion-MNIST. In Block B you replaced the manual update loop with PyTorch and learned how initialization and optimizers control whether training converges at all. This module addresses the next question: even when training loss goes to zero, why does test loss often stay high, and what engineering levers close that gap without throwing away representational power?
+
+Every regularization technique in this module trades something on the training set — usually peak accuracy or loss — for better behavior on unseen data. None of them replaces the discipline of a held-out validation set, careful hyperparameter tuning, or honest reporting. They are, however, the standard toolkit that makes large models trainable on finite data, and each one maps cleanly onto intuition you already built in earlier modules. The Block B spine continues here: when you write `nn.Dropout(0.5)`, you are implementing the same random masking idea you could write in NumPy in twenty lines; when you pass `label_smoothing=0.1`, you are changing the target vector in the cross-entropy you coded in Module 1.1.5. PyTorch did not invent regularization — it industrialized patterns you already understand.
+
+---
+
+## Learning Outcomes
+
+By the end of this module, you will be able to:
+
+1. **Define** overfitting precisely using simultaneous training and validation curves, and **diagnose** capacity mismatch (model size vs dataset size) using a controlled PyTorch experiment.
+2. **Implement** inverted dropout with `nn.Dropout`, **explain** why scaling by `1/(1−p)` at train time makes inference deterministic, and **configure** train vs `.eval()` behavior correctly in a full loop.
+3. **Apply** weight decay through the optimizer interface, **reference** the decoupled AdamW mechanics from Module 1.3.2 without conflating L2-in-gradient with true weight decay, and **select** typical penalty strengths for dense networks.
+4. **Build** early stopping with validation monitoring, patience, and best-checkpoint restoration, and **configure** label smoothing via `nn.CrossEntropyLoss(label_smoothing=ε)` connected back to Module 1.1.5's cross-entropy derivation.
+5. **Compare** data augmentation, stochastic depth, DropPath, and weight averaging (EMA/SWA) at a practitioner level, and **design** a combined regularization stack tuned on validation metrics rather than test leakage.
+
+---
+
+## Why This Module Matters
+
+A model that minimizes training loss is solving the wrong problem if your deployment environment presents inputs the optimizer never saw. Production ML systems fail quietly on this point: dashboards show declining training loss while validation loss creeps upward, and nobody notices until a downstream service starts returning nonsense. The engineering skill is not memorizing a list of regularizers; it is reading the train–validation gap, choosing interventions that address the diagnosed failure mode, and verifying that each intervention improves generalization rather than merely slowing convergence. Incident post-mortems in mature ML organizations almost always include a loss-curve replay; teams that log only training metrics discover overfitting only after customer impact.
+
+Regularization also connects the Block A from-scratch story to modern PyTorch idioms in a way that demystifies "magic" defaults. Dropout is not a mysterious regularizer bolted onto `nn.Module`; it is a train-time random mask with a deterministic inference path you can implement in ten lines. Weight decay is not separate from optimization; it is a penalty on weight magnitude that you already saw implicitly when Module 1.3.2 explained why AdamW decouples L2 from adaptive scaling. Label smoothing is not a hack for leaderboard points; it is a direct modification of the cross-entropy target distribution you derived in Module 1.1.5, discouraging logits from exploding toward ±∞ on easy examples. When you read a published recipe listing dropout 0.1, weight decay 0.05, and label smoothing 0.1 together, you should see three independent answers to the same question: how do we stop this model from memorizing?
+
+Finally, regularization choices interact. Dropout changes effective learning rate; weight decay interacts with initialization from Module 1.3.1; batch normalization (covered next in Module 1.3.4) has its own regularizing side effects. Practitioners who treat each knob independently often over-regularize — training loss stalls while validation barely moves — or under-regularize — validation improves for three epochs then degrades while training loss still falls. This module teaches you to compose the toolkit deliberately and tune on validation data, reserving the test set for a single final report. The engineering mindset is iterative diagnosis: measure the gap, apply one intervention, re-measure, document what moved.
+
+---
+
+## Part 1: The Generalization Problem
+
+### 1.1 Overfitting in Precise Terms
+
+**Overfitting** occurs when a model's predictions fit the training sample including its noise, idiosyncrasies, and sampling artifacts, rather than the underlying pattern that would transfer to new draws from the same distribution. Operationally, you observe it as **training error continuing to improve while validation error worsens or plateaus below training performance**. It is not enough to say "training accuracy is high"; overfitting is a *divergence* between train and validation curves over time or capacity.
+
+Consider a binary classification task with a small dataset. A linear model may underfit: both train and validation loss stay high because capacity is too low to capture the decision boundary. A moderately sized MLP may fit well: train and validation loss decrease together and stabilize at similar values. An enormous MLP with more parameters than examples can achieve near-zero training loss while validation loss rises — classic overfitting. The pattern is not about absolute accuracy numbers; it is about **divergence**. A model at 95% train and 94% validation is healthy; a model at 99.9% train and 82% validation is overfitting even if 82% beats your baseline.
+
+The **bias–variance tradeoff** frames the same phenomenon statistically. **Bias** is error from overly rigid assumptions (underfitting). **Variance** is error from sensitivity to training-set fluctuations (overfitting). Total expected error decomposes (under idealized assumptions) into bias, variance, and irreducible noise. Increasing model capacity reduces bias but typically increases variance; regularization pushes variance down, sometimes at the cost of slightly higher bias, seeking a better total error on unseen data. In practice you rarely compute bias and variance explicitly for a ResNet, but the vocabulary explains why adding capacity without regularization eventually hurts validation metrics even as training metrics keep improving.
+
+### 1.2 Capacity, Data, and the Train/Val/Test Split
+
+**Model capacity** is the effective flexibility of the function class your architecture and training procedure can represent. Depth, width, parameter count, and training duration all increase capacity. **Dataset size** and **label quality** constrain how much capacity you can use productively. A rule of thumb practitioners internalize: if your model has orders of magnitude more parameters than independent training examples, you need strong regularization, more data, or both.
+
+The **train/validation/test split** is non-negotiable engineering hygiene:
+
+| Split | Purpose | Used during training? |
+|-------|---------|----------------------|
+| **Train** | Update weights via backprop | Yes — every step |
+| **Validation** | Tune hyperparameters, pick checkpoints, compare architectures | Yes — for decisions, never for gradients |
+| **Test** | Final unbiased estimate of generalization | No — touch once at the end |
+
+Leakage happens when validation or test examples influence weight updates (e.g., tuning on test loss, or augmenting validation into training without relabeling splits). Module 1.3 established the evaluation loop with `model.eval()` and `torch.no_grad()`; this module assumes that loop exists and adds *what to monitor* (validation loss, not training loss alone) and *what to do when the gap widens*. Stratified splits matter for imbalanced classes: a random 80/10/10 split may leave rare classes with zero validation examples, making validation accuracy a noisy proxy that hides overfitting on head classes while the tail memorizes.
+
+### 1.3 Monitoring the Gap in Practice
+
+Production training pipelines should log **both** `train_loss` and `val_loss` every epoch (or every N steps for step-based training) to the same dashboard. The actionable signal is the **delta**: if train loss falls 20% over five epochs while val loss rises 5%, you are in the overfitting region regardless of absolute val performance. Set alerts on val loss divergence, not only on training failure. Checkpoint on best val metric, not latest epoch — Module 1.3's checkpointing section pairs directly with the early stopping logic in Part 4.
+
+When datasets are tiny, k-fold cross-validation estimates generalization more reliably than a single split, at the cost of k training runs. For engineering workflows with one fixed split, report val metrics with confidence intervals from bootstrap resampling if the validation set has fewer than a few thousand examples. The goal is the same: never optimize hyperparameters against noise you cannot measure.
+
+### 1.4 Underfitting, Overfitting, and the Goldilocks Region
+
+Diagnosis precedes prescription. Use train and validation curves together to classify behavior before adding regularizers:
+
+| Symptom | Train loss | Val loss | Likely diagnosis | First lever (not always regularization) |
+|---------|------------|----------|------------------|----------------------------------------|
+| Both high, similar | High | High | Underfitting | More capacity, train longer, better features, lower weight decay |
+| Train low, val high | Low | High or rising | Overfitting | Dropout, weight decay, augmentation, early stopping |
+| Both low, similar | Low | Low | Good fit | Monitor for drift; avoid unnecessary regularization |
+| Train low, val noisy | Low | Oscillates | Small val set or high variance | More val data, k-fold, EMA weights |
+
+Underfitting with heavy regularization is a common mistake after reading this module. If you add dropout 0.5, weight decay 0.1, and label smoothing 0.2 simultaneously on a already-small model, train accuracy may stall near chance while validation looks equally poor — you regularized away the model's ability to learn signal. Back off regularizers until train performance is acceptable, then tighten until validation stops improving.
+
+### 1.5 A Minimal Overfitting Demo in PyTorch 2.12
+
+The following script trains a deliberately oversized MLP on a tiny subset of Fashion-MNIST. Watch train accuracy approach 100% while validation accuracy stalls or drops:
+
+```python
+import torch
+import torch.nn as nn
+from torch.utils.data import DataLoader, Subset
+from torchvision import datasets, transforms
+
+torch.manual_seed(0)
+device = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+# Tiny train set (500 images), full test set for "validation"
+transform = transforms.ToTensor()
+full_train = datasets.FashionMNIST(root="./data", train=True, download=True, transform=transform)
+test_set = datasets.FashionMNIST(root="./data", train=False, download=True, transform=transform)
+
+train_subset = Subset(full_train, range(500))  # 500 samples
+train_loader = DataLoader(train_subset, batch_size=64, shuffle=True)
+val_loader = DataLoader(test_set, batch_size=256, shuffle=False)
+
+class HugeMLP(nn.Module):
+    def __init__(self):
+        super().__init__()
+        # ~1.6M parameters — far more than 500 examples
+        self.net = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(28 * 28, 2048),
+            nn.ReLU(),
+            nn.Linear(2048, 2048),
+            nn.ReLU(),
+            nn.Linear(2048, 10),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+
+model = HugeMLP().to(device)
+criterion = nn.CrossEntropyLoss()
+optimizer = torch.optim.Adam(model.parameters(), lr=1e-3)
+
+def accuracy(loader):
+    model.eval()
+    correct, total = 0, 0
+    with torch.no_grad():
+        for x, y in loader:
+            x, y = x.to(device), y.to(device)
+            pred = model(x).argmax(dim=1)
+            correct += (pred == y).sum().item()
+            total += y.size(0)
+    return correct / total
+
+for epoch in range(30):
+    model.train()
+    for x, y in train_loader:
+        x, y = x.to(device), y.to(device)
+        optimizer.zero_grad(set_to_none=True)
+        loss = criterion(model(x), y)
+        loss.backward()
+        optimizer.step()
+    train_acc = accuracy(train_loader)
+    val_acc = accuracy(val_loader)
+    print(f"epoch {epoch:02d}  train_acc={train_acc:.3f}  val_acc={val_acc:.3f}")
+```
+
+Typical output pattern (exact numbers vary with seed): train accuracy climbs above 0.95 by epoch 10 and toward 1.0 by epoch 25, while validation accuracy peaks around 0.78–0.82 early and may drift downward as training continues. That divergence is the signature you will recognize in production logs if you plot both curves — which you should, every run. Logging only `train_loss` is how teams discover overfitting weeks after deployment; logging `val_loss` alongside it turns the problem into a same-day hyperparameter decision.
+
+If you shrink the hidden width from 2048 to 128 while keeping 500 training samples, the train–validation gap usually narrows without any explicit regularizer — capacity alone moved you along the bias–variance curve. That ablation is worth running once: it separates "my model is too big for my data" from "my optimization is broken." Module 1.3.1 taught you that initialization controls whether signal propagates; this module assumes signal propagates and asks whether the model **uses** that signal to learn generalizable structure or to memorize labels.
+
+```ascii
+  loss / error
+      |
+      |   training loss  ----\
+      |                         \___  keeps falling
+      |   validation loss  ---\      \
+      |                        \______/  rises or flatlines
+      +---------------------------------> epochs
+              ^ overfitting region
+```
+
+---
+
+## Part 2: Dropout — Random Subnetworks at Train Time
+
+### 2.1 Mechanism and Inverted Dropout
+
+**Dropout** (Srivastava et al., 2014) randomly zeroes activations with probability `p` during training. For an activation vector `h`, a mask `m ~ Bernoulli(1−p)` element-wise multiplies: `h' = m ⊙ h`. Intuitively, each forward pass trains a thinned subnetwork; across many passes, the full network behaves like an ensemble of exponentially many sparse networks whose predictions are averaged at test time. With `n` hidden units, there are `2^n` possible subnetworks in principle; dropout samples one per step rather than training each explicitly.
+
+**Inverted dropout** scales surviving activations by `1/(1−p)` during training so that **inference requires no scaling**. If you did not scale at train time, expected activation magnitude at train would be `(1−p)` times inference magnitude, and you would need to multiply by `(1−p)` at test — easy to forget in a codebase with twelve model variants. PyTorch's `nn.Dropout(p)` implements inverted dropout: train multiplies by `1/(1−p)` on kept units; eval passes activations through unchanged. The scaling preserves the expected value of each activation **conditional on the input to the dropout layer**, which is why deeper stacks can stack many dropout layers without systematic shrinkage at inference.
+
+```python
+import torch
+import torch.nn as nn
+
+x = torch.ones(4, 8)  # batch=4, features=8
+drop = nn.Dropout(p=0.5)
+drop.train()
+y_train = drop(x)
+print(y_train[0])  # roughly half zeros, half 2.0 (because 1/(1-0.5)=2)
+
+drop.eval()
+y_eval = drop(x)
+print(torch.equal(y_eval, x))  # True — identity at eval
+```
+
+### 2.2 Where to Place Dropout
+
+Place dropout **after activation functions** in fully connected stacks, not on the raw logits layer before softmax/cross-entropy. Dropping logits arbitrarily changes the implied class prior; dropping hidden activations encourages redundant distributed representations that survive random unit removal. In transformer blocks, dropout appears on attention weights, residual outputs, and embedding layers — each location regularizes a different pathway; the same "after nonlinearity" intuition applies to MLP sublayers inside a block.
+
+Typical dropout rates vary by architecture generation. Classic fully connected nets on MNIST-era tasks often used `p=0.5` on hidden layers. Modern ResNets and ViTs frequently use lighter dropout (`p=0.1`–`0.2`) because batch normalization (Module 1.3.4) and massive datasets already constrain overfitting. When you inherit a recipe from a paper, treat dropout rate as dataset-dependent: CIFAR-scale with 50k images tolerates more than a 500-image fine-tuning job.
+
+| Layer type | Typical `p` | Notes |
+|------------|-------------|-------|
+| Input / embedding | 0.1–0.2 | Light — preserve information |
+| Hidden FC layers | 0.3–0.5 | Standard for MLPs |
+| CNN conv layers | 0.1–0.3 | Often lower; spatial correlation matters |
+| Output logits | 0 | Do not dropout the head |
+
+In Module 1.3 you learned that `model.train()` and `model.eval()` toggle not only BatchNorm statistics (Module 1.3.4 preview) but also dropout behavior. A validation pass with `model.train()` left on silently applies random masks — validation metrics become noisy and optimistically biased if you average many stochastic forward passes, or pessimistically biased if a single unlucky mask zeros critical units.
+
+### 2.3 Ensemble Interpretation and Back-Reference to Your MLP
+
+During training with dropout, each mini-batch optimizes a different subnetwork. At inference, the full network with all units active approximates the geometric mean of those subnetworks' predictions (under certain assumptions). That is why dropout reduces co-adaptation: neuron A cannot rely exclusively on neuron B always being present, because B may be dropped. Co-adaptation is particularly harmful with small data — two units may jointly memorize a spurious pixel pattern that disappears when one unit is removed.
+
+Compare to Module 1.1.7's `Layer` class: there, every hidden unit participated in every forward pass. Dropout is the engineering admission that, with finite data, full co-adaptation memorizes. Random omission forces robust features — the same reason bagging random forests reduces variance. From a backprop perspective, gradients flow only through surviving units in a given step; dropped units receive zero gradient for that step, which slows their individual updates but encourages alternate pathways to carry information. You do not need to implement that masking manually — `nn.Dropout` registers as an `nn.Module` and respects `model.train()` / `model.eval()` the same way BatchNorm will in the next module.
+
+```python
+class MLPWithDropout(nn.Module):
+    def __init__(self, p=0.3):
+        super().__init__()
+        self.net = nn.Sequential(
+            nn.Flatten(),
+            nn.Linear(784, 256),
+            nn.ReLU(),
+            nn.Dropout(p=p),
+            nn.Linear(256, 128),
+            nn.ReLU(),
+            nn.Dropout(p=p),
+            nn.Linear(128, 10),
+        )
+
+    def forward(self, x):
+        return self.net(x)
+```
+
+Re-run the overfitting demo from Part 1 with `p=0.4` after each ReLU. Validation accuracy typically improves and the train–val gap narrows, though peak train accuracy may fall — the intended trade. At inference, standard practice uses the deterministic full network (`model.eval()`). **Monte Carlo dropout** — running multiple stochastic forward passes at test time with dropout enabled and averaging predictions — is an optional refinement that approximates the ensemble average more closely; it costs latency and is rarely used in production vision serving, but it clarifies the train-time ensemble story.
+
+### 2.4 Dropout and Effective Learning Rate
+
+Dropout implicitly reduces the magnitude of activations that reach downstream layers (despite inverted scaling on survivors, the mask zeros information). Practitioners often find they can use a slightly higher learning rate with dropout than without, because the noise acts as a form of gradient regularization. If you add dropout and training stalls, try increasing learning rate modestly before removing dropout — the interaction with AdamW from Module 1.3.2 is empirical, not purely predictable from theory.
+
+---
+
+## Part 3: Weight Decay and the L2 View
+
+### 3.1 Penalizing Large Weights
+
+**Weight decay** adds a penalty proportional to the squared L2 norm of weights. In the regularization view, the objective becomes:
+
+```
+L_total = L_data + (λ/2) · ||W||²
+```
+
+Large weights allow sharp, wiggly decision boundaries that fit noise. Penalizing magnitude encourages smoother functions — similar spirit to early stopping, but applied every gradient step. The scalar `λ` (or its optimizer-specific analogue) controls strength. Geometrically, weight decay pulls parameters toward the origin, shrinking the volume of parameter space reachable under a fixed learning-rate budget. For linear models, L2 regularization corresponds to a Gaussian prior on weights; the MAP estimate trades off data fit against prior belief that weights are small.
+
+In PyTorch you usually pass **`weight_decay`** to the optimizer rather than adding an explicit L2 term to the loss, because optimizers apply decay with the correct coupling to momentum buffers and (for AdamW) decoupled scaling:
+
+```python
+optimizer = torch.optim.AdamW(
+    model.parameters(),
+    lr=3e-4,
+    weight_decay=0.01,  # typical range 1e-4 to 1e-1 depending on scale
+)
+```
+
+### 3.2 Reference Module 1.3.2 — Do Not Conflate Mechanisms
+
+Module 1.3.2 already explained that **L2 regularization baked into the gradient is not equivalent to decoupled weight decay under Adam**. Classic `Adam` adds L2 penalty to the gradient before adaptive scaling, so parameters with large second-moment estimates get weakened regularization. **`AdamW`** applies weight decay directly on weights after the adaptive update — the configuration you want when "weight decay" means "keep weights small" uniformly.
+
+This module owns the *generalization motivation* for weight decay. Module 1.3.2 owns the *optimizer mechanics*. When you tune `weight_decay=0.01` on AdamW, you are regularizing; when you mistakenly use L2-in-loss with Adam on a transformer, you may get inconsistent effective penalties across layers. If training underfits (train and val both poor), reduce weight decay; if overfitting persists with dropout, increase it modestly. A useful diagnostic: plot L2 norm of all parameters epoch-by-epoch. Steady growth alongside rising validation loss suggests decay is too weak; flat norm with stalled validation may mean decay is too strong relative to learning rate.
+
+Typical starting points for dense image classifiers: `1e-4` to `1e-2` on AdamW, always validated on a held-out set. Weight decay interacts with initialization (Module 1.3.1): poorly scaled init plus aggressive decay can stall learning entirely. Convolutional layers and bias terms are sometimes excluded from decay in legacy recipes; PyTorch applies `weight_decay` to all parameters in the optimizer group unless you construct separate param groups with `weight_decay=0` for biases and normalization scale parameters — a pattern you will see in vision transformer training scripts.
+
+Explicit L2 in the loss (`loss = ce_loss + 0.5 * lambda * sum(p.pow(2).sum() for p in model.parameters())`) is equivalent to weight decay under pure SGD, which is why older tutorials combine them. With AdamW, prefer the optimizer argument — duplicating both paths double-counts the penalty. Module 1.3.2's Adam versus AdamW discussion is the reference when a codebase mixes styles across files.
+
+---
+
+## Part 4: Early Stopping — Regularization by Truncation
+
+### 4.1 Monitoring Validation Loss
+
+**Early stopping** halts training when validation loss stops improving for `patience` epochs (or steps), then restores weights from the best validation checkpoint. It limits **effective capacity** by preventing the optimizer from continuing into the overfitting regime where training loss still decreases but validation loss increases. Unlike dropout or weight decay, early stopping adds no noise to forward passes and no penalty term to the objective — it only controls **how long** you optimize. That makes it the first regularizer to try when compute is expensive and the model architecture is already fixed.
+
+Tie this directly to Module 1.3's loop: you already compute validation loss inside `torch.no_grad()` with `model.eval()`. Early stopping adds bookkeeping — track the best epoch, deep-copy `state_dict()`, and break the loop when improvement stalls:
+
+```python
+import copy
+
+best_val_loss = float("inf")
+best_state = None
+patience = 5
+epochs_without_improve = 0
+
+for epoch in range(max_epochs):
+    train_one_epoch(model, train_loader, optimizer, criterion)
+    val_loss = evaluate_loss(model, val_loader, criterion)
+
+    if val_loss < best_val_loss:
+        best_val_loss = val_loss
+        best_state = copy.deepcopy(model.state_dict())
+        epochs_without_improve = 0
+    else:
+        epochs_without_improve += 1
+        if epochs_without_improve >= patience:
+            print(f"Early stop at epoch {epoch}")
+            break
+
+model.load_state_dict(best_state)
+```
+
+You can wrap the same logic in a small helper class or use community libraries, but the state machine is always: track best, count stalls, restore on stop. Module 1.3's checkpointing recommendation — save `state_dict()` on improvement — is the persistence layer for this pattern. In distributed training, only rank zero should write the best checkpoint to avoid race conditions on shared filesystems.
+
+### 4.2 Relationship to the Manual Training Loop (Module 1.1.7)
+
+In Module 1.1.7 you stopped training after a fixed epoch count because the NumPy lab prioritized clarity over production concerns. Early stopping is the production replacement for that fixed horizon: instead of `for epoch in range(50)`, you ask whether epoch 50 is justified by validation evidence. The manual loop's `W -= lr * dW` still runs every step; early stopping only decides when to halt and which `W` to keep. Combining early stopping with the AdamW schedule from Module 1.3.2 is standard — cosine annealing may still run for the full planned budget while early stopping exits early if validation saturates, or you couple them by reducing LR when validation plateaus (ReduceLROnPlateau scheduler).
+
+### 4.3 Patience, Checkpoints, and Implicit Regularization
+
+**Patience** balances noise and responsiveness. Validation loss is stochastic — especially with small validation sets — so `patience=1` stops on single-batch noise; `patience=20` may waste compute deep into overfitting. Values of 3–10 epochs are common for medium datasets. Step-based patience (number of optimizer steps without improvement) is preferable when epochs are enormous — fine-tuning a LLM may never complete a full epoch over billions of tokens.
+
+Save **`state_dict()`** (or full checkpoints with optimizer state if you will resume training). Early stopping is not merely "stop the loop"; it is "revert to the best generalizing parameters." Production training jobs should persist the best checkpoint to object storage, not the final epoch weights. When you reload for deployment, document which validation metric selected that checkpoint so incident reviewers can trace model lineage.
+
+Framed as regularization, early stopping restricts the **path length** through parameter space. The trajectory that minimizes training loss may pass through regions that generalize well early, then wander into memorization valleys. Stopping is cheaper than dropout when compute is the bottleneck — but it does not help if the model overfits within the first epoch (you need architectural or data-side fixes). Combining early stopping with dropout is standard: dropout slows memorization per epoch, early stopping cuts off epochs when memorization wins anyway.
+
+---
+
+## Part 5: Label Smoothing — Softening the Cross-Entropy Target
+
+### 5.1 From One-Hot to Smoothed Distributions
+
+Module 1.1.5 derived **cross-entropy** against a one-hot target: true class probability 1, others 0. That objective pushes logits for the correct class toward +∞ and all others toward −∞ — optimal for hard classification on infinite data, but on finite samples it encourages **over-confident predictions** that do not calibrate and can hurt generalization. Recall the stable softmax-CE implementation you wrote: subtract row max before `exp`, compute log-probabilities, dot with one-hot. Label smoothing changes only the target vector in that dot product — the forward numerics stay identical.
+
+**Label smoothing** replaces the one-hot vector `y` with:
+
+```
+y_smooth[k] = (1 - ε) + ε / K    if k == y_true
+            = ε / K              otherwise
+```
+
+for `K` classes and smoothing factor `ε` (often 0.1). PyTorch's `nn.CrossEntropyLoss(label_smoothing=ε)` distributes the smoothing mass **uniformly over all K classes**, so the true class keeps `(1−ε) + ε/K` rather than `(1−ε)` alone. Szegedy et al. (2016) originally used `ε/(K−1)` on the non-target classes only; the built-in PyTorch argument uses the uniform `ε/K` form instead. The model is trained to predict a slightly uncertain distribution, penalizing extreme logits even when the example is easy. Worked example for `K=10`, `ε=0.1`, true class index 3: target vector entries are **0.91** at index 3 and **0.01** at each of the other nine indices; cross-entropy against that target still penalizes a prediction of `[10, -10, -10, ...]` because the non-target logits are far from their smoothed targets, not from zero.
+
+PyTorch 2.12 exposes label smoothing directly on the loss module so you do not hand-build the target tensor on every batch:
+
+```python
+criterion = nn.CrossEntropyLoss(label_smoothing=0.1)
+logits = model(x)  # shape: (batch, 10)
+loss = criterion(logits, y)  # y: integer class indices, shape (batch,)
+```
+
+Internally, `CrossEntropyLoss` combines `log_softmax` with the smoothed target distribution — the same stable softmax-CE pipeline you implemented in Module 1.1.5, with a different target vector. You can verify equivalence on a toy batch by constructing the smoothed target manually and using `F.kl_div` or `- (target * log_softmax).sum(dim=1).mean()`; the built-in argument applies the uniform `ε/K` smoothing for you, so you never hand-build the smoothed target.
+
+### 5.2 Calibration and Generalization
+
+**Calibration** means predicted probabilities match empirical frequencies: among examples assigned 80% confidence, roughly 80% should be correct. Overfit models often assign 99.9% confidence to training memorized points while being wrong on shifted data. Label smoothing reduces the incentive to produce arbitrarily sharp logits, which often improves expected calibration on validation and test sets (Szegedy et al., 2016). Temperature scaling at inference is a separate post-hoc calibration technique; label smoothing acts during training.
+
+Label smoothing interacts with weight decay and dropout: all three discourage memorization of exact label boundaries. It does **not** replace handling class imbalance (that requires different techniques like weighted CE or focal loss). Typical `ε` values: 0.05–0.2 for ImageNet-scale classification; start with 0.1 when experimenting. Very large ε approaches uniform targets and can underfit; if train accuracy collapses, reduce smoothing before removing dropout. On imbalanced datasets, label smoothing applies uniformly across classes — minority classes receive the same `ε/K` mass on non-target slots, which can slightly help or hurt depending on base rates; monitor per-class validation recall when experimenting.
+
+### 5.3 Connection to Softmax Temperature and Inference Calibration
+
+At inference, some practitioners apply **temperature scaling** — dividing logits by T > 1 before softmax — to soften over-confident predictions without retraining. Label smoothing acts during training to prevent the model from learning infinitely sharp logits in the first place. The two techniques address calibration at different stages; smoothing is cheaper at deployment because it requires no held-out calibration set, though post-hoc temperature tuning on a validation slice can still help if production calibration drift appears.
+
+---
+
+## Part 6: Data Augmentation — Expanding the Effective Dataset
+
+**Data augmentation** applies label-preserving transformations to inputs at train time: random crops, flips, color jitter, cutouts, and similar perturbations. Each epoch presents slightly different views of the same underlying example, which enlarges the **effective training set** without collecting new labels. The regularization mechanism is not mystery noise — it **encodes invariances** the model should satisfy. If a horizontal flip does not change whether an image is a cat, training on flipped copies teaches the network that left-right position is irrelevant to the label, so it cannot memorize a spurious pixel pattern tied to one orientation. Augmentation is often the **strongest** regularizer in vision pipelines — stronger than moderate dropout on modern CNNs and ViTs — because it attacks overfitting at the input boundary where memorization of raw pixel patterns begins.
+
+Concrete vision examples make the principle tangible. **Random horizontal flip** (`RandomHorizontalFlip`) is standard on natural images where mirror symmetry preserves class identity. **Random crop with padding** (`RandomCrop` with `padding=4` on CIFAR-sized images) forces the model to recognize objects that are partially occluded or off-center rather than relying on a fixed background framing. **Color jitter** (small random shifts in brightness, contrast, saturation, and hue) prevents the network from overfitting to lighting conditions in a small studio dataset — a common failure mode when deployment cameras differ from training capture. Each transform must preserve semantic label: a horizontal flip preserves "cat vs dog"; a 90° rotation may not preserve "6 vs 9" in digit recognition unless your problem definition treats rotation as label-preserving.
+
+**Mixup** (Zhang et al., 2018) forms convex combinations of two input images and their one-hot labels, training the model on interpolated examples with soft targets — effectively merging augmentation and label smoothing in one step. **CutMix** (Yun et al., 2019) replaces a rectangular patch of one image with a patch from another and blends labels proportionally to the patch area, forcing the model to classify from partial context rather than memorizing global texture shortcuts. Both appear frequently in competitive vision training recipes; Module 1.4 (CNNs and computer vision) will implement full image-augmentation pipelines with `torchvision.transforms.v2`. Here the takeaway is architectural: augmentation is regularization through **input noise**, dropout through **activation noise**, weight decay through **parameter noise**. Stacking all three without monitoring validation loss often yields underfitting — the model never sees a clean example during training.
+
+A typical `torchvision.transforms` training pipeline composes deterministic preprocessing with stochastic augmentations; evaluation uses only the deterministic steps:
+
+```python
+# Sketch — full pipelines in the CNN module
+train_transform = transforms.Compose([
+    transforms.RandomHorizontalFlip(p=0.5),
+    transforms.RandomCrop(28, padding=4),
+    transforms.ColorJitter(brightness=0.2, contrast=0.2),
+    transforms.ToTensor(),
+])
+# Eval: no random transforms — only deterministic preprocessing
+eval_transform = transforms.ToTensor()
+```
+
+Pass `train_transform` to `datasets.*(..., transform=train_transform)` for the training split and `eval_transform` for validation and test. The `DataLoader` then serves augmented batches only during training; validation metrics reflect performance on clean, consistently preprocessed inputs — the same discipline as `model.eval()` for dropout.
+
+For tabular or text models where geometric transforms do not apply, analogous regularizers include feature noise injection, token dropout (randomly masking input tokens during training), and back-translation for text augmentation. The unifying idea remains label-preserving perturbation of inputs so the optimizer cannot rely on exact memorization of raw features. Vision dominates the augmentation literature because spatial invariances are well understood; the engineering transfer to other modalities is conceptual, not a copy-paste of `RandomCrop`.
+
+---
+
+## Part 7: Modern Regularizers — Brief Practitioner Survey
+
+### 7.1 Stochastic Depth and DropPath
+
+**Stochastic depth** (Huang et al., 2016) randomly **drops entire residual blocks** during training rather than individual activations. For a network with `L` blocks, block `l` is skipped with probability that increases with depth — shallow blocks almost always run, deep blocks are dropped more often. When a block is dropped, its residual contribution is zeroed and the input flows through the skip connection unchanged; surviving blocks are scaled so inference uses the full depth deterministically. The regularization effect is an **implicit ensemble over depths**: each training step optimizes a shallower subnetwork, and the full model at inference approximates an average over those depth configurations. This matters for very deep ResNets where per-activation dropout under-utilizes depth — dropping whole blocks forces the network to produce useful representations even when several layers are absent, reducing co-adaptation across the entire stack.
+
+**DropPath** applies the same idea to **individual sub-branches within a residual path**, which is the dominant pattern in vision transformers (ViTs) and hierarchical transformers like Swin. Instead of dropping an entire transformer block, DropPath may zero the output of the attention sublayer or the MLP sublayer before it is added back to the residual stream, with drop probability often scheduled to increase in deeper stages. Like stochastic depth, the surviving branch is scaled at train time so eval requires no adjustment. The intuition matches dropout's ensemble story but at coarser granularity: the model cannot rely on any single deep pathway always being present, so it distributes information across skip connections and shallower routes. You will encounter `DropPath` in timm and Hugging Face vision model configs; the `drop_path_rate` hyperparameter controls maximum drop probability at the deepest layer.
+
+### 7.2 Weight Averaging — EMA and SWA
+
+**Exponential moving average (EMA)** of model weights maintains a shadow copy updated each step: `θ_ema ← β·θ_ema + (1−β)·θ`. EMA weights often generalize better than raw training weights because they average out noise from mini-batch gradients — high-frequency oscillations along steep loss-surface directions cancel while the consistent descent toward a broad minimum accumulates. Geometrically, EMA traces a **smoothed path through weight space**, landing closer to flat regions of the loss landscape where small perturbations do not spike validation error. Diffusion and generative model training frequently deploy EMA copies for sampling even while the online weights continue optimizing aggressively.
+
+**Stochastic Weight Averaging (SWA)** (Izmailov et al., 2018) collects weight snapshots from the latter portion of training — or from multiple points along a learning-rate schedule — and averages them element-wise. SWA targets **wider optima**: individual SGD trajectories may oscillate within a narrow valley, but their average often sits in a flatter basin with better test error. SWA differs from EMA in mechanism: EMA tracks every step with exponential decay, while SWA may average only a handful of checkpoints from an explicitly flat region after warmup. Both methods regularize by **smoothing the parameter path** rather than injecting noise into forward passes. PyTorch does not ship a single `EMA` module in core `nn`, but libraries and training loops implement it in a dozen lines around `optimizer.step()`. When validation loss is noisy but trending down, comparing EMA or SWA weights against raw weights on validation is a low-cost generalization check before deployment.
+
+---
+
+## Part 8: Composing the Toolkit — Engineering Practice
+
+No single regularizer fixes all overfitting. A practical stack for a medium-sized classifier might include:
+
+| Technique | What it regularizes | Typical cost |
+|-----------|---------------------|--------------|
+| Train/val split + early stopping | training duration / path | compute saved |
+| Weight decay (AdamW) | parameter magnitude | slight underfit risk |
+| Dropout | co-adapted activations | lower train accuracy |
+| Label smoothing | logit sharpness | softer train CE |
+| Data augmentation | input memorization | longer epochs to converge |
+| Init (Module 1.3.1) | explosive activations | indirect |
+| Normalization (Module 1.3.4) | internal covariate shift | indirect + sometimes less dropout need |
+
+Tune on **validation** metrics. Adding dropout and weight decay simultaneously may over-regularize; ablate one knob at a time. Plot train and validation loss on the same axes every run. If validation improves when you remove a regularizer, you were over-penalizing. A practical ablation order for a new vision task: (1) establish baseline train/val curves with only early stopping, (2) add augmentation if inputs are images, (3) add weight decay on AdamW, (4) add dropout if gap persists, (5) add label smoothing if logits look over-confident on validation reliability diagrams.
+
+Normalization layers (BatchNorm, LayerNorm — Module 1.3.4) reduce internal drift and carry their own mild regularization via batch noise at train time; they are not substitutes for held-out validation but often let you use slightly higher learning rates and less dropout. Good initialization (Module 1.3.1) prevents early divergence so regularizers can act during meaningful learning rather than during recovery from blow-up. When BatchNorm is present, dropout before the next linear layer is sometimes reduced because normalized activations already vary across batches.
+
+The test set remains sacred: one final evaluation after all choices are frozen. Reporting test numbers while still tweaking augmentation strength is the same leakage as tuning on test loss directly. Document your validation protocol in experiment metadata — split ratios, seed, whether test was touched — so cross-family reviewers and future you can trust the generalization claims.
+
+```python
+# Combined example — not a full training script, but idiomatic PyTorch 2.12
+model = MLPWithDropout(p=0.3).to(device)
+criterion = nn.CrossEntropyLoss(label_smoothing=0.1)
+optimizer = torch.optim.AdamW(model.parameters(), lr=3e-4, weight_decay=0.01)
+
+# Inside train loop (Module 1.3 pattern):
+model.train()
+optimizer.zero_grad(set_to_none=True)
+loss = criterion(model(x), y)
+loss.backward()
+optimizer.step()
+
+# Validation + early stopping bookkeeping from Part 4
+# DataLoader uses augmentation in train_transform only (Part 6)
+```
+
+When reporting results to stakeholders, separate **training metrics** (useful for debugging convergence) from **validation metrics** (useful for model selection) and reserve **test metrics** for the final acceptance gate. A common anti-pattern in internal demos is showing monotonically improving training accuracy while validation flatlines — this module's opening scenario is fiction, but the failure mode appears in real organizations that optimize for demo metrics. Honest reporting of the train–validation gap builds trust and saves rework when models reach production.
+
+Choosing regularization strength is not a one-time architectural decision. Transfer learning often starts with a frozen backbone and small head: weight decay on the head only, light dropout, heavy augmentation on the new domain. Full fine-tuning increases capacity utilization and usually demands stronger regularization or early stopping because the backbone can adapt to spurious patterns in a small target dataset. The validation curve tells you which regime you are in within the first few epochs — if validation degrades while train improves on epoch 2, intervene immediately rather than waiting for a 100-epoch schedule to finish.
+
+Hyperparameter search over regularizer strengths should use validation loss or validation accuracy as the objective, never test performance. Random search over `(dropout_p, weight_decay, label_smoothing)` with ten to twenty trials often finds a workable combination faster than grid search, because regularizer interactions are nonlinear — the best dropout at `weight_decay=0` may differ from the best dropout at `weight_decay=0.01`. Log every trial with seed and split hash so results are reproducible when a reviewer asks why you chose `p=0.3` instead of `p=0.5`.
+
+---
+
+## Did You Know?
+
+- **Dropout was originally motivated by preventing co-adaptation of feature detectors** in deep networks, not by ensemble theory — the ensemble interpretation came later and helped explain why inverted scaling at train time matches test-time averaging (Srivastava et al., 2014, JMLR).
+- **Label smoothing was popularized in the Inception-v2/v3 line of work** as "label smoothing regularization" and became a default trick in large-scale image classification because it consistently improved top-1 accuracy and calibration on ImageNet (Szegedy et al., 2016).
+- **Early stopping is equivalent to L2 regularization in linear models** under certain quadratic approximations of the loss — the number of training iterations and the weight decay coefficient are coupled, which is why you should not tune both blindly without validation curves.
+- **Mixup and CutMix treat augmentation and label smoothing as one operation** by training on convex combinations of examples and their labels, which is why competitive vision recipes often enable them together rather than stacking many other regularizers on top.
+
+---
+
+## Common Mistakes
+
+| Mistake | Problem | Solution |
+|---------|---------|----------|
+| Validating with `model.train()` | Dropout and BatchNorm train behavior corrupt metrics | Call `model.eval()` before validation; use `torch.no_grad()` |
+| No validation split | Cannot detect overfitting until production | Hold out validation data; never tune on test |
+| Dropout on logits layer | Distorts class scores unpredictably | Dropout after hidden activations only; keep output head dense |
+| Using `Adam` L2 instead of `AdamW` for weight decay | Uneven regularization across parameters | Use `AdamW` with `weight_decay=` as in Module 1.3.2 |
+| Training until train loss = 0 | Often maximizes overfitting | Monitor val loss; apply early stopping |
+| Tuning all regularizers on test set | Optimistic bias; false confidence | Tune on validation; test once at end |
+| Forgetting `1/(1−p)` scaling when implementing custom dropout | Train/inference mismatch | Use `nn.Dropout` or scale explicitly |
+
+---
+
+## Quiz
+
+1. **You observe training loss decreasing while validation loss increases after epoch 15. Name this phenomenon and list two interventions from this module that address it.**
+
+   <details>
+   <summary>Answer</summary>
+   This is **overfitting** — the model improves on training data while generalization worsens. Interventions include **dropout** (reduce co-adaptation), **weight decay** (penalize large weights), **early stopping** (restore best validation checkpoint), **label smoothing** (reduce logit over-confidence), and **data augmentation** (expand effective training diversity). In practice you would apply one or two at a time, tuning on validation loss rather than training loss.
+   </details>
+
+2. **Why does PyTorch `nn.Dropout(p=0.5)` multiply surviving activations by 2 during training but apply no scaling during evaluation?**
+
+   <details>
+   <summary>Answer</summary>
+   This is **inverted dropout**. During training, each unit is kept with probability `1−p`, so the expected activation magnitude is `(1−p)` times the input unless compensated. Multiplying survivors by `1/(1−p)` restores expected magnitude to match inference, when all units are active. At eval, dropout is disabled and activations pass through unchanged — no extra scaling needed. Without inverted dropout, you would multiply by `(1−p)` at test time, which is easy to forget and causes train/test skew.
+   </details>
+
+3. **How does label smoothing with ε=0.1 change the target distribution for a 10-class problem when the true label is class 3?**
+
+   <details>
+   <summary>Answer</summary>
+   Class 3 receives probability `(1 − ε) + ε/K = 0.9 + 0.01 = 0.91`. Each of the other nine classes receives `ε / K = 0.1 / 10 = 0.01`. Cross-entropy then penalizes logits that are infinitely sharp toward class 3, encouraging the model to maintain modest logits on non-target classes — improving calibration and often generalization compared to hard one-hot targets from Module 1.1.5.
+   </details>
+
+4. **You use `torch.optim.Adam(model.parameters(), lr=1e-3, weight_decay=0.01)` and read that this applies L2 regularization. Why might Module 1.3.2 recommend `AdamW` instead for weight decay?**
+
+   <details>
+   <summary>Answer</summary>
+   In classic **Adam**, L2 penalty gradients are added to the adaptive gradient before division by root second moments, so parameters with larger historical gradient magnitudes experience **weaker effective regularization**. **AdamW** decouples weight decay: it shrinks weights directly after the Adam update step, applying uniform L2-style decay independent of adaptive scaling. For generalization, AdamW's decoupled decay matches the intended "keep all weights small" regularization view.
+   </details>
+
+5. **Early stopping with patience=3 restores the best validation checkpoint. Explain how this acts as implicit regularization even without dropout or weight decay.**
+
+   <details>
+   <summary>Answer</summary>
+   Early stopping truncates optimization before the model fully minimizes training loss in regions where validation error rises. It limits **effective model complexity along the optimization trajectory** — similar in spirit to restricting the norm of the solution in linear models. The best checkpoint often lies at an intermediate epoch where bias and variance trade off favorably; continuing training increases variance (memorization) without validation benefit.
+   </details>
+
+6. **Why is data augmentation often stronger than dropout for convolutional image classifiers?**
+
+   <details>
+   <summary>Answer</summary>
+   Augmentation increases **diversity of inputs** the network must handle — translations, flips, and photometric changes simulate new examples with the same label — directly addressing finite dataset size. Dropout only perturbs internal activations given whatever inputs appear; if inputs are limited, the network can still memorize specific pixels. Augmentation also avoids destroying spatial structure as aggressively as high dropout on conv features. Both can be combined, but augmentation is usually the first lever in vision.
+   </details>
+
+---
+
+## Hands-On Exercise
+
+**Task**: Starting from the Part 1 overfitting demo (500-sample Fashion-MNIST subset, oversized MLP), implement a regularization ablation: baseline, +dropout, +weight decay, +label smoothing, +early stopping. Compare validation accuracy curves across configurations and record which combination yields the best validation peak without touching the test set.
+
+Follow the numbered steps below in order. Copy the Part 1 script into a single runnable file and record train and validation accuracy per epoch for 30 epochs as your baseline with no regularization beyond the Adam optimizer. Then add `nn.Dropout(p=0.4)` after each ReLU, re-run, and compare epoch-wise train versus validation accuracy — expect a narrower gap and lower peak train accuracy. Switch to `AdamW(..., weight_decay=0.01)` with dropout disabled for one run to isolate weight decay, noting the validation peak epoch. Combine your best findings: use `CrossEntropyLoss(label_smoothing=0.1)` with dropout and AdamW together. Finally, implement early stopping with `patience=5` and restore `best_state`, comparing final validation accuracy of the restored checkpoint against the epoch-29 weights.
+
+When you finish all runs, confirm the success criteria below. Each item is a verifiable outcome; if any fails, rerun the range test or verify you selected regularizer strengths on validation data only.
+
+- [ ] Baseline shows train accuracy above 0.95 with validation plateau or decline below 0.85.
+- [ ] At least one regularized configuration improves best validation accuracy by two or more absolute points over baseline.
+- [ ] Early-stopped checkpoint beats final-epoch checkpoint on validation accuracy when overfitting is present.
+- [ ] All validation passes call `model.eval()` before computing metrics.
+
+Use the verification snippet below to print best validation accuracy after each configuration:
+
+```python
+# After each configuration, assert you used eval mode for validation
+assert not model.training
+val_acc = accuracy(val_loader)
+print(f"best val_acc={val_acc:.3f}")
+# Expect combined reg stack: val_acc often 0.82-0.88 vs baseline 0.78-0.82
+```
+
+---
+
+## Key Takeaways
+
+1. **Generalization is measured by the train–validation gap**, not training loss alone. Overfitting is train improving while validation worsens — diagnose it with curves before reaching for regularizers.
+2. **Dropout trains an ensemble of subnetworks** via inverted dropout (`nn.Dropout` scales by `1/(1−p)` at train time); always toggle `model.eval()` for validation and deployment.
+3. **Weight decay penalizes large weights** for smoother functions; use `AdamW`'s `weight_decay` per Module 1.3.2 rather than assuming L2-in-loss works identically under adaptive optimizers.
+4. **Early stopping is cheap, implicit regularization** — monitor validation loss, keep the best checkpoint, and stop when patience exhausts.
+5. **Label smoothing softens one-hot targets** in `CrossEntropyLoss`, connecting back to Module 1.1.5's CE while reducing over-confident logits and improving calibration.
+6. **Data augmentation is often the highest-leverage regularizer in vision**; modern additions include Mixup/CutMix, stochastic depth, DropPath, and EMA/SWA for parameter-path smoothing.
+7. **Compose regularizers deliberately and tune on validation**; normalization (Module 1.3.4) and initialization (Module 1.3.1) interact with the stack — ablate one knob at a time.
+
+---
+
+## Sources
+
+- Srivastava, N., Hinton, G., Krizhevsky, A., Sutskever, I., & Salakhutdinov, R. (2014). Dropout: A Simple Way to Prevent Neural Networks from Overfitting. *Journal of Machine Learning Research, 15*(1), 1929–1958. https://jmlr.org/papers/v15/srivastava14a.html
+- Szegedy, C., Vanhoucke, V., Ioffe, S., Shlens, J., & Wojna, Z. (2016). Rethinking the Inception Architecture for Computer Vision. *arXiv:1512.00567*. https://arxiv.org/abs/1512.00567
+- Huang, G., Sun, Y., Liu, Z., Sedra, D., & Weinberger, K. Q. (2016). Deep Networks with Stochastic Depth. *arXiv:1603.09382*. https://arxiv.org/abs/1603.09382
+- Goodfellow, I., Bengio, Y., & Courville, A. (2016). *Deep Learning*. MIT Press. Chapter 7: Regularization. https://www.deeplearningbook.org/contents/regul.html
+- Zhang, A., Lipton, Z. C., Li, M., & Smola, A. J. (2023). *Dive into Deep Learning* — Weight Decay. https://d2l.ai/chapter_linear-regression/weight-decay.html (see also Chapter 5 Dropout: https://d2l.ai/chapter_multilayer-perceptrons/dropout.html)
+- PyTorch 2.12 `nn.Dropout` documentation. https://pytorch.org/docs/stable/generated/torch.nn.Dropout.html
+- PyTorch 2.12 `CrossEntropyLoss` documentation. https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html
+- PyTorch 2.12 `torch.optim.AdamW` documentation. https://pytorch.org/docs/stable/generated/torch.optim.AdamW.html
+- Izmailov, P., Podoprikhin, D., Garipov, T., Vetrov, D., & Wilson, A. G. (2018). Averaging Weights Leads to Wider Optima and Better Generalization. *arXiv:1803.05407*. https://arxiv.org/abs/1803.05407
+- Zhang, H., Cisse, M., Dauphin, Y. N., & Lopez-Paz, D. (2018). mixup: Beyond Empirical Risk Minimization. *arXiv:1710.09412*. https://arxiv.org/abs/1710.09412
+- Yun, S., Han, D., Oh, S. J., Chun, S., Choe, J., & Yoo, Y. (2019). CutMix: Regularization Strategy to Train Strong Classifiers with Localizable Features. *arXiv:1905.04899*. https://arxiv.org/abs/1905.04899
+
+---
+
+## Next Module
+
+Continue to [Normalization Layers](/ai-ml-engineering/deep-learning/module-1.3.4-normalization-layers/) — how BatchNorm, LayerNorm, and related techniques stabilize internal activations, interact with dropout and weight decay, and carry their own regularizing effects during training.
+
+---
+
+## Learner check
+
+> | 1.3.3 | [Regularization & Generalization](/ai-ml-engineering/deep-learning/module-1.3.3-regularization-generalization/) |

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.3.4-normalization-layers.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.3.4-normalization-layers.md
@@ -1,0 +1,663 @@
+---
+title: "Normalization Layers"
+slug: ai-ml-engineering/deep-learning/module-1.3.4-normalization-layers
+sidebar:
+  order: 1004.4
+---
+
+> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 4-5 hours
+>
+> **Prerequisites**: Module 1.3.1 (Weight Initialization — understanding activation and gradient variance across depth), Module 1.3.2 (Optimizers & LR Dynamics — how effective step size interacts with gradient scale), and Module 1.1.7 (Tiny NumPy NN Lab — you hand-wrote the training loop where activation statistics went unmonitored).
+>
+> **Primary tools**: PyTorch 2.12, `torch.nn.BatchNorm1d/2d`, `torch.nn.LayerNorm`, `torch.nn.RMSNorm`, `torch.nn.GroupNorm`.
+
+---
+
+In early 2015, Sergey Ioffe and Christian Szegedy posted a paper to arXiv titled "Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift." The paper was short — nine pages — and the core idea was startlingly simple: after every layer, re-standardize the activations to zero mean and unit variance using the statistics of the current mini-batch, then let the network learn an affine transformation (scale γ and shift β) on top of the normalized values. The authors reported that adding batch normalization to a then-standard Inception network allowed them to train the model 14 times faster, reach higher accuracy, and eliminate the need for dropout in many configurations. Within two years, BatchNorm was a default architectural component — not an optional trick or a hyperparameter to tune, but a layer you included in every convolutional block as routinely as a ReLU.
+
+The story behind BatchNorm's invention speaks to a pain every practitioner has felt. Deep networks were finicky. Before BatchNorm, training a deep convolutional network meant weeks of tuning learning rates, monitoring gradient norms, and hoping the initialization was good enough to survive the first thousand steps. The problem was not that the theory was wrong — backpropagation had been known for decades, and the SGD update rule was correct — but that the interaction between weight updates and activation statistics was poorly understood. Every training step changed the weights, every weight change shifted the activation distribution at the next layer, and the downstream layers had to continuously re-adapt to a moving target. The deeper the network, the more layers there were to compound the drift, and the harder training became. BatchNorm's elegance was that it attacked the problem not at the optimizer or the architecture but at the activation itself: don't let the distribution drift in the first place.
+
+Ioffe and Szegedy's hypothesis — that this drift, which they called "internal covariate shift," was the root cause of training instability — turned out to be partially wrong, and understanding why is essential to understanding what normalization layers actually do. Santurkar et al. (2018) designed an elegant experiment to test the internal-covariate-shift hypothesis directly. They trained networks with BatchNorm but injected explicit, time-varying noise (a random per-step shift and scale) after each BN layer, deliberately reintroducing — even amplifying — covariate shift throughout training. These "noisy-BN" networks trained essentially as well as standard BN networks, despite having large, unstable activation distributions. If internal covariate shift reduction were the mechanism by which BatchNorm accelerated training, this deliberate amplification of covariate shift should have harmed performance. It did not. The result is a knockout: BatchNorm helps training through a different mechanism entirely.
+
+What Santurkar and colleagues found is that BatchNorm smooths the loss landscape. More precisely, the gradient of the loss with respect to the parameters has a smaller Lipschitz constant in BatchNorm-trained networks — the gradient changes less abruptly as you move through parameter space. A smoother landscape means that (a) the gradient at your current position is a better predictor of the gradient a step ahead, so larger learning rates are safer; (b) the loss is less sensitive to small parameter perturbations, improving generalization; and (c) the optimizer is less likely to get stuck in sharp minima that correspond to poor generalization performance on unseen data. The practical takeaway is important enough to restate: normalization layers do not work by keeping input distributions fixed. They work by reparameterizing the optimization problem in a way that makes gradient descent more effective. This is a more nuanced claim than the original paper's framing, and it explains a puzzle the original theory could not resolve — namely, why normalization helps even in shallow three-layer networks where internal covariate shift is negligible.
+
+The normalization family has grown well beyond BatchNorm. Layer Normalization (Ba et al., 2016) normalizes across features per sample, making it batch-independent and the natural choice for recurrent networks and Transformers where batch composition and sequence length are variable. RMSNorm (Zhang & Sennrich, 2019) drops the mean-centering step from LayerNorm entirely, normalizing by root-mean-square only — the cheaper operation that modern LLMs like LLaMA and Mistral now use at every attention and feed-forward sub-layer. Group Normalization (Wu & He, 2018) divides channels into groups and normalizes within each group, providing batch-independent normalization for vision tasks where GPU memory constraints force batch sizes of 2 or 4 — object detection on high-resolution images, medical image segmentation, video understanding. InstanceNorm, the extreme case of GroupNorm with one group per channel, is the normalizer at the heart of neural style transfer.
+
+In Module 1.3.1 you learned that weight initialization sets the *starting* activation scale so that the network is trainable at step zero. Normalization layers are the mechanism that *maintains* trainable activation scale as training proceeds. Where initialization is the first engineering decision — applied once, at network creation — normalization is the ongoing decision, re-applied every forward pass, and its correct configuration determines whether the optimizer's carefully chosen hyperparameters remain valid throughout training. Misconfiguring normalization — using batch statistics in evaluation mode, normalizing over the wrong axis, forgetting the mode toggle — produces silent correctness bugs that degrade deployed accuracy by 1-5% without ever raising an error, raising a NaN, or crashing the process. This module teaches you the exact computation inside every normalization layer, the train-vs-eval behavior that distinguishes them, and how to choose one for a given architecture.
+
+---
+
+## Learning Outcomes
+
+By the end of this module, you will be able to:
+
+1. **Implement** BatchNorm's forward pass — including the running-mean update rule `running = (1−momentum)·running + momentum·batch_stat` and the train-vs-eval statistics switch — in both raw PyTorch tensor operations and the `nn.BatchNorm` API, and **verify** that a normalized feature channel has mean ≈ 0 and std ≈ 1.
+
+2. **Derive** the normalized axes for BatchNorm (batch + spatial), LayerNorm (feature), RMSNorm (feature, no mean subtraction), and GroupNorm (grouped channels), and **predict** which normalizers are batch-dependent versus batch-independent from their normalization axes alone.
+
+3. **Diagnose** the small-batch BatchNorm failure mode — noisy μ and σ estimates producing inaccurate training-time normalization and drift between training and inference statistics — and **select** GroupNorm or LayerNorm as the appropriate replacement when batch sizes fall below 8.
+
+4. **Compare** the empirical effect of BatchNorm against Santurkar et al.'s loss-smoothing hypothesis and **select** the appropriate normalizer for a given architecture: BatchNorm for large-batch vision CNNs, LayerNorm for Transformers and sequence models, RMSNorm for modern LLMs, GroupNorm for small-batch vision, and InstanceNorm for style transfer.
+
+5. **Place** a normalization layer correctly in a residual block — pre-norm vs post-norm — and **explain** why pre-norm training is more stable at initialization, permitting deeper networks to train without specialized warmup schedules.
+
+---
+
+## Why This Module Matters
+
+Consider a fifty-layer convolutional network trained with perfectly tuned He initialization (Module 1.3.1), AdamW (Module 1.3.2), and a well-chosen cosine learning-rate schedule. Step zero: every activation has standard deviation near 1.0, gradients flow cleanly, the optimizer's adaptive buffers see well-scaled signals. Now take one optimizer step. The weights change. The activation distribution at layer 25 shifts — not dramatically, but the mean might drift from 0.02 to 0.07, the standard deviation from 1.0 to 1.3. Another hundred steps: the shift compounds. By step 1,000, the optimizer is receiving gradients whose scale, direction, and conditioning are all different from what the initialization promised. The loss landscape your learning-rate schedule was designed around has deformed.
+
+This drift is not a bug. It is a mathematical inevitability of updating weights in a composition of nonlinear functions. Every weight matrix in every layer participates in a forward computation that multiplies its input by the weight values; when those values change, the output distribution changes, and lower layers experience the cumulative effect of all upstream changes. The only question is how you respond to the drift. Without normalization, you respond by lowering the learning rate — giving the optimizer smaller, more cautious steps to avoid the worst consequences of a shifting landscape, paying for stability with wall-clock time and sometimes with final accuracy because the optimizer cannot explore the parameter space aggressively enough. With normalization, you respond by re-standardizing activations at every layer, keeping the signal in roughly the same range throughout training so that the optimizer's carefully chosen hyperparameters remain valid from step 1 to step 100,000.
+
+The back-reference thread from this module to the Block A from-scratch material is direct and concrete. In Module 1.1.6 you derived backpropagation VJPs by hand: `dL/dx = dL/dy · W^T`, and you traced how gradient magnitude compounds across layers exactly like activation magnitude compounds in the forward pass. In Module 1.1.7 you trained a tiny three-layer MLP and updated weights with the manual rule `W -= lr * dW` — a training loop that implicitly relied on activations staying roughly unit-scale through a shallow network where drift was negligible because there were only two weight matrices to compound errors through. In Module 1.1.8 you built a scalar autograd engine (the `Value` class) that computed gradients through arbitrary computation graphs by traversing backward through every operation, including element-wise transforms. Normalization layers are the engineering solution to the problem you didn't have at depth 3 but that becomes dominant at depth 30 and 50 and 100: the multiplication of many layers amplifying small distribution shifts into large, training-destabilizing changes. When you call `loss.backward()` in PyTorch and the autograd engine traces through a normalization layer, it computes exactly the VJP of the normalization operation `y = (x − μ)/σ · γ + β` — the same kind of VJP you derived by hand in A6, node by node, but now applied to a multi-input operation where the statistics μ and σ are themselves functions of the batch. The engine is doing what you did on paper, and if you understand the VJP structure you can predict how gradient flow through a normalization layer differs from gradient flow through a bare linear layer.
+
+The train-vs-eval behavior of BatchNorm is the single most common source of silent accuracy bugs in production deep learning. A model trained with `model.train()` and deployed with `model.eval()` uses different statistics — in training, the per-batch mean and variance; in evaluation, the frozen running-mean and running-variance buffers accumulated during training. If you forget the mode toggle, or if your inference framework (ONNX, TensorRT, CoreML, a handwritten C++ inference loop) doesn't faithfully reproduce the PyTorch BatchNorm eval-mode computation, the deployed model normalizes with the wrong statistics. The outputs look reasonable — no NaN, no crash, no obviously wrong prediction — but systematically differ from the training-time behavior, degrading accuracy by 1-5% in production. This bug survives basic smoke tests, passes unit tests that compare single-sample outputs across frameworks, and only surfaces when someone computes aggregate metrics over a real test set and notices the degradation. This module teaches you not just the "what" but the "how to verify" — the ten-line probe you can run before deploying any model to confirm that your normalization layers are using the statistics you think they are using.
+
+There is also a subtler reason this module matters: normalization layers are not optional polish or a hyperparameter to try if training is unstable. They are architectural decisions that interact with every other component of the training pipeline. The choice of BatchNorm versus LayerNorm determines whether your model's predictions depend on batch composition. The choice of pre-norm versus post-norm placement in residual blocks determines whether your hundred-layer Transformer can train without a 10,000-step warmup schedule. The `momentum` parameter in BatchNorm — a number whose default value of 0.1 is rarely changed — determines how many batches of history inform the running statistics and therefore how long you must train before the running statistics stabilize. A practitioner who treats normalization as a black-box layer that "just works" will eventually encounter a regime — small batch size, variable-length sequences, distributed training across unevenly loaded GPUs — where the black box stops working and the training loss curve becomes inexplicable. This module gives you the mental model to open the box and fix it.
+
+---
+
+## Part 1: Why Normalize — Activation Statistics Drift, Measured
+
+Before introducing any normalization layer, run the experiment that forces you to see the problem. The goal is to measure activation statistics in a deep network, take one training step, and observe that even with perfect He initialization the activation distribution shifts measurably. The shift is small after one step — but training involves thousands of steps, and the small per-step drift compounds.
+
+### 1.1 Drift after one update
+
+The experiment is straightforward: build a depth-30 MLP with He initialization (the best practice from Module 1.3.1), pass a batch of random inputs through it, record the per-layer activation standard deviations, then run one SGD step with a dummy loss and measure again. The numbers you see depend on the random seed and the specific architecture, but the pattern is consistent: deeper layers drift more because they accumulate the effect of weight changes in all preceding layers.
+
+```python
+import torch
+import torch.nn as nn
+
+torch.manual_seed(42)
+depth, width = 30, 256
+batch = 128
+
+# Build a deep ReLU MLP with He init
+layers = []
+for i in range(depth):
+    lin = nn.Linear(width, width)
+    nn.init.kaiming_normal_(lin.weight, nonlinearity='relu')
+    nn.init.zeros_(lin.bias)
+    layers.append(lin)
+    layers.append(nn.ReLU())
+
+model = nn.Sequential(*layers)
+model.train()
+
+x = torch.randn(batch, width)
+
+# Measure activation stds (no autograd needed)
+with torch.no_grad():
+    h = x
+    pre_update_stds = []
+    for name, module in model.named_children():
+        h = module(h)
+        if isinstance(module, nn.ReLU):
+            pre_update_stds.append(h.std().item())
+    print(f"Before training — layer 1 std: {pre_update_stds[0]:.3f}, "
+          f"layer 15 std: {pre_update_stds[14]:.3f}, "
+          f"layer 30 std: {pre_update_stds[-1]:.3f}")
+
+# One real training step: a FRESH forward WITH autograd, then backward
+optimizer = torch.optim.SGD(model.parameters(), lr=1e-4)
+optimizer.zero_grad(set_to_none=True)
+out = model(x)                 # fresh forward, grad enabled
+loss = out.mean()              # bounded dummy objective for demonstration
+loss.backward()
+optimizer.step()
+
+# Record activation stds AFTER one update, same input
+with torch.no_grad():
+    h = x
+    post_update_stds = []
+    for name, module in model.named_children():
+        h = module(h)
+        if isinstance(module, nn.ReLU):
+            post_update_stds.append(h.std().item())
+    print(f"After 1 SGD step  — layer 1 std: {post_update_stds[0]:.3f}, "
+          f"layer 15 std: {post_update_stds[14]:.3f}, "
+          f"layer 30 std: {post_update_stds[-1]:.3f}")
+```
+
+Even with He initialization, the standard deviation at the deepest layers shifts after a single SGD step — with seed 42 and the code above, layer 15 moves from 0.757 to 0.755 and layer 30 from 1.292 to 1.279, though the exact before/after pair depends on the random seed and the specific pattern of weight updates. The direction of the shift is not the point; what matters is that it happens at all, and that it compounds. With a bounded mean loss and a learning rate of 1e-4 the one-step shift is modest, but training for 10,000 steps at this learning rate means 10,000 opportunities for the distribution to drift further, and the optimizer must navigate a loss surface whose geometry changes as the weight values change.
+
+### 1.2 The original hypothesis (and why it's incomplete)
+
+Ioffe and Szegedy (2015) framed the problem they were solving as "internal covariate shift": the distribution of each layer's inputs changes during training because the parameters of all preceding layers change. Their proposed fix — re-standardize layer inputs to zero mean and unit variance, then let the network learn an affine transformation on top — made intuitive sense. A layer trained to expect inputs with mean zero and variance one would not need to waste capacity adapting to shifting input statistics. The normalization decoupled the layers: each layer could assume stable input statistics regardless of what the preceding layers were doing.
+
+This framing is elegant and was widely cited for years. It is also, as Santurkar et al. demonstrated, not the mechanism by which BatchNorm actually helps. The Santurkar experiment was devilishly simple: they trained networks with BatchNorm but injected explicit, time-varying noise (a random per-step shift and scale) after each BN layer, deliberately reintroducing — even amplifying — covariate shift throughout training. These "noisy-BN" networks trained essentially as well as standard BN networks, despite having large, unstable activation distributions. If internal covariate shift reduction were the mechanism, this deliberate amplification of covariate shift should harm performance. It did not.
+
+The mechanism Santurkar identified is loss-landscape smoothing. BatchNorm reparameterizes the optimization so that the loss function L(θ) has a smaller Lipschitz constant with respect to the weights θ — meaning that ‖∇L(θ₁) − ∇L(θ₂)‖ ≤ C · ‖θ₁ − θ₂‖ with a smaller constant C. A smaller Lipschitz constant means the gradient is a more reliable direction signal: the first-order Taylor approximation ∇L(θ)·Δθ is accurate over larger steps Δθ, so you can increase the learning rate without risking the instability that occurs when you step past the radius where the linear approximation holds. Empirically, networks with BatchNorm tolerate learning rates 5× to 30× higher than networks without it, directly because the smoother landscape makes gradient descent's local-linearity assumption valid over longer distances.
+
+The practical insight is worth internalizing: normalization layers are not primarily about fixing activation distributions. They are about making the optimization problem numerically better-conditioned. This is why normalization helps even in shallow networks (where internal covariate shift is minimal), why it helps with optimizers like Adam that already adapt per-parameter step sizes, and why the specific form of normalization matters less than you might think — LayerNorm, RMSNorm, and GroupNorm all provide loss-landscape smoothing through different axes, and the differences between them are more about batch-dependence and computational cost than about fundamentally different mechanisms.
+
+### 1.3 The back-reference: why init alone is not enough
+
+Module 1.3.1 taught you that initialization sets `Var(W) = 2/n_in` (He) or `Var(W) = 2/(n_in + n_out)` (Xavier) so that the activation standard deviation stays near 1.0 *at step zero*. That analysis assumed the weights are random and independent — an assumption that holds exactly before the first gradient step and becomes increasingly wrong as training proceeds. Once training begins, weights within the same layer become correlated with each other, weights across layers become correlated through the gradient signal, and the simple variance-propagation formula `Var(out) = n_in · Var(W) · Var(in)` derived under the independence assumption no longer accurately predicts the activation scale.
+
+You can initialize perfectly and still watch activation statistics drift by step 1,000. The initialization fixes the problem at t=0; normalization fixes it at every t > 0. Normalization layers can be thought of as "continuous re-initialization" — after every layer, after every batch, they pull activations back toward zero mean and unit variance regardless of what the preceding weights are doing. This redundancy with initialization is not wasteful. It is the engineering principle of defense in depth: initialization gives you a good starting point, and normalization keeps you there throughout training. The combination of good initialization and normalization is more robust than either alone because each addresses a different time scale of the drift problem — static vs dynamic, step zero vs all steps.
+
+---
+
+## Part 2: Batch Normalization
+
+### 2.1 The exact computation
+
+For a mini-batch of size `m`, consider a single feature channel. Let the values of that feature across the batch be `x₁, x₂, ..., xₘ`. For `BatchNorm1d`, these are the `m` values of one feature across the batch. For `BatchNorm2d`, these are the `m × H × W` activations of one channel — the normalization pools over batch and spatial dimensions together. BatchNorm computes four quantities in sequence:
+
+```
+μ_B = (1/m) · Σ x_i                       ← batch mean
+σ²_B = (1/m) · Σ (x_i − μ_B)²            ← batch variance (biased estimator)
+x̂_i = (x_i − μ_B) / √(σ²_B + ε)          ← normalize
+y_i = γ · x̂_i + β                          ← scale and shift
+```
+
+The learnable parameters γ (gamma, scale) and β (beta, shift) are one pair per feature channel. The constant ε is small — PyTorch defaults to `1e-5` — and exists solely to prevent division by zero when the batch variance is exactly zero (which can happen when a feature is constant across the batch, e.g., for dead ReLU units that output zero for every sample). The affine transformation by γ and β is not optional: without it, every layer's output would be forced to exactly zero mean and unit variance, stripping the network of the ability to represent transformations that change the scale or shift the mean. The learnable affine parameters restore the representational capacity that the normalization step removes, and the network learns, per channel, the optimal scale and shift for the downstream computation.
+
+### 2.2 The PyTorch equivalent, built by hand
+
+To make every step of the operation concrete, here is a manual implementation that produces identical results to `nn.BatchNorm1d` (up to floating-point precision). The key detail is the `dim=0` argument on `.mean()` and `.var()`: normalizing over the batch dimension means every feature channel gets its own μ and σ² computed from the batch samples alone, and no information crosses between feature channels during normalization.
+
+```python
+import torch
+import torch.nn as nn
+
+torch.manual_seed(0)
+batch, features = 32, 16
+x = torch.randn(batch, features)  # (32, 16)
+
+# Manual BatchNorm1d — step by step
+eps = 1e-5
+mu = x.mean(dim=0, keepdim=True)         # (1, 16) — mean over batch dimension
+var = x.var(dim=0, unbiased=False, keepdim=True)  # (1, 16) — biased variance
+x_hat = (x - mu) / torch.sqrt(var + eps) # (32, 16)
+
+gamma = nn.Parameter(torch.ones(features))
+beta  = nn.Parameter(torch.zeros(features))
+y_manual = gamma * x_hat + beta           # (32, 16)
+
+# PyTorch built-in — configure to always use batch stats for comparison
+bn = nn.BatchNorm1d(features, eps=eps, affine=True,
+                    momentum=None, track_running_stats=False)
+# momentum=None + track_running_stats=False: always batch stats, no buffers
+bn.weight.data.copy_(gamma)
+bn.bias.data.copy_(beta)
+
+y_pytorch = bn(x)
+
+print(f"Max difference: {(y_manual - y_pytorch).abs().max().item():.2e}")
+# Expected: ~1e-7 or smaller
+
+# Verify normalization: each feature should have ~0 mean, ~1 std
+# (before the affine transform, with γ=1 and β=0, these are exact)
+print(f"Feature 0 mean: {y_manual[:, 0].mean().item():.4f}")
+print(f"Feature 0 std:  {y_manual[:, 0].std(unbiased=False).item():.4f}")
+# With initial γ=1, β=0: mean ≈ 0.0, std ≈ 1.0
+```
+
+For `BatchNorm2d`, the normalization pools over three dimensions — batch, height, and width — for each channel independently. The effective sample size for the statistics is `N × H × W` per channel. With batch=32 and spatial size 28×28, that is 25,088 values per channel, giving very stable estimates of μ and σ² even if the per-channel distribution is non-Gaussian. This is why BatchNorm works so well at large batch sizes: the statistics are computed from tens of thousands of values and the sampling error is negligible.
+
+### 2.3 Train vs eval: the statistics switch
+
+The single most important behavioral detail in BatchNorm — and the source of more silent production bugs than any other normalization feature — is that it behaves differently in `.train()` and `.eval()` modes. The difference is not cosmetic; it is a fundamental design choice about which statistics to use for normalization.
+
+In **training mode** (`.train()`), BatchNorm computes μ_B and σ²_B from the current mini-batch, normalizes using those batch statistics, and simultaneously updates two persistent buffers — `running_mean` and `running_var` — using an exponential moving average:
+
+```
+running_mean = (1 − momentum) · running_mean + momentum · μ_B
+running_var  = (1 − momentum) · running_var  + momentum · σ²_B,unbiased
+```
+
+The σ²_B written into `running_var` is the **unbiased** batch variance (divide by m−1), not the biased estimator used for normalization.
+
+PyTorch's default `momentum=0.1` means each batch contributes 10% to the running estimate, and the effective memory of the running average — the number of batches it takes for a given batch's contribution to decay below 1% — is roughly `ln(0.01) / ln(1 − momentum)` ≈ 44 batches. After training, the running buffers approximate the population statistics of the training data distribution, weighted toward more recent batches.
+
+In **evaluation mode** (`.eval()`), BatchNorm uses the frozen `running_mean` and `running_var` — no batch statistics are computed, and the running buffers are not updated. The `momentum` parameter is irrelevant. The output for a given input is deterministic (independent of other samples in the batch) and approximates what the model would produce if the batch statistics were averaged over the entire training set.
+
+The **biased** variance estimator `σ²_B = Σ(x−μ)²/m` (dividing by m) is used to **normalize** the current batch, but the value written into the `running_var` buffer is the **unbiased** estimator `Σ(x−μ)²/(m−1)` — PyTorch applies Bessel's correction to the stored running variance, equivalent to `torch.var(unbiased=True)`, while normalization uses `torch.var(unbiased=False)`. (Ref: PyTorch `nn.BatchNorm1d` docs.) PyTorch's convention for the running-average update is `running = (1−momentum)·running + momentum·batch`. Other frameworks — notably TensorFlow and Keras — historically used the reverse convention `running = momentum·running + (1−momentum)·batch`, which means a PyTorch `momentum=0.1` corresponds to a TensorFlow `momentum=0.9`. When porting models between frameworks, this convention difference is a reliable source of subtle accuracy mismatches that are difficult to trace because both numbers look reasonable in isolation.
+
+### 2.4 The running-buffer probe
+
+The best way to trust that the buffers are doing what you expect is to print them, update them, and print again. The following probe shows the running statistics initialized to their defaults (mean=0, var=1), updated by two batches from different distributions, and then frozen during evaluation:
+
+```python
+import torch
+import torch.nn as nn
+
+torch.manual_seed(42)
+bn = nn.BatchNorm1d(4, momentum=0.1, track_running_stats=True)
+bn.train()
+
+# Before any forward pass, running_mean is initialized to 0, running_var to 1
+print(f"Initial running_mean: {bn.running_mean}")
+print(f"Initial running_var:  {bn.running_var}")
+
+x1 = torch.randn(8, 4)  # batch=8, features=4 — standard normal distribution
+_ = bn(x1)
+print(f"\nAfter batch 1 — running_mean: {bn.running_mean}")
+# Each entry is 0.1 * batch_mean + 0.9 * 0 = 0.1 * batch_mean
+# Since x1 is N(0,1), batch_mean ≈ 0, so running_mean stays near 0
+
+x2 = torch.randn(8, 4) * 2 + 5  # deliberately shifted: mean ≈ 5, std ≈ 2
+_ = bn(x2)
+print(f"After batch 2 — running_mean: {bn.running_mean}")
+# Now: 0.1 * batch2_mean + 0.9 * (0.1 * batch1_mean)
+# ≈ 0.1 * 5.0 + 0.9 * 0.0 ≈ 0.5 for each feature
+
+# Switch to eval — the running buffers are frozen
+bn.eval()
+x3 = torch.randn(8, 4)
+y3 = bn(x3)
+print(f"\nEval mode — norm uses running stats, not batch stats")
+print(f"running_mean: {bn.running_mean}")
+print(f"batch3 mean:   {x3.mean(dim=0)}")
+# These will differ; y3 uses running_mean, not batch3's mean
+
+# Verify: in eval mode, repeated forward passes with same input are identical
+y3_again = bn(x3)
+print(f"Eval output stable: {(y3 - y3_again).abs().max().item():.2e}")
+# Expected: 0.0 — running buffers don't change during eval
+```
+
+The probe reveals an important detail about the running-statistics lifecycle: the running buffers are updated during `.train()` forward passes only — not during `.backward()` and not during `.eval()`. If your training loop calls `.backward()` without a preceding `.forward()` (unusual but possible in custom training setups), the running statistics will not be updated for that step, and the accumulated population estimates will be biased.
+
+### 2.5 The small-batch problem
+
+BatchNorm's defining characteristic — normalizing using batch statistics — is also its Achilles' heel. When the batch size is small, the batch statistics μ_B and σ²_B are noisy estimators of the population statistics. A batch of 2 samples produces a mean estimate whose variance is σ²/2 (where σ² is the true population variance), and a variance estimate that is even noisier. The noise has two distinct consequences, both harmful at very small batch sizes.
+
+First, **training instability**: each forward pass normalizes with a different, inaccurate μ/σ pair. The noise injected into the activations by these fluctuating statistics depends on the specific samples in the batch, not on any learnable parameter, and the gradient signal is therefore corrupted by normalization noise that the optimizer cannot reduce by updating weights. At batch size 8 or above, this noise is modest and can even act as a beneficial regularizer — Ioffe and Szegedy observed that BatchNorm allowed them to remove dropout from their networks, because the stochasticity in the batch statistics provided enough regularization. At batch size 2 or 4, the noise is large enough to dominate the gradient signal, and training loss becomes erratic or diverges.
+
+Second, **train-inference mismatch**: the running statistics stored during training are a moving average of noisy batch estimates. With batch size 2, even after 100,000 updates, the running mean has not converged to the true population mean — its variance is reduced by the momentum averaging (effective window ~44 batches) but not eliminated because each batch estimate is itself extremely noisy. When you switch to eval mode and use these unconverged running statistics for inference, the normalization is systematically wrong, and the model's predictions on the same input differ from what they would have been with accurate population statistics.
+
+The practical rule of thumb: BatchNorm needs a batch size of at least 16 for reliable statistics. At batch size 8, the performance degradation is often measurable but small (0.5-1% accuracy). At batch size 4, the degradation is significant. At batch size 2, BatchNorm is essentially broken — use GroupNorm for vision or LayerNorm for sequences. The coupling effect is also worth noting: because BatchNorm normalizes using batch statistics, the prediction for sample `i` depends on which other samples happen to be in the same batch. This dependence is why `SyncBatchNorm` exists — in distributed training, each GPU computes its own batch statistics from its local batch, and without synchronization, the effective batch for statistics is the per-GPU batch, not the global batch.
+
+---
+
+## Part 3: Layer Normalization
+
+### 3.1 Normalize over features, not over the batch
+
+Layer Normalization (Ba et al., 2016) takes the opposite approach from BatchNorm: instead of normalizing each feature across the batch, it normalizes across features for each individual sample. For an input vector `x ∈ R^H` (a single sample with H features), the computation is structurally identical to BatchNorm but with the reduction axis reversed:
+
+```
+μ = (1/H) · Σ_{j=1}^{H} x_j              ← per-sample mean (over features)
+σ² = (1/H) · Σ_{j=1}^{H} (x_j − μ)²      ← per-sample variance
+x̂_j = (x_j − μ) / √(σ² + ε)              ← normalize
+y_j = γ_j · x̂_j + β_j                       ← scale and shift (per-feature γ, β)
+```
+
+The critical difference from BatchNorm: the statistics μ and σ² are computed from the features of a *single sample*. There is no batch dependence, no concept of population versus batch statistics, no running buffer to maintain, and — most importantly for deployment — no difference in behavior between `model.train()` and `model.eval()`. A LayerNorm layer produces identical outputs in both modes, given the same input, regardless of batch size or batch composition. The mode independence eliminates an entire class of production bugs that BatchNorm introduces.
+
+The learnable parameters γ and β are per-feature (one pair for each of the H features), giving the network the ability to rescale and shift each feature dimension independently after normalization. This is the same affine mechanism as BatchNorm; the difference is only in which axis the normalization is applied to.
+
+### 3.2 Shape conventions in PyTorch
+
+`nn.LayerNorm(normalized_shape)` normalizes over the last `len(normalized_shape)` dimensions of the input. The most common patterns in practice:
+
+```python
+# Input shape (batch, features) — standard for MLPs
+ln = nn.LayerNorm(256)           # normalized_shape = 256 (a single int)
+x = torch.randn(32, 256)
+y = ln(x)                        # normalizes over dim=-1 (the 256 features)
+
+# Input shape (batch, seq_len, d_model) — standard for Transformers
+ln = nn.LayerNorm(512)           # normalized_shape = 512
+x = torch.randn(32, 100, 512)   # batch=32, seq_len=100, d_model=512
+y = ln(x)                        # normalizes over the last dim (512) per token
+# Each of the 32*100 = 3200 tokens is normalized independently
+
+# Input shape (batch, C, H, W) — LayerNorm in vision (less common)
+ln = nn.LayerNorm([64, 32, 32]) # normalized_shape is a list of 3 dims
+x = torch.randn(8, 64, 32, 32)
+y = ln(x)                        # normalizes over dims [-3, -2, -1] → C*H*W
+# Each sample's (64, 32, 32) tensor is normalized as one 65,536-element vector
+```
+
+### 3.3 Why Transformers use LayerNorm
+
+The Transformer architecture, introduced by Vaswani et al. (2017), processes variable-length sequences of tokens. Each token position is represented by a `d_model`-dimensional vector, and the self-attention and feed-forward operations are applied independently to each token position — the model is position-wise in its computation except for the attention mechanism, which mixes information across positions. Using BatchNorm in a Transformer would create several problems simultaneously.
+
+The most immediate problem is padding. Sequences in a batch rarely have the same length; shorter sequences are padded with a special padding token to match the length of the longest sequence. If BatchNorm were applied, the padding tokens' features would contribute to μ_B and σ²_B, distorting the statistics for real tokens. A sequence with 10 real tokens and 90 padding tokens would be normalized using statistics dominated by the padding distribution, which is not representative of the real data.
+
+The second problem is batch dependence. A Transformer processes variable-length sequences, and the batch composition can change dramatically from step to step — one batch might contain short sentences averaging 15 tokens, while the next contains long paragraphs averaging 200 tokens. BatchNorm's running statistics, updated at each step, would need to track statistics across this heterogeneous population, and the statistics for a given feature would represent an average over all sequence lengths, which may not be meaningful.
+
+LayerNorm solves both problems by normalizing per token, per feature dimension. Each token is normalized using only its own feature values — no cross-token interaction, no cross-batch dependence. A padding token is normalized using its own features and remains a padding token; it does not affect the normalization of real tokens. The batch composition and sequence length are irrelevant to the normalization computation. And because there is no train/eval distinction, the inference behavior is deterministic given the input regardless of batch size — including batch size 1, which is common in online serving.
+
+### 3.4 Manual verification
+
+You can verify the computation by replicating LayerNorm manually and comparing with the PyTorch implementation. The key is to normalize over `dim=-1` (the last dimension) and use the biased variance estimator:
+
+```python
+import torch
+import torch.nn as nn
+
+torch.manual_seed(0)
+batch, features = 4, 8
+x = torch.randn(batch, features)
+
+# Manual LayerNorm — normalize over the last dimension
+eps = 1e-5
+mu = x.mean(dim=-1, keepdim=True)              # (4, 1) — per-sample mean
+var = x.var(dim=-1, unbiased=False, keepdim=True)  # (4, 1) — biased variance
+x_hat = (x - mu) / torch.sqrt(var + eps)       # (4, 8)
+
+ln = nn.LayerNorm(features, eps=eps)
+y_pytorch = ln(x)
+
+print(f"Max difference: {(x_hat - y_pytorch).abs().max().item():.2e}")
+# Before learnable affine, ln(x) ≈ x_hat — difference ~1e-7
+
+# Verify per-sample statistics: each row should have ~0 mean, ~1 std
+print(f"Row 0 mean: {x_hat[0].mean().item():.4f}")
+print(f"Row 0 std:  {x_hat[0].std(unbiased=False).item():.4f}")
+# Without affine transform, these are exactly 0.0 and 1.0
+
+# Train vs eval: LayerNorm is mode-independent
+ln.eval()
+y_eval = ln(x)
+ln.train()
+y_train = ln(x)
+print(f"Train vs eval diff: {(y_train - y_eval).abs().max().item():.2e}")
+# Always 0.0 — LayerNorm has no mode-dependent behavior
+```
+
+The train/eval equivalence is the property that makes LayerNorm the safe default for any architecture where batch dependence is undesirable. It eliminates the need for running-statistics management, mode-toggle discipline, and population-statistic convergence checks that BatchNorm requires.
+
+---
+
+## Part 4: RMSNorm — Drop the Mean, Keep the Scale
+
+### 4.1 The formula
+
+RMSNorm (Zhang & Sennrich, 2019) simplifies LayerNorm by removing the mean-centering step. For an input vector `x ∈ R^H`, the computation reduces to two operations: compute the root-mean-square of the features, and divide each feature by that value.
+
+```
+RMS(x) = √( (1/H) · Σ_{j=1}^{H} x_j² + ε )
+x̂_j = x_j / RMS(x)
+y_j = γ_j · x̂_j
+```
+
+There is no bias term β, no mean subtraction, and only a learnable gain parameter γ (one per feature). The normalization preserves the sign of every feature and the relative magnitudes between features, while constraining the root-mean-square of the feature vector to approximately 1 (before the learned gain). This is a more minimal operation than LayerNorm: instead of forcing the distribution to zero mean and unit variance, it forces only the scale (RMS) to unity and leaves the mean whatever it naturally is.
+
+The absence of the bias term β follows from a deeper design choice. Zhang & Sennrich (2019) argue that LayerNorm's **re-centering** (mean subtraction) is dispensable — the **re-scaling** invariance is what matters for optimization — so RMSNorm drops mean-centering and the bias term, reporting **7%–64% per-layer runtime reductions** while matching LayerNorm accuracy. Mean-centering ensures that the normalized features are centered at zero, which symmetrizes the distribution around the origin and may help with activation functions like GELU that behave differently in negative and positive regimes. But the experimental evidence from large-scale language modeling suggests that this symmetry is not necessary — the RMS-constraint alone is sufficient to keep the optimization well-conditioned, and the saved computation (one fewer reduction per normalization) more than justifies the simplification at the scale of billion-parameter models trained on trillion-token corpora.
+
+### 4.2 Why modern LLMs prefer RMSNorm
+
+The computational saving from omitting mean subtraction is modest but real: LayerNorm requires two reduction operations per normalization (sum for mean, sum of squares for variance), while RMSNorm requires only one (sum of squares for RMS). In a large Transformer, normalization is applied after every attention block and every feed-forward block — for an 80-layer model, that is 160 normalization operations per token per forward pass. Dropping half the reduction operations saves roughly 10-15% of the normalization compute, which at the scale of a trillion-token pretraining run translates to non-trivial wall-clock savings measured in GPU-hours.
+
+Empirically, RMSNorm performs comparably to LayerNorm on language modeling benchmarks. The LLaMA family (Touvron et al., 2023), Mistral (Jiang et al., 2023), and many subsequent open-weight LLMs use RMSNorm as their primary normalization layer, applied before the attention and feed-forward sub-layers in a pre-norm configuration. The success of these models at scales from 7B to 405B parameters demonstrates that the mean-centering step — the step that LayerNorm adds beyond RMSNorm — is not necessary for effective training at scale. The normalization landscape has effectively bifurcated: RMSNorm for large language models, LayerNorm for the original Transformer and most non-LLM sequence architectures.
+
+The architectural pattern is a literal swap: where a standard Transformer has `nn.LayerNorm(d_model)`, an RMSNorm-based architecture has `nn.RMSNorm(d_model)`. The interface is **nearly** identical — both take `normalized_shape` and `eps` — though in PyTorch 2.12 `nn.RMSNorm` has no `bias`, its `eps` defaults to `None`, and `nn.LayerNorm` exposes `elementwise_affine=True, bias=True`. The position in the network is the same (pre-norm, before the sub-layer).
+
+### 4.3 PyTorch code
+
+`nn.RMSNorm` is available in PyTorch 2.12 as a stable API:
+
+```python
+import torch
+import torch.nn as nn
+
+batch, seq_len, d_model = 2, 16, 512
+x = torch.randn(batch, seq_len, d_model)
+
+rms = nn.RMSNorm(d_model, eps=1e-5)
+rms.eval()  # RMSNorm is mode-independent (like LayerNorm)
+y = rms(x)  # (2, 16, 512) — normalized over last dim per token
+
+# Manual verification
+eps = 1e-5
+rms_manual = torch.sqrt((x ** 2).mean(dim=-1, keepdim=True) + eps)
+x_hat_manual = x / rms_manual
+print(f"Max diff (manual vs PyTorch): {(x_hat_manual - y).abs().max().item():.2e}")
+# ~1e-7 — identical up to floating-point precision before learned gain
+
+# Per-token RMS after normalization (before gain, γ=1)
+rms_per_token = torch.sqrt((y ** 2).mean(dim=-1))
+print(f"RMS per token (first 3 tokens): {rms_per_token[0, :3]}")
+# Each element ≈ 1.0 — the RMS constraint is satisfied
+```
+
+---
+
+## Part 5: Group Normalization
+
+### 5.1 Batch-independent normalization for vision
+
+Group Normalization (Wu & He, 2018) was designed to solve a specific, practical problem: modern vision tasks — object detection, instance segmentation, video understanding, high-resolution medical imaging — require large input resolutions that force small per-GPU batch sizes, often 2 or 4. BatchNorm degrades badly at these batch sizes, as discussed in Section 2.5. LayerNorm, applied over all channels and spatial dimensions, is too aggressive for vision: normalizing all 64 or 128 or 256 channels of a feature map as a single distribution washes out the channel-wise structure that the convolutional filters have learned. GroupNorm steers a middle course.
+
+Instead of normalizing over the batch (like BN) or over all channels (like LN), GroupNorm divides the C channels into G groups of C/G channels each and normalizes within each group independently. For a single sample with shape `(C, H, W)`, each group computes its mean and variance over the `(C/G) × H × W` values belonging to that group and normalizes those values. The normalization is per-sample (no batch dependence) and per-group (not per-channel, not all-channel), giving GroupNorm two advantages:
+
+The first advantage is **batch-size independence**: the statistics are computed from a single sample's features, so batch size 2 produces exactly the same per-sample normalization quality as batch size 256. There is no running buffer, no train/eval distinction, and no population-statistic convergence to worry about. The second advantage is **channel-group expressivity**: because normalization happens within groups and not across all channels, different groups of channels can have different means and variances. A feature map where channels 0-15 represent edge detectors and channels 48-63 represent color blobs will have those two groups normalized independently, preserving their distinct statistical properties.
+
+### 5.2 The API
+
+`nn.GroupNorm(num_groups, num_channels)` requires that `num_channels` is divisible by `num_groups`. The standard pattern is to choose `num_groups` as a small divisor of the channel count — typically 32 for networks with 64+ channels, or 8-16 for shallower networks.
+
+```python
+import torch
+import torch.nn as nn
+
+# 64 channels, 4 groups → each group normalizes 16 channels
+gn = nn.GroupNorm(num_groups=4, num_channels=64)
+
+x = torch.randn(8, 64, 32, 32)  # (N, C, H, W) — batch of 8
+y = gn(x)                         # (8, 64, 32, 32) — same shape
+
+# Special cases that illustrate the design space:
+# num_groups=1 → equivalent to LayerNorm over (C, H, W) per sample
+# num_groups=num_channels → InstanceNorm (one group per channel)
+```
+
+The special cases are instructive. At `num_groups=1`, GroupNorm normalizes all channels as a single group — this is functionally equivalent to applying LayerNorm over the `(C, H, W)` dimensions per sample. At `num_groups=C` (one group per channel), GroupNorm normalizes each channel independently over its `H × W` spatial dimensions — this is InstanceNorm, the normalization used in neural style transfer to separate content (spatial structure) from style (channel-wise mean and variance).
+
+### 5.3 When to use GroupNorm
+
+The paper's experimental results are decisive. On ImageNet classification with a ResNet-50, GroupNorm with batch size 2 achieves 75.9% top-1 accuracy, only 0.5% below BatchNorm at batch size 256 (76.4%). At batch size 2, BatchNorm's error rises to 34.7% (≈65.3% top-1 accuracy) while GroupNorm holds at 24.1% error (≈75.9% accuracy) — a 10.6 error-point gap that GroupNorm closes almost entirely. On object detection and segmentation tasks where batch sizes are forced small by high-resolution inputs, GroupNorm consistently matches or exceeds BatchNorm's accuracy without any batch-size dependence.
+
+InstanceNorm — the extreme case of GroupNorm with one group per channel — is the normalizer at the heart of neural style transfer. The original style transfer literature (Ulyanov et al., 2016; Huang & Belongie, 2017) showed that normalizing each feature map independently removes the "style" information (encoded in the per-channel mean and variance) while preserving the "content" information (encoded in the spatial activation pattern). This property is specific to InstanceNorm and does not generalize to other normalizers: BatchNorm and LayerNorm both mix information across channels in ways that blend style and content.
+
+---
+
+## Part 6: Choosing and Placing Normalization
+
+### 6.1 The decision table
+
+Choosing a normalization layer is not a hyperparameter search problem. The choice follows directly from the architecture type and the constraints on batch size and sequence format. The following table summarizes the practical decision rules that cover the vast majority of cases encountered in production deep learning.
+
+| Normalizer | Normalizes over | Batch-dependent? | Best for | Avoid when |
+|---|---|---|---|---|
+| **BatchNorm** | `(N, H, W)` per channel | Yes — train/eval split, running buffers | Vision CNNs, batch ≥ 16 | Batch < 8; recurrent nets; variable-length sequences |
+| **LayerNorm** | Feature dim per sample | No — identical train/eval | Transformers, NLP, RNNs | Vision CNNs (degrades vs BN on large-batch ImageNet) |
+| **RMSNorm** | Feature dim per sample | No — identical train/eval | Modern LLMs (LLaMA, Mistral) | Tasks where mean-centering is critical (rare; few known cases) |
+| **GroupNorm** | Grouped channels per sample | No — identical train/eval | Small-batch vision, detection, segmentation | Large-batch ImageNet (BN still marginally better at batch 256+) |
+| **InstanceNorm** | `(H, W)` per channel, per sample | No — identical train/eval | Style transfer, image generation | Classification, detection (destroys channel correlations useful for semantics) |
+
+For vision CNNs trained with batch size 256 on ImageNet-scale datasets, BatchNorm remains the best-tested choice. Its batch statistics are highly accurate at this batch size, its regularizing side effect from batch-statistic noise is beneficial, and decades of empirical tuning have validated its hyperparameters. For Transformers and sequence models, LayerNorm (or RMSNorm for large-scale LLM training) is the standard — batch dependence is a liability for variable-length sequences, and per-token normalization respects the independence of sequence positions. For vision tasks with batch size constrained to 8 or below, GroupNorm replaces BatchNorm with minimal accuracy loss. For style transfer, InstanceNorm is the only normalizer that provides the style-content separation the task requires.
+
+### 6.2 Pre-norm vs post-norm in residual blocks
+
+A residual block computes `output = F(x) + x`, where `F` is a sub-network — a stack of convolutions, a self-attention block followed by a feed-forward network, or any composition of learnable transformations. The normalization layer can be placed either before `F` (pre-norm) or after the addition (post-norm), and the choice has dramatic consequences for training stability as depth increases.
+
+**Pre-norm**: normalize before the sub-network, then add the residual. `output = F(LN(x)) + x`. In this configuration, the residual path `x` passes through to the output unchanged — the identity connection is clean, and gradients can flow backward through this path without attenuation or transformation. Only the sub-network input is normalized. This is the standard in modern Transformers from GPT-2 onward and in all large language models.
+
+**Post-norm**: normalize after the addition. `output = LN(F(x) + x)`. This was the original Transformer design (Vaswani et al., 2017). Both the residual path and the sub-network output pass through the normalization layer, which constrains the scale of the combined signal.
+
+The stability difference between the two configurations is large and well-documented. In post-norm, the residual signal is normalized, which means the effective contribution of the identity path is scaled down along with the sub-network output. At initialization, when `F(x)` is small (weights are small, the sub-network output is near zero), the residual connection should dominate and provide a near-identity function — but post-norm scales that identity down, potentially amplifying the untrained sub-network's random output relative to the stable identity path. Pre-norm avoids this by normalizing only the sub-network input; the identity path `+ x` is never normalized, so its contribution is always at full scale. This is why pre-norm Transformers can train reliably without the careful learning-rate warmup that the original post-norm Transformer required, and why scaling Transformers to hundreds of layers became feasible only after the field adopted pre-norm.
+
+The trade-off is not one-sided. Some evidence suggests that post-norm can achieve slightly better final accuracy when training succeeds — because the normalization at the output of the residual block constrains the signal at the point where it feeds into the next block, providing tighter control over activation scale throughout the network. But this accuracy advantage is conditional on the network surviving the early training steps, which at depth 50 or 100 is far from guaranteed with post-norm. The practical rule: use pre-norm for any residual architecture deeper than ~12 layers, and consider post-norm only for shallow residual networks where stability is not the bottleneck.
+
+This topic receives full architectural treatment in Module C4 (the Transformer architecture), where the attention mechanism, residual streams, and normalization placement are analyzed as a system with explicit gradient-flow analysis. For this module, the key takeaway is that normalization placement is an architectural decision, not a hyperparameter, and the choice between pre-norm and post-norm determines whether your deep network can train at all without specialized warmup schedules.
+
+### 6.3 Normalization as a regularizer
+
+BatchNorm's use of per-batch statistics has a side effect that its inventors recognized immediately: it injects noise into the activations. Every mini-batch has slightly different μ and σ, and the normalized activations for a given sample differ depending on which other samples happen to be in the same batch. This stochasticity acts as a mild regularizer — the network cannot rely on precise activation values because those values shift slightly from batch to batch, so it must learn representations that are robust to small perturbations.
+
+Ioffe and Szegedy observed that this regularizing effect was strong enough to replace dropout in many configurations. Dropout randomly zeros activations during training to prevent co-adaptation of features; BatchNorm's batch-statistic noise provides a different form of stochasticity that achieves a similar regularizing goal. Networks trained with BatchNorm often achieve their best generalization without dropout, and adding dropout on top of BatchNorm can sometimes harm performance by introducing too much noise.
+
+This regularizing side effect is specific to batch-dependent normalizers. LayerNorm, RMSNorm, and GroupNorm are deterministic per sample — given the same input, they always produce the same output, regardless of batch composition. They provide no regularization from normalization noise. If you replace BatchNorm with GroupNorm in a vision model, you may need to add or increase dropout to compensate for the loss of the BatchNorm noise regularizer.
+
+The interaction with BatchNorm's regularization also connects to Module 1.3.2's discussion of batch size and gradient noise. The stochasticity in BatchNorm's statistics is correlated with the stochasticity in the gradient estimates: both depend on which samples happen to be in the current batch. When you increase batch size, both sources of noise decrease together, which is part of why the linear scaling rule for learning rate (Goyal et al., 2017) works — larger batches produce less noisy gradients and less noisy normalization, both of which permit larger learning rates.
+
+---
+
+## Did You Know?
+
+- **BatchNorm was preceded by "whitening" approaches.** Earlier work attempted to whiten activations — zero mean, unit variance, *and* decorrelated — before each layer. The problem with whitening is that it requires computing the full covariance matrix and its inverse square root, an O(d³) operation for d-dimensional features that is expensive to compute and nontrivial to backpropagate through because the eigendecomposition or Cholesky factorization is not a simple element-wise operation. Ioffe and Szegedy's key insight was that per-dimension normalization — mean and variance only, no decorrelation — is sufficient, because the subsequent learned linear transform (the weight matrix of the next layer, plus the learned γ and β of the normalization itself) can handle the necessary rotation. This reduced the cost from O(d³) to O(d) and made normalization cheap enough to insert at every layer of every network, which is why BatchNorm succeeded where whitening failed.
+
+- **The "frozen BatchNorm" trick** is a common fine-tuning practice. When adapting a pretrained vision model to a new task with a small dataset (fewer than a few thousand samples), it is often better to freeze the BatchNorm running statistics — set the layer to eval mode and do not update the running buffers — and only update the affine parameters γ and β, or even freeze those as well and only train the task-specific head. The reasoning: the running statistics computed from the large source dataset (e.g., ImageNet with 1.2 million images) are high-quality population estimates. Overwriting them with noisy statistics from a small target dataset produces worse normalization and degrades the model's ability to leverage its pretrained features.
+
+- **`SyncBatchNorm`** converts BatchNorm to use global statistics across all GPUs in a distributed training run. In standard `DistributedDataParallel`, each GPU normalizes using only its own per-GPU batch. With 8 GPUs each processing 32 samples, each GPU's BatchNorm sees only 32 samples for its statistics — and if memory constraints force per-GPU batch size to 4, each GPU sees only 4 samples. `SyncBatchNorm` (`torch.nn.SyncBatchNorm`) communicates μ and σ² across GPUs so the effective batch for statistics is the global batch size (256 in the first example, 32 in the second). The communication overhead is modest — two all-reduce operations per normalization layer — and the benefit is that your BatchNorm statistics are as accurate as if you had trained on a single GPU with the global batch size.
+
+- **Weight Standardization** (Qiao et al., 2019) takes the dual approach: instead of normalizing activations, standardize the *weights* of each layer to zero mean and unit variance. The idea is that if the weights are constrained to zero mean and unit variance, the output of a convolution has more stable statistics even without activation normalization. Combined with GroupNorm (which handles the residual activation drift), Weight Standardization eliminated BatchNorm from vision training entirely on ImageNet, achieving competitive accuracy (75.9% with ResNet-50 at batch size 256) without any batch-dependent statistics. The approach has not seen widespread adoption — BatchNorm remains simpler and more battle-tested — but it demonstrates that the normalization axis (activations vs weights, features vs batch) is a design choice, not a mathematical necessity.
+
+---
+
+## Common Mistakes
+
+| Mistake | Problem | Solution |
+|---------|---------|----------|
+| Forgetting `model.eval()` before inference | BatchNorm continues to use per-batch statistics and update running buffers during inference, producing outputs that depend on batch composition and silently degrade over time | Switch the module to evaluation mode with `model.eval()` before inference — this is what flips BN/Dropout to their eval behavior; optionally also wrap the forward in `with torch.inference_mode():` for speed. `torch.inference_mode()` ALONE does not change the module's train/eval state, so BN/Dropout stay in training behavior without the eval-mode call. Verify with `assert not model.training` |
+| Applying BatchNorm to a batch size of 1 or 2 | The batch statistics are extremely noisy — the variance estimate from 2 samples has ~50% relative error; running estimates converge poorly; training and inference drift apart systematically | Use GroupNorm for vision tasks, LayerNorm for sequences when batch ≤ 8 |
+| Using BatchNorm in Transformers or RNNs | Padded positions contribute to μ and σ, distorting statistics for real tokens; batch composition affects per-sample predictions | Use LayerNorm or RMSNorm — per-token, per-feature normalization respects sequence independence |
+| Confusing `momentum` conventions between frameworks | PyTorch: `running = (1−m)·running + m·batch`; TensorFlow/Keras (historical): `running = m·running + (1−m)·batch` | When porting models, set PyTorch `momentum = 1.0 − TF_momentum`; verify by printing `running_mean` after a few batches |
+| Applying weight decay to γ and β of normalization layers | Weight decay penalizes large γ values, which reduces the effective learning rate for early layers and can prevent the network from learning useful feature scales | Exclude normalization parameters from weight decay: `no_decay = [p for n, p in model.named_parameters() if 'norm' in n or 'bias' in n]` |
+| Normalizing after ReLU instead of before | ReLU zeros negative activations, shifting the mean of surviving values upward; normalizing after ReLU produces a non-zero mean that BatchNorm then re-centers, wasting the learnable β parameter's capacity | Place normalization *before* the activation function (conv → BN → ReLU), the standard ordering in ResNet and most modern CNNs |
+| Using BatchNorm's unbiased variance estimator when replicating the computation | `torch.var(unbiased=False)` is used for **normalization**, but the `running_var` buffer stores `torch.var(unbiased=True)`; the default `torch.var()` (unbiased) matches the buffer, not the normalization step | Always pass `unbiased=False` when replicating BatchNorm's *normalization* variance computation; the discrepancy is invisible at batch=256 but matters at batch=4 |
+
+---
+
+## Quiz
+
+1. **BatchNorm uses batch statistics in train mode and running statistics in eval mode. If you deploy a model with `model.train()` instead of `model.eval()`, what two problems occur, and why might they go undetected in a brief smoke test?**
+
+   <details>
+   <summary>Answer</summary>
+   First, the model uses per-batch μ and σ instead of the frozen running estimates, so the prediction for a given input depends on which other inputs happen to be in the same inference batch — outputs are non-deterministic and vary with batch composition. Second, the forward pass continues to update the running buffers via `running = (1−momentum)·running + momentum·batch_stat`, gradually overwriting the carefully accumulated training-set population statistics with the inference data distribution. The bug often passes brief smoke tests because (a) if the inference batch happens to be large and well-distributed, the per-batch stats approximate the population stats well, and (b) the model still produces outputs in a reasonable range — the degradation is statistical (1-5% accuracy drop) rather than catastrophic. It surfaces only when someone computes aggregate metrics over a properly distributed test set.
+   </details>
+
+2. **A 50-layer ResNet is pretrained with BatchNorm and batch size 256 on ImageNet. You need to fine-tune it on a medical imaging dataset where GPU memory limits you to batch size 4. What will happen if you leave BatchNorm in train mode during fine-tuning, and what is the correct fix?**
+
+   <details>
+   <summary>Answer</summary>
+   With batch size 4, the per-batch μ and σ estimates are extremely noisy. Each forward pass normalizes with a different, inaccurate μ/σ pair — the fluctuations inject uninformative noise into the activations, and gradients computed from those noisy activations are themselves corrupted. Training loss shows high variance between steps. Simultaneously, the running-mean update `running = 0.9·running + 0.1·batch_stat` accumulates the noisy batch estimates, and the running buffers drift away from the true ImageNet population statistics toward a noisy estimate of the small medical dataset's statistics. The correct fix has two options. Option A: freeze the BatchNorm layers in eval mode (use pretrained ImageNet running statistics) and only train the affine parameters γ and β — or simply freeze all BatchNorm parameters and train only the final classifier. Option B: replace BatchNorm with GroupNorm before fine-tuning (`nn.GroupNorm(num_groups=32, num_channels=C)`), which provides batch-independent normalization and trains stably at any batch size. Option A is simpler; Option B is better if the domain shift is large enough that the ImageNet statistics are substantially wrong for the medical images.
+   </details>
+
+3. **Explain why the learnable parameters γ and β are essential to BatchNorm. What would happen if you normalized to zero mean and unit variance without them?**
+
+   <details>
+   <summary>Answer</summary>
+   Without γ and β, every layer's output is constrained to exactly zero mean and unit variance for every feature channel. A ReLU following such a normalization layer receives activations where roughly half the values are negative and zeroed out, and the surviving half have a mean shifted upward from zero. The network cannot represent transformations that require a different scale or mean — a sigmoid activation expecting inputs in [−1, 1] always receives unit-variance inputs regardless of what is optimal for the task; a layer that needs to amplify one feature and suppress another cannot do so because the normalization fixes the scale. The learnable γ and β restore full representational capacity: γ lets the network learn, per channel, the optimal scale (amplify important features, attenuate noise), and β lets it learn the optimal shift (bias the normalized distribution toward positive or negative values as the downstream computation requires). The normalization provides stable optimization; the affine parameters provide expressive power.
+   </details>
+
+4. **Layer Normalization computes μ = (1/H)·Σ x_j per sample. If H = 1 (a single feature), what is the output of LayerNorm, and why is this a degenerate case?**
+
+   <details>
+   <summary>Answer</summary>
+   With H = 1, the single feature value x_1 is also the mean: μ = x_1. The variance is σ² = (x_1 − x_1)² / 1 = 0. The normalized value is x̂_1 = (x_1 − x_1) / √(0 + ε) = 0. For any input, the normalized output is identically 0, and the final output after the affine transform is y = γ · 0 + β = β — a constant independent of the input. LayerNorm requires at least 2 features to compute a meaningful variance and produce a non-degenerate normalization. This degenerate case is avoided in practice because LayerNorm is always applied over at least dozens of features — d_model ≥ 64 in Transformers, H × W ≫ 1 in vision LayerNorm.
+   </details>
+
+5. **You replace BatchNorm with GroupNorm in a CNN and observe that validation accuracy drops 1.5% at batch size 256, the same batch size where BatchNorm has always excelled. Is GroupNorm a worse normalizer?**
+
+   <details>
+   <summary>Answer</summary>
+   GroupNorm is not worse in any absolute sense; the comparison at batch size 256 is BatchNorm's home turf. At this batch size, BatchNorm's statistics are estimated from N × H × W values — for a 256×28×28 feature map that is over 200,000 samples per channel, producing extremely accurate μ and σ. Additionally, the small residual noise from batch statistics acts as a beneficial regularizer that GroupNorm, being deterministic per sample, cannot provide. The 1.5% gap is the cost of giving up both accurate large-sample statistics and batch-noise regularization. The fair comparison is at batch size 2 or 4, where BatchNorm's statistics are noisy and GroupNorm's batch-independence becomes an advantage — in that regime GroupNorm outperforms BatchNorm by 2-4%, which is exactly the regime GroupNorm was designed for. The normalizer choice depends on the operational constraint (batch size), not on an abstract ranking of "better" versus "worse."
+   </details>
+
+6. **Santurkar et al. (2018) showed that BatchNorm smooths the loss landscape. What does "smoothing" mean precisely, and why does it allow higher learning rates?**
+
+   <details>
+   <summary>Answer</summary>
+   Smoothing means the loss function L(θ) has a smaller Lipschitz constant with respect to the weights θ — formally, there exists a constant C such that ‖∇L(θ₁) − ∇L(θ₂)‖ ≤ C · ‖θ₁ − θ₂‖ for all θ₁, θ₂ in the relevant region of parameter space. A smaller C means the gradient does not change abruptly as you move through weight space. The practical consequence: the first-order Taylor approximation ∇L(θ_t)·Δθ — which gradient descent uses to decide its step direction and magnitude — is accurate over larger steps Δθ. If the gradient changes slowly, taking a larger step in the current gradient direction remains a good move; if the gradient changes rapidly (large Lipschitz constant), a large step lands you in a region where the gradient points somewhere else entirely and the update is counterproductive. This is why BatchNorm-trained networks tolerate learning rates 5× to 30× higher than un-normalized networks: the smoother landscape makes gradient descent's local-linearity assumption valid over longer distances. The Santurkar experiments validated this by measuring the effective β-smoothness of the loss along the optimization trajectory and showing it is consistently smaller with BatchNorm.
+   </details>
+
+---
+
+## Hands-On Exercise
+
+**Task**: Build a small CNN with and without BatchNorm, train both on Fashion-MNIST, and measure (a) training speed (loss after N steps), (b) sensitivity to learning rate, and (c) the value of the running mean buffer after training.
+
+1. Set up a minimal CNN: `Conv2d(1, 16, 3) → ReLU → Conv2d(16, 32, 3) → ReLU → AdaptiveAvgPool2d(4) → Flatten → Linear(512, 10)`. Train for 5 epochs on Fashion-MNIST with `torch.optim.SGD`, lr=0.01, batch=64. Record the final training loss and the activation mean/std at the output of the first Conv2d (before ReLU).
+
+2. Insert BatchNorm after each Conv2d (before ReLU, so: `Conv2d → BatchNorm2d → ReLU`). Re-train with identical hyperparameters. Record: the final training loss, the activation mean/std at the output of the first BatchNorm (should be ∼0, ∼1), and the running-mean buffer of the first BatchNorm layer after training.
+
+3. Repeat the BatchNorm experiment with lr=0.1 (10× higher). Record whether training diverges. Compare with the no-BN network at lr=0.1 — it should diverge or produce much higher loss.
+
+4. Switch to batch size 4 and compare BatchNorm vs GroupNorm. Replace `BatchNorm2d(16)` with `GroupNorm(num_groups=4, num_channels=16)` and `BatchNorm2d(32)` with `GroupNorm(num_groups=8, num_channels=32)`. Train both for 5 epochs at lr=0.01 and record final training loss.
+
+```python
+# Verification scaffold — run after completing the four experiments above
+import torch
+import torch.nn as nn
+
+# After training the BatchNorm model:
+bn_layer = model_with_bn[1]  # first BatchNorm2d, after first Conv2d
+print(f"BatchNorm running mean (first 8 of {bn_layer.num_features} channels):")
+print(bn_layer.running_mean[:8])
+print(f"BatchNorm running var  (first 8):")
+print(bn_layer.running_var[:8])
+
+# The running mean should be meaningfully non-zero — the data has structure
+# that the running statistics have captured.
+
+# At batch_size=4, GroupNorm should train to a lower loss than BatchNorm:
+print(f"BN final train loss (bs=4):  {bn_bs4_loss:.4f}")
+print(f"GN final train loss (bs=4):  {gn_bs4_loss:.4f}")
+# Expected: gn_bs4_loss < bn_bs4_loss (GroupNorm handles small batches better)
+```
+
+Success criteria:
+
+- [ ] The BN model at lr=0.01 reaches lower training loss than the no-BN model after 5 epochs.
+- [ ] The no-BN model diverges or trains poorly at lr=0.1; the BN model does not.
+- [ ] The running-mean buffer after training is meaningfully non-zero (it learned population statistics from the data).
+- [ ] At batch size 4, GroupNorm achieves lower final training loss than BatchNorm.
+
+---
+
+## Key Takeaways
+
+Normalization layers re-standardize activations during training so that deep networks remain trainable despite weight updates shifting activation distributions across layers. They address the *dynamic* problem of distribution drift that initialization solves statically at step zero. Without normalization, activation statistics compound across depth — a small shift at layer 3 becomes a large shift at layer 30 — and the optimizer must continuously re-adapt to a moving target.
+
+BatchNorm normalizes over the batch and spatial dimensions per channel, computing per-batch μ and σ² and maintaining running-mean and running-variance buffers via `running = (1−momentum)·running + momentum·batch_stat`. The train-vs-eval statistics switch — batch statistics in `.train()`, frozen running buffers in `.eval()` — must be explicitly managed: forgetting `model.eval()` before inference produces silent accuracy degradation that passes basic smoke tests. The running-buffer update uses PyTorch's `(1−momentum)` convention, which differs from TensorFlow's historical convention, making the `momentum` value a portability trap.
+
+LayerNorm normalizes over the feature dimension per sample, is batch-independent, and has identical train and eval behavior. This makes it the natural choice for Transformers and sequence models where batch composition and sequence length vary, and where the per-token independence of normalization is essential for correct handling of padding and variable-length inputs. RMSNorm simplifies LayerNorm further by dropping the mean-centering step and the bias term, normalizing by root-mean-square only — the cheaper operation that modern LLMs use at every sub-layer.
+
+GroupNorm normalizes within groups of channels per sample, providing batch-independent normalization for vision tasks where GPU memory constraints force small batch sizes. InstanceNorm (GroupNorm with one group per channel) is the normalizer for style transfer, where per-channel normalization separates content from style. The choice of normalizer follows directly from the architecture type and batch-size constraint, not from hyperparameter search.
+
+Santurkar et al. (2018) demonstrated that BatchNorm's primary mechanism is smoothing the loss landscape — reducing the gradient's Lipschitz constant — rather than reducing internal covariate shift. This explains why normalization helps even in shallow networks where covariate shift is negligible, and why BatchNorm-trained networks tolerate learning rates 5× to 30× higher than un-normalized networks.
+
+Normalization placement in residual blocks — pre-norm versus post-norm — is an architectural decision with stability consequences. Pre-norm (normalize before the sub-layer, then add the residual) preserves a clean identity path for gradient flow and is the standard for deep Transformers. Post-norm was the original design but requires careful warmup schedules to survive early training at depth.
+
+---
+
+## Sources
+
+- Ioffe, S., & Szegedy, C. (2015). Batch Normalization: Accelerating Deep Network Training by Reducing Internal Covariate Shift. *ICML 2015*. arXiv:1502.03167. https://arxiv.org/abs/1502.03167
+- Ba, J. L., Kiros, J. R., & Hinton, G. E. (2016). Layer Normalization. *arXiv:1607.06450*. https://arxiv.org/abs/1607.06450
+- Zhang, B., & Sennrich, R. (2019). Root Mean Square Layer Normalization. *NeurIPS 2019*. arXiv:1910.07467. https://arxiv.org/abs/1910.07467
+- Wu, Y., & He, K. (2018). Group Normalization. *ECCV 2018*. arXiv:1803.08494. https://arxiv.org/abs/1803.08494
+- Santurkar, S., Tsipras, D., Ilyas, A., & Madry, A. (2018). How Does Batch Normalization Help Optimization? *NeurIPS 2018*. arXiv:1805.11604. https://arxiv.org/abs/1805.11604
+- Ulyanov, D., Vedaldi, A., & Lempitsky, V. (2016). Instance Normalization: The Missing Ingredient for Fast Stylization. *arXiv:1607.08022*. https://arxiv.org/abs/1607.08022
+- Qiao, S., Wang, H., Liu, C., Shen, W., & Yuille, A. (2019). Micro-Batch Training with Batch-Channel Normalization and Weight Standardization. *arXiv:1903.10520*. https://arxiv.org/abs/1903.10520
+- Touvron, H., et al. (2023). LLaMA: Open and Efficient Foundation Language Models. *arXiv:2302.13971*. https://arxiv.org/abs/2302.13971
+- Jiang, A. Q., et al. (2023). Mistral 7B. *arXiv:2310.06825*. https://arxiv.org/abs/2310.06825
+- Huang, X., & Belongie, S. (2017). Arbitrary Style Transfer in Real-Time with Adaptive Instance Normalization. *ICCV 2017*. arXiv:1703.06868. https://arxiv.org/abs/1703.06868
+- Goyal, P., et al. (2017). Accurate, Large Minibatch SGD: Training ImageNet in 1 Hour. *arXiv:1706.02677*. https://arxiv.org/abs/1706.02677
+- Vaswani, A., et al. (2017). Attention Is All You Need. *NeurIPS 2017*. https://arxiv.org/abs/1706.03762
+- PyTorch 2.12 documentation: `torch.nn.BatchNorm1d`. https://pytorch.org/docs/stable/generated/torch.nn.BatchNorm1d.html
+- PyTorch 2.12 documentation: `torch.nn.LayerNorm`. https://pytorch.org/docs/stable/generated/torch.nn.LayerNorm.html
+- PyTorch 2.12 documentation: `torch.nn.RMSNorm`. https://pytorch.org/docs/stable/generated/torch.nn.RMSNorm.html
+- PyTorch 2.12 documentation: `torch.nn.GroupNorm`. https://pytorch.org/docs/stable/generated/torch.nn.GroupNorm.html
+- Dive into Deep Learning — Batch Normalization: https://d2l.ai/chapter_convolutional-modern/batch-norm.html
+- Stanford CS231n — Training Neural Networks, Part 2 (Normalization): https://cs231n.github.io/neural-networks-2/
+
+---
+
+## Next Module
+
+Continue to [Training Deep Networks: Normalization, Regularization & Optimization](/ai-ml-engineering/deep-learning/module-1.4-cnns-computer-vision/) — where the normalization machinery in this module combines with explicit regularization techniques (dropout, weight decay in practice, data augmentation) and the optimizer discipline from Module 1.3.2 into a full training-stability toolkit.
+
+## Learner check
+
+> | 1.3.4 | [Normalization Layers](/ai-ml-engineering/deep-learning/module-1.3.4-normalization-layers/) |


### PR DESCRIPTION
## NN Block B — Wave 2 (epic #1793, Phase 2)

"Training as engineering," wave 2: the training-loop rescope + the regularization and normalization modules. All three T0, cross-family reviewed (different model family than author), every finding orchestrator-ground-checked, full `astro build` green (2151 pages, 0 schema errors). PyTorch 2.12.

| Module | Slug | Author | Cross-family review |
|--------|------|--------|---------------------|
| B2 The Training Loop (rescope `1.3`) | `module-1.3-training-neural-networks` | codex gpt-5.5 | cursor — APPROVE_WITH_NITS (executed code on torch); 3 consistency nits fixed |
| B5 Regularization & Generalization | `module-1.3.3-…` (net-new) | cursor auto | agy/gemini-3.1-pro — fixed PyTorch label-smoothing formula (uniform `ε/K`), SWA citation, subsection order, +expand |
| B6 Normalization Layers | `module-1.3.4-…` (net-new) | deepseek-v4-pro | codex R1 (BN running-variance, `no_grad` code, GroupNorm numbers, Santurkar/RMSNorm) + R2 (drift-demo explosion) — all fixed |

**Review-rigor highlights** (T0 verifier blind to all of these):
- B6's BatchNorm section claimed biased variance is used for *both* normalization and the `running_var` buffer — corrected to PyTorch's actual behavior (biased for normalization, **unbiased**/Bessel-corrected for the buffer).
- B6's GroupNorm numbers were wrong; web-verified against the paper (batch-size-2: BN 34.7% / GN 24.1% error, 10.6-pt gap).
- B5 taught Szegedy's `ε/(K−1)` label smoothing while referencing PyTorch's `CrossEntropyLoss`, which uses uniform `ε/K` — corrected.

**Next-chain re-chained:** `1.3.2`→`1.3.3` (was the temp `1.4` pointer from Wave 1), `1.3`→`1.3.1`, `1.3.3`→`1.3.4`, `1.3.4`→`1.4` (temp until B7). index.md updated (1.3 retitled; 1.3.3/1.3.4 rows). Block B now **5/8 modules** live (B1–B6 minus B7/B8). Wave B-3 = B7 (diagnostics) + B8 (numerical stability) + gut/redirect the mislabeled `1.4`.

Refs #1793.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
