### PR TITLE
feat(#1842): generative-ai sub-track — expand+de-fab 1.5 & 1.6 to T0 (cross-family reviewed)

### DIFF
--- a/src/content/docs/ai-ml-engineering/generative-ai/module-1.5-vector-space-visualization.md
+++ b/src/content/docs/ai-ml-engineering/generative-ai/module-1.5-vector-space-visualization.md
@@ -5,14 +5,6 @@ sidebar:
   order: 306
 ---
 
-## Why This Module Matters
-
-In November 2018, a leading global fashion retailer deployed a highly anticipated feature for the holiday shopping season: an updated search engine for their catalog. Historically, the retailer relied strictly on exact keyword matching, utilizing traditional inverted indices and TF-IDF scoring. If a user searched for "crimson winter coat," the system would strictly scan the relational database for the exact strings "crimson," "winter," and "coat." While highly predictable and easily debuggable, this rigid approach entirely ignored the implicit semantic intent of the user's query. When users began searching for "burgundy cold weather jacket," the keyword-based system returned zero results, despite the warehouse being fully stocked with thousands of perfectly matching items that happened to use slightly different product descriptions.
-
-The financial impact was immediate and devastating. Internal monitoring dashboards triggered critical alerts as the "null search result" rate spiked by twenty-two percent globally within a matter of hours. Customers, assuming the items were simply out of stock or unavailable, often abandoned their shopping carts and migrated to competitor websites. Over a grueling three-day holiday weekend period, the retailer estimated a direct, unrecoverable revenue loss of twelve million dollars. The root cause was not a catastrophic software bug, a network switch failure, or a database outage, but a fundamental, architectural limitation of the core search mechanism itself. The legacy system did not understand meaning; it only understood strict, mechanical character arrays.
-
-This failure forced the engineering team to overhaul their approach and implement true semantic search using continuous vector spaces. By converting both their product catalog and user queries into high-dimensional embeddings, they enabled mathematical comparisons of meaning that transcend basic vocabulary. The system could now mathematically prove that "burgundy" and "crimson" occupied the exact same coordinate region in semantic space, automatically returning relevant results regardless of exact wording. This module explores the exact mathematical techniques that engineering teams use to visualize, manipulate, and query meaning through sophisticated mathematics. You will learn to treat abstract concepts as geometric coordinates, allowing you to perform arithmetic on ideas and build scalable search systems that genuinely understand human intent.
-
 ## Learning Outcomes
 
 By the end of this intensive module, you will be capable of the following advanced engineering tasks:
@@ -22,9 +14,15 @@ By the end of this intensive module, you will be capable of the following advanc
 - **Diagnose** critical memory and latency bottlenecks in high-throughput production search pipelines and apply scalar and product quantization strategies to optimize throughput.
 - **Implement** fault-tolerant, horizontally scalable vector databases within a modern Kubernetes v1.35 environment, utilizing advanced Approximate Nearest Neighbor (ANN) index structures.
 
+## Why This Module Matters
+
+Hypothetical scenario: an e-commerce team launches a catalog search feature built on exact keyword matching with inverted indices and TF-IDF scoring. A shopper searches for "crimson winter coat," and the system returns products whose descriptions contain those exact tokens. Another shopper searches for "burgundy cold weather jacket" — synonymous intent, different vocabulary — and receives empty results even though matching inventory exists under alternate product copy. Monitoring shows elevated null-result rates; shoppers assume items are unavailable and leave. The root cause is not a crashed database or a misconfigured load balancer, but an architectural limitation: the retrieval layer matches character strings, not meaning.
+
+A semantic search redesign converts both catalog entries and queries into dense embeddings and compares them in vector space. The model places "burgundy" and "crimson" in nearby regions, so paraphrased queries retrieve relevant products without hand-maintained synonym tables. This module teaches the mathematics behind that shift: how to visualize embedding geometry, validate analogies with vector arithmetic, and build production retrieval pipelines with approximate nearest-neighbor indexes. You will treat language as coordinates, not categories — and engineer systems that reason about similarity the way humans do when they recognize that two phrases mean the same thing even when they share no words.
+
 ## The Geometry of Meaning
 
-The conceptual leap required to master modern generative artificial intelligence is recognizing that human language can be robustly represented as coordinates in a vast, continuous geometric space. Prior to this mathematical innovation, software engineers treated text primarily as categorical variables, sparse one-hot encoded arrays, or simple hashed integers. These legacy methods completely discarded the rich, contextual relationships between words.
+The conceptual leap required to master modern generative artificial intelligence is recognizing that human language can be robustly represented as coordinates in a vast, continuous geometric space. Prior to this mathematical innovation, software engineers treated text primarily as categorical variables, sparse one-hot encoded arrays, or simple hashed integers. These legacy methods completely discarded the rich, contextual relationships between words. One-hot encoding assigns every token an orthogonal axis, so every pair of distinct words is equidistant — "dog" and "cat" are no closer than "dog" and "bankruptcy." Hashing tricks compress vocabulary but still treat collisions as semantic equivalence by accident. Embeddings instead learn a low-dimensional manifold where neighborhood structure is the training objective, which is why they enable both fuzzy retrieval and the visualization workflows you will build in the hands-on exercise.
 
 Before studying the deeper theory in this module, you might have generated a standard embedding vector using an open-source library and wondered about its practical utility when returning a seemingly random array of floating-point numbers:
 
@@ -83,7 +81,7 @@ quadrantChart
     "terrible": [0.4, 0.1]
 ```
 
-Distance in this multi-dimensional mathematical space serves as an incredibly reliable metric for semantic similarity. We can measure the absolute Euclidean distance or cosine similarity mathematically to empirically verify topical relevance across disparate data points.
+Distance in this multi-dimensional mathematical space serves as an incredibly reliable metric for semantic similarity when you pick the right function for your embedding model. We can measure Euclidean distance or cosine similarity mathematically to empirically verify topical relevance across disparate data points, then choose the same metric at index time so offline evaluations match online retrieval behavior.
 
 ```python
 # Words about food cluster together
@@ -145,9 +143,43 @@ Cluster 3 (Animals):
 
 > **Pause and predict**: If you generated an embedding for the word "Java", where exactly would it land in the clusters above? Would it sit strictly in Cluster 1 due to code, or might it sit halfway between Cluster 1 and Cluster 2 because of the coffee association? Consider how the underlying embedding model's specific training data distribution directly influences the final geometric coordinates.
 
+## How Embeddings Are Produced
+
+The geometric structure of an embedding space is not arbitrary magic — it is the output of a training objective that rewards certain vector arrangements and penalizes others. Classical word embeddings such as Word2Vec and GloVe learn coordinates by predicting context: a word's vector should help predict surrounding words in a sliding window over a large corpus. Skip-gram and continuous-bag-of-words variants differ in whether you predict context from a center word or the center from context, but both push co-occurring tokens into similar regions because that arrangement lowers prediction loss.
+
+Modern sentence and document embeddings extend the same principle with contrastive learning. During training, the model sees pairs of texts labeled similar (two paraphrases, a query and its answer, an anchor and a positive example) and pairs labeled dissimilar (random negatives or hard negatives mined from the batch). The loss function pulls similar pairs closer in cosine distance and pushes dissimilar pairs apart, often with a temperature-scaled softmax over in-batch negatives. Sentence-transformer models wrap a transformer encoder with a pooling layer (mean pooling, CLS token, or attention pooling) and fine-tune the entire stack on these contrastive objectives. The result is a fixed-length vector per input string whose geometry reflects semantic relationships the training data emphasized.
+
+Understanding the training recipe matters when you debug retrieval quality in production. If your domain vocabulary (medical codes, internal acronyms, product SKUs) was underrepresented during pre-training, vectors for those tokens may sit in noisy regions of space. Fine-tuning on domain-specific contrastive pairs — query–document clicks, support-ticket resolutions, approved FAQ matches — reshapes local geometry without retraining the entire foundation model from scratch. The embedding dimension (384, 768, 1536) is an architectural choice: higher dimensions can encode more nuance but increase memory and distance-computation cost linearly in the dimension count.
+
+## Comparing Similarity Metrics
+
+Once texts are embedded, retrieval reduces to comparing vectors. Three metrics appear constantly in vector search systems, and choosing the wrong one silently degrades ranking quality even when the embedding model itself is excellent.
+
+**Cosine similarity** measures the angle between two vectors, ignoring magnitude. For vectors $\mathbf{a}$ and $\mathbf{b}$, $\text{cosine}(\mathbf{a}, \mathbf{b}) = \frac{\mathbf{a} \cdot \mathbf{b}}{\|\mathbf{a}\| \|\mathbf{b}\|}$, ranging from $-1$ to $1$. Cosine is the default for text embeddings because transformer outputs are often L2-normalized during training, and semantic similarity is treated as directional alignment rather than raw proximity from the origin. Two documents about the same topic with different lengths should score highly even if one vector has larger magnitude.
+
+**Dot product** computes $\mathbf{a} \cdot \mathbf{b} = \sum_i a_i b_i$ without dividing by magnitudes. When all vectors are unit-normalized, dot product and cosine are equivalent. When they are not, dot product favors longer vectors — which can accidentally boost verbose documents that happen to have larger activation norms. Some production systems deliberately use dot product on unnormalized vectors when magnitude encodes confidence or importance, but that is an explicit design choice, not an accident.
+
+**Euclidean distance** measures straight-line separation: $\|\mathbf{a} - \mathbf{b}\|_2$. For unit vectors, Euclidean distance and cosine similarity are monotonically related ($\|\mathbf{a}-\mathbf{b}\|^2 = 2 - 2\cos\theta$), so ranking by ascending distance matches ranking by descending cosine. For unnormalized vectors, Euclidean distance mixes angle and magnitude effects. FAISS `IndexFlatL2` and `IndexHNSWFlat` with L2 metric use squared Euclidean distance; many text pipelines instead normalize vectors once at index time and search with inner product (`IndexFlatIP`) to recover cosine semantics efficiently.
+
+| Metric | Normalization required? | Sensitive to vector length? | Typical index type |
+|--------|-------------------------|----------------------------|-------------------|
+| Cosine | Recommended | No (after normalization) | Inner product on L2-normalized vectors |
+| Dot product | Optional | Yes | `IndexFlatIP` |
+| Euclidean (L2) | Optional | Yes | `IndexFlatL2`, `IndexHNSWFlat` |
+
+**Practical rule**: L2-normalize all embeddings at ingestion and query time, then use inner-product search — mathematically equivalent to cosine, well supported by ANN libraries, and immune to document-length artifacts unless you intentionally encode length in the vector norm.
+
+## The Curse of Dimensionality
+
+High-dimensional spaces behave counterintuitively, and those behaviors directly affect both visualization and nearest-neighbor search. In low dimensions, intuitive notions of "near" and "far" hold: if two points are close in 2D, they are genuinely similar along most axes. As dimensionality grows, volume concentrates in the shell of the hypersphere rather than near the center — most random points become almost equidistant from each other. The ratio of the distance to the nearest neighbor versus the farthest neighbor approaches 1 as dimension increases, which means brute-force distance rankings become unstable noise unless the data manifold has strong low-dimensional structure.
+
+This phenomenon explains why you cannot trust a 2D scatter plot as a literal map of production geometry. Dimensionality reduction for visualization necessarily distorts relationships: PCA preserves global variance but may squash local clusters; t-SNE preserves local neighborhoods but separates clusters artificially; neither plot is a faithful coordinate system for retrieval decisions. It also explains why ANN indexes are necessary at scale: exact linear scan not only costs $O(N)$ per query but also fights numerical noise in high dimensions where marginally closer neighbors may not be semantically better matches.
+
+Engineering mitigations include: (1) using models trained with cosine-style objectives so meaningful signal lives in direction, not radial distance from the origin; (2) applying product quantization or scalar quantization to compress vectors while preserving relative ordering well enough for first-stage retrieval; (3) combining dense retrieval with metadata filters or BM25 reranking so semantic neighbors must also satisfy hard constraints; and (4) monitoring recall@k on a labeled evaluation set whenever you change dimensionality, quantization, or index parameters — plots alone will not catch a recall collapse.
+
 ## Visualizing Embeddings in 2D and 3D Space
 
-Real-world production embeddings often contain 384, 768, or even up to 1536 distinct spatial dimensions. Because human visual perception and cognition are strictly limited to three physical dimensions, engineering teams must rely heavily on highly sophisticated dimensionality reduction techniques to explore the topological data visually and detect hidden biases.
+Real-world production embeddings often contain 384, 768, or even up to 1536 distinct spatial dimensions. Because human visual perception and cognition are strictly limited to three physical dimensions, engineering teams must rely heavily on highly sophisticated dimensionality reduction techniques to explore the topological data visually and detect hidden biases. Before plotting, sample strategically: visualizing ten thousand random document embeddings in t-SNE may take minutes and produce unreadable overplots, while stratified sampling (equal draws per product category, language, or user segment) reveals whether clusters are driven by true semantics or confounding metadata like author team or publication date. Color points by metadata fields in the scatter plot — if every color separates cleanly, your embedding may be encoding superficial facets you intended to filter downstream rather than deep topical content. Document the random seed and hyperparameters (`perplexity` for t-SNE, `n_neighbors` and `min_dist` for UMAP) alongside the figure so teammates can reproduce the visualization when the embedding model version changes.
 
 ### Technique 1: PCA (Principal Component Analysis)
 
@@ -229,6 +261,27 @@ embeddings_2d = tsne.fit_transform(embeddings)
 
 # Plot (same as above)
 ```
+
+### Technique 3: UMAP (Uniform Manifold Approximation and Projection)
+
+UMAP is another non-linear reduction method, often chosen when you need a visualization that preserves more global structure than t-SNE while still revealing tight local clusters. UMAP constructs a fuzzy topological representation of the high-dimensional data and optimizes a low-dimensional layout to match it. In practice, UMAP plots frequently show continuous gradations between related topics (for example, a smooth path from "kubernetes" through "containers" to "docker") where t-SNE may fracture the same region into disconnected islands.
+
+```python
+import umap
+
+reducer = umap.UMAP(n_components=2, random_state=42, n_neighbors=15, min_dist=0.1)
+embeddings_2d = reducer.fit_transform(embeddings)
+```
+
+### Choosing PCA, t-SNE, or UMAP
+
+| Method | What it preserves | What it distorts | When to use |
+|--------|-------------------|------------------|-------------|
+| **PCA** | Global variance along principal axes | Local neighborhood structure | Quick exploratory plots; preprocessing before other methods |
+| **t-SNE** | Local pairwise neighborhoods | Global distances between clusters | Presentations focused on cluster separation |
+| **UMAP** | Local structure plus more global topology | Fine-grained distances | Publication-quality exploratory maps; larger datasets |
+
+None of these outputs should drive production retrieval thresholds. Use them to inspect bias, discover duplicate clusters, or communicate qualitative structure to stakeholders — then validate any architectural decision with offline recall metrics and online click-through data.
 
 ## Vector Arithmetic: Math on Meaning
 
@@ -343,9 +396,11 @@ king - man + woman ≈
 
 > **Stop and think**: If you perform the mathematical operation `programmer - coffee + tea`, what do you realistically expect the resulting vector coordinate to represent? Will it be a literal "tea-drinking programmer", or will the model find the closest existing professional stereotype in its underlying training data? Always consider the implicit cultural bias inherent in the massive training corpus.
 
+Vector arithmetic is a diagnostic tool, not a guaranteed API. Analogies like `king - man + woman ≈ queen` work because gender and royalty axes were strongly represented in historical training corpora; they may fail for rare entities, multilingual inputs, or domain jargon the model saw infrequently. In production, never expose raw arithmetic as user-facing search syntax unless you validate outputs on your vocabulary. Instead, use arithmetic to probe whether a fine-tuned model encodes a business relationship you care about — for example, subtracting a generic product embedding from a specific SKU embedding to see whether the residual vector aligns with brand or category neighbors. If arithmetic consistently fails for your domain, invest in contrastive fine-tuning on labeled pairs rather than forcing users to trust brittle analogy tricks.
+
 ## Building Production Semantic Search
 
-Deeply understanding advanced vector math in a conceptual vacuum is strictly only the first critical step. Engineering a highly robust, fault-tolerant semantic search system that reliably serves millions of concurrent global users requires incredibly strict architectural rigor, extensive profiling, and continuous performance tuning at the database level.
+Deeply understanding advanced vector math in a conceptual vacuum is strictly only the first critical step. Engineering a highly robust, fault-tolerant semantic search system that reliably serves millions of concurrent global users requires incredibly strict architectural rigor, extensive profiling, and continuous performance tuning at the database level. The offline path ingests raw documents, normalizes text (Unicode normalization, language detection, PII redaction where required), chunks or whole-doc encodes them, L2-normalizes vectors, and writes to an ANN index with durable storage. The online path embeds the query once, executes ANN search with configured `efSearch` or `nprobe`, optionally applies metadata filters before or after the graph walk depending on your database's pre-filtering support, reranks with auxiliary signals, and returns identifiers that map to object storage for full text snippets. Keeping these paths separate prevents a traffic spike on search from starving batch reindex jobs — and prevents an accidental full re-embed from blocking live queries when you run both on the same GPU pool without queue isolation.
 
 ```text
 Query → Embedding → Compare to all docs → Top-K results
@@ -382,7 +437,7 @@ def naive_search(query: str, embeddings: dict, top_k: int = 5):
     return sorted(scores, key=lambda x: x[1], reverse=True)[:top_k]
 ```
 
-To achieve millisecond query latency, we must willingly abandon mathematical exactness and employ Approximate Nearest Neighbor (ANN) algorithms. The Hierarchical Navigable Small World (HNSW) algorithm is currently the undisputed industry standard for balancing extreme retrieval speed and high operational recall within vector topology.
+To achieve millisecond query latency, we must willingly abandon mathematical exactness and employ Approximate Nearest Neighbor (ANN) algorithms. Hierarchical Navigable Small World (HNSW) graphs are widely used in production vector search because they balance retrieval speed and recall across a range of dataset sizes and hardware profiles.
 
 ```text
 Layer 2: •────────────────────────────•  (sparse, long jumps)
@@ -420,15 +475,35 @@ results = [
 ]
 ```
 
-When building modern cloud-native infrastructure, deploying a dedicated vector database provides durable persistent storage layers, dynamic horizontal scaling mechanisms, and highly tuned built-in ANN indexing strategies right out of the box without manual engineering overhead.
+### HNSW Internals: Layers, Parameters, and Recall Tradeoffs
 
-| Database | Open Source | Cloud | Best For |
-|----------|-------------|-------|----------|
-| **Qdrant** | Yes | Yes | General purpose, Rust performance |
-| **Weaviate** | Yes | Yes | GraphQL API, multi-modal |
-| **Milvus** | Yes | Yes | Scale (billions of vectors) |
-| **Pinecone** | No | Yes | Managed, easy to use |
-| **Chroma** | Yes | No | Lightweight, embeddings |
+HNSW builds a multi-layer navigable small-world graph. The bottom layer (layer 0) contains every vector and dense local edges to approximate $M$ nearest neighbors per node. Upper layers are subsamples of the dataset with progressively sparser long-range edges. Search starts at an entry point in the top layer, greedily walks toward the query vector, then drops to the next layer until it reaches layer 0 for fine-grained refinement. Long jumps at high layers locate the correct region quickly; dense connectivity at layer 0 improves final ranking accuracy.
+
+Two parameters dominate tuning:
+
+- **`M`** (neighbors per node): Higher $M$ increases graph connectivity, memory footprint, and build time, but typically improves recall because the greedy walk has more paths to the true nearest neighbors.
+- **`efConstruction`** (build-time beam width): Larger values produce higher-quality graphs during indexing at the cost of slower ingestion. This is a one-time cost per index build.
+- **`efSearch`** (query-time beam width): Larger values explore more candidates per query, improving recall and latency together — this is the primary runtime knob for the recall–latency tradeoff.
+
+Suppose you index one million 384-dimensional vectors. With `M=32` and `efConstruction=200`, build time may take minutes on a single node but yields a graph that reaches 95%+ recall@10 when `efSearch=128`. Dropping `efSearch` to 32 might cut query latency by half while recall@10 falls into the high eighties — acceptable for a first-stage candidate generator paired with a cross-encoder reranker, unacceptable for a single-stage legal search product. Always measure recall@k on a labeled holdout set when you change these values; the correct setting is workload-specific, not universal.
+
+### IVF and Product Quantization: Worked Memory Example
+
+**Inverted File (IVF)** indexes partition the vector space into `nlist` clusters (centroids). At query time, only the nearest centroids — controlled by `nprobe` — are searched, reducing comparisons from $N$ to roughly $(N/\text{nlist}) \times \text{nprobe}$. Increasing `nprobe` improves recall at higher latency.
+
+**Product Quantization (PQ)** splits each $D$-dimensional vector into $m$ subvectors of dimension $D/m$, replaces each subvector with the ID of its nearest codebook centroid, and stores only the IDs. A 768-dimensional `float32` vector normally occupies $768 \times 4 = 3072$ bytes. With PQ using $m=48$ subvectors and 8-bit codes per subvector, storage drops to 48 bytes per vector — a 64× compression ratio — at the cost of approximate distances computed via asymmetric distance computation (ADC) lookup tables.
+
+Numeric illustration: one million vectors at 768 dimensions in `float32` require roughly 3 GB of raw vector data. PQ-compressed storage for the same set is on the order of 48 MB for the codes plus modest codebook overhead. Query-time distance is approximate; reranking the top 100 PQ candidates with exact cosine on full-precision vectors is a common hybrid pattern that recovers most accuracy while keeping the index resident in RAM.
+
+When building modern cloud-native infrastructure, deploying a dedicated vector database provides durable persistent storage layers, dynamic horizontal scaling mechanisms, and built-in ANN indexing strategies without hand-rolling FAISS configuration for every service.
+
+| Database | Open Source | Cloud | Typical use case |
+|----------|-------------|-------|------------------|
+| **Qdrant** | Yes | Yes | Low-latency filtering with payload metadata |
+| **Weaviate** | Yes | Yes | GraphQL-native APIs and multi-modal vectors |
+| **Milvus** | Yes | Yes | Very large collections with distributed sharding |
+| **Pinecone** | No | Yes | Fully managed hosted vector index |
+| **Chroma** | Yes | No | Lightweight local prototyping and notebooks |
 
 Using the high-level Qdrant Python client, we can interface directly with a deployed, production-grade distributed database cluster to securely upsert and immediately query exceptionally large continuous vector payloads.
 
@@ -469,7 +544,9 @@ for result in results:
 
 ## Scaling Semantic Search
 
-When carefully transitioning a localized, proof-of-concept prototype to a live, global production environment, severe computational and memory bottlenecks will consistently emerge. The very first and arguably most critical architectural optimization you must apply is enforcing massive batching during the initial embedding generation process.
+When carefully transitioning a localized, proof-of-concept prototype to a live, global production environment, severe computational and memory bottlenecks will consistently emerge. The very first and arguably most critical architectural optimization you must apply is enforcing massive batching during the initial embedding generation process. Embedding models are throughput engines: a transformer forward pass amortizes fixed overhead across the batch dimension, so encoding one string at a time leaves GPU tensor cores idle while Python loop overhead dominates wall-clock time. Start with batch sizes that fill GPU memory without triggering out-of-memory kills — often 32 to 128 for sentence encoders on a single consumer GPU — and measure documents per second before optimizing index parameters. Ingestion pipelines should separate **encode**, **normalize**, **quantize**, and **index** stages so you can replay indexing from a parquet cache of embeddings without re-running the neural network when you only change HNSW settings.
+
+Sharding becomes necessary when a single node's RAM cannot hold the full HNSW graph plus metadata payloads. Consistent hashing on document ID routes each vector to a fixed shard, keeping updates localized. At query time, a coordinator broadcasts the query embedding to every shard (or to a routing layer that narrows candidates via coarse centroids), collects each shard's top-k results, and performs a final merge-sort to produce global top-k. The merge step is cheap relative to ANN search because k is small (10–100), but network fan-out grows with shard count — cap shards per query using IVF-style routing when you have hundreds of partitions. Replication adds read throughput: read-only replicas serve query traffic while the primary accepts writes, though eventual consistency means a freshly upserted document may lag milliseconds to seconds behind on replicas depending on your replication protocol.
 
 ```python
 # DON'T: Sequential encoding
@@ -543,7 +620,9 @@ flowchart TD
 
 ## Production Best Practices
 
-Deploying a truly robust and immensely scalable architecture necessitates implementing deeply aggressive edge caching strategies. You must never recompute massive static document embeddings dynamically on the fly during a live user query.
+Deploying a truly robust and immensely scalable architecture necessitates implementing deeply aggressive edge caching strategies. You must never recompute massive static document embeddings dynamically on the fly during a live user query. Treat the embedding of a document as a build artifact versioned alongside the model name and tokenizer revision: when you upgrade from `all-MiniLM-L6-v2` to `all-mpnet-base-v2`, plan a full re-embed migration rather than mixing incompatible vector spaces in one index. Cache query embeddings only when queries repeat exactly — autocomplete prefixes and templated support macros hit cache often; long-tail natural language questions rarely do. For repeated internal analytics queries, a short-TTL Redis cache keyed by normalized query text can shave tens of milliseconds without staleness risk.
+
+Evaluation discipline separates prototypes from products. Maintain a golden set of query–document relevance judgments (even a few hundred hand-labeled pairs beats flying blind). Report recall@k, mean reciprocal rank, and nDCG on that set whenever you change embedding model, index type, `efSearch`, or quantization level. Online, log click-through rate at rank position and null-result rate segmented by query category. A rising null-result rate with flat offline recall usually means traffic shifted to out-of-domain vocabulary — a signal to fine-tune or add hybrid BM25 rather than crank `efSearch` indefinitely.
 
 ```python
 # DON'T: Embed on every query
@@ -644,9 +723,9 @@ def robust_search(query):
 
 ## Real-World Applications
 
-### Application 1: kaizen RAG Enhancement
+### RAG Context Retrieval
 
-Providing accurate context to language models is paramount. Upgrading traditional keyword matching systems to utilize semantic search drastically enhances the contextual richness passed into Generation pipelines.
+Providing accurate context to language models is paramount. Upgrading traditional keyword matching systems to utilize semantic search drastically enhances the contextual richness passed into Generation pipelines. In retrieval-augmented generation, the retriever's job is to surface chunks whose embeddings lie close to the question embedding before the generator ever sees a token. Poor retrieval cannot be corrected by a larger LLM: if the top-five chunks discuss an outdated API version, the model will confidently synthesize wrong instructions. Chunking strategy interacts directly with embedding geometry — oversized chunks dilute semantic focus and push vectors toward generic topic centroids; undersized chunks lose cross-sentence context. A common pattern embeds overlapping windows (for example 512 tokens with 64-token stride), stores chunk metadata `{source, heading, timestamp}`, and reranks semantic hits with a cross-encoder that scores query–passage pairs with a slower but sharper interaction model.
 
 ```python
 # Before: Keyword matching
@@ -665,9 +744,9 @@ def retrieve_context(query):
 # Result: Better context → better answers!
 ```
 
-### Application 2: vibe Content Discovery
+### Content Recommendation and Discovery
 
-Platforms with massive educational catalogs rely on automated semantic discovery routines to seamlessly recommend structurally related courses to engaging users without manual tagging overhead.
+Platforms with massive educational catalogs rely on automated semantic discovery routines to seamlessly recommend structurally related courses to engaging users without manual tagging overhead. Item-to-item recommendation via embeddings avoids maintaining hand-curated prerequisite graphs: when a learner finishes a module on Kubernetes networking, nearest-neighbor search over course descriptions surfaces policy, service mesh, and CNI deep dives even if editors never linked them manually. Cold-start items with few interactions still receive vectors from their syllabus text, so new courses participate in recommendations on launch day rather than waiting for collaborative-filtering signal to accumulate. Combine embedding similarity with popularity decay and completion-rate boosts so niche but high-quality modules do not lose to generic intro content that merely sits closer to the centroid of all course vectors.
 
 ```python
 def explore_similar_lessons(lesson_id):
@@ -684,9 +763,9 @@ def explore_similar_lessons(lesson_id):
     return sorted(similarities, key=lambda x: x[1], reverse=True)[:5]
 ```
 
-### Application 3: contrarian News Clustering
+### News Topic Clustering
 
-Financial intelligence systems rapidly consume enormous streams of daily news. Vector clustering algorithms allow these systems to automatically aggregate volatile reports into unified, coherent economic themes.
+Financial intelligence systems rapidly consume enormous streams of daily news. Vector clustering algorithms allow these systems to automatically aggregate volatile reports into unified, coherent economic themes. K-means or hierarchical clustering on headline-plus-summary embeddings groups articles about the same earnings event even when headlines use different ticker symbols or euphemisms ("workforce optimization" versus "layoffs"). Visualization with t-SNE or UMAP on a daily batch helps analysts sanity-check whether clusters align with human judgment before alerts fire. Drift monitoring matters: when a central bank policy shift redefines vocabulary across the corpus, yesterday's centroids may mis-cluster today's articles — schedule periodic re-clustering or use streaming clustering algorithms that incrementally update centroids rather than assuming static topic geometry.
 
 ```python
 from sklearn.cluster import KMeans
@@ -712,9 +791,9 @@ def cluster_daily_news(articles):
     return clusters
 ```
 
-### Application 4: Work Infrastructure Docs
+### Internal Runbook and Documentation Search
 
-Internal site reliability engineering (SRE) teams frequently lose vital time searching through heavily nested Markdown documentation. Semantic indexing drastically streamlines incident runbook discovery during severe outages.
+Internal site reliability engineering (SRE) teams frequently lose vital time searching through heavily nested Markdown documentation. Semantic indexing drastically streamlines incident runbook discovery during severe outages. During an incident, engineers phrase queries as symptoms ("Redis connection pool exhausted on checkout") while runbooks are titled by component ("Tuning `maxclients` for cache-tier Redis"). Keyword search fails across that vocabulary gap; embedding search maps symptom language to procedural content when both were encoded by the same domain-aware model. Pair semantic retrieval with ownership metadata (`team=payments`, `tier=critical`) so results respect organizational boundaries, and boost recently updated documents to surface runbooks that match the current architecture rather than deprecated playbooks that still mention decommissioned services.
 
 ```python
 # Index all documentation
@@ -737,6 +816,72 @@ for path, score in results:
     print(f"{score:.3f} - {path}")
 ```
 
+## Deploying Vector Search on Kubernetes
+
+Production vector databases are stateful workloads: they hold gigabytes to terabytes of index data that must survive pod restarts. A `Deployment` with ephemeral container storage loses the index on every reschedule; for serious workloads, use a `StatefulSet` with persistent volumes and stable network identities.
+
+Resource sizing starts from your index footprint. Estimate raw vector storage as `num_vectors × dimension × bytes_per_component`, then add 30–50% overhead for HNSW graph edges, metadata payloads, and write-ahead logs. A collection of five million 384-dimensional `float32` vectors needs roughly 7.5 GB for vectors alone; with HNSW at `M=16`, plan for 12–16 GB RAM on the indexing node before OS and sidecar overhead. CPU scales with query QPS and `efSearch`; GPU acceleration helps batch embedding generation, not usually single-query ANN lookup unless you use GPU-native FAISS builds.
+
+Below is a minimal Kubernetes v1.35–compatible `StatefulSet` for Qdrant with persistent storage and resource limits. Adjust `storageClassName` and capacity to match your cluster.
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: qdrant
+spec:
+  serviceName: qdrant-headless
+  replicas: 1
+  selector:
+    matchLabels:
+      app: qdrant
+  template:
+    metadata:
+      labels:
+        app: qdrant
+    spec:
+      containers:
+      - name: qdrant
+        image: qdrant/qdrant:v1.12.5
+        ports:
+        - containerPort: 6333
+          name: http
+        - containerPort: 6334
+          name: grpc
+        resources:
+          requests:
+            memory: "4Gi"
+            cpu: "500m"
+          limits:
+            memory: "8Gi"
+            cpu: "2000m"
+        volumeMounts:
+        - name: qdrant-storage
+          mountPath: /qdrant/storage
+  volumeClaimTemplates:
+  - metadata:
+      name: qdrant-storage
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 50Gi
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: qdrant
+spec:
+  selector:
+    app: qdrant
+  ports:
+  - port: 6333
+    targetPort: 6333
+    name: http
+```
+
+Operational checklist for cluster deployment: pin image tags instead of `:latest`; configure liveness and readiness probes on the HTTP health endpoint; back up persistent volume snapshots before major version upgrades; run embedding workers as separate `Deployment` objects so GPU batch jobs do not contend with latency-sensitive search pods; and expose the service inside the cluster with a `ClusterIP` or service mesh, terminating TLS at the ingress. For multi-replica Qdrant or Milvus clusters, consult each project's consensus and sharding requirements before scaling `replicas` blindly — some configurations expect a single writable coordinator while others support Raft-based leader election across nodes. Network policies should allow only the retrieval service account to reach port 6333, preventing arbitrary pods from dumping the entire vector index. Capacity planning reviews should revisit PVC size quarterly: HNSW graphs grow superlinearly with `M`, and payload fields attached to each point consume disk independent of vector dimension.
+
 ## Module Summary
 
 To solidify the core concepts, recall the fundamental mathematical transformations that power these vast, multi-dimensional semantic retrieval systems at scale:
@@ -751,14 +896,23 @@ Distance in space ∝ Semantic distance
 
 ## The Surprising Economics of Vector Search
 
-The complex engineering decision between relying on exhaustive brute force scanning and implementing advanced HNSW graph indexing is purely an operational economic one, driven intensely by hardware latency targets and specific enterprise budget constraints.
+The engineering decision between exhaustive brute-force scanning and HNSW graph indexing is an operational tradeoff driven by latency targets, memory budgets, and acceptable recall loss — not by which algorithm looks more sophisticated on a slide. Order-of-magnitude comparisons illustrate why ANN indexes become mandatory as collections grow:
 
-| System | Documents | Latency | Hardware Cost |
-|--------|-----------|---------|---------------|
-| Brute Force (1M docs) | 1M | 1,000ms | $0 |
-| FAISS HNSW (1M docs) | 1M | 1ms | $0 |
-| Brute Force (1B docs) | 1B | 1,000,000ms | $0 |
-| FAISS HNSW (1B docs) | 1B | 10ms | ~$50K/year |
+| Approach | Collection size | Query pattern | Typical outcome |
+|----------|-----------------|---------------|-----------------|
+| Brute force | ~1M vectors | Full linear scan per query | Latency grows linearly with corpus size; fine for offline batch jobs |
+| HNSW (FAISS or DB-native) | ~1M vectors | Greedy graph walk | Sub-10 ms queries on modest hardware when tuned |
+| Brute force | ~1B vectors | Full linear scan per query | Impractical for interactive search without massive parallel hardware |
+| HNSW + sharding | ~1B vectors | Per-shard ANN then merge top-k | Feasible with distributed vector databases and horizontal scale-out |
+
+The "hardware cost" column disappears from real planning spreadsheets because the dominant costs are RAM for the index, embedding compute during ingestion, and engineering time to tune `efSearch`, `M`, and sharding strategy against a labeled evaluation set.
+
+## Did You Know?
+
+- **Word2Vec (2013)**: Tomas Mikolov and colleagues introduced efficient neural word embeddings in [Efficient Estimation of Word Representations in Vector Space](https://arxiv.org/abs/1301.3781), popularizing the idea that arithmetic on word vectors captures linguistic regularities.
+- **HNSW graphs (2016)**: Malkov and Yashunin's [HNSW paper](https://arxiv.org/abs/1603.09320) describes the layered small-world graph structure that FAISS, hnswlib, and many vector databases implement for approximate nearest-neighbor search.
+- **FAISS at billion scale**: Meta's [FAISS library](https://github.com/facebookresearch/faiss) documents GPU- and CPU-backed indexes designed for datasets far too large for naive linear scan, including IVF and product-quantization variants.
+- **UMAP for visualization**: McInnes, Healy, and Melville's [UMAP](https://umap-learn.readthedocs.io/en/latest/) method is widely used alongside t-SNE when teams want exploratory plots that preserve more global topology between clusters.
 
 ## Common Mistakes
 
@@ -771,16 +925,51 @@ The complex engineering decision between relying on exhaustive brute force scann
 | Computing embeddings sequentially | Processing documents individually underutilizes hardware accelerators and drastically increases overall batch time. | Utilize batch encoding with appropriate sizes to maximize GPU memory bandwidth and system throughput. |
 | Deploying to end-of-life Kubernetes | Running vector databases on deprecated orchestrators risks severe stability failures and security flaws. | Ensure all cluster deployments explicitly target K8s version v1.35 or higher to maintain strict compatibility and support. |
 
-## Did You Know?
+## Knowledge Check
 
-1. On January 16, 2013, researcher Tomas Mikolov and his team published the foundational Word2Vec paper, fundamentally shifting how modern researchers approached NLP representation.
-2. In October 2019, Google search integrated massive BERT embeddings into their primary algorithm, helping improve query comprehension and semantic matching for over 10 percent of all global searches.
-3. The Pinecone managed vector database startup achieved a staggering enterprise valuation of 750 million dollars in April 2023, signaling a massive corporate shift toward dedicated semantic infrastructure.
-4. An unoptimized exact brute force search over 1 billion 768-dimensional vectors requires the hardware to stream approximately 3 terabytes of physical memory bandwidth per single user query.
+Please carefully test your architectural understanding of continuous vector spaces and highly scalable semantic indexing using the scenarios below.
+
+<details>
+<summary>Question 1: You are tasked with analyzing the visual semantic drift of user queries over a 12-month period. The embeddings have 1536 dimensions. You need to create a dense, localized map to show deep clusters. Which algorithm is most appropriate?</summary>
+t-SNE is the most appropriate choice for this specific visualization task. It is a highly specialized non-linear technique specifically engineered for visualization and clustering in two or three dimensions. It preserves local structure exceptionally well, making it strictly ideal for identifying distinct groupings of user queries, whereas PCA focuses mostly on broad global variance.
+</details>
+
+<details>
+<summary>Question 2: A production database containing 50 million text documents is experiencing query latency spikes exceeding 2000ms. The system currently executes a raw dot product against every row. What core architectural change is required?</summary>
+The system desperately requires an Approximate Nearest Neighbor (ANN) index. Transitioning from brute force exact search to a graph algorithm like HNSW or IVF will dramatically shift the query time complexity from linear to logarithmic. This necessary trade-off of marginal accuracy loss will rapidly drop the latency into the sub-10ms range.
+</details>
+
+<details>
+<summary>Question 3: Your infrastructure team must immediately reduce the memory footprint of the active vector cluster by at least 60 percent without fundamentally altering the embedding generation model. How can this be reliably achieved?</summary>
+The infrastructure team should implement strict vector quantization, specifically converting the default Float32 precision embeddings down to Int8 (8-bit precision) representation. This straightforward conversion natively reduces the physical storage RAM requirements by 75 percent. The minor accuracy loss in semantic search is typically negligible and entirely acceptable for enterprise retrieval tasks.
+</details>
+
+<details>
+<summary>Question 4: You calculate `Rome - Italy + Japan` using mathematical vector arithmetic. Assuming the model has strong geographical training data, what exactly should the resulting coordinates approximate?</summary>
+The resulting multi-dimensional coordinates will mathematically approximate the vector for the concept "Tokyo". The mathematical subtraction effectively extracts the geopolitical relationship "capital city of" by subtracting the country identity and then adding that latent semantic relationship back to the target country, proving that spatial direction encodes real-world properties.
+</details>
+
+<details>
+<summary>Question 5: A client complains that broadly searching for "Apple" returns detailed fruit recipes rather than large tech company articles. How can a hybrid search architecture resolve this complaint?</summary>
+Hybrid search structurally resolves this by smartly combining semantic similarity with deterministic metadata filters. By allowing the client to append a strict metadata filter (e.g., `category="technology"` or `date > 2024`), the system reranks the semantic results more precisely. It cleanly blends the continuous vector proximity score with the strict boolean constraint to guarantee absolute relevance.
+</details>
+
+<details>
+<summary>Question 6: When scaling a massive semantic search application across a clustered Kubernetes environment, why is it absolutely critical to use batch processing during the initial massive document ingestion phase?</summary>
+Generating high-dimensional embeddings sequentially vastly underutilizes the massive parallel processing capabilities of modern hardware accelerators and GPUs. Batch encoding successfully passes large chunks of documents through the transformer model simultaneously in a single pass. This massively optimizes memory bandwidth and can easily accelerate the entire indexing pipeline by 10x to 50x compared to simple iterative loop processing.
+</details>
 
 ## Hands-On Exercise: Vector Search from Scratch
 
-This highly structured laboratory exercise requires an active Python virtual environment and a running Kubernetes cluster. Note: ensure your cluster and terminal environment and a running Kubernetes v1.35 cluster if deploying the Qdrant component natively. We will systematically construct a vector arithmetic search pipeline locally and then cleanly migrate it to a fast local FAISS index before tackling cluster deployment.
+This laboratory exercise requires a Python virtual environment and, for Task 5, a Kubernetes v1.35 cluster. You will build a vector arithmetic pipeline locally, index it with FAISS HNSW, and deploy a persistent vector database with a StatefulSet manifest.
+
+**Success criteria** (check off as you complete each item):
+
+- [ ] Virtual environment created with `sentence-transformers`, `scikit-learn`, `numpy`, `faiss-cpu`, and `matplotlib` installed
+- [ ] `vector_lab.py` generates embeddings and returns sensible results for `king - man + woman`
+- [ ] FAISS HNSW index returns nearest neighbors for a paraphrase query such as "royal"
+- [ ] Kubernetes StatefulSet manifest applied and Qdrant pod reaches Ready state
+- [ ] You can articulate when to use cosine similarity versus L2 distance after L2 normalization
 
 ### Task 1: Initialize the Environment
 
@@ -943,66 +1132,24 @@ spec:
       targetPort: 6333
 ```
 
-Apply it using `kubectl apply -f qdrant-deployment.yaml` to spin up the stateful database instance inside your cluster. We assert that this manifest passes static validation for v1.35 and deploys smoothly.
+Apply it using `kubectl apply -f qdrant-deployment.yaml` to spin up the stateful database instance inside your cluster. For production persistence, prefer the StatefulSet pattern documented earlier in this module over a bare `Deployment` with ephemeral storage.
 </details>
 
-## Knowledge Check
+## Next Module
 
-Please carefully test your architectural understanding of continuous vector spaces and highly scalable semantic indexing using the scenarios below.
-
-<details>
-<summary>Question 1: You are tasked with analyzing the visual semantic drift of user queries over a 12-month period. The embeddings have 1536 dimensions. You need to create a dense, localized map to show deep clusters. Which algorithm is most appropriate?</summary>
-t-SNE is the most appropriate choice for this specific visualization task. It is a highly specialized non-linear technique specifically engineered for visualization and clustering in two or three dimensions. It preserves local structure exceptionally well, making it strictly ideal for identifying distinct groupings of user queries, whereas PCA focuses mostly on broad global variance.
-</details>
-
-<details>
-<summary>Question 2: A production database containing 50 million text documents is experiencing query latency spikes exceeding 2000ms. The system currently executes a raw dot product against every row. What core architectural change is required?</summary>
-The system desperately requires an Approximate Nearest Neighbor (ANN) index. Transitioning from brute force exact search to a graph algorithm like HNSW or IVF will dramatically shift the query time complexity from linear to logarithmic. This necessary trade-off of marginal accuracy loss will rapidly drop the latency into the sub-10ms range.
-</details>
-
-<details>
-<summary>Question 3: Your infrastructure team must immediately reduce the memory footprint of the active vector cluster by at least 60 percent without fundamentally altering the embedding generation model. How can this be reliably achieved?</summary>
-The infrastructure team should implement strict vector quantization, specifically converting the default Float32 precision embeddings down to Int8 (8-bit precision) representation. This straightforward conversion natively reduces the physical storage RAM requirements by 75 percent. The minor accuracy loss in semantic search is typically negligible and entirely acceptable for enterprise retrieval tasks.
-</details>
-
-<details>
-<summary>Question 4: You calculate `Rome - Italy + Japan` using mathematical vector arithmetic. Assuming the model has strong geographical training data, what exactly should the resulting coordinates approximate?</summary>
-The resulting multi-dimensional coordinates will mathematically approximate the vector for the concept "Tokyo". The mathematical subtraction effectively extracts the geopolitical relationship "capital city of" by subtracting the country identity and then adding that latent semantic relationship back to the target country, proving that spatial direction encodes real-world properties.
-</details>
-
-<details>
-<summary>Question 5: A client complains that broadly searching for "Apple" returns detailed fruit recipes rather than large tech company articles. How can a hybrid search architecture resolve this complaint?</summary>
-Hybrid search structurally resolves this by smartly combining semantic similarity with deterministic metadata filters. By allowing the client to append a strict metadata filter (e.g., `category="technology"` or `date > 2024`), the system reranks the semantic results more precisely. It cleanly blends the continuous vector proximity score with the strict boolean constraint to guarantee absolute relevance.
-</details>
-
-<details>
-<summary>Question 6: When scaling a massive semantic search application across a clustered Kubernetes environment, why is it absolutely critical to use batch processing during the initial massive document ingestion phase?</summary>
-Generating high-dimensional embeddings sequentially vastly underutilizes the massive parallel processing capabilities of modern hardware accelerators and GPUs. Batch encoding successfully passes large chunks of documents through the transformer model simultaneously in a single pass. This massively optimizes memory bandwidth and can easily accelerate the entire indexing pipeline by 10x to 50x compared to simple iterative loop processing.
-</details>
-
-## Key Links
-
-- Vector Arithmetic: `module_10/01_vector_arithmetic.py`
-- Production Semantic Search: `module_10/02_production_search.py`
-- `module_10/01_vector_arithmetic.py`
-- `module_10/02_production_search.py`
-- [Paper](https://arxiv.org/abs/1301.3781)
-- [Paper](https://nlp.stanford.edu/pubs/glove.pdf)
-- [Paper](https://arxiv.org/abs/1603.09320)
-- [Paper](https://arxiv.org/abs/1810.04805)
-- [GitHub](https://github.com/facebookresearch/faiss)
-- [GitHub](https://github.com/spotify/annoy)
-- [GitHub](https://github.com/nmslib/hnswlib)
-- [Website](https://qdrant.tech/)
-
-## Next Steps
-
-**Next module**: [Module 1.6: Reasoning Models](./module-1.6-reasoning-models)
-
-You have successfully mastered the complex mathematical principles of deep semantic meaning and high-dimensional coordinate visualization. In the upcoming module, you will thoroughly examine how highly modern, reasoning-focused architectures meticulously plan extensive multi-step solutions, identify exactly when they massively outperform standard generative models, and analyze exactly how to deploy them effectively and securely in mission-critical production systems.
+Continue to [Module 1.6 — Reasoning Models](/ai-ml-engineering/generative-ai/module-1.6-reasoning-models/) to study how modern reasoning-focused architectures spend additional test-time compute on internal deliberation before producing answers. You will also learn how to route queries between fast standard models and slower reasoning models in production pipelines without blowing latency budgets on simple extraction tasks or lookups.
 
 ## Sources
 
-- [Efficient Estimation of Word Representations in Vector Space](https://arxiv.org/abs/1301.3781) — Foundational word-embedding paper that underpins the module's discussion of vector-space semantics.
-- [Efficient and robust approximate nearest neighbor search using Hierarchical Navigable Small World graphs](https://arxiv.org/abs/1603.09320) — Primary source for HNSW, the ANN indexing approach referenced in the production search sections.
-- [FAISS](https://github.com/facebookresearch/faiss) — Practical upstream implementation of dense-vector similarity search and ANN indexing used throughout the module.
+- [Efficient Estimation of Word Representations in Vector Space](https://arxiv.org/abs/1301.3781) — Mikolov et al.; foundational Word2Vec paper underpinning vector-space semantics and analogies.
+- [GloVe: Global Vectors for Word Representation](https://nlp.stanford.edu/pubs/glove.pdf) — Pennington, Socher, and Manning; co-occurrence matrix factorization approach to word embeddings.
+- [BERT: Pre-training of Deep Bidirectional Transformers](https://arxiv.org/abs/1810.04805) — Devlin et al.; contextual embeddings that supersede static word vectors in many pipelines.
+- [Efficient and robust approximate nearest neighbor search using Hierarchical Navigable Small World graphs](https://arxiv.org/abs/1603.09320) — Malkov and Yashunin; primary reference for HNSW graph indexing.
+- [FAISS: A library for efficient similarity search](https://github.com/facebookresearch/faiss) — Meta's CPU/GPU ANN library used for HNSW, IVF, and product quantization examples.
+- [Product Quantization for Nearest Neighbor Search](https://arxiv.org/abs/1011.3029) — Jégou et al.; foundational PQ paper behind FAISS compression and ADC distance tables.
+- [Sentence-BERT (SBERT)](https://arxiv.org/abs/1902.05667) — Reimers and Gurevych; contrastive sentence embeddings that power many `sentence-transformers` retrieval models.
+- [scikit-learn PCA](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html) — Documentation for linear dimensionality reduction used in visualization examples.
+- [scikit-learn t-SNE](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html) — Documentation for non-linear neighborhood-preserving visualization.
+- [UMAP documentation](https://umap-learn.readthedocs.io/en/latest/) — McInnes et al.; non-linear reduction alternative with stronger global structure preservation.
+- [Qdrant documentation](https://qdrant.tech/documentation/) — Vector database deployment, filtering, and HNSW configuration for production clusters.
+- [Visualizing Data using t-SNE](https://www.jmlr.org/papers/volume9/vandermaaten08a.html) — van der Maaten and Hinton; original t-SNE paper explaining perplexity and neighborhood preservation.

--- a/src/content/docs/ai-ml-engineering/generative-ai/module-1.5-vector-space-visualization.md
+++ b/src/content/docs/ai-ml-engineering/generative-ai/module-1.5-vector-space-visualization.md
@@ -41,6 +41,8 @@ Paris - France + Italy ≈ Rome
 good - bad + terrible ≈ excellent
 ```
 
+Sentiment-reversal analogies like `good - bad + terrible ≈ excellent` depend on the model having a consistent sentiment axis and are less reliable than the canonical king−man+woman example.
+
 When we systematically map and plot these distinct coordinates in a simplified two-dimensional visualization plane, a profound geometric property emerges. When we plot these coordinates in a simplified two-dimensional visualization, the proximity of the points corresponds directly to the similarity of their underlying meaning. Concepts representing positive sentiment organically pull toward one coordinate direction, while negative sentiment concepts naturally pull in the exact opposite mathematical direction.
 
 ```text
@@ -466,7 +468,7 @@ index.add(embeddings_matrix)
 
 # Search
 query_emb = model.encode(query).astype('float32').reshape(1, -1)
-distances, indices = index.search(query_emb, k=5)
+distances, indices = index.search(query_emb, k=5)  # returns squared-L2 distances (monotonic; fine for ranking)
 
 # Get results
 results = [
@@ -483,7 +485,7 @@ Two parameters dominate tuning:
 
 - **`M`** (neighbors per node): Higher $M$ increases graph connectivity, memory footprint, and build time, but typically improves recall because the greedy walk has more paths to the true nearest neighbors.
 - **`efConstruction`** (build-time beam width): Larger values produce higher-quality graphs during indexing at the cost of slower ingestion. This is a one-time cost per index build.
-- **`efSearch`** (query-time beam width): Larger values explore more candidates per query, improving recall and latency together — this is the primary runtime knob for the recall–latency tradeoff.
+- **`efSearch`** (query-time beam width): Larger values explore more candidates per query, improving recall at the cost of higher latency — this is the primary runtime knob for the recall–latency tradeoff.
 
 Suppose you index one million 384-dimensional vectors. With `M=32` and `efConstruction=200`, build time may take minutes on a single node but yields a graph that reaches 95%+ recall@10 when `efSearch=128`. Dropping `efSearch` to 32 might cut query latency by half while recall@10 falls into the high eighties — acceptable for a first-stage candidate generator paired with a cross-encoder reranker, unacceptable for a single-stage legal search product. Always measure recall@k on a labeled holdout set when you change these values; the correct setting is workload-specific, not universal.
 
@@ -568,8 +570,8 @@ pca = PCA(n_components=128)
 reduced_embeddings = pca.fit_transform(embeddings)
 
 # Storage: 66% reduction
-# Speed: 3x faster
-# Accuracy: ~5% loss (acceptable for many use cases)
+# Fewer dimensions → cheaper distance math; real speedup depends on index type and k
+# Accuracy impact depends on how much variance the kept components capture — measure on a labeled holdout set
 ```
 
 Alternatively, hardware quantization offers massive system memory savings with truly negligible accuracy degradation by aggressively compressing the floating-point precision of the stored topological coordinates inside the memory buffer.
@@ -582,10 +584,11 @@ embeddings_f32 = embeddings.astype('float32')
 embeddings_f16 = embeddings.astype('float16')
 
 # Int8 (8-bit): 1 byte per dimension
-embeddings_i8 = (embeddings * 127).astype('int8')
+scale = np.abs(embeddings).max()
+embeddings_i8 = (embeddings / scale * 127).astype('int8')
 
 # Storage: 75% reduction (float32 → int8)
-# Accuracy: <1% loss
+# Accuracy impact is usually small but data-dependent — measure recall@k on your eval set
 ```
 
 At extreme planetary scales involving hundreds of millions of unique enterprise documents, heavy search requests must be dynamically partitioned and intelligently sharded across a widely distributed cluster of independent compute nodes.
@@ -1074,7 +1077,7 @@ index.add(emb_matrix)
 
 # Query for "royal"
 query_vec = model.encode("royal").astype('float32').reshape(1, -1)
-distances, indices = index.search(query_vec, k=3)
+distances, indices = index.search(query_vec, k=3)  # returns squared-L2 distances (monotonic; fine for ranking)
 
 words_list = list(vocab_embeddings.keys())
 print("Closest to 'royal':")
@@ -1090,16 +1093,15 @@ Finally, write a robust Kubernetes manifest file to deploy a high-performance Qd
 <details>
 <summary>View Solution</summary>
 
-Create a file named `qdrant-deployment.yaml`:
+Create a file named `qdrant-statefulset.yaml`:
 
 ```text
 apiVersion: apps/v1
-kind: Deployment
+kind: StatefulSet
 metadata:
   name: qdrant
-  labels:
-    app: qdrant
 spec:
+  serviceName: qdrant-headless
   replicas: 1
   selector:
     matchLabels:
@@ -1111,28 +1113,44 @@ spec:
     spec:
       containers:
       - name: qdrant
-        image: qdrant/qdrant:latest
+        image: qdrant/qdrant:v1.12.5
         ports:
         - containerPort: 6333
+          name: http
         resources:
-          limits:
+          requests:
             memory: "2Gi"
+            cpu: "500m"
+          limits:
+            memory: "4Gi"
             cpu: "1000m"
+        volumeMounts:
+        - name: qdrant-storage
+          mountPath: /qdrant/storage
+  volumeClaimTemplates:
+  - metadata:
+      name: qdrant-storage
+    spec:
+      accessModes: ["ReadWriteOnce"]
+      resources:
+        requests:
+          storage: 10Gi
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: qdrant-svc
+  name: qdrant-headless
 spec:
+  clusterIP: None
   selector:
     app: qdrant
   ports:
-    - protocol: TCP
-      port: 6333
-      targetPort: 6333
+  - port: 6333
+    targetPort: 6333
+    name: http
 ```
 
-Apply it using `kubectl apply -f qdrant-deployment.yaml` to spin up the stateful database instance inside your cluster. For production persistence, prefer the StatefulSet pattern documented earlier in this module over a bare `Deployment` with ephemeral storage.
+Apply it using `kubectl apply -f qdrant-statefulset.yaml` to spin up the persistent vector database inside your cluster.
 </details>
 
 ## Next Module
@@ -1147,9 +1165,9 @@ Continue to [Module 1.6 — Reasoning Models](/ai-ml-engineering/generative-ai/m
 - [Efficient and robust approximate nearest neighbor search using Hierarchical Navigable Small World graphs](https://arxiv.org/abs/1603.09320) — Malkov and Yashunin; primary reference for HNSW graph indexing.
 - [FAISS: A library for efficient similarity search](https://github.com/facebookresearch/faiss) — Meta's CPU/GPU ANN library used for HNSW, IVF, and product quantization examples.
 - [Product Quantization for Nearest Neighbor Search](https://arxiv.org/abs/1011.3029) — Jégou et al.; foundational PQ paper behind FAISS compression and ADC distance tables.
-- [Sentence-BERT (SBERT)](https://arxiv.org/abs/1902.05667) — Reimers and Gurevych; contrastive sentence embeddings that power many `sentence-transformers` retrieval models.
+- [Sentence-BERT (SBERT)](https://arxiv.org/abs/1908.10084) — Reimers and Gurevych; contrastive sentence embeddings that power many `sentence-transformers` retrieval models.
 - [scikit-learn PCA](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html) — Documentation for linear dimensionality reduction used in visualization examples.
 - [scikit-learn t-SNE](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html) — Documentation for non-linear neighborhood-preserving visualization.
 - [UMAP documentation](https://umap-learn.readthedocs.io/en/latest/) — McInnes et al.; non-linear reduction alternative with stronger global structure preservation.
 - [Qdrant documentation](https://qdrant.tech/documentation/) — Vector database deployment, filtering, and HNSW configuration for production clusters.
-- [Visualizing Data using t-SNE](https://www.jmlr.org/papers/volume9/vandermaaten08a.html) — van der Maaten and Hinton; original t-SNE paper explaining perplexity and neighborhood preservation.
+- [Visualizing Data using t-SNE](https://www.jmlr.org/papers/v9/vandermaaten08a.html) — van der Maaten and Hinton; original t-SNE paper explaining perplexity and neighborhood preservation.

--- a/src/content/docs/ai-ml-engineering/generative-ai/module-1.6-reasoning-models.md
+++ b/src/content/docs/ai-ml-engineering/generative-ai/module-1.6-reasoning-models.md
@@ -5,14 +5,6 @@ sidebar:
   order: 307
 ---
 
-## Why This Module Matters
-
-In late 2024, a leading quantitative trading firm attempted to automate its internal data pipeline migrations by deploying a state-of-the-art standard large language model. The engineering team built a system that read legacy database schemas and generated migration scripts in real-time. Because standard models operate on a "System 1" paradigm—predicting the next token based on surface-level statistical patterns without internal deliberation—the model hallucinated a subtle but catastrophic table join condition. When the script executed autonomously in production, it created a cascading row-level lock on the primary transaction database. This halted all high-frequency trades for twenty-two minutes, resulting in an estimated fourteen million dollar loss. The engineering team realized too late that complex, multi-step logical constraints cannot be reliably solved by fast-response pattern matching.
-
-This incident underscored a critical limitation in the generative AI landscape: standard models lack the capacity to "think" before they speak. The advent of reasoning models, designed around "System 2" cognitive principles, fundamentally alters this dynamic. By utilizing test-time compute—spending additional processing time and generating hidden tokens to explore, evaluate, and backtrack through a chain of thought before returning a final answer—these models can solve complex mathematics, advanced coding problems, and intricate logic puzzles that consistently defeat standard models. However, this capability introduces entirely new engineering challenges around cost management, latency expectations, and API integration.
-
-Understanding when and how to deploy reasoning models is no longer an optional architectural skill; it is a mandatory competency for AI engineers building autonomous systems. Designing a pipeline that routes simple extraction tasks to fast, cheap models while reserving expensive, high-latency reasoning models for complex planning is the difference between a highly profitable application and a financially ruinous architecture. This module explores the mechanics, integration patterns, and optimization strategies necessary to leverage modern reasoning models effectively.
-
 ## Learning Outcomes
 
 By the end of this module, you will be able to:
@@ -21,13 +13,25 @@ By the end of this module, you will be able to:
 - **Evaluate** the total cost of ownership for reasoning pipelines by analyzing hidden chain-of-thought token consumption in production logs.
 - **Diagnose** pipeline bottlenecks caused by reasoning model latency spikes and implement appropriate asynchronous fallback mechanisms.
 
+## Why This Module Matters
+
+Hypothetical scenario: A financial software team asks a fast text-generation model to help migrate a legacy reporting pipeline. The system reads old database schemas, drafts SQL changes, and submits migration scripts for an automated approval path. On a simple table rename, it works well. On a more tangled task involving several joins, deferred constraints, and a hidden dependency between two reports, the model produces a confident answer that looks syntactically clean but reasons from the wrong relationship between tables.
+
+The team catches the mistake during review, but the near miss teaches the real lesson. A fast next-token model is excellent when the task resembles patterns it has seen: summarize this paragraph, classify this support ticket, extract the invoice number, draft a short message, or translate a known intent into a common API call. It is much weaker when the task requires maintaining several constraints, noticing that an early assumption has become invalid, exploring alternatives, and deciding that the safest answer is to stop and ask for missing information.
+
+Reasoning models address that class of work by spending extra inference-time compute before returning the visible answer. The practical idea is simple: a model can trade tokens, time, and money for more deliberate problem solving. Instead of generating only the final response, it may allocate an internal scratchpad, compare candidate solutions, use a verifier, revise a failed attempt, or decide that a narrower plan is safer than a broad one. The user may not see the internal reasoning, but the application still pays the latency and token cost.
+
+That tradeoff is why reasoning models are an engineering topic, not just a model-release topic. If every request in a product goes through the slowest reasoning path, latency rises and unit economics become fragile. If no request can reach a reasoning model, the system may fail exactly where the business needs careful multi-step judgment. The production skill is to recognize which tasks deserve extra thinking, how much thinking to buy, how to observe that spend, and how to route the rest through cheaper paths without pretending that all prompts need the same model.
+
 ## Section 1: The Shift from System 1 to System 2 Thinking
 
-In human psychology, Daniel Kahneman popularized the framework of System 1 and System 2 thinking. System 1 is fast, instinctive, and emotional (e.g., instantly recognizing a face). System 2 is slower, more deliberative, and more logical (e.g., solving a complex calculus problem). Historically, large language models have functioned exclusively as System 1 entities. A standard model like GPT-4 or Claude 3.5 Sonnet performs a single forward pass through its neural network to generate the next token. If it makes a logical misstep early in its response, it cannot backtrack. Instead, it suffers from the "snowball effect," where subsequent tokens compound the initial error as the model attempts to remain consistent with its flawed context.
+The System-1/System-2 language is a useful analogy, not a claim that language models think like people. System 1 means fast pattern completion: the model maps the prompt and prior context to the next likely tokens with little visible deliberation. System 2 means deliberate problem solving: the system spends additional computation exploring a plan, checking intermediate assumptions, and sometimes revising before it commits to the final answer.
 
-Reasoning models, such as OpenAI's o1 and o3 series or DeepSeek's R1, introduce System 2 mechanics to artificial intelligence. These models are heavily trained using large-scale reinforcement learning (RL) techniques specifically designed to reward accurate multi-step reasoning. During inference, they generate a hidden, internal chain of thought before producing user-facing output. This internal scratchpad allows the model to test hypotheses, recognize dead ends, backtrack, and try alternative logical approaches.
+Standard chat models can still solve many multi-step problems, especially when the prompt is familiar and the answer shape is obvious. The risk appears when the first plausible continuation is wrong but locally convincing. Once a generated answer commits to a mistaken assumption, later tokens often rationalize that assumption instead of reopening it. In a code migration, that might mean the model explains a bad schema relationship beautifully; in an incident summary, it might connect events in a neat order that the logs do not support.
 
-This fundamental difference changes the physical execution profile of the model. Standard models are bound by predictable input-to-output compute ratios. Reasoning models decouple their intelligence from their output length, scaling their cognitive capabilities dynamically based on the amount of compute they are permitted to consume during inference.
+Reasoning models change the execution profile by making inference more elastic. The system may spend extra hidden tokens, run repeated samples, call a verifier, or use a learned policy that has been rewarded for reaching correct answers on tasks where intermediate reasoning matters. The final answer can be short even when the internal work was long. That is the key mental shift: output length is no longer a reliable proxy for work performed, cost incurred, or latency experienced.
+
+The best analogy is a code reviewer switching from skim mode to design-review mode. Skim mode is appropriate for a typo, a documentation cleanup, or a known refactor pattern. Design-review mode is appropriate when a change touches concurrency, security boundaries, payment logic, or a migration path that cannot be rolled back easily. Reasoning models give your application a way to request that design-review mode, but they do not remove the need to decide when that mode is justified.
 
 ```mermaid
 graph TD
@@ -43,79 +47,162 @@ graph TD
     I --> E
 ```
 
+The diagram hides one important production detail: the application usually receives only the final answer and a small amount of metadata, not the raw reasoning trace. Some APIs expose summaries or encrypted reasoning artifacts, and some open-weight models can emit visible thinking text, but the durable engineering rule is the same either way. Treat reasoning as expensive internal work that needs a budget, a timeout, and an evaluation plan, not as free explanatory text.
+
 ## Section 2: The Mechanics of Test-Time Compute
 
-The core innovation driving reasoning models is the concept of test-time compute scaling. Unlike standard models, where the processing power used is strictly proportional to the length of the final text, reasoning models scale their intelligence by consuming more compute during inference (test-time). This is analogous to giving a human engineer an hour to review a pull request versus five minutes; more time generally yields a deeper, more accurate analysis.
+Test-time compute means computation spent after the prompt arrives. Pretraining compute teaches a model broad language and world patterns. Post-training compute, such as supervised fine-tuning or reinforcement learning, shapes behavior before deployment. Test-time compute is different: it is the extra work performed during a live request, and the application pays for it every time that route is used.
 
-To expose this capability to developers, API providers have introduced new configuration parameters. In standard models, engineers tweak `temperature` or `top_p` to control output randomness. In reasoning models, these parameters are often locked to preserve the integrity of the underlying reinforcement learning policy. Instead, developers configure parameters like `reasoning_effort` to explicitly budget how much internal compute the model is allowed to expend.
+A useful way to reason about the budget is to split a request into three token buckets. Input tokens are the prompt, retrieved context, tool results, and conversation history. Visible output tokens are the answer returned to the user or the structured payload consumed by your application. Reasoning tokens are internal generation or search tokens used to arrive at that answer. Depending on the provider and model, those reasoning tokens may be hidden, summarized, encrypted, exposed as explicit thinking text, or represented only in usage metadata.
 
-A higher reasoning effort instructs the model that it is permitted to generate thousands of hidden tokens to explore massive decision trees. This dramatically increases both the latency and the financial cost of the API call, but significantly improves performance on complex tasks.
+The budget knob is usually expressed as an effort level, a thinking budget, or a maximum output allowance that includes hidden reasoning. The exact API field changes quickly, so the durable concept matters more than the name. Low effort asks the model to spend less internal work and return faster. Higher effort gives it more room to explore, verify, and revise. If the task is genuinely hard, the extra work can improve reliability; if the task is simple, the same extra work is just cost and delay.
+
+Consider an illustrative request with 1,200 input tokens and a desired final JSON answer of about 250 visible tokens. A fast model might consume those 1,200 input tokens and generate the 250-token output directly. A reasoning model with a modest budget might spend 1,500 hidden reasoning tokens before the same 250 visible tokens. A high-budget route might spend 8,000 hidden reasoning tokens and still return only 250 visible tokens. The user sees roughly the same answer length in all three cases, but the billable and latency profile can differ by an order of magnitude.
+
+That is why the first observability question for reasoning systems is not "How long was the answer?" It is "How many tokens did the system spend before producing the answer, and did those tokens buy measurable quality?" A useful dashboard separates input, visible output, hidden reasoning, tool-call retries, total wall-clock latency, and task success. Without that split, teams often misdiagnose cost spikes as "users asked longer questions" when the real driver was a routing change that sent routine traffic through a deeper reasoning path.
 
 ```python
-import os
 import time
-from openai import OpenAI
+from dataclasses import dataclass
 
-# Initialize the client (ensure OPENAI_API_KEY is set in your environment)
-client = OpenAI(api_key=os.environ.get("OPENAI_API_KEY"))
 
-def execute_reasoning_task(prompt: str, effort_level: str = "medium") -> dict:
-    """
-    Executes a complex task using a reasoning model, demonstrating how to
-    configure test-time compute and capture the resulting token economics.
-    
-    effort_level must be one of: 'low', 'medium', 'high'.
-    """
-    print(f"Initiating request with reasoning effort: {effort_level}")
-    start_time = time.time()
-    
-    try:
-        response = client.chat.completions.create(
-            model="o3-mini",
-            messages=[
-                {"role": "user", "content": prompt}
-            ],
-            # This parameter dictates the test-time compute budget
-            reasoning_effort=effort_level 
+@dataclass
+class ReasoningRun:
+    effort: str
+    input_tokens: int
+    visible_output_tokens: int
+    hidden_reasoning_tokens: int
+    latency_seconds: float
+
+    @property
+    def total_tokens(self) -> int:
+        return self.input_tokens + self.visible_output_tokens + self.hidden_reasoning_tokens
+
+
+def estimate_tokens(text: str) -> int:
+    """A rough local estimate; production systems should use provider tokenizers."""
+    return max(1, len(text) // 4)
+
+
+def simulate_reasoning_call(prompt: str, effort: str = "medium") -> ReasoningRun:
+    """Simulate how a reasoning-budget knob changes cost and latency."""
+    hidden_budget = {
+        "low": 800,
+        "medium": 2500,
+        "high": 7000,
+    }
+    if effort not in hidden_budget:
+        raise ValueError("effort must be one of: low, medium, high")
+
+    input_tokens = estimate_tokens(prompt)
+    visible_output_tokens = 240
+    hidden_reasoning_tokens = hidden_budget[effort]
+
+    # Keep the sleep tiny so the example remains runnable in a lesson environment.
+    time.sleep(0.05)
+    latency_seconds = 0.3 + hidden_reasoning_tokens / 1800
+
+    return ReasoningRun(
+        effort=effort,
+        input_tokens=input_tokens,
+        visible_output_tokens=visible_output_tokens,
+        hidden_reasoning_tokens=hidden_reasoning_tokens,
+        latency_seconds=round(latency_seconds, 2),
+    )
+
+
+if __name__ == "__main__":
+    task = "Design a rollback-safe database migration plan for a service with dependent reports."
+    for level in ["low", "medium", "high"]:
+        run = simulate_reasoning_call(task, level)
+        print(
+            f"{run.effort:>6} | total={run.total_tokens:>5} tokens | "
+            f"hidden={run.hidden_reasoning_tokens:>5} | latency={run.latency_seconds:>4}s"
         )
-        
-        execution_time = time.time() - start_time
-        usage = response.usage
-        
-        # Extract token metrics, including hidden reasoning tokens
-        total_tokens = usage.total_tokens
-        completion_tokens = usage.completion_tokens
-        reasoning_tokens = getattr(usage.completion_tokens_details, 'reasoning_tokens', 0)
-        visible_tokens = completion_tokens - reasoning_tokens
-        
-        return {
-            "output": response.choices[0].message.content,
-            "latency_seconds": round(execution_time, 2),
-            "total_tokens": total_tokens,
-            "visible_tokens": visible_tokens,
-            "hidden_reasoning_tokens": reasoning_tokens
-        }
-        
-    except Exception as e:
-        print(f"API Error: {e}")
-        return {}
-
-# Example usage (commented out for safety in production pipelines)
-# result = execute_reasoning_task("Prove that there are infinitely many prime numbers, step by step.", "high")
-# print(f"Latency: {result['latency_seconds']}s | Hidden Tokens: {result['hidden_reasoning_tokens']}")
 ```
 
-> **Pause and predict**: Suppose you are building a real-time customer support chatbot that needs to resolve complex billing discrepancies by querying a massive SQL database. Based on the concept of test-time compute, predict what would happen to the user experience if you route all incoming user messages through a reasoning model set to 'high' effort, and propose an architectural modification to mitigate this issue.
+> **Pause and predict**: Suppose you are building a real-time support assistant that handles greetings, password-reset questions, and complex billing disputes. Based on the token-budget walkthrough, predict what happens if every message uses the high-effort route, then propose a routing rule that keeps basic questions responsive while still escalating ambiguous financial cases.
 
-## Section 3: Architectural Patterns for Reasoning Models
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> | Family or approach | Reasoning-control surface verified at authoring time | Engineering note |
+> |--------------------|------------------------------------------------------|------------------|
+> | OpenAI o-series and reasoning-capable API models | The Responses API documents a `reasoning` configuration with effort-style controls, usage metadata that can report reasoning tokens, and optional reasoning summaries rather than raw chain-of-thought exposure. | Treat reasoning effort as a cost, latency, and quality knob; reserve context/output space for hidden reasoning so the call does not finish with no visible answer. |
+> | DeepSeek-R1 family | The technical report describes reinforcement learning that incentivizes reasoning patterns such as self-reflection, verification, and strategy adaptation. | Useful as a research reference for train-time RL-for-reasoning; deployment details depend on the host, checkpoint, and serving stack. |
+> | Anthropic Claude extended/adaptive thinking | The API documentation describes thinking blocks, adaptive thinking, effort controls, and model-dependent support for manual token budgets. | Check current model support before copying an old request body, because supported thinking modes and budget fields can change by model version. |
+> | Google Gemini thinking | The Gemini API documentation describes thinking controls, thinking budgets or levels depending on model generation, and thought signatures for maintaining thought context across turns. | Preserve returned signatures or reasoning artifacts exactly when the API requires them, especially around tool use and multi-turn flows. |
+> | Qwen/QwQ and Qwen thinking-mode models | Qwen project materials describe QwQ as an open-weight reasoning model trained with reinforcement learning, while the Qwen3 report describes unified thinking and non-thinking modes with a budget mechanism. | Open-weight reasoning changes the cost/privacy/deployment tradeoff, but the same routing and observability discipline still applies. |
 
-Deploying reasoning models in production requires specific architectural patterns to mitigate their high latency and massive token costs. Attempting to use a reasoning model as a drop-in replacement for a standard model will almost certainly lead to budget overruns and user interface timeouts. The industry has converged on two primary patterns for handling System 2 workloads.
+The snapshot is intentionally small. It is not a leaderboard, an endorsement, or a permanent roster. Its purpose is to show that the same durable abstraction appears across multiple model families: some control asks the model to think more or less, some metadata exposes or summarizes that thinking, and production systems need to decide when that added work is worth buying.
+
+## Section 3: Train-Time Reasoning vs Inference-Time Search
+
+Reasoning improvements come from two different places that are easy to blur together. Train-time work changes the model before you call it. Inference-time work changes how much computation the system spends while answering a particular prompt. A production architecture may use both, but they have different costs, owners, and failure modes.
+
+Train-time reasoning work includes supervised examples, preference optimization, reinforcement learning on verifiable tasks, process supervision, distillation from stronger models, and curriculum design that rewards correct multi-step solutions. The model vendor or model-training team pays that cost ahead of time. The result is a model that has learned better habits: checking work, decomposing problems, noticing contradictions, or producing intermediate representations that support more reliable answers.
+
+Inference-time work is paid on every request. It includes hidden thinking tokens, self-consistency sampling, search over multiple candidate answers, verifier calls, tool-use loops, and budgeted retries. This is where application engineers have direct control. You can set a budget, route only difficult requests, stop a long-running job, ask for a structured final answer, or decide that a high-value task should get a second pass before a user sees it.
+
+The two forms reinforce each other. A model trained to reason productively can make better use of extra inference-time budget than a model that merely rambles when given more tokens. At the same time, a strong training recipe does not make all requests free. If your application asks for deep reasoning on every FAQ, the serving bill still rises and users still wait. The durable engineering question is therefore not "Which model thinks?" but "Which tasks need extra thinking, and how do we measure whether it helped?"
+
+### Chain-of-Thought, Self-Consistency, Tree Search, and Graph Search
+
+Chain-of-thought is the simplest mental model: the system creates intermediate reasoning steps before the final answer. In older prompting patterns, developers often asked the model to expose those steps directly. In modern reasoning systems, the raw trace may be hidden, summarized, or represented as internal tokens. Either way, the durable idea is decomposition. The model has a place to transform "solve this" into smaller claims, calculations, constraints, and checks before it answers.
+
+Self-consistency adds sampling. Instead of trusting one reasoning path, the system generates several candidate paths and chooses the final answer that appears most consistent across them or scores highest under a verifier. This can improve reliability on arithmetic, symbolic, or commonsense tasks because a single unlucky path is less likely to dominate the final answer. The tradeoff is direct: if you sample five candidates, you may pay close to five times the inference work unless the implementation shares computation or stops early.
+
+Tree-of-thought generalizes that idea into explicit search. The system explores multiple partial solution branches, evaluates promising branches, expands the best ones, and backtracks when a branch fails. This is a better fit for puzzles, planning, code repair, and tasks where an early decision can close off a better answer. The price is orchestration complexity: you now need a branching policy, a scoring function, stopping criteria, and guardrails against runaway exploration.
+
+Graph-of-thought treats intermediate ideas as nodes that can be merged, revised, decomposed, or connected rather than only arranged in a line or tree. That is useful when a problem has interacting subproblems: a database migration touches schema design, data backfill, rollback, monitoring, and deployment ordering. A graph can let the system revise the rollback node after the backfill node exposes a dependency, then feed that change back into the deployment plan.
+
+These strategies do not have to be visible to the end user. A reasoning model may internalize parts of them through training, while an application may implement others explicitly with multiple calls and a verifier. When you design a production workflow, decide which layer owns the deliberation. If the model already performs enough internal reasoning for a task, a large external tree search may waste money. If the model routinely misses a safety constraint, an explicit verifier step may be more reliable than asking the same model to "think harder."
+
+## Section 4: When a Reasoning Model Is Worth It
+
+A reasoning model is worth the extra cost when failure is expensive, the answer depends on several linked constraints, and the system has enough time to deliberate. The common trap is to equate "important" with "needs reasoning." A password-reset answer may be important for user trust, but it is usually a retrieval and policy-consistency task. A small database migration may be less visible, yet require careful ordering, rollback, and constraint analysis. Importance matters, but reasoning need comes from task structure.
+
+Use this decision framework before routing a task to the expensive path. First, ask whether the answer can be found directly in provided context. If a retrieval result contains the exact policy sentence, a fast model or deterministic template may be enough. Second, ask whether the task requires combining multiple facts into a conclusion. Multi-hop reasoning, cross-document reconciliation, or code changes across several files are stronger candidates. Third, ask whether an early mistake will be hard to detect. If the output is a proposed SQL migration, security exception, or production runbook, silent plausibility is dangerous.
+
+Fourth, ask whether the system can verify the result cheaply. If a unit test, schema validator, type checker, SQL dry run, or rules engine can catch mistakes, you may not need a high-effort model on the first pass. A cheaper model can propose the answer, then deterministic tools can reject bad outputs. Fifth, ask whether latency is acceptable. A background compliance review can wait; an autocomplete keystroke cannot. Sixth, ask whether the user or business process benefits from a better answer enough to pay for it.
+
+Here is a practical routing rubric:
+
+| Task Type | Reasoning Need | Better Default |
+|-----------|----------------|----------------|
+| Greeting, FAQ, simple extraction, known formatting | Low, because the answer path is direct and easy to verify. | Fast model, retrieval, or deterministic template. |
+| Summarization of one short document | Usually low, unless the summary must reconcile conflicting evidence. | Fast model with citation or quote constraints. |
+| Multi-document policy interpretation | Medium to high, because the answer may require conflict resolution and exception handling. | Router plus reasoning model for ambiguous or high-risk cases. |
+| Code change across files or APIs | High when behavior, tests, and architecture interact. | Reasoning model for planning or verification, standard workers for mechanical edits. |
+| Math proof, algorithm analysis, migration planning | High, because intermediate assumptions need checking. | Reasoning model with explicit budget and verifier where possible. |
+| Creative brainstorming | Variable, because novelty does not always require deep reasoning. | Fast model first; escalate only when constraints or planning dominate. |
+
+The rubric is not a moral hierarchy of tasks. It is a budget-control tool. A production system can start with conservative rules, collect outcomes, and then tune thresholds. If the router escalates too often, costs rise and latency suffers. If it escalates too rarely, hard tasks fail silently. The goal is not to minimize reasoning usage; it is to buy reasoning where it measurably improves correctness, safety, or user value.
+
+## Section 5: Architectural Patterns for Reasoning Models
+
+Deploying reasoning models in production requires patterns that isolate expensive thinking from routine traffic. Treating a reasoning model as a drop-in replacement for every standard model call is usually a budget and latency mistake. The durable patterns are cascades, supervisor-worker systems, verifier loops, and asynchronous execution.
 
 ### 1. The Semantic Router (Cascade Pattern)
-In this architecture, every incoming request first hits a fast, cheap standard model configured as a classifier. This router evaluates the complexity of the prompt. If the request is a simple data extraction, summarization, or greeting, the standard model handles it entirely, returning a response in milliseconds. If the router identifies a complex logic puzzle, a multi-file code generation request, or an ambiguous analytical task, it forwards the prompt to the reasoning model. This ensures that expensive test-time compute is reserved only for tasks that actually require it.
+
+In a cascade, every incoming request first reaches a low-cost classifier or rule-based gate. The router estimates difficulty, risk, and latency tolerance. Simple requests go to a fast model or deterministic path. Ambiguous, multi-step, or high-risk requests move to the reasoning route. This preserves user responsiveness for ordinary traffic while still giving hard tasks a path to deeper compute.
+
+The router does not have to be a model. It can combine keyword rules, embedding similarity, business metadata, user tier, tool availability, and model confidence. A support assistant might route messages with "refund", "chargeback", and "account locked" to a deeper review only when the account state contains conflicting signals. A code assistant might escalate when the changed files include concurrency primitives, authentication, database migrations, or failing tests. A legal-document assistant might escalate when retrieved clauses disagree or when the requested output is a binding recommendation rather than a neutral summary.
 
 ### 2. The Supervisor-Worker Pattern
-For sprawling, multi-step agentic workflows, a reasoning model acts as the "Supervisor." The user submits a massive goal (e.g., "Audit this entire repository for security vulnerabilities"). The reasoning model uses its test-time compute to formulate a comprehensive execution plan and break the goal down into smaller sub-tasks. It then delegates these sub-tasks to multiple instances of fast, standard "Worker" models running in parallel. The workers return their results to the Supervisor, which uses another burst of reasoning to verify the work, aggregate the findings, and generate the final report.
+
+For sprawling multi-step workflows, a reasoning model can act as the supervisor while cheaper workers perform bounded subtasks. The supervisor plans, decomposes, assigns, and verifies. Workers summarize files, run searches, draft small changes, classify evidence, or execute deterministic checks. The supervisor then aggregates the results and decides whether the plan is complete.
+
+This pattern works because planning and verification are usually more reasoning-heavy than every individual subtask. A repository audit, for example, does not need a high-effort model to read every dependency file. It may need one to decide which dependency signals matter, which findings are duplicates, and which mitigation plan respects project constraints. The supervisor-worker split buys expensive reasoning only at the coordination points.
+
+### 3. The Verifier Loop
+
+A verifier loop separates proposal from checking. One model or deterministic process proposes an answer; another step checks it against tests, schemas, policies, citations, or examples. When the verifier fails, the system can retry with a higher reasoning budget, request missing context, or return a narrower answer. This pattern is especially useful when a cheap verifier exists. Unit tests, linters, JSON Schema, SQL `EXPLAIN`, type checkers, and citation reachability checks are often cheaper and more reliable than a second model opinion.
+
+The verifier loop also prevents the "deep model as oracle" failure mode. Reasoning models can still be confidently wrong, especially when the prompt lacks evidence or asks for a judgment outside the model's context. A verifier anchors the workflow to observable facts. The point is not that the verifier is perfect; it is that the system has at least one independent way to reject plausible nonsense before it reaches a user.
+
+### 4. Asynchronous Reasoning Jobs
+
+High-effort reasoning is often incompatible with synchronous request/response UX. If a job may take long enough to make the interface feel frozen, return a job identifier, show progress states, and let the user continue. A background worker can own the reasoning call, stream status updates, enforce a token budget, and fall back to a lower-effort summary if the job exceeds its service-level objective.
 
 ```mermaid
 graph TD
@@ -132,34 +219,91 @@ graph TD
     C --> J
 ```
 
-## Section 4: Prompting Paradigm Shift - Goal Orientation
+## Section 6: Worked Cost Model for a Cascade
 
-Prompt engineering for reasoning models requires unlearning many of the best practices established over years of working with standard models. Standard models benefit significantly from techniques like "Chain of Thought" prompting (explicitly telling the model to "think step by step"), providing dense few-shot examples, and writing highly prescriptive formatting instructions that guide the model's cognitive process.
+Use an illustrative cost model to understand the cascade pattern without relying on any vendor's current pricing. Imagine a product receives 10,000 requests per day. Eighty percent are simple lookup or extraction tasks, fifteen percent are medium analytical tasks, and five percent are hard planning tasks. A fast route costs 1 cost unit per request and responds quickly. A medium reasoning route costs 10 units. A high reasoning route costs 40 units because it spends more hidden tokens and holds compute longer.
 
-Reasoning models, conversely, natively generate their own chain of thought. Forcing them to follow a human-prescribed sequence of steps can actually degrade their performance. By dictating the algorithm, you artificially constrain the model's internal, highly optimized search space, preventing it from discovering more efficient logical pathways during its test-time compute phase. 
+If every request goes through the high reasoning route, the daily cost is 400,000 units. If every request goes through the fast route, the daily cost is 10,000 units, but hard tasks may fail exactly where correctness matters. A simple cascade that sends 80 percent to fast, 15 percent to medium, and 5 percent to high costs 8,000 + 15,000 + 20,000 = 43,000 units. That is far more than the all-fast baseline but far less than the all-high route, and it spends the high budget where it is most likely to help.
 
-Prompting reasoning models is fundamentally about setting clear, unambiguous goals, defining strict constraints, and providing comprehensive edge-case context. It is goal-oriented rather than process-oriented.
+The important number is not the hypothetical 43,000 units. The important behavior is marginal escalation. If the router becomes too nervous and sends 20 percent of traffic to high reasoning, cost rises sharply. If it becomes too strict and sends only one percent to high reasoning, hard-task quality may fall. Good routing thresholds are empirical: sample real traffic, label task difficulty, run offline comparisons, and decide which additional successes justify the additional tokens.
 
-### Prompting Anti-patterns vs Best Practices
+Latency has the same shape. Users tolerate different delays for different jobs. A chat interface answering "Where is the invoice settings page?" should feel immediate. A background job producing a migration plan can show a pending state. A code-review assistant can do a fast first pass in the UI and attach a deeper review later. The architecture should match the user's waiting model instead of pretending every model call belongs in the same synchronous path.
 
-| Anti-Pattern | Why it Fails with Reasoning Models | Best Practice |
-|--------------|------------------------------------|---------------|
-| Appending "Think step by step" | Redundant. The model natively generates a hidden chain of thought. Adding this consumes input tokens and may confuse the internal reinforcement learning policy. | State the end goal clearly without prescribing the cognitive process. |
-| Providing dense few-shot examples | The model relies on internal logical deduction rather than pattern matching. Few-shot examples can over-constrain the solution space. | Provide zero-shot prompts with comprehensive edge-case constraints and strict rule definitions. |
-| Formatting micromanagement (e.g., "Use bullet points for step 2") | The model allocates compute to solving the core problem. Excessive formatting rules distract the reasoning process and increase failure rates on the main logic. | Request specific output formats (like JSON or Markdown) only at the very end of the prompt as a final constraint. |
-| Providing a mandated solution path | Forcing the model down a specific algorithmic path prevents it from exploring alternative, potentially optimal branches during test-time compute. | Define the parameters of success and the input variables, allowing the model to derive the optimal path independently. |
+```python
+def cascade_daily_cost(
+    requests_per_day: int,
+    simple_rate: float,
+    medium_rate: float,
+    hard_rate: float,
+) -> dict:
+    """Compute illustrative cascade economics in provider-neutral cost units."""
+    if round(simple_rate + medium_rate + hard_rate, 6) != 1.0:
+        raise ValueError("traffic rates must sum to 1.0")
 
-## Section 5: Cost, Latency, and Troubleshooting
+    unit_cost = {
+        "fast": 1,
+        "medium_reasoning": 10,
+        "high_reasoning": 40,
+    }
+    simple = requests_per_day * simple_rate * unit_cost["fast"]
+    medium = requests_per_day * medium_rate * unit_cost["medium_reasoning"]
+    hard = requests_per_day * hard_rate * unit_cost["high_reasoning"]
 
-The most significant engineering challenge when adopting reasoning models is managing variable costs and unpredictable latency. When querying a standard model, latency is generally a function of the input length and the generated output length. You often receive the first token quickly, allowing you to start streaming the response to the user almost immediately.
+    return {
+        "all_fast": requests_per_day * unit_cost["fast"],
+        "all_high_reasoning": requests_per_day * unit_cost["high_reasoning"],
+        "cascade": int(simple + medium + hard),
+    }
 
-With reasoning models, the "time to first token" is massive. The model might spend thirty seconds generating thousands of hidden tokens before it outputs the first visible character. Since API providers charge for these hidden reasoning tokens at the same rate as visible output tokens, a single query can easily cost dollars rather than fractions of a cent.
+
+print(cascade_daily_cost(10_000, simple_rate=0.80, medium_rate=0.15, hard_rate=0.05))
+```
+
+The simulator deliberately uses "cost units" rather than currency. Real token prices, context windows, model names, and discount programs change quickly, and anchoring a lesson on a price table would make it obsolete. For your own system, replace the unit costs with current provider pricing, measured token counts, infrastructure overhead, and support costs caused by latency or wrong answers.
+
+## Section 7: Prompting Paradigm Shift - Goal Orientation
+
+Prompting reasoning models is less about teaching the model a visible step sequence and more about defining the problem boundary. With a fast model, developers often use explicit chain-of-thought prompts, dense examples, and formatting instructions to coax a useful intermediate path. With a reasoning-capable route, the better default is to state the goal, provide evidence, define constraints, and specify the final answer contract without over-prescribing the internal algorithm.
+
+That does not mean prompts should be vague. Reasoning models are not mind readers, and extra compute cannot recover facts that were never provided. A good prompt tells the model what success means, which inputs are authoritative, which tradeoffs matter, which constraints cannot be violated, and when to refuse or ask for missing context. The model gets freedom in how it reasons, not freedom in what evidence it may invent.
+
+Here is a weak prompt for a database migration review: "Think step by step and write a migration plan for these schema changes." It asks for process, but it does not define safety. It does not say whether downtime is acceptable, whether rollback is required, which tables are large, which reports depend on the schema, or what output format the deployment system expects. A model can spend a large reasoning budget exploring an underspecified space and still return an unsafe plan.
+
+A stronger prompt is goal-oriented: "Given the schema diff, table sizes, foreign-key relationships, and report dependencies below, produce a rollback-safe migration plan. Preserve read availability, avoid exclusive locks on hot tables, include preflight checks, include a rollback trigger for each phase, and return only a Markdown table with columns Phase, Action, Verification, Rollback, and Risk. If any dependency is missing, return `NEEDS_CONTEXT` with the exact missing item." This prompt does not dictate the reasoning path, but it sharply defines the target and failure conditions.
+
+### Prompting Anti-Patterns vs Better Defaults
+
+| Anti-Pattern | Why it Fails | Better Default |
+|--------------|--------------|----------------|
+| Asking for visible chain-of-thought as the main instruction | It may waste tokens, leak sensitive intermediate text, or conflict with APIs that hide raw reasoning. | Ask for the final answer plus a concise justification, assumptions, and verification steps. |
+| Mandating a rigid algorithm before the model sees the evidence | The model may follow a bad human path even when another decomposition is safer. | Define constraints and success criteria, then let the model choose a plan within those boundaries. |
+| Providing examples that imply the wrong domain shape | Few-shot examples can anchor the model on surface format instead of the current task's constraints. | Provide schemas, policies, tests, and edge cases from the actual task rather than decorative examples. |
+| Mixing final formatting rules into every sentence | The prompt becomes noisy, and the model may optimize for layout over substance. | Put the final output contract in one compact section after the task constraints. |
+| Hiding uncertainty requirements | The model may force a confident answer when the evidence is incomplete. | Tell the model exactly when to return `NEEDS_CONTEXT`, `UNSAFE`, or a bounded partial answer. |
+
+For reasoning models, the best prompt often feels like a specification rather than a tutorial. It names the task, evidence, constraints, output contract, and refusal conditions. It should also tell the model what not to optimize. For example, "Do not minimize steps at the expense of rollback safety" is clearer than "be careful." "Prefer asking for missing context over inventing a dependency" is clearer than "avoid hallucination."
+
+The final answer should be easy for downstream code to validate. JSON Schema, Markdown tables with fixed columns, typed fields, and explicit status codes make observability easier. A free-form essay can be pleasant for a human, but it is harder to route, score, diff, and retry. If the reasoning route is part of a production workflow, the output should be structured enough that the rest of the system can decide what happened.
+
+## Section 8: Cost, Latency, and Troubleshooting
+
+The most significant engineering challenge when adopting reasoning models is variability. A standard response path often has latency that roughly tracks input length, output length, and tool-call count. A reasoning path can add hidden work that varies by task difficulty, prompt ambiguity, budget setting, retry behavior, and whether the model gets stuck exploring dead ends. The user might see a short final answer after a long silent wait.
+
+Observability must therefore treat reasoning as a first-class resource. Log the route selected, router confidence, budget setting, input tokens, visible output tokens, hidden reasoning tokens when available, tool-call count, retry count, timeout reason, final status, and downstream verification result. Store enough task metadata to compare similar requests over time without logging sensitive user data unnecessarily. The dashboard should answer whether deeper reasoning improved task success, not merely whether it produced more fluent text.
+
+Failure mode one is over-thinking. The model spends a large budget on a task that a fast model or deterministic rule could solve. Symptoms include high reasoning-to-output ratios, long latency on simple intents, and user complaints about basic tasks feeling slow. Fix over-thinking with better routing, lower default budgets, early exits, and deterministic handlers for high-volume simple requests.
+
+Failure mode two is silent truncation. A model may spend most of its allowed generation budget internally and then run out of room before producing a complete visible answer. The application sees a partial response, an incomplete status, or an empty answer after paying for input and reasoning work. Fix this by reserving output space, setting explicit maximums, detecting incomplete statuses, and retrying with either a narrower prompt or a larger budget only when the task justifies it.
+
+Failure mode three is budget drift. A prompt change, retrieval expansion, or new router threshold silently increases average hidden tokens. Because visible answers look the same, teams may not notice until invoices or latency alerts spike. Fix this with per-route budgets, weekly token histograms, regression tests for representative prompts, and deployment gates that compare pre-change and post-change token profiles.
+
+Failure mode four is reasoning without grounding. Extra thinking does not create facts. If the prompt lacks evidence, a reasoning model can produce a more coherent unsupported answer. Fix this with retrieval citations, tool calls, validators, refusal rules, and clear instructions to return missing-context statuses. A high reasoning budget should make the model more careful with evidence, not more creative with gaps.
 
 ### Implementing Asynchronous Fallbacks
 
-To prevent infrastructure timeouts caused by the massive "time to first token" of reasoning models, pipelines must abandon synchronous HTTP requests. Instead, engineers should implement an asynchronous webhook or polling fallback mechanism. When the semantic router forwards a request to a reasoning model, the API should immediately return a `202 Accepted` status with a `job_id`. The client then polls a status endpoint while the reasoning model computes the response in a background worker queue. If the reasoning model times out, the background worker can execute a fallback query to a standard model using a constrained prompt to guarantee a response.
+To prevent infrastructure timeouts, treat deep reasoning as a job when the service-level objective allows it. The request handler can return `202 Accepted` with a `job_id`, a status URL, and an estimated completion state. A background worker owns the model call, enforces the reasoning budget, records metadata, and writes the final result. The client polls or subscribes to updates while the user interface shows a pending state instead of a frozen spinner.
 
-To debug a poorly performing reasoning pipeline, engineers must rely on token metadata rather than just reading the output text. Analyzing the ratio of reasoning tokens to output tokens is the primary diagnostic method. If a model uses an astronomical number of reasoning tokens to produce a simple output, it indicates that the prompt is too ambiguous, forcing the model to evaluate an unnecessarily large hypothesis space before committing to an answer.
+Fallbacks should be explicit rather than accidental. If the reasoning job exceeds its budget, the worker can return a lower-confidence summary, ask for missing context, or provide a partial plan marked as incomplete. For high-risk tasks, the correct fallback may be "no automated answer" rather than a cheap model guess. For low-risk tasks, a fast route may be good enough. The fallback policy belongs in product and risk design, not buried as a generic exception handler.
 
 ```python
 def analyze_reasoning_efficiency(response_metadata: dict) -> float:
@@ -184,72 +328,85 @@ def analyze_reasoning_efficiency(response_metadata: dict) -> float:
     print(f"Visible Output Tokens: {visible_tokens}")
     print(f"Reasoning to Output Ratio: {ratio:.2f}:1")
     
-    if ratio > 50.0:
+    if ratio > 20.0:
         print("DIAGNOSTIC WARNING: Highly inefficient reasoning detected.")
-        print("Action Required: Review prompt constraints. The model is ")
-        print("expending massive compute searching for a logical pathway.")
-        print("Ensure the end-goal is strictly defined.")
+        print("Action Required: Check routing, prompt constraints, and budget.")
+        print("The model may be spending hidden work on an underspecified task.")
         
     return ratio
 ```
 
-> **Stop and think**: You are designing an automated code review system. A pull request contains a five-line change to a CSS file and a massive, six-hundred-line change to a core multi-threaded Rust scheduling module. If your system passes the entire pull request uniformly to a reasoning model, what specific token-billing inefficiencies will occur, and how would you design the system to prevent this?
+The threshold in the example is intentionally local policy, not a universal law. A proof assistant might accept a high reasoning-to-output ratio because the final answer is short and the task is hard. A customer-support FAQ should not. The point of the function is to make the hidden-work ratio visible enough that each route can define its own normal range.
+
+> **Stop and think**: You are designing an automated code review system. A pull request contains a small styling change and a large change to concurrency-sensitive scheduling logic. If your system sends the entire pull request through one high-effort route, which parts waste hidden reasoning tokens, and how would you split planning, file triage, deterministic tests, and final verification?
+
+## Section 9: Evaluating Whether Reasoning Helped
+
+The most mature reasoning architecture is useless if you cannot tell whether it improved outcomes. Offline benchmarks are useful for orientation, but they are not a substitute for your product's task distribution. A science benchmark, a math benchmark, and a software-repair benchmark each stress different skills. Your application may need policy reconciliation, migration planning, long-context retrieval, or careful refusal when evidence is missing. The evaluation set should therefore begin with real tasks that represent your users, risks, and failure costs.
+
+Build an evaluation set with difficulty labels before tuning the router. Include simple tasks that should stay on the fast route, medium tasks where either route might be acceptable, and hard tasks that you believe require extra deliberation. For each task, define the expected evidence, acceptable answer shape, disallowed behavior, and verification method. A support assistant might require a cited policy paragraph and forbid account-specific claims without tool evidence. A code assistant might require passing tests and a patch that changes only relevant files. A migration planner might require rollback steps, lock-risk notes, and explicit missing-context detection.
+
+Then compare routes, not just models. Run the same task through a fast baseline, a low-effort reasoning route, a higher-effort reasoning route, and any explicit verifier loop you are considering. Score correctness, grounding, latency, token spend, retry count, and human-review burden. A high-effort route that improves correctness by a small amount but doubles human cleanup may not be a win. A low-effort route plus deterministic verifier may beat a deeper route because it catches the exact failures that matter in your workflow.
+
+Use error taxonomy rather than a single pass/fail number. Label failures as missing evidence, wrong calculation, invalid format, unsafe assumption, tool misuse, timeout, incomplete output, over-escalation, or under-escalation. This tells you what to fix. Missing evidence points to retrieval or prompt constraints. Wrong calculation may point to reasoning budget, verifier design, or a specialized tool. Invalid format points to output contract and parser tests. Over-escalation points to router thresholds. Under-escalation points to task signals that the router failed to notice.
+
+Finally, evaluate over time. Reasoning systems drift because prompts change, upstream models change, retrievers add larger chunks, users discover new workflows, and routers inherit new business rules. Keep a small canary set that runs before deployment and a larger sampled set that runs on a schedule. Track not only average score but also tail latency, hidden-token percentiles, incomplete responses, and escalation distribution. A reasoning feature is production-ready when you can explain why each route exists, when it fires, what it costs, what quality it buys, and how you will notice when that bargain stops holding.
 
 ## Did You Know?
 
-- In late 2024, OpenAI released the o1 model series, which demonstrated that scaling inference compute could yield performance gains comparable to scaling pre-training compute, fundamentally shifting how hardware demands are forecasted in data centers.
-- The DeepSeek R1 model utilized a dual-phase training approach involving cold-start supervised fine-tuning followed by large-scale reinforcement learning, achieving state-of-the-art reasoning on complex math benchmarks in early 2025.
-- Hidden reasoning tokens can account for up to 95% of the total completion tokens generated in highly complex algorithmic queries, drastically altering the unit economics of AI API consumption for enterprise applications.
-- During internal beta testing, some early reasoning models generated internal chains of thought exceeding 30,000 tokens before producing a single word of user-facing output, resulting in absolute latencies exceeding two full minutes per query.
+- Test-time scaling is not one technique. Research literature studies repeated sampling, verifier-guided search, adaptive compute allocation, process reward models, and model-internal reasoning policies; production APIs then expose only a small control surface over some of that machinery.
+- Chain-of-thought prompting was originally useful because it made intermediate work visible in the prompt and answer. Modern reasoning deployments often hide raw reasoning for safety, policy, or product reasons, so engineers must rely on final-answer quality, summaries, metadata, and independent verification.
+- A reasoning model can be worse than a fast model for routine tasks because it may spend time solving a problem that does not exist. The win condition is not "always think longer"; it is "allocate more compute when the task structure rewards deliberation."
+- Evaluation must include business outcomes, not only benchmark scores. A model that performs well on math or coding benchmarks may still be the wrong default for a low-latency support workflow if most user requests are simple and the hard cases require retrieval or human approval.
 
 ## Common Mistakes
 
 | Mistake | Why it Happens | How to Fix |
 |---------|----------------|------------|
-| Using few-shot prompting | Developers carry over habits from standard models, attempting to guide the model via pattern matching. | Use zero-shot prompts with exhaustive goal definitions and strict failure constraints. |
-| Setting low timeouts on API calls | Standard APIs return in milliseconds; developers expect the same, leading to connection drops. | Implement asynchronous request handling and drastically extend network timeout configurations. |
-| Ignoring hidden token costs | Developers only measure the visible output length, missing the massive internal compute being billed. | Monitor API usage metadata specifically for `reasoning_tokens` and set strict budget alerts. |
-| Applying temperature settings | Attempting to force creativity breaks the highly tuned internal logic policy of the model. | Remove temperature parameters entirely; use the `reasoning_effort` toggle to control depth. |
-| Using reasoning models for summarization | Summarization requires pattern extraction, not multi-step logical deduction, wasting expensive compute. | Route all summarization and basic extraction tasks strictly to standard, high-speed models. |
-| Prescribing step-by-step algorithms | Developers micromanage the logic flow, restricting the model's native ability to find optimal paths. | Define the final state constraints and allow the model to autonomously determine the best algorithm. |
-| Failing to stream responses to the UI | Standard models provide instant feedback; reasoning models cause long periods of dead silence. | Implement placeholder UI updates, skeleton loaders, or intermediate status checks during the reasoning phase. |
+| Routing every request to the reasoning path | Teams equate the most careful route with the safest route, even when most traffic is direct lookup or extraction. | Start with a semantic router, collect task labels, and escalate only when complexity, risk, or ambiguity justify the cost. |
+| Measuring only visible output tokens | The final answer may be short while the internal reasoning work is long, so normal completion-length dashboards miss the real spend. | Track input, visible output, hidden reasoning, retries, tool calls, latency, and verification success as separate fields. |
+| Treating extra thinking as factual grounding | A model can reason coherently from missing or false evidence, producing a polished answer that is still unsupported. | Pair reasoning routes with retrieval, citations, validators, and explicit missing-context statuses. |
+| Copying prompting habits unchanged | Prompts written for fast models often over-prescribe step order while under-specifying evidence, constraints, and failure states. | Write prompts as task specifications: goal, evidence, constraints, output contract, and refusal conditions. |
+| Setting one timeout for every route | A low-latency UI path and a background analysis job have different waiting models, but teams often reuse the same HTTP timeout. | Use synchronous calls for fast paths and job-based asynchronous execution for high-effort reasoning work. |
+| Ignoring deterministic verifiers | Teams ask a model to self-check work that a schema, unit test, linter, or policy engine could reject more cheaply. | Put deterministic checks after generation and retry only the failing portion with a clearer prompt or higher budget. |
+| Letting router thresholds drift | New prompts, retrieval chunks, or classifier changes silently increase escalation rates and token burn. | Version routing rules, monitor escalation percentages, and compare pre/post deployment cost and quality distributions. |
 
 ## Quiz
 
 <details>
-<summary>Question 1: You deploy a customer service bot backed exclusively by a reasoning model. Users immediately complain that it takes up to forty seconds to answer basic questions like "What are your business hours?". What architectural flaw causes this, and how should it be fixed?</summary>
+<summary>Question 1: You deploy a support assistant backed exclusively by a high-effort reasoning route. Users say basic questions feel sluggish, while complex account disputes are more accurate. What architectural flaw causes this mixed result, and how should it be fixed?</summary>
 <br>
-The architectural flaw is the lack of a semantic router. Reasoning models inherently possess a massive "time-to-first-token" latency because they generate internal chains of thought regardless of the query's simplicity. Passing trivial FAQ questions to a reasoning model forces the system to perform unnecessary computation. To fix this, implement a cascade architecture where a fast, standard model classifies the intent first. If it is a simple question, the standard model usually answers quickly; only more complex queries are routed to the reasoning model.
+The flaw is using one expensive route for tasks with very different reasoning needs. Simple FAQ and extraction requests do not benefit much from hidden deliberation, so they pay latency without buying quality. Add a semantic router that handles direct questions through retrieval, templates, or a fast model, then escalates ambiguous, high-risk, or multi-step disputes to the reasoning route. Track escalation rate and outcome quality so the router can be tuned with real traffic rather than guesswork.
 </details>
 
 <details>
-<summary>Question 2: Your automated code generation pipeline sends the following prompt to an o3 model: "Write a Python script to parse this CSV. First, import pandas. Second, read the file. Third, drop nulls. Fourth, print." The output is sub-optimal and takes longer than expected to generate. Why did this prompt fail?</summary>
+<summary>Question 2: A code assistant prompt says, "Think step by step. First import a library, second parse the file, third drop nulls, fourth print the answer." The output follows the sequence but misses an edge case in the requirements. What is wrong with the prompt?</summary>
 <br>
-This prompt relies on the anti-pattern of micromanagement. Reasoning models perform best when they are given a final goal and allowed to utilize their internal test-time compute to discover the optimal logical pathway. By artificially forcing the model to follow a rigid, human-prescribed sequence of steps, you constrained its internal search space, which conflicts with its reinforcement learning training. You should rewrite the prompt to define the desired end-state and input constraints, rather than the step-by-step algorithm.
+The prompt micromanages the process while underspecifying the goal. It tells the model which steps to take, but it does not define input edge cases, correctness criteria, validation rules, or the final output contract. A better prompt states the desired behavior, the authoritative inputs, required handling for nulls and malformed rows, the verification command, and the exact output format. The model can then choose an implementation path while remaining constrained by the real requirements.
 </details>
 
 <details>
-<summary>Question 3: An enterprise analytics dashboard shows that your API costs skyrocketed by 800% overnight after switching a backend classification pipeline from a standard LLM to a reasoning model. However, the user-facing output text length remained identical. What hidden metric is driving this massive cost increase?</summary>
+<summary>Question 3: A dashboard shows that output length stayed stable after a routing change, but total cost and latency rose sharply. Which hidden metric should you inspect first, and why?</summary>
 <br>
-The cost increase is driven by hidden reasoning tokens. Unlike standard models, reasoning models scale their intelligence by generating an internal chain of thought before outputting the final answer. API providers bill for these hidden tokens at the same rate as standard completion tokens. Even if the final output is only a few words, the model may have generated tens of thousands of internal reasoning tokens to arrive at that conclusion, exponentially inflating the cost per request.
+Inspect hidden reasoning tokens or the closest provider-specific equivalent in usage metadata. The visible answer can remain the same size while the model spends much more internal work reaching that answer. You should also inspect escalation rate, retry count, and timeout status, because a router threshold change or retry loop can multiply the number of expensive calls even when each final answer looks normal.
 </details>
 
 <details>
-<summary>Question 4: You are building an autonomous agent that must navigate a highly dynamic web environment to scrape data. Because the layout changes constantly, you configure the reasoning model API call with a strict HTTP network timeout of ten seconds to ensure the agent feels responsive and fails fast. The agent ends up failing 90% of the time. What is the root cause?</summary>
+<summary>Question 4: A background planning job sometimes takes longer than the product's normal chat timeout. The team lowers the timeout so failures are fast, but important plans now return incomplete answers. What should change?</summary>
 <br>
-The root cause is a fundamental misunderstanding of time-to-first-token latency in System 2 models. Reasoning models require significant time—often stretching into tens of seconds or minutes—to generate their internal chain of thought before they begin transmitting the response. A ten-second timeout forcibly terminates the API connection while the model is still executing its test-time compute. You must rearchitect the system to use asynchronous polling or vastly extend the network timeout limits.
+The job should not share the same synchronous timeout as an interactive chat response. Move high-effort planning into an asynchronous job with a `job_id`, status polling or notifications, explicit token and wall-clock budgets, and a clear fallback policy. For high-risk work, the fallback may be a missing-context or incomplete status rather than a cheap model guess. The user interface should communicate progress instead of pretending the task is an instant chat turn.
 </details>
 
 <details>
-<summary>Question 5: A data science team is attempting to force a reasoning model to generate diverse, highly creative marketing copy by setting the `temperature` parameter to 1.5 in their API integration. The API immediately returns an error. Why does this specific parameter configuration fail with reasoning models?</summary>
+<summary>Question 5: A product manager asks whether every creative brainstorming request should use a reasoning model because "thinking harder must produce better ideas." How would you evaluate that claim?</summary>
 <br>
-Reasoning models rely on a highly tuned reinforcement learning policy focused on logical deduction and accuracy, rather than probability-based creativity. Altering the temperature disrupts this internal logic policy, causing the reasoning trace to degrade into nonsense or endless loops. Consequently, API providers typically lock the temperature parameter (often hardcoded to 1.0) and require developers to manage output complexity using the `reasoning_effort` parameter instead.
+Evaluate the task structure rather than the label "creative." If the request is open-ended ideation with few constraints, a fast model may produce enough variety at lower latency and cost. If the request must satisfy many constraints, reconcile strategy, obey policy, or plan a launch sequence, deeper reasoning may help. Run an offline comparison with representative prompts, define quality criteria before testing, and include latency and cost in the decision.
 </details>
 
 <details>
-<summary>Question 6: You implement the `analyze_reasoning_efficiency` script from this module on your production logs. You notice that for queries asking the model to validate specific JSON schemas, the reasoning-to-output token ratio consistently exceeds 60:1. What does this indicate about your prompt, and what should be your next step?</summary>
+<summary>Question 6: Your reasoning-to-output ratio is high for JSON validation prompts, but a deterministic JSON Schema validator is available. What is the better architecture?</summary>
 <br>
-A massive reasoning-to-output ratio indicates that the model is struggling heavily to define the problem space and is generating massive internal decision trees to find a solution. This usually means the prompt is overly ambiguous and lacks strict constraints or necessary context. Your next step should be to radically revise the prompt to explicitly define the schema rules, provide the exact validation constraints, and clearly outline the failure conditions, thereby narrowing the search space for the model.
+Use the deterministic validator as the primary checker and reserve the model for tasks the validator cannot solve, such as explaining failures to a user or suggesting a repair plan when several constraints interact. Asking a reasoning model to rediscover formal schema rules wastes hidden tokens and may still miss edge cases. The durable pattern is proposal plus deterministic verification, with escalation only for ambiguous repair or policy interpretation.
 </details>
 
 ## Hands-On Exercise: Building a Semantic Router Simulator
@@ -257,14 +414,25 @@ A massive reasoning-to-output ratio indicates that the model is struggling heavi
 In this exercise, you will build a Python simulation of a Semantic Router that dynamically routes tasks to either a fast standard model or a high-latency reasoning model. You will calculate the simulated token costs to prove the financial viability of the cascade pattern.
 
 ### Task 1: Define the Router Logic
-Create a new file named `semantic_router.py`. Inside it, write a function `classify_task(prompt: str) -> str` that inspects the input string. If the prompt contains words like "calculate", "prove", "architect", or "analyze", return `"reasoning"`. Otherwise, return `"standard"`.
+
+- [ ] Create a new file named `semantic_router.py`.
+- [ ] Add a `classify_task(prompt: str) -> str` function that returns `"reasoning"` for prompts containing signals such as "calculate", "prove", "architect", "analyze", "debug", "migrate", or "tradeoff".
+- [ ] Return `"standard"` for direct lookup, greeting, extraction, or summarization prompts that do not contain those complexity signals.
 
 <details>
 <summary>View Solution for Task 1</summary>
 
 ```python
 def classify_task(prompt: str) -> str:
-    complex_keywords = ["calculate", "prove", "architect", "analyze", "debug"]
+    complex_keywords = [
+        "calculate",
+        "prove",
+        "architect",
+        "analyze",
+        "debug",
+        "migrate",
+        "tradeoff",
+    ]
     prompt_lower = prompt.lower()
     
     for keyword in complex_keywords:
@@ -276,16 +444,19 @@ def classify_task(prompt: str) -> str:
 </details>
 
 ### Task 2: Implement the Standard Model Mock
-Write a function `mock_standard_api(prompt: str) -> dict`. It should simulate a standard model response. Calculate `input_tokens` as `len(prompt) // 4`. Generate a static output string, calculate `output_tokens`, and return a dictionary with latency (e.g., 0.5s) and zero hidden tokens.
+
+- [ ] Write `mock_standard_api(prompt: str) -> dict` to simulate a fast route.
+- [ ] Calculate `input_tokens` as `max(1, len(prompt) // 4)`, generate a short static output string, and calculate `output_tokens` the same way.
+- [ ] Return latency, input tokens, visible output tokens, zero hidden tokens, and `cost_units` so the exercise does not depend on current vendor pricing.
 
 <details>
 <summary>View Solution for Task 2</summary>
 
 ```python
 def mock_standard_api(prompt: str) -> dict:
-    input_tokens = len(prompt) // 4
+    input_tokens = max(1, len(prompt) // 4)
     output_text = "Here is the direct answer based on standard pattern matching."
-    output_tokens = len(output_text) // 4
+    output_tokens = max(1, len(output_text) // 4)
     
     return {
         "model_used": "standard-fast",
@@ -293,44 +464,49 @@ def mock_standard_api(prompt: str) -> dict:
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "hidden_tokens": 0,
-        "total_cost": (input_tokens * 0.0001) + (output_tokens * 0.0002)
+        "cost_units": (input_tokens * 1) + (output_tokens * 2),
     }
 ```
 </details>
 
 ### Task 3: Implement the Reasoning Model Mock
-Write a function `mock_reasoning_api(prompt: str, effort: str = "medium") -> dict`. Simulate test-time compute by generating a massive number of hidden tokens based on the effort level (low=1000, medium=5000, high=15000). Adjust the latency accordingly, and calculate the total cost where hidden tokens cost the same as output tokens.
+
+- [ ] Write `mock_reasoning_api(prompt: str, effort: str = "medium") -> dict` to simulate test-time compute.
+- [ ] Use effort levels to control hidden tokens: low uses 800, medium uses 2500, and high uses 7000.
+- [ ] Calculate latency and `cost_units` from hidden tokens so the simulator shows why a reasoning route should be reserved for harder tasks.
 
 <details>
 <summary>View Solution for Task 3</summary>
 
 ```python
 def mock_reasoning_api(prompt: str, effort: str = "medium") -> dict:
-    input_tokens = len(prompt) // 4
+    input_tokens = max(1, len(prompt) // 4)
     output_text = "After deep deliberation, here is the verified logical solution."
-    output_tokens = len(output_text) // 4
+    output_tokens = max(1, len(output_text) // 4)
     
-    effort_multipliers = {"low": 1000, "medium": 5000, "high": 15000}
+    effort_multipliers = {"low": 800, "medium": 2500, "high": 7000}
     hidden_tokens = effort_multipliers.get(effort, 5000)
     
-    latency = hidden_tokens / 1000  # Simulate 1 second per 1000 tokens
+    latency = 0.8 + hidden_tokens / 1800
     
-    # Hidden tokens are billed identically to output tokens
-    total_cost = (input_tokens * 0.003) + ((output_tokens + hidden_tokens) * 0.015)
+    cost_units = (input_tokens * 3) + ((output_tokens + hidden_tokens) * 8)
     
     return {
         "model_used": "reasoning-deep",
-        "latency_s": latency,
+        "latency_s": round(latency, 2),
         "input_tokens": input_tokens,
         "output_tokens": output_tokens,
         "hidden_tokens": hidden_tokens,
-        "total_cost": total_cost
+        "cost_units": cost_units,
     }
 ```
 </details>
 
 ### Task 4: Build the Integration Pipeline
-Write a `process_request(prompt: str)` function that uses the router to classify the task, calls the appropriate mock API, and prints a diagnostic report showing the selected model, latency, and total cost.
+
+- [ ] Write `process_request(prompt: str)` so it calls the router first.
+- [ ] Send `"reasoning"` tasks to `mock_reasoning_api(prompt, effort="medium")` and all other tasks to `mock_standard_api(prompt)`.
+- [ ] Print a diagnostic report showing route, model, latency, visible tokens, hidden tokens, and cost units.
 
 <details>
 <summary>View Solution for Task 4</summary>
@@ -349,13 +525,17 @@ def process_request(prompt: str):
     print(f"Execution Report:")
     print(f"  Model:   {result['model_used']}")
     print(f"  Latency: {result['latency_s']} seconds")
+    print(f"  Visible: {result['output_tokens']} tokens")
     print(f"  Hidden:  {result['hidden_tokens']} tokens")
-    print(f"  Cost:    ${result['total_cost']:.4f}")
+    print(f"  Cost:    {result['cost_units']} units")
 ```
 </details>
 
 ### Task 5: Analyze the Token Economics
-Add a test suite at the bottom of `semantic_router.py` with two prompts: "Summarize this brief email" and "Analyze the time complexity of this recursive function." Compare the cost and latency outputs to validate the architectural necessity of the router.
+
+- [ ] Add a test suite at the bottom of `semantic_router.py` with at least three prompts: one simple summary, one direct extraction, and one reasoning-heavy analysis.
+- [ ] Run the script and compare latency, hidden-token use, and cost units across routes.
+- [ ] Explain in one paragraph why the cascade avoids paying for hidden reasoning tokens on simple requests while still escalating hard prompts.
 
 <details>
 <summary>View Solution for Task 5</summary>
@@ -365,6 +545,7 @@ Add a test suite at the bottom of `semantic_router.py` with two prompts: "Summar
 if __name__ == "__main__":
     prompts = [
         "Summarize this brief email regarding the team lunch.",
+        "Extract the invoice number from this sentence: invoice KD-1042 is overdue.",
         "Analyze the time complexity of this recursive function and prove its bounds."
     ]
 
@@ -372,15 +553,15 @@ if __name__ == "__main__":
         process_request(p)
         
 # Expected Output Analysis:
-# The first prompt costs fractions of a cent and returns in 0.5s.
-# The second prompt costs significantly more (e.g., $75.0+) and takes 5.0s,
-# proving that routing is essential to prevent bankrupting the system on trivial tasks.
+# The first two prompts should use the standard route with zero hidden tokens.
+# The final prompt should use the reasoning route with higher latency and cost units,
+# demonstrating why routing is essential for cost and responsiveness.
 ```
 
 **Checkpoint Verification:**
 Execute the simulator to confirm your routing logic works:
 ```bash
-python3 semantic_router.py
+.venv/bin/python semantic_router.py
 ```
 </details>
 
@@ -388,14 +569,29 @@ python3 semantic_router.py
 - [ ] Your router correctly identifies complex tasks versus simple extraction tasks.
 - [ ] The standard model mock calculates cost accurately without incorporating hidden tokens.
 - [ ] The reasoning model mock dynamically scales hidden tokens and latency based on the effort parameter.
-- [ ] The final cost analysis accurately reflects the massive billing disparity caused by test-time compute.
+- [ ] The integration report prints route, model, latency, visible tokens, hidden tokens, and cost units.
+- [ ] The final analysis explains why the cascade pattern is cheaper and more responsive than sending every prompt to the reasoning route.
 
 ## Next Module
 
-Now that you understand the mechanics, latency profiles, and cost implications of System 2 thinking, it is time to deploy these models into autonomous workflows. In the next module, **Module 2.7: Multi-Agent Orchestration Patterns**, we will explore how to build robust supervisor frameworks where reasoning models manage fleets of standard models to execute massive, repository-scale refactoring tasks without timing out your infrastructure.
+Now that you understand reasoning budgets, cascade routing, and the cost-latency-accuracy tradeoff, continue into the next sub-track with [Module 1.1: Vector Databases Deep Dive](/ai-ml-engineering/vector-rag/module-1.1-vector-databases-deep-dive/). Retrieval systems give reasoning workflows grounded evidence, which is often the difference between careful analysis and a polished answer based on missing context.
 
 ## Sources
 
-- [Thinking, Fast and Slow](https://en.wikipedia.org/wiki/Thinking,_Fast_and_Slow) — Useful background for the System 1/System 2 analogy used throughout the module.
-- [Learning to reason with LLMs](https://openai.com/index/learning-to-reason-with-llms/) — Primary OpenAI release explaining train-time vs test-time compute and the behavior of reasoning models.
-- [DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via Reinforcement Learning](https://arxiv.org/abs/2501.12948) — Primary paper for one of the major reasoning-model families referenced in the module.
+- [Learning to Reason with LLMs](https://openai.com/index/learning-to-reason-with-llms/) — Research release discussing reinforcement learning, train-time compute, test-time compute, chain-of-thought behavior, and hidden reasoning policies.
+- [OpenAI API Reasoning Guide](https://developers.openai.com/api/docs/guides/reasoning) — Current API documentation for reasoning effort, reasoning-token accounting, incomplete responses, and summaries in the dated snapshot.
+- [OpenAI Reasoning Best Practices](https://developers.openai.com/api/docs/guides/reasoning-best-practices) — Current API guidance on reasoning items, state handling, and function-calling behavior for reasoning-capable workflows.
+- [DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via Reinforcement Learning](https://arxiv.org/abs/2501.12948) — Technical report on reinforcement learning for reasoning behavior, including self-reflection and verification patterns.
+- [Anthropic Extended Thinking Documentation](https://platform.claude.com/docs/en/build-with-claude/extended-thinking) — Current vendor documentation for extended or adaptive thinking controls, budget behavior, and thinking summaries in the dated snapshot.
+- [Gemini API Thinking Documentation](https://ai.google.dev/gemini-api/docs/thinking) — Current vendor documentation for thinking controls, thinking budgets or levels, and thought signatures in the dated snapshot.
+- [QwQ-32B: Embracing the Power of Reinforcement Learning](https://qwenlm.github.io/blog/qwq-32b/) — Qwen project page describing QwQ as an open-weight reasoning model trained with reinforcement learning.
+- [Qwen3 Technical Report](https://arxiv.org/abs/2505.09388) — Technical report describing unified thinking and non-thinking modes, thinking budgets, and open model availability.
+- [Chain-of-Thought Prompting Elicits Reasoning in Large Language Models](https://arxiv.org/abs/2201.11903) — Foundational paper for prompting models to produce intermediate reasoning steps before final answers.
+- [Self-Consistency Improves Chain of Thought Reasoning in Language Models](https://arxiv.org/abs/2203.11171) — Paper introducing repeated reasoning samples and answer aggregation as an inference-time reliability strategy.
+- [Tree of Thoughts: Deliberate Problem Solving with Large Language Models](https://arxiv.org/abs/2305.10601) — Paper generalizing linear chain-of-thought into branch exploration, evaluation, and backtracking.
+- [Graph of Thoughts: Solving Elaborate Problems with Large Language Models](https://arxiv.org/abs/2308.09687) — Paper modeling intermediate reasoning artifacts as graph nodes that can be combined, revised, and transformed.
+- [Scaling LLM Test-Time Compute Optimally Can Be More Effective than Scaling Model Parameters](https://arxiv.org/abs/2408.03314) — Research on allocating inference-time compute adaptively by prompt difficulty rather than using one fixed strategy.
+- [RouteLLM: Learning to Route LLMs with Preference Data](https://arxiv.org/abs/2406.18665) — Research reference for routing between weaker and stronger models to balance response quality and cost.
+- [Let's Verify Step by Step](https://arxiv.org/abs/2305.20050) — Process-supervision paper useful for understanding verifier-style training and step-level feedback for reasoning tasks.
+- [GPQA: A Graduate-Level Google-Proof Q&A Benchmark](https://arxiv.org/abs/2311.12022) — Evaluation reference for hard science questions that test expert-level multi-step reasoning.
+- [SWE-bench: Can Language Models Resolve Real-World GitHub Issues?](https://arxiv.org/abs/2310.06770) — Evaluation reference for software-engineering tasks that require codebase context, planning, and grounded changes.


### PR DESCRIPTION
## generative-ai sub-track — review+expand the 2 `shipped_unreviewed` modules to T0

First batch of the #1842 ai-ml-engineering campaign. Both modules were `shipped_unreviewed` at rubric 5.0 but ground-truthed as genuine **T3** (thin + unlabeled fabricated openers). Expanded to T0, de-fabricated, durable-content-applied, cross-family reviewed, all findings fixed.

### `module-1.5-vector-space-visualization` (cursor author → deepseek R1)
- **Expand** 2,266 → 5,026 body words; **sources** 3 → 12 (all reachable, ground-checked).
- **De-fab**: replaced the fabricated *"Nov 2018 fashion retailer, $12M loss, null-search +22%"* opener with a labeled `Hypothetical scenario:` (no invented figures).
- Renamed generator-placeholder app titles (kaizen/vibe/contrarian/Work) to plain descriptive ones; fixed canonical section order (Learning→Why→…→Did You Know→Common Mistakes→Knowledge Check→Hands-On→Next Module).
- **R1 (deepseek, NEEDS_CHANGES → all fixed, ground-checked real):** efSearch "recall+latency together" was backwards; PCA "3x faster/~5% loss" universal claims softened; Hands-On Task 5 manifest rewritten from `Deployment`+`:latest`+no-PVC to a `StatefulSet`+`:v1.12.5`+`volumeClaimTemplates`+headless Service+requests/limits (matching the module body); int8 quantization given a calibrated scale; FAISS squared-L2 noted; sentiment-analogy caveat added.
- **Source fixes (orchestrator ground-check):** SBERT citation pointed to an unrelated vaccination paper (`1902.05667` → `1908.10084`); t-SNE JMLR URL 404 (`volume9` → `v9`).

### `module-1.6-reasoning-models` (codex gpt-5.5 author → deepseek R1)
- **Expand** 1,780 → 5,050 body words; **sources** 3 → 17.
- **De-fab**: replaced the fabricated *"late-2024 trading firm, $14M loss, 22-min outage"* opener with a labeled `Hypothetical scenario:`.
- **Durable-content rule applied** (volatile topic): all model-family specifics quarantined into ONE dated **`Landscape snapshot — as of 2026-06`** peer table ("not a leaderboard, an endorsement, or a permanent roster"); zero leadership/ranking claims; cost model uses abstract cost-units, not fake pricing.
- **R1 (deepseek, APPROVE_WITH_NITS):** cost-model arithmetic, train-time-vs-inference distinction, router code, and prompting guidance all verified correct; the two arXiv IDs it couldn't web-verify (Qwen3 `2505.09388`, RouteLLM `2406.18665`) confirmed correct by orchestrator. One non-blocking P3 (cost-unit granularity note) left as-is.

### Verification
- `verify_module.py`: both **T0**, all gates green (1.5 = 5,026w; 1.6 = 5,050w/17 src).
- `npm run build` in PRIMARY: **green, 2,171 pages, 0 schema errors**.
- All cross-family reviews ground-checked against the live files; all source URLs reachability-checked (1.6's lone openai.com 403 is a Cloudflare bot-block on a live page).

Completes the **generative-ai** sub-track (6/6). Refs #1842.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
