### PR TITLE
fix(on-premises): drop stale revision_pending on 1.2 server-sizing (#1881)

### DIFF
--- a/src/content/docs/on-premises/planning/module-1.2-server-sizing.md
+++ b/src/content/docs/on-premises/planning/module-1.2-server-sizing.md
@@ -1,6 +1,5 @@
 ---
 citations_verified: true
-revision_pending: true
 title: "Module 1.2: Server Sizing & Hardware Selection"
 slug: on-premises/planning/module-1.2-server-sizing
 sidebar:


### PR DESCRIPTION
One-line frontmatter cleanup. The `revision_pending: true` banner pinned module 1.2 (already reviewed in #1882, T0, heuristic 5.0, stage COMMITTED, APPROVE) to `needs_rewrite` on the /quality board. Removing it flips it to `done`, completing on-premises wave 1. Refs #1881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)