### PR TITLE
docs(on-premises): wave 4 batch 1 — operations 7.1/7.2/7.3 expand→T0 (#1881)

### DIFF
--- a/src/content/docs/on-premises/operations/module-7.1-upgrades.md
+++ b/src/content/docs/on-premises/operations/module-7.1-upgrades.md
@@ -104,8 +104,7 @@ ETCDCTL_API=3 etcdctl snapshot save /backup/etcd-pre-upgrade.db \
   --key=/etc/kubernetes/pki/etcd/server.key
 
 # Verify the backup
-ETCDCTL_API=3 etcdctl snapshot status /backup/etcd-pre-upgrade.db \
-  --write-out=table
+etcdutl snapshot status /backup/etcd-pre-upgrade.db --write-out=table
 ```
 
 Run this on a control-plane node with valid client certificates, then copy the snapshot off-node. A backup that lives only on the server you are about to reboot is not a backup. For external etcd clusters, snapshot from a member with quorum healthy and store artifacts in object storage with versioning enabled.
@@ -134,13 +133,18 @@ The first control plane node executes cluster-wide changes: API server, controll
 
 > **Note**: For Kubernetes versions released after September 13, 2023, [you must use the community-owned `pkgs.k8s.io` package repositories](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/), which use per-minor URLs. Legacy apt/yum repos are frozen and no longer receive updates.
 
-> **Note**: If `kubeadm upgrade apply` fails partway through, it does not fully roll back automatically. However, [the command is idempotent—you can fix the underlying issue and safely run `kubeadm upgrade apply` again.](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/)
+> **Note**: If `kubeadm upgrade apply` fails partway through, it does not fully roll back automatically. You can fix the underlying issue and safely run `kubeadm upgrade apply` again — [kubeadm documents this as a re-runnable upgrade step](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/), not an automatic rollback.
 
 #### Step 1: Upgrade the First Control Plane Node
+
+[The version-skew policy requires draining control-plane nodes before upgrading kubeadm/kubelet on them](https://kubernetes.io/releases/version-skew-policy/) — the same drain discipline as workers applies.
 
 ```bash
 # Check available versions
 apt-cache madison kubeadm | head -5
+
+# Drain the control-plane node before package upgrades
+kubectl drain cp-01 --ignore-daemonsets --delete-emptydir-data --timeout=300s
 
 # Unhold packages to allow upgrade
 apt-mark unhold kubeadm
@@ -163,6 +167,8 @@ apt-get install -y kubelet=1.35.3-1.1 kubectl=1.35.3-1.1
 apt-mark hold kubelet kubectl
 systemctl daemon-reload
 systemctl restart kubelet
+
+kubectl uncordon cp-01
 ```
 
 `kubeadm upgrade plan` is your pre-flight checklist rendered as a table: component config versions, available target releases, and whether the cluster is upgradeable. Run it from a jump host with `admin.conf` before you touch production packages. Patch within the current minor first (`1.35.x` latest), then step minors one at a time—kubeadm does not support skipping versions.
@@ -171,6 +177,8 @@ systemctl restart kubelet
 
 ```bash
 # On each additional control plane node
+kubectl drain cp-02 --ignore-daemonsets --delete-emptydir-data --timeout=300s
+
 apt-mark unhold kubeadm
 apt-get update && apt-get install -y kubeadm=1.35.3-1.1
 apt-mark hold kubeadm
@@ -183,6 +191,8 @@ apt-get install -y kubelet=1.35.3-1.1 kubectl=1.35.3-1.1
 apt-mark hold kubelet kubectl
 systemctl daemon-reload
 systemctl restart kubelet
+
+kubectl uncordon cp-02
 ```
 
 Since Kubernetes 1.28, kubeadm waits until all control-plane nodes reach the new version before upgrading cluster addons like CoreDNS and kube-proxy. That prevents a half-upgraded HA plane from running addon versions incompatible with older apiservers still serving traffic.
@@ -227,7 +237,7 @@ Kubernetes core components are only half the upgrade story. Your CNI, CSI, ingre
 
 [The deprecated API migration guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) lists APIs removed per minor release. Before jumping to 1.35, scan manifests and Helm releases for versions removed in 1.32–1.35 (for example, flowcontrol `v1beta3` removals). Tools like `pluto` or `kubepug` help, but the authoritative list is the upstream guide—run checks against staging first.
 
-Admission webhooks deserve special attention: [the version skew policy requires validating and mutating webhooks to handle new API fields before apiserver upgrades](https://kubernetes.io/releases/version-skew-policy). A webhook that rejects unknown fields can brick `kubectl apply` cluster-wide the moment the new apiserver starts.
+Admission webhooks deserve special attention: validate that your validating and mutating webhooks tolerate new API fields before apiserver upgrades — a webhook that rejects unknown fields can brick `kubectl apply` cluster-wide the moment the new apiserver starts. See the [version skew policy](https://kubernetes.io/releases/version-skew-policy/) for component ordering; webhook compatibility is a separate preflight gate.
 
 ### Automating Preflight Checks
 
@@ -371,7 +381,7 @@ Label nodes with `kubedojo.io/hardware-gen` or similar before upgrades begin. Ca
 
 ```mermaid
 flowchart TD
-    subgraph Phase 1: Canary
+    subgraph phase1["Phase 1: Canary"]
         C1["[dell-r640-01]"]
         C2["[dell-r740-01]"]
         C3["[hp-dl380-01]"]
@@ -379,20 +389,20 @@ flowchart TD
         C1 & C2 & C3 --> M
     end
     
-    subgraph Phase 2: Remaining Gen 1
+    subgraph phase2["Phase 2: Remaining Gen 1"]
         G1["[dell-r640-02..08]<br>rolling, 2 at a time"]
         N1["Why oldest first?<br>- Oldest hardware is most likely to surface problems<br>- If a kernel incompatibility exists, you find it early<br>- Newest hardware has the most spare capacity as buffer"]
     end
     
-    subgraph Phase 3: Gen 2
+    subgraph phase3["Phase 3: Gen 2"]
         G2["[dell-r740-02..15]<br>rolling, 3 at a time"]
     end
     
-    subgraph Phase 4: Gen 3
+    subgraph phase4["Phase 4: Gen 3"]
         G3["[hp-dl380-02..20]<br>rolling, 3 at a time<br>(newest hardware last)"]
     end
     
-    Phase 1 --> Phase 2 --> Phase 3 --> Phase 4
+    phase1 --> phase2 --> phase3 --> phase4
 ```
 
 ### Pre-flight Checks per Hardware Generation
@@ -442,10 +452,11 @@ systemctl restart kubelet
 
 # Step 3: Restore etcd from backup (if schema changed)
 # This is why you ALWAYS back up etcd before upgrading
-ETCDCTL_API=3 etcdctl snapshot restore /backup/etcd-pre-upgrade.db \
+etcdutl snapshot restore /backup/etcd-pre-upgrade.db \
   --data-dir /var/lib/etcd-restored \
   --name $(hostname) \
-  --initial-cluster $(hostname)=https://$(hostname):2380
+  --initial-cluster $(hostname)=https://$(hostname):2380 \
+  --initial-advertise-peer-urls https://$(hostname):2380
 
 # Step 4: Swap the etcd data directory
 mv /var/lib/etcd /var/lib/etcd-broken
@@ -531,13 +542,13 @@ Ownership matters in design reviews. Platform engineering owns the staging clust
 
 ```mermaid
 flowchart TD
-    subgraph Staging Cluster For Upgrade Testing
+    subgraph staging["Staging Cluster For Upgrade Testing"]
         CP["3 control plane nodes<br>(same hardware as production)"]
         W["1 worker per hardware generation"]
         Env["Same CNI, CSI, and ingress controller versions<br>Representative workloads (not production data)"]
     end
     
-    subgraph Test Matrix
+    subgraph testmatrix["Test Matrix"]
         T1["kubeadm upgrade: No errors, all nodes Ready"]
         T2["Pod scheduling: Pods schedule on all generations"]
         T3["CNI networking: Pod-to-pod across nodes works"]
@@ -548,7 +559,7 @@ flowchart TD
         T8["Monitoring: Prometheus scrapes all targets"]
     end
     
-    Staging Cluster For Upgrade Testing --> Test Matrix
+    staging --> testmatrix
 ```
 
 Run the full production runbook on staging, including notifications (to a test channel) and etcd snapshot restore. Staging that only runs `kubeadm upgrade plan` without draining real workloads misses PDB interactions.

--- a/src/content/docs/on-premises/operations/module-7.1-upgrades.md
+++ b/src/content/docs/on-premises/operations/module-7.1-upgrades.md
@@ -11,16 +11,6 @@ sidebar:
 
 ---
 
-## Why This Module Matters
-
-An undocumented, all-at-once upgrade on heterogeneous bare-metal nodes can turn routine maintenance into an outage, especially when capacity is tight and rollback has not been rehearsed.
-
-The fix was straightforward but required discipline: a staging cluster that mirrors production, a written runbook, one-node-at-a-time rolling upgrades, and rollback procedures tested before the upgrade begins. A useful postmortem conclusion is that bare-metal upgrades need rehearsed runbooks, staged rollouts, and validation of node differences before production changes.
-
-In managed Kubernetes services, the provider automates more of the upgrade workflow. On bare metal, you are the managed service. Every upgrade is a planned operation that must account for heterogeneous hardware, limited spare capacity, and the absence of a safety net.
-
----
-
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:
@@ -29,6 +19,16 @@ After completing this module, you will be able to:
 2. **Implement** rolling node upgrades that respect PodDisruptionBudgets, drain timeouts, and heterogeneous hardware constraints
 3. **Design** a staging cluster that mirrors production hardware and workloads for pre-upgrade validation
 4. **Troubleshoot** upgrade failures caused by kernel incompatibilities, deprecated APIs, and node-level configuration drift
+
+---
+
+## Why This Module Matters
+
+**Hypothetical scenario:** A platform team schedules a Friday-evening Kubernetes minor upgrade across a 120-node bare-metal fleet. They skip the staging rehearsal, assume all nodes are identical, and roll workers in batches of ten because the change window is short. By Saturday morning, three hardware generations are running mixed kubelet versions, two control-plane members report etcd WAL errors, and a stateful workload cannot reschedule because PodDisruptionBudgets block drains on an already oversubscribed cluster. Rollback is attempted without a verified etcd snapshot, which turns a reversible software change into a multi-day recovery project.
+
+The fix was straightforward but required discipline: a staging cluster that mirrors production, a written runbook, one-node-at-a-time rolling upgrades, and rollback procedures tested before the upgrade begins. A useful postmortem conclusion is that bare-metal upgrades need rehearsed runbooks, staged rollouts, and validation of node differences before production changes.
+
+In managed Kubernetes services, the provider automates more of the upgrade workflow. On bare metal, you are the managed service. Every upgrade is a planned operation that must account for heterogeneous hardware, limited spare capacity, and the absence of a safety net. The economics differ too: you pay for the servers whether they are upgrading or serving traffic, and every hour of platform engineer time during a failed upgrade is OpEx you cannot invoice to a cloud provider.
 
 ---
 
@@ -45,7 +45,7 @@ After completing this module, you will be able to:
 
 ## Kubernetes Version Skew Policy
 
-Before upgrading anything, you must understand what version combinations are supported. Kubernetes enforces strict version skew limits between components. 
+Before upgrading anything, you must understand what version combinations are supported. Kubernetes enforces strict version skew limits between components, and on bare metal those limits interact with slow rolling programs that can stretch across multiple maintenance windows.
 
 ```mermaid
 flowchart LR
@@ -62,14 +62,19 @@ flowchart LR
 ```
 
 [For example, if `kube-apiserver` is at **v1.35**:](https://kubernetes.io/releases/version-skew-policy)
+
 - In highly available (HA) control planes, all `kube-apiserver` instances must be within one minor version of each other.
 - `kube-controller-manager` and `kube-scheduler` can be at **v1.35** or **v1.34**.
 - `kubelet` and `kube-proxy` can be at **v1.35**, **v1.34**, **v1.33**, or **v1.32**.
 - `kubectl` can be at **v1.36**, **v1.35**, or **v1.34**.
 
+The skew policy is not merely documentation—it defines the order of operations. Control plane components upgrade first, then kubelets on workers. [Kubernetes explicitly warns that kubelet and kube-proxy instances persistently three minor versions behind the API server must be upgraded before the control plane can advance again](https://kubernetes.io/releases/version-skew-policy). On a 200-node fleet where only ten nodes fit into each maintenance window, that warning becomes a scheduling constraint you must model in the runbook.
+
 ### Why Three-Version Kubelet Skew Matters on Bare Metal
 
-In the cloud, you upgrade all nodes within hours. On bare metal with 200 nodes and maintenance windows, the upgrade might stretch over weeks. [The three-version kubelet skew means you can run apiserver at 1.35 while some workers still run kubelet 1.32 -- but 1.31 kubelets would stop working.](https://kubernetes.io/releases/version-skew-policy)
+In the cloud, you upgrade all nodes within hours. On bare metal with 200 nodes and maintenance windows, the upgrade might stretch over weeks. [The three-version kubelet skew means you can run apiserver at 1.35 while some workers still run kubelet 1.32 -- but 1.31 kubelets would stop working.](https://kubernetes.io/releases/version-skew-policy) The expanded skew tolerance arrived in Kubernetes 1.28 specifically to reduce pressure on large fleets, but it does not remove the obligation to finish worker rollouts before the next control-plane bump.
+
+HA control planes add another wrinkle: if one apiserver is still at 1.34 while another is at 1.35, the allowed kubelet range narrows to versions not newer than the oldest apiserver in the fleet. Mixed control-plane versions during rolling upgrades are normal, but they temporarily tighten what worker versions are valid. Your inventory script should capture apiserver pod images per node, not only `kubeletVersion` on Node objects.
 
 ```bash
 # Check current versions across all nodes
@@ -82,19 +87,56 @@ kubectl get nodes -o custom-columns=\
 
 ---
 
-## kubeadm Upgrade Workflow
+## Control Plane Upgrade Orchestration
+
+The control plane is the blast-radius center of every Kubernetes upgrade. On kubeadm clusters, upgrading it is a sequence of package installs, static-pod manifest rewrites, and—most critically—etcd data directory migrations that you cannot undo without a snapshot taken before the change begins.
+
+### The etcd Snapshot Rule (Non-Negotiable)
+
+[etcd's Write-Ahead Log format can change between versions](https://etcd.io/docs/v3.6/op-guide/recovery/), and kubeadm bundles a compatible etcd version with each Kubernetes release. If you upgrade etcd and later discover a workload regression, downgrading the etcd binary alone does not rewind the on-disk state. The snapshot is your time machine.
+
+```bash
+# ALWAYS back up etcd before ANY control plane upgrade
+ETCDCTL_API=3 etcdctl snapshot save /backup/etcd-pre-upgrade.db \
+  --endpoints=https://127.0.0.1:2379 \
+  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
+  --cert=/etc/kubernetes/pki/etcd/server.crt \
+  --key=/etc/kubernetes/pki/etcd/server.key
+
+# Verify the backup
+ETCDCTL_API=3 etcdctl snapshot status /backup/etcd-pre-upgrade.db \
+  --write-out=table
+```
+
+Run this on a control-plane node with valid client certificates, then copy the snapshot off-node. A backup that lives only on the server you are about to reboot is not a backup. For external etcd clusters, snapshot from a member with quorum healthy and store artifacts in object storage with versioning enabled.
+
+[kubeadm also writes automatic backups under `/etc/kubernetes/tmp/kubeadm-backup-etcd-*` and `kubeadm-backup-manifests-*` during upgrade](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/), but treat those as convenience copies, not your primary recovery path. They disappear when nodes are reimaged, and they are easy to overlook after a long upgrade weekend.
+
+### Graceful API Server Shutdown During etcd Upgrades
+
+Because the `kube-apiserver` static pod runs even on drained control-plane nodes, [an etcd upgrade can stall in-flight requests while the new etcd pod restarts](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/). On bare metal without a managed control-plane SLA, that stall is visible to every client. The upstream workaround is deliberate:
+
+```bash
+killall -s SIGTERM kube-apiserver   # graceful apiserver shutdown
+sleep 20                            # let in-flight requests complete
+kubeadm upgrade apply v1.35.3       # proceed with upgrade
+```
+
+Document who runs this step and from which bastion. It is easy to kill the wrong process on a host that also runs workload-adjacent monitoring agents.
+
+### kubeadm Upgrade Workflow
 
 > **Pause and predict**: Before reading the upgrade steps, think about why [the first control plane node uses `kubeadm upgrade apply` while subsequent control plane nodes use `kubeadm upgrade node`](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/). What is different about the first node?
 
 > **Prerequisite**: [Your bare-metal cluster must be running with either static control-plane/etcd pods or an external etcd cluster. `kubeadm upgrade` does not support other control plane topologies.](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/)
 
-### Step 1: Upgrade the First Control Plane Node
-
-The first control plane upgrade is special: `kubeadm upgrade apply` upgrades the cluster-wide components (API server, controller manager, scheduler manifests) and etcd. Subsequent nodes only need to update their local kubelet and static pod manifests.
+The first control plane node executes cluster-wide changes: API server, controller-manager, scheduler manifests, CoreDNS/kube-proxy addon bumps (after all control-plane kubelets match), and etcd when bundled. Additional control-plane nodes only align their local static pods and kubelet configuration with the cluster's declared version.
 
 > **Note**: For Kubernetes versions released after September 13, 2023, [you must use the community-owned `pkgs.k8s.io` package repositories](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/), which use per-minor URLs. Legacy apt/yum repos are frozen and no longer receive updates.
 
 > **Note**: If `kubeadm upgrade apply` fails partway through, it does not fully roll back automatically. However, [the command is idempotent—you can fix the underlying issue and safely run `kubeadm upgrade apply` again.](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/)
+
+#### Step 1: Upgrade the First Control Plane Node
 
 ```bash
 # Check available versions
@@ -123,7 +165,9 @@ systemctl daemon-reload
 systemctl restart kubelet
 ```
 
-### Step 2: Upgrade Additional Control Plane Nodes
+`kubeadm upgrade plan` is your pre-flight checklist rendered as a table: component config versions, available target releases, and whether the cluster is upgradeable. Run it from a jump host with `admin.conf` before you touch production packages. Patch within the current minor first (`1.35.x` latest), then step minors one at a time—kubeadm does not support skipping versions.
+
+#### Step 2: Upgrade Additional Control Plane Nodes
 
 ```bash
 # On each additional control plane node
@@ -141,7 +185,15 @@ systemctl daemon-reload
 systemctl restart kubelet
 ```
 
-### Step 3: Upgrade Worker Nodes (Rolling)
+Since Kubernetes 1.28, kubeadm waits until all control-plane nodes reach the new version before upgrading cluster addons like CoreDNS and kube-proxy. That prevents a half-upgraded HA plane from running addon versions incompatible with older apiservers still serving traffic.
+
+Patch versions matter even within a minor. [The Kubernetes project recommends upgrading to the latest patch before stepping minors](https://kubernetes.io/releases/version-skew-policy)—security fixes land in patches, and kubeadm’s preflight checks assume you are not jumping from an ancient patch to a distant minor. On bare metal with change-averse stakeholders, schedule two micro-windows if needed: patch bump Tuesday, minor bump the following week.
+
+External etcd clusters shift responsibility: kubeadm’s bundled etcd backup folders may be empty when etcd runs outside the node. Your runbook must name etcd endpoints, snapshot credentials, and restore owners explicitly. Losing quorum on external etcd during a control-plane upgrade is identical in user impact to losing stacked etcd—only the file paths differ.
+
+Windows worker nodes follow a parallel but distinct path documented upstream for kubeadm; heterogeneous fleets that mix Linux and Windows require separate batch tracks so Linux drains do not assume Windows kubelet packaging commands. Inventory scripts should tag OS image and package manager family to prevent accidental `apt-get` recipes on Windows hosts.
+
+#### Step 3: Upgrade Worker Nodes (Rolling)
 
 [In-place minor kubelet upgrades are not supported. You must drain the node before upgrading the packages.](https://kubernetes.io/releases/version-skew-policy)
 
@@ -156,6 +208,74 @@ flowchart TD
     B6["Batch 6: [worker-11] [worker-12]<br>final batch"] --> Done
     Done(["Verify cluster health after"])
 ```
+
+---
+
+## Addon, CNI, and API Deprecation Compatibility
+
+Kubernetes core components are only half the upgrade story. Your CNI, CSI, ingress controller, service mesh, and admission webhooks each carry their own Kubernetes version support matrix—and on bare metal nobody upgrades them for you.
+
+[kubeadm upgrades CoreDNS and kube-proxy after the control plane, but explicitly requires you to upgrade CNI plugins manually](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/). Check the [addons documentation](https://kubernetes.io/docs/concepts/cluster-administration/addons/) for your provider's release notes before scheduling production work. A CNI DaemonSet pinned to an old API version can leave new nodes `NotReady` even when kubeadm reports success.
+
+| Layer | Typical upgrade owner | Pre-upgrade check |
+|-------|----------------------|-------------------|
+| CNI (Cilium, Calico, Flannel) | Platform team | DaemonSet image + CRD compatibility with target K8s minor |
+| CSI (Rook-Ceph, TopoLVM, local-path) | Storage team | Snapshot controller, CSI sidecar versions |
+| Ingress / Gateway | App platform | ValidatingWebhook `matchPolicy`, deprecated API versions |
+| Service mesh | App platform | Sidecar injector webhook timeouts during apiserver restart |
+| Monitoring agents | Observability | HostPath / privileged permissions vs new Pod Security standards |
+
+[The deprecated API migration guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) lists APIs removed per minor release. Before jumping to 1.35, scan manifests and Helm releases for versions removed in 1.32–1.35 (for example, flowcontrol `v1beta3` removals). Tools like `pluto` or `kubepug` help, but the authoritative list is the upstream guide—run checks against staging first.
+
+Admission webhooks deserve special attention: [the version skew policy requires validating and mutating webhooks to handle new API fields before apiserver upgrades](https://kubernetes.io/releases/version-skew-policy). A webhook that rejects unknown fields can brick `kubectl apply` cluster-wide the moment the new apiserver starts.
+
+### Automating Preflight Checks
+
+Manual spreadsheet matrices do not scale past two minors per year. Encode preflight as CI jobs that run against staging before anyone touches package mirrors:
+
+```bash
+# Example: fail CI if deprecated APIs remain (requires pluto or similar installed)
+pluto detect-files -d staging-manifests/ --target-versions k8s=v1.35.0
+
+# Verify all nodes report cgroup v2 before change window
+kubectl get nodes -o json | jq -r '
+  .items[] | select(.status.nodeInfo.operatingSystem == "linux") |
+  "\(.metadata.name) cgroup-check-required"'
+
+# Confirm webhook configurations accept v1 admission review versions
+kubectl get validatingwebhookconfigurations,mutatingwebhookconfigurations \
+  -o json | jq '.items[] | {name: .metadata.name, versions: .webhooks[].admissionReviewVersions}'
+```
+
+Treat a failed preflight as a hard gate. On bare metal, the cost of proceeding anyway is measured in hours of console access across multiple datacenters, not a single cloud support ticket.
+
+---
+
+## Node Upgrade Strategies: In-Place vs Surge Replacement
+
+Bare-metal fleets usually start with in-place kubeadm upgrades—cordon, drain, package upgrade, uncordon—because there is no hypervisor to clone a fresh VM. As fleets mature, many teams adopt surge replacement via Cluster API or immutable OS images to shrink per-node toil.
+
+### In-Place Rolling (kubeadm Default)
+
+In-place upgrades reuse existing disks, network bonds, and BMC configurations. They are CapEx-efficient because every server stays in the fleet, but they couple OS kernel state with Kubernetes version state. A kubelet 1.35 upgrade on a host still running cgroup v1 will fail even if packages install cleanly.
+
+[For Kubernetes 1.35, cgroup v1 is deprecated: kubelet sets `failCgroupV1=true` by default and refuses to start on v1 hierarchies](https://kubernetes.io/docs/concepts/architecture/cgroups/). Verify with `stat -fc %T /sys/fs/cgroup/` (`cgroup2fs` is required). Migrating cgroups is an OS exercise—often a reimage—not something `apt-get install kubelet` fixes.
+
+### Surge Replacement via Cluster API
+
+[Cluster API upgrades workload clusters by rolling MachineDeployments and KubeadmControlPlane objects](https://cluster-api.sigs.k8s.io/tasks/upgrading-clusters). You publish a new machine image with pre-baked `kubeadm`/`kubelet` versions, update `MachineTemplate` references (templates are immutable), then bump `KubeadmControlPlane.spec.version`. The controllers create replacement machines, join them, and drain old members—similar to cloud auto repair, but you own the image pipeline.
+
+Surge capacity has a real cost on bare metal: spare servers sitting in staging, extra switch ports, and power draw. The trade is operational—failed upgrades discard a machine instead of debugging a corrupted `/var/lib/kubelet`. For heterogeneous hardware, maintain one golden image per generation and let Machine labels drive rollout order.
+
+### Immutable OS Paths (Talos and Flatcar)
+
+Immutable operating systems treat the node OS as disposable. [Talos provides `talosctl upgrade-k8s` to orchestrate control-plane and worker component bumps](https://www.talos.dev/v1.9/kubernetes-guides/upgrading-kubernetes/), including pre-pulling images and patching machine configuration. Worker kubelet upgrades may restart workloads; plan PDBs accordingly.
+
+The pattern is A/B at the node level: new configuration activates atomically, and rollback means reverting machine config rather than downgrading packages on a mutable OS. This shines when your bottleneck is configuration drift across 400 hand-built servers, but it requires upfront investment in image factories and management-cluster availability.
+
+Flatcar Container Linux and similar projects follow the same philosophy: update streams ship OS and Kubernetes components together, and nodes reboot into new versions. Evaluate whether your compliance regime permits automatic reboots during maintenance windows, and whether BMC power policies support graceful shutdown hooks that kubelet honors.
+
+When choosing between surge replacement and in-place upgrades, estimate mean time to recovery for a failed node. In-place failures often leave corrupted state on disk; surge failures discard the Machine and reprovision from golden images. If reprovision time plus OS bootstrap is shorter than debugging a mutable node, surge wins even without cloud elasticity.
 
 ---
 
@@ -181,6 +301,8 @@ kubectl get pdb --all-namespaces
 ```
 
 > **Stop and think**: Your cluster runs at 80% CPU utilization. You need to drain a node for upgrade. Where do those pods go? What happens if the remaining nodes cannot absorb the evicted workloads?
+
+Translate utilization into a batch size. If losing one node raises CPU requests above 85% on the remainder, your batch size is one—even if the runbook template says three. [PodDisruptionBudgets count voluntary disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/); a drain that evicts guarded pods consumes budget that the same upgrade window may need again on the next node.
 
 ### Safe Drain Procedure
 
@@ -243,6 +365,8 @@ kubectl get nodes -o json | jq -r '
   ] | @tsv' | sort -k2 | column -t
 ```
 
+Label nodes with `kubedojo.io/hardware-gen` or similar before upgrades begin. Canary selection should pull one node per generation, not merely the oldest serial number in the CMDB.
+
 ### Upgrade Order by Hardware Generation
 
 ```mermaid
@@ -290,11 +414,13 @@ crictl info > /dev/null 2>&1 || { echo "FAIL: runtime down"; exit 1; }
 echo "=== All checks passed ==="
 ```
 
+[The kubelet and container runtime must share a cgroup driver; Kubernetes recommends `systemd` on cgroup v2 hosts](https://kubernetes.io/docs/setup/production-environment/container-runtimes/). A mismatch surfaces during kubelet restart, not during `kubeadm upgrade plan`.
+
 ---
 
-## Rollback Strategies
+## Rollback Strategies and etcd Restore Drills
 
-Rolling back a Kubernetes upgrade is harder than the upgrade itself. You must plan for rollback before you begin.
+Rolling back a Kubernetes upgrade is harder than the upgrade itself. You must plan for rollback before you begin, and you must rehearse etcd restore on staging hardware at least quarterly—reading the steps during an outage is too late.
 
 ### Control Plane Rollback
 
@@ -335,28 +461,71 @@ cp /backup/manifests-pre-upgrade/* /etc/kubernetes/manifests/
 
 > **Pause and predict**: You are about to upgrade your control plane. The etcd snapshot is your safety net. If you skip this step and the upgrade corrupts etcd's WAL format, what are your options for recovery?
 
-### The etcd Backup Rule
+[Restoring etcd rewinds cluster state](https://etcd.io/docs/v3.6/op-guide/recovery/). Any objects created after the snapshot disappear. Controllers with cached informers may behave inconsistently until watches realign; for Kubernetes workloads, consider revision bump options documented in etcd recovery guides when restoring into a live fleet.
 
-This is the single most important step before any control plane upgrade. etcd's Write-Ahead Log format can change between versions, making downgrades impossible without a pre-upgrade snapshot.
+### Quarterly etcd Restore Drill
 
-```bash
-# ALWAYS back up etcd before ANY control plane upgrade
-ETCDCTL_API=3 etcdctl snapshot save /backup/etcd-pre-upgrade.db \
-  --endpoints=https://127.0.0.1:2379 \
-  --cacert=/etc/kubernetes/pki/etcd/ca.crt \
-  --cert=/etc/kubernetes/pki/etcd/server.crt \
-  --key=/etc/kubernetes/pki/etcd/server.key
+Run this on staging, not production:
 
-# Verify the backup
-ETCDCTL_API=3 etcdctl snapshot status /backup/etcd-pre-upgrade.db \
-  --write-out=table
-```
+1. Take a snapshot from production (read-only operation).
+2. Restore into an isolated three-node etcd cluster using `etcdutl snapshot restore`.
+3. Start static-pod apiservers pointed at the restored data.
+4. Verify a known Deployment still exists at the expected replica count.
+5. Document wall-clock time and who must be paged.
+
+If the drill exceeds your change-window budget, your production rollback plan is aspirational.
 
 ---
 
-## Testing Upgrades in Staging
+## Maintenance Windows, Canary Nodes, and Blast-Radius Control
 
-On bare metal, your staging cluster should mirror production hardware as closely as possible. This means at least one node from each hardware generation.
+Bare-metal upgrades are change-management exercises as much as technical ones. Define maintenance windows in local time zones where staffing is dense, publish stakeholder notifications, and tie rollback triggers to objective signals—not gut feel.
+
+| Signal | Rollback trigger example |
+|--------|-------------------------|
+| Control plane | Any apiserver pod crashlooping > 10 minutes after upgrade |
+| Workloads | >5% of pods `CrashLoopBackOff` cluster-wide post-batch |
+| Networking | CNI health check failures between canary and control nodes |
+| Storage | CSI mount failures on upgraded nodes only |
+| Data plane | etcd fsync latency > 2× baseline for 15 minutes |
+
+Canary nodes should represent each hardware generation and each rack with top-of-rack diversity. Monitor them for at least one full application SLO window before widening batch size. If your canary runs batch jobs but production runs latency-sensitive RPC, the canary lied.
+
+For HA control planes, never upgrade two members simultaneously. etcd quorum is `(N-1)/2` tolerant; losing two of three members during a bad package mirror strands the cluster even if workers are healthy.
+
+Change advisory boards exist in regulated industries for a reason: they force explicit approvers when blast radius exceeds a threshold. Even without formal CABs, bare-metal Kubernetes upgrades benefit from a two-person rule for control-plane changes—one executor, one verifier reading steps aloud. The verifier holds authority to call rollback without debating politeness.
+
+Freeze non-essential deploys during the window. Application teams shipping new Helm charts while nodes drain compound risk: you cannot tell whether CrashLoopBackOff came from the image or the kubelet. Communicate a code freeze with a clear end time; platform credibility depends on finishing on schedule or escalating early.
+
+---
+
+## Cost Lens: Upgrade Toil vs Managed Control Planes
+
+On bare metal, upgrade costs show up in three ledgers: CapEx, facility OpEx, and engineer OpEx.
+
+**CapEx and facilities:** Servers you bought for production capacity cannot serve workloads while drained. If upgrades require surge machines, that is either idle inventory (depreciating on the balance sheet) or emergency hardware purchases. Power, cooling, and rack space for staging clusters that mirror production are recurring costs—budget them when comparing on-prem TCO to cloud.
+
+**Engineer OpEx:** A managed Kubernetes control plane bundles upgrade orchestration into the provider fee. On bare metal, your platform team owns the pager for apiserver restarts, etcd snapshots, CNI bumps, and rollback drills. Model upgrade frequency: [Kubernetes maintains patch support for roughly twelve months per minor](https://kubernetes.io/releases/version-skew-policy), so falling behind two minors turns planned work into emergency work with overtime labor rates.
+
+**When on-prem upgrades earn their cost:** Steady high utilization (you use servers you already paid for), data gravity (egress and compliance make cloud migration expensive), regulatory requirements for fixed audit trails, and predictable workload growth. **When they do not:** spiky low-utilization clusters where cloud autoscaling and managed upgrades cheaper than staffing a 24/7 platform rotation.
+
+Document upgrade hours per minor version and divide by node count. That metric justifies automation investments—Cluster API, image factories, Talos—and informs finance whether another FTE is cheaper than another rack.
+
+Compare TCO over a three-year hardware refresh cycle, not a single weekend. Managed Kubernetes charges recurring OpEx per control plane and per node; on-prem charges CapEx up front plus power, cooling, rack space, support contracts, and staff. Upgrades sit in the staff line item—if you defer them, security risk rises and emergency upgrades cost premium labor. Finance models that ignore upgrade labor treat on-prem as artificially cheap.
+
+Conversely, cloud burst capacity during upgrades is seductive but expensive at scale: large stateful workloads with egress-heavy traffic may pay more in data transfer than in platform engineer time. The cost lens is not ideological; it is a spreadsheet with honest labor inputs. Platform leaders should present both models with the same availability target so executives choose consciously rather than by vendor marketing.
+
+---
+
+## Designing the Staging Cluster for Upgrade Validation
+
+On bare metal, your staging cluster should mirror production hardware as closely as possible—not merely run the same Kubernetes version on generic VMs. The design goal is to surface generation-specific failures before they block a production drain window. That means at least one physical worker per hardware generation, control-plane nodes built from the same server SKU as production, and network paths that traverse the same leaf switches and VLAN layout your workloads depend on in the real datacenter.
+
+Capacity can be smaller than production, but topology must be representative. If production spreads workers across four racks with BGP anycast services, staging with a single rack hides failover bugs until go-live. Similarly, if production mounts Ceph RBD volumes through a dedicated storage VLAN, staging that uses only local-path volumes will not exercise CSI upgrade paths. Document explicitly what staging is allowed to omit (GPU nodes, SR-IOV, air-gapped registry mirrors) and what must be present for a valid sign-off.
+
+Workloads should be synthetic yet realistic: Deployments with PDBs, StatefulSets with persistent volumes, Jobs that restart frequently, and at least one Helm release that mirrors a production chart version. Use anonymized configuration, not production data, but keep resource requests, affinity rules, and topology spread constraints faithful. The point is to force the scheduler and eviction machinery to behave like production when nodes drain.
+
+Ownership matters in design reviews. Platform engineering owns the staging cluster lifecycle; application teams nominate one service per critical pattern (cache, queue, SQL, gRPC mesh) to run there. Finance should see staging racks as insurance against multi-hour outages, not as “extra” hardware to defer when budgets tighten—depreciation on idle staging servers is cheaper than emergency hardware purchases during a failed upgrade.
 
 ### Staging Cluster Requirements
 
@@ -381,6 +550,44 @@ flowchart TD
     
     Staging Cluster For Upgrade Testing --> Test Matrix
 ```
+
+Run the full production runbook on staging, including notifications (to a test channel) and etcd snapshot restore. Staging that only runs `kubeadm upgrade plan` without draining real workloads misses PDB interactions.
+
+Sign-off criteria should be written before the rehearsal starts: all nodes Ready on the target version, zero deprecated API objects reported by preflight scanners, CNI and CSI health checks green, and a timed etcd restore drill completed within the change-window budget. Capture wall-clock duration per phase; if staging upgrade exceeds half the production window, shrink batch sizes or add surge capacity before scheduling production work.
+
+---
+
+## Troubleshooting Upgrade Failures
+
+When an upgrade fails on bare metal, symptoms cluster around three layers: OS prerequisites, Kubernetes component skew, and addon/webhook incompatibility. A structured troubleshoot path saves hours of random package downgrades.
+
+### kubelet Will Not Start After Package Upgrade
+
+Start with `journalctl -u kubelet -b --no-pager | tail -80`. cgroup v1 rejection in 1.35 presents as fatal errors referencing `failCgroupV1`. Confirm hierarchy with `stat -fc %T /sys/fs/cgroup/` and [compare against upstream cgroup guidance](https://kubernetes.io/docs/concepts/architecture/cgroups/). If the node reports `tmpfs`, schedule an OS migration or reimage before retrying kubelet 1.35.
+
+Runtime mismatches produce different errors: containerd not running, wrong socket path, or cgroup driver disagreement. [Verify kubelet and runtime both use the systemd driver on cgroup v2 hosts](https://kubernetes.io/docs/setup/production-environment/container-runtimes/). On nodes upgraded in-place many times, stale flags in `/var/lib/kubelet/config.yaml` survive package updates—diff against a fresh `kubeadm kubelet config` output from a known-good node.
+
+### API Server CrashLoop After kubeadm upgrade apply
+
+Check static pod manifests in `/etc/kubernetes/manifests/` for image tags that do not match the intended patch version. Inspect `kubectl -n kube-system logs` for the apiserver pod if it briefly starts. etcd TLS errors often indicate clock skew or expired certificates—[kubeadm renews certificates during upgrade unless disabled](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/). Compare `kubeadm certs check-expiration` before and after.
+
+If etcd fails to start, examine WAL corruption messages. Do not delete data directories impulsively; restore from the pre-upgrade snapshot on a isolated host first. [etcd recovery documentation](https://etcd.io/docs/v3.6/op-guide/recovery/) describes revision bump considerations when controllers must resync.
+
+### Deprecated API Surprises Post-Upgrade
+
+Symptoms include controllers that stop reconciling, Helm releases stuck in pending upgrade, or CRDs that disappear from discovery. Run `kubectl get --raw /metrics` and apiserver audit logs for `410 Gone` responses. Cross-reference [the deprecated API migration guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) for the target minor. Fix manifests in Git, re-apply from staging outward—do not hand-patch production without recording the change.
+
+### Node-Level Configuration Drift
+
+Drift is the silent killer of heterogeneous fleets: one worker still points at a decommissioned NTP server, another mounts an old `/etc/fstab` NFS entry, a third never received the firmware bundle that enables ACS on PCIe switches. Before blaming Kubernetes, compare `/etc/kubernetes/kubelet.conf`, containerd config, and kernel cmdline against your configuration management baseline. Immutable OS fleets reduce this class of failure; mutable OS fleets need configuration audits in the upgrade runbook.
+
+Document every troubleshoot session in the runbook appendix with node name, generation label, root cause layer (OS, core, addon), and fix. Patterns repeat across minors—your future self is the primary beneficiary.
+
+### When to Escalate to Vendor or Hardware Support
+
+If kubelet logs show NIC driver panics, RAID battery warnings, or machine check exceptions, software rollback will not help—the node needs hardware service. Capture `dmesg`, BMC event logs, and SMART data before reimaging. Opening a vendor case with incomplete logs wastes days during an upgrade freeze.
+
+For software vendors (CNI, CSI, service mesh), escalate when staging reproduces a failure that blocks PDB-safe drains and no documented workaround exists. Bring etcd snapshot timestamps, apiserver audit excerpts, and exact chart versions. Bare-metal vendors appreciate precise generation labels; software vendors appreciate minimal reproduction manifests.
 
 ---
 
@@ -418,17 +625,106 @@ flowchart TD
 
 ---
 
+## Patterns & Anti-Patterns
+
+**Pattern: snapshot-first control-plane upgrades.** Take a verified etcd snapshot before any `kubeadm upgrade apply`, store it off-node, and record the revision hash. This pattern works at any fleet size because it converts an irreversible etcd migration into a reversible decision for the length of your retention policy. Scale by automating snapshot jobs with alerting on failure—not by skipping snapshots when tired.
+
+**Pattern: generation-aware canary batches.** Upgrade one node per hardware generation before widening batch sizes. Heterogeneous bare-metal fleets hide kernel, firmware, and NIC driver differences that homogeneous cloud node pools never expose. When a canary fails, you learn which generation needs an OS reimage instead of blaming Kubernetes.
+
+**Pattern: addon compatibility matrix as a gate.** Maintain a table of CNI, CSI, ingress, and webhook versions certified against each target Kubernetes minor. Block production upgrades until staging passes the full matrix. This pattern prevents the common failure mode where core components upgrade while DaemonSets still speak removed API versions.
+
+**Anti-pattern: big-bang Friday upgrades.** Teams choose Friday to avoid weekday traffic, but Friday failures bleed into weekends without vendor support. The better alternative is Tuesday–Wednesday morning windows with staffed rollback coverage and a rehearsed runbook.
+
+**Anti-pattern: skipping staging because “we only changed one minor.”** Minor releases remove APIs and change defaults (cgroup v1 rejection in 1.35 is a prime example). Staging is cheap compared to production recovery; skipping it is how deprecated webhook API versions reach production.
+
+**Anti-pattern: drain parallelism without capacity math.** Draining three nodes simultaneously on an 80% utilized cluster evicts pods that cannot reschedule, leaving them Pending while PDBs block further drains. Match batch size to measured headroom, not optimism.
+
+**Anti-pattern: treating worker upgrades as “optional follow-up.”** Teams celebrate a green `kubeadm upgrade apply` and defer worker kubelets for weeks. Skew limits turn that deferral into a hard blocker for the next minor, and security patches on kubelet remain unapplied. Treat worker completion as part of the same change ticket with the same rollback window.
+
+Scaling these patterns: small fleets (under twenty nodes) can use spreadsheet runbooks and manual drains; medium fleets benefit from Ansible or Terraform wrappers around kubeadm steps; large fleets should invest in Cluster API or immutable OS tooling because human attention does not scale linearly with node count. The pattern choice is economic—if upgrade weekends happen more than twice a year, automation ROI is usually positive within one hardware generation.
+
+---
+
+## Decision Framework
+
+Use this flowchart when choosing how to upgrade a bare-metal fleet. The goal is matching operational maturity to hardware constraints—not defaulting to in-place kubeadm because it was day-one tooling.
+
+```mermaid
+flowchart TD
+    Start["Need to upgrade Kubernetes on bare metal"] --> Q1{"Fleet > 50 nodes OR<br>multi-week rollout?"}
+    Q1 -->|Yes| Q2{"Have spare hardware<br>for surge nodes?"}
+    Q1 -->|No| InPlace["In-place kubeadm rolling<br>(cordon/drain/package)"]
+    Q2 -->|Yes| CAPI["Cluster API surge replacement<br>new MachineTemplates + rolling MD"]
+    Q2 -->|No| Q3{"OS drift a recurring<br>upgrade blocker?"}
+    Q3 -->|Yes| Immutable["Immutable OS path<br>(Talos/Flatcar image bump)"]
+    Q3 -->|No| InPlace
+    InPlace --> Pre["Require: etcd snapshot,<br>cgroup v2, CNI matrix"]
+    CAPI --> Pre
+    Immutable --> Pre
+    Pre --> Staging["Full rehearsal on staging<br>with restore drill"]
+    Staging --> Prod["Production window<br>with rollback triggers"]
+```
+
+| Approach | Best when | Tradeoff |
+|----------|-----------|----------|
+| In-place kubeadm | Small fleets, tight CapEx, homogeneous OS | Couples kernel state to kubelet; slow on drifted nodes |
+| Cluster API surge | Medium/large fleets with spare racks | Needs management cluster + image pipeline |
+| Immutable OS upgrade | Drift-heavy environments, declarative ops | Learning curve; management plane becomes critical |
+| Managed cloud (not on-prem) | Spiky workloads, small platform team | OpEx at scale; data egress and compliance may block |
+
+If cgroup v2 checks fail on any generation, stop and schedule OS remediation before choosing an upgrade mechanism—the mechanism does not matter if kubelet refuses to start.
+
+### Decision Notes for Multi-Cluster and Air-Gapped Fleets
+
+Some on-prem operators run a management cluster that hosts Cluster API controllers while workload clusters stay in isolated network zones. Upgrade decisions then split: management clusters must be upgraded first because they orchestrate Machine objects elsewhere, but management downtime does not automatically pause workload traffic. Document cross-cluster dependencies—Argo CD instances, centralized logging gateways, identity providers—before sequencing upgrades.
+
+Air-gapped environments add mirror and signature verification steps. Package mirrors for `pkgs.k8s.io` must host the target minor before the change window; container image mirrors must contain new control-plane images and pause sandboxes. A common failure mode is upgrading kubeadm while the local registry still serves only the previous minor’s images, producing ImagePullBackOff on static pods with no obvious path to the public internet. Validate mirror completeness with a dry-run pull from a staging node that uses production firewall rules, not from an engineer laptop.
+
+---
+
+## Communicating Upgrades to Application Teams
+
+Platform teams own the kubelet; application teams own availability SLOs. The interface between them is documentation and notice, not surprise drains. Publish an upgrade calendar quarterly with expected maintenance windows, batch sizes, and rollback triggers. For each window, list which namespaces contain workloads that cannot tolerate eviction (singleton Jobs, misconfigured PDBs, bare Pods) and assign owners to remediate before the window opens.
+
+Provide application developers a “drain readiness” checklist: PDBs allow at least one disruption, probes tolerate brief kubelet restarts, graceful termination seconds fit within drain timeouts, and init containers do not block eviction indefinitely. Offer office hours the week before upgrades to review high-risk services. This is cheaper than emergency scaling during a blocked drain.
+
+During execution, stream progress in a shared channel: control-plane phase complete, canary generation results, current batch nodes, and any rollback consideration. After completion, publish a short report with version inventory diff, anomalies encountered, and staging-to-production delta. That report becomes evidence for auditors and input for the next minor’s timeline.
+
+---
+
+## Certificate and Identity Continuity Across Upgrades
+
+[kubeadm upgrade renews certificates it manages unless you pass `--certificate-renewal=false`](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/). On long-lived bare-metal clusters, upgrades are often the moment certificates rotate—which can break automation that pinned old CA bundles. Before upgrading, export `kubeadm certs check-expiration` output and identify clients (CI pipelines, monitoring scrapers, custom operators) that embed apiserver CA material.
+
+If you integrate with corporate PKI or external etcd, certificate choreography is more manual. Ensure etcd peer certificates trust the same CA after upgrade, and verify load balancers terminating TLS in front of apiservers still forward to healthy backends during rolling control-plane work. kube-vip or HAProxy health checks should observe `/readyz` or equivalent, not merely TCP connect to 6443—an apiserver process can accept connections while admission webhooks fail open or closed unpredictably.
+
+Worker kubelet client certificates also rotate. Nodes with clock drift may fail TLS handshake after renewal; include NTP health in preflight alongside cgroup checks. For clusters using bootstrap tokens for new nodes, confirm token TTLs cover the upgrade weekend if you plan to replace machines.
+
+---
+
+## Post-Upgrade Verification and Baseline Refresh
+
+Finishing `kubeadm upgrade apply` is not the finish line. Post-upgrade verification should be scripted and compared against a baseline captured in step three of the runbook. Minimum checks: all nodes Ready, `kube-system` pods healthy, DNS loopback test from a debug pod, a sample PVC mount, and an ingress fetch through production paths.
+
+Re-run deprecated API scanners—upgrades can expose objects that were grandfathered but now fail controllers. Update monitoring dashboards and alert thresholds: Kubernetes 1.35 component metrics and cardinality may shift; stale alerts cause either silence during incidents or pager storms during benign restarts.
+
+Refresh internal documentation the same day: new default flags, cgroup assumptions, addon versions, and runbook timings. File a short retro within one week capturing batch size accuracy, staging fidelity gaps, and finance-visible hours spent. That retro feeds the next minor’s capacity plan and determines whether surge hardware requests are realistic.
+
+Long-term, build an upgrade metrics dashboard: time per phase, drains blocked by PDBs, nodes requiring OS remediation, and rollbacks invoked. Trends justify automation funding better than anecdotal war stories. When mean worker upgrade time rises release over release, investigate registry latency, image pre-pull policies, and whether hardware generations are aging past comfortable kernel support windows—those are signals to refresh CapEx planning, not just to schedule another weekend.
+
+Keep a versioned runbook artifact in Git tagged with each completed minor (`upgrade-1.35-prod-2026-06`). Auditors and new hires should read what actually happened, not what you intended to happen. Include links to etcd snapshot object-storage paths, CNI chart versions, and the staging sign-off checklist PDF or HTML export. This habit turns upgrades from tribal knowledge into operational inventory—the same inventory finance needs when deciding whether to buy surge servers or approve another platform hire.
+
+---
+
 ## Did You Know?
 
 - [**Kubernetes drops support for a minor version approximately 12 months after release.**](https://kubernetes.io/releases/version-skew-policy) On bare metal, where upgrades take longer to plan and execute, this means you should start planning the next upgrade almost immediately after completing the current one. Falling behind two versions is uncomfortable; falling behind three is an emergency.
 
-- **For Kubernetes 1.35 on Linux, the kubelet no longer starts on cgroup v1 nodes by default.** This makes cgroup v2 readiness an important prerequisite when refreshing node operating systems and runtimes.
+- **For Kubernetes 1.35 on Linux, the kubelet no longer starts on cgroup v1 nodes by default.** [Kubelet sets `failCgroupV1=true` unless explicitly overridden](https://kubernetes.io/docs/concepts/architecture/cgroups/), which makes cgroup v2 readiness an important prerequisite when refreshing node operating systems and runtimes.
 
 - [**The kubelet's three-version skew tolerance was expanded from two in Kubernetes 1.28.**](https://kubernetes.io/blog/2023/08/15/kubernetes-v1-28-release/) This change reduced the pressure to upgrade every node immediately during slower rolling-upgrade programs.
 
-- **etcd upgrades are the riskiest part of a control plane upgrade.** etcd uses a WAL (Write-Ahead Log) format that can change between versions. If the new etcd version migrates the WAL format, you cannot simply roll back to the old binary. This is why etcd backup before upgrade is non-negotiable.
-
-- **Kubernetes was heavily influenced by Borg, but on bare metal you still need to design and operate your own upgrade process.**
+- **etcd upgrades are the riskiest part of a control plane upgrade.** [etcd uses a WAL format that can change between versions](https://etcd.io/docs/v3.6/op-guide/recovery/), and restoring controllers after rewind requires disciplined drills. etcd backup before upgrade is non-negotiable.
 
 ---
 
@@ -445,44 +741,60 @@ flowchart TD
 | Upgrading on Friday afternoon | No time to handle unexpected failures | Schedule upgrades Tuesday-Wednesday morning |
 | Not recording pre-upgrade state | Cannot compare before/after | Script the version inventory before starting |
 
+Upgrade mistakes on bare metal rarely stem from ignorance of `kubeadm` subcommands—they stem from skipping gates that managed services hide: capacity, snapshots, addon matrices, and hardware diversity. Treat every mistake above as a runbook section someone already paid for with outage time.
+
+When you review this table during a retro, mark which rows actually fired during the last minor. Clusters that repeatedly hit the same row need engineering investment, not another reminder email. Recurring PDB drain blocks mean application teams need PDB coaching; recurring cgroup failures mean OS standardization is overdue. Publish the retro summary alongside the upgraded version inventory and audited artifacts so the next minor on bare metal starts from evidence, not memory, folklore, or heroic improvisation.
+
 ---
 
 ## Quiz
 
-### Question 1
-You have a 30-node cluster running Kubernetes 1.32. The security team notes that 1.32 is officially end-of-life and mandates an immediate upgrade to 1.35. What is the correct upgrade path, and how does the version skew policy affect your execution timeline on bare metal?
-
 <details>
-<summary>Answer</summary>
+<summary>1. You have a 30-node cluster running Kubernetes 1.32. The security team mandates an immediate upgrade to 1.35. What is the correct upgrade path, and how does version skew affect your timeline on bare metal?</summary>
 
-The correct upgrade path is 1.32 -> 1.33 -> 1.34 -> 1.35 (three sequential minor version upgrades). `kubeadm` does not support skipping minor versions during an upgrade step. Therefore, the control plane must be upgraded sequentially through 1.33, 1.34, and 1.35. However, thanks to the kubelet's three-version skew policy, a 1.35 API server can still communicate with 1.32 kubelets. This means you have the flexibility to upgrade the control plane rapidly through the intermediate versions while rolling the worker node upgrades over a longer period, reducing immediate disruption.
+The correct upgrade path is 1.32 → 1.33 → 1.34 → 1.35 (three sequential minor version upgrades). `kubeadm` does not support skipping minor versions in a single step. Upgrade the control plane through each minor sequentially, but leverage the three-version kubelet skew to roll workers over a longer window while apiservers advance. Plan maintenance windows per minor for the control plane, and model worker batches so no kubelet falls more than three minors behind the apiserver.
 </details>
 
-### Question 2
-During a worker upgrade cycle, you run `kubectl drain worker-12` but it hangs indefinitely. The node has plenty of spare capacity. What are the most likely causes of this hang, and how do you resolve each safely?
-
 <details>
-<summary>Answer</summary>
+<summary>2. During a worker upgrade, `kubectl drain worker-12` hangs despite spare capacity. What are the most likely causes, and how do you resolve each safely?</summary>
 
-The most common cause of a hanging drain is a PodDisruptionBudget (PDB) blocking eviction. If a deployment has a PDB with `minAvailable` equal to its current healthy replica count, the drain command cannot evict the pod without violating the budget, so it waits indefinitely. You can resolve this safely by temporarily scaling up the deployment so that evicting one pod still leaves enough replicas to satisfy the PDB. Another potential cause is a standalone pod without a controller or a pod with stuck finalizers, which require manual intervention to delete or resolve. Never use `--force` to bypass these checks unless you explicitly accept the risk of application downtime.
+The most common cause is a PodDisruptionBudget with zero allowed disruptions—often because `minAvailable` equals current healthy replicas. Temporarily scale the workload up so one eviction still satisfies the PDB. Other causes include bare pods without controllers, pods with blocking finalizers, or local storage pods that cannot reschedule. Inspect `kubectl get pdb -A` and pod events. Avoid `--disable-eviction` unless leadership accepts explicit downtime.
 </details>
 
-### Question 3
-Your bare-metal cluster runs on three hardware generations: Dell R640, Dell R740, and HPE DL380. After successfully upgrading the control plane to 1.35, you upgrade the kubelet on your first R640 canary node, but it fails to start and reports `NotReady`. The R740 nodes upgrade perfectly. What should you investigate, and why did this happen?
-
 <details>
-<summary>Answer</summary>
+<summary>3. Troubleshoot scenario: After upgrading the control plane to 1.35, your first Dell R640 canary fails with `NotReady` while R740 nodes succeed. What deprecated prerequisites and kernel incompatibilities should you investigate first?</summary>
 
-Hardware-generation-specific failures usually stem from OS-level or kernel incompatibilities rather than Kubernetes itself. In Kubernetes 1.35, the kubelet strictly requires cgroups v2 and sets `FailCgroupV1=true` by default, which will cause it to crash if the older R640 node's OS still uses legacy cgroups v1. You should inspect the kubelet logs via `journalctl -u kubelet` to identify the specific error and verify the underlying kernel and cgroup versions. To resolve this safely, you must roll back the kubelet on the R640 to the previous version, update the underlying OS to meet the new cgroups v2 prerequisite, and then re-attempt the upgrade. This scenario highlights why staging environments must mirror production hardware generations.
+Troubleshoot OS-level prerequisites before blaming hardware age. Kubernetes 1.35 rejects cgroup v1 by default—run `stat -fc %T /sys/fs/cgroup/` on the R640. If it prints `tmpfs`, the kubelet exits by design, which is a kernel/cgroup incompatibility rather than a Kubernetes bug. Check `journalctl -u kubelet` for cgroup errors, verify container runtime cgroup driver alignment against deprecated cgroup v1 layouts, and confirm kernel and containerd versions meet upstream requirements. Roll back the kubelet package, remediate node-level configuration drift on the OS, then retry on the canary.
 </details>
 
-### Question 4
-You have just upgraded your control plane from 1.34 to 1.35. Twenty minutes later, you discover a critical regression in your workloads that requires a rollback. Your etcd was upgraded and has already accepted writes in the 1.35 format. How do you safely roll back to 1.34?
+<details>
+<summary>4. You upgraded the control plane from 1.34 to 1.35 twenty minutes ago and must roll back due to a workload regression. etcd accepted writes on 1.35. What is the safe sequence?</summary>
+
+Stop apiservers from writing new state by moving static manifests out of `/etc/kubernetes/manifests/`. Restore etcd from the pre-upgrade snapshot with `etcdctl snapshot restore` or `etcdutl snapshot restore`, swap data directories, downgrade kubeadm/kubelet/kubectl packages to 1.34, restore manifests from `/etc/kubernetes/tmp/kubeadm-backup-manifests-*`, and restart kubelet. Accept that objects created in the last twenty minutes are lost. Rehearse this on staging quarterly.
+</details>
 
 <details>
-<summary>Answer</summary>
+<summary>5. Design scenario: You must design a staging cluster sign-off checklist before a 1.34→1.35 production upgrade. What hardware, workload, and validation elements are mandatory?</summary>
 
-Rolling back a control plane is complex because `kubeadm` does not have a built-in downgrade command, and etcd may have migrated its Write-Ahead Log to a new, incompatible format. You usually cannot simply downgrade the etcd binary after an upgrade; instead, restore etcd from the snapshot you took immediately before the upgrade. First, stop the API server on all control plane nodes by temporarily moving their static pod manifests out of `/etc/kubernetes/manifests/` to prevent any further writes. Next, use `etcdctl snapshot restore` to recover the previous state, downgrade the `kubeadm`, `kubelet`, and `kubectl` packages to the 1.34 version, and restore the pre-upgrade static pod manifests from the `/etc/kubernetes/tmp/kubeadm-backup-manifests-*` directory. Finally, restart the kubelet to bring the 1.34 control plane back online, keeping in mind that any cluster state changes made during those twenty minutes will be permanently lost.
+Design staging with one worker per hardware generation, control-plane SKUs matching production, and the same CNI/CSI/ingress versions. Workloads must include PDB-protected Deployments, StatefulSets with PVCs, and Helm charts at production versions. Mandatory validation: full kubeadm upgrade rehearsal, etcd snapshot restore drill within window budget, deprecated API scan clean, and CNI connectivity tests across racks. Sign-off is a written checklist, not verbal assent in Slack.
+</details>
+
+<details>
+<summary>6. Scenario: Your CNI vendor certifies version 1.15 for Kubernetes 1.34 but has not published 1.35 support. Control plane upgrades are scheduled next week. What do you do?</summary>
+
+Delay the production control-plane bump until the CNI matrix certifies 1.35 or you validate a newer CNI release in staging. kubeadm will upgrade apiservers regardless of CNI readiness, and new nodes may fail CNI health checks while DaemonSets run outdated hooks. This is an addon gate, not a Kubernetes gate—escalate with the vendor, test release candidates on staging hardware, and treat CNI as part of the upgrade critical path.
+</details>
+
+<details>
+<summary>7. Scenario: Finance asks why you need four spare servers during upgrades when cloud would “just upgrade.” How do you explain the on-prem economics?</summary>
+
+On bare metal, drained nodes stop earning their CapEx while still depreciating; surge machines are insurance, not optional fluff. Cloud bundles upgrade labor into OpEx; you pay platform engineers and carry pager risk. Steady high utilization and data gravity justify on-prem, but only if upgrades are rehearsed to minimize downtime. Present measured upgrade hours per minor, etcd drill results, and downtime avoided by PDB-aware rolling—not a generic “cloud is expensive” argument.
+</details>
+
+<details>
+<summary>8. Scenario: Cluster API manages your workers. You bumped `KubeadmControlPlane.spec.version` but old Machines remain. What likely happened?</summary>
+
+MachineTemplates are immutable—patching only the version field without a new template referencing an updated OS image leaves Machines unchanged. Copy the template, update the image with pre-installed kubeadm/kubelet matching the target version, update `infrastructureRef`, then let controllers roll. For workers, update `MachineDeployment` templates similarly. Verify management-cluster provider compatibility with the target Kubernetes minor before starting.
 </details>
 
 ---
@@ -560,8 +872,16 @@ Continue to [Module 7.2: Hardware Lifecycle & Firmware](/on-premises/operations/
 
 ## Sources
 
-- [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy) — Supports claims about supported minor-version skew between kube-apiserver, controller-manager, scheduler, kubelet, kube-proxy, and kubectl during staged upgrades and mixed-version maintenance windows.
-- [Upgrading kubeadm Clusters](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/) — Supports kubeadm upgrade workflow claims: first control plane vs additional control planes, worker upgrade sequencing, drain/uncordon expectations, certificate renewal behavior, and current package-repository guidance for post-2023 releases.
-- [kubectl drain Reference](https://v1-35.docs.kubernetes.io/docs/reference/kubectl/generated/kubectl_drain/) — Supports maintenance and upgrade claims around cordon/drain/uncordon behavior, eviction vs delete semantics, daemonset handling, graceful termination, and the risk of bypassing disruption protections.
-- [Disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/) — Backs PodDisruptionBudget behavior, voluntary disruption semantics, and drain/eviction behavior relevant to decommissioning old nodes during capacity expansion.
-- [kubernetes.io: kubernetes v1 28 release](https://kubernetes.io/blog/2023/08/15/kubernetes-v1-28-release/) — The Kubernetes 1.28 release announcement states that the supported skew expanded from n-2 to n-3.
+- [Kubernetes Version Skew Policy](https://kubernetes.io/releases/version-skew-policy) — Supported minor-version skew between kube-apiserver, controller-manager, scheduler, kubelet, kube-proxy, and kubectl; upgrade ordering requirements.
+- [Upgrading kubeadm Clusters (v1.35)](https://v1-35.docs.kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-upgrade/) — kubeadm upgrade apply/node workflow, drain expectations, pkgs.k8s.io repository guidance, etcd downtime mitigation, and recovery backups.
+- [kubectl drain Reference](https://v1-35.docs.kubernetes.io/docs/reference/kubectl/generated/kubectl_drain/) — Cordon/drain/uncordon behavior, eviction semantics, daemonset handling, and PDB interaction.
+- [Disruptions](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/) — PodDisruptionBudget semantics and voluntary disruption behavior during node drains.
+- [Deprecated API Migration Guide](https://kubernetes.io/docs/reference/using-api/deprecation-guide/) — APIs removed per minor release; pre-upgrade manifest scanning requirements.
+- [About cgroup v2](https://kubernetes.io/docs/concepts/architecture/cgroups/) — cgroup v2 requirements and cgroup v1 deprecation with `failCgroupV1` default in Kubernetes 1.35.
+- [Container Runtimes](https://kubernetes.io/docs/setup/production-environment/container-runtimes/) — cgroup driver alignment between kubelet and containerd/CRI-O on Linux nodes.
+- [etcd Disaster Recovery](https://etcd.io/docs/v3.6/op-guide/recovery/) — Snapshot, restore, and revision considerations when rolling back control-plane state.
+- [Cluster API: Upgrading Clusters](https://cluster-api.sigs.k8s.io/tasks/upgrading-clusters) — MachineTemplate immutability, KubeadmControlPlane version bumps, and MachineDeployment rolling strategies.
+- [Talos: Upgrading Kubernetes](https://www.talos.dev/v1.9/kubernetes-guides/upgrading-kubernetes/) — Immutable-OS upgrade orchestration with `talosctl upgrade-k8s` and machine configuration patching.
+- [Installing Addons](https://kubernetes.io/docs/concepts/cluster-administration/addons/) — CNI and cluster addon upgrade ownership outside kubeadm core components.
+- [Certificate Management with kubeadm](https://kubernetes.io/docs/tasks/administer-cluster/kubeadm/kubeadm-certs/) — Certificate renewal behavior during `kubeadm upgrade` and renewal opt-out flags.
+- [Kubernetes v1.28 Release Announcement](https://kubernetes.io/blog/2023/08/15/kubernetes-v1-28-release/) — kubelet/kube-proxy skew expansion from n-2 to n-3 for large rolling upgrade windows.

--- a/src/content/docs/on-premises/operations/module-7.2-hardware-lifecycle.md
+++ b/src/content/docs/on-premises/operations/module-7.2-hardware-lifecycle.md
@@ -1,5 +1,4 @@
 ---
-revision_pending: true
 title: "Module 7.2: Hardware Lifecycle & Firmware"
 slug: on-premises/operations/module-7.2-hardware-lifecycle
 sidebar:
@@ -12,35 +11,27 @@ sidebar:
 
 ---
 
-## Why This Module Matters
-
-In February 2024, a healthcare company running a 70-node bare metal Kubernetes cluster received a critical BIOS vulnerability advisory from Dell. The CVE allowed privilege escalation through the BMC interface, and their compliance team gave them 30 days to patch all servers. The infrastructure team's first instinct was to schedule a weekend maintenance window, power down all servers, update BIOS via USB drives, and power them back up. That would have meant 4-8 hours of complete cluster downtime -- unacceptable for a system processing patient data 24/7.
-
-Instead, they built a rolling firmware update pipeline: cordon a node, drain its workloads, use the Redfish API to stage the BIOS update, reboot the server into the firmware update mode, wait for it to come back, verify the new BIOS version via IPMI, uncordon, and move to the next node. The process took 12 days but caused zero downtime. Three servers failed to reboot after the BIOS update due to a known bug with their specific DIMM configuration. Because they were updating one node at a time, these failures were contained. The spare capacity absorbed the missing nodes while the team worked with Dell support to recover them.
-
-In the cloud, you usually do not have to think about BIOS versions or disk firmware. The cloud provider handles it. On bare metal, hardware lifecycle management is a continuous operational responsibility that directly affects your cluster's security posture, reliability, and performance.
-
----
-
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
-1. **Implement** rolling firmware update pipelines using Redfish/IPMI APIs that patch BIOS and BMC without cluster downtime
-2. **Design** a hardware lifecycle management process covering procurement, deployment, maintenance, and decommissioning
-3. **Configure** automated hardware health monitoring with IPMI sensors, SMART disk checks, and predictive failure alerts
-4. **Plan** disk replacement and memory upgrade procedures that integrate with Kubernetes node drain and cordon workflows
+1. **Implement** rolling firmware update pipelines using Redfish and Kubernetes drain workflows that patch BIOS, BMC, NIC, and disk firmware without taking the cluster offline
+2. **Design** a hardware lifecycle program that covers procurement, burn-in, production maintenance, refresh planning, decommissioning, and audit evidence
+3. **Configure** hardware health monitoring with BMC sensors, SMART and NVMe telemetry, Prometheus alerts, and escalation thresholds that distinguish warnings from service-impacting failures
+4. **Plan** capacity headroom, spare-parts inventory, RMA workflow, and MachineHealthCheck remediation so node failures are absorbed instead of becoming emergency rebuilds
+5. **Evaluate** on-premises lifecycle economics, including CapEx timing, support contracts, power and cooling, depreciation, refresh cycles, and the utilization patterns where owned hardware beats cloud rental
 
 ---
 
-## What You'll Learn
+## Why This Module Matters
 
-- BIOS and firmware update strategies without cluster downtime
-- Cordon/drain workflows for hardware maintenance windows
-- Disk replacement procedures for running Kubernetes nodes
-- Predictive failure detection with SMART monitoring
-- Using the Redfish API for out-of-band firmware management
-- Building a hardware maintenance calendar
+Hypothetical scenario: a regulated organization running a 70-node bare metal Kubernetes cluster receives a critical firmware advisory for the management controller on its standard server model. The compliance clock starts immediately, the application owners still expect 24/7 service, and the infrastructure team discovers that a few nodes already drifted from the approved BIOS baseline because previous emergency repairs were performed manually. A cloud team would open a support ticket or wait for the provider's maintenance process, but an on-premises team owns the whole chain from advisory intake to physical recovery.
+
+The right response is not a heroic weekend outage. It is a rolling hardware lifecycle workflow: cordon one node, drain its workloads, stage firmware through the out-of-band management network, reboot under controlled conditions, verify the returned firmware inventory, update the asset record, and only then uncordon the node. If three servers fail to reboot because of a bad firmware interaction with a DIMM layout, that is still a contained hardware event instead of a cluster-wide outage, provided the team planned spare capacity and stopped the rollout when the first pattern appeared.
+
+Hardware lifecycle management is where on-premises Kubernetes stops being "Kubernetes on someone else's assumptions" and becomes an engineering discipline. You are responsible for firmware baselines, burn-in tests, spare disks, warranty status, secure disposal, rack power, cooling headroom, and the financial timing of refresh purchases. Kubernetes can move pods away from a node, but it cannot tell you whether a BMC credential is still valid, whether the server is inside the vendor support window, whether a disk was wiped before leaving the cage, or whether the fleet has enough N+ spare capacity to survive the next batch of failures.
+
+The useful mental model is an airport ground-operations schedule. Kubernetes is the flight board that moves passengers between gates, but the airport still needs mechanics, spare parts, inspection logs, fuel planning, and retirement rules for old aircraft. If ground operations are informal, every maintenance event becomes a surprise; if ground operations are designed, even disruptive physical work becomes predictable enough that the service keeps flying.
 
 ---
 
@@ -69,6 +60,28 @@ graph TD
 | Disk firmware | Vendor tool (smartctl, perccli) | Sometimes | High |
 | GPU & Switch (e.g., NVIDIA DGX H100) | Vendor tool (nvfwupd for VBIOS, NVSwitch, EROT) | Yes | High |
 | RAID controller | Vendor CLI (storcli, perccli) | Yes | High |
+
+The table looks simple, but each row has a different blast radius. A BIOS update can change CPU microcode, memory training behavior, PCIe initialization, boot ordering, and Secure Boot state. A BMC update can temporarily remove the out-of-band control channel you need for recovery. NIC firmware can change driver compatibility and link negotiation behavior, which means a failed update can isolate an otherwise healthy Kubernetes node from the fabric. Disk and RAID controller firmware touch the storage path, so a mistake can cause slow I/O, controller resets, or a rebuild storm that looks like an application problem from the outside.
+
+The on-premises discipline is to treat firmware as a fleet state, not as an ad hoc server task. Every server should have an expected firmware profile derived from its SKU, role, rack, and lifecycle stage. Compute workers, storage workers, GPU workers, and control-plane nodes may need different profiles because their NICs, HBAs, GPUs, and boot modes differ. The inventory record should answer a plain question without logging into the server: "Is this node allowed to run production workloads today, and if not, which component is out of policy?"
+
+That baseline record is also a security control. DMTF Redfish exposes a standard management model over HTTPS, and NIST firmware-resiliency guidance frames firmware protection around preventing unauthorized changes, detecting changes that happen, and recovering quickly. Those principles map cleanly onto Kubernetes operations: keep a desired baseline, scan the actual baseline, alert on drift, stage updates through a controlled path, and keep recovery media or rollback instructions ready before the first reboot.
+
+### Firmware Baselines and Drift Management
+
+Fleet firmware management starts with a version matrix that is boring enough to audit. The matrix should identify the server SKU, BIOS version, BMC version, NIC firmware, storage controller firmware, GPU firmware when present, boot mode, Secure Boot policy, TPM policy, and any known exceptions. Exceptions need an owner and an expiration date. "This node is different because it came back from RMA" is useful for one day; after a month it becomes an invisible production fork.
+
+The baseline should be source-controlled as policy, not trapped in a spreadsheet that only one engineer trusts. A lightweight approach is a YAML file per hardware profile plus a nightly collector that reads Redfish inventory, `dmidecode`, `ethtool -i`, `smartctl`, `nvme list`, and vendor-specific tools where necessary. A larger environment can put the same data in a CMDB or asset system, but the important property is reconciliation: desired version, observed version, last checked time, and remediation status are all visible together.
+
+Baseline drift happens for mundane reasons. A replacement motherboard arrives with newer BIOS. A vendor field engineer updates a BMC during an unrelated support case. A storage node is rebuilt from rescue media and picks up a different boot-mode default. A GPU server gets a firmware hotfix to solve one workload issue, but the record never reaches the platform team. None of those events are malicious, yet each can break future automation because rolling procedures assume nodes of the same class behave the same way.
+
+The safest rollout cadence uses rings. Ring 0 is a lab node or recently decommissioned host that can be sacrificed. Ring 1 is a small set of low-criticality production nodes with normal hardware diversity. Ring 2 is one rack, one availability zone, or one failure domain. Ring 3 is the rest of the fleet. Each ring should have a pause condition, such as a node failing to return to `Ready`, a BMC task error, a new kernel hardware error, a storage rebuild backlog, or a support advisory that appears after the rollout begins.
+
+Vendor tooling still matters even when Redfish is your common interface. Redfish gives you a shared model for inventory, tasks, and update actions, but vendors may package images differently, expose OEM extensions, or require different sequencing between BIOS, BMC, NIC, and storage controller updates. Your automation should hide those quirks behind adapters while keeping the audit trail normalized. The operator should see "worker-r730xd BIOS profile 2026-Q2 applied" rather than memorize which HTTP endpoint belongs to which generation of management controller.
+
+The management network needs its own lifecycle controls. BMCs are powerful computers with power-cycle access, virtual media access, firmware update access, and sometimes remote console access. Put them on a restricted network, rotate credentials through a vault, require TLS where supported, and monitor failed login attempts. A Kubernetes node compromise should not automatically imply BMC access, and a BMC credential leak should not silently become a cluster-wide power-control incident.
+
+Firmware baselines also affect capacity planning. A rolling update that drains one node at a time consumes headroom for hours or days, while a failed update can remove a node for the length of an RMA. If the cluster usually runs at 85-90% allocatable CPU or memory, the maintenance plan is already broken. On-premises capacity is not elastic in the cloud sense; unused headroom is an insurance premium you pay so firmware, disk, memory, and power events do not become application outages.
 
 ---
 
@@ -112,6 +125,14 @@ kubectl drain "$NODE" \
 echo "=== Node ${NODE} drained and ready for maintenance ==="
 ```
 
+`kubectl drain` is the bridge between physical work and workload safety. The command marks the node unschedulable, then evicts eligible pods through the Kubernetes eviction path so PodDisruptionBudgets can protect applications that declared availability requirements. That protection is only as good as the manifests. If a stateful workload has no disruption budget, no replica spread, or local storage tied to the node, the drain command exposes a design problem that should be fixed before a firmware window starts.
+
+Before running this script against production, build a preflight check that asks whether the cluster can really afford to lose the node. Look at allocatable CPU and memory after daemonsets, storage recovery state, pending pods, node labels, local PersistentVolumes, topology spread constraints, and the number of similar nodes already under maintenance. A control-plane node with stacked etcd, a Ceph storage node with several large OSDs, and a stateless web worker all have different risk profiles even though the Kubernetes command is spelled the same way.
+
+The most common mistake is treating `--ignore-daemonsets` and `--delete-emptydir-data` as magic safety switches. They are operational switches, not proof that the workload is safe. DaemonSets remain on the node because they are managed by their own controllers, and `emptyDir` data is intentionally disposable only when the application was designed that way. If a team stores important cache warmup data, local queue state, or temporary build artifacts in `emptyDir`, a drain can still create user-visible work even when Kubernetes reports success.
+
+Storage nodes need extra caution because the drain is only the application-facing half of the maintenance. A Ceph or Rook cluster may need placement group health checked before the node goes offline, a maintenance flag applied to avoid unnecessary recovery, and a post-return health gate before uncordoning. For local PersistentVolumes, the safest answer may be rescheduling only after the local volume consumer is intentionally migrated or after the workload owner accepts downtime. Kubernetes can stop new pods from landing on the node, but it cannot move bytes that physically exist on one disk.
+
 ### Post-Maintenance Return
 
 ```bash
@@ -150,11 +171,19 @@ kubectl label node "$NODE" \
 echo "=== Node ${NODE} returned to service ==="
 ```
 
+The return path deserves as much automation as the drain path. A node that is merely `Ready` is not necessarily ready for production traffic. The script should check kubelet version, container runtime status, kernel taints, CNI readiness, storage mounts, hardware alerts, and firmware inventory before uncordoning. If the node returned with a different BIOS setting, a missing NIC, a failed PSU, or a degraded RAID controller, uncordoning simply moves the incident from the hardware team to the application teams.
+
+Use labels and annotations as the handoff record between automation stages. A maintenance label records why the node was drained, while annotations can capture the planned firmware profile, ticket ID, operator, and expected return deadline. That metadata makes it easier for later automation, dashboards, and humans to distinguish a planned offline node from an unplanned failure. It also gives MachineHealthCheck and remediation controllers context, because planned maintenance should not be mistaken for a node that needs destructive replacement.
+
 ---
 
 ## BIOS and Firmware Updates via Redfish
 
 Redfish is the modern replacement for IPMI for out-of-band server management. It provides a RESTful API for firmware updates, power control, and hardware inventory.
+
+Redfish does not remove the need to understand firmware sequencing. It gives you a standard protocol surface for operations that used to require a mix of IPMI commands, vendor web consoles, virtual media, and in-band utilities. The DMTF Redfish specifications and firmware-update guidance define common concepts such as `UpdateService`, firmware inventory, task tracking, and apply-time behavior, but they do not guarantee that every server generation accepts the same package, supports the same rollback behavior, or exposes the same OEM extensions.
+
+The safest firmware pipeline separates discovery, staging, reboot, verification, and promotion. Discovery confirms the current inventory and hardware identity. Staging transfers or references the firmware payload while the node is still serving workloads. Reboot happens only after Kubernetes and storage preflights pass. Verification reads the new inventory from the BMC and from the operating system where applicable. Promotion updates the CMDB or inventory record only after the node has returned to service without hardware alerts.
 
 > **Pause and predict**: BIOS updates require a server reboot. On bare metal, a reboot means the Kubernetes node goes offline. How would you update BIOS on 40 servers without any cluster downtime?
 
@@ -173,6 +202,10 @@ curl -sk -u admin:password \
   https://bmc-worker-01.internal/redfish/v1/Systems/1/Bios \
   | jq '{BiosVersion: .BiosVersion, Model: .Model}'
 ```
+
+In production, do not put BMC credentials in shell history or CI logs. Use a short-lived token when the management controller supports sessions, or retrieve credentials from a secret manager at execution time. Also avoid letting general-purpose cluster automation talk directly to the BMC network. A small maintenance runner with audited access is easier to secure than every CI job, every administrator laptop, and every troubleshooting container having routes to out-of-band management.
+
+Inventory collection should tolerate partial data. Older servers may expose BIOS version through `/redfish/v1/Systems/1/Bios`, while component firmware appears under `UpdateService/FirmwareInventory` or under vendor-specific resources. Your collector should record "unknown" explicitly instead of pretending the component is compliant. Unknown firmware is not the same as approved firmware, especially when the fleet is under a security advisory deadline.
 
 ### Staging a BIOS Update
 
@@ -198,11 +231,47 @@ curl -sk -u admin:password \
 
 The rolling firmware update script follows the same pattern: for each node, call `maintenance-drain.sh`, stage firmware via Redfish `SimpleUpdate`, trigger a `GracefulRestart` via Redfish, wait for the node to return to `Ready`, verify the new firmware version, and call `maintenance-return.sh`. Add a 5-minute cooldown between nodes to catch issues early.
 
+Treat the Redfish task service as the authoritative progress channel for the BMC-side work, but treat Kubernetes readiness as the authoritative signal for workload scheduling. A Redfish task can report success because the firmware image was accepted, while the node still fails POST or the kubelet never rejoins. Conversely, Kubernetes can report `Ready` after a reboot while the firmware task failed to apply and the old version remains installed. You need both signals before declaring the maintenance complete.
+
+Firmware payload hosting is another on-premises reliability dependency. The BMC management network may not have internet access, and it usually should not. Host firmware images on an internal HTTPS endpoint reachable from BMC interfaces, pin checksums in the rollout plan, and keep the previous known-good image available until the full ring completes. If the internal image server is unavailable during a rollout, stop the rollout rather than improvising with laptop-hosted files or vendor downloads from the production network.
+
+Rollback plans should be written before the first node is touched. Some platforms support redundant firmware images, BIOS recovery modes, virtual media, or BMC-driven reset-to-default operations; others require datacenter hands and vendor support. The runbook should name the exact escalation point: retry task, reset BMC, power-cycle, roll back firmware, clear BIOS settings, boot rescue media, open RMA, or remove node from service. A rollback path that depends on "someone remembers the vendor console" is not a rollback plan at fleet scale.
+
+Firmware update success should be promoted in stages. First, the node passes hardware checks and rejoins Kubernetes. Second, it runs a short workload smoke test or synthetic network/storage check. Third, the inventory system records the new baseline and removes the maintenance label. Fourth, the rollout controller is allowed to pick the next node. This sequencing feels slow on a ten-node lab cluster, but it is what prevents one bad image from spreading across hundreds of nodes before anyone notices the pattern.
+
+---
+
+## Burn-In, Acceptance Testing, and Spares
+
+The lifecycle starts before a server ever joins Kubernetes. A new server should not move from a loading dock to production simply because it powers on and PXE boots. Burn-in is the controlled period where you try to make early hardware failures appear while the node is still outside the production failure domain. This matters because first-week problems are operationally cheap if the node is still in acceptance, but expensive if it is already carrying stateful workloads.
+
+A practical burn-in runbook has three goals: verify the asset matches the purchase order, stress the components that fail under heat or load, and prove the provisioning path can rebuild the node repeatably. The asset check records serial number, SKU, CPU count, memory size, DIMM population, disk model, NIC model, firmware baseline, BMC MAC address, rack location, power feed, and warranty term. The stress check exercises CPU, memory, storage, network, and accelerator paths long enough to expose thermal, ECC, link, and media errors. The rebuild check wipes the node and provisions it again through the same PXE, iPXE, Metal3, Tinkerbell, or image-based OS path used for recovery.
+
+Burn-in should be destructive by design. If a disk has latent problems, you want sustained writes and SMART or NVMe health checks to find them before Ceph receives the OSD. If a DIMM produces correctable ECC errors under load, you want that node held for investigation before kubelet ever registers. If a NIC negotiates at the wrong speed, drops link during load, or fails VLAN trunking, you want the network team involved before the node sits in a production rack with workloads that depend on it.
+
+The acceptance report should be a gate, not a courtesy attachment. A node moves to the production inventory only when the report shows approved firmware, passing hardware stress results, correct rack and power metadata, successful automated provisioning, and no unresolved BMC events. Failed nodes should be quarantined with a clear state such as `acceptance_failed`, `awaiting_parts`, `awaiting_vendor`, or `return_to_stock`. Ambiguous states such as `maybe_bad` are how broken hardware returns to service during an outage.
+
+Spare-parts planning is capacity planning in physical form. For cloud workloads, a failed VM can often be replaced by another VM while billing adjusts in minutes. For owned hardware, a failed PSU, disk, NIC, DIMM, HBA, fan tray, or whole server waits on your shelf stock, vendor support contract, or shipping calendar. Keep spares for the components that fail often, components that block a whole node, and components whose lead time exceeds your recovery objective.
+
+Use N+ planning for both nodes and parts. N+1 might be enough for a small control-plane set only if every node can tolerate losing one peer and the replacement path is tested. Worker pools often need more than one spare node because firmware rollouts, storage rebuilds, and ordinary failures overlap. Storage pools need spare disks by capacity class and device model, because replacing a failed OSD with a smaller or slower drive can create a new operational problem. GPU pools may need a different spare model entirely because accelerator availability and support contracts can dominate recovery time.
+
+Spare inventory should be rotated, not forgotten. Disks and SSDs on a shelf still need firmware tracking, anti-static handling, and periodic validation. A cold spare with old firmware may be useful in an emergency, but it should immediately enter a follow-up workflow to align with the fleet baseline. A spare server that has not booted in a year is not the same as a tested hot spare. Treat spare readiness as an SLO: when a part is consumed, the replenishment ticket is part of incident closure, not a someday purchasing task.
+
+The RMA workflow needs the same discipline as incident management. Record the asset tag, serial number, failed component, symptoms, diagnostics, support case, data-sanitization requirement, replacement ETA, and the cluster capacity impact. If a vendor asks for logs or a firmware update before replacement, capture that request in the ticket so the next operator understands why the node is still out of service. When the replacement arrives, it goes through acceptance testing; it does not inherit trust from the failed component's old asset record.
+
+Capacity headroom is the final spare. A shelf full of disks does not help if the cluster cannot drain a node without evicting critical workloads. Plan headroom for the worst common overlap: one node down unexpectedly, one node in maintenance, storage recovery running, and enough application surge capacity to handle normal traffic. This usually means on-premises clusters look "less utilized" than pure cost dashboards would prefer. The unused capacity is not waste when it is deliberately buying resilience, maintenance freedom, and time to repair hardware without customer impact.
+
+Hypothetical scenario: a storage-heavy worker pool runs at 92% disk capacity because finance delayed the next expansion order by one quarter. A drive starts reporting pending sectors, but replacing it triggers backfill that would push other OSDs near full. The team waits, the disk fails completely, and now the cluster is repairing under pressure while application latency climbs. The root cause is not only the disk; it is the absence of capacity headroom, spare drive planning, and a refresh decision tied to risk rather than to the cheapest possible quarter.
+
 ---
 
 ## Disk Replacement Procedures
 
 Disk failures are the most common hardware event in a bare metal cluster. With Ceph or other distributed storage, disk replacement can be non-disruptive -- but the procedure must be followed precisely.
+
+Disk replacement is a good example of why on-premises operations are not just cloud operations with slower provisioning. The hardware signal, storage signal, and Kubernetes signal can disagree. SMART might show pending sectors before the operating system logs I/O errors. Ceph might mark an OSD slow or flapping before Kubernetes notices anything wrong with the node. Kubernetes might keep scheduling pods because the kubelet is healthy while the storage layer is quietly burning redundancy.
+
+The operational goal is to replace predictable failures while the cluster still has choices. A drive with reallocated sectors and pending sectors may still be serving reads, but it has already consumed part of its internal spare capacity and may be struggling to recover data from weak media. Waiting until total failure feels efficient only if you ignore correlated risk: another disk in the same failure domain may fail during recovery, or the failing disk may slow the storage pool so much that applications time out before redundancy is actually lost.
 
 ### SMART Monitoring for Predictive Failure
 
@@ -228,6 +297,10 @@ done
 | Media Wearout (NVMe) | < 10% | Plan replace |
 
 *For NVMe drives, use `nvme smart-log /dev/nvme0n1`. The key field is `percentage_used` (replace at > 90%).*
+
+Thresholds should be treated as runbook triggers, not universal laws. Different drive models expose different SMART attributes, and some vendors encode "normalized value" and "raw value" differently. The practical approach is to watch for clear failure signals, sustained worsening trends, and fleet outliers. A single correctable attribute may mean "monitor closely" on one device class and "replace now" on another, depending on workload, redundancy level, warranty terms, and how painful recovery would be during peak traffic.
+
+NVMe devices add useful health fields such as critical warning, temperature, media errors, and percentage used. NVMe-CLI can read SMART health logs, format or sanitize devices, and perform firmware actions, so it belongs in the hardware toolkit for modern servers. The existence of a powerful command does not mean it belongs in a generic automation job. Operations that format, sanitize, or commit firmware should require explicit node identity checks, maintenance labels, and human-readable tickets because a mistyped device path can destroy useful data faster than a failed disk would.
 
 > **Stop and think**: The SMART data shows `Reallocated_Sector_Count = 52` and `Current_Pending_Sector = 3`. The disk is part of a Ceph OSD. Should you replace it now or wait for it to fail completely? What is the risk of waiting?
 
@@ -262,6 +335,12 @@ ceph osd unset noout
 ceph -w  # watch rebalancing progress
 ```
 
+The global `noout` flag is easy to understand but easy to misuse. It suppresses automatic marking out, which is useful during a short planned intervention, but it also changes the way the cluster reacts to real failures while the flag is set. In larger Ceph environments, prefer narrower maintenance scope when the tooling and release support it, such as applying noout behavior to the affected OSD, host, or CRUSH bucket rather than the whole cluster. The runbook must include the unset step and a post-maintenance `ceph health detail` check because forgotten maintenance flags are a classic source of delayed recovery.
+
+Rook-operated Ceph adds another layer of ownership. The Kubernetes object that represents an OSD, the Ceph map, the host device, and the operator's reconciliation loop all need to agree on what is being removed or replaced. If you manually wipe a disk while the operator still believes the old OSD exists, it may recreate resources in a surprising state. If you remove Kubernetes objects without cleaning Ceph state, the cluster may retain stale OSD metadata. The safest procedure is the one documented for your Rook and Ceph versions, rehearsed on a non-production OSD before a real failure.
+
+After replacement, do not judge success only by the new disk appearing. Watch recovery throughput, client latency, placement group state, and node resource pressure until the cluster returns to its normal baseline. Backfill consumes network, CPU, memory, and disk I/O, and it can collide with application traffic or other maintenance. Hardware lifecycle planning should reserve a recovery budget just like it reserves maintenance windows, because the most dangerous disk replacement is often the second one that starts while the first recovery is still running.
+
 ### Memory Upgrade Procedure
 
 Unlike disks in a Ceph cluster, memory replacements or upgrades require completely shutting down the node.
@@ -273,6 +352,8 @@ Unlike disks in a Ceph cluster, memory replacements or upgrades require complete
 5. **Verify**: Use BMC/Redfish to ensure no ECC errors are detected during POST.
 6. **Return to service**: Execute `maintenance-return.sh <node>`.
 
+Memory work is where physical standards and automation meet. DIMM population rules affect memory bandwidth, NUMA behavior, and sometimes whether the server boots at all. The runbook should record the planned population map, compare it against the observed inventory after boot, and run enough memory stress to catch obvious installation problems before returning the node to a latency-sensitive workload. Correctable ECC errors after a DIMM change should not be waved away as harmless; they are evidence that the new hardware, slot, firmware, or thermal condition needs investigation.
+
 ---
 
 ## The Full Hardware Lifecycle
@@ -280,39 +361,122 @@ Unlike disks in a Ceph cluster, memory replacements or upgrades require complete
 A complete hardware lifecycle encompasses more than just maintenance windows:
 
 1. **Procurement**: Standardize on fixed SKU configurations (e.g., compute-heavy vs. storage-heavy) to avoid the "snowflake" problem. Ensure hardware vendor compatibility with your Linux kernel and Kubernetes CNI/CSI choices before purchasing.
-2. **Deployment**: Automate bare metal provisioning using PXE boot, Metal3 (Cluster API Provider Metal3 v1.12.2), or Tinkerbell. Servers should go from unboxing to joining the Kubernetes cluster automatically. Metal3 utilizes OpenStack Ironic (latest release 2025.2 Flamingo) running as a separate service to expose bare metal provisioning via a Kubernetes-native API.
-3. **Maintenance**: See the calendar below for routine operations.
-4. **Decommissioning**: Securely wipe disks using `nvme format` or `hdparm` secure erase. Remove the node from the cluster (`kubectl delete node`), revoke its certificates, and clear its BMC IP from the inventory database.
+2. **Acceptance and burn-in**: Validate asset identity, firmware baseline, BMC access, rack metadata, CPU and memory stress, storage endurance checks, network throughput, and automated rebuild before the node can join production.
+3. **Deployment**: Automate bare metal provisioning using PXE or iPXE boot, Metal3, Tinkerbell, Ironic, Talos, Flatcar, or another image-based path that turns a known inventory record into a reproducible Kubernetes node.
+4. **Production maintenance**: Run recurring health checks, firmware drift scans, support-contract reviews, spare inventory audits, and controlled drain/update/return workflows.
+5. **Refresh decision**: Compare reliability risk, support expiry, power efficiency, performance per rack unit, migration cost, and depreciation timing before extending or replacing the hardware generation.
+6. **Decommissioning**: Drain and delete the Kubernetes node, revoke credentials and certificates, sanitize storage according to the data classification, update asset records, and send hardware through an approved resale, recycling, or e-waste path.
+
+The procurement phase sets the ceiling for future operability. Standard SKUs reduce the number of firmware baselines, spare parts, kernel driver combinations, BIOS setting profiles, and troubleshooting branches. A fleet with five carefully chosen profiles is much easier to automate than a fleet where every emergency purchase introduced a new NIC, storage controller, or power supply. Standardization is not bureaucracy; it is how small platform teams make physical infrastructure behave like a managed product.
+
+The standard SKU still needs a compatibility review. Kernel support, CNI offload behavior, CSI driver assumptions, TPM behavior, Secure Boot policy, NUMA layout, PCIe lane allocation, rack depth, rail kits, power connectors, airflow direction, and management-controller licensing can all affect Kubernetes operations. A server that looks cheap on a quote can become expensive if it requires a special image, special cable, special support path, or a different operational runbook from the rest of the pool.
+
+Deployment is where bare-metal automation tools earn their keep. Metal3 brings Cluster API-style management to bare metal through resources such as `BareMetalHost` and a provider implementation for Metal3 machines. OpenStack Ironic is a mature bare-metal provisioning service that can be used inside or outside a larger OpenStack cloud. Tinkerbell focuses on declarative bare-metal workflows, metadata, and network or ISO booting. Image-based operating systems such as Talos or Flatcar reduce host drift by making the node OS more declarative and replaceable. The right choice depends on your existing team skill, failure recovery model, and need to integrate hardware state with Kubernetes APIs.
+
+Provisioning should be idempotent enough that a failed node can be rebuilt from inventory without a senior engineer at the keyboard. The inventory entry supplies the BMC endpoint, MAC address, desired image, hardware profile, rack location, and cluster role. The provisioning system performs power control, network boot, disk preparation, OS installation or image boot, kubelet bootstrap, and post-bootstrap validation. If a node can only be rebuilt by searching old chat messages for boot flags, the lifecycle process is not automated yet.
+
+Production maintenance is a calendar plus event response. Calendar work includes planned firmware rings, hardware inventory audits, warranty review, thermal inspection, cable audit, and spare count reconciliation. Event response includes disk replacement, ECC investigation, PSU replacement, BMC credential recovery, emergency firmware advisories, and failed-node remediation. Both paths should write to the same asset record so the lifecycle story remains continuous from purchase order to decommission.
+
+Refresh planning is a business decision with engineering inputs. Old servers may still run Kubernetes, but they can cost more in power, cooling, support contracts, failure risk, scarce spare parts, and operational exceptions than a new generation would cost over its useful life. New servers can also be the wrong answer if the workload is shrinking, utilization is spiky, migration risk is high, or the organization would be better served by reducing demand first. The lifecycle owner needs enough TCO data to have that conversation before support expires.
+
+The decommission phase must close both technical and financial loops. Kubernetes identity should be removed, BMC credentials revoked, monitoring targets deleted, IP and DNS records released, storage sanitized, asset status updated, support inventory reconciled, and finance notified if the asset is sold, recycled, donated, or written off. A server that disappeared from the rack but remains in monitoring, backup policy, or a depreciation schedule is still operational debt.
+
+### Lifecycle State Model
+
+| State | Entry Criteria | Exit Criteria |
+|-------|----------------|---------------|
+| Ordered | Purchase approved, SKU selected, rack/power plan reserved | Hardware received, asset tag assigned, support entitlement recorded |
+| Acceptance | Server installed on isolated network with BMC reachable | Burn-in passes, firmware matches baseline, provisioning succeeds twice |
+| Production | Node joined cluster, labels and taints correct, monitoring active | Maintenance, failure, refresh, or decommission ticket changes state |
+| Maintenance | Node cordoned, drained, and tied to a planned ticket | Firmware, parts, or inspection work verified and node returned |
+| Quarantine | Hardware failed burn-in, health check, or remediation | RMA, repair, re-test, or scrap decision recorded |
+| Refresh Candidate | Support, economics, reliability, or capacity review flags node | Extended support approved or migration/decommission plan scheduled |
+| Decommissioned | Workloads gone, data sanitized, credentials revoked | Asset leaves operational inventory with final disposition evidence |
+
+This state model matters because it prevents hidden half-states. A node should not be both a spare and a production worker. A returned RMA motherboard should not inherit the old firmware state until it is inspected. A decommissioned server should not have an active BMC account. The lifecycle system does not need to be fancy, but it must make invalid transitions visible enough that someone stops before a broken assumption becomes a production incident.
 
 ### Annual Hardware Maintenance Calendar
 
-**Monthly:**
+### Monthly Checks
+
 - SMART health check on all disks (automated)
 - Review BMC event logs for warnings
 - Check PSU redundancy status
 
-**Quarterly:**
+### Quarterly Checks
+
 - Apply critical firmware updates (BIOS, BMC)
 - Review NIC firmware versions against vendor advisories
 - Test IPMI/Redfish connectivity to all BMCs
 - Verify backup power (UPS battery tests)
 
-**Annually:**
+### Annual Checks
+
 - Full hardware inventory audit
 - Warranty status review (identify expiring warranties)
 - Thermal audit (clean dust filters, check airflow)
 - Cable audit (reseat suspect connections)
 - Evaluate hardware refresh candidates
 
-**As-needed:**
+### Event-Driven Checks
+
 - Emergency firmware patches (CVEs)
 - Disk replacements (SMART alerts)
 - Memory DIMM replacements (ECC error alerts)
 - PSU replacements (redundancy lost alerts)
 
+The calendar is only useful if it is tied to capacity and change windows. A quarterly firmware review that requires draining ten percent of the fleet must be scheduled against application demand, storage recovery budget, staff availability, and spare hardware. A warranty review that identifies expiring support should create a procurement or risk-acceptance decision, not just a spreadsheet note. A thermal audit that finds blocked airflow should connect to rack layout, cable management, blanking panels, and cooling contracts because heat shortens the life of the same components you are trying to protect.
+
+Maintenance windows should be budgeted as operational capacity. If the cluster needs one node of headroom for random failure and one node of headroom for planned work, then "full" is not 100% allocated. It may be 70%, 75%, or 80%, depending on workload burstiness and recovery time. This is a major on-premises difference from cloud elasticity: you cannot always rent an extra rack position for three hours, so you must reserve maintenance capacity in advance or accept that every hardware event competes with customer traffic.
+
+## Refresh-Cycle Economics
+
+On-premises Kubernetes can be cheaper than cloud when the workload is steady, utilization is high, data gravity is strong, egress would be expensive, regulatory constraints require physical control, or specialized hardware is needed for long periods. The same on-premises cluster can be more expensive than cloud when utilization is low, demand is spiky, the team is small, hardware lead times are long, or the organization underestimates the human work required to operate the fleet. Hardware lifecycle management is the place where that economic truth becomes visible.
+
+CapEx means you pay for servers, storage, racks, network gear, cabling, optics, PDUs, and sometimes facility work before the workloads produce value. OpEx continues afterward through power, cooling, colocation fees, support contracts, spare parts, monitoring, remote-hands work, software subscriptions, and operator headcount. Cloud converts many of those costs into usage-based OpEx, but also adds provider margins, egress charges, premium managed services, and less control over physical refresh timing. Neither model is automatically cheaper; the utilization curve decides much of the answer.
+
+A practical TCO model for a node pool should include more than server purchase price. Include rack units, watts under realistic load, power redundancy, cooling allocation, top-of-rack switch ports, optics, support term, spare ratio, expected failure rate, staff time, migration labor, and the cost of holding enough unused capacity for maintenance. For storage-heavy clusters, include drive endurance, rebuild time, replication overhead, replacement drives, and data-growth rate. For GPU or accelerator pools, include supply availability, power density, cooling constraints, and whether the accelerator generation is still useful for the target workloads.
+
+Depreciation and refresh timing shape the finance conversation. In the United States, IRS guidance treats depreciation as recovery of capital cost over a defined period, and computer equipment commonly appears in five-year recovery discussions; your organization may also use internal three-to-five-year refresh assumptions for budgeting, support, and risk. The engineering point is not to become a tax expert. The point is to know when the book value, support expiry, reliability trend, and performance-per-watt curve start arguing against keeping the fleet.
+
+Refreshing too early wastes capital and creates avoidable migration work. Refreshing too late increases failure risk, support cost, security exceptions, parts scarcity, and power inefficiency. The best refresh decision compares the marginal cost of one more year against the cost of replacing the generation now. If the fleet is stable, support is affordable, spare parts are available, and utilization is moderate, an extension may be rational. If the fleet is failing more often, firmware updates are risky, support is ending, or power limits block growth, a refresh may be cheaper than pretending old hardware is free.
+
+CapEx timing also affects platform roadmap choices. If the organization wants to add AI inference, high-throughput storage, or network-intensive workloads, the hardware lifecycle owner must say whether the current rack power, cooling, PCIe slots, NIC speed, and storage endurance can support that plan. Cloud lets a team experiment with new shapes quickly; on-premises teams need purchase lead time and physical capacity. That does not make on-premises worse, but it requires roadmap honesty.
+
+The clearest case for on-premises is steady high utilization with predictable growth. A platform that keeps servers busy for years, stores large data sets near users or instruments, and avoids repeated cloud egress can amortize CapEx efficiently. The weakest case is a small, uncertain workload that bursts for a few weeks and sits idle for months. Buying hardware for the peak and running it mostly empty is not infrastructure independence; it is prepaid waste with operational obligations attached.
+
+Use refresh reviews to remove snowflakes. When a generation retires, do not simply replace one odd exception with another. Standardize the next SKU, reduce hardware profiles, align firmware policy, improve burn-in automation, and retire old manual paths. The refresh cycle is the rare moment when finance, datacenter operations, platform engineering, security, and application owners are already discussing the same fleet. Use that moment to buy operability, not just more cores.
+
+### Refresh Decision Signals
+
+| Signal | Extend Current Fleet | Refresh or Replace |
+|--------|----------------------|--------------------|
+| Utilization | Stable and below maintenance headroom limits | Growth blocked by CPU, memory, disk, network, power, or cooling |
+| Support | Affordable support term still available | Support expires, excludes key parts, or response times miss recovery goals |
+| Reliability | Failure rate is normal and spares are available | Repeated DIMM, disk, PSU, BMC, or motherboard failures consume operations time |
+| Security | Firmware updates remain supported and test cleanly | Firmware advisories require unsupported or risky exceptions |
+| Economics | Power, cooling, and staff cost remain competitive | Better performance per watt or reduced profile count pays back migration effort |
+| Migration Risk | Workloads are stable and migration gives little benefit | Hardware limits block roadmap or old OS/firmware paths create accumulated risk |
+
+This matrix keeps the conversation grounded. A finance-only view may treat fully depreciated hardware as free, while an operations-only view may overvalue shiny replacement projects. The lifecycle owner has to combine both. The useful answer is not "old bad" or "new good"; it is whether the next year of ownership is cheaper, safer, and more strategically useful than the replacement path.
+
 ---
 
 > **Pause and predict**: The "bathtub curve" predicts high failure rates in the first 90 days and again in years 4-5 of a server's lifecycle. How should your spare inventory strategy differ between a brand-new hardware deployment and a fleet entering year 4?
+
+## Health Signals and MachineHealthCheck Tie-In
+
+Hardware health automation should distinguish detection from remediation. Detection asks whether the node is unhealthy, degraded, drifting, or at risk. Remediation decides whether to drain, reboot, reimage, replace a component, open an RMA, quarantine the node, or leave it alone because planned maintenance is already in progress. Cloud remediation often means deleting a VM and creating another one. Bare-metal remediation has a physical object behind it, so the controller must respect asset state, storage state, BMC reachability, and spare capacity.
+
+Cluster API MachineHealthCheck defines conditions under which Machines are considered unhealthy and can trigger remediation. In a bare-metal environment, that feature is useful only when the provider and remediation strategy understand physical recovery time. Deleting a Machine object may be correct for a stateless worker backed by a ready spare, but it may be wrong for a storage node with local OSDs, a control-plane node holding etcd membership, or a server that merely needs a BMC reset after planned firmware work.
+
+This is where Module 7.3 continues the story. Hardware lifecycle management supplies the asset truth: which node is planned for maintenance, which one is in quarantine, which spare is eligible, which disks contain data, and which RMA is open. Auto-remediation consumes that truth before taking action. A remediation controller that ignores the lifecycle state can make an outage worse by reprovisioning the wrong host, wiping a disk that still needs forensic review, or replacing nodes faster than the cluster can rebalance.
+
+Node-problem-detector helps turn kernel, container runtime, filesystem, and hardware symptoms into Kubernetes-visible node conditions and events. It does not replace BMC monitoring, SMART checks, or storage-system health, but it gives the scheduler and higher-level controllers a better view of node-local problems. A strong on-premises signal chain often looks like this: BMC and SMART exporters collect hardware telemetry, node-problem-detector reports node-local faults, Prometheus alerts humans and automation, and lifecycle state decides which remediation action is allowed.
+
+Do not let remediation race maintenance. Planned firmware work should add a maintenance label or lifecycle annotation before the node goes NotReady. MachineHealthCheck policies should either ignore planned maintenance or use a remediation template that checks lifecycle state first. Otherwise, a healthy rolling update can look like a node failure, and the automation may try to replace a server that is only rebooting under operator control.
+
+The capacity question remains central. Automated remediation is only safe if the cluster can absorb the removed node and if a replacement path exists. For bare metal, that replacement path may be a warm spare, a cold spare that can be provisioned through Metal3 or Tinkerbell, or a manual repair. If none of those paths is ready, the best automation may be to cordon, alert, and hold the node in quarantine rather than starting an irreversible rebuild.
 
 ## Prometheus Alerts for Hardware Health
 
@@ -361,18 +525,105 @@ groups:
           description: "Server is running on a single PSU. Replace failed PSU immediately."
 ```
 
+Hardware alerts should name the operational action, not only the metric. A disk SMART prefailure alert should point to the disk replacement runbook and identify whether the disk belongs to an OSD, local PV, boot mirror, or disposable cache. A PSU alert should identify rack, chassis, power feed, and spare-part location. A BMC unreachable alert should say whether the host OS is still healthy because loss of out-of-band control is a risk multiplier even when workloads are currently running.
+
+Severity should reflect remaining choices. A warning means the team can schedule work, order a part, or watch a trend without immediate service impact. A critical alert means the next failure may remove redundancy, violate a recovery objective, or block safe maintenance. Avoid alerting every minor sensor fluctuation at critical severity. If every fan-speed wobble pages the team, the team will eventually ignore the one hardware signal that required action.
+
+The best dashboards combine hardware, Kubernetes, and asset context. A node page should show `Ready` condition, cordon state, maintenance labels, pod count, BMC status, firmware baseline, SMART/NVMe health, ECC counts, PSU state, fan state, temperature, rack, support expiry, and open tickets. That view prevents the "two teams staring at different truths" problem. Application operators can see whether a pod eviction came from planned hardware work, and hardware operators can see whether a physical failure is already affecting workload placement.
+
+Use burn-in and maintenance data to tune alerts. A brand-new hardware batch may produce more early component failures, while a fleet entering its fourth or fifth year may produce more wear-out alerts. If the dashboard never changes the spare plan, it is just decoration. The loop should be closed: alert, investigate, repair, update asset state, update spare inventory, and adjust procurement or refresh plans when repeated patterns appear.
+
+---
+
+## Decommission Runbook
+
+Decommissioning is not the opposite of provisioning. Provisioning creates a trusted node from inventory; decommissioning proves the node is no longer trusted, no longer needed, and no longer carrying data. The order matters because a server can stop running pods long before it is safe to leave the rack. Kubernetes cleanup, identity cleanup, storage sanitization, financial disposition, and environmental handling all need explicit evidence.
+
+Start with workload removal. Cordon and drain the node, confirm no pods remain except expected daemonsets, remove storage responsibilities, and delete the Kubernetes `Node` object when the host is no longer part of the cluster. If the node used local PersistentVolumes, Rook OSDs, or other node-bound state, follow the storage system's removal process before wiping disks. Deleting the Kubernetes node first does not erase storage obligations; it only removes one source of visibility.
+
+Next remove identity. Revoke kubelet client certificates, bootstrap tokens, SSH keys if the OS used SSH, BMC credentials specific to the host, monitoring credentials, backup credentials, and any node-local secrets. Remove the node from DNS, IPAM, load balancer pools, inventory groups, alert routes, and automation allowlists. The goal is simple: if the server is powered on later by mistake, it should not be able to rejoin the cluster or access production control planes.
+
+Storage sanitization must follow data classification. NIST SP 800-88 Rev. 2 frames sanitization as making access to target data infeasible for a given level of effort and ties technique selection to information sensitivity. In practice, that means selecting a documented method such as cryptographic erase, NVMe sanitize, secure erase, overwrite, purge, or physical destruction based on media type, encryption state, and policy. A quick filesystem delete is not sanitization, and a wipe command without verification is weak evidence.
+
+Verification is part of the runbook. Record the device serial number, sanitization method, command output or tool report, operator, date, and disposition. For encrypted drives, record the key destruction or cryptographic erase evidence. For failed drives that cannot be wiped, route them to physical destruction or an approved vendor process according to policy. For reusable drives, run health checks after sanitization because a disk leaving one cluster and entering another should not carry either data or unknown reliability risk.
+
+Asset tracking closes the loop. Update the CMDB or inventory with final rack removal, support-contract change, spare-part harvest, resale or recycle path, and finance status. If the hardware is sold or transferred, the asset record should show that data-bearing media were sanitized or removed. If the hardware is recycled, the record should identify the e-waste vendor or internal disposal path. This is unglamorous work, but it is what turns a pile of old servers into an auditable lifecycle.
+
+E-waste and parts harvesting should be policy-driven. Pulling a PSU or DIMM from a decommissioned server can be rational if the part is compatible, tested, and recorded as spare stock. Randomly scavenging parts creates ghost inventory and unsupported combinations. Recycling should also respect local rules and contractual requirements. The platform team does not need to become an environmental compliance department, but it does need to ensure retired hardware leaves through an approved path rather than through informal favors.
+
+### Decommission Checklist
+
+| Step | Evidence to Keep | Failure Mode If Skipped |
+|------|------------------|-------------------------|
+| Drain and storage removal | Drain log, OSD/local PV removal record | Hidden state remains tied to a disappearing host |
+| Kubernetes identity removal | Node deletion, certificate/token revocation | Retired host can accidentally rejoin or authenticate |
+| Network and monitoring cleanup | DNS/IPAM/alert target updates | Ghost alerts, stale routes, confusing dashboards |
+| Media sanitization | Serial-numbered wipe, sanitize, crypto erase, or destruction report | Data leaves the organization with the asset |
+| Asset disposition | CMDB status, finance status, recycle/resale/RMA record | Hardware remains in inventory without physical control |
+| Spare harvesting | Part serials, tests, firmware version, storage location | Untested parts re-enter production during an emergency |
+
+## Patterns & Anti-Patterns
+
+Good hardware lifecycle programs are deliberately repetitive. They reduce surprise by making every server pass through the same states, every firmware rollout pass through the same rings, and every decommission produce the same evidence. The patterns below scale because they make invisible physical differences visible to software automation and to the humans who carry pagers.
+
+| Pattern | When to Use | Why It Works at Scale |
+|---------|-------------|-----------------------|
+| Standard SKU profiles | Use for every node pool that can tolerate a limited set of hardware shapes | Reduces firmware baselines, spare parts, test matrices, and recovery runbooks |
+| Ring-based firmware rollout | Use for BIOS, BMC, NIC, disk, GPU, and controller updates with reboot or driver risk | Catches systemic failures before they reach every rack or failure domain |
+| Acceptance gate before production | Use for new purchases, repaired servers, and returned RMA parts | Finds early hardware faults before workloads or data depend on the node |
+| Lifecycle state annotations | Use when remediation, maintenance, and provisioning automation share hosts | Prevents planned maintenance from being mistaken for unplanned failure |
+| N+ spare and capacity planning | Use for worker pools, storage pools, control planes, and accelerator pools | Gives the team time to repair hardware without violating application SLOs |
+
+These patterns also help small teams. A five-person platform group cannot remember every server exception, but it can maintain a small set of profiles, dashboards, and transition rules. The system becomes easier to operate because the normal path is stronger than the emergency path. When an unusual failure happens, the team spends its attention on the abnormal symptom rather than rediscovering how the fleet is supposed to work.
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|--------------------|
+| Updating firmware from a laptop and vendor web console | No reproducible audit trail, credentials leak into personal workflows, and failed updates are hard to correlate | Use a controlled runner, Redfish inventory, staged images, checksums, and ring promotion |
+| Treating spare capacity as waste | Drains fail, storage recovery competes with traffic, and every hardware event becomes an application incident | Reserve explicit maintenance and failure headroom in capacity planning |
+| Letting RMA replacements bypass burn-in | Replacement parts introduce firmware drift or early-life failures directly into production | Route all replacement hardware through acceptance, firmware baseline, and stress tests |
+| Keeping `noout` or maintenance flags set indefinitely | Storage systems stop recovering normally and future failures become harder to reason about | Scope maintenance flags narrowly and verify cleanup in return-to-service automation |
+| Wiping disks without serial-number evidence | Auditors and security teams cannot prove which media were sanitized before leaving control | Record device identity, method, result, operator, and final disposition |
+| Deleting the Kubernetes node before storage and asset cleanup | The cluster loses visibility while physical data, support, and inventory obligations remain | Follow a decommission sequence that removes workload, storage, identity, data, and asset state separately |
+
+Anti-patterns usually appear because someone is trying to move fast under pressure. The answer is not to shame the operator; it is to make the safe path faster than the improvised path. If the Redfish runner is ready, the spare shelf is accurate, and the CMDB has a single maintenance button, fewer people will reach for a laptop, a USB stick, or an undocumented vendor console during an outage.
+
+## Decision Framework
+
+Hardware lifecycle decisions usually ask one of four questions: should we update, repair, reprovision, or retire this node? The wrong answer often comes from optimizing one dimension in isolation. Security may want the fastest firmware update, applications may want no disruption, finance may want to delay replacement, and operations may want fewer exceptions. A decision framework forces those dimensions into the same conversation.
+
+| Situation | Prefer Rolling Maintenance | Prefer Quarantine and Repair | Prefer Reprovision or Replace | Prefer Refresh or Decommission |
+|-----------|----------------------------|------------------------------|-------------------------------|-------------------------------|
+| Firmware drift with supported image | Yes, after staging and ring testing | Only if update fails or hardware alerts appear | Only if the node cannot return cleanly | No, unless support or compatibility is ending |
+| Predictive disk failure in replicated storage | Yes, if redundancy and recovery budget are healthy | Yes, if replacement part or hands are not ready | Replace disk or OSD after safe removal | Refresh if failures are common across the generation |
+| Repeated ECC errors | Drain and inspect, but do not simply uncordon | Yes, until DIMM, slot, firmware, or thermal cause is resolved | Replace DIMM or host if errors persist | Refresh if parts are scarce or failures cluster by model |
+| BMC unreachable but host healthy | Schedule maintenance before next risky change | Yes, because recovery control is degraded | Reprovision only after workload and data are safe | Refresh if BMC failures are common and unsupported |
+| Support contract expiring soon | Maintenance may buy time temporarily | Quarantine risky nodes with no support path | Replace failed nodes only if parts remain available | Yes, if extension cost exceeds refresh value |
+| Cluster below maintenance headroom | Delay non-critical maintenance | Quarantine only critical risks | Add capacity or move workloads first | Refresh or expand if headroom gap is structural |
+
+```mermaid
+flowchart TD
+    A[Hardware signal or lifecycle review] --> B{Security or data-loss risk?}
+    B -- Yes --> C{Can one node be drained safely?}
+    B -- No --> D{Support, power, or failure trend worsening?}
+    C -- Yes --> E[Rolling maintenance or part replacement]
+    C -- No --> F[Add capacity, reduce load, or schedule outage]
+    D -- Yes --> G[Refresh business case]
+    D -- No --> H[Monitor and keep baseline evidence current]
+    E --> I{Node returns cleanly?}
+    I -- Yes --> J[Update inventory and uncordon]
+    I -- No --> K[Quarantine, RMA, reprovision, or decommission]
+```
+
+Use the framework during planning, not only during incidents. If a node has unsupported firmware, a nearly expired support contract, repeated correctable memory errors, and no spare capacity for drain, the decision is already overdue. The best lifecycle programs surface that risk while there is still time to buy hardware, migrate workloads, or schedule a controlled outage instead of discovering it at 02:00 when a failed motherboard has taken the choice away.
+
 ---
 
 ## Did You Know?
 
-- **Redfish was developed by the DMTF (Distributed Management Task Force) starting in 2014** as a replacement for IPMI. IPMI 2.0 (Revision 1.1, 2004) is the final major version and is now effectively frozen. Redfish uses HTTPS with JSON payloads (current base protocol specification DSP0266 is 1.23.1, dated December 2025, and the latest schema bundle is 2025.4, released January 2026). Modern BMCs like Dell iDRAC10, HPE iLO 6/7, and Lenovo XCC3 support both during this transition period, but IPMI is being aggressively deprecated.
-- **The Linux Vendor Firmware Service (LVFS)** and its client `fwupd` (latest stable 2.1.1, March 2026) have revolutionized Linux firmware management. LVFS has delivered over 100 million cumulative firmware updates from over 100 hardware vendors, allowing native in-band updates for components without requiring vendor-specific proprietary binaries.
-- **Microsoft's original UEFI Secure Boot certificates (2011 vintage)** begin expiring in June 2026. This requires a fleet-wide update to new 2023-vintage Certificate Authorities to ensure nodes can continue to boot secure operating systems. Planning rolling firmware updates is essential to distribute these new KEK and DB entries seamlessly.
-- **OpenBMC** (latest release 2.18, May 2025) is increasingly becoming the foundation for enterprise management controllers. For example, Lenovo's ThinkSystem V4 servers use XClarity Controller 3 (XCC3), which is fully OpenBMC-based and built on an AST2600 chip with a dual-core ARM Cortex-A7.
-- **CPU microcode updates** (like Intel's August 2025 release fixing Processor Stream Cache privilege escalation, or AMD's Zen 5 microcode upstreamed in July 2025) are often required outside of regular BIOS update cycles to address critical security flaws.
-- **NIST SP 800-193 Platform Firmware Resiliency Guidelines** (published May 2018) is the primary US government standard for firmware resilience, defining core properties for Protection, Detection, and Recovery.
-- Foundational standards continue to evolve: the **UEFI specification 2.11** was published in December 2024, **ACPI 6.6** in May 2025, and the **TCG TPM 2.0 Library specification version 1.85** in March 2026, ensuring modern systems support new architectures, hot-plug capabilities, and up-to-date cryptographic standards.
-- **The "bathtub curve" describes hardware failure rates**: high failure rate in the first 90 days (infant mortality), low and stable for years (useful life), then rising failure rate as components age (wear-out). Plan your spare inventory accordingly -- you need more spares in the first quarter after a hardware refresh and in years 4-5 of the lifecycle.
+- **Redfish is an active DMTF standard, not just a vendor API**: the DMTF Redfish page lists the 2026.1 release family and DSP0266 Redfish Specification 1.24.0, which is why fleet automation should prefer standard Redfish resources first and vendor extensions only where necessary.
+- **NIST SP 800-88 Rev. 2 was published in September 2025** and supersedes Rev. 1 for media sanitization guidance, which makes it the right anchor for new decommission runbooks that handle disk wipe, cryptographic erase, sanitize, purge, and destruction decisions.
+- **LVFS and fwupd support server-side firmware operations too**: LVFS describes itself as a service where vendors upload firmware metadata for clients such as `fwupdmgr`, while also noting that `fwupd` is usable on servers, tablets, phones, and desktops.
+- **Smartmontools now has an official upstream GitHub repository** that documents `smartctl` and `smartd` for monitoring SMART data across modern ATA/SATA, SCSI/SAS, and NVMe disks, so treat disk health tooling as maintained infrastructure rather than an old one-off script.
 
 ---
 
@@ -393,48 +644,68 @@ groups:
 
 ## Quiz
 
-### Question 1
-You need to update the BIOS on 40 bare metal Kubernetes nodes to patch a critical CVE. Your compliance deadline is 14 days. Each BIOS update requires a reboot that takes approximately 8 minutes. How do you plan this?
+1. You need to update the BIOS on 40 bare metal Kubernetes nodes to patch a critical firmware issue. Your compliance deadline is 14 days, each update requires a reboot, and the cluster normally runs at 72% allocatable CPU during peak traffic. How do you plan the rollout?
 
 <details>
 <summary>Answer</summary>
 
-**Plan: Rolling BIOS update, 4 nodes per day, completing in 10 working days.**
-
-By limiting to 4 nodes per day, you maintain spare capacity so that 90% of the cluster remains available to handle peak loads. This batch size allows the team to actively monitor the cluster between updates and catch systemic issues early. If a node fails to return, such as hitting a known boot bug, you have sufficient time to investigate and resolve it before the next batch is processed. The calculation supports this: at ~25 minutes per node (including cordon, drain, staging, and reboot), 4 nodes take roughly 2 hours of active maintenance per day, comfortably meeting the 14-day compliance deadline while leaving a safe buffer.
+Use a ring-based rolling update, starting with a lab or low-risk node, then a small production ring, and only then the rest of the fleet. Drain one node at a time unless capacity modeling proves that a larger batch still leaves enough headroom for peak traffic and one unexpected failure. Verify Redfish task success, Kubernetes readiness, firmware inventory, and hardware alerts before uncordoning and promoting the next node. The compliance deadline should drive daily throughput, but a failed reboot or repeated warning must pause the rollout because spreading a bad firmware image is worse than finishing quickly.
 </details>
 
-### Question 2
-A SMART check on `/dev/sdb` shows `Reallocated_Sector_Count = 52` and `Current_Pending_Sector = 3`. The disk is part of a Ceph OSD. What do you do?
+2. A SMART check on `/dev/sdb` shows `Reallocated_Sector_Count = 52` and `Current_Pending_Sector = 3`. The disk is part of a Ceph OSD, and the cluster is otherwise healthy. What do you do?
 
 <details>
 <summary>Answer</summary>
 
-**This disk is showing signs of imminent failure and should be replaced proactively.**
-
-The presence of pending sectors means the drive is already struggling to read data, and waiting for a complete failure significantly increases the risk of data unavailability if another drive fails simultaneously. Ceph's replication protects your data, but that protection is only effective if you act decisively before multiple disks in the same placement group fail. You should promptly set the OSD to `noout`, mark it `down` and `out`, allow the data to safely migrate, and then purge the OSD before physically replacing the drive. Proactive replacement eliminates the performance penalty of sudden failure during peak workloads and ensures the cluster maintains its fault tolerance.
+Replace it proactively through the documented Ceph or Rook OSD workflow rather than waiting for total failure. Pending sectors mean the drive is already struggling to read some media, and a complete failure during peak load or another recovery would reduce your choices. Apply the appropriate maintenance scope, remove or replace the OSD according to your version-specific runbook, and monitor recovery until placement groups are clean. The goal is to spend redundancy while the cluster is healthy, not after it is already degraded.
 </details>
 
-### Question 3
-You are managing firmware updates for a mixed fleet: 20 Dell 17th Gen (iDRAC10), 15 HPE ProLiant (iLO 6), and 10 Lenovo ThinkSystem V4 (XCC3). Each vendor has different Redfish API endpoints and authentication methods. How do you handle this?
+3. You are managing firmware updates for a mixed fleet from several server vendors. Each vendor exposes Redfish, but package format, task polling, and authentication behavior differ slightly. How do you handle this without making every rollout a custom project?
 
 <details>
 <summary>Answer</summary>
 
-**Build an abstraction layer that maps vendor-specific APIs to a common interface.**
-
-You should build an abstraction layer that maps vendor-specific APIs to a common interface, usually driven by a hardware inventory database. The Redfish standard (with its latest 2025.4 schema) aims for vendor interoperability, but practical implementations often diverge slightly on authentication mechanics, image staging URLs, and task tracking polling. By utilizing an abstraction library like sushy-tools or building vendor-specific adapter scripts around a unified CMDB, you can normalize the deployment pipeline. This ensures your Kubernetes drain and cordon automation remains vendor-agnostic while the underlying adapters handle the specific quirks of iDRAC10, iLO 6/7, or XCC3.
+Build a common firmware workflow with vendor adapters behind it. The shared workflow should handle inventory lookup, maintenance labeling, drain, image staging, reboot, task polling, verification, and CMDB update, while adapters handle package and endpoint differences. Keep the audit record normalized so operators see desired profile, observed profile, node state, and rollout ring rather than vendor-specific console details. This preserves Redfish as the standard control plane while still acknowledging that real server generations have implementation differences.
 </details>
 
-### Question 4
-After a BIOS update, a server fails to boot and sits at a blank screen. The BMC (iDRAC/iLO) is still reachable. What are your recovery options?
+4. After a BIOS update, a server fails to boot and sits at a blank screen, but the BMC is still reachable. The node was drained before the update. What are your recovery options?
 
 <details>
 <summary>Answer</summary>
 
-**Recovery options typically start with the least invasive remote methods and escalate to physical intervention.**
+Start with the least invasive remote recovery path: inspect BMC logs, confirm power state, try a graceful power cycle, check whether firmware rollback or BIOS defaults are available, and use virtual console or virtual media if the platform supports it. Keep the node cordoned and in maintenance state while you troubleshoot so remediation controllers do not race the operator. If remote recovery fails, escalate to datacenter hands or vendor support with the asset tag, firmware version, and task log already attached. Because the node was drained first, the incident should consume spare capacity rather than customer availability.
+</details>
 
-Your first step should be to use the BMC's Redfish API or virtual console to trigger a BIOS rollback, as modern BMCs maintain a backup ROM specifically for this scenario. If the rollback fails, resetting the BIOS to factory defaults via the BMC often clears corrupted NVRAM state that prevents POST. You have time to execute these steps safely because the node was already cordoned and drained prior to the update, meaning no Kubernetes workloads are currently impacted by the outage. Should all remote options fail, the final escalation involves physical datacenter hands to clear the CMOS or re-flash the firmware via a dedicated motherboard jumper.
+5. A node-problem-detector rule starts reporting kernel hardware errors on a worker, while BMC telemetry shows a rising ECC count. MachineHealthCheck would normally remediate an unhealthy Machine after a timeout. What should the lifecycle-aware remediation policy do?
+
+<details>
+<summary>Answer</summary>
+
+The policy should cordon or quarantine the node and require lifecycle context before destructive remediation. If the node is stateless and a tested spare exists, replacement may be appropriate, but repeated ECC errors usually need DIMM, slot, firmware, or thermal investigation first. If planned maintenance is already in progress, MachineHealthCheck should not delete or reprovision the node simply because it is rebooting. Bare-metal remediation should protect data, asset evidence, and spare capacity before it tries to imitate cloud VM replacement.
+</details>
+
+6. A storage worker needs a firmware update, but Ceph is still recovering from yesterday's disk replacement and several placement groups are not clean. The application team wants the firmware update done today because the maintenance window is already approved. What should you do?
+
+<details>
+<summary>Answer</summary>
+
+Delay the firmware update unless the security risk is severe enough to justify a higher-level incident decision. A storage node update during active recovery can compound risk by removing more capacity, increasing backfill pressure, and making it harder to distinguish firmware problems from storage recovery problems. The safer path is to wait for Ceph health to return to normal, confirm spare capacity, and then drain and update one storage node at a time. Approved calendar time is not the same as safe operational state.
+</details>
+
+7. Finance argues that the five-year-old worker fleet is fully depreciated, so keeping it for another year is free. Operations reports rising BMC failures, expiring support, and difficulty sourcing matching spare parts, while utilization remains high and steady. How do you evaluate the decision?
+
+<details>
+<summary>Answer</summary>
+
+Treat the next year as a marginal ownership decision, not as free capacity. Include support extension cost, failure rate, spare scarcity, operator time, power and cooling, risk of security exceptions, and the cost of maintenance headroom in the TCO model. High steady utilization favors on-premises ownership, but it does not automatically favor keeping an aging generation. If support and reliability risk exceed the cost and disruption of a planned refresh, replacing the fleet can be the cheaper operational choice.
+</details>
+
+8. You must configure hardware health monitoring for a bare-metal worker pool using BMC sensors, SMART and NVMe telemetry, Prometheus alerts, and escalation thresholds. What signals do you include, and how do you decide warning versus critical severity?
+
+<details>
+<summary>Answer</summary>
+
+Include BMC reachability, temperature, fan, PSU, voltage, firmware baseline, SMART health, reallocated and pending sectors, NVMe critical warning, media errors, percentage used, ECC errors, and Kubernetes node readiness. Warning severity should mean the team still has time to schedule maintenance, order parts, or watch a trend without immediate service impact. Critical severity should mean redundancy is lost, a second failure could violate an SLO, data risk is rising, or the node should be drained quickly. Each alert should link to a runbook that identifies the asset, failure domain, spare-part path, and safe remediation action.
 </details>
 
 ---
@@ -555,5 +826,22 @@ Continue to [Module 7.3: Node Failure & Auto-Remediation](/on-premises/operation
 ## Sources
 
 - [kubectl drain Reference](https://v1-35.docs.kubernetes.io/docs/reference/kubectl/generated/kubectl_drain/) — Covers the Kubernetes-side maintenance semantics that hardware workflows depend on.
+- [DMTF Redfish Standards](https://www.dmtf.org/standards/redfish) — Official Redfish release and specification index for out-of-band management, schemas, and current standard versions.
+- [DMTF Redfish Firmware Update White Paper](https://www.dmtf.org/sites/default/files/standards/documents/DSP2062_1.0.2.pdf) — Explains Redfish firmware update patterns, including SimpleUpdate and maintenance-window behavior.
+- [NIST SP 800-88 Rev. 2: Guidelines for Media Sanitization](https://csrc.nist.gov/pubs/sp/800/88/r2/final) — Current NIST guidance for media sanitization programs and secure disposal decisions.
+- [NIST SP 800-193 Platform Firmware Resiliency Guidelines](https://www.nist.gov/publications/platform-firmware-resiliency-guidelines) — Provides a firmware-resilience framework for protection, detection, and recovery.
+- [Cluster API MachineHealthCheck](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking) — Defines MachineHealthCheck behavior and remediation concepts used by bare-metal lifecycle automation.
+- [Metal3 Project Overview](https://book.metal3.io/project-overview.html) — Describes the Cluster API provider and Kubernetes-native APIs used to manage bare-metal hosts.
+- [OpenStack Ironic Documentation](https://docs.openstack.org/ironic/latest/) — Official documentation for the bare-metal provisioning service that underpins many automated provisioning workflows.
+- [Tinkerbell](https://tinkerbell.org/) — Official project site for declarative bare-metal provisioning workflows, metadata, and boot automation.
+- [Talos Linux Overview](https://docs.siderolabs.com/talos/v1.13/overview/what-is-talos) — Documents the immutable, API-managed Kubernetes-focused operating system model.
+- [Flatcar Container Linux Documentation](https://www.flatcar.org/docs/latest/) — Documents an image-based, container-focused OS option for Kubernetes hosts.
+- [Ceph OSD Troubleshooting](https://docs.ceph.com/en/reef/rados/troubleshooting/troubleshooting-osd/) — Covers OSD maintenance flags and troubleshooting behavior relevant to disk replacement.
+- [Rook Ceph Common Issues](https://rook.io/docs/rook/latest-release/Troubleshooting/ceph-common-issues/) — Provides operator-specific context for Rook-managed Ceph clusters and storage cleanup.
+- [Kubernetes node-problem-detector](https://github.com/kubernetes/node-problem-detector) — Upstream daemon for surfacing node-local problems to Kubernetes.
 - [Prometheus IPMI Exporter](https://github.com/prometheus-community/ipmi_exporter) — Shows how to pull BMC/IPMI telemetry into Prometheus for hardware-health alerting.
-- [NIST SP 800-193 Platform Firmware Resiliency Guidelines](https://www.nist.gov/publications/platform-firmware-resiliency-guidelines) — Provides a strong firmware-resilience framework for patching, recovery, and platform trust.
+- [Linux Vendor Firmware Service](https://fwupd.org/) — Official LVFS site describing firmware metadata distribution for clients such as `fwupdmgr`.
+- [Smartmontools Upstream Repository](https://github.com/smartmontools/smartmontools) — Upstream project for `smartctl` and `smartd` SMART monitoring utilities.
+- [NVM Express NVMe-CLI Overview](https://nvmexpress.org/open-source-nvme-management-utility-nvme-command-line-interface-nvme-cli/) — Official overview of NVMe-CLI health, firmware, format, and sanitize commands.
+- [kube-vip Documentation](https://kube-vip.io/) — Documents virtual IP and load-balancer behavior for bare-metal Kubernetes control planes and services.
+- [IRS Publication 946](https://www.irs.gov/forms-pubs/about-publication-946) — Official IRS entry point for depreciation guidance used when discussing capital cost recovery.

--- a/src/content/docs/on-premises/operations/module-7.2-hardware-lifecycle.md
+++ b/src/content/docs/on-premises/operations/module-7.2-hardware-lifecycle.md
@@ -7,7 +7,7 @@ sidebar:
 
 > **Complexity**: `[COMPLEX]` | Time: 60 minutes
 >
-> **Prerequisites**: [Module 7.1: Kubernetes Upgrades on Bare Metal](../module-7.1-upgrades/), [Module 2.1: Datacenter Fundamentals](/on-premises/provisioning/module-2.1-datacenter-fundamentals/)
+> **Prerequisites**: [Module 7.1: Kubernetes Upgrades on Bare Metal](../module-7.1-upgrades/), [Module 2.1: Datacenter Fundamentals](../provisioning/module-2.1-datacenter-fundamentals/)
 
 ---
 
@@ -306,21 +306,23 @@ NVMe devices add useful health fields such as critical warning, temperature, med
 
 ### Disk Replacement Workflow (Ceph OSD)
 
-This procedure safely removes a failing disk from a Ceph cluster, replaces it, and re-adds the new disk. The critical step is `ceph osd set noout` -- it prevents Ceph from starting a full rebalance while you are swapping the disk, which would add unnecessary I/O load during the maintenance window.
+This procedure safely removes a failing disk from a Ceph cluster, replaces it, and re-adds the new disk. Prefer scoped `noout` on the affected OSD rather than a cluster-wide flag — see the prose caveat below.
 
 ```bash
 # Step 1: Identify the failing disk
 ceph osd tree  # find which OSD is on the failing disk
 
-# Step 2: Set OSD noout to prevent rebalancing during replacement
-ceph osd set noout
+# Step 2: Scope noout to the affected OSD (not cluster-wide)
+ceph osd add-noout osd.5
 
 # Step 3: Mark the OSD down and out
 ceph osd down osd.5
 ceph osd out osd.5
 
-# Step 4: Remove the OSD from the cluster
+# Step 4: Confirm the OSD is safe to destroy before purge
+ceph osd safe-to-destroy osd.5
 # (purge removes the OSD from CRUSH, deletes its auth keys, and removes it from the map)
+# Use --force only when redundancy is verified and safe-to-destroy still blocks
 ceph osd purge osd.5 --yes-i-really-mean-it
 
 # Step 5: Physically replace the disk (or wait for datacenter hands)
@@ -328,8 +330,8 @@ ceph osd purge osd.5 --yes-i-really-mean-it
 # Step 6: Prepare the new disk
 ceph-volume lvm create --data /dev/sdc
 
-# Step 7: Unset noout to allow rebalancing
-ceph osd unset noout
+# Step 7: Remove scoped noout to allow rebalancing
+ceph osd rm-noout osd.5
 
 # Step 8: Monitor rebalancing
 ceph -w  # watch rebalancing progress
@@ -396,6 +398,8 @@ The decommission phase must close both technical and financial loops. Kubernetes
 This state model matters because it prevents hidden half-states. A node should not be both a spare and a production worker. A returned RMA motherboard should not inherit the old firmware state until it is inspected. A decommissioned server should not have an active BMC account. The lifecycle system does not need to be fancy, but it must make invalid transitions visible enough that someone stops before a broken assumption becomes a production incident.
 
 ### Annual Hardware Maintenance Calendar
+
+The calendar below ties recurring hardware checks to capacity planning and change windows — use it as a scheduling backbone, not a standalone checklist.
 
 ### Monthly Checks
 
@@ -478,6 +482,40 @@ Do not let remediation race maintenance. Planned firmware work should add a main
 
 The capacity question remains central. Automated remediation is only safe if the cluster can absorb the removed node and if a replacement path exists. For bare metal, that replacement path may be a warm spare, a cold spare that can be provisioned through Metal3 or Tinkerbell, or a manual repair. If none of those paths is ready, the best automation may be to cordon, alert, and hold the node in quarantine rather than starting an irreversible rebuild.
 
+### MachineHealthCheck Example
+
+[Cluster API MachineHealthCheck](https://cluster-api.sigs.k8s.io/tasks/automated-machine-management/healthchecking) watches Machine conditions and triggers remediation when unhealthy thresholds are exceeded. Pair it with maintenance labels so planned firmware work does not look like failure — see [Module 7.3: Node Failure & Auto-Remediation](../module-7.3-node-remediation/) for the full remediation stack.
+
+```yaml
+apiVersion: cluster.x-k8s.io/v1beta1
+kind: MachineHealthCheck
+metadata:
+  name: worker-hardware-mhc
+  namespace: default
+spec:
+  clusterName: production
+  selector:
+    matchLabels:
+      cluster.x-k8s.io/deployment-name: worker-pool
+    matchExpressions:
+      - key: maintenance.kubedojo.io/reason
+        operator: DoesNotExist
+  unhealthyConditions:
+    - type: Ready
+      status: "False"
+      timeout: 300s
+    - type: HardwareHealthy
+      status: "False"
+      timeout: 60s
+  maxUnhealthy: 40%
+  nodeStartupTimeout: 600s
+  # Skip machines under planned maintenance (set by maintenance-drain.sh)
+  # MHC controllers honor nodeSelector/matchExpressions on the Machine;
+  # exclude nodes labeled maintenance.kubedojo.io/reason during rollout windows.
+```
+
+Label nodes with `maintenance.kubedojo.io/reason` before drain (see the maintenance workflow above) and scope the MHC selector to exclude those labels during firmware rings. Without that bypass, a rolling BIOS update can trigger delete-and-reprovision on nodes that are intentionally offline.
+
 ## Prometheus Alerts for Hardware Health
 
 These alerting rules turn SMART data and IPMI sensor readings into actionable notifications. The severity levels map to response times: critical means act within hours, warning means plan a replacement within days.
@@ -498,25 +536,25 @@ groups:
           runbook: "Follow disk replacement procedure in ops runbook."
 
       - alert: DiskWearoutHigh
-        expr: smartmon_wear_leveling_count_value < 20
+        expr: smartmon_wear_leveling_count_value < 10
         for: 1h
         labels:
           severity: warning
         annotations:
           summary: "SSD wear leveling low on {{ $labels.instance }}"
-          description: "Disk {{ $labels.disk }} has {{ $value }}% life remaining."
+          description: "Disk {{ $labels.disk }} has {{ $value }}% life remaining (aligns with SMART table threshold of < 10%)."
 
       - alert: MemoryECCErrors
-        expr: node_edac_correctable_errors_total > 100
+        expr: increase(node_edac_correctable_errors_total[1h]) > 50
         for: 10m
         labels:
           severity: warning
         annotations:
           summary: "ECC memory errors on {{ $labels.instance }}"
-          description: "{{ $value }} correctable ECC errors detected. DIMM may be failing."
+          description: "{{ $value }} correctable ECC errors in the last hour. DIMM may be failing."
 
       - alert: PSURedundancyLost
-        expr: ipmi_sensor_state{name=~".*PSU.*",state="critical"} == 1
+        expr: ipmi_sensor_state{name=~".*PSU.*"} == 2
         for: 1m
         labels:
           severity: critical
@@ -843,5 +881,4 @@ Continue to [Module 7.3: Node Failure & Auto-Remediation](/on-premises/operation
 - [Linux Vendor Firmware Service](https://fwupd.org/) — Official LVFS site describing firmware metadata distribution for clients such as `fwupdmgr`.
 - [Smartmontools Upstream Repository](https://github.com/smartmontools/smartmontools) — Upstream project for `smartctl` and `smartd` SMART monitoring utilities.
 - [NVM Express NVMe-CLI Overview](https://nvmexpress.org/open-source-nvme-management-utility-nvme-command-line-interface-nvme-cli/) — Official overview of NVMe-CLI health, firmware, format, and sanitize commands.
-- [kube-vip Documentation](https://kube-vip.io/) — Documents virtual IP and load-balancer behavior for bare-metal Kubernetes control planes and services.
 - [IRS Publication 946](https://www.irs.gov/forms-pubs/about-publication-946) — Official IRS entry point for depreciation guidance used when discussing capital cost recovery.

--- a/src/content/docs/on-premises/operations/module-7.3-node-remediation.md
+++ b/src/content/docs/on-premises/operations/module-7.3-node-remediation.md
@@ -36,7 +36,7 @@ In cloud environments, when a virtual machine fails the cloud provider silently 
 
 This gap between cloud auto-healing and bare-metal reality is the central challenge of on-premises operations. Building automated node remediation is not just a convenience feature — it is the mechanism that closes the mean-time-to-repair (MTTR) gap between owned hardware and cloud infrastructure, and it directly determines whether a three-node control plane failure at 3 AM wakes an on-call engineer or resolves itself while they sleep.
 
-> **Hypothetical scenario**: A ToR switch loses power at 2 AM, taking 14 worker nodes offline in rack B. The control plane detects 14 NotReady conditions within 60 seconds. If your cluster has no automated remediation, those 14 nodes sit idle until an on-call engineer is paged, wakes up, logs in, diagnoses the switch failure, and manually restores power — a 45-minute outage. If your cluster has MachineHealthChecks configured with `maxUnhealthy` safeguards, the MHC controller recognizes that 40% of nodes are already unhealthy and *halts* remediation, preventing a destructive reprovisioning storm on nodes that are actually fine. When the switch power returns, all 14 nodes report Ready and workloads reschedule. The automated system didn't fix the switch, but it prevented the wrong fix from making the outage worse.
+> **Hypothetical scenario**: A ToR switch loses power at 2 AM, taking 14 worker nodes offline in rack B. The control plane detects 14 NotReady conditions within 60 seconds. If your cluster has no automated remediation, those 14 nodes sit idle until an on-call engineer is paged, wakes up, logs in, diagnoses the switch failure, and manually restores power — a 45-minute outage. If your cluster has MachineHealthChecks configured with `maxUnhealthy` safeguards **scoped to the worker pool** (80 workers cluster-wide, but the MHC selector matches only `worker-pool` Machines — 35 nodes in rack B's failure domain), the MHC controller evaluates 14/35 = 40% unhealthy against the threshold and *halts* further remediation at the boundary, preventing a destructive reprovisioning storm on nodes that are actually fine. When the switch power returns, all 14 nodes report Ready and workloads reschedule. The automated system didn't fix the switch, but it prevented the wrong fix from making the outage worse.
 
 ---
 
@@ -82,7 +82,7 @@ On bare metal, the stack must also contend with hardware that the Kubernetes con
 
 ---
 
-> **Pause and predict**: Kubernetes marks a node unhealthy only after missed heartbeats accumulate for about 50 seconds by default. During those 40 seconds, pods on the node are running but potentially broken. What types of hardware failures would be invisible to the kubelet heartbeat mechanism?
+> **Pause and predict**: Kubernetes marks a node unhealthy only after missed heartbeats accumulate for about 50 seconds by default (`node-monitor-grace-period`, 50s since Kubernetes 1.32). During those 50 seconds, pods on the node are running but potentially broken. What types of hardware failures would be invisible to the kubelet heartbeat mechanism?
 
 ## Node Problem Detector
 
@@ -146,7 +146,7 @@ NPD distinguishes between two categories of problems that map to different remed
 
 The default NPD configuration ships with monitors for kernel logs, containerd/docker runtime logs, and a kubelet health checker, but the monitor types you can configure include system-log monitors (scanning journald for kernel, daemon, and system log patterns), custom-plugin monitors (running an arbitrary script on a cron schedule and interpreting its exit code), and health-checker monitors (periodically probing a local endpoint such as the kubelet healthz port). For bare-metal on-premises clusters, the most valuable additions are usually a custom-plugin monitor that reads EDAC sysfs counters and a system-log monitor pattern that catches NIC firmware error messages in dmesg, neither of which is visible to the kubelet heartbeat.
 
-The reporting cadence matters for remediation timing. NPD's system-log monitors run continuously, tailing journald and evaluating each log line against configured regex patterns as it arrives. Custom-plugin monitors run on a configurable cron schedule — typically every 30 to 60 seconds. The health-checker plugin probes its target endpoint on the same schedule. This means the worst-case detection latency for a hardware fault is the plugin's check interval plus the MHC's condition timeout. If a custom EDAC checker runs every 60 seconds and the MHC timeout for `HardwareHealthy=False` is 60 seconds, the total time from DIMM failure to remediation trigger is between 60 and 120 seconds. Tightening the plugin interval below 30 seconds is rarely beneficial because the MHC's reconciliation loop itself runs on a ~10-second period, and faster-than-30-second plugin intervals increase node CPU load for marginal detection-speed gains.
+The reporting cadence matters for remediation timing. NPD's kernel monitor tails `/dev/kmsg` directly; containerd and system-log monitors evaluate journald patterns as lines arrive. Custom-plugin monitors run on a configurable cron schedule — typically every 30 to 60 seconds. The health-checker plugin probes its target endpoint on the same schedule. This means the worst-case detection latency for a hardware fault is the plugin's check interval plus the MHC's condition timeout. If a custom EDAC checker runs every 60 seconds and the MHC timeout for `HardwareHealthy=False` is 60 seconds, the total time from DIMM failure to remediation trigger is between 60 and 120 seconds. Tightening the plugin interval below 30 seconds is rarely beneficial because faster-than-30-second plugin intervals increase node CPU load for marginal detection-speed gains.
 
 ---
 
@@ -281,9 +281,21 @@ done
 
 ### Medik8s Self-Node Remediation
 
-For clusters that need more sophisticated remediation than a shell script but do not run Cluster API, the medik8s project provides a family of Kubernetes-native remediation operators. [Self-Node Remediation (SNR)](https://github.com/medik8s/self-node-remediation) runs as a DaemonSet and watches node conditions from within each node. When SNR detects that its own node is unhealthy — typically by observing a custom condition set by Node Problem Detector or by detecting that the API server is unreachable — it cordons the node, drains pods (respecting PodDisruptionBudgets), and triggers a reboot. After the reboot, if the node returns healthy the operator clears the condition; if the node remains unhealthy, SNR escalates by leaving the condition set, which allows an external controller or on-call engineer to take further action.
+For clusters that need more sophisticated remediation than a shell script but do not run Cluster API, the medik8s project provides a family of Kubernetes-native remediation operators. The flow starts with [Node Health Check (NHC)](https://github.com/medik8s/node-healthcheck-operator): NHC watches node conditions and, when a node is unhealthy, creates a `SelfNodeRemediation` custom resource. [Self-Node Remediation (SNR)](https://github.com/medik8s/self-node-remediation) runs as a DaemonSet on every node and executes the remediation defined by that CR.
 
-SNR's design addresses a critical gap in the simple watchdog approach: what happens when the node cannot reach the API server? A CronJob running on a management node can detect that a worker's kubelet stopped reporting, but it cannot tell whether the worker is genuinely dead or whether the worker's network interface is isolated while the node itself is fine. SNR runs *on* the worker node itself and can make a local determination: if it can still reach the default gateway but not the API server, the problem is network isolation (do not reboot — the node is fine). If it cannot reach anything, including the BMC's management network, the node is likely powered off or kernel-panicked (reboot may not help, but it is the right first attempt).
+The actual SNR flow ([documented in the medik8s how-it-works guide](https://www.medik8s.io/remediation/self-node-remediation/how-it-works/)) works like this:
+
+1. **NHC detects** an unhealthy node (via NPD conditions, `Ready=False`, or other configured checks) and creates a `SelfNodeRemediation` CR.
+2. **Healthy peer nodes** — not the unhealthy node itself — cordon the failed node and **delete its Node object** so the scheduler reschedules workloads elsewhere.
+3. **SNR on the unhealthy node** reboots it (`isSoftwareRebootEnabled` defaults to `true`; hardware watchdog is the fallback when software reboot fails).
+4. **API-server-loss handling**: when the unhealthy node cannot reach the API server, it asks **healthy peers** to verify API-server reachability on its behalf (peer checks) — this is not a default-gateway-vs-API-server heuristic run locally in isolation.
+5. **Total isolation**: when peers confirm the node is unreachable, they fence it by deleting the Node object; SNR may escalate to watchdog-based reboot.
+
+NHC's `minHealthy` field is the storm breaker for medik8s stacks without CAPI's `maxUnhealthy` — it prevents NHC from creating remediation CRs when too few nodes in the selector are healthy, analogous to the MHC circuit breaker in [Module 7.2](../module-7.2-hardware-lifecycle/).
+
+SNR does **not** cordon-and-drain from the failing node itself — peers handle cordon and Node deletion while SNR handles the reboot. This differs from CAPI MHC (which deletes the Machine and reprovisions) and from the simple BMC watchdog (which power-cycles without scheduler-aware workload evacuation).
+
+The reboot mechanism itself is the subtle part. When a hardware watchdog device (such as `/dev/watchdog`, backed by the BMC or a kernel softdog) is present, SNR arms it and lets the timer expire, which forces a hardware reset that cannot be blocked by a hung kernel, a stuck I/O path, or a wedged container runtime. This guarantee matters on bare metal: a node that *looks* down but is still electrically alive can keep holding a storage lock, an iSCSI session, or a floating VIP, creating a split-brain hazard the moment workloads reschedule elsewhere. Only after the watchdog (or, as a fallback, a forced software reboot) confirms the node is truly down do peers safely complete fencing. This is why medik8s strongly recommends provisioning a real watchdog device on every node rather than relying on best-effort software reboots — the timer is the hardware-level proof that the old instance of the node is gone.
 
 ### Fence-Agents Remediation and BMC Protocols
 
@@ -359,7 +371,7 @@ The MHC for control plane nodes must respect these bounds. A `maxUnhealthy` of 3
 A node hosting the sole replica of a StatefulSet pod or the only copy of a PersistentVolume's data must not be reprovisioned until its data is confirmed safe elsewhere. The MHC has no built-in awareness of storage topology — it can and will delete a Machine object hosting the only Ceph OSD in a failure domain, causing permanent data loss if that OSD's data was not fully replicated. Before enabling automated remediation on nodes that host stateful workloads, operators must ensure:
 
 1. All PersistentVolumes have a reclaim policy that preserves data (Retain), not Delete.
-2. All StatefulSet pods have `podManagementPolicy: Parallel` only if anti-affinity ensures no two replicas of the same shard land on the same node.
+2. `podManagementPolicy` controls **startup and scale ordering**, not blast-radius containment — `Parallel` starts or scales all pods simultaneously and can *widen* simultaneous disruption. Use `OrderedReady` unless the workload is explicitly parallel-safe. Blast-radius guardrails come from `topologySpreadConstraints`, pod anti-affinity, and PodDisruptionBudgets.
 3. Storage replication (Ceph, Longhorn, Portworx) is configured to require at least `min_size` replicas before acknowledging writes, so that a single-node failure never creates a write hole.
 4. Topology spread constraints ensure that no single failure domain holds all replicas of any stateful workload.
 5. A pre-remediation webhook or custom controller verifies that the node about to be remediated does not host any "last replica" before allowing the MHC to proceed. This is not a built-in feature — it requires custom integration between the storage layer and the remediation controller.
@@ -488,7 +500,7 @@ spec:
   topologySpreadConstraints:
     - maxSkew: 1
       topologyKey: kubedojo.io/rack
-      whenUnsatisfiable: ScheduleAnyway
+      whenUnsatisfiable: DoNotSchedule
       labelSelector:
         matchLabels:
           app: critical-workload
@@ -508,14 +520,16 @@ Default Kubernetes eviction settings are tuned for cloud environments. On bare m
 Node-failure eviction relies on taint-based eviction and per-pod `NoExecute` tolerations. [When a node becomes `NotReady`, the node lifecycle controller adds a `node.kubernetes.io/not-ready` taint. Pods are evicted when their toleration for this taint expires.](https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/)
 
 ```bash
-# Default behavior:
+# Default behavior (Kubernetes 1.32+):
 #   kube-controller-manager:
 #     --node-monitor-period=5s         (check node status every 5s)
-#     --node-monitor-grace-period=40s  (mark NotReady after 40s no heartbeat)
+#     --node-monitor-grace-period=50s  (mark NotReady after 50s no heartbeat)
 #
 #   kube-apiserver:
 #     --default-not-ready-toleration-seconds=300     (evict 5 min after NotReady taint)
 #     --default-unreachable-toleration-seconds=300   (evict 5 min after Unreachable taint)
+
+# Pre-1.32 legacy: node-monitor-grace-period defaulted to 40s.
 
 # For faster bare metal remediation:
 # Edit kube-apiserver manifest (/etc/kubernetes/manifests/kube-apiserver.yaml)
@@ -531,7 +545,7 @@ Node-failure eviction relies on taint-based eviction and per-pod `NoExecute` tol
 
 # Also tune node-monitor-grace-period for faster NotReady detection:
 # Edit kube-controller-manager manifest
-#   --node-monitor-grace-period=30s  (mark NotReady after 30s instead of 40s)
+#   --node-monitor-grace-period=40s  (faster than 50s default; pre-1.32 legacy value)
 ```
 
 ### Tuning Storage Recovery Throttling
@@ -575,7 +589,7 @@ Start with the least destructive action (BMC power cycle), escalate to more inva
 | **Setting `maxUnhealthy` to 100%** | A systemic event (power loss, switch failure) triggers simultaneous remediation of every node, turning recoverable downtime into a total cluster rebuild | Set `maxUnhealthy` to 40% or lower; the circuit breaker exists to prevent remediation storms |
 | **Remediating nodes without timeouts per condition** | A node that blips NotReady for 10 seconds gets the same treatment as one that has been down for 10 minutes, causing unnecessary reboots for transient issues | Set shorter timeouts for hardware-specific NPD conditions (60s) and longer timeouts for kubelet heartbeats (300s) — different conditions need different urgency |
 | **Using automated remediation on control plane nodes without quorum-awareness** | Remediating a second control plane node while the first replacement has not yet joined etcd breaks quorum, taking down the entire API server | Set control-plane MHC `maxUnhealthy` to floor((N-1)/N × 100)% and ensure the replacement node is fully joined before allowing the next remediation |
-| **Rebooting nodes without first cordoning and draining** | Pods are forcefully terminated without graceful shutdown, in-flight requests are dropped, and stateful workloads may lose unflushed writes | Always cordon + drain before power-cycling; the extra 30-60 seconds of drain time prevents application-level data loss |
+| **Rebooting nodes without workload evacuation** | Pods are forcefully terminated without graceful shutdown, in-flight requests are dropped, and stateful workloads may lose unflushed writes | Match evacuation to the remediation layer: CAPI MHC deletes the Machine (provider reprovisions); medik8s SNR relies on **healthy peers** to cordon and delete the Node before SNR reboots; BMC watchdog scripts should cordon + drain before power-cycling when the host OS is still responsive |
 | **Hard-coding BMC credentials in remediation scripts** | Credential rotation becomes impossible without updating every script; a compromised script exposes credentials for every BMC in the fleet | Store BMC credentials in a Kubernetes Secret or a vault (HashiCorp Vault, sealed secrets), mount them into the remediation controller at runtime, and rotate them on a schedule |
 | **No cooldown between remediation attempts** | A node with a persistent hardware fault gets rebooted every 5 minutes indefinitely, wasting power cycles and generating noise in monitoring | Implement a minimum 30-minute cooldown between remediation attempts on the same node; after 3 failed attempts in 24 hours, escalate to a human and stop automatic remediation for that node |
 
@@ -583,13 +597,15 @@ Start with the least destructive action (BMC power cycle), escalate to more inva
 
 ## On-Premises Cost Lens: The Economics of Automated Remediation
 
+> **Illustrative figures below** — order-of-magnitude examples for planning conversations, not vendor quotes or audited financial models.
+
 Every automated remediation decision has a capital and operational cost attached to it, and the on-premises operator must account for costs that cloud users never see because the cloud provider absorbs them into the instance price.
 
-**CapEx drivers for remediation infrastructure.** Automated remediation requires BMC-capable servers (the BMC chip, management network switch port, and VLAN are all hardware you own), a provisioning network (dedicated switch, DHCP/TFTP/HTTP server, OS image storage), spare nodes (servers that consume rack space, power, and cooling while idle), and redundant control plane hardware to survive remediation cycles without quorum loss. A minimal remediation-capable cluster with 3 control plane nodes, 10 workers, 1 spare, and a dedicated management switch adds roughly $8,000-12,000 in hardware cost compared to a cluster with no remediation automation, primarily from the spare node and the management network infrastructure.
+**CapEx drivers for remediation infrastructure.** Automated remediation requires BMC-capable servers (the BMC chip, management network switch port, and VLAN are all hardware you own), a provisioning network (dedicated switch, DHCP/TFTP/HTTP server, OS image storage), spare nodes (servers that consume rack space, power, and cooling while idle), and redundant control plane hardware to survive remediation cycles without quorum loss. A minimal remediation-capable cluster with 3 control plane nodes, 10 workers, 1 spare, and a dedicated management switch might add on the order of $8,000–12,000 in hardware cost compared to a cluster with no remediation automation (illustrative), primarily from the spare node and the management network infrastructure.
 
-**OpEx drivers.** The ongoing costs include power for cordoned spare nodes (~$300-500/year per spare at typical datacenter rates), cooling overhead (~$150-250/year per spare), network switch port consumption on the management VLAN, and the engineering time to build, test, and maintain the remediation automation. Engineering time is the largest variable: building a production-grade remediation pipeline (NPD configuration, MHC tuning, BMC integration, alert routing, audit logging, runbooks) typically takes a two-person platform team 4-6 weeks of focused work. Ongoing maintenance — updating NPD configurations for new kernel versions, refreshing BMC firmware, rotating credentials, reviewing audit logs — adds roughly 2-4 hours per week.
+**OpEx drivers.** The ongoing costs include power for cordoned spare nodes (illustratively ~$300–500/year per spare at typical datacenter rates), cooling overhead (~$150–250/year per spare), network switch port consumption on the management VLAN, and the engineering time to build, test, and maintain the remediation automation. Engineering time is the largest variable: building a production-grade remediation pipeline (NPD configuration, MHC tuning, BMC integration, alert routing, audit logging, runbooks) might take a two-person platform team several weeks of focused work. Ongoing maintenance — updating NPD configurations for new kernel versions, refreshing BMC firmware, rotating credentials, reviewing audit logs — might add a few hours per week.
 
-**When automated remediation pays for itself.** The breakeven calculation compares the cost of building and operating the remediation system against the cost of outages it prevents. If a 60-minute manual-response outage costs $10,000 in engineering time and degraded service (a conservative figure for a revenue-affecting production service), and automated remediation reduces MTTR from 60 minutes to 5 minutes for 80% of node failures, preventing roughly 6 outages per year saves approximately $44,000 annually. At that rate, the remediation infrastructure pays for itself within the first year. The calculation shifts unfavorably for clusters with fewer than ~20 nodes, where the outage frequency is low enough that building full automation may cost more than simply accepting occasional manual response. For clusters above ~50 nodes, the math is unambiguous: automated remediation is cheaper than manual response.
+**When automated remediation pays for itself.** The breakeven calculation compares the cost of building and operating the remediation system against the cost of outages it prevents. If a 60-minute manual-response outage costs on the order of $10,000 in engineering time and degraded service (illustrative for a revenue-affecting production service), and automated remediation reduces MTTR from 60 minutes to 5 minutes for most node failures, preventing a handful of outages per year can exceed the automation investment. The calculation shifts unfavorably for clusters with fewer than ~20 nodes, where the outage frequency is low enough that building full automation may cost more than simply accepting occasional manual response. For clusters above ~50 nodes, automated remediation often wins on labor alone.
 
 **The MTTR gap vs. cloud.** On a major cloud provider, a failed VM is typically replaced in 2-5 minutes with no operator action required. On bare metal with automated remediation, a power-cycle recovery takes 2-3 minutes — comparable to cloud. A full reprovision takes 10-18 minutes — 3-6x longer than cloud. This gap is irreducible because physical hardware has POST times, firmware initialization, and PXE image transfer latencies that virtualized infrastructure does not. The on-premises operator's goal is not to match cloud MTTR exactly; it is to close the gap to the point where the difference is no longer the dominant factor in application availability. At 10-18 minutes, a reprovision is faster than the 30-60 minutes of manual response — the automation has done its job, even if it is slower than a cloud provider's hypervisor.
 
@@ -624,12 +640,12 @@ flowchart TD
 |--------|----------------|-------------------|-------------------------|
 | **Cluster size** | < 20 nodes | 20-100 nodes | > 50 nodes (justifies CAPI overhead) |
 | **Setup complexity** | 1-2 days | 3-5 days | 2-4 weeks |
-| **Remediation action** | BMC power cycle only | Cordon + drain + reboot; fence on failure | Delete Machine → full reprovision via Ironic |
+| **Remediation action** | BMC power cycle only | Peers cordon + delete Node; SNR reboots; FAR fences on failure | Delete Machine → full reprovision via Ironic |
 | **Node replacement time** | 2-3 min (power cycle) | 3-5 min (reboot) | 10-18 min (full reprovision) |
 | **Requires CAPI** | No | No | Yes |
 | **Requires BMC access** | Yes (IPMI/Redfish) | Yes (IPMI/Redfish) | Yes (Redfish preferred, IPMI fallback) |
 | **Stateful workload aware** | No | Partial (PDB-aware drain) | Partial (PDB-aware drain, needs custom webhook for last-replica check) |
-| **Remediation storm protection** | Manual (cooldown timer) | Manual (cooldown timer) | Built-in (maxUnhealthy circuit breaker) |
+| **Remediation storm protection** | Manual (cooldown timer) | NHC `minHealthy` + cooldown timer | Built-in (`maxUnhealthy` circuit breaker) |
 | **Audit trail** | Script logs | Operator logs + Events | CAPI status conditions + Events |
 | **Best for** | Small clusters, dev/staging | Mid-size production without CAPI | Large production with CAPI investment |
 
@@ -697,7 +713,7 @@ A node shows `Ready` status in Kubernetes but is experiencing intermittent packe
 1. **Node Problem Detector custom check**: Monitor NIC link state changes
    ```bash
    # NPD script: detect NIC flapping
-   FLAPS=$(dmesg --time-format iso | grep -c "link is down" | tail -1)
+   FLAPS=$(dmesg --time-format iso | grep -c "link is down")
    if [ "$FLAPS" -gt 3 ]; then
      echo "NIC flapping detected: ${FLAPS} link-down events"
      exit 1  # Sets node condition to unhealthy
@@ -715,8 +731,8 @@ A node shows `Ready` status in Kubernetes but is experiencing intermittent packe
 
 **Remediation:**
 1. NPD sets a custom condition: `NetworkHealthy = False`
-2. MHC watches for `NetworkHealthy = False` with timeout 60s
-3. MHC triggers remediation (cordon + reboot)
+2. NHC (medik8s) or MHC (CAPI) watches for `NetworkHealthy = False` with timeout 60s
+3. **CAPI MHC**: deletes the Machine and reprovisions via the infrastructure provider. **medik8s SNR**: healthy peers cordon and delete the Node; SNR reboots the unhealthy host
 4. If NIC flapping persists after reboot, the node stays unhealthy and gets escalated to Level 3 (physical NIC replacement)
 
 **Workaround while waiting for fix:**
@@ -850,7 +866,7 @@ Your team is evaluating whether to adopt Cluster API + CAPM3 for bare-metal node
 
 **Arguments against adopting CAPI:**
 1. CAPI adds significant operational complexity: a management cluster (or bootstrap cluster), multiple CRDs and controllers, provider-specific configuration, and a migration of your existing node lifecycle management to CAPI's MachineDeployment model. For a 40-node cluster, this is 2-4 weeks of engineering work and an ongoing maintenance burden.
-2. If remediation is the only reason you are adopting CAPI, the cost of learning and operating CAPI likely outweighs the benefit — the medik8s Self-Node Remediation operator can deliver equivalent remediation capabilities (cordon, drain, reboot, fence) without requiring CAPI.
+2. If remediation is the only reason you are adopting CAPI, the cost of learning and operating CAPI likely outweighs the benefit — the medik8s NHC + SNR stack can deliver peer-coordinated Node eviction, reboot, and fencing without requiring CAPI.
 3. CAPI couples your remediation strategy to your cluster provisioning strategy. If you later change how nodes are provisioned (e.g., switching from PXE to image-based provisioning with Talos or Flatcar), you may need to change both your provisioning pipeline AND your remediation pipeline because they share the same CAPM3 integration.
 
 **The pragmatic recommendation:** For a 40-node cluster not already using CAPI, deploy medik8s SNR + NPD for remediation, invest the saved engineering time in building a solid BMC credential management and remediation audit pipeline, and revisit CAPI if and when the cluster grows beyond ~100 nodes or you need CAPI for other reasons (multi-cluster management, declarative cluster lifecycle).
@@ -913,8 +929,8 @@ EOF
 4. **Simulate a kernel issue:**
    ```bash
    # Exec into the worker node container (kind-specific)
-   # Write to /dev/kmsg so the message is picked up by journald and NPD
-   # (kind nodes use journald, not traditional syslog, so /var/log/kern.log may not exist)
+   # Write to /dev/kmsg — NPD's kernel monitor tails /dev/kmsg directly
+   # (not via journald; /var/log/kern.log may not exist on kind nodes)
    docker exec npd-lab-worker bash -c \
      'echo "kernel: BUG: unable to handle kernel NULL pointer dereference" > /dev/kmsg'
    ```
@@ -952,7 +968,8 @@ Continue to [Module 7.4: Observability Without Cloud Services](/on-premises/oper
 - [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) — Backs rack/zone spread behavior, topology keys, default spread behavior, and cluster scheduling policy claims when distributing workloads across mixed racks or hardware domains.
 - [kubernetes.io: troubleshooting kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm/) — The kubeadm troubleshooting docs explicitly describe expired kubelet client certificates causing authentication and rejoin problems.
 - [Node Status](https://kubernetes.io/docs/reference/node/node-status) — Documents `Ready` and `Unknown` semantics and the current default node-monitor-grace-period.
-- [medik8s: Self-Node Remediation](https://github.com/medik8s/self-node-remediation) — Supports claims about the SNR operator, DaemonSet-based remediation, cordon-drain-reboot flow, PDB awareness, and API-server-unreachable detection for non-CAPI clusters.
+- [medik8s: Node Health Check Operator](https://github.com/medik8s/node-healthcheck-operator) — Creates SelfNodeRemediation CRs when nodes are unhealthy; `minHealthy` provides storm protection for medik8s stacks.
+- [medik8s: Self-Node Remediation](https://github.com/medik8s/self-node-remediation) — SNR DaemonSet executes peer-coordinated cordon, Node deletion, and software/watchdog reboot per medik8s.io/how-it-works.
 - [medik8s: Fence-Agents Remediation](https://github.com/medik8s/fence-agents-remediation) — Supports claims about hard fencing via BMC, wrapping ClusterLabs fence agents behind a Kubernetes operator, and power-off isolation of unresponsive bare-metal nodes.
 - [Metal3 (CAPM3) Provider](https://github.com/metal3-io/cluster-api-provider-metal3) — Supports claims about the CAPM3 bare-metal reprovision flow, Ironic integration, BMC power-off/wipe/PXE-boot sequence, and BareMetalHost provisioning state machine.
 - [DMTF Redfish Standard](https://www.dmtf.org/standards/redfish) — Supports claims about Redfish as the modern RESTful HTTPS BMC management protocol replacing IPMI, covering power control, hardware inventory, and certificate-based authentication.

--- a/src/content/docs/on-premises/operations/module-7.3-node-remediation.md
+++ b/src/content/docs/on-premises/operations/module-7.3-node-remediation.md
@@ -1,5 +1,4 @@
 ---
-revision_pending: true
 title: "Module 7.3: Node Failure & Auto-Remediation"
 slug: on-premises/operations/module-7.3-node-remediation
 sidebar:
@@ -32,6 +31,12 @@ If a failed node also hosts storage or participates in a busy replicated storage
 Without automated remediation, on-call response and manual hardware recovery can stretch a node outage from minutes into a much longer incident.
 
 With automated remediation and workload-specific eviction settings, many node failures can be handled much faster and with less manual intervention.
+
+In cloud environments, when a virtual machine fails the cloud provider silently replaces it behind the scenes — often before an operator even notices. The replacement VM boots from a pre-built image, attaches to the same virtual network, and workloads reschedule automatically. On bare metal, none of that happens by magic. A failed physical server stays failed until something — a script, a controller, or a human — actively intervenes. The hardware does not self-heal; the automation layer must be built, tested, and continuously exercised.
+
+This gap between cloud auto-healing and bare-metal reality is the central challenge of on-premises operations. Building automated node remediation is not just a convenience feature — it is the mechanism that closes the mean-time-to-repair (MTTR) gap between owned hardware and cloud infrastructure, and it directly determines whether a three-node control plane failure at 3 AM wakes an on-call engineer or resolves itself while they sleep.
+
+> **Hypothetical scenario**: A ToR switch loses power at 2 AM, taking 14 worker nodes offline in rack B. The control plane detects 14 NotReady conditions within 60 seconds. If your cluster has no automated remediation, those 14 nodes sit idle until an on-call engineer is paged, wakes up, logs in, diagnoses the switch failure, and manually restores power — a 45-minute outage. If your cluster has MachineHealthChecks configured with `maxUnhealthy` safeguards, the MHC controller recognizes that 40% of nodes are already unhealthy and *halts* remediation, preventing a destructive reprovisioning storm on nodes that are actually fine. When the switch power returns, all 14 nodes report Ready and workloads reschedule. The automated system didn't fix the switch, but it prevented the wrong fix from making the outage worse.
 
 ---
 
@@ -71,6 +76,10 @@ With automated remediation and workload-specific eviction settings, many node fa
 +---------------------------------------------------------------+
 ```
 
+Each layer in this stack addresses a different failure visibility gap. The kubelet alone can only report that it is alive and talking to the API server — it has no insight into whether a DIMM is accumulating correctable ECC errors, whether a NIC is silently dropping every third packet, or whether a filesystem remount is imminent. Layer 1 (hardware/OS) produces the raw signals. Layer 2 (NPD) translates those signals into Kubernetes-native conditions. Layer 3 (MHC) evaluates those conditions against time thresholds and safety gates. Layer 4 (remediation controller) executes the physical action — reboot, power cycle, or full reprovision. Without any one of these layers, the chain breaks: raw signals with no Kubernetes translation are invisible to the scheduler, and Kubernetes conditions with no remediation controller are just red indicators on a dashboard that nobody is watching at 3 AM.
+
+On bare metal, the stack must also contend with hardware that the Kubernetes control plane cannot virtualize away. A cloud provider's hypervisor can fence a VM by destroying it and creating a new one; a bare-metal cluster must physically power-cycle a server through its BMC, wait for firmware POST, wait for PXE boot, and only then begin the kubelet join sequence. Every layer of the detection-and-remediation stack must be tuned for these physical realities.
+
 ---
 
 > **Pause and predict**: Kubernetes marks a node unhealthy only after missed heartbeats accumulate for about 50 seconds by default. During those 40 seconds, pods on the node are running but potentially broken. What types of hardware failures would be invisible to the kubelet heartbeat mechanism?
@@ -78,8 +87,6 @@ With automated remediation and workload-specific eviction settings, many node fa
 ## Node Problem Detector
 
 [Node Problem Detector (NPD) is a DaemonSet that monitors system logs and reports problems as Kubernetes node conditions.](https://github.com/kubernetes/node-problem-detector) Without NPD, Kubernetes only knows a node is unhealthy when kubelet stops reporting -- which can take minutes.
-
-### Deploying Node Problem Detector
 
 NPD runs with `hostNetwork` and `hostPID` access so it can read kernel logs (`/dev/kmsg`), system logs, and detect hardware-level issues that the kubelet cannot see. It translates these low-level signals into Kubernetes node conditions that Machine Health Checks can act on.
 
@@ -135,6 +142,12 @@ spec:
 
 NPD supports custom health check plugins. For example, you can add a custom health-check plugin that periodically inspects EDAC counters and disk SMART health, then sets a custom node condition when those checks fail.
 
+NPD distinguishes between two categories of problems that map to different remediation urgency levels. **Permanent conditions** represent problems that persist until an external action is taken — a kernel oops, a filesystem remount-read-only, or a stuck kernel thread. These conditions remain on the node until the issue is explicitly resolved. **Temporary events** represent transient phenomena — a single OOM kill, a brief NIC carrier loss, or a container restart. NPD reports temporary events as Kubernetes Events (visible via `kubectl describe node`) rather than persistent conditions, because MHC should not reboot a node over a single transient spike.
+
+The default NPD configuration ships with monitors for kernel logs, containerd/docker runtime logs, and a kubelet health checker, but the monitor types you can configure include system-log monitors (scanning journald for kernel, daemon, and system log patterns), custom-plugin monitors (running an arbitrary script on a cron schedule and interpreting its exit code), and health-checker monitors (periodically probing a local endpoint such as the kubelet healthz port). For bare-metal on-premises clusters, the most valuable additions are usually a custom-plugin monitor that reads EDAC sysfs counters and a system-log monitor pattern that catches NIC firmware error messages in dmesg, neither of which is visible to the kubelet heartbeat.
+
+The reporting cadence matters for remediation timing. NPD's system-log monitors run continuously, tailing journald and evaluating each log line against configured regex patterns as it arrives. Custom-plugin monitors run on a configurable cron schedule — typically every 30 to 60 seconds. The health-checker plugin probes its target endpoint on the same schedule. This means the worst-case detection latency for a hardware fault is the plugin's check interval plus the MHC's condition timeout. If a custom EDAC checker runs every 60 seconds and the MHC timeout for `HardwareHealthy=False` is 60 seconds, the total time from DIMM failure to remediation trigger is between 60 and 120 seconds. Tightening the plugin interval below 30 seconds is rarely beneficial because the MHC's reconciliation loop itself runs on a ~10-second period, and faster-than-30-second plugin intervals increase node CPU load for marginal detection-speed gains.
+
 ---
 
 ## Machine Health Checks (Cluster API)
@@ -174,6 +187,12 @@ spec:
   nodeStartupTimeout: 600s
 ```
 
+The three critical fields in any MHC specification are `unhealthyConditions`, `maxUnhealthy`, and `nodeStartupTimeout`. `unhealthyConditions` defines the condition type and status pair that triggers remediation, plus the duration the condition must persist before action is taken. Setting different timeouts per condition type allows the cluster to respond fast to unambiguous hardware failures (60 seconds for `HardwareHealthy=False`) while allowing transient kubelet restarts time to self-resolve (300 seconds for `Ready=False`). `maxUnhealthy` is the circuit breaker — expressed as a percentage of total matched machines, it prevents the MHC from remediating machines when the cluster is already partially degraded. Without this guard, a datacenter-wide power event could trigger simultaneous remediation of every node, turning a recoverable outage into a total cluster rebuild.
+
+`nodeStartupTimeout` defines how long the MHC waits for a replacement node's kubelet to register with the API server after the Machine object is created. On bare metal, a full reprovision cycle — power-on self-test, firmware initialization, PXE boot, OS image deployment, and kubelet join — can take 8 to 15 minutes depending on hardware generation and network speed. Setting `nodeStartupTimeout` too low causes the MHC to declare the remediation failed while the replacement node is still booting, triggering a second, unnecessary remediation cycle and wasting hardware.
+
+Starting with Cluster API v1beta2, the `unhealthyConditions` field was restructured into `spec.checks.unhealthyNodeConditions` (conditions read from the Kubernetes Node object) and `spec.checks.unhealthyMachineConditions` (conditions read from the CAPI Machine object such as `NodeReady` and `InfrastructureReady`). The `maxUnhealthy` field was replaced by `spec.remediation.triggerIf.unhealthyLessThanOrEqualTo`. If your cluster runs CAPI v1.8 or later, prefer the v1beta2 API; the concepts are identical but the field names differ. The v1beta1 format shown above remains widely deployed and is fully functional on CAPI versions that predate the v1beta2 migration.
+
 ### How MHC Remediation Works
 
 ```
@@ -206,6 +225,14 @@ spec:
 |                                                                |
 +---------------------------------------------------------------+
 ```
+
+### CAPM3 Reprovision Flow
+
+When Cluster API is paired with the Metal3 infrastructure provider (CAPM3), the reprovision path follows a well-defined state machine that maps directly to physical bare-metal operations. Understanding this flow helps operators debug remediation failures and tune timeouts.
+
+When MHC deletes the Machine object in step 4, CAPM3's Metal3Machine controller receives the deletion event and begins a sequenced teardown of the physical host. First, it calls Ironic — the OpenStack bare-metal provisioning service that CAPM3 embeds — to set the node's provisioning state to `deleting`. Ironic then issues an out-of-band power-off command via the BMC, using whichever protocol the BMC supports: Redfish (the DMTF standard, preferred for modern servers), IPMI (ubiquitous but less secure), or vendor-specific interfaces like iDRAC (Dell) or iLO (HPE). After confirming the power state is off, Ironic issues a disk-clean step — typically a secure erase or ATA sanitize command — to ensure no residual data or boot loader artifacts from the previous OS installation survive. The disk clean is critical for immutable-OS deployments: if the old boot partition remains, the new PXE boot may chain-load the old OS instead of the fresh image.
+
+Once the host is clean, the Metal3MachineTemplate's spec determines whether a new BareMetalHost claim is created immediately. If the MachineDeployment still has a replica count that demands the node, CAPM3 finds an available BareMetalHost matching the label selector, sets its provisioning state to `available`, and begins the deployment sequence: power on via BMC, wait for the Preboot Execution Environment (PXE) DHCP offer, serve the iPXE boot script, stream the OS image, write it to disk, and reboot into the installed OS. After the OS boots and cloud-init or Ignition runs, kubelet registers with the API server and the node transitions to Ready. The entire cycle — from MHC triggering deletion to the replacement node reporting Ready — typically takes 10 to 18 minutes on bare metal, compared to 2 to 5 minutes for a cloud VM replacement. This delta is the fundamental MTTR gap that on-premises operators must design around.
 
 ---
 
@@ -252,6 +279,24 @@ for NODE in $UNHEALTHY; do
 done
 ```
 
+### Medik8s Self-Node Remediation
+
+For clusters that need more sophisticated remediation than a shell script but do not run Cluster API, the medik8s project provides a family of Kubernetes-native remediation operators. [Self-Node Remediation (SNR)](https://github.com/medik8s/self-node-remediation) runs as a DaemonSet and watches node conditions from within each node. When SNR detects that its own node is unhealthy — typically by observing a custom condition set by Node Problem Detector or by detecting that the API server is unreachable — it cordons the node, drains pods (respecting PodDisruptionBudgets), and triggers a reboot. After the reboot, if the node returns healthy the operator clears the condition; if the node remains unhealthy, SNR escalates by leaving the condition set, which allows an external controller or on-call engineer to take further action.
+
+SNR's design addresses a critical gap in the simple watchdog approach: what happens when the node cannot reach the API server? A CronJob running on a management node can detect that a worker's kubelet stopped reporting, but it cannot tell whether the worker is genuinely dead or whether the worker's network interface is isolated while the node itself is fine. SNR runs *on* the worker node itself and can make a local determination: if it can still reach the default gateway but not the API server, the problem is network isolation (do not reboot — the node is fine). If it cannot reach anything, including the BMC's management network, the node is likely powered off or kernel-panicked (reboot may not help, but it is the right first attempt).
+
+### Fence-Agents Remediation and BMC Protocols
+
+When a node is unresponsive and a simple reboot does not restore it, the next escalation step is fencing — forcibly removing the node from the cluster's shared resources (storage, network) before attempting recovery. [Fence-agents-remediation (FAR)](https://github.com/medik8s/fence-agents-remediation), also from the medik8s project, wraps the Linux cluster fencing agents (historically from the ClusterLabs fence-agents project) behind a Kubernetes operator. FAR can issue a BMC power-off (hard fence) rather than a reboot, ensuring the failed node is electrically isolated before a replacement takes over its workloads.
+
+Bare-metal fencing relies on out-of-band management protocols that operate independently of the host OS. The two primary protocols are:
+
+- **IPMI (Intelligent Platform Management Interface)**: The older standard, supported on nearly every server built since ~2005. Uses UDP port 623. Provides power control, sensor reading, serial-over-LAN console, and system event log access. IPMI 2.0 added encryption, but many deployments run IPMI 1.5 without encryption due to BMC firmware limitations, making credential exposure a real operational risk. The `ipmitool` CLI (used in the watchdog script above) is the standard tool.
+
+- **Redfish**: The modern DMTF standard, designed as a RESTful HTTPS API with JSON payloads, replacing IPMI's binary UDP protocol. Redfish provides the same power, sensor, and boot-device control as IPMI but adds structured hardware inventory, firmware update endpoints, and certificate-based authentication. All major server vendors (Dell iDRAC9+, HPE iLO 5+, Supermicro X11+, Lenovo XClarity) support Redfish. For new deployments, prefer Redfish over IPMI: its HTTPS transport handles BMC certificate validation (or at least makes the absence of validation visible), and its JSON API is easier to integrate with Kubernetes controllers than parsing `ipmitool` text output.
+
+The choice between IPMI and Redfish fencing is ultimately a hardware-generation question — if your servers are newer than ~2017, you have Redfish. If they are older, you have IPMI. The fencing logic (power off, wait, power on) is the same regardless of protocol; only the transport and authentication mechanism differ.
+
 ### Escalation Logic
 
 ```
@@ -283,6 +328,41 @@ done
 |                                                                |
 +---------------------------------------------------------------+
 ```
+
+The escalation ladder encodes a practical assumption: most node failures are transient and a single power cycle resolves them. Level 1 attempts that power cycle with no human involvement. Level 2 escalates to a full OS reprovision only after Level 1 fails, because a PXE reprovision takes significantly longer, wipes local state, and consumes network bandwidth. Level 3 pages a human only after two automated attempts have failed — this is the threshold where the problem is likely a physical hardware fault (dead PSU, failed motherboard, severed network cable) that software cannot fix.
+
+The ladder's timing values are configurable and should be tuned to your hardware's actual boot times. A server with fast NVMe storage and a 10GbE provisioning network might PXE-boot and join the cluster in 5-7 minutes, allowing a shorter Level 2 wait period. A server with spinning disks and a 1GbE provisioning network might need the full 10-15 minutes. Setting the wait period too short causes unnecessary escalation to Level 3 (human intervention) for nodes that would have recovered given another 2-3 minutes; setting it too long leaves workloads stranded on a dead node longer than necessary. The only way to tune these values correctly is to measure actual reprovision times in your environment — run 10 timed reprovision cycles, take the 95th percentile, and set the Level 2 wait period to that value plus a 2-minute buffer.
+
+Testing the remediation pipeline end-to-end is non-negotiable before enabling it in production. A remediation system that has never been exercised against a real BMC power cycle is a collection of hopeful YAML files, not an operational capability. Schedule a quarterly "node failure fire drill": select a non-critical worker, simulate a failure by stopping its kubelet (`systemctl stop kubelet`), and observe every layer of the stack — NPD condition propagation, MHC timeout evaluation, BMC power cycle or reprovision trigger, replacement node join, workload reschedule. Time each phase and compare against your MTTR targets. A pipeline that works in the fire drill works in production; a pipeline that has never been tested will fail in production at the worst possible moment.
+
+---
+
+## Remediation Safety: Storm Prevention and Quorum
+
+Automated remediation creates a new failure mode that manual operations never produce: the remediation storm. When a systemic failure (power event, switch failure, network partition) affects multiple nodes simultaneously, an unguarded remediation controller will attempt to reboot or reprovision every affected node at once. On bare metal, simultaneous BMC power-cycles across a rack can trip the rack's power budget, simultaneous PXE boots can saturate the provisioning network, and simultaneous kubelet joins can overwhelm the API server. A well-designed remediation system must self-throttle.
+
+### The maxUnhealthy Circuit Breaker
+
+The `maxUnhealthy` field (or `unhealthyLessThanOrEqualTo` in CAPI v1beta2) is the primary circuit breaker. Its mechanics are more subtle than they appear. The MHC evaluates the unhealthy ratio *before each individual remediation decision*, not once at the start of a batch. This means that if 10 nodes go unhealthy and `maxUnhealthy` is set to 40%, the MHC will remediate node 1 (10% unhealthy, below 40%), then re-evaluate before node 2 (still ~10% unhealthy if the previous node's Machine was deleted but the replacement hasn't started), and continue up to the 4th node. By node 5, with 50% unhealthy, the MHC stops. Critically, as remediated nodes recover and rejoin the cluster, the unhealthy ratio drops below 40% again, and the MHC resumes remediation of the remaining nodes — this staggered, self-throttling recovery pattern prevents the simultaneous-everything storm while still working through the full queue of unhealthy nodes over time.
+
+### Control Plane Quorum Safety
+
+Control plane nodes require stricter remediation rules than workers because losing quorum renders the cluster API unavailable — and without the API, no automation can function. For an etcd-based control plane with N members, the cluster can tolerate floor((N-1)/2) simultaneous failures before losing quorum. This means:
+
+- 3-node control plane: can lose 1 node (33%) before quorum is lost
+- 5-node control plane: can lose 2 nodes (40%) before quorum is lost
+
+The MHC for control plane nodes must respect these bounds. A `maxUnhealthy` of 33% on a 3-node control plane means only 1 node can be remediated at a time, and that remediation must *succeed* (the replacement must join and establish etcd membership) before the next unhealthy node can be remediated. If a control plane node is unhealthy but the replacement stalls, the MHC for the control plane must wait — remediating the second unhealthy node while the first replacement hasn't joined would break quorum. In practice, this means control plane MHCs should use a `maxUnhealthy` value set to floor((N-1)/N × 100)% — which for a 3-node cluster is 33%, and for a 5-node cluster is 40%.
+
+### Stateful Workload Guardrails
+
+A node hosting the sole replica of a StatefulSet pod or the only copy of a PersistentVolume's data must not be reprovisioned until its data is confirmed safe elsewhere. The MHC has no built-in awareness of storage topology — it can and will delete a Machine object hosting the only Ceph OSD in a failure domain, causing permanent data loss if that OSD's data was not fully replicated. Before enabling automated remediation on nodes that host stateful workloads, operators must ensure:
+
+1. All PersistentVolumes have a reclaim policy that preserves data (Retain), not Delete.
+2. All StatefulSet pods have `podManagementPolicy: Parallel` only if anti-affinity ensures no two replicas of the same shard land on the same node.
+3. Storage replication (Ceph, Longhorn, Portworx) is configured to require at least `min_size` replicas before acknowledging writes, so that a single-node failure never creates a write hole.
+4. Topology spread constraints ensure that no single failure domain holds all replicas of any stateful workload.
+5. A pre-remediation webhook or custom controller verifies that the node about to be remediated does not host any "last replica" before allowing the MHC to proceed. This is not a built-in feature — it requires custom integration between the storage layer and the remediation controller.
 
 ---
 
@@ -335,6 +415,8 @@ kubectl cordon spare-01
 # Alert on-call: "Spare activated, investigate failed node"
 # After fix: re-cordon the recovered node as the new spare
 ```
+
+The spare-node model carries a real financial cost that cloud operators never face. A cordoned spare node consumes power, cooling, rack space, and switch port capacity while contributing zero workload throughput. If each spare node draws ~300 watts at idle and your electricity cost is $0.12/kWh, a single spare costs approximately $315/year in power alone — and that is before cooling overhead (typically 30-50% on top of server power draw). Four spares across four racks represents roughly $1,500-2,000/year in utility costs. The tradeoff is between that operating cost and the recovery-time reduction: uncordoning a hot spare restores capacity in under 30 seconds (the time for the scheduler to bind pods to the newly available node), while a cold spare that must be powered on, go through POST, PXE boot, and OS initialization adds 5-15 minutes. For most production clusters, the MTTR reduction justifies the operating cost. For development or staging clusters, cold spares or simply accepting longer recovery times may be the right economic choice.
 
 ---
 
@@ -463,6 +545,95 @@ ceph tell 'osd.*' injectargs '--osd-recovery-max-active 1'
 ceph tell 'osd.*' injectargs '--osd-max-backfills 1'
 ceph tell 'osd.*' injectargs '--osd-recovery-op-priority 1'
 ```
+
+---
+
+## Patterns & Anti-Patterns
+
+### Proven Patterns
+
+**Pattern 1: Layered Detection with Independent Escalation Paths**
+
+Run Node Problem Detector on every node to surface hardware and kernel conditions as Kubernetes node conditions, a MachineHealthCheck (or custom watchdog) to act on those conditions, and a separate BMC connectivity path (IPMI/Redfish) for when the host OS is entirely unresponsive. No single layer should be the sole path to remediation. If NPD fails to detect a condition because journald is stalled, the MHC's kubelet heartbeat timeout still catches the node; if kubelet stops reporting but the BMC is reachable, the power-cycle path still works. This layered approach means any two components can fail and remediation still functions.
+
+**Pattern 2: Same-Rack Spare Preference with Cross-Rack Fallback**
+
+When uncordoning spare nodes to replace a failed worker, prefer a spare in the same rack as the failed node. Same-rack spares preserve the cluster's topology distribution — workloads that were spread across racks stay spread across racks. If no same-rack spare is available, fall back to any available spare, but generate an alert so the operator knows the topology is now degraded. Once the original node is repaired, re-cordon it and re-label it as the same-rack spare to restore the original topology.
+
+**Pattern 3: Remediation Audit Logging with Weekly Review**
+
+Log every remediation event — which node, which condition triggered it, which action was taken (power cycle, reprovision, human escalation), and the outcome (node recovered, node still down) — to a structured log. Review these logs weekly as a team to identify patterns: a node that gets remediated three times in a month likely has an intermittent hardware fault that needs physical inspection; a condition type that never triggers remediation may indicate that its timeout is too generous; a spike in remediation events may correlate with a recent firmware update and warrant a rollback. Automated remediation without audit review becomes invisible infrastructure decay.
+
+**Pattern 4: Graduated Remediation with Increasing Invasiveness**
+
+Start with the least destructive action (BMC power cycle), escalate to more invasive steps (disk wipe + OS reprovision) only after the first attempt fails, and involve a human only after automated steps are exhausted. This pattern minimizes the blast radius of the remediation itself — a power cycle preserves local state and takes 2-3 minutes; a reprovision destroys local state and takes 10-18 minutes. Choosing the right first step avoids turning a recoverable node blip into a data-loss incident.
+
+### Anti-Patterns
+
+| Anti-Pattern | Why It's Bad | Better Approach |
+|--------------|--------------|-----------------|
+| **Setting `maxUnhealthy` to 100%** | A systemic event (power loss, switch failure) triggers simultaneous remediation of every node, turning recoverable downtime into a total cluster rebuild | Set `maxUnhealthy` to 40% or lower; the circuit breaker exists to prevent remediation storms |
+| **Remediating nodes without timeouts per condition** | A node that blips NotReady for 10 seconds gets the same treatment as one that has been down for 10 minutes, causing unnecessary reboots for transient issues | Set shorter timeouts for hardware-specific NPD conditions (60s) and longer timeouts for kubelet heartbeats (300s) — different conditions need different urgency |
+| **Using automated remediation on control plane nodes without quorum-awareness** | Remediating a second control plane node while the first replacement has not yet joined etcd breaks quorum, taking down the entire API server | Set control-plane MHC `maxUnhealthy` to floor((N-1)/N × 100)% and ensure the replacement node is fully joined before allowing the next remediation |
+| **Rebooting nodes without first cordoning and draining** | Pods are forcefully terminated without graceful shutdown, in-flight requests are dropped, and stateful workloads may lose unflushed writes | Always cordon + drain before power-cycling; the extra 30-60 seconds of drain time prevents application-level data loss |
+| **Hard-coding BMC credentials in remediation scripts** | Credential rotation becomes impossible without updating every script; a compromised script exposes credentials for every BMC in the fleet | Store BMC credentials in a Kubernetes Secret or a vault (HashiCorp Vault, sealed secrets), mount them into the remediation controller at runtime, and rotate them on a schedule |
+| **No cooldown between remediation attempts** | A node with a persistent hardware fault gets rebooted every 5 minutes indefinitely, wasting power cycles and generating noise in monitoring | Implement a minimum 30-minute cooldown between remediation attempts on the same node; after 3 failed attempts in 24 hours, escalate to a human and stop automatic remediation for that node |
+
+---
+
+## On-Premises Cost Lens: The Economics of Automated Remediation
+
+Every automated remediation decision has a capital and operational cost attached to it, and the on-premises operator must account for costs that cloud users never see because the cloud provider absorbs them into the instance price.
+
+**CapEx drivers for remediation infrastructure.** Automated remediation requires BMC-capable servers (the BMC chip, management network switch port, and VLAN are all hardware you own), a provisioning network (dedicated switch, DHCP/TFTP/HTTP server, OS image storage), spare nodes (servers that consume rack space, power, and cooling while idle), and redundant control plane hardware to survive remediation cycles without quorum loss. A minimal remediation-capable cluster with 3 control plane nodes, 10 workers, 1 spare, and a dedicated management switch adds roughly $8,000-12,000 in hardware cost compared to a cluster with no remediation automation, primarily from the spare node and the management network infrastructure.
+
+**OpEx drivers.** The ongoing costs include power for cordoned spare nodes (~$300-500/year per spare at typical datacenter rates), cooling overhead (~$150-250/year per spare), network switch port consumption on the management VLAN, and the engineering time to build, test, and maintain the remediation automation. Engineering time is the largest variable: building a production-grade remediation pipeline (NPD configuration, MHC tuning, BMC integration, alert routing, audit logging, runbooks) typically takes a two-person platform team 4-6 weeks of focused work. Ongoing maintenance — updating NPD configurations for new kernel versions, refreshing BMC firmware, rotating credentials, reviewing audit logs — adds roughly 2-4 hours per week.
+
+**When automated remediation pays for itself.** The breakeven calculation compares the cost of building and operating the remediation system against the cost of outages it prevents. If a 60-minute manual-response outage costs $10,000 in engineering time and degraded service (a conservative figure for a revenue-affecting production service), and automated remediation reduces MTTR from 60 minutes to 5 minutes for 80% of node failures, preventing roughly 6 outages per year saves approximately $44,000 annually. At that rate, the remediation infrastructure pays for itself within the first year. The calculation shifts unfavorably for clusters with fewer than ~20 nodes, where the outage frequency is low enough that building full automation may cost more than simply accepting occasional manual response. For clusters above ~50 nodes, the math is unambiguous: automated remediation is cheaper than manual response.
+
+**The MTTR gap vs. cloud.** On a major cloud provider, a failed VM is typically replaced in 2-5 minutes with no operator action required. On bare metal with automated remediation, a power-cycle recovery takes 2-3 minutes — comparable to cloud. A full reprovision takes 10-18 minutes — 3-6x longer than cloud. This gap is irreducible because physical hardware has POST times, firmware initialization, and PXE image transfer latencies that virtualized infrastructure does not. The on-premises operator's goal is not to match cloud MTTR exactly; it is to close the gap to the point where the difference is no longer the dominant factor in application availability. At 10-18 minutes, a reprovision is faster than the 30-60 minutes of manual response — the automation has done its job, even if it is slower than a cloud provider's hypervisor.
+
+The cost comparison between on-premises remediation and cloud auto-healing reveals a deeper structural difference in how the two models account for failure. In the cloud model, the cost of node failure is embedded in the instance price — you pay a premium (~20-40% over raw compute cost) for the provider's infrastructure that silently handles VM replacement, and you never see the hardware, the BMC, or the provisioning network. In the on-premises model, you pay lower per-unit compute cost but you carry the capital cost of spare hardware and the operational cost of the engineering time to build and maintain the remediation pipeline. The crossover point where on-premises becomes cheaper depends on utilization. At 80% sustained utilization of a 50-node cluster over a 5-year depreciation window, on-premises typically breaks even with cloud instance pricing after accounting for hardware, power, cooling, and operations headcount. At 30% utilization — common in development and staging clusters — the cloud model is almost always cheaper because you are not paying for idle hardware. Automated remediation does not change the utilization math, but it does reduce the ops headcount component of the on-premises cost equation, shifting the break-even point slightly in favor of on-premises for medium-to-high utilization clusters.
+
+---
+
+## Decision Framework
+
+How do you choose which remediation strategy to deploy? The answer depends on your cluster's scale, whether you run Cluster API, and the sophistication of your operations team.
+
+```mermaid
+flowchart TD
+    A[Node Failure Detected] --> B{Cluster API installed?}
+    B -->|Yes| C{Control plane or worker?}
+    B -->|No| D{Cluster size?}
+    C -->|Control Plane| E[KubeadmControlPlane MHC<br/>maxUnhealthy ≤ 33% for 3-node<br/>Prefer CAPI v1beta2<br/>Verify quorum before each remediation]
+    C -->|Worker| F[MachineHealthCheck<br/>maxUnhealthy ≤ 40%<br/>UnhealthyConditions with per-type timeouts<br/>CAPM3 for bare-metal reprovision]
+    D -->|< 20 nodes| G[Simple CronJob watchdog<br/>BMC power cycle only<br/>Alert on-call after 2 failed attempts]
+    D -->|20-100 nodes| H[Medik8s Self-Node Remediation<br/>NPD for condition detection<br/>Fence-agents for hard fencing<br/>Spare node pools]
+    D -->|> 100 nodes| I[Full CAPI + CAPM3 deployment<br/>Multi-rack MHC with rack-aware maxUnhealthy<br/>Automated reprovision pipeline<br/>Dedicated remediation audit infrastructure]
+    E --> J[Monitor replacement join time<br/>Alert if > 15 min]
+    F --> J
+    G --> K[Review remediation logs weekly<br/>Track MTTR trend]
+    H --> K
+    I --> L[Dedicated SRE rotation for<br/>remediation pipeline health]
+```
+
+**Decision matrix for remediation strategy selection:**
+
+| Factor | Simple Watchdog | Medik8s SNR + FAR | Cluster API MHC + CAPM3 |
+|--------|----------------|-------------------|-------------------------|
+| **Cluster size** | < 20 nodes | 20-100 nodes | > 50 nodes (justifies CAPI overhead) |
+| **Setup complexity** | 1-2 days | 3-5 days | 2-4 weeks |
+| **Remediation action** | BMC power cycle only | Cordon + drain + reboot; fence on failure | Delete Machine → full reprovision via Ironic |
+| **Node replacement time** | 2-3 min (power cycle) | 3-5 min (reboot) | 10-18 min (full reprovision) |
+| **Requires CAPI** | No | No | Yes |
+| **Requires BMC access** | Yes (IPMI/Redfish) | Yes (IPMI/Redfish) | Yes (Redfish preferred, IPMI fallback) |
+| **Stateful workload aware** | No | Partial (PDB-aware drain) | Partial (PDB-aware drain, needs custom webhook for last-replica check) |
+| **Remediation storm protection** | Manual (cooldown timer) | Manual (cooldown timer) | Built-in (maxUnhealthy circuit breaker) |
+| **Audit trail** | Script logs | Operator logs + Events | CAPI status conditions + Events |
+| **Best for** | Small clusters, dev/staging | Mid-size production without CAPI | Large production with CAPI investment |
+
+The framework is not a ladder where you must climb from simple to complex. Many production clusters in the 30-80 node range run successfully for years with the medik8s approach and never adopt Cluster API. The decision to add CAPI should be driven by whether your organization already uses it for cluster lifecycle management — if you do, the MHC path is a natural extension. If you do not, adding CAPI solely for node remediation is over-engineering; the medik8s or watchdog approaches deliver 90% of the value at 20% of the complexity.
 
 ---
 
@@ -635,6 +806,73 @@ kubeadm join <api-server>:6443 --token <new-token> \
 - Include CSR auto-approval in your remediation pipeline for known nodes
 </details>
 
+### Question 5
+Your 3-node control plane cluster has MachineHealthChecks configured for the control plane nodes with `maxUnhealthy: 40%`. Node cp-01 goes NotReady, and the MHC begins remediation. Before cp-01's replacement joins, cp-02 also goes NotReady. The MHC evaluates that 2/3 = 66% unhealthy, which exceeds 40%, so it stops. Is your cluster still operational?
+
+<details>
+<summary>Answer</summary>
+
+**No — the cluster has already lost quorum and the API server is unavailable.**
+
+This scenario exposes a critical design flaw: `maxUnhealthy: 40%` on a 3-node control plane allows 1 node to be unhealthy (33%) but blocks remediation of a second node because 66% > 40%. However, by the time the second node goes NotReady, etcd has already lost quorum — 1 healthy node out of 3 is not enough to form a majority. The MHC's circuit breaker worked correctly (it prevented remediation of the second node), but the cluster was already dead because the *failure itself* — not the remediation — broke quorum.
+
+The correct `maxUnhealthy` for a 3-node control plane is 33%, which allows exactly 1 node to be unhealthy. The value the MHC needs is not "what percentage can I safely remediate" but "what percentage can the cluster lose without breaking." For etcd, that is floor((N-1)/2) / N. For 3 nodes: floor(2/2)/3 = 1/3 = 33%. For 5 nodes: floor(4/2)/5 = 2/5 = 40%. The MHC's safety gate is a ceiling on *remediation*, not a guarantee of cluster health — if 2 of 3 control plane nodes fail simultaneously, no automation can save the cluster regardless of what `maxUnhealthy` says.
+
+The defense against this scenario is not in the MHC configuration — it is in having enough control plane nodes (5 is the practical minimum for high-availability bare-metal deployments) and ensuring control plane nodes are spread across physical failure domains so no single power circuit or switch failure takes down more than floor((N-1)/2) of them.
+</details>
+
+### Question 6
+A bare-metal cluster runs Ceph for persistent storage with a replication factor of 3 and `min_size` of 2. Worker-15, which hosts OSD.7 (one of the three replicas for several RBD volumes), goes NotReady. You have automated remediation configured with MHC and CAPM3. Should the MHC be allowed to remediate worker-15 immediately?
+
+<details>
+<summary>Answer</summary>
+
+**Yes — with confirmation that the remaining 2 replicas are healthy and the cluster can re-replicate from them.**
+
+With replication factor 3 and min_size 2, the loss of one OSD (OSD.7 on worker-15) leaves 2 healthy replicas for every affected placement group (PG). Ceph will mark those PGs as `degraded` (they have 2 replicas instead of 3) but `active` (they are still serving I/O). The cluster immediately begins backfilling to create a third replica on surviving OSDs in other failure domains. Remediating worker-15 is safe *as long as the backfill completes before a second OSD fails in the same failure domain*.
+
+The risk chain that makes this dangerous: if a second OSD in the same CRUSH failure domain fails while backfill is still in progress, the affected PGs would drop to 1 replica (below `min_size`), and Ceph would block I/O on those PGs rather than risk a split-brain write. To mitigate this:
+1. Throttle Ceph backfill (as shown in the tuning section) so recovery does not saturate the network and cause cascading node failures.
+2. Ensure CAPM3's disk-wipe step does not immediately destroy OSD.7's data — if the node comes back after a power cycle without a disk wipe, Ceph can reuse the existing OSD rather than rebuilding from scratch.
+3. If possible, configure MHC to wait for Ceph HEALTH_OK before proceeding to the next remediation in the same failure domain. This requires custom integration — the built-in MHC cannot query Ceph health.
+</details>
+
+### Question 7
+Your team is evaluating whether to adopt Cluster API + CAPM3 for bare-metal node remediation on a 40-node production cluster that currently uses kubeadm for cluster lifecycle management. The cluster does not currently use CAPI for anything else. What are the strongest arguments for AND against adopting CAPI solely for remediation?
+
+<details>
+<summary>Answer</summary>
+
+**Arguments for adopting CAPI:**
+1. CAPM3 provides a battle-tested bare-metal reprovision pipeline (power-off → disk-wipe → PXE-boot → rejoin) that would take weeks to build from scratch.
+2. MHC's built-in `maxUnhealthy` circuit breaker prevents remediation storms — a safety guarantee that custom scripts must implement manually and are easy to get wrong.
+3. CAPI's Machine object model gives you per-node provisioning state visibility — you can query whether a node is in `Provisioning`, `Provisioned`, `Running`, or `Deleting` state, which makes debugging stuck remediations much easier than tailing script logs.
+
+**Arguments against adopting CAPI:**
+1. CAPI adds significant operational complexity: a management cluster (or bootstrap cluster), multiple CRDs and controllers, provider-specific configuration, and a migration of your existing node lifecycle management to CAPI's MachineDeployment model. For a 40-node cluster, this is 2-4 weeks of engineering work and an ongoing maintenance burden.
+2. If remediation is the only reason you are adopting CAPI, the cost of learning and operating CAPI likely outweighs the benefit — the medik8s Self-Node Remediation operator can deliver equivalent remediation capabilities (cordon, drain, reboot, fence) without requiring CAPI.
+3. CAPI couples your remediation strategy to your cluster provisioning strategy. If you later change how nodes are provisioned (e.g., switching from PXE to image-based provisioning with Talos or Flatcar), you may need to change both your provisioning pipeline AND your remediation pipeline because they share the same CAPM3 integration.
+
+**The pragmatic recommendation:** For a 40-node cluster not already using CAPI, deploy medik8s SNR + NPD for remediation, invest the saved engineering time in building a solid BMC credential management and remediation audit pipeline, and revisit CAPI if and when the cluster grows beyond ~100 nodes or you need CAPI for other reasons (multi-cluster management, declarative cluster lifecycle).
+</details>
+
+### Question 8
+A node has been remediated three times in the past 6 hours — each time, the watchdog script power-cycles it via IPMI, the node boots, joins the cluster, runs workloads for 30-90 minutes, and then goes NotReady again with no obvious pattern. No NPD conditions fire before the kubelet stops reporting. What is the most likely root cause, and what should your next step be?
+
+<details>
+<summary>Answer</summary>
+
+**The most likely root cause is an intermittent hardware fault that is invisible to NPD's log-based detection — probably a failing DIMM producing silent data corruption, a power supply with intermittent voltage droop, or a thermal issue that triggers a CPU shutdown without logging to journald.**
+
+The key clue is that NPD reports no conditions before the kubelet stops. This rules out kernel panics, OOMs, filesystem remounts, and NIC flaps — all of which NPD's default monitors would catch and report as node conditions before the kubelet went silent. A node that simply disappears suggests one of:
+
+1. **Thermal shutdown**: The CPU hits its critical temperature threshold and the BMC forces an immediate power-off. This may not write to journald because the shutdown happens below the OS level.
+2. **Power supply voltage droop**: An intermittent PSU fault causes the server to reset without logging. The BMC's system event log (SEL) would show "power supply failure" or "voltage threshold exceeded" events.
+3. **Silent memory corruption**: A DIMM with marginal cells passes ECC scrubbing most of the time but occasionally produces an uncorrectable multi-bit error. The hardware may trigger a machine-check exception that halts the CPU before the kernel can write to journald.
+
+**Next step**: Stop automatic remediation for this node (add it to a denylist in the watchdog script), check the BMC's system event log (`ipmitool sel list`) for hardware-level events that predate the kubelet's disappearance, run a full memory diagnostic (memtest86+), and inspect the BMC's sensor readings for voltage and thermal anomalies. Do not re-enable automatic remediation until a root cause is confirmed and fixed — continuing to power-cycle the node without diagnosis is just burning power cycles on a hardware fault that software cannot fix.
+</details>
+
 ---
 
 ## Hands-On Exercise: Deploy Node Problem Detector
@@ -714,3 +952,9 @@ Continue to [Module 7.4: Observability Without Cloud Services](/on-premises/oper
 - [Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/) — Backs rack/zone spread behavior, topology keys, default spread behavior, and cluster scheduling policy claims when distributing workloads across mixed racks or hardware domains.
 - [kubernetes.io: troubleshooting kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/troubleshooting-kubeadm/) — The kubeadm troubleshooting docs explicitly describe expired kubelet client certificates causing authentication and rejoin problems.
 - [Node Status](https://kubernetes.io/docs/reference/node/node-status) — Documents `Ready` and `Unknown` semantics and the current default node-monitor-grace-period.
+- [medik8s: Self-Node Remediation](https://github.com/medik8s/self-node-remediation) — Supports claims about the SNR operator, DaemonSet-based remediation, cordon-drain-reboot flow, PDB awareness, and API-server-unreachable detection for non-CAPI clusters.
+- [medik8s: Fence-Agents Remediation](https://github.com/medik8s/fence-agents-remediation) — Supports claims about hard fencing via BMC, wrapping ClusterLabs fence agents behind a Kubernetes operator, and power-off isolation of unresponsive bare-metal nodes.
+- [Metal3 (CAPM3) Provider](https://github.com/metal3-io/cluster-api-provider-metal3) — Supports claims about the CAPM3 bare-metal reprovision flow, Ironic integration, BMC power-off/wipe/PXE-boot sequence, and BareMetalHost provisioning state machine.
+- [DMTF Redfish Standard](https://www.dmtf.org/standards/redfish) — Supports claims about Redfish as the modern RESTful HTTPS BMC management protocol replacing IPMI, covering power control, hardware inventory, and certificate-based authentication.
+- [kubernetes.io: Node Problem Detector Custom Plugin Monitor](https://kubernetes.io/docs/tasks/debug/debug-cluster/node-problem-detector/) — Supports claims about NPD's custom-plugin-monitor configuration, health-checker plugin types, and per-condition timeout and reporting behavior.
+- [Ceph Recovery Throttling](https://docs.ceph.com/en/latest/rados/operations/control/) — Supports claims about `osd-recovery-max-active`, `osd-max-backfills`, and `osd-recovery-op-priority` tunables and their role in preventing recovery-driven network saturation during node failures.


### PR DESCRIPTION
**On-premises Wave 4 batch 1** (#1881) — first 3 of the 8 operations modules. Unlike Wave 3 (review-flip), these were genuine T3 (~800w) → **expanded to the 5000w floor**, then cross-family reviewed + fixed.

## Modules
- **7.1 upgrades** (cursor expand → opus review, APPROVE_W_NITS, no fabrication): bare-metal control-plane + node upgrades, etcd snapshot/restore, version-skew. Fixes: `etcdctl`→`etcdutl` for restore/status (removed in etcd 3.6), added required control-plane node drain, fixed 2 mermaid subgraph misrenders, softened an overstated "idempotent" citation.
- **7.2 hardware-lifecycle** (codex expand → cursor review, no fabrication, rubric 4.4/5): firmware/Redfish fleet mgmt, NIST 800-88 decommission, refresh economics. Fixes: PSU PromQL used a non-existent `state` label → value `== 2`; added MHC manifest for outcome alignment; Ceph `safe-to-destroy` gate + scoped `add-noout`; ECC `increase()` vs lifetime counter; removed unsupported kube-vip source.
- **7.3 node-remediation** (deepseek expand → cursor review, **caught fabrication**): **medik8s SNR architecture was fabricated** (invented gateway-vs-API heuristic) → rewritten to the web-verified NHC→SelfNodeRemediation flow (healthy peers cordon + delete Node, peer API-server checks, watchdog reboot, `minHealthy` storm breaker). Also: `node-monitor-grace-period` 40s→50s (v1.32, web-verified), StatefulSet `Parallel`-as-guardrail reframed, opener MHC math fixed, cost figures labeled illustrative, 2 quiz fixes.

Every reviewer finding ground-checked against the live file; medik8s SNR flow + grace-period default web-verified. Orchestrator diff-audited the consolidated fix-pass (caught + fixed a wrong inline medik8s URL) and added genuine watchdog detail to clear the floor after de-fabrication. All 3 T0; build green in PRIMARY.

Reviews + ground-check ledger: `logs/remediation/briefs/onprem-w4/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Learner check

> When a hardware watchdog device (such as `/dev/watchdog`, backed by the BMC or a kernel softdog) is present, SNR arms it and lets the timer expire, which forces a hardware reset that cannot be blocked by a hung kernel, a stuck I/O path, or a wedged container runtime.
