### PR TITLE
fix(security): tighten created-file perms 0o644→0o600 (CodeQL py/overly-permissive-file ×4)

### DIFF
--- a/scripts/agent_runtime/usage.py
+++ b/scripts/agent_runtime/usage.py
@@ -129,7 +129,7 @@ def write_record(record: dict[str, Any]) -> None:
     try:
         path = _usage_file(record["agent"], record["entrypoint"])
         line = (json.dumps(record, ensure_ascii=False, default=str) + "\n").encode("utf-8")
-        fd = os.open(str(path), os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o644)
+        fd = os.open(str(path), os.O_APPEND | os.O_CREAT | os.O_WRONLY, 0o600)
         try:
             os.write(fd, line)
         finally:

--- a/scripts/quality/gates.py
+++ b/scripts/quality/gates.py
@@ -435,7 +435,7 @@ def _ledger_lock(path: Path):
     """
     path.parent.mkdir(parents=True, exist_ok=True)
     lock_path = path.with_suffix(path.suffix + ".lock")
-    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o644)
+    fd = os.open(str(lock_path), os.O_CREAT | os.O_RDWR, 0o600)
     try:
         fcntl.flock(fd, fcntl.LOCK_EX)
         try:

--- a/scripts/quality/stages.py
+++ b/scripts/quality/stages.py
@@ -1266,7 +1266,7 @@ def _merge_lock(timeout: float = 120.0):
     two workers can't clobber main concurrently (Codex must #5)."""
     import fcntl
     path = _merge_lock_path()
-    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o644)
+    fd = os.open(path, os.O_RDWR | os.O_CREAT, 0o600)
     deadline = time.monotonic() + timeout
     try:
         while True:

--- a/scripts/quality/state.py
+++ b/scripts/quality/state.py
@@ -172,7 +172,7 @@ def state_lease(slug: str, timeout: float = 5.0) -> Iterator["LeasedState"]:
     STATE_DIR.mkdir(parents=True, exist_ok=True)
     lock_path = STATE_DIR / f"{slug}.json.lock"
     # Open with O_CREAT so the lock file materializes on first touch.
-    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o644)
+    fd = os.open(lock_path, os.O_RDWR | os.O_CREAT, 0o600)
     deadline = time.monotonic() + timeout
     try:
         while True:


### PR DESCRIPTION
Resolves 4 open CodeQL **`py/overly-permissive-file`** (HIGH) alerts (#33–#36).

Each was `os.open(..., 0o644)` creating a **world-readable** file. All four are local-only files (three `flock` lock files + one per-user usage log) that nothing else needs to read, so the correct mode is owner-only **`0o600`**.

| File | Line | Purpose |
|---|---|---|
| `scripts/agent_runtime/usage.py` | 132 | usage log (append) |
| `scripts/quality/stages.py` | 1269 | git-main merge lock |
| `scripts/quality/state.py` | 175 | per-module state lock |
| `scripts/quality/gates.py` | 438 | ledger lock |

Change is `0o644 → 0o600` only — same flags, same calls.

**Author:** agy (gemini-3.1-pro). **Ground-checked:** diff verified (4/4 correct, no `0o644` remaining), `ruff check` clean. CodeQL will re-scan and clear the alerts on merge.

Refs #1812 (security hardening).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
