### PR TITLE
feat(#1842): mlops 1.7-1.10 — expand+review to T0

### DIFF
--- a/src/content/docs/ai-ml-engineering/mlops/module-1.10-ml-monitoring.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.10-ml-monitoring.md
@@ -5,24 +5,38 @@ sidebar:
   order: 611
 ---
 
-In 2021, a system could still look healthy on conventional uptime, latency, and error dashboards while the model's business decisions were degrading. 
+> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6 hours  
+> **Prerequisites**: [Module 1.9: Model Serving](./module-1.9-model-serving/)
 
-But beneath those reassuring metrics, a catastrophic algorithmic failure was unfolding. The machine learning model had been meticulously trained on historical housing market data, learning intricate patterns regarding location, square footage, school districts, and pricing. It ingested features and spat out purchasing prices, driving Zillow to buy thousands of homes. When market conditions changed abruptly, the historical patterns the model relied on no longer held. The model, however, possessed no awareness of this paradigm shift. It simply continued executing its primary function, purchasing houses at fundamentally flawed valuations.
+In March 2020, consumer behavior changed faster than most production machine learning systems could adapt. Commute-hour shopping patterns vanished. Fraud models trained on travel-season signals began flagging legitimate home purchases. Inventory systems that predicted condiment demand from years of steady retail rhythms suddenly faced bulk-order spikes they had never seen in training data. [MIT Technology Review documented these failures across retail, fraud detection, and supply-chain forecasting](https://www.technologyreview.com/2020/05/11/1001563/covid-pandemic-broken-ai-machine-learning-amazon-retail-fraud-humans-in-the-loop/) as a defining lesson of the pandemic era: models do not crash when the world changes — they keep serving predictions with the same confident HTTP 200 responses they always did.
 
-The failure led Zillow to wind down Zillow Offers, take major write-downs, and cut a large share of staff. This disaster was not caused by a software crash or an infrastructure outage; it was caused by a profound failure in machine learning monitoring. The model never threw an exception. It simply failed silently, highlighting the critical difference between monitoring software execution and monitoring algorithmic cognition.
+The infrastructure looked healthy. Latency dashboards stayed green. Error rates stayed near zero. That is the central terror of unmonitored ML in production: algorithmic failure is often silent. A traditional REST API either returns valid JSON or a 500 Internal Server Error. An ML prediction API will happily return a perfectly formatted 200 OK response containing a prediction that is completely, dangerously wrong. Teams that monitor only containers, CPUs, and request counts discover problems weeks later — when chargebacks spike, inventory sits unsold, or a regulator asks why automated decisions shifted for one demographic group but not another.
 
-## What You'll Be Able to Do
+This module teaches the observability layer that closes that gap: how to detect data drift, concept drift, and performance degradation before business metrics collapse, how to wire statistical tests and alerting into production pipelines, and how to connect monitoring signals back into retraining and governance workflows.
+
+## Learning Outcomes
 
 By the end of this module, you will be able to:
-- Design robust observability architectures capable of detecting silent ML failures in production environments.
-- Diagnose and differentiate between covariate shift (data drift) and relationship shift (concept drift) using statistical methods.
-- Implement actionable explainability frameworks (SHAP, LIME) to trace degraded predictions back to specific feature variations.
-- Evaluate model fairness and demographic parity across critical sub-populations to prevent biased outcomes.
-- Implement comprehensive model governance and audit logging systems that satisfy stringent regulatory frameworks.
 
-## The Foundations of ML Observability
+- **Design** robust observability architectures capable of detecting silent ML failures in production environments.
+- **Diagnose** and differentiate between covariate shift (data drift) and relationship shift (concept drift) using statistical methods.
+- **Implement** actionable explainability frameworks (SHAP, LIME) to trace degraded predictions back to specific feature variations.
+- **Evaluate** model fairness and demographic parity across critical sub-populations to prevent biased outcomes.
+- **Implement** comprehensive model governance and audit logging systems that satisfy stringent regulatory frameworks.
 
-To understand why traditional monitoring is wholly inadequate for machine learning systems, we must analyze the fundamental differences in failure modes. A traditional REST API either returns a valid JSON response or a 500 Internal Server Error. An ML prediction API will happily return a perfectly formatted 200 OK response containing a prediction that is completely, dangerously wrong. 
+## Why This Module Matters
+
+Software observability answers whether the system is running. ML observability answers whether the system is still right. That distinction sounds subtle until you watch a model silently degrade for months while every infrastructure alert stays quiet. Production ML systems fail in four places that conventional monitoring rarely watches: the input feature distribution, the relationship between features and labels, the distribution of model outputs, and the delayed arrival of ground-truth labels that would tell you whether predictions were correct.
+
+Without deliberate ML monitoring, teams discover problems through downstream business pain — increased fraud losses, wrong inventory allocations, biased hiring recommendations, or failed clinical triage — long after the model started making bad decisions. [Google's MLOps guidance treats continuous monitoring as a first-class pipeline stage](https://cloud.google.com/architecture/mlops-continuous-delivery-and-automation-pipelines-in-machine-learning), not an optional dashboard bolted on after launch. The monitoring layer captures baselines at training time, compares production traffic against those baselines on a schedule, exports drift scores and performance metrics to systems like Prometheus, routes alerts through runbooks, and feeds confirmed degradation back into retraining workflows you built in earlier modules.
+
+Think of ML monitoring as the nervous system connecting model serving to model improvement. Serving handles requests; monitoring watches whether the world still matches what the model learned; alerting tells humans or automation that something changed; explainability helps you understand which features drove the change; governance records what you knew and when you knew it. Skip any link in that chain and you are flying blind with a confident autopilot.
+
+> **Landscape snapshot — as of 2026-06. Verify against vendor docs before relying on specifics.** Common open-source monitoring stacks pair Evidently or TensorFlow Data Validation for drift reports with Prometheus for metric export and Grafana for dashboards. Managed ML observability platforms (WhyLabs, Arize, Fiddler, and others) add hosted drift detection and alerting. The [EU AI Act regulatory framework](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai) imposes documentation, monitoring, and transparency obligations on high-risk AI systems in the European market. Tool version numbers, pricing tiers, and product feature rosters change quarterly — treat them as snapshots, not curriculum spine.
+
+## 1. ML Observability Architecture
+
+To understand why traditional monitoring is wholly inadequate for machine learning systems, we must analyze the fundamental differences in failure modes and build a layered architecture that watches every stage where silent failure can hide. A mature observability stack for ML is not a single dashboard; it is a pipeline that ingests inputs, predictions, delayed labels, and system metrics, runs statistical comparisons against frozen training baselines, and emits actionable signals when the world diverges from what the model expects. 
 
 ```text
 TRADITIONAL SOFTWARE              ML SYSTEMS
@@ -106,15 +120,25 @@ flowchart TD
     AL --> V
 ```
 
-> **Did You Know?** The canonical Knight Capital 2012 <!-- incident-xref: knight-capital-2012 --> incident in *Infrastructure as Code* is the reference point here: when boundary monitoring is incomplete and operators lack fast signal quality, automation can drift into runaway impact quickly.
+The four monitoring layers deserve explicit design attention because each catches failures the others miss. **Input monitoring** watches whether the feature vectors arriving at inference time still resemble training data — missing values, out-of-range numerics, new categorical levels, and schema changes all show up here before they poison predictions. **Output monitoring** tracks the distribution of scores, classes, or regression values the model emits; a sudden shift in positive-class rate often signals trouble even when you cannot yet measure accuracy. **Performance monitoring** compares predictions to ground truth once labels arrive, segmented by customer cohort, geography, device type, or any slice the business cares about. **System monitoring** covers latency, throughput, error rates, GPU memory, and queue depth — the familiar DevOps layer that tells you the serving path is alive but says nothing about whether predictions are still correct.
 
-## Diagnosing Drift Types
+Baseline creation is the step most teams skip and later regret. At training time, freeze reference histograms, means, standard deviations, and percentile bounds for every monitored feature, plus the prediction distribution on the holdout set. Store that baseline artifact alongside the model in your registry. Every production monitoring job compares live traffic against that artifact — not against last week's traffic, which may already be drifted. [TensorFlow Data Validation (TFDV)](https://www.tensorflow.org/tfx/guide/tfdv) formalizes this pattern with `Schema` objects and `Statistics` protos; Evidently and custom Python jobs implement the same idea with pandas and scipy. The implementation varies; the invariant does not: you need an immutable reference distribution captured at promotion time.
 
-Drift is the silent killer of ML models. It occurs when the statistical properties of the environment change over time, rendering the model's learned weights obsolete. We classify drift into three distinct categories, each requiring different detection strategies.
+Alert routing should mirror severity. Informational drift (PSI between 0.1 and 0.2) logs to a dashboard for the ML team to review during business hours. Warning-level performance drops notify Slack channels with a linked runbook. Critical drift on a regulated or revenue-critical model pages on-call and may trigger automated traffic throttling or a rollback to the previous model version. The goal is not maximum alerts — it is maximum signal. An alert without a runbook is noise; a runbook without a baseline comparison is guesswork.
+
+## 2. Diagnosing Drift Types
+
+Drift is the silent killer of ML models. It occurs when the statistical properties of the environment change over time, rendering the model's learned weights obsolete even though the serving binary and container image are unchanged. We classify drift into distinct categories because each type implies a different remediation: retrain on fresher data, rebuild features, change the model architecture, or fix an upstream data pipeline bug. Treating all drift as "retrain the model" wastes compute and hides root causes.
+
+The taxonomy starts with **covariate shift** (data drift): the distribution of inputs changes while the conditional relationship between features and the target label stays the same. A credit model trained on urban applicants may still be statistically valid if rural applicants arrive with different income distributions but the same income-to-default relationship. Performance may degrade because the model sees unfamiliar regions of feature space, but the underlying meaning of features is stable. **Concept drift** (relationship shift) is more dangerous: the inputs may look identical, but they now mean something different. The COVID-era remote-work example below is canonical — "remote job posting" shifted from a signal of low housing demand to high demand without changing the feature encoding. **Label drift** (prior shift) changes the base rate of the target class itself. **Prediction drift** changes the model's output distribution, which may reflect input drift, concept drift, or a bug in the serving path.
+
+Detection strategy follows taxonomy. Input drift uses per-feature PSI, KS tests, or Jensen-Shannon divergence against training baselines. Concept drift often requires performance monitoring segmented by time or cohort, because input distributions may look stable while error rates climb. Prediction drift monitors output histograms directly and serves as an early warning when labels are delayed. [IBM's model drift overview](https://www.ibm.com/think/topics/model-drift) and [Microsoft's dataset monitoring guidance](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-monitor-datasets) describe the same categories with vendor-specific tooling; the statistical ideas are portable.
 
 ### Data Drift (Covariate Shift)
 
-Data drift occurs when the input feature distributions change, even if the underlying relationship between those features and the target variable remains identical. For example, a credit scoring model might suddenly receive applications from a completely different geographic demographic than it was trained on.
+Data drift occurs when the input feature distributions change, even if the underlying relationship between those features and the target variable remains identical. For example, a credit scoring model might suddenly receive applications from a completely different geographic demographic than it was trained on. The model still interprets `annual_income` the same way — higher income still means lower default risk in the learned function — but the distribution of incomes no longer matches what the model saw during training. Tree-based models may handle mild covariate shift gracefully by splitting on familiar thresholds; linear models and neural networks trained on normalized features can degrade faster because they extrapolate outside the training envelope.
+
+Operational teams often discover data drift through secondary symptoms before PSI alerts fire: customer support tickets about "wrong" recommendations, manual reviewers overriding model decisions more often, or upstream data engineers reporting a new API version. That is why input monitoring should include schema validation (unexpected columns, type changes, null rate spikes) alongside distributional tests. A feature can pass PSI while being semantically wrong — imagine a currency field that silently switched from USD to cents. Schema checks catch encoding bugs; PSI catches population shifts.
 
 ```text
 DATA DRIFT EXAMPLE
@@ -149,7 +173,9 @@ flowchart LR
 
 ### Concept Drift
 
-Concept drift is far more insidious. It occurs when the fundamental relationship between the input features and the target variable shifts. The inputs might look exactly the same, but they now mean something entirely different.
+Concept drift is far more insidious. It occurs when the fundamental relationship between the input features and the target variable shifts. The inputs might look exactly the same, but they now mean something entirely different. Regulatory changes illustrate concept drift cleanly: a feature that was a legitimate risk signal yesterday becomes illegal to use tomorrow, and the label definition itself may change when compliance teams redefine what counts as fraud or default. Seasonal concept drift is subtler — ice cream demand correlates with temperature in summer but with school holidays in winter if your training data mixed both patterns.
+
+Adaptation strategies depend on drift speed. Gradual concept drift may justify scheduled retraining on rolling windows of recent labeled data. Sudden concept drift (pandemic, policy shock, competitor launch) may require immediate rollback and emergency retraining with human-reviewed labels. Some production systems maintain a **champion/challenger** arrangement: the champion serves most traffic while a challenger model trains on fresher data; monitoring metrics decide when to promote the challenger. The monitoring layer supplies the promotion signal — not gut feeling.
 
 ```text
 CONCEPT DRIFT EXAMPLE
@@ -180,7 +206,7 @@ flowchart LR
     B1 & B2 --> A1 & A2
 ```
 
-> **Did You Know?** The formal academic definition of "concept drift" was introduced in 1996 by researchers Gerhard Widmer and Miroslav Kubat in their seminal paper "Learning in the Presence of Concept Drift and Hidden Contexts." The concept was established in the academic literature long before it became common language in production ML practice.
+When you suspect concept drift, input-only tests will lie to you. The correct diagnostic sequence is: confirm input drift (if any), confirm prediction drift, then compare performance metrics across rolling windows once labels arrive. If inputs are stable but performance drops, you are likely facing concept drift or label quality issues. If inputs shifted but performance is stable, the model may generalize well enough — or it may be making wrong predictions for new reasons that aggregate to similar accuracy on average. Segment-level metrics expose that trap.
 
 ### Prediction Drift
 
@@ -215,19 +241,45 @@ def detect_prediction_drift(
     }
 ```
 
-### Statistical Detection Methods
+Prediction drift is your best real-time proxy when ground truth lags by days or weeks. Fraud labels may arrive thirty days after a transaction; churn labels may take ninety days. During that gap, you cannot compute accuracy, but you can ask whether the model is still producing the same score distribution it produced during validation. A binary classifier that historically approved twelve percent of applications and suddenly approves thirty-five percent is behaving differently even if you do not yet know whether those approvals are wrong. Pair prediction drift alerts with business KPI monitors — chargeback rate, manual review queue depth, customer complaint volume — to distinguish model issues from genuine population change.
 
-To mathematically prove that drift has occurred, MLOps engineers rely on several core algorithms to compare production distributions against training baselines.
+## 3. Statistical Detection Methods
+
+To mathematically prove that drift has occurred, MLOps engineers rely on several core algorithms to compare production distributions against training baselines. No single test is universally best: PSI is interpretable for scorecard teams, the Kolmogorov-Smirnov test is rigorous for continuous features, and Jensen-Shannon divergence behaves well in automated pipelines because it is symmetric and bounded. Production systems often compute all three for critical features and alert when any crosses a threshold, reducing false negatives at the cost of some redundant computation.
+
+Choosing bin counts and sample sizes matters more than beginners expect. PSI with too few bins is noisy; with too many bins, sparse cells inflate scores. A common pattern is ten decile bins for scorecard features and fifty bins for high-cardinality continuous variables. Statistical tests need enough production samples to be meaningful — checking drift on fifty requests after a deploy is premature; checking only daily aggregates may miss intraday pipeline bugs. Align window size with business rhythm: fraud models may need five-minute windows; demand forecasts may need daily rollups.
 
 #### Population Stability Index (PSI)
 
-PSI is a common heuristic for quantifying how much a population has shifted over time.
+PSI is a common heuristic for quantifying how much a population has shifted over time. Credit risk and marketing scorecard teams adopted PSI because it produces a single interpretable number per feature that non-statisticians can read on a dashboard. The intuition is straightforward: bin the reference and current distributions the same way, compare the proportion of records in each bin, and sum the weighted log-ratio differences. Large PSI means the live population would look surprising to someone who only saw training data. PSI is not a hypothesis test — it does not give you p-values — so pair it with KS tests when you need statistical significance for audit documentation.
 
 ```python
+def psi_bin_edges_from_reference(reference: np.ndarray, bins: int = 10) -> np.ndarray:
+    """Build bin edges from reference with open-ended outer bins for overflow values."""
+    _, inner_edges = np.histogram(reference, bins=bins)
+    return np.concatenate([[-np.inf], inner_edges[1:-1], [np.inf]])
+
+
+def calculate_psi_from_histograms(
+    ref_percents: np.ndarray,
+    cur_percents: np.ndarray,
+    epsilon: float = 1e-4,
+) -> float:
+    """Compute PSI from aligned bin proportions (same bins, same order)."""
+    ref_percents = np.asarray(ref_percents, dtype=float)
+    cur_percents = np.asarray(cur_percents, dtype=float)
+    ref_percents = ref_percents / ref_percents.sum()
+    cur_percents = cur_percents / cur_percents.sum()
+    ref_percents = np.clip(ref_percents, epsilon, 1)
+    cur_percents = np.clip(cur_percents, epsilon, 1)
+    return float(np.sum((cur_percents - ref_percents) * np.log(cur_percents / ref_percents)))
+
+
 def calculate_psi(
     reference: np.ndarray,
     current: np.ndarray,
-    bins: int = 10
+    bins: int = 10,
+    bin_edges: np.ndarray | None = None,
 ) -> float:
     """
     Calculate Population Stability Index.
@@ -236,26 +288,21 @@ def calculate_psi(
     PSI 0.1-0.25: Moderate change, investigate
     PSI > 0.25: Significant change, action required
     """
-    # Create bins from reference data
-    _, bin_edges = np.histogram(reference, bins=bins)
+    if bin_edges is None:
+        bin_edges = psi_bin_edges_from_reference(reference, bins=bins)
 
-    # Calculate percentages in each bin
-    ref_percents = np.histogram(reference, bins=bin_edges)[0] / len(reference)
-    cur_percents = np.histogram(current, bins=bin_edges)[0] / len(current)
+    ref_counts = np.histogram(reference, bins=bin_edges)[0]
+    cur_counts = np.histogram(current, bins=bin_edges)[0]
 
-    # Avoid division by zero
-    ref_percents = np.clip(ref_percents, 0.0001, 1)
-    cur_percents = np.clip(cur_percents, 0.0001, 1)
+    ref_percents = ref_counts / len(reference)
+    cur_percents = cur_counts / len(current)
 
-    # PSI formula
-    psi = np.sum((cur_percents - ref_percents) * np.log(cur_percents / ref_percents))
-
-    return psi
+    return calculate_psi_from_histograms(ref_percents, cur_percents)
 ```
 
 #### Kolmogorov-Smirnov Test
 
-The KS test is a non-parametric test that compares the cumulative distributions of two distinct datasets, seeking the maximum absolute distance between them.
+The KS test is a non-parametric test that compares the cumulative distributions of two distinct datasets, seeking the maximum absolute distance between them. Unlike PSI, the KS test returns a p-value you can cite in audit reports: "we reject the null hypothesis that production and training distributions are identical at α=0.05." The trade-off is interpretability — stakeholders understand PSI buckets more intuitively than p-values. Many teams alert on PSI for daily operations and generate KS test reports weekly for compliance archives. For high-stakes models, run both and escalate when either fires.
 
 ```python
 def ks_drift_test(
@@ -283,7 +330,7 @@ def ks_drift_test(
 
 #### Jensen-Shannon Divergence
 
-Unlike Kullback-Leibler (KL) divergence, JS divergence is [symmetric and typically yields a finite value in a bounded range](https://en.wikipedia.org/wiki/Jensen%E2%80%93Shannon_divergence), making it exceptionally reliable for automated monitoring pipelines.
+Unlike Kullback-Leibler (KL) divergence, JS divergence is [symmetric and typically yields a finite value in a bounded range](https://en.wikipedia.org/wiki/Jensen%E2%80%93Shannon_divergence), making it exceptionally reliable for automated monitoring pipelines. KL divergence blows up when one distribution assigns zero mass where another assigns positive mass — common when a new categorical level appears in production. JS divergence handles that gracefully, which matters for unattended nightly drift jobs that should not crash on novel category values. Normalize JS to the 0–1 scale for dashboard display; values above 0.3 on critical features warrant human review in most deployments.
 
 ```python
 def js_divergence(
@@ -313,11 +360,15 @@ def js_divergence(
     return jensenshannon(ref_hist, cur_hist)
 ```
 
+Threshold selection should be conservative at first. Industry heuristics treat PSI below 0.1 as stable, 0.1–0.25 as investigate, and above 0.25 as act — but those cutoffs assume scorecard-style credit models with stable binning. A recommendation model with heavy-tailed click distributions may need calibrated thresholds per feature. Store thresholds in version-controlled config alongside the model card so auditors can see what you considered acceptable at deployment time.
+
 > **Pause and predict**: If you train a machine learning model to optimize logistics routes based on historical weather patterns, and an unprecedented massive hurricane occurs, drastically altering road availability, which specific type of drift will your model experience first? Why?
 
-## Performance Metrics and Explainability
+## 4. Performance Monitoring and Explainability
 
-Once you identify drift, the next imperative is proving how much performance has actually degraded. You must track performance metrics dynamically over rolling intervals.
+Once you identify drift, the next imperative is proving how much performance has actually degraded and explaining which features drove the change. Accuracy alone is a dangerous summary statistic: a model can maintain ninety-four percent overall accuracy while recall on a critical minority segment collapses. Production monitoring must therefore track the right metric for the business cost structure — precision when false positives are expensive, recall when false negatives are dangerous, MAE or RMSE for regression with asymmetric error costs — and compute those metrics over rolling windows segmented by every population the business cares about.
+
+Label delay is the defining constraint of performance monitoring design. When ground truth arrives instantly (click prediction, next-token classification), you can mirror offline evaluation in production. When labels lag (loan default, patient readmission, fraud confirmation), you need a layered strategy: real-time prediction drift and data quality checks as early warnings, delayed batch jobs that join predictions to labels when they arrive, and explicit tracking of label latency itself because slow labels can hide degradation. [Google's Rules of ML](https://developers.google.com/machine-learning/guides/rules-of-ml) emphasize that evaluation must match the production decision boundary; the same discipline applies to monitoring metrics you choose at deploy time.
 
 ```text
 CLASSIFICATION METRICS
@@ -346,7 +397,9 @@ R²              1 - SS_res / SS_tot            Variance explained
 
 ### Sliding Window Monitoring
 
-Because production systems operate on continuous streams of incoming requests rather than static batch files, performance must be calculated over sliding windows. This ensures transient spikes do not permanently skew the aggregate performance metric.
+Because production systems operate on continuous streams of incoming requests rather than static batch files, performance must be calculated over sliding windows. This ensures transient spikes do not permanently skew the aggregate performance metric. The `SlidingWindowMonitor` class below implements count-based windows for illustration; production systems should prefer time-based windows as discussed in the quiz section. When you detect degradation, capture the window's predictions and features in cold storage before the window rolls forward — post-incident SHAP analysis needs the actual samples that triggered the alert, not aggregate statistics alone.
+
+Connecting monitoring to retraining closes the MLOps loop. When `check_degradation` returns `alert: True`, the monitoring job should attach a drift report artifact, open a pipeline run in your orchestrator, and notify the model owner with segment-level metrics. Automatic retraining without human review is risky early in maturity; automatic ticket creation with evidence attached is almost always the right first automation step.
 
 ```python
 class SlidingWindowMonitor:
@@ -408,15 +461,17 @@ class SlidingWindowMonitor:
         }
 ```
 
-> **Did You Know?** At large scale, recommendation systems often track many business and model-health metrics, and even small regressions can matter materially.
+Sliding windows must be time-aware under bursty traffic. A fixed sample-count window of one hundred predictions behaves differently at ten requests per second versus ten requests per hour; during a flash sale, the window may represent milliseconds of traffic and overreact to noise. Prefer time-based windows (rolling one hour, rolling twenty-four hours) for performance metrics and reserve count-based windows for low-volume models where time windows would never fill.
 
 ### Explainability Frameworks
 
-Detecting a failure is only the first step. Diagnosing the exact feature responsible for the failure is where explainability comes in. You cannot effectively debug an algorithmic black box without tools like SHAP or LIME.
+Detecting a failure is only the first step. Diagnosing the exact feature responsible for the failure is where explainability comes in. You cannot effectively debug an algorithmic black box without tools like SHAP or LIME that attribute individual predictions to input features. In monitoring workflows, explainability is not an ethics-only exercise — it is an incident response tool. When PSI spikes on `device_type`, SHAP values on misclassified samples tell you whether the model started overweighting mobile traffic. When demographic parity drops, localized explanations on the disadvantaged cohort reveal which features shifted.
+
+Use explainability surgically. Global SHAP summaries computed nightly highlight which features dominate predictions across the fleet. Local explanations on alerted samples help on-call engineers during incidents. Neither replaces drift detection; both accelerate root-cause analysis after detection fires. Tree-based models use `TreeExplainer` efficiently; arbitrary models fall back to `KernelExplainer` with a small background sample. Budget compute: explaining every prediction in real time is usually prohibitive; explaining a stratified sample from each alert window is practical.
 
 #### SHAP (SHapley Additive exPlanations)
 
-SHAP relies on [cooperative game theory](https://arxiv.org/abs/1705.07874) to distribute the "payout" (the final prediction) among the "players" (the input features) fairly.
+SHAP relies on [cooperative game theory](https://arxiv.org/abs/1705.07874) to distribute the "payout" (the final prediction) among the "players" (the input features) fairly. The Shapley value is the only attribution method that satisfies consistency, local accuracy, and missingness axioms — which is why SHAP became the default explainability tool in many production monitoring runbooks when teams need defensible feature attribution during incidents.
 
 ```python
 import shap
@@ -469,7 +524,7 @@ def explain_prediction_shap(model, X_sample, feature_names):
 
 #### LIME (Local Interpretable Model-agnostic Explanations)
 
-LIME operates by generating a new, localized dataset around the target prediction and [fitting a simpler, inherently interpretable linear model](https://arxiv.org/abs/1602.04938) to approximate the complex model's behavior in that specific hyperspace.
+LIME operates by generating a new, localized dataset around the target prediction and [fitting a simpler, inherently interpretable linear model](https://arxiv.org/abs/1602.04938) to approximate the complex model's behavior in that specific hyperspace. LIME is model-agnostic — it works on any predictor with a `predict_proba` method — which makes it useful when SHAP's tree-specific optimizers do not apply.
 
 ```python
 from lime.lime_tabular import LimeTabularExplainer
@@ -498,13 +553,23 @@ def explain_prediction_lime(model, X_train, X_sample, feature_names):
     }
 ```
 
+### Fairness Monitoring in Production
+
+Fairness monitoring belongs in the same dashboard as accuracy because aggregate metrics hide disparate impact. Track positive prediction rate, true positive rate, and false positive rate across protected or business-critical subgroups — geography, product tier, language, age band — and alert when disparity ratios cross policy thresholds. The eighty-percent rule (disparity ratio between 0.8 and 1.25) is a common starting heuristic in U.S. fair lending practice, but your organization may enforce stricter bounds. When disparity triggers, run explainability filtered to the affected subgroup before assuming the model is biased: sometimes upstream data collection changed for one cohort (a classic covariate shift) rather than the model learning a spurious correlation.
+
 > **Stop and think**: You are deploying a Kubernetes v1.35 cluster to run Prometheus and Grafana for your ML models. If your predictions suddenly start taking 800ms instead of 50ms, but the mathematical accuracy remains stable at 95%, what downstream business metrics might be quietly degrading as a result of this latency?
 
-## Alerting, Runbooks, and Governance
+## 5. Alerting, Governance, and the Feedback Loop
 
-A monitoring system without effective alerting is merely a data graveyard. Implementing robust instrumentation requires exporting metrics into specialized time-series databases like Prometheus.
+A monitoring system without effective alerting is merely a data graveyard. Implementing robust instrumentation requires exporting metrics into specialized time-series databases like Prometheus, defining alert rules that encode business tolerances, and connecting those alerts to runbooks that tell humans exactly what to investigate. The feedback loop closes when confirmed drift or performance degradation triggers retraining, shadow evaluation, or rollback — wiring you practiced in [Module 1.8: ML Pipelines](./module-1.8-ml-pipelines/).
+
+Governance ties monitoring to accountability. Model cards document intended use, limitations, and which metrics you monitor. Audit logs record training events, deployments, threshold changes, and alert acknowledgments. Regulated industries and the [EU AI Act framework](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai) increasingly expect demonstrable monitoring — not just that a model was accurate at launch, but that you detected and responded to degradation afterward. [NIST's AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework) provides a durable structure for mapping monitoring controls to organizational risk tolerance without tying the curriculum to a specific vendor compliance product.
 
 ### Prometheus Metric Definitions
+
+Prometheus uses a pull model: a scraper polls your `/metrics` endpoint on an interval and stores time series in its database. That fits ML serving well because you expose counters and gauges from the inference process without pushing to a remote collector on every prediction. Use **Counters** for monotonically increasing events (total predictions). Use **Histograms** for latency distributions because they pre-compute buckets that PromQL can query with `histogram_quantile`. Use **Gauges** for values that rise and fall (rolling accuracy, current PSI per feature). Label every metric with `model_name` and `model_version` so you can compare champion and challenger during canary deployments.
+
+Alert rules should encode business meaning, not statistical curiosity. `ml_drift_score > 0.25 for 10m` is a starting point, but tie severity to feature tier: drift on a cosmetic feature is informational; drift on `transaction_amount` in fraud detection is critical. Document the mapping in the model card so future engineers understand why thresholds exist. [Prometheus alerting overview](https://prometheus.io/docs/alerting/latest/overview/) describes routing labels to Alertmanager receivers — match `severity: critical` to PagerDuty and `severity: warning` to Slack during business hours.
 
 ```python
 from prometheus_client import Counter, Histogram, Gauge, start_http_server
@@ -590,7 +655,8 @@ groups:
           description: "Model {{ $labels.model_name }} accuracy is {{ $value }}"
 
       - alert: HighPredictionLatency
-        expr: histogram_quantile(0.95, ml_prediction_latency_seconds_bucket) > 0.5
+        # Per-replica P95; for service-level across replicas use sum by (model_name, le) (...)
+        expr: histogram_quantile(0.95, rate(ml_prediction_latency_seconds_bucket[5m])) > 0.5
         for: 2m
         labels:
           severity: warning
@@ -621,9 +687,7 @@ groups:
 
 ### Governance and Compliance
 
-With increasing regulatory scrutiny, model governance is no longer optional. Deployments must be documented via Model Cards, and every state change must be audited.
-
-> **Did You Know?** The European Union's AI Act, formalized in 2024, enforces strict regulations on high-risk algorithmic systems. Non-compliance regarding audit logging, monitoring, and transparency can result in fines up to 35 million EUR, or 7% of the offending company's global annual revenue.
+With increasing regulatory scrutiny, model governance is no longer optional. Deployments must be documented via Model Cards, and every state change must be audited. Regulators and internal risk teams increasingly ask three questions after an incident: what did you monitor, when did alerts fire, and what did you do about them? Monitoring without audit trails fails the third question even when the first two are perfect.
 
 #### The Model Card
 
@@ -708,6 +772,8 @@ class ModelCard:
 
 #### The Audit Trail
 
+Audit logs differ from prediction logs. Prediction logs capture every inference for drift analysis — high volume, retained for weeks. Audit logs capture state transitions — low volume, retained for years. Events worth auditing include model registration, approval, deployment, retirement, threshold changes, manual overrides, and alert acknowledgments. Immutable append-only storage (JSONL files, WORM object storage, or audit tables with insert-only permissions) prevents tampering after an incident. When a regulator asks "when did you know the model was drifting?", the audit trail answers with timestamps and actors, not recollections from a sprint retrospective.
+
 ```python
 @dataclass
 class AuditEvent:
@@ -778,7 +844,9 @@ class ModelAuditLog:
 
 ### Runbooks and Thresholding
 
-Never configure an alert without explicitly linking it to an actionable runbook.
+Never configure an alert without explicitly linking it to an actionable runbook. On-call engineers under stress will not remember whether PSI 0.22 warrants rollback or investigation — the runbook must say so. Good runbooks list immediate triage steps (check deploy history, check upstream pipeline, compare segment metrics), escalation paths (ML lead → serving on-call → product owner), and explicit "do not" guidance (do not retrain on unlabeled live data without review). Store runbooks in the same repository as alert rules so they version together.
+
+Threshold dictionaries like `DRIFT_THRESHOLDS` below should live in config files reviewed in pull requests, not hardcoded in application logic scattered across services. When thresholds change, the audit log should record who approved the change and which model versions were affected. Regulators and post-incident reviewers ask exactly that question.
 
 ```markdown
 # Model Degradation Runbook
@@ -862,6 +930,14 @@ def check_monitoring_health(monitoring_system) -> dict:
     return health
 ```
 
+### Meta-Monitoring: Is Your Monitoring Healthy?
+
+The `check_monitoring_health` function below addresses an uncomfortable question: what if your monitoring system itself is broken? Baselines go stale when nobody refreshes them after quarterly retraining. Cron jobs stop firing when credentials expire. Alert channels get muted after repeated false positives. Meta-monitoring runs daily checks on baseline age, feature coverage percentage, time since last drift job, and the ratio of alerts acknowledged to alerts fired. If you monitored eighty percent of features but the model uses forty inputs, you have a twenty-percent blind spot that will eventually hurt you.
+
+### Data Quality Monitoring
+
+Before drift tests run, validate data quality at ingress: null rates per feature, min/max bounds, categorical cardinality, and duplicate request IDs. Data quality failures should short-circuit inference or route to a safe default model — serving predictions on corrupt features produces confident wrong answers faster than serving nothing. [TensorFlow Data Validation getting started guide](https://www.tensorflow.org/tfx/data_validation/get_started) demonstrates anomaly detection against a schema; the same anomalies map directly to Prometheus counters (`ml_schema_violations_total`) for alerting.
+
 ### Best Practices Checklist
 
 ```text
@@ -892,50 +968,23 @@ System:
   □ Queue depths
 ```
 
-### ML Monitoring Tools Comparison
+### Choosing a Monitoring Stack
 
-```text
-┌────────────────┬─────────────┬─────────────┬─────────────┬─────────────┐
-│    Tool        │   Drift     │   Metrics   │   Alerts    │   Cost      │
-├────────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
-│ Evidently      │  Built-in │  ML+sys   │ ️ Basic    │ Free/OS     │
-│ WhyLabs        │  Advanced │  ML-focus │  Built-in │ Free tier   │
-│ Arize          │  Advanced │  ML-focus │  Built-in │ Paid        │
-│ Fiddler        │  Built-in │  ML-focus │  Built-in │ Paid        │
-│ MLflow         │ ️ Basic    │  ML-focus │  Manual   │ Free/OS     │
-│ Prometheus     │  Manual   │  System   │  Built-in │ Free/OS     │
-│ Datadog        │ ️ Manual   │  System   │  Built-in │ Paid        │
-└────────────────┴─────────────┴─────────────┴─────────────┴─────────────┘
+Teams usually start with open-source metrics and dashboards (Prometheus, Grafana) plus a Python drift job (Evidently, TFDV, or custom scipy scripts) because the concepts transfer everywhere. Managed ML observability platforms add hosted drift detection, collaboration workflows, and integrations at the cost of vendor dependency and data-handling review. Cloud-provider dataset monitoring fits teams already committed to a single cloud ML platform. The decision framework is capability-based: Do you need real-time streaming drift or daily batch reports? How delayed are your labels? Do regulators require immutable audit logs? Answer those questions first; product names second. See the landscape snapshot in *Why This Module Matters* for current vendor options.
 
-Recommendation:
-- Start: begin with a simple open-source stack for metrics, dashboards, and basic model checks, and verify current licensing before choosing named tools.
-- Scale: add a dedicated managed ML observability platform when you need richer drift, alerting, and governance workflows.
-- Enterprise: compare commercial observability platforms against your governance, security, integration, and support requirements.
-```
+### Drift-Triggered Retraining
 
-| Approach | Annual Cost | Pros | Cons |
-|----------|-------------|------|------|
-| Open source | Significant internal engineering time | Full control, no vendor lock-in | Meaningful operational overhead |
-| Managed platform | Higher recurring spend than self-hosted tools | Faster setup, advanced features | Vendor dependency and data-handling tradeoffs |
-| Cloud-native | Costs vary with usage and cloud provider | Integrated with the surrounding ML platform | Less flexible and potentially more locking to one cloud |
-| Enterprise | Often priced for larger organizations and heavier governance needs | Compliance features and support | May be overkill for smaller teams |
+Monitoring earns its keep when it triggers action. Define explicit policies: if PSI exceeds 0.25 on any Tier-1 feature for twenty-four hours, open a retraining ticket; if rolling seven-day AUC drops more than five points, shadow-deploy the candidate from the last pipeline run; if prediction latency p95 doubles, page serving on-call before paging ML research. Automate the easy paths (open tickets, attach drift reports, kick off evaluation jobs) but keep promotion human-gated until your pipeline trust matures. The worst outcome is alert fatigue where drift fires weekly and nobody acts — that trains the organization to ignore monitoring entirely.
 
-### The Economics of Observability
+## Did You Know?
 
-| Scenario | Monitoring Cost | Potential Failure Cost | ROI |
-|----------|----------------|----------------------|-----|
-| E-commerce recommendations | Monitoring spend is often much smaller than the revenue impact of degraded recommendations |
-| Fraud detection | The cost of missed monitoring can far exceed the cost of running the monitoring itself |
-| Healthcare risk scoring | In regulated settings, monitoring can reduce large operational and compliance risks |
-| Trading algorithms | For high-speed trading systems, weak monitoring can lead to outsized losses very quickly |
+1. The Population Stability Index (PSI), one of the most common drift metrics in production, comes from the credit-scoring industry, not modern MLOps: a PSI below 0.1 conventionally signals no significant shift, 0.1–0.25 a moderate shift worth investigating, and above 0.25 a population change large enough to justify rebuilding the model — thresholds that predate ML monitoring tooling and are still used as defaults today.
 
-| Without Monitoring | With Monitoring |
-|-------------------|-----------------|
-| Model drift undetected for 3 months | Drift detected within hours |
-| $5M in fraudulent transactions approved | $50K in fraud before alert |
-| 2 weeks to diagnose root cause | 2 hours to diagnose |
-| Customer trust damaged | Rapid response preserves trust |
-| Regulatory scrutiny | Audit trail demonstrates diligence |
+2. The formal study of concept drift predates modern MLOps platforms; [Gama et al.'s 2014 survey](https://arxiv.org/abs/1410.5430) catalogs detection and adaptation strategies still referenced in production drift design today.
+
+3. [Google's "Data Validation for Machine Learning" paper](https://research.google/pubs/pub46555/) introduced schema-based validation patterns that evolved into TensorFlow Data Validation and influenced batch monitoring jobs across the ecosystem.
+
+4. [Underspecification research from Google](https://arxiv.org/abs/1907.10579) showed that models with identical test accuracy can behave differently in deployment — a reminder that monitoring must compare live behavior to baselines, not assume offline metrics guarantee production equivalence.
 
 ## Common Mistakes
 
@@ -948,8 +997,11 @@ Recommendation:
 | **Skipping Baseline Generation** | Mathematical divergence formulas cannot function without a highly precise frozen artifact to compare against. | Mandate baseline statistical generation within your core continuous integration pipeline. |
 | **Monitoring Only Outputs** | Evaluating only predictions masks feature degradation, meaning the model might be right for the wrong reasons. | Track upstream feature distributions concurrently with downstream prediction outputs. |
 | **Omitting K8s Limits** | Memory-intensive pandas/numpy monitoring scripts can consume unbounded resources, causing OutOfMemory node panics. | Explicitly define `resources.limits` for both CPU and memory in your Kubernetes v1.35 YAMLs. |
+| **Treating Monitoring as One-Time Setup** | Baselines captured at launch go stale after retraining, seasonality, or product changes; unmaintained dashboards become wallpaper. | Refresh baselines after every promoted model version and review alert thresholds quarterly. |
 
 ### Mistake Context: Code Implementations
+
+The code contrasts below show monitoring anti-patterns side by side with production-shaped alternatives. Read them as design reviews, not style preferences — each "wrong" example mirrors a real incident postmortem.
 
 ```python
 #  WRONG - Average hides problems
@@ -1031,73 +1083,9 @@ class DelayedGroundTruthMonitor:
         pass
 ```
 
-## Interview Preparation
+## 6. End-to-End Implementation Guide
 
-### Question 1: "Your model's accuracy dropped 5% overnight. Walk me through your debugging process."
-
-```python
-# Check feature distributions
-current_stats = production_data.describe()
-baseline_stats = training_data.describe()
-drift_report = compare_distributions(current_stats, baseline_stats)
-
-# Check prediction distribution
-pred_distribution = predictions.value_counts(normalize=True)
-# Is the model predicting one class way more than usual?
-
-# Check by segment
-for segment in ['new_users', 'power_users', 'mobile', 'desktop']:
-    segment_accuracy = calculate_accuracy(segment_filter)
-    print(f'{segment}: {segment_accuracy}')
-```
-
-### Question 2: "How would you monitor a model for fairness in production?"
-
-```python
-def monitor_fairness(predictions, actuals, protected_attribute):
-    groups = set(protected_attribute)
-    metrics = {}
-
-    for group in groups:
-        mask = protected_attribute == group
-        metrics[group] = {
-            'positive_rate': predictions[mask].mean(),
-            'tpr': recall_score(actuals[mask], predictions[mask]),
-            'fpr': false_positive_rate(actuals[mask], predictions[mask]),
-        }
-
-    # Calculate disparity ratios
-    groups_list = list(groups)
-    disparity = metrics[groups_list[0]]['positive_rate'] / metrics[groups_list[1]]['positive_rate']
-
-    return {
-        'group_metrics': metrics,
-        'demographic_parity_ratio': disparity,
-        'alert': disparity < 0.8 or disparity > 1.25  # 80% rule
-    }
-```
-
-### Question 3: "How do you balance comprehensive monitoring with alert fatigue?"
-
-```yaml
-# Level 1: Informational (logged, no notification)
-- Minor drift (PSI 0.05-0.1)
-- Latency increase <50%
-- Volume changes <20%
-
-# Level 2: Warning (Slack, business hours only)
-- Moderate drift (PSI 0.1-0.2)
-- Accuracy drop 2-5%
-- Anomalous segments
-
-# Level 3: Critical (PagerDuty, immediate)
-- Severe drift (PSI >0.25)
-- Accuracy drop >5%
-- Complete model failure
-- Data pipeline down
-```
-
-## End-to-End Implementation Guide
+Production monitoring is not a single cron job — it is three cooperating components: baseline capture at training time, instrumented inference that logs features and predictions, and a scheduled monitoring job that compares live traffic to the baseline and exports metrics. The code below walks through each piece. Adapt storage (local JSONL, object storage, feature store) to your environment; keep the contracts stable so you can swap implementations without rewriting statistical tests.
 
 To securely tie these concepts together, execute the following implementation path:
 
@@ -1115,9 +1103,11 @@ def create_baseline(training_data: pd.DataFrame, model, feature_names: list) -> 
         'predictions': {}
     }
 
-    # Feature baselines
+    # Feature baselines — freeze bin edges once; reuse for every production comparison
     for feature in feature_names:
         col = training_data[feature]
+        _, inner_edges = np.histogram(col, bins=50)
+        bin_edges = psi_bin_edges_from_reference(col.values, bins=50)
         baseline['features'][feature] = {
             'mean': float(col.mean()),
             'std': float(col.std()),
@@ -1129,7 +1119,8 @@ def create_baseline(training_data: pd.DataFrame, model, feature_names: list) -> 
                 '75': float(col.quantile(0.75)),
                 '95': float(col.quantile(0.95))
             },
-            'histogram': np.histogram(col, bins=50)[0].tolist()
+            'inner_bin_edges': inner_edges.tolist(),
+            'histogram': np.histogram(col, bins=bin_edges)[0].tolist()
         }
 
     # Prediction baseline
@@ -1212,14 +1203,20 @@ def run_monitoring_check(baseline_path: str, predictions_path: str, hours: int =
     if len(recent_predictions) < 100:
         return {'status': 'insufficient_data', 'count': len(recent_predictions)}
 
-    # Check each feature for drift
+    # Check each feature for drift using the baseline's frozen bin edges
     alerts = []
+    feature_psi = {}
     for feature in baseline['features']:
-        baseline_hist = baseline['features'][feature]['histogram']
+        inner_edges = np.array(baseline['features'][feature]['inner_bin_edges'])
+        bin_edges = np.concatenate([[-np.inf], inner_edges[1:-1], [np.inf]])
+        ref_counts = np.array(baseline['features'][feature]['histogram'])
         current_values = [p['features'][feature] for p in recent_predictions]
-        current_hist = np.histogram(current_values, bins=50)[0]
+        cur_counts = np.histogram(current_values, bins=bin_edges)[0]
 
-        psi = calculate_psi_from_histograms(baseline_hist, current_hist)
+        ref_percents = ref_counts / ref_counts.sum()
+        cur_percents = cur_counts / len(current_values)
+        psi = calculate_psi_from_histograms(ref_percents, cur_percents)
+        feature_psi[feature] = psi
 
         if psi > 0.25:
             alerts.append({
@@ -1238,7 +1235,12 @@ def run_monitoring_check(baseline_path: str, predictions_path: str, hours: int =
     for alert in alerts:
         send_alert(alert)
 
-    return {'status': 'complete', 'alerts': alerts}
+    return {'status': 'complete', 'alerts': alerts, 'feature_psi': feature_psi}
+
+# Hourly cron: compare traffic, alert, and export per-feature PSI to Prometheus
+results = run_monitoring_check('model_baseline.json', 'predictions.jsonl')
+if results.get('status') == 'complete':
+    export_metrics_to_prometheus(results, model_name='fraud_model')
 ```
 
 ```python
@@ -1260,58 +1262,81 @@ def export_metrics_to_prometheus(monitoring_results: dict, model_name: str):
         drift_gauge.labels(feature=feature).set(psi)
 ```
 
-## Summary
+[Grafana's documentation](https://grafana.com/docs/grafana/latest/) covers dashboard design for Prometheus metrics; pair drift gauges with prediction latency histograms and rolling accuracy panels on one page so on-call engineers do not chase tabs during incidents. [Evidently's Report API](https://docs.evidentlyai.com/docs/library/report) walks through `Dataset.from_pandas(...)`, `Report([DataDriftPreset()])`, and `report.run(...)` to generate HTML drift reports from pandas DataFrames for teams that want report-style outputs alongside time-series metrics.
 
-```text
-ML MONITORING ESSENTIALS
-========================
+## Quiz
 
-DRIFT TYPES:
-  Data Drift    → Input distribution changed
-  Concept Drift → Input-output relationship changed
-  Prediction Drift → Output distribution changed
+<details>
+<summary>1. Your production fraud model returns HTTP 200 on every request. Prometheus shows healthy latency and zero errors, but chargebacks rose sharply over two weeks. How does your observability architecture detect this silent ML failure?</summary>
 
-DETECTION METHODS:
-  PSI           → Population Stability Index
-  KS Test       → Distribution comparison
-  JS Divergence → Symmetric distance measure
+Infrastructure metrics alone cannot catch algorithmic degradation. A robust observability architecture monitors prediction drift (shift in fraud-score distribution), input feature drift (PSI on transaction attributes), and delayed performance metrics once chargeback labels arrive. It compares all three against training baselines, segments by merchant category, and alerts when business KPIs diverge from model expectations even though serving health is green. Silent ML failures require ML-specific layers — not just uptime dashboards.
 
-EXPLAINABILITY:
-  SHAP          → Feature contributions (game theory)
-  LIME          → Local linear approximations
+</details>
 
-GOVERNANCE:
-  Model Cards   → Documentation for transparency
-  Audit Logs    → Track all model events
-  Access Control → Who can deploy/modify
+<details>
+<summary>2. PSI on the `user_age` feature spikes to 0.30, but rolling accuracy has not dropped. How do you diagnose whether this is covariate shift (data drift) or concept drift?</summary>
 
-TOOLS:
-  Prometheus    → Metrics collection
-  Grafana       → Visualization
-  Evidently     → ML-specific monitoring
-  WhyLabs       → Advanced drift detection
+High PSI confirms input distribution changed — that is covariate shift by definition. Stable accuracy suggests the feature-to-label relationship may still hold for the new age distribution (the model generalizes), but verify with segment-level metrics because aggregate accuracy hides localized failures. If inputs were stable but accuracy dropped, concept drift would be the leading hypothesis. Next steps: inspect age histograms, check upstream pipeline changes, and run SHAP on misclassified samples in the shifted cohort.
 
-BEST PRACTICES:
-   Monitor inputs, outputs, AND performance
-   Set thresholds with baselines
-   Create runbooks for alerts
-   Automate retraining when needed
-   Document everything (model cards)
-```
+</details>
+
+<details>
+<summary>3. Ground truth for your loan default model arrives sixty days after prediction. Which monitoring signals do you prioritize for real-time observability?</summary>
+
+Prioritize prediction drift (shift in default probability outputs), input data drift (PSI per feature), and business proxy metrics (early delinquency indicators). Real-time accuracy is impossible with sixty-day label delay. If the model historically scores twelve percent of applicants as high-risk and suddenly scores thirty percent, that prediction drift is an immediate observability signal that the model or population changed — without waiting for default labels.
+
+</details>
+
+<details>
+<summary>4. After a performance alert, SHAP analysis shows `credit_utilization` suddenly dominates predictions for one demographic segment. How do explainability frameworks help your investigation?</summary>
+
+SHAP attributes individual predictions to features, revealing that `credit_utilization` gained influence for that segment. This narrows investigation from "the model got worse" to "this feature behaves differently for this cohort." Compare utilization distributions in the segment against training baselines, check for upstream encoding changes, and evaluate whether retraining or feature repair is the right fix. Explainability connects drift detection to actionable root-cause analysis.
+
+</details>
+
+<details>
+<summary>5. Overall accuracy stays at ninety-four percent, but demographic parity ratio between two groups dropped from 0.95 to 0.65. How do you evaluate fairness across sub-populations?</summary>
+
+Aggregate accuracy masks disparate impact. Compute positive prediction rate, TPR, and FPR per group; the parity ratio collapse signals the model treats groups differently even while overall error is low. Filter SHAP and performance metrics to the disadvantaged group, compare feature distributions against training data for that cohort, and determine whether the issue is data drift (collection changed for one group) or model bias. Fairness monitoring requires segment-level dashboards, not global accuracy alone.
+
+</details>
+
+<details>
+<summary>6. A regulator requests proof of who deployed model v2.3, what monitoring thresholds were active, and when drift alerts fired. What governance and audit logging artifacts do you provide?</summary>
+
+Provide the model card (intended use, limitations, monitored metrics), the audit log entries for training, approval, and deployment (actor, timestamp, version), version-controlled alert threshold configs, and alert acknowledgment records with linked runbook actions. Governance requires immutable event history — not just current dashboard state — so you can demonstrate diligence after deployment, satisfying regulatory frameworks that expect traceable monitoring and response.
+
+</details>
+
+<details>
+<summary>7. During a flash sale, prediction volume increases one hundred times. Your SlidingWindowMonitor uses a fixed sample window of one hundred predictions. What failure occurs and how do you redesign it?</summary>
+
+The sample window cycles in milliseconds during the surge, making the monitor hyper-sensitive to micro-bursts and triggering false positive accuracy alerts. Redesign with time-based rolling windows (e.g., five-minute aggregates) that behave consistently regardless of traffic volume. High-volume events need window semantics tied to clock time, not sample count.
+
+</details>
+
+<details>
+<summary>8. P95 prediction latency jumps from 45ms to 800ms while accuracy remains stable. CPU utilization is unchanged. What do you investigate first in your monitoring stack?</summary>
+
+Stable CPU with high latency suggests waiting on external dependencies (feature store lookups, remote embedding services) or I/O contention rather than model compute. Check Prometheus latency histograms broken down by dependency, verify network timeouts, inspect memory limits for swapping, and review recent deploys that may have added synchronous calls. System metrics and ML metrics together narrow the bottleneck.
+
+</details>
 
 ## Hands-On Exercises
 
-Before beginning, ensure your local Python environment is prepared with the required data science and ML observability dependencies:
+These five progressive exercises build a minimal but production-shaped ML monitoring stack: statistical drift detection, Prometheus instrumentation, SHAP-based incident explanation, governance gates, and a Kubernetes deployment manifest with resource limits. Together they mirror the architecture diagram from Section 1 — you are not learning isolated tricks but wiring a coherent observability path from training baseline to production alert.
+
+Before beginning, ensure your local Python environment is prepared with the required data science and ML observability dependencies. Use a virtual environment so package versions do not collide with other projects on your machine.
 
 ```bash
 pip install pandas numpy scipy prometheus-client shap lime scikit-learn
 ```
 
-The following progressive exercises demand full implementations rather than partial fill-in-the-blank logic. Review the starter templates derived from our standard library, and then consult the fully executable solutions in the toggles below.
+Work through each task in order because later tasks assume you understand PSI thresholds and Prometheus metric types from earlier steps. Each task includes a collapsible reference solution — attempt the implementation yourself first, then compare. The success checklist at the end lists verifiable outcomes you should confirm before moving to the next module.
 
 ### Task 1: Build a Drift Detector
 
-*Starter Template provided in project guidelines:*
+The first hands-on task implements PSI-based drift detection against a frozen training baseline — the same statistical foundation used in production Evidently and custom monitoring jobs. Complete the `calculate_psi`, `check_drift`, and `generate_report` methods in the starter template below, then compare your output against the reference solution.
 
 ```python
 class ProductionDriftMonitor:
@@ -1380,6 +1405,26 @@ print(monitor.generate_report())
 import numpy as np
 import pandas as pd
 
+
+def psi_bin_edges_from_reference(reference: np.ndarray, bins: int = 10) -> np.ndarray:
+    _, inner_edges = np.histogram(reference, bins=bins)
+    return np.concatenate([[-np.inf], inner_edges[1:-1], [np.inf]])
+
+
+def calculate_psi_from_histograms(
+    ref_percents: np.ndarray,
+    cur_percents: np.ndarray,
+    epsilon: float = 1e-4,
+) -> float:
+    ref_percents = np.asarray(ref_percents, dtype=float)
+    cur_percents = np.asarray(cur_percents, dtype=float)
+    ref_percents = ref_percents / ref_percents.sum()
+    cur_percents = cur_percents / cur_percents.sum()
+    ref_percents = np.clip(ref_percents, epsilon, 1)
+    cur_percents = np.clip(cur_percents, epsilon, 1)
+    return float(np.sum((cur_percents - ref_percents) * np.log(cur_percents / ref_percents)))
+
+
 class ProductionDriftMonitor:
     def __init__(self, baseline_data: pd.DataFrame, alert_threshold: float = 0.1):
         self.baseline_data = baseline_data
@@ -1390,17 +1435,12 @@ class ProductionDriftMonitor:
     def calculate_psi(self, feature: str, production_data: pd.DataFrame) -> float:
         reference = self.baseline_data[feature].values
         current = production_data[feature].values
-        bins = 10
-        _, bin_edges = np.histogram(reference, bins=bins)
-        ref_percents = np.histogram(reference, bins=bin_edges)[0] / len(reference)
-        cur_percents = np.histogram(current, bins=bin_edges)[0] / len(current)
-        
-        # Smooth zero counts
-        ref_percents = np.clip(ref_percents, 0.0001, 1)
-        cur_percents = np.clip(cur_percents, 0.0001, 1)
-        
-        psi = np.sum((cur_percents - ref_percents) * np.log(cur_percents / ref_percents))
-        return psi
+        bin_edges = psi_bin_edges_from_reference(reference, bins=10)
+        ref_counts = np.histogram(reference, bins=bin_edges)[0]
+        cur_counts = np.histogram(current, bins=bin_edges)[0]
+        ref_percents = ref_counts / len(reference)
+        cur_percents = cur_counts / len(current)
+        return calculate_psi_from_histograms(ref_percents, cur_percents)
 
     def check_drift(self, production_data: pd.DataFrame) -> dict:
         results = {'feature_psi': {}, 'drifted_features': [], 'alert_level': 'none'}
@@ -1442,7 +1482,7 @@ print(monitor.generate_report())
 
 ### Task 2: Create an ML Monitoring Dashboard
 
-*Starter Template provided in project guidelines:*
+The second task wires inference events into Prometheus metrics so Grafana can visualize prediction volume, latency, and rolling accuracy. Instrumentation at the prediction boundary is the cheapest place to capture features for later drift analysis — if you only log from a nightly batch job, you miss intraday pipeline failures.
 
 ```python
 from prometheus_client import Counter, Histogram, Gauge, start_http_server
@@ -1559,7 +1599,7 @@ for alert in monitor.check_alerts():
 
 ### Task 3: Implement Model Explainability
 
-*Starter Template provided in project guidelines:*
+The third task connects SHAP explanations to incident response: when an alert fires, engineers need human-readable attribution, not raw float arrays. Implement `explain_prediction` and `generate_text_explanation` so the top contributing features surface in plain language.
 
 ```python
 import shap
@@ -1688,7 +1728,7 @@ print(res['explanation'])
 
 ### Task 4: Build a Model Governance System
 
-*Starter Template provided in project guidelines:*
+The fourth task enforces approval gates before deployment and maintains an audit log that regulators expect. Monitoring thresholds are meaningless if anyone can deploy an unreviewed model that bypasses them — governance and observability are one system.
 
 ```python
 from dataclasses import dataclass
@@ -1861,6 +1901,8 @@ class ModelRegistry:
 
 ### Task 5: Kubernetes v1.35 Monitoring Deployment
 
+The fifth task deploys the monitoring exporter as a Kubernetes Deployment with explicit CPU and memory limits. Drift jobs that load large pandas DataFrames into memory can trigger OOM kills without limits — taking down monitoring exactly when you need it most. Liveness probes ensure Kubernetes restarts stuck containers; resource requests help the scheduler place pods on nodes with adequate capacity. This manifest is illustrative: replace the image reference with your organization's registry path before deploying to a real cluster.
+
 To deploy your Prometheus monitoring infrastructure inside a contemporary KubeDojo K8s cluster, ensure you define strict limits to prevent memory ballooning during intensive histogram calculations. First, create the target namespace safely, then save the following manifest to `monitor-stack.yaml` and deploy it:
 
 ```bash
@@ -1924,46 +1966,29 @@ kubectl get pods -n mlops-prod -l app=drift-monitor
 - [ ] Task 4 correctly prevents deployment of a model lacking strict governance review.
 - [ ] Task 5 successfully deploys via `kubectl apply -f monitor-stack.yaml` on v1.35.
 
-## Quiz
-
-<details>
-<summary>Scenario 1: You are on-call when PagerDuty fires an alert for DataDriftDetected on a single feature (user age), but the ModelAccuracyDrop alert has not fired. Should you immediately trigger a model rollback?</summary>
-No. Data drift indicates the input population shifted, but if ModelAccuracyDrop hasn't triggered, the model's fundamental relationships might still be generalizing correctly over the new distribution. You should immediately investigate the shift using PSI tools to verify if it represents a transient anomaly (e.g., a sudden marketing campaign targeting younger users) rather than blindly rolling back a functional model.
-</details>
-
-<details>
-<summary>Scenario 2: Your fraud detection model operates in an environment where confirmed fraud labels arrive 30 days after the transaction. You need to implement real-time monitoring. Which metric should you prioritize?</summary>
-You must prioritize Prediction Drift (output distribution changes). Since calculating real-time accuracy is impossible due to the 30-day lag on ground truth labels, monitoring the frequency at which the model predicts positive fraud classes acts as an immediate proxy. If the model historically flags 2% of transactions as fraud and suddenly flags 15%, you have an immediate signal that behavior may have degraded without waiting 30 days for confirmation.
-</details>
-
-<details>
-<summary>Scenario 3: A new model version is deployed to your production Kubernetes v1.35 cluster. Immediately, the HighPredictionLatency alert triggers, showing p95 latency jumped from 45ms to 800ms. CPU utilization on the Pods remains identical. What is the most likely architectural bottleneck?</summary>
-The most likely bottleneck is external dependency latency or resource lock contention rather than algorithmic inefficiency. Since CPU utilization remains identical, the Pods are likely waiting on an external network call (such as a remote feature store lookup) or experiencing severe memory swapping due to missing `resources.limits` directives, forcing the container to stall execution while waiting on I/O.
-</details>
-
-<details>
-<summary>Scenario 4: You are investigating a drop in an e-commerce recommendation model's performance. The PSI for the "device_type" feature has suddenly spiked to 0.40. What is your very first investigative step?</summary>
-Your first step should be to investigate the upstream data engineering pipeline and client-side logging mechanisms. A PSI of 0.40 indicates massive, severe structural change. Often, extreme categorical shifts are caused by software bugs (like a web update mislabeling 'mobile' traffic as 'desktop') rather than a true overnight change in customer demographics.
-</details>
-
-<details>
-<summary>Scenario 5: A healthcare model's accuracy on the general population remains at 94%, but an audit log shows the Demographic Parity Ratio between two protected groups dropped from 0.95 to 0.65. How do you diagnose the root cause?</summary>
-You must utilize localized explainability frameworks like SHAP or LIME specifically filtered against the disadvantaged protected group. By generating SHAP values exclusively for the instances within that demographic cohort, you can pinpoint the specific underlying features pushing those predictions downward, exposing the localized covariate shift driving the biased outcome.
-</details>
-
-<details>
-<summary>Scenario 6: You've configured a SlidingWindowMonitor with a window size of 100 samples. During a flash sale event, prediction volume increases 100x. What monitoring failure will occur, and how do you redesign the system to handle it?</summary>
-The fixed sample window will cycle entirely within a fraction of a second, causing the monitor to become hyper-sensitive and trigger false positive alerts based on transient micro-bursts of variance. To fix this, you must redesign the monitor to operate on strict time-based rolling windows (e.g., rolling 5-minute aggregations) rather than arbitrary sample-count windows.
-</details>
-
 ## Next Module
 
-Now that you have constructed mathematically rigorous observability around your models, revisit [Module 1.8: ML Pipelines](./module-1.8-ml-pipelines) to wire monitoring signals back into retraining, validation, and controlled promotion workflows.
+Now that you have constructed mathematically rigorous observability around your models, revisit [Module 1.8: ML Pipelines](./module-1.8-ml-pipelines) to wire monitoring signals back into retraining, validation, and controlled promotion workflows. The monitoring layer you built here supplies the triggers — drift scores, performance drops, fairness disparities — that tell the pipeline when to retrain, shadow-test a challenger, or roll back to the previous champion. Without monitoring, pipelines run on schedule whether the model needs updating or not; with monitoring, retraining becomes evidence-driven rather than calendar-driven.
 
 ## Sources
 
-- [Jensen-Shannon divergence](https://en.wikipedia.org/wiki/Jensen%E2%80%93Shannon_divergence) — Background reference for the section's claim that JS divergence is symmetric and finite under the common base-2 normalization.
-- [Prometheus Alerting Overview](https://prometheus.io/docs/alerting/latest/overview/) — Overview of the alerting flow that matches the module's Prometheus and Alertmanager architecture.
-- [A Unified Approach to Interpreting Model Predictions](https://arxiv.org/abs/1705.07874) — Primary SHAP paper describing Shapley-value-based feature attribution.
-- ["Why Should I Trust You?": Explaining the Predictions of Any Classifier](https://arxiv.org/abs/1602.04938) — Primary LIME paper on local surrogate explanations for individual predictions.
-- [Model Cards for Model Reporting](https://arxiv.org/abs/1810.03993) — Primary reference for the model-card governance pattern used in the module.
+- [MIT Technology Review — COVID-era AI model failures](https://www.technologyreview.com/2020/05/11/1001563/covid-pandemic-broken-ai-machine-learning-amazon-retail-fraud-humans-in-the-loop/) — Primary source for the module opener on pandemic-driven distribution shift.
+- [Google MLOps: Continuous delivery and automation pipelines](https://cloud.google.com/architecture/mlops-continuous-delivery-and-automation-pipelines-in-machine-learning) — Framework placing continuous monitoring in the ML lifecycle.
+- [Google — Data Validation for Machine Learning](https://research.google/pubs/pub46555/) — Schema-based validation patterns underlying TFDV-style monitoring.
+- [Google — Rules of ML](https://developers.google.com/machine-learning/guides/rules-of-ml) — Production evaluation and monitoring discipline.
+- [TensorFlow Data Validation (TFDV)](https://www.tensorflow.org/tfx/guide/tfdv) — Reference implementation for schema and statistics-based drift detection.
+- [TensorFlow — Data validation getting started](https://www.tensorflow.org/tfx/data_validation/get_started) — Hands-on TFDV workflow documentation.
+- [Evidently AI — Report API](https://docs.evidentlyai.com/docs/library/report) — `Dataset.from_pandas`, `Report`, and HTML drift report generation.
+- [Prometheus — Introduction overview](https://prometheus.io/docs/introduction/overview/) — Metrics collection architecture for ML serving instrumentation.
+- [Prometheus — Alerting overview](https://prometheus.io/docs/alerting/latest/overview/) — Alertmanager routing referenced in the module's alert rules.
+- [Grafana documentation](https://grafana.com/docs/grafana/latest/) — Dashboard visualization for Prometheus ML metrics.
+- [IBM — Model drift overview](https://www.ibm.com/think/topics/model-drift) — Durable taxonomy of data drift and concept drift.
+- [Microsoft — Monitor datasets in Azure ML](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-monitor-datasets) — Cloud-provider dataset drift monitoring patterns.
+- [Gama et al. — A Survey on Concept Drift Adaptation](https://arxiv.org/abs/1410.5430) — Academic reference for concept drift detection strategies.
+- [D'Amour et al. — Underspecification in ML pipelines](https://arxiv.org/abs/1907.10579) — Why identical test metrics can yield different production behavior.
+- [SHAP — Lundberg & Lee (2017)](https://arxiv.org/abs/1705.07874) — Shapley-value feature attribution for model explanations.
+- [LIME — Ribeiro et al. (2016)](https://arxiv.org/abs/1602.04938) — Local surrogate explanations for individual predictions.
+- [Model Cards — Mitchell et al. (2019)](https://arxiv.org/abs/1810.03993) — Governance documentation pattern used in the module.
+- [Jensen-Shannon divergence](https://en.wikipedia.org/wiki/Jensen%E2%80%93Shannon_divergence) — Mathematical background for symmetric distribution distance.
+- [EU AI Act — Regulatory framework](https://digital-strategy.ec.europa.eu/en/policies/regulatory-framework-ai) — European monitoring and transparency obligations for high-risk AI.
+- [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework) — Durable risk-based framing for production AI controls.

--- a/src/content/docs/ai-ml-engineering/mlops/module-1.7-data-pipelines.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.7-data-pipelines.md
@@ -5,19 +5,10 @@ sidebar:
   order: 608
 ---
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6
-## A Familiar Failure Mode: When Unversioned Training Data Derails a Launch
 
-**Imagine a model team in the final hours before launch.**
+## Hypothetical Scenario: When Unversioned Training Data Derails a Launch
 
-A team was preparing to launch a new personalized pricing model after months of work, with very little margin for last-minute uncertainty about the training data.
-
-The model had performed beautifully in testing. A/B tests showed a 23% increase in conversion rates. Leadership was ecstatic. The CEO had already announced the launch to investors.
-
-In one common failure mode, a team realizes just before launch that nobody can say with confidence which dataset produced the candidate model.
-
-Her stomach dropped.
-
-She opened the data folder and found chaos:
+**Hypothetical scenario:** A model team is in the final hours before launch after months of work on a personalized pricing model, with very little margin for last-minute uncertainty about the training data. Offline evaluation looked strong and leadership has already communicated the launch externally. Then someone asks a basic question nobody can answer with confidence: which exact dataset version produced the candidate model about to ship? The engineer who opens the shared folder finds a graveyard of ambiguous filenames rather than a catalog of record:
 
 ```
 data/
@@ -31,37 +22,83 @@ data/
 └── train_march_update.csv
 ```
 
-"Which one did we use for the production model?" she typed back, dreading the answer.
+When the team traces filenames against experiment notes, they discover the launch candidate was trained on a different file than the one used in validation — `train_v3_FINAL_REAL.csv` versus `train_FINAL_USE_THIS.csv` are not the same dataset. The launch slips, engineering time is spent re-running training and audits, and the team implements the data versioning and pipeline controls that should have existed from the beginning.
 
-Silence. Then: "I... I'm not sure. I think Dave used one of them but he's on vacation."
-
-The team eventually discovered that the launch candidate had been trained on the wrong dataset version, so the model they planned to ship did not match the one they had validated. The model they'd tested had used `train_v3_FINAL_REAL.csv`. They were completely different datasets.
-
-The launch was delayed, the team absorbed significant business and engineering costs, and they ultimately had to implement the data versioning practices that should have existed from the beginning.
-
-> "We version our code religiously. But our data was stored like photos on my grandmother's computer—folders named 'vacation pics' and 'vacation pics (2)'. That inconsistency cost us everything."
-> — A common MLOps failure pattern.
-
-This module teaches you how to avoid Jennifer's nightmare. You'll learn to version data like code, manage features across teams, and validate data quality automatically. These aren't nice-to-haves—they're the foundation of production ML that actually works.
-
-The stakes are higher than you might think. In ML, your model is only as good as your data—and your data is only as valuable as your ability to track, version, and validate it. A model trained on corrupted data doesn't throw errors. It doesn't crash. It quietly makes terrible predictions that destroy trust, revenue, and sometimes careers.
-
-By the end of this module, you'll have the tools and practices to ensure that never happens to you.
+This pattern is common in teams that version code in Git but treat datasets as disposable files on shared drives. In ML, your model is only as good as your data — and your data is only as trustworthy as your ability to track, version, validate, and orchestrate it through reproducible pipelines. A model trained on corrupted or mismatched data rarely throws errors; it quietly makes bad predictions that erode trust and revenue until someone traces the failure back to the data layer.
 
 ---
 
-## What You'll Be Able to Do
+## What You'll Be Able To Do
 
-By the end of this module, you will:
-- Master DVC for dataset and model versioning—the industry standard for tracking datasets like code
+After working through the theory, tool walkthroughs, and hands-on checkpoints below, you should be able to explain how each layer of the stack fits together and implement the core workflows yourself:
+- Master DVC for dataset and model versioning—a widely adopted approach for tracking datasets like code
 - Understand feature stores and implement Feast—the solution to feature engineering chaos
 - Implement data validation with Great Expectations—unit tests for your data
-- Build reproducible ML pipelines with versioned data—because "it worked on my machine" isn't acceptable
+- Build reproducible ML data pipelines with versioned data, scheduling, and orchestrated dependencies
 - Understand data lineage and governance—tracing data from source to model for debugging and compliance
 
 ---
 
-##  Theory
+## Why This Module Matters
+
+Machine learning systems fail in production far more often at the data layer than at the model layer. Teams invest months tuning architectures while their training tables live in folders named `final_v2_REAL.csv`, their feature definitions diverge across three services, and their nightly ingestion jobs fail silently because nobody wired dependencies or validation gates. Data pipelines — the scheduled, dependency-aware workflows that ingest, transform, validate, and publish ML-ready datasets — are how you turn ad-hoc scripts into infrastructure you can trust.
+
+Without orchestrated data pipelines, every retrain becomes forensic archaeology: which upstream export ran, which transformation version produced this partition, and whether validation ran before training started. With them, you declare dependencies explicitly, backfill historical partitions safely, and block training when expectations fail. The durable concepts — DAGs, idempotency, ETL versus ELT, lineage — outlast any single orchestrator; the tools (Airflow, Dagster, Prefect, and others) are interchangeable implementations of the same operational spine.
+
+This module teaches that spine alongside the data-management tools that sit inside it: DVC for versioning, Feast for consistent features, Great Expectations for validation, and lineage systems for auditability. Module 1.8 goes deeper on ML workflow orchestration for training and deployment; here you focus on the data moving through those workflows.
+
+---
+
+## Data Pipelines for ML: Orchestration, ETL, and Dependencies
+
+### What Counts as a Data Pipeline?
+
+An ML data pipeline is a repeatable workflow that moves raw inputs through transformation and validation stages until they are safe to consume for training or serving. Unlike a one-off notebook export, a pipeline declares what runs, in what order, on what schedule, and what must succeed before downstream steps proceed. Orchestrators such as [Apache Airflow](https://airflow.apache.org/docs/apache-airflow/stable/), [Dagster](https://docs.dagster.io/), and [Prefect](https://docs.prefect.io/) exist to express that graph — historically as task-based DAGs (Airflow, Prefect) or asset-based graphs where data products are first-class (Dagster).
+
+Think of the pipeline as a factory line for datasets. Ingestion stations pull from APIs, databases, or object storage. Transformation stations clean, join, and engineer features. Quality stations run expectations before anything reaches the training floor. Storage stations write versioned artifacts and register metadata. If any station skips a step or uses a different recipe than yesterday, the finished product — your training table — is not the same product even when the filename unchanged.
+
+### ETL Versus ELT: Where Transformation Runs
+
+**ETL (Extract, Transform, Load)** transforms data before it lands in the warehouse or lake. Extraction pulls from sources into a staging area; transformation applies business rules, aggregations, and feature logic; load writes curated tables downstream jobs consume. ETL keeps heavy computation close to the pipeline engine and produces narrow, ML-ready tables early. It suits teams with strict schema contracts and centralized data engineering ownership.
+
+**ELT (Extract, Load, Transform)** loads raw data first, then transforms inside the warehouse or lakehouse using SQL or Spark. Extraction and load prioritize speed and completeness; transformation happens where storage and compute colocate. ELT suits exploratory feature work and teams that want raw history preserved for reprocessing when definitions change. ML teams often hybridize: ELT for raw retention, ETL-style Python or Spark steps for complex feature engineering that SQL cannot express cleanly.
+
+The choice affects pipeline design. ETL pipelines fail fast when upstream schemas drift because transforms run before load commits. ELT pipelines defer failure to transform time but preserve raw inputs for backfills when you fix a bug in feature logic. Neither is universally correct; the tradeoff is where you pay transformation cost and how easily you can recompute history.
+
+### Scheduling, Sensors, and Data Dependencies
+
+Production data rarely arrives at a fixed clock. A nightly sales export might land at 02:10 some days and 03:40 others. Hard-coding `sleep(3600)` between jobs creates flaky pipelines. Orchestrators express **dependencies** explicitly: task B runs only after task A succeeds, or after a **sensor** detects that today's partition exists in object storage.
+
+Scheduling defines the cadence (`@daily`, cron expressions, or event triggers). **Backfills** replay historical intervals — essential when you fix a transformation bug and must rebuild three months of feature tables without manual one-off scripts. Safe backfills require **idempotent** tasks: re-running the same date partition overwrites or upserts deterministically instead of duplicating rows.
+
+Data dependencies also cross team boundaries. Your training pipeline may depend on a finance team's ledger export and a product team's event stream. Document those edges in lineage metadata and alert upstream owners when your SLA misses — otherwise ML becomes the last team to discover a silent upstream failure.
+
+### Backfills: Replaying History Safely
+
+**Hypothetical scenario:** A data engineer discovers that a window function in the daily feature job used the wrong partition column for three weeks. Training and serving both consumed the bad feature, but offline metrics looked stable because the bug was consistent — not random noise. Fixing the SQL is easy; rebuilding trust requires reprocessing every affected date partition and proving downstream models retrained on the corrected tables. Stakeholders will ask whether predictions issued during the bad window must be re-scored; lineage and partition metadata are how you scope that answer without reprocessing the entire history of the business.
+
+Backfills are how you replay orchestrated pipelines across historical intervals. The orchestrator schedules the same DAG once per date (or hour) in a range, writing into deterministic partition paths such as `s3://features/ds=2026-05-01/`. Idempotency is non-negotiable: each replay must replace that partition entirely or upsert on a primary key so retries and overlaps do not duplicate rows. Coordinate with consumers — freeze training jobs, bump feature-store materialization versions, or mark partitions as `staging` until validation passes — so models do not blend old and new statistics in the same batch.
+
+Operational teams often maintain a backfill playbook: identify blast radius with lineage, run Great Expectations on a canary partition, replay in ascending date order to simplify dependency checks, and attach the rebuilt dataset hash to experiment metadata before promoting models. That playbook turns a scary "recompute three weeks" request into a routine pipeline operation rather than a weekend of manual CSV juggling. Document the playbook beside the DAG so on-call engineers inherit the sequence instead of reinventing it during an incident. Treat backfill drills as routine capacity tests, not emergency-only procedures, so the team practices partition replays before production pressure hits.
+
+### Feature Pipelines Inside the Data Layer
+
+Feature pipelines are specialized data pipelines that compute, validate, and publish features for both offline training and online serving. They sit between raw ingestion and model training, often feeding a feature store. The failure mode you are preventing is training-serving skew: training reads batch-computed features while serving recomputes with slightly different code or timestamps.
+
+A mature feature pipeline version-controls transformation code (Git), version-controls outputs (DVC or warehouse time travel), validates with Great Expectations checkpoints, and registers definitions in a feature store so serving pulls the same logic. Orchestration ties the stages together so materialization runs after upstream facts land and before training DAGs start.
+
+> **Landscape snapshot — as of 2026-06. Verify against vendor docs before relying on specifics.**
+>
+> | Capability | Apache Airflow | Dagster | Prefect |
+> |------------|----------------|---------|---------|
+> | Primary abstraction | Task-based DAG | Software-defined assets | Python `@flow` / `@task` |
+> | Typical metadata store | Airflow metastore (often PostgreSQL) | Dagster instance storage | Prefect server / cloud API |
+> | Common ML use | Batch ingestion, sensors, cron retraining triggers | Data-aware pipelines with typed assets | Dynamic Python-native flows with hybrid execution |
+> | Docs entry point | [airflow.apache.org](https://airflow.apache.org/docs/apache-airflow/stable/) | [docs.dagster.io](https://docs.dagster.io/) | [docs.prefect.io](https://docs.prefect.io/) |
+
+---
+
+## Theory
 
 ### The Data Management Problem
 
@@ -73,7 +110,7 @@ The data management problem has three layers, each more insidious than the last:
 
 **Layer 2: Feature Inconsistency.** Different teams compute the same features differently. Your data science team calculates "user_age" one way in Python. Your backend team calculates it another way in SQL. Your mobile team calculates it a third way in Swift. Same concept, three implementations, three bugs waiting to happen.
 
-**Layer 3: Silent Quality Degradation.** Data drifts silently. Your training data had 2% missing values. New production data has 15% missing. Your model doesn't fail—it just makes increasingly worse predictions. By the time someone notices, the damage is done.
+**Layer 3: Silent Quality Degradation.** **Hypothetical scenario:** Data drifts silently. Suppose your training snapshot had roughly 2% missing values, but new production batches arrive with roughly 15% missing — your model doesn't fail; it just makes increasingly worse predictions. By the time someone notices, the damage is done.
 
 Think of data versioning like a time machine for your datasets. Git lets you travel back in time through your code history. DVC lets you do the same with your data. You can answer questions like "What dataset did model v2.3 use?" and "What changed between training runs?" Instead of guessing, you can know.
 
@@ -105,19 +142,12 @@ With DVC:
     - commit ghi789: "Initial train data v3.0 (40K samples)"
 ```
 
-### Did You Know? The 85% Failure Rate
+### Did You Know? Why Data Quality Decides Production Success
 
 Data quality and data management problems are a common reason ML systems fail to deliver in production, which is one reason data-centric approaches gained traction.
 
 The Data-Centric AI movement represents a philosophical shift in how we think about ML. For years, the ML community focused on model architecture—new layers, new attention mechanisms, new training techniques. Kaggle competitions rewarded clever model ensembles. Research papers emphasized architectural innovations.
 
-Andrew Ng challenged this orthodoxy. In his now-famous "Landing AI" presentation, he showed that systematic data improvement often beats sophisticated modeling. A company using a simple model on carefully curated data consistently outperformed competitors using state-of-the-art architectures on messy data.
-
-The key insight: models are commoditizing, but data remains differentiating. Anyone can download the same open-source model. Not everyone has clean, well-versioned, high-quality data. The competitive advantage has shifted from "who has the best model" to "who has the best data."
-
-Andrew Ng put it bluntly in a 2021 keynote:
-
-> "In AI, data is food. You can have the most sophisticated kitchen in the world, but if your ingredients are rotten, your meal will be terrible. We've been obsessing over the kitchen while ignoring the pantry."
 
 ---
 
@@ -125,7 +155,7 @@ Andrew Ng put it bluntly in a 2021 keynote:
 
 ### What is DVC?
 
-[DVC (Data Version Control) is Git for data and ML models](https://github.com/iterative/dvc). Think of it like a librarian for your datasets—it keeps track of every version, knows where everything is stored, and can retrieve any historical version on demand.
+[DVC (Data Version Control) is Git for data and ML models](https://dvc.org/doc). Think of it like a librarian for your datasets—it keeps track of every version, knows where everything is stored, and can retrieve any historical version on demand.
 
 To understand why DVC matters, imagine trying to manage a library without a catalog system. Every book is somewhere on the shelves, but nobody knows where. Readers wander the stacks hoping to stumble across what they need. When someone asks "do we have the 1985 edition of this textbook?" the librarian can only shrug.
 
@@ -133,7 +163,7 @@ That's what data management looks like without DVC. Datasets exist somewhere on 
 
 DVC creates that missing catalog. Every dataset gets a unique identifier. Every version is tracked. Every change is logged. When someone asks "what data trained model v2.3?" the answer is one command away.
 
-The core insight is elegant: Git is terrible at tracking large files, but great at tracking small text files. So [DVC creates small "pointer" files (`.dvc` files) that Git tracks, while the actual data lives in external storage (S3, GCS, Azure, or local disk)](https://github.com/iterative/dvc). It's like keeping a library card catalog in Git while the actual books sit on warehouse shelves.
+The core insight is elegant: Git is terrible at tracking large files, but great at tracking small text files. So [DVC creates small "pointer" files (`.dvc` files) that Git tracks, while the actual data lives in external storage (S3, GCS, Azure, or local disk)](https://dvc.org/doc/user-guide/data-management/remote-storage). It's like keeping a library card catalog in Git while the actual books sit on warehouse shelves.
 
 ```
 DVC ARCHITECTURE
@@ -163,9 +193,9 @@ DVC ARCHITECTURE
 
 The DVC workflow mirrors Git closely enough that much of it will feel familiar if you already know Git. This wasn't accidental—Dmitry Petrov deliberately designed DVC to feel familiar. When you've been using Git for a decade, the last thing you want is to learn a completely new paradigm for data.
 
-The mental model is simple: DVC handles big files the same way Git handles small files. `git add` becomes `dvc add`. `git push` becomes `dvc push`. `git pull` becomes `dvc pull`. The commands feel natural because they are natural—just extended to work with data.
+The mental model is simple: DVC handles big files the same way Git handles small files. `git add` becomes `dvc add`. `git push` becomes `dvc push`. `git pull` becomes `dvc pull`. The commands feel natural because they extend a workflow you already know — just applied to datasets and model artifacts that Git was never designed to store inline.
 
-The key commands map directly:
+The key commands map directly to that mental model:
 
 ```bash
 # Initialize DVC in a Git repo
@@ -201,7 +231,7 @@ outs:
     path: train.csv
 ```
 
-This file is like a receipt. It says "the file `train.csv` has this specific hash and this size." When you `dvc pull`, DVC uses this receipt to fetch the exact right version from storage.
+This file is like a receipt. It says "the file `train.csv` has this specific hash and this size." When you `dvc pull`, DVC uses this receipt to fetch the exact right version from storage, which is why reproducing a teammate's environment reduces to matching Git commits and running one pull command.
 
 ### DVC Pipelines: Reproducibility Built In
 
@@ -251,7 +281,7 @@ stages:
           cache: false
 ```
 
-[DVC automatically builds a dependency graph and only re-runs stages when their inputs change](https://github.com/iterative/dvc). Changed the preprocessing script? Only preprocessing and downstream stages re-run. Changed a hyperparameter? Only training and evaluation re-run. It's incremental builds for ML.
+[DVC automatically builds a dependency graph and only re-runs stages when their inputs change](https://dvc.org/doc/user-guide/pipelines). Changed the preprocessing script? Only preprocessing and downstream stages re-run. Changed a hyperparameter? Only training and evaluation re-run. It's incremental builds for ML.
 
 ```
 DVC PIPELINE DAG
@@ -290,22 +320,15 @@ DVC PIPELINE DAG
 
 ### Did You Know? The Origin of DVC
 
-DVC was created by **Dmitry Petrov**, a former Microsoft data scientist, in 2017. The name is a play on "CSV" (Comma-Separated Values), which is ironic since DVC handles any file type. Dmitry founded **Iterative.ai**, the company behind DVC, which raised $20M in funding.
+DVC was created by Dmitry Petrov in 2017 and is maintained by Iterative.ai with a large open-source community. The name plays on CSV even though DVC handles any file type — a reminder that the project began with everyday tabular datasets before expanding to pipelines, metrics, and model artifacts.
 
-The project started from Dmitry's frustration at Microsoft:
+The success of DVC highlights an important lesson: ML tools succeed when they meet practitioners where they are. DVC did not ask data scientists to learn a completely new paradigm. It built on Git, which most developers already know. The learning curve is gentle because the concepts are familiar — just applied to a new domain.
 
-> "I kept seeing the same pattern. Teams would build amazing models, then spend weeks trying to reproduce them because nobody knew which data version they'd used. Git solved this for code 20 years ago. Why were we still living in the dark ages for data?"
-> — Dmitry Petrov, DVC creator
-
-DVC has a large open-source community.
-
-The success of DVC highlights an important lesson: ML tools succeed when they meet practitioners where they are. DVC didn't ask data scientists to learn a completely new paradigm. It built on Git, which most developers already know. The learning curve is gentle because the concepts are familiar—just applied to a new domain.
-
-This is why DVC won against more ambitious alternatives like Pachyderm (which required Kubernetes and a complete infrastructure overhaul). DVC is a scalpel where others offered chainsaws. You can add it to an existing project in five minutes and see immediate benefits. That simplicity drove adoption, and adoption drove community, and community drove features.
+This tradeoff explains why many teams adopt DVC before heavier platforms such as Pachyderm, which targets Kubernetes-native data versioning and typically demands more infrastructure upfront. DVC is a scalpel where others offered chainsaws. You can add it to an existing project in five minutes and see immediate benefits. That low-friction onboarding drove community adoption, which in turn expanded the feature set.
 
 ### DVC Experiments
 
-DVC also tracks experiments, letting you run multiple training configurations and compare results:
+Experiment tracking is where DVC overlaps with dedicated tools like MLflow, but stays tightly coupled to your data and pipeline hashes. You can run multiple training configurations, compare metrics side by side, and promote the winning run to a branch without maintaining a separate spreadsheet of hyperparameters:
 
 ```bash
 # Run experiment with parameter changes
@@ -332,16 +355,10 @@ This is like git branches for hyperparameters. You can try dozens of configurati
 
 Feature engineering is where data science meets software engineering—and usually crashes. The problem isn't computing features; it's managing them across teams, environments, and time.
 
-Here's a scenario that happens at virtually every company using ML. Your recommendation team builds a user embeddings feature. It works great. Your fraud team hears about it and wants to use it too. But they can't just import it—they're using different languages, different databases, different deployment infrastructure. So they reimplement it. Three months later, a third team reimplements it again.
-
-Now you have three implementations of the "same" feature:
-- Team A: Python, computes on-demand, uses birthdate field
-- Team B: SQL, batch computed nightly, uses signup_year minus birth_year
-- Team C: Java, cached in Redis, uses age_bucket categories
+**Hypothetical scenario:** Your recommendation team builds a user embeddings feature. It works well in offline tests. Your fraud team hears about it and wants the same signal, but they cannot import the code directly — different language, database, and deployment stack — so they reimplement it. Three months later, a third team reimplements it again. You now have three implementations of the same conceptual feature: Team A computes on-demand in Python from birthdate; Team B computes nightly in SQL from signup year minus birth year; Team C serves cached age buckets from Redis in Java.
 
 Same concept. Three implementations. Three sources of bugs. When Team A discovers an edge case and fixes it, Teams B and C continue using buggy versions. When the underlying data schema changes, each team scrambles independently to fix their code.
 
-This is feature engineering chaos, and it's shockingly common. A 2020 Tecton survey found that **87% of ML practitioners had experienced feature engineering bugs** in production. Feature stores exist to solve this problem.
 
 Think of it like a restaurant kitchen without recipes. Every chef makes their own version of "garlic sauce"—some add cream, some don't, some roast the garlic first. Customers get inconsistent dishes, and when a chef leaves, their recipes leave with them.
 
@@ -380,21 +397,7 @@ The most insidious problem in production ML is **training-serving skew**. Your m
 
 It's like training a translator on formal English, then deploying them in a room full of teenagers using slang. The "language" is different enough that the skills don't transfer.
 
-Here's a concrete example of how this happens. Your training pipeline computes "days_since_last_purchase" using this logic:
-
-```python
-# Training: Spark job running on historical data
-days_since = (snapshot_date - last_purchase_date).days
-```
-
-Your serving pipeline computes it using this logic:
-
-```python
-# Serving: Python running in real-time
-days_since = (datetime.now() - last_purchase_date).days
-```
-
-Spot the difference? Training uses `snapshot_date` (the date when the training data was created). Serving uses `datetime.now()` (the current moment). If your training data is two weeks old, every serving prediction has a 14-day bias. Your model learned that "20 days since last purchase" means one thing. In production, it means something different.
+Here's a concrete example of how training-serving skew appears in practice. Your training pipeline computes `days_since_last_purchase` in a Spark job using a fixed snapshot date baked into the historical extract, while your serving pipeline computes the same feature name in Python with `datetime.now()` at request time. If training data was materialized two weeks ago, every live prediction carries a systematic offset the model never saw during training — the feature name matches, but the semantics drift.
 
 This bug doesn't crash your system. It doesn't throw exceptions. It just makes your model subtly wrong—and wrong in a way that's almost impossible to debug without understanding the training-serving gap.
 
@@ -434,30 +437,24 @@ FEAST ARCHITECTURE
 └─────────────────────────────────────────────────────────────────────┘
 ```
 
-The architecture has two key components:
-- **Offline Store**: For historical data and training. Think "data warehouse for features."
-- **Online Store**: For low-latency serving. Think "Redis with ML superpowers."
+The architecture deliberately separates concerns so each store can optimize for its access pattern without forcing one database to do everything poorly:
+
+- **Offline Store**: For historical data and training — a warehouse or lakehouse optimized for scans and joins.
+- **Online Store**: For low-latency serving — often Redis, DynamoDB, or Postgres tuned for key lookups.
+
+Let's walk through a complete feature definition example that shows how entities, sources, and TTL interact. Feast uses Python for definitions — the lingua franca of most data science teams — so feature views live in version-controlled code beside training scripts rather than in a proprietary UI-only format:
 
 ### Feast Feature Definitions
-
-Feast uses Python to define features—like schemas for your ML data. This is a deliberate design choice: Python is the lingua franca of data science, so feature definitions live in Python rather than YAML or a proprietary format.
-
-The mental model is similar to database schemas. Just as a database schema defines what columns a table has and what types they contain, a Feast feature view defines what features exist and how to compute them. The difference is that Feast adds ML-specific concepts: entities (what you're predicting about), timestamps (for point-in-time correctness), and TTL (how long features remain valid).
-
-Let's walk through a complete example:
 
 ```python
 # feature_repo/features.py
 from datetime import timedelta
-from feast import Entity, Feature, FeatureView, FileSource, ValueType
+from feast import Entity, FeatureView, Field, FileSource
+from feast.types import Float32, Int64, String
 
 # Define entity (the thing we're making predictions about)
 # Like a primary key in a database
-user = Entity(
-    name="user_id",
-    value_type=ValueType.INT64,
-    description="User identifier"
-)
+user = Entity(name="user", join_keys=["user_id"])
 
 # Define data source (where features come from)
 user_features_source = FileSource(
@@ -470,17 +467,17 @@ user_features_source = FileSource(
 # Like a table in a database
 user_features = FeatureView(
     name="user_features",
-    entities=["user_id"],
+    entities=[user],
     ttl=timedelta(days=365),  # How long features are valid
-    features=[
-        Feature(name="age", dtype=ValueType.INT64),
-        Feature(name="total_purchases", dtype=ValueType.INT64),
-        Feature(name="avg_order_value", dtype=ValueType.FLOAT),
-        Feature(name="days_since_last_purchase", dtype=ValueType.INT64),
-        Feature(name="favorite_category", dtype=ValueType.STRING),
+    schema=[
+        Field(name="age", dtype=Int64),
+        Field(name="total_purchases", dtype=Int64),
+        Field(name="avg_order_value", dtype=Float32),
+        Field(name="days_since_last_purchase", dtype=Int64),
+        Field(name="favorite_category", dtype=String),
     ],
     online=True,  # Available for real-time serving
-    source=user_features_source
+    source=user_features_source,
 )
 ```
 
@@ -527,29 +524,20 @@ online_features = store.get_online_features(
 
 ### Did You Know? The Origin of Feature Stores
 
-Feature stores emerged from **Uber's Michelangelo platform** in 2017. Large ML organizations repeatedly report feature-engineering inconsistencies, training-serving skew, and stale features as major sources of production issues.
-
-Their solution, Michelangelo's feature store, became the template for an industry. **Willem Pienaar**, who worked on Michelangelo, later created Feast at Gojek and donated it to the Linux Foundation AI & Data.
-
-Today, every major cloud provider has their own feature store:
-- AWS SageMaker Feature Store
-- GCP Vertex AI Feature Store
-- Azure Machine Learning Feature Store
-
-The open-source Feast remains the most flexible option, supporting multiple backends and deployment patterns.
+Feature stores emerged from Uber's Michelangelo platform in 2017, where feature inconsistency and training-serving skew showed up repeatedly at scale. Willem Pienaar, who worked on Michelangelo, later created Feast at Gojek and contributed it to the Linux Foundation AI & Data. Hyperscale vendors also offer managed feature-store products (for example [Amazon SageMaker Feature Store](https://docs.aws.amazon.com/sagemaker/latest/dg/feature-store.html), [Vertex AI Feature Store](https://cloud.google.com/vertex-ai/docs/featurestore), and [Azure Machine Learning managed features](https://learn.microsoft.com/en-us/azure/machine-learning/concept-asset-management)) alongside open-source options such as Feast, which supports multiple offline and online backends when you need hybrid deployment patterns.
 
 ---
 
 ## 3. Data Validation with Great Expectations
 
-### Why This Module Matters
+### Why Data Validation Belongs in the Pipeline
 
 Data validation is like quality control in manufacturing. You wouldn't ship products without inspection, so why train models on uninspected data?
 
 The problem is that data fails silently. Your pipeline runs successfully, your model trains successfully, your deployment succeeds—and then your model makes terrible predictions because the input data was garbage.
 
-Consider a real scenario. Your e-commerce model predicts customer churn. It's trained on customer data: age, purchase history, days since last login, etc. One day, your upstream data team changes the age calculation. Instead of computing age from birthdate, they now use a self-reported age field. This field has:
-- Missing values for 20% of users (who didn't fill it out)
+**Hypothetical scenario:** Your e-commerce model predicts customer churn. It's trained on customer data: age, purchase history, days since last login, and so on. One day, your upstream data team changes the age calculation. Instead of computing age from birthdate, they now use a self-reported age field. That field might have:
+- Missing values for a sizable share of users who skipped the optional field
 - Outliers like "999" (from users trying to skip the field)
 - String values like "twenty-five" (from users who didn't follow instructions)
 
@@ -561,9 +549,9 @@ Data validation prevents this. You define what "good data" looks like upfront. B
 DATA QUALITY ISSUES
 ===================
 
-Common Problems:
-────────────────
-• Missing values increased from 1% to 15%
+Common Problems (illustrative examples):
+──────────────────────────────────────
+• Missing values increased sharply (for example, from a low single-digit rate to a much higher one)
 • Categorical column has new unexpected values
 • Numerical column has outliers (negative ages)
 • Data distribution shifted (concept drift)
@@ -615,112 +603,118 @@ GREAT EXPECTATIONS ARCHITECTURE
 
 ### Common Expectations
 
-Great Expectations provides many built-in expectations—pre-built validation rules you can apply to your data. The name "expectations" is intentional: these are assertions about what your data should look like. Think of them as unit tests for data.
+Great Expectations provides many built-in expectations — pre-built validation rules you can apply without writing custom assertion code for every column. Instead of hand-rolling Python checks for "does this column exist?" you call `expect_column_to_exist("user_id")`; instead of bespoke range logic you call `expect_column_values_to_be_between("age", 0, 120)`. The API reads like documentation of your data contract, which makes suites reviewable by stakeholders who do not read pipeline code.
 
-The genius of Great Expectations is its expressiveness. Instead of writing custom Python code to check "does this column exist?" you call `expect_column_to_exist("user_id")`. Instead of writing validation logic for "are all values between 0 and 100?", you call `expect_column_values_to_be_between("age", 0, 100)`. The code reads like English documentation of your data contract.
-
-Here are the essential expectations every data scientist should know:
+Here are the essential expectations every data scientist should know when bootstrapping a training-table suite:
 
 ```python
 import great_expectations as gx
+import great_expectations.expectations as gxe
 
-# Create context and validator
 context = gx.get_context()
-validator = context.get_validator(...)
 
-# Column existence - does the data have the columns we expect?
-validator.expect_column_to_exist("user_id")
-validator.expect_column_to_exist("age")
-validator.expect_column_to_exist("email")
-
-# Data types - are values the right type?
-validator.expect_column_values_to_be_of_type("user_id", "int64")
-validator.expect_column_values_to_be_of_type("age", "int64")
-validator.expect_column_values_to_be_of_type("email", "str")
-
-# Null checks - are required fields populated?
-validator.expect_column_values_to_not_be_null("user_id")
-validator.expect_column_values_to_not_be_null("email")
-
-# Value ranges - are values within reasonable bounds?
-validator.expect_column_values_to_be_between("age", min_value=0, max_value=120)
-validator.expect_column_values_to_be_between("purchase_amount", min_value=0)
-
-# Uniqueness - are IDs actually unique?
-validator.expect_column_values_to_be_unique("user_id")
-validator.expect_column_values_to_be_unique("email")
-
-# Patterns - do strings match expected formats?
-validator.expect_column_values_to_match_regex(
-    "email",
-    r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$"
+# GX 1.x: register a batch definition, then attach expectations to a suite
+batch_definition = (
+    context.data_sources.add_pandas(name="my_datasource")
+    .add_dataframe_asset(name="user_data")
+    .add_batch_definition_whole_dataframe(name="user_data_batch")
 )
 
-# Categorical values - are categories from expected set?
-validator.expect_column_values_to_be_in_set(
-    "country",
-    ["US", "UK", "CA", "DE", "FR"]
+suite = context.suites.add(gx.ExpectationSuite(name="user_data_suite"))
+
+# Column existence — does the data have the columns we expect?
+suite.add_expectation(gxe.ExpectColumnToExist(column="user_id"))
+suite.add_expectation(gxe.ExpectColumnToExist(column="age"))
+suite.add_expectation(gxe.ExpectColumnToExist(column="email"))
+
+# Data types — are values the right type?
+suite.add_expectation(gxe.ExpectColumnValuesToBeOfType(column="user_id", type_="int64"))
+suite.add_expectation(gxe.ExpectColumnValuesToBeOfType(column="age", type_="int64"))
+suite.add_expectation(gxe.ExpectColumnValuesToBeOfType(column="email", type_="str"))
+
+# Null checks — are required fields populated?
+suite.add_expectation(gxe.ExpectColumnValuesToNotBeNull(column="user_id"))
+suite.add_expectation(gxe.ExpectColumnValuesToNotBeNull(column="email"))
+
+# Value ranges — are values within reasonable bounds?
+suite.add_expectation(gxe.ExpectColumnValuesToBeBetween(column="age", min_value=0, max_value=120))
+suite.add_expectation(gxe.ExpectColumnValuesToBeBetween(column="purchase_amount", min_value=0))
+
+# Uniqueness — are IDs actually unique?
+suite.add_expectation(gxe.ExpectColumnValuesToBeUnique(column="user_id"))
+suite.add_expectation(gxe.ExpectColumnValuesToBeUnique(column="email"))
+
+# Patterns — do strings match expected formats?
+suite.add_expectation(
+    gxe.ExpectColumnValuesToMatchRegex(
+        column="email",
+        regex=r"^[a-zA-Z0-9_.+-]+@[a-zA-Z0-9-]+\.[a-zA-Z0-9-.]+$",
+    )
 )
 
-# Distribution checks - has the data distribution shifted?
-validator.expect_column_mean_to_be_between("age", min_value=25, max_value=45)
-validator.expect_column_stdev_to_be_between("purchase_amount", min_value=10, max_value=100)
+# Categorical values — are categories from expected set?
+suite.add_expectation(
+    gxe.ExpectColumnValuesToBeInSet(column="country", value_set=["US", "UK", "CA", "DE", "FR"])
+)
 
-# Row count - do we have expected data volume?
-validator.expect_table_row_count_to_be_between(min_value=1000, max_value=1000000)
+# Distribution checks — has the data distribution shifted?
+suite.add_expectation(gxe.ExpectColumnMeanToBeBetween(column="age", min_value=25, max_value=45))
+suite.add_expectation(
+    gxe.ExpectColumnStdevToBeBetween(column="purchase_amount", min_value=10, max_value=100)
+)
 
-# Column count - has the schema changed?
-validator.expect_table_column_count_to_equal(15)
+# Row count — do we have expected data volume?
+suite.add_expectation(gxe.ExpectTableRowCountToBeBetween(min_value=1000, max_value=1000000))
+
+# Column count — has the schema changed?
+suite.add_expectation(gxe.ExpectTableColumnCountToEqual(value=15))
 ```
 
 ### Automated Validation in Pipelines
 
-The real power of Great Expectations emerges when you embed it in your pipelines. Instead of manually running validation, [you configure "checkpoints" that run automatically before critical operations](https://github.com/great-expectations/great_expectations_action)—before training, before deployment, before any step that assumes data quality.
+The real power of Great Expectations emerges when you embed checkpoints in orchestrated pipelines rather than running validation manually before each train. Configure a named checkpoint once, then invoke it after ingestion, after transformation, and immediately before model training so bad batches fail fast:
 
-This is the difference between reactive and proactive data quality. Reactive means discovering bad data after it's caused problems. Proactive means catching bad data before it enters your pipeline. The latter is usually cheaper.
-
-Here's how to set up automated validation:
+Here is a minimal pattern for wiring that gate:
 
 ```python
-# Create checkpoint for automated validation
-checkpoint = context.add_checkpoint(
-    name="user_data_checkpoint",
-    validations=[
-        {
-            "batch_request": {
-                "datasource_name": "my_datasource",
-                "data_asset_name": "user_data",
-            },
-            "expectation_suite_name": "user_data_suite",
-        }
-    ]
+from great_expectations import Checkpoint, ValidationDefinition
+
+# GX 1.x: link batch definition + suite, then group in a checkpoint
+validation_definition = context.validation_definitions.add(
+    ValidationDefinition(
+        name="user_data_validation",
+        data=batch_definition,
+        suite=suite,
+    )
 )
 
-# Run checkpoint (e.g., in CI/CD or before training)
-results = checkpoint.run()
+checkpoint = context.checkpoints.add(
+    Checkpoint(
+        name="user_data_checkpoint",
+        validation_definitions=[validation_definition],
+    )
+)
+
+# Run checkpoint against the ingestion DataFrame (in-memory batches pass data at run time)
+result = checkpoint.run(batch_parameters={"dataframe": df})
 
 # Check if validation passed
-if not results.success:
-    print(" Data validation failed!")
-    for result in results.run_results.values():
-        for validation_result in result.validation_result.results:
-            if not validation_result.success:
-                print(f"   {validation_result.expectation_config.expectation_type}")
+if not result.success:
+    print("Data validation failed!")
+    for validation_result in result.results:
+        # validation_result is an ExpectationSuiteValidationResult
+        for exp_result in validation_result.results:
+            if not exp_result.success:
+                print(f"  - {exp_result.expectation_config.type}")
     raise ValueError("Cannot proceed with invalid data")
 else:
-    print(" Data validation passed!")
+    print("Data validation passed!")
 ```
 
 ### Did You Know? The Great Expectations Origin
 
-Great Expectations was created by **Abe Gong** and **James Campbell** in 2017 at Superconductive, a data reliability startup. The name comes from the Charles Dickens novel, symbolizing the "expectations" we have for our data—and the drama when those expectations are violated.
 
-The founders had a memorable pitch:
-
-> "We realized that data teams spent 80% of their time on data quality issues, but had zero tools to catch problems before they became disasters. It's like doing surgery without X-rays—you don't see the problem until you're already cutting."
-> — Abe Gong, Great Expectations co-founder
-
-The project has a large open-source community. It's become the de facto standard for data validation in ML pipelines.
+The project has a large open-source community and is widely used for data validation in ML pipelines — see the [Great Expectations documentation](https://docs.greatexpectations.io/docs/) for current integration patterns.
 
 ---
 
@@ -732,13 +726,15 @@ Data lineage tracks where data comes from and where it goes—like a family tree
 
 Think of it like supply chain tracking. When a product is recalled, manufacturers can trace every component back to its source. Data lineage provides the same capability for ML: when a model fails, you can trace exactly which data, transformations, and code were involved.
 
-Here's why lineage matters in practice. Your fraud detection model suddenly starts flagging 50% more legitimate transactions as fraudulent. Users are angry. Revenue is dropping. You need to figure out what changed.
+**Hypothetical scenario:** Your fraud detection model suddenly starts flagging noticeably more legitimate transactions as fraudulent. Users are angry. Revenue is dropping. You need to figure out what changed.
 
 Without lineage, you're blind. Did the model change? Did the features change? Did the training data change? Did some upstream ETL job modify the data schema? You have no way to know without manually checking dozens of systems.
 
 With lineage, you can trace the problem systematically. You look at the model's lineage and see it was retrained yesterday. The lineage shows it used features from the `fraud_features_v3` table. You trace `fraud_features_v3` and find it depends on a transformation that was updated two days ago. You examine that transformation and find a bug—someone changed a timezone calculation that shifted all timestamps by 8 hours. Bug found in minutes, not days.
 
-Lineage isn't just about debugging—it's about confidence. When a regulator asks "what data was used to make this decision about this customer?" you can answer precisely. When GDPR requires you to trace a user's data through your system, you have a map. When an audit asks about model decisions, you have receipts.
+Lineage isn't just about debugging — it's about confidence. When a regulator asks "what data was used to make this decision about this customer?" you can answer precisely. When GDPR requires you to trace a user's data through your system, you have a map. When an audit asks about model decisions, you have receipts.
+
+In practice, lineage collectors hook into orchestrators and transformation frameworks to emit OpenLineage events: which job ran, which input datasets it read, which output datasets it wrote, and which Git commit or container image defined the logic. Catalogs such as DataHub ingest those events into a searchable graph. The ML-specific win is connecting that graph to experiment tracking — so model `v2.3.1` links not only to metrics but to exact feature table snapshots and validation results.
 
 ```
 DATA LINEAGE
@@ -767,11 +763,7 @@ Questions Lineage Answers:
 
 ### Data Governance Best Practices
 
-Governance is the set of policies and practices that ensure data is managed responsibly. It's like corporate governance for data—defining who can access what, how changes are tracked, and how compliance is maintained.
-
-In traditional software, governance often means "red tape that slows us down." In ML, governance means "guardrails that prevent expensive disasters." The difference is that ML failures are often invisible, gradual, and expensive. A governance failure in traditional software usually causes an obvious crash. A governance failure in ML causes models to slowly drift into wrongness.
-
-Effective data governance answers six key questions:
+Governance is the set of policies and practices that ensure data is managed responsibly — who may read it, how changes are audited, and how incidents escalate. In traditional software, governance is often treated as bureaucracy; in ML it is how you prevent invisible degradation. Effective data governance answers six recurring questions that auditors, regulators, and on-call engineers all ask eventually:
 
 **1. Where did this data come from?** (Provenance)
 Every dataset should have a birth certificate. Where was it collected? Who processed it? What transformations were applied? This matters when you discover a bug—you need to trace it back to the source.
@@ -780,7 +772,7 @@ Every dataset should have a birth certificate. Where was it collected? Who proce
 Not all data should be available to all teams. PII requires special handling. Financial data has compliance requirements. Healthcare data has HIPAA restrictions. Governance defines who can see what.
 
 **3. How is this data being used?** (Usage Tracking)
-Knowing that 47 models depend on a particular table changes how carefully you modify it. Usage tracking reveals these dependencies before you accidentally break downstream consumers.
+When many downstream models and dashboards depend on a particular table, even a small schema change can break consumers you did not know existed. Usage tracking and lineage metadata reveal those dependencies before you modify or deprecate a dataset.
 
 **4. How long should we keep this data?** (Retention)
 Data storage isn't free. More importantly, old data creates liability. GDPR's "right to be forgotten" means you must be able to delete user data on request. Retention policies define when data should be archived or deleted.
@@ -835,7 +827,7 @@ Here's the key insight: **you don't need all these tools, and you definitely don
 
 ### When to Use What
 
-Different tools solve different problems. Here's a decision matrix:
+Different tools solve different problems along the data lifecycle, and the decision matrix below is a durable map — not a shopping list. Use it to match pain points to capabilities before adopting another component you must operate:
 
 ```
 TOOL SELECTION MATRIX
@@ -868,7 +860,7 @@ TOOL SELECTION MATRIX
 
 ### Complexity vs Value
 
-Start simple and add complexity as needed:
+Start simple and add complexity when a specific failure mode appears — the complexity/value curve is not linear, and most incidents trace to missing basics rather than missing exotic tooling:
 
 ```
 TOOL COMPLEXITY VS VALUE
@@ -895,40 +887,92 @@ Low  └────────────────────────
 
 ### The 80/20 Rule of Data Management
 
-For most teams, especially those early in their ML journey, here's the pragmatic approach:
+Most teams early in their ML journey get disproportionate value from a small set of practices before they need a full enterprise platform. **Start with DVC and Git** so every dataset and model artifact has a content hash you can tie to training runs — that alone eliminates a large class of "which CSV was it?" incidents, lets you share data through remotes instead of USB drives, and makes rollbacks a checkout rather than a panic. **Add Great Expectations** once data quality issues have cost you real time: unexpected nulls after an upstream schema change, silent drift in categorical distributions, or days lost debugging a model that trained successfully on garbage rows. **Add Feast** when feature consistency becomes organizational: two teams compute the same feature differently, training-serving skew shows up in production metrics, or inference requires sub-second feature lookups you cannot recompute on the fly. **Invest in a full data platform** when self-service feature access, compliance-driven lineage, and cross-team SLAs justify the operational overhead of cataloging, access control, and dedicated data engineering.
 
-**Start with DVC + Git.** This solves 80% of data management pain:
-- You can track datasets and models
-- You can reproduce experiments
-- You can share data across your team
-- You can roll back to previous versions
-
-**Add Great Expectations when...** you've been burned by data quality issues:
-- A model failed because of unexpected nulls
-- A schema change broke your pipeline
-- You spent days debugging a data drift issue
-
-**Add Feast when...** multiple teams share features OR you're building real-time ML:
-- Two teams computed the same feature differently
-- Training-serving skew caused production issues
-- You need sub-second feature lookups for inference
-
-**Add a full data platform when...** you have 50+ data scientists and need enterprise features:
-- Multiple teams need self-service access to features
-- Compliance requirements mandate comprehensive lineage
-- Cost of data quality issues justifies the investment
-
-Don't let tool FOMO drive your decisions. Every tool you add is a tool you need to maintain, monitor, and train people on. Start simple and add complexity only when it solves real problems.
+Do not let tool FOMO drive the roadmap. Every component you adopt is a component you must upgrade, monitor, and teach. Add complexity when a concrete incident or SLA gap proves you need it — not because a vendor slide says your stack is incomplete.
 
 ---
 
-##  Hands-On Exercises
+## Common Mistakes
+
+| Mistake | Problem | Solution |
+|---------|---------|----------|
+| Treating shared-drive CSV folders as "version control" | Nobody can reproduce which file trained which model; validation and production diverge silently | Track datasets with DVC (or equivalent) and reference `.dvc` hashes in training configs and pipeline parameters |
+| Running transforms differently in batch training versus online serving | Training-serving skew degrades accuracy without obvious errors | Centralize feature definitions in a feature store and orchestrate one materialization path for offline and online stores |
+| Skipping validation before expensive training jobs | Bad upstream data wastes GPU hours and can promote corrupt models | Embed Great Expectations checkpoints as hard gates in orchestrated pipelines; fail fast when expectations break |
+| Non-idempotent pipeline tasks combined with automatic retries | Retries duplicate rows, double-charge aggregations, or corrupt partitions | Design tasks to upsert or replace partitions by run date; make backfills safe to re-run |
+| Hard-coded absolute paths and schedules in scripts | Pipelines break when environments change or upstream data arrives late | Parameterize paths and dates; use orchestrator sensors or asset checks for upstream readiness |
+| Passing large DataFrames through orchestrator metadata (e.g., Airflow XCom) | Workers and metadata databases exhaust memory serializing multi-gigabyte objects | Write artifacts to object storage; pass URIs and schema hashes between tasks |
+| Ignoring lineage until production incidents | Debugging takes days because teams cannot trace which transform or dataset version changed | Adopt OpenLineage or catalog tools; record dataset versions in experiment and model metadata |
+| Backfilling without isolating downstream consumers | Rebuilt tables change statistics mid-flight while models still read old snapshots | Coordinate backfills with partition markers, feature store TTLs, and training schedule blackouts |
+
+---
+
+## Knowledge Check
+
+<details>
+<summary>1. What problem does DVC solve that Git alone cannot handle well for ML datasets?</summary>
+
+**Answer:** Git stores full file blobs in history, which becomes impractical for large binary datasets and model artifacts. [DVC](https://dvc.org/doc) tracks lightweight `.dvc` pointer files in Git while storing actual bytes in remote object storage and a local cache keyed by content hash. That gives you Git-like versioning, sharing, and reproducibility without bloating the repository or re-uploading unchanged data on every commit.
+</details>
+
+<details>
+<summary>2. What is training-serving skew, and how does a feature store like Feast reduce it?</summary>
+
+**Answer:** Training-serving skew happens when features are computed differently offline (batch Spark jobs, historical snapshots) versus online (real-time API code), so the model sees a different feature distribution in production. [Feast](https://docs.feast.dev/) stores feature definitions once and serves the same transformations through offline historical retrieval and low-latency online lookups, aligning training and inference on one implementation.
+</details>
+
+<details>
+<summary>3. Name five categories of checks you should encode as Great Expectations on an ML training table.</summary>
+
+**Answer:** Typical suites cover column existence and schema stability; null constraints on required fields; numeric ranges (for example age between 0 and 120); uniqueness on identifiers; categorical value sets; regex patterns for emails; row-count bands; and distribution statistics (mean or standard deviation windows) to catch drift. The point is to treat these as automated pipeline gates, not ad-hoc notebook checks.
+</details>
+
+<details>
+<summary>4. When would you choose Feast in addition to DVC rather than DVC alone?</summary>
+
+**Answer:** DVC excels at versioning datasets, models, and reproducible pipeline stages for experiments. Feast addresses a different problem: shared, discoverable feature definitions with online serving and point-in-time correct joins for training. Add Feast when multiple teams reuse features, when you need sub-second inference lookups, or when training-serving consistency becomes a recurring incident category.
+</details>
+
+<details>
+<summary>5. What is data lineage, and why does it matter for governance and debugging?</summary>
+
+**Answer:** Data lineage records how datasets flow from sources through transformations to models and predictions. When accuracy drops or regulators ask what data influenced a decision, lineage lets you identify the exact upstream export, transformation version, and feature snapshot involved. Tools such as [OpenLineage](https://openlineage.io/) and [DataHub](https://datahubproject.io/docs/) standardize capturing that graph from orchestrated jobs.
+</details>
+
+<details>
+<summary>6. How do ETL and ELT differ, and why does the choice affect ML pipeline backfills?</summary>
+
+**Answer:** ETL transforms before load, producing curated tables early and failing when transforms break on schema drift. ELT loads raw data first and transforms inside the warehouse or lakehouse, preserving raw history for recomputation. ELT simplifies backfills when you fix feature logic—you re-run transforms on stored raw partitions—while ETL may require re-extracting from sources if staging data was not retained.
+</details>
+
+<details>
+<summary>7. Why must orchestrated data pipeline tasks be idempotent before you enable automatic retries or historical backfills?</summary>
+
+**Answer:** Orchestrators retry failed tasks and replay date partitions during backfills. If a task blindly appends rows or increments counters, a retry duplicates data and corrupts aggregates. Idempotent tasks replace or upsert a deterministic partition for each run key, so the same logical date can be processed multiple times without changing the final table state.
+</details>
+
+<details>
+<summary>8. How do DVC pipelines help you build reproducible ML data workflows with versioned dependencies?</summary>
+
+**Answer:** A `dvc.yaml` pipeline declares stages, commands, dependencies, parameters, and outputs. DVC builds a DAG and reruns only stages whose inputs changed, caching intermediate artifacts by hash. Combined with Git for code and `.dvc` files for data, you can reproduce exactly which preprocessing, training, and evaluation steps produced a given model metric.
+</details>
+
+---
+
+## Hands-On Exercises
+
+Work through these in order. Each exercise reinforces one layer of the data pipeline stack: versioning, orchestrated stages, features, and validation.
 
 ### Exercise 1: Set Up DVC
 
+- [ ] Initialize a Git repository and run `dvc init` in a clean project directory
+- [ ] Track a sample CSV with `dvc add` and commit the generated `.dvc` pointer file
+- [ ] Configure a remote (local path or cloud bucket) and verify `dvc push` / `dvc pull` round-trip the artifact
+
 ```bash
-# Initialize
-pip install dvc dvc-s3
+# Initialize (S3 remotes: install the s3 extra — see DVC docs for remote setup)
+pip install "dvc[s3]"
 git init
 dvc init
 
@@ -944,6 +988,10 @@ dvc push
 
 ### Exercise 2: Create a DVC Pipeline
 
+- [ ] Author a `dvc.yaml` with at least preprocess and train stages and explicit `deps` / `outs`
+- [ ] Change only a hyperparameter in `params.yaml` and confirm DVC reruns downstream stages only
+- [ ] Inspect `dvc dag` to verify the dependency graph matches your mental model
+
 ```yaml
 # dvc.yaml
 stages:
@@ -958,30 +1006,34 @@ stages:
 
 ### Exercise 3: Define Feast Features
 
+- [ ] Define an `Entity` and a `FeatureView` with at least three features and a TTL
+- [ ] Materialize features and retrieve historical rows with `get_historical_features` for a fixed timestamp
+- [ ] Fetch the same feature names with `get_online_features` and compare values for one entity
+
 ```python
-from feast import Entity, Feature, FeatureView, ValueType
+from datetime import timedelta
+from feast import Entity, FeatureView, Field, FileSource
+from feast.types import Float32, Int64, String
 
-# Define entity
-user = Entity(name="user_id", value_type=ValueType.INT64)
-
-# Define feature view
-# ... complete the implementation
+# Define entity and data source, then build a FeatureView — see Feast Feature Definitions above
+user = Entity(name="user", join_keys=["user_id"])
+# ... complete FileSource, schema=[Field(...)], and run `feast apply`
 ```
 
-### Exercise 4: Create Great Expectations Suite
+### Exercise 4: Create a Great Expectations Suite
+
+- [ ] Create an expectation suite with at least ten expectations spanning schema, nulls, ranges, and row counts
+- [ ] Run a checkpoint against a sample batch and confirm failures surface clearly
+- [ ] Document the suite in Data Docs and wire the checkpoint as a pre-training gate in your pipeline sketch
 
 ```python
 import great_expectations as gx
+import great_expectations.expectations as gxe
 
 context = gx.get_context()
-suite = context.add_expectation_suite("my_suite")
+suite = context.suites.add(gx.ExpectationSuite(name="my_suite"))
 
-# Add at least 10 expectations covering:
-# - Column existence
-# - Data types
-# - Value ranges
-# - Null checks
-# - Distribution properties
+# Add at least 10 expectations — see Common Expectations above, then wire ValidationDefinition + Checkpoint
 ```
 
 ---
@@ -998,7 +1050,7 @@ If you remember nothing else from this module, remember these eight principles t
 
 4. **Lineage enables debugging.** When a model fails in production, lineage lets you trace back to the root cause—whether it's bad data, broken code, or shifted distributions.
 
-5. **Start simple, add complexity as needed.** DVC alone solves 80% of data management pain. Add Feast and Great Expectations when their specific problems become acute.
+5. **Start simple, add complexity as needed.** DVC alone addresses most early reproducibility pain before you need a full platform. Add Feast and Great Expectations when their specific problems become acute.
 
 6. **Data quality > model complexity.** Andrew Ng's Data-Centric AI movement has it right: a simple model on good data beats a complex model on messy data.
 
@@ -1006,70 +1058,29 @@ If you remember nothing else from this module, remember these eight principles t
 
 8. **Automation is key.** Manual data validation doesn't scale. Embed Great Expectations checkpoints into your CI/CD pipelines.
 
-The journey from "data chaos" to "data maturity" doesn't happen overnight. It's an iterative process of identifying pain points, implementing solutions, and building habits. The tools in this module—DVC, Feast, Great Expectations—are battle-tested solutions to problems that have cost real companies real money.
+The journey from ad-hoc CSV folders to orchestrated, validated, versioned data pipelines is incremental. Teams usually feel the pain in a predictable order: first they cannot reproduce experiments, then they get burned by schema drift, then feature inconsistencies appear across services, and finally compliance asks for lineage they cannot produce. The tooling in this module maps cleanly onto that maturity curve — DVC when reproducibility breaks, Great Expectations when silent data bugs slip through, Feast when features become a shared product, orchestrators when cron scripts sprawl, and lineage when audits or incidents demand traceability.
 
-Start with DVC. When that's second nature, add Great Expectations. When feature consistency becomes a problem, consider Feast. Each tool earns its place by solving a real problem you've experienced. That's the path to a data infrastructure you can trust.
-
----
-
-##  Further Reading
-
-### Documentation
-- [DVC Documentation](https://dvc.org/doc)
-- [Feast Documentation](https://docs.feast.dev/)
-- [Great Expectations](https://docs.greatexpectations.io/)
-
-### Papers & Articles
-- "Hidden Technical Debt in Machine Learning Systems" (Google, 2015)
-- "Data Management Challenges in Production ML" (Polyzotis et al., 2018)
-- "Feast: Feature Store for Machine Learning" (Gojek, 2020)
+Start with DVC plus explicit pipeline stages in `dvc.yaml`. Wire Great Expectations checkpoints into those stages before GPU-heavy training. Introduce Feast when the same features feed multiple models or online inference. Layer Airflow, Dagster, or Prefect when schedules, sensors, and cross-team dependencies outgrow manual runs. Each addition should close a failure mode you have already experienced — that discipline keeps operational load proportional to real risk.
 
 ---
 
-## Interview Preparation
+## Next Module
 
-**Q: Why can't you just use Git for machine learning data?**
-
-Git stores complete file copies for every version. A 10GB dataset with 100 versions would need 1TB of storage. Git also has no concept of cloud storage backends or large file handling. DVC solves this by storing pointers in Git while keeping actual data in S3, GCS, or Azure Blob Storage. It's designed from the ground up for large binary files common in ML.
-
-**Q: How would you handle training-serving skew in production?**
-
-Training-serving skew occurs when features computed during training differ from production. The solution is a feature store like Feast that provides a single source of truth. Features are computed once, stored centrally, and served consistently to both training pipelines and online serving. This eliminates the "recompute features differently" anti-pattern.
-
-**Q: What's your approach to data validation in ML pipelines?**
-
-Use Great Expectations to define explicit contracts about your data. Run validation at every pipeline stage: after ingestion, after transformation, and before model training. Critical validations include: no null values in required columns, values within expected ranges, distributions matching historical data, and schema matching expectations. Integrate these as gates in CI/CD — failing validation stops the pipeline.
+Continue to [Module 1.8: ML Pipelines](./module-1.8-ml-pipelines/) for workflow orchestration patterns that wire validated, versioned data into training, evaluation, and deployment DAGs.
 
 ---
-
-##  Knowledge Check
-
-1. **What problem does DVC solve that Git doesn't?**
-
-2. **What is training-serving skew and how do feature stores prevent it?**
-
-3. **Name 5 common Great Expectations validators.**
-
-4. **When would you choose Feast over just using DVC?**
-
-5. **What is data lineage and why is it important?**
-
----
-
-## ⏭️ Next Steps
-
-You now understand data versioning and feature stores! These are critical for reproducible ML.
-
-**Up Next**: Module 50 - ML Pipeline & Workflow Orchestration
-
----
-
-_Module 49 Complete! You now understand DVC, Feast, and Great Expectations!_
-_"Bad data = bad models. Version your data like you version your code."_
-_Remember Jennifer Chen's $50 million bug—don't let it happen to you._
 
 ## Sources
 
-- [DVC Official Repository](https://github.com/iterative/dvc) — Primary source for DVC's data versioning, pipelines, remotes, and experiment-tracking behavior.
-- [Feast Official Repository](https://github.com/feast-dev/feast) — Primary source for Feast's offline/online store model and feature-store workflow.
-- [Great Expectations Official Repository](https://github.com/great-expectations/great_expectations) — Primary source for expectations-based data validation and generated documentation concepts.
+- [DVC Documentation](https://dvc.org/doc) — Data and model versioning, pipelines, remotes, and experiment tracking.
+- [DVC GitHub Repository](https://github.com/treeverse/dvc) — Source reference for pipeline DAG behavior and cache semantics.
+- [Feast Documentation](https://docs.feast.dev/) — Offline/online stores, feature views, and point-in-time retrieval.
+- [Feast GitHub Repository](https://github.com/feast-dev/feast) — Reference implementation for feature-store architecture.
+- [Great Expectations Documentation](https://docs.greatexpectations.io/docs/) — Expectations, checkpoints, and Data Docs.
+- [Great Expectations GitHub Repository](https://github.com/great-expectations/great_expectations) — Core validation APIs and integration patterns.
+- [Apache Airflow Documentation](https://airflow.apache.org/docs/apache-airflow/stable/) — Task-based DAG orchestration, scheduling, and sensors.
+- [Dagster Documentation](https://docs.dagster.io/) — Asset-based orchestration and data-aware pipelines.
+- [Prefect Documentation](https://docs.prefect.io/) — Python-native flow orchestration and deployment models.
+- [OpenLineage](https://openlineage.io/) — Open standard for capturing job and dataset lineage events.
+- [DataHub Documentation](https://datahubproject.io/docs/) — Metadata catalog and lineage graph for data platforms.
+- [Data Mesh Principles (Martin Fowler)](https://martinfowler.com/articles/data-mesh-principles.html) — Durable framing for decentralized data ownership and pipeline contracts.

--- a/src/content/docs/ai-ml-engineering/mlops/module-1.8-ml-pipelines.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.8-ml-pipelines.md
@@ -6,24 +6,87 @@ sidebar:
 ---
 > **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 6-8
 
-**Prerequisites**: Module 49 (Data Versioning & Feature Stores)
+**Prerequisites**: [Module 1.7: Data Pipelines](./module-1.7-data-pipelines/) (data versioning, feature stores, and validation)
 
-Modern workflow orchestrators emerged partly in response to the operational pain of tracing failures across cron jobs, scripts, and upstream data dependencies.
+A notebook trains a model once. Production retrains it on a schedule, validates every artifact, caches expensive steps, branches on metric thresholds, and leaves an audit trail that another engineer can replay six months later. That gap between a one-off experiment and a repeatable system is what ML pipeline frameworks exist to close. Pipeline tools such as Kubeflow Pipelines, TensorFlow Extended (TFX), ZenML, and Metaflow express machine learning work as a directed acyclic graph of components, pass typed artifacts between steps, compile the graph to a runtime, and apply caching so you do not pay twice for unchanged preprocessing.
 
-Tracing failures across loosely coupled cron jobs can take hours, and stale ML outputs can affect the business before anyone notices.
-
-Over the next few months, Beauchemin engineered a fundamentally different approach: a robust system where tasks explicitly declared their dependencies, where failures triggered immediate alerts, and where engineers could visualize the entire pipeline execution at a glance. He called it "Airflow," and [Airbnb open-sourced it in 2015](https://airflow.apache.org/docs/apache-airflow/stable/project.html). Today, Airflow is widely used for workflow orchestration, and its history illustrates why teams move away from ad-hoc cron-based pipelines as systems grow more critical.
+The broader orchestration story still matters because ML pipelines sit on top of schedulers and clusters. [Maxime Beauchemin's work at Airbnb led to Apache Airflow](https://airflow.apache.org/docs/apache-airflow/stable/project.html), which popularized DAGs-as-code for data workflows when cron scripts stopped scaling. Kubeflow Pipelines, Argo Workflows, Prefect, Dagster, and Temporal each answer adjacent questions—Kubernetes-native ML steps, asset lineage, durable long-running workflows—but the durable spine across all of them is the same: declare dependencies explicitly, make steps idempotent where possible, store artifacts outside task memory, and treat the compiled graph as the contract between data science and platform engineering.
 
 ---
 
 ## What You'll Be Able to Do
 
-By the end of this module, you will be able to:
-- **Design** end-to-end ML training pipelines that orchestrate data preparation, model training, and conditional deployment.
-- **Implement** durable execution patterns for long-running machine learning workloads using Temporal workflows.
-- **Diagnose** silent failures and pipeline cascading errors using log analysis and data health checks.
-- **Evaluate** the trade-offs between asset-based orchestration (Dagster) and task-based DAGs (Airflow) for data-centric ML teams.
-- **Compare** Kubernetes-native execution (Kubeflow) against traditional orchestrators for GPU-accelerated workloads.
+By the end of this module, you will be able to design, implement, compile, diagnose, and compare production ML pipelines using the frameworks and orchestration patterns below.
+- **Design** end-to-end ML training pipelines with components, typed artifacts, caching, and conditional deployment gates.
+- **Implement** pipeline definitions using Kubeflow Pipelines as the primary Kubernetes-native example and map equivalent concepts to TFX, ZenML, and Metaflow.
+- **Compile** a pipeline graph to a portable runtime specification and explain how the scheduler materializes container steps on a cluster.
+- **Diagnose** silent failures, cache misses, and cascading pipeline errors using run metadata, logs, and data health checks.
+- **Compare** task-based DAG orchestrators (Airflow, Prefect) against ML-native pipeline SDKs (Kubeflow, TFX, ZenML, Metaflow) for GPU training and reproducibility.
+
+---
+
+## Why This Module Matters
+
+Every production ML system eventually outgrows a single script. Data arrives on different cadences, training consumes GPUs for hours, evaluation must gate promotion, and regulators ask which dataset and code revision produced a given model artifact. Without a pipeline layer, teams glue together cron jobs, shell scripts, and manual notebook exports. Each step might work in isolation while the composed system fails silently: an empty extract succeeds with exit code zero, downstream training runs on zero rows, and deployment pushes a useless artifact because nobody validated row counts at the boundary.
+
+ML pipeline frameworks treat each step as a component with declared inputs and outputs, not as an opaque function that mutates shared filesystem state. Artifacts—datasets, models, metrics, evaluation reports—are first-class objects stored in object storage or a metadata backend, and the orchestrator passes references between steps instead of serializing multi-gigabyte tables through a message bus. Caching hashes component inputs so unchanged preprocessing is skipped on the next run, which saves real money when feature engineering dominates wall-clock time. Conditional edges encode business rules such as "deploy only if accuracy exceeds the champion model," which turns informal checklist culture into executable policy.
+
+Think of ML orchestration like an airport control tower coordinating specialized ground crews. Individual planes know how to fly, but without sequencing, fueling, baggage loading, and runway assignment, chaos follows. The pipeline compiler is the flight plan; the runtime is the tower; artifacts are the cargo manifests that prove what moved between stations. Whether you run on Kubeflow inside a shared Kubernetes cluster, on TFX inside a managed Vertex pipeline, on ZenML with a stack abstraction, or on Metaflow with cloud-backed `@step` decorators, the engineering judgment is the same: isolate side effects, version artifacts, make retries safe, and never trust a green checkmark without data validation at every handoff.
+
+---
+
+## Did You Know?
+
+- Kubeflow Pipelines compiles Python pipeline definitions into an [Argo Workflows](https://argoproj.github.io/workflows/) YAML specification, which is why the same DAG concepts appear in both the ML SDK and the underlying Kubernetes workflow engine.
+- TFX introduced the notion of [ML Metadata (MLMD)](https://www.tensorflow.org/tfx/guide/mlmd) to record lineage across pipeline components, predating many open-source experiment-tracking integrations that teams bolt on today.
+- ZenML separates **stacks** (orchestrator, artifact store, experiment tracker) from **pipelines**, so the same Python pipeline code can target a local runner in development and a Kubeflow or Kubernetes orchestrator in production without rewriting step logic.
+- Metaflow's `@step` decorator persists intermediate results to cloud object storage automatically, which is why resuming a failed multi-day training workflow does not require custom checkpoint plumbing in user code.
+
+> **Landscape snapshot — as of 2026-06. Verify against vendor docs before relying on specifics.**
+>
+> | Framework | Typical SDK / entrypoint | Primary runtime target | Notable pipeline concepts |
+> |-----------|--------------------------|------------------------|---------------------------|
+> | Kubeflow Pipelines | `kfp.dsl` Python SDK | Kubernetes (Argo Workflows) | `@dsl.component`, `Input`/`Output` artifacts, `compiler.Compiler()` |
+> | TFX | Pipeline DSL + standard components | KFP, Vertex AI, Apache Beam runners | ExampleGen, Transform, Trainer, Tuner, Pusher, MLMD lineage |
+> | ZenML | `@step` / `@pipeline` decorators | Local, Kubeflow, Kubernetes, Airflow, etc. | Stacks, artifact stores, model registry integrations |
+> | Metaflow | `@step` / `@flow` decorators | AWS Batch, Kubernetes, local | Datastore artifacts, `--with` cards, resume after failure |
+> | Airflow / Prefect / Dagster | Task or asset decorators | Self-hosted or managed control planes | General workflow orchestration; often wrap ML pipeline runners |
+
+---
+
+## Pipeline Fundamentals: Components, Artifacts, and Compilation
+
+Before comparing tools, internalize the vocabulary they share. A **pipeline** is a directed acyclic graph whose nodes are **components** (also called steps or tasks) and whose edges are data or control dependencies. A **component** is a containerized unit of work with declared inputs and outputs: it might preprocess parquet files, train an estimator, evaluate on a holdout set, or register a model. An **artifact** is a persistent output of a component—training data snapshot, serialized model, metric bundle, HTML evaluation report—not an in-memory object that vanishes when the pod exits.
+
+Artifact typing matters because it enables schema validation and UI visualization. Kubeflow Pipelines uses types such as `Dataset`, `Model`, and `Metrics`. TFX wires components through standard artifact classes recorded in MLMD. ZenML materializes artifacts through its artifact store abstraction. Metaflow writes pickles or structured files to its datastore and exposes them as flow inputs to downstream steps. The implementation differs, but the design goal is identical: the orchestrator should know *what* was produced, *where* it lives, and *which upstream revision* fed each step.
+
+**Compilation** is the act of translating a high-level pipeline definition into something a runtime can execute. In Kubeflow Pipelines, `compiler.Compiler().compile(pipeline_fn, 'pipeline.yaml')` emits an Argo Workflow manifest. That manifest lists container images, commands, resource requests, volume mounts, and dependency edges. The Kubeflow API server or Argo controller then schedules pods on Kubernetes. TFX compiles to a runner-specific representation (Kubeflow, Beam, or Vertex). ZenML resolves the active stack and delegates to the configured orchestrator backend. Metaflow packages code and dependencies into a flow graph executed by its runtime agent. Compilation separates *authoring time* (Python in your repo) from *run time* (pods on a cluster), which is how the same pipeline definition can be unit-tested locally and promoted unchanged to production.
+
+**Caching** compares a fingerprint of each component's inputs—data hashes, parameter values, container image digest—against prior successful runs. When the fingerprint matches, the orchestrator reuses stored artifacts instead of re-executing the container. Caching is not magic; it requires deterministic components and stable input addressing. If your preprocessing step reads "latest" data without pinning a version, the cache key changes unpredictably or, worse, serves stale outputs. Production teams pin dataset revisions (DVC, Delta Lake versions, snapshot IDs) and treat cache invalidation as a data governance decision, not a framework toggle.
+
+**Conditional and parallel execution** extend linear DAGs. A training pipeline might fan out hyperparameter trials in parallel, then reduce results in a selection step. A metric threshold might route execution to `deploy` or `alert` branches. Kubeflow supports conditional groups in its SDK; Airflow uses branch operators; Metaflow merges paths with `join`. Parallelism without artifact discipline creates race conditions—two steps writing the same path—so frameworks encourage unique artifact URIs per run ID.
+
+Finally, pipelines connect to **experiment tracking** and **model registries** at the boundaries. Training components log parameters and metrics to MLflow, Weights & Biases, or Neptune; registration components push approved models to a registry with stage transitions. The pipeline is the spine; tracking and serving are organs attached at defined interfaces. Module 1.6 covered experiment tracking; Module 1.9 will cover serving. Here, the focus is the graph that reliably produces the artifact those systems consume.
+
+```text
+ML PIPELINE LIFECYCLE (DURABLE SPINE)
+=====================================
+
+  Author (Python SDK)  -->  Compile (YAML / IR)  -->  Schedule (controller)
+         |                          |                         |
+         v                          v                         v
+   Components +              Argo / Beam /            Pods + artifact
+   typed I/O                  Vertex spec               store writes
+         |                          |                         |
+         +--------------------------+-------------------------+
+                                    v
+                          Metadata + cache lookup
+                                    |
+                                    v
+                    Experiment tracker / model registry (optional hooks)
+```
+
+The diagram is intentionally tool-agnostic. When you read Kubeflow, TFX, ZenML, or Metaflow documentation, map each feature to one of these stages. If a feature does not map cleanly—say, a UI-only button with no artifact record—that is a signal the platform is hiding state you will need during an incident review.
 
 ---
 
@@ -33,9 +96,7 @@ By the end of this module, you will be able to:
 
 Before dedicated orchestration tools, teams ran ML pipelines with cron jobs and bash scripts. This worked for simple pipelines, but as companies grew, the limitations became painful. The lack of standardized dependency management meant scripts had to arbitrarily sleep and guess when upstream data would be ready.
 
-> **Did You Know?** Large engineering organizations historically accumulated many cron jobs, and debugging them became a significant operational burden.
-
-The core problems of the cron era were common across many engineering teams:
+The core problems of the cron era were common across many engineering teams because cron itself is only a clock, not a dependency graph. Teams bolted together shell wrappers, but nothing recorded which upstream extract failed or which dataset version a model consumed.
 - **No dependency management**: Cron does not natively know that job A must finish successfully before job B starts.
 - **No visibility**: You could not see what was running, what failed, or why without logging into servers.
 - **No retries**: Failures meant manual intervention or complete data loss.
@@ -43,21 +104,17 @@ The core problems of the cron era were common across many engineering teams:
 
 ### The Birth of Modern Orchestration (2014-2016)
 
-**Airflow emerges at Airbnb (2014)**. Maxime Beauchemin's frustration became the industry's solution. Key innovations included [expressing DAGs as pure Python code, explicit dependency management, a rich UI visualization, and extensible operator classes](https://airflow.apache.org/docs/apache-airflow/1.10.1/index.html). Airbnb open-sourced it in 2015, and it rapidly became the defacto industry standard.
+**Airflow emerges at Airbnb (2014)**. Maxime Beauchemin's frustration became the industry's solution. Key innovations included [expressing DAGs as pure Python code, explicit dependency management, a rich UI visualization, and extensible operator classes](https://airflow.apache.org/docs/apache-airflow/stable/index.html). Airbnb open-sourced it in 2015, and it rapidly became one of the most widely adopted workflow orchestrators.
 
-> **Did You Know?** Airflow's name has its own project lore, but the important point is that it emerged as a Python-based alternative to ad-hoc scheduling.
-
-**Apache Oozie**. [Oozie was a Hadoop workflow engine that defined workflows in XML and managed dependent jobs](https://oozie.apache.org/docs/5.2.0/DG_Overview.html).
+**Apache Oozie**. [Oozie was a Hadoop workflow engine that defined workflows in XML and managed dependent jobs](https://oozie.apache.org/docs/5.2.0/DG_Overview.html). Oozie mattered for batch Hadoop ecosystems; modern ML teams rarely start there, but the pattern—XML or code declaring DAG edges—reappears whenever a platform compiles pipelines to a lower-level workflow engine.
 
 ### The Kubernetes Revolution (2017-2020)
 
-As ML workflows transitioned to containerized environments, orchestration tools had to adapt natively to Kubernetes primitives:
+As ML workflows transitioned to containerized environments, orchestration tools had to adapt natively to Kubernetes primitives instead of assuming long-lived VMs with locally attached disks. Containerized steps need explicit artifact volumes, image pull secrets, and resource requests so the scheduler can place GPU work intelligently.
 
 **Kubeflow**: [Kubeflow is an open-source toolkit for building and running machine learning workflows on Kubernetes](https://github.com/kubeflow/pipelines).
 
-> **Did You Know?** Early Kubernetes-based ML tooling often required substantial YAML and operational setup before higher-level SDKs improved the developer experience.
-
-**Argo Workflows**: [Argo Workflows is a Kubernetes-native workflow engine that defines containerized workflows declaratively](https://argoproj.github.io/workflows/).
+**Argo Workflows**: [Argo Workflows is a Kubernetes-native workflow engine that defines containerized workflows declaratively](https://argoproj.github.io/workflows/). Kubeflow Pipelines still compiles to Argo under the hood on many distributions, which is why learning Argo pod patterns pays off even when authors never write raw Workflow YAML.
 
 ### The Modern Era (2020-Present)
 
@@ -65,19 +122,15 @@ The latest evolution of orchestration tools acknowledges that machine learning c
 
 **Prefect**: Takes a Python-native approach to orchestration. Flows are regular Python functions decorated with `@flow` and `@task`, rather than a separate workflow DSL.
 **Dagster**: Introduced "[Software-Defined Assets](https://github.com/dagster-io/dagster)." Instead of thinking about what tasks you run, you think about what data you produce.
-**n8n**: Visual workflow automation for the AI era. Non-programmers can build RAG pipelines by dragging and connecting nodes visually.
-
-> **Did You Know?** [n8n is a visual automation platform with native AI capabilities and self-hosting options](https://github.com/n8n-io/n8n).
+**Metaflow**: Netflix-originated Python flows with `@step` decorators and automatic artifact persistence to cloud object storage, optimized for data scientist ergonomics and resume-after-failure semantics.
 
 ---
 
-## Why Pipeline Orchestration Matters
+## Why Orchestration Still Surrounds ML Pipelines
 
-Every ML system in production strictly requires orchestration. Training a model once in a Jupyter notebook is trivial. Training it daily, implementing rigorous data validation, extracting new features, evaluating the model against a baseline, and deploying it securely—that is where orchestration becomes essential. 
+Pipeline SDKs solve ML-specific artifact and component problems, but they still rely on a scheduler somewhere in the stack. Training a model once in a Jupyter notebook is trivial; training it daily with validation, feature extraction, champion/challenger evaluation, and gated deployment is where orchestration becomes essential. General orchestrators (Airflow, Prefect, Dagster) often *trigger* ML pipeline runs or wrap individual tasks, while ML-native frameworks (Kubeflow, TFX, ZenML, Metaflow) own the graph inside the run. Mature platforms frequently combine both: Airflow kicks off a Kubeflow Pipeline run at 06:00 UTC after upstream ETL sensors succeed.
 
-Think of ML orchestration like an airport control tower. Individual planes (ML tasks) know how to fly perfectly well independently, but without central coordination, you would have catastrophic chaos. Planes would take off into each other, land on occupied runways, and fuel trucks would collide with baggage carts. The control tower (orchestrator) ensures everything happens in the exact right order, at the precise right time, using the correct resources.
-
-The reality of operating Machine Learning in production environments is stark:
+The operational contrast between ad-hoc scripts and orchestrated pipelines is worth internalizing because it explains why platform teams standardize on compiled graphs instead of shared cron entries:
 
 ```text
 WITHOUT ORCHESTRATION              WITH ORCHESTRATION
@@ -104,24 +157,24 @@ Ad-hoc scheduling                 Intelligent scheduling
 
 ## The Orchestration Landscape
 
-To navigate the complex tooling environment, we must categorize orchestrators based on their core philosophy.
+To navigate the complex tooling environment, we must categorize orchestrators based on their core philosophy rather than on marketing names alone. Some tools optimize for data-engineering batch schedules, others for ML artifact graphs, and others for portable ML authoring; the diagram below groups common options by whether they are general orchestrators or ML-native pipeline frameworks.
 
 ```text
 ┌─────────────────────────────────────────────────────────────────────────┐
 │                    ML ORCHESTRATION TOOLS                                │
 ├─────────────────────────────────────────────────────────────────────────┤
 │                                                                          │
-│  CODE-FIRST                          VISUAL/LOW-CODE                     │
-│  ──────────                          ──────────────                      │
+│  GENERAL ORCHESTRATION               ML-NATIVE PIPELINES                 │
+│  ────────────────────                ───────────────────                 │
 │                                                                          │
 │  ┌─────────────┐  ┌─────────────┐   ┌─────────────┐  ┌─────────────┐   │
-│  │   AIRFLOW   │  │   PREFECT   │   │     n8n     │  │  LANGFLOW   │   │
-│  │  (Apache)   │  │  (Modern)   │   │  (Visual)   │  │ (LangChain) │   │
+│  │   AIRFLOW   │  │   PREFECT   │   │    ZENML    │  │  METAFLOW   │   │
+│  │  (Apache)   │  │  (Modern)   │   │  (Stacks)   │  │  (Flows)    │   │
 │  │             │  │             │   │             │  │             │   │
-│  │ Python DAGs │  │ Python-     │   │ Drag-drop   │  │ AI chains   │   │
-│  │ Scheduling  │  │ native      │   │ 400+ nodes  │  │ Visual      │   │
-│  │ Battle-     │  │ Dynamic     │   │ AI nodes    │  │ builder     │   │
-│  │ tested      │  │ Hybrid      │   │ Self-host   │  │             │   │
+│  │ Python DAGs │  │ Python-     │   │ @step /     │  │ @step /     │   │
+│  │ Scheduling  │  │ native      │   │ @pipeline   │  │ @flow       │   │
+│  │ Battle-     │  │ Dynamic     │   │ Stack       │  │ Datastore   │   │
+│  │ tested      │  │ Hybrid      │   │ portability │  │ resume      │   │
 │  └─────────────┘  └─────────────┘   └─────────────┘  └─────────────┘   │
 │                                                                          │
 │  ┌─────────────┐  ┌─────────────┐   ┌─────────────┐  ┌─────────────┐   │
@@ -139,15 +192,15 @@ To navigate the complex tooling environment, we must categorize orchestrators ba
 │  │  (Durable)  │  ───────────────────                                   │
 │  │             │  Complex ML Pipelines → Airflow, Kubeflow              │
 │  │ Long-       │  Data Engineering    → Dagster, Airflow                │
-│  │ running     │  Quick AI Prototypes → n8n, LangFlow                   │
-│  │ Reliable    │  Production Agents   → n8n, Temporal                   │
+│  │ running     │  Portable ML authoring → ZenML, Metaflow               │
+│  │ Reliable    │  Human approval gates  → Temporal                      │
 │  │ workflows   │  Long-running Jobs   → Temporal                        │
 │  └─────────────┘  K8s-native ML       → Kubeflow                        │
 │                                                                          │
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-Visualized as a dependency matrix:
+The same landscape can be visualized as a dependency matrix when you need to explain relationships to stakeholders who will not read a full toolchain comparison document.
 ```mermaid
 graph TD
     classDef code fill:#f9f9f9,stroke:#333,stroke-width:2px;
@@ -161,9 +214,9 @@ graph TD
     CodeFirst --> Dagster[Dagster - Asset]:::code
     CodeFirst --> Kubeflow[Kubeflow - K8s ML]:::code
     CodeFirst --> Temporal[Temporal - Durable]:::code
+    CodeFirst --> ZenML[ZenML - Stacks]:::code
+    CodeFirst --> Metaflow[Metaflow - Flows]:::code
 
-    VisualLowCode --> n8n[n8n - Visual]:::visual
-    VisualLowCode --> LangFlow[LangFlow - LangChain]:::visual
     VisualLowCode --> Windmill[Windmill - Scripts]:::visual
     VisualLowCode --> Flowise[Flowise - LLM]:::visual
 ```
@@ -172,9 +225,11 @@ graph TD
 
 ## Apache Airflow Deep Dive
 
+Airflow remains the reference implementation for calendar-driven DAG orchestration even when ML teams adopt Kubeflow or TFX for the training graph itself. Understanding Airflow matters because it is often the outer loop: sensors wait for warehouse exports, a trigger operator launches a Kubeflow Pipeline run, and email or Slack callbacks fire when the inner ML job completes. Airflow thinks in tasks and schedules; ML pipeline SDKs think in artifacts and container images. Production platforms connect the two layers instead of forcing one tool to do everything.
+
 ### What is Airflow?
 
-Airflow is a widely used workflow orchestrator that lets you [define workflows as code, schedule them, and monitor them through a web UI](https://airflow.apache.org/docs/apache-airflow/1.10.1/index.html).
+Airflow is a widely used workflow orchestrator that lets you [define workflows as code, schedule them, and monitor them through a web UI](https://airflow.apache.org/docs/apache-airflow/stable/index.html). The scheduler evaluates DAG definitions stored in a metadata database, enqueueing work when interval or external triggers match policy. Workers—or a Kubernetes executor—pull tasks and execute Python callables or operators. Task state, logs, and XCom metadata return to the database so operators can debug failed runs without SSH access to individual boxes.
 
 ```text
 AIRFLOW ARCHITECTURE
@@ -201,7 +256,7 @@ AIRFLOW ARCHITECTURE
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-Architectural Flow:
+The scheduler, executor, workers, metadata database, and web UI form a control plane that is separate from the data plane where your ML containers actually train models. The following diagram highlights how scheduling decisions flow into execution.
 ```mermaid
 graph TD
     Scheduler[Scheduler] --> Executor[Executor]
@@ -235,7 +290,7 @@ with DAG(
     'ml_training_pipeline',
     default_args=default_args,
     description='Daily ML model training pipeline',
-    schedule_interval='@daily',  # or '0 6 * * *' for 6 AM
+    schedule='@daily',  # or '0 6 * * *' for 6 AM
     catchup=False,
     tags=['ml', 'training'],
 ) as dag:
@@ -291,7 +346,7 @@ from airflow.operators.python import BranchPythonOperator
 from airflow.utils.trigger_rule import TriggerRule
 
 @dag(
-    schedule_interval='@daily',
+    schedule='@daily',
     start_date=datetime(2024, 1, 1),
     catchup=False,
 )
@@ -380,14 +435,14 @@ ml_pipeline = ml_pipeline_with_branching()
 
 ## Kubeflow Pipelines
 
-### Why This Module Matters
+[Kubeflow Pipelines](https://github.com/kubeflow/pipelines) is the Kubernetes-native ML pipeline SDK most platform teams encounter when standardizing GPU training on shared clusters. Each component runs in its own container pod; the compiler emits a workflow specification the control plane schedules like any other batch workload. Think of Kubeflow like an automated factory line where stations have different tooling—CPU preprocessing pods versus GPU training pods—but share a single artifact warehouse (S3, GCS, or MinIO) and a metadata database that records run lineage.
 
-Kubeflow Pipelines is strictly designed for [orchestrating ML workloads natively on Kubernetes](https://github.com/kubeflow/pipelines). Think of Kubeflow like an automated factory assembly line where each independent station (container) has highly specialized hardware equipment. The data processing station has different tools than the massive GPU-enabled model training station, but they all connect seamlessly via shared artifact storage. 
+Kubeflow fits teams that already operate Kubernetes competently and want ML steps to inherit cluster primitives: namespaces, quotas, GPU device plugins, secrets, and network policies. It is less attractive when the organization has no cluster appetite and prefers a managed SaaS runner; in that case ZenML or a cloud TFX/Vertex path may reduce operational surface area while preserving similar DAG concepts.
 
-Kubeflow is absolutely critical for:
-- Massively distributed GPU-intensive training jobs.
-- Reproducible, containerized data science experiments.
-- Enabling multi-tenant ML platforms for large enterprise teams.
+Kubeflow is a strong default when your platform team already runs Kubernetes with GPU node pools, object storage, and tenant isolation policies, and when you want ML steps to look like ordinary batch workloads to cluster operators.
+- Distributed GPU-intensive training jobs with per-step resource requests.
+- Reproducible, containerized experiments where artifact URIs are auditable.
+- Multi-tenant ML platforms that isolate teams by namespace and quota.
 
 ```text
 KUBEFLOW PIPELINES ARCHITECTURE
@@ -421,7 +476,7 @@ KUBEFLOW PIPELINES ARCHITECTURE
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-Kubeflow Execution Flow:
+After compilation, the Kubeflow control plane schedules pods, writes artifacts to object storage, and surfaces run progress in the UI as shown in the execution flow below.
 ```mermaid
 flowchart TD
     subgraph Python SDK
@@ -442,6 +497,10 @@ flowchart TD
 ```
 
 ### Kubeflow Pipeline Definition
+
+The Python SDK uses `@dsl.component` to declare containerized functions. `Input[Dataset]` and `Output[Model]` parameters tell the compiler how to wire artifact paths into the container filesystem. `set_accelerator_type` paired with `set_accelerator_limit` requests GPUs on the generated pod spec (KFP v2 deprecated the older `set_gpu_limit` helper), and `set_memory_limit` sets memory bounds. After authoring, `compiler.Compiler().compile()` produces YAML you upload to the Kubeflow UI or API; each run instantiates pods, records metrics in the metadata store, and applies caching when step signatures match prior successful executions.
+
+When debugging Kubeflow, inspect three layers: the compiled YAML (did dependencies and artifact paths serialize correctly?), the pod events (GPU, image pull, OOM), and the artifact bucket (did the step write the expected file?). Most "mysterious" skips are cache hits—valuable in production, confusing during development if you forgot you pinned inputs.
 
 ```python
 from kfp import dsl
@@ -559,7 +618,7 @@ def ml_training_pipeline(
         n_estimators=n_estimators,
         max_depth=max_depth
     )
-    train_task.set_gpu_limit(1)
+    train_task.set_accelerator_type('nvidia.com/gpu').set_accelerator_limit(1)
     train_task.set_memory_limit('8G')
 
     # Step 3: Deploy
@@ -577,113 +636,135 @@ compiler.Compiler().compile(
 )
 ```
 
+### Caching and Conditional Steps in Kubeflow
+
+Caching in Kubeflow Pipelines is enabled at the pipeline and task level. When a task's input artifact URIs, parameters, and container image digest match a previous run, the controller can mark the step skipped and surface prior outputs in the UI. This behavior is essential for iterative model tuning where only the trainer hyperparameters change. Teams disable caching temporarily during debugging so every step re-executes, then re-enable it for scheduled production runs.
+
+Conditional execution uses `dsl.If` or legacy condition components to express predicates on metric artifacts or parameters. The antipattern is encoding business logic only inside a shell script without recording the decision in metadata—auditors cannot see *why* deployment was skipped. Prefer explicit branch components whose inputs are typed metric artifacts so the UI and MLMD-style lineage reflect the gate.
+
 ---
 
-## n8n: Visual AI Workflows
+## TensorFlow Extended (TFX)
 
-### Why n8n?
+[TensorFlow Extended (TFX)](https://www.tensorflow.org/tfx) is Google's production ML platform toolkit built around standardized pipeline components and ML Metadata (MLMD). Where Kubeflow gives you generic `@dsl.component` containers, TFX ships opinionated components—`ExampleGen`, `StatisticsGen`, `SchemaGen`, `ExampleValidator`, `Transform`, `Trainer`, `Tuner`, `Evaluator`, `Pusher`—that implement TensorFlow-friendly best practices for data validation and training. Teams on TensorFlow or Keras often adopt TFX because the components encode years of production lessons: compute statistics before training, enforce schemas, export transformed features consistently, and push only models that pass evaluation thresholds.
 
-n8n is a visual workflow automation platform that includes AI-oriented integrations and self-hosting options. Imagine n8n like building logic with complex LEGO blocks—each block (referred to as a node) performs a highly specific function, and you string them together visually to create massive AI workflow backends. Non-programmers, such as business analysts, can easily construct scalable RAG pipelines, internal chatbot backend systems, and extensive document processors by simply dragging and connecting these nodes. Meanwhile, [developers can still write complex Python or JavaScript code inside custom logic blocks](https://github.com/n8n-io/n8n) when specialized manipulation is required.
+TFX pipelines compile to a runner abstraction. The same pipeline definition can execute locally for development, on Kubeflow Pipelines for on-prem Kubernetes, on Apache Beam for large-scale preprocessing, or on managed Vertex AI Pipelines in Google Cloud. That portability mirrors the durable spine from earlier: components declare artifacts; MLMD records lineage; the runner materializes containers. The volatile choice is *which runner* your organization operates today—consult the landscape snapshot rather than treating one runner as universal.
 
-```text
-n8n FOR AI WORKFLOWS
-====================
+MLMD deserves explicit attention because it is the lineage brain behind TFX. Each component execution creates `Execution` records linked to `Artifact` entities (datasets, models, statistics protos). When compliance asks which training data produced a given production model version, MLMD answers with a graph query instead of a spreadsheet archaeology project. Even if you do not adopt full TFX, study MLMD's data model; Kubeflow and Vertex integrations increasingly mirror similar metadata concepts.
 
-┌─────────────────────────────────────────────────────────────────┐
-│                        n8n WORKFLOW                              │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  ┌─────────┐    ┌─────────┐    ┌─────────┐    ┌─────────┐      │
-│  │ TRIGGER │───▶│  FETCH  │───▶│   LLM   │───▶│  STORE  │      │
-│  │         │    │  DATA   │    │ PROCESS │    │ RESULT  │      │
-│  │ Webhook │    │  HTTP   │    │ OpenAI  │    │ Postgres│      │
-│  │ Cron    │    │ DB      │    │ Claude  │    │ Vector  │      │
-│  │ Email   │    │ S3      │    │ Ollama  │    │ Notion  │      │
-│  └─────────┘    └─────────┘    └─────────┘    └─────────┘      │
-│                                                                  │
-│  AI-SPECIFIC NODES:                                              │
-│  ─────────────────                                               │
-│  • OpenAI (gpt-5, embeddings)                                    │
-│  • Anthropic (Claude)                                            │
-│  • Ollama (local models)                                         │
-│  • Vector Stores (Pinecone, Qdrant, Supabase)                   │
-│  • Document Loaders (PDF, web, etc.)                            │
-│  • Text Splitters (chunk documents)                              │
-│  • LangChain nodes                                               │
-│                                                                  │
-│  EXAMPLE RAG WORKFLOW:                                           │
-│  ┌──────┐   ┌──────┐   ┌──────┐   ┌──────┐   ┌──────┐          │
-│  │Webhook│─▶│Embed │─▶│Vector│─▶│ LLM  │─▶│Return│          │
-│  │Query │   │Query │   │Search│   │Answer│   │Response│          │
-│  └──────┘   └──────┘   └──────┘   └──────┘   └──────┘          │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
+```python
+# Illustrative TFX pipeline shape (API evolves; verify against current TFX docs)
+from tfx.orchestration import pipeline
+from tfx.components import CsvExampleGen, StatisticsGen, SchemaGen, ExampleValidator
+
+def create_tfx_pipeline(pipeline_name: str, pipeline_root: str, data_root: str) -> pipeline.Pipeline:
+    example_gen = CsvExampleGen(input_base=data_root)
+    statistics_gen = StatisticsGen(examples=example_gen.outputs['examples'])
+    schema_gen = SchemaGen(statistics=statistics_gen.outputs['output'])
+    example_validator = ExampleValidator(
+        statistics=statistics_gen.outputs['output'],
+        schema=schema_gen.outputs['output'],
+    )
+    # Transform, Trainer, Evaluator, and Pusher wire similarly with artifact edges
+    return pipeline.Pipeline(
+        pipeline_name=pipeline_name,
+        pipeline_root=pipeline_root,
+        components=[example_gen, statistics_gen, schema_gen, example_validator],
+        enable_cache=True,
+    )
 ```
 
-Visualizing the RAG node execution logic:
-```mermaid
-flowchart LR
-    trigger[Webhook Query Trigger] --> embed[Embed Query Node]
-    embed --> vdb[Vector Database Search]
-    vdb --> llm[LLM Generation Node]
-    llm --> respond[Return Webhook Response]
+The snippet is intentionally structural rather than copy-paste runnable: TFX component constructors change across releases, and your runner configuration belongs in environment-specific settings. The lesson is the graph of named artifacts (`examples`, `statistics`, `schema`) flowing through validated stages before a trainer ever sees data.
+
+---
+
+## ZenML
+
+[ZenML](https://docs.zenml.io/) targets teams that want ML pipeline code to stay portable across orchestrators. You decorate Python functions with `@step` and compose them in a `@pipeline`. ZenML resolves the active **stack**—orchestrator, artifact store, container registry, experiment tracker, model registry, secrets manager—and injects the correct backends at runtime. The same `train_pipeline()` can run locally with a local orchestrator during development, then execute on Kubeflow or Kubernetes in staging without rewriting step bodies.
+
+Stacks are ZenML's answer to the "works on my laptop" problem. A stack is a named configuration bundle: artifact store points at S3, orchestrator points at a Kubeflow instance, experiment tracker points at MLflow. Switching stacks is how you promote code paths across environments while keeping Python source identical. This indirection adds concepts to learn upfront but pays off when data scientists should not hardcode cluster endpoints in notebooks.
+
+Artifact handling is explicit. Steps return materialized objects; ZenML serializes them to the configured artifact store and passes handles downstream. Integrations exist for popular trackers and registries, which lets ZenML sit between raw Kubeflow and a full MLOps portal. ZenML is often the right bridge when you have multiple orchestrators in the enterprise (Airflow for ETL, Kubeflow for training) but want one Python authoring experience for ML steps.
+
+```python
+from zenml import step, pipeline
+
+@step
+def load_data() -> str:
+  return "/data/train.parquet"
+
+@step
+def train_model(data_path: str) -> float:
+  # training logic returns a metric such as accuracy
+  return 0.91
+
+@pipeline
+def training_pipeline():
+  data = load_data()
+  train_model(data)
+
+if __name__ == "__main__":
+  training_pipeline()
 ```
 
-### n8n Workflow Example (JSON)
+After `zenml init` and stack configuration, `training_pipeline()` runs on whichever orchestrator the active stack defines. Consult ZenML docs for the exact CLI to register stacks and connect remote orchestrators; those commands churn faster than the stack abstraction itself.
 
-Behind the visual UI, n8n pipelines are natively stored as massive JSON documents. This also makes them straightforward to export and track in Git.
+---
 
-```json
-{
-  "name": "AI Document Q&A",
-  "nodes": [
-    {
-      "name": "Webhook",
-      "type": "n8n-nodes-base.webhook",
-      "parameters": {
-        "path": "ask",
-        "method": "POST"
-      }
-    },
-    {
-      "name": "Embed Question",
-      "type": "@n8n/n8n-nodes-langchain.embeddingsOpenAi",
-      "parameters": {
-        "model": "text-embedding-3-small"
-      }
-    },
-    {
-      "name": "Vector Store Search",
-      "type": "@n8n/n8n-nodes-langchain.vectorStoreQdrant",
-      "parameters": {
-        "operation": "search",
-        "topK": 5
-      }
-    },
-    {
-      "name": "Generate Answer",
-      "type": "@n8n/n8n-nodes-langchain.openAi",
-      "parameters": {
-        "model": "gpt-5",
-        "prompt": "Based on the following context, answer the question.\n\nContext: {{$node['Vector Store Search'].json.results}}\n\nQuestion: {{$node['Webhook'].json.question}}"
-      }
-    },
-    {
-      "name": "Return Response",
-      "type": "n8n-nodes-base.respondToWebhook",
-      "parameters": {
-        "responseBody": "={{$node['Generate Answer'].json.text}}"
-      }
-    }
-  ],
-  "connections": {
-    "Webhook": { "main": [[{ "node": "Embed Question" }]] },
-    "Embed Question": { "main": [[{ "node": "Vector Store Search" }]] },
-    "Vector Store Search": { "main": [[{ "node": "Generate Answer" }]] },
-    "Generate Answer": { "main": [[{ "node": "Return Response" }]] }
-  }
-}
+## Metaflow
+
+[Metaflow](https://docs.metaflow.org/) originated at Netflix for data science workflows that need easy local development and painless cloud scaling. Flows are Python scripts with `@step` functions and a `@flow` decorator (or class-based flows in newer APIs). Metaflow's runtime packages code, dependencies, and datastore configuration, then executes steps—locally or on AWS Batch / Kubernetes depending on configuration—with automatic persistence of intermediate artifacts to S3 (or compatible object storage).
+
+Metaflow optimizes for **resume** semantics. If a long-running training step fails on hour six of eight, rerunning the flow skips completed upstream steps because their artifacts already exist in the datastore. That behavior resembles Kubeflow caching but is oriented toward individual data scientist ergonomics rather than multi-tenant cluster scheduling. Metaflow also supports cards—lightweight HTML reports attached to steps—which help teams review training curves without opening a separate tracker for every experiment.
+
+Metaflow is less prescriptive than TFX about ML component types. You write arbitrary Python inside steps, which accelerates adoption for teams that do not want ExampleGen/Transform ceremony. The tradeoff is that you must supply your own validation and registry discipline; Metaflow will happily persist a broken model pickle if you skip evaluation gates.
+
+```python
+from metaflow import FlowSpec, step, card
+
+class TrainFlow(FlowSpec):
+    @step
+    def start(self):
+        self.dataset_uri = "s3://ml-data/train.parquet"
+        self.next(self.train)
+
+    @card
+    @step
+    def train(self):
+        # load self.dataset_uri, fit model, set self.accuracy
+        self.accuracy = 0.93
+        self.next(self.evaluate)
+
+    @step
+    def evaluate(self):
+        if self.accuracy < 0.90:
+            raise ValueError("Model below quality bar")
+        self.next(self.end)
+
+    @step
+    def end(self):
+        print("Flow complete")
+
+if __name__ == "__main__":
+    TrainFlow()
 ```
+
+Run with `python trainflow.py run` locally, or configure Metaflow's metadata and compute backends for cloud execution. The `card` decorator is optional but illustrates how Metaflow surfaces step-level narratives alongside persisted artifacts.
+
+---
+
+## Choosing Among ML-Native Pipeline Frameworks
+
+Kubeflow Pipelines, TFX, ZenML, and Metaflow all implement the same durable spine—typed artifacts, compilation to a runtime, caching, and lineage—but they optimize for different operating constraints. Kubeflow Pipelines fits teams that already run Kubernetes and want Argo-backed ML DAGs with first-class GPU scheduling on pod specs. TFX fits TensorFlow-centric organizations that want opinionated validation components (`ExampleGen`, `StatisticsGen`, `SchemaGen`, `ExampleValidator`) and MLMD lineage without inventing those stages from scratch. ZenML fits enterprises that need one Python `@pipeline` to target a local stack in development and a Kubeflow or Kubernetes stack in production by swapping stack configuration instead of rewriting step bodies. Metaflow fits data science teams that prioritize `@step` ergonomics, automatic datastore artifacts, and resume-after-failure semantics over multi-tenant cluster scheduling features.
+
+General orchestrators (Airflow, Prefect, Dagster) and durable workflow engines (Temporal) typically surround these frameworks rather than replace them. Airflow might trigger a Kubeflow Pipeline run after warehouse sensors succeed; Temporal might coordinate a multi-day training workflow with a human approval gate while Kubeflow or TFX owns the artifact graph inside each training run. The decision is therefore two-layered: pick the ML-native compiler that matches your artifact and runtime requirements, then pick the outer scheduler that matches your cadence, sensors, and approval policies.
+
+| Framework | Best when | Watch out for |
+|-----------|-----------|---------------|
+| Kubeflow Pipelines | Kubernetes is the training runtime; GPU steps need native pod resource fields | Platform setup overhead; authors must understand K8s scheduling |
+| TFX | TensorFlow shops need standardized validation components and MLMD lineage | Runner and component APIs evolve across releases |
+| ZenML | Same pipeline code must run locally and on remote orchestrators via stacks | Stack registration before first remote execution |
+| Metaflow | Individual data scientists need resilient flows with automatic artifact persistence | Less prescriptive validation—you supply evaluation gates |
 
 ---
 
@@ -748,7 +829,7 @@ if __name__ == "__main__":
     ml_pipeline()
 ```
 
-**Prefect vs Airflow**:
+Prefect and Airflow both schedule Python callables, but they optimize for different developer ergonomics: Airflow assumes a central scheduler and explicit DAG files, while Prefect treats flows as plain functions that can run locally or remotely with less boilerplate.
 ```text
 PREFECT                              AIRFLOW
 ───────                              ───────
@@ -852,7 +933,7 @@ defs = Definitions(
 )
 ```
 
-**Dagster's Asset Graph Visualization**:
+Dagster renders software-defined assets as a medallion-style graph where bronze, silver, gold, and ML layers appear as nodes with explicit lineage edges in the UI.
 ```text
 ┌─────────────┐
 │  raw_users  │ (Bronze)
@@ -874,7 +955,7 @@ defs = Definitions(
 └─────────────┘
 ```
 
-Asset Dependency Graph:
+The asset dependency graph below is the mental model Dagster users reason about when deciding which partitions to rematerialize after an upstream schema change.
 ```mermaid
 graph TD
     Bronze[raw_users Bronze Asset] --> Silver[clean_users Silver Asset]
@@ -891,7 +972,7 @@ Temporal is designed for [durable, long-running workflows that preserve workflow
 ```python
 from temporalio import activity, workflow
 from temporalio.client import Client
-from temporalio.worker import Worker
+from temporalio.common import RetryPolicy
 from dataclasses import dataclass
 from datetime import timedelta
 
@@ -926,6 +1007,12 @@ async def deploy_model(model_path: str) -> str:
     """Deploy to production."""
     print(f"Deploying {model_path}...")
     return "https://api.company.com/model/v1"
+
+@activity.defn
+async def wait_for_human_approval(training_result: dict) -> bool:
+    """Pause until a compliance reviewer approves the model."""
+    print(f"Awaiting approval for metrics: {training_result}")
+    return True
 
 # Workflow (the orchestration)
 @workflow.defn
@@ -996,7 +1083,7 @@ async def main():
     print(f"Training complete: {result}")
 ```
 
-**When to Use Temporal**:
+Temporal complements rather than replaces ML pipeline compilers: use it when workflow state must survive process restarts across days or weeks, especially for human approval gates that outlive any single Kubernetes pod.
 ```text
 USE TEMPORAL WHEN:
 ──────────────────
@@ -1019,7 +1106,7 @@ DON'T USE TEMPORAL WHEN:
 
 ## Comparison Matrix
 
-To objectively summarize the architectural differences between platforms:
+To objectively summarize the architectural differences between platforms, compare paradigm, operational cost, and the failure modes each system optimizes for rather than treating popularity as a technical requirement.
 
 ```text
 ┌────────────────┬─────────────┬─────────────┬─────────────┬─────────────┬─────────────┐
@@ -1044,19 +1131,15 @@ To objectively summarize the architectural differences between platforms:
 │ Managed Cloud  │  MWAA     │  Prefect  │  Dagster  │  Vertex   │  Temporal │
 │                │   GCP       │   Cloud     │   Cloud     │   AI        │   Cloud     │
 ├────────────────┼─────────────┼─────────────┼─────────────┼─────────────┼─────────────┤
-│ Community      │ ⭐⭐⭐⭐⭐  │ ⭐⭐⭐⭐    │ ⭐⭐⭐⭐    │ ⭐⭐⭐⭐    │ ⭐⭐⭐      │
+│ Community      │ Very large  │ Large       │ Large       │ Large       │ Growing     │
 └────────────────┴─────────────┴─────────────┴─────────────┴─────────────┴─────────────┘
 ```
-
-| Feature | AIRFLOW | PREFECT | DAGSTER | KUBEFLOW | TEMPORAL |
-|---|---|---|---|---|---|
-| Paradigm | Task-based DAGs | Task-based Flows | Asset-based Assets | Container Pipelines | Durable Workflows |
-| Learning Curve | Medium | Low | Medium | High | High |
-| Best For | Data/ML Pipelines | Modern Pipelines | Data Products | K8s ML Training | Long-running |
 
 ---
 
 ## Production Patterns
+
+Production ML pipelines reuse a small set of control-flow patterns regardless of vendor SDK. Retries absorb transient infrastructure faults, branching encodes promotion policy, parallelism speeds embarrassingly parallel work, and sensors synchronize with late-arriving data. The snippets below show how different orchestrators express the same ideas; translate them mentally when you move from Airflow to Kubeflow or ZenML.
 
 ### Pattern 1: Retry with Exponential Backoff
 
@@ -1211,15 +1294,15 @@ START HERE
                                           │ AIRFLOW │         │ PREFECT │
                                           └─────────┘         └─────────┘
 
-VISUAL/LOW-CODE NEEDS:
-──────────────────────
-• Quick AI prototypes      → n8n
-• LangChain flows          → LangFlow
-• LLM chat flows           → Flowise
-• Multi-language scripts   → Windmill
+ML-NATIVE PIPELINE NEEDS:
+─────────────────────────
+• K8s-native GPU training  → Kubeflow Pipelines
+• TensorFlow validation    → TFX
+• Stack portability        → ZenML
+• Data scientist ergonomics → Metaflow
 ```
 
-Visualizing the decision tree matrix:
+The decision tree matrix below condenses the comparison into a sequence of questions about Kubernetes requirements, workflow duration, asset-centric modeling, and appetite for self-hosted operations.
 ```mermaid
 flowchart TD
     start[Start Evaluation] --> q1{Do you need Kubernetes-native ML workload execution?}
@@ -1241,7 +1324,7 @@ When massive pipelines catastrophically fail at 3 AM, engineering teams require 
 
 ### Step 1: Identify the Failure Scope
 
-First, determine precisely what component failed and how deeply the error cascaded:
+First, determine precisely what component failed and how deeply the error cascaded, because the remediation path differs when a single training pod OOMs versus when the scheduler stops dispatching work entirely.
 
 ```text
 FAILURE SCOPE ASSESSMENT
@@ -1270,13 +1353,7 @@ SILENT FAILURE:
 
 ### Step 2: Analyze Task Logs
 
-Every professional orchestrator provides granular task logs. Engineers must know how to extract them efficiently:
-
-**Airflow**: `airflow tasks logs <dag_id> <task_id> <execution_date>`
-
-**Prefect**: Navigate via the Flow runs page, click the designated run, and open the Task logs panel.
-
-**Dagster**: Open the specific Asset details view, explore the Materialization history, and review the deep Log viewer.
+Every professional orchestrator provides granular task logs, and engineers must know how to extract them efficiently during an incident instead of clicking randomly in the UI. For Airflow, use `airflow tasks logs <dag_id> <task_id> <execution_date>` from the CLI or the equivalent log link in the web UI. For Prefect, open the flow run page, select the failed task, and read the task log panel which preserves stdout from the worker process. For Dagster, open the asset detail view, inspect the materialization history for the failing partition, and read the structured log viewer which correlates step events with asset keys.
 
 ### Step 3: Reproduce Locally
 
@@ -1334,9 +1411,9 @@ def data_health_check(df: pd.DataFrame, context: str) -> None:
 
 ### Pro Tips from Production Engineers
 
-**"The Log Line That Saved Us Hours"**
+Experienced pipeline owners treat observability as part of the pipeline contract, not as an afterthought added only after the first outage. The three patterns below—structured start logs, training checkpoints, and canary transforms—show up repeatedly in postmortems because they shrink the search space when a run fails at 03:00.
 
-Always log context explicitly at task start:
+Always log context explicitly at task start because the first lines in a task log often determine how quickly someone recognizes resource starvation versus code failure:
 ```python
 @task
 def process_batch(batch_id: str):
@@ -1346,11 +1423,9 @@ def process_batch(batch_id: str):
     # ... your logic
 ```
 
-This exceptionally simple pattern has saved countless engineering hours. When something violently fails, you can quickly see the raw resource state when it initially started. This simple pattern can shorten debugging by recording execution context at task start, which makes later failures easier to interpret.
+When something fails hours into a run, those opening log lines reveal whether the worker started with enough memory and whether CPU contention was already present before your training code executed.
 
-**"The Checkpoint Pattern"**
-
-For massive long-running training tasks, manually checkpoint progress continually so infrastructure retries do not restart entirely from epoch zero:
+For massive long-running training tasks, checkpoint progress continually so infrastructure retries do not restart entirely from epoch zero when a spot instance disappears or a node drains for maintenance:
 ```python
 @task
 def train_model_with_checkpoints(config: dict):
@@ -1370,9 +1445,7 @@ def train_model_with_checkpoints(config: dict):
             torch.save(model.state_dict(), checkpoint_path)
 ```
 
-**"The Canary Test Pattern"**
-
-Before blindly executing processing over terabytes of data, rapidly test on a minuscule sample:
+Before executing transforms over terabytes of data, run a canary transform on a tiny sample so schema mistakes surface in seconds instead of after hours of cluster time:
 ```python
 @task
 def safe_transform(data_path: str):
@@ -1394,9 +1467,23 @@ def safe_transform(data_path: str):
 
 ---
 
+## Connecting Pipelines to Experiment Tracking and Model Registries
+
+Pipeline components should not silently train models in a vacuum. Experiment tracking systems such as MLflow, Weights & Biases, or Neptune capture parameters, metrics, and artifacts for human comparison, while model registries add stage transitions (`Staging`, `Production`) with approval semantics. The integration point is usually a training or evaluation component that logs metrics as pipeline artifacts *and* emits a tracker run ID stored in ML Metadata or Kubeflow run labels.
+
+Design the handoff explicitly: the training component writes `model.tar.gz` to object storage, logs `accuracy` and `f1` to your tracker, and returns a structured metrics artifact consumed by a conditional deploy component. The registry step should reference immutable artifact URIs, not mutable paths like `/latest/model.pkl`. If your registry allows mutable aliases, your pipeline must still record the content hash or version ID that was promoted so rollback means redeploying a known artifact, not hoping the alias still points to the same bytes.
+
+ZenML and TFX integrate trackers and registries through stack components or first-class pipeline steps. Kubeflow users often invoke MLflow from inside `@dsl.component` containers. Metaflow users attach cards or call tracker APIs directly inside `@step` functions. None of these patterns remove the need for pipeline-level gates: tracking tells you what happened; branching decides whether production may change.
+
+When debugging promotion mistakes, correlate three IDs: pipeline run ID, tracker run ID, and registry model version. If those identifiers diverge in your spreadsheets, your automation is incomplete. Mature teams generate a single promotion record object—sometimes a JSON artifact attached to the final step—that lists all three identifiers plus the dataset snapshot hash used for training.
+
+Serving systems discussed in the next module consume registry entries. That means your pipeline's final artifact must include not only the model binary but also the inference schema: feature names, dtypes, and preprocessing graph or ONNX opset version. Pipelines that stop at `model.pkl` without exporting serving metadata push complexity into the deployment team and invite train-serve skew.
+
+---
+
 ## Production War Stories
 
-### Silent Failure Scenario
+### Hypothetical scenario: Silent Failure
 
 A production ML pipeline can fail silently if an upstream extraction step returns empty data without raising an exception.
 
@@ -1420,7 +1507,7 @@ def validate_data(df: pd.DataFrame) -> pd.DataFrame:
     return df
 ```
 
-### Circular Dependency Scenario
+### Hypothetical scenario: Circular Dependency
 
 Large Airflow deployments can accumulate poorly documented cross-DAG dependencies that become difficult to reason about over time.
 
@@ -1432,7 +1519,60 @@ Untangling undocumented dependency loops can take days and materially delay down
 
 ---
 
+## Building Your First Production Pipeline
+
+A production ML pipeline is more than a training script inside a nightly cron job. It is a contract between data engineering, machine learning, and platform teams about how artifacts move from raw storage through validation, feature materialization, training, evaluation, registration, and optional deployment. The orchestration layer coordinates *when* each stage runs; the pipeline SDK defines *what* each stage consumes and produces; object storage and metadata services prove *which revision* flowed into a given model binary.
+
+When you design your first pipeline, start from artifact boundaries rather than from favorite tools. Identify immutable inputs (dataset snapshot ID, feature view version, container image digest), mutable parameters (hyperparameters, thresholds), and outputs that downstream systems require (registered model URI, evaluation report, promotion decision). Only then pick whether Kubeflow, TFX, ZenML, or Metaflow is the best compiler for your runtime. Many teams trigger an ML-native pipeline from Airflow or Dagster once upstream ETL sensors succeed—the outer orchestrator handles calendar scheduling while the inner pipeline handles ML artifact typing.
+
+### Architecture Reference
+
+```text
+PRODUCTION ML PIPELINE ARCHITECTURE
+===================================
+
+┌─────────────────────────────────────────────────────────────────────────────┐
+│                            ORCHESTRATION LAYER                               │
+│  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐    ┌─────────────┐ │
+│  │   TRIGGER   │───▶│  VALIDATE   │───▶│   TRAIN     │───▶│   DEPLOY    │ │
+│  │   (Sensor)  │    │   (Data)    │    │   (Model)   │    │ (Conditional)│ │
+│  └─────────────┘    └─────────────┘    └─────────────┘    └─────────────┘ │
+│         │                  │                  │                  │          │
+│         │                  │                  │                  │          │
+└─────────┼──────────────────┼──────────────────┼──────────────────┼──────────┘
+          │                  │                  │                  │
+          ▼                  ▼                  ▼                  ▼
+┌─────────────┐    ┌─────────────┐    ┌─────────────┐    ┌─────────────┐
+│  DATA LAKE  │    │  FEATURE    │    │  EXPERIMENT │    │  MODEL      │
+│   (S3/GCS)  │    │   STORE     │    │   TRACKER   │    │  REGISTRY   │
+│             │    │  (Feast)    │    │  (MLflow)   │    │  (MLflow)   │
+└─────────────┘    └─────────────┘    └─────────────┘    └─────────────┘
+```
+
+Visualizing the production deployment logic:
+```mermaid
+flowchart TD
+    subgraph Orchestration Layer
+        Trigger[Trigger Sensor] --> Validate[Validate Data]
+        Validate --> Train[Train Model]
+        Train --> Deploy[Deploy Conditional]
+    end
+    subgraph Storage and Tracking
+        dl[(Data Lake S3/GCS)]
+        fs[(Feature Store Feast)]
+        et[Experiment Tracker MLflow]
+        mr[Model Registry MLflow]
+    end
+    Trigger -.-> dl
+    Validate -.-> fs
+    Train -.-> et
+    Deploy -.-> mr
+```
+---
+
 ## Common Mistakes and How to Avoid Them
+
+Pipeline failures are rarely mysterious once you inspect artifact boundaries and scheduler metadata. The mistakes below appear repeatedly across Kubeflow, TFX, ZenML, Metaflow, and general orchestrators such as Airflow because they violate the same durable principles: pass references not payloads, pin versions, make retries safe, and fail loudly on empty data.
 
 | Mistake | Why | Fix |
 |---|---|---|
@@ -1442,6 +1582,8 @@ Untangling undocumented dependency loops can take days and materially delay down
 | Ignoring explicit timezone configurations | Inconsistent timezone handling can cause schedules to run at unintended times, especially around DST changes | Standardize purely on UTC globally and explicitly define timezone aware executions |
 | Severe lack of rigorous data quality gates | Upstream bad data silently trains and deploys garbage models into live production | Implement rigid row count, strict null check, and comprehensive schema validation tasks upfront |
 | Infinite execution retries without backoff | Unintentionally slams recovering downstream APIs and severely exacerbates ongoing outages | Set explicit maximum task retries and enforce exponential backoff delays across all workers |
+| Disabling cache without noticing during debug | Developers think a step re-ran but the UI reused prior artifacts, leading to false conclusions about code changes | Toggle cache explicitly, bump input artifact versions, or annotate runs when validating new trainer code |
+| Compiling pipelines without pinning container images | Identical YAML parameters can execute different library versions when `:latest` tags move | Pin image digests or immutable tags in every component definition before promoting to production |
 
 ### Mistake 1: Hardcoding Configuration
 
@@ -1519,159 +1661,45 @@ def transform(data_path: str) -> str:
     return output_path
 ```
 
----
 
-## Interview Preparation
+## Quiz
 
-### Question 1: "How would you design an ML pipeline that needs to train on data arriving at different times?"
+<details>
+<summary>1. Scenario: You are managing a nightly batch ML job that systematically trains an XGBoost model on yesterday's sales data. The core data pipeline takes exactly 45 minutes to execute, and isolated failures are typically caused by missing upstream relational database partitions. Which orchestration platform is best suited for this task and why?</summary>
 
-**Strong Answer**:
-"I would implement a robust sensor-based approach utilizing aggressive watermarking. Here is the system design:
+**Answer:** Apache Airflow or Prefect fits this scenario. The job is a short, calendar-driven batch DAG with clear task dependencies and partition-wait requirements—exactly what task-based orchestrators handle well. You do not need Temporal's durable multi-day workflow state for a nightly 45-minute job, and Kubeflow is unnecessary unless the training graph itself must compile to Kubernetes pods. Airflow's sensor ecosystem is a practical fit for delaying the run until yesterday's database partition lands.
+</details>
 
-1. **Data arrival sensors**: Utilize isolated FileSensors or entirely custom API sensors that efficiently poll for data readiness. Each specific source has its own isolated sensor with a strictly configurable timeout.
-2. **Watermark tracking**: Explicitly track the absolutely latest complete data timestamp for each given source. Ensure you do not start the intensive training loop until all sources cross the watermark.
-3. **Graceful degradation**: If one singular source is extremely late but the others are perfectly ready, make a dynamic decision based on core business needs—either pause (prioritizing data quality) or forcefully proceed with yesterday's stale data (prioritizing rapid freshness).
-4. **Alerting**: If any sensor violates the strict SLA, alert the primary on-call engineer instantly before the pipeline is allowed to auto-fail.
+<details>
+<summary>2. Scenario: Your core data science team forcefully complains that they repeatedly do not understand the Airflow DAG boilerplate code logic. They conceptually think purely in terms of "data artifacts" like raw tables, intelligently cleaned tables, and engineered analytical features. Which advanced tool should you immediately migrate to?</summary>
 
-```python
-from airflow.sensors.filesystem import FileSensor
-from airflow.utils.dates import days_ago
+**Answer:** Dagster is the best match. The team thinks in assets—raw tables, cleaned tables, engineered features—not in Airflow operator boilerplate. Dagster's Software-Defined Assets model centers the graph on what data is produced and how assets depend on each other, while Airflow centers on task execution records. Data scientists can write Python functions that materialize DataFrames, and Dagster infers lineage from those asset definitions.
+</details>
 
-# Define sensors for each data source
-wait_for_transactions = FileSensor(
-    task_id='wait_for_transactions',
-    filepath='/data/transactions/{{ ds }}/*.parquet',
-    timeout=3600 * 4,  # 4 hour SLA
-    mode='reschedule'
-)
+<details>
+<summary>3. Scenario: Your data science team writes one Python training pipeline that must run on a laptop during development and on a shared Kubeflow cluster in production without rewriting step logic. Which ML-native framework emphasizes stack-based portability?</summary>
 
-wait_for_user_data = FileSensor(
-    task_id='wait_for_user_data',
-    filepath='/data/users/{{ ds }}/*.parquet',
-    timeout=3600 * 2,  # 2 hour SLA
-    mode='reschedule'
-)
+**Answer:** ZenML. Its stack abstraction separates pipeline code from runtime backends—local orchestrator and artifact store in development, Kubeflow (or Kubernetes) orchestrator and remote artifact store in production. The same `@step` and `@pipeline` definitions run in both environments after you switch the active stack, which is the portability problem this scenario describes.
+</details>
 
-# Both must complete before training starts
-[wait_for_transactions, wait_for_user_data] >> start_training
-```
+<details>
+<summary>4. Scenario: Your highly-regulated machine learning verification pipeline inevitably involves a multi-day neural network training step explicitly followed by a mandatory manual human-in-the-loop compliance approval step. If the underlying Kubernetes bare-metal node randomly reboots during exactly day two, the critical workflow must aggressively resume exactly where it precipitously crashed. Which tool is strictly architecturally required?</summary>
 
-### Question 3: "How do you handle ML pipeline failures at 3 AM?"
+**Answer:** Temporal. It persists workflow state in an event history and resumes from the last completed step after worker or node failure. Airflow typically marks the in-flight task failed when a worker dies, which can force a full re-run of a multi-day training step. Temporal's durable execution model is built for workflows that span days and include human approval gates that outlive any single pod.
+</details>
 
-**Strong Answer**:
-"Production ML requires defense in depth architecture:
+<details>
+<summary>5. Why is it functionally incredibly dangerous to pass a massive 10GB Pandas DataFrame between two discrete Apache Airflow operational tasks using the XCom communication subsystem?</summary>
 
-**Prevention (before failure)**:
-- Implement data validation tasks that aggressively fail fast on unexpected bad input distributions.
-- Apply strict resource limits (memory, execution timeout) to immediately prevent runaway zombie jobs.
-- Design fully idempotent tasks that consistently handle orchestrator retries safely.
+**Answer:** XCom is designed for small metadata—run IDs, row counts, metric scalars—not multi-gigabyte payloads. Airflow serializes XCom values into its metadata database (often PostgreSQL). Passing a 10GB DataFrame forces worker memory pressure during serialization and can bloat or destabilize the metadata store. Pass a URI to object storage or a shared path reference instead, and load the data inside the downstream task.
+</details>
 
-**Detection (catch failures quickly)**:
-- Enable automatic retries with increasing exponential backoff intervals (e.g., 3 attempts, 5-10-20 minute delays).
-- Trigger SLA alerts when executing tasks wildly exceed their historically expected duration.
-- Enforce comprehensive data quality monitoring (total row counts, extreme null rates, unexpected value distributions).
+<details>
+<summary>6. Scenario: You notice that tasks in your Airflow cluster are successfully entering the "queued" state but remain there indefinitely without starting. Based on the operational responsibilities of an orchestrator's components, which system component is most likely experiencing a critical failure?</summary>
 
-```python
-default_args = {
-    'retries': 3,
-    'retry_delay': timedelta(minutes=5),
-    'retry_exponential_backoff': True,
-    'email_on_failure': True,
-    'email': ['ml-oncall@company.com'],
-    'sla': timedelta(hours=2)  # Alert if task runs too long
-}
+**Answer:** The executing workers (or the executor component) are most likely failing. The central scheduler has successfully performed its responsibility of parsing the DAG, determining the tasks are ready, and placing them in the execution queue. The failure occurs at the next step, where the operational "muscle" (the workers) should be actively extracting and running those queued tasks.
+</details>
 
-@task(on_failure_callback=notify_pagerduty)
-def train_model():
-    # Training logic
-    pass
-```
-
-The fundamental goal is not purely zero failures—it is extremely fast detection, reliable automatic recovery, and minimizing the necessity of manual human intervention at 3 AM."
-
----
-
-## The Economics of ML Orchestration
-
-### Build vs. Buy Analysis
-
-| Approach | Monthly Cost | Hidden Costs | Best For |
-|----------|-------------|--------------|----------|
-| Managed Airflow (MWAA) | Pricing varies with environment size and usage | Lower day-to-day ops overhead than self-hosting | Teams already standardized on AWS |
-| Self-hosted Airflow | Infrastructure cost varies by scale and architecture | Higher ops overhead | Teams that need deeper customization and control |
-| Prefect Cloud | Pricing varies by plan and workload | Lower platform management overhead | Teams that want a managed Prefect control plane |
-| Dagster Cloud | Pricing varies by plan and workload | Lower platform management overhead | Data-centric teams that want managed Dagster services |
-| Kubeflow (self-hosted) | Cost depends heavily on cluster size and GPU usage | Kubernetes expertise required | Teams running Kubernetes-native ML platforms |
-| Temporal Cloud | Pricing varies by workload shape and scale | Added workflow-modeling complexity | Long-running, durable workflow use cases |
-
-### The Real Cost Formula
-
-```text
-Total Cost = Infrastructure + Engineering Time + Failure Cost
-
-Infrastructure:
-- Managed service fees OR self-hosted compute
-- Database (metadata store)
-- Storage (logs, artifacts)
-
-Engineering Time:
-- Initial setup: 40-200 hours
-- Ongoing maintenance: 4-20 hours/month
-- Debugging failures: 10-40 hours/month (without orchestration: 3x more)
-
-Failure Cost:
-- Revenue loss per hour of downtime
-- Data quality issues reaching customers
-- Engineer time for manual recovery
-```
-
----
-
-## Building Your First Production Pipeline
-
-### Architecture Reference
-
-```text
-PRODUCTION ML PIPELINE ARCHITECTURE
-===================================
-
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                            ORCHESTRATION LAYER                               │
-│  ┌─────────────┐    ┌─────────────┐    ┌─────────────┐    ┌─────────────┐ │
-│  │   TRIGGER   │───▶│  VALIDATE   │───▶│   TRAIN     │───▶│   DEPLOY    │ │
-│  │   (Sensor)  │    │   (Data)    │    │   (Model)   │    │ (Conditional)│ │
-│  └─────────────┘    └─────────────┘    └─────────────┘    └─────────────┘ │
-│         │                  │                  │                  │          │
-│         │                  │                  │                  │          │
-└─────────┼──────────────────┼──────────────────┼──────────────────┼──────────┘
-          │                  │                  │                  │
-          ▼                  ▼                  ▼                  ▼
-┌─────────────┐    ┌─────────────┐    ┌─────────────┐    ┌─────────────┐
-│  DATA LAKE  │    │  FEATURE    │    │  EXPERIMENT │    │  MODEL      │
-│   (S3/GCS)  │    │   STORE     │    │   TRACKER   │    │  REGISTRY   │
-│             │    │  (Feast)    │    │  (MLflow)   │    │  (MLflow)   │
-└─────────────┘    └─────────────┘    └─────────────┘    └─────────────┘
-```
-
-Visualizing the production deployment logic:
-```mermaid
-flowchart TD
-    subgraph Orchestration Layer
-        Trigger[Trigger Sensor] --> Validate[Validate Data]
-        Validate --> Train[Train Model]
-        Train --> Deploy[Deploy Conditional]
-    end
-    subgraph Storage and Tracking
-        dl[(Data Lake S3/GCS)]
-        fs[(Feature Store Feast)]
-        et[Experiment Tracker MLflow]
-        mr[Model Registry MLflow]
-    end
-    Trigger -.-> dl
-    Validate -.-> fs
-    Train -.-> et
-    Deploy -.-> mr
-```
 
 ---
 
@@ -1719,7 +1747,7 @@ default_args = {
 with DAG(
     'ml_training_exercise',
     default_args=default_args,
-    schedule_interval='@daily',
+    schedule='@daily',
     start_date=datetime(2024, 1, 1),
     catchup=False
 ) as dag:
@@ -1731,6 +1759,9 @@ with DAG(
 
 **Task 3: Develop the Core Python Callables**
 At the exact top of your `ml_dag.py` (positioned below the absolute imports), write the functional Python logic required to extract a dataset, calculate a training iteration, and evaluate deployment thresholds.
+
+> **Caution:** `/tmp` paths work on a single local worker only. On distributed or Kubernetes executors, tasks may run on different machines—pass artifact URIs through the pipeline's artifact store (S3, GCS, or Airflow's configured storage), not the local filesystem.
+
 ```python
 import pandas as pd
 from sklearn.ensemble import RandomForestClassifier
@@ -1801,7 +1832,7 @@ def decide_deployment(**kwargs):
 with DAG(
     'ml_training_exercise',
     default_args=default_args,
-    schedule_interval='@daily',
+    schedule='@daily',
     start_date=datetime(2024, 1, 1),
     catchup=False
 ) as dag:
@@ -1828,7 +1859,7 @@ with DAG(
 ```
 </details>
 
-**Success Checklist**:
+Confirm the Airflow exercise succeeded before moving on:
 - [ ] Airflow parses the DAG logic flawlessly without raising import errors.
 - [ ] `airflow dags test ml_training_exercise` runs completely successfully.
 - [ ] The dynamic branching operator strictly selects the correct deployment task path based on the generated XCom metrics.
@@ -1904,17 +1935,16 @@ if __name__ == "__main__":
 ```
 </details>
 
-**Success Checklist**:
+Confirm the Prefect exercise succeeded before moving on:
 - [ ] The Python script officially executes cleanly without throwing syntax errors.
 - [ ] You vividly see Prefect orchestration metadata logs aggressively outputting directly to your primary terminal.
 - [ ] The application console explicitly prints the accurate string names of the processed structural users.
 
 ### Exercise 3: Design a Dagster Asset Graph
 
-**Goal**: Rigorously construct a completely executable Dagster pipeline brilliantly demonstrating software-defined functional assets.
+This exercise constructs a bronze-to-ML asset graph in Dagster so you can see how software-defined assets differ from task-only DAGs. You will install Dagster locally, define a raw bronze asset, derive silver and gold assets with explicit dependencies, and materialize the graph from the Dagster UI.
 
-**Task 1: Set Up Dagster Libraries**
-Immediately install Dagster execution frameworks alongside its integrated webserver ecosystem.
+Begin by installing Dagster, the webserver package, and pandas inside the same virtual environment you used for the earlier exercises, then confirm the CLI reports a successful installation before you author assets.
 ```bash
 pip install dagster dagster-webserver pandas
 
@@ -1922,8 +1952,7 @@ pip install dagster dagster-webserver pandas
 dagster --version
 ```
 
-**Task 2: Define Core Bronze Assets**
-Instantiate the `dagster_assets.py` file utilizing the foundational starter asset configuration:
+Create a file named `dagster_assets.py` and seed it with the bronze asset stub below, which will become the root of your lineage graph once you add silver, gold, and model assets in the next task.
 
 ```python
 from dagster import asset, AssetExecutionContext, Definitions
@@ -1944,8 +1973,7 @@ def raw_events(context: AssetExecutionContext) -> pd.DataFrame:
 # Define silver, gold, and ml_model assets
 ```
 
-**Task 3: Implement Strategic Silver, Gold, and ML Assets**
-Immediately below the raw foundational asset, comprehensively write the remaining pipeline assets to construct a deep linear graph. Explicitly ensure you accurately use the `deps` parameter so Dagster functionally understands execution dependencies.
+Below the bronze asset, implement silver, gold, and ML model assets that form a linear dependency chain. Use the `deps` parameter and typed function arguments so Dagster can infer execution order and render the lineage graph without manual task wiring.
 
 <details>
 <summary>View Final Solution for Exercise 3</summary>
@@ -2001,90 +2029,29 @@ defs = Definitions(
 ```
 </details>
 
-**Success Checklist**:
+Confirm the Dagster exercise succeeded before finishing the module:
 - [ ] Executing `dagster dev -f dagster_assets.py` brilliantly launches the graphical UI seamlessly.
 - [ ] Aggressively navigating to `localhost:3000` vividly displays the absolute complete asset lineage graph.
 - [ ] Radically clicking the "Materialize All" execution button correctly operates the pipeline sequentially.
 
----
-
-## Quiz
-
-<details>
-<summary>1. Scenario: You are managing a nightly batch ML job that systematically trains an XGBoost model on yesterday's sales data. The core data pipeline takes exactly 45 minutes to execute, and isolated failures are typically caused by missing upstream relational database partitions. Which orchestration platform is best suited for this task and why?</summary>
-
-**Answer:** Apache Airflow or Prefect would be the absolute optimal choice for this exact operational scenario. The required task is a classically structured, relatively short-duration analytical batch job equipped with highly transparent file execution dependencies, which is profoundly what DAG-based orchestrators excel at natively. You fundamentally do not require the extraordinarily complex, extremely durable execution transaction guarantees embedded inside Temporal, nor do you strictly demand Kubernetes-native orchestrations like Kubeflow. Airflow's historically extensive sensor ecosystem makes it trivial to passively delay execution execution until database partitions formally arrive.
-</details>
-
-<details>
-<summary>2. Scenario: Your core data science team forcefully complains that they repeatedly do not understand the Airflow DAG boilerplate code logic. They conceptually think purely in terms of "data artifacts" like raw tables, intelligently cleaned tables, and engineered analytical features. Which advanced tool should you immediately migrate to?</summary>
-
-**Answer:** Dagster is overwhelmingly the ideal pipeline orchestrator for a deeply data-centric engineering team that thinks specifically in terms of persistent data assets. Unlike legacy systems like Airflow, which meticulously focuses heavily on the rigid operational execution tracking of transient tasks (the specific "how"), Dagster's Software-Defined Assets paradigm aggressively focuses completely on the actual data artifacts being mathematically produced (the absolute "what"). This profound structural paradigm shift allows specialized data scientists to rapidly write pure Python functions that elegantly return complex DataFrames, while the core orchestration engine magically infers the operational execution lineage graph automatically.
-</details>
-
-<details>
-<summary>3. Scenario: You are rapidly engineering an orchestrator backend for an advanced LLM corporate chatbot. Strictly non-technical prompt designers fundamentally need to frequently modify the retrieval-augmented generation (RAG) execution flow, graphically swapping out various vector databases or inference API endpoints visually. What orchestrator system should you immediately deploy?</summary>
-
-**Answer:** n8n or LangFlow would undoubtedly be the singularly most appropriate architectural choice here. These deeply visual, highly integrated low-code orchestrators proactively allow non-programmers to define overwhelmingly complex systemic workflows simply by dragging and structurally connecting intuitive nodes. Within n8n, prompt engineers can vividly connect a webhook trigger to an active vector search node and an LLM textual generation node without writing a single line of raw computational Python script. This effectively democratizes the operational maintenance of the AI inference pipeline and aggressively removes the central data engineering team as a critical operational bottleneck.
-</details>
-
-<details>
-<summary>4. Scenario: Your highly-regulated machine learning verification pipeline inevitably involves a multi-day neural network training step explicitly followed by a mandatory manual human-in-the-loop compliance approval step. If the underlying Kubernetes bare-metal node randomly reboots during exactly day two, the critical workflow must aggressively resume exactly where it precipitously crashed. Which tool is strictly architecturally required?</summary>
-
-**Answer:** Temporal is distinctly the only tool currently listed that consistently provides true durable computational execution uniquely capable of seamlessly handling this precise catastrophic scenario. Traditional operational orchestrators like Apache Airflow will usually mark a running task as failed if the underlying isolated worker suddenly dies, often requiring a full execution retry of that specific massive task. Temporal deliberately saves the exact executing state of the complex workflow continuously into its highly resilient event history.
-</details>
-
-<details>
-<summary>5. Why is it functionally incredibly dangerous to pass a massive 10GB Pandas DataFrame between two discrete Apache Airflow operational tasks using the XCom communication subsystem?</summary>
-
-**Answer:** XCom (Cross-Communication) is architecturally designed exclusively to pass highly minimal structural metadata, such as unique execution IDs or tiny statistical metrics, persistently between separated execution tasks by storing this dense information deeply inside Airflow's core backend relational database (usually PostgreSQL). Attempting to aggressively pass an entire 10GB analytical DataFrame will reliably completely exhaust the volatile memory of the executing worker node and fatally crash the backend orchestration database by attempting to serialize and violently insert massive BLOB fragments.
-</details>
-
-<details>
-<summary>6. Scenario: You notice that tasks in your Airflow cluster are successfully entering the "queued" state but remain there indefinitely without starting. Based on the operational responsibilities of an orchestrator's components, which system component is most likely experiencing a critical failure?</summary>
-
-**Answer:** The executing workers (or the executor component) are most likely failing. The central scheduler has successfully performed its responsibility of parsing the DAG, determining the tasks are ready, and placing them in the execution queue. The failure occurs at the next step, where the operational "muscle" (the workers) should be actively extracting and running those queued tasks.
-</details>
 
 ---
 
-## Summary
+## Next Module
 
-```text
-ORCHESTRATION TOOLS SUMMARY
-===========================
-
-AIRFLOW:   Industry standard, battle-tested, large community
-PREFECT:   Modern, Python-native, better developer experience
-DAGSTER:   Asset-based, data-centric, great for analytics
-KUBEFLOW:  Kubernetes-native, ML-focused, GPU support
-TEMPORAL:  Durable execution, long-running, reliable
-n8n:       Visual, low-code, AI-native nodes
-
-WHEN TO USE:
-────────────
-Data Engineering     → Airflow, Dagster
-ML Training          → Kubeflow, Airflow
-Quick Prototypes     → n8n, Prefect
-Long-running Jobs    → Temporal
-Modern Teams         → Prefect, Dagster
-```
-
----
-
-## Next Steps
-
-[Module 51](/ai-ml-engineering/mlops/module-1.9-model-serving/) will meticulously cover Model Deployment & Serving Patterns, aggressively including FastAPI endpoints, optimized gRPC servers, rolling canary deployments, and extensive A/B testing infrastructure designed explicitly for Kubernetes environments.
+Continue to [Module 1.9: Model Serving](./module-1.9-model-serving/) for deployment patterns—FastAPI and gRPC inference endpoints, canary rollouts, and Kubernetes-native serving controls that consume the artifacts your pipelines produce.
 
 ## Sources
 
 - [Apache Airflow Project History](https://airflow.apache.org/docs/apache-airflow/stable/project.html) — Official project history covering Airflow's origins and open-source timeline.
-- [Apache Airflow 1.10.1 Documentation](https://airflow.apache.org/docs/apache-airflow/1.10.1/index.html) — Primary documentation for Airflow concepts such as DAGs, dependencies, operators, scheduling, and the web UI.
+- [Apache Airflow Documentation](https://airflow.apache.org/docs/apache-airflow/stable/index.html) — Primary documentation for Airflow concepts such as DAGs, dependencies, operators, scheduling, and the web UI.
 - [Apache Oozie Overview](https://oozie.apache.org/docs/5.2.0/DG_Overview.html) — Official overview of Oozie's XML-defined workflow model and Hadoop job orchestration.
 - [Kubeflow Pipelines README](https://github.com/kubeflow/pipelines) — Primary overview of Kubeflow Pipelines as a Kubernetes-oriented ML workflow platform.
 - [Argo Workflows Documentation](https://argoproj.github.io/workflows/) — Official documentation for Argo's Kubernetes-native, declarative workflow engine.
+- [TensorFlow Extended (TFX) Guide](https://www.tensorflow.org/tfx/guide) — Official TFX documentation for pipeline components, runners, and ML Metadata integration.
+- [ZenML Documentation](https://docs.zenml.io/) — Stack-based pipeline orchestration, artifact stores, and integration guides.
+- [Metaflow Documentation](https://docs.metaflow.org/) — Flow authoring, datastore artifacts, and cloud execution configuration.
 - [Dagster README](https://github.com/dagster-io/dagster) — Primary project overview describing Dagster's software-defined asset approach.
-- [n8n README](https://github.com/n8n-io/n8n) — Primary overview of n8n's workflow automation, AI features, self-hosting, and code extensibility.
 - [Airflow TaskFlow Tutorial](https://airflow.apache.org/docs/apache-airflow/stable/tutorial/taskflow.html) — Official TaskFlow reference for Python-first task composition and data passing in Airflow 2.x.
 - [Prefect README](https://github.com/PrefectHQ/prefect) — Primary overview of Prefect's Python `@flow` and `@task` workflow model.
 - [Temporal Architecture Overview](https://github.com/temporalio/temporal/blob/main/docs/architecture/README.md) — Primary architecture reference for Temporal's durable execution and failure-recovery model.

--- a/src/content/docs/ai-ml-engineering/mlops/module-1.9-model-serving.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.9-model-serving.md
@@ -4,30 +4,43 @@ slug: ai-ml-engineering/mlops/module-1.9-model-serving
 sidebar:
   order: 610
 ---
-> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6
----
-**Prerequisites**: [Module 1.8: ML Pipelines](./module-1.8-ml-pipelines/)
+> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6 hours
 
-Seattle. November 2021. The Zillow Offers division, previously hailed as the vanguard of algorithmic real estate, was in systemic freefall. Their sophisticated home price prediction model—the foundational core of their iBuying business—was generating systematically flawed appraisals. The machine learning model failed to account for a rapid, unforeseen cooldown in the housing market, leading the company to dramatically overpay for thousands of properties across the country.
-
-The catastrophic failure wasn't isolated to the model's statistical predictive capabilities; it was a fundamental breakdown of model serving, observability, and automated deployment guardrails. Zillow had deployed a powerful machine learning engine but completely lacked the rapid feedback loops and progressive canary deployment strategies required to safely throttle the system when real-world market conditions diverged from the training data distributions. Without a mature serving layer, there was no automated circuit breaker to halt the runaway algorithms.
-
-Because the engineering teams could not quickly identify the severe data drift or safely roll back to a more conservative pricing algorithm without paralyzing their core operations, the financial losses cascaded uncontrollably. By the end of the quarter, [Zillow announced it would wind down its iBuying operation entirely](https://www.prnewswire.com/news-releases/zillow-group-reports-third-quarter-2021-financial-results--shares-plan-to-wind-down-zillow-offers-operations-301414460.html). The widely-reported follow-on impacts (financial write-downs in the hundreds of millions, layoffs across the Offers business) ultimately damaged Zillow's reputation. This incident perfectly illustrates that deploying a model to production without an escape hatch is an unacceptable existential risk to the business.
+**Prerequisites**: Complete [Module 1.8: ML Pipelines](./module-1.8-ml-pipelines/) first so you understand artifact promotion, orchestration, and how training outputs become versioned deployables.
 
 ## What You'll Be Able to Do
 
-By the end of this module, you will be able to:
+By the end of this module, you will be able to apply the following serving skills in production-style designs and labs:
 - **Design** robust, scalable model serving architectures utilizing load balancers, API gateways, and specialized inference serving layers.
 - **Evaluate** and **compare** advanced, framework-specific serving solutions (Triton, TorchServe) against general-purpose web frameworks for production workloads.
-- **Implement** progressive delivery strategies (Canary, Blue-Green) on Kubernetes v1.35+ to mitigate the risk of catastrophic model rollouts.
+- **Implement** canary rollouts on Kubernetes v1.35+ and explain when blue-green cutover is preferable for instant rollback.
 - **Diagnose** production bottlenecks by implementing rigorous request validation, health checks, and graceful shutdown patterns.
 - **Debug** misconfigured serving infrastructures by analyzing resource saturation and latency telemetry.
 
-## 1. The Deployment Chasm
+## Why This Module Matters
 
-Training a highly accurate machine learning model is merely the starting line. Getting that model into a production environment, serving predictions reliably at a massive scale, and maintaining its integrity over time constitutes the vast majority of an ML engineer's workload. Data scientists often optimize for accuracy in a pristine, static environment, whereas ML engineers must optimize for reliability, latency, and throughput in a chaotic, distributed system.
+In November 2021, Zillow's iBuying division wound down after its home-price forecasting model struggled to price homes accurately during a rapid housing-market cooldown. [Zillow announced the wind-down of Zillow Offers](https://www.prnewswire.com/news-releases/zillow-group-reports-third-quarter-2021-financial-results--shares-plan-to-wind-down-zillow-offers-operations-301414460.html) in its third-quarter 2021 results, citing forecasting unpredictability, inventory write-downs, and balance-sheet volatility from holding homes longer than expected. The filing documents a forecasting and business failure—not specific deficiencies in serving infrastructure.
 
-Think of training a machine learning model like engineering a prototype hypercar in a closed laboratory. It is blindingly fast, powerful, and performs beautifully on a meticulously controlled test track. However, deployment is akin to entering that exact car into a grueling 24-hour endurance race. Suddenly, you require a highly coordinated pit crew (DevOps), comprehensive telemetry (monitoring), race strategy (deployment patterns), and a backup vehicle for when catastrophic failures occur (rollback). Most laboratory prototypes never survive race day without this massive infrastructure supporting them.
+A serving-focused reading of this kind of failure is instructive: had the system exposed progressive rollout, traffic splitting, latency-aware monitoring, and automated circuit breakers, operators might have throttled or rolled back inference before losses cascaded. **That serving-control lesson is our analytical framing, not a claim from Zillow's filing.** The durable takeaway for ML engineers: deploying a model without versioned rollback, traffic splitting, and production observability is an operational risk, not merely a research inconvenience.
+
+Model serving is where machine learning becomes a product. Training optimizes accuracy on historical data; serving optimizes reliability, latency, throughput, and safe change under live traffic. A classifier that scores well offline can still harm users if the API returns 500 errors during rollout, if GPU memory spikes under batch load, or if a new model version silently degrades tail latency for your most active customers. Serving engineers therefore design around failure modes that data scientists rarely encounter in notebooks: cold starts, queue buildup, protocol overhead, accelerator saturation, schema drift between training and inference, and the human cost of an incident at 2 a.m.
+
+The durable pattern across every stack—whether you choose FastAPI, KServe, Seldon Core, BentoML, Triton, TorchServe, or vLLM—is the same. You expose a versioned inference endpoint behind load balancing and health gating, you measure latency and error budgets continuously, you batch or scale to match hardware economics, and you roll out changes progressively so a bad artifact never takes 100% of traffic instantly. You also document which metric proves success for each model—latency for routing, calibration for risk, conversion for recommendations—because serving without an evaluation contract invites endless post-incident arguments. This module teaches that spine tool-agnostically and uses concrete frameworks as worked examples.
+
+## Did You Know?
+
+- The ONNX interchange format was introduced at NeurIPS 2017 and later gained broad cross-framework support, which is why many serving pipelines treat ONNX export as the default portability step between training and optimized runtimes.
+- Dynamic batching in specialized inference servers can raise GPU utilization dramatically because accelerators are designed for parallel matrix work; sequential single-row inference often leaves most SIMD capacity idle even when the server appears busy on CPU metrics.
+- Canary and shadow deployments solve different problems: canary routing limits blast radius for a new model version, while shadow routing duplicates live traffic to a candidate model without affecting user-visible responses—useful for drift checks before any promotion.
+- Tail latency (P95/P99) frequently matters more than median latency for user trust; a serving tier that looks healthy at P50 can still fail product SLOs if a fraction of requests wait behind cold GPUs, oversized payloads, or lock contention in preprocessing.
+
+## 1. The Serving Lifecycle and the Deployment Chasm
+
+Training a highly accurate machine learning model is merely the starting line. Getting that model into a production environment, serving predictions reliably at scale, and maintaining its integrity over months of shifting data constitutes the bulk of an ML engineer's workload. Data scientists optimize for accuracy on curated snapshots; serving engineers optimize for reliability, latency, throughput, and safe change under adversarial network conditions, partial outages, and human operators deploying on Friday afternoons.
+
+Think of training like building a prototype hypercar in a closed laboratory. It is fast, powerful, and beautiful on a controlled test track. Serving is entering that same car in a 24-hour endurance race where you need a pit crew (platform automation), telemetry (metrics and tracing), race strategy (rollout policy), and a spare vehicle (versioned rollback). Most laboratory prototypes do not survive race day without that infrastructure, and most notebook models do not survive production without an equally deliberate serving design.
+
+The serving lifecycle has five durable stages that every team implements under different names. First, **package**: serialize weights, preprocessing logic, and metadata into an immutable artifact registered with a version. Second, **build**: bake the artifact into a container or runtime bundle with explicit resource requests and startup behavior. Third, **expose**: front the runtime with a stable network identity, authentication, and request schema. Fourth, **operate**: monitor latency histograms, error rates, saturation, and data-quality signals while autoscaling on the right metric. Fifth, **change**: promote, canary, shadow, or roll back versions without breaking clients. Skipping any stage creates the "deployment chasm" between research and production:
 
 The stark contrast between the research phase and the production phase is often referred to as the deployment gap:
 
@@ -43,11 +56,31 @@ Manual updates                     Automated rollouts
 No monitoring                      Full observability
 ```
 
-> **Did You Know?** Industry surveys consistently show that a large share of machine-learning pilots never make it to production because deployment complexity and operational maturity are often underprepared.
+Crossing the chasm requires explicit contracts. Clients should send validated feature vectors or documents, not opaque blobs that crash parsers. Logs should record model version, schema hash, and latency per request so post-incident replay can separate routing bugs from stale weights or feature drift. Servers should distinguish **liveness** (process up) from **readiness** (model loaded and able to score). Deployments should keep at least one prior version addressable for rollback. Dashboards should chart P50, P95, and P99 latency separately because optimizing the median while ignoring the tail is how teams ship regressions that only power users feel. These contracts are boring until an incident proves they were load-bearing.
 
-## 2. Serving Architecture and Web Frameworks
+## 2. Online, Batch, and Streaming Inference
 
-A robust model serving architecture decouples the client applications from the raw inference engines. This decoupling allows engineers to route traffic, split loads for A/B testing, and scale the inference hardware independently of the front-end clients. By treating the model as a modular microservice, updates can be rolled out invisibly to the end user.
+Not every prediction request belongs on the same serving path. **Online inference** answers synchronous user or service calls—fraud checks at checkout, search ranking, chat completions—where latency budgets are tight and errors are immediately visible. **Batch inference** scores large stored datasets on a schedule or after an ETL job finishes; latency is measured in minutes or hours, but cost per million rows dominates. **Streaming inference** consumes unbounded event streams (click logs, sensor readings) and may use windowed features; throughput and backpressure matter more than single-request milliseconds.
+
+The architectural fork happens early. Online paths usually sit behind API gateways or service meshes with horizontal pod autoscaling on request rate, queue depth, or GPU utilization. Batch paths are often Kubernetes Jobs, workflow steps, or queue workers that scale to zero between runs. Streaming paths may pair with stream processors and asynchronous embedding workers where predictions land in a feature store or secondary topic rather than returning directly to a mobile client.
+
+Latency and throughput trade off differently in each mode. Online serving minimizes time-to-first-byte for a single prediction, which pushes you toward warm GPUs, small payloads, and efficient protocols like gRPC when JSON becomes a bottleneck. Batch serving maximizes rows per GPU-second, which pushes you toward dynamic batching, larger memory footprints, and asynchronous job IDs when a synchronous HTTP call would time out. Teams that force batch scoring through the same synchronous REST tier as the mobile app usually discover the problem as growing P99 latency during nightly ETL, not as a training metric regression.
+
+Scale-to-zero is attractive for sporadic workloads—internal admin tools, rarely used models, development namespaces—but it collides with cold-start reality. Loading multi-gigabyte weights, compiling CUDA kernels, or fetching artifacts from object storage can take tens of seconds. Production online APIs therefore pre-warm replicas, use readiness gates, or keep a minimum replica count; batch jobs may tolerate cold starts if the job runtime is hours. The decision is economic and SLO-driven, not ideological.
+
+Security and multi-tenancy belong in the serving story even when this module focuses on mechanics. Inference endpoints can leak training data memorization through confident wrong answers, expose model theft via unlimited query APIs, or become cryptocurrency-mining targets if GPUs are reachable without auth. Rate limiting at the gateway, per-tenant API keys, and audit logs of model version per request are baseline controls—not extras—for any externally reachable predictor.
+
+## 3. Serving Architecture and Traffic Management
+
+A robust model serving architecture decouples client applications from raw inference engines. This decoupling allows engineers to route traffic, split loads for experiments, enforce authentication at the edge, and scale inference hardware independently of front-end clients. By treating the model as a modular microservice, updates can roll out invisibly to end users when versioning and traffic policies are explicit.
+
+The request path typically traverses four layers. **Clients** (web, mobile, backend jobs) speak HTTP or gRPC. A **load balancer or API gateway** terminates TLS, enforces rate limits, and attaches tracing identifiers. A **routing plane** selects which model version or experiment arm should score the request—stable, canary, shadow, or A/B cohort. The **model serving layer** loads artifacts, executes preprocessing and inference, and returns structured responses with version metadata. **Model storage** (object store, registry, or mounted volume) supplies immutable artifacts; it should never be confused with the ephemeral container filesystem.
+
+Treating the serving layer as a black box is tempting but dangerous. Preprocessing—tokenization, image resizing, feature lookups—often dominates tail latency when it is implemented as single-threaded Python on the request path. Observability must span the whole path, not only the `model.forward()` call. When debugging saturation, inspect queue depth at the gateway, thread pool utilization in the server, GPU memory pressure, and deserialization cost before retraining.
+
+## 4. Building Custom REST Services with FastAPI
+
+The diagram below shows how clients, routing, serving, and storage connect in a typical production layout. FastAPI is a common choice for the serving layer when teams need a Python-native HTTP API with schema validation, OpenAPI docs, and async I/O without adopting a full inference-server framework yet.
 
 ```mermaid
 flowchart TD
@@ -80,9 +113,9 @@ flowchart TD
     SL --> MS
 ```
 
-### Building with FastAPI
+### Request Validation and the Lifespan Hook
 
-FastAPI has emerged as the premier framework for writing custom ML model serving layers in Python. It offers asynchronous execution by default and strict type validation out of the box via Pydantic, ensuring that malformed tensors do not crash your backend inference engines.
+FastAPI has become a default choice for custom ML serving layers in Python because it combines async I/O, automatic OpenAPI generation, and strict input validation through Pydantic models. For serving, validation is not cosmetic: malformed tensors, wrong feature lengths, and out-of-range values should return structured 4xx responses before they touch NumPy or torch and produce opaque 500 errors that waste GPU cycles and confuse on-call engineers. The `lifespan` context manager loads the model once per worker process and releases it on shutdown, which pairs naturally with Kubernetes readiness probes that should fail until loading completes.
 
 ```python
 from contextlib import asynccontextmanager
@@ -185,16 +218,16 @@ async def model_info():
     }
 ```
 
-### Implementing Batch Predictions
+### Implementing Batch and Asynchronous Predictions
 
-Hardware accelerators like GPUs are drastically underutilized when processing single, sequential requests. To maximize throughput and justify the high hardware costs, you must implement batch predictions. FastAPI handles this elegantly using its asynchronous background tasks capabilities.
+Hardware accelerators like GPUs are drastically underutilized when processing single, sequential requests. To maximize throughput and justify accelerator cost, production systems batch rows on the server, accept client-side batches, or offload large scoring jobs to asynchronous workers. FastAPI can expose both synchronous `/predict/batch` endpoints for medium-sized payloads and `/predict/async` job submission for workloads that exceed HTTP timeout budgets. The async pattern returns a `job_id` immediately so clients poll or subscribe for completion—essential when a million-row scoring job would otherwise trip gateway timeouts even though the model itself is healthy.
 
 ```python
 from fastapi import BackgroundTasks
 from typing import List
 from uuid import uuid4
 
-from datetime import datetime
+from datetime import UTC, datetime
 
 class BatchRequest(BaseModel):
     instances: List[List[float]]
@@ -243,7 +276,7 @@ def process_batch_async(job_id: str, instances: list[list[float]]) -> None:
             "status": "completed",
             "predictions": predictions,
             "batch_size": len(instances),
-            "completed_at": datetime.utcnow().isoformat() + "Z",
+            "completed_at": datetime.now(UTC).isoformat().replace("+00:00", "Z"),
         }
     except Exception as e:
         batch_jobs[job_id] = {"status": "failed", "error": str(e)}
@@ -276,11 +309,11 @@ async def predict_async_status(job_id: str):
     return batch_jobs[job_id]
 ```
 
-## 3. High-Performance Serving with gRPC
+## 5. High-Performance Serving with gRPC
 
-As your service scales to thousands of requests per second, the overhead of parsing JSON text payloads becomes a severe bottleneck. Think of REST and gRPC like sending a hand-written letter versus utilizing an automated binary Morse code transmission. REST sends human-readable JSON, which is excellent for debugging but extremely slow for machines to deserialize.
+As your service scales to thousands of requests per second, the overhead of parsing JSON text payloads becomes a severe bottleneck on CPU and network bandwidth. REST with JSON is excellent for developer ergonomics and quick debugging; gRPC with Protocol Buffers is excellent when both ends of the wire are machines that must move high-dimensional tensors or embeddings with minimal serialization tax. Think of REST as a handwritten letter—readable, flexible, and slow to produce at scale—and gRPC as a compact binary protocol where field tags and packed numeric arrays deserialize with predictable cost.
 
-gRPC uses Protocol Buffers—a strictly typed, compact binary format that allows machines to parse complex multi-dimensional tensors much more efficiently.
+gRPC also gives you a first-class streaming model. Unary RPCs mirror classic request/response HTTP. Client streaming, server streaming, and bidirectional streaming let you pipeline feature generation and inference for workloads where waiting for a full payload before scoring is wasteful. Service meshes and load balancers must be configured for HTTP/2 when you adopt gRPC, which is an operational cost—but one that many high-QPS ML platforms pay willingly once JSON parsing shows up in flame graphs.
 
 ```mermaid
 graph TD
@@ -299,13 +332,11 @@ graph TD
     end
 ```
 
-> **Pause and predict**: If your gRPC service is receiving 10,000 requests per second, how would adding a dynamic batching layer of 50ms alter your P99 latency and overall throughput?
-
-*Answer: It would increase the P99 latency by a maximum of 50ms (plus inference time) but would exponentially increase your throughput by allowing the GPU to process thousands of requests simultaneously in a single forward pass, preventing the server from collapsing under the sheer volume of sequential connections.*
+**Pause and predict:** If your gRPC service receives 10,000 small requests per second and you add a 50ms dynamic batching window, P99 latency for any single request may rise by up to 50ms plus batch inference time, but aggregate throughput often climbs sharply because the GPU executes one wide forward pass instead of thousands of sequential micro-passes that leave SIMD units idle.
 
 ### Protocol Buffer Definitions
 
-To utilize gRPC, you define your data structures strictly in a `.proto` file. This definition acts as an unbreakable binding contract between the client and the serving cluster, eliminating runtime schema errors.
+To utilize gRPC, you define your data structures strictly in a `.proto` file. This definition acts as a binding contract between clients and servers: field numbers, types, and repeated fields are versioned explicitly, which reduces the class of "silent JSON shape drift" bugs that plague loosely typed REST gateways. For ML teams, the `.proto` file should live in the same repository as the model schema documentation so data scientists and serving engineers negotiate feature contracts in one place.
 
 ```protobuf
 // model_service.proto
@@ -363,7 +394,7 @@ message Empty {}
 
 ### Implementing the gRPC Servicer
 
-The Python implementation maps these strongly typed objects directly into the runtime context, bypassing the standard HTTP stack entirely for maximum performance.
+The Python implementation maps strongly typed protobuf messages into NumPy or torch tensors inside servicer methods, bypassing much of the HTTP/JSON stack. Thread pool sizing on `grpc.server` becomes a tuning knob: too few workers and you starve concurrent RPCs; too many and you contend on the Python GIL or GPU context switches. For GPU-backed servicers, keep heavy inference on a bounded worker queue and avoid doing preprocessing on the RPC thread if it blocks the pool.
 
 ```python
 import grpc
@@ -436,13 +467,34 @@ def serve():
     server.wait_for_termination()
 ```
 
-## 4. Production Serving Frameworks
+## 6. Production Serving Frameworks
 
-When your traffic volume outgrows custom FastAPI or gRPC scripts, you must migrate to specialized production frameworks that offer dynamic batching out-of-the-box.
+When traffic volume, framework diversity, or GPU sharing requirements outgrow hand-rolled FastAPI services, teams adopt specialized inference platforms that implement dynamic batching, multi-model hosting, metrics endpoints, and Kubernetes-native scaling integrations. The durable selection criteria are not brand loyalty but workload fit: framework lock-in, need for LLM-specific scheduling, multi-tenant GPU density, ensemble graphs, and how much custom preprocessing lives outside the server.
 
-### TorchServe
+> **Landscape snapshot — as of 2026-06. Verify against vendor docs before relying on specifics.**
+>
+> | Platform | Primary sweet spot | Notes |
+> |---|---|---|
+> | [KServe](https://kserve.github.io/website/) | Kubernetes-native InferenceService CRDs, serverless scale patterns | Strong when you want GitOps-friendly model rollouts on K8s |
+> | [Seldon Core](https://docs.seldon.io/projects/seldon-core/en/latest/) | Graph-based deployments, A/B and multi-armed routing | Useful for complex inference graphs beyond a single model container |
+> | [BentoML](https://docs.bentoml.com/en/latest/) | Developer-centric packaging to containerized services | Fast path from Python class to production image |
+> | [NVIDIA Triton](https://github.com/triton-inference-server/server) | Multi-framework GPU serving, ensembles, dynamic batching | Baseline for high-throughput mixed ONNX/TRT/PyTorch/TF models |
+> | [TorchServe](https://pytorch.org/serve/) | PyTorch-first serving with handlers and management APIs | **Legacy / inherited estates only** — official docs state it is no longer actively maintained and has no planned security patches (as of 2026-06) |
+> | [vLLM](https://docs.vllm.ai/en/latest/) | LLM throughput with PagedAttention and continuous batching | Default discussion point for open-weights LLM online serving |
 
-Developed jointly by AWS and Meta, TorchServe provides a robust, standardized environment for serving PyTorch models without writing complex multithreading boilerplate code. It natively supports dynamic batching, rich metrics logging, and multi-model serving on single instances.
+None of these tools removes the need for rollout discipline, observability, or schema validation—they implement the **how** of inference execution while you still own the **when** and **which version** via platform policy.
+
+**KServe** (and similar Kubernetes-native controllers) wrap containers with InferenceService CRDs so data scientists submit a model URI and framework type while platform teams enforce standard annotations for autoscaling, ingress, and canary traffic. The durable benefit is GitOps: desired model revisions live in version control beside application manifests, and rollbacks become revert commits rather than manual `kubectl` surgery. **Seldon Core** extends that idea to directed acyclic graphs of transformers, routers, and combiners—valuable when production inference is a pipeline of models rather than a single `predict()` call. **BentoML** optimizes the inner loop from Python class to OCI image for teams that want developer speed before adopting cluster-wide CRDs.
+
+**CPU versus GPU serving** is a cost and latency decision, not a moral one. Small tree models, linear models, and lightly quantized embeddings often serve cheaper on CPU with horizontal scale-out, especially when QPS is moderate and GPU nodes would sit idle. Deep networks, large transformers, and wide batch scoring usually need GPUs to meet tail-latency targets, but GPU efficiency requires batching and careful memory budgeting—an A100 rented for single-row REST calls is frequently a budget leak. Many platforms run preprocessing on CPU autoscaled Deployments and inference on GPU node pools with taints, which isolates expensive accelerators from generic web traffic.
+
+**vLLM** and comparable LLM servers add continuous batching and memory-efficient KV-cache management for generative workloads where classic dynamic batching assumptions break down. Token streaming changes client protocols: users tolerate time-to-first-token more than time-to-full-completion, so dashboards must track both. LLM serving also amplifies prompt-validation needs—unbounded prompts are a denial-of-wallet attack against your GPU fleet.
+
+### TorchServe (legacy)
+
+Developed jointly by AWS and Meta, TorchServe provides a standardized environment for serving PyTorch models without writing multithreading and batching boilerplate for every project. Handlers split preprocessing, inference, and postprocessing into lifecycle hooks, which keeps teams from entangling I/O and tensor code in one giant endpoint function. TorchServe exposes management APIs for registering model versions and can host multiple models per process when GPU memory allows.
+
+As of 2026-06, the [official TorchServe page](https://pytorch.org/serve/) states the project is **no longer actively maintained** with no planned security patches. Treat TorchServe as guidance for inherited PyTorch estates you cannot migrate immediately—not as a recommended choice for new greenfield serving. For new deployments, prefer Triton, KServe, BentoML, or a maintained custom FastAPI/gRPC layer unless organizational constraints force you to operate an existing TorchServe fleet.
 
 ```python
 # TorchServe handler example
@@ -491,9 +543,11 @@ class ModelHandler(BaseHandler):
 
 ### Triton Inference Server
 
-NVIDIA's Triton is the pinnacle of high-performance hardware-accelerated serving. It supports concurrent model execution, dynamic batching, and highly efficient ensemble scheduling. Ensemble scheduling is incredibly powerful because it allows you to chain preprocessing models directly to inference models completely within GPU memory, avoiding any costly network hops or memory transfers back to the CPU.
+NVIDIA Triton is a multi-framework inference server aimed at maximizing hardware utilization across diverse model types in one shared GPU pool. It supports concurrent model execution, dynamic batching with configurable queue delay, and ensemble scheduling that chains preprocessing and inference stages without round-tripping tensors back through HTTP microservices. That matters when preprocessing is itself a GPU-friendly model (for example, a ONNX-based image resize graph) and you want both stages colocated to protect tail latency.
 
-```python
+Triton also exposes Prometheus metrics and standardized gRPC/HTTP inference protocols, which helps platform teams build a single autoscaler and dashboard template even when individual product teams train in PyTorch, TensorFlow, or export to ONNX/TensorRT. The operational cost is higher configuration surface area—`config.pbtxt` per model, instance groups, and precision modes must be deliberate—but the payoff is predictable throughput when many models share expensive accelerators.
+
+```protobuf
 # Triton model configuration
 # config.pbtxt
 
@@ -547,6 +601,8 @@ ensemble_scheduling {
 }
 ```
 
+When teams ask "which server is best," translate the question into workload constraints: required frameworks, need for ensembles, LLM versus classical ML, multi-tenant GPU sharing, expected QPS growth, and how much custom Python must run inside the process. A startup serving one PyTorch image classifier on modest QPS should not adopt Triton on day one; a platform team hosting forty models for internal products probably should not maintain forty bespoke FastAPI codebases either. The comparison table summarizes tradeoffs at a glance, but your SLO and staffing reality pick the row.
+
 ### Framework Comparison
 
 | Feature | FastAPI | TorchServe | Triton | TF Serving |
@@ -559,13 +615,23 @@ ensemble_scheduling {
 | Complexity | Low | Medium | High | Medium |
 | Use Case | Simple APIs | PyTorch models | High perf multi-model | TF models |
 
-## 5. Deployment Patterns
+Choosing between custom FastAPI and a dedicated server is a capacity and governance question. FastAPI wins when models are small, traffic is moderate, and teams want full control in Python. Triton wins when dynamic batching, multi-model GPU sharing, or standardized metrics matter more than writing your own handlers; TorchServe remains relevant only for legacy PyTorch fleets you have not yet migrated. KServe and Seldon add Kubernetes CRDs and traffic policies when platform teams must enforce uniform rollouts across dozens of models owned by different product groups.
 
-Advanced deployment patterns are non-negotiable for enterprise ML platforms. They provide the safety nets required to deploy models confidently, ensuring you can pull the plug instantly if the new weights behave erratically.
+## 7. Autoscaling, Request Batching, and Saturation Signals
+
+Autoscaling for inference should track the bottleneck metric, not whichever graph is easiest to export. CPU-based Horizontal Pod Autoscaler rules work for lightweight sklearn APIs but lie about GPU-backed transformers: CPU can look idle while requests queue behind a saturated GPU or a single-threaded tokenizer. Queue depth, in-flight requests, P95 latency, or custom metrics from the inference server (Triton and TorchServe expose Prometheus endpoints) often make better scaling signals. Event-driven autoscalers such as KEDA can scale from zero on queue length for batch scoring workers, but online APIs with strict tail-latency SLOs usually keep a non-zero minimum replica count.
+
+Request batching trades latency for throughput by holding requests briefly to form a wider tensor. A 10–50ms batching window might raise tail latency slightly while doubling effective QPS on the same GPU. The correct window is empirical: too short and you gain nothing; too long and product teams miss interactive SLOs. Server-side batching (inside Triton/TorchServe/vLLM) is preferable to asking every client to batch, because clients have uneven arrival times and you retain centralized observability.
+
+When debugging resource saturation, read signals in order: ingress 5xx rate and latency histograms, replica count and HPA events, per-pod GPU utilization and memory, inference server queue metrics, then application logs. Jumping straight to retraining while P99 spikes during rollouts is a common anti-pattern when the real issue is cold GPU replicas or missing readiness gates.
+
+## 8. Deployment Patterns for Safe Model Change
+
+Advanced deployment patterns are non-negotiable for enterprise ML platforms. They provide the safety nets required to deploy models confidently, ensuring you can pull the plug instantly if the new weights behave erratically on live data distributions you did not fully capture offline.
 
 ### Blue-Green Deployment
 
-Blue-Green routing provisions an entirely identical production environment alongside your current one. You perform the deployment to the hidden environment, run extensive smoke tests, and then instruct the load balancer to switch traffic instantaneously. The rollback is equally instantaneous, providing massive psychological safety for the operations team.
+Blue-green routing provisions an entirely parallel production environment alongside your current one. You deploy the candidate model to the idle color, run smoke and shadow comparisons against production traffic captures, then flip the load balancer atomically. Rollback is another atomic flip, which is invaluable when the new artifact passes health checks but degrades business metrics. The cost is duplicated infrastructure during cutover—often acceptable for high-risk models where downtime or bad predictions are more expensive than spare GPUs.
 
 ```mermaid
 flowchart TD
@@ -596,7 +662,11 @@ flowchart TD
 
 ### Canary Deployment
 
-Canary deployments gradually expose the new model version to a tiny subset of real production traffic, slowly increasing the percentage as confidence grows. Automatic rollback typically occurs quickly if error rates spike, latency breaches P99 thresholds, or downstream systems report anomalies.
+Canary deployments gradually expose a new model version to a small slice of real production traffic, increasing weight as error budgets and latency SLOs remain green. Kubernetes Ingress controllers (as in the hands-on lab), service mesh routes, or platform CRDs like KServe and Seldon can implement weighted splits. Automatic rollback should trigger on objective signals—rising 5xx rate, P99 regression beyond a threshold, or business guardrails—not on intuition after a calendar deadline.
+
+### Shadow Deployment
+
+Shadow deployments duplicate live requests to a candidate model without returning its output to users. The stable model still serves responses, while shadow workers score asynchronously for comparison logging. This pattern catches training-serving skew and data drift before any user sees a bad prediction, and it pairs well with replaying historical traffic captures when live shadow cost is too high. The operational price is doubled inference compute during the shadow window, which must be budgeted.
 
 ```mermaid
 flowchart TD
@@ -612,7 +682,7 @@ flowchart TD
 
 ### A/B Testing
 
-Canary deployment and A/B testing are often confused because both route subsets of traffic, but they serve different goals. Canary deployment is an operational safety pattern: you shift a tiny, controlled slice of users while watching error budgets, SLOs, and rollback signals. A/B testing is a statistical product strategy: deterministic user segmentation allows you to compare business outcomes between control and treatment groups without contamination across variants.
+Canary deployment and A/B testing are often confused because both route subsets of traffic, but they serve different goals. Canary deployment is an operational safety pattern: you shift a tiny, controlled slice of users while watching error budgets, SLOs, and rollback signals. A/B testing is a statistical product strategy: deterministic user segmentation lets you compare business outcomes between control and treatment groups without contamination across variants. The hash-based router below uses SHA-256 instead of Python's randomized `hash()` so assignment stays stable across processes and pod restarts—a requirement for valid experiment analysis.
 
 ```python
 import hashlib
@@ -673,8 +743,6 @@ class ABTestRouter:
         """
         Statistical analysis of A/B test results.
         """
-        from scipy import stats
-
         exp = self.experiments[experiment_id]
         control = exp["metrics"]["control"]
         treatment = exp["metrics"]["treatment"]
@@ -682,11 +750,18 @@ class ABTestRouter:
         control_accuracy = sum(m["correct"] for m in control) / len(control)
         treatment_accuracy = sum(m["correct"] for m in treatment) / len(treatment)
 
-        # Statistical significance test
-        control_correct = [m["correct"] for m in control]
-        treatment_correct = [m["correct"] for m in treatment]
+        # Two-proportion z-test for binary conversion outcomes
+        from statsmodels.stats.proportion import proportions_ztest
 
-        t_stat, p_value = stats.ttest_ind(control_correct, treatment_correct)
+        control_n = len(control)
+        treatment_n = len(treatment)
+        control_successes = sum(m["correct"] for m in control)
+        treatment_successes = sum(m["correct"] for m in treatment)
+
+        z_stat, p_value = proportions_ztest(
+            [control_successes, treatment_successes],
+            [control_n, treatment_n],
+        )
 
         return {
             "control_accuracy": control_accuracy,
@@ -700,19 +775,16 @@ class ABTestRouter:
         }
 ```
 
-> **Stop and think**: When implementing A/B testing for a recommendation engine, why is deterministic routing based on a hash of the user ID critical for the validity of your statistical results?
+**Stop and think:** When implementing A/B testing for a recommendation engine, deterministic routing based on a hash of the user ID is critical because the same user must always see the same model variant; otherwise refreshes bounce between arms, ruining both UX and the independence assumptions behind hypothesis tests.
 
-*Answer: If routing isn't deterministic, a single user refreshing the page might randomly bounce between the control and treatment models. This obliterates user experience and completely invalidates the statistical independence required for an accurate hypothesis test.*
+## 9. Model Optimization for Serving Economics
 
-## 6. Model Optimization
-
-To scale massively without burning through capital, models must be heavily optimized post-training.
-
-> **Did You Know?** The ONNX format was announced at the 2017 Neural Information Processing Systems (NeurIPS) conference and within two years, it had support from over 30 frameworks and hardware platforms.
+To scale inference without unbounded infrastructure spend, teams optimize the artifact and runtime after training converges. Optimization is not one knob—it is a pipeline: export to a portable graph format, compile for target hardware, choose precision (FP32, FP16, INT8), and validate accuracy on a representative evaluation slice after each transform. Skipping accuracy validation after quantization is how teams ship fast models that silently mis-rank or miscalibrate probabilities.
 
 ### ONNX format conversion
 
 ```python
+import numpy as np
 import onnx
 import onnxruntime as ort
 import torch
@@ -727,14 +799,14 @@ def export_to_onnx(model, sample_input, output_path):
         sample_input,
         output_path,
         export_params=True,
-        opset_version=14,
-        do_constant_folding=True,
+        opset_version=17,
         input_names=['input'],
         output_names=['output'],
-        dynamic_axes={
+        dynamic_shapes={
             'input': {0: 'batch_size'},
-            'output': {0: 'batch_size'}
-        }
+            'output': {0: 'batch_size'},
+        },
+        dynamo=True,
     )
 
     # Verify the model
@@ -784,9 +856,9 @@ class ONNXPredictor:
         }
 ```
 
-### TensorRT
+### TensorRT on NVIDIA GPUs
 
-Converting to TensorRT yields exponential gains on NVIDIA hardware by fusing kernel operations and quantizing weights. It rewrites the computational graph to perfectly match the underlying physical architecture of the specific GPU model.
+TensorRT compiles ONNX or native graphs into engines tuned for a specific GPU architecture by fusing layers, picking kernels, and optionally lowering precision. Engines are hardware-specific artifacts: an engine built for one SKU is not portable to another, which affects your CI pipeline—you typically build engines per deployment target or per instance type family. Always benchmark with representative batch sizes; a graph that is faster at batch 1 may lose at batch 32 if memory bandwidth becomes the limiter.
 
 ```python
 # TensorRT for NVIDIA GPU optimization
@@ -813,7 +885,7 @@ def optimize_with_tensorrt(onnx_path: str, engine_path: str):
 
     # Configure builder
     config = builder.create_builder_config()
-    config.max_workspace_size = 1 << 30  # 1GB
+    config.set_memory_pool_limit(trt.MemoryPoolType.WORKSPACE, 1 << 30)  # 1GB
 
     # Enable FP16 for faster inference (with minimal accuracy loss)
     if builder.platform_has_fast_fp16:
@@ -831,22 +903,15 @@ def optimize_with_tensorrt(onnx_path: str, engine_path: str):
     print(f"TensorRT engine saved to {engine_path}")
 ```
 
-**Optimization Impact:**
+The `benchmark()` helper in the ONNX example above is the right habit: warm up GPUs, measure P50/P95/P99, and record throughput at realistic batch sizes. Publish those numbers per environment rather than treating marketing benchmarks as universal truth.
 
-| Framework | Latency (ms) | Throughput (QPS) |
-|---|---|---|
-| PyTorch (eager) | 15.2 | 66 |
-| PyTorch (compiled) | 8.5 | 118 |
-| ONNX Runtime | 6.2 | 161 |
-| TensorRT FP32 | 4.1 | 244 |
-| TensorRT FP16 | 2.3 | 435 |
-| TensorRT INT8 | 1.5 | 667 |
+## 10. Diagnosing Production Bottlenecks: Validation, Health Checks, and Graceful Shutdown
 
-> **Note**: Numbers in this table are illustrative and depend heavily on hardware generation, batch profile, and operator settings; treat these as directional examples rather than guaranteed production baselines.
+Model serving operates in a hostile environment where networks drop packets, clients send malformed payloads, nodes drain during rollouts, and GPUs exhaust memory under bursty batch traffic. **Diagnosing** production bottlenecks starts at the contract boundary: validate inputs early, expose differentiated health endpoints, and shut down without aborting in-flight predictions. These patterns are load-bearing for the fourth learning outcome in this module—without them, dashboards show green while users time out.
 
-## 7. Best Practices for Reliability
+Request validation belongs at the edge of inference, not inside catch-all exception handlers that return 500 for bad client data. Pydantic validators should enforce feature dimensionality, numeric ranges, and forbidden nulls so operators can distinguish client bugs from server regressions in logs. Health checks should separate **liveness** (restart a stuck process) from **readiness** (stop sending traffic until weights are loaded). Graceful shutdown hooks should wait for active requests to finish after SIGTERM so Kubernetes rollouts do not truncate predictions mid-flight—especially important when mean inference time is hundreds of milliseconds.
 
-Model serving operates in a hostile environment where networks drop packets and downstream services constantly fail. Defensive programming is strictly required.
+When latency spikes without obvious errors, inspect validation overhead, lock contention, batching windows, GPU memory fragmentation, and artifact download time on new replicas. Many "model got worse" incidents are serving regressions: a new container image forgot to pin a preprocessor version, readiness flipped true before warm-up completed, or HPA added cold pods during a traffic spike.
 
 ### Health Checks and Kubernetes Probes
 
@@ -863,6 +928,8 @@ async def ready():
         raise HTTPException(503, "Model not loaded")
     return {"status": "ready", "model_version": "1.2.0"}
 ```
+
+Readiness should fail when `model is None` or when a warm-up inference has not completed; liveness should remain tolerant of slow models unless the process is deadlocked. Startup probes help large LLM containers that legitimately need minutes to load shards before either liveness or readiness semantics apply.
 
 ### Graceful Shutdowns
 
@@ -890,6 +957,8 @@ class GracefulShutdown:
             await asyncio.sleep(0.1)
 ```
 
+On Kubernetes, set `terminationGracePeriodSeconds` high enough to cover P99 inference duration plus buffer, and coordinate with preStop hooks if the load balancer needs a drain signal before SIGTERM reaches the app.
+
 ### Aggressive Request Validation
 
 ```python
@@ -908,9 +977,11 @@ class PredictionRequest(BaseModel):
         return v
 ```
 
-### Model Versioning
+Return 422 for schema violations when possible so client teams get actionable feedback; reserve 500 for genuine server faults after validation passes.
 
-A centralized model registry serves as the system of record. Reverting to a previous state must be a fast, automated API call, not an archaeological expedition through an S3 bucket.
+### Model Versioning and Rollback
+
+A centralized model registry serves as the system of record. Reverting to a previous state must be a fast, automated API call, not an archaeological expedition through an object store. The registry example below tracks stages (`staging`, `production`, `archived`) so promotion and rollback are explicit state transitions rather than copy commands that overwrite live files.
 
 ```python
 import json
@@ -994,41 +1065,25 @@ class ModelRegistry:
         }
 ```
 
-## 8. Common Mistakes and The Economics of Inference
+The most expensive operational mistake is still overwriting active artifacts in place without a versioned escape hatch, because rollback becomes archaeology across laptops and unlabeled object-store keys. Promotion should be a pointer swap, registry stage change, or traffic-weight change—not a destructive copy that erases the only known good weights.
 
-> **Did You Know?** Even small improvements in model-serving efficiency compound quickly at scale by reducing infrastructure and cloud costs.
+## 11. Debugging Misconfigured Serving with Latency and Saturation Telemetry
 
-> **Did You Know?** In latency-sensitive applications, teams treat tail-latency targets as a hard product metric because small user-experience regressions can materially affect adoption and trust.
+When on-call pages fire, teams often debate whether the model "went bad" or the platform misbehaved. In practice, most acute serving incidents are platform misconfigurations observable in metrics: traffic routed to cold replicas, autoscaler adding Pods that fail readiness, JSON parsing dominating CPU, GPU memory exhausted by batch size changes, or ingress timeouts shorter than P99 inference. **Debugging** misconfigured serving starts by separating client errors, server errors, and latency inflation without assuming retraining is the fix.
 
-If you don't track your serving costs, your successful model will bankrupt the engineering department.
+Build a standard triage checklist. First, split HTTP status codes—4xx spikes after a client release suggest schema drift; 5xx spikes after a model promotion suggest readiness or loading failures. Second, compare P50, P95, and P99 latency—median shifts often track CPU saturation, while tail-only regression frequently tracks queueing, batching windows, or GPU cold starts. Third, correlate replica count with latency; if latency rises as HPA adds Pods, you likely have a cold-start or artifact-download problem, not insufficient replicas. Fourth, inspect inference-server metrics (queue time, batch size, GPU utilization) before opening Jupyter.
 
-| Component | Typical Cost | Notes |
-|-----------|--------------|-------|
-| Compute (CPU) | $0.05-0.10/hour/vCPU | For preprocessing, lightweight models |
-| Compute (GPU) | $0.50-4.00/hour | A10G: $0.50, A100: $3-4 |
-| Load balancer | $0.025/hour + $0.008/GB | Often overlooked fixed cost |
-| Storage (model artifacts) | $0.02/GB/month | Minimal unless you keep many versions |
-| Network egress | $0.09/GB | Can add up with high throughput |
-| Model registry | $0-500/month | Free tiers available, enterprise costs more |
+Resource saturation has different signatures. CPU at 100% with low GPU utilization on a supposedly GPU model means preprocessing or serialization is stuck on host threads—consider moving transforms into ONNX/TRT, using gRPC, or batching. GPU at 100% with growing queue depth means you need more replicas, wider batching, or a smaller precision mode—not necessarily a new architecture. Memory climbing linearly with traffic often signals per-request allocations in Python handlers rather than model weights themselves. Network egress spikes on REST image APIs point to uncompressed payloads that gRPC or thumbnail preprocessing should shrink.
 
-| Scale | Monthly Cost | Cost per 1M Predictions |
-|-------|-------------|-------------------------|
-| Small (100K/day) | $500-2,000 | $15-60 |
-| Medium (10M/day) | $5,000-20,000 | $1.50-6 |
-| Large (1B/day) | $100,000-500,000 | $0.10-0.50 |
+Kubernetes-specific failures show up in events before application logs. `Pending` Pods during scale-out point to insufficient GPU, overly tight resource requests, or missing tolerations. `OOMKilled` containers after a batch-size change means limits were sized for single-row inference only. Endpoints empty while Pods are Running almost always means readiness always fails—often because `/ready` returns 200 before the model can actually score. Rollout stuck at `0 of N updated` frequently means the new Pod never becomes ready while the old ReplicaSet still carries traffic, which is correct safety behavior but confusing if you expected instant promotion.
 
-### Critical Anti-Patterns
+Latency histograms should be the language between ML and platform teams. Publish SLOs as explicit thresholds on P99 and error rate, not as "the model seems slower." When comparing canary and stable, compare histograms and business guardrails together—a canary with better click-through but worse P99 may still be unacceptable for checkout flows. Keep a dashboard row per model version with request rate, 4xx/5xx ratio, P50/P95/P99, GPU memory, and batch delay so rollbacks are evidence-based clicks rather than debates.
 
-| Mistake | Why it Happens | Fix |
-|---|---|---|
-| Deploying Without Rollback | Teams prioritize speed over safety, assuming the model is "perfect." | Automate versioned deployments and keep old versions on standby. |
-| Ignoring P99 Latency | P50 looks fine, but tail latency affects your most active/important users. | Set alerts based on P95/P99 metrics and optimize tail latency. |
-| Testing with Stale Data | Production data drifts; models overfit to historical distributions. | Use shadow deployments or replay recent production traffic. |
-| Missing Load Tests | "Works on my machine" mentality; lack of simulated peak traffic. | Run soak tests at 2-5x expected peak load. |
-| Hardcoding Model Paths | Model paths are baked into the container, requiring full rebuilds to swap. | Use dynamic loading from a Model Registry or environmental variables. |
-| Training/Serving Skew | Re-implementing feature engineering in serving differently than training. | Utilize a centralized Feature Store for both training and inference. |
+Tracing a single slow request end-to-end often reveals surprises: time in API gateway auth, feature store lookups, or S3 artifact checks dominates while `predict()` is fast. Distributed tracing with a consistent `request_id` propagated from ingress through preprocessing to inference makes those splits visible. Without tracing, teams optimize the model while users wait on unrelated I/O.
 
-The most inexcusable error is overwriting active files directly in production without a versioned escape hatch:
+Finally, document "known good" baseline metrics after every successful promotion. Rollback decisions become trivial when the stable version historically runs at 40ms P99 and the canary sits at 220ms with identical traffic—no committee required. That discipline turns the fifth learning outcome into a habit: misconfiguration leaves fingerprints in saturation and latency telemetry long before accuracy metrics move.
+
+Operational reviews should also capture **capacity headroom**: if peak traffic uses 85% of GPU memory with batching enabled, the next marketing campaign or holiday spike has no margin. Load tests at two to five times expected peak remain the cheapest way to learn whether autoscaling adds cold Pods faster than queues drain, whether ingress timeouts align with tail latency, and whether your registry can supply artifacts quickly enough when many replicas start concurrently. Treat those tests as part of the serving lifecycle, not as optional performance theater.
 
 ```text
 # BAD: Overwriting the production model
@@ -1041,6 +1096,8 @@ ln -sf /models/v2.1.0 /models/current
 # Rollback = ln -sf /models/v2.0.0 /models/current
 ```
 
+Serving well is a loop, not a launch event. You ship a versioned artifact behind validated APIs and differentiated health checks, expose it through progressive traffic policies, watch P50/P95/P99 and saturation signals instead of only accuracy, and optimize graphs when telemetry proves inference—not training—is the bottleneck. The summary below condenses the durable vocabulary you should recognize in design reviews and incident channels.
+
 ## Summary
 
 ```text
@@ -1050,7 +1107,7 @@ MODEL DEPLOYMENT PATTERNS
 SERVING OPTIONS:
 FastAPI        - Simple, flexible, Python-native
 gRPC           - High performance, strong typing
-TorchServe     - PyTorch-native, dynamic batching
+TorchServe     - PyTorch-native (legacy; unmaintained as of 2026-06)
 Triton         - Multi-framework, GPU optimized
 TF Serving     - TensorFlow models
 
@@ -1070,7 +1127,18 @@ Throughput     - Queries per second
 Availability   - 99.9% uptime target
 ```
 
----
+## Common Mistakes
+
+| Mistake | Why It Happens | What To Do Instead |
+|---|---|---|
+| Deploying without rollback | Teams assume offline metrics guarantee live safety and skip version pinning. | Keep prior artifacts addressable; automate blue-green or canary promotion and one-command rollback. |
+| Ignoring P99 latency | Mean dashboards look healthy while tail users wait behind cold GPUs or queues. | Alert on P95/P99, batching delay, and queue depth—not only CPU and mean latency. |
+| Marking ready before warm-up | HTTP listeners start before weights finish loading or GPUs allocate memory. | Gate readiness on model load plus a representative warm-up inference. |
+| Returning 500 for bad inputs | Unvalidated payloads crash inference code and hide client bugs. | Validate with Pydantic (or equivalent) and return structured 4xx errors at the boundary. |
+| Scaling on the wrong metric | HPA tracks CPU while GPUs saturate or JSON parsing dominates. | Scale on server queue depth, GPU utilization, request rate, or custom latency metrics. |
+| Training/serving skew | Preprocessing reimplemented differently in the API than in training. | Share feature definitions via a feature store or packaged transform artifact. |
+| Skipping shadow or canary validation | Models promote straight to 100% after offline tests on stale slices. | Shadow or canary on live traffic with automatic rollback thresholds. |
+| Ignoring graceful drain on rollout | SIGTERM kills workers immediately while requests are mid-inference. | Track in-flight work, lengthen grace periods, and use preStop hooks where needed. |
 
 ## Quiz
 
@@ -1100,29 +1168,29 @@ GPUs are specifically designed for massive parallel processing. Processing a bat
 </details>
 
 <details>
-<summary>6. Scenario: You need to deploy multiple iterations of a pricing model to measure which one generates higher overall user conversion rates over a 2-week period. Should you use Canary deployment or A/B testing?</summary>
-A/B testing. Canary deployment primarily protects operational stability by exposing new behavior to small, tightly monitored traffic windows. A/B testing is built for product learning: you compare long-horizon business outcomes across deterministic, hash-stable cohorts to avoid cross-contamination between cohorts.
+<summary>6. Scenario: A pricing model passes offline evaluation and you must promote it with instant rollback if business metrics degrade—downtime during cutover is unacceptable. Should you use canary routing or blue-green deployment, and why?</summary>
+Blue-green deployment. Canary routing limits blast radius gradually but still mixes old and new versions in the request path during promotion. Blue-green provisions a parallel environment, validates the candidate stack in isolation, then flips the load balancer atomically so every client hits the new version at once—or flips back instantly if metrics fail. That atomic cutover and one-step rollback match high-stakes models where partial mixed-version exposure is itself a product risk.
 </details>
 
 <details>
-<summary>8. Framework choice: You need to serve a high-throughput recommendation model and frequently test model architecture variants. Which serving stack is the better baseline to support dynamic batching and mixed precision across multiple frameworks, and when is TorchServe preferable?</summary>
-Triton is the better baseline when you need cross-framework flexibility, advanced tensor engine features, and aggressive batching optimizations across mixed model types. TorchServe is preferable when the stack is primarily PyTorch-native, you want a simpler setup with built-in model versioning, and your workload doesn’t require complex multi-framework scheduling in the same serving cluster.
+<summary>8. Framework choice: You need to serve a high-throughput recommendation model and frequently test model architecture variants. Which serving stack is the better baseline to support dynamic batching and mixed precision across multiple frameworks, and when might TorchServe still appear in production?</summary>
+Triton is the better baseline when you need cross-framework flexibility, advanced tensor engine features, and aggressive batching optimizations across mixed model types. TorchServe may still appear in inherited PyTorch estates, but as of 2026-06 it is no longer actively maintained with planned security patches—do not choose it for new greenfield serving. Prefer Triton, KServe, BentoML, or a maintained custom layer unless migration constraints force you to operate an existing TorchServe fleet.
 </details>
 
 <details>
-<summary>7. What occurs if a deployed serving container lacks a configured liveness probe in its Kubernetes Pod specification?</summary>
-If the serving application deadlocks or crashes silently without exiting the main process, Kubernetes has no mechanism to detect the failure state. The dead container will continue to receive traffic from the Service, resulting in dropped requests and severely degraded system availability until manual intervention occurs.
+<summary>7. Scenario: Production inference passes liveness checks, but malformed feature vectors trigger 500 errors, rollouts drop in-flight requests, and P99 latency spikes during scale-out. How do you diagnose and fix these bottlenecks using request validation, differentiated health checks, and graceful shutdown?</summary>
+Diagnose in layers: rising 500s with valid infrastructure health often mean missing request validation—add strict schema checks that return 4xx before inference. Rollout timeouts during scale events point to readiness marking true before warm-up completes; gate `/ready` on loaded weights and a dummy inference. Truncated responses during deploys indicate missing graceful shutdown—track active requests on SIGTERM and align `terminationGracePeriodSeconds` with P99 inference time. Latency spikes on new replicas without error spikes often mean cold GPU or artifact download; fix with pre-warmed images, cached artifacts, or minimum replicas rather than retraining.
 </details>
 
 ---
 
 ## Hands-On Exercise: Full-Stack Model Deployment
 
-In this progressive lab, you will build, containerize, and safely deploy a machine learning API to a Kubernetes v1.35+ cluster using modern rollout practices.
+In this progressive lab, you will build, containerize, and safely deploy a machine learning API to a Kubernetes v1.35+ cluster using readiness gates, immutable image tags, and weighted canary routing. The exercise intentionally uses a tiny sklearn model so you can focus on serving contracts—the same Kubernetes and ingress patterns apply when the container hosts a multi-gigabyte GPU model.
 
 ### Task 1: Train a Classifier Locally
 
-First, create the model artifact that we will eventually serve.
+First, create the model artifact that the serving layer will load at startup, because every later step—container image, probes, and rollout—assumes a concrete file on disk with a known schema.
 
 <details>
 <summary>Solution & Checkpoint</summary>
@@ -1147,7 +1215,7 @@ print("Model saved to model.joblib")
 
 **Execution:**
 ```bash
-pip install scikit-learn joblib
+pip install scikit-learn==1.5.2 joblib
 python train.py
 ```
 
@@ -1156,13 +1224,14 @@ python train.py
 
 ### Task 2: Build the FastAPI Serving Layer
 
-Create the REST interface that implements liveness and readiness logic.
+Create the REST interface that implements differentiated liveness and readiness logic, returning 503 from `/ready` until the joblib artifact is loaded so Kubernetes does not route traffic to half-initialized workers.
 
 <details>
 <summary>Solution & Checkpoint</summary>
 
 Create a file named `server.py`:
 ```python
+import os
 from contextlib import asynccontextmanager
 
 from fastapi import FastAPI, HTTPException
@@ -1171,7 +1240,7 @@ import joblib
 import numpy as np
 
 MODEL_PATH = "model.joblib"
-MODEL_PATH_INFO = "1.0.0"
+MODEL_VERSION = os.getenv("MODEL_VERSION", "1.0.0")
 model = None
 
 
@@ -1191,7 +1260,7 @@ class PredictRequest(BaseModel):
     features: list[float]
 
 def _model_version() -> str:
-    return MODEL_PATH_INFO
+    return MODEL_VERSION
 
 @app.post("/predict")
 async def predict(req: PredictRequest):
@@ -1200,7 +1269,7 @@ async def predict(req: PredictRequest):
     if len(req.features) != 4:
         raise HTTPException(status_code=400, detail="Require exactly 4 features")
     pred = model.predict(np.array([req.features]))
-    return {"prediction": int(pred[0])}
+    return {"prediction": int(pred[0]), "model_version": _model_version()}
 
 @app.get("/health")
 async def health():
@@ -1224,7 +1293,7 @@ uvicorn server:app --host 0.0.0.0 --port 8000 &
 
 ### Task 3: Containerize the Application
 
-Package the model and API into an immutable, versioned container artifact.
+Package the model and API into an immutable, versioned container image so promotion means changing an image tag or digest, not mutating files on a running Pod filesystem.
 
 <details>
 <summary>Solution & Checkpoint</summary>
@@ -1232,6 +1301,9 @@ Package the model and API into an immutable, versioned container artifact.
 Create a file named `Dockerfile`:
 ```dockerfile
 FROM python:3.11-slim
+
+ARG MODEL_VERSION=1.0.0
+ENV MODEL_VERSION=${MODEL_VERSION}
 
 WORKDIR /app
 COPY requirements.txt .
@@ -1244,11 +1316,11 @@ EXPOSE 8000
 CMD ["uvicorn", "server:app", "--host", "0.0.0.0", "--port", "8000"]
 ```
 
-Create `requirements.txt`:
+Create `requirements.txt` (pin the same scikit-learn version used in Task 1 training):
 ```text
 fastapi==0.103.1
 uvicorn==0.23.2
-scikit-learn==1.3.0
+scikit-learn==1.5.2
 joblib==1.3.2
 ```
 
@@ -1262,7 +1334,7 @@ docker build -t local-registry/churn-api:v1 .
 
 ### Task 4: Deploy to Kubernetes
 
-Deploy the container using standard Kubernetes v1.35 resource definitions, ensuring readiness probes are properly defined.
+Deploy the container using standard Kubernetes v1.35 resource definitions with readiness and liveness probes wired to the endpoints you implemented, then validate failure recovery by temporarily breaking readiness and watching endpoints drain.
 
 <details>
 <summary>Solution & Checkpoint</summary>
@@ -1324,18 +1396,20 @@ kubectl rollout status deployment/churn-api-v1
 ```
 
 - [ ] Checkpoint: Run `kubectl get pods -l app=churn-api` and verify both replicas reach the `Running` state and `1/1` readiness.
-- [ ] Validation drill: run a readiness failure simulation and confirm recovery:
+- [ ] Validation drill: run a readiness failure simulation and confirm recovery. Patching the Deployment template starts a new ReplicaSet; **old Ready pods keep serving while new pods fail readiness—the rollout stalls, which is the point**:
   ```bash
   kubectl patch deployment churn-api-v1 --type='json' -p='[{"op":"replace","path":"/spec/template/spec/containers/0/readinessProbe/httpGet/path","value":"/not-ready"}]'
-  kubectl wait --for=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'=False pod -l app=churn-api,version=v1 --timeout=90s
-  kubectl patch deployment churn-api-v1 --type='json' -p='[{"op":"replace","path":"/spec/template/spec/containers/0/readinessProbe/httpGet/path","value":"/ready"}]'
-  kubectl wait --for=condition=ready pod -l app=churn-api,version=v1 --timeout=90s
+  NEW_RS=$(kubectl get rs -l app=churn-api,version=v1 --sort-by=.metadata.creationTimestamp -o jsonpath='{.items[-1].metadata.name}')
+  HASH=$(kubectl get rs "$NEW_RS" -o jsonpath='{.spec.template.metadata.labels.pod-template-hash}')
+  kubectl wait --for=jsonpath='{.status.conditions[?(@.type=="Ready")].status}'=False pod -l app=churn-api,version=v1,pod-template-hash="$HASH" --timeout=90s
+  kubectl rollout undo deployment/churn-api-v1
+  kubectl rollout status deployment/churn-api-v1 --timeout=120s
   ```
 </details>
 
 ### Task 5: Implement Nginx Canary Routing
 
-Simulate a risky rollout of v2 by deploying a canary stack and applying a weighted Ingress.
+Simulate a risky rollout of v2 by deploying a parallel Deployment and Service plus a weighted Ingress annotation, observing how only a fraction of requests reach the candidate stack while the stable version continues to serve the majority.
 
 <details>
 <summary>Solution & Checkpoint</summary>
@@ -1431,21 +1505,37 @@ spec:
 
 **Execution:**
 ```bash
-docker tag local-registry/churn-api:v1 local-registry/churn-api:v2
+docker build --build-arg MODEL_VERSION=2.0.0-canary -t local-registry/churn-api:v2 .
 kubectl apply -f ingress-canary.yaml
 ```
 
-- [ ] Checkpoint: Use a bash loop `for i in {1..100}; do curl -H "Host: api.example.com" http://<ingress-ip>/predict -s; done` to validate that approximately 10% of the traffic routes to the canary pods while the rest hits the stable v1 service.
+- [ ] Checkpoint: POST to the ingress and count `model_version` labels—approximately 10% should report `2.0.0-canary` while the rest report `1.0.0`:
+  ```bash
+  for i in {1..100}; do
+    curl -s -X POST -H "Host: api.example.com" -H "Content-Type: application/json" \
+      -d '{"features":[0,0,0,0]}' "http://<ingress-ip>/predict"
+  done | jq -r '.model_version' | sort | uniq -c
+  ```
 </details>
 
 ---
 
-## Next Steps
+## Next Module
 
-Now that you have established robust, scalable deployment strategies for serving predictions, you must ensure you have deep visibility into their behavior. Proceed to [Module 1.10: ML Monitoring](./module-1.10-ml-monitoring), where we dive into establishing latency telemetry, alert fatigue, and detecting statistical model drift.
+Continue to [Module 1.10: ML Monitoring](./module-1.10-ml-monitoring/) to instrument the serving paths you built here—latency histograms, error budgets, drift detection, and alert design that keep models trustworthy after deployment. Monitoring closes the loop opened in this module: serving exposes versioned predictions under SLOs, and observability tells you when to roll back, retrain, or fix the platform before users notice.
 
 ## Sources
 
-- [Triton Inference Server](https://github.com/triton-inference-server/server) — Covers dynamic batching, ensembles, metrics, and inference protocol options for production model serving.
-- [Liveness, Readiness, and Startup Probes](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/) — Authoritative reference for probe behavior, readiness gating, and startup handling in Kubernetes deployments.
-- [Optimize Models for Inference](https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus05-bp03.html) — Summarizes serving-time optimization tradeoffs around latency, throughput, and cost in a way that fits this module's optimization section.
+- [Triton Inference Server](https://github.com/triton-inference-server/server) — Dynamic batching, ensemble scheduling, metrics, and multi-framework inference protocols.
+- [KServe Documentation](https://kserve.github.io/website/) — Kubernetes-native InferenceService patterns and serverless scaling integrations.
+- [Seldon Core Documentation](https://docs.seldon.io/projects/seldon-core/en/latest/) — Graph-based inference deployments and advanced traffic routing for experiments.
+- [BentoML Documentation](https://docs.bentoml.com/en/latest/) — Packaging Python models into containerized production services.
+- [PyTorch TorchServe](https://pytorch.org/serve/) — Handler model, management APIs, and PyTorch-focused serving workflows.
+- [vLLM Documentation](https://docs.vllm.ai/en/latest/) — LLM serving with PagedAttention, continuous batching, and throughput-oriented scheduling.
+- [ONNX](https://onnx.ai/) — Open neural network exchange format for portable graphs between training and runtimes.
+- [NVIDIA TensorRT Documentation](https://docs.nvidia.com/deeplearning/tensorrt/) — GPU engine compilation, precision modes, and deployment guidance.
+- [FastAPI Documentation](https://fastapi.tiangolo.com/) — Async Python APIs, Pydantic validation, and OpenAPI integration for custom serving layers.
+- [gRPC Introduction](https://grpc.io/docs/what-is-grpc/introduction/) — RPC semantics, HTTP/2 transport, and protobuf contracts for high-throughput services.
+- [Kubernetes Liveness, Readiness, and Startup Probes](https://kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/) — Probe behavior that gates traffic during model load and rollout.
+- [AWS Well-Architected ML Lens — Optimize Models for Inference](https://docs.aws.amazon.com/wellarchitected/latest/machine-learning-lens/mlsus05-bp03.html) — Latency, throughput, and cost tradeoffs for inference optimization.
+- [Zillow Q3 2021 Results — Zillow Offers Wind-Down](https://www.prnewswire.com/news-releases/zillow-group-reports-third-quarter-2021-financial-results--shares-plan-to-wind-down-zillow-offers-operations-301414460.html) — Primary source for the iBuying wind-down discussed in Why This Module Matters.


### PR DESCRIPTION
Part of the **#1842** ai-ml-engineering campaign — `mlops` sub-track, batch 2 of 2 (completes the sub-track).

Four modules expanded/reviewed to tier **T0**, each cross-family reviewed with every claim + source web-ground-checked:

| Module | Before → After | Author → Reviewer(s) | Verdict |
|---|---|---|---|
| 1.7 data-pipelines | 4176 → 5031 bw / 12 src | cursor → deepseek + codex | NEEDS_CHANGES ×2 → fixed → clean |
| 1.8 ml-pipelines | 2002 → 5490 bw / 13 src | cursor → deepseek | NEEDS_CHANGES → fixed → APPROVE+nits |
| 1.9 model-serving | 1511 → 5103 bw / 13 src | cursor → codex | NEEDS_CHANGES → fixed → clean |
| 1.10 ml-monitoring | 1163 → 5023 bw / 20 src | cursor → deepseek + codex | NEEDS_CHANGES ×2 → fixed → clean |

**Verifier-blind defects caught by cross-family review (web-verified both directions):** 1.7 Feast `FeatureView(features=)`→`schema=[Field]` + Great Expectations 1.x `checkpoint.run(batch_parameters=...)` runtime API + unlabeled stats → `Hypothetical scenario:`; 1.8 KFP `set_gpu_limit`→`set_accelerator_type().set_accelerator_limit()`, removed off-topic n8n block, Airflow `schedule_interval`→`schedule`; 1.9 Zillow opener over-attribution corrected (analytical-framing disclaimer added), readiness-drill hang + canary-lab `GET`/`POST` bugs fixed, `datetime.utcnow`/TensorRT/sklearn currency, **TorchServe flagged no-longer-maintained**; 1.10 PSI binning correctness (open-ended bins + shared edges), Prometheus export wiring, PromQL `rate()` fix.

A deepseek 1.9 review that hallucinated a "frameworks absent" blocker was discarded and re-run through codex.

Local `npm run build` clean (2171 pages, no schema errors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)