### PR TITLE
docs(ai-infra): expand ai-infrastructure 1.1/1.2/1.3 to T0 (#1842)

### DIFF
--- a/src/content/docs/ai-ml-engineering/ai-infrastructure/module-1.1-cloud-ai-services.md
+++ b/src/content/docs/ai-ml-engineering/ai-infrastructure/module-1.1-cloud-ai-services.md
@@ -5,496 +5,246 @@ sidebar:
   order: 702
 ---
 
-> **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 5-6
+> **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 5-6 hours
 **Prerequisites**: Phase 10 complete (DevOps & MLOps)
 
-## The 3 AM Page That Broke the Generative AI Launch
+## Learning Outcomes
 
-**Seattle, Washington. November 27, 2025. 3:17 AM.**
+By the end of this module, you will be able to:
 
-Sarah Martinez was dreaming about her upcoming vacation when her phone started buzzing. Three alerts, then ten, then forty-seven in the span of two minutes. Her company's highly anticipated Generative AI shopping assistant had just gone live for Black Friday, and the system was completely buckling.
+- **Explain** what managed Cloud AI services abstract away and which capacity dimensions remain your responsibility as a consumer.
+- **Compare** regional, geographic cross-region, and global routing models across major cloud AI platforms using a vendor-agnostic taxonomy.
+- **Design** quota-aware client architectures that prevent 429 retry cascades through backpressure, circuit breakers, and asymmetric scaling.
+- **Analyze** token-metered cost structures—including input versus output tokens, caching, and batch versus real-time pricing—to balance over- and under-provisioning.
+- **Evaluate** any managed AI offering against a structured requirements framework using the Cloud AI Services Rosetta Stone as a cross-vendor reference.
 
-Half-asleep, she logged into their observability platform to find a wall of red. User-facing latency for the chat interface had spiked from 800ms to 12 seconds. Error rates had jumped from 0.1% to 42%. The underlying Kubernetes clusters (running v1.35) were perfectly healthy. CPU was low. Memory was stable. The problem wasn't their infrastructure—it was their consumption of managed Cloud AI services.
+## Why This Module Matters
 
-Four hours later, after escalating to their cloud provider's enterprise support, they found the cascading failure. The team had relied on a global endpoint for their foundation models without realizing the regional rate limits. A sudden spike in complex user queries exhausted their on-demand token quota. Retries amplified the traffic, triggering API throttling, which caused upstream services to queue requests until memory exhausted. The total revenue impact? $2.3 million in abandoned shopping carts. The fix? Purchasing provisioned throughput and implementing cross-region inference profiles—a change that took minutes to apply but hours to diagnose.
+**Hypothetical scenario:** Your team launches a customer-facing chat assistant backed entirely by a managed foundation-model API. Kubernetes clusters are healthy—CPU and memory look fine—but user-facing latency climbs from under a second to ten seconds or more. Error rates spike. Support tickets flood in. The root cause is not a pod crash or a misconfigured Deployment; it is exhaustion of on-demand token quotas on a regional endpoint, amplified by aggressive client retries that trigger cascading HTTP 429 responses. The fix involves purchasing provisioned throughput, routing through a cross-region inference profile, and redesigning retry policy—but only after hours of confusion because traditional infrastructure dashboards showed green.
 
-Sarah realized that while managed AI services (like Amazon Bedrock or Azure Foundry) abstract away the GPUs, they do *not* abstract away the need for rigorous capacity planning and proactive operations. What if an AIOps system had seen the token consumption velocity building before the 429 Too Many Requests errors fired? What if they had predicted the throughput requirements instead of reacting to failures? This module bridges these two worlds: mastering the landscape of Cloud AI Services, and applying AIOps to keep them running flawlessly.
+This pattern is increasingly common because managed Cloud AI services shift the hard problem. You no longer provision GPU nodes, patch CUDA drivers, or schedule model weights across a cluster. Instead, you provision *capacity contracts*—quotas, throughput commitments, endpoint geography, and routing profiles—that behave like invisible infrastructure. Teams that treat a managed foundation-model endpoint as "just another REST call" discover that abstraction has boundaries. The GPUs are gone from your runbook, but capacity engineering remains.
 
-## What You'll Be Able to Do
-
-By the end of this module, you will:
-- **Compare** regional and global deployment architectures across Amazon Bedrock, OCI, Azure Foundry, and Google Vertex AI.
-- **Design** capacity plans for provisioned throughput and dedicated AI clusters to avoid rate-limiting cascades.
-- **Implement** predictive autoscaling and time-series forecasting for LLM token consumption.
-- **Diagnose** complex API latency and anomaly events using statistical and machine learning AIOps methods.
-- **Evaluate** the asymmetric costs of over-provisioning versus under-provisioning in the context of expensive managed AI APIs.
+This module teaches the durable spine of consuming hosted foundation-model services: deployment models, quota mechanics, token economics, and a cross-vendor mental model you can apply to any new entrant. For the broader discipline of AI-powered operations—anomaly detection algorithms, causal RCA graphs, automated runbooks—see [AIOps](../module-1.2-aiops/), which owns that operational depth. Here we focus on what you must understand *before* you can operate managed AI APIs reliably at production scale.
 
 ---
 
-## The Landscape of Managed Cloud AI Services
+## Why "Serverless AI" Still Needs Capacity Engineering
 
-Before we can monitor and scale our AI usage, we must understand the strict boundaries and deployment models of the top-tier Cloud AI platforms. Because you don't manage the underlying hardware, your "infrastructure" becomes your configuration of endpoints, regions, and throughput commitments.
+The phrase "serverless AI" captures a genuine shift in operational burden. When you invoke a foundation model through a managed API, the provider owns model loading, GPU scheduling, weight updates, and hardware failure recovery. Your application sends a request; the service returns tokens. From a developer's perspective, this feels like infinite scale—until it does not. Every managed AI platform enforces limits: requests per minute, tokens per minute, concurrent connections, and sometimes separate burst versus sustained quotas. These limits exist because inference is compute-intensive and providers must protect multi-tenant fairness.
 
-### Amazon Bedrock: Provisioned Throughput and Cross-Region Routing
+Understanding the abstraction boundary is the first engineering skill this module builds. Above the boundary, you manage application logic, prompt design, and user experience. Below the boundary—inside the provider's data center—the service manages hardware. *At* the boundary, you negotiate capacity through configuration choices that are easy to overlook during a prototype phase but become critical at launch. Choosing on-demand versus provisioned throughput, picking a regional endpoint versus a cross-region inference profile, and deciding whether data may leave a geographic boundary are all capacity decisions even though none of them involve SSH access to a GPU node.
 
-Amazon Bedrock presents foundation models for text, image, and embedding workloads, actively supporting inference, evaluation, knowledge-base creation, and agent use cases. As of our latest evaluations, Bedrock's model catalog includes Anthropic Claude 4.x entries (including Claude Opus 4.6 and Claude Sonnet 4.6), DeepSeek 3.x family entries, and Meta Llama 4 models.
+The mental model that helps most teams is to treat a managed AI endpoint like a load-balanced microservice with opaque autoscaling rules. You cannot see queue depth directly, but you observe it through latency percentiles, time-to-first-token, and throttle response codes. You cannot scale GPU count yourself, but you can purchase dedicated throughput, switch routing profiles, or shard traffic across multiple endpoints. Capacity engineering for Cloud AI services is therefore a discipline of *observing proxy metrics* and *adjusting contractual knobs* rather than resizing instance types.
 
-When deploying globally, you must understand Bedrock's regional strategy. Bedrock publishes per-model region availability with separate columns for single-region support and cross-region inference profile support. If you rely on a single region, a localized spike can throttle your application. Cross-region inference profiles dynamically route requests across multiple AWS regions to absorb spikes, but they introduce variable latency that your upstream microservices must be configured to handle gracefully.
+Self-hosted inference—covered in later modules in this track—reintroduces GPU visibility but trades away managed elasticity. Many production architectures hybridize: managed APIs for fast-moving foundation models and self-hosted endpoints for stable, high-volume, or privacy-sensitive workloads. The Rosetta Stone's self-hosted column exists to remind you that "Cloud AI Services" is a consumption choice, not a permanent architectural destiny. Teams often start managed, measure unit economics at scale, and selectively repatriate workloads when the math and operational maturity justify running their own inference stack.
 
-For production workloads, relying on on-demand pricing is dangerous. Bedrock model customization uses *provisioned throughput*. Once purchased, custom model inference uses dedicated model IDs and ARNs, guaranteeing your capacity regardless of noisy neighbors.
+Multi-tenant capacity adds another layer. On-demand endpoints share provider infrastructure with other customers. During provider-wide demand spikes—or during your own traffic surges—you may encounter noisy-neighbor throttling even when your application's Kubernetes layer looks idle. Dedicated or provisioned capacity isolates you from some of this contention at the cost of committed spend. The tradeoff between flexibility and guaranteed headroom is central to every production architecture decision in this space.
 
-### OCI Generative AI: Enterprise Agents and Dedicated Clusters
+Finally, capacity engineering extends to the clients that call these APIs. An inference gateway, a batch enrichment pipeline, and an interactive chat UI have different latency and burst profiles. If all three share one endpoint with one quota, a batch job can starve interactive users without any single component appearing "broken" in isolation. Partitioning endpoints, quotas, and retry budgets by workload class is as important as partitioning Kubernetes namespaces—perhaps more so, because the throttle happens outside your cluster.
 
-Oracle Cloud Infrastructure (OCI) Generative AI is positioned as a fully managed service for chat, embeddings, and rerank, notably featuring OpenAI-compatible API support. OCI is documented as available across commercial (OC1), government (OC4), and sovereign (OC19) region families.
+Platform engineers should document the abstraction boundary explicitly in architecture diagrams. Draw a line between "our cluster" and "provider inference plane," listing every knob your team controls: endpoint ID, routing profile, API key scope, retry policy, max output tokens, and provisioned commitment IDs. Anything not on your side of the line is a vendor ticket, a purchase order, or a configuration change in the cloud console—not a `kubectl scale` command. That single diagram prevents more launch-day incidents than any amount of autoscaling tuning.
 
-Model availability in OCI Generative AI is strictly region-dependent and tracked with on-demand, dedicated, and (in some cases) interconnect-only availability markers. While OCI allows the use of pretrained hosted models via console, CLI, and API, enterprise scale requires custom model import, fine-tuning, and hosting on **dedicated AI clusters**. These clusters provide isolated compute resources that protect your workloads from multi-tenant throttling.
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
 
-OCI enterprise AI features have rapidly expanded to support complex agentic workflows, including an Responses-compatible API plus tool hooks (including MCP), memory APIs, vector stores, and NL2SQL capabilities.
+| Capability | Amazon Bedrock | Google Vertex AI | Azure AI Foundry | OCI Generative AI |
+|---|---|---|---|---|
+| On-demand inference | Per-model regional quotas (RPM/TPM) | Per-model regional quotas | Standard deployment type | On-demand hosted models |
+| Provisioned / dedicated throughput | Provisioned Throughput (Model Units) | Provisioned Throughput (where supported) | Provisioned Throughput units | Dedicated AI clusters |
+| Cross-region routing | Geographic and global inference profiles | Regional endpoints; limited global endpoint | Global, data-zone, and regional deployments | Region-specific model availability |
+| OpenAI-compatible API | Converse API (native); some third-party compat layers | OpenAI-compatible endpoints (select models) | Azure OpenAI-compatible endpoints | Documented OpenAI-compatible API |
+| Fine-tuning / customization | Custom models require Provisioned Throughput | Regional endpoints required for tuning | Model deployment per project | Custom model import and fine-tuning |
+| Agent / tool protocols | Agents, knowledge bases, tool use | Vertex AI Agent Builder ecosystem | Agent frameworks via Foundry | Responses API, tool hooks, MCP support documented |
 
-### Azure Foundry & Google Vertex AI: The Global Endpoint Dilemma
-
-Microsoft Azure Foundry's "sold-directly" models page states that these include all Azure OpenAI models plus selected third-party providers, billed directly through your Azure subscription backed by a Microsoft SLA. The catalog currently includes the advanced GPT-5.4 series (e.g., gpt-5.4, gpt-5.4-mini, gpt-5.4-nano, gpt-5.4-pro). Azure documents both standard and provisioned deployment styles, including global routing options to distribute traffic automatically.
-
-Conversely, Google Cloud's Vertex AI takes a different approach. Vertex AI does *not* offer a global location for standard operations; users must choose a supported region for most dataset and model tasks. For Generative AI specifically, a global endpoint exists at `locations/global`, but it comes with severe caveats: the global endpoint does not guarantee data residency and omits critical capabilities like model tuning and specific batch prediction paths. Despite this, the Vertex generative model endpoint tables boast massive models, including Gemini 2.5 and 3.1 preview model IDs.
-
-> **Stop and think**: If your compliance team mandates strict data residency within the European Union, how does this requirement change your architectural choice between Azure Foundry's global routing and Vertex AI's regional endpoints?
-
-### 4 Facts You Should Know
-
-1. **Deprecation Horizons:** Azure's classic Foundry Agent Service docs were officially marked as deprecated as of 2027-03-31, migrating users to newer hub-based project limitations and strict GPT-5 registration requirements.
-2. **Agent Maturation:** OCI Generative AI Enterprise AI Agents reached General Availability on 2026-03-31, signaling enterprise readiness for complex multi-step reasoning.
-3. **Security Enhancements:** API keys for OCI Generative AI models were added on 2026-01-21, and OCI Generative AI added AI guardrails for on-demand mode shortly after on 2026-02-09.
-4. **Historical Efficiency:** Google's Borg system (predecessor to Kubernetes) has used ML for resource prediction since 2013, achieving just 23% resource slack compared to 46-60% slack for manually-managed jobs.
+*This table is illustrative, not a leaderboard or endorsement. Capabilities vary by model and region; confirm against current vendor documentation before designing production architecture.*
 
 ---
 
-## From Firefighting to Prevention: AIOps for AI APIs
+## Deployment and Routing Models
 
-### Why Traditional Operations Can't Scale
+Managed AI platforms expose several durable routing patterns. Learning the taxonomy—not memorizing product marketing names—lets you map any new vendor announcement into a familiar slot within minutes.
 
-Think of traditional cloud operations like a fire department that can only respond after a building is engulfed. Even when consuming managed Cloud AI APIs, reacting to rate limits is too slow. Every incident follows a painful timeline:
+**Single-region endpoints** bind inference to one cloud region. Requests stay local, latency is predictable, and data residency is straightforward to reason about because both storage and compute remain in the chosen region. The tradeoff is a hard ceiling: when that region's quota is exhausted, every client receives throttling responses until demand subsides or you reconfigure routing. Single-region endpoints suit workloads with strict compliance boundaries, predictable traffic, and tolerance for manual failover during regional incidents.
 
-```text
-REACTIVE OPS TIMELINE
-=====================
+**Geographic cross-region inference profiles** route requests across multiple regions *within* a geography—such as US, EU, or APAC—while keeping data processing inside that geography's boundary. Providers typically expose these as unified model identifiers that abstract away the underlying regional ARNs. Throughput can exceed single-region quotas because traffic spreads across the profile's member regions. Latency becomes less predictable because a request may land in any member region, and some capabilities (notably provisioned throughput on some platforms) may not attach to inference profiles at all. Geographic profiles suit production workloads that need higher burst capacity without abandoning data-residency requirements.
 
-00:00  Problem begins (CPU spike, memory leak)
-00:15  Threshold exceeded
-00:16  Alert fires
-00:20  Engineer acknowledges
-00:35  Investigation begins
-00:50  Root cause identified
-01:10  Fix deployed
-01:15  Service recovered
+**Global routing endpoints** extend cross-region logic across commercial regions worldwide, prioritizing available capacity and sometimes offering cost advantages over strictly geographic routing. The tradeoff is explicit: global endpoints may process data outside your preferred jurisdiction and often omit features tied to regional data stores—custom tuning, certain batch pipelines, or residency-sensitive logging. Global routing belongs in workloads where maximum throughput and cost efficiency outweigh strict residency, not in regulated environments where audit trails must prove geographic containment.
 
-Total downtime: 1+ hour
-User impact: Significant
-```
+**Dedicated versus multi-tenant capacity** forms an orthogonal axis. Multi-tenant on-demand endpoints charge per token with no upfront commitment; you share capacity with other customers and accept throttle risk during peaks. Dedicated or provisioned throughput reserves model capacity measured in provider-specific units—Model Units, provisioned tokens per minute, or isolated AI clusters—delivering predictable performance at committed cost. Custom fine-tuned models on several platforms *require* provisioned capacity because the provider must host your weights on reserved hardware.
 
-By the time a human receives an alert that Bedrock is returning `429 Throttled` errors, the damage is done. Your LLM-powered application is already failing customer requests, and retries are only making the queue depth worse.
+Understanding when to move from on-demand to provisioned capacity is one of the highest-value decisions in this module. Stay on on-demand while traffic is unpredictable, quotas are far from exhaustion, and the cost of occasional throttling is acceptable—typical for internal tools and early prototypes. Move to provisioned throughput when you have measured sustained utilization above roughly seventy percent of on-demand limits for multiple weeks, when marketing or compliance events create known spikes, or when SLA commitments to customers make any 429 unacceptable. The transition is usually a configuration and billing change, not an application rewrite, provided you already route through a gateway that can swap model identifiers.
 
-### The Proactive Alternative
+Data residency deserves explicit architectural treatment because it intersects with every routing choice. A compliance policy that mandates EU-only processing rules out global endpoints entirely and may rule out geographic profiles whose member regions extend beyond the EU. Conversely, a latency-sensitive US consumer application might accept global routing to survive Black-Friday-scale bursts. Document the residency decision alongside the routing decision in your architecture records; auditors ask about data location, not about which model identifier string you passed to the SDK.
 
-AIOps (Artificial Intelligence for IT Operations) flips the script. Instead of reacting, it predicts.
+Cross-region failover at the application layer remains your responsibility even when the provider offers inference profiles. Profiles handle *within-vendor* routing; they do not replace a multi-vendor fallback strategy when an entire cloud has an outage. Mature architectures maintain secondary endpoints—often in a different vendor or a self-hosted stack covered in later modules—and switch through gateway-level circuit breakers when primary endpoints degrade.
+
+Latency SLOs should be defined differently for managed AI than for traditional microservices. Time-to-first-token and tokens-per-second during generation often dominate user-perceived latency more than network round-trip to the gateway. Capacity planning therefore tracks not only RPM and TPM but also output length distributions—a shift toward longer answers increases TPM consumption even when request rate stays flat. Instrument both request rate and average output tokens per request as first-class metrics in your gateway.
 
 ```text
-PROACTIVE AI OPS TIMELINE
-=========================
+ROUTING DECISION TREE (DURABLE TAXONOMY)
+=========================================
 
--02:00  AI detects anomalous pattern
--01:45  Prediction: "CPU will exceed threshold in ~2 hours"
--01:30  Automated scaling triggered
--01:00  Additional capacity online
-00:00   Would-be incident prevented
-
-Total downtime: 0
-User impact: None
+Start: Do compliance rules require data in a specific geography?
+  |
+  +-- YES --> Use regional or geographic-cross-region endpoints ONLY
+  |           (verify profile member regions match policy)
+  |
+  +-- NO  --> Is predictable latency more important than burst headroom?
+              |
+              +-- YES --> Single-region + provisioned throughput
+              |
+              +-- NO  --> Geographic or global inference profile
+                          + monitor p99 latency variance
 ```
 
-What does an AIOps platform actually do? It observes, engages, and acts.
+When you deploy an inference gateway in Kubernetes—as many teams do to centralize authentication, logging, and routing—the gateway becomes the enforcement point for these decisions. It selects endpoint identifiers, attaches quota-aware retry policies, and exposes metrics your autoscaler consumes. The gateway does not eliminate capacity planning; it concentrates it in one place where platform engineers can reason about traffic holistically.
 
-```mermaid
-flowchart TD
-    Platform[AIOps Platform] --> Observe
-    Platform --> Engage
-    Platform --> Act
+Consider how three common workload classes map to routing choices. A low-latency customer chatbot benefits from geographic cross-region profiles within the compliance boundary, strict output token caps, and provisioned headroom during known peak hours. An internal document summarization batch job tolerates minutes of latency and should use batch APIs where available, with scheduling that pauses when interactive utilization crosses warning thresholds. A developer sandbox can remain on cheap on-demand endpoints with hard daily spend caps, isolated from production quota pools so experiments never starve paying users. These are not product features—they are architectural patterns you implement through endpoint partitioning and gateway policy.
 
-    subgraph Observe
-    O1[Collect]
-    O2[Ingest]
-    O3[Store]
-    end
-
-    subgraph Engage
-    E1[Correlate]
-    E2[Analyze]
-    E3[Prioritize]
-    end
-
-    subgraph Act
-    A1[Automate]
-    A2[Remediate]
-    A3[Optimize]
-    end
-```
-
-Without AIOps, operators suffer from **Alert Fatigue**. A sudden spike in API latency might trigger 500 alerts across different microservices. AIOps uses ML correlation to group those into a single, actionable root cause.
-
-```text
-ALERT NOISE REDUCTION
-=====================
-
-Before AIOps:
-  500 alerts/day → 480 false positives → Alert fatigue!
-
-After AIOps:
-  500 alerts/day → ML correlation → 20 actionable incidents
-
-Techniques:
-  • Alert deduplication
-  • Correlation (related alerts grouped)
-  • Suppression (known patterns)
-  • Dynamic thresholds
-```
-
-With AIOps, Root Cause Analysis happens at machine speed:
-
-```text
-RCA WITH AI
-===========
-
-Incident: API latency spike
-
-Traditional approach:
-  1. Check API servers
-  2. Check database
-  3. Check network
-  4. Check dependencies... (hours later)
-  5. Found: Redis memory pressure
-
-AI approach:
-  1. Correlate all metrics at incident time
-  2. Identify: Redis memory spike precedes API latency
-  3. Causal analysis: Redis evictions → cache misses → DB load → API latency
-  4. Root cause: Redis memory (confidence: 94%)
-
-Time: Minutes vs Hours
-```
-
-To build this capability, you need a proactive architecture that ingests everything from Kubernetes custom metrics to CloudWatch data from your Bedrock endpoints.
-
-```mermaid
-flowchart TD
-    subgraph Data Collection
-    P[Prometheus] & CW[CloudWatch] & CM[Custom Metrics] & L[Logs]
-    end
-
-    subgraph Data Processing
-    TSDB[Time Series DB] & FE[Feature Engineering] & AGG[Aggregation]
-    end
-
-    subgraph AI/ML Engine
-    AD[Anomaly Detection] & FM[Forecasting Models] & CP[Capacity Planning] & IP[Incident Prediction]
-    end
-
-    subgraph Action Engine
-    AS[Auto-scaling] & AL[Alerting] & RB[Runbooks] & REC[Recommendations]
-    end
-
-    Data Collection --> Data Processing
-    Data Processing --> AI/ML Engine
-    AI/ML Engine --> Action Engine
-```
-
-The market has exploded with tools to implement this architecture:
-
-```text
-AIOPS TOOLS (2024)
-==================
-
-Full Platforms:
-  • Datadog AI       - Watchdog for anomaly detection
-  • Dynatrace Davis  - AI-powered root cause analysis
-  • Splunk ITSI      - ML-powered IT service intelligence
-  • New Relic AI     - Applied Intelligence
-  • Moogsoft         - AI incident management
-
-Open Source:
-  • Prometheus + ML  - Custom anomaly detection
-  • Grafana ML       - Machine learning for observability
-  • OpenTelemetry    - Observability data collection
-  • Skywalking       - APM with ML capabilities
-
-Cloud Native:
-  • AWS DevOps Guru  - ML-powered insights
-  • Azure Monitor    - Smart detection
-  • GCP Operations   - Anomaly detection
-```
+Failover testing belongs in the same category as regional DR drills. Quarterly, deliberately misconfigure a staging endpoint to return sustained 429 responses and verify that your gateway circuit breaker routes to the secondary profile within the expected time bound. Measure whether fallback endpoints preserve data residency and whether degraded responses meet product requirements when the primary model tier is unavailable.
 
 ---
 
-## Anomaly Detection: Finding Trouble in Token Streams
+## Quotas, Rate Limits, and the 429 Cascade
 
-### Understanding What Makes Infrastructure Metrics Unique
+HTTP 429 Too Many Requests is the defining failure mode of managed AI consumption. Unlike a 500-series error that suggests provider instability, a 429 often means *your architecture is working correctly from the provider's perspective*—you simply exceeded a contracted or default limit. Treating 429 as a transient glitch and retrying immediately is one of the most expensive mistakes teams make.
 
-Token consumption and API latency are highly seasonal. A spike at 9 AM on Monday is normal; a spike at 3 AM on Sunday is an anomaly. The challenge is decomposing a raw metric signal:
+Quotas on managed AI platforms typically decompose into requests per minute (RPM) and tokens per minute (TPM), sometimes with separate input and output token buckets. Burst allowances may permit short spikes above sustained limits, but sustained traffic above the sustained threshold triggers throttling even when burst capacity remains. Understanding which bucket your workload exhausts first matters for remediation: a chat application with long outputs may hit output TPM while RPM looks healthy, whereas a high-frequency classification service may exhaust RPM with modest token counts.
 
-```text
-METRIC DECOMPOSITION
-====================
+The 429 cascade follows a predictable mechanical sequence. An initial traffic spike—or a sudden increase in output length because users ask harder questions—consumes quota headroom. Some requests receive 429 responses. Naive client libraries retry with exponential backoff, but many application frameworks retry aggressively by default, *multiplying* effective request rate. Each retry consumes additional quota—or queue slots—without delivering user value. Latency rises because requests wait in client-side queues. Upstream services time out waiting for LLM responses, triggering their own retries. Within minutes, a modest quota overrun becomes a full service degradation that no amount of Kubernetes pod scaling can fix, because the bottleneck lives outside the cluster.
 
-Raw Signal = Trend + Seasonality + Residual + Anomaly
+Preventing cascades requires defense in depth at the client and gateway layers. **Backpressure** means slowing or rejecting new work when quota utilization crosses a threshold—typically 70–80% of sustained limits—rather than waiting for hard 429s. **Retry budgets** cap the total retry attempts per time window across all clients sharing an endpoint. **Jittered exponential backoff** spreads retry timing so thundering herds do not synchronize. **Circuit breakers** stop forwarding traffic to an endpoint that returns sustained 429s, failing fast to a secondary route or a degraded response mode rather than amplifying load.
 
-         ┌─────────────────────────────────────────┐
-Raw:     │  ∿∿∿∿∿╱∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿  │
-         └─────────────────────────────────────────┘
-                    ↓ Decompose
-         ┌─────────────────────────────────────────┐
-Trend:   │  ────────────╱─────────────────────────  │  (gradual growth)
-         └─────────────────────────────────────────┘
-         ┌─────────────────────────────────────────┐
-Season:  │  ∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿∿  │  (daily pattern)
-         └─────────────────────────────────────────┘
-         ┌─────────────────────────────────────────┐
-Residual:│  ─────────────────────────────────────── │  (noise)
-         └─────────────────────────────────────────┘
-         ┌─────────────────────────────────────────┐
-Anomaly: │  ────────────────█─────────────────────  │  (true anomaly!)
-         └─────────────────────────────────────────┘
-```
+Design backpressure with explicit user experience tradeoffs. A chat application might show "high demand, please wait" with estimated queue position when utilization crosses the warning threshold, rather than accepting new sessions that will timeout sixty seconds later. An API might return HTTP 503 with a `Retry-After` header sourced from your quota monitor rather than forwarding to the provider and burning remaining headroom. These product decisions require collaboration between platform and application teams; the gateway implements the policy, but product defines acceptable degradation modes.
 
-For clarity in modern visualization, this decomposition pipeline can also be represented structurally:
+Asymmetric scaling complements quota awareness on the gateway itself. When predictive metrics—token consumption velocity, queue depth proxies, or forecasted RPM—indicate an approaching limit, scale gateway replicas up aggressively to parallelize and shed load through caching or request shaping. Scale down conservatively after demand subsides, because quota limits reset on provider schedules that may not align with your traffic decay. The HorizontalPodAutoscaler `behavior` block in Kubernetes expresses this pattern natively by separating `scaleUp` and `scaleDown` policies.
 
-```mermaid
-flowchart TD
-    Raw[Raw Infrastructure Signal] --> Decompose[Decomposition Engine]
-    Decompose --> T[Trend Component: Gradual Growth]
-    Decompose --> S[Seasonality Component: Daily Patterns]
-    Decompose --> R[Residual Component: Background Noise]
-    R --> Check{Threshold Analysis}
-    Check -->|Exceeds Limits| Anomaly[True Anomaly Detected]
-```
+Observability for quota management differs from traditional CPU monitoring. Export provider-side metrics where available—CloudWatch for Bedrock, Cloud Monitoring for Vertex, Azure Monitor for Foundry, OCI Monitoring for Generative AI—and correlate them with application-side counters for tokens sent, tokens received, retry counts, and 429 rates. A dashboard that shows green Kubernetes health alongside climbing 429 rates is the canonical early-warning signal for managed AI incidents.
 
-### Statistical Methods
-
-The simplest approaches use statistics. **Z-Score Detection** compares values to the mean, but it struggles with seasonality:
-
-```python
-def zscore_anomaly(value, mean, std, threshold=3.0):
-    """
-    Simple but effective for normally distributed data.
-    Assumes: Data follows Gaussian distribution
-    """
-    z = abs(value - mean) / std
-    return z > threshold
-
-# Problem: Doesn't handle seasonality or trends
-```
-
-A **Modified Z-Score** using Median Absolute Deviation (MAD) is far more robust against outliers corrupting your baseline. Because it uses the median rather than the mean, a sudden extreme spike will not drag the entire baseline up, allowing the algorithm to correctly identify the spike as an anomaly rather than establishing a new normal:
-
-```python
-def mad_anomaly(value, median, mad, threshold=3.5):
-    """
-    More robust to outliers than standard Z-score.
-    MAD = Median Absolute Deviation
-    """
-    modified_z = 0.6745 * (value - median) / mad
-    return abs(modified_z) > threshold
-```
-
-### Machine Learning Methods
-
-For multi-dimensional metrics (e.g., token count *and* response length *and* latency), we need ML. **Isolation Forests** work on the principle that anomalies are rare and distinct, making them easy to "isolate" with random splits in the data.
-
-```mermaid
-graph TD
-    A[Root Data] --> B[Split 1]
-    B --> C[Split 2]
-    C --> D[Split 3]
-    D --> E((Normal Point<br>Many Splits Needed))
-
-    A --> F[Split 1]
-    F --> G((Anomaly<br>One Split Isolates!))
-```
-
-Anomalies have short isolation paths.
-
-Autoencoders take a completely different approach. They learn to compress and reconstruct normal data. When fed an anomaly, the reconstruction fails dramatically.
+For deep treatment of time-series forecasting, anomaly detection algorithms, and automated incident correlation applied to these metrics, see [AIOps](../module-1.2-aiops/). This module establishes *what to measure and why*; Module 1.2 teaches *how to build the ML pipelines* that forecast token consumption and detect pre-throttle anomalies.
 
 ```text
-AUTOENCODER ANOMALY DETECTION
-=============================
+429 CASCADE TIMELINE (SIMPLIFIED)
+=================================
 
-Normal data:
-  Input: [0.5, 0.6, 0.4, 0.5]
-  Reconstructed: [0.51, 0.59, 0.41, 0.49]
-  Error: 0.02  Low = Normal
+T+0    Traffic spike consumes 90% of TPM quota
+T+30s  First 429 responses; clients begin retries
+T+60s  Effective request rate doubles due to retries
+T+90s  Quota fully exhausted; most requests fail or queue
+T+5m   Upstream timeouts propagate; user-visible outage
+T+30m  Quota window resets OR ops purchases provisioned capacity
 
-Anomalous data:
-  Input: [0.5, 0.6, 9.9, 0.5]  ← Anomaly!
-  Reconstructed: [0.52, 0.58, 0.45, 0.51]
-  Error: 8.95  High = Anomaly!
+Prevention: backpressure at 70%, retry budget, circuit breaker to fallback
 ```
 
-### Time Series Specific Methods
+Token consumption forecasting—predicting when you will hit limits before 429s fire—is the specific AIOps intersection this module endorses. The forecast inputs include historical TPM by hour-of-day, campaign calendars, rolling output-token averages, and deployment events that change prompt templates. The output is a capacity action: purchase provisioned throughput, enable a cross-region profile, or throttle non-critical batch workloads. General-purpose anomaly detection on CPU metrics will not catch this failure mode; quota-aware forecasting will.
 
-Infrastructure metrics are sequential. **ARIMA** explicitly models temporal dependencies, capturing autoregression and moving averages to predict what the next point *should* be:
-
-```python
-# Fit ARIMA model to capture normal patterns
-# Anomalies = points where residuals exceed threshold
-
-from statsmodels.tsa.arima.model import ARIMA
-
-model = ARIMA(data, order=(1, 1, 1))
-fitted = model.fit()
-residuals = fitted.resid
-
-# Points where |residual| > 3 * std(residuals) are anomalies
-threshold = 3 * residuals.std()
-anomalies = abs(residuals) > threshold
-```
-
-Alternatively, Facebook's **Prophet** was built specifically to handle complex daily, weekly, and yearly seasonality, making it exceptionally powerful for long-term capacity planning:
-
-```python
-from prophet import Prophet
-
-model = Prophet(interval_width=0.99)
-model.fit(df)
-forecast = model.predict(df)
-
-# Anomalies fall outside prediction interval
-anomalies = (df['y'] < forecast['yhat_lower']) | \
-            (df['y'] > forecast['yhat_upper'])
-```
+Client-side architecture deserves equal attention. SDK defaults often retry on any error, including 429, without respecting `Retry-After` headers when present. Wrap provider SDKs in a gateway layer that centralizes retry policy, enforces per-tenant budgets, and converts hard throttles into queue delays with user-visible status rather than opaque timeouts. Implement token counting before dispatch—estimate input tokens from prompt length and cap requested max output—so you can reject oversize requests locally without consuming provider quota. These patterns cost engineering time upfront but prevent the exponential failure mode that makes managed AI incidents so confusing to debug.
 
 ---
 
-## Predictive Autoscaling & Capacity Planning
+## Cost Model of Token-Metered Services
 
-If your anomaly detection works, you can predict load *before* it hits.
+Managed AI economics invert the familiar cloud compute model. Instead of paying for vCPU-hours whether or not you use them, you pay per token processed—with separate meters often applied to input and output tokens. Output tokens frequently cost more per unit because generation consumes more compute than prompt ingestion. A prompt that elicits a verbose answer therefore costs disproportionately more than the same prompt engineered for concision, making prompt design a direct cost lever.
 
-### Why Reactive Scaling Loses
+**Input versus output asymmetry** shapes architecture. Retrieval-augmented generation pipelines that inject large context windows consume input tokens on every request even when the answer is short. Caching strategies—provider-side prompt caching where available, or application-side semantic caches—reduce repeated input token charges for stable context. Teams that ignore input token volume while optimizing output length often discover that their bill scales with document corpus size rather than user count.
 
-If you wait for token queues to fill up, your users suffer.
+Agentic workflows compound both sides of the meter. Each tool call may inject additional context into the prompt—tool results, memory retrieval, MCP resource payloads—inflating input tokens on every reasoning step. Multi-step agents therefore consume quota faster than single-shot completion APIs for equivalent user-facing tasks. When evaluating agent platforms in the Rosetta Stone, budget capacity for the full loop, not just the first model call. Capacity planning for agents is an emerging discipline; start with measured traces of real agent sessions rather than extrapolating from simple chat benchmarks.
 
-```text
-REACTIVE SCALING PROBLEM
-========================
+**Context and prompt caching** (where platforms support it) trades memory residency for discounted re-processing of identical prompt prefixes. The durable concept is straightforward: if thousands of requests share a static system prompt or a fixed knowledge-base preamble, caching that prefix avoids re-billing full input tokens on each call. Cache hit rates become a financial KPI alongside latency. Verify current caching availability and pricing in the landscape snapshot; implementations differ by vendor and model.
 
-Time     Load    Replicas    Status
-─────────────────────────────────────
-09:00    100     2           OK
-09:15    200     2           Overloaded!
-09:16    200     2           Alert fires
-09:18    200     3           Scaling...
-09:20    200     4           Still catching up
-09:22    200     5           Finally stable
-09:25    150     5           Over-provisioned
-09:30    100     5           Wasting money
+**Batch versus real-time pricing** introduces a second axis. Batch inference APIs accept jobs with higher latency tolerance—minutes to hours—in exchange for lower per-token cost. Real-time endpoints prioritize responsiveness at standard or premium rates. Architectures that can defer non-interactive work—nightly summarization, bulk classification, embedding backfills—should route through batch channels when available, reserving real-time quota for user-facing paths.
 
-Problem: Always chasing the load, never ahead of it
-```
+**Over-provisioning versus under-provisioning** carries asymmetric business risk in token-metered services, analogous to but sharper than traditional cloud sizing. Under-provisioning on-demand quota produces 429 errors and lost user sessions—often far costlier than the tokens you failed to purchase. Over-provisioning dedicated throughput produces idle committed spend—annoying on a finance review but rarely catastrophic in a single incident. Production policies therefore bias toward early provisioned capacity for launch events and conservative scale-down afterward.
 
-Predictive scaling forecasts the future and scales in advance.
+Abstract cost reasoning helps before you look up any price table. Define a **cost unit** as one million input tokens and one million output tokens at on-demand rates, then express workloads as multiples of that unit. A support chat averaging 2,000 input and 500 output tokens per session at 10,000 sessions per day consumes predictable unit multiples that finance can budget. Ratios matter more than absolute dollars: if output tokens cost three times input tokens, shortening average response length by twenty percent may dominate savings compared to negotiating a ten percent input discount.
 
-```mermaid
-flowchart TD
-    HM[Historical Metrics] --> ML[ML Model<br>Time Series]
-    ML --> PL[Predicted Load]
-    PL --> SD[Scaler Decision]
-    SD --> SU[Scale Up Now<br>Proactive]
-    SD --> SDL[Scale Down Later<br>Conservative]
-```
+Committed-use discounts and provisioned throughput contracts introduce time horizon decisions. Hourly provisioned units suit spiky but predictable campaigns; monthly commitments suit steady production baselines. Breaking commitments early may forfeit savings, so align purchase duration with traffic forecasts validated against historical token metrics—not against engineering optimism at launch time.
 
-To forecast the future, you can use simple methods like **Exponential Smoothing**:
+Walk through a qualitative cost comparison without attaching dollar figures to volatile price tables. Imagine a support assistant handling ten thousand sessions daily, each averaging two thousand input tokens and five hundred output tokens. If output tokens carry triple the unit cost of input tokens in your provider's meter, output represents a larger share of spend than raw token counts suggest—shortening responses through prompt engineering may dominate savings compared to chasing marginal input discounts. If thirty percent of requests repeat an identical system prompt, prompt caching—where the platform supports it—can remove a substantial fraction of input charges for cache hits. If half the workload is overnight batch summarization deferrable by six hours, batch pricing tiers may cut that half's cost independently of interactive rates. These ratio-based thought experiments survive pricing changes; look up current unit prices in the landscape snapshot when you need numbers for a budget proposal.
 
-```python
-def exponential_smoothing(data, alpha=0.3):
-    """
-    alpha: smoothing factor (0-1)
-    Higher alpha = more weight on recent observations
-    """
-    result = [data[0]]
-    for i in range(1, len(data)):
-        result.append(alpha * data[i] + (1 - alpha) * result[-1])
-    return result
-```
+---
 
-Or you can use **Holt-Winters** to factor in trend and seasonality:
+## Cloud AI Services Rosetta Stone
 
-```text
-HOLT-WINTERS COMPONENTS
-=======================
+The Cloud track teaches infrastructure through Rosetta Stone tables that map durable capabilities across AWS, GCP, and Azure. Managed AI services benefit from the same pattern because vendor marketing names change while underlying capabilities persist. The table below maps **durable capabilities** (rows) to **current vendor offerings** (columns). Use it to translate a requirement document written for one cloud into equivalent configurations on another, or to slot a new entrant into your evaluation framework.
 
-Level (L):      Base value, updated each period
-Trend (T):      Rate of change
-Seasonality (S): Repeating pattern
+| Durable capability | Amazon Bedrock | Google Vertex AI | Azure AI Foundry | OCI Generative AI | Self-hosted (see Module 1.3+) |
+|---|---|---|---|---|---|
+| On-demand foundation-model API | InvokeModel / Converse | Generative AI API | Foundry model deployments | Generative AI API | vLLM / SGLang endpoints |
+| Provisioned / dedicated throughput | Provisioned Throughput (MUs) | Provisioned Throughput | Provisioned Throughput units | Dedicated AI clusters | GPU node pools + model replicas |
+| Geographic cross-region routing | Inference profiles (US/EU/APAC) | Limited; check regional tables | Data-zone and global deployments | Region-bound model lists | Multi-cluster + DNS failover |
+| Global routing (max throughput) | Global inference profiles | `locations/global` (feature gaps) | Global deployment type | Not equivalent; regional | Anycast / multi-region gateway |
+| Data residency guarantees | Regional and geographic profiles | Regional endpoints; global caveats | Regional and data-zone options | OC1/OC4/OC19 realms | Full control; you operate residency |
+| OpenAI-compatible API surface | Via Converse; ecosystem compat | OpenAI-compatible endpoints | Azure OpenAI API shape | Documented compat API | OpenAI API compat layers |
+| Fine-tuning / custom weights | Custom models + provisioned | Regional tuning endpoints | Foundry fine-tuning | Import + fine-tune on dedicated | Full training stack ownership |
+| Embeddings / rerank APIs | Titan Embeddings et al. | Vertex embedding models | Foundry embedding deployments | Embedding and rerank endpoints | Sentence-transformers / custom |
+| Knowledge / RAG integration | Knowledge Bases for Bedrock | Vertex AI Search / RAG Engine | Foundry + Azure AI Search | Vector stores documented | Own vector DB + pipeline |
+| Agent / tool / MCP support | Agents, action groups | Agent Builder | Agent frameworks | Responses API, MCP hooks | LangChain / custom MCP servers |
+| Guardrails / safety filters | Guardrails for Bedrock | Safety filters / Model Garden policies | Content filters | AI guardrails (on-demand) | Prompt rules + own moderation |
+| Batch inference | Batch inference jobs | Batch prediction endpoints | Batch deployments | Check current batch APIs | Offline job queues |
+| Audit / enterprise logging | CloudTrail, CloudWatch | Cloud Audit Logs | Azure Monitor / Diagnostic | OCI Audit / Logging | Your observability stack |
 
-Forecast = (Level + k * Trend) * Seasonality[k]
+Reading the Rosetta Stone effectively means focusing on rows, not columns. When a product manager asks for "global routing with EU residency," translate that into two row requirements—cross-region routing *and* data residency—and discover immediately that global endpoints and strict EU residency conflict on several platforms. When a security reviewer asks for "OpenAI-compatible API with private networking," locate the compat API row and verify whether private endpoints exist for that vendor's deployment type.
 
-Where k = periods ahead to forecast
-```
+No column is universally superior. Each vendor optimizes for different enterprise anchors: existing cloud commitments, compliance certifications, model catalog breadth, or OpenAI API compatibility. Present them as peers with capability tradeoffs, not as a ranked leaderboard that will stale within weeks.
 
-For massive scale, Deep Learning architectures like **LSTMs** (Long Short-Term Memory networks) capture non-linear patterns over time:
+When onboarding a new platform engineer, walk the Rosetta row-by-row with your organization's actual ADRs rather than column-by-column through vendor marketing. Ask which rows are hard requirements—EU residency, custom model hosting, MCP tool support—and mark columns that fail any hard row as disqualified before comparing soft preferences like catalog breadth. This inversion prevents the common anti-pattern of choosing a cloud because "we already use it for compute" without verifying that the specific model and routing capabilities you need exist in your target region.
 
-```python
-# Sequence-to-sequence prediction
-# Input: Last 24 hours of metrics (hourly)
-# Output: Next 4 hours prediction
+---
 
-model = Sequential([
-    LSTM(64, input_shape=(24, n_features), return_sequences=True),
-    LSTM(32),
-    Dense(16, activation='relu'),
-    Dense(4)  # Predict next 4 hours
-])
-```
+## Evaluating Any Managed AI Service
 
-### The Scaling Decision: Asymmetric Costs
+New managed AI offerings launch frequently. A durable evaluation framework protects you from re-architecting on every press release. The following checklist applies to any vendor—hyperscaler, sovereign cloud, or specialized inference provider—and maps directly to Rosetta Stone rows.
 
-If you are purchasing OCI Dedicated AI Clusters or Bedrock Provisioned Throughput, you must understand that the cost of being wrong is asymmetric. Wasting $100 on an unused node is annoying. Losing 10,000 user sessions to timeout errors is disastrous.
+**Step 1: Classify workload requirements.** Document latency class (interactive, near-real-time, batch), data sensitivity (public, internal, regulated), expected token volume ranges, and model customization needs (base model only, fine-tuned, or fully custom). These inputs determine which routing and capacity rows in the Rosetta Stone matter for your decision. Be explicit about peak multipliers—Black Friday traffic is not average traffic times two; measure historical peaks or accept that you are guessing.
 
-```python
-def calculate_desired_replicas(
-    predicted_load: float,
-    current_replicas: int,
-    target_utilization: float = 0.7,
-    capacity_per_replica: float = 100,
-    min_replicas: int = 2,
-    max_replicas: int = 100
-) -> int:
-    """
-    Calculate optimal replica count based on predicted load.
+**Step 2: Verify residency and compliance.** Match regulatory obligations to endpoint geography options. Ask whether prompts, outputs, and logs remain in jurisdiction, whether global routing can override regional selection, and whether fine-tuning data storage locations differ from inference locations. If the vendor cannot answer with documentation citations, treat residency as unverified. Involve legal and security stakeholders before production—not after a regulator asks where prompts were processed.
 
-    Key insight: Scale for PREDICTED load, not current load.
-    """
-    # Required capacity with headroom
-    required_capacity = predicted_load / target_utilization
+**Step 3: Map quota and throughput mechanics.** Obtain default and increasable RPM/TPM limits for your target models and regions. Identify whether provisioned throughput is mandatory for your use case—custom models, guaranteed SLAs, or high sustained load usually require it. Model the 429 cascade risk for your peak traffic multiplier by running load tests that include realistic retry behavior, not idealized clients that fail fast.
 
-    # Calculate replicas needed
-    desired = math.ceil(required_capacity / capacity_per_replica)
+**Step 4: Model total cost of ownership.** Compute token costs using input/output split, caching discounts, and batch eligibility. Add provisioned commitment costs, data egress, logging, and gateway infrastructure. Compare ratio scenarios (±30% traffic) rather than single-point estimates. Present finance with a range, not a single monthly number, because token workloads are inherently variable.
 
-    # Apply constraints
-    desired = max(min_replicas, min(max_replicas, desired))
+**Step 5: Assess integration surface.** Evaluate SDK quality, OpenAI compatibility if migrating existing clients, authentication model (API keys, IAM, workload identity), and private connectivity options (VPC endpoints, Private Link, service gateways). Integration cost often dominates engineering time compared to per-token price differences. A two-percent unit price advantage loses to a six-week migration if SDK gaps force custom HTTP clients.
 
-    # Scale up aggressively, scale down conservatively
-    if desired > current_replicas:
-        return desired  # Scale up immediately
-    elif desired < current_replicas:
-        # Only scale down if consistently lower for N periods
-        return current_replicas  # Hold for now
+**Step 6: Test failure behavior.** In a staging environment, deliberately exhaust quotas and observe 429 response bodies, retry-after headers, and recovery time after quota reset. Failover to secondary endpoints and measure circuit-breaker effectiveness. Providers differ sharply in error payload helpfulness—some return actionable error codes; others return opaque messages that complicate automated remediation.
 
-    return current_replicas
-```
+**Step 7: Plan operational ownership.** Assign owners for quota monitoring, provisioned capacity renewals, model version upgrades, and deprecation migrations. Managed services shift hardware toil but create contract toil—renewals, limit increase tickets, and model ID changes still land on your platform team.
 
-To implement this practically in a modern cluster, you would utilize the Kubernetes Custom Metrics API. Here is how you configure a Kubernetes v1.35 HorizontalPodAutoscaler to consume a predictive metric and execute the asymmetric scaling behavior defined above:
+**Authentication and network path.** Beyond model capabilities, evaluate how workloads authenticate—API keys, cloud IAM roles, workload identity federation—and whether private connectivity (VPC endpoints, Private Link, service gateways) is required so inference traffic never traverses the public internet. These requirements rarely appear in model catalog comparisons but dominate enterprise security reviews. A model that meets every Rosetta row for capability still fails evaluation if it cannot be reached from your network zone without violating policy.
+
+**Observability contract.** Before signing a production commitment, confirm which metrics the vendor exports natively—TPM/RPM utilization, throttle counts, latency percentiles, error codes—and which you must derive from application-side instrumentation. Gaps in provider metrics force you to build token counters in your gateway, which is feasible but should be planned effort, not a launch-week surprise.
+
+Document evaluations in an architecture decision record (ADR) that references Rosetta Stone row IDs rather than vendor slogans. When a vendor ships a new feature, ask which row it affects; if none, the feature may be marketing noise relative to your requirements.
+
+Revisit ADRs on a quarterly cadence even when nothing is broken. Managed AI platforms change model availability, deprecate endpoints, and adjust default quotas without fanfare comparable to a major Kubernetes version release. A lightweight quarterly review—compare your ADR assumptions against the current landscape snapshot, re-run staging quota drills, and confirm provisioned commitments still match traffic growth—catches drift before it becomes an incident. Treat this review like certificate expiry checks: boring, scheduled, and invaluable.
+
+---
+
+## Operating Managed AI Services
+
+Operating managed AI APIs combines the capacity concepts above with day-two practices: monitoring, incident response, and continuous capacity adjustment. This section covers operations *specific to Cloud AI consumption*—not the general AIOps curriculum.
+
+**Monitoring stack.** At minimum, instrument four metric groups: provider quota utilization (RPM/TPM percentages where exposed), application token counters (input/output per service), error taxonomy (429 versus 5xx versus timeout), and latency (time-to-first-token and total generation time). Correlate provider metrics with gateway metrics to distinguish external throttling from internal bottlenecks. Dashboards should visualize quota headroom on the same page as Kubernetes pod counts so on-call engineers never misdiagnose a quota incident as a cluster problem.
+
+Build alert thresholds on quota utilization, not just error rates. By the time 429 rates trigger a page, users have already suffered. Warning alerts at seventy percent sustained utilization give time to enable cross-region routing or pause batch workloads before hard throttling begins. Pair these alerts with runbook links that distinguish provider-side actions from cluster-side actions so responders do not waste minutes scaling Deployments.
+
+**Runbook priorities for 429 incidents.** First, stop retry amplification—disable or tighten client retry policies at the gateway. Second, shed non-critical traffic (pause batch jobs, reduce max output tokens temporarily). Third, activate secondary routing (cross-region profile, alternate model tier, fallback vendor). Fourth, initiate provisioned throughput purchase or quota increase request with provider support. Fifth, post-incident, reconcile forecast models if you maintain them per [AIOps](../module-1.2-aiops/) guidance.
+
+During the incident, preserve evidence for the postmortem: snapshot provider quota graphs, export gateway retry counters, and record which routing profile was active. Quota incidents often look like mysterious latency in aggregate dashboards; the evidence bundle proves whether the root cause was exhaustion, retry storms, or an unrelated application regression. This discipline also builds the historical dataset that forecasting pipelines in Module 1.2 require.
+
+**Capacity planning cadence.** Review token consumption weekly during growth phases, monthly at steady state. Before marketing events or product launches, pre-purchase provisioned capacity or pre-approve quota increase tickets. Align planning horizons: hours-ahead for autoscaling gateway replicas, days-ahead for quota increases, weeks-ahead for provisioned commitments, quarters-ahead for contract negotiations.
+
+**Model lifecycle management.** Providers deprecate model IDs, release new versions, and change default endpoints. Maintain an inventory mapping application configuration to model identifiers and routing profiles. Test new model versions in shadow traffic before cutover. Deprecation notices require the same rigor as any upstream API breaking change.
+
+**Security operations.** Rotate API keys and workload credentials on schedule; prefer short-lived tokens and IAM roles over long-lived secrets. Scope keys to minimum models and operations required. Audit prompt logging policies—full prompt capture aids debugging but creates data-governance surface area.
+
+**Incident communication.** When a quota incident occurs, status pages should describe user impact and remediation in business terms—"elevated response latency for AI features"—while internal runbooks track TPM utilization, active routing profile, and provisioned capacity headroom. Correlating external user reports with internal provider metrics quickly distinguishes quota throttling from application bugs, preventing wasted hours debugging Kubernetes when the fix is a capacity contract change.
+
+Predictive autoscaling for an inference gateway—scaling Kubernetes replicas based on forecasted token demand rather than CPU—closes the loop between quota awareness and infrastructure action. The HPA example below demonstrates asymmetric behavior: aggressive scale-up when a custom metric predicts token pressure, conservative scale-down to avoid thrashing.
 
 ```yaml
-# Example Kubernetes v1.35+ HorizontalPodAutoscaler
-# Demonstrating asymmetric predictive scaling
+# Kubernetes v1.35+ HorizontalPodAutoscaler for an AI inference gateway
+# Scales on a custom metric exported by your gateway (predicted token load)
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
 metadata:
@@ -534,448 +284,189 @@ spec:
         periodSeconds: 300
 ```
 
-### Feature Engineering: The Secret Sauce
+The gateway deployment must export `predicted_token_usage_15m` through the custom metrics API—typically via Prometheus adapter or a metrics pipeline fed by token consumption forecasts. For methodology on building those forecasts (ARIMA, Prophet, isolation-based anomaly detection on token streams), defer to [AIOps](../module-1.2-aiops/).
 
-None of these ML models work well on raw metrics alone. **Feature Engineering** transforms raw data into signals that ML algorithms can easily digest.
+---
 
-```python
-def engineer_features(metrics_df, window_sizes=[5, 15, 60]):
-    """
-    Create features for infrastructure ML models.
+## Did You Know?
 
-    Key insight: Raw metrics alone are not enough.
-    ML models need derived features that capture patterns.
-    """
-    features = {}
-
-    for metric in metrics_df.columns:
-        for window in window_sizes:
-            # Rolling statistics
-            features[f'{metric}_mean_{window}m'] = \
-                metrics_df[metric].rolling(window).mean()
-            features[f'{metric}_std_{window}m'] = \
-                metrics_df[metric].rolling(window).std()
-            features[f'{metric}_min_{window}m'] = \
-                metrics_df[metric].rolling(window).min()
-            features[f'{metric}_max_{window}m'] = \
-                metrics_df[metric].rolling(window).max()
-
-            # Rate of change
-            features[f'{metric}_delta_{window}m'] = \
-                metrics_df[metric].diff(window)
-
-            # Percentiles
-            features[f'{metric}_p95_{window}m'] = \
-                metrics_df[metric].rolling(window).quantile(0.95)
-
-    # Time-based features (for seasonality)
-    features['hour_of_day'] = metrics_df.index.hour
-    features['day_of_week'] = metrics_df.index.dayofweek
-    features['is_weekend'] = features['day_of_week'] >= 5
-    features['is_business_hours'] = \
-        (features['hour_of_day'] >= 9) & (features['hour_of_day'] <= 17)
-
-    return pd.DataFrame(features)
-```
-
-> **Pause and predict**: If you only fed raw CPU utilization into a model, without extracting the `hour_of_day` or `is_weekend` features, what kind of false positives would your model generate?
-
-### Strategic Capacity Planning
-
-Finally, AIOps isn't just for tomorrow; it's for next year. Capacity planning answers specific business questions across different horizons:
-
-```text
-CAPACITY PLANNING QUESTIONS
-===========================
-
-Short-term (days-weeks):
-  "Will we have enough capacity for Black Friday?"
-  "Can we handle the marketing campaign traffic?"
-
-Medium-term (months):
-  "When will we need to add more database nodes?"
-  "How much should we budget for Q3 compute?"
-
-Long-term (years):
-  "When will we outgrow our current architecture?"
-  "What's our 3-year infrastructure cost projection?"
-```
-
-To answer these, you apply mathematical growth models to your long-term metrics:
-
-1. **Linear Growth:** Adds a constant amount.
-   ```text
-   Capacity = Initial + (Growth_Rate × Time)
-   Example: 100 users + (10 users/day × 30 days) = 400 users
-   ```
-2. **Exponential Growth:** Growth compounds.
-   ```text
-   Capacity = Initial × (1 + Growth_Rate)^Time
-   Example: 100 users × 1.10^30 = 1,745 users (10% daily growth)
-   ```
-3. **Logistic Growth:** The S-Curve. Growth accelerates, then hits market saturation and slows down.
-   ```text
-   Capacity = Carrying_Capacity / (1 + e^(-k(t-t0)))
-   More realistic: Growth slows as market saturates
-   ```
-
-You pair these growth models with strict utilization analysis to decide *when* to buy more provisioned throughput.
-
-```mermaid
-graph LR
-    U[Utilization Analysis] --> O[Over-provisioned < 40%]
-    O --> O1[Wasting money]
-    O --> O2[Right-size instances]
-    O --> O3[Consider spot/preemptible]
-
-    U --> OP[Optimal 40-70%]
-    OP --> OP1[Headroom for spikes]
-    OP --> OP2[Cost-efficient]
-    OP --> OP3[Maintain current sizing]
-
-    U --> AR[At Risk 70-85%]
-    AR --> AR1[Plan scaling soon]
-    AR --> AR2[Monitor closely]
-    AR --> AR3[Prepare capacity]
-
-    U --> C[Critical > 85%]
-    C --> C1[Scale immediately]
-    C --> C2[Risk of outages]
-    C --> C3[Emergency action needed]
-```
+- **Cross-region inference profiles and provisioned throughput are often separate product paths.** On Amazon Bedrock, inference profiles increase on-demand throughput via geographic or global routing, but provisioned throughput requires invoking dedicated model ARNs—a design constraint that catches teams expecting one knob to solve both burst and guaranteed capacity.
+- **Global endpoints frequently trade features for reach.** Google Cloud documents that Vertex AI's global endpoint does not guarantee data residency and omits capabilities such as model tuning available on regional endpoints—making "global" a throughput tool, not a compliance shortcut.
+- **Azure Foundry deployment types encode residency and routing policy.** Microsoft documents distinct global, data-zone, and regional deployment types with different data processing boundaries—choosing a deployment type is equivalent to choosing a compliance and latency class.
+- **Open standards for agent tooling outlast individual vendor agent products.** The Model Context Protocol (MCP) provides a cross-vendor interface for tools and context, while AGENTS.md conventions document agent behavior across harnesses—both change far slower than any single cloud agent SKU.
 
 ---
 
 ## Common Mistakes
 
-| Mistake | Why it Happens | How to Fix It |
-| :--- | :--- | :--- |
-| **Using Global Endpoints for Tuning** | Teams assume Vertex AI's `locations/global` supports everything. | Read the docs: `locations/global` omits capabilities like batch tuning and provides no data residency guarantees. Choose a specific region. |
-| **Trusting Z-Scores for Traffic Spikes** | Z-scores assume a Gaussian distribution, but web traffic is highly seasonal. | Use Seasonal Decomposition (like Prophet or ARIMA) to subtract the daily/weekly pattern before looking for anomalies. |
-| **Symmetric Autoscaling** | Engineers configure scale-down rules to be just as fast as scale-up rules. | Implement asymmetric scaling: scale up aggressively on predicted load, but scale down slowly (wait for N periods) to avoid thrashing. |
-| **Ignoring API Key Security** | Teams hardcode credentials when connecting to OCI Generative AI. | OCI introduced dedicated API keys for generative models in early 2026. Use robust secret management (like HashiCorp Vault or K8s External Secrets). |
-| **On-Demand for Production** | Betting that on-demand Bedrock limits won't be hit during a launch. | Purchase Provisioned Throughput for custom models. Use the dedicated Model ID/ARN to ensure guaranteed capacity. |
-| **Feeding Raw Data to ML** | Throwing raw `token_count` metrics into an LSTM without preprocessing. | Implement a Feature Engineering pipeline (rolling means, standard deviations, deltas) before the model layer. |
-
----
-
-## Hands-On Exercise: Implementing Proactive ML Scripts
-
-In this lab, you will complete the foundational Python classes required to build an AIOps pipeline. We will build a fully executable environment where you will set up your virtual environment, generate synthetic test data to simulate an infrastructure load, and validate your anomaly detection, autoscaling, and capacity planning code against this data.
-
-### Task 0: Environment Setup and Data Generation
-
-Before writing our AIOps logic, we must establish a clean execution environment. We will use standard data science libraries. Follow these steps on your workstation to prepare your workspace.
-
-1. **Create and activate a virtual environment:**
-   ```bash
-   python3 -m venv aiops-lab
-   source aiops-lab/bin/activate
-   ```
-
-2. **Install the required dependencies:**
-   ```bash
-   pip install numpy pandas scikit-learn prophet statsmodels
-   ```
-
-3. **Generate Synthetic Infrastructure Data:**
-   Create a file named `generate_data.py` and run it to create our test dataset. This script generates 30 days of synthetic token usage data, injecting trends, seasonality, and a distinct anomaly that our models will need to catch.
-
-   ```python
-   import pandas as pd
-   import numpy as np
-   from datetime import datetime
-
-   print("Generating synthetic infrastructure metrics...")
-   dates = pd.date_range(start='2026-03-01', periods=720, freq='h')
-   base_load = 100
-   trend = np.linspace(0, 50, 720)
-   seasonality = np.sin(np.arange(720) * (2 * np.pi / 24)) * 30
-   noise = np.random.normal(0, 5, 720)
-
-   data = base_load + trend + seasonality + noise
-   # Inject an artificial anomaly at hour 500
-   data[500] += 200
-
-   df = pd.DataFrame({'timestamp': dates, 'token_usage': data})
-   df.to_csv('synthetic_metrics.csv', index=False)
-   print("Test data created successfully: synthetic_metrics.csv")
-   ```
-   Execute this script from your terminal: `python generate_data.py`.
-
-### Task 1: Build an Anomaly Detector
-
-You are given the following class stub. Create a file named `detector.py` and implement the logic to combine Statistical Methods (MAD) and Machine Learning (Isolation Forest).
-
-```python
-# TODO: Implement multi-method anomaly detection
-class InfrastructureAnomalyDetector:
-    """
-    Detect anomalies in infrastructure metrics using:
-    1. Statistical methods (Z-score, MAD)
-    2. Isolation Forest
-    3. Seasonal decomposition
-
-    Combine results with voting for robust detection.
-    """
-    pass
-```
-
-<details>
-<summary><strong>View Solution: Task 1</strong></summary>
-
-```python
-import numpy as np
-from sklearn.ensemble import IsolationForest
-
-class InfrastructureAnomalyDetector:
-    """
-    Detect anomalies in infrastructure metrics using:
-    1. Statistical methods (Z-score, MAD)
-    2. Isolation Forest
-    3. Seasonal decomposition
-
-    Combine results with voting for robust detection.
-    """
-    def __init__(self):
-        self.iso_forest = IsolationForest(contamination=0.05, random_state=42)
-
-    def fit_predict(self, data):
-        # Method 1: MAD
-        median = np.median(data)
-        mad = np.median(np.abs(data - median))
-        modified_z = 0.6745 * (data - median) / mad
-        mad_anomalies = np.abs(modified_z) > 3.5
-
-        # Method 2: Isolation Forest
-        data_reshaped = data.reshape(-1, 1)
-        self.iso_forest.fit(data_reshaped)
-        iso_preds = self.iso_forest.predict(data_reshaped)
-        iso_anomalies = iso_preds == -1
-
-        # Voting: Anomaly if both agree
-        final_anomalies = mad_anomalies & iso_anomalies
-        return final_anomalies
-```
-</details>
-
-**Checkpoint Verification:**
-To test your detector against the data we generated, append the following execution block to `detector.py` and run it:
-```python
-import pandas as pd
-
-if __name__ == "__main__":
-    df = pd.read_csv('synthetic_metrics.csv')
-    detector = InfrastructureAnomalyDetector()
-    anomalies = detector.fit_predict(df['token_usage'].values)
-    anomaly_indices = np.where(anomalies)[0]
-    print(f"Detected {len(anomaly_indices)} anomalies at indices: {anomaly_indices}")
-    if 500 in anomaly_indices:
-        print("SUCCESS: The injected anomaly at index 500 was successfully detected!")
-    else:
-        print("FAILURE: The injected anomaly was missed.")
-```
-
-### Task 2: Implement Predictive Autoscaler
-
-You are given the following class stub for scaling decisions. Create a file named `autoscaler.py` and implement the exponential smoothing forecast and the asymmetric scaling decision logic.
-
-```python
-# TODO: Build a predictive autoscaler
-class PredictiveAutoscaler:
-    """
-    1. Collect historical load data
-    2. Train forecasting model
-    3. Predict load N minutes ahead
-    4. Calculate optimal replica count
-    5. Make scaling decision
-    """
-    pass
-```
-
-<details>
-<summary><strong>View Solution: Task 2</strong></summary>
-
-```python
-import math
-
-class PredictiveAutoscaler:
-    """
-    1. Collect historical load data
-    2. Train forecasting model
-    3. Predict load N minutes ahead
-    4. Calculate optimal replica count
-    5. Make scaling decision
-    """
-    def __init__(self, target_utilization=0.7, capacity_per_replica=100):
-        self.target_utilization = target_utilization
-        self.capacity_per_replica = capacity_per_replica
-
-    def predict_next_load(self, historical_data, alpha=0.3):
-        # Simple Exponential Smoothing
-        result = [historical_data[0]]
-        for i in range(1, len(historical_data)):
-            result.append(alpha * historical_data[i] + (1 - alpha) * result[-1])
-        return result[-1]
-
-    def make_decision(self, predicted_load, current_replicas, min_rep=2, max_rep=50):
-        req_capacity = predicted_load / self.target_utilization
-        desired = math.ceil(req_capacity / self.capacity_per_replica)
-        desired = max(min_rep, min(max_rep, desired))
-
-        if desired > current_replicas:
-            return desired # Scale up aggressively
-        return current_replicas # Hold steady / scale down conservatively
-```
-</details>
-
-**Checkpoint Verification:**
-To test your autoscaler, append this execution block to `autoscaler.py` and run it:
-```python
-if __name__ == "__main__":
-    scaler = PredictiveAutoscaler(target_utilization=0.7, capacity_per_replica=100)
-    # Simulate a sudden historical load spike
-    recent_history = [100, 110, 105, 150, 250, 400]
-    predicted = scaler.predict_next_load(recent_history, alpha=0.5)
-    decision = scaler.make_decision(predicted, current_replicas=3)
-
-    print(f"Predicted next load: {predicted:.2f} tokens/sec")
-    print(f"Scaling decision: Update replicas to {decision}")
-    if decision > 3:
-        print("SUCCESS: Autoscaler aggressively scaled up in response to the predicted spike.")
-```
-
-### Task 3: Capacity Planning Model
-
-You are given the final stub to project future long-term growth. Create a file named `planner.py` and implement the exponential growth calculation and the utilization recommendation engine.
-
-```python
-# TODO: Create capacity provision planner
-class CapacityPlanner:
-    """
-    1. Analyze historical growth
-    2. Fit growth model (linear, exponential, logistic)
-    3. Forecast future capacity needs
-    4. Generate recommendations
-    """
-    pass
-```
-
-<details>
-<summary><strong>View Solution: Task 3</strong></summary>
-
-```python
-import numpy as np
-
-class CapacityPlanner:
-    """
-    1. Analyze historical growth
-    2. Fit growth model (linear, exponential, logistic)
-    3. Forecast future capacity needs
-    4. Generate recommendations
-    """
-    def __init__(self, initial_users, growth_rate):
-        self.initial = initial_users
-        self.growth_rate = growth_rate
-
-    def forecast_exponential(self, days_ahead):
-        # Capacity = Initial × (1 + Growth_Rate)^Time
-        capacity = self.initial * (1 + self.growth_rate)**days_ahead
-        return int(capacity)
-
-    def generate_recommendation(self, current_utilization):
-        if current_utilization < 0.40:
-            return "Over-provisioned: Right-size instances to save costs."
-        elif current_utilization <= 0.70:
-            return "Optimal: Maintain current sizing."
-        elif current_utilization <= 0.85:
-            return "At Risk: Plan scaling soon. Monitor closely."
-        else:
-            return "Critical: Scale immediately to prevent outages."
-```
-</details>
-
-**Checkpoint Verification:**
-Test your capacity planner by appending this execution block to `planner.py` and running it:
-```python
-if __name__ == "__main__":
-    planner = CapacityPlanner(initial_users=1000, growth_rate=0.05)
-    forecast_30_days = planner.forecast_exponential(30)
-    print(f"30-day capacity forecast: {forecast_30_days} users")
-
-    recommendation = planner.generate_recommendation(current_utilization=0.88)
-    print(f"System Recommendation: {recommendation}")
-    if "Critical" in recommendation:
-        print("SUCCESS: High utilization correctly flagged as Critical.")
-```
-
-### End-to-End Success Checklist
-- [ ] Virtual environment created and dependencies installed without errors.
-- [ ] Synthetic data script `generate_data.py` executed successfully and produced a CSV.
-- [ ] Anomaly detector catches the strictly injected anomaly at index 500.
-- [ ] Predictive autoscaler calculates a required replica count greater than the current count during simulated spikes.
-- [ ] Capacity planner successfully evaluates a 0.88 utilization threshold as a critical systemic risk.
+| Mistake | Why it happens | How to fix |
+|---|---|---|
+| **Treating 429 as a transient error** | Retry defaults assume server-side flakiness, not quota exhaustion. | Implement retry budgets, backpressure at 70–80% quota utilization, and circuit breakers; purchase headroom before launch. |
+| **Using global endpoints for regulated data** | Global routing simplifies SDK configuration and improves burst throughput. | Match endpoint geography to residency policy; use regional or geographic profiles and verify member regions in documentation. |
+| **Sharing one endpoint across batch and interactive workloads** | Simplicity during prototyping carries into production. | Partition endpoints or quotas by workload class; shed batch traffic first during pressure. |
+| **Scaling Kubernetes pods during quota incidents** | On-call playbooks default to HPA/KEDA without checking provider metrics. | Add provider quota dashboards; scale routing and capacity contracts before replica counts. |
+| **Ignoring output token cost** | Prompt engineering focuses on input context size. | Track input/output split; cap max output tokens per route; measure cost per successful user task. |
+| **Symmetric gateway scale-down** | Symmetric policies are the HPA default and look "balanced." | Configure asymmetric `behavior`: fast scale-up on predicted token load, slow scale-down with stabilization windows. |
+| **Skipping quota exhaustion drills** | Staging environments use tiny traffic and never hit limits. | Deliberately exhaust staging quotas quarterly; validate runbooks and fallback routes under real 429 responses. |
 
 ---
 
 ## Knowledge Check
 
 <details>
-<summary><strong>Scenario 1: You are deploying an application to Google Cloud that requires strict EU data residency and the ability to run custom fine-tuning jobs on Gemini 2.5. An engineer suggests using the `locations/global` endpoint to simplify routing. Is this a sound architectural decision?</strong></summary>
-No, this is a dangerous decision. The `locations/global` endpoint in Vertex AI explicitly does not guarantee data residency, violating the EU compliance requirement. Furthermore, global endpoints omit critical capabilities, specifically preventing custom batch model tuning. You must explicitly choose a supported regional endpoint in the EU.
+<summary><strong>Scenario 1: Your EU-regulated healthcare application must keep patient prompts within the EU. An engineer proposes using a global inference endpoint to handle launch-day traffic spikes. What is wrong with this approach?</strong></summary>
+
+Global inference endpoints route requests to available commercial regions worldwide and typically do not guarantee data residency within the EU. Even if average latency improves, compliance requirements fail. The correct approach is a geographic cross-region profile confined to EU member regions—or a single EU regional endpoint with provisioned throughput for headroom—verified against current vendor documentation for data processing locations.
 </details>
 
 <details>
-<summary><strong>Scenario 2: Your system experiences a massive, unexpected surge in token consumption at 2:00 PM on a Tuesday. Your monitoring system uses a standard Z-score anomaly detector. Why might the Z-score fail to flag the beginning of this spike?</strong></summary>
-Standard Z-scores are highly susceptible to outliers. If the spike builds rapidly, the extreme values heavily inflate the standard deviation calculation of the recent window. As the standard deviation grows, the Z-score (which divides by the standard deviation) shrinks, effectively masking the anomaly. A Modified Z-score using Median Absolute Deviation (MAD) would be far more robust in this scenario.
+<summary><strong>Scenario 2: Kubernetes shows all gateway pods at 30% CPU, but users report timeouts. CloudWatch/Bedrock metrics show TPM at 98%. What is the likely root cause and first action?</strong></summary>
+
+The bottleneck is provider-side token quota exhaustion, not compute inside the cluster. Scaling pods will not increase available TPM. First action: stop retry amplification at the gateway, shed non-critical batch traffic, and either enable a cross-region inference profile or initiate provisioned throughput purchase while quota resets or support processes an increase.
 </details>
 
 <details>
-<summary><strong>Scenario 3: Your team's Amazon Bedrock usage triggers an alert: you have hit 86% of your on-demand token limits during a marketing push. Your manager wants to know what action to take according to standard utilization analysis.</strong></summary>
-At >85% utilization, the system is in a "Critical" state with a high risk of application outages due to 429 rate-limiting. The immediate action is to scale up by purchasing Provisioned Throughput for your custom models. This allocates dedicated model IDs and ARNs, ensuring you have the required headroom to survive the traffic spike.
+<summary><strong>Scenario 3: You need guaranteed capacity for a fine-tuned custom model on a platform where custom models require dedicated hosting. Which Rosetta Stone row guides your decision?</strong></summary>
+
+The **Provisioned / dedicated throughput** row. Custom weights require reserved model capacity on most hyperscaler platforms—not on-demand shared endpoints. You must purchase provisioned units or dedicated cluster capacity and invoke the provisioned model identifier rather than the default on-demand ID.
 </details>
 
 <details>
-<summary><strong>Scenario 4: You are building an AIOps predictive autoscaler. Your historical load indicates an incoming traffic spike, so the ML model predicts you need 15 replicas instead of the current 5. The traffic spike ends after 10 minutes, and the model predicts you only need 3 replicas. How should your autoscaler react at these two distinct moments?</strong></summary>
-The autoscaler must handle the asymmetric cost of failure. When predicting 15 replicas, it must scale up *immediately* and aggressively to prevent user outages. When predicting 3 replicas after the spike, it must scale down *conservatively* (e.g., waiting for N consecutive periods of low predictions) to avoid thrashing and being caught off-guard if the traffic returns.
+<summary><strong>Scenario 4: A batch embedding job and a live chat API share one endpoint. Overnight, embedding traffic spikes and chat error rates climb. What architectural change prevents recurrence?</strong></summary>
+
+Partition workloads by endpoint or quota allocation. Batch embedding should use a separate endpoint—ideally batch-priced if available—with its own retry and throttle policy. Interactive chat retains dedicated RPM/TPM headroom. Optionally schedule batch jobs off-peak with explicit backpressure when interactive utilization exceeds thresholds.
 </details>
 
 <details>
-<summary><strong>Scenario 5: Your team wants to integrate an LLM agent that executes database queries natively (NL2SQL) while maintaining long-term conversation memory. Which OCI Generative AI capability directly supports this architecture?</strong></summary>
-OCI Generative AI's Enterprise AI features include built-in agentic workflows. This includes an OpenAI-compatible Responses API, memory APIs, vector stores, and explicit tool hooks (including MCP) that support NL2SQL capabilities natively within the platform.
+<summary><strong>Scenario 5: Finance asks whether shortening average model responses by 25% is worth more than switching to a cheaper input-token rate. Output tokens cost 3× input tokens, and output represents 40% of total token spend. How do you reason about this?</strong></summary>
+
+Output is 40% of spend at 3× input cost, so output reduction disproportionately affects the bill. A 25% output length reduction saves roughly 10% of total token cost (0.25 × 0.40), often exceeding marginal input-rate negotiations. Run the calculation with your actual input/output ratio before committing; ratios vary by workload.
 </details>
 
 <details>
-<summary><strong>Scenario 6: A team implements an Autoencoder for anomaly detection on their API gateway metrics. Over a period of three months, the model's false positive rate slowly increases until it is alerting constantly on normal traffic. What phenomenon is occurring, and how should the team address it?</strong></summary>
-The model is experiencing data drift. As the baseline behavior of the system naturally evolves over months (due to feature releases, user growth, or natural pattern shifts), the static Autoencoder's reconstruction error for newly "normal" traffic increases. The team must implement a continuous training pipeline to periodically retrain the Autoencoder on recent healthy data to update its understanding of normal behavior.
+<summary><strong>Scenario 6: Your HPA scales gateway pods on CPU utilization, but 429 rates spike during predictable daily peaks. What metric should replace or supplement CPU in the HPA?</strong></summary>
+
+A custom metric reflecting token demand or predicted token usage—such as `predicted_token_usage_15m` exported from your gateway's forecasting pipeline. CPU poorly correlates with LLM API quota pressure because inference compute happens on the provider side; token velocity correlates directly with TPM exhaustion.
 </details>
 
 <details>
-<summary><strong>Scenario 7: You are configuring a Kubernetes v1.35 HorizontalPodAutoscaler to consume a custom metric generated by your predictive ML model. You want the HPA to scale up rapidly when the ML model predicts a spike, but scale down very slowly to prevent thrashing. How do you configure this natively in the HPA?</strong></summary>
-You should utilize the HPA's `behavior` field, which allows independent configuration of `scaleUp` and `scaleDown` policies. By setting the `scaleDown.stabilizationWindowSeconds` to a high value (like 1800 seconds) and defining conservative scaling policies, while keeping `scaleUp` aggressive, you achieve the required asymmetric scaling.
+<summary><strong>Scenario 7: A vendor announces a new "global agent" product. Your evaluation framework requires assessing agent support. Which rows and steps apply before adoption?</strong></summary>
+
+Map the announcement to Rosetta Stone rows: **Agent / tool / MCP support**, **Data residency**, and **Quota / throughput mechanics**. Follow evaluation Steps 2–6: verify residency claims, test quota behavior under load, model cost including tool-call token overhead, and failure behavior when tool endpoints throttle independently of the main model.
 </details>
 
 ---
 
-## ⏭️ Next Steps
+## Hands-On Exercise
 
-You now understand the architecture of Cloud AI Services and how to wrap them in an AIOps framework to prevent rate-limit disasters and capacity bottlenecks!
+**Task:** Build quota-aware monitoring and asymmetric gateway scaling for a managed AI inference gateway. You will simulate token consumption metrics, implement backpressure logic, and validate an HPA manifest for Kubernetes 1.35.
 
-**Up Next**: Module 1.2 - LLM Gateways and Traffic Management
+### Part 1: Token Quota Monitor
 
-In Module 1.2, we'll dive deeper into:
-- Implementing an API Gateway over multiple Bedrock and Azure endpoints.
-- Semantic caching to reduce token consumption costs.
-- Circuit breakers and fallback routing when a Cloud AI region fails.
+Create `quota_monitor.py` that tracks utilization against configurable RPM and TPM limits and recommends actions before hard throttling.
+
+```python
+#!/usr/bin/env python3
+"""Quota utilization monitor for managed AI endpoints."""
+from dataclasses import dataclass
+
+@dataclass
+class QuotaLimits:
+    rpm: int
+    tpm: int
+    burst_rpm: int | None = None
+
+@dataclass
+class QuotaSnapshot:
+    requests_last_minute: int
+    tokens_last_minute: int
+
+def utilization(snapshot: QuotaSnapshot, limits: QuotaLimits) -> dict[str, float]:
+    """Return RPM and TPM utilization as fractions (0.0–1.0+)."""
+    rpm_limit = limits.burst_rpm or limits.rpm
+    return {
+        "rpm": snapshot.requests_last_minute / rpm_limit,
+        "tpm": snapshot.tokens_last_minute / limits.tpm,
+    }
+
+def recommend_action(util: dict[str, float], warn: float = 0.7, critical: float = 0.9) -> str:
+    """Recommend backpressure or capacity action based on utilization."""
+    peak = max(util["rpm"], util["tpm"])
+    if peak >= critical:
+        return "CRITICAL: Enable backpressure, shed batch traffic, consider provisioned throughput"
+    if peak >= warn:
+        return "WARN: Reduce retry rates, activate cross-region profile if available"
+    return "OK: Continue monitoring"
+```
+
+Append a `__main__` block that simulates rising utilization and prints recommendations, then run a quick validation. Expect `WARN` above 0.7 and `CRITICAL` above 0.9.
+
+```bash
+python3 quota_monitor.py
+```
+
+### Part 2: Retry Budget Calculator
+
+Create `retry_budget.py` that computes maximum safe retries without exceeding a retry amplification factor.
+
+```python
+def max_safe_retries(base_rps: float, quota_rpm: int, headroom_factor: float = 1.5) -> int:
+    """
+    Given base requests per second and an RPM quota, return the max retries
+    per request that keep the total effective rate (original requests plus
+    retries) at or below the quota divided by a safety headroom_factor.
+    A headroom_factor of 1.5 reserves ~33% of the quota as burst headroom.
+    """
+    base_rpm = base_rps * 60
+    safe_ceiling = quota_rpm / headroom_factor
+    if safe_ceiling <= base_rpm:
+        return 0
+    # Total RPM if each request retries n times: base_rpm * (1 + n) <= safe_ceiling
+    max_n = int((safe_ceiling - base_rpm) / base_rpm)
+    return max(0, max_n)
+```
+
+Verify: at 100 RPS against a 10,000 RPM quota, safe retries should be bounded well below naive unlimited retry policies.
+
+### Part 3: Validate HPA Manifest
+
+Save the HPA YAML from the **Operating Managed AI Services** section as `hpa-ai-gateway.yaml`. Validate syntax:
+
+```bash
+kubectl apply --dry-run=client -f hpa-ai-gateway.yaml
+```
+
+Confirm the manifest uses `autoscaling/v2`, defines separate `scaleUp` and `scaleDown` behavior blocks, and references a custom metric name suitable for token forecasting.
+
+### Success Checklist
+
+- [ ] `quota_monitor.py` reports `OK`, `WARN`, and `CRITICAL` at appropriate utilization thresholds.
+- [ ] `retry_budget.py` demonstrates that unlimited retries can exceed quota at modest base traffic.
+- [ ] `hpa-ai-gateway.yaml` passes `kubectl apply --dry-run=client` without errors.
+- [ ] You can articulate which actions belong in *this* module (quota, routing, provisioning) versus [AIOps](../module-1.2-aiops/) (forecasting algorithms, RCA).
 
 ---
 
-_Module 1.1 Complete!_
-_"The best incident is the one that never happens."_
+## Next Module
+
+You now understand the durable architecture of Cloud AI Services—routing models, quota mechanics, token economics, and cross-vendor evaluation—and how to operate them without mistaking provider throttling for cluster failure.
+
+**Up Next:** [AIOps](../module-1.2-aiops/)
+
+In Module 1.2, you will build the operational depth this module intentionally deferred: statistical and ML-based anomaly detection on infrastructure telemetry, AI-powered causal graphs for root cause analysis, hybrid log parsing pipelines, and the forecasting methods that feed token consumption predictions referenced here.
+
+---
 
 ## Sources
 
-- [Amazon Bedrock Cross-Region Inference](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html) — Best primary source for Bedrock geography, global routing, burst handling, and Provisioned Throughput tradeoffs.
-- [Microsoft Foundry Deployment Types](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/deployment-types) — Explains Azure global, data-zone, and regional deployment behavior, including routing, data processing location, and latency tradeoffs.
-- [Vertex AI Deployments and Endpoints](https://docs.cloud.google.com/vertex-ai/generative-ai/docs/learn/locations) — Covers the global endpoint, data residency caveats, supported models, and feature limitations that drive architecture decisions.
-- [OCI Generative AI Overview](https://docs.oracle.com/en-us/iaas/Content/generative-ai/overview.htm) — Summarizes OCI model access, dedicated AI clusters, Responses API, tools, memory, and NL2SQL in one place.
+- [Amazon Bedrock Cross-Region Inference](https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference.html) — Geographic and global inference profiles, throughput tradeoffs, and the separation from Provisioned Throughput.
+- [Amazon Bedrock Provisioned Throughput](https://docs.aws.amazon.com/bedrock/latest/userguide/prov-throughput.html) — Model Units, dedicated capacity for base and custom models, and hourly commitment mechanics.
+- [Google Vertex AI Locations and Endpoints](https://cloud.google.com/vertex-ai/generative-ai/docs/learn/locations) — Regional versus global endpoint behavior, data residency caveats, and feature availability by location.
+- [Microsoft Foundry Deployment Types](https://learn.microsoft.com/en-us/azure/foundry/foundry-models/concepts/deployment-types) — Global, data-zone, and regional deployment models with data processing and routing implications.
+- [Azure AI Foundry Provisioned Throughput](https://learn.microsoft.com/en-us/azure/ai-foundry/openai/concepts/provisioned-throughput) — Provisioned capacity units (PTUs) and when dedicated throughput replaces standard deployments.
+- [OCI Generative AI Overview](https://docs.oracle.com/en-us/iaas/Content/generative-ai/overview.htm) — Hosted models, dedicated AI clusters, and OpenAI-compatible API entry points.
+- [OCI Generative AI Dedicated AI Clusters](https://docs.oracle.com/en-us/iaas/Content/generative-ai/ai-cluster.htm) — Isolated compute for fine-tuning and hosting custom models away from multi-tenant throttling.
+- [Model Context Protocol Specification](https://modelcontextprotocol.io/specification/2025-03-26) — Open standard for tool and context integration across AI platforms and agent harnesses.
+- [AGENTS.md Convention](https://agents.md/) — Cross-tool documentation convention for agent behavior, complementary to vendor-specific rule files.
+- [Large-scale cluster management at Google with Borg](https://research.google/pubs/large-scale-cluster-management-at-google-with-borg/) — Verma et al., EuroSys 2015; foundational reading on cluster resource management, slack resources, and over-commitment that informs capacity thinking even when GPUs are provider-managed.
+- [Kubernetes Horizontal Pod Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) — Official documentation for HPA v2 behavior configuration including asymmetric scale-up and scale-down policies.

--- a/src/content/docs/ai-ml-engineering/ai-infrastructure/module-1.2-aiops.md
+++ b/src/content/docs/ai-ml-engineering/ai-infrastructure/module-1.2-aiops.md
@@ -6,23 +6,11 @@ sidebar:
 ---
 
 > **AI/ML Engineering Track** | Complexity: `[MEDIUM]` | Time: 6-8
-**Prerequisites**: Module 53 (AI for Proactive Cloud Management)
-
-## Why This Module Matters: The Incident That Changed Everything
-
-**Austin, Texas. July 19, 2024. 04:09 UTC.**
-
-What began as a routine sensor configuration update pushed by CrowdStrike to its Falcon sensor quickly escalated into one of the largest IT outages in global history. Within minutes, approximately 8.5 million Windows devices across the globe crashed into endless Blue Screen of Death (BSOD) boot loops. The financial impact was staggering, with direct losses estimated at over $5.4 billion. Airlines grounded thousands of flights, hospitals canceled critical surgeries, and global banking infrastructure ground to a halt.
-
-The profound tragedy of the CrowdStrike outage was not just the bug itself—a logic error caused by an out-of-bounds memory read when processing a newly deployed channel file—but the catastrophic delay in Root Cause Analysis (RCA). Traditional monitoring systems were flooded with offline alerts, but the actual root cause was obscured by the sheer volume of disconnected infrastructure failures. Engineers spent crucial hours manually correlating the timing of the global crashes with recent deployment manifests. Because the affected machines could not boot to forward their crash dumps to centralized logging platforms, the observability pipeline was effectively blind.
-
-If a mature, automated AIOps architecture had been orchestrating the rollout, the outcome could have been drastically different. An AI-driven causal graph could have instantaneously correlated the sub-millisecond deployment of the `C-00000291*.sys` channel file with the cascading host offline metrics, halting the staggered rollout before it reached global saturation. The transition to AI-powered operations is no longer just about saving engineering time; it is an absolute business necessity to prevent total systemic collapse at enterprise scale.
-
----
+**Prerequisites**: Module 1.1 (Cloud AI Services)
 
 ## Learning Outcomes
 
-By the end of this module, you will be able to:
+By the end of this module, you will be able to reason from raw telemetry to safe remediation decisions instead of treating AIOps as vendor magic:
 - **Diagnose** complex performance bottlenecks and distributed system failures using AI-powered causal graphs and topology mapping.
 - **Design** a resilient, hybrid log parsing pipeline that combines deterministic template mining with dynamic LLM inference for unknown formats.
 - **Implement** statistical baseline modeling and machine-learning-based anomaly detection for high-throughput time-series infrastructure telemetry.
@@ -31,13 +19,27 @@ By the end of this module, you will be able to:
 
 ---
 
+## Why This Module Matters
+
+**The incident that changed everything** is a useful starting point because it shows how quickly operational failure can move faster than manual diagnosis.
+
+**Austin, Texas. July 19, 2024. 04:09 UTC.** What began as a routine sensor configuration update pushed by CrowdStrike to its Falcon sensor quickly escalated into one of the largest IT outages in global history. Within minutes, [Microsoft estimated that approximately 8.5 million Windows devices](https://blogs.microsoft.com/blog/2024/07/20/helping-our-customers-through-the-crowdstrike-outage/) across the globe crashed into endless Blue Screen of Death (BSOD) boot loops. Airlines grounded thousands of flights, hospitals canceled critical surgeries, and global banking infrastructure ground to a halt. [Parametrix Insurance's estimate](https://www.parametrixinsurance.com/reports-white-papers/crowdstrikes-impact-on-the-fortune-500) put US Fortune-500 direct losses at roughly $5.4 billion, though the total global economic impact was undoubtedly far larger once supply-chain ripple effects and lost productivity were accounted for.
+
+The profound tragedy of the CrowdStrike outage was not just the bug itself -- [CrowdStrike's preliminary post-incident report described an out-of-bounds memory read](https://www.crowdstrike.com/en-us/blog/falcon-content-update-preliminary-post-incident-report/) when processing the Channel File 291 update -- but the catastrophic delay in Root Cause Analysis (RCA). Traditional monitoring systems were flooded with offline alerts, but the actual root cause was obscured by the sheer volume of disconnected infrastructure failures. Engineers spent crucial hours manually correlating the timing of the global crashes with recent deployment manifests. Because the affected machines could not boot to forward their crash dumps to centralized logging platforms, the observability pipeline was effectively blind.
+
+If a mature, automated AIOps architecture had been orchestrating the rollout, the outcome could have been drastically different. An AI-driven causal graph could have correlated the deployment of the `C-00000291*.sys` channel file with the cascading host-offline metrics in a small canary cohort and blocked the global push — CrowdStrike's content updates were not staged or canaried at the time, which is precisely why the bad file reached global saturation within minutes (the public post-incident report committed to adding staged deployment afterward). The transition to AI-powered operations is no longer just about saving engineering time; it is an absolute business necessity to prevent total systemic collapse at enterprise scale.
+
+The CrowdStrike incident is an extreme case, but the underlying pattern repeats every day in data centers and cloud regions around the world: a configuration change, a library update, a subtle memory leak -- each one silently degrading a system until it crosses a threshold and becomes an incident. The traditional response model treats each incident as a unique puzzle to be solved by human intuition, but modern infrastructure has outgrown human-scale reasoning. The number of possible failure modes in a Kubernetes cluster with 200 microservices, each with its own dependencies, configuration parameters, and resource profiles, is combinatorially vast. AIOps is the discipline of applying machine learning, statistical modeling, and automated reasoning to this operational complexity -- not to replace SREs, but to give them leverage over problems that would otherwise take hours or days to diagnose manually. This module will take you through the full AIOps stack: from ingesting and parsing the raw telemetry, through detecting anomalies and tracing their root causes, to safely automating the response.
+
 ## The Log Analysis Revolution: From Regex to Machine Learning
 
 ### The Fundamental Problem: More Data Than Humans Can Process
 
 Think of logs like the black box flight data recorder on an airplane. Every microservice, sidecar proxy, database cluster, and network appliance in your infrastructure is constantly streaming state changes to standard output. This diagnostic telemetry is invaluable until you confront the sheer mathematical scale involved in modern cloud-native architectures.
 
-A moderately sized startup with a microservice architecture generates roughly 50 to 100 GB of logs per day. Enterprise platforms and hyperscalers routinely ingest over 1 PB (petabyte) of log data daily. At one petabyte per day, you are looking at approximately 10 billion individual log events. Human-scale analysis—the traditional workflow of `grep`, `awk`, and visual scanning—simply cannot keep pace with machine-scale data generation. To find the root cause of an incident, you are essentially looking for a specific drop of water while drinking from a firehose. 
+A moderately sized startup with a microservice architecture generates roughly 50 to 100 GB of logs per day. Enterprise platforms and hyperscalers routinely ingest over 1 PB (petabyte) of log data daily. At one petabyte per day, you are looking at approximately 10 billion individual log events. Human-scale analysis—the traditional workflow of `grep`, `awk`, and visual scanning—simply cannot keep pace with machine-scale data generation. To find the root cause of an incident, you are essentially looking for a specific drop of water while drinking from a firehose.
+
+The challenge is not just one of scale, but of three compounding dimensions. **Volume** is the raw byte count — petabytes streaming through your ingestion pipeline every day, far exceeding what any team can manually review. **Velocity** is the rate of arrival: a Kubernetes cluster can emit hundreds of thousands of log events per second during a cascading failure, and by the time a human opens a dashboard, the diagnostic window has already passed. **Variety** is the format diversity problem — every component in your stack speaks a different dialect, from structured JSON emitted by modern service meshes to semi-structured syslog from legacy appliances to completely unstructured stack traces from application code. AI is uniquely suited to address all three: machine learning models process volume at line speed, detect velocity anomalies in real time, and generalize across format variety without per-source configuration. This is why the shift from regex to AI is not an incremental improvement but a qualitative leap in what is operationally possible. 
 
 ### The Log Format Jungle
 
@@ -113,7 +115,19 @@ Return only valid JSON."""
 # Works for ANY format without regex maintenance!
 ```
 
-**Did You Know?** On May 21, 2025, Datadog released Toto, an open-weights time-series foundation model containing 151 million parameters, released under the Apache 2.0 license to help democratize AI observability.
+This LLM-first approach is elegant but has a critical operational constraint: **token economics**. Every byte of log data passed to an LLM costs money and latency. Consider the math: at a conservative $0.50 per million input tokens, parsing 10 billion daily log events — even with an average of just 50 tokens per log line — costs roughly $250,000 per day. The LLM inference latency, measured in hundreds of milliseconds per call, also makes it far too slow for high-throughput streaming pipelines where decisions must be made in microseconds.
+
+### The Hybrid Architecture: Drain3 + LLM
+
+The production-grade solution is a two-tier pipeline. The first tier uses **Drain3**, a deterministic log template mining algorithm, to handle the vast majority of known log formats at near-zero computational cost. Drain3 works by constructing a fixed-depth parse tree where each tree node represents a token position in the log message. As raw log lines arrive, Drain3 traverses the tree token by token, matching static structure tokens (like `User`, `logged`, `in`, `from`) while parameterizing dynamic tokens (like `john`, `192.168.1.1`) into wildcard placeholders. The tree depth is fixed — typically 4 to 6 levels — which keeps both traversal and insertion to O(n) complexity where n is the token count of a single log line, not the size of the entire log corpus. This means Drain3 can process millions of log events per second on modest hardware.
+
+The important detail is that Drain3 does not compare every new log line against every template already discovered. It first narrows the search space using cheap structural hints such as token count and early-position tokens, then compares the candidate line against only the cluster templates that could plausibly match. Dynamic values are masked before they pollute the tree: timestamps, UUIDs, pod names, request IDs, IP addresses, and numeric counters become parameters rather than new branches. Without that masking step, a Kubernetes pod restart would create a brand-new template every time because the pod suffix changed, and the parser would confuse normal identity churn with a novel operational behavior. Template mining is therefore less like natural-language understanding and more like building a high-speed grammar for your infrastructure.
+
+This also explains why deterministic mining and LLM parsing complement each other instead of competing. Drain3 is excellent when the structure is stable and the variable fields are predictable, but it cannot infer intent from a previously unseen stack trace or a vendor message whose fields are reordered in a surprising way. The LLM is better at semantic recovery: it can infer that `upstream prematurely closed connection` is probably a proxy/backend relationship rather than a generic string. The safe architecture uses that semantic power sparingly, converts the LLM output into an explicit template, and stores the template with provenance, confidence, and review metadata. In production, you also need template aging and rollback. If a bad LLM parse turns a rare security event into a harmless-looking wildcard template, the pipeline must be able to quarantine that template, replay the affected log window, and restore the previous deterministic parser state.
+
+The second tier is the LLM fallback. Only when Drain3 encounters a log line that fails to match any known template — typically an entirely new log format introduced by a recent deployment — does the system invoke the more expensive LLM path. The LLM parses the novel format and the resulting structured template is fed back into Drain3's parse tree, so the next occurrence of that format is handled deterministically. This hybrid design gives you the speed and cost-efficiency of deterministic parsing for 99%+ of your log volume, while retaining the flexibility of LLM-powered generalization for the long tail of unknown formats. It is the same architectural principle behind CPU cache hierarchies: keep the fast path fast, and pay the expensive path only when necessary.
+
+A notable example of industry investment in this direction: Datadog released Toto, an open-weights time-series foundation model under the Apache 2.0 license in 2025, designed to democratize AI-driven observability beyond proprietary vendor stacks. Foundation models for observability data represent a shift from per-customer training to shared pre-trained representations that can be fine-tuned on individual infrastructure patterns.
 
 ---
 
@@ -160,9 +174,17 @@ def detect_frequency_anomaly(
     return abs(z_score) > threshold_std
 ```
 
+The z-score approach is simple, but understanding its limitations is essential before deploying it in production. The z-score assumes a normal distribution of log frequencies, which holds reasonably well for steady-state systems but breaks down during deployments, traffic ramps, and scheduled maintenance windows — exactly the times when false positives are most disruptive. A more robust alternative is the **Median Absolute Deviation (MAD)**, which uses the median instead of the mean and is therefore resistant to the outlier contamination that plagues moment-based statistics during incident conditions. Another common refinement is **exponentially weighted moving averages (EWMA)**, which give more weight to recent observations and decay the influence of older data, allowing the anomaly threshold to adapt to slowly drifting baselines without manual recalibration. Production-grade anomaly detection systems typically combine multiple statistical tests — z-score for rapid detection, MAD for robustness, and EWMA for drift adaptation — and then use an ensemble voting mechanism to suppress false positives. The principle is that no single statistical test is reliable enough on its own; the system must cross-validate across methods before raising an alert.
+
 ### Deep Learning for Sequence Analysis
 
 Sometimes the volume of logs is perfectly normal, but the order of operations is wrong. Deep learning architectures, particularly Long Short-Term Memory networks (LSTMs), excel at modeling sequential data. By training an LSTM on normal log sequences, the model learns to predict the next log template. If the actual incoming log template has a vanishingly low predicted probability, it is flagged as an anomaly.
+
+To understand why LSTMs are the architecture of choice here, consider the problem through the lens of what makes log sequences difficult to model. A normal operational sequence might be: authentication success, then database query, then cache write, then HTTP 200 response. The critical information is not just which events occur but the **order** and **distance** between them. A cache write that happens before authentication is suspicious, even if the individual events are all normal. Traditional recurrent neural networks struggle with this because of the vanishing gradient problem — the influence of early tokens in a long sequence decays exponentially during backpropagation, making it impossible to learn dependencies that span more than a few steps.
+
+LSTMs solve this with an explicit **memory cell** and three gating mechanisms: the forget gate decides what old information to discard, the input gate decides what new information to store, and the output gate decides what to expose to the next layer. This architecture allows an LSTM to remember that an authentication event occurred 50 steps ago and use that information to evaluate whether the current cache write is contextually appropriate.
+
+The canonical application of this approach to log analysis is **DeepLog**, introduced by researchers at the University of Utah in 2017. DeepLog treats log anomaly detection as a multi-class classification problem: given a sequence of log template keys (the numeric IDs assigned by Drain3 or a similar template miner), predict the probability distribution over the next possible template key. During training, the model learns the normal transition patterns of your system. During inference, if the actual next template has a probability below a configurable threshold — typically set at the 0.1st percentile of the training distribution — the sequence is flagged as anomalous. The key insight is that DeepLog does not need labeled anomaly data; it learns normality from benign operational logs and treats deviation from that learned normality as the anomaly signal.
 
 ```python
 # Train LSTM on normal log sequences
@@ -205,7 +227,11 @@ Return JSON: {{"is_anomaly": bool, "confidence": 0-1, "explanation": "..."}}"""
     return llm.generate(prompt)
 ```
 
-**Did You Know?** Prometheus became the second project ever to graduate from the CNCF in August 2018, following only Kubernetes. It revolutionized how we collect the time-series metrics that feed these sophisticated AI anomaly engines.
+The value of LLM-based detection is not speed — an LLM call takes hundreds of milliseconds compared to microseconds for a statistical test — but **semantic precision**. Consider a log line that reads `Connection to payment-gateway-a timed out after 30s`. A statistical model sees a spike in timeout events and raises an alert. An LLM reads the same line and recognizes that `payment-gateway-a` is a critical dependency for the checkout flow, that the 30-second timeout matches the configured circuit-breaker threshold, and that the previous five occurrences were all against `payment-gateway-b` in the European region. The LLM can then produce an explanation like: "The timeout pattern has shifted from the EU region to the US-East payment gateway; this is not a global connectivity issue but a region-specific degradation, likely caused by the network configuration change deployed to us-east-1 at 14:00 UTC." This is the kind of contextual reasoning that turns an alert into a diagnosis.
+
+The practical deployment model is a **cascade**: statistical and sequence-based models operate as the first line of defense, scanning every log event at line speed with near-zero latency. Only when these fast models flag an anomaly does the system assemble a context window — the anomalous event plus the surrounding log lines, related metrics, and topology information — and pass it to the LLM for semantic interpretation. This cascade design keeps the cost per log event at the sub-cent level for 99.9% of your ingest volume, while still delivering human-quality diagnostic reasoning on the events that actually matter.
+
+It is worth noting the infrastructure that makes these ML pipelines possible at scale. Prometheus, which became the second project ever to graduate from the CNCF in August 2018 following only Kubernetes, revolutionized time-series metrics collection with its pull-based model. The metrics that feed AI anomaly engines — request latencies, error rates, resource utilization — flow through Prometheus and its ecosystem before reaching the ML models that reason about them.
 
 ---
 
@@ -234,6 +260,8 @@ Time to resolution: 2 hours
 
 AI disrupts this linear process by performing parallel multidimensional correlation. The AIOps engine ingests thousands of metric streams simultaneously, isolating temporal correlations in milliseconds.
 
+But here is where the distinction between **correlation** and **causation** becomes the central engineering challenge of AIOps. A correlation engine can tell you that API latency spikes and Redis memory pressure both increased at 14:03:17 UTC. What it cannot tell you — without causal reasoning — is whether the Redis pressure *caused* the latency spike, whether both were caused by an unseen third factor (like a traffic surge), or whether the latency spike actually caused the Redis pressure through a feedback loop of retried requests flooding the cache. Mistaking correlation for causation in incident response leads to treating symptoms while the root cause continues to degrade the system. This is why every AIOps vendor's "90%+ noise reduction" claim must be scrutinized: reducing the number of alerts by grouping correlated events is easy; correctly identifying which single event is the root cause is hard.
+
 ```text
 AI RCA TIMELINE
 ===============
@@ -242,7 +270,7 @@ AI RCA TIMELINE
 00:01  AI correlates all metrics at incident time
 00:02  AI identifies: Redis memory spike precedes API latency
 00:03  AI generates causal chain:
-       Redis memory ↑ → Cache evictions → DB load ↑ → API latency ↑
+       Redis memory spike → Cache evictions → DB load increase → API latency spike
 00:04  AI suggests: "Scale Redis or increase memory limit"
 00:05  Engineer confirms and deploys fix
 
@@ -252,6 +280,10 @@ Time to resolution: 5 minutes
 ### Causal Graph Analysis: Understanding Cause and Effect
 
 The most advanced AIOps platforms move beyond mere correlation to true causal inference. They construct topological maps of the infrastructure and overlay time-series events to build directed causal graphs. This allows the AI to differentiate between the true root cause (e.g., a Redis memory limit) and downstream symptoms (e.g., API timeouts).
+
+Constructing a causal graph in a live production system is not a purely algorithmic exercise — it requires blending three sources of knowledge. First, the **topological layer** comes from service discovery, Kubernetes pod-to-service mappings, and network flow logs: these tell the system that Service A calls Service B, and Service B depends on Redis. Second, the **temporal layer** comes from time-series metric correlation with Granger causality tests: if Redis memory pressure consistently spikes 30 seconds before API latency increases, the temporal arrow points from Redis toward API — not the reverse. Third, the **domain layer** encodes SRE knowledge as explicit constraints: a database restart cannot be caused by a frontend JavaScript error, regardless of what the temporal data suggests. The resulting graph is a directed acyclic structure where edges represent causal influence, and the root cause is the node with no incoming edges within the incident's temporal window.
+
+This approach draws from Judea Pearl's causal hierarchy, which distinguishes three levels of reasoning. Level 1 is **association** — observing that two variables move together (what pure correlation engines do). Level 2 is **intervention** — asking "if I scale Redis, will API latency decrease?" (what A/B tests and canary deployments answer). Level 3 is **counterfactual** reasoning — asking "would the outage have occurred if we had not deployed that configuration change?" (the gold standard for RCA). Production AIOps platforms operate primarily at Levels 1 and 2 today, with Level 3 remaining an active area of research. Understanding which level your toolchain operates at tells you exactly how much trust to place in its root cause attributions.
 
 ```mermaid
 graph TD
@@ -302,6 +334,10 @@ Be specific and cite evidence from logs/metrics."""
     return llm.generate(prompt)
 ```
 
+The word **evidence** in that prompt is not cosmetic. LLM-based RCA is only useful when it is grounded in telemetry, topology, deployment history, and known runbook constraints. If you hand a model a vague incident title and ask for a root cause, it will usually produce a plausible story, not an operationally defensible diagnosis. A production RCA assistant should therefore behave like a careful incident commander: retrieve the relevant traces, narrow the time window, compare the incident against recent changes, cite the exact log templates or metric deltas that support each claim, and explicitly name the evidence that is missing. The output should be a ranked hypothesis list with confidence and falsification steps, not a single confident paragraph.
+
+Grounding also protects the organization from dangerous automation coupling. Suppose the LLM concludes that "database saturation" caused an outage because it sees high CPU on the primary database. If the topology graph shows that a cache deployment happened first, the metric history shows cache misses spiking before database CPU, and the deployment log shows a changed cache key prefix, then the database is a victim rather than the source. The model must be forced to reconcile those facts before it recommends a remediation. That is why the best AIOps systems combine causal graphs, retrieval, deterministic checks, and human-readable evidence trails. The LLM contributes synthesis and natural-language explanation; the telemetry graph contributes the discipline that keeps the explanation honest.
+
 ---
 
 ## Intelligent Incident Response: From Alert to Resolution
@@ -309,6 +345,10 @@ Be specific and cite evidence from logs/metrics."""
 ### The Evolution of Runbooks
 
 Early automation in operations took the form of imperative runbooks—static scripts that codified specific troubleshooting paths. While useful, they were brittle and unable to adapt to novel edge cases.
+
+Traditional runbooks encode the accumulated wisdom of on-call engineers into software: "when alert X fires, run diagnostic Y, and if result is Z, execute remediation W." This works beautifully for known failure modes but collapses the moment the system encounters a scenario the runbook author did not anticipate. The script hits its final `else` branch, escalates to a human, and the engineer is now debugging at 3 AM with no more context than if the runbook had never existed. Worse, runbooks rot over time. A script written six months ago assumes a specific process name, a specific log file path, a specific API endpoint -- any of which may have changed in the intervening releases. The runbook becomes not just useless but actively misleading, suggesting fixes for a system state that no longer exists.
+
+The deeper structural problem with imperative runbooks is that they encode **what to do** but not **why to do it**. A runbook that says "restart the auth service if CPU exceeds 90% for 5 minutes" has no understanding of whether the CPU spike is caused by a deployment, a traffic surge, a memory leak, or a cryptographic operation gone exponential. The AI-powered approach addresses this by separating diagnosis from action: the AI first determines *why* the system is unhealthy, then selects the appropriate remediation from a library of safe actions, each tagged with its preconditions and blast radius.
 
 ```python
 # Traditional runbook as code
@@ -394,6 +434,10 @@ Start at Level 1 → Build trust → Progress to higher levels
 Never skip levels. Trust is earned through successful remediations.
 ```
 
+The level framework is useful, but its real-world value depends on understanding the **blast radius** at each tier and the **economic calculus** of false positives. At Level 1 (Suggest), a false positive costs an engineer 30 seconds of attention -- negligible. At Level 2 (Approve), a false positive costs the engineer a review cycle, and if the suggestion is poor enough to erode trust, the engineer starts ignoring the AI's recommendations entirely -- a hidden cost that compounds over time. At Level 3 (Auto-remediate, low risk), a false positive that needlessly restarts a pod during off-peak hours is a minor inconvenience. But at Level 4, a false positive that triggers a database failover or rolls back a production deployment can itself become the incident. The safety principle is simple: the maximum potential damage of an automated action must be strictly smaller than the damage of the incident it is trying to fix. If your pager alerts you to a 5% latency increase and the AI responds by failing over an entire region, the cure is worse than the disease.
+
+Progressive adoption follows a maturity ladder that every organization must climb honestly. **Month 1**: operate exclusively at Level 1 in production, with the AI posting diagnostic suggestions to a Slack channel. Track how many suggestions the on-call engineer actually uses. **Month 2**: promote the highest-confidence suggestion categories to Level 2, requiring one-click approval. Track the approval-to-execution ratio -- if engineers are blindly approving without reading, the system is not providing enough context; if they are rejecting most suggestions, the model's confidence calibration is wrong. **Month 3 and beyond**: identify low-risk, high-volume actions (pod restarts, HPA scale adjustments, cache clears) and promote them to Level 3. Only after six months of demonstrated accuracy on Level 3 actions should any organization consider Level 4 for state-mutating operations. The organizations that have been most successful with AIOps -- and this is visible in the postmortems published by large-scale operators -- are those that treated automation maturity as an engineering discipline measured in months, not a feature flag toggled in an afternoon.
+
 To implement these levels safely, engineering teams must wrap AI remediation workflows in rigorous programmatic guardrails that enforce circuit breakers and rate limits.
 
 ```python
@@ -433,7 +477,7 @@ async def auto_remediate(alert: Alert) -> RemediationResult:
         return escalate_to_human(alert, error=e)
 ```
 
-**Did You Know?** On March 10, 2025, Gartner officially rebranded its "Market Guide for AIOps Platforms" to the "Market Guide for Event Intelligence Solutions (EIS)", defining its core objectives as Augmentation, Acceleration, and Automation.
+The market landscape around AIOps has evolved significantly. In 2025, Gartner retired the "AIOps" market category label, rebranding it to "Event Intelligence Solutions (EIS)" with core objectives defined as Augmentation, Acceleration, and Automation. This nomenclature shift reflects the maturation of the space from a buzzword-driven category to a set of concrete operational capabilities that platforms are expected to deliver.
 
 ---
 
@@ -482,57 +526,21 @@ flowchart LR
 
 ### Commercial Platforms and Open Source
 
-The observability landscape is fiercely competitive, split between heavy enterprise platforms and nimble open-source stacks. Adopting open-source tooling avoids vendor lock-in but requires significant engineering effort to maintain the underlying message brokers (like Kafka) and indexing databases (like Elasticsearch). 
+The observability landscape is fiercely competitive. The durable spine of AIOps — log parsing, anomaly detection, causal reasoning, and automated remediation — is independent of any specific vendor. The commercial platforms compete on integration depth, UI polish, and managed-service convenience; the open-source ecosystem competes on cost, transparency, and avoiding lock-in. Both are valid depending on organizational maturity and engineering capacity.
 
-```text
-AIOPS PLATFORMS (2024)
-======================
-
-Enterprise:
-  • Splunk ITSI        - ML-powered IT service intelligence
-  • Datadog           - Watchdog AI for anomaly detection
-  • Dynatrace Davis   - AI-powered root cause analysis
-  • New Relic         - Applied Intelligence
-  • ServiceNow ITOM   - AIOps with ITSM integration
-
-Specialized:
-  • Moogsoft          - AI incident management (pioneer)
-  • BigPanda          - Event correlation and automation
-  • PagerDuty         - Intelligent incident response
-  • OpsRamp           - Hybrid infrastructure AIOps
-
-Cloud-Native:
-  • AWS DevOps Guru   - ML-powered operational insights
-  • Azure Monitor     - Smart detection and diagnostics
-  • GCP Operations    - Integrated logging and monitoring
-```
-
-**Did You Know?** In November 2023, New Relic was taken private by Francisco Partners and TPG in a massive transaction valued at $6.5 billion. According to New Relic's self-published 2026 data report, their AIOps users ship code at an 80% higher frequency.
-
-```text
-OPEN SOURCE AIOPS
-=================
-
-Log Management:
-  • Elasticsearch + Kibana (ELK)
-  • Grafana Loki
-  • Apache Kafka (streaming)
-
-Anomaly Detection:
-  • Apache Spark MLlib
-  • PyOD (Python Outlier Detection)
-  • Alibi Detect
-
-Log Parsing:
-  • Drain3
-  • Logparser
-  • Spell
-
-Automation:
-  • Ansible + AWX
-  • Rundeck
-  • StackStorm
-```
+> **Landscape snapshot — as of June 2026. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> | Category | Key Players |
+> |---|---|
+> | Enterprise AIOps | Splunk ITSI, Datadog Watchdog, Dynatrace Davis, New Relic (taken private 2023), ServiceNow ITOM |
+> | Event Correlation | Moogsoft, BigPanda, PagerDuty |
+> | Cloud-Native AIOps | AWS DevOps Guru, Azure Monitor, GCP Operations Suite |
+> | Open-Source Log Management | Elasticsearch + Kibana (ELK), Grafana Loki, Apache Kafka |
+> | Open-Source Anomaly Detection | Apache Spark MLlib, PyOD, Alibi Detect |
+> | Open-Source Log Parsing | Drain3, Logparser, Spell |
+> | Open-Source Automation | Ansible AWX, Rundeck, StackStorm |
+>
+> This table is illustrative of the category landscape, not a leaderboard or endorsement. Evaluate tools against your own operational requirements, not market-share claims.
 
 ### Architecture Overview
 
@@ -609,7 +617,20 @@ class AIOpsIntegration:
 
 ### The State of OpenTelemetry (2026)
 
-To feed the architecture above, the industry has standardized around the CNCF OpenTelemetry (OTel) project. OTel provides a single, vendor-agnostic standard for emitting telemetry. However, it is critical to understand the project's maturity matrix when architecting an AIOps pipeline. As of April 2026, OpenTelemetry traces, metrics, and logs have all reached full stability and are widely adopted in production. Conversely, the continuous profiling signal (*profiles*) remains in active development status. Relying on profiles for critical ML anomaly detection introduces risk, as breaking protocol changes are still occurring in upstream releases.
+To feed the architecture above, the industry has standardized around the CNCF OpenTelemetry (OTel) project. OTel provides a single, vendor-agnostic standard for emitting telemetry. However, it is critical to understand the project's maturity matrix when architecting an AIOps pipeline. As of June 2026, OpenTelemetry traces, metrics, and logs have all reached full stability and are widely adopted in production. Conversely, the continuous profiling signal (*profiles*) remains in active development status. Relying on profiles for critical ML anomaly detection introduces risk, as breaking protocol changes are still occurring in upstream releases. Always consult the official [OpenTelemetry Specification Status Summary](https://opentelemetry.io/docs/specs/status/) before making architecture decisions that depend on a particular signal's maturity.
+
+The OTel signal maturity model is worth understanding in detail because it directly shapes what your AIOps pipeline can safely consume. Signals progress through three stages. **Experimental** signals have unstable APIs — field names, data structures, and semantic conventions can change between releases without notice. You should never build production AIOps logic on experimental signals; your anomaly detection models will break silently when the upstream schema shifts. **Stable** signals have frozen APIs with backward-compatibility guarantees. Traces reached stability first (the trace specification reached v1.0 in 2021), followed by metrics (2023), and finally logs (2024). These three signals now form the reliable backbone that every serious AIOps pipeline should ingest. **Deprecated** signals are being phased out — they still work but will be removed in a future release, and new deployments should not adopt them.
+
+The *profiles* signal illustrates why maturity tracking matters practically. Continuous profiling gives you flame graphs of CPU and memory usage at the function level — precisely the kind of high-resolution data that would let an AIOps engine pinpoint whether a latency regression is caused by a specific code path in your authentication module or a garbage collection pause in your JVM. The data is extraordinarily valuable for RCA, but as of mid-2026, the protocol is still evolving. An AIOps pipeline that hard-codes assumptions about the profiles data model today will incur maintenance debt every time the specification changes. The prudent engineering decision is to architect your pipeline to accept profiles as an optional, non-critical signal — valuable when available, but never a dependency for your core anomaly detection and alerting paths.
+
+---
+
+## Did You Know?
+
+- Prometheus became the second project ever to graduate from the CNCF in August 2018, following only Kubernetes. Its pull-based metrics collection model became the de facto standard that modern AI anomaly engines consume.
+- Datadog released Toto, an open-weights time-series foundation model under the Apache 2.0 license in 2025, designed to democratize AI-driven observability beyond proprietary vendor stacks.
+- In 2025, Gartner retired the "AIOps" market category label, rebranding it to "Event Intelligence Solutions (EIS)" with core objectives defined as Augmentation, Acceleration, and Automation.
+- The CrowdStrike Falcon sensor outage of July 19, 2024 affected approximately 8.5 million Windows devices and is widely considered the largest single IT outage in history, with an insurer's estimate placing US Fortune-500 direct losses at roughly $5.4 billion.
 
 ---
 
@@ -627,6 +648,52 @@ To feed the architecture above, the industry has standardized around the CNCF Op
 
 ---
 
+## Knowledge Check
+
+<details>
+<summary><strong>Question 1: Scenario</strong> - An e-commerce site experiences a 400% spike in checkout latency, but the log aggregation tool shows zero error-level logs. Which anomaly detection strategy is best suited to catch this?</summary>
+
+**Answer**: Performance and metrics-derived anomaly detection (specifically sequence or duration anomalies). Since the system is not failing outright, error logs will not exist. By evaluating the mathematical duration of the logs or tracking time-series metric throughput, an AI agent can flag the performance anomaly without relying on string-based "ERROR" flags.
+</details>
+
+<details>
+<summary><strong>Question 2: Scenario</strong> - You are designing a log parsing pipeline for an enterprise with 500+ legacy microservices. Why is a hybrid approach combining Drain3 and LLMs superior to pure LLM parsing?</summary>
+
+**Answer**: Pure LLM parsing is cost-prohibitive and relatively slow at petabyte scale. A hybrid pipeline leverages Drain3 to rapidly categorize known templates and variable structures using fixed-depth trees. The LLM is then selectively invoked only as a fallback for entirely new, unseen log formats, optimizing both compute costs and processing latency.
+</details>
+
+<details>
+<summary><strong>Question 3: Scenario</strong> - A Level 4 automated runbook restarts a database during a traffic spike, which immediately corrupts the index and causes a prolonged outage. What critical safety guardrail was missing from the AIOps architecture?</summary>
+
+**Answer**: The system lacked context-aware risk checks and rollback capability. A Level 4 automation generally should not execute a state-mutating operation (like a database restart) without verifying whether the issue is load-based versus crash-based. Furthermore, no auto-remediation should execute unless an automated rollback function is verified and available.
+</details>
+
+<details>
+<summary><strong>Question 4: Scenario</strong> - An AIOps vendor claims their Event Intelligence Solution provides a "95% alert noise reduction." How do you technically validate their correlation engine against your actual infrastructure?</summary>
+
+**Answer**: You must measure your historical Mean Time to Detect (MTTD) and Mean Time to Resolution (MTTR) baseline using your own data. By feeding historical incidents into their correlation engine and comparing the engine's consolidated alerts against your manual ticket logs, you verify causation over simple correlation, bypassing marketing metrics.
+</details>
+
+<details>
+<summary><strong>Question 5: Scenario</strong> - A monitoring dashboard shows a spike in "Cache Miss" metrics, followed immediately by "DB Slow" alerts. How does an AI causal graph differentiate the root cause from the symptoms in this scenario?</summary>
+
+**Answer**: The AI causal graph traces temporal and topological dependencies across the stack. It observes that the cache miss event mathematically preceded the database latency event, and understands topologically that a cache miss increases database queries. Therefore, it identifies the cache miss as the causal origin, labeling the database slowness as a downstream symptom.
+</details>
+
+<details>
+<summary><strong>Question 6: Scenario</strong> - Your OpenTelemetry trace and metric signals are stable, but you want to incorporate continuous code profiling into your AIOps ML models. Based on the CNCF OpenTelemetry project's current status, what risk must you mitigate?</summary>
+
+**Answer**: As of June 2026, while OpenTelemetry traces, metrics, and logs are stable, the *profiles* signal remains in the development stage. You must mitigate the risk of breaking API/Protocol changes and acknowledge it is not yet production-ready for enterprise deployment.
+</details>
+
+<details>
+<summary><strong>Question 7: Scenario</strong> - A team wants to implement AI-generated Kubernetes remediation artifacts (like those introduced by Dynatrace in 2025) directly into their K8s v1.35 production cluster. What is the safest implementation strategy?</summary>
+
+**Answer**: The team should implement the artifacts at Automation Level 2 (Approve). The AI generates the remediation YAML (e.g., adjusting CPU/Memory limits), but a human operator must review and apply the artifact to the v1.35 cluster. Full automation (Level 3 or 4) should only be adopted after establishing long-term trust in the AI's generation accuracy.
+</details>
+
+---
+
 ## Hands-On Exercise: Building the AIOps Foundations
 
 In this lab, you will move beyond theory and execute a local simulation of an AIOps pipeline. To ensure these examples are fully executable in your local terminal or CI/CD lab validation environments, we will begin by mocking the LLM integration.
@@ -636,7 +703,7 @@ In this lab, you will move beyond theory and execute a local simulation of an AI
 Execute the following Python setup in your local environment. This creates the foundational dependencies and the dummy LLM interface required for the subsequent tasks.
 
 ```python
-# Save as lab_setup.py and run: python3 lab_setup.py
+# Save as lab_setup.py and run: .venv/bin/python lab_setup.py
 import json
 import re
 import statistics
@@ -698,7 +765,7 @@ class IntelligentLogParser:
 
 # Executable Test:
 # parser = IntelligentLogParser(llm_client)
-# print(parser.parse('192.168.1.1 - - [13/Apr/2026:10:00:00 +0000] "GET /" 200 123'))
+# print(parser.parse('192.168.1.1 - - [13/Apr/2026:10:00:00 +0000] "GET / HTTP/1.1" 200 123'))
 ```
 </details>
 
@@ -749,7 +816,7 @@ class LogAnomalyDetector:
 
 # Executable Test:
 # detector = LogAnomalyDetector(threshold=2.0)
-# for i in range(15): detector.analyze_frequency(10) # Seed baseline
+# for c in [9, 11, 10, 12, 8, 10, 11, 9, 10, 12, 8, 11, 9, 10, 11]: detector.analyze_frequency(c)  # Seed a baseline WITH variance (a flat baseline gives std=0, which the guard treats as no-anomaly)
 # is_anomaly = detector.analyze_frequency(150) # Feed massive spike
 # print(f"Spike detected? {is_anomaly}")
 ```
@@ -811,12 +878,15 @@ Robusta KRR queries Prometheus for actual pod usage and recommends CPU/memory li
 # Ensure you are connected to your K8s v1.35 context
 kubectl cluster-info
 
-# Run Robusta KRR via Docker to scan the 'production' namespace
-docker run --rm -it \
+# First port-forward Prometheus to your host so the container can reach it:
+#   kubectl port-forward -n monitoring svc/prometheus-server 9090:9090
+# Then run Robusta KRR via Docker to scan the 'production' namespace.
+# The image is published to Docker Hub as robustadev/krr (it is NOT on ghcr.io).
+docker run --rm -it --add-host=host.docker.internal:host-gateway \
   -v ~/.kube/config:/root/.kube/config \
-  ghcr.io/robusta-dev/krr:latest simple \
+  robustadev/krr:latest simple \
   --namespace production \
-  --prometheus-url http://prometheus-server.monitoring.svc.cluster.local:9090
+  --prometheus-url http://host.docker.internal:9090
 ```
 
 *CI/CD Pipeline Note:* If you are executing this within an automated, non-interactive CI/CD pipeline script, omit the `-it` flags to prevent the process from hanging while attempting to allocate a TTY. 
@@ -831,62 +901,15 @@ This generates an AI-informed report suggesting exact YAML adjustments for your 
 
 ---
 
-## Knowledge Check
+## Next Module
 
-<details>
-<summary><strong>Question 1: Scenario</strong> - An e-commerce site experiences a 400% spike in checkout latency, but the log aggregation tool shows zero error-level logs. Which anomaly detection strategy is best suited to catch this?</summary>
+You now know how to build an AIOps pipeline end to end — from parsing raw telemetry through anomaly detection and root-cause analysis to safely automated remediation.
 
-**Answer**: Performance and metrics-derived anomaly detection (specifically sequence or duration anomalies). Since the system is not failing outright, error logs will not exist. By evaluating the mathematical duration of the logs or tracking time-series metric throughput, an AI agent can flag the performance anomaly without relying on string-based "ERROR" flags.
-</details>
+**Up Next**: [High-Performance LLM Inference](../module-1.3-vllm-sglang-inference/)
 
-<details>
-<summary><strong>Question 2: Scenario</strong> - You are designing a log parsing pipeline for an enterprise with 500+ legacy microservices. Why is a hybrid approach combining Drain3 and LLMs superior to pure LLM parsing?</summary>
+In module 1.3, you will explore how vLLM and SGLang push LLM inference to production scale -- the same class of models you've just learned to integrate into AIOps pipelines for log parsing, anomaly detection, and root cause analysis. Understanding inference infrastructure closes the loop: the AI models that power your operations platform must themselves run on infrastructure you can reason about.
 
-**Answer**: Pure LLM parsing is cost-prohibitive and relatively slow at petabyte scale. A hybrid pipeline leverages Drain3 to rapidly categorize known templates and variable structures using fixed-depth trees. The LLM is then selectively invoked only as a fallback for entirely new, unseen log formats, optimizing both compute costs and processing latency.
-</details>
-
-<details>
-<summary><strong>Question 3: Scenario</strong> - A Level 4 automated runbook restarts a database during a traffic spike, which immediately corrupts the index and causes a prolonged outage. What critical safety guardrail was missing from the AIOps architecture?</summary>
-
-**Answer**: The system lacked context-aware risk checks and rollback capability. A Level 4 automation generally should not execute a state-mutating operation (like a database restart) without verifying whether the issue is load-based versus crash-based. Furthermore, no auto-remediation should execute unless an automated rollback function is verified and available.
-</details>
-
-<details>
-<summary><strong>Question 4: Scenario</strong> - An AIOps vendor claims their Event Intelligence Solution provides a "95% alert noise reduction." How do you technically validate their correlation engine against your actual infrastructure?</summary>
-
-**Answer**: You must measure your historical Mean Time to Detect (MTTD) and Mean Time to Resolution (MTTR) baseline using your own data. By feeding historical incidents into their correlation engine and comparing the engine's consolidated alerts against your manual ticket logs, you verify causation over simple correlation, bypassing marketing metrics.
-</details>
-
-<details>
-<summary><strong>Question 5: Scenario</strong> - A monitoring dashboard shows a spike in "Cache Miss" metrics, followed immediately by "DB Slow" alerts. How does an AI causal graph differentiate the root cause from the symptoms in this scenario?</summary>
-
-**Answer**: The AI causal graph traces temporal and topological dependencies across the stack. It observes that the cache miss event mathematically preceded the database latency event, and understands topologically that a cache miss increases database queries. Therefore, it identifies the cache miss as the causal origin, labeling the database slowness as a downstream symptom.
-</details>
-
-<details>
-<summary><strong>Question 6: Scenario</strong> - Your OpenTelemetry trace and metric signals are stable, but you want to incorporate continuous code profiling into your AIOps ML models. Based on the CNCF OpenTelemetry project's current status, what risk must you mitigate?</summary>
-
-**Answer**: As of April 2026, while OpenTelemetry traces, metrics, and logs are stable, the *profiles* signal remains in the development stage. You must mitigate the risk of breaking API/Protocol changes and acknowledge it is not yet production-ready for enterprise deployment.
-</details>
-
-<details>
-<summary><strong>Question 7: Scenario</strong> - A team wants to implement AI-generated Kubernetes remediation artifacts (like those introduced by Dynatrace in 2025) directly into their K8s v1.35 production cluster. What is the safest implementation strategy?</summary>
-
-**Answer**: The team should implement the artifacts at Automation Level 2 (Approve). The AI generates the remediation YAML (e.g., adjusting CPU/Memory limits), but a human operator must review and apply the artifact to the v1.35 cluster. Full automation (Level 3 or 4) should only be adopted after establishing long-term trust in the AI's generation accuracy.
-</details>
-
----
-
-## ⏭ Next Steps
-
-You've successfully completed all the core technical infrastructure modules!
-
-**Up Next**: [History of AI/ML](../history/module-1.1-history-of-ai-machine-learning/)
-
-Learn the fascinating history behind the statistical models and algorithms you've just deployed:
-- Module 55: History of AI/ML - Foundations
-- Module 56: History of AI/ML - Modern Era
-- Module 57: History of AI/ML - Future Directions
+After completing the AI Infrastructure modules, the [History of AI/ML](../history/module-1.1-history-of-ai-machine-learning/) track provides the historical context behind the algorithms and architectures you've deployed.
 
 ---
 
@@ -896,5 +919,19 @@ _"The best alert is the one that tells you exactly what's wrong and how to fix i
 ## Sources
 
 - [OpenTelemetry Specification Status Summary](https://opentelemetry.io/docs/specs/status/) — Useful for verifying which telemetry signals are stable enough to treat as production-grade inputs to an AIOps stack.
+- [OpenTelemetry Profiles](https://opentelemetry.io/docs/specs/otel/profiles/) — Defines the profiles signal and explains why code-level profiling is relevant to root-cause analysis.
+- [OpenTelemetry Profiles Enters Public Alpha](https://opentelemetry.io/blog/2026/profiles-alpha/) — Documents the current maturity of the profiles signal and why it should be treated differently from stable logs, metrics, and traces.
 - [CNCF Announces Prometheus Graduation](https://www.cncf.io/announcements/2018/08/09/prometheus-graduates/) — Provides historical context on Prometheus as a core metrics foundation in modern observability pipelines.
 - [What Is Amazon DevOps Guru?](https://docs.aws.amazon.com/devops-guru/latest/userguide/welcome.html) — Gives a concrete example of a managed AIOps-style service and the kinds of ML-backed operational insights vendors actually document.
+- [Helping Our Customers Through the CrowdStrike Outage](https://blogs.microsoft.com/blog/2024/07/20/helping-our-customers-through-the-crowdstrike-outage/) — Provides Microsoft's estimate of affected Windows devices and recovery context for the opener.
+- [CrowdStrike's Impact on the Fortune 500](https://www.parametrixinsurance.com/reports-white-papers/crowdstrikes-impact-on-the-fortune-500) — Supports the insurer-estimated US Fortune-500 direct-loss figure used in the incident framing.
+- [Falcon Content Update Preliminary Post Incident Report](https://www.crowdstrike.com/en-us/blog/falcon-content-update-preliminary-post-incident-report/) — Provides CrowdStrike's public technical description of the Channel File 291 failure mode.
+- [Drain: An Online Log Parsing Approach with Fixed Depth Tree](https://pinjiahe.github.io/publication/2017-ICWS) — Primary publication page for the Drain algorithm used to explain fixed-depth-tree log-template mining.
+- [Drain3](https://github.com/logpai/Drain3) — Open-source implementation reference for streaming log-template mining based on the Drain algorithm.
+- [DeepLog: Anomaly Detection and Diagnosis from System Logs](https://users.cs.utah.edu/~lifeifei/papers/deeplog.pdf) — Primary paper for the LSTM-based log-sequence anomaly detection mechanics discussed in the module.
+- [Introducing Winston: Event Driven Diagnostic and Remediation Platform](https://techblog.netflix.com/2016/08/introducing-winston-event-driven.html) — Practical runbook automation reference showing event-driven diagnostics and remediation in production operations.
+- [Auto-Remediation Defined](https://stackstorm.com/2015/08/07/auto-remediation-defined/) — Defines auto-remediation as event-triggered automation and supports the automation-level discussion.
+- [MicroHECL: High-Efficient Root Cause Localization in Large-Scale Microservice Systems](https://arxiv.org/abs/2103.01782) — Research reference for topology-aware root-cause localization in microservice systems.
+- [Root Cause Analysis for Microservices Based on Causal Inference](https://arxiv.org/html/2408.13729v1) — Survey-style evaluation of causal inference methods for microservice RCA, useful for understanding limits and tradeoffs.
+- [Toto and BOOM Unleashed](https://www.datadoghq.com/blog/ai/toto-boom-unleashed/) — Datadog's announcement of the Toto open-weights observability time-series foundation model and BOOM benchmark.
+- [Gartner Market Guide for Event Intelligence Solutions](https://www.gartner.com/en/documents/6250551) — Primary Gartner page documenting the Event Intelligence Solutions framing and its augmentation, acceleration, and automation objectives.

--- a/src/content/docs/ai-ml-engineering/ai-infrastructure/module-1.3-vllm-sglang-inference.md
+++ b/src/content/docs/ai-ml-engineering/ai-infrastructure/module-1.3-vllm-sglang-inference.md
@@ -5,295 +5,326 @@ sidebar:
   order: 704
 ---
 
-## Why This Module Matters
-
-AI products can suffer severe service degradation during launches when concurrency spikes expose inefficient batching and KV-cache management, causing dropped requests, long TTFT, and poor GPU utilization. 
-
-When inference bottlenecks are misunderstood, teams can lose users, overspend on hardware, and still fail to fix the real problem if the workload is memory-bound rather than compute-bound.
-
-Moving from naive batching to a modern inference engine can materially improve throughput and latency while reducing serving cost, but the exact gains depend on the workload, model, and hardware.
+> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 3-4 hours | Prerequisites: AIOps, GPU fundamentals, transformer attention, and basic OpenAI-compatible HTTP APIs
 
 ## Learning Outcomes
 
 By the end of this module, you will be able to:
-*   **Evaluate** the architectural differences between static batching and continuous batching in the context of LLM inference throughput.
-*   **Diagnose** memory fragmentation issues in naive LLM serving implementations and explain how PagedAttention resolves them.
-*   **Design** a high-throughput inference architecture using vLLM or sglang for models like Llama 4 or DeepSeek V3, balancing latency and throughput requirements.
-*   **Implement** advanced inference optimizations including prefix caching, [chunked prefill, and speculative decoding](https://github.com/vllm-project/vllm) to maximize hardware utilization.
-*   **Compare** the performance profiles of vLLM and sglang specifically for structured output generation and complex prompting workflows.
 
-## The Anatomy of LLM Inference: Prefill and Decode
+- **Diagnose** whether an LLM serving workload is compute-bound, memory-bandwidth-bound, or queue-bound by separating prefill, decode, and scheduler behavior.
+- **Explain** how PagedAttention, continuous batching, prefix caching, and RadixAttention reduce waste without pretending that any one engine removes hardware limits.
+- **Design** a single-node inference service with realistic model IDs, pinned container tags, tensor parallelism, cache sizing, and Prometheus metrics.
+- **Compare** serving optimizations such as chunked prefill, speculative decoding, quantization, and disaggregated prefill/decode using durable tradeoffs rather than vendor hype.
+- **Validate** a vLLM deployment with a repeatable load test that measures TTFT, latency, throughput, and KV-cache pressure, and explain how validating an sglang deployment would differ.
 
-To understand why engines like vLLM and sglang exist, we must first break down how an autoregressive Large Language Model generates text. Inference occurs in two distinct phases: the **Prefill** phase and the **Decode** phase. 
+## Why This Module Matters
 
-During the prefill phase, the model processes the entire input prompt simultaneously. It computes the Key and Value (KV) vectors for every token in the prompt and stores them in GPU memory (the KV cache). This phase is heavily compute-bound. The GPU is performing massive matrix multiplications, and high utilization is easily achieved because the operations are highly parallelizable across the sequence length.
+Hypothetical scenario: a small AI product team ships a support assistant that works beautifully during internal testing. The prompt template is long, the model answers well, and a single request streams tokens quickly enough that nobody worries about infrastructure. Launch traffic changes the shape of the problem. Hundreds of users arrive at once, several paste long tickets, and the service starts reporting slow time to first token, uneven streaming, and GPU memory exhaustion even though the dashboard says the GPU arithmetic units are not fully busy.
 
-The decode phase is entirely different. The model generates one token at a time. To generate the next token, it must read the entire KV cache of all previous tokens from High Bandwidth Memory (HBM) into the GPU's streaming multiprocessors (SMs). It computes the new token, appends its KV vectors to the cache, and repeats. This phase is severely memory-bandwidth bound. The arithmetic intensity (the ratio of compute operations to memory bytes accessed) is very low.
+The first instinct is often to buy a larger GPU or move to a larger model, but the symptoms point somewhere more specific. Autoregressive decoding is frequently limited by memory bandwidth and KV-cache capacity, not raw matrix multiplication. A naive server can waste memory through over-allocation, stall active users while a long prompt is being prefetched, or hold a static batch open while one slow request keeps generating. In that situation, adding hardware without changing the inference engine simply gives the same scheduler more room to waste.
+
+Modern inference engines such as vLLM and sglang are important because they attack the serving problem at the right layer. They do not make transformer inference free, and they do not erase the need for capacity planning, but they provide better memory management, better batching, better cache reuse, and better control over latency/throughput tradeoffs. This module teaches the durable mechanics underneath those tools so you can reason from workload shape to engine configuration instead of copying flags from a stale blog post.
+
+## The Inference Roofline: Prefill vs Decode
+
+Autoregressive LLM serving has two phases that place very different pressure on the GPU. During prefill, the engine processes the entire prompt and builds the key/value vectors that future tokens will attend to. This work is mostly large matrix multiplication over a known sequence. The GPU can expose a lot of parallelism because many prompt tokens can be processed together, so prefill often behaves like a compute-heavy phase where arithmetic throughput matters.
+
+Decode is different because the model produces one token at a time. For each new token, the attention layers need to read the previously stored KV cache, combine it with the current hidden state, and append new key/value vectors for the generated token. The amount of arithmetic per byte fetched from memory is much lower than in prefill. Once the model weights are resident and the batch is steady, decode often behaves like a memory-bandwidth-bound phase rather than a compute-bound phase.
+
+The roofline model gives you a useful mental picture for this distinction. A workload with high arithmetic intensity performs many floating-point operations for every byte moved, so its speed is capped by compute throughput. A workload with low arithmetic intensity moves many bytes for relatively little math, so its speed is capped by memory bandwidth. Prefill usually sits closer to the compute side of that roofline; decode usually sits closer to the bandwidth side because every token must consult growing history.
+
+This is why the phrase "GPU utilization" can mislead inference teams. A dashboard might show low streaming multiprocessor utilization during decode, yet the service cannot accept more users because HBM bandwidth or KV-cache memory is saturated. The GPU is not idle in a useful sense; it is waiting on memory movement. The correct response is not always a faster model kernel. Sometimes the response is larger effective batches, tighter KV-cache packing, shorter prompts, or a serving policy that protects interactive users from long-context requests.
+
+Batch size changes the decode economics because a single decode iteration can process the next token for many active sequences at once. The engine still reads a lot of KV-cache data, but it amortizes scheduling overhead and uses the GPU more efficiently across users. Too small a batch underuses the hardware during decode. Too large a batch may increase queueing, TTFT, and inter-token latency for interactive users. The engineering goal is not "maximum batch size"; it is enough active work to keep the memory-bound phase productive without violating the product latency budget.
+
+The prefill/decode split also explains why long prompts have a different failure mode from long answers. A long prompt causes a large prefill burst before the first token can stream, so it primarily damages TTFT for that request and can interrupt decode work for other users if the scheduler is naive. A long answer consumes KV-cache blocks over time, so it primarily increases cache residency and decode bandwidth demand. Both are expensive, but they stress different parts of the serving loop.
+
+Think of an inference engine as an operating system for tokens. The GPU is the CPU, the KV cache is memory, user requests are processes, and every decode step is a scheduling tick. A simple server that treats each request as a private job wastes the shared machine. A high-performance server must multiplex requests, evict finished work, share cached prefixes, and keep memory allocation predictable while still returning tokens quickly enough for humans to trust the interface.
 
 ```mermaid
 sequenceDiagram
     participant User
-    participant Inference Engine
-    participant GPU Compute
-    participant GPU Memory (KV Cache)
+    participant Engine
+    participant Compute
+    participant Cache
 
-    User->>Inference Engine: Send Prompt ("Write a story...")
-    Note over Inference Engine, GPU Compute: Phase 1: Prefill (Compute Bound)
-    Inference Engine->>GPU Compute: Process entire prompt in parallel
-    GPU Compute->>GPU Memory (KV Cache): Store KV vectors for prompt tokens
-    GPU Compute-->>Inference Engine: First Token Generated
+    User->>Engine: Prompt with system + user tokens
+    Note over Engine,Compute: Prefill: high parallelism, compute-heavy
+    Engine->>Compute: Process prompt tokens together
+    Compute->>Cache: Store KV vectors for prompt
+    Compute-->>Engine: First token ready
 
-    Note over Inference Engine, GPU Memory (KV Cache): Phase 2: Decode (Memory Bound)
-    loop Autoregressive Generation
-        Inference Engine->>GPU Memory (KV Cache): Read ALL previous KV vectors
-        GPU Memory (KV Cache)-->>GPU Compute: Transfer data
-        GPU Compute->>GPU Compute: Compute next token
-        GPU Compute->>GPU Memory (KV Cache): Append new token's KV vectors
-        GPU Compute-->>Inference Engine: Next Token Generated
+    Note over Engine,Cache: Decode: one step per generated token, memory-heavy
+    loop Until stop condition
+        Engine->>Cache: Read prior KV cache
+        Cache-->>Compute: Move history through HBM
+        Compute->>Compute: Compute next token
+        Compute->>Cache: Append new KV block
+        Compute-->>Engine: Stream token
     end
-    Inference Engine-->>User: Complete Response
 ```
 
-When serving multiple users, naive implementations process requests sequentially or use static batching, where requests are grouped together and padded to the length of the longest request in the batch. This results in massive GPU memory waste due to padding and internal fragmentation, limiting the maximum batch size. Since the decode phase is memory-bandwidth bound, one of the main ways to increase overall throughput is to increase the batch size, which allows the GPU to process multiple tokens while loading the KV cache once. 
+The practical lesson is that prefill and decode deserve separate measurements. A single "average latency" hides whether users are waiting before the first token, seeing stutters between tokens, or waiting in a queue before the engine admits the request. Good inference operations measure TTFT, inter-token latency, total request latency, throughput, and cache pressure together. If you only measure one of them, you can optimize a number while making the user experience worse.
 
-> **Stop and think**: If a model requires 20GB of weights to load into memory, and an A100 GPU has 80GB of memory, how do you maximize the use of the remaining 60GB? What happens if your batch size is too small?
+## KV-Cache Memory: PagedAttention and Continuous Batching
 
-## PagedAttention: The Core of vLLM
+The KV cache is the serving engine's working set. Each sequence stores key and value tensors for every layer and every token that the model may attend to in future decode steps. For large models, long contexts, and many active users, the cache can become the dominant memory consumer after model weights. A small mistake in allocation policy can therefore remove much more capacity than a small mistake in ordinary application memory.
 
-The breakthrough that enabled vLLM to dominate the open-source inference landscape was **PagedAttention**. [Inspired by virtual memory and paging in traditional operating systems, PagedAttention eliminates the need to allocate contiguous blocks of memory for the KV cache.](https://arxiv.org/abs/2309.06180)
+Naive KV-cache management allocates large contiguous tensors for each request based on a maximum possible sequence length. That approach is simple because tensor indexing is straightforward, but it is wasteful because the engine does not know how many tokens the request will actually generate. If a request reserves room for thousands of tokens and stops after a short answer, the unused space is still trapped inside its allocation. Other requests cannot use it even though no meaningful data lives there.
 
-In traditional attention mechanisms, the KV cache for a sequence is stored in a contiguous tensor. Because the final length of the generated text is unknown at the start, the system must over-allocate memory based on the maximum possible generation length. This leads to internal fragmentation (allocated but unused memory) and external fragmentation (small gaps between allocations). Research showed that in naive systems, up to 60-80% of KV cache memory was wasted.
+The PagedAttention paper describes this waste using the same vocabulary operating systems use for memory allocation. Internal fragmentation appears when an allocation contains unused space, such as the unused tail of a reserved sequence buffer. External fragmentation appears when free memory exists in scattered gaps that cannot satisfy a large contiguous allocation. In the PagedAttention evaluation, conventional serving systems could waste a large fraction of KV-cache memory, which directly reduced the number of sequences that fit on the GPU.
 
-PagedAttention divides the KV cache into fixed-size blocks (e.g., blocks of 16 or 32 tokens). These blocks do not need to be contiguous in physical GPU memory. A block table maps the logical blocks of a sequence to physical blocks in memory. 
+PagedAttention changes the abstraction. Instead of requiring each sequence's KV cache to occupy one contiguous physical region, vLLM stores KV data in fixed-size blocks. A per-sequence block table maps logical token positions to physical blocks in GPU memory. The logical sequence still looks contiguous to the attention kernel, but physical memory can be non-contiguous. This is the same separation that makes virtual memory useful in an operating system: the program sees a clean address space while the system packs physical pages efficiently.
 
 ```mermaid
 graph TD
-    subgraph Logical View (Per Request)
-        Seq1[Sequence 1 Logical Blocks<br>Block 0, Block 1, Block 2]
-        Seq2[Sequence 2 Logical Blocks<br>Block 0, Block 1]
+    subgraph Logical Sequences
+        A[Request A logical blocks: 0, 1, 2]
+        B[Request B logical blocks: 0, 1]
     end
 
-    subgraph Block Table
-        BT1_0[Logical 0 -> Physical 5]
-        BT1_1[Logical 1 -> Physical 2]
-        BT1_2[Logical 2 -> Physical 8]
-        BT2_0[Logical 0 -> Physical 1]
-        BT2_1[Logical 1 -> Physical 9]
+    subgraph Block Tables
+        A0[A: logical 0 -> physical 5]
+        A1[A: logical 1 -> physical 2]
+        A2[A: logical 2 -> physical 8]
+        B0[B: logical 0 -> physical 1]
+        B1[B: logical 1 -> physical 9]
     end
 
-    subgraph Physical GPU Memory (KV Cache)
-        P0[Physical Block 0]
-        P1[Physical Block 1 (Seq 2)]
-        P2[Physical Block 2 (Seq 1)]
-        P3[Physical Block 3]
-        P4[Physical Block 4]
-        P5[Physical Block 5 (Seq 1)]
-        P6[Physical Block 6]
-        P7[Physical Block 7]
-        P8[Physical Block 8 (Seq 1)]
-        P9[Physical Block 9 (Seq 2)]
+    subgraph Physical KV Cache
+        P1[Physical block 1]
+        P2[Physical block 2]
+        P5[Physical block 5]
+        P8[Physical block 8]
+        P9[Physical block 9]
     end
 
-    Seq1 --> BT1_0
-    Seq1 --> BT1_1
-    Seq1 --> BT1_2
-    
-    Seq2 --> BT2_0
-    Seq2 --> BT2_1
-
-    BT1_0 --> P5
-    BT1_1 --> P2
-    BT1_2 --> P8
-    
-    BT2_0 --> P1
-    BT2_1 --> P9
+    A --> A0 --> P5
+    A --> A1 --> P2
+    A --> A2 --> P8
+    B --> B0 --> P1
+    B --> B1 --> P9
 ```
 
-Because blocks are allocated on demand, PagedAttention virtually eliminates memory waste. This near-zero waste allows vLLM to cram significantly more sequences into a single batch. Since decode operations are memory-bound, a larger batch size directly translates to higher throughput (tokens per second) with only a marginal increase in latency per token. Furthermore, PagedAttention allows physical blocks to be shared across different sequences, which is highly beneficial for complex sampling methods like parallel decoding or beam search.
+Blocks are allocated on demand as sequences grow. If a request stops early, the engine releases only the blocks it actually used. If a request needs more output, the engine attaches another block. The only unavoidable internal waste is usually the unused portion of the final block for a sequence, which is much smaller than reserving the full maximum length up front. The result is higher effective KV-cache capacity and more room for concurrent decode work.
 
-## Continuous Batching (Iteration-Level Scheduling)
+PagedAttention also enables copy-on-write sharing. When two sequences share the same prefix, they can point to the same physical KV blocks for that prefix. If one sequence later diverges, the shared blocks remain read-only and the engine allocates new blocks for the divergent suffix. This matters for sampling, beam search, agent branches, and prompt templates where many requests begin with identical instructions. Sharing avoids recomputing and duplicating data that is logically the same.
 
-Static batching waits for all requests in a batch to complete before starting the next batch. If Request A finishes in 10 tokens, but Request B takes 500 tokens, the compute resources allocated for Request A sit idle for 490 iterations. 
+Continuous batching solves a different but complementary problem. Static batching groups requests together and waits for the whole batch to finish before admitting new work. That policy is easy to reason about, but it is poor for generated text because outputs have variable length. One user may finish in ten tokens while another needs hundreds. If the engine holds the batch open until the longest request finishes, the short request's slot remains idle for many decode iterations.
 
-[vLLM utilizes **Continuous Batching** (also known as in-flight batching or iteration-level scheduling)](https://github.com/vllm-project/vllm). The scheduler operates at the token iteration level. As soon as Request A emits its final token (e.g., `<EOS>`), it is immediately evicted from the batch. The scheduler then pulls a new request from the queue and inserts it into the active batch for the very next token generation step.
+Continuous batching, also called in-flight batching or iteration-level scheduling, treats each decode iteration as a scheduling opportunity. When a request emits an end token, hits a stop sequence, or reaches a token limit, the engine removes it from the active set. On the next iteration, the scheduler can admit a queued request into the batch. The active batch therefore changes over time, which keeps the GPU busy without forcing every request to have the same length.
 
-This means the batch size can be dynamically adjusted at each iteration, which usually keeps GPU utilization high. The inference engine is constantly churning, mixing prefill operations for new requests with decode operations for existing requests.
+The interesting scheduling problem is that new requests need prefill before they can join decode. A scheduler can prioritize prefill to reduce TTFT for queued users, but too much prefill work can interrupt smooth streaming for users already receiving tokens. A scheduler can prioritize decode to protect inter-token latency, but too much decode priority can leave new users waiting. Production tuning is a policy decision, not a single magic flag. You choose which latency you are willing to spend.
 
-### Implementing vLLM in Production
+Chunked prefill is one answer to that tension. Instead of processing a very long prompt as one monolithic prefill operation, the engine can split the prompt into smaller chunks and interleave those chunks with decode work. The long-context request may take longer to reach its first token, but active streaming users see fewer stalls. That is usually the right tradeoff for interactive products where visible pauses in generated text are more damaging than a slightly slower first token for a document-sized request.
 
-Deploying vLLM is straightforward due to its [OpenAI-compatible server](https://github.com/vllm-project/vllm). Here is an example of how a platform engineering team might deploy a Llama 4 model using vLLM in a Kubernetes environment.
+This memory/scheduling pair is the core reason engines such as vLLM produce better practical throughput than a basic transformer loop. PagedAttention increases how many useful sequences fit in memory. Continuous batching increases how often the GPU has useful work at each token step. Neither feature changes the mathematical cost of attention, but both reduce avoidable waste around the model. That is infrastructure engineering: keep the expensive accelerator doing work that users actually value.
+
+## Cache Reuse: Prefix Caching and RadixAttention
+
+Many LLM products repeat prompt material. A chat assistant may prepend the same system instructions to every request. A retrieval-augmented generation system may reuse a long policy block before adding user-specific context. An agent framework may branch into several candidate actions that share a conversation history. If the engine recomputes the shared prefix every time, it spends prefill compute on work whose result is already known.
+
+Automatic prefix caching stores KV blocks for prompt prefixes and reuses them when a later request begins with the same token sequence. In vLLM, this is commonly explained as a hash-based cache over blocks. When a new request arrives, the engine can detect that the initial blocks match cached blocks and attach those blocks to the request's block table. The request still needs prefill for the new suffix, but it can skip the shared prefix.
+
+The operational catch is that prefix caching requires exact token-level reuse. Two prompts that look similar to a human may not produce the same token sequence. A trailing space, a changed timestamp, reordered tool descriptions, or a per-user sentence inserted into the middle of the system prompt can break the cache hit. Platform teams often need prompt hygiene as much as engine configuration: keep stable instructions stable, place variable fields after stable prefixes, and avoid injecting request-specific noise near the beginning of the prompt.
+
+sglang's RadixAttention approaches the same class of problem through a different data structure. Instead of only reacting to block hashes, it organizes reusable KV-cache prefixes in a radix tree. Shared prompt segments become paths through the tree, and divergent suffixes branch at the point where prompts differ. This is particularly natural for programs that generate many related prompts, such as tree search, self-consistency sampling, multi-agent debate, or structured generation with repeated schemas.
+
+The durable distinction is "reactive hash reuse" versus "proactive prefix organization." Hash-based prefix caching is a powerful general optimization for identical prefixes, and it works well when a product sends the same system prompt repeatedly. A radix tree is more expressive for workloads with many branches that share long partial histories, because the cache structure mirrors the prompt program's branching shape. You should choose based on workload structure rather than assuming that one cache mechanism is universally superior.
+
+Structured output generation adds another reason to care about inference engines. Prompting a model to "return valid JSON" is not the same as constraining the decoder to produce tokens that obey a schema. Runtime-level guided decoding can mask invalid tokens according to a grammar, JSON schema, or finite-state machine. This reduces format errors and can reduce wasted retries, but it can also add CPU-side overhead if the constraint machinery is inefficient.
+
+sglang emphasizes programmable prompting and structured generation, while vLLM also supports guided decoding features through its OpenAI-compatible serving stack. The important production habit is to test the actual output contract under load. A schema-constrained endpoint may have different inter-token latency from an unconstrained endpoint, and a model that follows a JSON instruction in a notebook may still fail on edge cases when the prompt grows or the answer contains nested arrays.
+
+Cache reuse is one place where product design and infrastructure design meet directly. A product manager may ask for per-user personalization at the start of every prompt because it reads naturally. An inference engineer may move that personalization after a stable system prefix because it preserves cache hits. Neither person is wrong; they are optimizing different layers. High-quality platform work makes the tradeoff explicit and gives teams a prompt layout that preserves both behavior and serving efficiency.
+
+When debugging cache behavior, avoid relying only on subjective latency impressions. Measure first-run and second-run TTFT with identical prompts, inspect cache-related metrics when the engine exposes them, and vary only one part of the prompt at a time. If a supposed cache hit does not appear, compare tokenized prompts rather than raw strings. The engine caches tokens, not paragraphs, and the tokenizer is the authority on whether two prefixes are identical.
+
+## Parallelism, Quantization, and Disaggregated Serving
+
+Single-node inference often begins with one GPU, but real deployments quickly encounter models or concurrency targets that require multiple accelerators. Tensor parallelism splits individual matrix operations across GPUs, usually within the same node. Each GPU stores a shard of the model weights and participates in the same layer computation. This can make a model fit and can improve throughput, but every layer now requires communication across the interconnect.
+
+The interconnect matters because tensor parallelism is synchronization-heavy. NVLink and NVSwitch provide much higher bandwidth and lower latency between GPUs than ordinary PCIe topologies. A tensor-parallel configuration that behaves well on an eight-GPU server with fast GPU-to-GPU links may underperform on a cheaper machine where GPUs communicate mostly through PCIe. The model may technically fit, but the communication overhead can erase the benefit of splitting the work.
+
+Pipeline parallelism splits layers across devices. One GPU runs early layers, another runs later layers, and microbatches move through the pipeline. This is useful when the model is too large for one device and the topology favors a staged flow, but it introduces pipeline bubbles and can complicate scheduling for variable-length decode. Pipeline parallelism is common in training discussions, yet serving teams still need to evaluate whether the added scheduling complexity helps their specific inference workload.
+
+Data parallelism is simpler: run multiple independent replicas of the serving engine and route requests across them. Each replica holds the whole model or its own tensor-parallel group. This is often the cleanest scaling method when one replica already meets single-request latency needs. The tradeoff is memory duplication. If each replica loads the same large model weights, you spend more VRAM on copies, but you also reduce cross-GPU synchronization and gain failure isolation.
+
+Expert parallelism appears with mixture-of-experts models, where different tokens activate different expert networks. The serving challenge is routing tokens to the right experts while keeping communication and load balance under control. From an infrastructure perspective, MoE models are not simply dense models with more parameters. Active parameters, expert placement, router behavior, and all-to-all communication patterns all affect serving cost. Treat MoE deployment as its own architecture review, not a parameter-count comparison.
+
+Quantization attacks a different bottleneck: representation size. Serving with FP16 or BF16 weights is common because it preserves quality and hardware support is broad, but smaller formats can reduce memory footprint and bandwidth demand. INT8, FP8, AWQ, and GPTQ approaches make different choices about calibration, activation awareness, hardware kernels, and quality preservation. The practical question is not whether quantization is fashionable; it is whether the chosen format is supported by the engine, the GPU, and the model family with acceptable quality loss.
+
+Weight-only quantization can make a model fit into less memory, but it may not always speed up decode if kernels, cache format, or hardware support are weak. Activation or KV-cache quantization can reduce runtime memory movement, but it can be more sensitive to quality and implementation details. A benchmark that reports tokens per second without quality checks is incomplete. A benchmark that reports quality without latency and throughput is equally incomplete. Serving quantization is a three-way tradeoff among memory, speed, and answer quality.
+
+FP8 is attractive on modern accelerators that provide native support because it can reduce memory bandwidth and storage pressure while retaining a floating-point dynamic range. INT8 is mature and widely understood, but actual speedups depend on optimized kernels. AWQ and GPTQ are post-training quantization families that compress weights with calibration data or layer-wise error control. These techniques are useful serving tools, but they should be validated on representative prompts, not only on a single benchmark score.
+
+Disaggregated prefill/decode serving is a current architectural trend because the two phases want different resource shapes. Prefill benefits from compute-heavy parallel processing over long prompts. Decode benefits from memory bandwidth, KV-cache residency, and steady scheduling over many active sequences. A disaggregated architecture can send prompt processing to prefill workers and then transfer KV state to decode workers. That separation can improve utilization when prompt lengths and generation lengths vary widely.
+
+The cost of disaggregation is data movement and operational complexity. KV transfer is not free, and a design that moves too much state across slow links can lose the benefit it sought. Disaggregation also creates new failure modes: prefill and decode pools must be sized separately, routing must preserve request state, and observability must explain which phase is saturated. It is a powerful pattern for larger platforms, but it is usually premature for a learner workstation or a small single-node service.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> | Item | Snapshot value | Why it is quarantined here |
+> | :--- | :--- | :--- |
+> | vLLM release used in this module | `v0.22.1`, with lab image `vllm/vllm-openai:v0.22.1-ubuntu2404` | Container tags and CLI flags change between minor versions, so the lab pins a real tag instead of using `latest`. |
+> | Prefix caching flag | vLLM V1 documentation describes prefix caching as enabled by default when supported, but the lab still passes `--enable-prefix-caching` for explicitness. | Defaults are volatile, and an explicit flag makes the exercise easier to audit against a pinned version. |
+> | Speculative decoding syntax | Recent vLLM uses `--speculative-config '{"method":"draft_model","model":"...","num_speculative_tokens":5}'` rather than the older split flags. | Speculative-decoding CLI syntax has changed, so examples must be checked against the pinned docs. |
+> | Small lab model | `Qwen/Qwen2.5-1.5B-Instruct` | The model ID exists on Hugging Face and is small enough for a 16 GB class GPU in a learner lab. |
+> | Larger example target model | `Qwen/Qwen2.5-7B-Instruct`, optionally drafted by `Qwen/Qwen2.5-1.5B-Instruct` | These are real model IDs used only as examples; production choices depend on licenses, hardware, and quality tests. |
+> | sglang package snapshot | PyPI lists the current sglang package line separately from vLLM; verify the exact release before installing. | sglang server options and structured-output behavior evolve quickly, so this module teaches concepts before flags. |
+>
+> This snapshot is illustrative, not a leaderboard, endorsement, or promise that these versions remain current after 2026-06.
+
+The safest way to use a snapshot is to keep volatile details out of the durable explanation. The durable explanation says that prefill and decode have different bottlenecks, KV-cache memory needs careful allocation, cache reuse depends on prompt identity, tensor parallelism depends on interconnects, and quantization trades quality against memory and speed. The snapshot says which exact tag and model IDs were verified while this module was expanded. Future maintainers can update the snapshot without rewriting the underlying lesson.
+
+A good design review turns those ideas into constraints before anyone writes a manifest. Start with the largest prompt you plan to accept, the longest answer you plan to stream, the number of simultaneous users you need to tolerate, and the latency budget for each user class. Then choose the smallest model that satisfies quality, the memory format that preserves that quality, the number of GPUs needed for weights and cache, and the routing policy that protects important traffic. This order prevents a common failure: selecting a serving engine first and then discovering that the workload shape contradicts the chosen configuration.
+
+For a single-node service, the most useful design artifact is a capacity worksheet rather than a tool comparison table. List model weight memory, expected KV-cache memory per active request, maximum context length, target concurrent sequences, and memory reserved for framework overhead. Add the interconnect topology if tensor parallelism is required, because two GPUs connected through a slow path do not behave like two GPUs connected through NVLink. The worksheet will not predict every kernel-level detail, but it forces the team to make the hidden assumptions visible before launch traffic tests them.
+
+## Serving Operations: Metrics, Tuning, and Failure Modes
+
+Inference operations should begin with user-visible latency, not only accelerator counters. Time to first token measures how long a user waits before streaming begins. Inter-token latency measures the smoothness of the stream after it begins. Total request latency measures completion time. Throughput measures tokens or requests per second across the service. Goodput measures useful work that meets the service-level objective, which is often more important than raw maximum throughput.
+
+TTFT is usually sensitive to queueing and prefill. If TTFT rises while inter-token latency stays acceptable, the engine may be admitting too much work, prefill may be overloaded, or prefix caching may be missing. If TTFT is good but generated text stutters, decode scheduling or memory bandwidth may be the bottleneck. If both are bad, the service may be saturated at the request queue, the KV cache may be full, or the model may simply be too large for the target hardware.
+
+KV-cache utilization is a capacity signal rather than a vanity metric. A cache that is nearly full can still work for a short time, but it leaves little room for prompt length variation or sudden bursts. When cache pressure remains high, new requests queue, long requests are rejected, or the engine must evict reusable prefixes that would have improved TTFT. Watching cache utilization alongside request waiting time tells you whether the bottleneck is memory residency or scheduler policy.
+
+Throughput should be interpreted in context. A batch offline job can optimize for tokens per second because no human is watching the stream. A support chatbot should usually sacrifice some aggregate throughput to protect TTFT and smooth decode. An internal evaluation harness might want deterministic runs and stable concurrency more than raw speed. The same engine can serve all three patterns, but not with the same configuration and routing policy.
+
+The most common tuning mistake is changing one flag without designing the measurement. For example, increasing `--max-num-seqs` may improve throughput in an offline test and damage interactive latency in production. Lowering `--gpu-memory-utilization` may prevent out-of-memory failures but reduce concurrency. Enabling chunked prefill may smooth decode while increasing TTFT for long prompts. Every change should be paired with a hypothesis, a workload, and a metric that can disprove the hypothesis.
+
+Prometheus metrics make this work less mysterious. vLLM exposes an HTTP metrics endpoint, including request, latency, and cache-related metrics. The exact metric names can change as the project evolves, so dashboards should be reviewed when the engine is upgraded. Still, the categories are durable: queue state, running requests, waiting requests, prompt/generation token counts, KV-cache usage, TTFT, and per-token latency. A useful dashboard shows all of them together.
+
+Capacity planning should distinguish model memory from runtime memory. Model weights occupy a relatively fixed amount of VRAM once loaded. KV cache grows with active sequences and context length. Temporary activations, CUDA graphs, communication buffers, and framework overhead consume additional space. Setting a memory utilization flag to the absolute maximum leaves no room for these overheads, which can turn ordinary traffic variation into an out-of-memory incident.
+
+Routing strategy becomes important once you operate more than one replica. If prefix caching is valuable, randomly balancing every request across every replica can destroy cache locality. If some requests need long contexts and others need short chat responses, mixing them in one pool can make latency noisy. A better platform may route stable system-prompt traffic to a warm cache pool, batch jobs to a throughput pool, and long-document work to a pool with chunked prefill and larger context limits.
+
+Observability also helps separate model quality problems from serving problems. A user may report that the assistant is "slow and wrong." Slow might be queueing, prefill, decode, client rendering, or network buffering. Wrong might be a retrieval issue, a prompt issue, a quantization regression, or a model-selection issue. If the serving layer reports precise timing and cache behavior, the team can avoid blaming the model for infrastructure problems or blaming the scheduler for prompt-quality problems.
+
+The final operational habit is version discipline. Do not copy a command with `latest`, do not assume a model repository exists because its name sounds plausible, and do not keep old flags after an engine changes its CLI. Pin the container image, pin the model ID, record the docs you used, and upgrade deliberately. High-performance inference is moving quickly enough that stale examples are a real reliability risk.
+
+When a service degrades, write the incident question in the same language as the serving phases. "The model is slow" is too vague to guide action. "TTFT rose after the deploy while inter-token latency stayed flat" points toward queueing, prefill, model loading, or prefix-cache behavior. "Inter-token latency rose while TTFT stayed flat" points toward decode scheduling, memory bandwidth, cache pressure, or a noisy neighbor on the GPU. "Throughput rose but goodput fell" means the system is doing more work that violates the user-facing objective. This vocabulary is how platform engineers keep diagnosis from turning into random flag changes.
+
+The same vocabulary helps with load testing. A realistic test should mix short chat prompts, long-context prompts, and repeated-prefix prompts in proportions that resemble the product. It should run long enough for cache warmth, memory fragmentation, and queue behavior to appear. It should report percentiles, not only averages, because the slowest users often reveal scheduler problems first. If the service has separate pools for interactive and batch traffic, test the pools separately and together. A benchmark that cannot reproduce the expected contention pattern is a demonstration, not evidence.
+
+Here is a Kubernetes-oriented sketch that uses verified model IDs and a pinned vLLM image. It is intentionally small enough to read, not a complete production manifest with probes, autoscaling, authentication, or model download secrets.
 
 ```yaml
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vllm-llama-deployment
+  name: vllm-qwen-deployment
   labels:
-    app: vllm
+    app: vllm-qwen
 spec:
-  replicas: 2
+  replicas: 1
   selector:
     matchLabels:
-      app: vllm
+      app: vllm-qwen
   template:
     metadata:
       labels:
-        app: vllm
+        app: vllm-qwen
     spec:
       containers:
-      - name: vllm-server
-        image: vllm/vllm-openai:v0.6.0
-        command: ["python3", "-m", "vllm.entrypoints.openai.api_server"]
-        args:
-        - "--model"
-        - "meta-llama/Llama-4-70B-Instruct"
-        - "--tensor-parallel-size"
-        - "4" # Running across 4 GPUs
-        - "--gpu-memory-utilization"
-        - "0.90"
-        - "--max-model-len"
-        - "8192"
-        resources:
-          limits:
-            nvidia.com/gpu: "4"
-        ports:
-        - containerPort: 8000
+        - name: vllm-server
+          image: vllm/vllm-openai:v0.22.1-ubuntu2404
+          args:
+            - "--model"
+            - "Qwen/Qwen2.5-7B-Instruct"
+            - "--tensor-parallel-size"
+            - "2"
+            - "--gpu-memory-utilization"
+            - "0.90"
+            - "--max-model-len"
+            - "8192"
+            - "--enable-prefix-caching"
+          resources:
+            limits:
+              nvidia.com/gpu: "2"
+          ports:
+            - containerPort: 8000
 ```
 
-Notice the `--tensor-parallel-size` argument. For large models like a 70B parameter model, a single GPU does not have enough VRAM to hold the weights and the KV cache. [vLLM natively supports Megatron-LM style Tensor Parallelism](https://github.com/vllm-project/vllm/blob/main/docs/serving/parallelism_scaling.md), splitting the model's matrices across multiple GPUs on the same node, allowing them to compute attention and feed-forward layers synchronously. The `--max-model-len 8192` flag bounds the maximum context window, limiting the KV cache memory pre-allocated per sequence and preventing out-of-memory errors on massive prompts.
+The speculative decoding syntax below is deliberately shown as a pinned-version example, not a universal incantation. It uses a larger Qwen model as the target and a smaller Qwen model as the draft. The exact speedup depends on how often the draft model predicts tokens that the target model accepts, the overhead of running the draft, the hardware, and the workload.
 
-## Advanced Optimizations: Prefix Caching and Chunked Prefill
-
-As inference engines matured, engineers realized that PagedAttention was just the foundation. New bottlenecks emerged, specifically around long system prompts and massive context windows.
-
-### Automatic Prefix Caching (APC)
-
-In many applications (like chat interfaces or agents), users send the exact same massive system prompt over and over again. Computing the KV cache for a 4,000-token system prompt takes significant compute time for every single request. 
-
-Prefix caching allows vLLM to hash the blocks of the prompt. If a new request shares the exact same prefix as a previously processed request (which is still in memory), vLLM simply points the new request's block table to the existing physical blocks in the KV cache. This bypasses the prefill compute phase entirely for that portion of the prompt, drastically reducing Time to First Token (TTFT).
-
-```mermaid
-graph LR
-    subgraph Request 1
-        P1[System Prompt] --> U1[User Query A]
-    end
-    
-    subgraph Request 2
-        P2[System Prompt] --> U2[User Query B]
-    end
-    
-    subgraph GPU KV Cache
-        CacheSys[Cached System Prompt Blocks]
-        CacheA[User Query A Blocks]
-        CacheB[User Query B Blocks]
-    end
-    
-    P1 -.-> |Prefilled & Cached| CacheSys
-    U1 -.-> CacheA
-    
-    P2 ===> |Cache Hit! No Compute| CacheSys
-    U2 -.-> CacheB
-```
-
-### Chunked Prefill
-
-When an engine mixes continuous batching with new requests, a massive new request (e.g., 32k tokens) can cause a severe latency spike for all other requests currently in the decode phase. The GPU must pause decoding to compute the massive prefill, causing a stutter in the generated output for active users.
-
-Chunked prefill solves this by breaking the prefill phase into smaller chunks. Instead of prefilling 32k tokens at once, the engine might prefill 1,024 tokens alongside the decode operations of the active batch, then prefill the next 1,024 tokens on the next iteration. This smooths out latency and prevents long prompts from starving active decoding sessions. It can typically be enabled in vLLM by passing `--enable-chunked-prefill`.
-
-> **Pause and predict**: Imagine your team just deployed a 100k-context documentation Q&A bot. During peak hours, simple "hello" messages take 5 seconds to generate their first token whenever someone else uploads a massive PDF. Based on the chunked prefill mechanism, how would enabling this feature change the experience for both the PDF uploader and the users saying "hello"?
-
-### Speculative Decoding
-
-Speculative decoding uses a smaller, faster "draft" model to guess the next several tokens, and then uses the larger "target" model to verify those tokens in a single parallel step. If the draft model's guesses are correct, multiple tokens are generated in the time it usually takes to generate one.
-
-To implement speculative decoding in vLLM, you specify the draft model using the `--speculative-model` flag. For example, when serving a large model, you might use a smaller model from the same family as the draft. The `--num-speculative-tokens` flag dictates how many tokens the draft model guesses per step, with a value like 5 balancing the overhead of running the draft model against potential speedups:
 ```bash
-python3 -m vllm.entrypoints.openai.api_server \
-  --model meta-llama/Llama-4-70B-Instruct \
-  --speculative-model meta-llama/Llama-4-8B-Instruct \
-  --num-speculative-tokens 5
+vllm serve Qwen/Qwen2.5-7B-Instruct \
+  --speculative-config '{"method":"draft_model","model":"Qwen/Qwen2.5-1.5B-Instruct","num_speculative_tokens":5}' \
+  --gpu-memory-utilization 0.90
 ```
-
-## sglang: RadixAttention and Structured Generation
-
-While vLLM pioneered PagedAttention, **sglang** (developed by researchers at LMSYS/Berkeley) introduced **RadixAttention**. sglang is built for complex prompting workflows: agentic loops, few-shot prompting, and heavily structured JSON generation.
-
-In vLLM, prefix caching is a reactive optimization based on block hashing. [RadixAttention in sglang maintains the KV cache as a Radix Tree. This means it proactively manages prefixes across all active and recently finished requests.](https://arxiv.org/abs/2312.07104) It is significantly more efficient at sharing KV caches for highly complex, branching prompt structures (e.g., Tree of Thoughts, or multiple agents sharing a context).
-
-Furthermore, [sglang excels at constrained decoding (e.g., forcing the LLM to output valid JSON matching a specific schema)](https://github.com/sgl-project/sglang). Traditional engines process the output token by token, running a regex or grammar parser on CPU to mask out invalid tokens at every step, causing massive overhead. sglang utilizes a compressed finite state machine (FSM) compiled in advance, allowing it to jump ahead. For structured outputs, sglang can reduce decoding overhead by compiling constraints ahead of time instead of relying on prompt wording alone.
-
-### Throughput vs. Latency Tradeoffs
-
-When deploying these systems, platform engineers must tune parameters based on the product requirements. There is a fundamental tradeoff between throughput (tokens per second across all users) and latency (Time to First Token and Inter-Token Latency for a single user).
-
-| Metric | Goal | Configuration Action | Tradeoff |
-| :--- | :--- | :--- | :--- |
-| **Max Throughput** (e.g., Batch offline data processing) | Process highest volume of data per hour. | Increase maximum batch size (`--max-num-seqs`). Allocate maximum VRAM to KV Cache. | Increases TTFT and Inter-Token Latency. Individual requests take longer, but total volume is higher. |
-| **Lowest TTFT** (e.g., Chatbot responsiveness) | Start generating text as quickly as possible. | Prioritize prefill operations. Reduce maximum batch size. | Lowers overall system throughput. Hardware is underutilized. |
-| **Smooth Decoding** (e.g., Reading streaming text) | Prevent stutters during generation. | Enable Chunked Prefill. Set strict latency SLAs in the scheduler. | Slightly delays TTFT for long-context requests to protect decoding requests. |
 
 ## Did You Know?
 
-*   Before PagedAttention, memory fragmentation in LLM inference could lead to up to **80%** of GPU memory being allocated but completely unusable.
-*   By implementing continuous batching and PagedAttention, vLLM achieved up to **24x** higher throughput compared to Hugging Face Transformers upon its initial release.
-*   The Radix Tree structure used in sglang's RadixAttention allows for [exact prefix matching in **O(L)** time](https://en.wikipedia.org/wiki/Radix_tree), where L is the length of the sequence, making it highly efficient for branching agentic workflows.
-*   Speculative decoding, an advanced feature in modern engines, uses a tiny "draft" model to predict tokens and a large "target" model to verify them, [sometimes increasing generation speed by **2.5x** without modifying the target model's weights](https://arxiv.org/abs/2302.01318).
+- > **PagedAttention memory waste was a measured systems problem, not a slogan.** The 2023 paper reported that conventional KV-cache allocation could waste up to 60-80% of memory in evaluated serving settings, which is why block-based allocation mattered.
+- > **vLLM's 24x throughput claim belongs to its 2023 initial-release context.** The project reported up to 24x higher throughput than Hugging Face Transformers in launch benchmarks, but modern comparisons must be rerun against current versions.
+- > **RadixAttention borrows the radix-tree idea for prompt programs.** Matching work grows with the relevant prefix path, which is useful when many requests branch from shared prompt histories rather than arriving as unrelated strings.
+- > **Speculative decoding speedups are workload-dependent.** The 2023 speculative sampling paper reported around 2x-3x generation acceleration in studied settings, but acceptance rate and draft-model overhead decide whether a deployment benefits.
 
 ## Common Mistakes
 
-| Mistake | Why it happens | How to fix it |
+| Mistake | Why it happens | How to fix |
 | :--- | :--- | :--- |
-| **Running out of VRAM (OOM) at startup.** | Setting `--gpu-memory-utilization` to 1.0. The engine needs a small amount of memory for PyTorch context and activations outside the KV cache. | Set `--gpu-memory-utilization 0.90` (or lower if running other processes). |
-| **Low throughput with small batch sizes.** | Misunderstanding memory bounds. Using small batch sizes leaves SMs idle during the decode phase. | Increase concurrency testing. Allow the engine to scale the batch size dynamically up to the memory limit. |
-| **Ignoring Tensor Parallelism.** | Attempting to load a model larger than a single GPU's VRAM using standard Hugging Face device maps, resulting in slow interconnect overhead. | Use native `--tensor-parallel-size N` to leverage high-speed NVLink for synchronous matrix splitting. |
-| **Not using Prefix Caching for Chatbots.** | Forgetting to enable automatic prefix caching when a massive system prompt is prepended to every single user query. | Enable `--enable-prefix-caching`. Ensure the system prompt is completely identical across requests. |
-| **Spikes in inter-token latency.** | Large prefill requests are blocking the decode operations of active batch requests. | Enable Chunked Prefill to distribute the prefill compute across multiple iterations. |
-| **Using generic inference for strict JSON.** | Forcing JSON via prompts alone, leading to high token usage and occasional formatting errors. | Use engines like sglang or vLLM's guided decoding with JSON schema constraints to enforce structure at the logits level. |
-| **Failing to monitor KV Cache usage.** | Treating the inference engine as a black box. If the KV cache is consistently 100% full, requests will start queueing and latency will keep rising until capacity is added or demand drops. | Monitor Prometheus metrics exported by vLLM (for example, KV-cache usage) and scale out before sustained cache saturation starts causing queueing. |
+| Treating decode as a compute-bound workload | GPU dashboards show idle arithmetic units, so the team assumes kernels are inefficient rather than recognizing memory-bandwidth pressure. | Separate prefill and decode metrics, then tune batch size, cache capacity, and prompt length before changing hardware. |
+| Copying stale vLLM flags | Blog posts and examples survive longer than the CLI syntax they describe, especially for speculative decoding and cache defaults. | Pin the vLLM version, read the matching docs, and quarantine volatile flags in a dated snapshot. |
+| Using invented model IDs | Model names sound regular, so teams guess repository names that do not exist or are gated differently than expected. | Verify model IDs on Hugging Face or the vendor registry before writing manifests, tests, or curriculum examples. |
+| Maximizing `--gpu-memory-utilization` | The setting looks like a simple way to increase capacity, but frameworks need memory for activations, graphs, communication, and overhead. | Leave headroom, test with realistic prompt lengths, and watch cache usage plus out-of-memory behavior under burst traffic. |
+| Breaking prefix-cache hits with prompt personalization | Teams insert timestamps, user names, or dynamic tool lists before stable system instructions, changing the token prefix every request. | Keep stable prompt material first, move variable fields after the shared prefix, and compare tokenized prompts when debugging cache misses. |
+| Routing cache-sensitive traffic randomly | A load balancer distributes related requests across replicas, so each engine sees fewer repeated prefixes and cache warmth disappears. | Route by workload, tenant, or prompt family when cache locality matters, and monitor TTFT before and after routing changes. |
+| Measuring only raw tokens per second | Offline throughput improves while interactive users see worse TTFT or uneven streaming, creating a misleading success metric. | Track goodput against SLOs, TTFT, inter-token latency, queue depth, and KV-cache utilization together. |
 
-## Quiz
+## Knowledge Check
 
 <details>
-<summary>1. A machine learning team reports that their newly deployed inference server is only utilizing 20% of the GPU compute capacity, yet it cannot accept any more concurrent requests. What is the most likely architectural bottleneck?</summary>
-The system is memory-bound due to the KV cache filling up. Because the decode phase has low arithmetic intensity, the compute units (SMs) sit idle while waiting for KV cache data to be transferred from memory. The system cannot accept more requests because there is no physical memory left to allocate for new KV cache blocks, even though the compute units have spare cycles.
+<summary>1. Diagnose this LLM serving workload: it may be compute-bound, memory-bandwidth-bound, or queue-bound, and the service has low GPU compute utilization, high request waiting time, and high KV-cache utilization during long conversations. What bottleneck should you investigate first?</summary>
+Investigate KV-cache capacity and decode memory bandwidth before assuming the GPU arithmetic units are too slow. Long conversations consume cache blocks, and decode must repeatedly read that history. If the cache is full, new requests queue even when compute utilization appears low. A useful next step is to inspect cache metrics, active sequence counts, context lengths, and waiting-request metrics together.
 </details>
 
 <details>
-<summary>2. You are tasked with deploying a customer support chatbot. The system prompt is 2,500 tokens, and user queries average 50 tokens. Which vLLM feature is absolutely critical to minimize Time to First Token (TTFT)?</summary>
-Automatic Prefix Caching (APC) is critical. Because every request shares the exact same 2,500-token system prompt, APC allows vLLM to compute the KV cache for the system prompt once. Subsequent requests will hit the cache, completely bypassing the heavy prefill compute phase for those 2,500 tokens, drastically reducing TTFT.
+<summary>2. A team increases maximum batch size and sees better overnight summarization throughput, but live chat users report slower first tokens. What tradeoff did the team expose?</summary>
+The team optimized aggregate throughput at the expense of interactive latency. Larger active batches can improve memory-bound decode efficiency, but they can also increase queueing and delay prefill for new chat requests. The correct response is usually workload separation or policy tuning, such as a throughput pool for offline jobs and a latency pool for live chat.
 </details>
 
 <details>
-<summary>3. Your infrastructure team is replacing a legacy Hugging Face Transformers deployment with vLLM on the same A100 GPU cluster. Previously, the system could only handle a batch size of 8 before crashing with Out of Memory (OOM) errors, despite metrics showing only 40% actual memory utilization. Why will migrating to vLLM's PagedAttention architecture immediately allow you to increase this batch size without adding more hardware?</summary>
-The legacy system was severely limited by internal and external memory fragmentation caused by contiguous memory allocation. Because it had to pre-allocate maximum potential sequence lengths in contiguous blocks, 60% of the GPU's memory was reserved but unused, leading to OOM errors at small batch sizes. PagedAttention solves this by treating the KV cache like virtual memory, allocating fixed-size, non-contiguous blocks only as tokens are generated. This dynamic allocation virtually eliminates memory waste, freeing up the "trapped" 60% of VRAM so the scheduler can pack significantly more concurrent requests into the batch, thereby maximizing throughput on the exact same hardware.
+<summary>3. Two prompts share the same system instructions, but prefix caching does not appear to reduce TTFT. What should you check before blaming the engine?</summary>
+Check whether the token prefixes are actually identical. Formatting differences, timestamps, user-specific text, reordered tools, or hidden whitespace can change the token sequence. Prefix caching works on token identity, not semantic similarity. Move variable content after the stable prefix and compare tokenized prompts if the behavior remains unclear.
 </details>
 
 <details>
-<summary>4. During a high-traffic event, active users complain that the chatbot's text generation stutters and pauses mid-sentence. You notice that these pauses correlate with other users submitting massive 20k-token documents for summarization. How do you architect a solution?</summary>
-You must implement Chunked Prefill. Currently, the massive prefill operations are monopolizing the GPU compute, starving the decode operations of the active batch. Chunked prefill will break the 20k-token prefill into smaller segments, interleaving them with the decode steps of active users, thereby smoothing out the inter-token latency and eliminating the stutters.
+<summary>4. Why can PagedAttention increase throughput without changing the model's mathematical outputs?</summary>
+PagedAttention changes memory management, not model semantics. It stores KV cache in fixed-size physical blocks and maps logical sequence positions through block tables. That reduces internal and external fragmentation, allowing more concurrent sequences to fit in GPU memory. More useful concurrent decode work can improve throughput while the attention computation still produces the same kind of outputs.
 </details>
 
 <details>
-<summary>5. You are building an agentic workflow that utilizes Tree of Thoughts prompting. The prompt branches into multiple parallel generation paths that share a large, complex history. Would you prioritize deploying vLLM or sglang, and why?</summary>
-You would prioritize sglang. Its RadixAttention mechanism uses a Radix Tree to proactively manage and share KV caches across complex, branching prompt structures. It is significantly more efficient than vLLM's hash-based prefix caching for workflows where multiple generation paths share heavily overlapping, structured contexts.
+<summary>5. When would sglang's RadixAttention be especially attractive compared with ordinary identical-prefix caching?</summary>
+It is attractive when the workload contains many related prompt branches that share long partial histories, such as agent search, tree-of-thought exploration, self-consistency sampling, or structured prompt programs. A radix tree can organize shared prefixes and divergent suffixes in a way that mirrors the program structure. For simple repeated system prompts, hash-based prefix caching may already be sufficient.
 </details>
 
 <details>
-<summary>6. A data engineering team is using your vLLM cluster overnight to summarize 50,000 historical customer support tickets, while a small team of night-shift agents uses the same cluster for live chat assistance. The data engineers complain that their job takes too long, but when you increase the `--max-num-seqs` parameter to process more tickets simultaneously, the night-shift agents report the chat interface has become unusable. What fundamental tradeoff is causing this conflict, and how does the batch size configuration directly impact both workloads?</summary>
-This conflict illustrates the fundamental architectural tension between optimizing for total throughput versus individual request latency. By increasing the maximum sequence limit, you are allowing the scheduler to pack a massive number of offline batch requests into the GPU simultaneously. While this dramatically increases the total tokens processed per second (throughput) by keeping the GPU's compute units highly saturated, it usually forces most requests—including the live chat queries—to wait longer in the queue and during the decode phase for their turn to compute. To serve the interactive UI effectively, you must artificially restrict the batch size, which ensures low Time to First Token (TTFT) and smooth generation for the agents, but forces the data engineers to process fewer tickets concurrently.
+<summary>6. A quantized model fits on a smaller GPU but produces subtle answer regressions in domain-specific prompts. What was missing from the validation plan?</summary>
+The plan validated memory fit without validating answer quality on representative prompts. Serving quantization must be evaluated across memory footprint, latency/throughput, and task quality. The team should compare outputs against an unquantized baseline, include domain-specific tests, and verify that the chosen quantization format has optimized kernels on the target hardware.
 </details>
 
-## Hands-On Exercise: Deploying and Profiling vLLM
+<details>
+<summary>7. Design a single-node inference service with a realistic model ID, pinned container tag, tensor parallelism only when needed, cache sizing, and Prometheus metrics. Why might disaggregating prefill and decode help a large platform but be premature for this learner workstation design?</summary>
+Disaggregation can match compute-heavy prefill and memory-bandwidth-heavy decode to different worker pools, which helps at scale when prompt lengths and generation lengths vary widely. It also requires KV transfer, routing, separate pool sizing, and more observability. A learner workstation usually benefits more from understanding single-node scheduling, cache behavior, and metrics before adding distributed state movement.
+</details>
 
-In this exercise, you will deploy a local vLLM instance, send concurrent requests, and profile the impact of continuous batching and prefix caching.
+## Hands-On Exercise
 
-**Prerequisites:** A Linux environment with Docker, an NVIDIA GPU (at least 16GB VRAM, e.g., T4, RTX 4080, or A10g), and the NVIDIA Container Toolkit installed.
+In this exercise, you will launch a local vLLM OpenAI-compatible server, send concurrent requests that share a long system prompt, and inspect metrics that reveal cache pressure. The lab uses `Qwen/Qwen2.5-1.5B-Instruct` because the model ID is real and the model is small enough for a 16 GB class GPU in many learner environments. If your GPU has less memory, use the same measurement structure with a smaller model that your hardware can load.
+
+The exercise is not a benchmark contest. Its purpose is to make the serving mechanics visible. You will run the same prompt pattern twice, observe how repeated stable prefixes affect latency, and inspect the Prometheus endpoint for KV-cache utilization. The absolute numbers will depend on your GPU, driver, container runtime, and network path. The shape of the measurement is the lesson.
+
+Before you run the commands, state your expectation in writing. The first run should include more cold-path work because the process has just loaded the model and has not yet reused the stable system prompt. The second run may show lower average latency if the shared prefix remains cached and the GPU has enough memory to keep those blocks resident. If the second run is not faster, that is still a useful result: it tells you to check cache pressure, prompt identity, warmup behavior, and whether the workload is large enough for the optimization to matter.
+
+After the lab, resist the urge to generalize from one number. A single 20-request test can demonstrate the mechanics, but it cannot certify a production service. Repeat the test with different concurrency levels, different prompt lengths, and a version of the prompt that deliberately changes the first sentence on every request. That comparison shows why stable prefixes, cache capacity, and scheduler policy are part of the same design problem. The goal is not to memorize the exact latency on your GPU; the goal is to recognize which knob explains which symptom.
+
+**Prerequisites:** Linux, Docker, an NVIDIA GPU with the NVIDIA Container Toolkit, enough disk space for the model cache, and a shell where Docker can access the GPU. If your environment requires Hugging Face authentication for other models, authenticate outside this lab; the Qwen model used here does not require inventing a private model name.
 
 **Task 1: Launch the vLLM Server**
-Start a vLLM server using Docker, hosting a small instruction-tuned model (e.g., Qwen 2.5 1.5B). Enable prefix caching.
 
-Note: The `--ipc=host` flag is required to give the container access to the host's shared memory, which PyTorch requires for efficient inter-process communication.
+Start a pinned vLLM container and expose the OpenAI-compatible API on port 8000. The `--ipc=host` flag gives the container access to host shared memory, which avoids avoidable PyTorch multiprocessing problems in many Docker setups.
 
 <details>
 <summary>Solution</summary>
@@ -303,95 +334,134 @@ docker run --gpus all \
   -v ~/.cache/huggingface:/root/.cache/huggingface \
   -p 8000:8000 \
   --ipc=host \
-  vllm/vllm-openai:v0.6.0 \
+  vllm/vllm-openai:v0.22.1-ubuntu2404 \
   --model Qwen/Qwen2.5-1.5B-Instruct \
   --enable-prefix-caching \
-  --gpu-memory-utilization 0.8
+  --max-model-len 4096 \
+  --gpu-memory-utilization 0.80
 ```
-*Wait for the server to report `Uvicorn running on http://0.0.0.0:8000`. In a separate terminal, verify the server is ready by running: `curl -s http://localhost:8000/v1/models | grep Qwen`.*
+
+Wait for the server to report that the application is running, then verify the model endpoint from a second terminal.
+
+```bash
+curl -s http://127.0.0.1:8000/v1/models | grep Qwen
+```
 </details>
 
-**Task 2: Write a Load Testing Script**
-Write a Python script using `asyncio` and `aiohttp` to send 20 concurrent requests to the server. All requests should use an identical long system prompt (simulate this with a large paragraph of text) and a unique short user query. First, ensure you have the required Python HTTP library installed, then create the load testing script.
+**Task 2: Create a Concurrent Client**
+
+Create a small `asyncio` client that sends repeated requests with an identical long system prompt and unique short user messages. This shape is intentionally cache-friendly so the second run can show the effect of stable prefixes more clearly.
 
 <details>
 <summary>Solution</summary>
 
-**Note:** Open a new terminal session to run the client commands, as the vLLM server is running in the foreground in your first terminal.
-
 ```bash
-pip install aiohttp
-cat << 'EOF' > load_test.py
+.venv/bin/python -m pip install aiohttp
+cat << 'PY' > load_test.py
 import asyncio
-import aiohttp
 import time
 
-SYSTEM_PROMPT = "You are a highly detailed technical assistant. " * 200 # Simulate long prompt
-URL = "http://localhost:8000/v1/chat/completions"
+import aiohttp
 
-async def fetch(session, index):
+
+SYSTEM_PROMPT = "You are a precise technical assistant for infrastructure teams. " * 120
+URL = "http://127.0.0.1:8000/v1/chat/completions"
+MODEL = "Qwen/Qwen2.5-1.5B-Instruct"
+
+
+async def fetch(session: aiohttp.ClientSession, index: int) -> float:
     payload = {
-        "model": "Qwen/Qwen2.5-1.5B-Instruct",
+        "model": MODEL,
         "messages": [
             {"role": "system", "content": SYSTEM_PROMPT},
-            {"role": "user", "content": f"Briefly explain concept number {index} in physics."}
+            {
+                "role": "user",
+                "content": f"Explain one practical inference-serving lesson for scenario {index}.",
+            },
         ],
-        "max_tokens": 50
+        "max_tokens": 60,
+        "temperature": 0.2,
     }
-    start_time = time.time()
-    async with session.post(URL, json=payload) as response:
+    start = time.perf_counter()
+    async with session.post(URL, json=payload, timeout=120) as response:
+        response.raise_for_status()
         await response.json()
-        end_time = time.time()
-        return end_time - start_time
+    return time.perf_counter() - start
 
-async def main():
+
+async def main() -> None:
     async with aiohttp.ClientSession() as session:
-        tasks = [fetch(session, i) for i in range(20)]
-        results = await asyncio.gather(*tasks)
-        print(f"Average latency: {sum(results)/len(results):.2f} seconds")
-        print(f"Max latency: {max(results):.2f} seconds")
+        durations = await asyncio.gather(*(fetch(session, i) for i in range(20)))
+    print(f"Average latency: {sum(durations) / len(durations):.2f} seconds")
+    print(f"Maximum latency: {max(durations):.2f} seconds")
+    print(f"Minimum latency: {min(durations):.2f} seconds")
+
 
 if __name__ == "__main__":
     asyncio.run(main())
-EOF
+PY
 ```
 </details>
 
-**Task 3: Analyze Prefix Caching**
-Run your script twice in a row. Observe the latency differences between the first run and the second run.
+**Task 3: Run the Client Twice**
 
-<details>
-<summary>Solution</summary>
-
-Run the script: `python load_test.py`. 
-During the first run, the first request will trigger a massive prefill computation for the simulated long system prompt. Subsequent requests in that batch, and definitely in the second run, will experience drastically lower latency. The second run will be significantly faster overall because the KV cache for the `SYSTEM_PROMPT` is fully populated and shared across all 20 concurrent requests via PagedAttention and Prefix Caching.
-</details>
-
-**Task 4: Query Prometheus Metrics**
-vLLM exposes metrics automatically. Use `curl` to fetch the metrics and grep for KV cache utilization.
+Run the client twice without restarting the server. The first run warms the model path and shared prompt cache. The second run should often show lower latency when the stable prefix remains cached, although exact results depend on cache capacity and other activity on the GPU.
 
 <details>
 <summary>Solution</summary>
 
 ```bash
-curl -s http://localhost:8000/metrics | grep vllm:gpu_cache_usage_perc
+.venv/bin/python load_test.py
+.venv/bin/python load_test.py
 ```
-*Output should look similar to `vllm:gpu_cache_usage_perc{model_name="..."} 0.15`. This indicates 15% of the allocated KV cache blocks are currently in use.*
+
+Compare the averages and maximums **across the two runs** — that cross-run delta is the prefix-cache signal, because within a single run concurrency and continuous batching also affect latency and can mask the cache effect. For a cleaner isolation, send one *sequential* identical request before and after warming the cache and compare just those two timings, then scale up to the concurrent load test. If the second run is not faster, inspect whether the server stayed up, whether memory pressure evicted cached blocks, and whether the prompt was exactly identical between runs.
+</details>
+
+**Task 4: Inspect Prometheus Metrics**
+
+Fetch the metrics endpoint and look for cache usage. Metric names can evolve between vLLM versions, so start with a broad grep and then narrow the dashboard to the names exposed by your pinned image.
+
+<details>
+<summary>Solution</summary>
+
+```bash
+curl -s http://127.0.0.1:8000/metrics | grep -E 'vllm:.*cache|vllm:.*request|vllm:.*time'
+```
+
+For the pinned image, look for metrics that describe GPU cache usage, running requests, waiting requests, and latency buckets. If no metrics appear, verify that you queried the same port as the server and that the container is still running.
 </details>
 
 **Success Checklist:**
-- [ ] vLLM container started successfully without Out of Memory errors.
-- [ ] Load testing script executed 20 concurrent connections.
-- [ ] Observed latency reduction demonstrating prefix cache hits.
-- [ ] Successfully queried and interpreted the `gpu_cache_usage_perc` Prometheus metric.
+
+- [ ] The pinned vLLM container starts and serves `Qwen/Qwen2.5-1.5B-Instruct` without an out-of-memory error.
+- [ ] You can design a single-node inference service from the pinned container tag, verified model ID, GPU count, cache budget, and metrics endpoint.
+- [ ] The `/v1/models` endpoint returns the expected Qwen model ID from `127.0.0.1:8000`.
+- [ ] The concurrent client sends 20 requests and prints average, maximum, and minimum latency.
+- [ ] Two consecutive runs produce measurements you can explain using prefix reuse, cache pressure, or workload variation.
+- [ ] The `/metrics` endpoint exposes request or cache metrics that you can connect to TTFT, throughput, or KV-cache utilization.
 
 ## Next Module
 
-Now that you understand how to maximize single-node throughput using vLLM and sglang, the next challenge is managing state and routing across a distributed cluster of these engines. In the next module, **Module 6.4: Multi-Node Inference and Semantic Routing**, we will explore how to use tools like Ray Serve and Lorax to route incoming requests to specific GPUs based on cached prefixes and LoRA adapter states, ensuring high availability and optimal cluster-wide utilization.
+Single-node engines are easiest to understand when you can see the scheduler, cache, and metrics in one place. The next step is to choose a learner-scale local stack that lets you practice those ideas without overbuilding a production platform. Continue with [Module 1.4: Local Inference Stack for Learners](../module-1.4-local-inference-stack-for-learners/).
 
 ## Sources
 
-- [Efficient Memory Management for Large Language Model Serving with PagedAttention](https://arxiv.org/abs/2309.06180) — Primary paper for PagedAttention, KV-cache waste, and the original vLLM throughput claims.
-- [Efficiently Programming Large Language Models using SGLang](https://arxiv.org/abs/2312.07104) — Primary paper for RadixAttention, SGLang's runtime model, and structured-generation acceleration.
-- [vLLM Parallelism and Scaling](https://github.com/vllm-project/vllm/blob/main/docs/serving/parallelism_scaling.md) — Official repo documentation for tensor parallelism and practical multi-GPU deployment choices.
-- [Accelerating Large Language Model Decoding with Speculative Sampling](https://arxiv.org/abs/2302.01318) — Primary source for the draft-and-verify decoding pattern and its reported speedups.
+- [vLLM PyPI release history](https://pypi.org/project/vllm/) — verifies the current vLLM package line and why the module pins a dated release snapshot.
+- [vLLM Docker deployment documentation](https://docs.vllm.ai/en/v0.22.1/deployment/docker/) — official deployment reference for the `vllm/vllm-openai` image family and Docker serving pattern.
+- [vLLM serve CLI documentation](https://docs.vllm.ai/en/v0.22.1/cli/serve/) — official CLI reference for pinned serve flags, including memory, prefix caching, and speculative configuration.
+- [vLLM automatic prefix caching documentation](https://docs.vllm.ai/en/stable/features/automatic_prefix_caching/) — official explanation of prefix-cache behavior and current default guidance.
+- [vLLM metrics documentation](https://docs.vllm.ai/en/stable/design/metrics/) — official reference for Prometheus metrics used to monitor request, latency, and KV-cache behavior.
+- [vLLM launch blog: Easy, Fast, and Cheap LLM Serving with PagedAttention](https://vllm.ai/blog/2023-06-20-vllm) — source for the dated 2023 initial-release throughput comparison against Hugging Face Transformers.
+- [Efficient Memory Management for Large Language Model Serving with PagedAttention](https://arxiv.org/abs/2309.06180) — primary paper for PagedAttention, block tables, KV-cache fragmentation, and cache sharing.
+- [Orca: A Distributed Serving System for Transformer-Based Generative Models](https://www.usenix.org/conference/osdi22/presentation/yu) — primary systems paper for iteration-level scheduling and continuous batching concepts.
+- [Efficiently Programming Large Language Models using SGLang](https://arxiv.org/abs/2312.07104) — primary paper for sglang, RadixAttention, and structured prompting runtime concepts.
+- [SGLang project repository](https://github.com/sgl-project/sglang) — upstream project reference for sglang runtime, serving, and structured-generation capabilities.
+- [Qwen/Qwen2.5-1.5B-Instruct model card](https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct) — verifies the small Hugging Face model ID used in the hands-on lab.
+- [Qwen/Qwen2.5-7B-Instruct model card](https://huggingface.co/Qwen/Qwen2.5-7B-Instruct) — verifies the larger example target model ID used in the speculative-decoding example.
+- [vLLM quantization documentation](https://docs.vllm.ai/en/stable/features/quantization/) — official reference for serving quantization options such as FP8, INT8, AWQ, and GPTQ support.
+- [AWQ: Activation-aware Weight Quantization for LLM Compression and Acceleration](https://arxiv.org/abs/2306.00978) — primary quantization reference for activation-aware weight compression tradeoffs.
+- [GPTQ: Accurate Post-Training Quantization for Generative Pre-trained Transformers](https://arxiv.org/abs/2210.17323) — primary quantization reference for layer-wise post-training compression.
+- [Accelerating Large Language Model Decoding with Speculative Sampling](https://arxiv.org/abs/2302.01318) — primary paper for draft-and-verify speculative decoding and its reported speedups.
+- [DistServe: Disaggregating Prefill and Decoding for Goodput-optimized Large Language Model Serving](https://arxiv.org/abs/2401.09670) — research source for disaggregated prefill/decode serving and goodput-oriented scheduling.
+- [Splitwise: Efficient Generative LLM Inference Using Phase Splitting](https://arxiv.org/abs/2311.18677) — research source for separating inference phases across hardware to improve serving efficiency.


### PR DESCRIPTION
## Summary

`ai-ml-engineering/ai-infrastructure` `shipped_unreviewed` drain (campaign **#1842**) — the 3 thin modules (all genuine T3, ~1,700 prose words) expanded to **T0** (5,000-word floor), de-fabricated, durable-content-snapshotted, and cross-family reviewed.

| Module | Before | After | Key work |
|---|---|---|---|
| **1.1 Cloud AI Services** | T3 1,734w | T0 5,006w | De-dup the duplicated AIOps tutorial vs 1.2 (cross-ref instead); durable **Landscape snapshot** + **Cloud AI Services Rosetta**; **de-fab** the fabricated "Seattle/$2.3M" opener → `Hypothetical scenario:`; fixed wrong Next link; 11 sources |
| **1.2 AIOps** | T3 1,708w | T0 5,229w | **De-fab**: removed unverifiable "New Relic 80%" stat; CrowdStrike `$5.4B` attributed to Parametrix + 3 cited sources; sources 3→17; fixed **KRR docker image** (`ghcr.io`→`robustadev/krr`, a non-existent-image trap), spike-detector seed bug, in-cluster Prometheus URL; dangling prereq + nav |
| **1.3 High-Performance LLM Inference (vLLM & sglang)** | T3 1,776w | T0 5,271w | Removed **fabricated Llama-4 model IDs** → real Qwen; pinned **vLLM v0.22.1** (web-verified real tag) + modern `--speculative-config` syntax; 18 sources |

## Review

Cross-family R1 each (different model family than author), every finding ground-checked + web-verified:
- **1.1** (cursor author) → **opus** APPROVE_WITH_NITS (web-verified every Rosetta cell incl. OCI OC19 realm; 2 P2s fixed: 404 source URL, retry-budget naming).
- **1.2** (deepseek+codex authors) → **opus** NEEDS_CHANGES → fixed (P1 KRR image + spike-seed + Prometheus URL + 4 prose/nav corrections; all 8 dated claims verified clean — "cleanest fabricated-stat sweep on this track").
- **1.3** (codex author) → **cursor** APPROVE_WITH_NITS (re-verified Qwen IDs / vLLM v0.22.1 / spec syntax / 18 sources HTTP 200; 4 P2s fixed).

## Verification

- `npm run build` green in PRIMARY — **2171 pages, 0 schema errors** (PR CI has no full astro build).
- `check_site_health.py` — **0 errors** (cross-refs to 1.2/1.3/1.4 resolve).
- All 3 modules `verify_module.py` **T0**, `reasons: []`.

## Learner check

> Decode is different because the model produces one token at a time.

Refs #1842

🤖 Generated with [Claude Code](https://claude.com/claude-code)
