### PR TITLE
security(#1812): lockfile-integrity tripwire + detection runbook + local-dev guidance

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -44,6 +44,11 @@ jobs:
         with:
           path: dist
 
+  # CONTAIN boundary (#1812): `build` runs `npm ci` / `npm run build` with only
+  # `contents: read` — NO OIDC or Pages token is available at install time. `deploy`
+  # holds `id-token: write` + `pages: write` but runs NO npm commands. A compromised
+  # dependency executing during `npm ci` cannot reach the OIDC/Pages credential.
+  # Do NOT co-locate `npm install`/`npm ci` with the privileged deploy job.
   deploy:
     environment:
       name: github-pages

--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -21,6 +21,7 @@ jobs:
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
 
       - name: Set up Node.js
@@ -34,6 +35,16 @@ jobs:
 
       - name: Lifecycle-script tripwire
         run: python3 scripts/security/check_install_scripts.py
+
+      - name: Lockfile-integrity tripwire
+        env:
+          LOCKFILE_BASE: ${{ github.event.pull_request.base.sha || github.event.before }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            python3 scripts/security/check_lockfile_integrity.py --three-dot
+          else
+            python3 scripts/security/check_lockfile_integrity.py
+          fi
 
       # Hard gate (review: all three reviewers, #1813): an invalid/forged registry
       # signature fails CI. Verified to exit 0 on the current tree (116 attestations).

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -9,11 +9,22 @@ If you discover a security issue in KubeDojo's content (e.g., a command that cou
 
 ## Scope
 
-KubeDojo is educational content (markdown files). There is no application code, backend, or user data. Security concerns are limited to:
+KubeDojo is primarily educational content (markdown modules), but the repository also has a **CI/build pipeline** and an **npm dependency supply chain** (Astro/Starlight site build). Security concerns include:
 
 - Commands or YAML examples that could be harmful if copy-pasted
 - Accidental inclusion of real credentials or tokens in examples
 - Links to malicious external resources
+- Compromised or malicious npm dependencies and lockfile tampering
+- GitHub Actions workflow misconfiguration
+
+There is no production application backend or learner user data stored in this repo.
+
+## Supply-Chain Security
+
+Miasma-class npm supply-chain defenses are tracked in [issue #1812](https://github.com/kube-dojo/kube-dojo.github.io/issues/1812).
+
+- **Maintainers:** [docs/security/detection-runbook.md](docs/security/detection-runbook.md) — what each control detects and how to triage CI failures
+- **Developers:** [docs/security/local-dev-supply-chain.md](docs/security/local-dev-supply-chain.md) — `.npmrc` script blocking, local rebuild, token hygiene
 
 ## Content Security
 

--- a/docs/security/detection-runbook.md
+++ b/docs/security/detection-runbook.md
@@ -52,7 +52,7 @@ Layers: **PREVENT** (stop execution) → **DETECT** (surface changes) → **CONT
 
 | | |
 |---|---|
-| **What** | Git-diff tripwire: any change to a dependency's `version`, `resolved`, or `integrity` in `package-lock.json` **without** a matching `package.json` change in the same range. |
+| **What** | Git-diff tripwire: any installer-affecting metadata change (version, resolved, integrity, bin, dependency edges, os/cpu, install-script flag, …) in `package-lock.json` **without** a matching `package.json` change in the same range. |
 | **Attack signal** | Silent lockfile swap — attacker mutates the lockfile to point at a malicious tarball while leaving `package.json` unchanged; `npm ci` installs it blindly. |
 | **Where it surfaces** | Workflow **Supply-chain detection** → job `detect` → step **Lockfile-integrity tripwire**. CI failure (exit 1) with `[lockfile-swap]` paths. |
 | **Time-to-detect** | Next PR/push (minutes). |

--- a/docs/security/detection-runbook.md
+++ b/docs/security/detection-runbook.md
@@ -1,0 +1,121 @@
+# Supply-chain detection runbook
+
+Operational guide for Miasma-class npm/CI supply-chain defenses ([issue #1812](https://github.com/kube-dojo/kube-dojo.github.io/issues/1812)).
+
+## Strategy
+
+You cannot fully prevent being *reached* by a dependency attack. Failure conditions are a malicious hook **executing**, reaching a **secret**, **spreading** to other packages, or doing any of that **undetected**. Success means **zero blast radius** (hooks do not run, secrets are unreachable at install time) plus **fast time-to-detect** when the tree changes.
+
+Layers: **PREVENT** (stop execution) → **DETECT** (surface changes) → **CONTAIN** (limit credential exposure) → **RESPOND** (triage below).
+
+---
+
+## Controls
+
+### 1. `ignore-scripts=true` (`.npmrc`) — PREVENT
+
+| | |
+|---|---|
+| **What** | Blocks all dependency lifecycle scripts (`preinstall` / `install` / `postinstall`) on `npm install` and `npm ci`. |
+| **Attack signal** | N/A — primary control. A Miasma-class worm's execution point is an install hook; this neutralises it in CI and local dev. |
+| **Where it surfaces** | Every `npm ci` / `npm install` (local + CI). Not a CI failure by itself. |
+| **Time-to-detect** | Immediate at install time (hook does not run). |
+| **Response** | No tripwire fire. After install, run `npm rebuild esbuild sharp --ignore-scripts=false` if you need a local build (see [local-dev-supply-chain.md](./local-dev-supply-chain.md)). |
+
+---
+
+### 2. Lifecycle-script tripwire (`scripts/security/check_install_scripts.py`) — DETECT
+
+| | |
+|---|---|
+| **What** | Scans `package-lock.json` for unaudited install-time code: new `hasInstallScript` packages, allow-list abuse, non-registry `resolved` URLs, `file:`/local links, alias masquerade. |
+| **Attack signal** | New or changed install hook; dependency resolved from git/tarball/local; compromised allow-listed package adding rogue hooks. |
+| **Where it surfaces** | Workflow **Supply-chain detection** → job `detect` → step **Lifecycle-script tripwire**. CI failure (exit 1). |
+| **Time-to-detect** | Next PR/push to `main` (minutes). |
+| **Response** | 1. Read stderr lines (`[install-hook]`, `[non-registry]`, etc.). 2. Inspect lockfile diff and the flagged package on the registry. 3. If legitimate (e.g. new native dep), update `ALLOWLIST_INSTALL` / `EXPECTED_HOOKS` in the script in a **separate reviewed commit**. 4. If malicious, do not merge; rotate tokens (see local-dev doc); report via [SECURITY.md](../../SECURITY.md). |
+
+---
+
+### 3. Provenance / signature gate (`npm audit signatures`) — DETECT
+
+| | |
+|---|---|
+| **What** | Verifies npm registry package attestations/signatures for locked dependencies. |
+| **Attack signal** | Unsigned package, invalid signature, or forged provenance after a republish attack. |
+| **Where it surfaces** | Workflow **Supply-chain detection** → job `detect` → step **Verify dependency provenance / signatures**. CI failure. May also appear in GitHub **Security** tab depending on org settings. |
+| **Time-to-detect** | Next PR/push (minutes). |
+| **Response** | 1. Identify which package failed from `npm audit signatures` output. 2. Compare lockfile `integrity` / `resolved` with the known-good registry artifact. 3. If supply-chain incident, block merge, rotate credentials, audit recent publishes. 4. If npm/registry outage or tooling bug, document and track separately — do not disable without review. |
+
+---
+
+### 4. Lockfile-integrity tripwire (`scripts/security/check_lockfile_integrity.py`) — DETECT
+
+| | |
+|---|---|
+| **What** | Git-diff tripwire: any change to a dependency's `version`, `resolved`, or `integrity` in `package-lock.json` **without** a matching `package.json` change in the same range. |
+| **Attack signal** | Silent lockfile swap — attacker mutates the lockfile to point at a malicious tarball while leaving `package.json` unchanged; `npm ci` installs it blindly. |
+| **Where it surfaces** | Workflow **Supply-chain detection** → job `detect` → step **Lockfile-integrity tripwire**. CI failure (exit 1) with `[lockfile-swap]` paths. |
+| **Time-to-detect** | Next PR/push (minutes). |
+| **Override** | Suppressed if HEAD commit message contains literal `[lockfile-only]` or env `LOCKFILE_OVERRIDE=1`. **This is an acknowledgement marker, not an authorization control** — an attacker could add the token; value is forcing human review of lockfile-only diffs (e.g. `npm audit fix`, transitive maintenance). |
+| **Response** | 1. Review every listed package path and field diff. 2. Confirm the resolved URL and integrity match intended registry artifacts. 3. If legitimate lockfile-only maintenance, re-commit with `[lockfile-only]` in the message **after** review, or bump `package.json` in the same PR. 4. If unexplained, treat as incident — do not merge. |
+
+---
+
+### 5. Dependabot cooldown (7 days) — slow adoption
+
+| | |
+|---|---|
+| **What** | `.github/dependabot.yml` sets `cooldown: { default-days: 7 }` on pip, github-actions, and npm ecosystems. |
+| **Attack signal** | Tag-mutation / republish attacks where a poisoned version is published and quickly auto-merged. |
+| **Where it surfaces** | Dependabot PRs delayed 7 days after a new tag. Not a CI failure. zizmor `dependabot-cooldown` audit in workflow **GitHub Actions security scan**. |
+| **Time-to-detect** | Up to 7 days before auto-proposed bump (disclosure window for the community). |
+| **Response** | When Dependabot opens a bump, normal review still applies; cooldown only delays adoption. Do not remove cooldown without security review. |
+
+---
+
+### 6. Build/deploy job separation (`deploy.yml`) — CONTAIN
+
+| | |
+|---|---|
+| **What** | `build` job: `npm ci` + build with `contents: read` only — **no** OIDC/Pages token. `deploy` job: `id-token: write` + `pages: write`, **no** npm. |
+| **Attack signal** | Compromised dependency executing during install and attempting to exfiltrate CI credentials. |
+| **Where it surfaces** | Architectural — not a detector. Failure would be credential misuse in Actions logs or external exfil (if prevention failed). |
+| **Time-to-detect** | N/A (prevents reach). |
+| **Response** | Never co-locate `npm ci` with the privileged deploy job. If refactoring workflows, preserve this boundary. |
+
+---
+
+### 7. zizmor + SHA-pinned actions — PREVENT / DETECT (Actions layer)
+
+| | |
+|---|---|
+| **What** | `zizmor` scans `.github/` for workflow vulnerabilities; all `uses:` actions are pinned to full commit SHAs. |
+| **Attack signal** | Mutable action tags, excessive permissions, unpinned third-party actions, missing Dependabot cooldown, etc. |
+| **Where it surfaces** | Workflow **GitHub Actions security scan** → job `zizmor`. CI failure on findings. |
+| **Time-to-detect** | PR touching `.github/workflows/**`, `.github/actions/**`, or `.github/dependabot.yml`. |
+| **Response** | Fix findings per zizmor output; run locally: `uvx zizmor --offline --strict-collection .github/`. |
+
+---
+
+### 8. harden-runner egress monitoring — PENDING
+
+| | |
+|---|---|
+| **What** | StepSecurity **harden-runner** egress allow-listing and anomaly detection for GitHub Actions runners. |
+| **Status** | **Not yet enabled** — requires installing the StepSecurity GitHub App at the **organisation** level (owner action; same class as issue #1798). |
+| **Attack signal** | Unexpected outbound connections from CI (exfiltration, C2) if a hook or action is compromised. |
+| **Where it surfaces** | Would appear in StepSecurity dashboard + optional CI annotations once enabled. |
+| **Response** | Track as follow-up to #1812; enable org app when owner approves. |
+
+---
+
+## Quick triage checklist
+
+When any **DETECT** control fires:
+
+1. **Do not merge** until understood.
+2. Run locally: `python3 scripts/security/check_install_scripts.py` and `python3 scripts/security/check_lockfile_integrity.py`.
+3. Inspect `git diff` for `package-lock.json` and `package.json`.
+4. Check registry pages for affected packages (version, publish date, maintainer).
+5. If incident: rotate npm and GitHub tokens, audit recent publishes, file a security report.
+6. Read [local-dev-supply-chain.md](./local-dev-supply-chain.md) for developer hygiene.

--- a/docs/security/local-dev-supply-chain.md
+++ b/docs/security/local-dev-supply-chain.md
@@ -1,0 +1,60 @@
+# Local development — supply-chain hygiene
+
+Developer guide for working safely with npm dependencies on KubeDojo ([issue #1812](https://github.com/kube-dojo/kube-dojo.github.io/issues/1812)).
+
+## Lifecycle scripts are blocked
+
+The repo root `.npmrc` sets:
+
+```ini
+ignore-scripts=true
+```
+
+`npm install` and `npm ci` **do not run** dependency `preinstall`, `install`, or `postinstall` hooks. That is intentional: a Miasma-class worm executes through those hooks to steal credentials and republish packages with forged provenance. Blocking scripts neutralises the attack locally, not only in CI.
+
+### Building the site locally
+
+Two audited native dependencies still need their install scripts after a fresh install:
+
+- **esbuild** — `postinstall` links the platform binary
+- **sharp** — `install` fetches the libvips native binary
+
+Plain `npm rebuild` honours `ignore-scripts=true` and is a **no-op**. Re-enable scripts only for those packages:
+
+```bash
+npm ci
+npm rebuild esbuild sharp --ignore-scripts=false
+npm run build
+```
+
+CI's **Deploy to GitHub Pages** workflow runs the same rebuild step automatically.
+
+## Token and credential hygiene
+
+Miasma-class malware harvests **local npm tokens** and **GitHub credentials** from developer machines. Reduce exposure:
+
+- Do **not** keep long-lived npm publish tokens on dev machines unless you are actively publishing.
+- Prefer **short-lived**, **scoped** GitHub tokens (fine-grained PATs or `gh auth` session tokens) over broad legacy PATs.
+- **Rotate** npm and GitHub tokens if you suspect exposure (suspicious lockfile diff, tripwire fire, or unexpected package publish).
+- **Never** commit real tokens — examples in this repo use placeholders only (`changeme`, `example.com`).
+
+## If a tripwire fires locally
+
+Run the same deterministic checks CI uses:
+
+```bash
+python3 scripts/security/check_install_scripts.py
+python3 scripts/security/check_lockfile_integrity.py
+```
+
+Then:
+
+1. Read the output — each line is tagged (`[install-hook]`, `[lockfile-swap]`, etc.).
+2. Open [detection-runbook.md](./detection-runbook.md) for the matching control and triage steps.
+3. Inspect `git diff package-lock.json package.json` before committing.
+4. For a **legitimate lockfile-only** change (e.g. `npm audit fix`), review carefully; CI accepts it only with the `[lockfile-only]` acknowledgement marker in the commit message (see runbook — not a security gate, only a review signal).
+
+## Further reading
+
+- [detection-runbook.md](./detection-runbook.md) — what each control does and how to respond
+- [SECURITY.md](../../SECURITY.md) — reporting vulnerabilities

--- a/scripts/security/check_lockfile_integrity.py
+++ b/scripts/security/check_lockfile_integrity.py
@@ -3,15 +3,16 @@
 
 `.npmrc` sets `ignore-scripts=true` (PREVENTION). `check_install_scripts.py` catches
 non-registry sources, local links, and alias masquerade. THIS tripwire's distinct job is
-to surface any lockfile dependency mutation (`version` / `resolved` / `integrity`) that
-is NOT accompanied by a `package.json` change — the "silent lockfile swap" where an
-attacker edits `package-lock.json` without touching `package.json` and `npm ci` installs
-the malicious artifact without complaint.
+to surface any installer-affecting lockfile metadata change (version, resolved,
+integrity, bin, dependency edges, os/cpu, install-script flag, …) that is NOT
+accompanied by a `package.json` change — the "silent lockfile swap" where an attacker
+edits `package-lock.json` without touching `package.json` and `npm ci` installs a
+different artifact or dependency tree without complaint.
 
 Decision:
-  - dependency tuples unchanged          → PASS (exit 0)
-  - lockfile tuples changed AND package.json also changed → PASS (normal dep bump)
-  - lockfile tuples changed AND package.json UNCHANGED    → FAIL (exit 1)
+  - package fingerprints unchanged       → PASS (exit 0)
+  - lockfile fingerprints changed AND package.json also changed → PASS (normal dep bump)
+  - lockfile fingerprints changed AND package.json UNCHANGED    → FAIL (exit 1)
 
 Override (acknowledgement marker, NOT an authorization control):
   A failure is suppressed when the HEAD commit message contains the literal token
@@ -45,8 +46,9 @@ from pathlib import Path
 REPO_ROOT = Path(__file__).resolve().parents[2]
 LOCKFILE = "package-lock.json"
 MANIFEST = "package.json"
-TUPLE_FIELDS = ("version", "resolved", "integrity")
+NOISE_FIELDS = frozenset({"funding", "license", "deprecated"})
 MAX_REPORT = 50
+MAX_FIELD_DISPLAY = 120
 OVERRIDE_TOKEN = "[lockfile-only]"
 
 
@@ -76,15 +78,31 @@ def diff_range(base: str, head: str, three_dot: bool) -> str:
     return f"{base}{sep}{head}"
 
 
+def diff_has_changes(range_spec: str, path: str) -> bool:
+    r = run_git(["diff", "--quiet", range_spec, "--", path], check=False)
+    if r.returncode == 0:
+        return False
+    if r.returncode == 1:
+        return True
+    print(
+        f"ERROR: git diff failed for {path} in {range_spec}: {r.stderr.strip()}",
+        file=sys.stderr,
+    )
+    raise RuntimeError(f"git diff failed for {path}")
+
+
 def manifest_changed_in_range(range_spec: str) -> bool:
-    return run_git(["diff", "--quiet", range_spec, "--", MANIFEST], check=False).returncode != 0
+    return diff_has_changes(range_spec, MANIFEST)
 
 
 def lockfile_changed_in_range(range_spec: str) -> bool:
-    return run_git(["diff", "--quiet", range_spec, "--", LOCKFILE], check=False).returncode != 0
+    return diff_has_changes(range_spec, LOCKFILE)
 
 
-def load_packages_at(ref: str) -> dict[str, dict[str, str | None]] | None:
+PackageFingerprint = dict[str, object]
+
+
+def load_packages_at(ref: str) -> dict[str, PackageFingerprint] | None:
     """Return packages map keyed by lockfile path, or None if lockfile absent at ref."""
     result = run_git(["show", f"{ref}:{LOCKFILE}"], check=False)
     if result.returncode != 0:
@@ -97,7 +115,7 @@ def load_packages_at(ref: str) -> dict[str, dict[str, str | None]] | None:
     return packages_from_json_text(result.stdout, f"{ref}:{LOCKFILE}")
 
 
-def packages_from_json_text(text: str, source: str) -> dict[str, dict[str, str | None]]:
+def packages_from_json_text(text: str, source: str) -> dict[str, PackageFingerprint]:
     try:
         data = json.loads(text)
     except json.JSONDecodeError as exc:
@@ -108,15 +126,15 @@ def packages_from_json_text(text: str, source: str) -> dict[str, dict[str, str |
     if not isinstance(packages, dict):
         return {}
 
-    out: dict[str, dict[str, str | None]] = {}
+    out: dict[str, PackageFingerprint] = {}
     for path, meta in packages.items():
         if not path or not isinstance(meta, dict):
             continue
-        out[path] = {field: meta.get(field) for field in TUPLE_FIELDS}
+        out[path] = {k: v for k, v in meta.items() if k not in NOISE_FIELDS}
     return out
 
 
-def load_packages_worktree(ref: str) -> dict[str, dict[str, str | None]]:
+def load_packages_worktree(ref: str) -> dict[str, PackageFingerprint]:
     """Load lockfile from the worktree when ref is HEAD, else via git show."""
     if ref in ("HEAD", "head"):
         lock_path = REPO_ROOT / LOCKFILE
@@ -134,9 +152,9 @@ def load_packages_worktree(ref: str) -> dict[str, dict[str, str | None]]:
     return pkgs if pkgs is not None else {}
 
 
-def dependency_tuple_changes(
-    before: dict[str, dict[str, str | None]] | None,
-    after: dict[str, dict[str, str | None]],
+def changed_package_paths(
+    before: dict[str, PackageFingerprint] | None,
+    after: dict[str, PackageFingerprint],
 ) -> list[str]:
     before = before or {}
     changed: list[str] = []
@@ -145,6 +163,13 @@ def dependency_tuple_changes(
         if before.get(path) != after.get(path):
             changed.append(path)
     return changed
+
+
+def format_field_value(value: object) -> str:
+    text = repr(value)
+    if len(text) <= MAX_FIELD_DISPLAY:
+        return text
+    return text[: MAX_FIELD_DISPLAY - 3] + "..."
 
 
 def override_active(head: str) -> bool:
@@ -177,7 +202,7 @@ def main(argv: list[str]) -> int:
     base = args.base or "HEAD~1"
     three_dot = args.three_dot
 
-    print(f"Lockfile-integrity tripwire — comparing {LOCKFILE} dependency tuples.")
+    print(f"Lockfile-integrity tripwire — comparing {LOCKFILE} package fingerprints.")
 
     if not ref_exists(head):
         print(f"ERROR: head ref not found: {head}", file=sys.stderr)
@@ -200,22 +225,21 @@ def main(argv: list[str]) -> int:
     try:
         before_pkgs = load_packages_at(base)
         after_pkgs = load_packages_worktree(head)
+        changed_paths = changed_package_paths(before_pkgs, after_pkgs)
+
+        if not changed_paths:
+            print("OK — no installer-affecting lockfile fingerprint changes.")
+            return 0
+
+        # Structured fingerprint compare is authoritative even if git diff merge-base differs.
+        pkg_json_changed = manifest_changed_in_range(range_spec)
+        lockfile_in_diff = lockfile_changed_in_range(range_spec)
     except RuntimeError:
         return 2
 
-    changed_paths = dependency_tuple_changes(before_pkgs, after_pkgs)
-
-    if not changed_paths:
-        print("OK — no dependency tuple changes in lockfile.")
-        return 0
-
-    # Structured tuple compare is authoritative even if git diff merge-base differs.
-    pkg_json_changed = manifest_changed_in_range(range_spec)
-    lockfile_in_diff = lockfile_changed_in_range(range_spec)
-
     if pkg_json_changed:
         print(
-            f"NOTE: {len(changed_paths)} dependency tuple(s) changed and "
+            f"NOTE: {len(changed_paths)} package fingerprint(s) changed and "
             f"{MANIFEST} also changed in {range_spec} — expected for dep bumps."
         )
         print("OK — lockfile change accompanied by manifest change.")
@@ -227,20 +251,20 @@ def main(argv: list[str]) -> int:
             "LOCKFILE_OVERRIDE=1) — acknowledging lockfile-only change."
         )
         print(
-            f"  {len(changed_paths)} dependency tuple(s) changed without "
+            f"  {len(changed_paths)} package fingerprint(s) changed without "
             f"{MANIFEST} change (reviewed/acknowledged)."
         )
         return 0
 
     print(
         f"\n  SUPPLY-CHAIN TRIPWIRE: silent lockfile swap — "
-        f"{len(changed_paths)} dependency tuple(s) changed without a "
+        f"{len(changed_paths)} package fingerprint(s) changed without a "
         f"{MANIFEST} change in {range_spec}:",
         file=sys.stderr,
     )
     if not lockfile_in_diff:
         print(
-            f"  (structured compare detected tuple drift; git diff may use a "
+            f"  (structured compare detected fingerprint drift; git diff may use a "
             f"different merge-base than {range_spec})",
             file=sys.stderr,
         )
@@ -250,10 +274,11 @@ def main(argv: list[str]) -> int:
         before = (before_pkgs or {}).get(path, {})
         after = after_pkgs.get(path, {})
         print(f"    [lockfile-swap] {path}", file=sys.stderr)
-        for field in TUPLE_FIELDS:
+        for field in sorted(set(before) | set(after)):
             if before.get(field) != after.get(field):
                 print(
-                    f"      {field}: {before.get(field)!r} → {after.get(field)!r}",
+                    f"      {field}: {format_field_value(before.get(field))} → "
+                    f"{format_field_value(after.get(field))}",
                     file=sys.stderr,
                 )
 

--- a/scripts/security/check_lockfile_integrity.py
+++ b/scripts/security/check_lockfile_integrity.py
@@ -1,0 +1,277 @@
+#!/usr/bin/env python3
+"""Supply-chain DETECTION tripwire — issue #1812 (Miasma-class worm defense).
+
+`.npmrc` sets `ignore-scripts=true` (PREVENTION). `check_install_scripts.py` catches
+non-registry sources, local links, and alias masquerade. THIS tripwire's distinct job is
+to surface any lockfile dependency mutation (`version` / `resolved` / `integrity`) that
+is NOT accompanied by a `package.json` change — the "silent lockfile swap" where an
+attacker edits `package-lock.json` without touching `package.json` and `npm ci` installs
+the malicious artifact without complaint.
+
+Decision:
+  - dependency tuples unchanged          → PASS (exit 0)
+  - lockfile tuples changed AND package.json also changed → PASS (normal dep bump)
+  - lockfile tuples changed AND package.json UNCHANGED    → FAIL (exit 1)
+
+Override (acknowledgement marker, NOT an authorization control):
+  A failure is suppressed when the HEAD commit message contains the literal token
+  `[lockfile-only]` OR env `LOCKFILE_OVERRIDE=1` is set. An attacker could add the
+  marker to their own PR — the real value is forcing the lockfile diff to be NOTICED
+  and reviewed; the marker only records that a human acknowledged it.
+
+Range selection (git-diff based, deterministic, no network):
+  - `--base <ref>` / `--head <ref>`; defaults: head=`HEAD`, base from env
+    `LOCKFILE_BASE` else `HEAD~1`.
+  - `--three-dot` uses `<base>...<head>` (merge-base diff — use for pull requests).
+  - Default (no `--three-dot`) uses `<base>..<head>` (two-dot — fine for push / local).
+
+Edge cases:
+  - No base commit (initial/shallow clone with one commit) → note + PASS (exit 0).
+  - Missing `package-lock.json` at base (newly added) → all entries are "new".
+  - `git`/JSON errors → non-zero exit with a clear message (fail closed).
+
+Exit 0 = clean or acknowledged. Exit 1 = silent lockfile swap signal.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+LOCKFILE = "package-lock.json"
+MANIFEST = "package.json"
+TUPLE_FIELDS = ("version", "resolved", "integrity")
+MAX_REPORT = 50
+OVERRIDE_TOKEN = "[lockfile-only]"
+
+
+def run_git(args: list[str], *, check: bool = True) -> subprocess.CompletedProcess[str]:
+    return subprocess.run(
+        ["git", *args],
+        cwd=REPO_ROOT,
+        capture_output=True,
+        text=True,
+        check=check,
+    )
+
+
+def ref_exists(ref: str) -> bool:
+    return run_git(["rev-parse", "--verify", ref], check=False).returncode == 0
+
+
+def commit_message(ref: str) -> str:
+    result = run_git(["log", "-1", "--format=%B", ref], check=False)
+    if result.returncode != 0:
+        return ""
+    return result.stdout
+
+
+def diff_range(base: str, head: str, three_dot: bool) -> str:
+    sep = "..." if three_dot else ".."
+    return f"{base}{sep}{head}"
+
+
+def manifest_changed_in_range(range_spec: str) -> bool:
+    return run_git(["diff", "--quiet", range_spec, "--", MANIFEST], check=False).returncode != 0
+
+
+def lockfile_changed_in_range(range_spec: str) -> bool:
+    return run_git(["diff", "--quiet", range_spec, "--", LOCKFILE], check=False).returncode != 0
+
+
+def load_packages_at(ref: str) -> dict[str, dict[str, str | None]] | None:
+    """Return packages map keyed by lockfile path, or None if lockfile absent at ref."""
+    result = run_git(["show", f"{ref}:{LOCKFILE}"], check=False)
+    if result.returncode != 0:
+        stderr = (result.stderr or "").lower()
+        if "does not exist" in stderr or "exists on disk, but not in" in stderr:
+            return None
+        print(f"ERROR: cannot read {LOCKFILE} at {ref}: {result.stderr.strip()}", file=sys.stderr)
+        raise RuntimeError(f"git show failed for {ref}:{LOCKFILE}")
+
+    return packages_from_json_text(result.stdout, f"{ref}:{LOCKFILE}")
+
+
+def packages_from_json_text(text: str, source: str) -> dict[str, dict[str, str | None]]:
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        print(f"ERROR: invalid JSON in {source}: {exc}", file=sys.stderr)
+        raise RuntimeError("invalid lockfile JSON") from exc
+
+    packages = data.get("packages")
+    if not isinstance(packages, dict):
+        return {}
+
+    out: dict[str, dict[str, str | None]] = {}
+    for path, meta in packages.items():
+        if not path or not isinstance(meta, dict):
+            continue
+        out[path] = {field: meta.get(field) for field in TUPLE_FIELDS}
+    return out
+
+
+def load_packages_worktree(ref: str) -> dict[str, dict[str, str | None]]:
+    """Load lockfile from the worktree when ref is HEAD, else via git show."""
+    if ref in ("HEAD", "head"):
+        lock_path = REPO_ROOT / LOCKFILE
+        if not lock_path.is_file():
+            print(f"ERROR: lockfile not found: {lock_path}", file=sys.stderr)
+            raise RuntimeError("missing worktree lockfile")
+        try:
+            text = lock_path.read_text(encoding="utf-8")
+        except OSError as exc:
+            print(f"ERROR: cannot read {lock_path}: {exc}", file=sys.stderr)
+            raise RuntimeError("missing worktree lockfile") from exc
+        return packages_from_json_text(text, str(lock_path))
+
+    pkgs = load_packages_at(ref)
+    return pkgs if pkgs is not None else {}
+
+
+def dependency_tuple_changes(
+    before: dict[str, dict[str, str | None]] | None,
+    after: dict[str, dict[str, str | None]],
+) -> list[str]:
+    before = before or {}
+    changed: list[str] = []
+    all_paths = sorted(set(before) | set(after))
+    for path in all_paths:
+        if before.get(path) != after.get(path):
+            changed.append(path)
+    return changed
+
+
+def override_active(head: str) -> bool:
+    if os.environ.get("LOCKFILE_OVERRIDE") == "1":
+        return True
+    return OVERRIDE_TOKEN in commit_message(head)
+
+
+def parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Detect silent package-lock.json dependency swaps (issue #1812)."
+    )
+    parser.add_argument(
+        "--base",
+        default=os.environ.get("LOCKFILE_BASE"),
+        help="Base ref (default: env LOCKFILE_BASE, else HEAD~1)",
+    )
+    parser.add_argument("--head", default="HEAD", help="Head ref (default: HEAD)")
+    parser.add_argument(
+        "--three-dot",
+        action="store_true",
+        help="Use three-dot diff range (merge-base; for pull requests)",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str]) -> int:
+    args = parse_args(argv[1:])
+    head = args.head
+    base = args.base or "HEAD~1"
+    three_dot = args.three_dot
+
+    print(f"Lockfile-integrity tripwire — comparing {LOCKFILE} dependency tuples.")
+
+    if not ref_exists(head):
+        print(f"ERROR: head ref not found: {head}", file=sys.stderr)
+        return 2
+
+    if base == "HEAD~1" and not ref_exists("HEAD~1"):
+        print(
+            "NOTE: no parent commit (initial or shallow clone) — skipping lockfile diff."
+        )
+        print("OK — nothing to compare.")
+        return 0
+
+    if not ref_exists(base):
+        print(f"ERROR: base ref not found: {base}", file=sys.stderr)
+        return 2
+
+    range_spec = diff_range(base, head, three_dot)
+    print(f"Range: {range_spec}")
+
+    try:
+        before_pkgs = load_packages_at(base)
+        after_pkgs = load_packages_worktree(head)
+    except RuntimeError:
+        return 2
+
+    changed_paths = dependency_tuple_changes(before_pkgs, after_pkgs)
+
+    if not changed_paths:
+        print("OK — no dependency tuple changes in lockfile.")
+        return 0
+
+    # Structured tuple compare is authoritative even if git diff merge-base differs.
+    pkg_json_changed = manifest_changed_in_range(range_spec)
+    lockfile_in_diff = lockfile_changed_in_range(range_spec)
+
+    if pkg_json_changed:
+        print(
+            f"NOTE: {len(changed_paths)} dependency tuple(s) changed and "
+            f"{MANIFEST} also changed in {range_spec} — expected for dep bumps."
+        )
+        print("OK — lockfile change accompanied by manifest change.")
+        return 0
+
+    if override_active(head):
+        print(
+            f"NOTE: override active ({OVERRIDE_TOKEN} in commit message or "
+            "LOCKFILE_OVERRIDE=1) — acknowledging lockfile-only change."
+        )
+        print(
+            f"  {len(changed_paths)} dependency tuple(s) changed without "
+            f"{MANIFEST} change (reviewed/acknowledged)."
+        )
+        return 0
+
+    print(
+        f"\n  SUPPLY-CHAIN TRIPWIRE: silent lockfile swap — "
+        f"{len(changed_paths)} dependency tuple(s) changed without a "
+        f"{MANIFEST} change in {range_spec}:",
+        file=sys.stderr,
+    )
+    if not lockfile_in_diff:
+        print(
+            f"  (structured compare detected tuple drift; git diff may use a "
+            f"different merge-base than {range_spec})",
+            file=sys.stderr,
+        )
+
+    shown = changed_paths[:MAX_REPORT]
+    for path in shown:
+        before = (before_pkgs or {}).get(path, {})
+        after = after_pkgs.get(path, {})
+        print(f"    [lockfile-swap] {path}", file=sys.stderr)
+        for field in TUPLE_FIELDS:
+            if before.get(field) != after.get(field):
+                print(
+                    f"      {field}: {before.get(field)!r} → {after.get(field)!r}",
+                    file=sys.stderr,
+                )
+
+    remaining = len(changed_paths) - len(shown)
+    if remaining > 0:
+        print(f"    … and {remaining} more path(s)", file=sys.stderr)
+
+    print(
+        "\n  This is how a Miasma-class attacker swaps a resolved tarball without "
+        "touching package.json. Review the lockfile diff.\n"
+        "  If legitimate (e.g. npm audit fix), either commit the change together "
+        f"with {MANIFEST} or add the acknowledgement marker [lockfile-only] to the "
+        "commit message (or set LOCKFILE_OVERRIDE=1 locally).\n"
+        "  The marker is NOT an authorization control — it only records human review.",
+        file=sys.stderr,
+    )
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Phase-1 follow-ups for #1812 (Miasma-class supply-chain defense-in-depth). Builds on #1813 (prevent + detect core). All authoring on non-Claude lanes (s105 directive).

## What's added
- **Lockfile-integrity tripwire** (`scripts/security/check_lockfile_integrity.py`, P2 DETECT) — surfaces any **installer-affecting** `package-lock.json` mutation (version/resolved/integrity **+ `bin`, dependency edges, os/cpu, install-script flag, link, …**) that is **not** accompanied by a `package.json` change — the "silent lockfile swap". Wired into `supply-chain.yml` (`fetch-depth: 0`, three-dot diff for PRs). Override via `[lockfile-only]` / `LOCKFILE_OVERRIDE=1` — documented honestly as an **acknowledgement marker, not an authorization control** (forces human review of unexplained lockfile diffs).
- **Detection runbook** (`docs/security/detection-runbook.md`, P3) — all 8 controls: what fires, where it surfaces, time-to-detect, triage. Includes the pending **harden-runner** (owner action).
- **Local-dev guidance** (`docs/security/local-dev-supply-chain.md`, P1) — `.npmrc` script blocking, the `npm rebuild esbuild sharp` recipe, token-rotation hygiene, tripwire triage.
- **deploy.yml CONTAIN comment** (P2) — locks the build/deploy job separation rationale (OIDC token unreachable at `npm ci` time).
- **SECURITY.md** — supply-chain scope + pointers; #1812 AC reconciliation in the issue.

## Cross-family review (codex, adversarial)
- **R1 (codex gpt-5.5): NEEDS_CHANGES** — two *validated* bypasses of the initial 3-field `{version,resolved,integrity}` tuple: a `bin` swap (repoints `.bin` symlinks) and a `dependencies`-map edit (drops a dep from the installed tree), neither caught by `check_install_scripts.py` or `npm audit signatures`. Plus a fail-open `git diff --quiet` path (returncode >1 collapsed to "changed").
- **R2 fix:** fingerprint the **full installer-affecting entry** (minus pure-metadata noise: funding/license/deprecated) — closes the whole class of field-level bypasses; `git diff` handling made **fail-closed** (0→clean, 1→changed, error→exit 2).
- **Orchestrator ground-check:** re-ran both demonstrated bypasses → now exit 1 (was 0); PASS/override/error paths correct; lockfile byte-identical; ruff + zizmor clean.

Refs #1812