### PR TITLE
fix(#1827): Hermes lanes get free web fact-check (browser) + codex review web on

### DIFF
--- a/scripts/agent_runtime/adapters/deepseek.py
+++ b/scripts/agent_runtime/adapters/deepseek.py
@@ -76,9 +76,13 @@ _HERMES_BANNER_RE = re.compile(
 # `hermes tools list`. We deliberately exclude memory / skills from
 # read-only to keep calibration runs reproducible; they're great for
 # real review/code work though.
-_TOOLSETS_READ_ONLY = "web"
-_TOOLSETS_WORKSPACE = "web,file,terminal,code_execution,todo"
-_TOOLSETS_DANGER = "web,file,terminal,code_execution,todo,memory,skills"
+# `browser` (headless browser automation) gives live web fact-checking WITHOUT
+# Firecrawl — the `web` tool (web_search/web_extract) is Firecrawl-gated and
+# fails closed when FIRECRAWL_API_KEY is unset, which silently starved reviews of
+# fact-checking and drove hallucination (s121, #1827). `browser` works standalone.
+_TOOLSETS_READ_ONLY = "web,browser"
+_TOOLSETS_WORKSPACE = "web,browser,file,terminal,code_execution,todo"
+_TOOLSETS_DANGER = "web,browser,file,terminal,code_execution,todo,memory,skills"
 
 
 class DeepSeekAdapter:

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -208,7 +208,7 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
         default_mode="read-only",
         default_timeout_s=1800,
         description="cross-family review of authored work (judgment)",
-        codex_search=False,
+        codex_search=True,  # reviewers MUST be able to web-verify volatile facts (#1827)
     ),
     "architect": TaskClassConfig(
         models={

--- a/tests/test_deepseek_adapter.py
+++ b/tests/test_deepseek_adapter.py
@@ -27,7 +27,7 @@ def test_build_invocation_read_only(monkeypatch) -> None:
         "--provider",
         "deepseek",
         "-t",
-        "web",
+        "web,browser",
         "--oneshot=p",
     ]
     assert "--yolo" not in cmd
@@ -50,7 +50,7 @@ def test_build_invocation_workspace_write(monkeypatch) -> None:
     cmd = plan.cmd
     assert "--yolo" in cmd
     toolsets = cmd[cmd.index("-t") + 1]
-    assert toolsets == "web,file,terminal,code_execution,todo"
+    assert toolsets == "web,browser,file,terminal,code_execution,todo"
 
 
 def test_build_invocation_danger(monkeypatch) -> None:


### PR DESCRIPTION
Closes the core of **#1827** (reviewer/author tool-access).

**Root cause found this session (#1842 mlops wave):** deepseek's review hallucinations (e.g. the 1.9 "serving frameworks absent" fabrication) were **tool-starvation**, not just model unreliability. The Hermes `web` tool (`web_search`/`web_extract`) is **Firecrawl-gated** and fails closed when `FIRECRAWL_API_KEY` is unset → deepseek reviews silently ran on training memory.

**Fix (no Firecrawl, no new key, verified live):**
- Hermes ships a separate **`browser`** tool (headless browser automation) that works standalone. The deepseek adapter only handed it the Firecrawl-gated `web` toolset. → **added `browser` to all 3 deepseek toolsets.** Proven end-to-end: with the full review toolset deepseek fetched `Node 26.3.0` and `Python 3.14` **live**.
- **codex `review` class: `codex_search` False→True** so reviewers web-verify volatile facts by default.
- Updated the two pinned toolset assertions in `test_deepseek_adapter.py` (three-way rule).

**Also verified (migration-relevant):** agy headless (`gemini-3.1-pro-high`) **has working live web grounding** — returned MLflow `3.13.0` (a post-training-cutoff fact). gemini-cli→agy migration unblocked on tool-access.

`ruff` clean · 10/10 adapter tests pass · no content/build impact.

Regression test: tests/test_deepseek_adapter.py (asserts `browser` is in the deepseek read-only/workspace toolsets; refs #1827)

🤖 Generated with [Claude Code](https://claude.com/claude-code)