### PR TITLE
docs(readme): full refresh — 8 tracks / 824 modules, fix stale counts + broken links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # KubeDojo
 
-**Free, comprehensive cloud native education.**
+**Free, comprehensive cloud native education — from Zero to Production.**
 
-Kubernetes certifications. Platform engineering. SRE. DevSecOps. MLOps.
+Terminal basics → Linux → Kubernetes certifications → Cloud → Platform engineering → On-prem → AI & AI/ML engineering.
 
-No paywalls. No upsells. Theory-first.
+No paywalls. No upsells. Theory-first, hands-on always.
+
+**🌐 Live site: [kube-dojo.github.io](https://kube-dojo.github.io/)** · [What's New / Changelog](https://kube-dojo.github.io/changelog/)
 
 ---
 
@@ -48,79 +50,33 @@ No paywalls. No upsells. Theory-first.
 
 ---
 
-## Learning Path
+## Learning Tracks
 
-```
-                              KUBEDOJO
-    ═══════════════════════════════════════════════════════════
+Eight structured tracks — **824 modules** — from absolute beginner to production systems, AI literacy, private infrastructure, and AI/ML engineering.
 
-    ┌─────────────────────────────────────────────────────────┐
-    │                                                         │
-    │   PREREQUISITES                        "Why Kubernetes?"│
-    │   └── docs/prerequisites/                               │
-    │       ├── Philosophy & Design          4 modules        │
-    │       ├── Cloud Native 101             5 modules        │
-    │       ├── Kubernetes Basics            8 modules        │
-    │       └── Modern DevOps                6 modules        │
-    │                                                         │
-    └────────────────────────┬────────────────────────────────┘
-                             │
-              ┌──────────────┴──────────────┐
-              │                             │
-              ▼                             ▼
-    ┌─────────────────────────┐   ┌─────────────────────────┐
-    │                         │   │                         │
-    │   LINUX DEEP DIVE       │   │   CERTIFICATIONS        │
-    │   └── docs/linux/       │   │   └── docs/k8s/         │
-    │       │                 │   │       │                 │
-    │       ├── foundations/  │   │       │  ENTRY LEVEL    │
-    │       │  System · Cgroup│   │       ├── KCNA          │
-    │       │  Network        │   │       ├── KCSA          │
-    │       │                 │   │       │                 │
-    │       ├── security/     │   │       │  PRACTITIONER   │
-    │       │  Hardening      │   │       ├── CKAD          │
-    │       │                 │   │       ├── CKA           │
-    │       └── operations/   │   │       └── CKS           │
-    │          Perf · Debug   │   │                         │
-    │          Shell Scripts  │   │                         │
-    │                         │   │                         │
-    └────────────┬────────────┘   └────────────┬────────────┘
-                 │                             │
-                 └──────────────┬──────────────┘
-                                │
-                                ▼
-    ┌─────────────────────────────────────────────────────────┐
-    │                                                         │
-    │   PLATFORM ENGINEERING              Beyond Certifications│
-    │   └── docs/platform/                                    │
-    │       │                                                 │
-    │       ├── foundations/         Theory that doesn't change│
-    │       │   Systems Thinking · Reliability · Distributed  │
-    │       │   Systems · Observability Theory · Security     │
-    │       │                                                 │
-    │       ├── disciplines/         Applied practices        │
-    │       │   SRE · Platform Engineering · GitOps · IaC ·   │
-    │       │   DevSecOps · MLOps · AIOps                     │
-    │       │                                                 │
-    │       └── toolkits/            Current tools (evolving) │
-    │           Prometheus · ArgoCD · Terraform · Vault ·     │
-    │           Backstage · Kubeflow · and more...            │
-    │                                                         │
-    └─────────────────────────────────────────────────────────┘
+| Track | Modules | Est. time | What it covers |
+|-------|--------:|-----------|----------------|
+| [Fundamentals](https://kube-dojo.github.io/prerequisites/) | 44 | ~55h | Zero to Terminal, Cloud Native 101, Kubernetes Basics. **Start here if you're new.** |
+| [Linux](https://kube-dojo.github.io/linux/) | 37 | ~50h | Everyday Use + Deep Dive — basic commands to kernel internals. |
+| [Cloud](https://kube-dojo.github.io/cloud/) | 92 | ~130h | AWS / GCP / Azure essentials, EKS/GKE/AKS deep dives, architecture patterns. |
+| [Certifications](https://kube-dojo.github.io/k8s/) | 195 | ~250h | CKA, CKAD, CKS, KCNA, KCSA + specialist & platform learning paths. |
+| [Platform Engineering](https://kube-dojo.github.io/platform/) | 241 | ~320h | SRE, GitOps, DevSecOps, MLOps, FinOps, Chaos Engineering + toolkits. |
+| [On-Premises](https://kube-dojo.github.io/on-premises/) | 57 | ~80h | Bare-metal Kubernetes from rack to cluster — networking, storage, ops. |
+| [AI](https://kube-dojo.github.io/ai/) | 37 | ~80h | AI foundations, prompting, verification, privacy, AI-native work from zero. |
+| [AI/ML Engineering](https://kube-dojo.github.io/ai-ml-engineering/) | 121 | ~160h | Local-first AI, RAG, MLOps, inference, fine-tuning, AI platform paths. |
 
-    ═══════════════════════════════════════════════════════════
-```
+> **🌐 Translations — work in progress.** A Ukrainian translation exists for part of the curriculum (~40%: Prerequisites, CKA, CKAD), but it is **incomplete and currently lags the English content** — recent English module rewrites have not yet been re-translated. Treat the English curriculum as the source of truth; the Ukrainian pages are deferred until the English is production-ready. Browse what exists at [kube-dojo.github.io/uk/](https://kube-dojo.github.io/uk/).
 
 ---
 
-## Status
+## Recommended Path
 
-| Track | Modules | Status |
-|-------|---------|--------|
-| [Prerequisites](docs/prerequisites/) | 23 | ✅ Complete |
-| [Kubernetes Certifications](docs/k8s/) | 142 | ✅ Complete |
-| [Linux Deep Dive](docs/linux/) | 28 | ✅ Complete |
-| [Platform Engineering](docs/platform/) | 102 | ✅ Complete |
+Not sure where to start? Follow this progression:
+
+```
+  Fundamentals  ─▶  CKA  ─▶  CKAD + CKS  ─▶  Cloud / AI / AI-ML  ─▶  Platform Eng  ─▶  On-Prem / Specialize
+   (44 mods)       (41)       (54)            (92 / 37 / 121)          (241)              (57+)
+```
 
 ---
 
@@ -128,22 +84,30 @@ No paywalls. No upsells. Theory-first.
 
 | You are... | Start here |
 |------------|------------|
-| New to containers/K8s | [Prerequisites](docs/prerequisites/) |
-| Want deep Linux knowledge | [Linux Deep Dive](docs/linux/) |
-| Want certifications | [KCNA](docs/k8s/kcna/) (entry) or [CKA](docs/k8s/cka/) (admin) |
-| Already certified | [Platform Engineering](docs/platform/) |
+| Never used a terminal before | [Zero to Terminal](https://kube-dojo.github.io/prerequisites/zero-to-terminal/) |
+| New to containers / K8s | [Prerequisites](https://kube-dojo.github.io/prerequisites/) |
+| Want K8s admin certification | [CKA](https://kube-dojo.github.io/k8s/cka/) |
+| Want K8s developer certification | [CKAD](https://kube-dojo.github.io/k8s/ckad/) |
+| Want K8s security certification | [CKS](https://kube-dojo.github.io/k8s/cks/) |
+| Entry-level K8s cert | [KCNA](https://kube-dojo.github.io/k8s/kcna/) or [KCSA](https://kube-dojo.github.io/k8s/kcsa/) |
+| Platform engineer | [CNPE Learning Path](https://kube-dojo.github.io/k8s/cnpe/) |
+| Multi-cloud Kubernetes | [Cloud Track](https://kube-dojo.github.io/cloud/) |
+| Need AI literacy from zero | [AI](https://kube-dojo.github.io/ai/) |
+| Building AI systems / local-first ML | [AI/ML Engineering](https://kube-dojo.github.io/ai-ml-engineering/) |
+| Running K8s on bare metal | [On-Premises](https://kube-dojo.github.io/on-premises/) |
+| Already certified, want depth | [Platform Engineering](https://kube-dojo.github.io/platform/) |
 
 ---
 
 ## Why This Exists
 
-A free, text-based curriculum for learning Kubernetes and platform engineering.
+A free, text-based curriculum for learning Kubernetes, cloud native, and platform engineering.
 
-- **Free** — No paywalls, open source
-- **Theory-first** — Understand principles before tools
-- **Text-based** — Searchable, version-controlled, no videos
+- **Free** — No paywalls, open source.
+- **Theory-first** — Understand principles before tools. You can't troubleshoot what you don't understand.
+- **Text-based** — Searchable, version-controlled, no videos.
 
-**What we are not:** A replacement for paid courses like KodeKloud or Udemy. We don't offer mock exams, video lessons, or hands-on labs for every module. For exam simulation, use [killer.sh](https://killer.sh). For interactive labs, use [killercoda.com](https://killercoda.com).
+**What we are not:** a replacement for paid courses like KodeKloud or Udemy. We don't ship video lessons. For realistic exam simulation, use [killer.sh](https://killer.sh). For interactive in-browser labs, use [killercoda.com](https://killercoda.com).
 
 ---
 
@@ -151,29 +115,40 @@ A free, text-based curriculum for learning Kubernetes and platform engineering.
 
 **Theory before hands-on.** You can't troubleshoot what you don't understand.
 
-**No memorization.** K8s docs are available during exams. We teach navigation, not YAML memorization.
+**No memorization.** K8s docs are available during exams — we teach navigation, not YAML memorization.
 
 **Principles over tools.** Tools change. Foundations don't. Learn both, in that order.
 
 ---
 
+## Tech Stack
+
+The site is built with [Astro](https://astro.build/) + [Starlight](https://starlight.astro.build/) and deployed to GitHub Pages. Content is authored in Markdown under `src/content/docs/`.
+
+```bash
+npm install
+npm run build      # build the static site to dist/
+npx astro dev      # local dev server with hot reload
+```
+
+---
+
 ## Contributing
 
-**What we need:**
-- **Hands-on exercises** — Real scenarios, not toy examples
-- **War stories** — Production incidents that teach lessons
-- **Tool expertise** — Deep-dives on ArgoCD, Prometheus, Vault, etc.
-- **Error fixes** — Typos, outdated commands, broken YAML
+**What we welcome:**
+- **Hands-on exercises** — real scenarios, not toy examples.
+- **War stories** — production incidents that teach a lesson (must cite a real, verifiable source; each incident is told once across the curriculum).
+- **Tool expertise** — deep-dives on ArgoCD, Prometheus, Vault, Cilium, etc.
+- **Error fixes** — typos, outdated commands, broken YAML, dead links.
 
 **What we don't build:**
-- Exam simulators — Use [killer.sh](https://killer.sh) (included with exam purchase)
-- Lab environments — Use [killercoda.com](https://killercoda.com) or local kind/minikube
-- Video content — Text-first, searchable, version-controlled
+- Exam simulators — use [killer.sh](https://killer.sh).
+- Video content — text-first, searchable, version-controlled.
 
 **How to contribute:**
-- Open an issue to discuss before large PRs
-- Follow existing module structure
-- Test all commands and YAML before submitting
+- Open an issue to discuss before large PRs.
+- Follow the existing module structure.
+- Test all commands and YAML before submitting, and run `npm run build` (0 errors) before opening a PR.
 
 ---
 


### PR DESCRIPTION
The root `README.md` was last touched **April 1** (pre-Astro-migration) and was significantly stale.

## Fixed
- **Status table** had only 4 tracks with wrong counts (23 / 142 / 28 / 102) and **omitted Cloud, AI, AI/ML Engineering, On-Premises entirely**. Now all **8 tracks, 824 modules** — counts match the live homepage (`src/i18n/homepage.ts`) and `check_site_health.py`.
- **All track links were broken** — they pointed at MkDocs-era `docs/<track>/` paths that 404 in the repo. Repointed to the live site (`https://kube-dojo.github.io/...`); every track, cert sub-track, and header link verified to resolve to a real index page.
- Redrew the **Learning Path** with all 8 tracks; added **Where to Start**, a live-site link, and a Tech Stack (Astro/Starlight) section.
- **Ukrainian framed honestly** as partial (~40%: Prerequisites, CKA, CKAD) and **currently lagging the English content** (recent rewrites not yet re-translated) — not presented as parity.

Docs-only; kept the 🇺🇦 dedication, Philosophy, and License intact.