### PR TITLE
feat(#1860): telemetry API endpoint + Monitor Agents page (harness/model rollup)

### DIFF
--- a/scripts/agent_telemetry.py
+++ b/scripts/agent_telemetry.py
@@ -5,23 +5,22 @@
 task_class, mode, elapsed, ok, response_chars) but carries NO quality signal.
 This module adds the missing layer: the orchestrator's ground-check VERDICT per
 dispatch, stored in `logs/agent_outcomes.jsonl` (gitignored, like the dispatch
-log), joined back to the dispatch log on `task_id` for a per-agent rollup.
+log), joined back to the dispatch log on `task_id`.
+
+**Harness ⟂ model** (the durable-content decomposition): a dispatch lane pairs a
+HARNESS (the runtime — hermes, cursor, codex, antigravity…) with a MODEL (the
+brain — deepseek-v4-pro, gpt-5.5, gemini-3.1-pro…). The `--agent` slug is the
+LANE; some lanes are bare harnesses, others are model-named lanes that run *on* a
+harness (e.g. `deepseek` and `qwen` both run on `hermes`). Telemetry rolls up by
+lane, by harness, and by model so you can tell a flaky harness from a weak model.
 
 Usage::
 
-    # after ground-checking a dispatch's output, record the outcome:
     python -m scripts.agent_telemetry annotate mlops-1.9-rev \\
         --activity review --role reviewer --outcome fabrication \\
-        --module ai-ml-engineering/mlops/1.9-model-serving \\
-        --note "claimed 'frameworks absent' — grep disproved (present 5-16x); discarded"
-
-    # for a direct-CLI agent not in smart_dispatch.jsonl (e.g. grok), pass --agent:
-    python -m scripts.agent_telemetry annotate grok-k8s-probe \\
-        --agent grok --model grok-build --activity research --outcome clean
-
-    # per-agent performance rollup:
-    python -m scripts.agent_telemetry report
-    python -m scripts.agent_telemetry report --agent deepseek
+        --module ai-ml-engineering/mlops/1.9-model-serving --note "..."
+    python -m scripts.agent_telemetry report            # by lane (default)
+    python -m scripts.agent_telemetry report --by harness   # or: lane | model | all
 """
 from __future__ import annotations
 
@@ -35,16 +34,29 @@ PRIMARY_REPO = Path(__file__).resolve().parent.parent
 DISPATCH_LOG = PRIMARY_REPO / "logs" / "smart_dispatch.jsonl"
 OUTCOME_LOG = PRIMARY_REPO / "logs" / "agent_outcomes.jsonl"
 
-# Outcome vocabulary (the orchestrator's ground-check verdict on a dispatch):
-#   clean       — output correct; review verdict held / findings real; no fabrication
-#   partial     — mostly good but needed a fix-pass / had minor real issues
-#   fabrication — invented content / review / tool-use provenance (the trust-killer)
-#   overturned  — review verdict was wrong and was discarded / re-run
-#   rejected_fp — raised >=1 false-positive finding that ground-check rejected
 OUTCOMES = ("clean", "partial", "fabrication", "overturned", "rejected_fp")
 ACTIVITIES = ("author", "review", "fix", "research", "mechanical")
-# outcomes that count against trust when computing a "miss rate"
-_MISS = {"fabrication", "overturned"}
+_MISS = {"fabrication", "overturned"}  # outcomes that count against trust
+
+# Lane -> harness (the runtime a lane dispatches through), derived from the
+# adapters: deepseek/qwen wrap `hermes`; cursor/opencode/codex/agy/gemini/claude
+# are their own CLIs. A lane absent here == its own harness.
+HARNESS_BY_LANE = {
+    "deepseek": "hermes",       # hermes --provider deepseek
+    "qwen": "hermes",           # hermes --provider openrouter (qwen)
+    "hermes": "hermes",
+    "opencode": "opencode",
+    "cursor": "cursor",
+    "codex": "codex",
+    "claude": "claude-code",
+    "agy": "antigravity",
+    "gemini": "gemini-cli",
+    "grok": "grok-cli",
+}
+
+
+def harness_of(lane: str | None) -> str:
+    return HARNESS_BY_LANE.get(lane or "", lane or "?")
 
 
 def _load_jsonl(path: Path) -> list[dict]:
@@ -62,14 +74,103 @@ def _load_jsonl(path: Path) -> list[dict]:
     return rows
 
 
-def _dispatch_index() -> dict[str, dict]:
-    """task_id -> most-recent dispatch record from smart_dispatch.jsonl."""
+def _dispatch_index(dispatch_log: Path = DISPATCH_LOG) -> dict[str, dict]:
     idx: dict[str, dict] = {}
-    for row in _load_jsonl(DISPATCH_LOG):
+    for row in _load_jsonl(dispatch_log):
         tid = row.get("task_id")
         if tid:
-            idx[tid] = row  # later rows win (most recent)
+            idx[tid] = row  # most recent wins
     return idx
+
+
+def _group(dispatches: list[dict], outcomes: list[dict], keyfn) -> dict[str, dict]:
+    """Group dispatch + outcome rows under keyfn(row). keyfn accepts either a
+    dispatch row or an outcome row (both carry `agent` and `model`)."""
+    g: dict[str, dict] = defaultdict(
+        lambda: {
+            "dispatches": 0,
+            "empty_or_failed": 0,
+            "elapsed_total": 0.0,
+            "elapsed_n": 0,
+            "by_class": defaultdict(int),
+            "models": set(),
+            "annotated": 0,
+            "outcomes": defaultdict(int),
+        }
+    )
+    for d in dispatches:
+        k = keyfn(d)
+        if not k:
+            continue
+        s = g[k]
+        s["dispatches"] += 1
+        s["by_class"][d.get("task_class") or "?"] += 1
+        if d.get("model"):
+            s["models"].add(d["model"])
+        if d.get("ok") is False or (d.get("response_chars") or 0) == 0:
+            s["empty_or_failed"] += 1
+        el = d.get("elapsed_s")
+        if isinstance(el, (int, float)):
+            s["elapsed_total"] += el
+            s["elapsed_n"] += 1
+    for o in outcomes:
+        k = keyfn(o)
+        if not k:
+            continue
+        s = g[k]
+        s["annotated"] += 1
+        s["outcomes"][o.get("outcome") or "?"] += 1
+    return g
+
+
+def _agent_stats(dispatches: list[dict], outcomes: list[dict]) -> dict[str, dict]:
+    """Per-lane stats (grouped by the dispatch `agent` slug). Stable for tests."""
+    return _group(dispatches, outcomes, lambda r: r.get("agent"))
+
+
+def _rows_from_group(group: dict[str, dict], key_name: str) -> list[dict]:
+    rows = []
+    for k in sorted(group, key=lambda x: -group[x]["dispatches"]):
+        s = group[k]
+        miss = sum(s["outcomes"].get(m, 0) for m in _MISS)
+        row = {
+            key_name: k,
+            "models": sorted(s["models"]),
+            "dispatches": s["dispatches"],
+            "empty_or_failed": s["empty_or_failed"],
+            "fail_pct": round(100 * s["empty_or_failed"] / s["dispatches"], 1) if s["dispatches"] else None,
+            "avg_elapsed_s": round(s["elapsed_total"] / s["elapsed_n"], 1) if s["elapsed_n"] else None,
+            "annotated": s["annotated"],
+            "miss": miss,
+            "miss_pct": round(100 * miss / s["annotated"], 1) if s["annotated"] else None,
+            "outcomes": dict(sorted(s["outcomes"].items())),
+            "by_class": dict(sorted(s["by_class"].items())),
+        }
+        # Only the lane view carries a separate harness field; for the by_harness
+        # view the group key already IS the harness (avoid a key collision).
+        if key_name == "lane":
+            row["harness"] = harness_of(k)
+        rows.append(row)
+    return rows
+
+
+def build_agent_telemetry(repo_root: Path | None = None, *, since: int | None = None) -> dict:
+    """JSON-serializable rollup used by both the CLI report and the API."""
+    dl = (repo_root / "logs" / "smart_dispatch.jsonl") if repo_root else DISPATCH_LOG
+    ol = (repo_root / "logs" / "agent_outcomes.jsonl") if repo_root else OUTCOME_LOG
+    dispatches = _load_jsonl(dl)
+    outcomes = _load_jsonl(ol)
+    if since:
+        dispatches = [d for d in dispatches if (d.get("ts") or 0) >= since]
+        outcomes = [o for o in outcomes if (o.get("ts") or 0) >= since]
+    return {
+        "generated_at": int(time.time()),
+        "dispatch_total": len(dispatches),
+        "annotated_total": len(outcomes),
+        "lanes": _rows_from_group(_group(dispatches, outcomes, lambda r: r.get("agent")), "lane"),
+        "by_harness": _rows_from_group(_group(dispatches, outcomes, lambda r: harness_of(r.get("agent"))), "harness"),
+        "by_model": _rows_from_group(_group(dispatches, outcomes, lambda r: r.get("model")), "model"),
+    }
 
 
 def annotate(args: argparse.Namespace) -> int:
@@ -86,6 +187,7 @@ def annotate(args: argparse.Namespace) -> int:
         "ts": int(time.time()),
         "task_id": args.task_id,
         "agent": agent,
+        "harness": harness_of(agent),
         "model": model,
         "task_class": disp.get("task_class"),
         "activity": args.activity,
@@ -98,81 +200,41 @@ def annotate(args: argparse.Namespace) -> int:
     OUTCOME_LOG.parent.mkdir(parents=True, exist_ok=True)
     with OUTCOME_LOG.open("a", encoding="utf-8") as fh:
         fh.write(json.dumps(record) + "\n")
-    print(f"recorded: {agent} ({model}) {args.activity}/{args.outcome} [{args.task_id}]")
+    print(f"recorded: {agent}/{harness_of(agent)} ({model}) {args.activity}/{args.outcome} [{args.task_id}]")
     return 0
 
 
-def _agent_stats(dispatches: list[dict], outcomes: list[dict]) -> dict[str, dict]:
-    stats: dict[str, dict] = defaultdict(
-        lambda: {
-            "dispatches": 0,
-            "empty_or_failed": 0,
-            "elapsed_total": 0.0,
-            "elapsed_n": 0,
-            "by_class": defaultdict(int),
-            "annotated": 0,
-            "outcomes": defaultdict(int),
-        }
-    )
-    for d in dispatches:
-        a = d.get("agent")
-        if not a:
-            continue
-        s = stats[a]
-        s["dispatches"] += 1
-        s["by_class"][d.get("task_class") or "?"] += 1
-        if d.get("ok") is False or (d.get("response_chars") or 0) == 0:
-            s["empty_or_failed"] += 1
-        el = d.get("elapsed_s")
-        if isinstance(el, (int, float)):
-            s["elapsed_total"] += el
-            s["elapsed_n"] += 1
-    for o in outcomes:
-        a = o.get("agent")
-        if not a:
-            continue
-        s = stats[a]
-        s["annotated"] += 1
-        s["outcomes"][o.get("outcome") or "?"] += 1
-    return stats
-
-
-def _pct(n: int, d: int) -> str:
-    return f"{(100.0 * n / d):.0f}%" if d else "—"
+def _print_table(title: str, key_name: str, rows: list[dict]) -> None:
+    print(f"\n{title}")
+    print("-" * 86)
+    extra = "harness" if key_name == "lane" else "models"
+    print(f"{key_name:<11}{extra:<14}{'disp':>5}{'fail%':>7}{'avg_s':>7}{'annot':>6}{'miss%':>7}  outcomes")
+    for r in rows:
+        side = (r["harness"] or "?") if key_name == "lane" else ",".join(r["models"])[:13]
+        oc = " ".join(f"{k}={v}" for k, v in r["outcomes"].items())
+        fail = f"{r['fail_pct']}%" if r["fail_pct"] is not None else "—"
+        miss = f"{r['miss_pct']}%" if r["miss_pct"] is not None else "—"
+        avg = round(r["avg_elapsed_s"]) if r["avg_elapsed_s"] is not None else 0
+        print(
+            f"{str(r[key_name]):<11}{side:<14}{r['dispatches']:>5}{fail:>7}{avg:>7}"
+            f"{r['annotated']:>6}{miss:>7}  {oc}"
+        )
 
 
 def report(args: argparse.Namespace) -> int:
-    dispatches = _load_jsonl(DISPATCH_LOG)
-    outcomes = _load_jsonl(OUTCOME_LOG)
-    if args.since:
-        dispatches = [d for d in dispatches if (d.get("ts") or 0) >= args.since]
-        outcomes = [o for o in outcomes if (o.get("ts") or 0) >= args.since]
-    stats = _agent_stats(dispatches, outcomes)
-    agents = sorted(stats, key=lambda a: -stats[a]["dispatches"])
-    if args.agent:
-        agents = [a for a in agents if a == args.agent]
-
-    print(f"Agent performance — {len(dispatches)} dispatches, {len(outcomes)} annotated outcomes")
-    print("=" * 78)
-    hdr = f"{'agent':<12}{'disp':>5}{'fail%':>7}{'avg_s':>7}{'annot':>6}{'miss%':>7}  outcomes"
-    print(hdr)
-    print("-" * 78)
-    for a in agents:
-        s = stats[a]
-        avg = s["elapsed_total"] / s["elapsed_n"] if s["elapsed_n"] else 0.0
-        miss = sum(s["outcomes"][k] for k in _MISS)
-        oc = " ".join(f"{k}={v}" for k, v in sorted(s["outcomes"].items()))
-        print(
-            f"{a:<12}{s['dispatches']:>5}{_pct(s['empty_or_failed'], s['dispatches']):>7}"
-            f"{avg:>7.0f}{s['annotated']:>6}{_pct(miss, s['annotated']):>7}  {oc}"
-        )
-    print("-" * 78)
-    print("fail% = empty/errored dispatches · miss% = (fabrication+overturned)/annotated · "
-          "annotate more to grow the signal")
-    if args.agent and agents:
-        s = stats[agents[0]]
-        print(f"\n{agents[0]} by task_class: " +
-              ", ".join(f"{k}={v}" for k, v in sorted(s["by_class"].items())))
+    data = build_agent_telemetry(since=args.since)
+    print(f"Agent performance — {data['dispatch_total']} dispatches, "
+          f"{data['annotated_total']} annotated outcomes")
+    print("=" * 86)
+    by = args.by
+    if by in ("lane", "all"):
+        _print_table("BY LANE (what you dispatch to)", "lane", data["lanes"])
+    if by in ("harness", "all"):
+        _print_table("BY HARNESS (the runtime)", "harness", data["by_harness"])
+    if by in ("model", "all"):
+        _print_table("BY MODEL (the brain)", "model", data["by_model"])
+    print("-" * 86)
+    print("fail% = empty/errored dispatches · miss% = (fabrication+overturned)/annotated")
     return 0
 
 
@@ -192,8 +254,8 @@ def main(argv: list[str] | None = None) -> int:
     a.add_argument("--session")
     a.set_defaults(func=annotate)
 
-    r = sub.add_parser("report", help="per-agent performance rollup")
-    r.add_argument("--agent")
+    r = sub.add_parser("report", help="performance rollup")
+    r.add_argument("--by", choices=("lane", "harness", "model", "all"), default="lane")
     r.add_argument("--since", type=int, help="unix ts lower bound")
     r.set_defaults(func=report)
 

--- a/scripts/agent_telemetry_page.py
+++ b/scripts/agent_telemetry_page.py
@@ -1,0 +1,129 @@
+"""HTML page for the agent-telemetry Monitor tab (#1860, phase 2).
+
+Renders the per-lane / per-harness / per-model performance rollup from
+`/api/telemetry/agents` (served by `agent_telemetry.build_agent_telemetry`).
+Kept in its own module so the big HTML/JS blob stays out of `local_api.py`;
+`local_api.route_request` wires `/agents` (this page) + `/api/telemetry/agents`
+(the JSON) and passes the shared nav/chrome in. The client builds the DOM with
+createElement + textContent (no innerHTML) so values are never interpreted as
+markup.
+"""
+from __future__ import annotations
+
+_PAGE_CSS = """
+.tel-main{max-width:1180px;margin:0 auto;padding:1.2rem}
+.tel-head h1{font-size:1.4rem;margin:0 0 .2rem}
+.tel-sub{color:#64748b;font-size:.9rem;margin-bottom:1rem}
+.tel-section{margin:1.6rem 0}
+.tel-section h2{font-size:1.05rem;color:#1e3a8a;margin:0 0 .1rem}
+.tel-section .hint{color:#64748b;font-size:.82rem;margin-bottom:.5rem}
+table.tg{border-collapse:collapse;width:100%;font-size:.88rem;background:#fff}
+table.tg th,table.tg td{border:1px solid #e2e8f0;padding:.35rem .55rem;text-align:right}
+table.tg th:first-child,table.tg td:first-child,
+table.tg th:nth-child(2),table.tg td.dim{text-align:left}
+table.tg th{background:#eff6ff;color:#1e293b;font-weight:600}
+table.tg td.k{font-weight:600;text-align:left}
+table.tg td.dim{color:#64748b;font-size:.82rem}
+table.tg td.bad{color:#dc2626;font-weight:700;background:#fef2f2}
+table.tg td.warn{color:#b45309;font-weight:600}
+.tel-legend{color:#64748b;font-size:.8rem;margin-top:1.2rem;border-top:1px solid #e2e8f0;padding-top:.6rem}
+.empty{color:#94a3b8;font-style:italic;padding:.5rem}
+"""
+
+# DOM is built with createElement + textContent only (no innerHTML) — values are
+# never parsed as markup.
+_PAGE_JS = """
+function pct(v){return v==null?'\\u2014':v+'%';}
+function num(v){return v==null?'\\u2014':String(Math.round(v));}
+function el(tag,text,cls){var e=document.createElement(tag);if(text!=null)e.textContent=text;if(cls)e.className=cls;return e;}
+function renderTable(hostId,rows,keyName,showHarness){
+  var host=document.getElementById(hostId);
+  host.textContent='';
+  if(!rows||!rows.length){host.appendChild(el('div','no data yet','empty'));return;}
+  var table=el('table',null,'tg');
+  var thead=el('thead'),htr=el('tr');
+  [keyName,showHarness?'harness':'models','disp','fail%','avg s','annot','miss%','outcomes']
+    .forEach(function(c){htr.appendChild(el('th',c));});
+  thead.appendChild(htr);table.appendChild(thead);
+  var tb=el('tbody');
+  rows.forEach(function(r){
+    var tr=el('tr');
+    tr.appendChild(el('td',r[keyName],'k'));
+    tr.appendChild(el('td',showHarness?(r.harness||'?'):(r.models||[]).join(', '),'dim'));
+    tr.appendChild(el('td',r.dispatches));
+    var f=el('td',pct(r.fail_pct));
+    if(r.fail_pct!=null&&r.fail_pct>=25)f.className='bad';else if(r.fail_pct!=null&&r.fail_pct>=10)f.className='warn';
+    tr.appendChild(f);
+    tr.appendChild(el('td',num(r.avg_elapsed_s)));
+    tr.appendChild(el('td',r.annotated));
+    var m=el('td',pct(r.miss_pct));if(r.miss_pct!=null&&r.miss_pct>0)m.className='bad';tr.appendChild(m);
+    var oc=Object.entries(r.outcomes||{}).map(function(kv){return kv[0]+'='+kv[1];}).join(' ');
+    tr.appendChild(el('td',oc||'\\u2014','dim'));
+    tb.appendChild(tr);
+  });
+  table.appendChild(tb);host.appendChild(table);
+}
+async function loadTelemetry(){
+  try{
+    var r=await fetch('/api/telemetry/agents');var d=await r.json();
+    document.getElementById('tel-summary').textContent=
+      d.dispatch_total+' dispatches \\u00b7 '+d.annotated_total+' annotated outcomes';
+    renderTable('tel-lanes',d.lanes,'lane',true);
+    renderTable('tel-harness',d.by_harness,'harness',false);
+    renderTable('tel-model',d.by_model,'model',false);
+  }catch(e){document.getElementById('tel-summary').textContent='failed to load: '+e;}
+}
+loadTelemetry();
+"""
+
+
+def render_agents_page_html(*, top_nav: str = "", nav_css: str = "", ds_link: str = "") -> str:
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Agents - KubeDojo Local Monitor</title>
+  {ds_link}
+  <style>
+{nav_css}
+{_PAGE_CSS}
+  </style>
+</head>
+<body>
+  {top_nav}
+  <main class="tel-main">
+    <div class="tel-head">
+      <h1>Agent Performance</h1>
+      <div class="tel-sub" id="tel-summary">loading&hellip;</div>
+    </div>
+
+    <div class="tel-section">
+      <h2>By lane</h2>
+      <div class="hint">what you dispatch to (a harness + model pairing)</div>
+      <div id="tel-lanes"><div class="empty">loading&hellip;</div></div>
+    </div>
+
+    <div class="tel-section">
+      <h2>By harness</h2>
+      <div class="hint">the runtime — isolates harness reliability from model quality (deepseek &amp; qwen both run on hermes)</div>
+      <div id="tel-harness"><div class="empty">loading&hellip;</div></div>
+    </div>
+
+    <div class="tel-section">
+      <h2>By model</h2>
+      <div class="hint">the brain — how a model performs regardless of which harness ran it</div>
+      <div id="tel-model"><div class="empty">loading&hellip;</div></div>
+    </div>
+
+    <div class="tel-legend">
+      <strong>fail%</strong> = empty/errored dispatches (operational, all history) ·
+      <strong>miss%</strong> = (fabrication + overturned) / annotated (quality, ground-checked outcomes) ·
+      grow the signal with <code>scripts/agent_telemetry.py annotate</code>.
+    </div>
+  </main>
+  <script>
+{_PAGE_JS}
+  </script>
+</body>
+</html>"""

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -4322,6 +4322,7 @@ def _render_top_nav(active: str) -> str:
         ("pipeline", "/pipeline", "Pipeline"),
         ("activity", "/activity", "Activity"),
         ("benchmarks", "/benchmarks", "Benchmarks"),
+        ("agents", "/agents", "Agents"),
         ("channels", "/channels", "Channels"),
         ("decisions", "/decisions", "Decisions"),
         ("health", "/health", "Health"),
@@ -8820,6 +8821,23 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
         return 200, render_activity_page_html(), "text/html; charset=utf-8"
     if path == "/health":
         return 200, render_health_page_html(), "text/html; charset=utf-8"
+    if path == "/agents":
+        from agent_telemetry_page import render_agents_page_html
+        return 200, render_agents_page_html(
+            top_nav=_render_top_nav("agents"),
+            nav_css=_TOP_NAV_CSS,
+            ds_link=_design_system_link(),
+        ), "text/html; charset=utf-8"
+    if path == "/api/telemetry/agents":
+        from agent_telemetry import build_agent_telemetry
+        since_raw = query.get("since", [None])[0]
+        since_val = None
+        if since_raw:
+            try:
+                since_val = int(since_raw)
+            except (TypeError, ValueError):
+                since_val = None
+        return 200, build_agent_telemetry(repo_root, since=since_val), "application/json; charset=utf-8"
     decision_page = _DECISION_ROUTES.route_decision_page_request(
         repo_root,
         path,

--- a/tests/test_agent_telemetry.py
+++ b/tests/test_agent_telemetry.py
@@ -1,7 +1,9 @@
-"""Unit tests for agent_telemetry report aggregation (#1860)."""
+"""Unit tests for agent_telemetry aggregation + harness/model rollup (#1860)."""
 from __future__ import annotations
 
-from agent_telemetry import _agent_stats
+import json
+
+from agent_telemetry import _agent_stats, build_agent_telemetry, harness_of
 
 
 def test_agent_stats_joins_dispatches_and_outcomes() -> None:
@@ -30,7 +32,6 @@ def test_agent_stats_joins_dispatches_and_outcomes() -> None:
     assert ds["outcomes"]["clean"] == 1
     assert ds["by_class"]["review"] == 2
     assert ds["by_class"]["draft"] == 1
-    # avg elapsed over the 3 dispatches = (200+100+10)/3
     assert round(ds["elapsed_total"] / ds["elapsed_n"], 1) == 103.3
 
     cx = stats["codex"]
@@ -41,3 +42,50 @@ def test_agent_stats_joins_dispatches_and_outcomes() -> None:
 
 def test_agent_stats_handles_empty() -> None:
     assert _agent_stats([], []) == {}
+
+
+def test_harness_of_mapping() -> None:
+    assert harness_of("deepseek") == "hermes"   # model-lane on hermes
+    assert harness_of("qwen") == "hermes"
+    assert harness_of("opencode") == "opencode"
+    assert harness_of("codex") == "codex"
+    assert harness_of("agy") == "antigravity"
+    assert harness_of("somethingnew") == "somethingnew"  # unknown lane == own harness
+    assert harness_of(None) == "?"
+
+
+def test_build_rolls_up_by_harness_and_model(tmp_path) -> None:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    # deepseek (model-lane on hermes) + hermes (lane) both -> hermes harness
+    dispatches = [
+        {"task_id": "a", "agent": "deepseek", "model": "deepseek-v4-pro", "ok": True,
+         "response_chars": 9, "elapsed_s": 100, "task_class": "review"},
+        {"task_id": "b", "agent": "hermes", "model": "claude-sonnet-4-6", "ok": True,
+         "response_chars": 9, "elapsed_s": 50, "task_class": "review"},
+        {"task_id": "c", "agent": "cursor", "model": "auto", "ok": True,
+         "response_chars": 9, "elapsed_s": 30, "task_class": "draft"},
+    ]
+    outcomes = [{"task_id": "a", "agent": "deepseek", "model": "deepseek-v4-pro",
+                 "outcome": "fabrication"}]
+    (logs / "smart_dispatch.jsonl").write_text(
+        "\n".join(json.dumps(d) for d in dispatches), encoding="utf-8")
+    (logs / "agent_outcomes.jsonl").write_text(
+        "\n".join(json.dumps(o) for o in outcomes), encoding="utf-8")
+
+    data = build_agent_telemetry(tmp_path)
+    assert data["dispatch_total"] == 3
+    by_h = {h["harness"]: h for h in data["by_harness"]}
+    # deepseek + hermes lanes collapse into one hermes harness row
+    assert by_h["hermes"]["dispatches"] == 2
+    assert by_h["hermes"]["annotated"] == 1
+    assert by_h["hermes"]["miss_pct"] == 100.0   # 1 fabrication / 1 annotated
+    assert by_h["cursor"]["dispatches"] == 1
+    # lane view keeps them separate, each with its harness label
+    lanes = {x["lane"]: x for x in data["lanes"]}
+    assert lanes["deepseek"]["harness"] == "hermes"
+    assert lanes["hermes"]["harness"] == "hermes"
+    # by_model keeps the brains distinct
+    by_m = {m["model"]: m for m in data["by_model"]}
+    assert by_m["deepseek-v4-pro"]["dispatches"] == 1
+    assert by_m["claude-sonnet-4-6"]["dispatches"] == 1


### PR DESCRIPTION
Phase 2 of #1860 (the CLI + store landed in #1861). Adds the requested API endpoint + Monitor UI page, and incorporates the harness⟂model correction.

**What's new**
- `GET /api/telemetry/agents` — JSON rollup.
- `/agents` — a Monitor "Agents" tab (nav link added) that fetches it and renders three tables.

**Harness ⟂ model (the conceptual fix).** `deepseek` and `qwen` are *models* that run on the **hermes** harness; `opencode` is its own harness. Treating "hermes" as a peer of "deepseek" conflated the two axes. `build_agent_telemetry` now returns three groupings:
- **by lane** — what you dispatch to (a harness+model pairing)
- **by harness** — the runtime; isolates harness reliability (hermes aggregates deepseek+qwen+hermes-lane)
- **by model** — the brain; e.g. `gpt-5.3-codex-spark` shows 28% fail vs cursor `auto` 0.3%

`build_agent_telemetry()` is shared by the CLI report (now `--by lane|harness|model|all`) and the API — one source of truth.

The page builds its DOM with `createElement` + `textContent` (no `innerHTML`).

ruff clean · 4/4 tests (incl. a regression test for the by-harness key-collision bug the smoke test caught) · `local_api.py` compiles · no content/build impact.

Regression test: tests/test_agent_telemetry.py (test_build_rolls_up_by_harness_and_model; refs #1860)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
