### PR TITLE
chore(gitignore): ignore .gemini/ — local gemini-cli state

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,6 +138,9 @@ worktrees/
 # agy / Antigravity CLI local state
 .antigravitycli/
 
+# gemini-cli local state (MCP server registrations etc.; per-developer, points at localhost services)
+.gemini/
+
 batch_state/
 logs/
 .envrc


### PR DESCRIPTION
Adds `.gemini/` to `.gitignore`. It is per-developer gemini-cli local state (MCP server registrations pointing at localhost services), the same class as the already-ignored `.antigravitycli/` and `.claude/settings.local.json`. It has been showing as untracked on `main` across sessions.

Cherry-picked the clean `.gitignore`-only commit (`c7374be7`) off the session-117 branch onto current `main`, so this carries **only** the gitignore line — none of the stale STATUS/handoff edits that the bundled PR #1838 also contained (those are superseded by sessions 118–119). PR #1838 should be closed in favor of this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)