### PR TITLE
docs(on-premises): wave 3 — 1.5/2.3 + multi-cluster 5.1–5.5 review→flip (#1881)

### DIFF
--- a/src/content/docs/on-premises/multi-cluster/module-5.1-private-cloud.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.1-private-cloud.md
@@ -1,7 +1,6 @@
 ---
 title: "Module 5.1: Private Cloud Platforms"
 slug: on-premises/multi-cluster/module-5.1-private-cloud
-revision_pending: false
 sidebar:
   order: 2
 ---
@@ -44,7 +43,7 @@ Neutron provides networks, subnets, routers, security groups, and advanced overl
 
 Glance stores bootable images that Nova consumes during instance creation. Platform teams often maintain golden images with hardened SSH settings, auditing agents, and preinstalled container runtime packages so kubeadm or Ansible runs finish quickly. Swift offers durable object storage for backups, Helm chart mirrors, or log archives when you do not want those objects on POSIX volumes. Cinder provides persistent block volumes that map cleanly to Kubernetes PersistentVolumeClaims when you install the Cinder CSI driver and storage classes with the right availability zone hints.
 
-Magnum clusters illustrate the alternative Kubernetes-on-OpenStack path where a COE template provisions masters and minions as Nova instances with Neutron networks already wired. Magnum suits teams that want OpenStack-native lifecycle APIs, but you must track Magnum, Heat, and Kubernetes version matrices together. When Magnum lags behind upstream Kubernetes, platform teams fall back to kubeadm on self-managed networks while still using Cinder and Octavia through the cloud provider, which is why this module emphasizes service ownership over any single installer.
+Magnum clusters illustrate the alternative Kubernetes-on-OpenStack path where a COE template provisions masters and minions as Nova instances with Neutron networks already wired. Magnum suits teams that want OpenStack-native lifecycle APIs, but you must track Magnum and Kubernetes version matrices (and whether your deployment uses the Heat- or CAPI-based driver—the legacy Heat driver is deprecated in favor of Cluster API drivers). When Magnum lags behind upstream Kubernetes, platform teams fall back to kubeadm on self-managed networks while still using Cinder and Octavia through the cloud provider, which is why this module emphasizes service ownership over any single installer.
 
 ```mermaid
 flowchart TB
@@ -73,7 +72,7 @@ flowchart TB
     KW --> NT
 ```
 
-Security groups act as stateful firewalls around instance ports; Kubernetes node security groups must allow kubelet, etcd, and CNI tunnel traffic between members while denying arbitrary corporate clients to kubelet port 10250. Document required rules in Git beside cluster templates so auditors can diff rule changes during penetration test remediations instead of discovering ad hoc holes opened during late-night incidents.
+Security groups act as stateful firewalls around instance ports; node security groups must allow kubelet and CNI tunnel traffic between members (and etcd peer/client traffic on control-plane nodes) while denying arbitrary clients to kubelet 10250. Document required rules in Git beside cluster templates so auditors can diff rule changes during penetration test remediations instead of discovering ad hoc holes opened during late-night incidents.
 
 Operational teams should also plan upgrades across the OpenStack control plane independently from Kubernetes minor version bumps. A broken Neutron agent rolling upgrade can strand new node joins while existing workloads keep running, which looks like a Kubernetes failure even though the kubelet is healthy. Document dependency order: Keystone and Galera or PostgreSQL backing stores first, then API services, then hypervisor agents, then Kubernetes cloud provider credentials rotation.
 
@@ -129,11 +128,11 @@ Content libraries distribute OVF templates for worker nodes with cloud-init scri
 
 ## CloudStack, oVirt, and Alternative Private Cloud Stacks
 
-Apache CloudStack targets organizations that want an Apache-licensed cloud management plane with a smaller service surface than full OpenStack. It presents zones, pods, clusters, primary storage, secondary storage, and system VMs that implement routing and console proxy functions. Kubernetes integration typically means launching instances through CloudStack’s compute service and attaching volumes through its disk offerings, then installing a CSI or in-tree provider where community support exists for your release combination.
+Apache CloudStack targets organizations that want an Apache-licensed cloud management plane with a smaller service surface than full OpenStack. It presents zones, pods, clusters, primary storage, secondary storage, and system VMs that implement routing and console proxy functions. Kubernetes integration typically means launching instances through CloudStack’s compute service and attaching volumes through its disk offerings, then installing the CloudStack CSI driver (csi.cloudstack.apache.org); in-tree cloud providers are removed in modern Kubernetes.
 
 CloudStack networking models include basic zones with flat networking and advanced zones with VLAN-isolated guest networks and virtual routers. The choice affects how you carve Service CIDRs and whether pod networks can reach corporate RFC1918 space without NAT hairpins. Because CloudStack clusters often serve managed service providers, quota and account isolation features map naturally to tenant namespaces in Kubernetes when you align project IDs with cloud accounts.
 
-oVirt, downstream of Red Hat Virtualization concepts, centers on datacenters, clusters, hosts, storage domains, and logical networks managed through the Engine API. RHV customers migrating to OpenShift Virtualization may recognize the lineage, but oVirt remains relevant for teams standardizing on KVM without adopting the entire OpenStack control plane footprint. Kubernetes nodes run as oVirt VMs with disks on NFS, iSCSI, or Fibre Channel domains depending on performance needs.
+oVirt is the upstream community KVM-management project; Red Hat Virtualization (RHV) was its downstream commercial distribution (now reaching end-of-life), with OpenShift Virtualization as the successor for RHV workloads. oVirt centers on datacenters, clusters, hosts, storage domains, and logical networks managed through the Engine API. Kubernetes nodes run as oVirt VMs with disks on NFS, iSCSI, or Fibre Channel domains depending on performance needs.
 
 Harvester and other hyperconverged platforms blur the line between virtualization and Kubernetes by shipping both layers together. This module mentions them because decision makers compare them against vSphere and OpenStack, yet the integration patterns for Kubernetes still reduce to reliable VM networking, persistent disks, and a cloud provider that understands the platform API. Evaluate these alternatives when your team size cannot operate a dozen OpenStack projects but you still need multi-tenant VM APIs better than manual vCenter clicks.
 
@@ -200,9 +199,9 @@ Cluster API can treat private cloud VMs as machines when providers exist for you
 
 Worker scaling should respect cloud quotas and IP address consumption. Autoscaler integrations need Nova or vSphere APIs that can create instances faster than pods accumulate, and they need pre-baked images to avoid thirty-minute apt installs during incidents. Store join tokens and bootstrap secrets in vaults with rotation policies; baking long-lived tokens into golden images has caused full-cluster compromises when an image leaked to a less trusted project.
 
-Red Hat OpenShift on RHV or oVirt inherits similar VM dependencies while adding Operator lifecycle for cluster components. VMware Tanzu Kubernetes Grid clusters provision through Tanzu Mission Control or standalone management clusters depending on edition, yet both still require compatible vSphere versions and NSX configurations documented in VMware interoperability matrices. Choose container-native paths when your organization values vendor-supported upgrade highways; choose kubeadm on Nova or vSphere VMs when you need maximum customization and already employ Ansible expertise.
+Red Hat OpenShift on RHV or oVirt inherits similar VM dependencies while adding Operator lifecycle for cluster components. VMware Tanzu Kubernetes Grid clusters provision through Tanzu Mission Control Self-Managed (TMC-SM) or standalone management clusters depending on edition—the Tanzu Mission Control SaaS offering reached end-of-life on 2025-11-15, with Broadcom directing customers to TMC-SM—yet both paths still require compatible vSphere versions and NSX configurations documented in VMware interoperability matrices. Choose container-native paths when your organization values vendor-supported upgrade highways; choose kubeadm on Nova or vSphere VMs when you need maximum customization and already employ Ansible expertise.
 
-The Kubernetes cloud provider documentation describes how provider IDs, routes, and load balancers reconcile per platform. On OpenStack, install the external cloud-controller-manager chart with correct `cloud.conf` secrets referencing Keystone application credentials scoped to the tenant project. On vSphere, enable the CPI and CSI with paravirtual or full feature sets matching your vCenter permissions model. Skipping either component produces nodes labeled `node.kubernetes.io/exclude-from-external-load-balancers` incorrectly or Services that never receive VIPs, which wastes days of CNI debugging.
+The Kubernetes cloud provider documentation describes how provider IDs, routes, and load balancers reconcile per platform. On OpenStack, install the external cloud-controller-manager chart with correct `cloud.conf` secrets referencing Keystone application credentials scoped to the tenant project. On vSphere, enable the CPI and CSI with paravirtual or full feature sets matching your vCenter permissions model. Skipping either leaves LoadBalancer Services `<pending>` and provider IDs unset, which wastes days of CNI debugging.
 
 ## IPAM, DHCP, and DNS Dependencies
 
@@ -327,7 +326,7 @@ Use the public OpenStack API quick start documentation to list endpoints for Key
 ```bash
 # After sourcing openrc for your project:
 openstack endpoint list --interface public -c "Service Name" -c URL
-openstack quota show --project "$(openstack project list -f value -c ID | head -1)"
+openstack quota show "$(openstack project list -f value -c ID | head -1)"
 openstack network list
 openstack flavor list
 ```
@@ -404,7 +403,7 @@ mkdir -p "$HOME/.kube"
 sudo cp -i /etc/kubernetes/admin.conf "$HOME/.kube/config"
 sudo chown "$(id -u):$(id -g)" "$HOME/.kube/config"
 kubectl get nodes
-kubectl apply -f https://raw.githubusercontent.com/flannel-io/flannel/master/Documentation/kube-flannel.yml
+kubectl apply -f https://github.com/flannel-io/flannel/releases/latest/download/kube-flannel.yml
 ```
 
 - [ ] I initialized a control plane VM on libvirt or OpenStack and joined nothing else yet.
@@ -423,7 +422,7 @@ Continue to [Module 5.2: Multi-Cluster Control Planes](./module-5.2-multi-cluste
 
 ## Learner Check
 
-> **Pause and predict**: your OpenStack cloud can boot instances quickly, yet Kubernetes Services of type LoadBalancer stay pending forever. Which two services would you inspect first, and what misconfiguration often explains the symptom? Keystone and Neutron are the usual starting points because the cloud controller must authenticate and create ports on the correct provider network with available addresses from the load balancer subnet pool.
+> **Pause and predict**: your OpenStack cloud can boot instances quickly, yet Kubernetes Services of type LoadBalancer stay pending forever. Which two services would you inspect first, and what misconfiguration often explains the symptom? After Keystone auth, inspect **Neutron and Octavia**—the cloud controller must create ports and listeners on the correct provider network with available addresses from the load balancer subnet pool (Octavia owns the LB VIP/listener path).
 
 ## Sources
 

--- a/src/content/docs/on-premises/multi-cluster/module-5.2-multi-cluster-control-planes.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.2-multi-cluster-control-planes.md
@@ -3,7 +3,6 @@ title: "Module 5.2: Multi-Cluster Control Planes"
 slug: on-premises/multi-cluster/module-5.2-multi-cluster-control-planes
 sidebar:
   order: 3
-revision_pending: false
 ---
 
 > **Complexity**: `[ADVANCED]` | Time: 55–65 minutes
@@ -90,7 +89,7 @@ CAPI intentionally splits **infrastructure lifecycle** from **application delive
 A minimal management-cluster install uses `clusterctl` to initialize providers:
 
 ```bash
-# Install clusterctl matching your target Kubernetes minor version
+# Install clusterctl per the CAPI release support matrix (illustrative pin v1.12.1)
 curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.1/clusterctl-linux-amd64 -o clusterctl
 chmod +x clusterctl && sudo mv clusterctl /usr/local/bin/
 
@@ -113,7 +112,7 @@ Production on-premises stacks add CAPV (vSphere), CAPO (OpenStack), or CAPM3 (Me
 
 Exercise scenario: a platform team must **design** a **management-cluster** **architecture** that **provisions** and **upgrades** **workload** **clusters** on VMware vSphere while keeping factory-edge sites on bare metal. They choose one management cluster in the primary datacenter running CAPI with CAPV for virtualized workload clusters and CAPM3 for metal edge sites. The design document lists three etcd nodes on fast storage, two worker nodes tainted for `fleet=capi`, and outbound Git access to an internal Gitea mirror.
 
-When a developer requests a staging cluster, the flow is: merge request adds a `Cluster` manifest to the `clusters/staging/` directory; CAPI controllers create three control-plane VMs and three workers through vSphere templates; upon `Ready`, Rancher Fleet imports the cluster label `env=staging` and applies the platform bundle (Cilium, Longhorn, ingress-nginx); only then do application pipelines receive kubeconfig credentials via OIDC. Upgrades follow the same Git trail: bump `spec.topology.version` on the `KubeadmControlPlane`, watch rolling VM replacement, then advance Fleet bundle pins after conformance tests pass.
+When a developer requests a staging cluster, the flow is: merge request adds a `Cluster` manifest to the `clusters/staging/` directory; CAPI controllers create three control-plane VMs and three workers through vSphere templates; upon `Ready`, Rancher Fleet imports the cluster label `env=staging` and applies the platform bundle (Cilium, Longhorn, ingress-nginx); only then do application pipelines receive kubeconfig credentials via OIDC. Upgrades follow the same Git trail: bump `KubeadmControlPlane.spec.version` on standalone clusters (or `Cluster.spec.topology.version` when using ClusterClass topology), watch rolling VM replacement, then advance Fleet bundle pins after conformance tests pass.
 
 This **design** deliberately keeps CAPM3 edge **clusters** off the same MachineDeployment template as vSphere staging **clusters** because BMC timing, firmware validation, and PXE networks differ from DRS-backed VM creation. Attempting one template for both surfaces would force edge exceptions into manual runbooks—the exact toil the management plane exists to eliminate. Documenting those boundaries in architecture reviews prevents “temporary” SSH steps from becoming permanent operational debt.
 
@@ -249,7 +248,7 @@ OCM’s policy framework attaches policies to `PlacementRule` or `Placement` dec
 
 Design policies for **fail-closed** platform safety: require labels, block `latest` tags in production placements, enforce resource quotas via generated policies, and validate ingress TLS settings. Keep application-team policies in separate Git repositories to avoid merge contention with platform engineers.
 
-Sync waves matter: admission policies must exist before workloads that violate them, or CI will flap. Use GitOps sync hooks or OCM `ManifestWork` dependencies to order installation.
+Sync waves matter: admission policies must exist before workloads that violate them, or CI will flap. Use Argo CD or Fleet sync waves, or controller/CI sequencing—`ManifestWork` has no arbitrary dependency primitive (OCM 1.3 adds kind-ordering only).
 
 To **implement** **policy** **distribution** safely, start from a golden repository structured by blast radius:
 
@@ -325,7 +324,7 @@ flowchart LR
 
 Choose networking based on whether you need pod IP reachability (Submariner gateways), cross-cluster **Service** DNS/discovery (Submariner Lighthouse or Cilium ClusterMesh), or L7 policy with mTLS (Istio). Many teams implement only GitOps federation first, then discover application dependencies that require east-west connectivity—budget time accordingly.
 
-**Submariner** deploys gateway nodes that encapsulate traffic between pod CIDRs. On-premises routing teams must install routes or BGP advertisements pointing remote pod CIDRs at Submariner gateways. **Lighthouse** publishes `ServiceExport` objects and serves MCS DNS so clients resolve remote cluster Services by name. NAT scenarios use Globalnet when overlapping service CIDRs cannot be renumbered. Latency-sensitive workloads should measure cross-site RTT before assuming pod-to-pod access is free.
+**Submariner** deploys gateway nodes that encapsulate traffic between pod CIDRs. Route Agents program node routing/VXLAN to the active Gateway; underlay prerequisites are gateway reachability, firewall rules, and NAT mapping—not BGP pod-CIDR advertisement on every router. **Lighthouse** publishes `ServiceExport` objects and serves MCS DNS so clients resolve remote cluster Services by name. NAT scenarios use Globalnet when overlapping service CIDRs cannot be renumbered. Latency-sensitive workloads should measure cross-site RTT before assuming pod-to-pod access is free.
 
 **Cilium ClusterMesh** requires mutual trust between cluster etcd-visible identities and compatible Cilium versions. Enable clustermesh-apiserver with proper TLS rotation; stale certificates break service discovery silently while pods still run locally. Global services excel at spreading HTTP backends across datacenters when health checks propagate quickly.
 
@@ -363,7 +362,7 @@ Backup scope checklist:
 
 Twelve Prometheus instances are unusable for executive dashboards and slow for on-call engineers. **Observability fan-in** centralizes metrics, logs, and traces while preserving per-cluster isolation labels.
 
-Common metrics pattern: Prometheus agents or lightweight scrapers on spokes remote-write to Thanos Receive or Grafana Mimir on the management site or a dedicated observability cluster. Mandatory labels include `cluster`, `environment`, `site`, and `platform_version`. OCM addon `ObservabilityMetric` resources can deploy collectors consistently.
+Common metrics pattern: Prometheus agents or lightweight scrapers on spokes remote-write to Thanos Receive or Grafana Mimir on the management site or a dedicated observability cluster. Mandatory labels include `cluster`, `environment`, `site`, and `platform_version`. OCM OpenTelemetry Collector addons (`ManagedClusterAddon` for the observability collector, or MultiClusterObservability in RHACM) can deploy collectors consistently.
 
 **HA deduplication differs by backend:** Thanos deduplicates redundant Prometheus replicas at **query time**—the Thanos Querier merges series and drops duplicates using `replica` external labels on scrape targets. Grafana Mimir deduplicates at **ingestion time** via its HA tracker: the distributor keeps samples from only one replica of a HA-paired Prometheus pair, so duplicates never land in long-term storage. Design remote-write labels and HA pairing accordingly when spokes run redundant scrapers.
 
@@ -383,7 +382,7 @@ Runbooks should state explicit **failover** steps: if the primary metrics store 
 
 1. Cluster API is a subproject of Kubernetes SIG Cluster Lifecycle—not a CNCF incubating project on its own—and providers ship independently from Kubernetes minor releases.
 2. Open Cluster Management’s klusterlet uses a pull model so edge clusters behind outbound-only firewalls can receive `ManifestWork` without exposing their API servers to the corporate CI network.
-3. Cilium ClusterMesh requires non-overlapping pod and service CIDRs across member clusters, a planning constraint that must be enforced before the first cluster is provisioned.
+3. Cilium ClusterMesh requires non-overlapping pod CIDRs, unique cluster names/IDs, and compatible datapath modes across member clusters—a planning constraint that must be enforced before the first cluster is provisioned.
 4. Losing management-cluster etcd quorum typically freezes fleet-wide GitOps and policy updates long before workload-cluster applications stop running—making hub monitoring easy to under-prioritize until the first failed upgrade window.
 
 Platform teams that treat the management cluster as “just another dev cluster” usually learn this lesson during the first coordinated Kubernetes minor upgrade across a fleet. Elevate hub SLOs, backup verification, and etcd latency alerts to the same tier as production workload apiserver monitoring on every private cloud and bare-metal site you operate fleet-wide.
@@ -528,7 +527,16 @@ These exercises use kind clusters and public documentation commands so you can p
 ### Exercise 1: Initialize Cluster API on a kind management cluster
 
 ```bash
-kind create cluster --name capi-mgmt
+cat > kind-capd.yaml <<'EOF'
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: /var/run/docker.sock
+    containerPath: /var/run/docker.sock
+EOF
+kind create cluster --name capi-mgmt --config kind-capd.yaml
 kubectl cluster-info --context kind-capi-mgmt
 
 curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.1/clusterctl-linux-amd64 -o /tmp/clusterctl
@@ -536,6 +544,7 @@ chmod +x /tmp/clusterctl
 /tmp/clusterctl init --infrastructure docker
 
 kubectl wait --for=condition=Ready pod -l cluster.x-k8s.io/provider=cluster-api -n capi-system --timeout=180s
+kubectl wait --for=condition=Ready pod -l cluster.x-k8s.io/provider=infrastructure-docker -n capd-system --timeout=180s
 kubectl get pods -n capi-system
 kubectl get pods -n capd-system
 ```
@@ -586,6 +595,7 @@ metadata:
   name: prometheus-scrape-contract
   namespace: observability-drill
 data:
+  # platform_version is mandatory for fan-in (see Observability section); one mandatory label is intentionally omitted for this drill
   required_labels: "cluster,environment,site"
 EOF
 

--- a/src/content/docs/on-premises/multi-cluster/module-5.3-cluster-api-bare-metal.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.3-cluster-api-bare-metal.md
@@ -116,12 +116,11 @@ spec:
   online: true
   bootMACAddress: "52:54:00:12:34:56"
   bmc:
-    address: "redfish+https://192.168.100.14"
+    address: "redfish+https://192.168.100.14/redfish/v1/Systems/1"
     credentialsName: rack2-u14-bmc-secret
     disableCertificateVerification: false
   rootDeviceHints:
     wwn: "5002538e4020a1b2"
-  hardwareProfile: unknown
 ```
 
 Hardware inventory management extends beyond CR creation. Platform teams label hosts by rack, failure domain, CPU generation, and role (`control-plane`, `worker`, `spare`). Machine templates use `hostSelector` to pin control planes to NVMe-backed hosts and workers to denser storage tiers. Maintain at least ten to fifteen percent spare BareMetalHosts powered off but registered; MachineHealthCheck remediation otherwise creates Machines that sit **Pending** forever when no Available host exists.
@@ -151,7 +150,7 @@ spec:
     spec:
       image:
         url: "https://images.internal.example/os/ubuntu-24.04-k8s-v1.35.qcow2"
-        checksum: "sha256:abcdef0123456789..."
+        checksum: "abcdef0123456789..."
         checksumType: sha256
         format: qcow2
       hostSelector:
@@ -196,7 +195,7 @@ spec:
   controlPlaneEndpoint:
     host: 10.10.50.100   # kube-vip VIP on CP VLAN
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ```
 
 Without a stable VIP, every control-plane Machine carries its own apiserver address and client kubeconfig breaks when that node is deprovisioned during upgrades or remediation events. Document which VLAN owns the VIP, which switches permit gratuitous ARP, how BGP sessions fail over during rack maintenance, and who between network and platform on-call receives the first page when apiserver TLS errors spike. MetalLB address pools for application Services should be carved from different subnets than API VIPs so a exhausted LoadBalancer pool cannot accidentally consume the control-plane address. Run quarterly failover drills: stop kube-vip on one control-plane node, verify clients reconnect through the VIP, then restore and confirm etcd member list matches Machine inventory in the management cluster.
@@ -438,7 +437,16 @@ Use the Docker infrastructure provider to observe CAPI Machine phases, controlle
 ```bash
 curl -L https://github.com/kubernetes-sigs/cluster-api/releases/download/v1.12.5/clusterctl-linux-amd64 -o clusterctl
 chmod +x clusterctl && sudo mv clusterctl /usr/local/bin/
-kind create cluster --name capi-mgmt
+cat > kind-capd.yaml <<'EOF'
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+nodes:
+- role: control-plane
+  extraMounts:
+  - hostPath: /var/run/docker.sock
+    containerPath: /var/run/docker.sock
+EOF
+kind create cluster --name capi-mgmt --config kind-capd.yaml
 export CLUSTER_TOPOLOGY=true
 clusterctl init --infrastructure docker
 clusterctl generate cluster lab --infrastructure docker \
@@ -500,7 +508,7 @@ spec:
   online: true
   bootMACAddress: "52:54:00:aa:bb:01"
   bmc:
-    address: redfish+https://192.0.2.1
+    address: redfish+https://192.0.2.1/redfish/v1/Systems/1
     credentialsName: lab-u01-bmc-secret
     disableCertificateVerification: true
 EOF
@@ -537,7 +545,7 @@ spec:
   controlPlaneEndpoint:
     host: 10.10.50.100
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: KubeadmControlPlane
@@ -564,7 +572,7 @@ spec:
   controlPlaneEndpoint:
     host: 10.10.50.100
     port: 6443
-  noCloudProvider: true
+  cloudProviderEnabled: false
 ---
 apiVersion: controlplane.cluster.x-k8s.io/v1beta1
 kind: TalosControlPlane

--- a/src/content/docs/on-premises/multi-cluster/module-5.4-fleet-management.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.4-fleet-management.md
@@ -25,7 +25,7 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-A regional manufacturer operated forty-seven bare-metal Kubernetes clusters across factory floors, warehouse edge racks, and two central datacenters. Each cluster was provisioned correctly the first time, yet the platform team spent most of their sprint capacity chasing configuration drift: monitoring agents missing on six clusters, ingress controller versions spanning three minor releases, and sealed secrets that expired silently because nobody owned rotation across sites. When a new compliance rule required Pod Security Admission on every production cluster, engineers opened forty-seven pull requests and still missed three edge locations that had been offline during the change window.
+Hypothetical scenario: a regional manufacturer operated forty-seven bare-metal Kubernetes clusters across factory floors, warehouse edge racks, and two central datacenters. Each cluster was provisioned correctly the first time, yet the platform team spent most of their sprint capacity chasing configuration drift: monitoring agents missing on six clusters, ingress controller versions spanning three minor releases, and sealed secrets that expired silently because nobody owned rotation across sites. When a new compliance rule required Pod Security Admission on every production cluster, engineers opened forty-seven pull requests and still missed three edge locations that had been offline during the change window.
 
 They replaced per-cluster GitOps silos with a fleet management plane that separated *what* should run from *where* it should run. A single Placement rule targeting `region=eu` and `hardware=bare-metal` pushed baseline policies to every matching cluster within minutes of registration, while pull-based agents on edge sites continued working through outbound-only firewalls. Bootstrap of a replacement cluster after hardware failure dropped from two days of manual kubectl to a documented join token flow plus automated ManifestWork delivery. The platform team could finally answer the executive question: *Which clusters are non-compliant right now?*
 
@@ -369,7 +369,7 @@ Capacity planning for hub clusters mirrors control plane sizing for large Kubern
 
 - **Rancher Fleet was designed for RKE2 and K3s edge fleets** before broader Kubernetes support, which explains its pull-agent-first model and tolerance for high-latency links to store backrooms and cell towers.
 - **Open Cluster Management originated in Red Hat's multicluster engine work** and became a CNCF Sandbox project; its Placement API inspired several downstream fleet schedulers.
-- **Argo CD ApplicationSet graduated to a core Argo CD controller**, so separate ApplicationSet installs are legacy; fleet designs should target the integrated controller metrics and sharding documentation.
+- **Argo CD ApplicationSet is bundled as a core Argo CD controller**, so separate ApplicationSet installs are legacy; fleet designs should target the integrated controller metrics and sharding documentation.
 - **Karmada's name derives from "karma" plus "armada"** reflecting its goal of scheduling armies of resources across clusters while allowing per-cluster overrides for real-world heterogeneity.
 
 ---
@@ -455,6 +455,7 @@ Create two kind clusters and join the spoke to the hub using the OCM CLI, then d
 kind create cluster --name fleet-hub
 kind create cluster --name fleet-spoke
 kubectl config use-context kind-fleet-hub
+# Inspect the script at the URL before piping to bash
 curl -L https://raw.githubusercontent.com/open-cluster-management-io/clusteradm/main/install.sh | bash
 clusteradm init --wait
 kubectl get pods -n open-cluster-management
@@ -558,7 +559,7 @@ spec:
   paths:
     - multi-cluster/helm
 EOF
-python3 -m pip install pyyaml
+python3 -m pip install --break-system-packages pyyaml  # lab convenience on PEP 668 hosts
 python3 -c "import yaml; yaml.safe_load(open('/tmp/fleet-lab/gitrepo.yaml'))" && echo "GitRepo YAML OK"
 python3 -c "import yaml; yaml.safe_load(open('/tmp/fleet-lab/baseline/fleet.yaml'))" && echo "fleet.yaml OK"
 grep -E 'kind:|repo:|paths:' /tmp/fleet-lab/gitrepo.yaml
@@ -649,7 +650,7 @@ spec:
         server: '{{.server}}'
         namespace: '{{.app}}'
 EOF
-python3 -m pip install pyyaml
+python3 -m pip install --break-system-packages pyyaml  # lab convenience on PEP 668 hosts
 python3 -c "import yaml; yaml.safe_load(open('/tmp/appset-lab/appset.yaml'))" && echo "ApplicationSet YAML OK"
 grep -c 'generators:' /tmp/appset-lab/appset.yaml
 grep 'matchLabels' /tmp/appset-lab/appset.yaml

--- a/src/content/docs/on-premises/multi-cluster/module-5.5-active-active-multi-site.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.5-active-active-multi-site.md
@@ -1,7 +1,6 @@
 ---
 title: "Module 5.5: Active-Active Multi-Site"
 slug: on-premises/multi-cluster/module-5.5-active-active-multi-site
-revision_pending: false
 sidebar:
   order: 55
 ---
@@ -66,7 +65,7 @@ Kubernetes control planes depend on etcd’s Raft consensus. Stretching one etcd
 
 ### Stretched etcd versus federated clusters
 
-A **stretched** cluster places etcd members (and sometimes control plane nodes) in multiple sites so one Kubernetes API remains authoritative. Quorum still requires ⌊n/2⌋+1 healthy members. A five-member etcd cluster tolerates two member failures; if WAN partition isolates two members in site A and two in site B, neither side holds majority and the API halts—preferable to split-brain writes, painful for operators who expected “survive one site loss” to mean “keep serving from the surviving site.” Stretching etcd across exactly two equal sites without a witness is the same quorum trap as two-datacenter databases: each side holds half the votes.
+A **stretched** cluster places etcd members (and sometimes control plane nodes) in multiple sites so one Kubernetes API remains authoritative. Quorum still requires ⌊n/2⌋+1 healthy members. A five-member etcd cluster tolerates two member failures; with **2+2+1** placement (two members in site A, two in site B, one witness in site C), the side that can still reach the witness keeps quorum (three votes); the halt case is the witness unreachable from both primary sites—or, with only four members split **2+2**, partition yields two versus two with no majority anywhere. Stretching etcd across exactly two equal sites without a witness is the same quorum trap as two-datacenter databases: each side holds half the votes.
 
 A **federated** approach runs independent Kubernetes clusters per site, each with local etcd quorum on fast storage. Fleet tools, GitOps, or multi-cluster ingress distribute workloads; global service discovery uses Cilium ClusterMesh or Submariner Lighthouse rather than one giant API server. Application failover shifts to DNS/GSLB and data replication rather than etcd leader election across cities. The tradeoff is no single `kubectl` context for all pods unless you build one with OCM or similar, but blast radius shrinks: Frankfurt etcd trouble does not London API availability.
 
@@ -166,7 +165,7 @@ flowchart LR
     ING2 --> SVC2
 ```
 
-Envoy-based ingress controllers can add **global rate limiting** and **active health checks** upstream of clusters, but they do not replace database conflict policies. Treat north-south routing as independent from east-west ClusterMesh connectivity: clients may land in Frankfurt while an internal batch job in London calls `payments.clusterset.local` across clusters.
+Envoy-based ingress controllers can add **global rate limiting** and **active health checks** upstream of clusters, but they do not replace database conflict policies. Treat north-south routing as independent from east-west ClusterMesh connectivity: clients may land in Frankfurt while an internal batch job in London calls `payments.finance.svc.clusterset.local` across clusters.
 
 Corporate DNS teams often resist delegating subzones to Kubernetes-hosted authoritative servers. A compromise keeps the parent zone in IPAM-managed BIND or Infoblox while automation pushes short-TTL records via API when health controllers detect ingress failure. Whether records originate from k8gb or external DNS, the contract is the same: health signal, record change, propagation delay, client retry. Run quarterly drills that fail ingress in one site and measure how long external synthetic monitors flip—compare results to internal kube-probe green dashboards.
 
@@ -235,7 +234,7 @@ sequenceDiagram
     participant DNS as CoreDNS + Lighthouse
     participant Broker as Broker API
     participant ClusterB as Cluster B endpoints
-    PodA->>DNS: lookup payments.clusterset.local
+    PodA->>DNS: lookup payments.finance.svc.clusterset.local
     DNS->>DNS: ServiceImport cache
     Broker-->>DNS: exported EndpointSlices
     DNS->>ClusterB: choose local or remote backend
@@ -380,9 +379,9 @@ Galera **flow control** likely throttles all sites when one replica lags over WA
 
 </details>
 
-<details><summary>Question 5: Connect services with Submariner Lighthouse. What Kubernetes object must exist before remote clusters resolve `my-svc.clusterset.local`?</summary>
+<details><summary>Question 5: Connect services with Submariner Lighthouse. What Kubernetes object must exist before remote clusters resolve `my-svc.default.svc.clusterset.local`?</summary>
 
-Create a **ServiceExport** for the Service in the source cluster. Lighthouse agents export ServiceImport and EndpointSlice objects to the Broker; remote clusters import copies and the Lighthouse DNS server answers `clusterset.local` queries via CoreDNS forwarding. Without export, Services remain local-only despite tunnels being up.
+Create a **ServiceExport** for the Service in the source cluster. Lighthouse agents export ServiceImport and EndpointSlice objects to the Broker; remote clusters import copies and the Lighthouse DNS server answers `*.svc.clusterset.local` queries (for example `my-svc.default.svc.clusterset.local`) via CoreDNS forwarding. Without export, Services remain local-only despite tunnels being up.
 
 </details>
 
@@ -445,12 +444,32 @@ Even member counts (2, 4) do not increase tolerated failures versus the next low
 Create two kind clusters, install Cilium with distinct cluster names/IDs, and inspect ClusterMesh enablement status. Requires Docker and the Cilium CLI.
 
 ```bash
-kind create cluster --name cm-a
-kind create cluster --name cm-b
+cat > kind-cm-a.yaml <<'EOF'
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  podSubnet: "10.244.0.0/16"
+  serviceSubnet: "10.96.0.0/12"
+nodes:
+- role: control-plane
+EOF
+cat > kind-cm-b.yaml <<'EOF'
+kind: Cluster
+apiVersion: kind.x-k8s.io/v1alpha4
+networking:
+  disableDefaultCNI: true
+  podSubnet: "10.245.0.0/16"
+  serviceSubnet: "10.97.0.0/12"
+nodes:
+- role: control-plane
+EOF
+kind create cluster --name cm-a --config kind-cm-a.yaml
+kind create cluster --name cm-b --config kind-cm-b.yaml
 cilium install --context kind-cm-a --set cluster.name=cm-a --set cluster.id=1
 cilium install --context kind-cm-b --set cluster.name=cm-b --set cluster.id=2
-cilium clustermesh enable --context kind-cm-a
-cilium clustermesh enable --context kind-cm-b
+cilium clustermesh enable --context kind-cm-a --service-type NodePort
+cilium clustermesh enable --context kind-cm-b --service-type NodePort
 cilium clustermesh status --context kind-cm-a
 cilium clustermesh status --context kind-cm-b
 kubectl --context kind-cm-a get pods -n kube-system -l k8s-app=cilium
@@ -493,7 +512,7 @@ grep -E '^kind:|^  name:' /tmp/lighthouse-lab/serviceexport.yaml
 
 <details><summary>Expected analysis</summary>
 
-Without Submariner CRDs installed, `kubectl apply` fails API discovery—that is expected in YAML-only labs. Production installs require Broker connectivity and non-overlapping Service CIDRs. Pair exports with NetworkPolicy allowing gateway paths on UDP 4500/4800 per Submariner prerequisites.
+Without Submariner CRDs installed, `kubectl apply` fails API discovery—that is expected in YAML-only labs. Production installs require Broker connectivity and non-overlapping Service CIDRs. Pair exports with infra firewall or security-group rules allowing gateway UDP 4500/4490 and node UDP 4800; keep application NetworkPolicies separate from gateway tunnel ports.
 
 </details>
 

--- a/src/content/docs/on-premises/planning/module-1.5-onprem-finops-chargeback.md
+++ b/src/content/docs/on-premises/planning/module-1.5-onprem-finops-chargeback.md
@@ -112,7 +112,7 @@ graph LR
 
 ### Enterprise agreements and reserved capacity pass-through
 
-When you buy servers under an enterprise agreement (EA) or reserved capacity from a vendor, the **discount belongs in the rate card**, not in a one-time spreadsheet celebration. Document the EA unit price, term, and which hardware pools it covers. Pass through to internal customers as a lower `CPU`/`RAM` rate on tagged node pools (`hardware-generation=2026-ea`) so teams scheduling onto EA nodes see the benefit. For burst cloud capacity purchased with committed use discounts, mirror the same pattern: a separate pricing zone `cloud-burst-west` with hourly rates derived from amortized commitment plus expected spot overflow.
+When you buy servers under an enterprise agreement (EA) or reserved capacity from a vendor, the **discount belongs in the rate card**, not in a one-time spreadsheet celebration. Document the EA unit price, term, and which hardware pools it covers. OpenCost OSS `default.json`/Helm `costModel` is **one global rate card** per cluster—per-node-pool rates require the CSV provider (`USE_CSV_PROVIDER=true`, mapping node labels to SKUs) or Kubecost. Treat "pricing zones" as a finance overlay; implement EA pass-through via CSV SKUs, separate OpenCost instances per hardware pool, or finance spreadsheets that reference node labels (`hardware-generation=2026-ea`). For burst cloud capacity purchased with committed use discounts, mirror the same pattern with a separate finance tier or CSV SKU for burst overflow.
 
 > **Stop and think:** A platform engineer amortizes only the server invoice over 60 months to minimize chargeback rates, but operations replaces that generation at 36 months. Who absorbs the early refresh cost, and how should the pricing model signal "expensive new pool" versus "discounted legacy pool"?
 
@@ -158,7 +158,7 @@ Hierarchy allocation mirrors how enterprises already structure budgets: business
 
 Chargeback disputes destroy trust faster than outage postmortems. Publish the rate card methodology—formula links to Module 1.4 line items, PUE source, platform tax percentage, idle policy—in the same document controllers sign. When an application lead challenges a bill, your first artifact is the PromQL query reproducing the allocation, not a screenshot of a pie chart. Mature programs record dispute outcomes and feed them into rate card revisions quarterly rather than arguing ad hoc in Slack.
 
-Multi-cluster estates should share one rate-card repository with environment-specific overlays (`zone=prod-dc-a`, `zone=dr-dc-b`) so finance compares dollars consistently. Dr clusters often run underutilized; showback should make DR overhead visible instead of hiding it in a blended average that discourages teams from testing failover. When DR is truly shared insurance, allocate a fixed percentage to every cost-center rather than pretending DR has no cost.
+Multi-cluster estates should share one rate-card repository with environment-specific finance overlays (prod-dc-a versus dr-dc-b tiers in CSV SKUs or separate OpenCost installs) so finance compares dollars consistently. Dr clusters often run underutilized; showback should make DR overhead visible instead of hiding it in a blended average that discourages teams from testing failover. When DR is truly shared insurance, allocate a fixed percentage to every cost-center rather than pretending DR has no cost.
 
 ---
 
@@ -174,6 +174,7 @@ Example custom pricing (hourly units—verify against your chart version):
 
 ```json
 {
+  "provider": "custom",
   "description": "On-Prem Bare Metal Pool Alpha — FY2026 rates",
   "CPU": "0.015",
   "spotCPU": "0.000",
@@ -181,7 +182,9 @@ Example custom pricing (hourly units—verify against your chart version):
   "spotRAM": "0.000",
   "GPU": "0.950",
   "storage": "0.0002",
-  "zone": "dc-alpha-rack-12"
+  "LBIngressDataCost": "0",
+  "FirstFiveForwardingRulesCost": "0",
+  "AdditionalForwardingRuleCost": "0"
 }
 ```
 
@@ -201,13 +204,16 @@ opencost:
     defaultClusterId: "on-prem-prod-baremetal-01"
   customPricing:
     enabled: true
-    provider: default
+    provider: custom
     costModel:
       description: "On-Prem Bare Metal Pool Alpha — FY2026 rates"
       CPU: "0.015"
       RAM: "0.005"
       GPU: "0.950"
       storage: "0.0002"
+      LBIngressDataCost: "0"
+      FirstFiveForwardingRulesCost: "0"
+      AdditionalForwardingRuleCost: "0"
 ```
 
 IBM Kubecost 3.x is a separate product with enterprise CSV pricing and version-specific architecture; treat Prometheus requirements as **version-dependent** and read the deployment guide for your release before teaching a single pipeline diagram.
@@ -240,11 +246,8 @@ groups:
     expr: |
       (
         sum by (namespace) (
-          avg by (namespace, node) (container_cpu_allocation)
-            * on (node) group_left () avg by (node) (node_cpu_hourly_cost)
-          +
-          avg by (namespace, node) (container_memory_allocation_bytes)
-            * on (node) group_left () avg by (node) (node_ram_hourly_cost) / (1024 * 1024 * 1024)
+          container_cpu_allocation * on(node) group_left node_cpu_hourly_cost
+          + container_memory_allocation_bytes * on(node) group_left node_ram_hourly_cost / (1024^3)
         )
       ) * 730 > 500
     for: 12h
@@ -405,19 +408,19 @@ Cross-functional office hours accelerate adoption. Platform brings live PromQL q
 | Phased showback before chargeback | First 6–12 months of FinOps | Builds trust; surfaces label gaps without budget warfare |
 | Label-enforced attribution | >3 teams on shared clusters | Prevents mystery spend in `default` |
 | VPA Off + FinOps review queue | >50 deployments | Surfaces savings without forced restarts |
-| Separate pricing zones per hardware generation | Mixed-age fleets | Steers batch jobs to depreciated nodes |
+| CSV SKUs or separate OpenCost instances per hardware pool | Mixed-age fleets | Steers batch jobs to depreciated nodes when global rate card cannot vary by label |
 | Monthly metric-to-invoice reconciliation | CFO oversight | Catches Prometheus gaps before they become disputes |
 
 | Anti-pattern | Why teams do it | Better approach |
 |--------------|-----------------|-----------------|
 | Cloud list price as on-prem proxy | Fast to model | Use Module 1.4 TCO inputs only |
-
-Patterns succeed when tied to observable metrics: idle percentage falling, untagged spend below two percent, bridge variance under five percent, and deferred rack purchases with written justification. Anti-patterns fail silently for quarters because capital is already spent—FinOps makes waste visible early enough to change procurement timelines instead of explaining variances after the fact.
 | Bill on usage, schedule on requests | Feels "fair" | Bill on max(request, usage) for capacity signals |
 | Hide idle cluster cost | Makes teams look efficient | Share idle explicitly |
 | Day-one hard chargeback | Executive pressure | Minimum six months showback |
 | Ignore PVC $/GB-hour | Focus on CPU charts | Price storage from array TCO |
 | Skip platform tax | Keep app rates low | Mark up rates; publish transparent overhead line |
+
+Patterns succeed when tied to observable metrics: idle percentage falling, untagged spend below two percent, bridge variance under five percent, and deferred rack purchases with written justification. Anti-patterns fail silently for quarters because capital is already spent—FinOps makes waste visible early enough to change procurement timelines instead of explaining variances after the fact.
 
 ---
 
@@ -464,7 +467,7 @@ Teaching FinOps to application teams lands better when you connect dollars to re
 ## Did You Know?
 
 - The [CNCF FinOps microsurvey (2023)](https://www.cncf.io/wp-content/uploads/2023/12/CNCF_Finops-Microsurvey-2023.pdf) reported that 49% of respondents saw Kubernetes drive cloud spend up, while 38% had no Kubernetes cost monitoring in place—visibility gaps are common even when clusters grow.
-- OpenCost implements the FinOps Foundation's [FOCUS specification](https://focus.finops.org/) for normalized cost and usage data, helping teams align on-prem metrics with cloud billing exports when running hybrid fleets.
+- OpenCost offers FOCUS-aligned custom-cost plugin schema and terminology; core allocation remains OpenCost-spec/Prometheus-based, not a native FOCUS export.
 - [Uptime Institute's Tier classification](https://uptimeinstitute.com/tiers) ties facility redundancy levels to construction and operating cost—Tier IV availability can cost roughly double Tier II for the same IT load, which must flow into per-kW allocation math.
 - The FinOps Foundation's 2021 Kubernetes report found only 14% of surveyed organizations had chargeback in place versus 44% using monthly estimates—most fleets still lack real-time pod-level accountability.
 
@@ -534,7 +537,7 @@ Admission only fixes forward-looking Pods: legacy workloads, DaemonSets, Operato
 <details>
 <summary>Question 8: Your EA provides 30% off servers delivered this quarter. How should internal customers see that benefit?</summary>
 
-Publish a lower custom pricing zone tied to node labels such as `ea-2026=true` or reduce CPU and RAM rates for that pool in the OpenCost JSON. Teams that schedule onto EA nodes should see cheaper showback than teams on list-priced hardware, steering batch and dev workloads toward discounted silicon. Document the pass-through methodology beside Module 1.4 quotes so finance can audit it the same way cloud RI discounts are passed to internal product lines.
+Pass EA discounts through CSV SKUs keyed to node labels such as `ea-2026=true`, separate OpenCost instances per hardware pool, or finance overlays—OpenCost's default `costModel` is cluster-global and cannot express per-pool CPU/RAM rates without the CSV provider (`USE_CSV_PROVIDER=true`). Teams that schedule onto EA nodes should see cheaper showback than teams on list-priced hardware. Document the pass-through methodology beside Module 1.4 quotes so finance can audit it the same way cloud RI discounts are passed to internal product lines.
 </details>
 
 ---
@@ -561,6 +564,7 @@ Task 1 establishes the finance-approved rate card in both a ConfigMap artifact f
 
 ```json
 {
+  "provider": "custom",
   "description": "Simulated On-Prem Datacenter Pricing Model",
   "CPU": "0.020",
   "spotCPU": "0.000",
@@ -568,7 +572,9 @@ Task 1 establishes the finance-approved rate card in both a ConfigMap artifact f
   "spotRAM": "0.000",
   "GPU": "1.500",
   "storage": "0.0005",
-  "zone": "on-prem-zone-alpha"
+  "LBIngressDataCost": "0",
+  "FirstFiveForwardingRulesCost": "0",
+  "AdditionalForwardingRuleCost": "0"
 }
 ```
 
@@ -581,12 +587,9 @@ helm upgrade --install opencost --repo https://opencost.github.io/opencost-helm-
   --set opencost.prometheus.internal.serviceName=prometheus-operated \
   --set opencost.prometheus.internal.port=9090 \
   --set opencost.customPricing.enabled=true \
-  --set opencost.customPricing.provider=default \
-  --set-string opencost.customPricing.costModel.description="Simulated On-Prem Datacenter Pricing Model" \
-  --set-string opencost.customPricing.costModel.CPU="0.020" \
-  --set-string opencost.customPricing.costModel.RAM="0.008" \
-  --set-string opencost.customPricing.costModel.GPU="1.500" \
-  --set-string opencost.customPricing.costModel.storage="0.0005"
+  --set opencost.customPricing.provider=custom \
+  --set opencost.customPricing.configmapName=opencost-custom-pricing \
+  --set opencost.customPricing.createConfigmap=false
 kubectl wait --for=condition=available deployment/opencost -n opencost --timeout=180s
 kubectl get configmap opencost-custom-pricing -n opencost
 ```

--- a/src/content/docs/on-premises/provisioning/module-2.3-immutable-os.md
+++ b/src/content/docs/on-premises/provisioning/module-2.3-immutable-os.md
@@ -1,5 +1,4 @@
 ---
-revision_pending: false
 title: "Module 2.3: Immutable OS for Kubernetes"
 slug: on-premises/provisioning/module-2.3-immutable-os
 sidebar:
@@ -82,7 +81,7 @@ Immutability in these operating systems is not a marketing term — it is enforc
 
 - **Talos Linux**: The root filesystem is SquashFS, a compressed read-only filesystem. There is no mechanism to remount it read-write. The `/var` partition is writable but ephemeral — it is wiped on upgrade. Only `/system/state` persists across upgrades.
 - **Bottlerocket**: The root filesystem is a dm-verity device — a block-level integrity mechanism where every read is verified against a Merkle hash tree. Any unauthorized block modification triggers a kernel panic and reboot.
-- **Flatcar Container Linux**: The root partition (`/usr`) is mounted read-only with dm-verity verification. Writable directories (`/etc`, `/var`) are separate partitions, and `/opt` is available for containerized workloads.
+- **Flatcar Container Linux**: The root partition (`/usr`) is mounted read-only with dm-verity verification. Writable directories (`/etc`, `/var`) are separate partitions, and `/opt` provides writable overlay/state space.
 - **Fedora CoreOS**: Uses rpm-ostree, which treats the OS as a content-addressed object store (similar to Git for binaries). The running deployment is a checked-out tree that cannot be modified in place.
 - **Kairos**: The OS image is a container — yes, the entire OS boots from an OCI container image pulled at install time. Immutability is inherent to the container model; you cannot modify a running container's image.
 
@@ -111,9 +110,11 @@ Talos is purpose-built for Kubernetes and nothing else. It has no SSH daemon, no
 │  │  ├── trustd        mTLS certificate management (port 50001)  ││
 │  │  ├── networkd      network configuration engine              ││
 │  │  ├── containerd    container runtime (CRI)                    ││
-│  │  │   ├── kubelet                                              ││
-│  │  │   ├── etcd          (control-plane nodes only)             ││
-│  │  │   └── kube-apiserver (control-plane nodes only)            ││
+│  │  │   └── kubelet                                              ││
+│  │  │       ├── kube-apiserver (static pod, control-plane only)  ││
+│  │  │       ├── kube-controller-manager (static pod)             ││
+│  │  │       └── kube-scheduler (static pod)                      ││
+│  │  ├── etcd          machined service (control-plane only)      ││
 │  │  └── dashboard     built-in TUI for node inspection           ││
 │  └──────────────────────────────────────────────────────────────┘│
 │                                                                    │
@@ -152,7 +153,7 @@ machine:
     bootloader: true
 ```
 
-Talos is also the only immutable OS where Kubernetes components (kubelet, etcd, kube-apiserver) run as system services managed by the OS init process (`machined`), not as static pods or systemd units. This means Talos can manage the full lifecycle of Kubernetes components atomically: when you upgrade Talos, the bundled Kubernetes version upgrades in lockstep, and vice versa.
+Talos runs kubelet and etcd as `machined` services, but kube-apiserver, kube-controller-manager, and kube-scheduler run as static pods managed by kubelet (verify with `talosctl get staticpods`). This means Talos can manage the full lifecycle of Kubernetes components atomically: when you upgrade Talos, the bundled Kubernetes version upgrades in lockstep, and vice versa.
 
 Operational implications of the no-SSH model:
 
@@ -174,7 +175,7 @@ Bottlerocket's tradeoff is that it is less "extreme" than Talos — SSH access e
 
 ### Flatcar Container Linux: The CoreOS Heir
 
-Flatcar is the community-maintained successor to CoreOS Container Linux (which Red Hat acquired and discontinued in 2018). It is the most "familiar-feeling" immutable OS — it runs systemd, supports SSH, has a `/usr` read-only root with an overlay for `/etc`, and uses Ignition (JSON-based provisioning config) instead of cloud-init.
+Flatcar is the community-maintained successor to CoreOS Container Linux—Red Hat acquired CoreOS in 2018, the community forked Flatcar that same year in anticipation of change, and Container Linux reached end-of-life in May 2020. It is the most "familiar-feeling" immutable OS — it runs systemd, supports SSH, has a `/usr` read-only root with an overlay for `/etc`, and uses Ignition (JSON-based provisioning config) instead of cloud-init.
 
 Flatcar's design philosophy is centered on reducing the conceptual distance between traditional Linux administration and immutable operations. The architecture preserves the tools and abstractions that Linux engineers already know — systemd, journalctl, SSH, bash — while enforcing immutability at the filesystem level through dm-verity and a read-only `/usr` partition. The key architectural characteristics that make this possible are:
 
@@ -301,7 +302,7 @@ Immutable OS without an update pipeline is just a frozen OS — secure at a mome
 
 ### A/B Partition Architecture
 
-All five distributions covered in this module use some form of A/B (dual-partition) update scheme. The principle is simple and, by now, battle-tested at planetary scale — ChromeOS has used A/B updates since 2012 across hundreds of millions of devices. The scheme works by maintaining two complete OS installations on separate disk partitions. At any moment, one partition is active (the running OS) and the other is passive (available to receive an update). The update is written to the passive partition while the active partition continues serving workloads, then the bootloader swaps roles on the next reboot. If the new OS fails to boot, the bootloader falls back to the previous partition automatically. The entire mechanism operates below the OS layer — it is a bootloader feature, not an OS feature — which is why it works identically across Talos, Bottlerocket, Flatcar, and Kairos despite their radically different userspace designs.
+Talos, Bottlerocket, Flatcar, and Kairos use A/B (dual-partition) update schemes; Fedora CoreOS uses rpm-ostree multi-deployment for equivalent atomic rollback rather than partition-level A/B. The principle is simple and, by now, battle-tested at planetary scale — ChromeOS has used A/B updates since 2012 across hundreds of millions of devices. The scheme works by maintaining two complete OS installations on separate disk partitions (or ostree deployments for FCOS). At any moment, one partition is active (the running OS) and the other is passive (available to receive an update). The update is written to the passive partition while the active partition continues serving workloads, then the bootloader swaps roles on the next reboot. If the new OS fails to boot, the bootloader falls back to the previous partition automatically. The entire mechanism operates below the OS layer — it is a bootloader feature, not an OS feature — which is why it works identically across Talos, Bottlerocket, Flatcar, and Kairos despite their radically different userspace designs.
 
 ```ascii
 ┌─────────────────────────────────────────────────────────────────┐
@@ -587,7 +588,7 @@ flowchart TD
 | Update protocol | talosctl upgrade | updog (TUF-based) | Omaha (Nebraska) | Container registry pull | Zincati (Cincinnati) |
 | Learning curve | High (new paradigm) | Medium (TOML + API) | Low (familiar Linux) | Low (familiar base distro) | Medium (rpm-ostree) |
 | Air-gap support | Yes (image cache) | Yes (private registry) | Yes (Nebraska server) | Yes (designed for) | Yes (Cincinnati mirror) |
-| CAPI provider | Sidero (native) | CAPB (community) | None (kubeadm-based) | Native CAPI | None (OpenShift MAPI) |
+| CAPI provider | Sidero (native) | CAPB (community) | CABPK + Ignition (no standalone CAPF) | Native CAPI | None (OpenShift MAPI) |
 
 The decision typically comes down to two dimensions: **security posture vs. operational familiarity**, and **Kubernetes lifecycle coupling**. Talos maximizes security at the cost of tooling investment. Flatcar minimizes operational disruption at the cost of a larger attack surface (SSH, systemd). Bottlerocket and Kairos occupy the middle: Bottlerocket for AWS-centric teams wanting strong immutability without the full Talos toolswitch, Kairos for teams that need their existing distribution ecosystem.
 
@@ -597,9 +598,9 @@ The decision typically comes down to two dimensions: **security posture vs. oper
 
 - **Talos Linux has no `/bin/sh` binary anywhere on the filesystem.** Even if an attacker escapes a container to the host, there is literally no shell interpreter to execute commands. This is the most extreme form of attack-surface reduction in any Linux distribution designed for server workloads. For comparison, a minimal Debian installation ships approximately 120 binaries in `/bin` and `/usr/bin`; Talos ships roughly 12 userspace binaries total.
 
-- **The A/B update scheme used by all immutable Kubernetes OSes was pioneered by ChromeOS in 2011.** ChromeOS devices use the same dual-partition layout with automatic fallback. Today, over 300 million ChromeOS devices use this mechanism. When Flatcar, Bottlerocket, and Talos adopted A/B updates, they were adopting a pattern validated at consumer-electronics scale over more than a decade.
+- **The A/B update scheme used by immutable Kubernetes OSes was pioneered by ChromeOS in 2012.** ChromeOS devices use the same dual-partition layout with automatic fallback. Today, hundreds of millions of ChromeOS devices use this mechanism. When Flatcar, Bottlerocket, and Talos adopted A/B updates, they were adopting a pattern validated at consumer-electronics scale over more than a decade.
 
-- **Flatcar Container Linux was forked from CoreOS Container Linux in 2018** after Red Hat acquired CoreOS and discontinued the community edition. The fork was maintained by Kinvolk (later acquired by Microsoft) and now operates as a CNCF Sandbox project. Microsoft contributes engineers and infrastructure to Flatcar because it underpins Azure's container-optimized OS strategy. The fork is a rare case where a corporate acquisition spawned a community project that outlived the original product's independent existence.
+- **Flatcar Container Linux was forked from CoreOS Container Linux in 2018** after Red Hat acquired CoreOS; Container Linux reached end-of-life in May 2020. The fork was maintained by Kinvolk (later acquired by Microsoft) and now operates as a **CNCF Incubating** project (accepted 2024-10-29). Microsoft contributes engineers and infrastructure to Flatcar because it underpins Azure's container-optimized OS strategy. The fork is a rare case where a corporate acquisition spawned a community project that outlived the original product's independent existence.
 
 - **Bootc (bootable containers) is an emerging model** that blurs the line between OS image and application container. With bootc, the entire OS is built as an OCI container image using a Containerfile, and the system boots directly from that image. This means the same `podman build` or `docker build` pipeline that produces your application containers can produce your OS images, with the same signing, scanning, and registry infrastructure. The model is being developed in the Fedora/CentOS ecosystem and represents the convergence of immutable OS and container-native operating models into a single toolchain.
 
@@ -647,7 +648,7 @@ Your security team mandates that every OS update must be cryptographically verif
 
 **The Update Framework (TUF)** provides multi-signer compromise resilience. TUF defines four metadata roles: Root (establishes trust anchors), Targets (lists valid update files and their hashes), Snapshot (prevents replay attacks by versioning the Targets metadata), and Timestamp (ensures freshness by providing the latest Snapshot version number).
 
-The key property is threshold signatures: the Root role requires a quorum of keys (e.g., 3 of 5) to sign new Targets metadata. If a single key is compromised, the attacker cannot sign valid Targets metadata because they lack the threshold. A client verifies that each piece of metadata is signed by the required number of trusted keys before accepting an update.
+The key property is threshold signatures: the **Targets** role signs `targets.json` (its threshold is defined in Root metadata); Root signs `root.json` to establish trust anchors and role thresholds. If a single key is compromised, the attacker cannot sign valid Targets metadata because they lack the threshold. A client verifies that each piece of metadata is signed by the required number of trusted keys before accepting an update.
 
 In practice: Bottlerocket's `updog` agent validates full TUF metadata (four-role model via the `tough` library) before applying an update — this is the native TUF implementation in the immutable-Kubernetes-OS space. Flatcar's Nebraska uses the Omaha protocol for signed, channel-aware rollouts, which provides signing and rollout control but does not implement the full TUF specification; for TUF compliance, organizations layer a TUF mirror in front of Nebraska. Talos uses a simpler Ed25519 signing model for installer images, but the same principle applies — a single key compromise does not grant unilateral push access if you configure multi-key verification.
 
@@ -840,7 +841,7 @@ talosctl mounts --nodes $CONTROLPLANE_IP
 <details>
 <summary>Solution: Task 2</summary>
 
-`talosctl services` shows that every system component runs as a service managed by `machined`. There is no systemd, no cron, no syslog daemon. The service count is notably small — typically 8-12 services on a control-plane node.
+`talosctl services` shows kubelet and etcd as `machined` services; `talosctl get staticpods` shows kube-apiserver, kube-controller-manager, and kube-scheduler as kubelet-managed static pods. There is no systemd, no cron, no syslog daemon. The service count is notably small — typically 8-12 services on a control-plane node.
 
 `talosctl processes` reveals approximately 20-30 processes total, compared to 100+ on a minimal Ubuntu server. This is the attack-surface reduction in practice. There is no shell (`/bin/sh`), no Python, no Perl, no text editors.
 
@@ -860,9 +861,10 @@ talosctl version --nodes $CONTROLPLANE_IP
 # Examine the disk layout via the API
 talosctl disks --nodes $CONTROLPLANE_IP
 
-# List available upgrades (Talos checks its image registry for newer versions)
-# Note: In air-gapped mode, this would point to your internal registry
-talosctl upgrade --dry-run --nodes $CONTROLPLANE_IP
+# Preview the Kubernetes component upgrade plan (--dry-run is supported on upgrade-k8s):
+talosctl upgrade-k8s --dry-run --nodes $CONTROLPLANE_IP
+# The OS upgrade itself takes an explicit installer image and has NO --dry-run flag; run it only when ready:
+# talosctl upgrade --image ghcr.io/siderolabs/installer:v1.9.0 --nodes $CONTROLPLANE_IP
 
 # View the upgrade controller status
 talosctl health --nodes $CONTROLPLANE_IP
@@ -875,7 +877,7 @@ talosctl health --nodes $CONTROLPLANE_IP
 
 `talosctl disks` shows the partition layout. On a bare-metal install, you would see two OS partitions (A and B) plus the persistent state partition and an EFI system partition. Inside Docker, the partition layout is simplified, but the concept is the same.
 
-`talosctl upgrade --dry-run` queries the configured image registry for newer Talos versions. In production, this registry is your internal mirror (for air-gap) or the public GitHub Container Registry. The `--dry-run` flag reports what version *would* be installed without making changes — this is the discovery phase of the update pipeline.
+`talosctl upgrade-k8s --dry-run` previews the Kubernetes component upgrade plan without applying it. The OS upgrade (`talosctl upgrade`) has **no `--dry-run` flag** — it takes an explicit installer `--image` (registry tag) and applies immediately, so stage the target image against your internal mirror (for air-gap) or the public GitHub Container Registry before running it. There is no "discover newer versions" step for the OS upgrade; you specify the target image explicitly.
 
 The health check confirms that all system services are running and that the cluster is in a state where an upgrade can safely proceed. If any service is unhealthy, Talos will refuse the upgrade — this prevents compounding an existing problem with an untested OS version.
 </details>


### PR DESCRIPTION
**On-premises Wave 3 (#1881)** — review-and-flip of the 7 non-done modules in the planning/provisioning stragglers + multi-cluster 5.1–5.5. All were dense T0 / heuristic-score 5.0, but **every one was NEEDS_CHANGES** on cross-family review (verifier-blind defects).

## Method
- `verify_module.py` sweep first → all 7 dense T0 → pure review-flip, no expansion.
- Cross-family review, mixed pool, **no gemini** (retired): opus (5.3), codex (5.2/5.5), cursor (5.1/2.3/1.5), deepseek (5.4). One agy timeout cleanly re-routed to cursor.
- **Every finding ground-checked against the live file**; one cursor FP rejected (Bottlerocket `apiclient` prefix-get). Currency web-verified: Flatcar=CNCF Incubating ✓, TMC SaaS EOL 2025-11-15 ✓, `talosctl upgrade --dry-run` unsupported ✓.
- Consolidated cursor fix-pass → orchestrator diff-audited every change (caught + fixed one cursor error: invalid `talosctl upgrade --dry-run`). Build green in PRIMARY (2171 pages).

## Verifier-blind defects fixed (highlights)
- **Lab-breakers**: 5.3 + 5.2 CAPD-on-kind missing host Docker-socket extraMount (5.3 waits for Ready → hard break); 5.5 Cilium kind ClusterMesh used two default kind clusters with overlapping CIDRs.
- **API/config errors**: `noCloudProvider`→`cloudProviderEnabled` (CAPM3); Redfish addr missing `/redfish/v1/Systems/<id>`; KCP `spec.version` vs `Cluster.spec.topology.version`; fabricated `ObservabilityMetric` CRD; Lighthouse MCS DNS short-names.
- **Conceptual**: Talos runs apiserver/cm/scheduler as static pods (not machined services); TUF Targets-vs-Root signing; FCOS uses ostree not partition A/B; etcd 2+2+1 witness quorum.
- **Currency** (web-verified): Flatcar CNCF Incubating; oVirt/RHV lineage + EOL; TMC SaaS EOL; CoreOS EOL 2020.
- **1.5 FinOps**: OpenCost single-global-rate-card vs CSV provider; `avg`→`sum group_left` PromQL undercount; **broken anti-pattern table repaired** (was rendering raw `|` live); unwired ConfigMap.

Stripped stale `revision_pending` frontmatter (5.1/5.2/2.3/5.5).

Reviews + ground-check ledger: `logs/remediation/briefs/onprem-w3/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)