### PR TITLE
fix(#1827): agy --add-dir <cwd> — fixes the agy 'fabrication' root cause

### DIFF
--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -124,6 +124,15 @@ class AgyAdapter:
         # --agent agy so callers can't accidentally route around this.
         cmd: list[str] = [agy_bin, "-p", prompt, "--dangerously-skip-permissions"]
 
+        # Add the dispatch working dir (worktree / repo) to agy's workspace.
+        # Antigravity sandboxes file ops to ~/.gemini/antigravity-cli/scratch/
+        # and IGNORES the process cwd, so without --add-dir agy can neither READ
+        # the file under review (-> s117 "reviewed a file it never read"
+        # confabulation) nor WRITE authored output into the repo (-> s115
+        # "no file written"; it went to the sandbox). One missing flag caused
+        # both past "agy fabrication" verdicts. (#1827)
+        cmd += ["--add-dir", str(cwd)]
+
         resolved_model = self._resolve_model_flag(model)
         if resolved_model:
             cmd += ["--model", resolved_model]

--- a/tests/test_agy_adapter.py
+++ b/tests/test_agy_adapter.py
@@ -1,0 +1,50 @@
+"""Unit tests for the ``AgyAdapter`` (Antigravity CLI) integration.
+
+Regression coverage for #1827: agy sandboxes file ops to
+``~/.gemini/antigravity-cli/scratch/`` and ignores the process cwd, so the
+dispatch worktree/repo MUST be added to agy's workspace via ``--add-dir <cwd>``
+or agy can neither read the file under review nor write authored output into
+the repo (the root cause of the s115 "no file written" and s117 "reviewed a
+file it never read" fabrication verdicts).
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+from agent_runtime.adapters.agy import AgyAdapter
+
+
+def _plan(monkeypatch, mode: str, cwd: Path):
+    monkeypatch.setattr(
+        "agent_runtime.adapters.agy.shutil.which", lambda _: "agy"
+    )
+    adapter = AgyAdapter()
+    return adapter.build_invocation(
+        prompt="p",
+        mode=mode,
+        cwd=cwd,
+        model=None,
+        task_id=None,
+        session_id=None,
+        tool_config=None,
+    )
+
+
+def test_add_dir_includes_worktree_workspace_write(monkeypatch) -> None:
+    cwd = Path("/repo/.worktrees/x")
+    plan = _plan(monkeypatch, "workspace-write", cwd)
+    assert "--add-dir" in plan.cmd
+    # --add-dir must be immediately followed by the cwd so agy can read+write there
+    assert plan.cmd[plan.cmd.index("--add-dir") + 1] == str(cwd)
+
+
+def test_add_dir_includes_worktree_read_only(monkeypatch) -> None:
+    # reviews (read-only) also need the file under review in agy's workspace
+    cwd = Path("/repo/.worktrees/y")
+    plan = _plan(monkeypatch, "read-only", cwd)
+    assert plan.cmd[plan.cmd.index("--add-dir") + 1] == str(cwd)
+
+
+def test_skip_permissions_present(monkeypatch) -> None:
+    plan = _plan(monkeypatch, "danger", Path("/tmp"))
+    assert "--dangerously-skip-permissions" in plan.cmd


### PR DESCRIPTION
Part of **#1827** (reviewer/author tool-access). Companion to #1857 (deepseek/codex web).

**Root cause of every past "agy fabrication."** Antigravity sandboxes file operations to `~/.gemini/antigravity-cli/scratch/` and **ignores the process cwd**. The adapter launched agy with `cwd=<worktree>` but never added that worktree to agy's **workspace**, so agy could neither **read** the file under review nor **write** authored output into the repo. One missing flag explains both historical verdicts:
- **s115** "authored a module, no file written" → it wrote to the sandbox; the "hallucinated `kube-dojo/`-prefixed path" was the *sandbox-relative* path.
- **s117** "reviewed a file it never read" → it couldn't read the worktree file → confabulated the content.

**Fix:** pass `--add-dir <cwd>` so the dispatch worktree/repo is in agy's workspace (read + write).

**Verified — agy works fine with tools + a proper prompt + the right workspace (no fabrication):**
- Direct CLI: agy wrote `AGYTEST.md` (`go1.26.4`, web-verified) into the worktree.
- `dispatch_smart` end-to-end (patched adapter): agy authored `E2E.md` (PostgreSQL `18`, web-verified) into the worktree.
- The earlier sandbox file was a real, accurate, kubernetes.io-cited 306-word readiness/liveness explainer — content quality was never the issue.

`ruff` clean · 3/3 new `tests/test_agy_adapter.py` pass · no content/build impact.

Regression test: tests/test_agy_adapter.py (asserts `--add-dir <cwd>` is in the agy command; refs #1827)

🤖 Generated with [Claude Code](https://claude.com/claude-code)