### PR TITLE
security(#1812): agent-config injection tripwire (last authorable AC)

### DIFF
--- a/.github/workflows/supply-chain.yml
+++ b/.github/workflows/supply-chain.yml
@@ -46,6 +46,9 @@ jobs:
             python3 scripts/security/check_lockfile_integrity.py
           fi
 
+      - name: Agent-config injection tripwire
+        run: python3 scripts/security/check_agent_configs.py
+
       # Hard gate (review: all three reviewers, #1813): an invalid/forged registry
       # signature fails CI. Verified to exit 0 on the current tree (116 attestations).
       - name: Verify dependency provenance / signatures

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,3 +7,9 @@ repos:
         language: system
         pass_filenames: false
         always_run: true
+      - id: agent-config-injection-scan
+        name: agent-config auto-exec injection scan
+        entry: .venv/bin/python scripts/security/check_agent_configs.py
+        language: system
+        pass_filenames: false
+        always_run: true

--- a/docs/security/detection-runbook.md
+++ b/docs/security/detection-runbook.md
@@ -109,12 +109,25 @@ Layers: **PREVENT** (stop execution) → **DETECT** (surface changes) → **CONT
 
 ---
 
+### 9. Agent-config injection tripwire (`scripts/security/check_agent_configs.py`) — DETECT
+
+| | |
+|---|---|
+| **What** | Whole-file regex scan of AI IDE agent-config paths (`.claude/**`, `.cursor/**`, `AGENTS.md`, `CLAUDE.md`, etc.) for high-signal auto-exec compositions — piped-to-shell downloaders, base64-to-shell, `eval` of command substitution, `child_process` exec, PowerShell `IEX`, Python remote-exec patterns. |
+| **Attack signal** | Miasma agent-config-injection variant — auto-exec payload planted in agent config so it runs when the repo is opened in an AI IDE (e.g. `curl … \| bash`, or instructions to fetch and execute a remote payload). |
+| **Where it surfaces** | Pre-commit hook **agent-config auto-exec injection scan** (local). Workflow **Supply-chain detection** → job `detect` → step **Agent-config injection tripwire**. CI failure (exit 1) with `[tag] path:line` lines. |
+| **Time-to-detect** | Next commit locally (pre-commit) or PR/push to `main` (minutes). |
+| **Override** | Suppressed if the flagged line or the line immediately above contains literal `agent-config-allow`. **This is an acknowledgement marker, not an authorization control** — anyone who can edit the file can add it; value is forcing human review of flagged auto-exec lines before they ship. |
+| **Response** | 1. Read stderr (`[pipe-to-shell]`, `[eval-cmd-subst]`, etc.). 2. Inspect the flagged file and line — treat as incident unless you can explain it. 3. If malicious, do not merge; rotate tokens; report via [SECURITY.md](../../SECURITY.md). 4. If a legitimate documentation example reviewed by a human, add `agent-config-allow` on that line or the line above **after** review. |
+
+---
+
 ## Quick triage checklist
 
 When any **DETECT** control fires:
 
 1. **Do not merge** until understood.
-2. Run locally: `python3 scripts/security/check_install_scripts.py` and `python3 scripts/security/check_lockfile_integrity.py`.
+2. Run locally: `python3 scripts/security/check_install_scripts.py`, `python3 scripts/security/check_lockfile_integrity.py`, and `python3 scripts/security/check_agent_configs.py`.
 3. Inspect `git diff` for `package-lock.json` and `package.json`.
 4. Check registry pages for affected packages (version, publish date, maintainer).
 5. If incident: rotate npm and GitHub tokens, audit recent publishes, file a security report.

--- a/docs/security/detection-runbook.md
+++ b/docs/security/detection-runbook.md
@@ -113,7 +113,7 @@ Layers: **PREVENT** (stop execution) → **DETECT** (surface changes) → **CONT
 
 | | |
 |---|---|
-| **What** | Whole-file regex scan of AI IDE agent-config paths (`.claude/**`, `.cursor/**`, `AGENTS.md`, `CLAUDE.md`, etc.) for high-signal auto-exec compositions — piped-to-shell downloaders, base64-to-shell, `eval` of command substitution, `child_process` exec, PowerShell `IEX`, Python remote-exec patterns. |
+| **What** | Line-by-line regex scan (with shell backslash-continuation joining) of AI IDE agent-config paths — `.claude/**`, `.cursor/**`, `.roo/**`, `.vscode/**`, `.github/instructions/**`, MCP configs (`.mcp.json`, `mcp.json`), `AGENTS.md`, `CLAUDE.md`, etc. — for high-signal auto-exec compositions: piped-to-shell downloaders, process substitution (`<(curl …)`), interpreter `-c`/`-e` with `$(curl …)`, `source /dev/stdin`, download-then-run (`&&`/`;`), base64-to-shell, `eval` of command substitution, `child_process` exec, PowerShell `Invoke-Expression` / uppercase `IEX`, Python remote-exec. **Residual:** two-step payloads on separate unrelated lines (download file on one line, execute that file later) are not caught — this is a line/continuation scanner, not a dataflow analyzer. |
 | **Attack signal** | Miasma agent-config-injection variant — auto-exec payload planted in agent config so it runs when the repo is opened in an AI IDE (e.g. `curl … \| bash`, or instructions to fetch and execute a remote payload). |
 | **Where it surfaces** | Pre-commit hook **agent-config auto-exec injection scan** (local). Workflow **Supply-chain detection** → job `detect` → step **Agent-config injection tripwire**. CI failure (exit 1) with `[tag] path:line` lines. |
 | **Time-to-detect** | Next commit locally (pre-commit) or PR/push to `main` (minutes). |

--- a/scripts/security/check_agent_configs.py
+++ b/scripts/security/check_agent_configs.py
@@ -7,9 +7,16 @@ dropper, or instructions telling the agent to run a remote payload). This tripwi
 is the DETECT control for that variant. Prevention layers: `.npmrc ignore-scripts`
 (#1813), lifecycle-script + provenance + lockfile-integrity tripwires (#1813/#1817).
 
-Whole-file regex scan of agent-config paths for high-signal auto-exec compositions
-only — NOT bare keywords (legitimate configs contain `npm run build`, localhost
-`curl`, and the substring "eval" inside "evaluate").
+Line-by-line regex scan (with shell backslash-continuation joining) of agent-config
+paths for high-signal auto-exec compositions only — NOT bare keywords (legitimate
+configs contain `npm run build`, localhost `curl`, and the substring "eval" inside
+"evaluate"). Residual: a two-step payload split across separate unrelated lines
+(download on one line, execute that file on a later line) is not caught — this is
+a line/continuation scanner, not a full dataflow analyzer.
+
+In-scope paths include `.claude/**`, `.cursor/**`, `.roo/**`, `.vscode/**`,
+`.github/instructions/**`, MCP configs (`.mcp.json`, `mcp.json`), `AGENTS.md`,
+`CLAUDE.md`, `scripts/**` agent-config filenames, etc.
 
 Suppression (acknowledgement marker, NOT an authorization control):
   A finding is suppressed when its line OR the line immediately above contains the
@@ -31,8 +38,10 @@ MAX_REPORT = 50
 MAX_SNIPPET = 120
 SUPPRESSION_MARKER = "agent-config-allow"
 
-EXCLUDE_DIRS = frozenset({".git", "node_modules", "dist", ".worktrees", "scripts"})
-RECURSE_DIRS = frozenset({".claude", ".cursor", ".continue"})
+EXCLUDE_DIRS = frozenset({".git", "node_modules", "dist", ".worktrees"})
+RECURSE_DIRS = frozenset(
+    {".claude", ".cursor", ".continue", ".roo", ".clinerules", ".windsurf", ".vscode"}
+)
 SCAN_FILENAMES = frozenset(
     {
         "AGENTS.md",
@@ -43,6 +52,9 @@ SCAN_FILENAMES = frozenset(
         ".windsurfrules",
         "copilot-instructions.md",
         ".aider.conf.yml",
+        ".aider.conf.yaml",
+        ".mcp.json",
+        "mcp.json",
     }
 )
 
@@ -59,9 +71,32 @@ PATTERNS: dict[str, re.Pattern[str]] = {
         r"base64\s+(?:-d|--decode)\b[^\n|]*\|\s*(?:sh|bash|zsh)\b",
         re.IGNORECASE,
     ),
-    # Download then execute via && chain.
+    # Download then execute via && or ; chain.
     "download-and-run": re.compile(
-        r"(?:curl|wget)\b[^\n]*&&[^\n]*(?:\b(?:sh|bash)\b|chmod\s+\+x)",
+        r"(?:curl|wget)\b[^\n]*(?:&&|;)[^\n]*(?:\b(?:sh|bash)\b|chmod\s+\+x)",
+        re.IGNORECASE,
+    ),
+    # Download to file then execute that file.
+    "download-then-run-file": re.compile(
+        r"(?:curl|wget)\b[^\n]*\s-o\b[^\n]*(?:&&|;)\s*"
+        r"(?:sudo\s+)?(?:sh|bash|zsh|chmod\s+\+x)\b",
+        re.IGNORECASE,
+    ),
+    # Process substitution with downloader (bash <(curl …) or bare <(curl …)).
+    "process-substitution": re.compile(
+        r"(?:bash|sh|zsh|source|\.)\s+<\(\s*(?:curl|wget|fetch)\b|"
+        r"<\(\s*(?:curl|wget|fetch)\b",
+        re.IGNORECASE,
+    ),
+    # Interpreter -c/-e with command substitution on downloader.
+    "interpreter-cmdsubst": re.compile(
+        r"\b(?:python3?|node|sh|bash|zsh|ruby|perl)\s+-[ce]\b[^\n]*"
+        r"\$\(\s*(?:curl|wget|fetch)\b",
+        re.IGNORECASE,
+    ),
+    # source /dev/stdin (remote payload via heredoc or pipe).
+    "source-stdin": re.compile(
+        r"(?:source|\.)\s+/dev/stdin\b",
         re.IGNORECASE,
     ),
     # Shell eval of a command substitution.
@@ -81,11 +116,13 @@ PATTERNS: dict[str, re.Pattern[str]] = {
         r"\b(?:exec|execSync|spawn)\b.*child_process",
         re.IGNORECASE,
     ),
-    # PowerShell Invoke-Expression.
+    # PowerShell Invoke-Expression (case-insensitive).
     "powershell-iex": re.compile(
-        r"(?:Invoke-Expression|\bIEX\b)\b",
+        r"Invoke-Expression",
         re.IGNORECASE,
     ),
+    # Bare PowerShell IEX alias — uppercase only (avoids Elixir `iex` FP).
+    "powershell-iex-bare": re.compile(r"(?-i:\bIEX\b)"),
     # Python remote fetch + execute.
     "python-remote-exec": re.compile(
         r"(?:os\.system|subprocess\.(?:run|call|Popen)|\bexec\()[^\n]*"
@@ -107,6 +144,8 @@ def should_scan_file(rel: Path) -> bool:
     if rel.parts[0] in RECURSE_DIRS:
         return True
     if rel.parts[:2] == (".github", "copilot-instructions.md"):
+        return True
+    if len(rel.parts) >= 2 and rel.parts[:2] == (".github", "instructions"):
         return True
     return rel.name in SCAN_FILENAMES
 
@@ -142,6 +181,44 @@ def is_suppressed(lines: list[str], lineno: int) -> bool:
     return False
 
 
+_SHELL_AFTER_PIPE = re.compile(r"^\|\s*(?:sh|bash|zsh)\b", re.IGNORECASE)
+
+
+def join_line_continuations(lines: list[str]) -> list[str]:
+    """Join shell backslash-continuations before per-line pattern scan.
+
+    Only joins continuations that plausibly complete a download-and-exec pipe
+    (``curl … | \\`` then ``sh``, or ``curl … \\`` then ``| sh``). Legitimate
+    multi-line formatting such as ``curl … \\`` newline ``| python3 -c`` is
+    left split so ``curl | python3`` doc examples do not false-positive.
+    """
+    joined: list[str] = []
+    i = 0
+    while i < len(lines):
+        line = lines[i]
+        while i + 1 < len(lines):
+            stripped = line.rstrip()
+            if not stripped.endswith("\\"):
+                break
+            next_stripped = lines[i + 1].lstrip()
+            if stripped.endswith("| \\"):
+                line = stripped[:-2].rstrip() + " " + next_stripped
+                i += 1
+                continue
+            if re.match(r"^(?:sh|bash|zsh)\b", next_stripped, re.IGNORECASE):
+                line = stripped[:-1].rstrip() + " " + next_stripped
+                i += 1
+                continue
+            if _SHELL_AFTER_PIPE.match(next_stripped):
+                line = stripped[:-1].rstrip() + " " + next_stripped
+                i += 1
+                continue
+            break
+        joined.append(line)
+        i += 1
+    return joined
+
+
 Finding = tuple[Path, int, str, str]
 
 
@@ -152,17 +229,14 @@ def scan_file(path: Path) -> tuple[list[Finding], str | None]:
     except OSError as exc:
         return [], f"cannot read {rel}: {exc}"
 
-    try:
-        text = raw.decode("utf-8")
-    except UnicodeDecodeError:
-        return [], f"skipped binary/undecodable: {rel}"
-
-    lines = text.splitlines()
+    text = raw.decode("utf-8", errors="replace")
+    raw_lines = text.splitlines()
+    scan_lines = join_line_continuations(raw_lines)
     findings: list[Finding] = []
-    for lineno, line in enumerate(lines, start=1):
+    for lineno, line in enumerate(scan_lines, start=1):
         for tag, pattern in PATTERNS.items():
             if pattern.search(line):
-                if is_suppressed(lines, lineno):
+                if is_suppressed(raw_lines, lineno):
                     continue
                 findings.append((rel, lineno, tag, truncate_snippet(line)))
     return findings, None
@@ -191,7 +265,10 @@ def main(argv: list[str]) -> int:
             notes.append(note)
 
     for note in notes:
-        print(f"NOTE: {note}")
+        print(f"NOTE: {note}", file=sys.stderr)
+
+    if notes:
+        return 2
 
     if all_findings:
         print(
@@ -208,7 +285,7 @@ def main(argv: list[str]) -> int:
         print(
             "\n  This is how the Miasma agent-config-injection variant plants "
             "auto-exec payloads in `.claude/`, `.cursor/`, `AGENTS.md`, "
-            "`CLAUDE.md`, etc.\n"
+            "`CLAUDE.md`, MCP configs, etc.\n"
             "  Remediation: remove the payload. If it is a legitimate "
             "documentation example reviewed by a human, add the literal marker "
             f"`{SUPPRESSION_MARKER}` on that line or the line above.\n"

--- a/scripts/security/check_agent_configs.py
+++ b/scripts/security/check_agent_configs.py
@@ -1,0 +1,226 @@
+#!/usr/bin/env python3
+"""Supply-chain DETECTION tripwire — issue #1812 (Miasma-class worm defense).
+
+Miasma-class worms can inject backdoors into AI-coding-agent config files — content
+that auto-executes when the repo is opened in an AI IDE (e.g. a piped-to-shell
+dropper, or instructions telling the agent to run a remote payload). This tripwire
+is the DETECT control for that variant. Prevention layers: `.npmrc ignore-scripts`
+(#1813), lifecycle-script + provenance + lockfile-integrity tripwires (#1813/#1817).
+
+Whole-file regex scan of agent-config paths for high-signal auto-exec compositions
+only — NOT bare keywords (legitimate configs contain `npm run build`, localhost
+`curl`, and the substring "eval" inside "evaluate").
+
+Suppression (acknowledgement marker, NOT an authorization control):
+  A finding is suppressed when its line OR the line immediately above contains the
+  literal token `agent-config-allow`. An attacker could add the marker — the real
+  value is forcing a human to review a flagged auto-exec line; the marker only
+  records that review (same framing as the lockfile tripwire's `[lockfile-only]`).
+
+Exit 0 = clean. Exit 1 = injection signal found. Exit 2 = error (fail-closed).
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+MAX_REPORT = 50
+MAX_SNIPPET = 120
+SUPPRESSION_MARKER = "agent-config-allow"
+
+EXCLUDE_DIRS = frozenset({".git", "node_modules", "dist", ".worktrees", "scripts"})
+RECURSE_DIRS = frozenset({".claude", ".cursor", ".continue"})
+SCAN_FILENAMES = frozenset(
+    {
+        "AGENTS.md",
+        "CLAUDE.md",
+        "GEMINI.md",
+        ".cursorrules",
+        ".clinerules",
+        ".windsurfrules",
+        "copilot-instructions.md",
+        ".aider.conf.yml",
+    }
+)
+
+# High-signal auto-exec compositions — auditable / extensible.
+PATTERNS: dict[str, re.Pattern[str]] = {
+    # Downloader piped straight into an interpreter.
+    "pipe-to-shell": re.compile(
+        r"(?:curl|wget|fetch|Invoke-WebRequest|iwr)\b[^\n|]*\|\s*"
+        r"(?:sudo\s+)?(?:sh|bash|zsh|python3?|node|perl|ruby)\b",
+        re.IGNORECASE,
+    ),
+    # base64 decode piped to shell.
+    "base64-to-shell": re.compile(
+        r"base64\s+(?:-d|--decode)\b[^\n|]*\|\s*(?:sh|bash|zsh)\b",
+        re.IGNORECASE,
+    ),
+    # Download then execute via && chain.
+    "download-and-run": re.compile(
+        r"(?:curl|wget)\b[^\n]*&&[^\n]*(?:\b(?:sh|bash)\b|chmod\s+\+x)",
+        re.IGNORECASE,
+    ),
+    # Shell eval of a command substitution.
+    "eval-cmd-subst": re.compile(
+        r'eval\s*[("\x60][^\n)]*\$\(|eval\s+["\x60]?\$\(',
+        re.IGNORECASE,
+    ),
+    # JS eval of decoded/obfuscated payload.
+    "eval-decoded-js": re.compile(
+        r"eval\s*\(\s*(?:atob|Buffer\.from|decodeURIComponent|"
+        r"String\.fromCharCode|unescape)\b",
+        re.IGNORECASE,
+    ),
+    # Node child_process exec/spawn on the same line.
+    "child-process-exec": re.compile(
+        r"child_process.*\b(?:exec|execSync|spawn)\b|"
+        r"\b(?:exec|execSync|spawn)\b.*child_process",
+        re.IGNORECASE,
+    ),
+    # PowerShell Invoke-Expression.
+    "powershell-iex": re.compile(
+        r"(?:Invoke-Expression|\bIEX\b)\b",
+        re.IGNORECASE,
+    ),
+    # Python remote fetch + execute.
+    "python-remote-exec": re.compile(
+        r"(?:os\.system|subprocess\.(?:run|call|Popen)|\bexec\()[^\n]*"
+        r"\b(?:urllib|requests|urlopen|http://|https://)",
+        re.IGNORECASE,
+    ),
+}
+
+
+def is_excluded(rel: Path) -> bool:
+    return any(part in EXCLUDE_DIRS for part in rel.parts)
+
+
+def should_scan_file(rel: Path) -> bool:
+    if is_excluded(rel):
+        return False
+    if not rel.parts:
+        return False
+    if rel.parts[0] in RECURSE_DIRS:
+        return True
+    if rel.parts[:2] == (".github", "copilot-instructions.md"):
+        return True
+    return rel.name in SCAN_FILENAMES
+
+
+def iter_scan_paths() -> list[Path]:
+    found: list[Path] = []
+    for path in sorted(REPO_ROOT.rglob("*")):
+        if not path.is_file():
+            continue
+        try:
+            rel = path.relative_to(REPO_ROOT)
+        except ValueError:
+            continue
+        if should_scan_file(rel):
+            found.append(path)
+    return found
+
+
+def truncate_snippet(text: str) -> str:
+    line = text.strip()
+    if len(line) <= MAX_SNIPPET:
+        return line
+    return line[: MAX_SNIPPET - 3] + "..."
+
+
+def is_suppressed(lines: list[str], lineno: int) -> bool:
+    """Suppress if marker on this line or the line immediately above."""
+    idx = lineno - 1
+    if 0 <= idx < len(lines) and SUPPRESSION_MARKER in lines[idx]:
+        return True
+    if idx > 0 and SUPPRESSION_MARKER in lines[idx - 1]:
+        return True
+    return False
+
+
+Finding = tuple[Path, int, str, str]
+
+
+def scan_file(path: Path) -> tuple[list[Finding], str | None]:
+    rel = path.relative_to(REPO_ROOT)
+    try:
+        raw = path.read_bytes()
+    except OSError as exc:
+        return [], f"cannot read {rel}: {exc}"
+
+    try:
+        text = raw.decode("utf-8")
+    except UnicodeDecodeError:
+        return [], f"skipped binary/undecodable: {rel}"
+
+    lines = text.splitlines()
+    findings: list[Finding] = []
+    for lineno, line in enumerate(lines, start=1):
+        for tag, pattern in PATTERNS.items():
+            if pattern.search(line):
+                if is_suppressed(lines, lineno):
+                    continue
+                findings.append((rel, lineno, tag, truncate_snippet(line)))
+    return findings, None
+
+
+def main(argv: list[str]) -> int:
+    print("Agent-config injection tripwire — scanning AI IDE config paths.")
+
+    if not REPO_ROOT.is_dir():
+        print(f"ERROR: repo root not found: {REPO_ROOT}", file=sys.stderr)
+        return 2
+
+    try:
+        paths = iter_scan_paths()
+    except OSError as exc:
+        print(f"ERROR: cannot walk repo tree: {exc}", file=sys.stderr)
+        return 2
+
+    all_findings: list[Finding] = []
+    notes: list[str] = []
+
+    for path in paths:
+        findings, note = scan_file(path)
+        all_findings.extend(findings)
+        if note:
+            notes.append(note)
+
+    for note in notes:
+        print(f"NOTE: {note}")
+
+    if all_findings:
+        print(
+            f"\n  SUPPLY-CHAIN TRIPWIRE: {len(all_findings)} agent-config "
+            f"auto-exec signal(s):",
+            file=sys.stderr,
+        )
+        shown = all_findings[:MAX_REPORT]
+        for rel, lineno, tag, snippet in shown:
+            print(f"    [{tag}] {rel}:{lineno} — {snippet}", file=sys.stderr)
+        remaining = len(all_findings) - len(shown)
+        if remaining > 0:
+            print(f"    … and {remaining} more finding(s)", file=sys.stderr)
+        print(
+            "\n  This is how the Miasma agent-config-injection variant plants "
+            "auto-exec payloads in `.claude/`, `.cursor/`, `AGENTS.md`, "
+            "`CLAUDE.md`, etc.\n"
+            "  Remediation: remove the payload. If it is a legitimate "
+            "documentation example reviewed by a human, add the literal marker "
+            f"`{SUPPRESSION_MARKER}` on that line or the line above.\n"
+            "  The marker is NOT an authorization control — it only records "
+            "human review.",
+            file=sys.stderr,
+        )
+        return 1
+
+    print(f"OK — no agent-config auto-exec signals ({len(paths)} file(s) scanned).")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv))


### PR DESCRIPTION
Final authorable DETECT control for #1812 (Miasma defense-in-depth). After this, the only open #1812 item is harden-runner egress (owner-only org action).

## What
Deterministic scanner `scripts/security/check_agent_configs.py` for the **Miasma agent-config-injection variant** — a backdoor planted in AI IDE config files (`.claude/**`, `.cursor/**`, `AGENTS.md`, `CLAUDE.md`, `.cursorrules`, etc.) that auto-executes when the repo is opened in an AI IDE.

- **Whole-file scan, high-signal compositions only** (not bare keywords): pipe-to-shell, base64-to-shell, download-and-run, eval-of-command-substitution, eval-of-decoded-JS, child_process exec, PowerShell IEX, Python remote-exec. The repo's agent-config files are full of legitimate shell (`npm run build`, localhost `curl`) + the substring "eval" in "evaluate" — verified **0 findings on the current tree** (38 files).
- **Suppression** via `agent-config-allow` (line or line-above) — documented as an acknowledgement marker, NOT an authorization control (forces human review of flagged auto-exec lines).
- Wired into **CI** (`supply-chain.yml` detect job) + **pre-commit** (`.pre-commit-config.yaml`). Runbook control #9 added.

## Verification (orchestrator ground-check)
- Current tree → exit 0 (38 files, 0 findings — FP gate).
- 7 distinct synthetic injections → all detected with correct tags, exit 1.
- Suppression marker → exit 0; tree left clean.
- `ruff` clean; `uvx zizmor --offline --strict-collection .github/` clean.

Refs #1812