### PR TITLE
docs(on-premises): wave 1 — planning + provisioning to T0/done (#1881)

### DIFF
--- a/src/content/docs/on-premises/planning/module-1.2-server-sizing.md
+++ b/src/content/docs/on-premises/planning/module-1.2-server-sizing.md
@@ -26,7 +26,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-In September 2022, a logistics company ordered twelve Dell PowerEdge R750xs servers for their new Kubernetes platform. Each server had dual 24-core Intel Xeon Gold 5317 processors, 256 GB of RAM, and four 1.92 TB SATA SSDs. The hardware cost $216,000. When the platform team deployed their first workloads — a real-time vehicle tracking system processing 50,000 GPS events per second — they discovered two critical mistakes that no amount of tuning could fix in software, because the constraints were physical.
+**Hypothetical scenario (a composite of common on-prem sizing failures).** A logistics company orders twelve Dell PowerEdge R750xs-class servers for a new Kubernetes platform. Each server has dual 24-core Intel Xeon Gold 5317 processors, 256 GB of RAM, and four 1.92 TB SATA SSDs — roughly $216,000 of hardware. When the platform team deploys its first workloads — a real-time vehicle tracking system processing 50,000 GPS events per second — they discovered two critical mistakes that no amount of tuning could fix in software, because the constraints were physical.
 
 First, the SATA SSDs could not keep up with etcd's fsync requirements. etcd commit latency exceeded 100 ms during peak hours, causing leader elections every few minutes. The API server became unreliable, deployments stalled mid-rollout, and the operations channel filled with `context deadline exceeded` errors that pointed at a healthy-looking control plane. They needed NVMe drives for the control-plane nodes — a $24,000 additional investment and two weeks of downtime for hardware replacement, plus a tense conversation with the procurement team about why "enterprise SSD" turned out not to be enough.
 
@@ -176,7 +176,7 @@ etcd is the most resource-sensitive component in a Kubernetes control plane beca
 │                                                               │
 │  Cluster Size    │ CP Nodes │ CPU/Node │ RAM/Node │ Storage  │
 │  ────────────────┼──────────┼──────────┼──────────┼──────────│
-│  < 10 nodes      │    3     │  4 cores │   8 GB   │ 50GB SSD │
+│  < 10 nodes      │    3     │  4 cores │   8 GB   │ 50GB NVMe│
 │  10-100 nodes    │    3     │  8 cores │  16 GB   │ 100GB NVMe│
 │  100-500 nodes   │    3     │ 16 cores │  32 GB   │ 200GB NVMe│
 │  500-2000 nodes  │    5     │ 32 cores │  64 GB   │ 500GB NVMe│
@@ -502,7 +502,7 @@ Twenty-five gigabit Ethernet is the modern minimum for any production Kubernetes
 | **Pattern: Pre-delivery storage benchmark** | Run etcd-shaped fio on every control-plane drive before sign-off. | **When to use:** Always, for any self-managed control plane on owned hardware. | Catches RAID-cache latency and wrong drive tier before production leader elections. |
 | **Pattern: NUMA-aware pools** | Label latency-sensitive pools; enable Topology Manager + CPU Manager static on those nodes only. | **When to use:** In-memory databases, low-latency APIs on bare metal. | Prevents silent 30–50% regressions from cross-socket memory traffic. |
 | **Anti-Pattern: Peak-only sizing** | Buying exactly enough silicon for Black Friday peak with zero headroom. | **Why it happens:** Finance caps capital; teams confuse peak requests with steady state. | First node loss or upgrade triggers mass evictions; add N+2 and growth buffer explicitly. |
-| **Anti-Pattern: Uniform mega-nodes** | Four 256-core / 2 TB servers instead of twelve 64-core / 512 GB servers at equal aggregate capacity. | **Why it happens:** Rack-space savings and simpler BOM. | Single failure displaces hundreds of pods; image pulls and storage rebuilds thundering-herd the cluster. |
+| **Anti-Pattern: Uniform mega-nodes** | Four 256-core / 2 TB servers instead of sixteen 64-core / 512 GB servers at equal aggregate capacity. | **Why it happens:** Rack-space savings and simpler BOM. | Single failure displaces hundreds of pods; image pulls and storage rebuilds thundering-herd the cluster. |
 | **Anti-Pattern: SATA etcd** | Using Tier-2 SATA SSDs for control-plane data directories because the label says "enterprise SSD." | **Why it happens:** Procurement conflates interface with fsync tail latency. | Leader elections, read-only API windows, and unexplained `context deadline exceeded` during deploys. |
 | **Anti-Pattern: Ignoring allocatable math** | Dividing total DIMMs by pod requests without kube/system reserved or DaemonSet tax. | **Why it happens:** Spreadsheet uses hardware specs, not `kubectl describe node` allocatable. | Systematic under-provisioning; RAM outages despite "plenty" of sticker capacity. |
 
@@ -606,7 +606,7 @@ The key insight is that with three servers you cannot afford to waste sixty perc
 </details>
 
 ### Question 4
-Your procurement team suggests buying four massive 256-core / 2 TB servers instead of twelve 64-core / 512 GB servers to save on rack space, since both options provide roughly the same total capacity. What operational risk does the four-server architecture introduce for Kubernetes?
+Your procurement team suggests buying four massive 256-core / 2 TB servers instead of sixteen 64-core / 512 GB servers to save on rack space, since both options provide roughly the same total capacity. What operational risk does the four-server architecture introduce for Kubernetes?
 
 <details>
 <summary>Answer</summary>

--- a/src/content/docs/on-premises/planning/module-1.2-server-sizing.md
+++ b/src/content/docs/on-premises/planning/module-1.2-server-sizing.md
@@ -374,15 +374,92 @@ Kubernetes ships with a [default of 110 pods per node](https://kubernetes.io/doc
 
 The CNI ceiling is often invisible until you hit it. Calico in IPAM-per-block mode allocates a /26 block to each node by default, which gives you sixty-four addresses per block and a hard upper bound on pods regardless of CPU and RAM headroom. Cilium with cluster-pool IPAM has its own per-node ceilings tied to the cluster CIDR. Verify the CNI configuration before you provision a node-pool that targets two hundred pods per node, or you will discover the constraint in production when a deployment refuses to schedule.
 
+### Few Large Nodes or Many Small Ones?
+
+The procurement conversation often collapses into a false dichotomy: buy fewer, bigger servers to save rack space, or buy many smaller servers to spread risk. Both answers can be wrong for the same workload, because the trade-off is multidimensional and Kubernetes amplifies whichever dimension you neglect. Few large nodes maximize bin-packing efficiency in theory — one scheduler decision places hundreds of pods — but they also maximize blast radius, per-node DaemonSet overhead, and the cost of any single failure event. Many small nodes shrink blast radius and make incremental growth cheaper, but they multiply fixed per-node costs: kubelet CPU, CNI agents, observability sidecars, BMC management, switch ports, and licensing lines that charge per socket regardless of utilization.
+
+Every worker node pays a tax before your first application pod schedules. The kubelet, container runtime, CNI plugin, node exporter, log shipper, and security agent collectively consume one to four vCPUs and two to eight gigabytes of RAM depending on pod density and policy stack. On a sixty-four-vCPU node that tax is noise; on a sixteen-vCPU node it can consume twenty percent of allocatable capacity before you account for system-reserved and kube-reserved settings. DaemonSets scale with node count, not node size, so a fleet of forty small nodes runs forty copies of every cluster-wide agent while a fleet of ten large nodes runs ten. The arithmetic favors larger nodes for DaemonSet-heavy platforms until blast radius and scheduling fragmentation push back.
+
+Pod-density limits interact with node size in ways the default `--max-pods=110` obscures. Kubernetes chose 110 as a conservative default because early clusters broke etcd and the API server watch cache when single nodes hosted thousands of pods; the limit remains configurable but upstream guidance still treats very high pod counts as a scaling risk. Raising `--max-pods` on a large node without raising CNI IPAM pools, without verifying API server LIST throughput, and without confirming your average pod size still fits CPU and RAM guarantees is how teams end up with nodes that report healthy capacity while refusing new pods for unrelated reasons. Size nodes so the binding constraint is intentional — CPU, RAM, or pod count — not an accidental collision between three independent limits.
+
+Licensing is the silent variable in the node-size decision on owned hardware. VMware, Windows Server Datacenter, Oracle Database, and several enterprise middleware stacks price per socket or per core regardless of how full the node runs. A dual-socket server with low utilization can cost more in license true-ups than two single-socket servers delivering the same pod capacity, even when the dual-socket machine wins on raw watts-per-core. Run the license model before you run the Kubernetes math, especially when JVM or Windows workloads dominate the fleet.
+
+> **Stop and think**: Your cluster runs 400 pods averaging 0.25 CPU and 1 GB RAM. Option A is eight nodes at 64 vCPU / 256 GB each; Option B is sixteen nodes at 32 vCPU / 128 GB each. Total capacity is identical. Which option tolerates a single node failure with less rescheduling pressure, and which option wastes more capacity to DaemonSet overhead? Sketch the DaemonSet tax before reading on.
+
+Option B spreads pods across more failure domains — losing one sixteen-node fleet member displaces twenty-five pods instead of fifty — but Option A runs half as many DaemonSet replicas and usually achieves better bin-packing because fewer scheduler boundaries exist. The right answer depends on your PodDisruptionBudget posture and spare headroom: if you size to sixty-five percent steady-state utilization, Option B survives one node loss with room to reschedule; if you size to eighty-five percent, Option B may cascade-evict while Option A still has slack. Neither SKU is universally correct; the decision framework later in this module turns these variables into a procurement checklist.
+
 ---
 
-## GPU Node Considerations
+## GPU and Accelerator Node Considerations
 
 GPU nodes break most of the rules above because the GPU itself dominates the cost and the surrounding silicon has to be sized to feed it. A modern training-class GPU (an NVIDIA H100 or B200) draws 700 to 1000 watts under load, consumes sixteen PCIe Gen5 lanes per device, and pairs with one to two CPU cores per GPU at most because the host's job is data movement, not compute. Filling a chassis with eight GPUs therefore demands a CPU and motherboard chosen to deliver lanes and power, not cores. AMD Genoa's 128-lane budget per socket is one of the reasons most reference designs for eight-GPU servers are single-socket EPYC — there are simply not enough Intel lanes to go around without bifurcation.
 
 Sizing the host RAM for GPU nodes is counter-intuitive: you want roughly two to three times the aggregate GPU memory, which on an eight-H100 server (640 GB of HBM3 across the GPUs) means 1.5 to 2 TB of host RAM. The reason is that training pipelines stage data in host memory before pushing it to the GPU, and inference servers cache model shards and KV caches on the host between requests. Under-provisioning host RAM forces every batch through the storage subsystem and turns a GPU-bound workload into a storage-bound one, which is the worst kind of stranded capacity because GPUs are the most expensive silicon in the rack.
 
 Kubernetes also forces you to think about scheduling: a single H100 cannot be split across pods without MIG (Multi-Instance GPU), and even with MIG the granularity is fixed by hardware. [The NVIDIA device plugin advertises GPUs as `nvidia.com/gpu: 1`, so two pods cannot share one device unless you opt into time-slicing or MIG](https://github.com/NVIDIA/k8s-device-plugin); both have throughput penalties relative to dedicated allocation. Plan capacity at the GPU-per-pod level, not the GPU-per-node level, and reserve at least one GPU per node as headroom because evicting a GPU pod is far slower than evicting a CPU pod (model load times dominate).
+
+Dedicated accelerator pools — GPU for training and inference, DPU or SmartNIC for storage or security offload — should almost never share a node pool with general workloads. Taint accelerator nodes with a hardware-specific taint, size the CPU and RAM envelope to feed the accelerator rather than to run arbitrary microservices, and cable them to a network tier that matches the traffic pattern (100–400 GbE or InfiniBand for training, not the same 25 GbE top-of-rack pair that serves stateless APIs). Mixing accelerators into a homogeneous SKU catalog feels operationally convenient until a batch job schedules onto an inference node and evicts latency-sensitive model servers; separate pools cost more line items on the purchase order but eliminate an entire class of production incidents.
+
+---
+
+## Compute Sizing: vCPU, Physical Cores, and Oversubscription
+
+Kubernetes exposes CPU in fractional units where **one CPU equals one hyperthread on typical x86 servers**, not one physical core. A dual-socket server with thirty-two cores per socket and simultaneous multithreading (SMT) advertises 128 `cpu` capacity to the scheduler even though only sixty-four physical cores exist. That distinction matters for CPU-bound workloads: two pods each requesting `2` CPU may land on the same physical core's two hyperthreads and contend for execution units, while the scheduler believes four CPUs are allocated. For latency-sensitive or HPC-style jobs, treat hyperthreads as a scheduling convenience, not as real isolated compute, and prefer whole-core requests with the [CPU Manager static policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-manager-policy/) on dedicated node pools.
+
+The CPU Manager pairs with the Topology Manager and, for Guaranteed-QoS pods, can pin workloads to specific cores and NUMA nodes. Static policy reserves exclusive cores; the none policy (default) lets the Linux scheduler move pods freely. On-prem clusters running databases, low-latency queues, or telco NFVs on bare metal frequently enable static policy on labeled pools while leaving general microservices on the default path. The cost is reduced bin-packing efficiency: exclusive cores cannot be shared, so allocatable CPU on a pinned pool is lower than the raw `/proc/cpuinfo` count suggests.
+
+CPU oversubscription — allowing sum(pod CPU requests) to exceed node capacity because average utilization stays low — is tempting on owned hardware where you pay for silicon whether it idles or not. Ratios of 2:1 or 3:1 request-to-capacity appear in internal private-cloud runbooks and can work when workloads are bursty and well-instrumented. The failure mode arrives on the first correlated spike: batch jobs, marketing events, or recovery after a node loss all raise utilization simultaneously, throttling every pod on the node through CFS shares without a clear owner. On-prem lacks cloud's infinite burst buffer; oversubscription without hard limits and without priority classes is how a "healthy" cluster enters CPU starvation. If you oversubscribe, cap it per node pool, enforce LimitRange defaults, and keep at least twenty percent physical core headroom for kubelet and DaemonSets.
+
+Hyperthreading itself should usually stay **enabled** for mixed microservice fleets because it improves throughput on I/O-bound pods at minimal power cost. Disable SMT only when vendor guidance or regulatory baselines require deterministic core isolation, or when running latency-sensitive numerical workloads where sibling hyperthread contention measurably regresses p99 latency. Document the BIOS setting in your golden image; a drifted SMT flag between racks changes allocatable CPU and invalidates capacity spreadsheets silently.
+
+---
+
+## Memory Sizing: Working Set, Page Cache, and Eviction Headroom
+
+Memory is the binding constraint on most on-prem Kubernetes fleets long before CPU saturates, because pod authors request RAM generously, JVM heaps are sized statically, and caches (Redis, Memcached, in-process) consume gigabytes that do not appear in CPU requests. The scheduler sums **requests**, not live working set, so a node can admit pods whose combined limits exceed physical RAM if limits are unset — and the kubelet will eventually evict pods when memory pressure crosses eviction thresholds. Sizing memory therefore starts from requested RAM plus explicit headroom for the operating system page cache when workloads depend on buffered I/O, not from `free -m` on an idle node.
+
+The page cache accelerates container filesystem and volume reads but is reclaimable under pressure; databases and streaming pipelines often benefit from leaving ten to twenty percent of node RAM outside pod requests so the kernel can cache without triggering premature eviction. Hugepages reduce TLB pressure for DPDK, certain databases, and some JVM configurations, but require pre-allocation at boot or through the kubelet and reduce flexible RAM available for ordinary pods. Reserve hugepages only on dedicated pools with a documented consumer; otherwise they strand capacity.
+
+Eviction thresholds — `memory.available` signals derived from `eviction-hard` and `eviction-soft` kubelet settings — define when the kubelet begins reclaiming pod memory. Defaults assume a general-purpose node; memory-heavy platforms often raise soft thresholds and pair them with PodDisruptionBudgets so evictions become controlled drains rather than random SIGKILLs. ECC RAM remains mandatory: silent bit flips in non-ECC DIMMs corrupt data without triggering reschedule, which is unacceptable on nodes running etcd members, databases, or long-lived caches.
+
+When profiling, compare Prometheus `container_memory_working_set_bytes` against requests over a full business cycle before buying RAM-heavy SKUs. A fleet averaging seventy-eight percent RAM utilization with twenty-two percent CPU utilization (a pattern this module returns to in the quiz) is not "efficient" — it signals a CPU-to-RAM ratio mismatch that the next hardware generation should correct, not replicate.
+
+---
+
+## Reserved vs Allocatable: A Worked Example
+
+Kubernetes never exposes 100% of hardware to pods. **Capacity** is what the node reports; **allocatable** is capacity minus kube-reserved, system-reserved, and eviction-threshold reservations. Procurement spreadsheets that divide total cluster RAM by pod requests without subtracting overhead systematically over-order nodes and under-order control-plane storage.
+
+Consider a worker SKU with 128 logical CPUs (64 cores with SMT) and 512 GiB RAM installed. A typical production kubelet configuration might set:
+
+```yaml
+# /var/lib/kubelet/config.yaml (illustrative)
+kubeReserved:
+  cpu: "2"
+  memory: "4Gi"
+systemReserved:
+  cpu: "2"
+  memory: "4Gi"
+evictionHard:
+  memory.available: "500Mi"
+  nodefs.available: "10%"
+```
+
+After reservation, allocatable CPU is roughly 124 logical CPUs and allocatable memory is roughly 503 GiB minus the 500 MiB eviction floor — call it **502 GiB** for planning. DaemonSets (monitoring, CNI, logging) consume another **3 vCPU and 6 GiB** before application pods schedule. Usable envelope for workloads: **121 vCPU and ~496 GiB**.
+
+Your pod catalog sums to **95 vCPU requested** and **420 GiB requested** at steady state. With thirty-percent growth headroom you plan for **124 vCPU** and **546 GiB**. CPU fits one node (121 ≥ 124 is false — you need a second node for CPU headroom); RAM fits one node for steady state but not with growth (546 > 496). **RAM is the binding dimension** after reservations, not the raw 512 GiB sticker on the DIMMs. Two nodes deliver 242 allocatable vCPU and ~992 GiB — enough for growth with N+1 spare if you target sixty-five percent steady-state utilization on RAM (420 / (2 × 496) ≈ 42%, leaving room for one node loss).
+
+Always run this arithmetic per node pool; GPU and control-plane SKUs use different reservation profiles. The upstream reference for reservation semantics is [Reserve compute resources on a node](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/) and the [Node allocatable](https://kubernetes.io/docs/concepts/architecture/nodes/#allocatable) documentation.
+
+---
+
+## Failure Domains, N+1 Headroom, and Disruption Budgets
+
+Hardware sizing and failure tolerance are the same spreadsheet. **N+1** means the cluster continues operating if one node disappears; **N+2** means two simultaneous failures (rolling upgrade plus hardware fault) still leave schedulable capacity. Production on-prem fleets should default to N+2 for worker pools above a dozen nodes because maintenance and failure correlate — patching node A while node B throws a memory error is routine, not a black-swan.
+
+PodDisruptionBudgets (PDBs) and pod anti-affinity rules translate application redundancy requirements into minimum node counts. An application with `replicas: 3` and `podAntiAffinity` requiring distinct hosts needs at least three workers available **after** reservations, not three workers total. If one node is cordoned for maintenance and another fails, anti-affinity plus PDB `minAvailable: 2` may block evictions and stall your upgrade. Size headroom so a single rack or PDU loss — map nodes to `topology.kubernetes.io/zone` labels matching physical layout — never drops available capacity below the sum of your tightest PDB budgets.
+
+Control-plane sizing follows the same logic with different numbers: three etcd members tolerate one loss; five tolerate two. Never run four members — even counts do not increase quorum tolerance. Spread control-plane nodes across independent PDUs or racks; stacking three CP VMs on one hypervisor defeats the purpose of three-node etcd.
 
 ---
 
@@ -413,6 +490,48 @@ Networking decisions have a similar structure: the speed line item on the bill o
 | 100GbE | High-throughput (storage, ML) | ~$300 |
 
 Twenty-five gigabit Ethernet is the modern minimum for any production Kubernetes cluster because the east-west traffic patterns of a typical microservices fleet plus a software-defined storage layer (Ceph, Rook, Longhorn) saturate 10 GbE quickly, especially during a node failure when the storage layer has to rebuild. One-gigabit is fine for the management network and out-of-band traffic to the BMC, but it is insufficient for any pod-to-pod traffic. Plan for two NICs per server bonded LACP into two top-of-rack switches so that a switch failure takes out half the bandwidth, not all of it.
+
+---
+
+## Patterns & Anti-Patterns
+
+| Pattern / Anti-Pattern | Description | Why It Happens / When to Use | Impact / Better Approach |
+|--------------------------|-------------|------------------------------|---------------------------|
+| **Pattern: Capacity buffer + scale-out** | Size steady-state utilization to 60–70% of allocatable CPU/RAM and add nodes when sustained utilization crosses a threshold for two weeks. | **When to use:** Any production fleet with seasonal traffic or batch windows. | Absorbs node loss and deployment surges without emergency procurement; trades capital efficiency for operational calm. |
+| **Pattern: Profile-matched node pools** | Separate compute-heavy, memory-heavy, storage, and GPU pools sized to pod request ratios. | **When to use:** Workload mix spans JVM services, caches, CI, and ML. | Eliminates stranded CPU or RAM; increases SKU count but raises fleet-wide utilization. |
+| **Pattern: Pre-delivery storage benchmark** | Run etcd-shaped fio on every control-plane drive before sign-off. | **When to use:** Always, for any self-managed control plane on owned hardware. | Catches RAID-cache latency and wrong drive tier before production leader elections. |
+| **Pattern: NUMA-aware pools** | Label latency-sensitive pools; enable Topology Manager + CPU Manager static on those nodes only. | **When to use:** In-memory databases, low-latency APIs on bare metal. | Prevents silent 30–50% regressions from cross-socket memory traffic. |
+| **Anti-Pattern: Peak-only sizing** | Buying exactly enough silicon for Black Friday peak with zero headroom. | **Why it happens:** Finance caps capital; teams confuse peak requests with steady state. | First node loss or upgrade triggers mass evictions; add N+2 and growth buffer explicitly. |
+| **Anti-Pattern: Uniform mega-nodes** | Four 256-core / 2 TB servers instead of twelve 64-core / 512 GB servers at equal aggregate capacity. | **Why it happens:** Rack-space savings and simpler BOM. | Single failure displaces hundreds of pods; image pulls and storage rebuilds thundering-herd the cluster. |
+| **Anti-Pattern: SATA etcd** | Using Tier-2 SATA SSDs for control-plane data directories because the label says "enterprise SSD." | **Why it happens:** Procurement conflates interface with fsync tail latency. | Leader elections, read-only API windows, and unexplained `context deadline exceeded` during deploys. |
+| **Anti-Pattern: Ignoring allocatable math** | Dividing total DIMMs by pod requests without kube/system reserved or DaemonSet tax. | **Why it happens:** Spreadsheet uses hardware specs, not `kubectl describe node` allocatable. | Systematic under-provisioning; RAM outages despite "plenty" of sticker capacity. |
+
+---
+
+## Decision Framework: How Many Nodes of What Size
+
+Use this flow when translating pod requests into a purchase order. It assumes you already collected CPU and RAM **requests** (not limits) weighted by replica count.
+
+```
+START → Sum pod CPU/RAM requests × 1.3 growth headroom
+      → Compute CPU:RAM ratio → pick matching worker SKU family
+      → Subtract kube/system reserved + DaemonSet tax → allocatable per node
+      → nodes = max( CPU_need / allocatable_cpu , RAM_need / allocatable_ram )
+      → Add N+2 (production) or N+1 (non-prod)
+      → Check pod-density + CNI IPAM + max-pods ceiling per node
+      → If any PDB/anti-affinity needs > (nodes − maintenance − 1), increase nodes
+      → Size CP separately: NVMe etcd benchmark + 3 or 5 members by cluster scale
+      → Verify rack power + cooling at 65% of PDU budget → END
+```
+
+| Decision Factor | Favor Fewer, Larger Nodes | Favor More, Smaller Nodes | On-Prem Notes |
+|-----------------|---------------------------|---------------------------|---------------|
+| **DaemonSet / agent count** | Lower replica count of node agents | Higher overhead; more switch ports | CNI, observability, and security stacks tax small nodes harder |
+| **Blast radius** | Single failure disrupts many pods | Failure displaces fewer workloads | Pair small nodes with strict PDBs and spare headroom |
+| **Bin-packing efficiency** | Fewer scheduler boundaries | More fragmentation at scale | Re-run sizing if average pod < 0.25 CPU |
+| **Licensing model** | May reduce per-socket fees if utilization high | Spreads per-socket licenses across more boxes | Oracle/Windows stacks may invert the economics |
+| **Incremental growth** | Each addition is expensive | Add one node at a time | Leave 30–40% empty rack units and PDU headroom |
+| **Pod density target** | Raise max-pods only with CNI + API headroom | Keep ≤110 unless measured otherwise | etcd/API watch load rises with object count, not just nodes |
 
 ---
 
@@ -502,7 +621,6 @@ The better approach is medium-sized servers in the 64-to-96-core range with 256 
 ### Question 5
 A platform team is benchmarking a Redis cache pod on a freshly provisioned dual-socket EPYC server with 96 cores per socket. In isolation Redis hits its target throughput easily, but once the node fills up with other tenants the Redis p99 latency triples and `numastat -p $(pgrep redis-server)` shows the process's resident memory split roughly fifty-fifty across the two NUMA nodes. The kubelet is running with default settings. What is the diagnosis, and what is the minimum set of changes to fix it without overhauling the cluster?
 
-<parameter name="$">
 <details>
 <summary>Answer</summary>
 
@@ -650,6 +768,15 @@ Continue to [Module 1.3: Cluster Topology Planning](../module-1.3-cluster-topolo
 
 ## Sources
 
-- [Kubernetes Node Resource Managers](https://kubernetes.io/docs/concepts/policy/node-resource-managers/) — Covers CPU, memory, and topology-aware allocation behavior that directly affects server-sizing decisions.
-- [Considerations for Large Clusters](https://kubernetes.io/docs/setup/best-practices/cluster-large/) — Provides upstream scaling criteria such as pods-per-node and general control-plane scaling guidance.
-- [Thread and Memory Placement on NUMA Systems: Asymmetry Matters](https://www.usenix.org/publications/login/oct15/lepers) — Gives a concrete, authoritative reference for how NUMA placement can materially alter performance on identical hardware.
+- [Kubernetes Node Resource Managers](https://kubernetes.io/docs/concepts/policy/node-resource-managers/) — CPU, memory, and topology-aware allocation behavior that directly affects server-sizing decisions.
+- [Reserve Compute Resources on a Node](https://kubernetes.io/docs/tasks/administer-cluster/reserve-compute-resources/) — Defines kube-reserved, system-reserved, and eviction thresholds used in allocatable capacity math.
+- [Node Allocatable Resources](https://kubernetes.io/docs/concepts/architecture/nodes/#allocatable) — Explains capacity versus allocatable and what the scheduler actually consumes.
+- [Configure the CPU Manager Policy](https://kubernetes.io/docs/tasks/administer-cluster/cpu-manager-policy/) — Static versus none policies for whole-core pinning on latency-sensitive pools.
+- [Control Topology Management Policies on a Node](https://kubernetes.io/docs/tasks/administer-cluster/topology-manager/) — NUMA alignment policies including `single-numa-node` for databases and caches.
+- [Memory Manager System Configuration](https://kubernetes.io/docs/tasks/administer-cluster/memory-manager/) — Static memory pinning paired with Topology Manager on bare-metal pools.
+- [Assign Memory Resources to Containers and Pods](https://kubernetes.io/docs/tasks/configure-pod-container/assign-memory-resource/) — Request/limit semantics and OOM behavior that drive RAM sizing.
+- [Considerations for Large Clusters](https://kubernetes.io/docs/setup/best-practices/cluster-large/) — Pods-per-node defaults, scaling limits, and control-plane pressure at scale.
+- [Pod Disruption Budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/#pod-disruption-budgets) — How `minAvailable` / `maxUnavailable` translate into minimum node headroom during maintenance.
+- [etcd Hardware recommendations](https://etcd.io/docs/v3.6/op-guide/hardware/) — Disk latency, CPU, and memory guidance for quorum members on owned hardware.
+- [Dell PowerEdge for Kubernetes reference architecture](https://infohub.delltechnologies.com/en-us/l/dell-poweredge-for-kubernetes-2-0/kubernetes-node-sizing-considerations/) — Vendor-neutral node sizing patterns for worker and control-plane roles (verify SKU against your workload profile).
+- [Thread and Memory Placement on NUMA Systems: Asymmetry Matters](https://www.usenix.org/publications/login/oct15/lepers) — Authoritative NUMA placement performance data for dual-socket sizing decisions.

--- a/src/content/docs/on-premises/planning/module-1.3-cluster-topology.md
+++ b/src/content/docs/on-premises/planning/module-1.3-cluster-topology.md
@@ -130,17 +130,17 @@ A robust cluster topology must intelligently expose this underlying hardware div
 
 Creating dedicated worker pools using node taints and tolerations establishes firm boundaries. These are programmatic boundaries that guarantee resource isolation at the scheduler level. Consider a scenario where you purchase a multi-million-dollar rack of NVIDIA A100 GPUs. These are intended to support a critical data science initiative. You absolutely cannot afford to have a generic, memory-leaking web application schedule onto those nodes. It would consume the underlying host's RAM, starving the ML models. 
 
-By applying a `NoSchedule` taint to the GPU nodes, you solve this problem. For example, you use `node.kubernetes.io/gpu=nvidia-a100:NoSchedule`. You instruct the Kubernetes scheduler to instantly reject any pod lacking a specific toleration. This guarantees that only specifically engineered ML workloads can execute there. These workloads must be configured to tolerate the taint. They must also explicitly request the GPU resource. They will be the only pods to ever execute on that expensive, specialized hardware pool.
+By applying a `NoSchedule` taint to the GPU nodes, you solve this problem. For example, you use `nvidia.com/gpu=nvidia-a100:NoSchedule`. You instruct the Kubernetes scheduler to instantly reject any pod lacking a specific toleration. This guarantees that only specifically engineered ML workloads can execute there. These workloads must be configured to tolerate the taint. They must also explicitly request the GPU resource. They will be the only pods to ever execute on that expensive, specialized hardware pool.
 
 ```yaml
 # Example: Tainting a node to protect specialized hardware
 # Run this command during hardware provisioning
-# kubectl taint nodes gpu-worker-01 node.kubernetes.io/gpu=nvidia-a100:NoSchedule
+# kubectl taint nodes gpu-worker-01 nvidia.com/gpu=nvidia-a100:NoSchedule
 
 apiVersion: v1
 kind: Pod
 metadata:
-  name: ML-model-training-job
+  name: ml-model-training-job
 spec:
   containers:
   - name: cuda-container
@@ -150,7 +150,7 @@ spec:
         nvidia.com/gpu: 1
   # This toleration allows the pod to bypass the protective taint
   tolerations:
-  - key: "node.kubernetes.io/gpu"
+  - key: "nvidia.com/gpu"
     operator: "Equal"
     value: "nvidia-a100"
     effect: "NoSchedule"
@@ -182,10 +182,11 @@ metadata:
 provisioner: rbd.csi.ceph.com
 parameters:
   clusterID: "ceph-production-cluster-id"
+  # Rack-aware replication is NOT a StorageClass parameter. It is enforced by
+  # the CRUSH rule bound to the Ceph pool referenced below: create the pool with
+  # a rack-failure-domain rule (e.g. `ceph osd crush rule create-replicated
+  # rack-aware default rack`), and the StorageClass simply points at that pool.
   pool: "kubernetes-production-pool"
-  # This specific parameter tells the CSI driver to utilize a CRUSH rule
-  # that strictly mandates replication across distinct physical racks.
-  topology.kubernetes.io/zone: "rack-level-replication-enforced"
 reclaimPolicy: Retain
 allowVolumeExpansion: true
 ```
@@ -402,7 +403,7 @@ You must meticulously deploy exactly one control plane node into each of the thr
 
 <details>
 <summary>Question 4: Your platform team recently purchased a highly expensive rack of NVIDIA GPUs. They are meant for machine learning workloads. During the first week of operation, you notice standard Java web applications randomly scheduling onto these nodes. These applications are starving the ML models. How do you implement a hardware segmentation strategy to fix this?</summary>
-You must immediately apply a `NoSchedule` taint to all the physical GPU nodes. For example, use `node.kubernetes.io/gpu=true:NoSchedule`. This programmatic taint actively repels any standard workload from the hardware. To allow the machine learning models to access the hardware, you must update their specific pod manifests. Include a corresponding toleration for that exact taint in their configuration. You must also include a `nodeSelector` explicitly directing them to the GPU hardware pool. This guarantees that only authorized workloads can consume the specialized compute resources.
+You must immediately apply a `NoSchedule` taint to all the physical GPU nodes. For example, use `nvidia.com/gpu=true:NoSchedule`. This programmatic taint actively repels any standard workload from the hardware. To allow the machine learning models to access the hardware, you must update their specific pod manifests. Include a corresponding toleration for that exact taint in their configuration. You must also include a `nodeSelector` explicitly directing them to the GPU hardware pool. This guarantees that only authorized workloads can consume the specialized compute resources.
 </details>
 
 <details>
@@ -411,7 +412,7 @@ The critical bottleneck is catastrophic disk latency. This is caused by the inad
 </details>
 
 <details>
-<summary>Question 6: An enterprise architect proposes stretching a single Kubernetes cluster across two datacenters. The datacenters are located 200 miles apart. He wants to achieve "active-active" disaster recovery. The leased fiber link between the sites has a consistent round-trip time (RTT) of 35 milliseconds. Why must you reject this multi-cluster topology design?</summary>
+<summary>Question 6: An enterprise architect proposes stretching a single Kubernetes cluster across two datacenters. The datacenters are located 200 miles apart. He wants to achieve "active-active" disaster recovery. The leased fiber link between the sites has a consistent round-trip time (RTT) of 35 milliseconds. Why must you reject this stretched-cluster topology design?</summary>
 You must reject this design entirely. The 35ms network latency far exceeds the practical limits for stable etcd Raft consensus. The etcd system relies on an incredibly tight default heartbeat interval of just 100 milliseconds. A 35ms RTT consumes a massive portion of that critical window immediately. This guarantees that the cluster will suffer from severe, continuous leader election instability under load. To achieve multi-datacenter resilience across that distance safely, you must deploy fully independent clusters in each site. You must then utilize global server load balancing (GSLB) to route traffic securely.
 </details>
 

--- a/src/content/docs/on-premises/provisioning/module-2.2-pxe-provisioning.md
+++ b/src/content/docs/on-premises/provisioning/module-2.2-pxe-provisioning.md
@@ -35,7 +35,7 @@ Think of PXE as a loading dock rather than as the finished warehouse. It does no
 
 PXE starts before Linux exists, before systemd exists, and before any Kubernetes component can help you. The only code running is firmware from the server, the NIC, and whichever UEFI or legacy BIOS path the hardware selected. That means the early boot path must be deliberately simple. Firmware can broadcast for network configuration, download a small boot program, and execute it. Everything else must be staged after that first handoff.
 
-The canonical PXE sequence is easier to reason about if you treat it as a contract between components. The NIC PXE ROM asks for enough network configuration to find a Network Bootstrap Program. DHCP or proxyDHCP answers with an address, a next-server value, and a boot filename or URI. TFTP, HTTP Boot, or iPXE retrieves the boot program. The boot program retrieves a kernel, an initramfs, and command-line arguments. The kernel starts the installer or an in-memory provisioning environment. The installer writes the target OS and prepares the first real boot.
+The canonical PXE sequence is easier to reason about if you treat it as a contract between components. The NIC PXE ROM asks for enough network configuration to find a Network Bootstrap Program. DHCP or proxyDHCP answers with an address, a next-server value (DHCP option 66), and a boot filename or URI (option 67); the client also advertises its firmware architecture via option 93 (client-arch) and its vendor class via option 60. TFTP, HTTP Boot, or iPXE retrieves the boot program. The boot program retrieves a kernel, an initramfs, and command-line arguments. The kernel starts the installer or an in-memory provisioning environment. The installer writes the target OS and prepares the first real boot.
 
 ```text
 +----------------+       +----------------+       +----------------+
@@ -112,6 +112,7 @@ tftp-root=/srv/pxe/tftp
 # Architecture tags from RFC 4578 option 93.
 dhcp-match=set:bios,option:client-arch,0
 dhcp-match=set:uefi-x64,option:client-arch,7
+dhcp-match=set:uefi-x64,option:client-arch,9
 dhcp-boot=tag:bios,undionly.kpxe
 dhcp-boot=tag:uefi-x64,ipxe.efi
 ```
@@ -172,7 +173,7 @@ A generated script for an Ubuntu worker might then look like this. The server re
 ```text
 #!ipxe
 set base-url http://10.20.0.10/images/ubuntu-24.04/amd64
-kernel ${base-url}/casper/vmlinuz ip=dhcp autoinstall ds=nocloud-net;s=http://10.20.0.10/seed/host-0008/
+kernel ${base-url}/casper/vmlinuz ip=dhcp url=http://10.20.0.10/images/ubuntu-24.04/ubuntu-24.04-live-server-amd64.iso autoinstall ds=nocloud-net;s=http://10.20.0.10/seed/host-0008/
 initrd ${base-url}/casper/initrd
 boot || goto failed
 
@@ -497,6 +498,7 @@ enable-tftp
 tftp-root=/srv/pxe/tftp
 dhcp-match=set:bios,option:client-arch,0
 dhcp-match=set:uefi-x64,option:client-arch,7
+dhcp-match=set:uefi-x64,option:client-arch,9
 dhcp-boot=tag:bios,undionly.kpxe
 dhcp-boot=tag:uefi-x64,ipxe.efi
 EOF
@@ -532,7 +534,7 @@ EOF
 cat > http/boot/host-0008.ipxe <<'EOF'
 #!ipxe
 set base-url http://10.20.0.10/images/ubuntu-24.04/amd64
-kernel ${base-url}/casper/vmlinuz ip=dhcp autoinstall ds=nocloud-net;s=http://10.20.0.10/seed/host-0008/
+kernel ${base-url}/casper/vmlinuz ip=dhcp url=http://10.20.0.10/images/ubuntu-24.04/ubuntu-24.04-live-server-amd64.iso autoinstall ds=nocloud-net;s=http://10.20.0.10/seed/host-0008/
 initrd ${base-url}/casper/initrd
 boot || goto failed
 

--- a/src/content/docs/on-premises/provisioning/module-2.4-declarative-bare-metal.md
+++ b/src/content/docs/on-premises/provisioning/module-2.4-declarative-bare-metal.md
@@ -13,11 +13,11 @@ sidebar:
 
 After completing this module, you will be able to:
 
-1. **Implement** Cluster API with Metal3 or Sidero providers to declaratively provision bare-metal Kubernetes clusters from scratch.
+1. **Implement** Cluster API with Metal3 or Tinkerbell providers to declaratively provision bare-metal Kubernetes clusters from scratch.
 2. **Design** a bare-metal host inventory with BMC credentials, hardware profiles, and network templates that integrates seamlessly with your GitOps pipelines.
 3. **Evaluate** multi-cluster architectural designs and implement robust deployment patterns using `kubectl apply` with version-controlled YAML manifests.
 4. **Diagnose** node provisioning failures in real time and establish automated remediation via MachineHealthChecks.
-5. **Compare** and contrast the architectural tradeoffs between CAPM3 (Metal3) and alternative infrastructure providers in highly regulated bare-metal environments.
+5. **Compare** and contrast the architectural tradeoffs between CAPM3 (Metal3), Cluster API Provider Tinkerbell, and simpler PXE pipelines in highly regulated bare-metal environments.
 
 ## Why This Module Matters
 
@@ -42,7 +42,7 @@ graph TD
     subgraph Management Cluster
         CAPI[CAPI Controller<br/>Manages Cluster, Machine CRDs]
         BP[Bootstrap Provider<br/>Talos/kubeadm<br/>Generates bootstrap config]
-        IP[Infra Provider<br/>Metal3/Sidero<br/>Provisions bare metal]
+        IP[Infra Provider<br/>Metal3/Tinkerbell<br/>Provisions bare metal]
     end
     
     subgraph Workload Cluster
@@ -69,17 +69,41 @@ To understand how the declarative model functions, you must understand the prima
 | `MachineDeployment` | Manages a set of worker machines (like a Deployment for pods) |
 | `MachineHealthCheck` | Auto-remediation for unhealthy nodes |
 | `BareMetalHost` (Metal3) | Represents a physical server |
-| `ServerClass` (Sidero) | Groups servers by hardware capabilities |
+| `Hardware` / provider inventory (Tinkerbell) | Describes physical machines and workflow targets |
 
 The core provider establishes the fundamental abstractions (like Machine and Cluster) required by all other controllers. When initializing an environment using the [`clusterctl init` command, Cluster API automatically installs the core provider, kubeadm bootstrap provider, and kubeadm control-plane provider unless those providers are explicitly controlled by flags](https://cluster-api.sigs.k8s.io/clusterctl/commands/init.html). Furthermore, `clusterctl init` always installs the latest available provider versions for explicitly selected providers, and does not install pre-release provider versions unless requested by tag.
 
 When bootstrapping an environment, operators sometimes wonder if they can bypass certain components to save resources or memory. Cluster API does not support skipping the core provider install from `clusterctl init`; skipping is only available for bootstrap/control-plane with `-` placeholders. The core controller is the absolute foundation of the ecosystem, as it is responsible for the top-level orchestration of the cluster lifecycle.
+
+The important mental shift is that Cluster API does not make physical servers behave like cloud instances by pretending the hardware is simple. Instead, it splits the problem into portable intent and provider-specific execution. The portable intent is expressed through `Cluster`, `Machine`, `MachineSet`, `MachineDeployment`, and `MachineHealthCheck` resources. The provider-specific execution is expressed through references such as `infrastructureRef` and `bootstrap.configRef`, where Metal3, Tinkerbell, kubeadm, Talos, Ignition, or another provider does the physical work that a cloud provider would normally hide.
+
+That split is why Cluster API is a good fit for GitOps-driven bare metal. A `MachineDeployment` says "keep five worker machines at Kubernetes v1.35.0"; it does not say "send Redfish command X, chain-load iPXE script Y, stream image Z, then run kubeadm join." The infrastructure provider watches the abstract request, chooses a compatible host, performs the out-of-band and boot workflow, writes the operating system or hands off to a bootstrap provider, and reports readiness back to the management cluster. If the server never appears as a Kubernetes `Node`, the failure is visible as resource status and events rather than as a lost terminal transcript.
+
+The chain looks like this:
+
+```text
+Git commit
+  -> GitOps controller applies CAPI YAML
+  -> CAPI reconciles Cluster and MachineDeployment
+  -> MachineSet creates Machine objects
+  -> infrastructure provider claims physical inventory
+  -> BMC power / boot workflow starts
+  -> OS image or installer writes the node
+  -> bootstrap provider turns the host into a Kubernetes node
+  -> Machine status points at the joined Node
+```
+
+This is also where Module 2.2 and Module 2.3 join the story. Module 2.2 taught the imperative PXE chain: DHCP, boot loader, installer, first boot, and node join. Module 2.3 taught the immutable operating-system discipline: Talos, Flatcar, RHCOS-style images, atomic updates, and rebuild-not-mutate thinking. This module puts a controller around both ideas. Instead of running a PXE script because a human decided the rack was ready, you let a reconciler compare Git-backed desired state with physical inventory and make the next safe move.
 
 ## Metal3 (CAPM3) Infrastructure and Ecosystem
 
 [CAPM3 is a Cluster API infrastructure provider that enables deploying Kubernetes clusters on bare-metal via Metal3](https://github.com/metal3-io/cluster-api-provider-metal3). By leveraging out-of-band management protocols, CAPM3 bridges the gap between cloud-native declarative logic and physical, tangible hardware. It effectively acts as the translation layer between Kubernetes API requests and the physical signals required to boot, wipe, and configure actual datacenter hardware.
 
 Metal3 requires physical machines with BMC access (e.g., Redfish/iDRAC/IPMI), an Ironic instance, and a Kubernetes management cluster (Kind is acceptable for development). A Metal3/Cluster API environment maps user-facing Kubernetes workload infrastructure to `Metal3Machine` and `BareMetalHost` objects, with BMO exposing Ironic capabilities via `BareMetalHost` CRDs.
+
+Metal3 is the more Kubernetes-native face of a proven bare-metal provisioning stack. The Bare Metal Operator keeps a Kubernetes inventory of physical machines, while Ironic does the lower-level work of talking to BMCs, setting boot devices, booting deploy ramdisks, inspecting hardware, cleaning disks, and writing images. Metal3's current docs describe it as a Kubernetes application that uses Kubernetes resources and APIs as its interface, while pairing with standalone Ironic instead of requiring the rest of OpenStack. That matters operationally: your platform team gets a Kubernetes API for inventory and lifecycle, but it still inherits Ironic's broad hardware-driver experience.
+
+The Metal3 project has also matured since early bare-metal experiments. The CNCF project page currently lists Metal3 as an incubating CNCF project, and the current CAPM3 repository shows active release work aligned with recent Cluster API lines. That does not mean "install it casually." It means Metal3 is no longer just a lab curiosity, but it still demands serious ownership of management-cluster availability, BMC network reachability, image hosting, Ironic logs, firmware variance, and version compatibility between Cluster API, CAPM3, Bare Metal Operator, and Ironic.
 
 ```mermaid
 graph TD
@@ -118,6 +142,10 @@ graph TD
 Architectural shifts in the Metal3 project have refined how the components interact. [Starting from CAPM3 release version 0.5.0, Baremetal Operator is decoupled from CAPM3 `clusterctl` deployment, so CAPM3 init must be accompanied by separate BMO/Ironic installation](https://github.com/metal3-io/cluster-api-provider-metal3). 
 
 To ensure a stable foundation, CAPM3 installation docs show example pinned versions and recommend a dependency flow: install clusterctl, kustomize, Ironic, Baremetal Operator, then core/bootstrap/control-plane providers before `clusterctl init --infrastructure metal3`. Establishing this exact order guarantees that the Ironic backend is actively listening before the controllers attempt to reconcile physical hosts. Failing to adhere to this order can result in reconciliation loops timing out or controllers entering a crash loop because their necessary physical backends are unreachable.
+
+Version selection is part of the architecture, not a cosmetic install detail. The upstream Cluster API book currently documents the v1.13 line, and the v1.13 release notes show Kubernetes v1.35 compatibility for management and workload clusters. The same release notes warn that old API versions have been removed and that providers should implement the v1beta2 contract. CAPM3's current release material likewise shows active migration work around v1beta2 APIs, while the Bare Metal Operator repository shows a separate release stream. A production platform should pin every provider version, record the compatibility matrix in the repo, and test upgrades in a staging management cluster before upgrading the live one.
+
+That compatibility discipline prevents a subtle failure mode: the manifests in Git can be syntactically valid YAML yet semantically invalid for the controllers you just upgraded. A `MachineDeployment` may still apply, but an old provider-specific template may be rejected by webhooks or ignored by a controller expecting a newer contract. When that happens on cloud infrastructure, you usually get a failed API call. On bare metal, you may also have half-claimed hosts, powered-on machines waiting in an installer, or BMC jobs still running from the old controller. Pinning and testing provider versions is how you keep "declarative" from becoming "surprisingly uncontrolled."
 
 ### BareMetalHost Definition
 
@@ -170,75 +198,69 @@ flowchart TD
 
 When a node enters the Deprovisioning state, Metal3 can securely erase the disks, ensuring that sensitive data is destroyed before the physical server is returned to the available pool for the next tenant. This stage is crucial in multi-tenant bare-metal environments to prevent cross-contamination of proprietary data.
 
-## Sidero: Talos-Native Bare Metal
+The `BareMetalHost` state machine is the place where physical reality becomes visible. A newly created host moves through registration when the operator verifies the BMC endpoint and credentials. It moves into inspection when Ironic boots an inspection ramdisk and collects CPU, memory, disk, NIC, boot mode, and firmware facts. It becomes available only after the operator has enough inventory data to safely match it to a future request. It enters provisioning when an image or custom deploy workflow is attached, and it reaches provisioned when the target image has been written and the server is expected to boot its real operating system.
 
-While Metal3 offers immense flexibility across different operating systems, Sidero is an alternative bare metal provider natively integrated with Talos Linux, optimizing for an immutable ecosystem. Because Talos is managed entirely via an API rather than an interactive shell, the provisioning process is highly streamlined.
+Those states are not merely labels for a dashboard. They are gates that protect the fleet. If inspection finds the wrong disk, missing RAM, or a boot MAC that does not match the inventory record, the host should not silently become a worker. If deprovisioning cannot clean the disk, the host should not return to the pool as if it were safe for a different workload. If registration cannot contact the BMC, the platform should fail before any team assumes the host can be remediated automatically at 3 AM. Good operators learn to read `status.provisioning.state`, `status.operationHistory`, `status.operationalStatus`, and events as the authoritative timeline of what happened to a server.
 
-### Sidero vs Metal3 Tradeoffs
+Out-of-band management is the control plane beneath the control plane. Redfish, IPMI, iDRAC, iLO, and similar BMC interfaces let a management cluster power a host on or off, select a one-time boot device, attach virtual media, inspect firmware state, and sometimes configure BIOS or RAID settings. Metal3 stores the credentials as Kubernetes Secrets referenced by the `BareMetalHost`, which is better than embedding passwords in PXE scripts but still requires serious secret handling. In production, these Secrets should come from a vault-backed external secret flow, be scoped to the management namespace, and be rotated on the same schedule as other privileged infrastructure credentials.
 
-| Feature | Metal3 (CAPM3) | Sidero |
-|---------|---------------|--------|
-| OS support | Any (Ubuntu, Flatcar, etc.) | Talos Linux only |
-| Provisioner | Ironic (complex, OpenStack heritage) | Built-in (simpler) |
-| BMC protocol | IPMI, Redfish, iDRAC, iLO | IPMI, Redfish |
-| Server discovery | Manual BareMetalHost CRDs | Auto-discovery via DHCP |
-| Image delivery | Ironic Python Agent (IPA) | Talos PXE image |
-| Complexity | Higher (Ironic is a large system) | Lower (fewer moving parts) |
-| Maturity | Older, more tested | Newer, less battle-tested |
-| Best for | Multi-OS environments | Talos-only environments |
+Ironic can drive both PXE/iPXE-style boot and Redfish virtual media boot, and the tradeoff matters. PXE and iPXE are widely understood and align directly with the boot chain from Module 2.2, but they depend on a correctly scoped DHCP or proxyDHCP path plus reachable boot artifacts. Redfish virtual media can avoid the unreliable TFTP stage by having the BMC present an ISO-like image to the server, but the exact quality of Redfish implementations varies by vendor and firmware generation. A mature platform tests both the happy path and recovery path for every server model it buys, because "supports Redfish" is not the same as "boots reliably through your exact virtual-media workflow."
 
-### Sidero Server Discovery
+Image-based provisioning is the cleanest fit for this model. Instead of installing Ubuntu and then running a long configuration-management playbook, the provider writes a complete OS image and lets first boot apply only the machine-specific bootstrap data. Talos, Flatcar, and RHCOS-style operating systems work especially well because the node's desired state is already expressed as an immutable artifact plus a small configuration document. That is the continuity with Module 2.3: Cluster API should not become a remote shell for mutating nodes; it should be the controller that replaces nodes when the desired OS, Kubernetes version, or bootstrap contract changes.
 
-Unlike CAPM3, where nodes must be manually registered with explicit BMC credentials upfront, Sidero heavily utilizes DHCP-based automated discovery. When a physical server is connected to the network and PXE booted, Sidero identifies it and automatically registers it as a resource. This significantly accelerates the onboarding of large racks of new hardware.
+## Tinkerbell and CAPT: Workflow-Driven Bare Metal
 
-```bash
-# Sidero auto-discovers servers when they PXE boot
-# Servers appear as Server CRDs automatically
+Tinkerbell is the other major bare-metal path you should understand. Its CNCF project page currently describes it as a sandbox project, and the upstream Tinkerbell site describes it as a bare-metal provisioning engine with network boot, metadata, BMC interaction, and workflow components. The Cluster API Provider Tinkerbell repository, commonly called CAPT, provides the infrastructure-provider bridge so Cluster API can request machines while Tinkerbell performs the provisioning workflow.
 
-# Check discovered servers
-kubectl get servers -n sidero-system
-# NAME                                   HOSTNAME      BMC              ACCEPTED
-# 00000000-0000-0000-0000-aabbccddeef1   server-01     10.0.100.10     false
-# 00000000-0000-0000-0000-aabbccddeef2   server-02     10.0.100.11     false
+Older Tinkerbell diagrams often talk about Boots, Hegel, and Tink. Current upstream docs present the stack slightly differently: Smee provides DHCP, iPXE, syslog, and network boot service; Tootles provides metadata service; HookOS is the in-memory operating-system installation environment; Tink provides the workflow server, controller, and worker; Rufio and PBnJ handle BMC interactions. The old names still appear in some repositories and team memory, but a current design review should map them to the current service names before writing runbooks or alert names.
 
-# Accept a server into the pool
-kubectl patch server 00000000-0000-0000-0000-aabbccddeef1 \
-  --type merge -p '{"spec":{"accepted": true}}'
+```text
+Cluster API Machine
+  -> CAPT infrastructure provider
+  -> Tinkerbell Hardware / workflow objects
+  -> Smee network boot
+  -> HookOS in-memory installer
+  -> Tink workflow actions write the OS image
+  -> Tootles/Hegel-style metadata feeds first boot
+  -> Rufio/PBnJ performs BMC power and boot tasks when configured
 ```
 
-Once accepted, operators can group hardware based on physical capabilities using the ServerClass resource. This allows the cluster API logic to dynamically select appropriately sized hardware for different node roles.
+Tinkerbell's design center is a workflow engine. A workflow combines hardware identity with a template of containerized actions: wipe a disk, stream an image, write a partition table, inject cloud-init or metadata, reboot, and report success. That model is attractive when the team wants explicit control over each provisioning step and already thinks in terms of repeatable pipelines. It is also attractive in edge environments where the network boot workflow must support unusual hardware, isolated sites, or a mixture of install targets that do not fit a single Ironic path.
 
-```yaml
-# Group servers by capability
-apiVersion: metal.sidero.dev/v1alpha2
-kind: ServerClass
-metadata:
-  name: worker-large
-spec:
-  qualifiers:
-    cpu:
-      - manufacturer: "AMD"
-        version: "EPYC.*"
-    systemInformation:
-      - manufacturer: "Dell Inc."
-  selector:
-    matchLabels:
-      rack: "rack-a"
-```
+The tradeoff is that Tinkerbell asks your team to own more of the workflow semantics. Metal3 plus Ironic gives you a large amount of provisioning behavior behind the `BareMetalHost` abstraction. Tinkerbell lets you see and customize the workflow more directly, but that flexibility means the team must test the action images, metadata contract, HookOS behavior, DHCP/iPXE reachability, and BMC task path. A broken workflow action can be as damaging as a broken Ansible playbook if it is allowed to run against the wrong hardware.
+
+### Metal3 vs Tinkerbell Tradeoffs
+
+| Dimension | Metal3 / CAPM3 | Tinkerbell / CAPT |
+|---|---|---|
+| Main abstraction | `BareMetalHost` plus CAPM3 infrastructure resources | Hardware, templates, workflows, and CAPT resources |
+| Provisioning engine | Ironic, exposed through Bare Metal Operator | Tink workflows with Smee, HookOS, metadata, and optional BMC services |
+| Best fit | Kubernetes-native host inventory, broad hardware management, strong BMH lifecycle visibility | Highly customized provisioning workflows, edge sites, explicit action pipelines |
+| Operational burden | Ironic, BMO, CAPM3, image hosting, BMC network | Tinkerbell stack services, workflow action images, metadata, BMC services |
+| Maturity signal | CNCF incubating project; active CAPM3 and BMO releases | CNCF sandbox project; active Tinkerbell and CAPT releases |
+| Failure mode to watch | Hosts stuck in registration, inspection, provisioning, or deprovisioning states | Workflows stuck because boot, metadata, action image, or BMC task failed |
+
+The most useful comparison is not "which one is better." It is "which control surface matches your team." A team that wants Kubernetes resources to represent physical hosts, wants Ironic's hardware-management depth, and can operate a somewhat heavier controller stack should usually evaluate Metal3 first. A team that wants workflow-level control, already has a strong PXE and image pipeline, and needs to customize the exact steps for each site should evaluate Tinkerbell. A team with one cluster and rare hardware churn may not need either yet; the simpler PXE path from Module 2.2 can be the right first milestone.
+
+### Provider Maturity and API Expectations
+
+Provider maturity changes faster than curriculum prose, so treat this section as a model for how to verify rather than as a license to skip release notes. As of the current upstream pages checked for this rewrite, Cluster API's book documents v1.13, the CAPM3 repository has v1.13-era examples and migration notes, Bare Metal Operator has an active v0.13 line, the Tinkerbell stack repository shows v0.23-era releases, and CAPT shows a v0.7-era release. Those numbers should not be copied blindly into production manifests; they should trigger a compatibility review in your own repo.
+
+The safest pattern is to pin the provider versions in a single `management-cluster/providers/` directory and document why each version is present. Include the Cluster API core version, bootstrap provider, control-plane provider, infrastructure provider, BMO or Tinkerbell stack version, image builder version, and any OS image version. When a provider upgrade lands, update the pin in Git, run a management-cluster upgrade rehearsal, create and delete a disposable workload cluster, and verify that failed-host cleanup still works. Declarative infrastructure does not eliminate upgrades; it gives you a place to review and rehearse them.
 
 ## Designing the Declarative Cluster
 
 Cluster declarations consist of several interoperable resources linking the requested abstraction with the hardware templates. Due to their length and complexity, they are cleanly separated into dedicated functional definitions. The true power of this architecture lies in combining these atomic resources to fully describe the entire cluster lifecycle.
 
-First, you define the core cluster networking and references to the control plane and infrastructure backends. This definition establishes the fundamental parameters of the environment, such as pod CIDR blocks and the names of the associated infrastructure providers.
+First, you define the core cluster networking and references to the control plane and infrastructure backends. This definition establishes the fundamental parameters of the environment, such as pod CIDR blocks and the names of the associated infrastructure providers. Current Cluster API examples use the `v1beta2` core API shape, while some infrastructure-provider resources may still have their own version cadence, so production manifests should be generated and pinned from the provider release you actually install.
 
 ```yaml
 # Define the workload cluster
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: Cluster
 metadata:
   name: production
-  namespace: default
+  namespace: metal3
 spec:
   clusterNetwork:
     pods:
@@ -246,43 +268,51 @@ spec:
     services:
       cidrBlocks: ["10.96.0.0/12"]
   controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
-    kind: TalosControlPlane
+    apiGroup: controlplane.cluster.x-k8s.io
+    kind: KubeadmControlPlane
     name: production-cp
   infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: MetalCluster
+    apiGroup: infrastructure.cluster.x-k8s.io
+    kind: Metal3Cluster
     name: production
 ```
 
 Next, the control plane is defined. This dictates the number of replicas and the precise version of Kubernetes that will be deployed. By adjusting the replica count here, the controllers will automatically provision additional physical servers to host the new control plane instances.
 
 ```yaml
-# Control plane (3 nodes from 'control-plane' server class)
-apiVersion: controlplane.cluster.x-k8s.io/v1alpha3
-kind: TalosControlPlane
+# Control plane (3 nodes from hosts matching role=control-plane)
+apiVersion: controlplane.cluster.x-k8s.io/v1beta2
+kind: KubeadmControlPlane
 metadata:
   name: production-cp
+  namespace: metal3
 spec:
   replicas: 3
   version: v1.35.0
-  infrastructureTemplate:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-    kind: MetalMachineTemplate
-    name: production-cp
-  controlPlaneConfig:
-    controlplane:
-      generateType: controlplane
+  machineTemplate:
+    spec:
+      infrastructureRef:
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: Metal3MachineTemplate
+        name: production-cp
+  kubeadmConfigSpec:
+    initConfiguration:
+      nodeRegistration:
+        name: "{{ ds.meta_data.name }}"
+    joinConfiguration:
+      nodeRegistration:
+        name: "{{ ds.meta_data.name }}"
 ```
 
 [Worker nodes are defined via a `MachineDeployment`, which mirrors the behavior of a standard Kubernetes `Deployment` but operates on physical servers instead of Pods. This enables rolling updates of entire physical nodes simply by changing the version field](https://cluster-api.sigs.k8s.io/tasks/upgrading-clusters.html).
 
 ```yaml
 # Worker machines (5 nodes from 'worker-large' server class)
-apiVersion: cluster.x-k8s.io/v1beta1
+apiVersion: cluster.x-k8s.io/v1beta2
 kind: MachineDeployment
 metadata:
   name: production-workers
+  namespace: metal3
 spec:
   replicas: 5
   clusterName: production
@@ -298,29 +328,37 @@ spec:
       version: v1.35.0
       bootstrap:
         configRef:
-          apiVersion: bootstrap.cluster.x-k8s.io/v1alpha3
-          kind: TalosConfigTemplate
+          apiGroup: bootstrap.cluster.x-k8s.io
+          kind: KubeadmConfigTemplate
           name: production-workers
       infrastructureRef:
-        apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-        kind: MetalMachineTemplate
+        apiGroup: infrastructure.cluster.x-k8s.io
+        kind: Metal3MachineTemplate
         name: production-workers
 ```
 
-Finally, the infrastructure templates link the logical machine requests to the specific server classes in your datacenter. This decouples the Kubernetes logic from the specific hardware layout, enabling highly reusable templates across multiple distinct datacenters.
+Finally, the infrastructure templates link the logical machine requests to the specific host labels in your datacenter. This decouples the Kubernetes logic from the specific hardware layout, enabling reusable templates across multiple distinct datacenters. In Metal3, `hostSelector` limits which `BareMetalHost` objects can satisfy a machine request, while the image fields define the OS artifact that Ironic writes to the chosen host.
 
 ```yaml
-apiVersion: infrastructure.cluster.x-k8s.io/v1alpha3
-kind: MetalMachineTemplate
+apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
+kind: Metal3MachineTemplate
 metadata:
   name: production-workers
+  namespace: metal3
 spec:
   template:
     spec:
-      serverClassRef:
-        apiVersion: metal.sidero.dev/v1alpha2
-        kind: ServerClass
-        name: worker-large
+      image:
+        url: http://images.example.internal/talos-worker-v1.35.0.raw
+        checksum: http://images.example.internal/talos-worker-v1.35.0.raw.sha256
+        checksumType: sha256
+        format: raw
+      hostSelector:
+        matchLabels:
+          role: worker-large
+          site: dc-a
+      dataTemplate:
+        name: production-workers
 ```
 
 Deploying this architecture requires merely applying the manifests and monitoring the rollout. The controllers immediately begin authenticating with physical servers, initiating PXE boots, and securely provisioning the operating system.
@@ -394,14 +432,15 @@ Git Repository
 ├── clusters/
 │   ├── production/
 │   │   ├── cluster.yaml        (Cluster definition)
-│   │   ├── control-plane.yaml  (TalosControlPlane)
+│   │   ├── control-plane.yaml  (KubeadmControlPlane)
 │   │   ├── workers.yaml        (MachineDeployment)
 │   │   └── health-checks.yaml  (MachineHealthCheck)
 │   ├── staging/
 │   └── dev/
 └── infrastructure/
-    ├── servers.yaml            (BareMetalHost inventory)
-    └── server-classes.yaml     (ServerClass definitions)
+    ├── hosts.yaml              (BareMetalHost or Hardware inventory)
+    ├── templates.yaml          (provider-specific machine templates)
+    └── images.yaml             (approved OS image references)
 ```
 
 ```mermaid
@@ -420,7 +459,15 @@ graph LR
     MgmtCluster -->|Provisions| WLCluster
 ```
 
-To create a cluster, simply author the declarative manifests and commit them. To upgrade the operating system, bump the version in Git. Flux or ArgoCD applies the change to the Management Cluster, and Cluster API safely cascades the upgrade across physical machines. All infrastructure changes are peer-reviewed as pull requests, completely eliminating rogue manual modifications.
+To create a cluster, simply author the declarative manifests and commit them. To upgrade the operating system, bump the version in Git. Flux or ArgoCD applies the change to the Management Cluster, and Cluster API safely cascades the upgrade across physical machines. All infrastructure changes are peer-reviewed as pull requests, which changes the social workflow as much as the technical workflow: server allocation, OS image choice, Kubernetes version, and remediation policy now receive the same review trail as application code.
+
+The reconciliation boundary is important. GitOps should apply desired-state resources into the management cluster; it should not run provisioning shell scripts directly from CI. If CI is allowed to SSH to a provisioning host, call BMC APIs, or write disks, then your Git repository is only a trigger for imperative automation. In a declarative design, GitOps writes `Cluster`, `MachineDeployment`, `BareMetalHost`, `Metal3MachineTemplate`, or Tinkerbell workflow objects, and the controllers reconcile them. The controllers own retries, status, finalizers, deprovisioning, and cleanup.
+
+That distinction gives you drift detection. If someone hand-edits a `BareMetalHost`, changes a `MachineDeployment` replica count with `kubectl edit`, or swaps an image URL in the management cluster, ArgoCD or Flux can show the object as out of sync and restore Git state. If someone SSHs into a provisioned node and installs packages, GitOps cannot see that drift because the node filesystem is outside the Kubernetes API. This is why declarative bare metal pairs so well with the immutable OS approach from Module 2.3: Git controls the desired machine objects, and the OS prevents hand-edited node state from becoming a hidden second source of truth.
+
+Declarative scale-out becomes boring in the best possible way. To add three workers, you add or label three eligible physical hosts, increase a `MachineDeployment` replica count, and merge the pull request. The management cluster then decides which hosts are available, boots them, writes the approved image, passes bootstrap data, waits for nodes to join, and updates status. If the site does not have enough spare inventory, the request remains pending instead of silently inventing capacity. That visible pending state is more useful than a spreadsheet row that claims a server is free when it has a dead BMC, wrong boot mode, or unrecoverable disk.
+
+Git also becomes the capacity ledger, but it should not be the only asset database. The repository should reference stable inventory identifiers, labels, racks, roles, and BMC endpoints, while the source-of-truth asset system still owns purchase date, warranty, depreciation, rack unit, power feed, serial number, and replacement history. When these systems disagree, block provisioning and quarantine the host. A reconciler that can wipe disks must be conservative about identity; guessing is how an automation platform turns into a data-loss incident.
 
 ### Pivoting Management State
 
@@ -434,9 +481,9 @@ In move operations, objects outside the default discovery graph move only when l
 
 Maintaining a fleet of bare-metal clusters requires rigorous adherence to version compatibility matrices. [Cluster API documents a multi-provider release-support policy: support and lifecycle decisions are based on tracked releases rather than implicit long-term retention](https://cluster-api.sigs.k8s.io/reference/versions.html). Operators must continuously plan upgrades to avoid falling out of the supported window.
 
-As documented, Cluster API maintained versions include a release timeline where N and N-1 are active, N-2 may be kept for emergency maintenance, with explicit EOL/maintenance dates per minor release. It applies Kubernetes-version compatibility rules with release-dependent matrices. For example, as of the version 1.13 pre-release documentation, Kubernetes support for management clusters is version 1.31.x–1.35.x and workload clusters are version 1.29.x–1.35.x.
+As documented, Cluster API maintained versions include a release timeline where N and N-1 are active, N-2 may be kept for emergency maintenance, with explicit EOL/maintenance dates per minor release. It applies Kubernetes-version compatibility rules with release-dependent matrices. For example, the current upstream v1.13 release notes list management-cluster support for Kubernetes v1.32.x through v1.35.x and workload-cluster support for v1.30.x through v1.35.x.
 
-CAPM3 versioning also enforces strict boundaries. [CAPM3 release compatibility includes a release 1.12.X line: CAPM3 API `v1beta1`, Cluster API contract `v1beta2`, and CAPI release 1.12.X](https://github.com/metal3-io/cluster-api-provider-metal3). API versions and deprecations are strictly staged across the ecosystem: v1alpha3 and v1alpha4 are not served, v1beta1 is deprecated, and will be unserved in the version 1.14 line. Attempting to deploy an unsupported CRD version against an upgraded controller will result in immediate rejection by the API server.
+CAPM3 versioning also enforces strict boundaries. [CAPM3 release compatibility and API documentation are maintained with the provider repository](https://github.com/metal3-io/cluster-api-provider-metal3), and the current docs show v1beta2 Cluster API examples while Metal3-specific resources continue to follow the provider's release contract. API versions and deprecations are staged across the ecosystem: the current Cluster API v1.13 notes state that v1alpha3 and v1alpha4 API versions have been removed and warn that v1beta1 is on track to stop being served in a future Cluster API line. Attempting to deploy an unsupported CRD version against an upgraded controller will result in immediate API-server rejection or webhook failures.
 
 When performing upgrades, changing the version initiates a carefully orchestrated rollout. [Cluster API version 1.12 introduced in-place updates and chained upgrades, including an update-extension model for in-place machine changes](https://kubernetes.io/blog/2026/01/27/cluster-api-v1-12-release/), drastically reducing the overhead of completely rebuilding bare-metal nodes for minor configuration tweaks. This innovation dramatically speeds up the delivery of minor configuration changes across massive hardware fleets.
 
@@ -452,15 +499,90 @@ When performing upgrades, changing the version initiates a carefully orchestrate
          version: v1.35.0  # was v1.34.0
    ```
 
+## Cost and Capacity Lens
+
+Declarative bare-metal provisioning is not free automation. It replaces one category of cost with another. The old cost is slow human work: spreadsheets, ad hoc PXE runs, manual disk wipes, snowflake debugging, and delayed recovery when failed servers wait for an engineer. The new cost is platform ownership: a management cluster, provider controllers, BMC network design, image pipelines, GitOps operations, version testing, alerting, and people who understand the reconcile loop. For one small lab cluster, that exchange may not pay back immediately. For a fleet of production clusters, it usually becomes the difference between owned hardware being an asset and owned hardware being a maintenance trap.
+
+The on-prem economics are shaped by CapEx and utilization. Servers, racks, switches, optics, PDUs, UPS capacity, cooling, support contracts, and spare parts are purchased before the first workload runs. Those assets depreciate over a refresh cycle, commonly planned around several years rather than cloud-instance minutes. If the workload is steady, predictable, data-heavy, or regulated, high utilization can make owned hardware financially attractive because the organization is not paying cloud premiums, cross-zone transfer, or persistent egress fees for every unit of work. If the workload is spiky, experimental, globally bursty, or small, the same hardware becomes stranded capital.
+
+Provisioning automation changes that calculation because it raises usable utilization. A server sitting idle because no one trusts its state is already paid for but not productive. A failed worker that cannot be replaced until a person investigates at business hours reduces the effective capacity of the fleet. A returned host that was not wiped properly cannot be safely reused by another team. Declarative workflows shorten the time from "hardware exists" to "Kubernetes capacity is schedulable," and they shorten the time from "node failed" to "replacement node joined." That does not change the purchase price, but it changes how much value the organization extracts from the purchase.
+
+The cost lens should also include operations headcount. Metal3, Tinkerbell, Ironic, Redfish, DHCP, image hosting, and GitOps are not a one-person side project once they run production clusters. A small team can operate them well if the scope is disciplined and the runbooks are honest. The danger is buying a large physical fleet to avoid cloud costs, then underfunding the platform work that makes the fleet safe. If manual provisioning consumes a senior engineer's week every time a rack arrives, the apparent savings disappear into labor, outage risk, and slow delivery.
+
+The best economic fit is a steady, high-utilization environment where clusters are created and replaced often enough that manual work is measurable pain. Examples include regulated internal platforms, edge sites with data gravity, egress-heavy analytics, manufacturing systems close to equipment, and private AI or virtualization estates with known demand. The weakest fit is a small organization with one or two clusters, low hardware churn, no dedicated platform team, and workloads that scale down to nearly zero for long periods. In that case, a simpler PXE pipeline from Module 2.2 plus disciplined immutable images from Module 2.3 may be enough until cluster count and churn justify a full CAPI provider.
+
+## Patterns & Anti-Patterns
+
+The strongest pattern is a self-hosted management cluster that provisions workload clusters but is not casually coupled to them. Many teams start with a temporary kind bootstrap cluster because Cluster API needs an existing Kubernetes API to install providers. They then create a durable management cluster, move the Cluster API objects into it with `clusterctl move`, and use that management cluster to provision workload clusters. This pattern works because the management cluster is treated as control-plane infrastructure with backups, HA, network reachability to BMCs, and strict change control, not as a random utility cluster.
+
+The second pattern is hardware-pool buffering. A declarative `MachineDeployment` can replace failed machines only if suitable inventory exists. Keep a small pool of inspected, available, unlabeled or appropriately labeled spare hosts per failure domain. The exact buffer depends on procurement lead time, failure rate, and maintenance windows, but the principle is simple: remediation should not consume the last healthy server in a rack unless a human intentionally accepts that risk. Without buffer capacity, automation can detect failures but cannot restore capacity.
+
+The third pattern is image promotion rather than node mutation. Build the OS image once, scan it, sign it, publish it to an internal image endpoint, and reference that immutable artifact from provider templates. Promote the image from lab to staging to production by changing Git, not by SSHing into nodes after they boot. This mirrors application delivery: the artifact is promoted through environments, and the reconciler rolls machines to the new artifact. When something fails, you roll back the image reference or replace machines, instead of trying to reverse a sequence of live edits.
+
+The fourth pattern is quarantine-first discovery. If a server appears on the provisioning VLAN but its BMC address, serial number, boot MAC, asset tag, or rack label does not match inventory, the system should place it in a discovered or unmanaged state and refuse to provision it. This is slower than blindly accepting every booting machine, but it prevents the worst class of automation failure: writing the wrong disk on the wrong server. The platform should make unknown hardware visible without making it dangerous.
+
+| Pattern | Why It Works | Scaling Signal |
+|---|---|---|
+| Dedicated management cluster | Separates lifecycle controllers from workload failure domains | Multiple workload clusters or multiple datacenters |
+| Spare inspected host pool | Lets remediation replace nodes without waiting for procurement | Any cluster with uptime objectives |
+| Immutable image promotion | Keeps node state reproducible and reviewable | Frequent security patches or OS updates |
+| Quarantine-first discovery | Prevents accidental wipes and identity confusion | Shared labs, edge sites, or mixed hardware |
+
+The most damaging anti-pattern is hand-editing provisioned nodes. It feels practical during an incident because the node is right there and the shell is familiar. It breaks the entire model because the desired state in Git no longer describes the running state. The next machine replacement, OS rollout, or node rebuild will erase the manual fix, and the team may not remember that production depended on it. The better approach is to change the image, bootstrap config, Kubernetes DaemonSet, or provider template, then let reconciliation replace or reconfigure machines through the approved path.
+
+Another anti-pattern is treating BMC credentials as ordinary deployment secrets. BMC access is more powerful than SSH access to one node: it can power machines off, change boot devices, attach media, and sometimes alter firmware. A leaked BMC password can become a fleet-wide outage or data-loss path. Keep BMC credentials in a dedicated secret management flow, audit who can read them, restrict the management cluster's network path to the BMC VLAN, and rotate credentials when hardware changes ownership.
+
+A third anti-pattern is rebuilding the cloud inside the datacenter without the staffing to operate it. Teams sometimes adopt Cluster API, Metal3, Tinkerbell, GitOps, external secrets, image signing, custom OS builds, and multi-site management in one leap. Each component is defensible, but the combination creates a platform whose failure modes no one has rehearsed. The better approach is phased: make PXE deterministic, make OS images immutable, introduce declarative inventory, automate one noncritical workload cluster, prove deprovisioning and recovery, then scale to production.
+
+A fourth anti-pattern is skipping deprovisioning tests. Provisioning demos are exciting because servers appear as nodes. Deprovisioning is where safety is proven. Can the platform drain the node, delete the `Machine`, clean or preserve disks according to policy, release or quarantine the host, and avoid reusing hardware that should stay out of rotation? A platform that can create clusters but cannot delete them cleanly will accumulate risky leftovers: stale credentials, orphaned BMH objects, disks containing tenant data, and inventory rows that no longer match reality.
+
+| Anti-Pattern | What Goes Wrong | Better Approach |
+|---|---|---|
+| Hand-editing nodes | Git and the running fleet diverge | Change images, bootstrap data, or Kubernetes resources |
+| Plaintext BMC handling | Fleet power control becomes a secret leak away | Vault-backed Secrets and restricted BMC network access |
+| Big-bang platform rollout | Too many unrehearsed failure modes arrive together | Phase from PXE to immutable images to CAPI |
+| Provision-only testing | Deletion, wipe, and cleanup bugs reach production | Test create, scale, upgrade, remediate, and delete paths |
+
+## Decision Framework
+
+Choose the simplest tool that satisfies the lifecycle problem you actually have. If the team only provisions a handful of long-lived clusters each year, a deterministic PXE pipeline with immutable OS images may be enough. If the team runs many clusters, frequently replaces hardware, needs Git-reviewed scaling, and wants Kubernetes-native host inventory, Cluster API plus Metal3 is a strong candidate. If the team has unusual provisioning workflows, edge locations, or needs workflow-level control over each installation action, Tinkerbell deserves evaluation. The decision is not permanent, but every step up adds controllers, versions, and operational responsibilities.
+
+```mermaid
+flowchart TD
+    Start[Need bare metal provisioning] --> Churn{Many clusters or frequent churn}
+    Churn -->|No| PXE[Use deterministic PXE plus immutable images]
+    Churn -->|Yes| K8sAPI{Want Kubernetes native host inventory}
+    K8sAPI -->|Yes| Metal3[Evaluate CAPI plus Metal3]
+    K8sAPI -->|No| Workflow{Need custom workflow steps}
+    Workflow -->|Yes| Tinkerbell[Evaluate CAPI plus Tinkerbell]
+    Workflow -->|No| PXE
+    Metal3 --> Skills{Team can run Ironic and BMC ops}
+    Skills -->|Yes| AdoptM3[Adopt with staged rollout]
+    Skills -->|No| PXE
+    Tinkerbell --> FlowSkills{Team can own workflow actions}
+    FlowSkills -->|Yes| AdoptTB[Adopt with staged rollout]
+    FlowSkills -->|No| PXE
+```
+
+| Situation | Prefer | Reason |
+|---|---|---|
+| One or two stable clusters, rare hardware changes | PXE pipeline from Module 2.2 | Lower operational overhead than a management-cluster platform |
+| Many workload clusters, shared hardware pool, Kubernetes-native inventory required | CAPI plus Metal3 | BMH lifecycle, Ironic integration, and Cluster API reconciliation align well |
+| Edge sites with custom install steps or unusual network boot constraints | CAPI plus Tinkerbell | Workflow engine exposes each provisioning action explicitly |
+| Immutable Talos or Flatcar fleet with strong image discipline | CAPI with image-based provisioning | The platform replaces nodes instead of mutating them in place |
+| No dedicated platform ownership | Simpler PXE first | Complex controllers without ownership create hidden reliability risk |
+| Regulated environment needing reviewable infrastructure changes | GitOps with CAPI provider | Pull requests create an audit trail for host allocation and lifecycle |
+
+Run the decision backward before committing. Ask what happens when the management cluster is unavailable, when the BMC network is partitioned, when a host is halfway through provisioning, when a bad OS image is promoted, when an engineer deletes a `Machine`, and when an entire rack loses power. If the answer is "someone will look at the console," the design is not yet declarative enough for production. If the answer is "the controller reports a bounded state, stops before data loss, and the runbook tells us which object to inspect," you are close.
+
+For many organizations, the pragmatic path is staged adoption. Keep the Module 2.2 PXE lane as a rescue and break-glass mechanism. Use Module 2.3 immutable images so every provisioning tool writes a reproducible artifact. Introduce Cluster API with the Docker provider in a lab so the team learns `Cluster`, `MachineDeployment`, `MachineHealthCheck`, and `clusterctl move` without touching real hardware. Then add Metal3 or Tinkerbell against a small nonproduction host pool, prove create-scale-upgrade-remediate-delete, and only then point production clusters at it. Declarative bare metal is powerful because it makes physical infrastructure boring, and boring is earned through rehearsal.
+
 ## Did You Know?
 
 1. See the Knight Capital 2012 <!-- incident-xref: knight-capital-2012 --> reference in *Infrastructure as Code* for the canonical bare-metal-level lesson on why fleet consistency has to be declarative.
-2. [The Metal3 project was officially accepted into the CNCF sandbox on 2020-09-08 and officially promoted to CNCF incubation status on 2025-08-14](https://www.cncf.io/projects/metal3-io/). Metal3 stands for "Metal Kubed" (Metal^3). It was created by Red Hat and is the bare metal infrastructure provider used by OpenShift's Assisted Installer for on-premises deployments.
-3. Cluster API release 1.12.0 fundamentally changed node lifecycle management by officially introducing in-place updates and chained upgrades.
-4. As of the version 1.13.0 pre-release, Cluster API officially supports Kubernetes workload clusters running versions 1.29.x through 1.35.x.
-5. Cluster API was created by Kubernetes SIG Cluster Lifecycle specifically because every cloud provider had built their own incompatible cluster management tooling. [CAPI provides a single API that works across AWS, Azure, GCP, vSphere, and bare metal](https://cluster-api.sigs.k8s.io/).
-6. Sidero was created by the same team that built Talos Linux (Sidero Labs). The name comes from the Greek word for "iron" — fitting for bare metal management.
-7. The largest known Cluster API deployment manages over 4,000 clusters across multiple infrastructure providers. Organizations like Deutsche Telekom and SAP use CAPI to manage their multi-cluster Kubernetes platforms at enterprise scale.
+2. [The Metal3 project was accepted into the CNCF on September 8, 2020 and moved to the Incubating maturity level on August 14, 2025](https://www.cncf.io/projects/metal3-io/), which is why it should be treated differently from one-off bare-metal scripts.
+3. [Tinkerbell is currently listed by CNCF as a Sandbox project](https://www.cncf.io/projects/tinkerbell/), so teams should evaluate CAPT with a stronger focus on release notes, workflow ownership, and local proof than they would for a more mature platform component.
+4. [Cluster API v1.13 release notes list Kubernetes v1.35 support for both management and workload clusters](https://github.com/kubernetes-sigs/cluster-api/releases), while also warning that old API versions are being removed across the provider ecosystem.
 
 ## Common Mistakes
 
@@ -470,9 +592,83 @@ When performing upgrades, changing the version initiates a carefully orchestrate
 | BMC credentials in plain text | Security risk | Use Kubernetes secrets + external secrets operator |
 | No server pool buffer | MachineHealthCheck tries to replace but no servers available | Maintain 2-3 spare servers in the pool |
 | Skipping hardware inspection | Deploying on servers with failed RAM or disks | Always let CAPI inspect hardware before marking available |
-| No disk wipe on deprovision | Previous tenant's data visible to next | Enable secure erase in Metal3/Sidero deprovisioning |
+| No disk wipe on deprovision | Previous tenant's data visible to next | Enable cleaning or quarantine on provider deprovisioning |
 | Single management cluster | Management cluster failure = total loss of control | Backup management cluster state; consider multi-site mgmt |
 | Not using GitOps | Cluster definitions are imperative and unauditable | Store all CAPI YAMLs in Git; deploy via ArgoCD/Flux |
+
+## Quiz
+
+### Question 1
+Your datacenter experiences a partial power failure that takes down the entire 3-node HA management cluster. However, the physical servers hosting your production workload clusters remain online. What happens to the applications running on the workload clusters, and what operational capabilities are lost while the management cluster is down?
+
+<details>
+<summary>Answer</summary>
+
+**Yes, workload clusters continue to function normally.** The management cluster strictly oversees the declarative lifecycle (creation, scaling, upgrades, health checks) of the workload clusters, acting as an external orchestrator. Once a workload cluster is fully provisioned, its control plane, worker nodes, and workloads operate entirely independently of the management cluster. However, during the outage, you lose the ability to scale nodes, trigger Kubernetes upgrades, or rely on `MachineHealthCheck` auto-remediation, meaning any hardware failures in the workload clusters will require manual intervention until the management cluster is restored. For this reason, it is typically advised to run the management cluster in a highly available configuration with regular etcd backups.
+</details>
+
+### Question 2
+A new security vulnerability requires you to urgently upgrade your 50-node bare-metal production cluster from Kubernetes v1.34.0 to v1.35.0. You are using Cluster API with a GitOps workflow. Describe the exact mechanism by which Cluster API rolls out this upgrade across the physical servers without causing application downtime.
+
+<details>
+<summary>Answer</summary>
+
+**Rolling upgrade via CAPI is managed similarly to a Pod Deployment rollout, but the units are physical machines.** First, you update the `version` field in your Git repository for the control-plane resource and `MachineDeployment` manifests, which ArgoCD or Flux applies to the management cluster. CAPI's controllers detect this version change and initiate a rolling update by provisioning a new physical machine with the updated version. Once the new machine joins the cluster and reports a `Ready` status, CAPI gracefully cordons and drains an old machine, deletes its `Machine` object, and allows the infrastructure provider to securely wipe and return the old server to the hardware pool. This process repeats across control plane and worker pools, ensuring that application workloads are rescheduled without downtime when enough spare capacity and disruption budgets exist.
+</details>
+
+### Question 3
+Your organization is designing a new edge computing platform. Team A wants provider-managed host inventory, Ironic-backed inspection, and broad hardware lifecycle support. Team B wants highly customized provisioning workflows with explicit image-writing actions at each site. How would you decide between Metal3 and Tinkerbell for the Cluster API infrastructure provider, and what are the architectural tradeoffs?
+
+<details>
+<summary>Answer</summary>
+
+**Your choice hinges on which control surface the team is prepared to operate.** If Team A needs Kubernetes-native host inventory, BareMetalHost state visibility, Ironic-backed inspection, and broad hardware management, Metal3 is the better first evaluation target even though it introduces Ironic, BMO, and CAPM3 as moving parts. If Team B needs workflow-level control over each provisioning step, custom action images, and site-specific image-writing logic, Tinkerbell is the better fit because its workflow engine makes those steps explicit. Neither choice removes the need for immutable image discipline, BMC network ownership, and staged testing. If the organization has only a few stable clusters and little hardware churn, a simpler PXE pipeline may still be the more responsible near-term choice.
+</details>
+
+### Question 4
+At 2:00 AM on a Sunday, a worker node in your bare-metal production cluster experiences a catastrophic NVMe drive failure, causing its kubelet to stop responding entirely. Walk through the automated sequence of events triggered by the MachineHealthCheck and explain what manual steps, if any, remain for the operations team on Monday morning.
+
+<details>
+<summary>Answer</summary>
+
+**The remediation is fully automated by the MachineHealthCheck controller, dramatically reducing downtime.** When the NVMe drive fails, the node's kubelet stops reporting, causing its status to eventually become `NotReady` or `Unknown`. The `MachineHealthCheck` constantly monitors these conditions; once the timeout threshold (e.g., 5 minutes) is breached, CAPI automatically marks the broken `Machine` for deletion. The infrastructure provider then forcefully deprovisions the server, effectively quarantining it from the available pool, while CAPI simultaneously provisions a brand-new `Machine` on a healthy standby server. By Monday morning, the cluster has already healed itself and restored full capacity, leaving the operations team with only the manual tasks of physically replacing the failed drive, verifying the hardware, and registering the repaired server back into the available bare-metal pool.
+</details>
+
+### Question 5
+Your team is building a custom management cluster and runs `clusterctl init` without any additional flags. During a subsequent audit, you discover that the kubeadm bootstrap and control-plane providers are actively running, even though your architectural design specified a custom bootstrap provider. Why did this happen, and what specific change to the initialization command would have prevented it?
+
+<details>
+<summary>Answer</summary>
+
+**This occurred because `clusterctl init` provisions a default set of providers unless explicitly overridden.** By design, when you execute `clusterctl init` without any flags, the tool automatically fetches and installs the latest versions of the core provider, the kubeadm bootstrap provider, and the kubeadm control-plane provider to ensure a functional baseline. Because your architecture required a custom bootstrap mechanism, the initialization command should have included specific flags or `-` placeholders to bypass the default kubeadm components. To prevent this, you must explicitly declare your custom providers in the command (e.g., `--bootstrap custom-provider`) so that clusterctl bypasses its default selections and aligns with your intended architectural design.
+</details>
+
+### Question 6
+Your team is migrating a bare-metal workload cluster to a new management cluster in a different datacenter. You execute `clusterctl move` to pivot the state. Afterward, the target management cluster successfully reports the status of `Cluster` and `Machine` objects, but it is completely unable to see or control the underlying physical servers (e.g., `BareMetalHost` objects). What critical step was missed during the pivot preparation, and why is it necessary?
+
+<details>
+<summary>Answer</summary>
+
+**The physical hosts were not explicitly labeled for the move operation before the pivot was initiated.** When executing `clusterctl move`, the command safely transfers standard Cluster API resources by following a default discovery graph. However, objects that reside outside this default graph—such as CAPM3's specific `BareMetalHost` CRDs—are ignored unless they are explicitly tagged. You must apply the `clusterctl.cluster.x-k8s.io/move` label (or a similar hierarchy label) to these non-standard objects so that the move command recognizes their association with the cluster. Failing to do so leaves the physical infrastructure definitions behind on the source cluster, resulting in orphaned hardware that the target management cluster cannot see or manage.
+</details>
+
+### Question 7
+You have just completed a `clusterctl move` operation to pivot management state to a newly built management cluster. A junior engineer panics and alerts you that all `Machine` and `Cluster` objects on the new management cluster show completely empty status fields, fearing that the physical nodes have lost their state and might be rebooted. How do you explain the architectural reason for this behavior to reassure them that the cluster state is not broken?
+
+<details>
+<summary>Answer</summary>
+
+**You can reassure the engineer that this is the expected, safe behavior of a pivot operation and the cluster state is completely intact.** The `clusterctl move` command is specifically designed to transfer the declarative definitions (the `spec` fields) of your workload clusters to the new management cluster. However, the `status` subresources are intentionally not restored because they represent ephemeral, point-in-time state maintained exclusively by active controllers. Once the move is complete and the new management cluster's controllers begin their first reconciliation loop, they will independently observe the workload cluster, verify the physical infrastructure, and automatically rebuild the status fields. The physical nodes and their workloads remain entirely unaffected during this controller handoff.
+</details>
+
+### Question 8
+To optimize resource utilization on a highly constrained edge management cluster, a platform engineer proposes modifying the `clusterctl init` command to skip the core provider installation, arguing that only the infrastructure and bootstrap providers are strictly necessary. Based on Cluster API's architecture, will this proposed optimization work? Explain the technical role of the core provider to justify your answer.
+
+<details>
+<summary>Answer</summary>
+
+**No, this proposed optimization will completely break the management cluster because the core provider is mandatory.** Cluster API fundamentally relies on the core provider to establish and manage the foundational Custom Resource Definitions, such as `Cluster` and `Machine`, which all other providers depend upon. While it is possible to skip the installation of bootstrap and control-plane providers using `-` placeholders during `clusterctl init`, the tool does not support skipping the core provider. Without the core controller orchestrating the top-level lifecycle logic and reconciling these primary objects, the infrastructure and bootstrap providers would have no abstract state to act upon, rendering the entire Cluster API deployment non-functional.
+</details>
 
 ## Hands-On Exercise: Cluster API with Docker (Simulation)
 
@@ -530,95 +726,29 @@ kind delete cluster --name capi-mgmt
 - [ ] Workers scaled from 2 to 4
 - [ ] Cluster deleted cleanly (all machines deprovisioned)
 
-## Quiz
-
-### Question 1
-Your datacenter experiences a partial power failure that takes down the entire 3-node HA management cluster. However, the physical servers hosting your production workload clusters remain online. What happens to the applications running on the workload clusters, and what operational capabilities are lost while the management cluster is down?
-
-<details>
-<summary>Answer</summary>
-
-**Yes, workload clusters continue to function normally.** The management cluster strictly oversees the declarative lifecycle (creation, scaling, upgrades, health checks) of the workload clusters, acting as an external orchestrator. Once a workload cluster is fully provisioned, its control plane, worker nodes, and workloads operate entirely independently of the management cluster. However, during the outage, you lose the ability to scale nodes, trigger Kubernetes upgrades, or rely on `MachineHealthCheck` auto-remediation, meaning any hardware failures in the workload clusters will require manual intervention until the management cluster is restored. For this reason, it is typically advised to run the management cluster in a highly available configuration with regular etcd backups.
-</details>
-
-### Question 2
-A new security vulnerability requires you to urgently upgrade your 50-node bare-metal production cluster from Kubernetes v1.34.0 to v1.35.0. You are using Cluster API with a GitOps workflow. Describe the exact mechanism by which Cluster API rolls out this upgrade across the physical servers without causing application downtime.
-
-<details>
-<summary>Answer</summary>
-
-**Rolling upgrade via CAPI is managed identically to a Pod Deployment rollout.** First, you update the `version` field (e.g., to `v1.35.0`) in your Git repository for the `TalosControlPlane` and `MachineDeployment` manifests, which ArgoCD or Flux applies to the management cluster. CAPI's controllers detect this version change and initiate a rolling update by provisioning a new physical machine with the updated version. Once the new machine joins the cluster and reports a `Ready` status, CAPI gracefully cordons and drains an old machine, deletes its `Machine` object, and allows the infrastructure provider to securely wipe and return the old server to the hardware pool. This process repeats—upgrading the control plane first, then the workers—ensuring that application workloads are seamlessly rescheduled without downtime, provided there is enough buffer capacity in your physical server pool.
-</details>
-
-### Question 3
-Your organization is designing a new edge computing platform. Team A wants to use standard Ubuntu with various custom kernel modules, while Team B insists on a minimal, immutable OS like Talos Linux to reduce the attack surface. Based on these OS preferences, how would you decide between Metal3 and Sidero for your Cluster API infrastructure provider, and what are the architectural tradeoffs?
-
-<details>
-<summary>Answer</summary>
-
-**Your choice between Metal3 and Sidero hinges entirely on your operating system strategy and desired operational complexity.** If Team A's requirement for standard Ubuntu and custom kernel modules prevails, you must choose Metal3. Metal3 utilizes Ironic under the hood, making it highly capable of PXE booting and provisioning a wide variety of traditional operating systems, though it introduces a more complex architectural footprint. Conversely, if Team B's vision for an immutable, minimal OS wins, Sidero is the optimal choice because it is purpose-built exclusively for Talos Linux. Sidero eliminates the heavy Ironic dependency, utilizing native DHCP-based auto-discovery to rapidly onboard hardware, resulting in a significantly simpler and more streamlined management stack tailored for immutable environments.
-</details>
-
-### Question 4
-At 2:00 AM on a Sunday, a worker node in your bare-metal production cluster experiences a catastrophic NVMe drive failure, causing its kubelet to stop responding entirely. Walk through the automated sequence of events triggered by the MachineHealthCheck and explain what manual steps, if any, remain for the operations team on Monday morning.
-
-<details>
-<summary>Answer</summary>
-
-**The remediation is fully automated by the MachineHealthCheck controller, dramatically reducing downtime.** When the NVMe drive fails, the node's kubelet stops reporting, causing its status to eventually become `NotReady` or `Unknown`. The `MachineHealthCheck` constantly monitors these conditions; once the timeout threshold (e.g., 5 minutes) is breached, CAPI automatically marks the broken `Machine` for deletion. The infrastructure provider then forcefully deprovisions the server, effectively quarantining it from the available pool, while CAPI simultaneously provisions a brand-new `Machine` on a healthy standby server. By Monday morning, the cluster has already healed itself and restored full capacity, leaving the operations team with only the manual tasks of physically replacing the failed drive, verifying the hardware, and registering the repaired server back into the available bare-metal pool.
-</details>
-
-### Question 5
-Your team is building a custom management cluster and runs `clusterctl init` without any additional flags. During a subsequent audit, you discover that the kubeadm bootstrap and control-plane providers are actively running, even though your architectural design specified a custom bootstrap provider. Why did this happen, and what specific change to the initialization command would have prevented it?
-
-<details>
-<summary>Answer</summary>
-
-**This occurred because `clusterctl init` provisions a default set of providers unless explicitly overridden.** By design, when you execute `clusterctl init` without any flags, the tool automatically fetches and installs the latest versions of the core provider, the kubeadm bootstrap provider, and the kubeadm control-plane provider to ensure a functional baseline. Because your architecture required a custom bootstrap mechanism, the initialization command should have included specific flags or `-` placeholders to bypass the default kubeadm components. To prevent this, you must explicitly declare your custom providers in the command (e.g., `--bootstrap custom-provider`) so that clusterctl bypasses its default selections and aligns with your intended architectural design.
-</details>
-
-### Question 6
-Your team is migrating a bare-metal workload cluster to a new management cluster in a different datacenter. You execute `clusterctl move` to pivot the state. Afterward, the target management cluster successfully reports the status of `Cluster` and `Machine` objects, but it is completely unable to see or control the underlying physical servers (e.g., `BareMetalHost` objects). What critical step was missed during the pivot preparation, and why is it necessary?
-
-<details>
-<summary>Answer</summary>
-
-**The physical hosts were not explicitly labeled for the move operation before the pivot was initiated.** When executing `clusterctl move`, the command safely transfers standard Cluster API resources by following a default discovery graph. However, objects that reside outside this default graph—such as CAPM3's specific `BareMetalHost` CRDs—are ignored unless they are explicitly tagged. You must apply the `clusterctl.cluster.x-k8s.io/move` label (or a similar hierarchy label) to these non-standard objects so that the move command recognizes their association with the cluster. Failing to do so leaves the physical infrastructure definitions behind on the source cluster, resulting in orphaned hardware that the target management cluster cannot see or manage.
-</details>
-
-### Question 7
-You have just completed a `clusterctl move` operation to pivot management state to a newly built management cluster. A junior engineer panics and alerts you that all `Machine` and `Cluster` objects on the new management cluster show completely empty status fields, fearing that the physical nodes have lost their state and might be rebooted. How do you explain the architectural reason for this behavior to reassure them that the cluster state is not broken?
-
-<details>
-<summary>Answer</summary>
-
-**You can reassure the engineer that this is the expected, safe behavior of a pivot operation and the cluster state is completely intact.** The `clusterctl move` command is specifically designed to transfer the declarative definitions (the `spec` fields) of your workload clusters to the new management cluster. However, the `status` subresources are intentionally not restored because they represent ephemeral, point-in-time state maintained exclusively by active controllers. Once the move is complete and the new management cluster's controllers begin their first reconciliation loop, they will independently observe the workload cluster, verify the physical infrastructure, and automatically rebuild the status fields. The physical nodes and their workloads remain entirely unaffected during this controller handoff.
-</details>
-
-### Question 8
-To optimize resource utilization on a highly constrained edge management cluster, a platform engineer proposes modifying the `clusterctl init` command to skip the core provider installation, arguing that only the infrastructure and bootstrap providers are strictly necessary. Based on Cluster API's architecture, will this proposed optimization work? Explain the technical role of the core provider to justify your answer.
-
-<details>
-<summary>Answer</summary>
-
-**No, this proposed optimization will completely break the management cluster because the core provider is mandatory.** Cluster API fundamentally relies on the core provider to establish and manage the foundational Custom Resource Definitions, such as `Cluster` and `Machine`, which all other providers depend upon. While it is possible to skip the installation of bootstrap and control-plane providers using `-` placeholders during `clusterctl init`, the tool does not support skipping the core provider. Without the core controller orchestrating the top-level lifecycle logic and reconciling these primary objects, the infrastructure and bootstrap providers would have no abstract state to act upon, rendering the entire Cluster API deployment non-functional.
-</details>
-
 ## Next Module
 
 Continue to [Module 3.1: Datacenter Network Architecture](/on-premises/networking/module-3.1-datacenter-networking/) to learn about spine-leaf topology, VLANs, and network design for on-premises Kubernetes.
 
 ## Sources
 
-- [cluster-api.sigs.k8s.io](https://cluster-api.sigs.k8s.io/) — The Cluster API book describes the project, its SIG ownership, and its declarative lifecycle-management purpose.
-- [cluster-api.sigs.k8s.io: concepts.html](https://cluster-api.sigs.k8s.io/user/concepts.html) — The Cluster API concepts documentation defines management clusters, workload clusters, providers, Machines, and reconciliation responsibilities.
-- [cluster-api.sigs.k8s.io: init.html](https://cluster-api.sigs.k8s.io/clusterctl/commands/init.html) — The clusterctl init command reference documents default provider installation, version selection, prerelease behavior, and skip semantics.
-- [github.com: cluster api provider metal3](https://github.com/metal3-io/cluster-api-provider-metal3) — The CAPM3 repository identifies the project as the Cluster API provider for Metal3 bare-metal infrastructure.
-- [github.com: baremetal operator](https://github.com/metal3-io/baremetal-operator) — The Bare Metal Operator repository documents BareMetalHost as the CRD for host enrollment, inspection, provisioning, and cleaning.
-- [cluster-api.sigs.k8s.io: upgrading clusters.html](https://cluster-api.sigs.k8s.io/tasks/upgrading-clusters.html) — Cluster API upgrade documentation covers MachineDeployment-driven rollouts and Kubernetes version changes.
-- [cluster-api.sigs.k8s.io: healthchecking.html](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking.html) — The Cluster API MachineHealthCheck documentation directly describes unhealthy conditions, remediation, and maxUnhealthy safeguards.
-- [cluster-api.sigs.k8s.io: move](https://cluster-api.sigs.k8s.io/clusterctl/commands/move) — The clusterctl move command reference documents object movement, provider compatibility requirements, and status behavior.
-- [cluster-api.sigs.k8s.io: versions.html](https://cluster-api.sigs.k8s.io/reference/versions.html) — The Cluster API version support page documents maintained releases, emergency maintenance, EOL dates, and Kubernetes compatibility matrices.
-- [kubernetes.io: cluster api v1 12 release](https://kubernetes.io/blog/2026/01/27/cluster-api-v1-12-release/) — The Kubernetes release blog for Cluster API v1.12 discusses in-place updates, chained upgrades, and the update-extension model.
-- [cncf.io: metal3 io](https://www.cncf.io/projects/metal3-io/) — The CNCF project page records Metal3's sandbox and incubation dates.
-- [cluster-api.sigs.k8s.io: quick start.html](https://cluster-api.sigs.k8s.io/user/quick-start.html) — The Cluster API quick start documents the Docker infrastructure provider as the local development/test path.
+- [Cluster API Book](https://cluster-api.sigs.k8s.io/) — Current Cluster API documentation, project scope, and versioned book entry point.
+- [Cluster API Concepts](https://cluster-api.sigs.k8s.io/user/concepts.html) — Management clusters, workload clusters, Machines, MachineDeployments, providers, and MachineHealthCheck behavior.
+- [clusterctl init](https://cluster-api.sigs.k8s.io/clusterctl/commands/init.html) — Default provider installation behavior, provider selection, and skip semantics.
+- [Cluster API Quick Start](https://cluster-api.sigs.k8s.io/user/quick-start.html) — Docker provider simulation path used by the hands-on exercise.
+- [Cluster API Releases](https://github.com/kubernetes-sigs/cluster-api/releases) — Current release notes, Kubernetes version support, and API deprecation warnings.
+- [Cluster API Version Support](https://cluster-api.sigs.k8s.io/reference/versions.html) — Release support and Kubernetes compatibility policy.
+- [Cluster API Provider Metal3](https://github.com/metal3-io/cluster-api-provider-metal3) — CAPM3 installation, BMO decoupling, pivoting notes, and active release context.
+- [CAPM3 API Documentation](https://github.com/metal3-io/cluster-api-provider-metal3/blob/main/docs/api.md) — Current CAPI and CAPM3 object examples, including `Cluster`, `MachineDeployment`, and `Metal3MachineTemplate`.
+- [Metal3 User Guide](https://book.metal3.io/) — Metal3 architecture, Kubernetes-native bare-metal management, and Ironic relationship.
+- [Metal3 Provisioning](https://book.metal3.io/bmo/provisioning.html) — BareMetalHost image provisioning and deprovisioning behavior.
+- [Metal3 Host State Machine](https://book.metal3.io/bmo/state_machine.html) — BareMetalHost registration, inspection, provisioning, deprovisioning, and status fields.
+- [Bare Metal Operator](https://github.com/metal3-io/baremetal-operator) — BMO inventory, inspection, image provisioning, and disk-cleaning capabilities.
+- [Ironic Redfish Driver](https://docs.openstack.org/ironic/latest/admin/drivers/redfish.html) — Redfish boot-mode handling and virtual-media boot behavior.
+- [Ironic Ramdisk and ISO Boot](https://docs.openstack.org/ironic/latest/admin/ramdisk-boot.html) — PXE, iPXE, and Redfish virtual-media ramdisk or ISO boot support.
+- [Tinkerbell Homepage](https://tinkerbell.org/) — Current Tinkerbell component overview and declarative bare-metal positioning.
+- [Tinkerbell Services](https://tinkerbell.org/docs/v0.22/services/) — Smee, Tootles, Tink, Rufio, PBnJ, and CAPT service documentation.
+- [Cluster API Provider Tinkerbell Docs](https://tinkerbell.org/docs/v0.22/services/cluster-api-provider-tinkerbell/) — Official Tinkerbell documentation for CAPT's role as a CAPI infrastructure provider.
+- [Cluster API Provider Tinkerbell Repository](https://github.com/tinkerbell/cluster-api-provider-tinkerbell) — CAPT release and compatibility context.
+- [Tinkerbell CNCF Project Page](https://www.cncf.io/projects/tinkerbell/) — Current CNCF maturity status and project description.
+- [Metal3 CNCF Project Page](https://www.cncf.io/projects/metal3-io/) — Current CNCF maturity status and project dates.

--- a/src/content/docs/on-premises/provisioning/module-2.4-declarative-bare-metal.md
+++ b/src/content/docs/on-premises/provisioning/module-2.4-declarative-bare-metal.md
@@ -23,7 +23,7 @@ After completing this module, you will be able to:
 
 The *Infrastructure as Code* module’s Knight Capital 2012 <!-- incident-xref: knight-capital-2012 --> reference is the canonical illustration of why bare-metal and cluster onboarding must be declarative: a single node out of sync can still collapse the reliability of a broader estate.
 
-Modern infrastructure relies on consistency. A financial services company managing multiple Kubernetes clusters across two datacenters using procedural configuration management and shell scripts faces similar risks. Traditionally, it took days to spin up a single cluster: time spent finding servers in an outdated spreadsheet, executing manual PXE boots, running installation binaries, and verifying networking. Decommissioning was equally dangerous, as engineers hesitated to wipe disks without absolute certainty about the server's state, leading to massive resource waste and security vulnerabilities. Every manual step in a provisioning pipeline introduces the potential for human error, turning what should be a deterministic process into a game of chance.
+Modern infrastructure relies on consistency. **Hypothetical scenario:** a financial services company managing multiple Kubernetes clusters across two datacenters using procedural configuration management and shell scripts faces similar risks. Traditionally, it took days to spin up a single cluster: time spent finding servers in an outdated spreadsheet, executing manual PXE boots, running installation binaries, and verifying networking. Decommissioning was equally dangerous, as engineers hesitated to wipe disks without absolute certainty about the server's state, leading to massive resource waste and security vulnerabilities. Every manual step in a provisioning pipeline introduces the potential for human error, turning what should be a deterministic process into a game of chance.
 
 Cluster API fundamentally changes this narrative. By extending Kubernetes to manage its own infrastructure, you can define a physical server cluster in YAML, apply it, and the system provisions hardware, installs the OS, bootstraps Kubernetes, and joins nodes—all declaratively, auditable, and fully version-controlled in Git. No manual steps. No spreadsheets. No single point of failure during deployment. By shifting from imperative scripts to declarative state, you eliminate the configuration drift class of outages at scale.
 
@@ -392,7 +392,7 @@ kubectl --kubeconfig production.kubeconfig get nodes
 
 ## Automated Remediation and Machine Health
 
-One of the most powerful features of Cluster API is the ability to automatically remediate failed nodes by replacing them with fresh hardware from the pool. This drastically reduces the mean time to recovery (MTTR) during hardware failures. [The `MachineHealthCheck` resource monitors the status of individual machines and aggressively evicts and replaces nodes that fall out of compliance](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking.html).
+One of the most powerful features of Cluster API is the ability to automatically remediate failed nodes by replacing them with fresh hardware from the pool. This drastically reduces the mean time to recovery (MTTR) during hardware failures. [The `MachineHealthCheck` resource monitors the status of individual machines and aggressively evicts and replaces nodes that fall out of compliance](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking.html). The manifest below uses the still-served `v1beta1` API; CAPI `v1beta2` restructured these into `spec.checks.unhealthyNodeConditions` / `spec.checks.nodeStartupTimeoutSeconds` and a `spec.remediation` block, so do not simply bump the `apiVersion` line without porting the field shape.
 
 ```yaml
 apiVersion: cluster.x-k8s.io/v1beta1
@@ -679,8 +679,22 @@ To optimize resource utilization on a highly constrained edge management cluster
 curl -L https://github.com/kubernetes-sigs/cluster-api/releases/latest/download/clusterctl-linux-amd64 -o clusterctl
 chmod +x clusterctl && sudo mv clusterctl /usr/local/bin/
 
-# Create a kind cluster as the management cluster
-kind create cluster --name capi-mgmt
+# The CAPI Docker provider (CAPD) provisions workload "machines" as sibling
+# containers on the HOST Docker daemon, so the kind management cluster must mount
+# the host Docker socket. Without this extraMount the machines hang in
+# Provisioning and the ControlPlaneReady wait below times out.
+cat > kind-cluster-with-extramounts.yaml <<'EOF'
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+  - role: control-plane
+    extraMounts:
+      - hostPath: /var/run/docker.sock
+        containerPath: /var/run/docker.sock
+EOF
+
+# Create a kind cluster as the management cluster (with the Docker socket mount)
+kind create cluster --name capi-mgmt --config kind-cluster-with-extramounts.yaml
 
 # Initialize CAPI with Docker provider
 clusterctl init --infrastructure docker


### PR DESCRIPTION
On-premises track drain **Wave 1** (planning + provisioning, curriculum order). Refs #1881.

Verifier-first scoping → 2 genuine expands + 2 review→flips. Every module cross-family reviewed (mixed families, no OAuth burst), **every finding ground-checked against the live file before fixing**, build green (2171 pages).

| Module | Verifier | Author | Reviewer (family) | Real defects fixed (all verifier-blind) |
|---|---|---|---|---|
| planning/1.2 server-sizing | T0/6048w | cursor (expand 3788→6048) | deepseek | **fabricated dated opener** (pre-existing) → `Hypothetical scenario:`; etcd-NVMe table contradiction; mega-node "equal aggregate capacity" arithmetic (now 16×64c/512GB = 4×256c/2TB exactly) |
| planning/1.3 cluster-topology | T0/5074w | — (review-flip) | opus | invalid RFC-1123 pod name; **reserved `node.kubernetes.io/gpu` taint namespace** → `nvidia.com/gpu`; **fabricated Ceph StorageClass param** removed; stretched-vs-multi-cluster quiz terminology |
| provisioning/2.2 pxe-provisioning | T0/5232w | — (review-flip) | cursor | **P1: Ubuntu autoinstall missing `url=`** (casper had no rootfs → install fails); match client-arch type 9; name DHCP options 66/67/60/93 |
| provisioning/2.4 declarative-bare-metal | T0/6444w | codex (expand 2788→6444) | opus | **P1: CAPD hands-on missing host docker.sock extraMount** (machines hang → `kubectl wait` times out); war-story `Hypothetical scenario:` label; MHC v1beta1↔v1beta2 field-shape note |

**Rejected (defensible, not changed):** deepseek's "64-core CP node is idle at 2000+ nodes" — the kube-apiserver is multi-threaded and CPU-scales with cluster size.

**Known minor follow-ups (not blocking flip):** 2.4 mermaid arrow IDs render phantom nodes (opus nit); 2.2 `${buildarch}` vs DHCP option-93 nuance (cursor P2); 2.2 dnsmasq case nit.

Notes:
- gemini's 2.2 review died with empty output (known headless failure) → re-routed to cursor.
- Build verified in primary (2171 pages, Complete!, no schema errors). PR CI runs site-health + dedup + CodeQL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)