### PR TITLE
docs(multimodal-ai): expand 1.2/1.3/1.4 to T0 — sub-track complete (#1842)

### DIFF
--- a/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.2-vision-ai.md
+++ b/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.2-vision-ai.md
@@ -4,1237 +4,428 @@ slug: ai-ml-engineering/multimodal-ai/module-1.2-vision-ai
 sidebar:
   order: 903
 ---
-> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6
----
-**Reading Time**: 7-8 hours
-**Prerequisites**: Module 22
----
-
-## Why This Module Matters
-
-San Francisco. October 2023. A Cruise autonomous vehicle was navigating a city street when a human-driven car struck a pedestrian, throwing them directly into the Cruise vehicle's path. The robotaxi executed a hard emergency brake, coming to a stop directly over the critically injured pedestrian. It was at this moment that the multimodal vision AI system made a catastrophic semantic error. Analyzing the scene from its undercarriage and external cameras, the model classified the space under the car as "clear" and initiated a maneuver to pull over to the side of the road, dragging the pedestrian for 20 feet.
-
-The financial and reputational impact was immediate and devastating. The California DMV promptly suspended Cruise's deployment permits, forcing the company to ground its nationwide fleet of about 400 autonomous vehicles. Within weeks, the CEO resigned, the company laid off 24 percent of its workforce, and General Motors slashed Cruise's internal valuation by more than half, erasing billions of dollars in enterprise value overnight. 
-
-This incident underscores a critical reality for AI and ML engineers: vision AI is no longer a research novelty constrained to ImageNet benchmarks. It is actively deployed in safety-critical, high-stakes production environments where the semantic gap between "detecting pixels" and "understanding physical context" can cost lives and billions of dollars. Mastering multimodal AI means understanding not just how to process image tensors, but how these models reason about the visual world, where their mathematical blind spots lie, and how to architect rigorous safety boundaries against their inevitable hallucinations.
+> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 5-6 hours | Prerequisites: [Module 1.1: Voice and Audio AI](../module-1.1-voice-audio-ai/)
 
 ## Learning Outcomes
 
-By the end of this module, you will be able to:
-- **Design** multimodal architectures that efficiently fuse visual encoders with large language models for complex spatial reasoning tasks.
-- **Implement** contrastive learning pipelines (like CLIP) to enable zero-shot image classification and semantic visual search across unstructured image datasets.
-- **Diagnose** failure modes and edge cases in vision-language models, including spatial hallucination, focal degradation, and OCR misalignments.
-- **Evaluate** the cost-performance tradeoffs of various Vision-Language Model APIs and open-weight models to optimize production deployment economics.
+- **Explain** how Vision Transformers convert images into patch tokens, use positional embeddings, and rely on attention rather than convolutional locality.
+- **Apply** CLIP-style contrastive embeddings for zero-shot classification and natural-language image search while recognizing where similarity is not the same as grounded reasoning.
+- **Analyze** common VLM architectures, including the frozen vision encoder, projection connector, and language-model attention pattern used by BLIP-2 and LLaVA-style systems.
+- **Design** multimodal prompts and production pipelines for OCR, structured extraction, grounding, batching, preprocessing, caching, and human review.
+- **Evaluate** reliability risks such as hallucinated layout, OCR transposition, spatial confusion, prompt overloading, and vendor-specific cost or latency changes.
 
----
+## Why This Module Matters
 
-## Part 1: The Evolution of Vision Transformers (ViT)
+Hypothetical scenario: a support operations team adds a vision-language model to its returns workflow. The first demo looks excellent: upload a photo of a damaged shipment, ask for a description, and receive a tidy paragraph that mentions the torn corner, the visible product label, and the likely replacement category. The prototype moves quickly because the model accepts images and text in one request, so the team does not need to train a separate detector, OCR model, layout parser, and language model before showing value. Two weeks later the same system starts routing valid returns to manual review because glossy packaging creates reflections that the model interprets as damage. The model has not "seen" the business rule; it has converted visual tokens into a plausible language answer.
 
-Before diving into complex multimodal models, we must understand how transformers learned to process visual data. The history of teaching computers to "see" is a story of persistent mathematical evolution, transitioning from rigid hand-crafted rules to highly generalized attention mechanisms.
+That gap is the reason vision AI matters for AI/ML engineers. A modern visual system is no longer just an image classifier that chooses from a fixed label set. It may retrieve product photos by natural language, read a scanned invoice, compare a build diagram with an implementation screenshot, describe an accessibility image, or answer a user question about a chart. Each task asks the model to bind pixels, text, spatial layout, and domain instructions into one decision. The engineering challenge is to understand how the binding works well enough to design prompts, preprocess images, choose model families, measure failures, and add guardrails where generative answers are too unreliable.
 
-### The Limitations of Convolutional Neural Networks
+The durable spine of this module is not a particular vendor API or model name. Those change quickly. The durable spine is the sequence of ideas that made vision-language systems practical: Vision Transformers turn images into token sequences, CLIP-style contrastive learning aligns image and text embeddings, VLM architectures connect visual features to a language model, multimodal prompts steer attention and output shape, and production systems control image quality, latency, cost, and verification. When you understand those layers, you can evaluate a new provider announcement without treating it as magic.
 
-Convolutional Neural Networks (CNNs) dominated computer vision for a decade (2012-2020). They operate by sliding mathematical filters across an image to detect hierarchical patterns: edges in the first layer, textures in the second, and complex shapes in the deeper layers. While groundbreaking, CNNs suffer from fundamental architectural limitations:
+## Part 1: From Pixels to Vision Tokens
 
-- **Fixed Receptive Field**: CNNs process local patterns first and global patterns later. They struggle to immediately understand the relationship between a pixel in the top-left corner and a pixel in the bottom-right corner.
-- **Lack of Global Attention**: Every pixel is initially treated with equal mathematical weight, making it computationally inefficient to focus solely on the most contextually relevant parts of an image.
-- **Scaling Bottlenecks**: As datasets grew to billions of images, researchers found that larger CNNs did not yield proportionally better results. Their architectural rigidity created an asymptotic limit on performance.
+Traditional computer vision was dominated for years by convolutional neural networks because convolutions express a useful prior: nearby pixels usually matter together. A convolutional filter slides across an image and looks for local patterns such as edges, corners, textures, and eventually larger shapes. This works extremely well for many tasks because images are not random grids; objects have locality, translation matters, and early features often repeat across the frame. The tradeoff is that global relationships are built gradually. A small patch in the top left and another patch in the bottom right influence each other only after many layers, pooling steps, or architectural additions.
 
-### ViT: An Image is Worth 16x16 Words
+The Vision Transformer changes the default assumption. Instead of starting with local filters, it starts by treating an image as a sequence of patches, much like a language transformer treats a sentence as a sequence of tokens. A common teaching example is a 224 by 224 RGB image split into 16 by 16 patches. That produces a 14 by 14 grid, or 196 patch tokens, and each patch carries the pixel information for a small square of the image. The model linearly projects each flattened patch into an embedding vector, adds a positional embedding so the transformer knows where the patch came from, and feeds the resulting sequence into self-attention layers.
 
-In October 2020, researchers at Google Brain published a paper that fundamentally altered the trajectory of computer vision. Their core insight was elegantly simple: instead of sliding filters over an image, treat the image exactly like a sequence of text tokens.
+The patch embedding step is easy to underestimate because it looks like a preprocessing detail, but it defines what the transformer can attend over. If the patch size is large, the sequence is short and attention is cheaper, but fine visual detail may be compressed before the model can reason about it. If the patch size is small, the sequence preserves more local detail, but attention becomes more expensive because every token can attend to every other token. This is the same scaling pressure you already know from language models: longer sequences give the model more evidence, but attention cost grows quickly as sequence length rises.
+
+The `[CLS]` token in a ViT is a learnable summary token that travels through the transformer alongside the image patches. During classification training, the final representation of this token becomes the input to the classifier head. You can think of it as a place where the model learns to gather task-relevant evidence from the patch sequence, although the model is not literally storing a human-readable explanation there. For dense tasks such as detection or segmentation, architectures often need different heads or feature extraction strategies because one global summary is not enough to locate many objects precisely.
 
 ```text
-Traditional approach:   Image → CNN → Features → Classifier
-ViT approach:          Image → Patches → Transformer → Classification
+Image tensor
+  |
+  | split into non-overlapping patches
+  v
+Patch vectors + position embeddings + CLS token
+  |
+  | transformer encoder self-attention
+  v
+Contextual visual token representations
+  |
+  | task head or connector
+  v
+Classification, retrieval, captioning, or VLM input
 ```
 
-To achieve this, the Vision Transformer (ViT) architecture completely discards convolutions. Instead, it slices the image into a grid of non-overlapping patches. 
+The key difference between ViTs and CNNs is inductive bias. A CNN assumes locality and translation-friendly filters from the beginning, which helps when data is limited because the architecture already matches many visual patterns. A pure ViT has weaker built-in visual assumptions. It can learn global relationships directly through attention, but it often needs more data, stronger augmentation, or large-scale pretraining before it catches up. This explains why the ViT paper emphasized scale: the architecture is flexible, but flexibility is not free.
 
-### The Mathematics of Patching
+This also explains why modern systems often combine ideas rather than treating CNNs and transformers as religious camps. Some vision models keep convolutional stems for early feature extraction, some use hierarchical transformer stages, and some use specialized attention windows for efficiency. As an engineer, the practical question is not "CNN or transformer forever?" The practical question is what visual evidence your task needs, how much data you have, what latency budget you must hit, and whether global relationships matter enough to pay for broader attention.
 
-Consider a standard 224x224 pixel image with 3 color channels (RGB). ViT slices this image into 16x16 pixel patches. This results in exactly 196 patches (14 rows by 14 columns). Each patch contains 16 * 16 * 3 = 768 pixels. This 3D tensor is mathematically flattened into a 1D vector of length 768. 
+## Part 2: CLIP and Shared Image-Text Spaces
 
-Because transformers are permutation invariant (they have no inherent concept of order), a positional embedding is added to each vector so the model knows where the patch originated. Finally, a special learnable token called the `[CLS]` (classification) token is prepended to the sequence. The entire sequence is then fed into a standard transformer encoder stack.
+CLIP made a different move from ordinary image classification. Instead of training an image model to predict one fixed label from a curated label set, CLIP trains an image encoder and a text encoder together so matching image-text pairs land near each other in a shared embedding space. During training, the model receives a batch of images and their associated captions. It computes image embeddings, text embeddings, and a similarity matrix where correct pairs should score higher than mismatched pairs. The learning signal is contrastive: pull matching pairs together and push non-matching pairs apart.
+
+That shared space is what makes zero-shot classification possible. Suppose you have an image and three candidate labels: "a photo of a forklift", "a photo of a bicycle", and "a photo of a server rack". You encode the image once, encode each text prompt, and choose the text embedding with the highest similarity to the image embedding. No new classifier head is required for those categories. The category definitions are supplied by language, which means prompt wording, synonyms, and domain vocabulary can change the result.
+
+```text
+Images in batch       Captions in batch
+      |                     |
+      v                     v
+Vision encoder        Text encoder
+      |                     |
+      v                     v
+Image embeddings      Text embeddings
+      \_____________________/
+             |
+             v
+Similarity matrix: correct image-caption pairs should score highest
+```
+
+CLIP is powerful because it changes the interface from "train a classifier for each taxonomy" to "describe the visual concept in text." That makes it useful for image search, deduplication, weak labeling, content triage, product matching, and dataset exploration. You can embed a large image corpus offline, embed a text query at request time, and retrieve visually relevant candidates by cosine similarity. This is often a much better product primitive than a hard classifier because users rarely search with the exact labels your team used during training.
+
+The limitation is that similarity is not the same as understanding. A CLIP-style model can tell you that an image is closer to "a damaged box" than to "a pristine box", but it does not inherently produce a faithful damage report, read every character on a label, or prove that an object is in a safe physical state. It also inherits biases from the image-text pairs used for training. If a concept is common in captions but visually subtle, the model may learn a useful shortcut rather than the visual distinction you care about. If your business decision needs exact evidence, CLIP retrieval should usually feed a second verification step rather than act alone.
+
+Prompt design matters even for zero-shot CLIP. "dog", "a dog", "a photo of a dog", and "a product photo of a dog toy" are not equivalent descriptions. The text encoder embeds the whole phrase, so the surrounding context changes the decision boundary. In practice, teams often test prompt templates, average multiple templates, and add negative prompts for confusing classes. A warehouse model distinguishing "empty shelf", "stocked shelf", and "blocked aisle" may need prompts that reflect the camera angle and environment, not generic web-photo labels.
+
+SigLIP and OpenCLIP illustrate the broader family rather than a replacement story. SigLIP explores a sigmoid loss that avoids requiring a global softmax over the whole batch, while OpenCLIP provides an open implementation and training ecosystem for CLIP-like models. The durable lesson is that image-text representation learning is now a reusable substrate. Whether the implementation uses the original CLIP loss, a sigmoid variant, or a newer training recipe, the engineering pattern remains: build embeddings that make text queries and images comparable.
+
+## Part 3: Vision-Language Models
+
+A Vision-Language Model goes beyond retrieval by connecting visual evidence to a generative language model. The common pattern is a vision encoder, a connector, and an LLM. The vision encoder turns the image into visual features. The connector projects those features into the embedding space expected by the language model. The language model then attends over a combined context containing visual embeddings and text prompt tokens, producing a natural-language answer, structured JSON, or tool call instruction.
+
+BLIP-2 is a useful reference architecture because it makes the connector explicit. Rather than retraining every component end to end, it uses frozen pretrained image encoders and frozen large language models, then learns a lightweight bridge called a Querying Transformer. The point is not that every production VLM literally uses BLIP-2. The point is that bridging modalities is an engineering problem: visual features have one geometry, language tokens have another, and the connector decides what information crosses the boundary.
+
+LLaVA demonstrates another influential pattern: connect a pretrained CLIP visual encoder to an instruction-tuned language model through a projection layer, then train on multimodal instruction-following data. This makes the model behave more like an assistant than a classifier. You can ask, "What is unusual about this diagram?" or "Which item in the photo violates the checklist?" and receive a conversational answer. That assistant behavior is convenient, but it is also where hallucination enters. The language model can produce a fluent answer even when the visual evidence is weak.
+
+```text
+Image
+  |
+  v
+Vision encoder
+  |
+  v
+Visual feature tokens
+  |
+  v
+Projection connector or query transformer
+  |
+  v
+LLM-compatible visual embeddings + user text tokens
+  |
+  v
+Generative language model
+  |
+  v
+Answer, JSON, classification rationale, or next action
+```
+
+Images become "tokens" in a conceptual sense, but the details vary by model family. Some systems represent an image as many patch-derived embeddings. Some resample visual features into a smaller fixed set of tokens. Some use dynamic resolution so a document page receives more tokens than a simple thumbnail. The important production consequence is that image size, aspect ratio, detail level, and the number of images can change latency and cost. If you do not control preprocessing, a user can accidentally turn a simple request into an expensive multimodal context.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> | Family or project | Durable role in this module | Volatile detail to verify before use |
+> |---|---|---|
+> | OpenAI vision-capable models | Hosted APIs for image inputs, visual reasoning, and structured multimodal responses | Current model IDs, image token accounting, pricing, and preferred endpoint |
+> | Anthropic Claude vision | Hosted image analysis through the Messages API and related Claude surfaces | Current model IDs, request-size limits, supported media types, and partner-platform constraints |
+> | Google Gemini vision | Hosted multimodal image tasks including captioning, classification, visual QA, and object detection-style use cases | Current model IDs, file upload rules, region or product availability, and quota behavior |
+> | Qwen-VL family | Open vision-language model family with document, chart, grounding, and agentic visual examples in its published materials | Current checkpoint names, licenses, serving stack, hardware needs, and safety policy |
+> | LLaVA family | Research and open-source pattern for visual instruction tuning with a vision encoder connected to an LLM | Current forks, licenses, base models, benchmark claims, and inference requirements |
+> | BLIP-2-style architectures | Reference pattern for frozen visual encoders, frozen LLMs, and a learned modality bridge | Which components are frozen, which connector is trained, and whether the released checkpoint fits the task |
+>
+> This table is illustrative, not a ranking or endorsement.
+
+The snapshot belongs in one place because vendor and model details age quickly. A module that says "use model X because it is cheapest" can become wrong before the learner finishes the track. Durable engineering prose should instead teach the questions: Does the system need exact OCR or semantic reasoning? Does it need low latency or high recall? Can it run locally, or must it call a hosted API? Can failed cases be routed to humans? Does the model return bounding boxes, points, citations, or only prose? Those questions survive model releases.
+
+VLMs also differ from dedicated computer vision models in their failure shape. An object detector usually returns boxes, scores, and classes. A VLM returns language. Language can compress uncertainty, hide missing evidence, and overfit to the user's implied goal. If the prompt asks, "Which safety violation is visible?" the model may search for a violation even when none is present. Production systems should ask neutral observation questions first, request evidence, and separate perception from policy judgment.
+
+The connector is where many architectural tradeoffs hide. A simple linear projection can be enough when the visual encoder already produces features that line up well with the language model's embedding space, but it may pass too many tokens or too little task-specific information. A query transformer, resampler, or learned pooling layer can compress many visual features into a smaller set of language-compatible vectors. Compression improves latency and context pressure, but it can discard small evidence such as a serial-number digit, a checkbox mark, or a tiny icon in a dense diagram. When you evaluate a VLM, ask what information the connector is allowed to preserve.
+
+Training usually happens in stages because fully end-to-end multimodal training is expensive and can damage capabilities that were already learned. A first stage may align image features with the language model's token space, often using caption-like data or image-text pairs. A later stage may teach instruction following with examples such as "describe the image", "answer this chart question", or "extract these fields as JSON." Some systems freeze the vision encoder and LLM, some fine-tune the connector, and some update more of the stack. The frozen-component pattern is attractive because it reuses strong pretrained models, but it can also preserve their blind spots.
+
+The phrase "the LLM attends to the image" should be read carefully. The LLM does not see pixels. It receives embedding vectors produced by the visual side of the system, and those vectors are shaped by patch size, resolution handling, connector design, and training data. If the image encoder never captured a faint watermark, the language model cannot recover it by reasoning harder. If the connector compressed a table too aggressively, the generated answer may sound precise while silently losing row structure. Prompting helps only after the evidence survives the visual path.
+
+This is why a VLM should not automatically replace specialized vision models. If your task is real-time obstacle detection, a dedicated detector or segmentation model may be faster, easier to calibrate, and easier to audit. If your task is answering a natural-language question about a messy screenshot, a VLM may be more useful because it can combine visible text, layout, and domain instructions. Strong systems often use both: a detector produces grounded candidates, OCR extracts text spans, CLIP retrieves related examples, and a VLM performs the final explanation or structured synthesis.
+
+## Part 4: Multimodal Prompting and Grounding
+
+A multimodal prompt is not just a text prompt with an image attached. The image determines the evidence available to the model, while the text determines what the model should attend to, how it should serialize the answer, and how it should handle uncertainty. A weak prompt asks, "What is in this image?" and receives a broad caption. A stronger prompt names the task, defines the output fields, asks the model to distinguish observed evidence from inference, and tells it what to do when the image is unreadable.
+
+For visual question answering, split the work into observation and decision. First ask the model to describe only visible evidence relevant to the task. Then ask it to apply the rule or choose an output label. This reduces the chance that a policy label appears before the visual evidence has been enumerated. The pattern is especially useful in safety, compliance, medical-adjacent, legal, finance, and operations contexts where a confident-looking answer can trigger a real workflow.
+
+```text
+Weak prompt:
+What is wrong with this shipment photo?
+
+Better prompt:
+List visible evidence only: packaging condition, readable labels, exposed product,
+water damage, crushed corners, and missing seals. If evidence is unclear, say
+"unclear". After the evidence list, classify the return reason as one of:
+no visible damage, cosmetic damage, shipping damage, unreadable image.
+Return JSON with evidence and classification.
+```
+
+OCR and document parsing are related but not identical. OCR extracts characters. Parsing preserves structure: which value belongs to which field, which row contains which line item, which signature box is empty, and which footnote modifies a table. A VLM can sometimes infer layout that plain OCR loses, but it can also hallucinate plausible structure when the page is faint, rotated, cropped, or visually dense. A robust document pipeline often combines image preprocessing, OCR with coordinates, VLM semantic extraction, schema validation, and human review for low-confidence cases.
+
+Grounding means connecting an answer back to a visual location. In a simple system, grounding may be a visible grid overlay where the model says "cell B3". In a model that supports localization outputs, grounding may be a bounding box or point. In a product workflow, grounding might be a cropped evidence image stored with the decision. The goal is to avoid answers that cannot be audited. "The seal is broken" is less useful than "The seal appears torn on the upper-right flap; confidence is low because glare crosses the same region."
+
+Structured extraction requires strict output contracts. If you need JSON, provide the schema, allowed enum values, null behavior, and validation expectations. Do not ask for a beautiful explanation and then parse it with brittle string splitting. If the model response must feed another system, validate it with a parser, reject invalid fields, and retry with a narrower prompt when necessary. For high-value workflows, store the prompt, image hash, model family, response, validation result, and human correction so future evaluations can reproduce the case.
+
+Multi-image prompting introduces another layer of ambiguity. Passing two product images as separate inputs usually preserves the distinction better than concatenating them into one wide collage, because the model and API can represent the images as separate items in the request. When comparing before-and-after photos, listing photos against customer uploads, or architecture diagrams against screenshots, label each image in the text prompt and ask the model to reason by image identity. The phrase "left image" becomes unreliable once images are resized, reflowed, or passed through different clients.
+
+Pointing and bounding-box workflows need explicit coordinate conventions. If a model or tool returns `[x1, y1, x2, y2]`, define whether those values are pixels, normalized coordinates, percentages, or grid cells. Define whether the origin is top-left, whether boxes include the boundary pixel, and how rotated images are handled. Many downstream bugs in visual systems are not neural-network failures; they are coordinate-system mismatches between the model response, frontend overlay, stored crop, and reviewer UI. A prompt that says "return a bounding box" is incomplete unless the application contract defines the coordinate frame.
+
+For structured extraction, prompt examples should include negative and partial cases rather than only perfect documents. A good invoice prompt says what to do when a field is missing, unreadable, crossed out, duplicated, or present only in a logo. A good chart prompt distinguishes title, axes, legend, visible datapoints, and inferred trend. A good screenshot prompt separates UI text that is actually visible from likely product knowledge. These distinctions reduce hallucinated structure because the model has an allowed path for uncertainty.
+
+The safest mental model is that a multimodal prompt sets up a small protocol. The image provides evidence, the system prompt defines non-negotiable behavior, the user prompt defines the task, the schema defines the output boundary, and the validator enforces that boundary. If any one of those pieces is missing, the model will fill the gap with a statistically plausible response. Production prompt engineering is therefore less about clever phrasing and more about removing ambiguity from the handoff between perception, reasoning, and software.
+
+## Part 5: Building Vision AI Applications
+
+The simplest useful vision application is semantic image search. You compute CLIP embeddings for a corpus of images, store the normalized vectors, and compare a user's text query embedding against the image embeddings. This can support natural-language browsing over diagrams, screenshots, product photos, or support attachments. The offline-online split is important: expensive image embedding happens once during ingestion, while query embedding and vector search happen on demand. The same pattern can also bootstrap labeling by retrieving visually similar examples for review.
 
 ```python
-# Conceptual ViT forward pass
-def vit_forward(image):
-    # 1. Patchify: [B, 3, 224, 224] → [B, 196, 768]
-    patches = split_into_patches(image, patch_size=16)
-    patch_embeddings = linear_projection(patches)
+from pathlib import Path
 
-    # 2. Add position embeddings
-    patch_embeddings += position_embeddings  # [B, 196, 768]
-
-    # 3. Prepend [CLS] token
-    cls_token = learnable_cls_token.expand(batch_size, 1, 768)
-    tokens = torch.cat([cls_token, patch_embeddings], dim=1)  # [B, 197, 768]
-
-    # 4. Transformer encoder
-    for layer in transformer_layers:
-        tokens = layer(tokens)  # Self-attention + FFN
-
-    # 5. Classification from [CLS]
-    cls_output = tokens[:, 0]  # [B, 768]
-    logits = classification_head(cls_output)  # [B, num_classes]
-
-    return logits
-```
-
-> **Pause and predict**: If we increase the ViT patch size from 16x16 to 32x32, what happens to the sequence length fed into the transformer? How does this impact the computational cost of the self-attention mechanism?
-
-The Vision Transformer proved that with sufficient data, global self-attention easily outperforms local convolutions. It established a new taxonomy of model sizes:
-
-| Model | Patch Size | Layers | Hidden Dim | Params | ImageNet Acc |
-|-------|------------|--------|------------|--------|--------------|
-| ViT-B/16 | 16 | 12 | 768 | 86M | 77.9% |
-| ViT-L/16 | 16 | 24 | 1024 | 307M | 79.7% |
-| ViT-H/14 | 14 | 32 | 1280 | 632M | 80.9% |
-| ViT-G/14 | 14 | 40 | 1408 | 1.8B | 83.3% |
-
----
-
-## Part 2: CLIP - Connecting Vision and Language
-
-While ViT revolutionized how models process images, it was still just a classification model. It required manually labeled datasets to learn specific categories. The true multimodal revolution began when OpenAI introduced CLIP (Contrastive Language-Image Pre-training) in January 2021, solving the "semantic gap" between pixels and text.
-
-### The CLIP Architecture
-
-CLIP consists of two entirely separate neural networks trained in parallel: a Vision Encoder (typically a ViT) and a Text Encoder (a standard text Transformer).
-
-```text
-         Image               Text
-           ↓                   ↓
-    ┌─────────────┐    ┌─────────────┐
-    │ Vision      │    │ Text        │
-    │ Encoder     │    │ Encoder     │
-    │ (ViT/ResNet)│    │ (Transformer)│
-    └─────────────┘    └─────────────┘
-           ↓                   ↓
-    Image Embedding    Text Embedding
-           ↓                   ↓
-    ┌───────────────────────────────┐
-    │      Contrastive Learning     │
-    │  (Match images with captions) │
-    └───────────────────────────────┘
-```
-
-For better maintainability and visual clarity, here is the architecture represented as a native flowchart:
-
-```mermaid
-flowchart TD
-    I[Image] --> VE[Vision Encoder: ViT/ResNet]
-    T[Text] --> TE[Text Encoder: Transformer]
-    VE --> IE[Image Embedding Vector]
-    TE --> TE2[Text Embedding Vector]
-    IE --> CL[Contrastive Learning Loss]
-    TE2 --> CL
-    CL -.-> |Maximizes similarity of matching pairs| CL
-```
-
-### Contrastive Learning: The Key Innovation
-
-Instead of predicting a specific class label, CLIP was trained on 400 million unstructured image-text pairs scraped from the internet. The objective function is known as Contrastive Loss. 
-
-During training, the model takes a batch of N images and their corresponding N captions. It computes a similarity matrix by multiplying the image embeddings by the text embeddings. The goal is to maximize the values on the diagonal of this matrix (the correct pairs) while minimizing all off-diagonal values (the incorrect pairs).
-
-```python
-# Simplified CLIP training step
-def clip_training_step(images, captions):
-    # Encode both modalities
-    image_embeddings = vision_encoder(images)  # [N, 512]
-    text_embeddings = text_encoder(captions)   # [N, 512]
-
-    # Normalize embeddings
-    image_embeddings = F.normalize(image_embeddings, dim=-1)
-    text_embeddings = F.normalize(text_embeddings, dim=-1)
-
-    # Compute similarity matrix
-    logits = image_embeddings @ text_embeddings.T  # [N, N]
-    logits = logits * temperature  # Learnable temperature parameter
-
-    # Contrastive loss: diagonal should be highest
-    labels = torch.arange(N)
-    loss_i2t = F.cross_entropy(logits, labels)      # Image → Text
-    loss_t2i = F.cross_entropy(logits.T, labels)    # Text → Image
-
-    return (loss_i2t + loss_t2i) / 2
-```
-
-### Zero-Shot Image Classification
-
-Because CLIP embeds images and text into the exact same mathematical latent space, it enables "zero-shot" classification. You do not need to train a new classification head. You simply encode your image, encode a list of text prompts describing your target categories, and find the text embedding with the highest cosine similarity to the image embedding.
-
-```python
-def zero_shot_classify(image, class_names):
-    # Create text prompts
-    prompts = [f"a photo of a {name}" for name in class_names]
-
-    # Encode image and texts
-    image_embedding = vision_encoder(image)
-    text_embeddings = text_encoder(prompts)
-
-    # Normalize
-    image_embedding = F.normalize(image_embedding, dim=-1)
-    text_embeddings = F.normalize(text_embeddings, dim=-1)
-
-    # Compute similarities
-    similarities = image_embedding @ text_embeddings.T
-
-    # Return class with highest similarity
-    predicted_class = class_names[similarities.argmax()]
-    return predicted_class
-```
-
-> **Stop and think**: Why does a model trained via contrastive learning (like CLIP) perform significantly better on zero-shot tasks than a model trained purely on cross-entropy classification over a fixed set of labels?
-
-### CLIP Variants and Successors
-
-The success of CLIP spawned an entire ecosystem of contrastive visual models, optimizing for larger scales, better loss functions, or open-source availability.
-
-| Model | Organization | Key Innovation |
-|-------|-------------|----------------|
-| CLIP | OpenAI | Original contrastive learning |
-| OpenCLIP | LAION | Open-source reproduction |
-| SigLIP | Google | Sigmoid loss (better than softmax) |
-| BLIP | Salesforce | Added image captioning |
-| BLIP-2 | Salesforce | Frozen LLM + Q-Former bridge |
-| EVA-CLIP | BAAI | Largest open CLIP (18B params) |
-
----
-
-## Part 3: Vision-Language Models (VLMs)
-
-While CLIP can match images to text, it cannot *generate* novel text. The modern era of multimodal AI is defined by Vision-Language Models (VLMs), which stitch a powerful vision encoder directly onto a Large Language Model, enabling complex visual reasoning, OCR, and spatial analysis.
-
-### The VLM Architecture
-
-A standard VLM consists of three heavily engineered components: the vision encoder, the projection connector, and the generative language model.
-
-```text
-                Image
-                  ↓
-         ┌────────────────┐
-         │ Vision Encoder │
-         │ (ViT / SigLIP) │
-         └────────────────┘
-                  ↓
-           Image Tokens
-                  ↓
-         ┌────────────────┐
-         │   Projection   │
-         │   (Connector)  │
-         └────────────────┘
-                  ↓
-         Visual Embeddings
-                  ↓
-┌──────────────────────────────────┐
-│                                  │
-│   [Visual] [Text Prompt Tokens]  │
-│                                  │
-│        Large Language Model      │
-│       (gpt-5, Claude, Llama)     │
-│                                  │
-└──────────────────────────────────┘
-                  ↓
-         Generated Response
-```
-
-Translated to a flowchart for clearer documentation:
-
-```mermaid
-flowchart TD
-    I[Image Input] --> VE[Vision Encoder: ViT / SigLIP]
-    VE --> IT[Image Tokens]
-    IT --> P[Projection Connector]
-    P --> VE2[Visual Embeddings]
-    VE2 --> LLM[Large Language Model: gpt-5, Claude, Llama]
-    TP[Text Prompt Tokens] --> LLM
-    LLM --> R[Generated Response]
-```
-
-The Projection Connector is the unsung hero of this architecture. Its primary purpose is to translate the high-dimensional visual features output by the Vision Encoder into the precise embedding dimension expected by the Language Model, acting as a bridge between the two neural networks.
-
-### Major Vision-Language Models in Production
-
-#### GPT-5 Vision (OpenAI)
-
-OpenAI continues to iterate heavily on their proprietary multimodal architecture. It remains the industry standard for complex visual logic, robust OCR, and multi-image spatial reasoning.
-
-```python
-from openai import OpenAI
-
-client = OpenAI()
-
-response = client.chat.completions.create(
-    model="gpt-5",
-    messages=[
-        {
-            "role": "user",
-            "content": [
-                {"type": "text", "text": "What's in this image?"},
-                {
-                    "type": "image_url",
-                    "image_url": {"url": "https://example.com/image.jpg"}
-                }
-            ]
-        }
-    ]
-)
-```
-
-#### Claude 3 Vision (Anthropic)
-
-Anthropic's Claude family excels at safety-critical detailed analysis, particularly concerning data-dense charts, graphs, and highly technical diagrams. It accepts images directly as base64 encoded strings.
-
-```python
-import anthropic
-import base64
-
-client = anthropic.Anthropic()
-
-# Load image as base64
-with open("image.jpg", "rb") as f:
-    image_data = base64.standard_b64encode(f.read()).decode("utf-8")
-
-response = client.messages.create(
-    model="claude-4.6-opus-20240229",
-    max_tokens=1024,
-    messages=[
-        {
-            "role": "user",
-            "content": [
-                {
-                    "type": "image",
-                    "source": {
-                        "type": "base64",
-                        "media_type": "image/jpeg",
-                        "data": image_data
-                    }
-                },
-                {
-                    "type": "text",
-                    "text": "Describe this image in detail."
-                }
-            ]
-        }
-    ]
-)
-```
-
-#### Gemini Vision (Google)
-
-Google's Gemini models are natively multimodal from the ground up, meaning they were not bolted together post-training. This grants them exceptional long-context visual reasoning and the ability to process raw video frames continuously.
-
-```python
-import google.generativeai as genai
-from PIL import Image
-
-genai.configure(api_key="YOUR_API_KEY")
-model = genai.GenerativeModel('gemini-3.5-pro')
-
-image = Image.open("image.jpg")
-response = model.generate_content([
-    "What's happening in this image?",
-    image
-])
-```
-
-#### LLaVA (Open Source)
-
-The Large Language and Vision Assistant (LLaVA) proved that open-source models could compete with proprietary giants. By combining a frozen CLIP encoder with a LLaMA model, it demonstrated that highly capable VLMs could be assembled and fine-tuned on modest hardware.
-
-```text
-Image → CLIP ViT-L/14 → Linear Projection → Vicuna/Llama-2
-                                                   ↓
-                                           Response Text
-```
-
-```mermaid
-flowchart LR
-    I[Image] --> C[CLIP ViT-L/14]
-    C --> LP[Linear Projection]
-    LP --> VL[Vicuna / Llama-2]
-    VL --> RT[Response Text]
-```
-
-### Comparing VLMs
-
-Choosing the correct model is an exercise in balancing latency, financial cost, and analytical depth.
-
-| Model | Best For | Limitations |
-|-------|----------|-------------|
-| GPT-4V | General vision tasks, complex reasoning | Cost, API-only |
-| Claude 3 | Detailed analysis, safety-critical | API-only |
-| Gemini | Video, long context | Regional availability |
-| LLaVA | Local deployment, customization | Lower quality than closed models |
-
----
-
-## Part 4: Multimodal Prompting Techniques
-
-Just as text-only LLMs require careful prompt engineering, visual models respond dramatically differently based on how their text constraints are formulated. The text prompt directs the model's attention mechanism across the visual patches.
-
-### Basic Visual Prompting
-
-A simple description prompt often yields a generic, high-level summary:
-
-```text
-User: What's in this image?
-```
-
-Adding specific focus forces the attention mechanism to drill down into localized patches:
-
-```text
-User: How many people are in this image? What are they doing?
-```
-
-Applying an expert persona calibrates the output vocabulary:
-
-```text
-User: As an art historian, analyze the composition and technique in this painting.
-```
-
-### Chain-of-Thought for Vision
-
-Visual reasoning improves significantly when the model is forced to explicitly outline its visual observations before executing logic. Without Chain-of-Thought (CoT), the model may skip critical visual details.
-
-**Without CoT**:
-```text
-User: [Image of a math problem]
-What is the answer?
-```
-
-**With CoT**:
-```text
-User: [Image of a math problem]
-Look at this problem carefully. First, identify what type of math problem it is.
-Then, list out all the given information.
-Finally, solve it step by step and show your work.
-```
-
-### Multi-Image Reasoning
-
-Modern APIs allow for multi-image inputs. This is highly effective for comparative analysis and quality control checks.
-
-```text
-User: [Image 1: Product listing photo]
-      [Image 2: Actual product received]
-
-Compare these two images. Is the product as advertised?
-List any differences you notice.
-```
-
-### Document and Diagram Understanding
-
-For heavily structured data, explicit output formatting requests ensure the VLM does not summarize away critical granular data.
-
-```text
-User: [Image of invoice]
-
-Extract all of the following information in JSON format:
-- Invoice number
-- Date
-- Vendor name
-- Line items (product, quantity, price)
-- Total amount
-- Tax amount
-```
-
-For complex technical topology:
-
-```text
-User: [Architecture diagram]
-
-Analyze this system architecture diagram:
-1. Identify all components and services
-2. Trace the data flow from user request to response
-3. Identify potential bottlenecks or single points of failure
-4. Suggest improvements for scalability
-```
-
----
-
-## Part 5: Building with Vision-Language Models
-
-Bridging the gap between a notebook script and a production system requires wrapping these models in robust, error-handled application logic. Below are three foundational archetypes for multimodal applications.
-
-### Application 1: Image Search with CLIP
-
-Building a semantic search engine requires calculating embeddings offline and querying them dynamically at runtime.
-
-```python
-from transformers import CLIPProcessor, CLIPModel
+import numpy as np
 import torch
 from PIL import Image
-import numpy as np
+from transformers import CLIPModel, CLIPProcessor
 
-class CLIPImageSearch:
+
+class LocalClipSearch:
     def __init__(self, model_name="openai/clip-vit-base-patch32"):
         self.model = CLIPModel.from_pretrained(model_name)
         self.processor = CLIPProcessor.from_pretrained(model_name)
-        self.image_embeddings = []
         self.image_paths = []
+        self.image_embeddings = None
 
-    def index_images(self, image_paths):
-        """Create embeddings for all images."""
-        self.image_paths = image_paths
-
-        for path in image_paths:
-            image = Image.open(path)
+    def index_folder(self, folder):
+        embeddings = []
+        for path in sorted(Path(folder).glob("*.jpg")):
+            image = Image.open(path).convert("RGB")
             inputs = self.processor(images=image, return_tensors="pt")
-
             with torch.no_grad():
-                embedding = self.model.get_image_features(**inputs)
-                embedding = embedding / embedding.norm(dim=-1, keepdim=True)
+                vector = self.model.get_image_features(**inputs)
+                vector = vector / vector.norm(dim=-1, keepdim=True)
+            embeddings.append(vector.cpu().numpy())
+            self.image_paths.append(str(path))
+        self.image_embeddings = np.vstack(embeddings)
 
-            self.image_embeddings.append(embedding.numpy())
-
-        self.image_embeddings = np.vstack(self.image_embeddings)
-
-    def search(self, query: str, top_k: int = 5):
-        """Search images using natural language query."""
-        inputs = self.processor(text=[query], return_tensors="pt")
-
+    def search(self, query, top_k=3):
+        inputs = self.processor(text=[query], return_tensors="pt", padding=True)
         with torch.no_grad():
-            text_embedding = self.model.get_text_features(**inputs)
-            text_embedding = text_embedding / text_embedding.norm(dim=-1, keepdim=True)
-
-        # Compute similarities
-        similarities = (text_embedding.numpy() @ self.image_embeddings.T)[0]
-
-        # Get top results
-        top_indices = np.argsort(similarities)[::-1][:top_k]
-
-        results = [
-            {"path": self.image_paths[i], "score": similarities[i]}
-            for i in top_indices
-        ]
-
-        return results
-
-# Usage
-search = CLIPImageSearch()
-search.index_images(["cat.jpg", "dog.jpg", "car.jpg", "house.jpg"])
-results = search.search("a furry pet playing")
+            text_vector = self.model.get_text_features(**inputs)
+            text_vector = text_vector / text_vector.norm(dim=-1, keepdim=True)
+        scores = (text_vector.cpu().numpy() @ self.image_embeddings.T)[0]
+        order = np.argsort(scores)[::-1][:top_k]
+        return [(self.image_paths[i], float(scores[i])) for i in order]
 ```
 
-### Application 2: Visual QA System
+A visual QA application adds a generative model after image ingestion. The application must encode or upload the image, attach a task prompt, receive the model response, validate it, and decide whether to accept, retry, escalate, or store the result. The tempting mistake is to let the VLM be the whole application. The stronger design treats the VLM as one component inside a workflow that also owns preprocessing, schema validation, observability, and policy decisions.
 
-Integrating base64 encoding with a prompt wrapper yields a robust question-answering utility.
+Image preprocessing is part of model quality, not just performance tuning. Normalize color mode to RGB unless the model or library requires another format. Strip corrupt metadata. Rotate based on EXIF orientation when appropriate. Resize according to task: a coarse scene classifier can use smaller images, while OCR and dense diagrams need enough resolution to preserve text. For document pages, consider contrast enhancement, deskewing, and cropping before the model call. A bad preprocessing pipeline can make a strong model look unreliable.
 
-```python
-from openai import OpenAI
-import base64
+Batching and caching determine whether a prototype survives production traffic. If many users upload the same asset, hash the image bytes and cache the model response for deterministic prompts. If many images need the same embedding model, batch them to use hardware efficiently. If hosted VLM calls dominate latency, separate ingestion-time analysis from user-facing request time where possible. A product catalog can precompute captions and embeddings before search traffic arrives; a live inspection workflow may need a fast first pass and a slower escalation path.
 
-class VisualQA:
-    def __init__(self):
-        self.client = OpenAI()
+Human review is not a failure of automation. It is a design control for ambiguous visual evidence. The review queue should include the original image, any cropped evidence, the model's observed evidence, the requested output, confidence or uncertainty signals if available, and validation failures. The reviewer should correct the structured fields rather than write free-form notes only, because those corrections become evaluation data. Over time, the team can measure which image conditions, prompt shapes, or model families trigger review most often.
 
-    def encode_image(self, image_path: str) -> str:
-        """Encode image to base64."""
-        with open(image_path, "rb") as f:
-            return base64.b64encode(f.read()).decode("utf-8")
+The deployment boundary should be chosen by failure cost. If a wrong answer only changes image search ranking, you can usually tolerate approximate embeddings, periodic offline evaluation, and lightweight rollback. If a wrong answer pays an invoice, rejects a customer return, unlocks an account, or classifies a safety condition, the VLM should not be the sole decision maker. Put deterministic checks around it, store evidence, and require a second path for expensive or irreversible actions. This is the same engineering instinct used in distributed systems: unreliable components can be useful when the surrounding protocol limits blast radius.
 
-    def ask(self, image_path: str, question: str) -> str:
-        """Ask a question about an image."""
-        image_data = self.encode_image(image_path)
+Another practical boundary is freshness. Product photos, UI screenshots, handwritten forms, and industrial labels can drift faster than the underlying model. A team may blame the provider when accuracy falls, but the real change may be a new camera app, a supplier label redesign, or a workflow that starts accepting screenshots from a different device class. Capture enough input metadata to separate model regression from data drift. Without that separation, teams often switch models repeatedly while leaving the actual ingestion problem untouched.
 
-        response = self.client.chat.completions.create(
-            model="gpt-5",
-            messages=[
-                {
-                    "role": "user",
-                    "content": [
-                        {
-                            "type": "text",
-                            "text": f"Look at this image carefully and answer: {question}"
-                        },
-                        {
-                            "type": "image_url",
-                            "image_url": {
-                                "url": f"data:image/jpeg;base64,{image_data}"
-                            }
-                        }
-                    ]
-                }
-            ],
-            max_tokens=500
-        )
+## Part 6: Production Reliability and Cost Control
 
-        return response.choices[0].message.content
+Vision workloads have a different cost profile from text-only workloads because image payloads can be large, tokenized into many visual tokens, and slow to upload or preprocess. The exact accounting depends on the provider and changes over time, so do not hard-code pricing assumptions into architecture docs. Instead, design with cost controls that remain valid: resize images before sending them, reject unsupported formats early, cap the number of images per request, cache repeated analyses, and route simple cases to cheaper local or specialized models when they meet the quality bar.
 
-# Usage
-vqa = VisualQA()
-answer = vqa.ask("diagram.png", "What components are shown in this architecture?")
-```
+Latency is also multi-part. There is client upload time, image decoding, resizing, model queueing, visual encoding, language generation, validation, and retry behavior. A system that feels instant in a notebook can feel slow in a web app because the user uploads a large phone photo over a weak connection. For user-facing workflows, return early progress states, compress safely, and avoid asking one VLM call to do ten unrelated jobs. For backend workflows, process images asynchronously and make the human-facing state explicit.
 
-### Application 3: Image Captioning Pipeline
+Failure modes deserve their own test set. Include blurry photos, cropped documents, glare, rotated labels, handwriting, low-contrast watermarks, dense diagrams, screenshots with small fonts, visually similar classes, adversarially placed text, and normal negative cases where nothing interesting is happening. The negative cases matter because multimodal models often try to satisfy the user's implied request. If every evaluation image contains a defect, the model can learn or appear to learn that a defect should always be found.
 
-A robust pipeline extracts multiple variations of textual analysis from a single expensive API call.
+OCR transposition is a practical risk. A VLM may swap adjacent digits, normalize a serial number into a more familiar pattern, or infer a missing character from context. That is dangerous for invoices, bank documents, medication labels, shipping IDs, and compliance evidence. When exact text matters, compare the VLM output against a dedicated OCR engine, apply checksums or format validation when possible, and mark low-quality regions for review. The VLM is often better at explaining layout than guaranteeing every character.
 
-```python
-from openai import OpenAI
-import base64
-from dataclasses import dataclass
-from typing import List
+Hallucinated structure is the document version of the same problem. The model may invent a table column that seems semantically likely, attach a total to the wrong line item, or summarize away a footnote. You can reduce this risk by requesting extracted fields with coordinates or evidence snippets, validating totals arithmetically, and separating "read what is present" from "infer what it means." If the image does not support a required field, the correct output is `null` or `unclear`, not a plausible guess.
 
-@dataclass
-class Caption:
-    short: str
-    detailed: str
-    keywords: List[str]
-    alt_text: str
+Security and privacy controls should be designed before launch. Images can contain faces, addresses, documents, screens, keys, barcodes, location clues, and proprietary diagrams. Decide whether images may leave your environment, whether you need redaction before model calls, how long images and responses are retained, and who can inspect failed cases. A local open-weight model may reduce data transfer risk but add operational risk; a hosted API may reduce operations but require stricter data-sharing review. The right answer depends on the data classification, not model popularity.
 
-class ImageCaptioner:
-    def __init__(self):
-        self.client = OpenAI()
+A reliable production pattern is a tiered pipeline. Use deterministic validation and lightweight models first, then escalate when evidence is ambiguous. For example, a support workflow might hash and cache the image, check resolution, run OCR, retrieve similar historical cases with CLIP, call a VLM for structured evidence, validate the JSON schema, and route uncertain cases to review. This pattern is slower to build than a single API call, but it gives you levers to improve quality without rewriting the whole product.
 
-    def caption(self, image_path: str) -> Caption:
-        """Generate multiple caption styles for an image."""
-        with open(image_path, "rb") as f:
-            image_data = base64.b64encode(f.read()).decode("utf-8")
+Evaluation should be task-specific rather than benchmark-shaped. A public benchmark may tell you that a model can answer general image questions, but your product may care about one narrow distinction such as "is the tamper seal intact?", "does this network diagram contain an unmanaged ingress path?", or "which invoice total is payable after tax?" Build an evaluation set from real or realistically staged examples, label the expected evidence, and score both the final answer and the supporting observation. A model that gets the right label for the wrong visual reason is still risky.
 
-        prompt = """Analyze this image and provide:
-        1. SHORT: A one-sentence caption (max 15 words)
-        2. DETAILED: A detailed description (2-3 sentences)
-        3. KEYWORDS: 5-10 relevant keywords, comma-separated
-        4. ALT_TEXT: Accessibility-friendly alt text
+Observability should capture enough context to debug visual failures without exposing more sensitive data than necessary. At minimum, store an image hash, preprocessing metadata, prompt version, model family, validation outcome, latency, retry count, and reviewer disposition. For privacy-sensitive images, store redacted crops or references rather than raw images when policy requires it. The key is to make failures reproducible: if a reviewer reports a transposed serial number, the team should know which prompt, model, crop, and preprocessing path produced the mistake.
 
-        Format your response exactly as:
-        SHORT: [caption]
-        DETAILED: [description]
-        KEYWORDS: [keywords]
-        ALT_TEXT: [alt text]"""
-
-        response = self.client.chat.completions.create(
-            model="gpt-5",
-            messages=[
-                {
-                    "role": "user",
-                    "content": [
-                        {"type": "text", "text": prompt},
-                        {
-                            "type": "image_url",
-                            "image_url": {"url": f"data:image/jpeg;base64,{image_data}"}
-                        }
-                    ]
-                }
-            ]
-        )
-
-        # Parse response
-        text = response.choices[0].message.content
-        lines = text.strip().split("\n")
-
-        result = {}
-        for line in lines:
-            if line.startswith("SHORT:"):
-                result["short"] = line.replace("SHORT:", "").strip()
-            elif line.startswith("DETAILED:"):
-                result["detailed"] = line.replace("DETAILED:", "").strip()
-            elif line.startswith("KEYWORDS:"):
-                keywords = line.replace("KEYWORDS:", "").strip()
-                result["keywords"] = [k.strip() for k in keywords.split(",")]
-            elif line.startswith("ALT_TEXT:"):
-                result["alt_text"] = line.replace("ALT_TEXT:", "").strip()
-
-        return Caption(**result)
-```
-
----
-
-## Part 6: Production Considerations and Economics
-
-Vision API calls are significantly more expensive than text-only operations. Deploying a VLM without strict guardrails on payload size is a guaranteed path to massive cost overruns.
-
-### Pricing Comparison
-
-| Provider | Model | Image Cost | Notes |
-|----------|-------|------------|-------|
-| OpenAI | gpt-5 | $0.00255 per 512x512 tile | Multiple tiles for larger images |
-| OpenAI | gpt-5-mini | $0.000638 per 512x512 tile | 4x cheaper, slightly lower quality |
-| Anthropic | Claude 3 Opus | ~$0.024 per 1000 input tokens | Images count as ~1500 tokens |
-| Anthropic | Claude 3 Sonnet | ~$0.003 per image | Much cheaper for most uses |
-| Anthropic | Claude 3 Haiku | ~$0.0005 per image | Best value for simple tasks |
-| Google | Gemini Pro Vision | Free tier, then $0.0025/image | Generous free quota |
-
-### Cost Optimization Strategies
-
-#### 1. Pre-API Image Resizing
-Never send raw 4K images to a VLM API. The provider will downsample or chunk the image anyway, billing you for discarded pixels. Implement client-side logic to constrain dimensions.
-
-```python
-   from PIL import Image
-
-   def resize_for_api(image_path, max_size=1024):
-       img = Image.open(image_path)
-       img.thumbnail((max_size, max_size))
-       return img
-```
-
-Implement task-specific dynamic resizing to ensure optimal bandwidth and cost:
-
-```python
-def optimize_for_api(image_path, task_type="general"):
-    """Resize images based on task requirements."""
-    from PIL import Image
-
-    img = Image.open(image_path)
-
-    # Task-specific optimal sizes
-    sizes = {
-        "general": 1024,      # Good balance
-        "ocr": 2048,          # Need text clarity
-        "classification": 512, # Usually sufficient
-        "thumbnail": 256       # Quick checks
-    }
-
-    max_dim = sizes.get(task_type, 1024)
-
-    if max(img.size) > max_dim:
-        img.thumbnail((max_dim, max_dim), Image.LANCZOS)
-
-    return img
-```
-
-#### 2. Implement Hashing and Caching
-Repeated API calls for identical imagery are wasteful. Generate an MD5 or SHA256 hash of the image bytes and cache the response text.
-
-```python
-   import hashlib
-
-   def hash_image(image_bytes):
-       return hashlib.md5(image_bytes).hexdigest()
-```
-
-Coupled with a local cache decorator:
-
-```python
-import hashlib
-from functools import lru_cache
-
-def hash_image(image_bytes):
-    return hashlib.sha256(image_bytes).hexdigest()
-
-@lru_cache(maxsize=10000)
-def cached_analyze(image_hash, prompt):
-    # Actual API call only on cache miss
-    return vlm.analyze(image_hash, prompt)
-```
-
-#### 3. Tiered Model Cascades
-Route easy classifications to fast, cheap models (like Claude Haiku or a local LLaVA deployment), and escalate to expensive flagship models only if the confidence score is low.
-
-```python
-def smart_analyze(image):
-    # First pass: cheap model for classification
-    result = haiku_classify(image)
-
-    if result.confidence > 0.9:
-        return result  # Easy case, done
-
-    # Second pass: expensive model for hard cases
-    return opus_analyze(image)
-```
-
----
-
-## Part 7: Production War Stories & Pitfalls
-
-### Pitfall 1: Expecting OCR Perfection
-
-Vision-Language Models are impressive at OCR, but they are not deterministic structural parsers. They will occasionally transpose digits or hallucinate characters that fit the linguistic context rather than the visual pixels.
-
-**Bad Approach**: Assuming the output is perfectly clean and structurally sound.
-```python
-# Trust VLM output directly
-text = vlm.extract_text(document)
-process_invoice(text)  # May have errors!
-```
-
-**Robust Approach**: Implement secondary validation and sanity checks.
-```python
-# Validate and verify
-text = vlm.extract_text(document)
-text = spell_check(text)
-if not validate_invoice_format(text):
-    flag_for_human_review()
-```
-
-### Pitfall 2: Ignoring Image Quality
-
-Garbage in, garbage out. If you send heavily compressed thumbnails to save bandwidth, the model will fall back on language priors and guess the contents based on statistics rather than vision.
-
-**Bad Approach**: Blindly sending any file.
-```python
-# Send tiny thumbnail
-analyze(thumbnail_50x50.jpg)
-```
-
-**Robust Approach**: Enforce minimum thresholds for visual acuity.
-```python
-# Ensure adequate resolution
-if image.size[0] < 512 or image.size[1] < 512:
-    raise ValueError("Image too small for reliable analysis")
-```
-
-### Pitfall 3: Single-Shot Complex Tasks
-
-Providing one giant, sprawling prompt forces the model to divide its attention excessively, resulting in dropped instructions and superficial visual scans.
-
-**Bad Approach**: Overloading the prompt context.
-```python
-# One giant prompt
-response = vlm.analyze("Count all objects, describe relationships,
-    identify brands, extract text, and determine location")
-```
-
-**Robust Approach**: Orchestrate multiple, focused, discrete queries.
-```python
-# Break into focused tasks
-objects = vlm.analyze("List all objects visible")
-relationships = vlm.analyze("Describe spatial relationships between objects")
-text = vlm.analyze("Extract any visible text")
-# Combine results
-```
-
----
+Drift appears in vision systems through input changes as much as model changes. A new mobile app may compress photos differently. A warehouse may change label printers. A product team may add dark-mode screenshots. A vendor may change model routing behind an API name. Monitor image dimensions, file types, OCR confidence, review rates, schema failures, and task-specific disagreement over time. When those signals move, investigate before assuming that the VLM has become worse or better in a general sense.
 
 ## Did You Know?
 
-1. In September 2012, Alex Krizhevsky's AlexNet architecture won the ImageNet Large Scale Visual Recognition Challenge by achieving a top-5 error rate of 15.3 percent, which was 10.8 percentage points lower than the runner-up, effectively launching the deep learning era.
-2. The original OpenAI CLIP model was trained on a private dataset of exactly 400 million image-text pairs scraped from the internet in January 2021.
-3. The open-source LAION-5B dataset, released to the public in March 2022, contains precisely 5.85 billion image-text pairs and required over 10,000 GPU hours strictly to compute the embedding metrics for filtering.
-4. Tesla's Autopilot hardware stack processes video streams from 8 simultaneous cameras at 36 frames per second, generating over 1.5 gigabytes of raw visual data per second per vehicle to feed its distributed fleet learning networks.
-
----
+- > The ViT paper showed that a pure transformer can process image patches directly, but its strongest results depend on large-scale pretraining rather than a built-in convolutional prior.
+- > The CLIP paper trained image and text encoders with natural-language supervision, making zero-shot transfer possible by comparing images with text prompts instead of training a new classifier head.
+- > BLIP-2 is a reference point for efficient VLM construction because it bridges frozen image encoders and frozen language models with a learned querying transformer.
+- > LLaVA helped popularize visual instruction tuning by connecting a CLIP visual encoder to a language model and training the combined system to follow image-plus-text instructions.
 
 ## Common Mistakes
 
-| Mistake | Why It Happens | Fix |
-|---------|----------------|-----|
-| Sending 4K images to APIs without resizing | APIs downsample or tile images into fixed grids (e.g., 512x512 blocks). You pay for pixels the model often discards during preprocessing. | Implement a client-side resize function to constrain the maximum dimension before making the network request. |
-| Using Vision-Language Models for exact spatial coordinates | LLM architectures lack inherent spatial geometry; they process flattened 1D sequences of tokens. | Utilize dedicated object detection models (like YOLOv8) for bounding boxes, or explicitly overlay a visible coordinate grid on the image. |
-| Trusting native OCR capabilities for structural data | Text in complex layouts (invoices, forms) gets serialized linearly, destroying the implicit column and row relationships. | Employ a hybrid approach: use a specialized OCR engine for coordinate extraction and the VLM strictly for semantic reasoning. |
-| Providing zero-shot prompts for complex reasoning | Vision tokens compete with text tokens for attention. Without intermediate steps, the model overlooks critical visual details. | Enforce Chain-of-Thought prompting. Command the model to list visible objects first, then reason about their interactions. |
-| Assuming consistent color perception across models | Image compression artifacts and varying color spaces (RGB vs BGR) fundamentally alter the pixel values fed into the vision encoder. | Standardize image preprocessing pipelines, explicitly converting all inputs to RGB and applying standardized normalization vectors. |
-| Ignoring base rate probability in security imagery | Models trained on web data expect images to contain highly engaging subjects of interest, leading to massive false-positive rates on normal scenes. | Calibrate the output logits and provide negative baseline examples (images with nothing happening) in the few-shot prompt context. |
-
----
-
-## Hands-On Exercises
-
-To master Multimodal AI, you must build operational pipelines locally. The following labs have been engineered to run end-to-end on your local machine.
-
-### Step 0: Lab Infrastructure Setup
-
-Before beginning the exercises, you must provision your local workspace, instantiate a clean Python environment, and acquire the necessary public domain assets. Execute the following bash commands in your terminal:
-
-```bash
-# 1. Create project workspace
-mkdir -p ~/vision-ai-lab/my_photos
-cd ~/vision-ai-lab
-
-# 2. Setup Python virtual environment
-python3 -m venv .venv
-source .venv/bin/activate
-
-# 3. Install core dependencies
-pip install transformers torch pillow pdf2image anthropic openai matplotlib numpy requests
-
-# 4. Download sample visual assets
-echo "Downloading test images..."
-wget -qO my_photos/cat.jpg "https://upload.wikimedia.org/wikipedia/commons/4/4d/Cat_November_2010-1a.jpg"
-wget -qO my_photos/dog.jpg "https://upload.wikimedia.org/wikipedia/commons/d/d4/Labrador_Retriever_%281210559%29.jpg"
-wget -qO my_photos/bird.jpg "https://upload.wikimedia.org/wikipedia/commons/4/45/Eopsaltria_australis_-_Mogo_Campground.jpg"
-wget -qO my_photos/car.jpg "https://upload.wikimedia.org/wikipedia/commons/a/a6/Automobile_car_gear_shift_pictures_free_public_domain_car_pictures_-_0323.jpg"
-wget -qO my_photos/house.jpg "https://upload.wikimedia.org/wikipedia/commons/3/30/Small_house_in_snow.jpg"
-wget -qO test_image.jpg "https://upload.wikimedia.org/wikipedia/commons/4/4d/Cat_November_2010-1a.jpg"
-wget -qO test.jpg "https://upload.wikimedia.org/wikipedia/commons/d/d4/Labrador_Retriever_%281210559%29.jpg"
-wget -qO diagram.png "https://upload.wikimedia.org/wikipedia/commons/thumb/1/10/Basic_architecture_of_a_microprocessor.png/500px-Basic_architecture_of_a_microprocessor.png"
-wget -qO sample.pdf "https://www.w3.org/WAI/ER/tests/xhtml/testfiles/resources/pdf/dummy.pdf"
-wget -qO product1.jpg "https://upload.wikimedia.org/wikipedia/commons/4/4d/Cat_November_2010-1a.jpg"
-wget -qO product2.jpg "https://upload.wikimedia.org/wikipedia/commons/d/d4/Labrador_Retriever_%281210559%29.jpg"
-
-# 5. Verify local state
-echo "Verifying lab state..."
-ls -la my_photos/ test_image.jpg diagram.png sample.pdf
-```
-**Checkpoint Verification**: Ensure all 11 files downloaded successfully and your `.venv` is actively sourced in your shell.
-
-### Exercise 1: Build Zero-Shot Image Classifier
-
-**Goal**: Construct a robust classification script utilizing the Hugging Face `transformers` implementation of OpenAI's CLIP model. Understand how prompt templating impacts classification accuracy.
-
-<details>
-<summary>View Solution and Code</summary>
-
-Ensure your environment is prepared (this should be handled by your setup script):
-```bash
-pip install transformers torch pillow
-```
-
-Create a file named `zero_shot.py` and implement the classifier logic:
-```python
-from transformers import CLIPProcessor, CLIPModel
-from PIL import Image
-import torch
-
-class ZeroShotClassifier:
-    def __init__(self):
-        self.model = CLIPModel.from_pretrained("openai/clip-vit-base-patch32")
-        self.processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
-
-    def classify(self, image_path, categories, prompt_template="a photo of a {}"):
-        image = Image.open(image_path)
-        prompts = [prompt_template.format(cat) for cat in categories]
-
-        inputs = self.processor(
-            text=prompts,
-            images=image,
-            return_tensors="pt",
-            padding=True
-        )
-
-        with torch.no_grad():
-            outputs = self.model(**inputs)
-            logits = outputs.logits_per_image
-            probs = logits.softmax(dim=1)
-
-        results = {cat: prob.item() for cat, prob in zip(categories, probs[0])}
-        return dict(sorted(results.items(), key=lambda x: x[1], reverse=True))
-
-# Usage
-classifier = ZeroShotClassifier()
-categories = ["dog", "cat", "bird", "car", "house"]
-results = classifier.classify("test_image.jpg", categories)
-print(results)
-```
-
-Append the following logic to test prompt engineering variance:
-```python
-templates = [
-    "a photo of a {}",
-    "a picture of a {}",
-    "an image containing a {}",
-    "a {} in a photograph"
-]
-
-for template in templates:
-    results = classifier.classify("test.jpg", categories, template)
-    print(f"{template}: {list(results.keys())[0]}")
-```
-Execute the script using `python3 zero_shot.py`.
-</details>
-
-### Exercise 2: Create Image Search Engine
-
-**Goal**: Develop a local semantic search engine capable of indexing a directory of unstructured images and returning the highest confidence matches based on natural language string queries.
-
-<details>
-<summary>View Solution and Code</summary>
-
-Create a file named `search_engine.py` to ingest your `my_photos` directory:
-```python
-import os
-import numpy as np
-from pathlib import Path
-
-class ImageSearchEngine:
-    def __init__(self):
-        self.model = CLIPModel.from_pretrained("openai/clip-vit-base-patch32")
-        self.processor = CLIPProcessor.from_pretrained("openai/clip-vit-base-patch32")
-        self.image_paths = []
-        self.embeddings = None
-
-    def index_folder(self, folder_path):
-        """Index all images in a folder."""
-        image_files = []
-        for ext in ['*.jpg', '*.jpeg', '*.png', '*.webp']:
-            image_files.extend(Path(folder_path).glob(f'**/{ext}'))
-
-        embeddings = []
-        for img_path in image_files:
-            try:
-                image = Image.open(img_path).convert('RGB')
-                inputs = self.processor(images=image, return_tensors="pt")
-
-                with torch.no_grad():
-                    emb = self.model.get_image_features(**inputs)
-                    emb = emb / emb.norm(dim=-1, keepdim=True)
-
-                embeddings.append(emb.numpy())
-                self.image_paths.append(str(img_path))
-            except Exception as e:
-                print(f"Error processing {img_path}: {e}")
-
-        self.embeddings = np.vstack(embeddings)
-        print(f"Indexed {len(self.image_paths)} images")
-
-    def search(self, query, top_k=5):
-        """Search images with natural language."""
-        inputs = self.processor(text=[query], return_tensors="pt")
-
-        with torch.no_grad():
-            text_emb = self.model.get_text_features(**inputs)
-            text_emb = text_emb / text_emb.norm(dim=-1, keepdim=True)
-
-        similarities = (text_emb.numpy() @ self.embeddings.T)[0]
-        top_indices = np.argsort(similarities)[::-1][:top_k]
-
-        return [
-            {"path": self.image_paths[i], "score": float(similarities[i])}
-            for i in top_indices
-        ]
-
-# Usage
-engine = ImageSearchEngine()
-engine.index_folder("./my_photos")
-results = engine.search("sunset over the ocean")
-```
-
-Integrate `matplotlib` to render the outputs visually:
-```python
-import matplotlib.pyplot as plt
-
-def show_results(results, query):
-    fig, axes = plt.subplots(1, len(results), figsize=(15, 5))
-    fig.suptitle(f"Query: {query}")
-
-    for ax, result in zip(axes, results):
-        img = Image.open(result["path"])
-        ax.imshow(img)
-        ax.set_title(f"Score: {result['score']:.3f}")
-        ax.axis('off')
-
-    plt.tight_layout()
-    plt.show()
-```
-</details>
-
-### Exercise 3: Document Understanding Pipeline
-
-**Goal**: Engineer a multimodal Retrieval-Augmented Generation (RAG) prototype that paginates a PDF, generates visual summaries using an Anthropic VLM, and answers queries contextually. *(Requires a valid Anthropic API key exported to your environment).*
-
-<details>
-<summary>View Solution and Code</summary>
-
-Create a file named `document_qa.py`. Establish the image conversion utilities:
-```python
-from pdf2image import convert_from_path
-import anthropic
-import base64
-from io import BytesIO
-
-def pdf_to_images(pdf_path, dpi=150):
-    """Convert PDF pages to images."""
-    return convert_from_path(pdf_path, dpi=dpi)
-
-def image_to_base64(image):
-    """Convert PIL image to base64."""
-    buffer = BytesIO()
-    image.save(buffer, format='PNG')
-    return base64.b64encode(buffer.getvalue()).decode()
-```
-
-Implement the hierarchical summarization logic:
-```python
-class DocumentQA:
-    def __init__(self):
-        self.client = anthropic.Anthropic()
-        self.pages = []
-        self.page_summaries = []
-
-    def load_document(self, pdf_path):
-        """Load and summarize each page."""
-        self.pages = pdf_to_images(pdf_path)
-
-        for i, page in enumerate(self.pages):
-            summary = self._summarize_page(page, i)
-            self.page_summaries.append(summary)
-
-    def _summarize_page(self, image, page_num):
-        """Get summary of a single page."""
-        response = self.client.messages.create(
-            model="claude-4.5-haiku-20240307",
-            max_tokens=500,
-            messages=[{
-                "role": "user",
-                "content": [
-                    {"type": "image", "source": {
-                        "type": "base64",
-                        "media_type": "image/png",
-                        "data": image_to_base64(image)
-                    }},
-                    {"type": "text", "text":
-                        f"Page {page_num + 1}. Summarize key information in 2-3 sentences."}
-                ]
-            }]
-        )
-        return response.content[0].text
-
-    def ask(self, question):
-        """Answer a question about the document."""
-        # First, find relevant pages
-        context = "\n".join([
-            f"Page {i+1}: {summary}"
-            for i, summary in enumerate(self.page_summaries)
-        ])
-
-        # Then, answer with relevant page images
-        response = self.client.messages.create(
-            model="claude-4.6-sonnet-20240229",
-            max_tokens=1000,
-            messages=[{
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": f"Document context:\n{context}\n\nQuestion: {question}"}
-                ]
-            }]
-        )
-        return response.content[0].text
-```
-</details>
-
-### Exercise 4: Multi-Image Comparison Tool
-
-**Goal**: Implement a competitive evaluation script that feeds multiple images sequentially into OpenAI's API to extract structured differences and business recommendations. *(Requires a valid OpenAI API key exported to your environment).*
-
-<details>
-<summary>View Solution and Code</summary>
-
-Create a file named `comparator.py` and implement the structured prompt logic:
-```python
-from openai import OpenAI
-import base64
-from dataclasses import dataclass
-from typing import List
-
-@dataclass
-class ComparisonResult:
-    similarities: List[str]
-    differences: List[str]
-    recommendation: str
-    confidence: float
-
-class ProductComparator:
-    def __init__(self):
-        self.client = OpenAI()
-
-    def compare(self, image1_path: str, image2_path: str) -> ComparisonResult:
-        """Compare two product images."""
-
-        with open(image1_path, "rb") as f:
-            img1_b64 = base64.b64encode(f.read()).decode()
-        with open(image2_path, "rb") as f:
-            img2_b64 = base64.b64encode(f.read()).decode()
-
-        response = self.client.chat.completions.create(
-            model="gpt-5",
-            messages=[{
-                "role": "user",
-                "content": [
-                    {"type": "text", "text": """
-Compare these two products. Provide:
-1. SIMILARITIES: List 3-5 things they have in common
-2. DIFFERENCES: List 3-5 key differences
-3. RECOMMENDATION: Which would you recommend and why?
-4. CONFIDENCE: How confident are you (0-100)?
-
-Format your response as:
-SIMILARITIES:
-- [item]
-DIFFERENCES:
-- [item]
-RECOMMENDATION: [text]
-CONFIDENCE: [number]
-"""},
-                    {"type": "image_url", "image_url": {
-                        "url": f"data:image/jpeg;base64,{img1_b64}"
-                    }},
-                    {"type": "image_url", "image_url": {
-                        "url": f"data:image/jpeg;base64,{img2_b64}"
-                    }}
-                ]
-            }],
-            max_tokens=1000
-        )
-
-        return self._parse_response(response.choices[0].message.content)
-
-    def _parse_response(self, text):
-        # Parse structured output
-        # ... parsing logic ...
-        pass
-```
-</details>
-
-**Success Checklist**:
-- [ ] Validated local `venv` and package installations.
-- [ ] Successfully indexed `my_photos` directory using CLIP text embeddings.
-- [ ] Confirmed Document QA processes the PDF pages into base64 payload cleanly.
-- [ ] Extracted multi-image comparison vectors.
-
----
+| Mistake | Why it happens | How to fix |
+|---|---|---|
+| Treating VLM prose as verified evidence | The language model can produce fluent explanations even when the visual signal is weak or ambiguous. | Ask for observed evidence separately, require `unclear` for missing evidence, and validate outputs before acting. |
+| Sending raw high-resolution images to every API call | Teams optimize for demo simplicity and forget that upload size, visual tokens, and provider accounting affect cost and latency. | Resize by task, cap dimensions, cache image hashes, and document model-specific accounting in a dated snapshot. |
+| Using CLIP similarity as a business decision | Contrastive embeddings are excellent for retrieval but do not prove exact object state, text content, or policy compliance. | Use CLIP for candidate generation, then add VLM verification, specialized detectors, OCR, or human review. |
+| Flattening document OCR before reasoning | Plain text extraction often destroys table layout, field proximity, checkboxes, and signatures. | Preserve coordinates, page images, crops, and schema validation so the model can reason with layout evidence. |
+| Concatenating multiple images into one collage | The model may mix visual evidence across regions, and resizing can make labels such as "left" or "right" unreliable. | Pass images as separate inputs when the API supports it, label each image in the prompt, and request per-image evidence. |
+| Asking one prompt to perform many unrelated tasks | The model divides attention across counting, OCR, classification, comparison, and summarization, causing omissions. | Decompose workflows into focused calls or staged prompts, then combine validated intermediate outputs. |
+| Ignoring negative and low-quality test cases | Demos usually contain clean images where the expected answer is present, hiding false positives and uncertainty handling. | Build an evaluation set with normal images, unclear images, glare, blur, small text, rotated pages, and adversarial text. |
 
 ## Knowledge Check
 
 <details>
-<summary><strong>Question 1</strong>: You are deploying a visual QA system for a real estate platform. Users upload photos of living rooms, and the system must identify the flooring material. To save costs, you pass a heavily compressed 150x150 pixel thumbnail to the VLM. The model repeatedly hallucinates "carpet" on hardwood floors. Why does this occur?</summary>
-<br>
-The heavy compression introduces aggressive visual artifacts that blur the distinct grain and specular highlights of the hardwood. In the absence of sharp visual features at the patch level, the VLM is forced to rely heavily on its language prior. It guesses "carpet" simply because it is a statistically common living room flooring in its internet-scraped training data. You must provide an image resolution of at least 512x512 for accurate texture recognition.
+<summary><strong>Question 1</strong>: A team increases ViT patch size from 16 by 16 to 32 by 32 for a fixed-size image and sees faster inference but worse small-text recognition. What changed?</summary>
+
+The larger patch size reduces the number of tokens, so self-attention has a shorter sequence and inference can be faster. The tradeoff is that each token now compresses a larger region of pixels before attention can operate. Small characters, thin lines, and subtle visual details may be averaged into one representation too early. For OCR-like tasks, smaller patches or higher-resolution processing can preserve evidence that a coarse patch grid loses.
 </details>
 
 <details>
-<summary><strong>Question 2</strong>: Your team is attempting to build an autonomous inventory drone. You feed the raw camera stream into an open-source LLaVA model to detect empty shelf space. The system runs at 0.5 frames per second, which is far too slow for real-time navigation. How should you re-architect the system?</summary>
-<br>
-A massive Vision-Language Model is the wrong architectural choice for real-time spatial detection. You should deploy a lightweight, specialized Convolutional Neural Network (like YOLO) or a dedicated edge model optimized purely for bounding box object detection. You should reserve the expensive, high-latency VLM strictly for complex, low-frequency reasoning tasks, such as reading a specific, damaged shipping label upon request.
+<summary><strong>Question 2</strong>: Your CLIP search system retrieves "safety helmet" images for the query "worker without helmet." Why is this not surprising?</summary>
+
+CLIP-style retrieval measures similarity between an image and a text prompt; it does not reliably implement logical negation. The words "worker" and "helmet" may dominate the embedding, while "without" may not create the negative concept you intend. A better design retrieves candidate worker images, then uses a detector or VLM verification prompt that asks for visible evidence of helmet presence and allows an explicit `unclear` outcome.
 </details>
 
 <details>
-<summary><strong>Question 3</strong>: During a contrastive learning training run for a new custom CLIP variant, you notice that the loss plateaus quickly and the model fails to learn fine-grained distinctions between dog breeds. Your batch size is 64. What is the fundamental issue?</summary>
-<br>
-The batch size is far too small for effective contrastive learning. The model relies entirely on the off-diagonal elements in the similarity matrix as negative examples. A batch of 64 provides only 63 negative examples per image, which are too easily distinguished by the model. You must scale the batch size into the thousands to consistently expose the model to "hard negatives" that mathematically force it to learn nuanced, fine-grained features.
+<summary><strong>Question 3</strong>: A document pipeline sends OCR text alone to an LLM and gets line-item totals attached to the wrong products. Why can the original page image help?</summary>
+
+The OCR text may flatten a two-dimensional page into a one-dimensional string, losing columns, row alignment, checkboxes, and spatial proximity. The page image preserves layout evidence that helps associate a price with the correct row or table region. A robust pipeline can combine OCR coordinates, page crops, VLM semantic extraction, and arithmetic validation rather than relying on flattened text alone.
 </details>
 
 <details>
-<summary><strong>Question 4</strong>: A legal tech startup uses a VLM API to analyze scanned contracts. When analyzing a page with a faint, low-contrast "CONFIDENTIAL" watermark, the model consistently fails to mention it, even when explicitly prompted: "Is there a watermark?" What is the most robust mitigation strategy?</summary>
-<br>
-The vision encoder's patch projection logic often washes out low-contrast, low-frequency visual signals before they even reach the language model component. To mitigate this blind spot, you should apply classical computer vision preprocessing to the image prior to the API request. Implementing histogram equalization or adaptive contrast enhancement locally will amplify the watermark's pixel variance, allowing the VLM to detect it.
+<summary><strong>Question 4</strong>: A VLM returns valid JSON for every invoice, but reviewers find that missing purchase-order numbers are replaced by plausible-looking values. What should change?</summary>
+
+The schema should define missing or unreadable fields as `null` or `unclear`, and the prompt should explicitly forbid guessing. The application should validate field formats, compare extracted values against OCR snippets or crops, and route low-confidence cases to review. Valid JSON only proves the response parsed; it does not prove the visual evidence supported every value.
 </details>
 
 <details>
-<summary><strong>Question 5</strong>: You are designing a pipeline to compare two product images (e.g., a listing photo vs. a customer upload). You programmatically concatenate both images into a single wide image horizontally and prompt the model to "spot the differences." The model performs poorly, hallucinating features from the left side onto the right side. Why does this happen?</summary>
-<br>
-By combining the images into one large tensor, you rely entirely on the model's positional embeddings to segregate the contexts. The global cross-attention mechanism allows patches from the left image to attend directly to patches on the right, leading to severe feature entanglement. You should pass the images as separate, distinct inputs in the API request payload, allowing the model to process their tokens independently before reasoning across them.
+<summary><strong>Question 5</strong>: A quality-control app concatenates "before" and "after" photos into one image, then asks the VLM to compare them. The model mixes details across the two sides. What is the better request shape?</summary>
+
+Pass the photos as separate image inputs when the API supports it, label them clearly in the prompt, and request evidence per image before asking for a comparison. Concatenation relies on the model preserving the human-intended boundary after resizing and tokenization. Separate inputs make it easier for the system and prompt to maintain image identity throughout the reasoning step.
 </details>
 
 <details>
-<summary><strong>Question 6</strong>: To optimize costs for an invoice processing pipeline, you decide to use a lightweight text-only LLM alongside a separate open-source OCR engine. You extract the text and send it to the LLM, but it consistently fails to associate prices with the correct line items. Why might a native multimodal VLM solve this more effectively?</summary>
-<br>
-A native VLM processes the visual layout and structural geometry of the document concurrently with the embedded text. The separate OCR engine flattens the two-dimensional spatial layout into a one-dimensional string, entirely destroying the visual proximity cues (like horizontal alignment or dashed leader lines) that indicate a price belongs to a specific item. The VLM retains this spatial context throughout its attention layers.
+<summary><strong>Question 6</strong>: A support workflow uses a hosted VLM for every uploaded image and then sees unpredictable monthly spend. Which controls should be added first?</summary>
+
+Add deterministic controls before changing models: cap image dimensions, reject unsupported formats, hash and cache repeated images, limit the number of images per request, and split simple classification from expensive reasoning. Then measure latency and cost by task type. Pricing details change across providers, but preprocessing, caching, batching, and routing remain durable cost-control techniques.
 </details>
 
----
+<details>
+<summary><strong>Question 7</strong>: A team builds a BLIP-2 or LLaVA-style VLM by freezing a vision encoder, training only a projection connector, and attaching an instruction-tuned LLM. The answers are fluent, but tiny serial numbers disappear. Which component is most likely responsible?</summary>
 
-## Essential References
+The projection connector or visual resampling path is the first place to inspect, because it controls how much visual detail survives from the frozen vision encoder into the LLM-compatible embedding sequence. The language model never sees raw pixels; it sees projected visual embeddings. If the connector compresses many patch features into too few tokens, small evidence can disappear before generation begins. A better design may need higher-resolution visual features, a less aggressive connector, OCR support, or a specialized crop path for serial-number regions.
+</details>
 
-- [OpenAI Vision API](https://platform.openai.com/docs/guides/vision)
-- [Claude Vision](https://docs.anthropic.com/claude/docs/vision)
-- [Google Gemini Vision](https://ai.google.dev/gemini-api/docs/vision)
-- [HuggingFace CLIP](https://huggingface.co/docs/transformers/model_doc/clip)
-- [Building with GPT-4V](https://cookbook.openai.com/articles/introducing_vision)
-- [CLIP for Image Search](https://rom1504.medium.com/image-search-with-clip-f2a8daf8a5f5)
-- [Running LLaVA Locally](https://llava-vl.github.io/)
+<details>
+<summary><strong>Question 8</strong>: A prototype works on clean demo photos but fails on real phone uploads with glare, rotation, and blur. What evaluation mistake caused this?</summary>
 
----
+The evaluation set represented the demo distribution rather than the production distribution. Vision systems need test cases for poor lighting, motion blur, rotated pages, compression artifacts, small text, reflections, normal negative examples, and ambiguous images. Without those cases, the team cannot measure false positives, uncertainty handling, preprocessing needs, or review volume before launch.
+</details>
 
-_Next: [Module 24 - Video AI & Generation](./module-1.3-video-ai) — Learn how to extend spatial reasoning into the temporal dimension by architecting continuous frame pipelines and dealing with the massive data requirements of video streams._
+## Hands-On Exercise
+
+In this exercise, you will build a small local CLIP image search lab and a deterministic preprocessing check. The goal is not to deploy a full VLM service; it is to practice the foundation that many production systems use before calling a generative model. You will create a tiny image corpus, index it with CLIP, query it with natural language, and inspect how prompt wording changes retrieval. The commands assume you are running from the KubeDojo repository root so the project `.venv` is available.
+
+```bash
+LAB_DIR="${TMPDIR:-/tmp}/vision-ai-lab"
+mkdir -p "$LAB_DIR/images"
+cd "$LAB_DIR"
+
+# Wikimedia Commons re-hashes file paths over time, so we use the hash-independent
+# Special:FilePath redirect (resolves to the current canonical URL) instead of a
+# pinned /a/ab/ hash path that can 404 after a re-hash or file deletion.
+curl -L -o images/cat.jpg   "https://commons.wikimedia.org/wiki/Special:FilePath/Cat_November_2010-1a.jpg"
+curl -L -o images/dog.jpg   "https://commons.wikimedia.org/wiki/Special:FilePath/Labrador_Retriever_(1210559).jpg"
+curl -L -o images/house.jpg "https://commons.wikimedia.org/wiki/Special:FilePath/Snowy_house.jpg"
+curl -L -o images/bird.jpg  "https://commons.wikimedia.org/wiki/Special:FilePath/Eopsaltria_australis_-_Mogo_Campground.jpg"
+```
+
+Create `$LAB_DIR/clip_search_lab.py` with the following script. It indexes all downloaded JPEG files, runs three natural-language queries, and prints the top matches. The script also normalizes image color mode and rejects very small images so you can see where preprocessing belongs in the application boundary.
+
+```python
+from pathlib import Path
+
+import numpy as np
+import torch
+from PIL import Image
+from transformers import CLIPModel, CLIPProcessor
+
+
+def load_image(path):
+    image = Image.open(path).convert("RGB")
+    if min(image.size) < 224:
+        raise ValueError(f"{path} is too small for this lab: {image.size}")
+    return image
+
+
+class ClipIndex:
+    def __init__(self, model_name="openai/clip-vit-base-patch32"):
+        self.model = CLIPModel.from_pretrained(model_name)
+        self.processor = CLIPProcessor.from_pretrained(model_name)
+        self.paths = []
+        self.embeddings = None
+
+    def index(self, image_dir):
+        vectors = []
+        for path in sorted(Path(image_dir).glob("*.jpg")):
+            image = load_image(path)
+            inputs = self.processor(images=image, return_tensors="pt")
+            with torch.no_grad():
+                vector = self.model.get_image_features(**inputs)
+                vector = vector / vector.norm(dim=-1, keepdim=True)
+            vectors.append(vector.cpu().numpy())
+            self.paths.append(path)
+        self.embeddings = np.vstack(vectors)
+
+    def search(self, query, top_k=2):
+        inputs = self.processor(text=[query], return_tensors="pt", padding=True)
+        with torch.no_grad():
+            vector = self.model.get_text_features(**inputs)
+            vector = vector / vector.norm(dim=-1, keepdim=True)
+        scores = (vector.cpu().numpy() @ self.embeddings.T)[0]
+        order = np.argsort(scores)[::-1][:top_k]
+        return [(self.paths[i].name, round(float(scores[i]), 4)) for i in order]
+
+
+if __name__ == "__main__":
+    index = ClipIndex()
+    index.index("images")
+    queries = [
+        "a photo of a household pet",
+        "a snowy building",
+        "a small bird perched outdoors",
+    ]
+    for query in queries:
+        print(query)
+        for name, score in index.search(query):
+            print(f"  {name}: {score}")
+```
+
+Run the script from the repository root so it uses the project virtual environment and installed dependencies. If the `transformers`, `torch`, or `pillow` packages are not installed in your local environment, install them into the project venv first using the same interpreter.
+
+```bash
+# From the KubeDojo repository root:
+.venv/bin/python -m pip install transformers torch pillow numpy
+.venv/bin/python "${TMPDIR:-/tmp}/vision-ai-lab/clip_search_lab.py"
+```
+
+After the first successful run, edit the query `"a photo of a household pet"` into `"a product catalog image of a household pet"` and run the script again. The labels in this tiny corpus may not change, but the scores usually move because the text encoder embeds the whole prompt. In a real system, you would record those prompt variants as evaluation cases rather than treating a single query string as the truth.
+
+**Success Checklist**
+
+- [ ] The four sample images exist under `$LAB_DIR/images`.
+- [ ] The script rejects no images for size or decoding errors.
+- [ ] Each query returns two ranked filenames with numeric similarity scores.
+- [ ] You changed one prompt template and observed whether scores or rankings moved.
+- [ ] You can explain why this CLIP lab is retrieval, not grounded visual reasoning.
+
+## Next Module
+
+Next: [Module 1.3: Video AI](../module-1.3-video-ai/) extends the same multimodal reasoning problem into time, where frame sampling, temporal grounding, and long-context evidence management become the central engineering constraints.
 
 ## Sources
 
-- [An Image is Worth 16x16 Words](https://arxiv.org/abs/2010.11929) — Foundational paper for Vision Transformers and the patch-based formulation used throughout the module.
-- [Learning Transferable Visual Models From Natural Language Supervision](https://arxiv.org/abs/2103.00020) — Primary source for CLIP, contrastive image-text learning, and zero-shot transfer.
-- [BLIP-2](https://arxiv.org/abs/2301.12597) — Clear primary reference for the modern frozen-vision-encoder plus LLM bridge pattern used by many VLMs.
+- [An Image is Worth 16x16 Words: Transformers for Image Recognition at Scale](https://arxiv.org/abs/2010.11929) — foundational ViT paper for patch embeddings, transformer encoders, and scale-dependent visual pretraining.
+- [Learning Transferable Visual Models From Natural Language Supervision](https://arxiv.org/abs/2103.00020) — primary CLIP paper for contrastive image-text pretraining and zero-shot classification with text prompts.
+- [BLIP-2: Bootstrapping Language-Image Pre-training with Frozen Image Encoders and Large Language Models](https://arxiv.org/abs/2301.12597) — reference architecture for frozen visual encoders, frozen LLMs, and a learned modality bridge.
+- [Visual Instruction Tuning](https://arxiv.org/abs/2304.08485) — LLaVA paper explaining visual instruction tuning and the vision-encoder-to-LLM connector pattern.
+- [Sigmoid Loss for Language Image Pre-Training](https://arxiv.org/abs/2303.15343) — SigLIP paper showing an alternative loss for language-image pretraining.
+- [OpenCLIP repository](https://github.com/mlfoundations/open_clip) — open implementation ecosystem for training and evaluating CLIP-style image-text models.
+- [Hugging Face Transformers CLIP documentation](https://huggingface.co/docs/transformers/en/model_doc/clip) — practical API reference for CLIP encoders, feature extraction, and similarity scoring.
+- [OpenAI Images and Vision guide](https://developers.openai.com/api/docs/guides/images-vision) — official OpenAI documentation for image inputs and vision-capable API workflows.
+- [Claude Vision documentation](https://platform.claude.com/docs/en/build-with-claude/vision) — official Anthropic documentation for Claude image inputs, limits, and multimodal usage patterns.
+- [Gemini Image Understanding documentation](https://ai.google.dev/gemini-api/docs/image-understanding) — official Google AI documentation for Gemini image input and visual task support.
+- [Qwen2.5-VL release notes](https://qwenlm.github.io/blog/qwen2.5-vl/) — Qwen team's published overview of its vision-language model family, grounding, document, and structured-output examples.
+- [LLaVA project page](https://llava-vl.github.io/) — project documentation for LLaVA's visual instruction data, CLIP visual encoder connection, and open-source release context.

--- a/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.3-video-ai.md
+++ b/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.3-video-ai.md
@@ -5,1058 +5,409 @@ sidebar:
   order: 904
 ---
 
+> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 4-5 hours | Prerequisites: [Vision AI](../module-1.2-vision-ai/), transformer attention, API cost awareness, and basic Kubernetes batch processing
+
+## Learning Outcomes
+
+By the end of this module, you will be able to connect video-specific modeling choices to production architecture decisions instead of treating video as a folder of still images with a higher storage bill.
+
+- **Design** adaptive frame extraction and sampling policies that balance recall, latency, and API spend for slow scenes, fast actions, and long archives. Sections: Frame Extraction and Sampling; Knowledge Check 1.
+- **Explain** how temporal video models, video transformers, and Vision LLM payloads represent multiple frames, temporal order, and long-range context. Sections: Temporal Modeling and Vision LLMs; Knowledge Check 2.
+- **Build** a long-video understanding workflow that separates captioning, action detection, summarization, video question answering, and map-reduce aggregation. Sections: Video Understanding Workflows; Knowledge Check 3.
+- **Evaluate** generation providers, adapter capability tables, generated-video provenance, and video job tradeoffs without turning volatile vendor claims into durable teaching material. Sections: Video Generation: Concepts and Constraints; Knowledge Checks 4 and 7.
+- **Operate** a Kubernetes-oriented video AI pipeline that uses queues, chunking, GPU batching, adaptive extraction, and observability boundaries for real-time event detection. Sections: Production Video AI on Kubernetes; Knowledge Checks 5-6.
+
 ## Why This Module Matters
 
-In May 2016, a fatal crash involving a semi-autonomous vehicle operating on a major highway highlighted a catastrophic limitation in early computer vision systems. The vehicle's cameras detected a white tractor-trailer crossing the road against a brightly lit sky, but the system failed to recognize the obstruction and did not brake, underscoring how brittle perception systems can be in complex real-world conditions. This incident tragically demonstrated that analyzing the world one frame at a time is fundamentally insufficient for understanding dynamic environments.
+At 4:36 p.m. eastern daylight time on May 7, 2016, a Tesla Model S operating with an automated vehicle control system struck a tractor-semitrailer near Williston, Florida. The National Transportation Safety Board investigation is not a "video AI benchmark," and it should not be reduced to one simplistic model-failure slogan. It is still a useful reminder for engineers because the incident involved a dynamic scene where perception, driver attention, system boundaries, and timing all mattered at once. A single static frame rarely contains the whole operational truth.
 
-Today, enterprise engineering teams face similar, if less lethal, challenges when applying legacy computer vision to massive video datasets. Teams that analyze safety video frame by frame often encounter false alarms and missed events until they add temporal context to the pipeline.
+Video AI matters because time changes the meaning of pixels. A still image can tell you that a person is standing near a doorway; a video can tell you whether the person just entered, is leaving, is waiting, dropped a package, or is being followed. A still frame can show a forklift near a pallet; a video can reveal whether the forklift paused safely, clipped a corner, or reversed into a blind spot. The hard part is not merely more data. The hard part is preserving the right temporal evidence while discarding enough redundant frames to make the system affordable.
 
-Video is the final frontier of multimodal artificial intelligence. While images capture a single static moment, video captures time, motion, narrative, and causality. Understanding and generating video requires systems to reason about sequences, predict future states, and maintain strict object permanence. The financial impact of mastering this domain can be substantial, from lowering moderation workload at scale to enabling new forms of generative interactive media.
+Hypothetical scenario: a retail operations team wants to audit thousands of hours of checkout-area footage for process bottlenecks. The first prototype samples one frame every second, sends each frame to a vision model, and asks whether the frame contains a queue. The demo works on a short clip, but production results are unreliable. A short rush of customers between sampled frames is missed, static scenes generate repeated API calls, and the summary says "busy counter" without identifying when the line formed, how long it lasted, or what event cleared it.
 
-## What You Will Be Able to Do
+That failure is common because image pipelines encourage the wrong abstraction. Video should be treated less like a bag of pictures and more like a compressed event stream. The engineering question is always, "Which temporal evidence must survive into the model context?" Sometimes the answer is a uniform sample across the whole clip. Sometimes it is a dense burst around motion, a keyframe at each scene boundary, a sliding window around a suspected action, or a hierarchical summary where short chunks are analyzed first and then merged.
 
-By the end of this rigorous module, you will be equipped to:
-- **Design** an adaptive frame sampling pipeline to optimize API costs and minimize compute resource overhead.
-- **Implement** a multimodal video understanding system utilizing state-of-the-art vision-language models for summarization and action tracking.
-- **Diagnose** temporal inconsistencies and context loss in legacy video processing applications.
-- **Evaluate** the cost-benefit trade-offs between running open-source diffusion models locally versus utilizing managed API services for generation.
-- **Implement** continuous video stream processing to detect events in real-time within a Kubernetes architecture.
+The analogy to remember is a security guard reviewing a long hallway camera. A guard does not stare with equal attention at every identical second of an empty hallway. They scrub faster through quiet periods, slow down when a door opens, rewind around suspicious movement, and write a report that separates observed evidence from inference. A good video AI system does the same thing mechanically: it samples, scores, chunks, reasons, and reports with explicit uncertainty.
 
-## Part 1: The Video AI Landscape
+## Frame Extraction and Sampling
 
-Understanding video is exponentially more complex than understanding images. If image classification is akin to reading a photograph, video understanding is akin to reading a sprawling novel where you must remember the events of previous chapters to understand the current page.
+Video ingestion begins before any neural network sees a tensor. A file container holds encoded video streams, audio streams, timestamps, keyframes, metadata, and compression artifacts. The model usually cannot consume that container directly, so the pipeline must decode some representation of the stream into frames, frame embeddings, audio snippets, transcripts, or native video payloads supported by a managed model. The first major design decision is therefore not "which model?" but "which evidence should we extract?"
 
-### The Architectural Challenges
+A naive extractor reads every frame and forwards it downstream. That seems faithful, but it is almost always wasteful. A ten-second clip at thirty frames per second contains three hundred frames, many of which may be nearly identical. If you send all three hundred frames to a paid Vision LLM, the dominant cost driver is no longer reasoning; it is the number, size, and resolution of images placed into the model context. If you run a local detector, the same over-extraction inflates GPU queues, storage writes, and memory pressure.
 
-Video data introduces strict requirements that images simply do not possess:
-1. **The Temporal Dimension**: A ten-second video recorded at 30 frames per second contains 300 discrete images. This represents orders of magnitude more data than standard image processing pipelines are designed to handle.
-2. **Motion and Causality**: Recognizing an action requires understanding the delta between frames. Detecting a glass shattering requires tracking the object before, during, and after the impact.
-3. **Long-Range Dependencies**: An event that occurs at the first second of a video may dictate the context of an event occurring at the final second.
-4. **Compute Density**: Processing spatial and temporal data simultaneously requires specialized attention mechanisms and significantly higher GPU memory allocations.
+Uniform sampling is the simplest countermeasure. You choose a fixed interval, such as one frame every second, and preserve a steady view across the clip. Uniform sampling is useful for high-level summarization because it gives the model a broad overview without making any local decision about what matters. It also has an obvious failure mode: events shorter than the interval can disappear completely. If a safety violation lasts three tenths of a second and your sampler looks once per second, there is no downstream prompt clever enough to recover evidence that was never extracted.
 
-### Landscape Taxonomy
+Dense sampling does the opposite. It preserves many frames around regions where small motion matters, such as sports analysis, manufacturing inspection, gesture recognition, medical procedure review, or driver-assistance logs. Dense sampling improves recall for fast events because consecutive frames reveal motion direction and timing. It also multiplies cost. A dense clip may be the right input for an action recognition model, but it is a poor default for a quiet storage-room camera where nothing changes for long periods.
 
-The ecosystem of video artificial intelligence is categorized into three primary domains: understanding, generation, and multimodal synthesis.
+Keyframe sampling uses video structure rather than wall-clock time. Modern video codecs already distinguish between independently decodable keyframes and frames that depend on nearby frames. Scene detection tools can also detect cuts, fades, or large visual changes. A keyframe sampler is valuable for summarization because it captures boundaries in visual narrative: a slide changes, a camera angle cuts, a truck enters a yard, or a user switches from screen share to webcam. The limitation is that keyframes describe changes in appearance, not necessarily changes in semantic importance.
 
-```mermaid
-graph TD
-    Root[Video AI Applications]
-    
-    Root --> Understanding[Understanding Analysis]
-    Understanding --> U1[Video Classification]
-    Understanding --> U2[Action Recognition]
-    Understanding --> U3[Object Tracking]
-    Understanding --> U4[Video Captioning]
-    Understanding --> U5[Video Q&A]
-    Understanding --> U6[Video Summarization]
-    
-    Root --> Generation[Generation Creation]
-    Generation --> G1[Text-to-Video]
-    Generation --> G2[Image-to-Video]
-    Generation --> G3[Video-to-Video Style Transfer]
-    Generation --> G4[Video Prediction]
-    Generation --> G5[Video Editing]
-    
-    Root --> Multimodal[Multimodal Combined]
-    Multimodal --> M1[Video + Audio Understanding]
-    Multimodal --> M2[Video + Text Search]
-    Multimodal --> M3[Video + Language Models]
-```
-
-## Part 2: Frame Extraction and Sampling Foundations
-
-Continuous video must be discretized into frames before neural networks can process the data. However, extracting every single frame is usually computationally expensive. Intelligent frame extraction is the cornerstone of efficient video AI.
-
-### The Baseline Extraction Function
-
-The fundamental operation utilizes OpenCV to traverse the video container and extract spatial arrays.
-
-```python
-import cv2
-from pathlib import Path
-from typing import List, Tuple
-import numpy as np
-
-def extract_frames(
-    video_path: str,
-    fps: int = 1,  # Frames per second to extract
-    max_frames: int = 100
-) -> List[np.ndarray]:
-    """
-    Extract frames from a video at specified fps.
-
-    Args:
-        video_path: Path to video file
-        fps: Frames per second to extract
-        max_frames: Maximum frames to extract
-
-    Returns:
-        List of frames as numpy arrays (BGR format)
-    """
-    cap = cv2.VideoCapture(video_path)
-
-    video_fps = cap.get(cv2.CAP_PROP_FPS)
-    frame_interval = int(video_fps / fps)
-
-    frames = []
-    frame_count = 0
-
-    while cap.isOpened() and len(frames) < max_frames:
-        ret, frame = cap.read()
-        if not ret:
-            break
-
-        if frame_count % frame_interval == 0:
-            frames.append(frame)
-
-        frame_count += 1
-
-    cap.release()
-    return frames
-```
-
-### Strategic Sampling Topologies
-
-Depending on the downstream analytical task, engineers must deploy specific sampling strategies.
-
-| Strategy | Description | Use Case |
-|----------|-------------|----------|
-| Uniform | Equal intervals | General analysis |
-| Key Frame | Scene changes | Video summarization |
-| Dense | High fps | Action recognition |
-| Sparse | Low fps | Long video understanding |
-| Adaptive | Based on motion | Efficient processing |
-
-To implement these strategies, we rely on array indexing and histogram comparisons to detect structural changes between sequential frames.
-
-```python
-def sample_frames_uniform(frames: List, n_samples: int) -> List:
-    """Uniformly sample n frames from a list."""
-    indices = np.linspace(0, len(frames) - 1, n_samples, dtype=int)
-    return [frames[i] for i in indices]
-
-def sample_frames_keyframes(frames: List, threshold: float = 0.3) -> List:
-    """Sample frames at scene changes (key frames)."""
-    keyframes = [frames[0]]
-
-    for i in range(1, len(frames)):
-        # Compare histogram difference
-        hist1 = cv2.calcHist([frames[i-1]], [0], None, [256], [0, 256])
-        hist2 = cv2.calcHist([frames[i]], [0], None, [256], [0, 256])
-        diff = cv2.compareHist(hist1, hist2, cv2.HISTCMP_CORREL)
-
-        if diff < threshold:  # Scene change detected
-            keyframes.append(frames[i])
-
-    return keyframes
-```
-
-> **Pause and predict**: If you sample a fast-paced sports broadcast at a fixed rate of one frame per second, what critical events might you completely miss, and how would that skew the accuracy of an action recognition model?
-
-## Part 3: Temporal Modeling and Vision LLMs
-
-Once frames are extracted, the system must establish relationships between them. Historically, computer vision relied on specialized neural architectures for this temporal binding.
-
-1. **3D Convolutional Neural Networks**: Expanding 2D filters into the time domain.
-   ```text
-   Input: [B, C, T, H, W] (batch, channels, time, height, width)
-   ```
-2. **Recurrent Architectures**: Utilizing Long Short-Term Memory to maintain state.
-   ```text
-   Frame embeddings → LSTM → Temporal context
-   ```
-3. **Sequence Transformers**: Passing individual frames as tokens to a self-attention block.
-   ```text
-   [CLS] [F1] [F2] [F3] ... [FN] → Self-Attention → Video embedding
-   ```
-4. **Video Vision Transformers (ViViT)**: Combining spatial patches with temporal metadata.
-   ```text
-   Video → Space-time patches → Transformer → Classification
-   ```
-
-Modern production systems frequently bypass training custom 3D CNNs, opting instead to leverage powerful managed vision-language models (VLMs) by passing encoded frame arrays.
-
-### Interactive Video Question and Answer
-
-By injecting a serialized sequence of frames into a Vision LLM payload, we can construct interactive querying systems.
-
-```python
-import base64
-import cv2
-from openai import OpenAI
-
-def video_qa_with_gpt4v(
-    video_path: str,
-    question: str,
-    n_frames: int = 10,
-    client: OpenAI = None
-) -> str:
-    """
-    Answer questions about a video using GPT-4V.
-
-    Args:
-        video_path: Path to video file
-        question: Question about the video
-        n_frames: Number of frames to sample
-        client: OpenAI client
-
-    Returns:
-        Answer from the model
-    """
-    client = client or OpenAI()
-
-    # Extract frames
-    frames = extract_frames(video_path, fps=1, max_frames=n_frames * 3)
-    sampled = sample_frames_uniform(frames, n_frames)
-
-    # Encode frames to base64
-    content = [{"type": "text", "text": f"These are {n_frames} frames from a video. {question}"}]
-
-    for i, frame in enumerate(sampled):
-        _, buffer = cv2.imencode('.jpg', frame)
-        base64_frame = base64.b64encode(buffer).decode('utf-8')
-        content.append({
-            "type": "image_url",
-            "image_url": {"url": f"data:image/jpeg;base64,{base64_frame}"}
-        })
-
-    response = client.chat.completions.create(
-        model="gpt-5",
-        messages=[{"role": "user", "content": content}],
-        max_tokens=500
-    )
-
-    return response.choices[0].message.content
-```
-
-### Generating Semantic Captions
-
-Similarly, we can instruct the model to synthesize a cohesive narrative describing the sequential events.
-
-```python
-def caption_video(
-    video_path: str,
-    style: str = "detailed",  # "brief", "detailed", "narrative"
-    client: OpenAI = None
-) -> str:
-    """Generate a caption for a video."""
-    client = client or OpenAI()
-
-    frames = extract_frames(video_path, fps=1, max_frames=30)
-    sampled = sample_frames_uniform(frames, 8)
-
-    prompts = {
-        "brief": "In one sentence, describe what happens in this video.",
-        "detailed": "Describe this video in detail, including actions, objects, and setting.",
-        "narrative": "Tell the story of what happens in this video, as if narrating a scene."
-    }
-
-    content = [{"type": "text", "text": prompts.get(style, prompts["detailed"])}]
-
-    for frame in sampled:
-        _, buffer = cv2.imencode('.jpg', frame)
-        base64_frame = base64.b64encode(buffer).decode('utf-8')
-        content.append({
-            "type": "image_url",
-            "image_url": {"url": f"data:image/jpeg;base64,{base64_frame}"}
-        })
-
-    response = client.chat.completions.create(
-        model="gpt-5",
-        messages=[{"role": "user", "content": content}],
-        max_tokens=300
-    )
-
-    return response.choices[0].message.content
-```
-
-### Video Summarization Strategies
-
-For extended sequences, structured summarization ensures critical events are logged chronologically without exceeding the token context limits of the underlying LLM.
-
-```python
-def summarize_video(
-    video_path: str,
-    max_segments: int = 5,
-    client: OpenAI = None
-) -> dict:
-    """
-    Summarize a video into key segments.
-
-    Returns:
-        {
-            "overview": "Overall summary",
-            "segments": [{"time": "0:00-0:30", "description": "..."}],
-            "key_events": ["event1", "event2"]
-        }
-    """
-    client = client or OpenAI()
-
-    # Sample more frames for long videos
-    frames = extract_frames(video_path, fps=0.5, max_frames=50)
-    sampled = sample_frames_uniform(frames, 12)
-
-    prompt = """Analyze these video frames and provide:
-    1. OVERVIEW: A 2-3 sentence summary of the entire video
-    2. SEGMENTS: Break down the video into key segments (up to 5)
-    3. KEY_EVENTS: List the most important events or moments
-
-    Format your response as:
-    OVERVIEW: [summary]
-    SEGMENTS:
-    - [description of segment 1]
-    - [description of segment 2]
-    KEY_EVENTS:
-    - [event 1]
-    - [event 2]
-    """
-
-    content = [{"type": "text", "text": prompt}]
-
-    for frame in sampled:
-        _, buffer = cv2.imencode('.jpg', frame)
-        base64_frame = base64.b64encode(buffer).decode('utf-8')
-        content.append({
-            "type": "image_url",
-            "image_url": {"url": f"data:image/jpeg;base64,{base64_frame}"}
-        })
-
-    response = client.chat.completions.create(
-        model="gpt-5",
-        messages=[{"role": "user", "content": content}],
-        max_tokens=600
-    )
-
-    # Parse response
-    text = response.choices[0].message.content
-
-    return {
-        "overview": text.split("OVERVIEW:")[1].split("SEGMENTS:")[0].strip() if "OVERVIEW:" in text else text,
-        "raw_response": text
-    }
-```
-
-## Part 4: Video Generation Architectures
-
-If video understanding is akin to reading a book, video generation is akin to writing an animate film where every physical law must be strictly maintained across the sequence. Generating a static image via diffusion requires roughly fifty denoising steps. Extrapolating that to a high-framerate video sequence introduces immense computational friction. 
-
-### The Video Generation Landscape
-
-| Model | Company | Type | Access |
-|-------|---------|------|--------|
-| Sora | OpenAI | Text-to-Video | Access and rollout have changed since the original preview; check current product docs |
-| Runway | Runway | Text/Image-to-Video | Model names and access depend on the current product generation and plan |
-| Pika | Pika Labs | Video generation | Availability and feature tiers change quickly; check current product docs |
-| [Stable Video](https://huggingface.co/stabilityai/stable-video-diffusion-img2vid-xt) | Stability AI | Image-to-Video | Open source |
-| Kling | Kuaishou | Video generation | Access and regional availability change frequently; check current product docs |
-| Dream Machine | Luma AI | Video generation | Web and API features vary by current model and plan |
-
-### Diffusion Over Space and Time
-
-To achieve temporal consistency, native video generation models do not process frames independently. They execute denoising operations across the entire sequence simultaneously via temporal attention blocks.
+Adaptive sampling is the production pattern that joins these ideas. The pipeline keeps a minimum heartbeat sample so long periods are not ignored, then raises the sampling rate when local signals suggest useful change. Signals can include histogram difference, optical flow magnitude, object detector deltas, audio energy, speech activity, scene boundary scores, camera motion, or an upstream event such as "door sensor opened." Adaptive sampling is not magic; it is a policy that trades false negatives against cost. Lower thresholds catch more events and spend more compute, while higher thresholds save money and miss subtle motion.
 
 ```mermaid
 flowchart TD
-    Prompt[Text Prompt] --> Encoder[Text Encoder CLIP/T5]
-    Encoder --> Model[Video Diffusion Model]
-    Model -.-> N1[Start with noise video]
-    Model -.-> N2[Iteratively denoise]
-    Model -.-> N3[Conditioned on text]
-    Model -.-> N4[Temporal attention layers]
-    Model --> Video[Generated Video]
+    Video[Encoded video stream] --> Decode[Decode metadata and frames]
+    Decode --> Baseline[Heartbeat sample]
+    Decode --> Motion[Motion and scene scoring]
+    Motion --> Decision{Is temporal evidence changing?}
+    Decision -->|No| Sparse[Sparse frame set]
+    Decision -->|Yes| Burst[Dense local burst]
+    Sparse --> Pack[Package frames with timestamps]
+    Burst --> Pack
+    Pack --> Model[Vision LLM or video model]
+    Model --> Result[Caption, event, answer, or alert]
 ```
 
-Advanced implementations, such as the conceptual architecture of OpenAI's Sora, utilize [Spacetime Patches](https://openai.com/index/video-generation-models-as-world-simulators/) fed into a Diffusion Transformer (DiT).
+The timestamp is as important as the image. A frame without time is only evidence of appearance. A frame with a timestamp can support claims such as "the person entered at 00:12," "the spill appears after the cart passes," or "the alert was raised two seconds after motion began." If you sample ten frames from a two-minute clip, store the original frame index, the time range each frame represents, and the sampling reason. Those fields let reviewers understand whether a summary is based on uniform coverage, a motion-triggered burst, or a scene boundary.
+
+Cost-aware sampling should be designed backward from the product decision. A moderation system that must catch short harmful inserts needs higher recall than a meeting summarizer that only needs agenda-level themes. A warehouse arrival detector can tolerate a few seconds of delay if it avoids analyzing empty pavement all night. A robot perception system cannot tolerate that delay because the physical world has already changed. The same video may need different samplers for archive search, real-time alerting, legal review, and generative editing.
+
+The practical rule is to write the sampling policy down as a contract. Include the minimum sample rate, maximum burst rate, trigger thresholds, maximum frames per clip, allowed image resolution, and escalation path for uncertain cases. If the model output is wrong, the first debugging question is whether the frame evidence contained the event. If the answer is no, you have a sampling failure, not a reasoning failure. If the answer is yes, you can debug prompt framing, model choice, temporal ordering, and assessment logic.
+
+Sampling contracts also make cost review concrete. Without a contract, a team debates video AI in vague terms such as "too expensive" or "not accurate enough." With a contract, the team can calculate how many candidate frames a one-hour source produces under normal conditions, how many more are produced during high-motion bursts, and how many model calls are required after batching. Those numbers can be reviewed against the product risk. A low-risk archive search tool might accept sparse evidence and cheaper summaries, while a safety-critical event detector might deliberately spend more on local dense windows before escalating only the most important frames to a managed model.
+
+The contract should include a fallback for ambiguity. If two adjacent selected frames imply that something important may have happened between them, the system should be able to request a local replay with a denser window instead of forcing the model to guess. This is similar to how a human reviewer scrubs backward and forward around a suspicious moment. The first pass finds likely regions cheaply; the second pass spends more compute only where uncertainty justifies it. That two-pass design is often a better product fit than either sampling everything or trusting one sparse pass.
+
+## Temporal Modeling and Vision LLMs
+
+Temporal modeling is the difference between identifying objects and understanding events. A model looking at one frame can label a ball, a hand, and a table. A temporal model can reason that the hand pushed the ball, the ball rolled, the ball struck a glass, and the glass fell. The objects are not enough. The system must preserve order, motion, persistence, and causality across the sequence.
+
+Classic video models extended image architectures into time. A 3D convolution applies filters across height, width, and time, so it can detect local spatiotemporal patterns such as a hand moving upward or a person turning. Recurrent models encode frames one after another and maintain hidden state. Optical-flow pipelines compute apparent pixel motion between frames and pass motion fields into a classifier. These approaches remain useful for constrained tasks, especially when the label set is narrow and latency must be predictable.
+
+Transformers changed the shape of video modeling by treating space and time as token dimensions. A video transformer can divide frames into patches or tubelets, attach positional information, and let attention connect patches across time. ViViT explored pure-transformer video classification with spatiotemporal tokens and factorized variants to reduce sequence cost. TimeSformer studied attention schemes for video and popularized the idea that spatial attention and temporal attention can be separated inside blocks. The durable lesson is not one paper's benchmark; it is that the token count grows quickly when you multiply patches by frames.
+
+That token growth explains why long videos remain hard. If one image becomes hundreds of visual tokens, then eight frames become thousands, and a long clip becomes more than a context window can reasonably carry. A Vision LLM that accepts multiple images is therefore not automatically a full video reasoner. It may see representative frames and answer well about visible objects, yet fail on timing-sensitive questions because the decisive transition happened between frames or because frame order was weakly represented in the prompt.
+
+Modern video-language models use several strategies to handle this pressure. Some pool frame features before passing them into the language model. Some sample a fixed number of frames and rely on temporal position embeddings. Some use dedicated video encoders that compress motion into fewer tokens. Some managed services accept video files directly and perform internal segmentation, transcription, frame extraction, and multimodal encoding. As an application engineer, you still need to know what evidence was likely preserved, because model convenience does not remove temporal blind spots.
+
+Frame ordering should be explicit whenever you build the payload yourself. Do not upload eight JPEGs and ask, "What happened?" without telling the model that frame 1 is earliest and frame 8 is latest. Include timestamps or ranges in the text surrounding each frame, and ask for uncertainty when the frames are too sparse. A good prompt says, "These frames are sampled from a 40-second clip at the listed timestamps; infer only what is supported by visible evidence and say when motion between samples is ambiguous."
+
+Temporal consistency failures appear in both understanding and generation. In understanding, a model may reverse cause and effect, merge two similar objects, miss a brief state change, or describe an action as continuous when it was only visible once. In generation, a model may drift object identity, change clothing between frames, violate physics, flicker lighting, or lose track of where an object should be after occlusion. Both classes of failure come from the same pressure: maintaining stable state over time is harder than describing a single image.
+
+The debugging workflow should separate evidence, ordering, and reasoning. First, inspect the sampled frames and confirm the event is visible. Second, confirm timestamps and frame order are correct after preprocessing, resizing, batching, and retry logic. Third, ask whether the model's answer requires information between frames. Fourth, test a denser local window around the disputed event. If a denser window fixes the answer, the model may be adequate and the sampler was too sparse. If the denser window still fails, you likely need a task-specific detector, a stronger video model, or a human review path.
+
+## Video Understanding Workflows
+
+Video understanding is not one task. Captioning, action detection, object tracking, visual question answering, summarization, moderation, retrieval, and anomaly detection each demand a different evidence shape. A captioning pipeline wants enough frames to describe the scene coherently. An action detector wants short windows with motion continuity. A retrieval pipeline wants embeddings that map visual, audio, and textual evidence into a searchable index. A compliance workflow wants auditable timestamps, confidence, and conservative claims.
+
+Captioning turns sampled evidence into language. A brief caption might be enough for search indexing, while a detailed caption might name objects, setting, actions, and visible text. The risk is over-narration. If a model sees a person holding a box in one frame and an empty shelf later, it may say the person stocked the shelf even if the transfer happened off camera. For operational systems, captions should distinguish direct observation from inference: "a person is visible near the shelf" is safer than "the person replenishes inventory" unless the motion sequence supports it.
+
+Event and action detection should be windowed. An action label such as "falling," "opening," "turning," or "handing over" depends on change across adjacent frames. The pipeline should create overlapping windows, score each window, and then merge adjacent positive windows into time ranges. This is more reliable than classifying isolated frames and trying to reconstruct action afterward. It also creates useful review artifacts because a human can inspect the exact window that triggered the event.
+
+Video question answering adds another layer because the user's question determines which evidence matters. "What color is the truck?" may need one clear frame. "Did the truck stop before entering the loading bay?" needs temporal context around entry. "How many times did the operator scan a package?" needs counting across a sequence and may require chunking. A VQA system should therefore route questions by evidence need: static visual, local temporal, global summary, audio-transcript, or cross-modal comparison.
+
+Long-video summarization is usually a map-reduce problem. The map step splits the video into chunks, extracts representative evidence for each chunk, and asks for structured local summaries. The reduce step combines those local summaries into a global answer, preserving timestamps and contradictions. This approach is not only about context-window limits. It also improves debuggability because every global statement can point back to the chunk that produced it.
 
 ```mermaid
 flowchart LR
-    Video1[Video] --> Compress[Compress VAE]
-    Compress --> Latent[Latent Space Patches]
-    Latent --> DiT[DiT Transformer]
-    Text[Text Embedding] --> DiT
-    DiT --> Decompress[Decompress VAE]
-    Decompress --> Video2[Generated Video]
+    Long[Long video] --> Split[Split into timestamped chunks]
+    Split --> Sample[Adaptive sample per chunk]
+    Sample --> Local[Local captions and events]
+    Local --> Index[Vector and metadata index]
+    Local --> Reduce[Global summary reducer]
+    Index --> QA[Video Q&A retrieval]
+    Reduce --> Report[Auditable summary]
+    QA --> Report
 ```
 
-> **Stop and think**: Why is generating a ten-second video exponentially more computationally expensive than generating ten independent high-resolution images using standard diffusion techniques?
+The reducer should not simply concatenate local summaries. It should normalize time, collapse repeated events, preserve uncertainty, and detect conflicts. For example, one chunk might say "the operator leaves the station," while the next chunk says "the operator is already absent." A useful global summary becomes "the operator appears to leave between 03:20 and 03:40, after which the station remains unattended." This phrasing communicates the evidence boundary more honestly than pretending the exact departure moment was observed.
 
-### Interfacing with Generation APIs
+Audio often changes the answer. A silent security clip may be understood visually, but meetings, lectures, support calls, manufacturing alarms, sports broadcasts, and medical recordings often require speech or environmental sound. A practical pipeline extracts audio, transcribes speech when appropriate, segments the transcript by timestamp, and aligns transcript spans with visual chunks. The model can then answer questions such as "What was being demonstrated when the alarm sounded?" or "Which slide was visible when the speaker mentioned rollback?"
 
-Interacting with managed generation services is typically achieved through asynchronous REST payloads.
+Retrieval is the durable pattern for large archives. Store chunk-level metadata, captions, transcript spans, embeddings, thumbnails, and event labels in a searchable system. At query time, retrieve candidate chunks before invoking an expensive model. This prevents a user question about a two-minute segment from causing an hour-long video to be reprocessed. It also lets you update the summarizer or question-answering model without re-decoding every source video, as long as your stored evidence is rich enough.
 
-```python
-# Note: Simplified example - actual API may differ
-import requests
-import os
+The output schema matters as much as the model prompt. Free-form prose is convenient for humans, but production systems need fields such as `start_time`, `end_time`, `evidence_frames`, `observed_objects`, `inferred_action`, `confidence`, `requires_review`, and `model_version`. A schema forces the model to expose the difference between a visible event and a guessed explanation. It also gives downstream systems stable hooks for alerting, search, dashboards, and human review queues.
 
-def generate_video_runway(
-    prompt: str,
-    duration: int = 4,  # seconds
-    style: str = "cinematic"
-) -> str:
-    """
-    Generate video using Runway Gen-3.
+Evaluation should be designed around the same schema. A video summarizer can be fluent while still being operationally weak if it fails to preserve timestamps, collapses repeated events, or invents a causal link. Build small review sets where the expected output is not just a paragraph but a set of event ranges, evidence frames, and allowed uncertainty. Then measure whether the pipeline selected the right evidence, whether the model described that evidence correctly, and whether the reducer preserved the timing. This separates sampler recall from model reasoning and prevents the team from blaming the wrong component.
 
-    Returns:
-        URL to generated video
-    """
-    api_key = os.getenv("RUNWAY_API_KEY")
+Human review is not an afterthought in serious video systems. Reviewers need thumbnails, short replay clips, transcript snippets, sampling reasons, and model explanations in one place. If the review interface only shows the final caption, reviewers cannot tell whether the model saw enough evidence. If it only shows raw video, reviewers cannot efficiently audit thousands of events. The review product should expose the model's evidence trail so humans can correct labels, mark uncertain cases, and feed those corrections back into sampler thresholds or evaluation datasets.
 
-    response = requests.post(
-        "https://api.runwayml.com/v1/generate",
-        headers={"Authorization": f"Bearer {api_key}"},
-        json={
-            "prompt": prompt,
-            "duration": duration,
-            "style": style,
-            "model": "gen3"
-        }
-    )
+## Video Generation: Concepts and Constraints
 
-    result = response.json()
-    return result.get("video_url")
+Video generation reverses the understanding problem. Instead of compressing a sequence into labels or text, the system expands text, images, video references, or editing instructions into a temporally coherent clip. The model must create objects, preserve identity, move a virtual camera, maintain lighting, respect prompt constraints, and produce plausible motion across frames. That is substantially harder than producing a still image because every generated frame must agree with surrounding frames.
+
+Diffusion-based generation starts from noise and iteratively denoises toward a sample that matches conditioning information. Latent diffusion reduces cost by operating in a compressed representation rather than directly on pixels. Video diffusion extends this idea into time by adding temporal layers, temporal attention, or 3D latent representations so the model denoises a sequence rather than independent images. Transformer-based video diffusion uses attention over spacetime tokens, which is conceptually close to treating a clip as a sequence of visual patches across both space and time.
+
+Text-to-video starts from a prompt. It is useful for ideation, storyboards, synthetic examples, creative previews, advertising drafts, and simulation-like visualizations where exact factual fidelity is not required. Image-to-video starts from a still image and asks the model to animate it, which can preserve composition better than pure text but still requires careful prompting around motion. Video-to-video and editing workflows use an existing clip as a reference, enabling changes to style, background, motion, or objects while attempting to preserve some source structure.
+
+The hard failure modes are temporal. A character may change face shape across frames. A logo may bend or mutate. Hands may merge with tools. A camera may move in an impossible way. Text may flicker. An object hidden behind another object may reappear in a different place. These failures are not merely aesthetic; they matter when generated clips are used for product mockups, training data, educational media, or decision support. Generated video should be labeled, reviewed, and kept out of evidence workflows unless provenance is explicit.
+
+Latency and cost realities should shape product design. Video generation usually runs asynchronously because rendering a clip involves many model evaluations and postprocessing steps. A user experience that expects a synchronous chat-style response will feel broken. A better design creates a job, stores the prompt and references, displays progress, supports cancellation, and records the generated asset with metadata. For batch workloads, queue depth, retry policy, content review, and storage lifecycle become part of the product rather than infrastructure afterthoughts.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> | Surface | Publicly documented shape in this snapshot | Engineering implication |
+> |---|---|---|
+> | OpenAI Sora Videos API | OpenAI developer docs describe Sora 2 video models and state that the Videos API and listed Sora 2 models are deprecated with a September 24, 2026 shutdown date. | Treat Sora-specific integrations as migration-sensitive and isolate provider adapters. |
+> | Google Veo on Google Cloud | Google Cloud docs list Veo 3.1 generation model IDs with text/image inputs and video outputs, with documented short clip lengths and fixed output formats. | Use the docs as a capability contract, not a general promise about arbitrary long generation. |
+> | Runway API | Runway's developer docs expose video generation and editing APIs and show current model examples such as Gen-4.5 and Aleph 2.0. | Model names are product-surface details; keep them in configuration. |
+> | Pika API | Pika's official API page directs developers to fal.ai for API access to Pika video models. | Confirm the actual integration surface and terms before designing around it. |
+> | Kling AI API | Kling's developer/API pages document image and video generation surfaces, including text-to-video and image-to-video endpoints. | Account for asynchronous job handling and provider-specific parameter maps. |
+> | Luma Dream Machine API | Luma docs describe video generation through request IDs, polling, and Ray model parameters for text-to-video and image-to-video workflows. | Design generation as queued work with durable task IDs and output download handling. |
+> | Gemini video understanding | Google Cloud docs list Gemini video-understanding support, including documented media limits for selected model families. | For long input, still design chunking and retrieval because limits and model rosters change. |
+>
+> This snapshot is illustrative, not a leaderboard or endorsement. The durable lesson is to isolate provider specifics behind adapters and keep model names, durations, prices, regions, and deprecation dates out of core business logic.
+
+The adapter boundary is the production control point. A clean generation service accepts a normalized job with prompt, source assets, safety settings, target aspect ratio, duration intent, output policy, and callback destination. Provider adapters translate that normalized job into a specific API call. When a provider changes model IDs, deprecates an endpoint, adds a watermark rule, or alters supported durations, the blast radius should be one adapter and one capability table, not every product workflow.
+
+Generation should also be separated from understanding in system design. A generated clip may be fed into an understanding model for validation, but that validation is not proof of real-world truth. It is a consistency check on generated media. For example, a product team might generate a training clip, then ask a video-understanding model whether the target object appears, whether motion roughly follows the prompt, and whether captions match the intended lesson. That loop can improve creative workflows, but it should never be confused with analyzing real footage.
+
+A useful generation job record is more like a build artifact than a chat response. It should preserve the normalized request, provider adapter, source assets, policy checks, output URI, review state, and failure reason if the provider rejects or times out. That record lets the product retry safely, compare providers, and explain why two clips from similar prompts are not identical. It also lets finance and operations teams attribute cost to product features without embedding vendor-specific billing logic in the creative workflow.
+
+The prompt itself should be treated as an instruction set with testable constraints. A prompt that says "show a worker safely stopping a forklift before a crossing" carries different risk from a prompt that says "show a forklift near a crossing." If the generated clip will be used in training material, the validation loop should check whether the stop is visible, whether the crossing is clear, whether the timing supports the safety lesson, and whether any generated signage or text is misleading. Video generation is powerful, but it still needs product-specific acceptance criteria.
+
+## Production Video AI on Kubernetes
+
+Production video AI pipelines are data pipelines before they are model pipelines. The ingestion layer receives files, live streams, webhooks, or object-storage events. The preprocessing layer extracts metadata, audio, frames, scene boundaries, thumbnails, and chunks. The inference layer runs local detectors, managed model calls, or GPU-served models. The aggregation layer writes summaries, events, embeddings, and review tasks. Kubernetes is useful because each layer has different scaling pressure and failure behavior.
+
+A common batch architecture uses object storage for source video, a queue for work items, CPU workers for decoding and sampling, GPU workers for local inference, and a database or search index for structured outputs. CPU workers should do as much cheap filtering as possible before GPU work begins. For example, a scene detector can reduce hours of quiet footage into a small number of candidate windows. That lets the GPU process meaningful windows instead of acting as a very expensive video decoder.
+
+Real-time streams add backpressure requirements. A camera or live broadcast does not stop producing frames because inference is slow. The pipeline needs a bounded buffer, a drop policy, and a priority rule. Some systems drop old frames and keep the newest view because freshness matters. Others preserve every frame around a triggered event because forensic completeness matters. A generic unbounded queue is the worst option because it hides overload until latency grows beyond the product's purpose.
+
+GPU batching is different for video understanding than for ordinary image classification. Batches can vary by frame count, resolution, and window length. If your model supports fixed shapes, preprocessing may need to pad, crop, resize, or bucket requests so the serving engine can combine compatible work. NVIDIA Triton documents dynamic batching for combining requests and sequence batching for stateful sequences; the distinction matters because some video workloads are stateless clips while others maintain stream-level state over time.
+
+Kubernetes exposes GPUs through device plugins and schedulable extended resources. That scheduling layer is necessary but not sufficient. A pod that requests a GPU can still waste it with tiny single-frame calls, unbatched work, slow downloads, or CPU-bound decoding. Good deployments separate CPU decode pools from GPU inference pools, monitor queue wait separately from inference time, and use autoscaling signals that reflect actual bottlenecks. Scaling GPU pods because object storage downloads are slow is an expensive misdiagnosis.
+
+```mermaid
+flowchart TD
+    Camera[Camera or uploaded video] --> Ingest[Ingest service]
+    Ingest --> Queue[Work queue with backpressure]
+    Queue --> CPU[CPU decode and adaptive sampling workers]
+    CPU --> Evidence[Evidence store: frames, audio, metadata]
+    Evidence --> GPU[GPU inference deployment]
+    GPU --> Events[Event and caption store]
+    Events --> Review[Human review and alert routing]
+    Events --> Search[Vector and metadata search]
+    GPU --> Metrics[Latency, queue, cost, and recall metrics]
+    CPU --> Metrics
 ```
 
-For animating static assets, Image-to-Video algorithms apply derived motion vectors to the spatial tensor.
+Observe the sampler, not just the model. A video AI service can appear healthy while silently missing events because the sampler is too sparse. Track how many frames were decoded, how many were selected, which triggers selected them, how many bursts occurred, and how often human reviewers found important events outside selected windows. Model latency, GPU utilization, and API spend are necessary metrics, but they do not tell you whether the right evidence reached the model.
 
-```python
-def image_to_video(
-    image_path: str,
-    motion_prompt: str = "gentle camera pan",
-    duration: int = 4
-) -> str:
-    """
-    Animate a static image into a video.
+The operational runbook should include replay. When an alert is disputed, engineers need to replay the exact source chunk, sampling policy, model configuration, prompt, and reducer version that produced it. Store enough metadata to reproduce the decision without relying on mutable vendor defaults. For managed APIs, record provider, model identifier, request parameters, input checksums, and response IDs. For local models, record container image, model weights checksum, preprocessing code version, and GPU batch settings.
 
-    Args:
-        image_path: Path to source image
-        motion_prompt: Description of desired motion
-        duration: Video length in seconds
+Security and privacy boundaries are also sharper with video. A frame may contain faces, screens, license plates, badges, medical information, or children. Redaction can happen before model calls, after detection, or during review, but it must be part of the architecture. If a managed service receives frames, the data handling terms matter. If a local cluster stores extracted frames, retention and access controls matter. The cheap choice is not always the safe choice, and the safe choice must be enforced in storage, logs, prompts, and review tools.
 
-    Returns:
-        Path to generated video
-    """
-    # Using Stable Video Diffusion (conceptual)
-    # Actual implementation would use specific SDK
+Failure handling should assume partial progress. A long video may decode successfully, fail on one corrupted segment, produce summaries for several chunks, and time out during the final reduce step. Throwing away all partial work makes retries expensive and hides useful evidence. A better controller stores chunk state independently, retries failed chunks with bounded attempts, and lets the reducer operate only when required chunks reach a valid terminal state. This is the same reason Kubernetes jobs, queues, and object stores fit video AI well: they let you make large media workflows resumable rather than fragile.
 
-    # 1. Load and encode image
-    # 2. Generate motion vectors from prompt
-    # 3. Run video diffusion model
-    # 4. Decode and save video
+Autoscaling should be based on stage-specific signals. CPU decode workers can scale on queue age and decode throughput. GPU inference workers can scale on batch queue wait, model latency, and device memory pressure. Reducers can scale on pending chunk summaries. Review queues can scale on human backlog and alert severity. A single "number of videos waiting" metric is too coarse because it cannot distinguish a storage bottleneck from an inference bottleneck. Separate signals keep teams from buying GPUs to solve a queue policy problem.
 
-    return "output_video.mp4"
-```
+## Did You Know?
 
-## Part 5: Applied Video Analysis 
+- **Frame math changes cost quickly**: a ten-second video at thirty frames per second contains three hundred frame positions, so a "send every frame" policy can turn a tiny clip into hundreds of visual inputs before the model does any reasoning.
+- **ViViT treated video as spatiotemporal tokens**: the paper's durable contribution for practitioners is the framing that video transformers must manage both spatial patches and temporal sequence length rather than simply reuse an image encoder unchanged.
+- **TimeSformer separated space and time attention**: the architecture study is useful because it makes the engineering tradeoff visible, showing that attention can be organized differently across frames and within frames.
+- **Scene detection can be deterministic**: FFmpeg and PySceneDetect expose scene-change style signals that can cheaply identify candidate boundaries before an expensive multimodal model is invoked.
 
-Beyond simple summarization, video models are frequently deployed to extract structured metadata concerning physical dynamics.
+## Common Mistakes
 
-### Action Recognition Parsing
-
-Action recognition translates pixel fluctuations into classified behavioral events, bound by exact timestamps.
-
-```python
-from dataclasses import dataclass
-from typing import List
-
-@dataclass
-class ActionDetection:
-    action: str
-    confidence: float
-    start_time: float
-    end_time: float
-
-def detect_actions(video_path: str, client: OpenAI = None) -> List[ActionDetection]:
-    """
-    Detect actions in a video.
-
-    Returns list of detected actions with timestamps.
-    """
-    client = client or OpenAI()
-
-    frames = extract_frames(video_path, fps=2, max_frames=60)
-    sampled = sample_frames_uniform(frames, 15)
-
-    prompt = """Analyze these video frames and identify all actions occurring.
-    For each action, estimate when it starts and ends (as frame numbers from 1-15).
-
-    Format:
-    ACTION: [action name]
-    START: [frame number]
-    END: [frame number]
-    CONFIDENCE: [high/medium/low]
-    ---
-    """
-
-    content = [{"type": "text", "text": prompt}]
-    for frame in sampled:
-        _, buffer = cv2.imencode('.jpg', frame)
-        base64_frame = base64.b64encode(buffer).decode('utf-8')
-        content.append({
-            "type": "image_url",
-            "image_url": {"url": f"data:image/jpeg;base64,{base64_frame}"}
-        })
-
-    response = client.chat.completions.create(
-        model="gpt-5",
-        messages=[{"role": "user", "content": content}],
-        max_tokens=500
-    )
-
-    # Parse and return actions
-    return [ActionDetection(
-        action="detected_action",
-        confidence=0.9,
-        start_time=0.0,
-        end_time=5.0
-    )]
-```
-
-### Localizing Target Objects
-
-Object tracking demands precise spatial localization iteratively applied over the temporal axis.
-
-```python
-def track_objects(
-    video_path: str,
-    object_query: str,  # e.g., "red car", "person in blue"
-    client: OpenAI = None
-) -> List[dict]:
-    """
-    Track a specific object through a video.
-
-    Returns list of positions per frame.
-    """
-    client = client or OpenAI()
-
-    frames = extract_frames(video_path, fps=5, max_frames=100)
-    sampled = sample_frames_uniform(frames, 10)
-
-    prompt = f"""Track the "{object_query}" through these video frames.
-    For each frame where the object is visible, describe its position.
-
-    Format per frame:
-    FRAME [N]: [position description, e.g., "center-left", "moving right"]
-    """
-
-    content = [{"type": "text", "text": prompt}]
-    for frame in sampled:
-        _, buffer = cv2.imencode('.jpg', frame)
-        base64_frame = base64.b64encode(buffer).decode('utf-8')
-        content.append({
-            "type": "image_url",
-            "image_url": {"url": f"data:image/jpeg;base64,{base64_frame}"}
-        })
-
-    response = client.chat.completions.create(
-        model="gpt-5",
-        messages=[{"role": "user", "content": content}],
-        max_tokens=400
-    )
-
-    return [{"frame": i, "position": "tracked"} for i in range(len(sampled))]
-```
-
-### Deterministic Scene Boundary Detection
-
-Using computer vision heuristics rather than massive neural networks allows for rapid structural parsing of the video stream.
-
-```python
-def detect_scenes(video_path: str) -> List[Tuple[float, float]]:
-    """
-    Detect scene boundaries in a video.
-
-    Returns list of (start_time, end_time) for each scene.
-    """
-    cap = cv2.VideoCapture(video_path)
-    fps = cap.get(cv2.CAP_PROP_FPS)
-
-    scenes = []
-    prev_hist = None
-    scene_start = 0
-    frame_idx = 0
-    threshold = 0.5
-
-    while cap.isOpened():
-        ret, frame = cap.read()
-        if not ret:
-            break
-
-        # Calculate histogram
-        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-        hist = cv2.calcHist([gray], [0], None, [256], [0, 256])
-        hist = cv2.normalize(hist, hist).flatten()
-
-        if prev_hist is not None:
-            correlation = cv2.compareHist(prev_hist, hist, cv2.HISTCMP_CORREL)
-
-            if correlation < threshold:
-                # Scene change detected
-                scene_end = frame_idx / fps
-                scenes.append((scene_start, scene_end))
-                scene_start = scene_end
-
-        prev_hist = hist
-        frame_idx += 1
-
-    # Add final scene
-    scenes.append((scene_start, frame_idx / fps))
-
-    cap.release()
-    return scenes
-```
-
-## Part 6: Architecting for Production Workloads
-
-Processing a feature-length film cannot follow the identical logic pathway as processing a brief web clip. System architecture must scale appropriately.
-
-### Chunked Hierarchical Processing
-
-Massive files will inevitably trigger OutOfMemory panics if ingested entirely into RAM. The established architectural pattern involves breaking the stream into isolated chunks, extracting metadata, and subsequently aggregating the chunked summaries.
-
-```python
-def process_long_video(
-    video_path: str,
-    chunk_duration: int = 60,  # seconds
-    client: OpenAI = None
-) -> dict:
-    """
-    Process a long video by chunking.
-
-    Returns:
-        {
-            "chunks": [{"start": 0, "end": 60, "summary": "..."}],
-            "overall_summary": "..."
-        }
-    """
-    cap = cv2.VideoCapture(video_path)
-    fps = cap.get(cv2.CAP_PROP_FPS)
-    total_frames = int(cap.get(cv2.CAP_PROP_FRAME_COUNT))
-    duration = total_frames / fps
-    cap.release()
-
-    chunks = []
-    chunk_summaries = []
-
-    for start in range(0, int(duration), chunk_duration):
-        end = min(start + chunk_duration, duration)
-
-        # Extract frames for this chunk
-        # Summarize chunk
-        chunk_summary = f"Chunk {start}-{end}: [summary would go here]"
-        chunk_summaries.append(chunk_summary)
-
-        chunks.append({
-            "start": start,
-            "end": end,
-            "summary": chunk_summary
-        })
-
-    # Combine chunk summaries into overall summary
-    overall = " ".join(chunk_summaries)
-
-    return {
-        "chunks": chunks,
-        "overall_summary": overall
-    }
-```
-
-### Preprocessing and Downsampling
-
-Every pixel sent to an external API incurs bandwidth delay and token costs. Intelligent systems strip excess data prior to transmission.
-
-```python
-def optimize_frames_for_api(
-    frames: List[np.ndarray],
-    max_size: int = 512,
-    quality: int = 80
-) -> List[str]:
-    """Optimize frames for API calls (reduce size/quality)."""
-    optimized = []
-
-    for frame in frames:
-        # Resize
-        h, w = frame.shape[:2]
-        if max(h, w) > max_size:
-            scale = max_size / max(h, w)
-            frame = cv2.resize(frame, None, fx=scale, fy=scale)
-
-        # Encode with reduced quality
-        _, buffer = cv2.imencode('.jpg', frame, [cv2.IMWRITE_JPEG_QUALITY, quality])
-        base64_frame = base64.b64encode(buffer).decode('utf-8')
-        optimized.append(base64_frame)
-
-    return optimized
-```
-
-### Threading Real-Time Streams
-
-When analyzing security cameras or live broadcasts, blocking operations result in dropped frames. Decoupling the ingestion loop from the inference loop via threaded queues ensures continuous stability.
-
-```python
-import queue
-import threading
-
-class VideoStreamProcessor:
-    """Process video streams in real-time."""
-
-    def __init__(self, buffer_size: int = 30):
-        self.frame_queue = queue.Queue(maxsize=buffer_size)
-        self.result_queue = queue.Queue()
-        self.running = False
-
-    def process_stream(self, video_source: str):
-        """Start processing a video stream."""
-        self.running = True
-
-        # Start capture thread
-        capture_thread = threading.Thread(target=self._capture_frames, args=(video_source,))
-        capture_thread.start()
-
-        # Start processing thread
-        process_thread = threading.Thread(target=self._process_frames)
-        process_thread.start()
-
-    def _capture_frames(self, source: str):
-        """Capture frames from video source."""
-        cap = cv2.VideoCapture(source)
-
-        while self.running and cap.isOpened():
-            ret, frame = cap.read()
-            if ret:
-                try:
-                    self.frame_queue.put(frame, timeout=1)
-                except queue.Full:
-                    continue
-            else:
-                break
-
-        cap.release()
-
-    def _process_frames(self):
-        """Process captured frames."""
-        while self.running:
-            try:
-                frame = self.frame_queue.get(timeout=1)
-                # Process frame
-                result = self._analyze_frame(frame)
-                self.result_queue.put(result)
-            except queue.Empty:
-                continue
-
-    def _analyze_frame(self, frame: np.ndarray) -> dict:
-        """Analyze a single frame."""
-        return {"frame_analyzed": True}
-
-    def stop(self):
-        """Stop processing."""
-        self.running = False
-```
-
-## Did You Know? Technical Milestones
-
-1. OpenAI published the Sora technical report on February 15, 2024, showing a text-to-video model that can generate minute-long videos while also documenting important limitations in physics and long-range consistency.
-2. The foundational Lucas-Kanade optical flow algorithm was published in 1981, yet remains deeply embedded in modern preprocessing stacks specifically for tracking lightweight pixel movement.
-3. The scale of modern media platforms is vast; hundreds of hours of video are uploaded to YouTube every minute, which makes automated moderation a necessity at large scale.
-4. Google decisively changed the landscape of contextual processing when they demonstrated Gemini 1.5 Pro natively ingesting and interrogating [an entire 45-minute video](https://cloud.google.com/vertex-ai/generative-ai/docs/models/gemini/1-5-pro) entirely within a single context window.
-
-## Common Pitfalls in Video AI Code
-
-The transition from static images to dynamic sequences introduces numerous traps. Let us review the anti-patterns explicitly.
-
-### Mistake 1: Treating Video as Independent Images
-
-```python
-# WRONG - Process frames independently
-def analyze_video(video_path):
-    results = []
-    for frame in extract_frames(video_path):
-        result = image_classifier(frame)  # No temporal context!
-        results.append(result)
-    return results
-
-# RIGHT - Maintain temporal context
-def analyze_video_with_context(video_path, window_size=5):
-    frames = extract_frames(video_path)
-    results = []
-
-    for i, frame in enumerate(frames):
-        # Include surrounding frames as context
-        start = max(0, i - window_size // 2)
-        end = min(len(frames), i + window_size // 2 + 1)
-        context_frames = frames[start:end]
-
-        result = video_classifier(context_frames, query_frame=i - start)
-        results.append(result)
-
-    return results
-```
-
-### Mistake 2: Fixed Frame Rates for All Content
-
-```python
-# WRONG - Same sampling for everything
-def extract_frames_fixed(video_path):
-    return extract_frames(video_path, fps=1)  # 1 frame per second
-
-# RIGHT - Adaptive sampling based on content
-def extract_frames_adaptive(video_path):
-    cap = cv2.VideoCapture(video_path)
-    frames = []
-    prev_frame = None
-
-    while cap.isOpened():
-        ret, frame = cap.read()
-        if not ret:
-            break
-
-        if prev_frame is not None:
-            # Calculate frame difference
-            diff = cv2.absdiff(frame, prev_frame).mean()
-
-            # High difference = motion = sample more
-            if diff > 30:
-                frames.append(frame)
-            elif diff > 10 and len(frames) % 5 == 0:
-                frames.append(frame)
-            elif len(frames) % 30 == 0:  # Minimum sampling
-                frames.append(frame)
-        else:
-            frames.append(frame)
-
-        prev_frame = frame
-
-    cap.release()
-    return frames
-```
-
-### Mistake 3: Ignoring Video Duration in API Costs
-
-```python
-# WRONG - Send all frames to vision API
-def expensive_video_analysis(video_path):
-    frames = extract_frames(video_path, fps=30)  # 30 fps!
-
-    for frame in frames:  # 10-second video = 300 API calls!
-        response = client.chat.completions.create(
-            model="gpt-5",
-            messages=[{"role": "user", "content": [
-                {"type": "image_url", "image_url": {"url": encode_frame(frame)}}
-            ]}]
-        )
-    # $0.01 per image × 300 = $3 per 10-second video
-
-# RIGHT - Intelligent sampling and batching
-def efficient_video_analysis(video_path):
-    frames = extract_frames(video_path, fps=1)  # 1 fps
-    sampled = sample_frames_uniform(frames, n_samples=10)  # 10 frames max
-
-    # Batch into single request
-    content = [{"type": "text", "text": "Analyze these video frames:"}]
-    for frame in sampled:
-        content.append({"type": "image_url", "image_url": {"url": encode_frame(frame)}})
-
-    response = client.chat.completions.create(
-        model="gpt-5",
-        messages=[{"role": "user", "content": content}]
-    )
-    # ~10 images × $0.01 = $0.10 per video
-```
-
-### The Fix Matrix
-
-| Mistake | Why It Happens | How to Fix It |
-|---------|----------------|---------------|
-| Treating Video as Independent Images | Developers reuse legacy image classification pipelines for video streams, ignoring motion and causal links. | Implement a sliding window approach to maintain temporal context across sequential frames. |
-| Fixed Frame Rates for All Content | Assuming a static sampling rate works universally leads to missed action in fast scenes and wasted compute in static scenes. | Use adaptive sampling that measures histogram differences to trigger frame extraction only during motion. |
-| Ignoring Video Duration in API Costs | Sending every frame of a high-framerate video to a paid vision API results in massive, unexpected billing spikes. | Batch requests with optimized, downscaled, and uniformly sampled frames to reduce token consumption. |
-| Neglecting Audio Tracks | Relying entirely on visual data ignores the rich context provided by speech, environmental sounds, and music. | Extract the audio stream and process it with a speech-to-text model, fusing the text embeddings with visual embeddings. |
-| Loading Full Videos Into Memory | Attempting to read massive video files directly into an array causes out-of-memory crashes on the host machine. | Use generator functions or chunked processing to read and release frames sequentially. |
-| Disregarding Temporal Consistency in Generation | Stitching together independently generated images results in severe flickering and object identity drift. | Utilize diffusion models with native temporal attention layers to enforce consistency across the generated sequence. |
-| Oversampling Static Scenes | Extracting frames during long, motionless periods provides zero new information. | Implement scene boundary detection and only process keyframes when a structural change occurs. |
-
-## The Economics of Video AI
-
-Video infrastructure scales expensively. Knowing when to build versus when to buy is a critical engineering decision.
-
-| Service | Video Understanding | Video Generation | Notes |
-|---------|---------------------|------------------|-------|
-| gpt-5 (Vision) | Usage-based | N/A | Estimate cost from current OpenAI pricing and your frame-sampling policy |
-| Google Gemini 1.5 | Usage-based | N/A | Native video support exists, but costs depend on the current model and billing plan |
-| Claude 3 Opus | Usage-based | N/A | Estimate cost from current Anthropic pricing and your frame-sampling policy |
-| Runway Gen-3 | N/A | Subscription/credit-based | Generation pricing varies by model, plan, and output settings |
-| Pika | N/A | Subscription/credit-based | Generation pricing varies by plan and feature tier |
-| Local (faster-whisper) | Hardware-dependent | N/A | Actual cost depends on GPU utilization, throughput, and amortization assumptions |
-| Local (SVD) | N/A | Hardware-dependent | Actual cost depends on GPU type, batch size, and amortization assumptions |
-
-### Break-Even Analysis: Video Understanding
-
-```text
-API cost (gpt-5): ~$0.10 per minute of video analyzed
-Local cost (GPU): ~$0.01 per minute (amortized A10)
-
-Break-even: ~1,000 minutes/month
-Below 1,000 min: Use API (simpler)
-Above 1,000 min: Consider local (10x cheaper)
-Above 10,000 min: Definitely local (saves $900+/month)
-```
-
-### Break-Even Analysis: Video Generation
-
-```text
-API cost (Runway): $3 per minute generated
-Local cost (GPU): ~$0.50 per minute (amortized A100)
-
-Break-even: ~100 minutes/month
-Below 100 min: Use API (quality, speed)
-Above 100 min: Consider local (6x cheaper)
-Above 1,000 min: Hybrid approach
-```
+| Mistake | Why it happens | How to fix |
+|---|---|---|
+| Sampling every frame by default | It feels faithful, and early demos are small enough that the cost is hidden. | Start with a written sampling contract that caps frames, resolution, and burst behavior per use case. |
+| Sampling one frame per second for every workload | Uniform sampling is easy to explain, so it becomes the default even when events are brief. | Use adaptive bursts around motion, scene changes, or external triggers when recall matters. |
+| Losing timestamps during preprocessing | Frame arrays move through code more easily than evidence records with metadata. | Store original frame index, timestamp, chunk ID, and sampling reason beside every selected frame. |
+| Asking a Vision LLM timing questions from sparse frames | The model may answer fluently even when the decisive transition happened between samples. | Prompt for uncertainty and rerun a denser local window for timing-sensitive questions. |
+| Treating generated video as factual evidence | Generated clips look like recordings, so downstream users may over-trust them. | Keep provenance metadata, labels, review states, and storage paths separate from real footage. |
+| Scaling GPU pods before measuring decode and queue time | GPU symptoms are visible, while CPU decode, storage reads, and queue contention are less glamorous. | Instrument ingestion, decode, sampling, inference, and aggregation as separate latency stages. |
+| Hard-coding provider model names across product code | Vendor video surfaces change quickly and examples become stale. | Place model IDs, durations, regions, and deprecation notes in a dated adapter capability table. |
 
 ## Knowledge Check
 
 <details>
-<summary>Scenario 1: You are analyzing a massive archive of warehouse security footage to detect when delivery trucks arrive. The yard is completely empty for hours at a time. You decide to uniformly sample one frame every second and pass it to a Vision LLM API. Why is this approach critically flawed, and what is the optimal architectural solution?</summary>
+<summary>1. Your team samples a sports clip at one frame per second and asks a Vision LLM whether a player touched the ball before it crossed a line. The answer is confident but wrong. What failed first?</summary>
 
-This approach is fundamentally flawed because it wastes immense financial and computational resources processing static, unchanging data. The uniform sampling guarantees thousands of redundant API calls during the empty hours. The optimal solution is to implement an adaptive sampling technique locally—such as measuring histogram correlation differences—to detect the structural change of a truck entering the frame. The system should only extract and forward keyframes to the expensive API when the threshold of visual motion is breached.
+The first failure is the sampling policy, not the language model. A one-frame-per-second sample can easily omit the short interval where contact occurred, so the model is asked to infer a timing-sensitive event from missing evidence. The fix is to preserve a denser local window around fast motion, include timestamps, and ask the model to separate visible contact from uncertain motion between frames.
 </details>
 
 <details>
-<summary>Scenario 2: A data science team attempts to construct a tool that generates natural language summaries of feature-length films using a classic 3D Convolutional Neural Network. While the model correctly identifies isolated actions like "running", it completely fails to output any coherent paragraphs describing the narrative sequence. What limitation are they encountering?</summary>
+<summary>2. A prototype sends eight unordered JPEGs from a long clip to a vision model and asks, "What happened before the alarm?" The model describes the alarm but reverses the sequence of two events. What should change in the payload?</summary>
 
-The team is encountering the semantic boundary of 3D CNNs. While these networks are highly capable of extracting spatiotemporal features over short, localized sequences to classify discrete actions, they entirely lack the generative capacity and long-range semantic reasoning required to synthesize natural language. To successfully generate narrative summaries, the architectural pipeline must be upgraded to a vision-language model or multimodal transformer that can ingest sequence embeddings and utilize self-attention to generate text.
+The payload should make temporal order explicit. Each frame should include its timestamp or time range, and the prompt should state that the images are ordered from earliest to latest. If the event depends on transitions between sparse frames, the system should retrieve a denser window around the alarm instead of expecting the model to reconstruct exact order from weak evidence.
 </details>
 
 <details>
-<summary>Scenario 3: Your financial director asks you to evaluate whether the engineering team should transition from a managed video generation API to a locally hosted open-source diffusion model on dedicated A100 instances. The product requires generating roughly 50 minutes of short clips per month. Based on standard break-even models, what should you advise?</summary>
+<summary>3. You need to summarize a two-hour maintenance video while preserving auditable evidence. Why is a map-reduce workflow better than one giant prompt?</summary>
 
-Based on standard break-even models, you should strongly advise remaining on the managed API service. The API costs roughly $150 per month for 50 minutes of generation. While the amortized compute cost of local execution might scale lower per minute, the break-even threshold is typically closer to 100 minutes per month. Below that volume, the enormous overhead of configuring, maintaining, and deploying complex infrastructure on local GPUs far outweighs the raw API billing.
+A map-reduce workflow respects context limits and improves traceability. The map step summarizes timestamped chunks with selected frames, transcript spans, and local events. The reduce step combines those structured outputs into a global summary while retaining links back to the chunks. A giant prompt is more likely to exceed limits, bury contradictions, and produce claims that cannot be traced to evidence.
 </details>
 
 <details>
-<summary>Scenario 4: An intern attempts to build a text-to-video script by generating 60 independent images using a standard image diffusion prompt, and then combining them into a video using an encoding library. What specific visual artifacts will occur, and what mechanism is missing from the architecture?</summary>
+<summary>4. A product manager wants to swap video generation providers every month to compare text-to-video, image-to-video, and video-editing quality. Why should model names and duration limits live outside core business logic?</summary>
 
-The resulting sequence will be unusable due to severe temporal flickering, object identity drift, and constantly shifting physics rules from frame to frame. The intern's pipeline is missing the temporal attention mechanism entirely. Native video diffusion models do not process images independently; they utilize spacetime patches and temporal attention layers to denoise the entire sequence concurrently, enforcing consistency and object permanence across time.
+Video generation providers change quickly. Model IDs, supported durations, regions, prices, deprecations, and input modes are volatile product facts. Keeping provider details in adapters and dated capability tables lets the application preserve a stable video job schema while each adapter translates that schema to the current provider API. This reduces migration risk and avoids stale assumptions scattered through product code.
 </details>
 
 <details>
-<summary>Scenario 5: Your Kubernetes data processing cluster executes a batch job designed to analyze long-form theatrical content. However, the worker pods consistently crash with OutOfMemory errors just seconds into execution, even with high resource limits. The logs show the crash occurring during the frame extraction step. What is the fundamental design error?</summary>
+<summary>5. A Kubernetes GPU deployment shows low utilization, but event-detection latency is high. Why might adding more GPU pods fail to help?</summary>
 
-The fundamental design error is that the extraction script attempts to load the entire uncompressed video stream into a continuous array resident in memory simultaneously. A feature-length film contains hundreds of thousands of frames that can quickly overwhelm typical RAM allocations. The script must be redesigned to utilize hierarchical chunking or python generator functions, ensuring frames are loaded, processed, summarized, and released sequentially to maintain a strict, minimal memory boundary.
+The bottleneck may be outside GPU inference. CPU decoding, object-storage reads, frame extraction, queue wait, image resizing, or unbatched tiny requests can dominate end-to-end latency. Adding GPU pods only helps when inference capacity is the limiting stage. The correct response is to instrument each stage separately and scale the stage that is actually saturated.
 </details>
 
 <details>
-<summary>Scenario 6: A media moderation platform uniformly extracts one frame every sixty seconds from user-uploaded content to detect policy violations. A user successfully uploads a video containing a highly explicit three-second clip hidden precisely in the middle of a five-minute file. Why did the system fail to flag this, and how must the architecture change?</summary>
+<summary>6. A live camera pipeline uses an unbounded queue between ingestion and inference. It never drops frames, but alerts arrive minutes late during busy periods. What design decision is missing?</summary>
 
-The system failed because uniform sparse sampling guarantees critical blind spots; a brief three-second event will almost certainly slip entirely unnoticed between the sixty-second extraction windows. To secure the platform, the architecture must transition to an adaptive motion-based sampling logic or utilize an aggressive scene boundary detection algorithm. A sudden deviation or structural cut in the video should typically trigger a dense extraction of local keyframes so rapid, high-impact events are less likely to be ignored.
+The pipeline is missing an explicit backpressure and drop policy. Real-time systems need bounded buffers and a rule for overload, such as preserving the newest frame for freshness or preserving dense windows around triggered events for review. An unbounded queue protects completeness only superficially because it destroys the latency budget that made the stream useful.
 </details>
 
-## Hands-On Exercise: Deploying an Adaptive Extraction Pipeline
+<details>
+<summary>7. A generated training clip is passed through a video-understanding model, which says the intended object is visible. Can the team treat the clip as evidence that the event happened in the real world?</summary>
 
-In this scenario-based lab, you will design and deploy a video processing job utilizing Kubernetes v1.35. The pod will execute an intelligent, adaptive frame sampling script that identifies scenes rather than dumping redundant frames blindly.
+No. The understanding model can validate consistency between the generated clip and the prompt, but it cannot turn synthetic media into real-world evidence. Generated video should carry provenance metadata and remain separate from recordings. The validation result is useful for creative quality control, not for factual claims about events outside the generation system.
+</details>
 
-### Task 1: Provision the Analytical Pod
-Create the baseline pod definition tailored for video workloads on a modern v1.35 cluster. Save the following configuration as `processor-pod.yaml`.
+## Hands-On Exercise
 
-```yaml
-apiVersion: v1
-kind: Pod
-metadata:
-  name: video-analyzer
-  labels:
-    tier: multimodal-processing
-spec:
-  containers:
-  - name: cv-engine
-    image: python:3.11-slim
-    command: ["sleep", "infinity"]
-    resources:
-      limits:
-        memory: "4Gi"
-        cpu: "2"
-```
+This exercise builds a deterministic adaptive sampler over synthetic frame metadata. It does not require OpenCV, a GPU, or a vendor API, which is intentional: the goal is to practice the production policy that decides which frames deserve expensive model attention. You will create a small dataset with quiet periods, scene changes, and a short fast event, then run a sampler that preserves heartbeat frames plus dense bursts around motion or scene changes.
 
-Apply the pod definition and verify readiness using non-interactive flags:
-```bash
-kubectl apply -f processor-pod.yaml
-kubectl wait --for=condition=Ready pod/video-analyzer --timeout=90s
-```
-
-### Task 2: Bootstrapping the Environment
-Inject the specific libraries required for spatial array manipulation and histogram generation directly into the running instance.
+Run the commands from the repository root so the exercise uses the project virtual environment explicitly.
 
 ```bash
-kubectl exec video-analyzer -- pip install opencv-python-headless numpy --quiet
-kubectl exec video-analyzer -- python -c "import cv2; print(f'OpenCV Version: {cv2.__version__}')"
-```
+REPO_ROOT="$(pwd)"
+WORKDIR="${TMPDIR:-/tmp}/kubedojo-video-ai"
+mkdir -p "$WORKDIR"
 
-### Task 3: Constructing the Logic Payload
-Instead of loading the entire video to memory, we implement the `detect_scenes` logic derived from the theory section. Write this script directly into the pod using a heredoc.
+cat > "$WORKDIR/frames.csv" <<'CSV'
+frame,timestamp,motion_score,scene_score,label
+0,0.0,0.01,0.01,empty hallway
+1,0.5,0.01,0.01,empty hallway
+2,1.0,0.02,0.02,empty hallway
+3,1.5,0.03,0.02,empty hallway
+4,2.0,0.78,0.12,door opens
+5,2.5,0.85,0.20,person enters
+6,3.0,0.64,0.10,person crosses frame
+7,3.5,0.20,0.04,person exits
+8,4.0,0.03,0.02,empty hallway
+9,4.5,0.02,0.02,empty hallway
+10,5.0,0.04,0.70,camera cuts to loading dock
+11,5.5,0.06,0.08,truck parked
+12,6.0,0.07,0.07,truck parked
+13,6.5,0.72,0.09,worker runs past truck
+14,7.0,0.69,0.08,worker leaves frame
+15,7.5,0.05,0.04,truck parked
+16,8.0,0.03,0.02,truck parked
+CSV
 
-```bash
-kubectl exec -i video-analyzer -- bash -c 'cat > /tmp/adaptive_sampler.py' << 'EOF'
-import cv2
+cat > "$WORKDIR/adaptive_sampler.py" <<'PY'
+import csv
+import json
 import sys
-import numpy as np
+from pathlib import Path
 
-def scan_boundaries(video_path, threshold=0.5):
-    print(f"Scanning {video_path} for structural boundaries...")
-    cap = cv2.VideoCapture(video_path)
-    fps = cap.get(cv2.CAP_PROP_FPS)
-    
-    if not cap.isOpened():
-        print("Failed to initialize capture.")
-        sys.exit(1)
 
-    prev_hist, frame_idx = None, 0
-    
-    while cap.isOpened():
-        ret, frame = cap.read()
-        if not ret: break
+def load_rows(path):
+    with Path(path).open(newline="", encoding="utf-8") as handle:
+        rows = list(csv.DictReader(handle))
+    for row in rows:
+        row["frame"] = int(row["frame"])
+        row["timestamp"] = float(row["timestamp"])
+        row["motion_score"] = float(row["motion_score"])
+        row["scene_score"] = float(row["scene_score"])
+    return rows
 
-        gray = cv2.cvtColor(frame, cv2.COLOR_BGR2GRAY)
-        hist = cv2.calcHist([gray], [0], None, [256], [0, 256])
-        hist = cv2.normalize(hist, hist).flatten()
 
-        if prev_hist is not None:
-            correlation = cv2.compareHist(prev_hist, hist, cv2.HISTCMP_CORREL)
-            if correlation < threshold:
-                timestamp = frame_idx / fps
-                print(f"Scene boundary detected at {timestamp:.2f} seconds.")
+def select_frames(
+    rows,
+    heartbeat_seconds=4.5,
+    motion_threshold=0.72,
+    scene_threshold=0.65,
+    motion_context_frames=1,
+):
+    selected = {}
+    last_heartbeat = None
 
-        prev_hist = hist
-        frame_idx += 1
+    for idx, row in enumerate(rows):
+        trigger_reasons = []
+        if last_heartbeat is None or row["timestamp"] - last_heartbeat >= heartbeat_seconds:
+            frame = row["frame"]
+            selected.setdefault(frame, set()).add("heartbeat")
+            last_heartbeat = row["timestamp"]
+        if row["motion_score"] >= motion_threshold:
+            trigger_reasons.append("motion")
+        if row["scene_score"] >= scene_threshold:
+            frame = row["frame"]
+            selected.setdefault(frame, set()).add("scene")
 
-    cap.release()
-    print("Scan complete.")
+        if trigger_reasons:
+            start = max(0, idx - motion_context_frames)
+            end = min(len(rows), idx + motion_context_frames + 1)
+            for neighbor in range(start, end):
+                if 0 <= neighbor < len(rows):
+                    frame = rows[neighbor]["frame"]
+                    selected.setdefault(frame, set()).update(
+                        trigger_reasons if neighbor == idx else {"context"}
+                    )
 
-# Simulate creating a blank dummy video for testing the script's execution paths
-out = cv2.VideoWriter('/tmp/dummy.avi', cv2.VideoWriter_fourcc(*'XVID'), 30, (640, 480))
-for _ in range(60): out.write(np.zeros((480, 640, 3), dtype=np.uint8))
-out.release()
+    output = []
+    for row in rows:
+        reasons = selected.get(row["frame"])
+        if reasons:
+            output.append(
+                {
+                    "frame": row["frame"],
+                    "timestamp": row["timestamp"],
+                    "label": row["label"],
+                    "reasons": sorted(reasons),
+                }
+            )
+    return output
 
-scan_boundaries('/tmp/dummy.avi')
-EOF
+
+def main():
+    if len(sys.argv) != 2:
+        raise SystemExit("usage: adaptive_sampler.py frames.csv")
+    rows = load_rows(sys.argv[1])
+    selected = select_frames(rows)
+    result = {
+        "input_frames": len(rows),
+        "selected_frames": len(selected),
+        "reduction_ratio": round(1 - (len(selected) / len(rows)), 3),
+        "selected": selected,
+    }
+    print(json.dumps(result, indent=2))
+
+
+if __name__ == "__main__":
+    main()
+PY
+
+"$REPO_ROOT/.venv/bin/python" "$WORKDIR/adaptive_sampler.py" "$WORKDIR/frames.csv" > "$WORKDIR/selected_frames.json"
+cat "$WORKDIR/selected_frames.json"
 ```
 
-### Task 4: Pipeline Execution and Validation
-Trigger the processing script within the pod and confirm it successfully evaluates the dummy file and terminates gracefully without throwing OutOfMemory exceptions.
-
-```bash
-kubectl exec video-analyzer -- python /tmp/adaptive_sampler.py
-```
+The expected result is not a single magic frame count; it is a defensible evidence set. With these defaults, the sample should cut the candidate frame set by roughly 40-60% while preserving heartbeat coverage through quiet periods, adding context around the door opening, including the scene cut to the loading dock, and keeping dense evidence around the worker running past the truck. If the sampler drops the "worker runs past truck" frames, recall is too low. If it selects nearly every quiet frame, cost control is too weak.
 
 ### Success Checklist
-- [ ] Pod successfully orchestrated on a v1.35 cluster.
-- [ ] Headless computer vision libraries validated via bash injection.
-- [ ] The adaptive boundary script deployed to `/tmp` via heredoc without syntax faults.
-- [ ] Pipeline execution completed against the synthetic asset without crashing.
 
----
+- [ ] The script runs with `.venv/bin/python` from the repository root and writes `selected_frames.json` under the temporary work directory.
+- [ ] The run reduces the input by roughly 40-60% instead of forwarding nearly every quiet frame.
+- [ ] The selected output includes context around the `door opens`, `person enters`, and `worker runs past truck` labels.
+- [ ] The selected output includes at least one heartbeat frame from a quiet period so the summary can still say which scene was inactive.
+- [ ] You can explain which threshold you would lower for a safety-critical detector and which threshold you would raise for a low-cost archive summarizer.
 
-**What's Next?** You have conquered the temporal axis of multimodal networks. Proceed to [Phase 6 - Deep Learning Foundations](/ai-ml-engineering/deep-learning/module-1.1-foundations), where we peel back the abstraction layer to dissect the raw calculus and tensor math powering the attention layers you just deployed.
+To extend this into Kubernetes, place the sampler behind a queue consumer and split responsibilities. CPU workers decode streams and compute motion or scene scores. GPU workers receive only selected windows or embeddings. A reducer service writes structured summaries and evidence links. The same policy you tested locally becomes a ConfigMap or service configuration, while the thresholds become observable production knobs rather than hidden constants in a notebook.
+
+## Next Module
+
+Next, continue to [Module 1.4: Multimodal-First AI Design](../module-1.4-multimodal-first-design/), where the focus shifts from video-specific pipelines to native multimodal architectures that reason across video, audio, images, and text in one interaction design.
 
 ## Sources
 
-- [Video understanding on Vertex AI](https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/video-understanding) — Practical documentation for prompting Gemini models with video inputs and understanding current supported workflows.
-- [ViViT: A Video Vision Transformer](https://arxiv.org/abs/2103.15691) — Canonical paper for transformer-based video understanding, directly relevant to the module's temporal-modeling section.
+- [NTSB Williston, Florida Automated Vehicle Crash Investigation](https://www.ntsb.gov/investigations/Pages/HWY16FH018.aspx) — Primary investigation page for the real 2016 crash used in the module opener.
+- [OpenCV VideoCapture Documentation](https://docs.opencv.org/4.x/d8/dfe/classcv_1_1VideoCapture.html) — Official OpenCV reference for reading video files, image sequences, and camera streams.
+- [FFmpeg Filters Documentation](https://ffmpeg.org/ffmpeg-filters.html) — Official filter reference documenting scene-change metadata and related video filtering primitives.
+- [PySceneDetect Detector Documentation](https://www.scenedetect.com/docs/latest/api/detectors.html) — Upstream documentation for content, adaptive, threshold, and histogram-based scene detection.
+- [ViViT: A Video Vision Transformer](https://arxiv.org/abs/2103.15691) — Primary paper for spatiotemporal tokenization and transformer-based video classification.
+- [Is Space-Time Attention All You Need for Video Understanding?](https://arxiv.org/abs/2102.05095) — Primary TimeSformer paper for space-time attention design tradeoffs.
+- [Video-ChatGPT: Towards Detailed Video Understanding via Large Vision and Language Models](https://arxiv.org/abs/2306.05424) — Primary paper connecting video encoders with LLM-style video dialogue.
+- [Video-LLaVA: Learning United Visual Representation by Alignment Before Projection](https://arxiv.org/abs/2311.10122) — Primary paper for a video-language baseline that unifies image and video representation.
+- [Google Cloud Gemini Video Understanding](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/capabilities/video-understanding) — Vendor documentation for current managed video-understanding inputs and limits.
+- [OpenAI Images and Vision Guide](https://developers.openai.com/api/docs/guides/images-vision) — Official OpenAI guide for image inputs used when video is represented as sampled frames.
+- [OpenAI Video Generation with Sora](https://developers.openai.com/api/docs/guides/video-generation) — Official OpenAI documentation for the Sora Videos API and its current deprecation status.
+- [OpenAI Video Generation Models as World Simulators](https://openai.com/index/video-generation-models-as-world-simulators/) — Technical report describing Sora concepts such as unified visual representations and spacetime patches.
+- [Google Cloud Veo 3.1 Documentation](https://docs.cloud.google.com/gemini-enterprise-agent-platform/models/veo/3-1-generate) — Vendor documentation for current Veo generation model IDs, inputs, outputs, and short-video constraints.
+- [Runway API Documentation](https://docs.dev.runwayml.com/) — Vendor documentation for Runway generation and editing API surfaces.
+- [Pika API Page](https://pika.art/api) — Official Pika page directing developers to the current API access route.
+- [Kling AI API Overview](https://kling.ai/document-api/quickStart%2FproductIntroduction%2Foverview) — Official Kling API overview for image and video generation surfaces.
+- [Luma Dream Machine API Documentation](https://docs.lumalabs.ai/docs/api) — Vendor documentation for request-ID based image and video generation workflows.
+- [Stable Video Diffusion: Scaling Latent Video Diffusion Models to Large Datasets](https://arxiv.org/abs/2311.15127) — Primary paper on latent video diffusion training and image-to-video generation.
+- [Kubernetes Device Plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/) — Official Kubernetes documentation for advertising GPUs and other special hardware to kubelet.
+- [NVIDIA Triton Dynamic Batching](https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/user_guide/batcher.html) — Official Triton documentation for dynamic and sequence batching concepts relevant to video inference serving.

--- a/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.4-multimodal-first-design.md
+++ b/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.4-multimodal-first-design.md
@@ -5,517 +5,387 @@ sidebar:
   order: 905
 ---
 
+> **AI/ML Engineering Track** | Phase 9 | Complexity: `[COMPLEX]` | Time: 60-75 minutes | Prerequisites: [Voice & Audio AI](../module-1.1-voice-audio-ai/), [Vision AI](../module-1.2-vision-ai/), and [Video AI](../module-1.3-video-ai/)
+
 ## Learning Outcomes
 
 By the end of this module, you will be able to:
-*   **Design** architectures that leverage native multimodal models to process text, audio, and visual data simultaneously within a single latent space.
-*   **Implement** real-time streaming interfaces for voice agents that achieve near-zero latency by eliminating intermediary transcription and synthesis steps.
-*   **Diagnose** latency bottlenecks and synchronization issues in high-bandwidth video and audio streaming applications.
-*   **Evaluate** the trade-offs between composite (bolt-on) multimodal systems and native foundational models across latency, cost, and semantic retention.
-*   **Construct** valid interleaved multimodal payloads and manage context windows to prevent state corruption during interruptions.
-*   **Compare** spatial and temporal compression strategies for streaming live video feeds into multimodal context windows.
+
+- **Distinguish** composite multimodal pipelines from native multimodal architectures and explain the tradeoffs in latency, auditability, cost, and semantic retention.
+- **Design** shared-context payloads that keep text, audio, image, and video evidence aligned without duplicating modality deep dives from the previous modules.
+- **Plan** streaming interactions that handle partial results, endpointing, barge-in, cancellation, and context truncation as first-class state transitions.
+- **Map** a multimodal application onto Kubernetes using gateway routing, sidecars, modality services, back-pressure, and GPU-aware scheduling boundaries.
+- **Evaluate** whether a use case should use early fusion, late fusion, specialist tools, or a native multimodal model based on failure modes rather than hype.
 
 ## Why This Module Matters
 
-Composite STT -> LLM -> TTS voice systems can accumulate enough latency that callers speak over delayed responses, corrupt context, and force an expensive rollback in safety-critical deployments.
+Hypothetical scenario: A support team ships a voice assistant by wiring together speech-to-text, a text-only language model, and text-to-speech. The demo works in a quiet conference room because every sentence arrives as a clean transcript, every response is short, and nobody interrupts the bot. The first production pilot feels different. Callers pause, mumble, talk over the assistant, switch languages, send screenshots, and expect the system to react while the conversation is still happening. The team keeps adding retries, transcript cleanup, silence timers, and client-side buffer hacks, but the user experience still feels brittle because the architecture treats audio, text, and visual evidence as separate jobs rather than one interaction.
 
-The failure was not a flaw in the LLM's reasoning, but an architectural limitation of the "bolt-on" approach. When converting speech to text, critical acoustic features—prosody, tone, emotion, background noise, and hesitation—were permanently lost. The LLM was blind to the panic in a caller's voice or the sound of labored breathing. The subsequent TTS generation sounded robotic and misaligned with the gravity of the situation. The telehealth company realized too late that true intelligence in audio requires understanding the audio natively, not merely a textual transcript of it.
+The deeper failure is not that any one model is weak. The deeper failure is that the system throws information away too early and then asks later components to infer what was lost. A transcript can preserve words, but it does not reliably preserve hesitation, urgency, overlapping speakers, background sound, or whether the user interrupted before the assistant finished speaking. An image caption can preserve a few objects, but it may discard layout, small text, spatial relationships, and uncertainty. A sampled video frame can preserve a scene, but it may miss the gesture or event that happened between frames. Once those details are compressed into a narrow intermediate representation, downstream reasoning can look confident while being grounded in an incomplete view of the situation.
 
-Multimodal-first AI design fundamentally solves this problem. Modern foundational models process audio, images, video, and text directly into a shared latent space. By removing the intermediaries, latency drops from seconds to milliseconds. More importantly, the model reasons over the full richness of the original signal. In this module, you will learn how to design systems that utilize these native capabilities, enabling real-time, high-fidelity interactions that were impossible with previous generations of AI architecture.
+Multimodal-first design starts from the opposite assumption: the user's experience is the unit of design, not the model endpoint. Sometimes that means using a native multimodal model that can attend across audio, image, video, and text representations in one context. Sometimes it means using a composite pipeline because a specialized detector, policy layer, or audit trail is more important than direct end-to-end reasoning. The engineering skill is knowing which boundary to draw, how to keep modalities aligned, how to stream partial evidence without corrupting state, and how to deploy the system on Kubernetes without turning GPU placement, back-pressure, and media routing into afterthoughts.
 
-## Section 1: The Evolution from Composite to Native Architectures
+This module is the design-patterns layer for the multimodal sub-track. The details of speech, vision, and video are handled in their own modules; here we focus on the architecture that joins them. By the end, you should be able to look at a proposed "multimodal" product and ask sharper questions: Where is information lost? Which components own timing? What is the shared state model? How does an interruption change history? Which pods need GPUs, which paths need low latency, and which payloads should never be sent to a general model at all?
 
-For years, building an application that could "see" or "hear" meant gluing distinct, specialized models together. This composite approach was a necessary stepping stone, but it introduced severe limitations in speed, context, and reliability.
+## Composite Versus Native Multimodal Design
 
-### The Composite Pipeline Bottleneck
+A composite multimodal system is a pipeline built from specialized models and services. A voice assistant might use one service to transcribe audio, a language model to reason over text, a retrieval layer to fetch product information, a moderation model to screen the response, and a speech synthesizer to speak back to the caller. A visual support assistant might use OCR, object detection, an image captioner, a language model, and a workflow engine. This pattern is not obsolete. It remains useful when each stage has a clear contract, when the organization needs separate observability for each decision, or when a specialized model solves a narrow problem better than a general model.
 
-A traditional voice-in, voice-out AI pipeline operates sequentially:
-1.  **Ingestion:** The user speaks. The audio is captured and sent to an STT service.
-2.  **Transcription:** The STT service converts the audio waveform into text. Paralinguistic data (tone, volume, background noise) is discarded.
-3.  **Reasoning:** The text is sent to an LLM. The LLM processes the text and generates a text response.
-4.  **Synthesis:** The text response is sent to a TTS service, which generates a synthetic audio waveform.
-5.  **Playback:** The audio is streamed back to the user.
+The drawback is that composite systems create semantic checkpoints. Every handoff decides what counts as the "truth" of the previous modality. Speech becomes text. An image becomes tags. A video becomes sampled frames. A screen recording becomes OCR plus event logs. These transformations are often necessary, but they are lossy. They also make the pipeline sequential unless you deliberately parallelize and reconcile the branches. If transcription waits for a full utterance, the language model cannot reason until the utterance is finished. If the language model waits for a complete answer before speech synthesis begins, the user hears silence. If a video summarizer waits for a full clip, the system cannot react to the live event that matters.
 
-This architecture is inherently flawed for real-time interactions. The latency of each step is additive. Furthermore, the intermediate representations (text) act as extreme lossy compression algorithms for the original modalities.
+Native multimodal design tries to reduce these losses by allowing one model family to ingest multiple modalities into a shared context. The application can send text instructions, audio chunks, image inputs, or video-derived tokens to one reasoning surface rather than forcing every modality through a text bottleneck first. The word "native" is easy to overuse, so treat it as a design claim that needs evidence. A genuinely native path should preserve modality-specific cues long enough for the model to use them, support interleaved inputs rather than only preprocessed captions, and expose streaming semantics if the user interaction is real time. If the system secretly transcribes, captions, and stitches outputs behind the scenes, it may still be useful, but it behaves like a composite pipeline from an architectural risk perspective.
 
-```mermaid
-graph TD
-    subgraph Composite Pipeline
-        A[User Audio] --> B(Speech-to-Text Model)
-        B -->|Lossy Text Transcript| C(Large Language Model)
-        C -->|Text Response| D(Text-to-Speech Model)
-        D --> E[Agent Audio]
-    end
+The first tradeoff is latency. A composite voice chain can optimize each component independently, but the user pays for the sum of capture delay, transcription delay, model delay, synthesis delay, network hops, and buffering. A native speech-to-speech path can begin reasoning over audio representations without waiting for a final transcript, and it can stream output audio as the response forms. That does not make latency vanish; network jitter, GPU queueing, tool calls, safety checks, and playback buffers still matter. The design improvement is that the system has fewer mandatory serialization points, so there are fewer places where a completed artifact must exist before the next step can start.
 
-    subgraph Native Multimodal Pipeline
-        F[User Audio] --> G(Native Multimodal Model)
-        G --> H[Agent Audio]
-    end
+The second tradeoff is error compounding. In a composite pipeline, each stage can turn uncertainty into an apparently clean input for the next stage. If speech recognition mishears a medication name, the language model may produce a fluent answer grounded in the wrong string. If OCR drops a minus sign from a screenshot, the reasoning layer may never know there was ambiguity. If a frame sampler misses the moment a worker removes a protective guard, the safety assistant may infer that the scene is stable. Native multimodal models can still be wrong, but they have a better chance of using raw or richer evidence when the relevant signal is not easily represented as text.
 
-    style B fill:#f9f,stroke:#333,stroke-width:2px
-    style C fill:#f9f,stroke:#333,stroke-width:2px
-    style D fill:#f9f,stroke:#333,stroke-width:2px
-    style G fill:#bbf,stroke:#333,stroke-width:4px
+The third tradeoff is control. Composite systems are often easier to inspect, gate, and certify because every stage can emit logs, confidence scores, and intermediate artifacts. A regulated workflow may need an auditable transcript, a separate medical-device classifier, or a deterministic business-rule engine even when a native model is available. Native models reduce glue code, but they can also concentrate behavior into a larger black box. Good multimodal-first architecture does not blindly prefer native models; it chooses the narrowest boundary that preserves the evidence needed for the task while keeping safety, cost, and operations understandable.
+
+Think of the design choice like airport security. A composite pipeline is a sequence of checkpoints: identity check, bag scan, metal detector, manual inspection, boarding pass validation. Each checkpoint is specialized and inspectable, but the passenger moves through them one at a time. A native multimodal model is closer to an experienced supervisor watching the whole flow at once: the person, the bag, the timing, the behavior, and the context are interpreted together. The supervisor can notice patterns the individual checkpoints miss, but you still need checkpoints for accountability, throughput, and policy enforcement. Multimodal-first design is deciding which work belongs to the supervisor, which work belongs to checkpoints, and how evidence moves between them.
+
+> **Landscape snapshot - as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+
+| Capability family | Public example docs | Design note to verify before production |
+|---|---|---|
+| Realtime native audio sessions | [OpenAI Realtime and audio](https://developers.openai.com/api/docs/guides/realtime) and [OpenAI Realtime with WebRTC](https://developers.openai.com/api/docs/guides/realtime-webrtc) | Confirm current model IDs, supported transports, audio formats, tool-calling behavior, pricing, and regional availability. |
+| Realtime voice and vision streams | [Gemini Live API](https://ai.google.dev/gemini-api/docs/live-api) | Confirm current input/output modalities, session limits, SDK behavior, and whether your deployment path uses the developer API or cloud platform controls. |
+| Open-model multimodal serving | [vLLM multimodal inputs](https://docs.vllm.ai/en/stable/features/multimodal_inputs/) | Confirm supported model architectures, media input schemas, batching behavior, and whether the serving engine treats a modality as stable or experimental. |
+
+> This snapshot is illustrative, not a leaderboard or endorsement. The durable design question is not "which vendor is ahead this month"; it is which interaction contract your system needs and what evidence each contract preserves.
+
+The practical decision framework is simple enough to use in design review. Use a composite pipeline when you need strong audit boundaries, specialized deterministic tools, independent scaling of stages, or a modality-specific model that clearly outperforms general reasoning for the task. Use a native multimodal model when the interaction depends on cues that would be damaged by translation into text or tags, when real-time turn-taking matters, or when cross-modal relationships are the point of the task. Use a hybrid when the model should perceive rich evidence but still call specialist tools for measurements, policy decisions, retrieval, or final actions.
+
+## Shared Latent Space, Fusion, and Cross-Modal Tokens
+
+The phrase "shared latent space" sounds abstract, but the engineering idea is concrete. Transformers operate over sequences of vectors. Text tokens, image patches, audio windows, and video tubelets all need to become vectors with compatible dimensions before attention can compare them. A model may use different front-end encoders for each modality, but once those encoders project their inputs into the model's working representation, the core network can learn relationships across modalities. A patch containing a red warning light, an audio segment containing a harsh engine knock, and text asking "is this safe to drive?" can influence the same reasoning process.
+
+The first design pattern is early fusion. In early fusion, modality representations are joined before or inside the main reasoning stack. The model can attend across text, image, and audio evidence during reasoning rather than treating one modality as a precomputed annotation. This is powerful when meaning depends on relationships: a spoken "this one" while the user points at a screen, a diagram whose labels must be read with the question, or a video where the timing of a sound explains the visual event. Early fusion is also expensive because the model must carry more tokens through attention, and attention cost grows quickly as context length grows.
+
+The second design pattern is late fusion. In late fusion, specialized components produce outputs that are combined later by a reasoning layer or decision engine. A production inspection system might run a defect detector on images, an audio anomaly detector on machine sound, and a rules engine over sensor thresholds, then send a compact summary to an LLM for explanation. Late fusion can be cheaper, more auditable, and easier to scale because each branch can be optimized separately. Its weakness is that cross-modal nuance may be lost before the final join. If the relevant clue is the alignment between a sound and a motion, late fusion has to preserve timing explicitly or the final reasoning layer will see disconnected facts.
+
+The third design pattern is retrieval-mediated fusion. Instead of sending every media object directly into the model, the system indexes modality-specific embeddings and retrieves only the relevant evidence. CLIP-style image-text embeddings, ImageBind-style joint embeddings, OCR indexes, transcript indexes, and event metadata can help the system find the right media slice before the expensive multimodal call. This pattern is especially useful for long videos, support archives, security footage, and industrial telemetry where the raw corpus is far larger than any context window. The risk is retrieval blindness: if the index representation misses the crucial signal, the model never receives the evidence.
+
+Tokenization is where many hidden design choices live. Text tokenizers split strings into subword units and map them to embeddings. Vision transformer style encoders split images into patches, flatten or project those patches, and add positional information so the model can reason about layout. Audio encoders may represent waveform windows, spectrogram patches, or learned audio tokens across time. Video encoders may form spatiotemporal "tubelets" so a token carries both appearance and motion. These are not just implementation details. They decide which distinctions are cheap, which are expensive, and which are impossible after preprocessing.
+
+Alignment is the training and evaluation problem behind the architecture. If a model is trained so that related text and image representations land near each other, it can answer questions about images using text instructions. If audio, depth, thermal, or motion representations are also aligned, the system can reason across more kinds of evidence. Alignment is never perfect. A model may align common objects well and rare industrial signals poorly. It may associate tone with sentiment in consumer conversations but fail in noisy factory audio. It may read large text in screenshots but miss small labels. Multimodal-first design therefore includes domain evaluation, not just endpoint integration.
+
+Context ordering matters because multimodal prompts are not bags of evidence. A user might say, "Compare this sound with the second image, not the first one," or provide a screenshot, then a correction, then an audio clip. Your payload structure should preserve the conversational and temporal order in which evidence arrived. Interleaved visual-language research such as Flamingo made this explicit: a model can use alternating text and media context when the architecture supports it. In applications, that means your request builder must avoid flattening everything into one caption or one transcript unless that is a deliberate design choice.
+
+State also matters after the model responds. If a native voice model outputs audio directly, the application still needs a representation of what happened for memory, audit, and future turns. The safe approach is to store layered state: raw media references when policy allows, derived artifacts such as transcripts or captions, model-visible context, user-visible playback spans, and action logs. Do not assume that the generated text equivalent of an audio response is identical to what the user heard. If the user interrupted at the halfway point, the future context should reflect the half that was actually played, not the full response the model intended to produce.
+
+The design review question for shared representation is: what must remain aligned across time? For a voice agent, align incoming audio chunks, endpointing events, outgoing audio chunks, tool calls, and the playback cursor. For a vision support agent, align the original image, crop coordinates, OCR text, model answer, and any human annotations. For a video agent, align timestamps, sampled frames, motion events, audio tracks, and selected keyframes. When you cannot answer how alignment is represented, the system is likely to fail under interruptions, retries, or dispute review.
+
+## Streaming Design for Real-Time Multimodal Interaction
+
+Real-time multimodal systems are not normal request-response applications with larger payloads. They are continuous state machines. Audio arrives while the model is thinking. The model may speak while it is still deciding whether to call a tool. The user may interrupt while output audio is buffered locally. Network conditions may reorder or delay chunks. A safety layer may need to stop generation after a partial response has already started. The architecture must define what can happen concurrently and which component owns the truth when events overlap.
+
+The minimum streaming loop has four paths. The capture path reads microphone frames, camera frames, screen frames, or sensor data and encodes them into transport messages. The ingress path authenticates the session, validates media shape, and applies back-pressure before forwarding data to inference. The inference path turns streaming evidence into model state and emits partial outputs. The egress path delivers response deltas to the client and tracks what the user actually received. Treating these as one blocking function is the fastest way to create jitter and stale context.
+
+Endpointing is the decision that the user has completed a turn, or at least paused long enough for the system to respond. In a composite pipeline, endpointing is often tied to speech recognition: wait for silence, finalize a transcript, send text to the LLM. In a native streaming path, endpointing can be softer. The model may receive audio continuously, maintain partial understanding, and begin preparing a response before a final transcript exists. The application still needs explicit events for "user started speaking," "user likely finished," "assistant started speaking," and "assistant audio was played through timestamp T." Without those events, barge-in handling becomes guesswork.
+
+Barge-in is the name for user interruption during assistant output. It is not a polish feature; it is a correctness feature. If the user says "stop" or "actually, I meant the other image" while the assistant is speaking, the system must stop playback quickly, cancel or revise generation, and update conversation history to match reality. The dangerous bug is appending the assistant's full generated response to history even though the user heard only the first part. Future model turns will then assume the user knows information that was never delivered. This creates confusing, sometimes unsafe conversations where the assistant refers back to invisible content.
+
+Partial results require similar discipline. A streaming model may emit text deltas, audio chunks, function-call arguments, safety annotations, or intermediate tool-call plans. The client should not treat every partial token as committed state. Some deltas are speculative until the model finalizes a message. Some audio chunks are committed once played. Some function calls should be held until a complete argument object validates against schema. A robust design separates "received from model," "validated," "sent to user," "played by user," and "committed to conversation history." That separation feels verbose in diagrams, but it prevents entire classes of bugs.
+
+Back-pressure is the other half of streaming correctness. If the client sends audio faster than the server can process it, buffers grow and latency becomes unbounded. If video frames arrive faster than the model path can accept them, the system must choose between dropping frames, lowering resolution, sampling keyframes, or switching to an event-driven summary. The wrong answer is silently queueing everything. Queues are useful only when their maximum size, drop policy, and user-visible behavior are intentional. A voice agent should usually prefer fresh audio over stale audio; a compliance recorder may prefer completeness over immediacy; a robotics controller may need deterministic deadlines.
+
+Transport choice shapes the operational model. WebSockets provide a persistent bidirectional channel that fits server-mediated streaming and works well for many backend-to-model paths. WebRTC is designed for real-time media, browser capture, jitter handling, and audio/video transport, and many browser voice applications benefit from its media stack. HTTP streaming can work for one-way deltas but is awkward for full-duplex interaction. The choice is not purely a developer convenience. It changes authentication, session handoff, load balancer behavior, packet loss handling, client implementation, and where you can observe the stream.
+
+Latency budgets should be broken into components rather than stated as a single marketing number. Capture buffering, codec work, client scheduling, network transit, gateway processing, queue wait, prefill, decoding, tool calls, safety checks, response transport, and audio playback all contribute. A native model can reduce mandatory conversions, but it cannot rescue a design that sends media through distant regions, lets GPU queues grow without admission control, or forces every turn through a slow synchronous tool. In design review, ask for a latency budget table with owners and measurement points, even if the first version uses approximate targets rather than fixed service-level objectives.
+
+Observability must also be multimodal. A text-only log of the final answer is not enough to debug a streaming failure. You need event timelines, chunk counters, queue depths, dropped-frame counts, endpointing decisions, cancellation events, tool-call boundaries, and playback acknowledgements. When privacy policy permits, store short-lived encrypted media references for debugging, but do not make raw-media retention the default unless the product and legal requirements justify it. Good observability lets you answer whether a bad answer came from missing evidence, bad retrieval, model reasoning, stale context, transport jitter, or a client playback bug.
+
+## Kubernetes Architecture for Multimodal Systems
+
+Kubernetes does not make a multimodal system reliable by itself. It gives you primitives for routing, scheduling, isolation, rollout, and observation, but you still have to map the media and inference flows onto those primitives deliberately. A clean architecture usually separates the realtime edge, modality preprocessing, model serving, tool execution, state storage, and offline evaluation paths. Combining all of them into one giant pod may be simple for a demo, but it makes latency, scaling, and failure isolation harder when traffic becomes uneven across modalities.
+
+A practical cluster layout starts with a gateway layer. The gateway terminates external connections, enforces authentication, applies coarse rate limits, and routes sessions to the right backend. For ordinary HTTP traffic, Gateway API or an ingress controller may be enough. For realtime media, the gateway must also respect long-lived connections, connection draining during deploys, sticky session requirements, and protocol differences between WebSocket and WebRTC flows. If the model provider is external, the gateway may broker ephemeral credentials so browsers do not hold long-lived secrets. If inference is internal, the gateway should route users to healthy regional or node-local serving pools.
+
+Behind the gateway, a session coordinator owns conversation state and modality routing. It decides whether a turn goes to a native multimodal model, a speech specialist, an OCR service, a video summarizer, a retrieval service, or a policy engine. The coordinator should not become a place where every media byte is copied forever. Its job is to hold references, sequence numbers, timestamps, and state transitions. It should know that audio chunk 184 arrived before the user interruption, that outgoing chunks 90 through 112 were played, that frame sample 17 corresponds to timestamp 12.4 seconds, and that a tool call was cancelled before execution.
+
+Sidecars are useful when a concern must be close to the workload but should not live inside model-serving code. A media-normalization sidecar can transcode incoming PCM, downscale frames, enforce payload limits, or attach timing metadata before the main container receives input. A policy sidecar can redact obvious secrets from screenshots or block disallowed file types. A metrics sidecar can emit chunk-level telemetry without modifying a vendor SDK. Use sidecars sparingly, because every sidecar adds CPU, memory, rollout, and debugging complexity. The design test is whether co-location solves a real latency, security, or ownership problem.
+
+Modality services should scale according to their bottlenecks. Audio normalization is usually CPU and network sensitive. OCR may be CPU, GPU, or accelerator sensitive depending on model choice. Video sampling can be CPU-heavy and bandwidth-heavy before it ever reaches a model. Native multimodal inference is usually GPU-memory and decode-throughput sensitive. Tool execution may be I/O-bound. If all paths share one deployment and one autoscaler, the busiest modality can starve the others. Split services where scaling curves differ, but keep the session model unified so cross-modal alignment does not disappear into service boundaries.
+
+GPU placement requires explicit scheduling boundaries. Kubernetes exposes vendor-specific accelerators through device plugins, and pods request those resources like extended resources. That gets a pod onto a node with a GPU, but it does not solve model cold starts, memory fragmentation, topology, or queueing. A native multimodal serving pod may need a large model resident in GPU memory, while a lightweight frame sampler should not consume a GPU at all. Use node labels, node affinity, taints, tolerations, and topology spread constraints to keep expensive inference workloads on the right nodes and keep stateless edge services resilient across zones or failure domains.
+
+Resource requests and quality of service matter because realtime workloads fail badly under noisy neighbors. If an audio gateway is CPU-throttled, users hear stutter. If a session coordinator is evicted, active conversations break. If a GPU server accepts unlimited sessions, queue wait dominates every turn. Kubernetes requests, limits, priority classes, and pod disruption budgets are not paperwork; they define which workloads survive pressure and how rollouts affect live sessions. For latency-sensitive paths, prefer admission control and graceful degradation over optimistic overcommit. It is better to reject or downgrade a new video stream than to make every active voice call unusable.
+
+Back-pressure belongs at multiple layers. The client should know when to lower frame rate or stop sending optional video. The gateway should enforce maximum message sizes, connection counts, and session rates. The coordinator should track downstream queue health and switch strategies when inference is saturated. The model-serving layer should expose queue depth, prefill time, decode time, and cancellation behavior. The storage layer should not block realtime turns because a debug artifact upload is slow. Each layer needs a small set of explicit overload decisions; otherwise overload becomes accidental buffering.
+
+The following high-level diagram shows one workable pattern. It is not a reference architecture to copy blindly. It is a map of ownership boundaries that you can adapt to your provider, privacy model, and latency target.
+
+```text
+Browser / mobile client
+  |  audio, frames, text, interruption events
+  v
+Realtime gateway
+  |  auth, rate limits, sticky session, protocol handling
+  v
+Session coordinator
+  |  state machine, modality routing, sequence numbers
+  +--> audio normalizer sidecar/service
+  +--> image/OCR service
+  +--> video sampler/event extractor
+  +--> retrieval and tool services
+  |
+  v
+Native multimodal serving pool
+  |  GPU nodes, admission control, streaming deltas
+  v
+Response egress
+  |  playback ack, cancellation, committed history
+  v
+State store + observability pipeline
 ```
 
-### The Native Multimodal Paradigm
+Rollouts require special care for long-lived sessions. A normal stateless web deployment can terminate old pods as new pods become ready. A realtime voice pod may hold active sessions for several minutes. Use readiness gates, connection draining, maximum session age, and explicit handoff behavior. If handoff is impossible, the product should define what users experience during deploys: finish current sessions on old pods, refuse new sessions during drain, and preserve enough state to recover if a pod dies. Avoid a rollout strategy that silently drops every active stream because the deployment controller saw enough new replicas become ready.
 
-Native multimodal models dispense with intermediate representations. Instead of using separate models to handle different data types, a single, unified transformer architecture is trained from the ground up on interleaved datasets of text, audio, images, and video.
+Security and privacy boundaries are part of the architecture, not a separate checklist. Multimodal inputs often contain voices, faces, screens, documents, locations, and bystanders. A gateway that accepts arbitrary screenshots may receive secrets even when users were not trying to share them. A video stream can reveal a workplace layout. Audio can include people who did not consent. The coordinator should know which media can be stored, which must be redacted, which can leave a region, which can be sent to an external provider, and which must be converted into a safer derived artifact first. The more native the model path, the more carefully you need to decide what raw evidence is allowed into it.
 
-When you pass an audio file to a native model, it does not transcribe it. It tokenizes the raw audio waveform (or a spectrogram representation) directly into continuous vectors that exist in the exact same latent space as text tokens. The model learns that the audio token for the sound of a barking dog is semantically adjacent to the text token for "dog" and the image patch token of a Golden Retriever.
+## Voice, Vision, and Video as Design Illustrations
 
-This [unified latent space](https://arxiv.org/abs/2305.05665) allows the model to perform cross-modal reasoning intrinsically. It can hear the sarcasm in a voice, read the text of a prompt, and look at an image, applying self-attention across all three modalities simultaneously.
+Voice is the easiest place to see why multimodal-first design changes architecture, but this module intentionally does not reteach the voice stack. For microphone capture, codecs, speech recognition, synthesis, prosody, and voice-specific safety, go back to [Voice & Audio AI](../module-1.1-voice-audio-ai/). The design lesson here is narrower: voice systems are timing systems. A useful voice agent needs capture, endpointing, generation, playback, interruption, and committed history to agree about what happened. If those clocks disagree, the model may be smart while the conversation feels broken.
 
-> **Pause and predict**: Imagine designing an AI drive-thru ordering system. If a customer says, "Yeah, sure, I *totally* want extra mayo" with a heavily sarcastic tone, how would a composite pipeline (STT -> LLM) misinterpret this compared to a native multimodal model, and what specific business impact would this failure have?
+The common voice design choice is whether to keep a transcript-centered architecture or move the live path to native audio. Transcript-centered systems are attractive because text is easy to log, search, redact, evaluate, and pass through existing LLM tools. Native audio systems are attractive because tone, timing, and direct audio output can matter for user experience. A hybrid architecture often works well: use native audio for the live turn, create transcripts and summaries asynchronously for audit and search, and make sure future model context distinguishes between what the model heard, what the transcript says, and what the user actually heard in response.
 
-## Section 2: Shared Latent Space and Cross-Modal Tokenization
+Vision has a different failure shape. The user often provides a still image, screenshot, scan, or camera frame, and latency may be less strict than voice. The hard part is preserving spatial evidence. A caption such as "a dashboard with warning lights" may be enough for a casual explanation, but not enough for troubleshooting because the position, color, label, and surrounding context of each warning light may matter. For image preprocessing, OCR, object detection, layout reasoning, and prompt patterns, use [Vision AI](../module-1.2-vision-ai/). The design lesson here is that the system should keep references to crops, coordinates, OCR spans, and original media so answers can be checked and corrected.
 
-To understand how native multimodal models work under the hood, we must examine how disparate data types are transformed into a common language that the transformer blocks can process.
+A strong visual support flow often combines native vision reasoning with specialist tools. The model can inspect the whole screenshot and infer user intent, while OCR extracts exact text, a UI automation tool verifies current state, and a policy layer blocks sensitive actions. This is not a step backward from native multimodal design. It is a hybrid that respects the limits of each component. Native perception gives broad context; tools provide exact measurements and actions; state tracking records which evidence justified the answer.
 
-### Modality-Specific Encoders
+Video is where bandwidth and context limits dominate. The previous [Video AI](../module-1.3-video-ai/) module owns the details of frame sampling, action recognition, temporal reasoning, and high-bandwidth media tradeoffs. The design lesson here is that video is not simply many images. If your system samples one frame every few seconds, it may understand a scene but miss a brief event. If it sends too many frames, it may drown the model in visual tokens and blow the latency budget. If it summarizes video too early, it may lose the temporal relationship that explained the event.
 
-While the core transformer network is unified, the initial ingestion of data requires modality-specific encoders to create the initial embeddings.
+Good video architecture starts with intent. A live safety monitor, a sports coaching assistant, a screen-recording tutor, and an archive search tool have different freshness requirements. The safety monitor may prefer low-resolution frequent frames plus event detectors. The archive search tool may prefer offline indexing and retrieval. The screen tutor may need OCR and UI event alignment more than raw frame rate. The sports coach may need short high-resolution bursts around detected motion. Multimodal-first design does not mean "send all pixels to the largest model." It means preserve the evidence that the task actually needs.
 
-1.  **Text Tokenization:** Text is split using standard subword tokenizers (like Byte-Pair Encoding or WordPiece) and mapped to dense vectors via an embedding matrix.
-2.  **Image Patching (Vision Transformers):** [Images are divided into a grid of non-overlapping patches](https://arxiv.org/abs/2010.11929) (e.g., 16x16 pixels). Each patch is flattened and linearly projected into a vector. Positional embeddings are added to retain spatial awareness.
-3.  **Audio Spectrograms:** Raw audio waveforms are often converted into Mel-spectrograms (visual representations of frequencies over time). These spectrograms are then processed similarly to images, cut into patches over the time dimension, and projected into embeddings.
-4.  **Video Tubelets:** Video combines spatial and temporal dimensions. Instead of processing every single frame independently (which is computationally prohibitive), [models extract "tubelets"—3D blocks of pixels spanning across multiple consecutive frames](https://arxiv.org/abs/2103.15691), capturing both appearance and motion.
-
-Once these modality-specific encoders project the raw data into embeddings of the same dimensionality (e.g., $d_{model} = 4096$), the transformer no longer cares where the data originated. It simply sees a sequence of vectors and applies multi-head self-attention across them.
-
-### Constructing a Multimodal Payload
-
-In modern APIs, developers pass interleaved modalities directly in the request payload. The SDK handles the heavy lifting of preparing the data for the respective encoders.
-
-```python
-import base64
-import requests
-import json
-
-# Simulating a native multimodal API request
-API_ENDPOINT = "https://api.example-ai.com/v1/multimodal/generate"
-API_KEY = "your_secure_api_key_here"
-
-def encode_file_to_base64(file_path):
-    with open(file_path, "rb") as file:
-        return base64.b64encode(file.read()).decode('utf-8')
-
-# We construct a payload where text, an image, and an audio clip are provided
-# in a specific sequence. The model processes them in exactly this order.
-payload = {
-    "model": "native-multimodal-v1",
-    "messages": [
-        {
-            "role": "user",
-            "content": [
-                {
-                    "type": "text",
-                    "text": "Analyze this engine sound and the corresponding dashboard image."
-                },
-                {
-                    "type": "audio",
-                    "audio_url": {
-                        "data": f"data:audio/wav;base64,{encode_file_to_base64('engine_knocking.wav')}"
-                    }
-                },
-                {
-                    "type": "image",
-                    "image_url": {
-                        "data": f"data:image/jpeg;base64,{encode_file_to_base64('dashboard_warning.jpg')}"
-                    }
-                },
-                {
-                    "type": "text",
-                    "text": "What is the most likely mechanical failure occurring here, and what should I do immediately?"
-                }
-            ]
-        }
-    ],
-    "max_tokens": 500,
-    "temperature": 0.2
-}
-
-headers = {
-    "Content-Type": "application/json",
-    "Authorization": f"Bearer {API_KEY}"
-}
-
-# The model will process the text, hear the knocking sound, see the check engine light,
-# and provide a synthesized diagnosis without needing intermediate transcription or image captioning.
-response = requests.post(API_ENDPOINT, headers=headers, data=json.dumps(payload))
-print(response.json())
-```
-
-This structural shift completely alters application design. Instead of building complex orchestration layers to coordinate multiple models, engineers focus on curating the right combination of multimodal inputs to provide the maximum context to a single model.
-
-## Section 3: Real-Time Streaming and Near-Zero Latency
-
-The most transformative application of native multimodal models is the real-time voice and video agent. When the model can ingest audio directly and output audio directly, the interaction paradigm shifts from a turn-based chat to a continuous, full-duplex conversation.
-
-### The Problem with REST APIs for Real-Time
-
-Standard HTTP requests operate on a request-response cycle. You send the entire audio clip, wait for the server to process it, and receive the entire response. This introduces unacceptable latency for natural conversation. Human conversational turn-taking typically happens on the order of a few hundred milliseconds. If an AI takes 2 seconds to reply, the interaction feels disjointed and unnatural.
-
-### WebSockets and WebRTC
-
-To achieve near-zero latency, multimodal applications utilize [persistent, bidirectional connections like WebSockets](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/index.html) or WebRTC.
-
-1.  **Continuous Ingestion:** The client captures audio from the microphone in small chunks (e.g., 20ms frames) and streams them continuously to the server.
-2.  **Streaming Inference:** The native model processes these audio tokens as they arrive, continuously updating its internal state and attention matrices.
-3.  **Early Generation:** As soon as the model detects an endpointing event (e.g., a pause indicating the user has finished speaking), it immediately begins generating response tokens.
-4.  **Streaming Output:** The model generates output audio tokens sequentially and streams them back to the client immediately. The client begins playback before the model has even finished generating the end of the sentence.
-
-```mermaid
-sequenceDiagram
-    participant User
-    participant Client
-    participant Multimodal_Model
-
-    Note over User, Client: Continuous Audio Capture
-    User->>Client: Speaks: "What is the capital..."
-    Client->>Multimodal_Model: Stream Audio Chunk 1
-    Client->>Multimodal_Model: Stream Audio Chunk 2
-    User->>Client: Speaks: "...of France?"
-    Client->>Multimodal_Model: Stream Audio Chunk 3 (Endpoint detected)
-    Note over Multimodal_Model: Immediate generation starts
-    Multimodal_Model->>Client: Stream Output Audio Chunk 1 ("The capital ")
-    Client->>User: Playback Audio
-    Multimodal_Model->>Client: Stream Output Audio Chunk 2 ("is Paris.")
-    Client->>User: Playback Audio
-```
-
-### Full-Duplex and Interruptibility
-
-A crucial feature of natural conversation is interruptibility. If the AI is giving a long explanation and the user interjects with "Wait, what about...", the AI must stop speaking immediately and process the new input.
-
-In a streaming native architecture, this is handled gracefully because the connection is bidirectional. The server is constantly listening to the incoming stream even while it is sending the outgoing stream. If the incoming stream registers speech while the model is outputting, the server sends a cancellation signal to the generation process, truncates the context window to only include the audio that was actually played to the user, and begins processing the user's interruption.
-
-> **Stop and think**: Suppose an AI tutor is explaining a complex math problem, and the student interrupts at the 5-second mark saying, "Wait, I don't understand step two." If the system accidentally appends the AI's fully generated 15-second explanation to the context window before processing the interruption, how will the AI respond to the student's question, and why?
-
-## Section 4: Implementing a Voice Agent Architecture
-
-Building a real-time voice agent requires robust asynchronous programming to handle the concurrent tasks of capturing microphone input, transmitting data, receiving data, and playing audio through the speakers.
-
-Below is a conceptual implementation using Python's `asyncio` and WebSockets to interface with a streaming native multimodal API. This example highlights the architectural pattern of separating the transmit and receive loops.
-
-```python
-import asyncio
-import websockets
-import json
-import pyaudio
-
-# Audio configuration constants
-FORMAT = pyaudio.paInt16
-CHANNELS = 1
-RATE = 24000
-CHUNK = 1024
-
-class RealTimeVoiceAgent:
-    def __init__(self, uri, api_key):
-        self.uri = uri
-        self.api_key = api_key
-        self.p = pyaudio.PyAudio()
-        
-        # Open audio stream for microphone input
-        self.input_stream = self.p.open(
-            format=FORMAT, channels=CHANNELS, rate=RATE,
-            input=True, frames_per_buffer=CHUNK
-        )
-        
-        # Open audio stream for speaker output
-        self.output_stream = self.p.open(
-            format=FORMAT, channels=CHANNELS, rate=RATE,
-            output=True, frames_per_buffer=CHUNK
-        )
-
-    async def send_audio(self, ws):
-        """Continuously reads from the microphone and sends over WebSocket."""
-        try:
-            while True:
-                # Read raw PCM data from the microphone
-                data = self.input_stream.read(CHUNK, exception_on_overflow=False)
-                
-                # Construct the JSON payload containing base64 encoded audio
-                import base64
-                encoded_data = base64.b64encode(data).decode("utf-8")
-                
-                message = {
-                    "event": "media",
-                    "media": {
-                        "payload": encoded_data
-                    }
-                }
-                await ws.send(json.dumps(message))
-                await asyncio.sleep(0.01) # Yield control briefly
-        except asyncio.CancelledError:
-            pass
-        except Exception as e:
-            print(f"Error in send_audio: {e}")
-
-    async def receive_audio(self, ws):
-        """Continuously listens for incoming WebSocket messages and plays audio."""
-        import base64
-        try:
-            async for message in ws:
-                data = json.loads(message)
-                
-                # Check if the server is sending back audio media
-                if data.get("event") == "media":
-                    audio_payload = data["media"]["payload"]
-                    pcm_data = base64.b64decode(audio_payload)
-                    # Play the audio through the speakers
-                    self.output_stream.write(pcm_data)
-                    
-                # Handle interruption events from the server
-                elif data.get("event") == "clear":
-                    print("\n[Server indicated an interruption, clearing buffers]")
-                    # In a production app, you would clear local playback buffers here
-                    
-        except asyncio.CancelledError:
-            pass
-        except Exception as e:
-            print(f"Error in receive_audio: {e}")
-
-    async def run(self):
-        """Manages the WebSocket connection and starts the async tasks."""
-        headers = {"Authorization": f"Bearer {self.api_key}"}
-        
-        print("Connecting to Multimodal AI Server...")
-        async with websockets.connect(self.uri, extra_headers=headers) as ws:
-            print("Connected. Start speaking.")
-            
-            # Send initial configuration (e.g., system instructions, voice settings)
-            config = {
-                "event": "setup",
-                "system_instruction": "You are a helpful, concise AI assistant.",
-                "voice": "alloy"
-            }
-            await ws.send(json.dumps(config))
-            
-            # Run both the sending and receiving loops concurrently
-            send_task = asyncio.create_task(self.send_audio(ws))
-            receive_task = asyncio.create_task(self.receive_audio(ws))
-            
-            # Wait for either task to complete (or fail)
-            done, pending = await asyncio.wait(
-                [send_task, receive_task],
-                return_when=asyncio.FIRST_COMPLETED
-            )
-            
-            # Cleanup pending tasks
-            for task in pending:
-                task.cancel()
-
-# Entry point
-if __name__ == "__main__":
-    agent = RealTimeVoiceAgent("wss://api.example-ai.com/v1/realtime", "YOUR_API_KEY")
-    try:
-        asyncio.run(agent.run())
-    except KeyboardInterrupt:
-        print("\nSession terminated by user.")
-```
-
-This code illustrates the fundamental paradigm shift. There is no `transcribe()` function and no `synthesize()` function. The application merely shuttles raw PCM audio bytes back and forth, relying entirely on the model's native multimodal processing capabilities.
-
-## Section 5: Processing Video and High-Bandwidth Modalities
-
-While audio streaming requires careful latency management, streaming video introduces extreme bandwidth constraints. A single uncompressed 1080p video stream at 30 frames per second generates immense amounts of data, far exceeding the real-time ingestion capabilities of current transformer contexts.
-
-### Spatiotemporal Compression Strategies
-
-To handle video natively, systems employ several strategies to compress the visual information before it hits the transformer's attention mechanism:
-
-| Compression Strategy | Description | Trade-offs |
-| :--- | :--- | :--- |
-| **Frame Sampling (FPS Reduction)** | Dropping the input rate from 30 FPS down to 1 or 2 FPS. The model only "sees" one frame every half-second. | **Pro:** Drastically reduces token count. <br>**Con:** Model becomes blind to rapid, transient events (e.g., a momentary flash of light, a quick hand gesture). |
-| **Spatial Downscaling** | Reducing the resolution of the incoming frames (e.g., from 1080p to 360p or 224x224) before patch extraction. | **Pro:** Exponentially reduces the number of patch tokens per frame. <br>**Con:** Severe loss of fine detail. Model cannot read small text or identify distant objects. |
-| **Delta Encoding / Motion Vectors** | Instead of passing full frames, the system passes a base frame and then only the pixel differences (deltas) of subsequent frames. | **Pro:** Highly efficient for static scenes. <br>**Con:** Fails dramatically in high-motion environments or when the camera pans rapidly. |
-| **Token Merging (ToMe)** | An algorithmic approach where adjacent image patches with similar semantic content are mathematically merged into a single token before entering deeper transformer layers. | **Pro:** Retains resolution where it matters while reducing token count in uniform areas (like empty skies). <br>**Con:** Requires custom modifications to the transformer architecture itself. |
-
-When designing a multimodal system that incorporates video, engineers must carefully profile the use case. A security camera analyzing a static parking lot can aggressively use Delta Encoding. However, a live sports analysis agent requires high frame rates to capture rapid movements and high resolution to track a small ball, necessitating massive computational overhead and optimized Token Merging techniques.
+Across all three modalities, the same pattern repeats. Keep raw evidence only when policy and cost justify it. Create derived artifacts for search, audit, and debugging. Preserve alignment metadata so those artifacts can be traced back to the original event. Decide which decisions are made by native reasoning and which are made by specialist tools. Measure latency and loss at each boundary. The strongest multimodal systems are not the ones with the most modalities in the prompt; they are the ones where every modality has a clear reason to be present and a clear path through the system.
 
 ## Did You Know?
 
-*   The transition from composite audio pipelines to native multimodal models typically reduces end-to-end response latency from an average of 3,200 milliseconds down to under 300 milliseconds.
-*   A single minute of uncompressed 1080p video contains billions of pixels, so practical multimodal systems need aggressive spatiotemporal compression before feeding video into model context.
-*   Native audio models can preserve prosodic and other nonverbal cues that plain text transcription drops.
-*   By the mid-2020s, many enterprise customer-service teams were piloting or deploying real-time voice agents alongside text chatbots.
+<blockquote>
+
+- The WebSocket API is defined for two-way interactive communication between a browser and a server, which is why it often appears in server-mediated realtime model sessions.
+- WebRTC exposes browser APIs for realtime audio, video, and data exchange, which makes it a natural fit for client-side speech and video interactions when the application needs media-aware transport.
+- Kubernetes device plugins are the standard framework for advertising hardware such as GPUs to kubelet, so GPU-aware multimodal serving depends on cluster hardware integration as well as model code.
+- ImageBind demonstrated a joint embedding approach across images, text, audio, depth, thermal, and IMU data, showing why shared representation is a design concept rather than a text-only trick.
+
+</blockquote>
 
 ## Common Mistakes
 
-| Mistake | Why it happens | How to Fix |
-| :--- | :--- | :--- |
-| **Assuming text prompts always override audio context.** | Developers assume standard text system prompts carry more weight than the user's audio input. | In practice, emotional audio cues can materially influence how a native audio model interprets an exchange, so you should test how tone interacts with your text instructions. Explicitly instruct the model on how to handle emotional audio divergence. |
-| **Buffering audio unnecessarily.** | Applying REST API mindsets to streaming systems by waiting for complete sentences before sending data over the WebSocket. | Stream raw audio chunks (e.g., 20ms or 50ms) immediately as they are captured. Let the server-side Voice Activity Detection (VAD) handle sentence boundaries. |
-| **Ignoring server-side interruptions.** | The client continues playing synthesized audio even after the user has spoken, leading to "talking over each other." | Implement robust event listeners on the WebSocket to immediately halt local audio playback when an `interruption` or `clear` event is received from the model. |
-| **Sending incompatible audio formats.** | Feeding standard MP3 or high-bitrate stereo audio directly into APIs expecting raw PCM data at specific sample rates. | Always transcode audio to the API's exact specifications (typically 16-bit PCM, 24kHz, mono) before transmission to avoid silent failures or distorted inference. |
-| **Appending unplayed tokens to history.** | When an interruption occurs, appending the *entire* generated response to the conversation history, including parts the user never heard. | Truncate the conversation history dynamically based on the exact timestamp of the interruption, appending only the tokens that were physically played through the speaker. |
-| **Treating video as sequential images.** | Passing independent frames to the model as if they were a slideshow, ignoring temporal dependencies. | Use APIs that support native video embeddings or temporal tubelets, allowing the model to understand motion and causality across time, not just static snapshots. |
+| Mistake | Why it happens | How to fix |
+|---|---|---|
+| Treating native multimodal as automatically better | Teams hear "single model" and assume the architecture is simpler in every dimension. | Compare evidence preservation, audit needs, cost, latency, and operational control before choosing native, composite, or hybrid boundaries. |
+| Hiding a composite pipeline behind a native-sounding API name | Product demos describe the user experience, while engineering docs omit intermediate transcription, captioning, or summarization stages. | Document the real data path and list every lossy transformation that happens before model reasoning. |
+| Appending unplayed assistant output to history | The server generated a full response, but the user interrupted before hearing all of it. | Commit only the output spans that were delivered or played, and store cancellation events as first-class conversation state. |
+| Letting video queues grow without a drop policy | Engineers want complete evidence and avoid deciding which frames to discard under load. | Define freshness rules per use case: drop stale frames for live assistance, preserve complete media for offline audit, or degrade resolution intentionally. |
+| Sending every modality to the most expensive model | The system lacks routing logic, so all inputs follow the same path regardless of task. | Route by intent and evidence need: OCR for exact text, detectors for narrow signals, native multimodal reasoning for cross-modal interpretation. |
+| Scaling all modality paths with one deployment | Early prototypes put gateway, preprocessing, coordination, and model calls in one service. | Split services where bottlenecks differ, but keep shared session IDs, timestamps, and state transitions consistent across the split. |
+| Ignoring GPU admission control | Kubernetes schedules the pod, so the team assumes inference capacity is handled. | Track model queue depth, active sessions, prefill/decode time, and reject or degrade new sessions before queues create user-visible lag. |
+| Logging only the final text answer | Text logs are familiar, but they hide media timing, partial output, cancellation, and playback behavior. | Capture event timelines, chunk counters, playback acknowledgements, and derived artifacts that let you debug multimodal state safely. |
 
-## Quiz
+## Knowledge Check
 
 <details>
-<summary>1. A financial services firm replaces their STT -> LLM -> TTS pipeline with a native multimodal model. Their primary goal is reducing latency for their automated phone banking system. Why does the native model achieve this?</summary>
-<br>
-The native model achieves lower latency because it eliminates the intermediary conversion steps. In the composite pipeline, the system must wait for transcription to finish before reasoning begins, and reasoning to finish before synthesis begins. A native model projects the raw audio into its latent space, reasons, and generates audio tokens directly, cutting out the computational overhead and network hops of the STT and TTS services.
+<summary>1. Scenario: A team proposes replacing a transcript-centered call-center bot with a native speech-to-speech model. What should you ask before approving the redesign?</summary>
+
+Ask which user-visible failures the redesign is supposed to fix and which controls must remain outside the native model. Native speech may preserve timing and tone better than a transcript-only pipeline, but the team may still need transcripts for audit, retrieval, compliance review, human handoff, and quality measurement. A good design explains how live audio, derived transcripts, tool calls, cancellation events, and committed playback history coexist rather than claiming that one model endpoint removes every architecture concern.
 </details>
 
 <details>
-<summary>2. Scenario: You are building an AI driving instructor that watches a live dashboard camera feed. When a car ahead suddenly brakes, the AI needs to alert the driver instantly. Which video compression strategy is LEAST appropriate for this use case?</summary>
-<br>
-Frame Sampling (FPS Reduction) is the least appropriate strategy here. Dropping the frame rate to 1 or 2 frames per second means the system might be completely blind to rapid, transient events like the sudden illumination of brake lights. By the time the next frame is sampled, it may be too late to issue a warning. Strategies that preserve temporal resolution, even at the cost of spatial fidelity, are better suited for collision avoidance.
+<summary>2. Scenario: A video assistant misses a brief safety event even though the model answers accurately about sampled frames. Is this primarily a reasoning failure?</summary>
+
+Not necessarily. It is likely an evidence-selection failure. If the frame sampler did not include the moment when the event happened, the model could not reason over it. The fix may be to adjust frame rate, add event detectors, preserve short bursts around motion, or route the use case to a lower-latency path. Multimodal systems often fail before inference because preprocessing decides which evidence exists.
 </details>
 
 <details>
-<summary>3. Scenario: A hospital deploys an emergency response AI. A caller says "I'm fine, just a small cut" but their voice is trembling, they are gasping for air, and there are loud crashes in the background. If the system uses a composite STT -> LLM pipeline versus a native multimodal model, how will the triage decisions differ and why?</summary>
-<br>
-In a composite pipeline, the STT model outputs only the text "I'm fine, just a small cut." The LLM, seeing only this text, will classify the triage priority as low. Conversely, a native multimodal model processes the raw audio waveform directly in its latent space. It detects the paralinguistic features—the trembling voice, the gasping, and the background crashes—which are semantically mapped alongside the text. This allows the native model to recognize the acute distress and prioritize the call as a high emergency, demonstrating how intermediate text representations fatally strip critical context.
+<summary>3. Scenario: Your voice agent keeps referring to details from an explanation the user interrupted. Which state boundary is probably wrong?</summary>
+
+The system is probably committing generated output rather than played output. When a user interrupts, future history should contain only what the user actually heard, plus the interruption event. If the full generated response is appended to context, the model believes the user received information that was never delivered, so later turns become confusing.
 </details>
 
 <details>
-<summary>4. Scenario: A user is interacting with your real-time voice agent. The agent starts explaining a complex concept. Ten seconds in, the user interrupts and says, "Skip to the summary." If you append the agent's full intended response to the context window, what problem will occur?</summary>
-<br>
-If you append the full intended response, the model's context window will contain information that the user never actually heard. In future turns, the model might reference details from the skipped portion, assuming the user possesses that knowledge. This leads to profound confusion and a breakdown in conversational coherence. You must truncate the context to match reality.
+<summary>4. Scenario: A product manager asks why you do not send every screenshot, audio clip, and video frame to one native model. How do you evaluate whether the use case should use early fusion, late fusion, specialist tools, or a native multimodal model?</summary>
+
+Explain that native multimodal reasoning is valuable when cross-modal interpretation matters, but specialist tools still provide exact measurements, policy controls, retrieval, and cheaper preprocessing. OCR may be better for exact text, an object detector may be better for a narrow visual signal, and a rules engine may be required for final action. A hybrid design sends the native model the evidence it needs while keeping deterministic work in components that are easier to test and audit.
 </details>
 
 <details>
-<summary>5. Scenario: Your engineering team is expanding a native multimodal model to support a new input type: tactile sensor data from a robotic hand. The core transformer network is already trained. What specific architectural component must your team build first to allow the transformer to understand this new tactile data alongside text and video, and why?</summary>
-<br>
-Your team must build a modality-specific encoder for the tactile sensor data. The core transformer network can only process data as sequences of vectors (embeddings) of a specific dimensionality (e.g., 4096). The new encoder's job is to take the raw, multi-dimensional time-series data from the tactile sensors and project it into that exact same latent space. Once the tactile data is converted into these standardized embeddings, the existing transformer blocks can seamlessly apply cross-modal attention between the touch data, text instructions, and visual feeds without requiring any changes to the core network itself.
+<summary>5. Scenario: A Kubernetes deployment has enough GPU nodes, but realtime sessions still feel slow during traffic spikes. What metrics would you inspect first?</summary>
+
+Inspect active sessions per model replica, model queue depth, prefill time, decode time, cancellation latency, gateway queueing, dropped or buffered media chunks, and client playback delay. Having GPU nodes only proves that pods can be scheduled. It does not prove that admission control, batching, model memory, network paths, or streaming egress are healthy under load.
 </details>
 
 <details>
-<summary>6. Scenario: You are debugging a voice agent using WebSockets. The model receives audio perfectly, but the client-side playback sounds choppy, metallic, and occasionally plays out of order. What is the most likely architectural flaw in your client code?</summary>
-<br>
-The client is likely failing to manage the asynchronous audio output buffer correctly. In a streaming architecture, audio tokens arrive in chunks over the WebSocket. If the client attempts to play them synchronously or doesn't buffer them into a continuous stream, the audio hardware will starve, resulting in choppy playback. Additionally, network jitter can cause chunks to arrive out of order; the client must sequence them properly before pushing them to the audio interface.
+<summary>6. Scenario: A visual troubleshooting assistant stores only final answers and no image references or crop coordinates. What review problem does this create?</summary>
+
+It makes the answer difficult to audit or correct. If the model says "replace the upper valve," reviewers need to know which image, crop, label, or OCR span led to that answer. Without evidence references, a wrong answer is hard to debug because you cannot tell whether the failure came from missing image detail, bad OCR, hallucinated spatial reasoning, or a downstream business rule.
 </details>
 
-## Hands-On Exercise: Building a Multimodal Context Payload
+<details>
+<summary>7. Scenario: A WebSocket-based prototype works locally, but browser users experience unstable audio over poor networks. Why might WebRTC be considered?</summary>
 
-In this exercise, you will construct a valid JSON payload for a native multimodal API that interleaved text, images, and audio, simulating a real-world diagnostic scenario.
-
-**Scenario:** You are building an AI mechanic assistant. The user provides a picture of an engine bay, an audio clip of a strange rattling sound, and a text question.
-
-**Task 1: Prepare the assets**
-*   Create a dummy text file named `rattle.wav`. (You don't need real audio, just the file).
-*   Create a dummy text file named `engine.jpg`.
-
-**Task 2: Write the encoding script**
-*   Write a Python script that reads both files and encodes them into Base64 strings.
-*   **Verification:** Add a print statement to output the first 20 characters of each Base64 string to verify successful encoding before proceeding.
+WebRTC is designed for realtime media transport in browsers, including audio and video handling, whereas a raw WebSocket stream leaves more media behavior to application code. WebSockets can still be appropriate for server-mediated events or backend streams, but browser speech and video applications often benefit from media-aware transport. The right answer depends on provider support, client complexity, observability, and deployment constraints.
+</details>
 
 <details>
-<summary>Show Solution for Task 1 & 2</summary>
+<summary>8. Scenario: An architecture diagram shows separate audio, image, video, retrieval, and model-serving services. What must be shared so cross-modal reasoning does not fall apart?</summary>
+
+They need shared session identity, ordering, timestamps, payload references, state transitions, and commitment rules. Service separation helps scaling and ownership only if the system preserves alignment metadata across those services. Otherwise each branch produces plausible artifacts that cannot be reliably joined into one user interaction.
+</details>
+
+## Hands-On Exercise
+
+In this exercise you will build a local design checker for a multimodal session envelope. The goal is not to call a vendor API. The goal is to practice the architecture habit this module has been teaching: represent modality events, preserve ordering, simulate back-pressure, and commit only the assistant output that the user actually received. The script uses only the Python standard library, so it should run in the repository environment without extra dependencies.
+
+Create a file named `multimodal_design_check.py` at the repository root (a throwaway scratch file — delete it afterward and do not commit it), paste the code below, and run it from that same repository root with `.venv/bin/python multimodal_design_check.py`. The script builds a session with text, audio, image, and video events, validates ordering and required metadata, simulates a saturated video path, and demonstrates context truncation after a user interruption.
 
 ```python
-import base64
+from dataclasses import dataclass
+from typing import Iterable
 
-# Create dummy files
-with open("rattle.wav", "wb") as f: f.write(b"dummy audio data")
-with open("engine.jpg", "wb") as f: f.write(b"dummy image data")
 
-def encode_file(filepath):
-    with open(filepath, "rb") as f:
-        return base64.b64encode(f.read()).decode("utf-8")
+@dataclass(frozen=True)
+class Event:
+    sequence: int
+    timestamp_ms: int
+    modality: str
+    payload_ref: str
+    committed: bool = False
 
-audio_b64 = encode_file("rattle.wav")
-image_b64 = encode_file("engine.jpg")
 
-print(f"Audio start: {audio_b64[:20]}")
-print(f"Image start: {image_b64[:20]}")
-```
-</details>
-
-**Task 3: Construct the Payload**
-*   Create a Python dictionary representing the API payload.
-*   The `messages` array must contain a single `user` role message.
-*   The `content` array must interleave the modalities in this specific order:
-    1. Text: "I hear this sound coming from the area shown in the image."
-    2. The Audio data.
-    3. The Image data.
-    4. Text: "Is it safe to drive to the nearest shop?"
-*   **Verification:** Run the script and verify it outputs the complete JSON payload without serialization errors.
-
-<details>
-<summary>Show Solution for Task 3</summary>
-
-```python
-import json
-
-payload = {
-    "model": "native-multimodal-latest",
-    "messages": [
-        {
-            "role": "user",
-            "content": [
-                {
-                    "type": "text",
-                    "text": "I hear this sound coming from the area shown in the image."
-                },
-                {
-                    "type": "audio",
-                    "audio_url": {
-                        "data": f"data:audio/wav;base64,{audio_b64}"
-                    }
-                },
-                {
-                    "type": "image",
-                    "image_url": {
-                        "data": f"data:image/jpeg;base64,{image_b64}"
-                    }
-                },
-                {
-                    "type": "text",
-                    "text": "Is it safe to drive to the nearest shop?"
-                }
-            ]
-        }
-    ]
+# NOTE: these modality tags are illustrative. Real bidirectional audio contracts use
+# different capture vs. playback rates — e.g. Gemini Live expects 16 kHz PCM input and
+# emits 24 kHz PCM output — so match the exact format your provider documents rather than
+# assuming one rate for both directions.
+REQUIRED_MODALITY_METADATA = {
+    "text": "utf8",
+    "audio": "pcm16-24khz-mono",
+    "image": "jpeg-or-png",
+    "video": "sampled-frame-or-event",
+    "assistant_audio": "pcm16-24khz-mono",
 }
 
-print(json.dumps(payload, indent=2))
+
+def validate_session(events: Iterable[Event]) -> list[str]:
+    problems: list[str] = []
+    previous_sequence = -1
+    previous_timestamp = -1
+
+    for event in events:
+        if event.sequence <= previous_sequence:
+            problems.append(f"sequence moved backward at {event}")
+        if event.timestamp_ms < previous_timestamp:
+            problems.append(f"timestamp moved backward at {event}")
+        if event.modality not in REQUIRED_MODALITY_METADATA:
+            problems.append(f"unknown modality {event.modality!r}")
+        if not event.payload_ref:
+            problems.append(f"missing payload reference at sequence {event.sequence}")
+        previous_sequence = event.sequence
+        previous_timestamp = event.timestamp_ms
+
+    return problems
+
+
+def apply_video_backpressure(events: list[Event], max_video_events: int) -> list[Event]:
+    kept: list[Event] = []
+    video_seen = 0
+
+    for event in events:
+        if event.modality != "video":
+            kept.append(event)
+            continue
+        video_seen += 1
+        if video_seen <= max_video_events:
+            kept.append(event)
+
+    return kept
+
+
+def commit_played_audio(events: list[Event], interruption_ms: int) -> list[Event]:
+    committed: list[Event] = []
+
+    for event in events:
+        if event.modality != "assistant_audio":
+            committed.append(event)
+            continue
+        if event.timestamp_ms <= interruption_ms:
+            committed.append(
+                Event(
+                    sequence=event.sequence,
+                    timestamp_ms=event.timestamp_ms,
+                    modality=event.modality,
+                    payload_ref=event.payload_ref,
+                    committed=True,
+                )
+            )
+
+    return committed
+
+
+session = [
+    Event(1, 0, "text", "user:compare-dashboard-and-sound"),
+    Event(2, 20, "audio", "audio/chunk-0001.pcm"),
+    Event(3, 40, "audio", "audio/chunk-0002.pcm"),
+    Event(4, 60, "image", "images/dashboard-warning.jpg"),
+    Event(5, 80, "video", "video/frame-0001.jpg"),
+    Event(6, 100, "video", "video/frame-0002.jpg"),
+    Event(7, 120, "video", "video/frame-0003.jpg"),
+    Event(8, 140, "assistant_audio", "assistant/chunk-0001.pcm"),
+    Event(9, 160, "assistant_audio", "assistant/chunk-0002.pcm"),
+    Event(10, 180, "assistant_audio", "assistant/chunk-0003.pcm"),
+]
+
+problems = validate_session(session)
+if problems:
+    raise SystemExit("\n".join(problems))
+
+reduced = apply_video_backpressure(session, max_video_events=2)
+committed = commit_played_audio(reduced, interruption_ms=160)
+
+print("validated events:", len(session))
+print("events after video back-pressure:", len(reduced))
+print("committed assistant chunks:", [e.payload_ref for e in committed if e.committed])
 ```
-</details>
 
-**Task 4: Implement Context Truncation Logic (Mental Exercise)**
-*   Write a pseudo-code function that takes a list of generated audio chunks and an `interruption_timestamp`. The function should return only the chunks that were generated *before* the interruption occurred, preventing the context window from being polluted with unplayed audio.
+Expected output:
 
-<details>
-<summary>Show Solution for Task 4</summary>
-
-```python
-def truncate_context(generated_chunks, interruption_timestamp):
-    played_chunks = []
-    current_time = 0.0
-    
-    for chunk in generated_chunks:
-        # Assuming each chunk has a known duration (e.g., 20ms)
-        chunk_duration = chunk.length / sample_rate
-        
-        if current_time + chunk_duration <= interruption_timestamp:
-            played_chunks.append(chunk)
-            current_time += chunk_duration
-        else:
-            # We reached the point of interruption. Stop appending.
-            break
-            
-    return played_chunks
+```text
+validated events: 10
+events after video back-pressure: 9
+committed assistant chunks: ['assistant/chunk-0001.pcm', 'assistant/chunk-0002.pcm']
 ```
-</details>
+
+Now modify the script in three small ways. First, add a second image event after the video events and verify that ordering still passes. Second, change one timestamp so it moves backward and confirm the validator rejects the session. Third, change `max_video_events` from `2` to `1` and explain what kind of product would prefer that drop policy. A live assistant might prefer lower latency and fresher frames, while an offline audit system would usually preserve the full media record somewhere outside the realtime model path.
 
 ### Success Checklist
-- [ ] Base64 encoding properly formats the binary data into strings.
-- [ ] The JSON payload correctly formats the `data` URIs (e.g., `data:audio/wav;base64,...`).
-- [ ] The sequence of the `content` array matches the logical flow of the user's prompt.
-- [ ] You understand why context truncation is mandatory for interruptible voice agents.
+
+- [ ] The script runs with `.venv/bin/python` and produces the expected output before you modify it.
+- [ ] You can identify which events are raw user evidence, which are assistant output, and which are committed history.
+- [ ] You can explain why the third assistant audio chunk is not committed after an interruption at `160` ms.
+- [ ] You can describe a video back-pressure policy in product terms instead of only saying "drop frames."
+- [ ] You can name which Kubernetes component in your design would enforce message size, session rate, and downstream queue limits.
 
 ## Next Module
 
-Now that you understand the architectural foundations of native multimodal processing and real-time streaming, you are ready to tackle the complexities of spatial reasoning. In [Module 8.5: Spatial and Embodied AI](/ai-ml-engineering/multimodal-ai/module-1.4-multimodal-first-design/), we will explore how these models are integrated with robotic systems and 3D environments, translating multimodal understanding into physical action in the real world.
+Multimodal AI is the last module in Phase 9. Continue to the next AI/ML Engineering section with [Deep Learning Foundations: NumPy, Pandas, and Data Tooling](../deep-learning/module-1.1-numpy-pandas-data-tooling/), where you will strengthen the model-building fundamentals that sit underneath many of the architectures discussed here.
 
 ## Sources
 
-- [arxiv.org: 2305.05665](https://arxiv.org/abs/2305.05665) — ImageBind explicitly presents a joint embedding space across multiple modalities, directly supporting the shared-space concept used here.
-- [arxiv.org: 2010.11929](https://arxiv.org/abs/2010.11929) — The ViT paper directly describes applying a transformer to sequences of image patches.
-- [arxiv.org: 2103.15691](https://arxiv.org/abs/2103.15691) — ViViT explicitly states that it extracts spatio-temporal tokens from input video, which supports the module's description of native video encoding.
-- [developer.mozilla.org: index.html](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API/index.html) — MDN directly documents WebSockets as two-way interactive communication and serves as a reasonable topical anchor for this transport-level claim.
+- [OpenAI Realtime and audio](https://developers.openai.com/api/docs/guides/realtime) - Documents realtime sessions as the path for live audio use cases and anchors the module's streaming voice-agent design discussion.
+- [OpenAI Realtime API with WebRTC](https://developers.openai.com/api/docs/guides/realtime-webrtc) - Explains the WebRTC connection path for browser-based speech-to-speech applications and supports the transport tradeoff section.
+- [Gemini Live API overview](https://ai.google.dev/gemini-api/docs/live-api) - Documents low-latency realtime voice and vision interactions for Gemini and supports the dated landscape snapshot.
+- [vLLM Multimodal Inputs](https://docs.vllm.ai/en/stable/features/multimodal_inputs/) - Shows how open-model serving frameworks represent multimodal inputs and why schemas, caching, and model support must be verified.
+- [MDN WebSocket API](https://developer.mozilla.org/en-US/docs/Web/API/WebSockets_API) - Documents two-way browser-server communication, which underpins the WebSocket streaming explanation.
+- [MDN WebRTC API](https://developer.mozilla.org/en-US/docs/Web/API/WebRTC_API) - Documents realtime audio, video, and data capabilities in browsers and supports the WebRTC design discussion.
+- [Kubernetes Schedule GPUs](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/) - Explains the Kubernetes GPU scheduling path and the role of device plugins for accelerator-backed workloads.
+- [Kubernetes Device Plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/) - Provides the official device-plugin framework reference for advertising GPUs and other specialized hardware.
+- [Kubernetes Gateway API](https://kubernetes.io/docs/concepts/services-networking/gateway/) - Documents Gateway API as a routing and infrastructure-provisioning family of Kubernetes APIs, supporting the gateway layer discussion.
+- [Kubernetes Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) - Supports the explanation of requests, limits, and resource isolation for latency-sensitive services.
+- [Kubernetes Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) - Supports the placement and resilience discussion for spreading workloads across failure domains.
+- [NVIDIA Kubernetes Device Plugin](https://github.com/NVIDIA/k8s-device-plugin) - Provides a concrete vendor device-plugin example for exposing NVIDIA GPUs to Kubernetes workloads.
+- [ImageBind: One Embedding Space To Bind Them All](https://arxiv.org/abs/2305.05665) - Primary research source for joint embeddings across images, text, audio, depth, thermal, and IMU data.
+- [Learning Transferable Visual Models From Natural Language Supervision](https://arxiv.org/abs/2103.00020) - The CLIP paper supports the discussion of contrastive image-text embedding spaces and retrieval-mediated fusion.
+- [An Image is Worth 16x16 Words](https://arxiv.org/abs/2010.11929) - Primary source for the vision-transformer patch-tokenization concept used in the shared-token discussion.
+- [ViViT: A Video Vision Transformer](https://arxiv.org/abs/2103.15691) - Primary source for spatiotemporal video tokens and efficient handling of long video token sequences.
+- [Flamingo: a Visual Language Model for Few-Shot Learning](https://arxiv.org/abs/2204.14198) - Supports the explanation of interleaved visual and textual inputs in multimodal context.
+- [Token Merging: Your ViT But Faster](https://arxiv.org/abs/2210.09461) - Supports the video and vision token-efficiency discussion without turning the module into a video deep dive.


### PR DESCRIPTION
Drains the remaining **multimodal-ai** \`shipped_unreviewed\` modules (1.2/1.3/1.4) for the \`ai-ml-engineering\` campaign (#1842). All on-topic — straight expand-to-T0 (no re-scope this wave).

## Modules (all verify_module.py T0)

| Mod | T3→T0 | Author → Reviewer | Notable |
|---|---|---|---|
| 1.2 Vision AI (ViT/CLIP/VLMs) | 1787→5000w | codex → opus (NEEDS_CHANGES → fixed) | **2/4 Commons lab image URLs 404'd** (one re-hashed, one deleted) → curl wrote 404 bodies into .jpg → PIL crash → broken hands-on. Fixed with hash-independent `Special:FilePath` redirect (all 4 verified 200). Verifier-blind lab-runnability. Essential-References consolidated into one `## Sources`; Part-7 war-story de-fabbed. |
| 1.3 Video AI | 995→5093w | codex → cursor (APPROVE_WITH_NITS) | biggest lift. Sampler tuned to ~41% reduction (was selecting 16/17 frames, contradicting its own cost guidance); LO→Knowledge-Check retag. Volatile video-model snapshot (Sora/Veo/Runway/Pika/Kling/Luma) **all web-verified by reviewer**; NTSB opener real + cited (dedup-clean). |
| 1.4 Multimodal-First Design | 1244→5097w | codex → cursor (APPROVE_WITH_NITS) | `## Section N` → canonical; voice/vision/video cross-ref de-dup (no modality re-teaching); audio-rate note; OpenAI Realtime / Gemini Live / vLLM snapshot web-verified. |

## Verification
- All 3 `verify_module.py` **T0** (5000–5097w).
- `npm run build` in primary: **2171 pages, 0 schema errors** (PR CI has no full astro build).
- `incident_dedup_gate.py`: **PASS** (NTSB Tesla opener used only in 1.3).
- `check_site_health.py`: **0 errors**.
- Every reviewer claim + every source/model-snapshot ground-checked against the live file. The opus 1.2 lab-image P1 was fixed + the 4 replacement URLs re-verified 200; deepseek's 1.4 review was non-functional (its lone P1 "broken Next Module link" was a verified false positive) → re-reviewed on cursor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)