### PR TITLE
docs(on-premises): wave 4 batch 3 — operations 7.4/7.7/7.9 reviewed → done (#1881)

### DIFF
--- a/src/content/docs/on-premises/operations/module-7.4-observability.md
+++ b/src/content/docs/on-premises/operations/module-7.4-observability.md
@@ -162,6 +162,9 @@ processors:
     timeout: 5s
 
 exporters:
+  # Endpoints below are illustrative cluster-internal addresses with plaintext
+  # transport for readability. In the regulated/air-gapped deployment this module
+  # targets, terminate these with internal mTLS (see the internal-TLS requirement above).
   prometheusremotewrite:
     endpoint: http://mimir-nginx.monitoring.svc.cluster.local/api/v1/push
     headers:
@@ -171,7 +174,7 @@ exporters:
   otlp/tempo:
     endpoint: tempo-distributor.monitoring.svc.cluster.local:4317
     tls:
-      insecure: true
+      insecure: true  # illustrative only — enable internal mTLS in a regulated deployment
 
 service:
   pipelines:
@@ -281,7 +284,7 @@ receivers:
       - to: platform-team@example.internal
         from: alertmanager@example.internal
         smarthost: smtp-relay.monitoring.svc.cluster.local:25
-        require_tls: false
+        require_tls: false  # illustrative only — require STARTTLS to the internal relay in a regulated deployment
   - name: platform-oncall-webhook
     webhook_configs:
       - url: http://incident-router.monitoring.svc.cluster.local/api/alertmanager

--- a/src/content/docs/on-premises/operations/module-7.7-self-hosted-registry.md
+++ b/src/content/docs/on-premises/operations/module-7.7-self-hosted-registry.md
@@ -6,14 +6,32 @@ sidebar:
   order: 77
 ---
 
-## Learning Outcomes
+## What You'll Be Able to Do
 
-* Configure a production-grade OCI-compliant container registry on bare metal Kubernetes.
-* Compare the architectural trade-offs between Harbor, Quay, Zot, and GitLab Container Registry.
-* Implement pull-through caching to mitigate upstream rate limits and reduce external bandwidth consumption.
-* Design a storage architecture utilizing S3-compatible object storage (e.g., Ceph RGW, MinIO) to back the registry.
-* Integrate image signing (Cosign) and vulnerability scanning (Trivy) into the registry lifecycle.
-* Diagnose common garbage collection and storage state inconsistencies in distributed registry deployments.
+After completing this module, you will be able to:
+
+1. **Compare** Harbor, Project Quay, Zot, GitLab Container Registry, and CNCF Distribution for on-premises registry use cases where hardware, staffing, and compliance constraints matter.
+2. **Explain** OCI manifests, blobs, tags, digests, and digest pinning so air-gapped Kubernetes releases remain reproducible after upstream registries change.
+3. **Design** storage, high availability, replication, and garbage-collection operations around filesystem or S3-compatible backends such as Ceph RGW and MinIO.
+4. **Configure** pull-through caching, containerd `hosts.toml` mirrors, custom CA trust, and Kubernetes image credentials without relying on deprecated runtime mirror stanzas.
+5. **Enforce** supply-chain controls with Cosign signatures, vulnerability scanning, robot accounts, and admission policy so only trusted images run on owned hardware.
+
+## Why This Module Matters
+
+Hypothetical scenario: a regulated manufacturer runs a Kubernetes platform in two company-owned datacenters, keeps production nodes behind an egress firewall, and discovers during a release freeze that dozens of workloads still pull base images directly from Docker Hub. The manifests passed tests in a connected staging lab, but production nodes cannot reach the public registry, the NAT egress address is shared by build workers, and the security team has no local record of which digest was approved. The immediate failure looks like an `ImagePullBackOff`, but the real problem is architectural: the organization does not control the place where its clusters fetch executable software.
+
+On-premises Kubernetes makes the container registry a tier-zero service. A cloud-managed registry hides storage durability, TLS renewal, scanner updates, regional replication, pull throttling, and garbage collection behind a provider API. In your own datacenter, every one of those concerns becomes a platform responsibility. The registry has to survive node drains, storage maintenance, expired internal certificates, upstream rate limits, and bursty deployment events without becoming the bottleneck that prevents workloads from starting.
+
+The cost tradeoff is not simply "self-hosting is cheaper" or "cloud is easier." A self-hosted registry consumes CapEx for storage nodes, NVMe or HDD capacity, network ports, rack space, power, cooling, backup media, and hardware refresh cycles. It also consumes OpEx through patching, certificate management, vulnerability database updates, pager coverage, and incident response. Self-hosting wins when utilization is steady, CI pulls are egress-heavy, data sovereignty matters, air-gap requirements are strict, or image layers are large enough that WAN bandwidth dominates the bill. Managed registries often win when the team is small, workload volume is spiky, compliance allows external control planes, and the operational headcount needed to run Postgres, Redis, object storage, scanners, and admission policy would exceed the storage savings.
+
+The practical goal of this module is to make registry design boring. A boring registry has explicit ownership, predictable storage growth, tested garbage collection, digest-based release inputs, signed artifacts, and a mirror strategy that keeps nodes working even when the public internet is unavailable. It does not surprise you during a cluster-wide rollout, a datacenter link failure, or a security audit.
+
+## Did You Know?
+
+* **Harbor is CNCF Graduated:** The CNCF project page lists Harbor as accepted on July 31, 2018, incubating on November 14, 2018, and graduated on June 15, 2020, which is why many enterprises treat it as the default full-featured open source registry choice for trusted content.
+* **Zot is CNCF Sandbox:** The CNCF project page lists zot as an OCI-native registry accepted at Sandbox maturity on December 13, 2022, making it useful for lightweight and edge-oriented deployments without implying the same maturity level as Harbor.
+* **Docker Hub limits are operational inputs:** Docker's current pull usage page lists unauthenticated pulls as limited per IPv4 address or IPv6 `/64` over a six-hour window, so a whole datacenter NAT can exhaust the allowance even when individual developers behave reasonably.
+* **Distribution garbage collection is stop-the-world:** The CNCF Distribution documentation explains that garbage collection marks live digests, sweeps unreferenced blobs, and should run while the registry is read-only or stopped to avoid corrupting images uploaded during the sweep.
 
 ## The Operational Reality of Bare Metal Registries
 
@@ -21,19 +39,43 @@ Running the upstream `distribution/distribution` (formerly Docker Registry) as a
 
 The OCI Distribution Specification ([marked as Standards Track with a published metadata date of November 2025](https://specs.opencontainers.org/distribution-spec/?v=v1.1.1)) defines a standardized API protocol for distributing OCI content, closely related to the OCI image format and runtime specifications. On bare metal, you do not have AWS ECR or GCP Artifact Registry abstracting this away. You are responsible for the metadata database, the caching layer, the storage backend, and the ingress routing for potentially gigabytes of concurrent image layer pulls during a cluster-wide horizontal pod autoscaling (HPA) event.
 
+The best analogy is a warehouse with a parts catalog. The blobs are the sealed boxes on shelves, the manifest is the packing slip that says which boxes make up a release, the tag is a human-friendly shelf label, and the digest is the tamper-evident serial number burned into the contents. Teams get into trouble when they treat the shelf label as the identity. A label can be moved, but a digest changes when the underlying bytes change.
+
+### OCI Fundamentals: Blobs, Manifests, Tags, and Digests
+
+An OCI registry is content-addressable. Image layers, configuration objects, manifests, indexes, signatures, and related artifacts are stored by digest, usually shown as a `sha256:` value. The digest is calculated from the content bytes, so two identical layers can be stored once and referenced by many images, while any byte-level change produces a different digest. This is the reason registries scale better than a naive tarball store: one common base layer can serve hundreds of application images without being duplicated for every tag.
+
+The manifest is the object that binds those pieces together. For a single-platform image, the manifest points to one configuration object and a list of layer blobs. For a multi-platform image, an image index points to manifests for different operating systems and architectures. The OCI 1.1 work also matters for modern supply-chain metadata because referrers allow artifacts such as signatures, SBOMs, and attestations to be associated with a subject image rather than hidden in a parallel naming convention.
+
+```text
+human tag              immutable identity             stored content
+---------              ------------------             --------------
+app:1.4.2       ->     manifest sha256:aaa...   ->     config sha256:bbb...
+                                                   ->   layer  sha256:ccc...
+                                                   ->   layer  sha256:ddd...
+signature       ->     referrer to sha256:aaa...
+sbom            ->     referrer to sha256:aaa...
+```
+
+Tags are mutable pointers. They are useful for humans, CI systems, and release notes, but they are weak release inputs because `registry.internal/platform/api:stable` can point to different manifests over time. Digests are immutable release inputs. A Kubernetes manifest can use `image: registry.internal/platform/api@sha256:...`, and the kubelet will pull the exact manifest digest that was approved, assuming the registry still stores it and the node can authenticate. In an air-gapped environment, digest pinning is what lets you prove that the image promoted into the disconnected site is the same image scanned and signed in the connected build site.
+
+This is also why tag deletion does not immediately reclaim storage. If two application images share a base layer and one tag is deleted, the shared layer must stay until no remaining manifest references it. The registry cannot safely delete by "what seems old"; it has to walk the graph of manifests and blobs. That graph is simple in concept, but it becomes expensive when the registry has many repositories, millions of tags, object storage latency, and signatures or SBOMs attached as related artifacts.
+
 ### Platform Comparisons
 
-When selecting a registry for on-premises deployment, the choice dictates your maintenance burden regarding databases, caching layers, and scanning integrations.
+When selecting a registry for on-premises deployment, the choice dictates your maintenance burden regarding databases, caching layers, and scanning integrations. Harbor and Quay are platform products, Zot and Distribution are registry engines, and GitLab Container Registry is usually chosen because the organization already runs GitLab. A fair comparison starts with failure domains, not feature checkboxes: ask what must be backed up, what must be highly available, and which team gets paged when a pull fails during a node replacement.
 
-| Feature | Harbor | Quay | Zot | GitLab Registry |
-| :--- | :--- | :--- | :--- | :--- |
-| **Origin / Backer** | [CNCF Graduated (Accepted 2018-07-31, Graduated 2020-06-15)](https://www.cncf.io/projects/harbor/) | Red Hat | CNCF Sandbox project | GitLab |
-| **Architecture** | Microservices (Registry, Core, Jobservice, Database, Redis) | Microservices (Quay, Clair, Postgres, Redis) | Minimal service footprint | Integrated with GitLab monolith |
-| **Scanning** | Pluggable (Trivy default, Clair optional) | Clair (tightly integrated) | Trivy (built-in via extensions) | Trivy / GitLab Secure |
-| **Storage Backend** | S3, GCS, Azure, Swift, OSS, local | S3, GCS, Azure, Swift, RadosGW, local | Local filesystem, S3 | S3, GCS, Azure, local |
-| **OIDC / SSO** | Yes (OIDC, LDAP, Active Directory) | [Yes (OIDC, LDAP, Keystone)](https://github.com/quay/quay) | Yes (OIDC, LDAP) | Yes (via GitLab instance) |
-| **Resource Footprint**| Heavy (~6-8 pods, requires DB/Redis) | Heavy (requires DB/Redis) | Extremely Lightweight | Bound to GitLab footprint |
-| **Best For** | Enterprise standard, policy enforcement | Red Hat ecosystems, OpenShift | Edge deployments, minimal operational overhead | Teams already using GitLab CI/CD heavily |
+| Feature | Harbor | Project Quay | Zot | GitLab Registry | CNCF Distribution |
+| :--- | :--- | :--- | :--- | :--- | :--- |
+| **Origin / Backer** | [CNCF Graduated (Accepted 2018-07-31, Graduated 2020-06-15)](https://www.cncf.io/projects/harbor/) | Red Hat / Project Quay | [CNCF Sandbox project](https://www.cncf.io/projects/zot/) | GitLab | [CNCF Sandbox project](https://www.cncf.io/projects/distribution/) |
+| **Architecture** | Microservices (Registry, Core, Jobservice, Database, Redis) | Microservices (Quay, Clair, Postgres, Redis) | Minimal OCI-native service footprint | Integrated with GitLab application and registry services | Registry daemon with external auth, storage, and policy wrapped by you |
+| **Scanning** | Pluggable scanners, commonly Trivy in current deployments | Clair integration is a major Quay pattern | Extension-based scanning and metadata features | GitLab security features and CI-driven scanning | No built-in enterprise scanner; integrate externally |
+| **Storage Backend** | S3-compatible object storage, shared PVCs, and other supported backends depending on deployment mode | S3-compatible object stores including RadosGW and local options documented by Quay | Local filesystem and object storage patterns documented by zot | Object storage configuration is recommended for larger GitLab self-managed setups | Filesystem for small deployments and S3-compatible storage for scalable production |
+| **OIDC / SSO** | Yes, through Harbor authentication integrations | [Yes (OIDC, LDAP, Keystone)](https://github.com/quay/quay) | Authn/authz options including local, LDAP, bearer, and related mechanisms | Yes, through the GitLab instance | External auth service or htpasswd/token integration configured by the operator |
+| **Resource Footprint** | Heavy relative footprint because Postgres, Redis, Jobservice, scanner, portal, and registry components matter | Heavy relative footprint because Quay, Clair, database, and cache tiers matter | Lightweight relative footprint, especially for edge and cache-oriented registry roles | Bound to the GitLab footprint and its backup/upgrade cadence | Lightweight daemon, but you must build the missing enterprise control plane |
+| **Best For** | Enterprise registry standard, RBAC, replication, proxy cache, scanning, and signed artifact workflows | Red Hat and OpenShift ecosystems, geo-replication, and teams aligned to Quay operations | Edge deployments, cache sites, constrained clusters, and simple OCI artifact serving | Teams already standardized on GitLab CI/CD and self-managed GitLab operations | Custom platforms that need a small registry core and are willing to own surrounding policy |
+
+Choose Harbor when you need a broad registry product and have the operational maturity to run its dependencies. Choose Quay when your platform already centers on Red Hat tooling or when Quay-specific replication and Clair workflows fit the organization. Choose Zot when the registry is a small, close-to-the-edge component and a full enterprise portal would be operational weight. Choose GitLab Container Registry when registry lifecycle is intentionally coupled to GitLab projects, runners, permissions, and backups. Choose raw Distribution when you want a composable registry primitive and are ready to provide auth, UI, scanning, signing visibility, replication, and cleanup policy yourself.
 
 ### Architecture of a Modern Registry
 
@@ -52,83 +94,237 @@ graph TD
     Scanner --> Storage
 ```
 
-1.  **Registry Core / UI:** Handles API requests, serves the web interface, and coordinates webhooks.
-2.  **Auth Service:** Generates bearer tokens for clients after authenticating them against the local DB or an OIDC provider.
-3.  **OCI Distribution:** The actual `distribution/distribution` or equivalent daemon that streams layer blobs to/from the storage backend.
-4.  **Database (PostgreSQL):** Stores metadata: users, projects, repository names, tags, RBAC policies, and replication rules. *It does not store image layers.*
-5.  **Cache/Queue (Redis):** Caches layer metadata and coordinates asynchronous jobs like replication, garbage collection, and scanning.
-6.  **Storage Backend:** Stores the immutable blobs (layers) and manifests. On bare metal, this should strictly be an S3-compatible endpoint (Ceph RadosGW or MinIO). Prefer object storage or a storage backend explicitly documented as supported by your registry; shared filesystems need careful validation before you rely on them for blob storage.
+1. **Registry Core / UI:** Handles API requests, serves the web interface, and coordinates webhooks, robot accounts, project configuration, audit views, and policy checks that are not part of the bare OCI distribution protocol.
+2. **Auth Service:** Generates bearer tokens for clients after authenticating them against the local DB or an OIDC provider, and it must advertise an external URL that container clients can resolve from every datacenter site.
+3. **OCI Distribution:** The actual `distribution/distribution` or equivalent daemon streams layer blobs to and from the storage backend, and it is the hot path for node pulls during scale-out events.
+4. **Database (PostgreSQL):** Stores metadata such as users, projects, repository names, tags, RBAC policies, audit references, and replication rules. It does not store image layers, but losing it can still make stored blobs unreachable through the registry.
+5. **Cache/Queue (Redis):** Caches layer metadata and coordinates asynchronous jobs like replication, garbage collection, scanning, and notification workflows, so persistence and eviction settings become day-2 operational concerns.
+6. **Storage Backend:** Stores the immutable blobs, manifests, signatures, SBOMs, and related OCI artifacts. On bare metal, this should usually be an S3-compatible endpoint such as Ceph RadosGW or MinIO, or a storage backend explicitly documented as supported by the registry.
+
+The split between metadata and content explains many registry outages. A Postgres failure may leave object storage intact but prevent users from authenticating, listing repositories, or applying policy. A Redis failure may not delete blobs, but it can strand scan jobs, replication jobs, and GC coordination. A storage failure may make the registry UI look healthy while every kubelet pull fails after token exchange. A production runbook has to check all three layers separately.
 
 ### Authentication and Image Pulling Behavior
 
-When integrating your self-hosted registry with Kubernetes, you must handle authentication securely and understand how the kubelet caches and requests images. 
+When integrating your self-hosted registry with Kubernetes, you must handle authentication securely and understand how the kubelet caches and requests images. [Starting with Kubernetes v1.26, the built-in (in-tree) cloud image-credential providers were removed; you now use a kubelet credential-provider plugin or attach `imagePullSecrets` to your Pods or ServiceAccounts (`imagePullSecrets` has always been available).](https://kubernetes.io/docs/concepts/containers/images/) Registry authentication is stored as a Kubernetes Secret. You should use `kubectl create secret docker-registry`, which creates the recommended `kubernetes.io/dockerconfigjson` secret type, superseding the legacy `kubernetes.io/dockercfg`.
 
-[Starting with Kubernetes v1.26, the legacy image credential mechanism was removed. You must now use kubelet credential provider configuration or attach `imagePullSecrets` to your Pods or ServiceAccounts.](https://kubernetes.io/docs/concepts/containers/images/) Registry authentication is stored as a Kubernetes Secret. You should use `kubectl create secret docker-registry`, which creates the recommended `kubernetes.io/dockerconfigjson` secret type (superseding the legacy `kubernetes.io/dockercfg`).
+Stop and think about namespace scope before you automate secret injection. If you define an `imagePullSecret` in the `default` namespace, a Pod in the `production` namespace cannot use it directly, because [`imagePullSecrets` entries must reference Secrets in the same namespace as the Pod](https://kubernetes.io/docs/concepts/containers/images/). The usual operational pattern is to attach pull credentials to a namespace-local ServiceAccount, then let Pods inherit that ServiceAccount unless a workload needs a narrower credential.
 
-> **Stop and think**: If you define an `imagePullSecret` in the `default` namespace, can a Pod in the `production` namespace use it to pull an image?
+Understanding the kubelet's image pulling behavior is equally important. When `imagePullPolicy` is omitted, [Kubernetes defaults it to `Always` for `:latest` tags or untagged images and to `IfNotPresent` for digest-based or tagged non-latest images](https://kubernetes.io/docs/concepts/containers/images/). Once set, the policy is not recomputed for the life of the Pod, so changing a tag in the registry does not change the image already selected by an existing Pod spec. With `IfNotPresent` or `Never`, the kubelet can reuse local cached images, which is helpful for resilience but dangerous if your authorization model assumes every Pod revalidates against the registry.
 
-Crucially, [`imagePullSecrets` entries must reference Secrets in the *same namespace* as the Pod](https://kubernetes.io/docs/concepts/containers/images/), and they are used directly by the kubelet to authenticate to private registries. To reduce operational toil, these credentials can be attached via a ServiceAccount-level `imagePullSecrets`, which are then automatically inherited by any Pods created with that ServiceAccount. Even for edge workloads or control plane components running as static Pods, `imagePullSecrets` and pre-pulled image approaches are fully supported for private registry access.
+Kubernetes 1.35 is the curriculum target for this track, and the image pulling documentation includes the `KubeletEnsureSecretPulledImages` feature as beta and enabled by default. The lesson for on-premises operators is not merely to memorize a feature gate. The lesson is that cached private images are part of your authorization surface, especially in clusters with pre-pulled golden images, edge nodes, or static control-plane Pods that cannot always reach the registry during bootstrap.
 
-Understanding the kubelet's image pulling behavior is equally important:
-* When `imagePullPolicy` is omitted, [Kubernetes defaults it to `Always` for `:latest` tags or untagged images. It sets it to `IfNotPresent` for digest-based or tagged non-latest images. Once set, this policy is immutable for the life of the Pod](https://kubernetes.io/docs/concepts/containers/images/), even if the tag changes in the registry.
-* With a policy of `IfNotPresent` or `Never`, the kubelet prefers local cached images. If you use cache-based strategies for private registry-driven pods, you must ensure all nodes share identical pre-pulled images.
-* To secure this caching layer, [Kubernetes v1.35 introduces the `KubeletEnsureSecretPulledImages` feature (beta, enabled by default)](https://kubernetes.io/docs/concepts/containers/images/), which strictly validates credentials when pre-pulled images are used, preventing unauthorized pods from accessing cached images originating from a private registry.
+### Storage Backend Design and Garbage Collection
 
-### Pull-Through Caching (Proxy Cache)
+Filesystem storage is simple and attractive for a lab, but it becomes risky when operators stretch it into production by mounting a shared filesystem under multiple registry replicas. Registry data is content-addressed and heavily concurrent. If the registry product documents a shared filesystem mode, follow those requirements exactly; otherwise treat local filesystem storage as a single-node or small-scale pattern. For highly available on-premises service, prefer an object store with documented S3-compatible behavior, lifecycle monitoring, backups, and capacity alerts.
 
-> **Pause and predict**: If your bare metal cluster scales out from 10 to 100 nodes, and every node attempts to pull the exact same 1GB image from Docker Hub simultaneously, what happens to your corporate firewall and external IP reputation?
+S3-compatible storage does not mean "any bucket-shaped API works equally well." Ceph RGW and MinIO can both expose S3-compatible APIs, but your registry workload cares about latency, consistency behavior, multipart uploads, object listing performance, retry behavior, and operational ownership. A registry pull storm creates many small metadata reads and a smaller number of large blob transfers. A GC job creates wide listings and deletes. A replication job creates sustained cross-site writes. Size the object-storage cluster for those access patterns instead of sizing only by total terabytes.
 
-Upstream rate limits (e.g., [Docker Hub's 100 pulls per 6 hours per IP](https://docs.docker.com/docker-hub/usage/pulls/)) will break bare metal clusters where all egress traffic NATs through a single IP address. 
+```yaml
+version: 0.1
+storage:
+  s3:
+    region: us-east-1
+    regionendpoint: https://rgw.registry-storage.internal
+    bucket: oci-registry
+    secure: true
+    v4auth: true
+    rootdirectory: /harbor-primary
+  delete:
+    enabled: true
+  maintenance:
+    readonly:
+      enabled: false
+```
 
-A proxy cache intercepts pull requests. If the layer exists locally, it serves it. If not, it pulls from the upstream, caches it locally, and serves it to the client.
+The garbage-collection locking nightmare is a consequence of the registry's mark-and-sweep model. A tag delete removes a reference; it does not prove that every blob beneath that tag is safe to delete. The collector first marks every digest still reachable from live manifests, then sweeps blobs not in the mark set. If a push is accepted while that scan is running, the collector can miss the newly referenced layers and delete data that a just-uploaded manifest expects to use. CNCF Distribution therefore documents read-only mode or stopping the registry for GC, and Harbor operators must verify the exact online-GC semantics for their Harbor release before treating cleanup as safe under load.
 
-In Harbor, a Proxy Cache is configured as a specific "Project" type. 
-If you create a proxy cache project named `dockerhub-proxy` linked to `https://hub.docker.com`, container runtimes must be configured to pull from `harbor.internal.corp/dockerhub-proxy/library/nginx:latest` instead of `nginx:latest`.
+Capacity planning should model dead bytes explicitly. Retention policies, tag immutability, signatures, SBOMs, failed uploads, scanner caches, and replication lag all affect storage use. A registry that accepts a steady 200 GB of new layers each week but only runs GC once per quarter needs storage for the live set plus the deleted-but-not-yet-collected set plus object-store replication overhead plus backup retention. If that margin is missing, the failure mode is ugly: pushes fail, scanners cannot download layers, garbage collection needs free space to work, and a rushed manual bucket cleanup can orphan manifests permanently.
 
-Alternatively, configure `containerd` on your bare metal nodes to transparently mirror requests:
+### Pull-Through Caching and Container Runtime Mirrors
+
+Pull-through caching solves two different problems. First, it saves WAN bandwidth by serving repeat pulls from inside the datacenter. Second, it reduces dependency on public registry availability and documented pull-rate limits. [Docker's current pull usage page](https://docs.docker.com/docker-hub/usage/pulls/) still makes rate limits an operational concern for unauthenticated and Personal-account traffic, and a bare-metal cluster often hides many nodes behind one egress address. If every node pulls the same large base image during a rollout, the registry rate limit sees the shared address, not your internal node count.
+
+In Harbor, a Proxy Cache is configured as a specific project type. If you create a proxy cache project named `dockerhub-proxy` linked to Docker Hub, developers can explicitly pull `harbor.internal.corp/dockerhub-proxy/library/nginx:latest` instead of `nginx:latest`. Harbor's current proxy-cache documentation also states that supported upstream targets include Harbor, Docker Hub, Docker registry, AWS ECR, Azure Container Registry, Google Container Registry, Quay, GitHub Container Registry, and JFrog Artifactory Registry. That breadth is useful, but it also means credentials used for upstream endpoints must be least-privilege and inside your trust boundary.
+
+For node-transparent behavior, configure containerd to read registry host configuration from `/etc/containerd/certs.d` and place a `hosts.toml` under the registry namespace. Do not use the old CRI `registry.mirrors` and `registry.configs` stanzas for new work; containerd documents those as deprecated when `config_path` is available. The exact path behavior for a Harbor proxy project must be tested with your containerd and Harbor versions, because path-aware mirrors need `override_path` when the mirror's API root is not the normal registry host root.
 
 ```toml
-# /etc/containerd/config.toml
-[plugins."io.containerd.grpc.v1.cri".registry.mirrors."docker.io"]
-  endpoint = ["https://harbor.internal.corp/v2/dockerhub-proxy"]
+# /etc/containerd/config.toml for containerd 2.x
+version = 3
+
+[plugins."io.containerd.cri.v1.images".registry]
+  config_path = "/etc/containerd/certs.d"
 ```
-*Note: Depending on the containerd version (1.5+ vs 1.7+), [registry configuration is moving to the `/etc/containerd/certs.d/` directory structure](https://github.com/containerd/containerd/blob/main/docs/hosts.md). Always verify your specific containerd version's configuration path.*
 
-### Vulnerability Scanning and Policy Enforcement
+```toml
+# /etc/containerd/certs.d/docker.io/hosts.toml
+server = "https://registry-1.docker.io"
 
-Storing images is only half the requirement. You must ensure images deployed to the cluster are free of critical CVEs.
+[host."https://harbor.internal.corp/v2/dockerhub-proxy"]
+  capabilities = ["pull", "resolve"]
+  ca = "/etc/containerd/certs.d/harbor.internal.corp/ca.crt"
+  override_path = true
+```
 
-Harbor uses Trivy by default. Scanning can be configured to run:
-*   **On Push:** Synchronously or asynchronously scans the image the moment the manifest is uploaded.
-*   **Scheduled:** Periodically scans the entire registry to catch newly published CVEs for existing, dormant images.
+Treat this as node configuration, not application configuration. Roll it with your bare-metal provisioning system, Talos or Flatcar machine configuration, Ansible, image-based OS pipeline, or whatever owns node bootstrap. Then verify from the node runtime, not from a laptop Docker daemon. A good rollout test is `crictl pull docker.io/library/busybox:latest` on one canary node, followed by registry access-log inspection to prove the pull was served through the internal cache. If your trust policy forbids fallback to the public registry, set the mirror as the authoritative `server` and test outage behavior before broad rollout.
 
-**Deployment Prevention:** Harbor allows configuring a project-level policy: "Prevent images with vulnerability severity of `CRITICAL` or higher from running." Harbor enforces this by refusing the layer pull request at the API level if the threshold is breached.
+### High Availability, Replication, and Site Boundaries
 
-### Artifact Signing with Cosign
+Harbor's HA documentation is blunt about the hidden dependencies: the chart can scale stateless components, but the operator must provide highly available ingress, PostgreSQL, Redis, and shared storage or external object storage. That matters because the registry's availability is the minimum of its dependencies. A three-replica Harbor core deployment still fails if the only Redis instance is evicted, if the ingress certificate expires, or if the object store endpoint is reachable from one rack but not another.
 
-Image tags are mutable; `v1.0.0` can be overwritten. Digests (`sha256:...`) are immutable but difficult for humans to verify. Cosign (part of the Sigstore project) solves this by attaching cryptographic signatures to OCI artifacts.
+Replication is not the same as backup. Harbor replication rules can push or pull artifacts between registries based on endpoints, filters, trigger modes, and bandwidth settings. Replication helps multi-site clusters pull from a nearby registry and helps air-gapped environments receive approved artifacts through a controlled promotion path. Backup protects you from accidental deletion, database corruption, failed upgrades, or ransomware inside the registry tier. You usually need both, and they have different recovery tests.
 
-Cosign stores signatures in the registry alongside the image. If you sign `alpine:3.18`, [Cosign pushes an object named `sha256-<image-digest>.sig` to the same repository](https://github.com/sigstore/cosign).
+Multi-site on-premises design should decide which registry is authoritative for each class of artifact. For example, the build site may be authoritative for application images, the disconnected production site may be authoritative only for the promoted release set, and edge sites may run Zot or Distribution as local caches that can be rebuilt from the regional Harbor instance. If every site is allowed to push the same repository and tag independently, conflict resolution becomes a policy problem that the OCI API will not solve for you.
 
-Registries that understand OCI referrers can surface signatures alongside their subject artifacts, but deletion and garbage-collection behavior remains registry-specific and should be verified in product documentation.
+Redis and Postgres deserve special attention because they do not store the image blobs but they define the control plane around those blobs. Harbor uses database state for projects, users, policies, replication rules, and repository metadata, while Redis participates in job queues and cache behavior. A failed Redis persistence configuration can leave scans or replications stuck in confusing states. A failed Postgres backup can leave terabytes of valid blobs in object storage with no trustworthy metadata path back to users. Test dependency failure modes before a real outage teaches them to you.
+
+### Vulnerability Scanning, Signing, and Admission Enforcement
+
+Storing images is only half the requirement. You must ensure images deployed to the cluster are allowed, scanned, signed, and traceable to an approved source. Harbor commonly integrates Trivy for vulnerability scanning, Quay commonly integrates Clair, and GitLab often ties registry scanning to the GitLab security workflow. Scanning can run on push, on schedule, or in CI before promotion. The important on-premises detail is that vulnerability databases also need egress, mirroring, or preloading; an air-gapped scanner with a stale database gives you a false sense of coverage.
+
+Image tags are mutable; `v1.0.0` can be overwritten. Digests (`sha256:...`) are immutable but difficult for humans to verify. Cosign, part of the Sigstore project, solves this by attaching cryptographic signatures to OCI artifacts. Cosign supports keyless signing through OIDC-backed identities and traditional key-based signing with local keys, KMS, or other key sources. In a connected enterprise environment, keyless signing can tie a signature to a CI identity. In a disconnected environment, key-based signing or private Sigstore infrastructure may be simpler to operate.
+
+Cosign stores signatures in the registry alongside the image. If you sign `alpine:3.18`, Cosign attaches the signature to the image: on registries that implement the OCI 1.1 referrers API it is stored as a referrer to the subject digest, while on older registries [Cosign falls back to pushing a separate tag named `sha256-<image-digest>.sig`](https://github.com/sigstore/cosign) in the same repository. Either way, deletion and garbage-collection behavior remains registry-specific and should be verified in product documentation. This is one of the reasons registry cleanup has to account for signatures, SBOMs, and attestations rather than treating tags as the whole state.
+
+Admission policy closes the loop. A registry policy that blocks vulnerable image pulls is useful, but it only fires when the cluster asks that registry for the image. Kyverno `verifyImages`, Sigstore policy-controller, Connaisseur, or a comparable admission controller can reject workloads before scheduling if the image is unsigned, signed by the wrong identity, or referenced only by a mutable tag. In on-premises environments, admission policy also helps prove to auditors that the cluster enforces the same trust boundary the registry UI describes.
+
+Robot accounts should replace human credentials in CI and node automation. A robot account scoped to one project and limited to push or pull is easier to rotate, audit, and revoke than a shared admin password hidden in a build variable. Combine that with tag immutability for release repositories, separate projects for cache and production images, and admission policies that require digest references for production namespaces. The result is a registry workflow where a compromised developer token cannot silently overwrite the artifact a production cluster will run.
+
+## Cost Lens: When Self-Hosting Wins
+
+The CapEx side of a self-hosted registry includes storage media, storage nodes, controller nodes if the registry runs outside the workload cluster, network switch ports, rack units, power distribution, cooling load, backup hardware, and refresh-cycle planning. The OpEx side includes patching the registry, patching Postgres and Redis, upgrading Helm charts, testing restore procedures, renewing internal certificates, maintaining vulnerability feeds, triaging failed scans, rotating robot tokens, and responding to image-pull incidents. The storage bytes are only one line item.
+
+Self-hosting usually wins when image traffic is steady and local. CI systems that rebuild many services from the same base layers can create huge repeated pull volume. A local proxy cache turns those repeated WAN pulls into local object-store reads. Production clusters with data-gravity constraints also benefit because images, SBOMs, and signatures remain in the same regulatory boundary as workloads and logs. Air-gapped sites have no real managed-cloud alternative unless the cloud provider's offline appliance satisfies the same compliance requirement, which is uncommon and still operationally heavy.
+
+Managed registries often win at small scale. If a team runs a few clusters, has no air-gap requirement, pulls modest image volume, and already trusts a cloud provider, the managed service may be cheaper than buying redundant storage and assigning operators. It may also reduce risk because the provider handles control-plane upgrades, storage durability, and regional endpoints. The crossover point is not a universal dollar number; it is the point where egress, latency, compliance, and release reliability cost more than the on-premises operations required to run the registry well.
+
+Depreciation changes the decision over time. Registry storage purchased for a three-to-five-year hardware cycle may look expensive in year one and cheap in year four if utilization remains high. The same equipment becomes a liability if image growth outpaces the plan, power costs rise, or the team has to refresh before depreciation completes. Mature platform teams track cost per stored TB, cost per million pulls, storage growth after GC, cache hit ratio, and operational incidents alongside normal infrastructure budgets. Those measurements keep self-hosting honest.
+
+## Patterns & Anti-Patterns
+
+**Pattern: Treat the registry as a platform dependency, not an application add-on.** Run it with its own SLO, backups, alerting, certificate ownership, capacity dashboard, and incident runbook. This pattern scales because every cluster and CI system depends on image availability, and because a registry outage blocks both new deployments and recovery from unrelated node failures.
+
+**Pattern: Use object storage and external dependencies for HA.** For Harbor, provide HA ingress, HA PostgreSQL, HA Redis, and S3-compatible object storage or a documented shared storage option before raising replica counts. This pattern scales because stateless registry pods can move across nodes while image content survives node loss and metadata services have their own recovery plan.
+
+**Pattern: Promote by digest through controlled registries.** Build in one project, scan and sign the digest, then promote the same digest into production or disconnected sites through replication or an explicit copy job. This pattern scales because audit evidence follows immutable content, not mutable tag names, and because rollback can target a known digest even after tags move.
+
+**Pattern: Put pull-through caches close to nodes.** Use Harbor proxy projects, Zot sync, Distribution pull-through cache, or another documented mirror near the clusters that consume the images. This pattern scales because cache hit ratio improves with repeated base layers, WAN dependence drops, and deployment storms stop looking like abuse to public registries.
+
+**Anti-pattern: Running production registry storage on an untested shared filesystem.** Teams fall into this because a RWX volume is easy to request and looks like ordinary persistence. The better approach is to use a registry-supported object store or prove the filesystem's locking, latency, backup, and failure semantics under concurrent push, pull, replication, and GC load.
+
+**Anti-pattern: Letting production manifests reference mutable tags.** Teams fall into this because tags are readable and CI examples often end with `latest` or a semantic version tag. The better approach is to deploy immutable digests, keep tags as metadata, and use admission policy to reject production workloads that are not pinned to approved digests.
+
+**Anti-pattern: Running garbage collection casually during business hours.** Teams fall into this because deleted tags make the UI look clean while object storage keeps growing. The better approach is to schedule GC with read-only mode or documented online-GC semantics, run dry runs, monitor object-store latency, and keep enough free space for cleanup to complete.
+
+**Anti-pattern: Sharing one admin credential across CI, nodes, and humans.** Teams fall into this because it works during bootstrap and avoids early RBAC design. The better approach is to create scoped robot accounts, namespace-local `imagePullSecrets`, separate pull and push credentials, and rotation procedures that do not require redeploying every workload.
+
+## Decision Framework
+
+Use this decision path when choosing a registry pattern for an on-premises Kubernetes environment. The decision is intentionally biased toward operations: pick the smallest system that meets compliance and reliability requirements, but do not choose a small registry if the missing control-plane features will be rebuilt poorly by every application team.
+
+```mermaid
+flowchart TD
+    A[Need a self-hosted registry?] --> B{Air-gap, data sovereignty, or heavy egress?}
+    B -- No --> C[Managed registry may be cheaper; validate compliance and egress]
+    B -- Yes --> D{Need enterprise UI, RBAC, scanning, replication?}
+    D -- Yes --> E{Red Hat / OpenShift centered?}
+    E -- Yes --> F[Evaluate Project Quay]
+    E -- No --> G[Evaluate Harbor]
+    D -- No --> H{Edge or constrained footprint?}
+    H -- Yes --> I[Evaluate Zot]
+    H -- No --> J{Already self-managing GitLab?}
+    J -- Yes --> K[Evaluate GitLab Container Registry]
+    J -- No --> L[Use CNCF Distribution only if you will own auth, policy, scanning, and replication]
+```
+
+| Decision pressure | Prefer Harbor or Quay | Prefer Zot or Distribution | Prefer GitLab Container Registry | Prefer managed cloud registry |
+| :--- | :--- | :--- | :--- | :--- |
+| Air-gapped promotion | Strong when replication, RBAC, and audit are needed | Strong for simple mirrors and edge caches | Good if GitLab already owns release promotion | Weak unless an approved offline option exists |
+| Small edge footprint | Often too heavy unless policy features are mandatory | Strong because fewer moving parts are required | Usually too coupled to GitLab services | Possible if edge has reliable cloud connectivity |
+| Enterprise policy | Strong for RBAC, scanning, replication, and UI workflows | Requires external policy and integration work | Strong inside GitLab-centered organizations | Strong if compliance allows provider control |
+| Operational headcount | Requires registry, DB, cache, storage, and scanner ownership | Requires fewer services but more custom integration | Requires GitLab operations maturity | Lowest local operations burden |
+| Cost driver | Wins with high local utilization and egress-heavy CI | Wins for local caches with modest feature needs | Wins when GitLab is already paid for and operated | Wins with low volume, spiky demand, and limited staff |
+
+## Common Mistakes
+
+| Mistake | Why it happens | Better approach |
+| :--- | :--- | :--- |
+| Treating the registry as a single Deployment with a PVC | The first lab install works, so teams assume production is just a bigger replica count | Design HA around ingress, Postgres, Redis, object storage, backups, and restore tests before scaling registry pods |
+| Depending on public registries from production nodes | Developers test from connected laptops, while production nodes sit behind shared NAT or strict egress policy | Use pull-through caches, internal mirrors, and pre-promoted digests so production pulls stay inside the datacenter |
+| Deploying by mutable tag only | Tags are easy to read and match human release names, but they do not identify immutable content | Pin production workloads to digests and keep tags as labels for humans, dashboards, and retention policy |
+| Running GC without read-only planning | Storage pressure creates urgency, and the UI hides the fact that blobs can still be referenced by manifests | Use dry runs, documented read-only or online-GC semantics, monitoring, and a rollback plan for the exact registry version |
+| Ignoring scanner and signature artifacts during cleanup | Operators think only image tags consume storage, while SBOMs, signatures, indexes, and failed uploads also occupy objects | Track all OCI artifact classes, verify referrer cleanup behavior, and include supply-chain metadata in capacity models |
+| Reusing a human admin token in CI and nodes | Bootstrap scripts often use the first credential that works and never revisit credential boundaries | Use scoped robot accounts, namespace-local pull secrets, rotation schedules, and separate credentials for push and pull paths |
+| Trusting Docker daemon tests for Kubernetes pulls | A laptop or build node may trust a CA that containerd on worker nodes has never seen | Configure `hosts.toml`, CA files, and credentials on the node runtime, then verify with `crictl` from a Kubernetes worker |
+
+## Quiz
+
+<details>
+<summary>Q1: Scenario: your organization blocks direct internet egress from bare metal nodes, but deployment manifests still reference `postgres:15`. Which architecture preserves those manifests while routing pulls internally?</summary>
+
+**Answer:** Configure containerd registry host configuration on every node so `docker.io` pulls are resolved through an internal mirror or proxy cache. A Harbor proxy cache project can work, but path handling must be tested with `hosts.toml` and `override_path` before rollout. Rewriting every manifest to an internal prefix is operationally valid, but it does not preserve the original manifests. A generic HTTP proxy is not enough because OCI clients still need registry authentication, digest resolution, and TLS trust to behave correctly.
+</details>
+
+<details>
+<summary>Q2: Scenario: Harbor project quotas show roughly 1 TB of active images, but the backing MinIO bucket consumes several times more storage after hundreds of tags were deleted. What should you investigate first?</summary>
+
+**Answer:** Investigate deleted manifests, unreferenced blobs, and whether garbage collection has actually reclaimed storage. Deleting a tag removes a metadata reference, while shared layers remain until no live manifest needs them. A registry GC pass must identify which digests are still reachable before deleting blobs. On Distribution-style registries, that is why read-only mode or documented online-GC behavior matters so strongly during cleanup.
+</details>
+
+<details>
+<summary>Q3: Scenario: an edge site has very limited CPU and memory, needs OCI image serving and simple mirroring, but does not need a full enterprise portal. Which registry family should you evaluate first?</summary>
+
+**Answer:** Evaluate Zot or a carefully wrapped CNCF Distribution deployment before choosing a heavier platform registry. Zot is designed as an OCI-native registry with a smaller operational footprint, while raw Distribution can be appropriate when you only need the registry primitive. Harbor and Quay provide richer enterprise features, but they bring database, cache, scanner, and job-service dependencies. The right answer changes if the edge site also needs RBAC workflows, audit-heavy operations, or built-in replication policy.
+</details>
+
+<details>
+<summary>Q4: Scenario: a pipeline signs `app:v1.0.0`, then another compromised job overwrites the same tag with different bytes. What happens when admission verifies the new image by digest?</summary>
+
+**Answer:** The original signature does not validate the new digest because Cosign signs the immutable content identity, not the mutable tag string. If admission policy resolves the tag to the new digest, it must find a valid signature for that digest and trusted identity. This is exactly why digest pinning and signature verification belong together. Tag immutability in the registry can reduce the risk, but cryptographic verification is what proves the bytes are the approved bytes.
+</details>
+
+<details>
+<summary>Q5: Scenario: a registry is fronted by a trusted internal CA, Docker pulls work from an engineer laptop, but Kubernetes Pods fail with `ImagePullBackOff` on every worker node. Where should you debug?</summary>
+
+**Answer:** Debug the node runtime trust store and containerd registry host configuration, not the laptop Docker configuration. Kubernetes image pulls are performed by the kubelet through the node's container runtime, so the worker must trust the registry CA and have the correct `hosts.toml` or credential configuration. A successful laptop pull only proves the laptop trusts the registry. Verify from a worker with `crictl pull` and inspect containerd logs before changing application manifests.
+</details>
+
+<details>
+<summary>Q6: Scenario: a team wants to run Harbor HA by setting every pod replica count to three while keeping the bundled single Postgres and Redis instances. What is the flaw in the design?</summary>
+
+**Answer:** The design scales stateless pods while leaving stateful dependencies as single points of failure. Harbor's HA model expects highly available ingress, PostgreSQL, Redis, and shared storage or external object storage. If Redis or Postgres fails, extra core or portal replicas do not preserve registry behavior. A production plan must define dependency HA, backup, restore, and monitoring before declaring the registry highly available.
+</details>
+
+<details>
+<summary>Q7: Scenario: finance asks whether the team should keep running an on-premises registry or move to a managed cloud registry. Which cost drivers should the platform team present?</summary>
+
+**Answer:** Present both CapEx and OpEx drivers: storage hardware, rack space, power, cooling, network gear, support contracts, depreciation, object-store growth, operator time, backup media, and incident response. Also present cloud storage, request volume, egress, support tier, and the operational savings of not running database, cache, scanner, and certificate workflows yourself. Self-hosting tends to win with steady high utilization, egress-heavy CI, data gravity, and strict air-gap needs. Managed registries tend to win for small scale, low utilization, spiky demand, and teams without registry operations headcount.
+</details>
 
 ## Hands-on Lab
 
-In this lab, we will deploy a lightweight instance of Harbor on a local `kind` cluster, configure a project, push an image, scan it with Trivy, and sign it with Cosign.
+In this lab, we will deploy a lightweight instance of Harbor on a local `kind` cluster, configure a project, push an image, scan it with Trivy, and sign it with Cosign. The lab deliberately uses a small, local setup rather than an HA object-storage design so you can practice the registry workflow without provisioning Ceph, MinIO, external Postgres, or external Redis. Treat it as a functional exercise, not as a production reference architecture.
 
 ### Prerequisites
-*   `kind` CLI installed.
-*   `kubectl` and `helm` installed.
-*   `docker` CLI installed.
-*   `cosign` CLI installed (`brew install cosign` or download binary).
 
-According to official installation guidance, Harbor can be deployed via Docker Compose or Kubernetes using Helm. The documented minimum resource and platform requirements include at least 2 CPU, 4 GB RAM, and a 40 GB disk. The host must run Docker Engine >20.10 and Docker Compose >2.3, and requires ports 80 and 443 to be open for registry and API access.
+* `kind` CLI installed on a workstation that can create a local Kubernetes cluster and map host ports for an ingress controller.
+* `kubectl` and `helm` installed with access to the local `kind` context that this exercise creates.
+* `docker` CLI installed and configured so it can push to a local insecure registry for this isolated lab.
+* `cosign` CLI installed with either Homebrew, a package manager, or the upstream binary release for your operating system.
 
-*Note: Check Harbor's current documentation branch and release page for the latest stable and prerelease versions before you deploy.*
+According to official installation guidance, Harbor can be deployed via Docker Compose or Kubernetes using Helm. The documented minimum resource and platform requirements include at least 2 CPU, 4 GB RAM, and a 40 GB disk. Those Docker Engine >20.10 and Docker Compose >2.3 host requirements apply to the **Docker Compose** install path; the Helm-on-Kubernetes path used in this lab instead needs a running cluster with `kubectl` and `helm` (see the lab prerequisites below). Both serve registry and API traffic over ports 80/443. Check Harbor's current documentation branch and release page for the latest stable and prerelease versions before you deploy outside a lab.
+
+### Success Criteria
+
+- [ ] Compare registry platforms by documenting why this lab's Harbor choice would or would not fit a second on-premises site with stricter availability requirements.
+- [ ] Explain the image digest you signed, record why the tag alone is not reproducible, and verify that Cosign binds the signature to immutable content.
+- [ ] Design a storage and garbage-collection runbook for promoting this lab registry to S3-compatible object storage backed by Ceph RGW or MinIO.
+- [ ] Configure a pull-through caching or containerd `hosts.toml` extension plan that would let Kubernetes nodes pull common upstream images through an internal mirror.
+- [ ] Enforce supply-chain controls by verifying the Cosign signature and describing how scanner policy or admission policy would block unsigned or high-risk images.
 
 ### Step 1: Provision the Cluster
 
-Create a local cluster with Ingress ports mapped to your host.
+Create a local cluster with Ingress ports mapped to your host. These host port mappings let the Harbor ingress answer on ordinary HTTP and HTTPS ports, which keeps the registry URL close to the shape you would use in a real datacenter.
 
 ```bash
 cat <<EOF > kind-config.yaml
@@ -154,7 +350,7 @@ EOF
 kind create cluster --config kind-config.yaml --name registry-lab
 ```
 
-Install the NGINX Ingress Controller:
+Install the NGINX Ingress Controller so Harbor can expose its portal and registry API through a Kubernetes Ingress instead of a node-local port-forward.
 
 ```bash
 kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
@@ -166,13 +362,15 @@ kubectl wait --namespace ingress-nginx \
 
 ### Step 2: Deploy Harbor via Helm
 
-For this lab, we will use internal persistent volumes instead of an external S3 bucket, disable HTTPS to avoid certificate trust issues in a local environment, and set a simple admin password.
+For this lab, we will use internal persistent volumes instead of an external S3 bucket, disable HTTPS to avoid certificate trust issues in a local environment, and set a simple admin password. A production deployment should use TLS, external object storage or a supported shared storage mode, externalized HA dependencies, and credentials managed by your secret-management process.
 
 ```bash
 helm repo add harbor https://helm.goharbor.io
 helm repo update
 
 cat <<EOF > harbor-values.yaml
+# ChartMuseum was removed in Harbor v2.8.0 and Notary deprecated in v2.8 (later removed);
+# current harbor/harbor charts ship neither — do not add chartmuseum/notary stanzas.
 expose:
   type: ingress
   tls:
@@ -180,7 +378,6 @@ expose:
   ingress:
     hosts:
       core: core.harbor.domain
-      notary: notary.harbor.domain
     className: nginx
 externalURL: http://core.harbor.domain
 harborAdminPassword: "Harbor12345"
@@ -188,8 +385,6 @@ persistence:
   persistentVolumeClaim:
     registry:
       size: 5Gi
-    chartmuseum:
-      size: 1Gi
     jobservice:
       size: 1Gi
     database:
@@ -200,8 +395,6 @@ persistence:
       size: 5Gi
 trivy:
   enabled: true
-notary:
-  enabled: false
 EOF
 
 helm install harbor harbor/harbor -n harbor --create-namespace -f harbor-values.yaml
@@ -213,43 +406,49 @@ kubectl wait --namespace harbor \
   --timeout=300s
 ```
 
-Map the local DNS. Add this to your `/etc/hosts`:
+Map the local DNS so the Docker client and your browser resolve the ingress host exactly as Harbor advertises it in login and push instructions. Add this to your `/etc/hosts` file with administrator privileges:
+
 ```text
 127.0.0.1 core.harbor.domain
 ```
 
 ### Step 3: Push an Image
 
-Because we disabled TLS, tell the Docker daemon to treat our Harbor instance as an insecure registry.
-*   **Linux:** Add `{"insecure-registries" : ["core.harbor.domain"]}` to `/etc/docker/daemon.json` and restart Docker.
-*   **Docker Desktop (Mac/Windows):** Add `core.harbor.domain` to the "Insecure registries" list in the Docker Engine settings UI and click Apply & Restart.
+Because we disabled TLS for this isolated lab, tell the Docker daemon to treat our Harbor instance as an insecure registry. Do not copy this exception into production; production registries should use a trusted internal CA and node-level runtime trust configuration.
 
-Login to Harbor using the Docker CLI:
+* **Linux:** Add `{"insecure-registries" : ["core.harbor.domain"]}` to `/etc/docker/daemon.json` and restart Docker so the daemon accepts the local HTTP registry.
+* **Docker Desktop (Mac/Windows):** Add `core.harbor.domain` to the "Insecure registries" list in the Docker Engine settings UI and click Apply & Restart so the desktop daemon accepts the lab endpoint.
+
+Login to Harbor using the Docker CLI, using the temporary lab password created in the Helm values file. In production, this step should use a project-scoped robot account rather than the administrator account.
+
 ```bash
 docker login core.harbor.domain -u admin -p Harbor12345
 ```
 
-Pull a public image, tag it for our local registry, and push it:
+Pull a public image, tag it for our local registry, and push it into Harbor. This reproduces the same core flow a CI system would perform after building an application image.
+
 ```bash
 docker pull alpine:3.18.0
 docker tag alpine:3.18.0 core.harbor.domain/library/alpine:3.18.0
 docker push core.harbor.domain/library/alpine:3.18.0
 ```
-*Expected Output:* The push completes successfully, and layers are written to the `library` project.
+
+Expected output: the push completes successfully, layers are written to the `library` project, and the Harbor UI shows the `alpine` repository with the pushed tag.
 
 ### Step 4: Vulnerability Scanning
 
-Harbor includes Trivy. We can trigger a scan via the API (or through the UI).
+Harbor includes Trivy integration in this lab configuration. We can trigger a scan via the UI, which is the clearest way to see how a registry connects stored artifacts to vulnerability metadata.
 
-1.  Navigate to `http://core.harbor.domain` in your browser.
-2.  Log in with `admin` / `Harbor12345`.
-3.  Click on the `library` project, then click on the `alpine` repository.
-4.  Select the checkbox next to `3.18.0` and click the "Scan" button.
-5.  Wait a few moments, and the vulnerabilities column will populate with a status (e.g., "Critical" or "None").
+1. Navigate to `http://core.harbor.domain` in your browser and confirm the portal loads through the ingress.
+2. Log in with `admin` / `Harbor12345`, using the lab credential rather than any real production password.
+3. Click on the `library` project, then click on the `alpine` repository to inspect the pushed artifact.
+4. Select the checkbox next to `3.18.0` and click the "Scan" button to start analysis through the configured scanner.
+5. Wait a few moments, and the vulnerabilities column will populate with a status such as "Critical", "High", "Low", or "None" depending on scanner data and image contents.
 
 ### Step 5: Sign the Image with Cosign
 
-Generate a Cosign keypair:
+Generate a Cosign keypair for a local key-based signing workflow. Keyless signing is often better for connected CI systems with OIDC identities, but key-based signing is easier to demonstrate in a local lab and remains relevant for disconnected sites.
+
 ```bash
 cosign generate-key-pair
 # Enter a password when prompted. This creates cosign.key and cosign.pub.
@@ -257,28 +456,34 @@ cosign generate-key-pair
 
 Sign the image we just pushed. We must use the image digest, not just the tag, to ensure immutable cryptographic verification.
 
-First, get the digest:
+First, inspect the local image metadata and extract the digest that Docker recorded after the push to Harbor:
+
 ```bash
 DIGEST=$(docker inspect --format='{{index .RepoDigests 0}}' core.harbor.domain/library/alpine:3.18.0 | awk -F'@' '{print $2}')
 echo $DIGEST
 ```
 
-Sign the digest:
+Sign the immutable digest rather than the mutable tag so the signature stays attached to the exact bytes you approved:
+
 ```bash
-cosign sign --key cosign.key core.harbor.domain/library/alpine@${DIGEST}
+cosign sign --allow-http-registry --key cosign.key core.harbor.domain/library/alpine@${DIGEST}
 # Provide the password you used to generate the key.
 # Type 'y' if prompted to upload the signature to the registry.
 ```
 
-Verify the signature was pushed:
-```bash
-cosign verify --key cosign.pub core.harbor.domain/library/alpine@${DIGEST}
-```
-*Expected Output:* A JSON payload proving the signature is valid and cryptographically linked to the specific image digest.
+Verify the uploaded signature from the registry so the lab proves both signing and registry-side signature retrieval:
 
-If you refresh the Harbor UI for the `alpine` repository, you will see a green checkmark indicating the artifact is signed.
+```bash
+cosign verify --allow-http-registry --key cosign.pub core.harbor.domain/library/alpine@${DIGEST}
+```
+
+Expected output: a JSON payload proves the signature is valid and cryptographically linked to the specific image digest rather than only to the human-readable tag.
+
+If you refresh the Harbor UI for the `alpine` repository, you will see a signature indicator in the Cosign/Notation panel (the exact badge is version- and UI-dependent). Record the digest, scan status, and signature verification result in your lab notes; those three facts form the minimum evidence chain for a promoted production image.
 
 ### Teardown
+
+Delete the local cluster when you are done so the lab registry, local persistent volumes, and insecure registry exception do not linger longer than necessary.
 
 ```bash
 kind delete cluster --name registry-lab
@@ -287,92 +492,82 @@ kind delete cluster --name registry-lab
 ## Practitioner Gotchas
 
 ### 1. The Garbage Collection Locking Nightmare
-Unlike a local filesystem, removing an image tag in a registry API only deletes the metadata mapping. The underlying blobs (layers) remain in the storage backend to support layer sharing across different images. Reclaiming storage requires running Garbage Collection (GC). 
 
-**The Gotcha:** Garbage-collection behavior has changed across Harbor releases, so verify the documented online-GC semantics for the exact version you run before scheduling cleanup jobs.
-**The Fix:** Test garbage collection under representative load on your chosen object-storage backend, because cleanup traffic can contend with normal pulls and pushes if the storage layer is undersized.
+Unlike a local filesystem, removing an image tag in a registry API only deletes the metadata mapping. The underlying blobs remain in the storage backend to support layer sharing across different images. Reclaiming storage requires running garbage collection, and the collector has to prove which blobs are no longer referenced before deleting them.
+
+**The Gotcha:** Garbage-collection behavior has changed across Harbor releases, so verify the documented online-GC semantics for the exact version you run before scheduling cleanup jobs. Even when a registry offers online GC, object-storage latency and registry load still affect how safely cleanup can run.
+
+**The Fix:** Test garbage collection under representative load on your chosen object-storage backend, because cleanup traffic can contend with normal pulls and pushes if the storage layer is undersized. Keep enough spare capacity for the cleanup process itself, and rehearse read-only mode before storage pressure makes the maintenance window urgent.
 
 ### 2. Orphaned Signatures After Tag Deletion
-When a user deletes an image tag from the registry UI, the associated Cosign signature (`sha256-...sig`) [may be left behind as an orphaned artifact](https://github.com/sigstore/cosign) if the registry does not strictly enforce OCI referential integrity.
-**The Fix:** Prefer registries that document how they present and clean up signature accessories, and validate that behavior in a test repository before you rely on automatic cleanup.
+
+When a user deletes an image tag from the registry UI, the associated Cosign signature (`sha256-...sig`) [may be left behind as an orphaned artifact](https://github.com/sigstore/cosign) if the registry does not strictly enforce OCI referential integrity. The visible tag list may look tidy while the repository still contains referrers, SBOMs, attestations, or older signature objects.
+
+**The Fix:** Prefer registries that document how they present and clean up signature accessories, and validate that behavior in a test repository before you rely on automatic cleanup. Include signatures and SBOMs in retention planning so security metadata does not become invisible storage drift.
 
 ### 3. Untrusted Custom CAs and Containerd
-You deploy Harbor with an internal enterprise CA certificate. You can pull images perfectly via `docker pull` on your laptop, but Kubernetes pods remain stuck in `ErrImagePull` / `ImagePullBackOff`.
-**The Gotcha:** The `containerd` daemon running on the Kubernetes nodes does not trust the enterprise CA by default, so the TLS handshake with the registry fails.
-**The Fix:** [You must distribute the CA certificate to every bare metal node.](https://github.com/containerd/containerd/blob/main/docs/hosts.md) Copy the `ca.crt` to `/usr/local/share/ca-certificates/` and run `update-ca-certificates` (Debian/Ubuntu) or `/etc/pki/ca-trust/source/anchors/` and run `update-ca-trust` (RHEL), then restart the `containerd` service on all nodes.
+
+You deploy Harbor with an internal enterprise CA certificate. You can pull images perfectly via `docker pull` on your laptop, but Kubernetes pods remain stuck in `ErrImagePull` or `ImagePullBackOff` because the worker node runtime does not trust the same CA chain.
+
+**The Gotcha:** The `containerd` daemon running on the Kubernetes nodes does not trust the enterprise CA by default, so the TLS handshake with the registry fails before image authentication succeeds. Laptop success does not prove node success because Docker Desktop and containerd have different trust paths.
+
+**The Fix:** Distribute the CA certificate to every bare-metal node through your node bootstrap process, configure containerd `hosts.toml` with the CA path, and verify with `crictl pull` from a worker. Avoid `skip_verify` except for isolated testing because it removes the protection TLS is supposed to provide.
 
 ### 4. Redis Persistence Failures Blocking Scans
-Harbor uses Redis heavily for job queueing (scans, replications, GC). If Redis restarts and its persistence (RDB/AOF) is corrupted or disabled, jobs silently disappear.
-**The Gotcha:** Users trigger Trivy scans, but the UI remains stuck in "Scanning..." indefinitely. The Core service dispatched the job to Redis, but the Jobservice pod died, Redis evicted the queue, and the state machine is permanently deadlocked waiting for a completion webhook.
-**The Fix:** Back Harbor job-service state with supported persistence settings and follow Harbor's documented recovery workflow if scan jobs become stuck; avoid recommending direct database edits without vendor documentation.
+
+Harbor uses Redis heavily for job queueing, including scans, replications, and garbage collection coordination. If Redis restarts and its persistence settings are wrong for your deployment, jobs can disappear or become stuck in states that confuse users and automation.
+
+**The Gotcha:** Users trigger Trivy scans, but the UI remains stuck in "Scanning..." indefinitely. The Core service dispatched the job to Redis, the Jobservice pod died, Redis lost the queue entry, and the state machine is now waiting for completion that will never arrive.
+
+**The Fix:** Back Harbor job-service state with supported persistence settings and follow Harbor's documented recovery workflow if scan jobs become stuck. Avoid direct database edits unless vendor documentation tells you exactly which state transition is safe.
 
 ### 5. Disk Exhaustion in the Scanner Pod
-Trivy operates by downloading the image layers from the registry core into the Trivy pod's local filesystem to perform static analysis. 
-**The Gotcha:** Scanner workloads need enough ephemeral or persistent storage for image analysis; oversized artifacts can exhaust node-local storage and disrupt scans if you underprovision the scanner.
-**The Fix:** Allocate a dedicated PersistentVolumeClaim (PVC) for the Trivy pod's cache and working directory, and enforce strict layer size limits at the Ingress controller level (e.g., `nginx.ingress.kubernetes.io/proxy-body-size: "0"` to allow large pushes, but rely on registry quotas to restrict total size).
 
-## Quiz
+Trivy operates by downloading or inspecting image contents and vulnerability databases during analysis. Scanner workloads need enough ephemeral or persistent storage for image analysis, cache data, and database updates, especially when images contain large language runtimes, package managers, or many filesystem layers.
 
-**Question 1**
-Your organization restricts all bare metal nodes from communicating directly with the internet. You need to allow deployments to specify `postgres:15` and pull it successfully. Which architecture natively solves this without altering the image tags in the deployment manifests?
-*   A) Deploy an NGINX reverse proxy in front of the cluster to tunnel TCP port 443 directly to Docker Hub.
-*   B) Configure a Proxy Cache project in Harbor and instruct developers to prefix their manifests with `harbor.internal/dockerhub-proxy/postgres:15`.
-*   C) Configure registry mirrors in `/etc/containerd/config.toml` on all cluster nodes to intercept pulls for `docker.io` and route them to your internal Harbor Proxy Cache.
-*   D) Set `imagePullPolicy: Always` and configure the kubelet with a global HTTP_PROXY environment variable pointing to Harbor.
+**The Gotcha:** Oversized artifacts can exhaust node-local storage and disrupt scans if you underprovision the scanner. The registry may still accept pushes while scans fail, which creates a policy gap between "stored" and "approved."
 
-*Correct Answer: C* (Configuring the containerd mirror allows the runtime to transparently rewrite `docker.io` requests to the internal cache without modifying the deployment YAML. This means the deployment manifests remain clean and portable across different environments. The container runtime seamlessly handles the interception and routing to your internal Harbor Proxy Cache. Consequently, this fully satisfies the air-gapped node requirements while ensuring developers do not have to rewrite their deployment manifests to include internal registry URLs.)
+**The Fix:** Allocate a dedicated PersistentVolumeClaim for the Trivy cache and working directory where your Harbor deployment supports it, monitor scanner storage separately from registry blob storage, and enforce image-size governance through registry quotas or admission policy rather than only through ingress request limits.
 
-**Question 2**
-During a routine operational check, you notice that your Harbor S3 bucket (MinIO) is consuming 5TB of data, but querying the Harbor API shows total project quotas utilizing only 1TB. You have recently deleted hundreds of old image tags via the Harbor UI. What is the most likely cause?
-*   A) Trivy is storing its vulnerability database updates in the S3 bucket.
-*   B) You deleted the tags, but Garbage Collection has not been executed to prune the unreferenced layer blobs from the storage backend.
-*   C) Cosign signatures are taking up 4TB of space because they are not compressed.
-*   D) The PostgreSQL database transaction logs have expanded and are writing backups to the S3 bucket automatically.
+## Next Module
 
-*Correct Answer: B* (Deleting an image tag in a container registry only removes the metadata pointer stored within the registry database. The actual layer blobs remain securely in the underlying S3 storage backend to support efficient layer sharing across different images. Because layers can be shared by multiple images, the registry does not immediately delete them to prevent breaking other active images. Reclaiming this physical storage capacity requires explicitly executing a Garbage Collection (GC) job, which scans for and permanently deletes unreferenced blobs from the S3 bucket.)
-
-**Question 3**
-You are designing a high-availability registry for a bare-metal edge environment with extreme resource constraints. The available hardware only provides 2 CPU cores and 4GB RAM for the entire registry infrastructure. You require OCI artifact support and basic pull-through caching, but do not need a web UI or complex RBAC. Which registry is the most appropriate choice?
-*   A) Harbor
-*   B) GitLab Container Registry
-*   C) Quay
-*   D) Zot
-
-*Correct Answer: D* (Zot is intentionally designed as a single Go binary to function as an OCI-native, extremely lightweight registry. This minimal architectural footprint makes it the ideal solution for edge environments where hardware is severely constrained. Because it does not rely on external databases or caching tiers, it avoids the memory penalties associated with traditional enterprise registries. In contrast, microservice-based architectures like Harbor or Quay require significant operational overhead, including separate PostgreSQL databases and Redis instances, which would likely strain a strict 2 CPU and 4GB RAM allocation.)
-
-**Question 4**
-A developer pushes `app:v1.0.0`, signs it using Cosign, and verifies the signature exists in Harbor. The next day, a compromised pipeline overwrites the `app:v1.0.0` tag with a new, malicious image containing cryptominers. What happens to the cryptographic signature?
-*   A) The signature remains valid because it is linked to the text tag `v1.0.0`.
-*   B) The signature is automatically transferred to the new image because Cosign trusts the Harbor admin account.
-*   C) The signature becomes invalid for the new image because the signature is cryptographically bound to the immutable digest (`sha256:...`) of the original image, not the mutable tag.
-*   D) Harbor will natively reject the push of the malicious image because the tag `v1.0.0` is permanently locked once signed.
-
-*Correct Answer: C* (Cosign cryptographic signatures are intrinsically bound to the immutable digest of the specific image layer configuration, rather than the mutable string tag. When the tag is overwritten with malicious layers, the underlying computed digest fundamentally changes. Because the original cryptographic signature does not match this new digest, the malicious image will fail verification when signature checks are enforced. This immutable binding ensures that even if a registry allows tag mutability, the deployment environment remains protected from the compromised pipeline.)
-
-**Question 5**
-You have configured Harbor with a project-level policy to prevent pulling images with `CRITICAL` vulnerabilities. A pod scaling event triggers, and the kubelet attempts to pull an image that was pushed and scanned clean 6 months ago. The pull is rejected by Harbor at the API level, citing a critical vulnerability. Why did this happen?
-*   A) The original Trivy scan results expired after 90 days and defaulted to a failed state.
-*   B) A scheduled Trivy scan ran recently, utilizing an updated vulnerability database, and identified a newly disclosed CVE in the dormant image.
-*   C) The containerd runtime on the node has its own vulnerability scanner that rejected the layer extraction.
-*   D) The Harbor database lost connection to Redis, causing the policy engine to fail open and reject all pulls.
-
-*Correct Answer: B* (Vulnerability databases are continuously updated by security researchers as new exploits are discovered in existing software packages. Scheduled periodic scans in Harbor re-evaluate all stored images against the latest CVE definitions, regardless of when they were originally pushed. An image that was perfectly clean six months ago likely contains software packages that have since been identified as vulnerable. Consequently, when the cluster scales and attempts to pull the image, Harbor's policy engine correctly blocks the deployment based on the newly discovered critical vulnerability.)
-
-## Further Reading
-
-*   [Harbor Architecture Overview (Official Docs)](https://goharbor.io/docs/edge/architecture/)
-*   [Zot Project GitHub Repository](https://github.com/project-zot/zot)
-*   [Sigstore Cosign Documentation](https://docs.sigstore.dev/cosign/system_config/overview/)
-*   [Trivy Vulnerability Scanner (Aqua Security)](https://aquasecurity.github.io/trivy/)
-*   [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec)
+Next, continue with [Observability at Scale](module-7.8-observability-at-scale/), where you will design monitoring, logging, and tracing systems that keep on-premises platforms debuggable under real operational load.
 
 ## Sources
 
-- [github.com: releases](https://github.com/distribution/distribution/releases) — The upstream release notes directly state both the first stable v3 release status and the removal of the `oss` and `swift` drivers.
-- [The OpenContainers Distribution Spec](https://specs.opencontainers.org/distribution-spec/?v=v1.1.1) — Backs OCI registry protocol and API standardization claims for self-hosted registries and image distribution workflows.
-- [cncf.io: harbor](https://www.cncf.io/projects/harbor/) — The CNCF project page lists the acceptance, incubation, and graduation dates explicitly.
-- [github.com: quay](https://github.com/quay/quay) — The Project Quay upstream README directly lists these authentication, storage, and Clair capabilities.
-- [kubernetes.io: images](https://kubernetes.io/docs/concepts/containers/images/) — The Kubernetes images documentation explicitly states that the legacy built-in mechanism was removed starting with v1.26.
-- [docs.docker.com: pulls](https://docs.docker.com/docker-hub/usage/pulls/) — Docker's own usage page publishes the 100-per-6-hours unauthenticated limit.
-- [github.com: hosts.md](https://github.com/containerd/containerd/blob/main/docs/hosts.md) — The upstream containerd registry configuration docs explicitly deprecate the old CRI mirror/config style and point to `config_path` and `hosts.toml`.
-- [github.com: cosign](https://github.com/sigstore/cosign) — The Cosign upstream README explicitly recommends digest-based signing and documents the registry storage naming convention.
+* [Harbor Architecture Overview (Official Docs)](https://goharbor.io/docs/edge/architecture/) explains Harbor's component model and is useful when mapping the diagram in this module to a real deployment.
+* [Zot Project GitHub Repository](https://github.com/project-zot/zot) is the upstream project home for the lightweight OCI-native registry discussed in the platform comparison.
+* [Sigstore Cosign Documentation](https://docs.sigstore.dev/cosign/system_config/overview/) provides the broader Cosign configuration context beyond the local keypair used in the lab.
+* [Trivy Vulnerability Scanner (Aqua Security)](https://aquasecurity.github.io/trivy/) links to the scanner documentation and project material behind Harbor's common scanning workflow.
+* [OCI Distribution Specification](https://github.com/opencontainers/distribution-spec) is the upstream specification repository for the API behavior used by OCI registries.
+
+- [CNCF Harbor project page](https://www.cncf.io/projects/harbor/) — Verifies Harbor's CNCF maturity history and trusted registry positioning.
+- [CNCF zot project page](https://www.cncf.io/projects/zot/) — Verifies zot's CNCF Sandbox maturity and OCI-native registry description.
+- [CNCF Distribution project page](https://www.cncf.io/projects/distribution/) — Verifies Distribution's CNCF Sandbox maturity and registry toolkit role.
+- [Harbor installation prerequisites](https://goharbor.io/docs/main/install-config/installation-prereqs/) — Verifies Harbor's documented minimum and recommended CPU, memory, disk, Docker Engine, Docker Compose, and port requirements.
+- [Harbor HA with Helm](https://goharbor.io/docs/main/install-config/harbor-ha-helm/) — Verifies Harbor's HA dependency model for ingress, PostgreSQL, Redis, shared storage, object storage, and replica settings.
+- [Harbor proxy cache documentation](https://goharbor.io/docs/main/administration/configure-proxy-cache/) — Verifies proxy-cache behavior, supported upstream registries, and Docker Hub rate-limit alignment notes.
+- [Harbor replication rule documentation](https://goharbor.io/docs/main/administration/configuring-replication/create-replication-rules/) — Verifies push and pull replication rule behavior, filtering, trigger modes, and bandwidth controls.
+- [Harbor pulling and pushing documentation](https://goharbor.io/docs/main/working-with-projects/working-with-images/pulling-pushing-images/) — Verifies Harbor's Docker client flow, V2 API requirement, insecure-registry behavior, and content-trust pull behavior.
+- [goharbor/harbor-helm releases](https://github.com/goharbor/harbor-helm/releases) — Verifies the current Harbor Helm chart repository and recent chart release stream.
+- [Project Quay HA deployment documentation](https://docs.projectquay.io/deploy_quay_ha.html) — Verifies Quay's HA, geo-replication, repository mirroring, Clair scanning, and enterprise registry positioning.
+- [Project Quay upstream repository](https://github.com/quay/quay) — Preserves the upstream Quay source link and backs authentication and component capability checks.
+- [GitLab container registry administration](https://docs.gitlab.com/administration/packages/container_registry/) — Verifies GitLab self-managed registry administration and storage-driver configuration.
+- [Zot getting-started documentation](https://zotregistry.dev/v2.1.16/admin-guide/admin-getting-started/) — Verifies zot container images, extensions, and lightweight OCI registry deployment details.
+- [OCI Distribution Specification](https://specs.opencontainers.org/distribution-spec/?v=v1.1.1) — Verifies OCI registry protocol and API standardization claims for image distribution workflows.
+- [OCI image media types specification](https://specs.opencontainers.org/image-spec/media-types/) — Verifies OCI image artifact media type references used in manifest, blob, and referrer discussion.
+- [CNCF Distribution configuration documentation](https://distribution.github.io/distribution/about/configuration/) — Verifies storage drivers, S3-compatible storage support, read-only maintenance mode, Redis cache, and deprecated configuration details.
+- [CNCF Distribution garbage collection documentation](https://distribution.github.io/distribution/about/garbage-collection/) — Verifies mark-and-sweep GC behavior, shared-layer references, dry-run mode, and read-only safety warning.
+- [containerd hosts documentation](https://containerd.io/docs/2.1/hosts/) — Verifies `hosts.toml`, `config_path`, mirror capabilities, CA fields, `override_path`, and deprecated old CRI mirror patterns.
+- [containerd CRI config documentation](https://containerd.io/docs/2.1/cri/config/) — Verifies current registry configuration paths for containerd 1.x and 2.x.
+- [Kubernetes image documentation](https://kubernetes.io/docs/concepts/containers/images/) — Verifies `imagePullSecrets`, image pull policy behavior, removed legacy credential mechanism, and Kubernetes 1.35 image credential behavior.
+- [Docker Hub pull usage and limits](https://docs.docker.com/docker-hub/usage/pulls/) — Verifies current Docker Hub pull-rate-limit categories and the need to soften exact numbers over time.
+- [Ceph Object Gateway S3 API](https://docs.ceph.com/en/latest/radosgw/s3/) — Verifies that Ceph RGW exposes an S3-compatible API for object-storage-backed registry designs.
+- [Cosign signing containers documentation](https://docs.sigstore.dev/cosign/signing/signing_with_containers/) — Verifies keyless signing, key-based signing, registry requirements, annotations, attestations, and signature location behavior.
+- [Cosign verifying signatures documentation](https://docs.sigstore.dev/cosign/verifying/verify/) — Verifies Cosign verification command patterns and key-based verification flow.
+- [Sigstore Cosign system configuration overview](https://docs.sigstore.dev/cosign/system_config/overview/) — Preserves the existing Cosign documentation source link for broader system configuration context.
+- [Trivy container-image target documentation](https://trivy.dev/docs/latest/guide/target/container_image/) — Verifies Trivy container image scanning behavior and SBOM-aware scanning notes.
+- [Trivy database documentation](https://trivy.dev/docs/latest/configuration/db/) — Verifies Trivy vulnerability database behavior and why scanner data freshness matters.
+- [Aqua Security Trivy documentation](https://aquasecurity.github.io/trivy/) — Preserves the existing Trivy documentation source link.
+- [Kyverno verifyImages overview](https://kyverno.io/docs/policy-types/cluster-policy/verify-images/overview/) — Verifies admission-time image signature and attestation verification concepts.
+- [Distribution release notes](https://github.com/distribution/distribution/releases) — Verifies the upstream release notes referenced for Registry v3 and storage-driver changes.

--- a/src/content/docs/on-premises/operations/module-7.9-serverless-bare-metal.md
+++ b/src/content/docs/on-premises/operations/module-7.9-serverless-bare-metal.md
@@ -6,50 +6,60 @@ sidebar:
   order: 79
 ---
 
-## Learning Outcomes
+## What You'll Be Able to Do
 
 *   **Design and evaluate** Knative Serving architectures alongside bare-metal compatible networking layers like Kourier and Contour.
 *   **Implement** event-driven scale-to-zero workloads utilizing KEDA and external metric triggers.
-*   **Compare and contrast** the architectural trade-offs between full Serverless platforms and lightweight FaaS frameworks in on-premises environments.
+*   **Compare and contrast** the architectural trade-offs between full serverless platforms and lightweight FaaS frameworks in on-premises environments.
 *   **Diagnose** cold start latency issues and implement mitigation strategies for compiled and interpreted application runtimes.
 *   **Configure** Knative Eventing brokers and triggers for decoupled message processing on premises.
 
 ## Why This Module Matters
 
-In early 2024, a major European telecommunications provider attempted to migrate a legacy VM-based messaging application to a bare-metal Kubernetes cluster. They aimed to reduce compute overhead by running their asynchronous SMS processing workers as serverless functions. Because they relied exclusively on a vanilla Horizontal Pod Autoscaler, they could not scale their idle workloads to zero. As a result, hundreds of processing pods remained active during off-peak hours, consuming vast amounts of reserved memory and CPU, entirely defeating the purpose of their serverless migration.
+**Hypothetical scenario:** A platform team migrates bursty internal APIs from always-on Deployments to scale-to-zero Knative Services on a bare-metal cluster. They skip MetalLB configuration, assume wildcard DNS will resolve automatically, and leave the default Horizontal Pod Autoscaler in place for queue workers. During an overnight batch window, hundreds of idle pods remain scheduled because HTTP-based HPA cannot scale to zero, while the one Knative Service they did deploy returns `503` errors on cold starts because the ingress proxy times out before the Activator finishes buffering. The team concludes that "serverless does not work on premises" and rolls back—without realizing they never built the load-balancing, DNS, and autoscaling substrate that cloud FaaS hides behind a console toggle.
 
-When they subsequently attempted to integrate a poorly configured event-driven framework to achieve scale-to-zero, they encountered severe network routing loops and dropped packets at the ingress layer. The resulting cold starts caused thousands of dropped SMS messages during a critical holiday surge. This architectural misstep cost the company over three million euros in service-level agreement (SLA) penalties and required an emergency rollback to their legacy virtual machines.
+Mastering serverless on bare metal is not about adopting a new deployment syntax; it is about accepting that **you are the cloud provider**. Managed FaaS bundles an ingress that buffers cold-start traffic, a metric pipeline that wakes sleeping pods, and a billing model that makes idle capacity someone else's problem. On owned hardware, every one of those mechanisms must exist in your cluster—and every watt of idle RAM still appears on your power bill. This module teaches how Knative Serving, Knative Eventing, KEDA, and alternative FaaS frameworks map onto bare-metal networking ([Module 3.3: Load Balancing Without Cloud](/on-premises/networking/module-3.3-load-balancing/)), local registries ([Module 7.7: Self-Hosted Registry](/on-premises/operations/module-7.7-self-hosted-registry/)), and the economic trade-offs of CapEx-heavy infrastructure.
 
-Mastering serverless architectures on bare metal is not merely about adopting a new deployment syntax; it is about taking absolute control of your compute footprint. In a managed cloud environment, the provider handles the complex ingress buffering and metric pipelines necessary to wake sleeping pods. On bare metal, you are the cloud provider. You must construct the exact mechanisms that detect an incoming request, buffer the connection, spin up the workload, and route the traffic without dropping the client connection. This module equips you with the deeply technical knowledge required to build and operate these mechanisms safely, efficiently, and with the utmost reliability.
+> **The Serverless-on-Metal Analogy**
+>
+> Cloud FaaS is like staying in a hotel: you pay per night, housekeeping appears magically, and you never think about the boiler room. Bare-metal serverless is like owning an apartment building with smart thermostats in every unit—you can turn heat off in empty flats, but you still own the radiators, the plumbing, and the electrician's phone number. Scale-to-zero reclaims *compute* you already paid for; it does not eliminate *ownership*.
 
 ## Did You Know?
 
 *   Knative was accepted to CNCF on March 2, 2022 (Incubating) and moved to Graduated on September 11, 2025.
-*   KEDA is a CNCF graduated project; it joined as Sandbox in 2020, moved to Incubating in 2021, and moved to Graduated on August 22, 2023.
-*   KEDA’s 2.19 documentation shows tested Kubernetes compatibility for versions 1.32–1.34 and states compatibility follows an N-2 policy with possible maintainer extensions.
+*   KEDA is a CNCF Graduated project; it joined as Sandbox in 2020, moved to Incubating in 2021, and moved to Graduated on August 22, 2023.
+*   KEDA's 2.20 documentation shows tested Kubernetes compatibility for versions 1.33–1.35 and states compatibility follows an N-2 policy with possible maintainer extensions.
 *   OpenFaaS Community Edition is limited for commercial use and intended for personal/non-production scenarios with a 60-day commercial usage limit.
 
 ## The Bare Metal Serverless Paradigm
 
-Running serverless architectures on bare metal shifts the operational burden entirely onto the platform engineering team. In public cloud environments, serverless abstracts infrastructure management away from the user. On bare metal, the goal is no longer avoiding infrastructure management, but rather optimizing resource utilization through aggressive bin-packing and accelerating developer velocity via simplified deployment abstractions. 
+Serverless on owned hardware is best understood as **request-driven autoscaling with optional scale-to-zero**, not as magic that eliminates infrastructure. You still operate Kubernetes, CNI, CSI, ingress, DNS, TLS, registries, and observability; you add autoscalers that understand concurrency and queue depth, plus an Activator that hides cold-start latency from clients. The economic win is higher average utilization of machines you already purchased—not outsourcing the data center.
 
-Cloud providers rely on proprietary load balancers, deeply integrated metric pipelines, and hidden control planes to route cold-start traffic and trigger rapid scaling. On bare metal, you must wire ingress controllers, service meshes, and metric adapters manually to achieve the exact same request-driven scaling mechanics. You are responsible for ensuring that the underlying network can route traffic to dynamically created endpoints within milliseconds.
+Running serverless architectures on bare metal shifts the operational burden entirely onto the platform engineering team. In public cloud environments, serverless abstracts infrastructure management away from the user: a `LoadBalancer` Service receives an IP within seconds, DNS integrates with the provider's edge, and per-invocation billing makes idle capacity economically invisible even when pods still exist somewhere in the provider's fleet. On bare metal, the goal is no longer avoiding infrastructure management, but rather optimizing resource utilization through aggressive bin-packing and accelerating developer velocity via simplified deployment abstractions while keeping TCO honest on your own balance sheet.
 
-Knative serves as the premier solution for this challenge. Knative is an open CNCF serverless and event-driven layer for Kubernetes with three components: Serving, Eventing, and Functions. By leveraging these components, you can transform a static bare-metal cluster into a highly dynamic, request-driven compute engine.
+Cloud providers rely on proprietary load balancers, deeply integrated metric pipelines, and hidden control planes to route cold-start traffic and trigger rapid scaling. On bare metal, you must wire ingress controllers, MetalLB or BGP speakers, and metric adapters manually to achieve the same request-driven scaling mechanics. You are responsible for ensuring that the underlying network can route traffic to dynamically created endpoints, that external clients can resolve service hostnames, and that ingress timeouts exceed your slowest cold-start percentile. A Knative Service that scales correctly inside the cluster but remains unreachable from the corporate network has failed architecturally even if every pod event looks healthy in `kubectl`.
 
-Crucially, Knative runs on any Kubernetes cluster, including on-premises environments. It does not rely on proprietary cloud hooks. Furthermore, Knative can be installed in production on an existing Kubernetes cluster (YAML or operator) and supports quickstart local installs on kind/Minikube. This portability ensures that the serverless workloads you design for your bare-metal datacenter can be seamlessly tested on a developer's laptop or eventually migrated to a public cloud if business needs dictate.
+Knative serves as the premier CNCF solution for this challenge. [Knative](https://www.cncf.io/projects/knative/) is an open serverless and event-driven layer for Kubernetes with three components: Serving (HTTP-triggered autoscaling runtime), Eventing (CloudEvents routing), and Functions (a developer framework atop both). By leveraging these components, you can transform a static bare-metal cluster into a highly dynamic, request-driven compute engine without surrendering data gravity or regulatory control to a hyperscaler.
+
+Crucially, Knative runs on any Kubernetes cluster, including on-premises environments. It does not rely on proprietary cloud hooks. Knative Serving and Eventing install independently, so security-conscious teams can adopt HTTP scale-to-zero without deploying message brokers they have not approved. This portability ensures that the serverless workloads you design for your bare-metal datacenter can be tested on kind or minikube locally and migrated later if business needs change—though this module assumes you are staying on owned hardware and optimizing for that economics model.
+
+The mental model for stakeholders outside platform engineering should emphasize **capacity reclamation**: when overnight batch jobs and CI namespaces need nodes, scaled-down Knative Services free schedulable CPU and RAM on the same workers without powering down hardware. That differs from cloud FaaS where provider-level bin-packing is opaque. Document reclaimed capacity in monthly reports—e.g., "serverless scale-to-zero returned 18 vCPU and 96 GiB to the batch pool on average"—so finance sees tangible value from the Knative investment beyond developer convenience alone.
 
 > **Pause and predict**: If you deploy a serverless function that scales to zero, what must happen to the very first network request that arrives before the container has even started? How does the system prevent the client from immediately receiving a "Connection Refused" error?
 
-## Knative: Serving and Eventing Foundations
+## Knative Serving: Revisions, Routes, and the Cold-Start Data Path
 
-Knative provides the foundational primitives for request-driven compute and complex event routing. The architecture is modular by design. Knative Serving and Eventing can be installed independently, allowing platform teams to adopt only the capabilities they strictly require without bloating their control plane.
+Knative Serving builds directly on Kubernetes to support deploying and serving serverless applications. It handles routing, immutable revision tracking, and autoscaling—including scale-to-zero controlled via `enable-scale-to-zero` in the autoscaler ConfigMap and per-service annotations. Understanding the object model is essential for debugging production incidents because `kubectl get pods` alone will not tell you which revision is live, which route receives traffic, or why the Activator still sits in the request path.
 
-### Knative Serving Architecture
+### The Knative Service Object Model
 
-Knative Serving builds directly on Kubernetes to support deploying and serving serverless applications. It handles the complex routing, revision tracking, and autoscaling required for serverless workloads. Most importantly, Knative Serving supports autoscaling to zero and allows this behavior to be controlled via scale-to-zero configuration.
+A **Knative Service** (`ksvc`) is the developer-facing API that owns three Kubernetes child resources wired together by the Serving controller:
 
-To achieve this, Knative declares that its services are built on Kubernetes pods/CRDs and manages workload lifecycle through Kubernetes-native resources. This means operators can inspect Knative workloads using standard `kubectl` commands.
+*   **Configuration** — holds the "latest intent" template (container image, env vars, resource limits). Each time you change the template, Knative creates a new immutable **Revision**.
+*   **Revision** — an immutable snapshot of a deployable unit. Revisions map to Kubernetes Deployments (or similar) plus the queue-proxy sidecar. You never patch a Revision; you create a new one and shift traffic.
+*   **Route** — defines how traffic splits across Revisions. A `ksvc` named `hello` with 100% traffic to `hello-00003` means the Route object—not the Deployment name—is the source of truth for which pods should receive requests.
+
+This separation enables canary releases and instant rollbacks: you adjust Route weights rather than re-running a CI pipeline. On bare metal, where you lack a managed "traffic manager" console, explicit Route objects are how you prove to auditors which code revision processed a given request.
 
 ```mermaid
 graph TD
@@ -62,23 +72,37 @@ graph TD
     Activator -->|Forwards Buffered Request| Pods
 ```
 
-Let's break down the critical components of this architecture:
+### Autoscaler, Activator, and Queue-Proxy
 
-*   **Autoscaler (KPA):** The Knative Pod Autoscaler collects metrics, primarily concurrency or requests-per-second (RPS), directly from the workload pods. It dictates the desired scale of the deployment. When these metrics drop to zero for a configurable grace period, the KPA scales the underlying deployment to zero.
-*   **Activator:** This is the most critical component for scale-to-zero operations. When a service is scaled to zero, the ingress routing table is dynamically updated to point to the Activator instead of the non-existent application pods. The Activator accepts the incoming request, buffers it in memory, and instantly reports the metric spike to the Autoscaler. It then waits patiently for the application pods to become ready, at which point it proxies the buffered requests to the newly spawned pods.
-*   **Queue-Proxy:** A lightweight sidecar container injected into every Knative Service pod. It enforces strict concurrency limits and continuously reports metrics back to the Autoscaler.
+The **Knative Pod Autoscaler (KPA)** collects concurrency or requests-per-second metrics—primarily via the queue-proxy sidecar—and sets desired replica count on the Revision's underlying Deployment. When metrics drop to zero for the configured `scale-to-zero-grace-period`, KPA scales the Deployment to zero replicas. The standard **Horizontal Pod Autoscaler (HPA)** cannot perform this final step because it requires at least one pod to scrape CPU or memory; KPA is purpose-built for serverless concurrency signals.
 
-### Networking Layer on Bare Metal
+The **Activator** is the cold-start buffer. When a Revision has zero ready pods, the Route sends traffic to Activator endpoints instead of application pods. Activator accepts TCP connections, holds requests in memory, signals the Autoscaler that load exists, and proxies buffered requests once pods pass readiness. If Activator memory or connection pools exhaust during a burst while still at zero replicas, clients see `503` errors even though Kubernetes is actively scheduling pods—this is an Activator capacity problem, not an application bug.
 
-Knative Serving requires an ingress networking layer to manage traffic routing, load balancing, and traffic splitting between different revisions of a service. While Istio is a common choice in enterprise environments, it carries a massive operational footprint and complexity. For bare metal deployments focused purely on serverless execution, lightweight alternatives are often vastly preferred.
+The **queue-proxy** sidecar enforces concurrency limits and reports occupancy to KPA. Every Knative Serving pod runs this sidecar; it is the metric source of truth for autoscaling decisions.
+
+Trace a cold request end-to-end on paper before an outage forces you to. The client resolves DNS to the MetalLB VIP, connects to Kourier Envoy listeners, matches a Knative Route host header, discovers zero ready backends for the target Revision, and gets forwarded to Activator endpoints. Activator accepts the session, increments concurrency metrics visible to KPA, waits for the Deployment to create a pod, waits for queue-proxy readiness, then splices the buffered request to the application container. Any broken link—DNS, VIP, ingress timeout, image pull, readiness probe—surfaces as "serverless is broken" to the developer even when Kubernetes events look superficially healthy.
+
+### Concurrency, KPA Targets, and Scale-to-Zero Grace
+
+[Knative concurrency configuration](https://knative.dev/docs/serving/autoscaling/concurrency/) distinguishes soft targets (`autoscaling.knative.dev/target`, default 100 concurrent requests per pod) from hard limits (`containerConcurrency`, where `0` means unlimited). The **target utilization percentage** (`autoscaling.knative.dev/target-utilization-percentage`, default 70%) tells KPA to scale out early—for example, at 70 concurrent requests per pod when the soft target is 100—so new replicas warm before hard limits force queue-proxy buffering.
+
+On bare metal, concurrency tuning interacts with physical CPU limits in ways cloud reference architectures rarely document. A soft target of 100 on a two-vCPU worker may be unrealistic if each request holds the CPU for hundreds of milliseconds; KPA will dutifully scale out, but every new replica pays a cold-start tax that shows up as tail latency at the MetalLB VIP. Start with conservative targets (20–50) for JVM and Python workloads, then increase only after measuring end-to-end latency through Kourier, not pod CPU alone. Hard limits (`containerConcurrency: 50`) enforce queuing inside queue-proxy; Knative documentation warns that low hard limits can harm throughput because surplus requests buffer rather than route to additional replicas.
+
+KPA differs from CPU-based HPA in both metric source and floor behavior. HPA reads `metrics.k8s.io` CPU/memory and cannot scale Deployments to zero replicas because the metrics pipeline expects a running pod. KPA reads request concurrency from queue-proxy and can scale to zero once the `stable-window` of no traffic elapses (plus any `scale-to-zero-pod-retention-period`); the separate `scale-to-zero-grace-period` governs how long the autoscaler waits for networking to be reprogrammed through the Activator before deleting the final pod. You can still attach HPA to a Knative Revision indirectly, but the supported serverless path is KPA with `autoscaling.knative.dev/class: kpa.autoscaling.knative.dev` (the default). Mixing autoscaler classes without understanding which controller owns scale bounds is a common source of "stuck at one pod" incidents during on-call.
+
+Scale-to-zero grace (`scale-to-zero-pod-retention-period` in the autoscaler ConfigMap plus per-revision `autoscaling.knative.dev/scale-to-zero-pod-retention-period`) defines how long KPA waits after the last request before terminating the final pod. Shorter grace saves RAM on idle nodes—directly lowering power draw in your datacenter—but increases cold-start frequency and Activator load during bursty reopenings. Longer grace behaves like a cheap keep-warm strategy without paying explicit `minScale` annotations. For internal tools with predictable business hours, aligning grace with office schedules (long grace overnight, short grace on weekends) can be cheaper than `minScale: 1` while still avoiding Monday-morning cold-start storms.
+
+The annotation `autoscaling.knative.dev/min-scale` sets a minimum replica count per Revision, effectively purchasing always-on capacity. On bare metal you pay for those pods in RAM and electricity whether or not requests arrive; use `minScale: 1` only when SLA tables quantify Activator buffering risk. The companion `autoscaling.knative.dev/max-scale` cap prevents runaway scale-out when metric noise or retry storms fool KPA into believing concurrency is infinite—especially important on fixed-size bare-metal fleets where there is no cloud autoscaler to conjure additional nodes behind your functions.
+
+## Bare-Metal Networking for Knative
+
+Knative Serving requires an ingress networking layer to manage traffic routing, TLS termination, and revision splitting. While Istio remains common in enterprises, its control-plane footprint often exceeds the benefit for pure FaaS clusters. Lightweight alternatives integrate cleanly with bare-metal `LoadBalancer` Services—provided you have already solved external IP allocation.
 
 | Networking Layer | Footprint | Primary Use Case | Bare Metal Considerations |
 | :--- | :--- | :--- | :--- |
-| **Kourier** | Very Low | Pure Knative ingress | Ideal for strict FaaS environments. Uses Envoy. Directly exposes LoadBalancer or NodePort services. |
-| **Contour** | Low | General Ingress + Knative | Good if Contour is already handling cluster ingress. |
-| **Istio** | High | Advanced traffic management | Required if mTLS or complex cross-service auth is needed. Requires significant tuning. |
-
-To visualize this table architecturally, consider the following flowchart of your ingress choices:
+| **Kourier** | Very Low | Pure Knative ingress | Ideal for strict FaaS environments. Uses Envoy. Exposes `LoadBalancer` Services directly. |
+| **Contour** | Low | General Ingress + Knative | Strong choice if Contour already terminates cluster ingress; [Contour's Knative guide](https://projectcontour.io/docs/main/guides/knative/) documents integration patterns. |
+| **Istio** | High | Advanced traffic management | Required when mTLS, fine-grained traffic policies, or service-mesh observability are mandatory. |
 
 ```mermaid
 flowchart TD
@@ -99,21 +123,37 @@ flowchart TD
     D --> D3[Bare Metal: Requires tuning, required for strict mTLS.]
 ```
 
-> **Caution:** When using bare metal without a MetalLB or Cilium BGP setup, Knative ingress gateways will default to `NodePort` or remain pending as `LoadBalancer`. Ensure your L2/L3 VIP configuration is entirely functional before attempting to deploy Knative, otherwise external traffic will simply drop.
+### MetalLB, kube-vip, and the Missing Cloud Load Balancer
 
-### Knative Eventing
+[MetalLB](https://metallb.io/) exists because Kubernetes does not implement `Service type=LoadBalancer` on bare metal without an integration layer. Without MetalLB (or an equivalent BGP/L2 speaker such as kube-vip documented in [Module 3.3](/on-premises/networking/module-3.3-load-balancing/)), Kourier's front-door Service remains `Pending` indefinitely and external clients cannot reach your functions. MetalLB hands out addresses from an `IPAddressPool` via L2 ARP mode for simple topologies or BGP mode when your spine-leaf fabric expects route advertisement.
 
-While Knative Serving focuses on request-driven synchronous traffic, Knative Eventing provides the infrastructure for routing asynchronous events from producers to consumers utilizing the open CloudEvents specification. 
+This is the fundamental on-prem difference: in AWS, creating a `LoadBalancer` Service triggers an ELB; in your datacenter, **you** must coordinate IP pools with the network team, ensure gratuitous ARP or BGP sessions are permitted, and document which VIP fronts production Knative routes. Skipping this step is the most common reason Knative "works in curl from the node" but fails from developer laptops.
 
-*   **Broker:** A routing hub for events. Producers fire events into the Broker, remaining entirely unaware of who or what will consume them.
-*   **Trigger:** Defines a strict filter and a subscriber destination. Consumers create Triggers to specify exactly which events they want the Broker to forward to them.
-*   **Channel / Subscription:** Lower-level primitives for direct publish/subscribe mechanics without the Broker's filtering complexity.
+### DNS: sslip.io for Labs, Wildcard Records for Production
 
-On bare metal environments, the backing storage for Brokers and Channels dictates your system's reliability. The default in-memory channel provided during installation is strictly for development. Production bare-metal deployments require a robust backing store, such as the Kafka broker implementation, to ensure at-least-once delivery semantics and prevent message loss during hardware failures.
+Knative assigns each Service a hostname derived from its name, namespace, and ingress domain—commonly `hello.default.<ingress-ip>.sslip.io` when using the [magic-DNS pattern](https://knative.dev/docs/install/install-yaml/#deploying-knative-serving) for labs. The `sslip.io` service resolves hostnames embedding IPv4 addresses, which removes manual DNS during testing. Production bare-metal clusters should **not** rely on sslip.io; instead, configure a private wildcard (`*.knative.internal.example.com`) pointing at the MetalLB VIP and set `domainTemplate` in `config-network` or use `DomainMapping` resources for explicit hostnames.
+
+Split-horizon DNS matters when workers run inside the cluster but callers sit on corporate laptops. The ingress VIP must resolve identically from both vantage points, or you will debug phantom "cold start" failures that are actually DNS NXDOMAIN errors. Cross-reference [Module 3.4: DNS & Certificate Infrastructure](/on-premises/networking/module-3.4-dns-certs/) when wiring cert-manager certificates for Knative routes.
+
+MetalLB L2 mode announces a VIP from one node at a time using ARP/NDP, which is ideal for flat L2 lab pods and smaller two-rack deployments where BGP would be overkill. BGP mode (often paired with [FRR-K8s per MetalLB documentation](https://metallb.io/)) advertises `/32` or `/128` routes to your spine switches, distributing VIP ownership across nodes and surviving ToR failures—closer to how cloud load balancers hide backend churn. Knative does not care which mode you pick as long as the Kourier `Service` receives a stable address; what changes is how your network team documents the VIP during change windows.
+
+TLS termination typically lands on Kourier or Contour ingress, not on individual function pods. On bare metal you are responsible for rotating certificates via cert-manager ClusterIssuers backed by your internal Vault PKI ([Module 3.4](/on-premises/networking/module-3.4-dns-certs/)). Wildcard certs matching your Knative domain template reduce issuance churn when developers create dozens of `ksvc` objects per namespace. Remember that cold starts extend the TLS handshake window: clients must use ingress timeouts that cover both TCP + TLS + Activator buffering + container boot, not just the steady-state RTT you measured during load tests.
+
+> **Caution:** When using bare metal without MetalLB or Cilium BGP, Knative ingress gateways default to `NodePort` or remain `Pending` as `LoadBalancer`. Ensure your L2/L3 VIP configuration is functional before deploying Knative; otherwise external traffic drops before it ever reaches the Activator.
+
+## Knative Eventing: Brokers, Triggers, and CloudEvents
+
+While Knative Serving focuses on synchronous HTTP, [Knative Eventing](https://knative.dev/docs/eventing/) routes asynchronous events using the [CloudEvents](https://cloudevents.io/) specification—a vendor-neutral envelope with attributes like `type`, `source`, and `id` that make events interoperable across languages and brokers.
+
+*   **Broker** — a routing hub. Producers send CloudEvents to the Broker ingress; they do not know which consumers exist.
+*   **Trigger** — a filter plus subscriber. Triggers select events by attributes (for example `type: dev.knative.samples.helloworld`) and deliver matching events to a Knative Service, Kubernetes Service, or custom URL.
+*   **Channel / Subscription** — lower-level publish/subscribe primitives when you need direct channels without the Broker abstraction.
+
+On bare metal, **broker backing storage** determines durability. The in-memory channel installed by quickstart manifests is strictly for development; production requires Kafka, RabbitMQ, or NATS-based channel implementations so broker restarts do not evaporate queued events during rack maintenance.
 
 ### Configuring Brokers and Triggers
 
-To configure an in-memory Broker and a corresponding Trigger that routes specific filtered events to a Knative Service, you must apply the following definitions. Note that they are separated here into distinct documents to ensure clean YAML parsing and application.
+The following manifests create a default Broker and a Trigger forwarding filtered events to a Knative Service. Apply them as separate documents to keep parsing clean.
 
 ```yaml
 apiVersion: eventing.knative.dev/v1
@@ -141,25 +181,22 @@ spec:
       name: hello
 ```
 
-## KEDA: Event-Driven Autoscaling
+Event sources—Kubernetes API events via SinkBinding, GitHub webhooks via GitHubSource, Kafka consumers via KafkaSource—connect to Brokers or Channels depending on integration maturity. Each source adapter translates external signals into CloudEvents with standardized attributes so Triggers can filter without knowing the upstream vendor. For on-prem Kafka already operated by your data platform team, the Kafka-backed channel implementation is usually the least surprising choice because retention policies, ACLs, and monitoring dashboards reuse existing runbooks instead of introducing another persistence layer operators must learn during an outage.
 
-Knative Serving is brilliant at scaling based on HTTP request concurrency, but what if your workload processes messages from a RabbitMQ queue, reads from a Kafka topic, or executes based on a schedule? This is where KEDA shines.
+Channel implementations trade operational complexity for durability. In-memory channels are acceptable only on developer laptops. Kafka channels survive broker pod restarts when topics are replicated across racks you already maintain for other applications. RabbitMQ and NATS channels appear in smaller installations where those brokers already exist for legacy workloads. The wrong choice is not "Kafka vs NATS" in the abstract—it is whichever distributed log your organization already staffs on-call for at 3 a.m.
 
-KEDA is a Kubernetes-based autoscaler that provides event-driven scale for Kubernetes workloads. KEDA is not a function-as-a-service platform itself; rather, it is a highly specialized autoscaling engine that works alongside and enhances the standard Horizontal Pod Autoscaler (HPA).
+Dead-letter handling deserves explicit design on bare metal because you cannot buy a managed "replay button." When a Trigger subscriber fails repeatedly, events land in a dead-letter sink (another Service or Kafka topic) that platform teams must monitor with the same rigor as production ingress. Pair Eventing with the observability patterns from [Module 7.8: Observability at Scale](/on-premises/operations/module-7.8-observability-at-scale/) so broker lag, undelivered events, and subscriber error rates appear on dashboards before message backlogs exhaust disk on your Kafka brokers.
 
-KEDA supports scaling Kubernetes Deployments and StatefulSets and can also scale custom resources that expose the Kubernetes `/scale` subresource. This flexibility allows platform engineers to bring serverless scaling characteristics to entirely legacy workloads, provided they are packaged correctly in Kubernetes.
+## KEDA: Event-Driven Autoscaling Beyond HTTP
 
-> **Stop and think**: If a custom resource does not expose the `/scale` subresource, can KEDA scale it directly? How might you architect a workaround if you are forced to scale a proprietary operator?
+Knative Serving excels at HTTP concurrency, but queue depth, cron schedules, Prometheus queries, and custom external signals require [KEDA](https://keda.sh/docs/) (Kubernetes Event-driven Autoscaling). KEDA is not a FaaS platform; it extends the HPA with an external metrics adapter and scales Deployments, StatefulSets, Jobs, or any custom resource exposing the `/scale` subresource.
 
-### Scale-to-Zero Mechanics with KEDA
+### ScaledObject vs ScaledJob
 
-The standard Kubernetes HPA fundamentally cannot scale workloads to zero. It requires at least one pod to exist so that metrics can be scraped. KEDA elegantly bridges this architectural gap.
+*   **ScaledObject** — targets long-running workloads (Deployments). KEDA scales replicas between `minReplicaCount` and `maxReplicaCount` based on triggers. Setting `minReplicaCount: 0` enables scale-to-zero for queue workers that should idle without pods.
+*   **ScaledJob** — targets Kubernetes Jobs. Each scaling event can spawn Job objects that run to completion—ideal for batch bursts where pods should exit after processing one message partition.
 
-1.  **Metric Server Adapter:** KEDA acts directly as a Kubernetes Metrics Server, exposing external metrics (like queue depths) to the cluster's internal HPA.
-2.  **KEDA Operator:** The KEDA controller continuously monitors the external event source.
-3.  **Scale 0 -> 1:** When the event source transitions from an empty state to having work (e.g., a message arrives in the queue), the KEDA operator bypasses the HPA and directly scales the workload Deployment from 0 to 1.
-4.  **Scale 1 -> N:** Once the workload is running and processing, KEDA steps back and hands off the scaling logic to the standard HPA, continuously feeding it the translated external metrics.
-5.  **Scale 1 -> 0:** When the queue empties, the HPA scales the deployment down to its configured minimum (usually 1). The KEDA operator detects the empty queue and forces the final scale down to 0.
+The standard HPA cannot scale to zero because it needs a pod to scrape. KEDA's operator watches external triggers directly: when a RabbitMQ queue transitions from empty to non-empty, KEDA scales from 0→1 before HPA participates; when the queue drains, KEDA forces the final scale-down after HPA reaches its minimum.
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
@@ -174,128 +211,352 @@ spec:
   triggers:
   - type: rabbitmq
     metadata:
+      protocol: amqp
       queueName: task_queue
-      queueLength: "5"
+      mode: QueueLength        # bare `queueLength` is deprecated — use mode + value
+      value: "5"
+      hostFromEnv: RABBITMQ_HOST   # AMQP URI from a Secret; or use authenticationRef → TriggerAuthentication
 ```
 
-> **Tip:** KEDA polling intervals dictate exactly how quickly a scale-from-zero event occurs. Aggressive polling (e.g., every 1 second) against massive external systems can induce severe control-plane starvation. Default polling is typically 30 seconds, which must be factored into your SLA calculations.
+KEDA ships [dozens of scalers](https://keda.sh/docs/2.20/scalers/prometheus/) covering message queues, databases, cloud metrics endpoints, and Kubernetes resources themselves. Verify trigger metadata against the exact KEDA minor version you install because field names drift between releases; copying a three-year-old `ScaledObject` from a blog post is a reliable way to create a scaler that silently never fires, leaving queues backed up while `kubectl get hpa` shows `<unknown>` metrics.
+
+Install KEDA into its own namespace with monitored webhook availability—the operator must admit `ScaledObject` resources before your application namespaces roll out. On bare-metal clusters with tight etcd latency budgets, watch KEDA's polling goroutines during load tests; they are tiny compared to application traffic but multiply when hundreds of `ScaledObject` resources poll the same Kafka cluster every thirty seconds. A Prometheus scaler, for example, requires `serverAddress`, a PromQL `query` returning a scalar, and `threshold` values:
+
+```yaml
+  triggers:
+  - type: prometheus
+    metadata:
+      serverAddress: http://prometheus.monitoring.svc:9090
+      query: sum(rate(http_requests_total{deployment="my-deployment"}[2m]))
+      threshold: "100"
+```
+
+> **Tip:** KEDA polling intervals dictate how quickly scale-from-zero occurs. Aggressive polling (every 1 second) against massive Kafka clusters can starve the control plane; default polling is often 30 seconds—factor that into SLA math for overnight batch jobs.
+
+### ScaledJob, Cron, and Prometheus Triggers
+
+Beyond `ScaledObject`, KEDA's **ScaledJob** resource launches Kubernetes Jobs when external signals fire—useful for nightly ETL on bare metal where you want pods to exit after processing a partition rather than idle as Deployments. A cron scaler (`type: cron` in KEDA metadata) scales an existing Deployment up during a scheduled window and back to zero afterward — unlike a Kubernetes CronJob, which creates a fresh Job (and its pods) per scheduled run and is meant for discrete batch tasks, not for keeping a service warm. Combine cron triggers with `minReplicaCount: 0` so dev clusters stay quiet on weekends.
+
+The Prometheus scaler queries your existing metrics tier ([Module 7.8](/on-premises/operations/module-7.8-observability-at-scale/)) with PromQL and scales when query results cross `threshold`. This bridges HTTP services you have not migrated to Knative: a Deployment behind a traditional Ingress can still scale from zero when `sum(rate(http_requests_total{service="legacy-api"}[2m]))` rises, provided the query returns a scalar and your Prometheus HA tier survives the polling load. Use `activationThreshold` to prevent flapping when metrics hover near noise floor.
+
+### KEDA vs Knative Eventing: When to Use Which
+
+Use **Knative Eventing** when you want CloudEvents routing, Broker/Trigger filtering, and tight integration with Knative Serving scale-to-zero HTTP targets—especially for event fan-out, content-based filtering, and decoupling producers from consumer URLs. Eventing shines when multiple subscribers must react to the same business event without the producer enumerating Service DNS names inside your datacenter.
+
+Use **KEDA** when the scaling signal is a metric external to HTTP—queue depth, Kafka lag, cron schedule, Prometheus query, Redis list length—and the workload is a standard Deployment, StatefulSet, or Job you are not ready to wrap in Knative CRDs. KEDA is the faster on-ramp for brownfield bare-metal clusters already full of Deployments operated by teams who do not want to learn `ksvc` semantics.
+
+Many on-prem platforms run both: Eventing ingests and routes events; KEDA scales the worker Deployments that drain backlogs. Avoid duplicating both on the same signal—pick one autoscaler owner per workload or you will fight conflicting scale directives during incidents.
 
 ## Alternative FaaS Frameworks
 
-If Knative provides the heavy infrastructure, alternative FaaS frameworks focus entirely on the developer experience and simplicity. Knative generally requires developers to build and push container images. Dedicated FaaS frameworks often abstract the container build process, allowing developers to deploy raw source code directly to the cluster.
+If Knative provides the infrastructure layer, alternative FaaS frameworks optimize developer experience. Knative expects container images; OpenFaaS and Fission add build pipelines and UX shortcuts—each with on-prem caveats.
 
 ### OpenFaaS
 
-OpenFaaS focuses heavily on operational simplicity. OpenFaaS CE and Pro documentation says OpenFaaS can run on any Kubernetes cluster, including self-managed on-prem or managed cloud. It uses a centralized API Gateway to route traffic to functions. Functions are cleanly packaged as containers via the `faas-cli` and utilize internal watchdog processes to pipe HTTP requests to standard input.
+[OpenFaaS](https://www.openfaas.com/) emphasizes operational simplicity. It runs on any Kubernetes cluster, including self-managed on-prem, using an API Gateway, optional NATS for async execution, and Prometheus-driven scaling. Functions package as containers via `faas-cli`; an internal watchdog forwards HTTP to process stdin/stdout.
 
-*   **Architecture:** The core platform consists of an API Gateway, NATS (for asynchronous execution), a Queue Worker, and Prometheus.
-*   **Scaling:** OpenFaaS uses Prometheus metrics (RPS) read by the API Gateway to scale function deployments. It supports scale-to-zero via the `faas-idler` component.
+Organizations must respect licensing: OpenFaaS Community Edition limits commercial production use (60-day commercial trial). CE also expects continuous internet connectivity for validation—air-gapped datacenters should evaluate OpenFaaS Standard. For single-node edge sites without Kubernetes, `faasd` runs on containerd directly—useful for remote industrial gateways where a full control plane is impractical.
 
-However, organizations must be acutely aware of licensing. OpenFaaS Community Edition is limited for commercial use and intended for personal/non-production scenarios with a 60-day commercial usage limit. Deploying CE into a revenue-generating environment violates this limit.
-
-Furthermore, deployment topology matters. OpenFaaS CE requires a Kubernetes cluster with full internet access continuously; air-gapped/restricted environments are positioned as better fit for OpenFaaS Standard. The CE edition routinely checks external registries and validation endpoints, which can quickly trigger a crash loop in a disconnected datacenter.
-
-For extreme edge use cases or isolated bare-metal environments lacking a full orchestration control plane, OpenFaaS can also be deployed as faasd on a single host without Kubernetes, using containerd and CNI. This makes it an incredibly versatile tool for IoT gateways or isolated industrial servers.
+OpenFaaS functions remain containers under the hood; the UX difference is CLI-driven packaging and a centralized gateway Deployment that scales function replicas from Prometheus RPS metrics. That maps onto bare-metal observability stacks from [Module 7.8](/on-premises/operations/module-7.8-observability-at-scale/) but still requires MetalLB in front of the gateway Service and the same Harbor pull paths Knative needs. Teams choosing OpenFaaS for simplicity should not skip DNS, TLS, or registry design reviews—datacenter networking realities apply regardless of CRD flavor.
 
 ### Fission
 
-Fission optimizes aggressively for cold start latency by maintaining a pool of pre-warmed environment containers. The Fission architecture consists of four primary components: a Controller, a Router, Environments (the pre-warmed containers), and a Builder (which compiles code in-cluster). When a request arrives, the router grabs a pre-warmed container, dynamically injects the function code, and routes the request. This provides near-instant cold starts (sub-100ms) but breaks the pattern of immutable container images, which often triggers alerts in strictly governed enterprise security environments. Additionally, maintaining these warm pools leads to a higher baseline resource consumption compared to scale-to-zero platforms.
+[Fission](https://fission.io/docs/architecture/) optimizes cold-start latency with pools of pre-warmed "environment" containers. The Router injects function code at request time instead of pulling a unique image per function. Sub-100ms starts are achievable for interpreted runtimes, but runtime mutation breaks immutable-image security models—image hashes in CI no longer match running containers, which triggers compliance findings in regulated environments. Warm pools also consume baseline RAM even when idle, partially offsetting scale-to-zero savings that finance expected from the serverless initiative.
+
+Choosing between Knative, OpenFaaS, and Fission is not a beauty contest; it is a staffing and compliance decision. Knative aligns with CNCF Graduated governance and integrates with existing ingress/DNS you already run for other workloads. OpenFaaS optimizes developer ergonomics when teams want `faas-cli` deploys without writing Dockerfiles, but licensing and air-gap constraints push serious on-prem estates toward Standard or away entirely. Fission targets latency-sensitive internal APIs where security accepts mutable runtime state. Document the choice in your platform decision log so auditors understand why some namespaces use `ksvc` while edge gateways still run `faasd`.
 
 ## Cold Start Optimization on Bare Metal
 
-Cold starts remain the primary operational hurdle in any serverless environment. A cold start consists of a strictly sequential chain of events:
-1.  Kubernetes scheduling the Pod to an available node.
-2.  The container runtime executing the image pull over the network.
-3.  The container runtime starting the container process.
-4.  The application framework bootstrapping (e.g., initializing the JVM or Node event loop).
-5.  The readiness probe finally passing and returning a 200 OK.
-
-On bare metal, network latency to an external container registry across the public internet is almost always the largest and most unpredictable variable.
+Cold starts are a sequential chain: schedule pod → pull image → start container → run application bootstrap → pass readiness probe. On bare metal, **image pull latency** across WAN links to public registries often dominates; JVM and heavy framework initialization rank second. Proxy inspection, NAT hairpins, and oversubscribed storage backplanes add variance that does not appear in cloud FaaS benchmarks, so always measure on the same MetalLB VIP path production clients use.
 
 ### Mitigation Strategies
 
-1.  **Image Locality and Aggressive Pre-pulling:** Utilize local registry mirrors (such as Harbor) running on the exact same L2 network as the compute nodes. Utilize tools like `kube-flannel` or specialized DaemonSets to pre-pull large base images onto all nodes before they are requested by a serverless workload.
-2.  **Runtime Selection and AOT Compilation:** Interpreted languages (Node.js, Python) have moderate startup times. JIT-compiled languages (Java/Spring, C#) suffer from extreme cold starts. Utilizing Ahead-of-Time (AOT) compiled languages like Go, Rust, or GraalVM Java offers the absolute best cold start performance, often cutting boot times from 15 seconds to under 50 milliseconds.
-3.  **Init Container Elimination:** Strictly avoid init containers in serverless workloads. They execute sequentially and completely block the main application container from even beginning to start.
-4.  **CPU Bursting Capabilities:** Container startup is inherently a massively CPU-intensive operation. Ensure serverless workloads have high CPU limits (or no limits at all) relative to their base requests, allowing them to instantly burst and consume idle node cycles during their critical initialization phase.
+1.  **Local registry mirrors** — Deploy Harbor or another registry on the same L2 network as workers ([Module 7.7](/on-premises/operations/module-7.7-self-hosted-registry/)). Pre-pull base images via DaemonSets so cold starts hit disk, not BGP transit.
+2.  **Runtime selection** — Go, Rust, or GraalVM-native Java minimize bootstrap time compared to stock Spring Boot on a cold JVM. Interpreted Node.js sits in the middle; choose runtimes based on measured cold-start percentiles, not developer preference alone.
+3.  **Eliminate init containers** — Init containers run sequentially and block the primary container from starting; they are anti-patterns for scale-to-zero HTTP handlers.
+4.  **CPU bursting** — Startup is CPU-spiky; throttling during pull/extract extends cold-start time beyond ingress timeouts.
+5.  **`minScale` keep-warm** — The `autoscaling.knative.dev/min-scale` annotation keeps N pods always running. This trades RAM for latency predictability—on bare metal you pay that RAM 24/7, so use `minScale: 1` only for latency-critical paths with measured traffic.
+6.  **Checkpoint/restore (advanced)** — [Forensic container checkpointing](https://kubernetes.io/blog/2022/12/05/forensic-container-checkpointing-alpha/) using CRIU (the `ContainerCheckpoint` feature gate) graduated to Beta in Kubernetes 1.30 and remains Beta as of Kubernetes 1.35 per [KEP-2008](https://github.com/kubernetes/enhancements/issues/2008) — it has not promoted to GA, so treat checkpoint/restore as experimental. On Kubernetes 1.35 clusters with CRI-O or containerd CRIU support enabled, restoring from checkpoints can skip parts of JVM warmup, but operational complexity (checkpoint storage on kubelet disk, conversion to OCI images via `checkpointctl build`) keeps this niche—verify feature gates and runtime support before promising checkpoint-based cold-start SLAs to application teams.
+
+Platform runbooks should list cold-start percentiles per runtime on actual bare-metal hardware, not laptop kind clusters. Publish a table internally: Go sample image p50/p99, Node p50/p99, Spring Boot p50/p99, each measured from curl through the MetalLB VIP after forced scale-to-zero. Developers choose runtimes with eyes open, and SREs set ingress timeouts with evidence instead of guessing.
+
+## Cost Lens: Serverless Economics on Owned Hardware
+
+Cloud FaaS charges per invocation and GB-second, which makes idle capacity look free even when it is not. Bare-metal serverless removes per-invocation billing but **never removes CapEx**: you already bought the servers, switches, rack space, power, cooling, and the engineers who operate MetalLB, Harbor, and the autoscalers.
+
+| Cost Driver | On-Prem Impact | Serverless Interaction |
+| :--- | :--- | :--- |
+| **Server CapEx** | Depreciated over 3–5 years | Scale-to-zero reclaims CPU/RAM for other workloads (batch, CI) instead of sitting idle |
+| **Power & cooling** | ~$1,200–1,900/yr per continuous kW (≈$0.14/kWh US commercial avg, EIA early-2026, ×PUE 1.3–1.6 — verify current) | Fewer running pods lowers draw, but Activator/ingress overhead remains |
+| **Network gear** | ToR/spine ports are fixed cost | MetalLB VIPs and BGP sessions are "free" marginally but require skilled ops |
+| **Registry & storage** | Harbor disks, backup tapes | Local pulls reduce WAN egress charges you would pay in cloud |
+| **Ops headcount** | Platform team salary | Knative + KEDA + MetalLB stack needs ongoing upgrades and on-call |
+
+**When scale-to-zero on bare metal wins:** bursty internal APIs (HR portals, reporting), dev/test namespace density, queue workers with long idle periods, and clusters where batch jobs can borrow nodes freed by scaled-down Services. **When always-on Deployments are cheaper/simpler:** steady high-QPS services where `minScale` would equal `maxScale` anyway, tiny clusters where Activator + ingress overhead exceeds savings, and teams without platform engineers to maintain Knative networking.
+
+Calculate TCO with utilization histograms, not peak headlines. If your workload holds 40% baseline traffic 24/7, serverless complexity may cost more engineering hours than rightsized Deployments with HPA. Conversely, if histograms show 95% idle time for hundreds of microservices, scale-to-zero can defer the next rack purchase by months even after accounting for Activator overhead.
+
+Depreciation matters for CapEx planning: servers you bought for "just in case" burst capacity sit on the balance sheet whether or not Knative scales them away. Serverless on bare metal optimizes **utilization of sunk cost**, not elimination of sunk cost. Finance teams still refresh hardware on schedule; platform teams use scale-to-zero to run batch, CI, and dev namespaces on the same nodes during off-peak windows. Track **reclaimed node-hours** monthly to justify the engineering investment in MetalLB, Harbor, and Knative upgrades to leadership.
+
+Egress and data gravity often favor on-prem serverless for event pipelines that would otherwise ship terabytes to a cloud FaaS vendor. You still pay switch ports and backup tape, but you avoid per-GB egress invoices. Regulatory constraints (data residency, air-gap) may mandate on-prem regardless of TCO; in those environments, OpenFaaS Standard or Knative with local registries are the realistic options—not CE builds that phone home for license validation.
+
+## Day-2 Operations: Upgrades, Quotas, and Multi-Tenancy
+
+Serverless platforms fail in production more often during upgrades than during initial install. Knative, KEDA, and ingress controllers each ship on independent release trains; pinning everything to `knative-v1.22.1` for Serving and net-kourier together is deliberate version coupling—mixing a newer Kourier with an older Serving webhook can reject `Service` updates with validation errors that look like application bugs. Maintain a version matrix in git, test upgrades on a staging bare-metal rack, and roll production namespaces only after cold-start and Eventing delivery tests pass.
+
+Resource quotas interact painfully with scale-to-zero if you cap `pods` per namespace too aggressively: the Activator may successfully schedule a cold-start pod only to hit `Forbidden: exceeded quota`, leaving clients hanging until timeout. Platform teams should either exempt `knative-serving` and `kourier-system` infrastructure namespaces from developer quotas or set quota limits high enough to absorb burst scale-out (remember max-scale annotations times concurrent Services). LimitRanges on CPU can silently lengthen cold starts by throttling image extraction; serverless namespaces often benefit from higher default CPU limits during the first minutes of pod life.
+
+Multi-tenancy on bare metal usually means namespace isolation, not hypervisor isolation. Knative Services in namespace `team-a` still share Activator, Kourier, and MetalLB VIPs with `team-b`. Use NetworkPolicies ([Module 3.6: Service Mesh on Bare Metal](/on-premises/networking/module-3.6-service-mesh-bare-metal/)) to prevent a compromised function from scraping neighbor Services. Per-tenant subdomain templates (`{svc}.{ns}.serverless.example.com`) simplify ACL reviews because firewall rules can reference predictable DNS patterns instead of ephemeral NodePorts.
+
+Backup and disaster recovery for Eventing brokers means backing the Kafka topics or RabbitMQ volumes—not just etcd. A restored Kubernetes control plane with empty broker storage is a platform that happily routes triggers to Services that never receive events. Document RPO/RTO for message backlogs the same way you document them for etcd snapshots.
+
+Change management for serverless platforms differs from traditional Deployments because scale-to-zero hides broken revisions until Monday morning traffic arrives. Require staging environments that mirror production MetalLB pools and DNS templates, and run synthetic cold-start probes every hour so Activator regressions page the on-call engineer before executives open the internal portal.
+
+## Patterns & Anti-Patterns
+
+Successful on-prem serverless estates repeat a handful of integration patterns because they minimize moving parts while respecting datacenter realities: routable VIPs, internal DNS, local registries, and autoscalers that understand scale-to-zero. The patterns below are not theoretical—they are the combinations platform engineers rediscover when cloud reference architectures are pasted onto owned hardware without adaptation.
+
+### Proven Patterns
+
+| Pattern | When to Use | Why It Scales |
+| :--- | :--- | :--- |
+| **Kourier + MetalLB L2 pool** | Pure FaaS clusters without service mesh | Minimal moving parts; Envoy ingress gets a routable VIP without Istio control-plane RAM |
+| **KEDA ScaledObject on queue depth** | Kafka/RabbitMQ workers with idle gaps | Decouples scaling signal from HTTP; reuses existing message infrastructure |
+| **Harbor pull-through cache + pre-pull DaemonSets** | Large images on multi-rack bare metal | Removes WAN pull variance from cold-start SLAs |
+| **Wildcard internal DNS + cert-manager** | Production Knative hostnames | Replaces sslip.io lab hacks with auditable DNS aligned to corporate PKI |
+
+When rolling out these patterns, instrument three signals from day one: Activator request latency (cold-path health), KPA scale latency (time from zero to ready pod), and MetalLB ARP/BGP event logs (VIP movement during node drains). Without them, developers will attribute every timeout to "Knative being slow" while the real fault is a stale ARP entry on the upstream router.
+
+### Anti-Patterns
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+| :--- | :--- | :--- |
+| **HPA-only "serverless"** | Pods never reach zero; idle RAM drains cluster | KPA via Knative Serving or KEDA `minReplicaCount: 0` |
+| **Istio for every FaaS cluster** | Control-plane memory rivals function workloads | Kourier/Contour until mTLS policies mandate mesh |
+| **sslip.io in production** | External dependency + non-corporate DNS | Private wildcard records on internal DNS |
+| **OpenFaaS CE in revenue workloads** | Licensing violation after 60 days | CNCF-graduated Knative or OpenFaaS Standard |
+| **Fission warm pools without budget** | Baseline RAM resembles always-on Deployments | Knative scale-to-zero with selective `minScale` |
+| **Sub-second KEDA polling on huge Kafka** | API server/etcd load spikes | 30s polling or webhook triggers where supported |
+
+Anti-patterns persist because they mirror cloud quickstarts: Istio everywhere, HPA as "autoscaling," public registries, sslip.io in production. Each shortcut saves an afternoon in the lab and costs weeks in production when bare-metal constraints surface during the first holiday traffic spike.
+
+## Decision Framework
+
+Platform architects rarely choose a single serverless product—they choose a **composition** of ingress, autoscaler, event router, and developer UX that matches their compliance, staffing, and traffic shape. The matrix and flowchart below condense weeks of architecture review into a repeatable questionnaire you can run with application teams before anyone pushes a `ksvc` to production.
+
+Use the flowchart below when choosing components for a new on-prem serverless capability, starting from the workload's trigger type and working outward to ingress and registry dependencies:
+
+```mermaid
+flowchart TD
+    Start([New workload needs scale-to-zero]) --> Q1{Trigger type?}
+    Q1 -->|HTTP request/response| Q2{Need CloudEvents routing?}
+    Q1 -->|Queue / cron / custom metric| KEDA[KEDA ScaledObject or ScaledJob]
+    Q2 -->|Yes| KE[Knative Eventing Broker + Trigger → Serving]
+    Q2 -->|No| KS[Knative Serving + Kourier/Contour]
+    KS --> Q3{Need fastest dev UX, single node?}
+    Q3 -->|Yes, edge only| OF[OpenFaaS faasd]
+    Q3 -->|No| Q4{Sub-100ms cold start mandatory?}
+    Q4 -->|Yes, security allows runtime inject| FI[Fission warm pools]
+    Q4 -->|No| KS2[Optimize image + registry path]
+    KEDA --> Q5{Workload long-running batch?}
+    Q5 -->|Yes| SJ[ScaledJob]
+    Q5 -->|No| SO[ScaledObject on Deployment]
+```
+
+| Decision | Choose Knative Serving | Choose KEDA | Choose OpenFaaS/Fission |
+| :--- | :--- | :--- | :--- |
+| HTTP API scale-to-zero | ✓ Primary | Add if metric is non-HTTP | OpenFaaS if team rejects CRDs |
+| Kafka consumer workers | Use Eventing or direct consumer | ✓ Primary | Rarely |
+| Edge single host | Overkill | Overkill | OpenFaaS faasd |
+| Strict immutable images | ✓ | ✓ | Fission risky |
+
+Walk through the flowchart with stakeholders and record the path in the ticket. If the answer is KEDA on a Deployment, you still need MetalLB and Harbor; if the answer is Knative Serving, you still need Eventing only when asynchronous fan-out is in scope. The decision framework prevents the common failure mode of installing every component "just in case" and then wondering why the cluster idles at 200 GB of control-plane RAM.
+
+HTTP-triggered synchronous APIs with unpredictable burstiness and tolerance for cold starts → Knative Serving with Kourier, local registry, and measured ingress timeouts. Long-running queue consumers with minutes-long processing → KEDA `ScaledObject` on Deployments, not Knative Serving. Scheduled batch with exit-on-complete semantics → KEDA `ScaledJob` or cron scaler. Edge single-node without Kubernetes → OpenFaaS `faasd`. Latency-sensitive internal APIs with mutable-runtime acceptance → Fission with explicit security sign-off.
+
+Revisit these decisions annually: registry latency improvements, Knative upgrades, and hardware refreshes change the answer. A workload that justified Fission warm pools at sub-100ms may become a Knative Service after GraalVM native images and Harbor pre-pull cut cold starts below your ingress timeout budget. Keep the decision log next to the version matrix so reviewers see both *what* you chose and *when* underlying infrastructure assumptions last changed.
 
 ## Common Mistakes
 
 | Mistake | Why It Happens | How to Fix It |
 | :--- | :--- | :--- |
-| **The Activator Bottleneck under burst load** | If cold start latency is high, a rapid traffic spike can exhaust the Knative Activator's memory and connection pools, leading to cascading 503 errors. | Ensure Activator deployments are scaled out and configured with appropriate resource limits in high-burst environments. |
-| **Relying on default DNS resolution for bare-metal testing** | Without cloud DNS integrators, wildcard routing fails, causing Knative services to remain entirely unreachable via standard URLs. | Deploy the `serving-default-domain.yaml` or configure a custom DomainMapping pointing directly to your Ingress IP. |
-| **Deploying Istio without mTLS needs** | Istio introduces massive control-plane overhead and proxy memory consumption, which is often overkill for pure FaaS. | Use Kourier as a lightweight alternative unless your security posture explicitly mandates Istio's advanced cross-service features. |
-| **Aggressive KEDA polling against heavy backends** | Polling a massive Kafka cluster or monolithic database every second can induce severe control-plane starvation and network congestion. | Use a minimum 30-second polling interval or leverage webhook-based scaling triggers where supported by the external system. |
-| **Overlooking OpenFaaS CE limits** | The Community Edition restricts commercial usage to 60 days, leading to potential licensing violations in production deployments. | Evaluate OpenFaaS Standard or Pro for commercial workloads, or migrate entirely to a fully open-source CNCF graduated project. |
-| **Ignoring image locality for cold starts** | Bare-metal nodes fetching multi-gigabyte container images from external registries will consistently time out the edge ingress proxy. | Implement local L2 registry mirrors, utilize daemonsets for pre-pulling base images, and eliminate sequential init containers. |
-| **Mismatched ingress timeouts** | The external LoadBalancer or edge proxy has a hard timeout that is shorter than the application's cold start time, resulting in 504 errors even if the pod eventually boots. | Align upstream ingress timeouts with the 99th percentile cold start time of your slowest serverless workload. |
-| **Ignoring metric resolution delays** | Default Prometheus scraping intervals are 15-30 seconds. Relying on external Prometheus queries for KEDA or Knative scaling artificially delays reaction time by the scrape interval. | Use dedicated, tightly polled metric adapters for scaling components rather than general-purpose cluster monitoring pipelines. |
-| **Failing to configure scale-to-zero bounds** | Workloads will scale infinitely or fail to scale down, consuming unnecessary resources or overwhelming the cluster memory. | Explicitly define the scale-to-zero configuration and establish strict maximum replica bounds in the Knative Service definition. |
-| **Deploying OpenFaaS CE air-gapped** | The CE installation mechanism and runtime checks mandate continuous internet access, causing immediate and permanent crash loops. | Transition to OpenFaaS Standard for restricted environments, or deploy an entirely air-gap compatible framework. |
-| **Abrupt pod termination during scale-down** | If a worker exits before acknowledging a queue message, the message returns to the queue, triggering an endless scale-up loop. | Implement robust SIGTERM handlers for graceful shutdown, and ensure `minReplicaCount: 1` if graceful shutdown cannot guarantee completion. |
+| **Activator bottleneck under burst load** | Traffic routes to Activator at zero replicas; connection pools exhaust before pods become ready. | Scale Activator replicas and raise resource limits; consider `minScale: 1` for burst-prone Services. |
+| **Missing DNS for bare-metal ingress** | Teams assume cloud DNS integrators; wildcard routes fail and Services look "ready" but are unreachable. | Configure `serving-default-domain` for labs or corporate wildcard DNS + DomainMapping for production. |
+| **Istio without mTLS requirements** | Copy-paste cloud reference architectures onto lean bare-metal clusters. | Default to Kourier; adopt Istio only when mesh policies are mandatory. |
+| **Aggressive KEDA polling or slow Prometheus scrapes** | Sub-second polling starves etcd; 30s Prometheus scrapes delay scale-out. | Use ≥30s polling defaults; dedicate low-latency metric paths for autoscaling, not generic monitoring. |
+| **OpenFaaS CE in production or air-gap** | CE licensing and online validation checks are easy to overlook. | Use OpenFaaS Standard in restricted/commercial environments or migrate to Knative. |
+| **Remote registry pulls during cold start** | Multi-GB images over WAN exceed ingress timeouts. | Local Harbor mirrors, pre-pull DaemonSets, eliminate init containers. |
+| **Ingress timeout shorter than cold start** | Edge proxy returns `504` while Activator still buffers. | Set ingress/proxy timeouts to the p99 cold-start duration of your slowest runtime. |
+| **Abrupt scale-down on queue workers** | SIGTERM without drain requeues messages and causes scale thrash. | Implement graceful shutdown handlers; keep `minReplicaCount: 1` if ack guarantees are impossible. |
+
+## Quiz
+
+<details>
+<summary><b>Question 1: The Activator Bottleneck</b></summary>
+<b>Scenario:</b> You deploy a Knative Service configured to scale to zero. During a load test, the service scales down to zero after the test ends. You then trigger a sudden spike of tens of thousands of requests. You observe memory usage spike dangerously, followed by cascading 503 errors before application pods become ready. Which component is most likely under-provisioned?
+<br><br>
+<b>Options:</b><br>
+A) The Istio Ingress Gateway, because it cannot route traffic to zero pods.<br>
+B) The Knative Autoscaler, because it fails to calculate metrics fast enough.<br>
+C) The Knative Activator, because it exhausts its connection pool buffering the traffic spike.<br>
+D) The queue-proxy sidecar, because it cannot enforce concurrency limits during boot.
+<br><br>
+<b>Correct Answer: C</b>
+<br><br>
+<b>Explanation:</b> At zero replicas, all traffic flows through the Activator, which buffers TCP connections while KPA scales the Deployment. Massive bursts can exhaust Activator memory and connection tables before pods pass readiness, producing 503 errors unrelated to application code. Scale Activator deployments and set realistic `minScale` annotations for burst-prone Services. Istio is not required for this data path when using Kourier.
+</details>
+
+<details>
+<summary><b>Question 2: Legacy Subresource Scaling</b></summary>
+<b>Scenario:</b> You implement event-driven architecture with a legacy application deployed via a proprietary Kubernetes operator. A developer proposes KEDA to scale this custom resource based on Kafka topic lag. What technical requirement must be met?
+<br><br>
+<b>Options:</b><br>
+A) The custom resource must implement the Knative queue-proxy sidecar.<br>
+B) The custom resource must expose the Kubernetes `/scale` subresource.<br>
+C) The custom resource must run strictly as a StatefulSet.<br>
+D) The custom resource must bypass the HPA entirely.
+<br><br>
+<b>Correct Answer: B</b>
+<br><br>
+<b>Explanation:</b> KEDA scales Deployments and StatefulSets natively and can scale custom resources only when they expose the standard `/scale` subresource. Without that API surface, KEDA cannot set desired replica counts. Extend the operator or front the workload with a Deployment ScaledObject instead of patching proprietary CRDs.
+</details>
+
+<details>
+<summary><b>Question 3: Comparing Serverless Platforms on Premises</b></summary>
+<b>Scenario:</b> A platform architect must compare architectural trade-offs between full serverless platforms (Knative) and lightweight FaaS frameworks (OpenFaaS CE) for an air-gapped bare-metal facility. OpenFaaS CE core services enter endless crash loops after install. What fundamental difference explains this failure mode?
+<br><br>
+<b>Options:</b><br>
+A) OpenFaaS CE requires continuous internet access for validation and assets.<br>
+B) OpenFaaS CE lacks support for strict mTLS encryption.<br>
+C) OpenFaaS CE cannot run on bare-metal nodes, only cloud VMs.<br>
+D) OpenFaaS CE requires a minimum of 50 compute nodes to initialize.
+<br><br>
+<b>Correct Answer: A</b>
+<br><br>
+<b>Explanation:</b> OpenFaaS CE expects internet connectivity for licensing validation and remote assets. Air-gapped environments should use OpenFaaS Standard or a fully offline CNCF stack like Knative with local registries. CE crash loops in disconnected datacenters are a documented deployment mismatch, not a Kubernetes bug.
+</details>
+
+<details>
+<summary><b>Question 4: Asynchronous Processing Pipeline</b></summary>
+<b>Scenario:</b> PDF uploads land on object storage and enqueue Kafka messages. Processing takes 4–5 minutes of heavy CPU. Workers should scale to zero when the topic is empty. Which approach fits bare-metal Kubernetes best?
+<br><br>
+<b>Options:</b><br>
+A) Knative Serving with a Kafka ingress adapter.<br>
+B) KEDA scaling a Deployment based on Kafka lag.<br>
+C) OpenFaaS synchronous API gateway.<br>
+D) Fission pre-warmed environment pods.
+<br><br>
+<b>Correct Answer: B</b>
+<br><br>
+<b>Explanation:</b> Long-running, queue-driven CPU work maps cleanly to a standard Deployment scaled by KEDA's Kafka scaler with `minReplicaCount: 0`. Knative Serving optimizes HTTP request lifetimes, not multi-minute batch jobs. HTTP gateways time out long before PDF rendering completes unless you add unnecessary complexity.
+</details>
+
+<details>
+<summary><b>Question 5: Knative Component Isolation</b></summary>
+<b>Scenario:</b> A financial institution wants Knative scale-to-zero HTTP but forbids unapproved message brokers inside the cluster. How should the platform team install Knative?
+<br><br>
+<b>Options:</b><br>
+A) They cannot proceed; Knative requires all components simultaneously.<br>
+B) Install Knative Serving independently of Knative Eventing.<br>
+C) Install Eventing but disable the Broker via a custom admission controller.<br>
+D) Use KEDA instead because Knative cannot function without Eventing.
+<br><br>
+<b>Correct Answer: B</b>
+<br><br>
+<b>Explanation:</b> Knative Serving and Eventing are independent install units. Teams may deploy Serving alone for HTTP autoscaling while omitting Eventing until messaging infrastructure is approved. KEDA addresses different scaling signals and does not replace Serving's Activator/KPA HTTP path.
+</details>
+
+<details>
+<summary><b>Question 6: Fission Cold Start Optimization</b></summary>
+<b>Scenario:</b> After deploying Fission for a Python API, security flags containers whose image hashes do not match CI-built images. What Fission mechanism explains the discrepancy?
+<br><br>
+<b>Options:</b><br>
+A) Fission compiles Python into a statically linked binary at runtime.<br>
+B) Fission bypasses the container runtime and runs functions on the host.<br>
+C) Fission injects function code dynamically into pre-warmed environment containers.<br>
+D) Fission downloads code from an external Git repository on every start.
+<br><br>
+<b>Correct Answer: C</b>
+<br><br>
+<b>Explanation:</b> Fission trades immutable images for speed by injecting source into warm environment containers at request time. Runtime disk and memory differ from the registry image hash, breaking supply-chain scanners. Regulated environments often prefer Knative with fully baked images despite slower cold starts.
+</details>
+
+<details>
+<summary><b>Question 7: Initial Request Routing</b></summary>
+<b>Scenario:</b> A developer curls the ClusterIP of a Knative Service scaled to zero and receives immediate "Connection Refused." Why did Knative not buffer the request?
+<br><br>
+<b>Options:</b><br>
+A) They bypassed the Activator, which holds connections only on the ingress route at zero replicas.<br>
+B) The Autoscaler only monitors queue-proxy metrics on running pods.<br>
+C) Istio Ingress is strictly required to buffer cold-start traffic.<br>
+D) Knative Services cannot be addressed via ClusterIP.
+<br><br>
+<b>Correct Answer: A</b>
+<br><br>
+<b>Explanation:</b> At zero replicas the Route targets Activator endpoints, not application pods. Direct ClusterIP curls skip Activator buffering and hit Services with no backends. Always test cold starts through the public ingress hostname that Knative assigns, not pod IPs.
+</details>
+
+<details>
+<summary><b>Question 8: Runtime Cold Start Risks</b></summary>
+<b>Scenario:</b> You migrate synchronous HTTP microservices to Knative Serving on bare metal with unpredictable traffic. Which runtime presents the highest cold-start operational risk?
+<br><br>
+<b>Options:</b><br>
+A) Go (statically compiled).<br>
+B) Rust (compiled).<br>
+C) Node.js (Express).<br>
+D) Java (Spring Boot, JVM warmup).
+<br><br>
+<b>Correct Answer: D</b>
+<br><br>
+<b>Explanation:</b> JVM + Spring Boot cold starts routinely reach tens of seconds on bare metal, forcing Activator buffering and ingress timeouts. Go and Rust often start in milliseconds; Node.js sits between. Measure p99 cold-start latency per runtime before promising scale-to-zero SLAs to application teams.
+</details>
 
 ## Hands-on Lab
 
-This comprehensive lab walks through deploying Knative Serving utilizing Kourier for ingress, deploying a highly optimized scale-to-zero service, and explicitly testing the autoscaler behavior on your bare-metal cluster.
+This lab deploys Knative Serving with Kourier ingress, creates a scale-to-zero Service, and validates cold-start behavior on bare metal. You need MetalLB or NodePort access per [Module 3.3](/on-premises/networking/module-3.3-load-balancing/). The exercise mirrors what platform teams run before handing a serverless namespace to application developers: prove ingress, DNS, autoscaling, and cold-start buffering work end-to-end on owned hardware rather than assuming cloud load balancers will appear automatically.
 
 ### Prerequisites
-*   A running Kubernetes cluster.
+
+*   A running Kubernetes 1.35-compatible cluster.
 *   `kubectl` configured with administrative access.
-*   The cluster must be capable of allocating `LoadBalancer` IPs (e.g., via MetalLB) or you must access services via `NodePort`.
+*   The cluster must allocate `LoadBalancer` IPs (MetalLB) or you must use `NodePort`.
 
 ### Step 1: Install Knative Serving CRDs and Core Components
 
-You must first install the foundational Knative Serving components directly from the official release artifacts.
+Apply the Knative Serving CRDs and core control-plane manifests from the official v1.22.1 release artifacts; this creates the activator, autoscaler, controller, and webhook Deployments in `knative-serving`. After a short reconciliation window, confirm all four pods report `Running` with `kubectl get pods -n knative-serving` before proceeding, because later ingress steps will fail silently if the webhook is not ready to admit `Service` resources.
 
 ```bash
-kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.14.0/serving-crds.yaml
-kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.14.0/serving-core.yaml
-```
-
-**Verification:**
-Wait a few moments, then verify the core components are actively running.
-```bash
+kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.22.1/serving-crds.yaml
+kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.22.1/serving-core.yaml
 kubectl get pods -n knative-serving
 # Expected: activator, autoscaler, controller, webhook are Running.
 ```
 
 ### Step 2: Install Kourier Networking Layer
 
-Kourier acts as the incredibly lightweight ingress gateway for Knative, perfectly suited for bare metal.
+Install Kourier as the Knative ingress class and patch `config-network` so Serving routes through `kourier.ingress.networking.knative.dev` rather than a heavier mesh. On bare metal, watch the `kourier` Service in `kourier-system` until MetalLB assigns an `EXTERNAL-IP`; capture that address into `INGRESS_HOST` because every subsequent DNS hostname embeds it.
 
 ```bash
-kubectl apply -f https://github.com/knative/net-kourier/releases/download/knative-v1.14.0/kourier.yaml
+kubectl apply -f https://github.com/knative-extensions/net-kourier/releases/download/knative-v1.22.1/kourier.yaml
 kubectl patch configmap/config-network \
   --namespace knative-serving \
   --type merge \
   --patch '{"data":{"ingress-class":"kourier.ingress.networking.knative.dev"}}'
-```
-
-**Verification:**
-Ensure the Kourier service has successfully acquired an IP.
-```bash
 kubectl get svc kourier -n kourier-system
-# Expected: A LoadBalancer service with an external IP or pending state.
-```
-
-Capture the External IP or NodePort. If using MetalLB, it will assign a routable IP. For the purposes of this lab execution, assume MetalLB assigned the IP `192.168.100.50`.
-
-```bash
 export INGRESS_HOST=$(kubectl -n kourier-system get svc kourier -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 ```
 
 ### Step 3: Configure DNS Magic (sslip.io)
 
-For lab environments, you must configure Knative to utilize a magic DNS service. This ensures that Services get automatically resolvable URLs based on the Ingress IP without requiring manual DNS configuration.
+Enable Knative's default domain integration so each `ksvc` receives a resolvable `*.sslip.io` hostname for lab use; production clusters should replace this pattern with internal wildcard DNS, but sslip.io removes manual record creation while you validate MetalLB and Kourier.
 
 ```bash
-kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.14.0/serving-default-domain.yaml
+kubectl apply -f https://github.com/knative/serving/releases/download/knative-v1.22.1/serving-default-domain.yaml
 ```
 
 ### Step 4: Deploy a Knative Service
 
-Create and deploy a highly responsive Knative Service utilizing a pre-built Go binary image.
+Deploy the upstream `helloworld-go` sample as a Knative Service and confirm `kubectl get ksvc hello` shows `READY True` with a URL containing your ingress IP, which proves the full Revision → Route → Kourier → MetalLB chain is wired correctly.
 
 ```bash
 cat <<EOF | kubectl apply -f -
@@ -313,217 +574,47 @@ spec:
             - name: TARGET
               value: "Bare Metal"
 EOF
-```
-
-**Verification:**
-Check the status of your newly deployed Knative Service (ksvc).
-```bash
 kubectl get ksvc hello
-# Expected:
-# NAME    URL                                      LATESTCREATED   LATESTREADY     READY   REASON
-# hello   http://hello.default.192.168.100.50.sslip.io   hello-00001     hello-00001     True
+# Expected URL like http://hello.default.<INGRESS_HOST>.sslip.io
 ```
 
 ### Step 5: Test Scale-to-Zero and Cold Start
 
-Wait approximately 60 seconds without sending any traffic to the service. Observe the Pods in the default namespace.
+After roughly sixty seconds of idle time, verify application pods disappear while the `ksvc` remains `Ready`, then curl the public ingress URL—not the ClusterIP—to observe the Activator buffering a cold start before a single pod returns.
 
 ```bash
 kubectl get pods
-# Expected: No pods found in default namespace. The service has scaled to zero.
-```
-
-Trigger a massive cold start by issuing a direct HTTP request. The request will hang momentarily while the Knative Activator buffers the connection and the cluster aggressively spins up the pod.
-
-```bash
 curl http://hello.default.${INGRESS_HOST}.sslip.io
-# Expected Output (after a slight delay): Hello Bare Metal!
-```
-
-Check the pods immediately after the request completes:
-
-```bash
 kubectl get pods
-# Expected: One pod running.
+# Expected: no pods while idle; one pod after curl completes.
 ```
 
 **Lab Success Checklist:**
 - [ ] Knative Serving core components deployed successfully.
-- [ ] Kourier networking layer configured and actively routing traffic.
-- [ ] Magic DNS correctly resolving directly to the LoadBalancer IP.
-- [ ] Hello-world service deployed, reachable, and returning the expected payload.
-- [ ] Service successfully scales back down to zero after a period of inactivity.
-
-## Quiz
-
-<details>
-<summary><b>Question 1: The Activator Bottleneck</b></summary>
-<b>Scenario:</b> You deploy a Knative Service configured to scale to zero. During a load test, the service scales down to zero after the test ends. You then trigger a sudden, massive spike of tens of thousands of requests. You observe the cluster's memory usage spike dangerously, followed by cascading 503 errors before any application pods become ready. Which component is most likely under-provisioned and failing under the sudden load?
-<br><br>
-<b>Options:</b><br>
-A) The Istio Ingress Gateway, because it cannot route traffic to zero pods.<br>
-B) The Knative Autoscaler, because it fails to calculate metrics fast enough.<br>
-C) The Knative Activator, because it exhausts its connection pool buffering the massive traffic spike.<br>
-D) The queue-proxy sidecar, because it cannot enforce concurrency limits during boot.
-<br><br>
-<b>Correct Answer: C</b>
-<br><br>
-<b>Explanation:</b> When a Knative service is scaled to zero, all incoming traffic is routed directly to the Activator. The Activator's job is to hold those TCP connections open while it waits for the Autoscaler to spin up new pods. If an incredibly massive spike hits while the service is at zero, the Activator will quickly exhaust its internal connection pools and memory buffers, resulting in cascading 503 errors before the application pods ever get a chance to start. You must provision the Activator appropriately for your expected burst traffic.
-</details>
-
-<details>
-<summary><b>Question 2: Legacy Subresource Scaling</b></summary>
-<b>Scenario:</b> You are implementing an event-driven architecture with an internal, legacy application deployed via a custom, proprietary Kubernetes operator. A developer proposes using KEDA to scale this custom resource based on the depth of an external Kafka topic. What technical requirement must be met for this to succeed?
-<br><br>
-<b>Options:</b><br>
-A) The custom resource must implement the Knative queue-proxy sidecar.<br>
-B) The custom resource must expose the Kubernetes `/scale` subresource.<br>
-C) The custom resource must run strictly as a StatefulSet.<br>
-D) The custom resource must bypass the HPA entirely.
-<br><br>
-<b>Correct Answer: B</b>
-<br><br>
-<b>Explanation:</b> KEDA supports scaling standard Kubernetes Deployments and StatefulSets out of the box. However, it can also scale any custom resource provided that the resource explicitly exposes the standard Kubernetes `/scale` subresource. If the proprietary operator does not implement this subresource, KEDA has no standardized API mechanism to instruct the resource to increase or decrease its replica count. Therefore, you would need to either implement the subresource in the operator or build a custom proxy scaling mechanism.
-</details>
-
-<details>
-<summary><b>Question 3: OpenFaaS Deployment Environments</b></summary>
-<b>Scenario:</b> A defense contractor attempts to deploy OpenFaaS Community Edition into a highly secure, completely air-gapped bare-metal facility. The deployment fails continuously, with core services entering endless crash loops. What is the fundamental architectural reason for this failure?
-<br><br>
-<b>Options:</b><br>
-A) OpenFaaS CE requires a Kubernetes cluster with full internet access continuously.<br>
-B) OpenFaaS CE lacks support for strict mTLS encryption.<br>
-C) OpenFaaS CE cannot run on bare-metal nodes, only cloud provider VMs.<br>
-D) OpenFaaS CE requires a minimum of 50 compute nodes to initialize.
-<br><br>
-<b>Correct Answer: A</b>
-<br><br>
-<b>Explanation:</b> OpenFaaS Community Edition is explicitly designed for personal and non-production environments with internet connectivity. It requires a Kubernetes cluster with full internet access continuously to validate licensing, fetch updates, and pull specific remote assets. For air-gapped or heavily restricted environments, the official documentation states that these are a better fit for OpenFaaS Standard, which is designed to operate seamlessly without external connectivity. Attempting to bypass these requirements with CE will result in crash loops as the validation checks inevitably fail.
-</details>
-
-<details>
-<summary><b>Question 4: Asynchronous Processing Pipeline</b></summary>
-<b>Scenario:</b> You are designing an asynchronous document processing pipeline. PDF uploads are saved to an S3-compatible store, which places a message on a Kafka topic. Processing a single PDF takes 4-5 minutes and consumes heavy CPU. You want the processing workers to scale down to zero when no documents are queued. Which architectural approach is best suited for this bare-metal Kubernetes environment?
-<br><br>
-<b>Options:</b><br>
-A) Knative Serving, utilizing the Kafka ingress adapter.<br>
-B) KEDA, scaling a standard Kubernetes Deployment based on Kafka topic lag.<br>
-C) OpenFaaS, using the synchronous API gateway.<br>
-D) Fission, utilizing pre-warmed environment pods.
-<br><br>
-<b>Correct Answer: B</b>
-<br><br>
-<b>Explanation:</b> KEDA scaling a standard Kubernetes Deployment is best suited for asynchronous, long-running processes (like a 4-5 minute PDF processor) triggered by a message queue. KEDA acts as an intelligent bridge, monitoring the Kafka topic depth and waking up the Deployment from zero replicas only when work arrives. Once active, the application processes the heavy payload at its own pace without worrying about HTTP gateway timeouts. Knative Serving, OpenFaaS, and Fission are primarily designed for synchronous, short-lived HTTP request-response workloads, making them inappropriate for heavy background processing.
-</details>
-
-<details>
-<summary><b>Question 5: Single Node Edge Computing</b></summary>
-<b>Scenario:</b> A rapidly growing agricultural startup needs to deploy a serverless platform onto a single, isolated bare-metal server located in a remote farming facility. They do not have the resources or need to run a full Kubernetes cluster on this single node, but they desperately want FaaS capabilities. Which deployment architecture solves this exact problem?
-<br><br>
-<b>Options:</b><br>
-A) Knative Serving installed via operator.<br>
-B) KEDA installed with an embedded etcd instance.<br>
-C) OpenFaaS deployed as faasd on the single host.<br>
-D) Fission deployed using Minikube.
-<br><br>
-<b>Correct Answer: C</b>
-<br><br>
-<b>Explanation:</b> While most serverless frameworks require a massive Kubernetes control plane, OpenFaaS offers a unique deployment model. OpenFaaS can also be deployed as `faasd` on a single host entirely without Kubernetes. It utilizes standard `containerd` and CNI directly, providing the exact same developer API and FaaS experience without the crushing overhead of maintaining a Kubernetes cluster on a resource-constrained edge device. This ensures the edge device dedicates its limited compute cycles to executing functions rather than managing orchestration state.
-</details>
-
-<details>
-<summary><b>Question 6: Knative Component Isolation</b></summary>
-<b>Scenario:</b> A security-conscious financial institution wants to leverage Knative for its excellent request-driven scale-to-zero capabilities. However, their internal policy strictly forbids deploying any unapproved message brokers or event routing hubs within the cluster. How should the platform team approach the Knative installation?
-<br><br>
-<b>Options:</b><br>
-A) They cannot proceed; Knative requires all components to be installed simultaneously.<br>
-B) They should install Knative Serving independently of Knative Eventing.<br>
-C) They must install Eventing but disable the Broker via a custom admission controller.<br>
-D) They should use KEDA instead, as Knative cannot function without Eventing.
-<br><br>
-<b>Correct Answer: B</b>
-<br><br>
-<b>Explanation:</b> Knative is heavily modular by design. Knative Serving and Eventing can be installed completely independently of one another. The platform team can install Knative Serving to gain the advanced HTTP request-driven autoscaling and scale-to-zero capabilities, while entirely omitting the Knative Eventing components to remain compliant with their strict internal security policies. This decoupling allows organizations to adopt Knative incrementally based on their specific architectural needs.
-</details>
-
-<details>
-<summary><b>Question 7: Resource Exhaustion Failures</b></summary>
-<b>Scenario:</b> A team deploys several asynchronous workloads using Knative Serving. They notice that after a week, the bare-metal cluster is completely out of memory. Upon investigation, they discover that hundreds of Knative pods are sitting idle, having successfully spun up to process requests but never scaling back down. What critical configuration was missed?
-<br><br>
-<b>Options:</b><br>
-A) The team forgot to install KEDA alongside Knative.<br>
-B) The team failed to configure the scale-to-zero bounds in the Knative Service.<br>
-C) The underlying Kubernetes HPA was set to a minimum of 5.<br>
-D) The Kourier ingress gateway dropped the termination signals.
-<br><br>
-<b>Correct Answer: B</b>
-<br><br>
-<b>Explanation:</b> Knative Serving absolutely supports autoscaling to zero, but it allows this behavior to be strictly controlled via scale-to-zero configuration annotations on the Knative Service itself. If the team explicitly disabled this feature, or misconfigured the grace periods and bounds, the workloads will remain active indefinitely, consuming precious bare-metal resources even when totally idle. Knative's autoscaler relies on these specific settings to know when it is safe to terminate the final pod. Without proper configuration, the system defaults to maintaining at least one running instance per service revision, ultimately leading to resource exhaustion over time.
-</details>
-
-<details>
-<summary><b>Question 8: Fission Cold Start Optimization</b></summary>
-<b>Scenario:</b> A platform team implements Fission on their bare metal cluster to minimize cold start times for a high-frequency internal API. After a successful rollout, the security team flags the deployment, noting that the containers running the Python functions do not match the image hashes pushed by the CI/CD pipeline. What architectural mechanism in Fission explains this discrepancy?
-<br><br>
-<b>Options:</b><br>
-A) Fission compiles Python into a statically linked binary at runtime, changing the image hash.<br>
-B) Fission bypasses the container runtime and runs functions directly on the host.<br>
-C) Fission injects function code dynamically into pre-warmed, generic environment containers upon request.<br>
-D) Fission modifies the container's entrypoint to download code from an external git repository on every start.
-<br><br>
-<b>Correct Answer: C</b>
-<br><br>
-<b>Explanation:</b> Fission achieves sub-100ms cold starts by maintaining a pool of pre-warmed environment containers. When a request arrives, it injects the raw function code dynamically. This breaks the pattern of immutable container images, which triggers alerts in strictly governed environments because the running container no longer matches a static, scannable image hash from the registry. Security scanners expect the exact binary payload to be baked into the image at build time. Because Fission modifies the container memory and disk at runtime, standard container provenance validation fails.
-</details>
-
-<details>
-<summary><b>Question 9: Initial Request Routing</b></summary>
-<b>Scenario:</b> A developer troubleshooting cold starts on a bare-metal Knative cluster bypasses the ingress and sends an HTTP request directly to the ClusterIP of an application pod that has just been scaled to zero. The request immediately fails with 'Connection Refused' instead of pausing and completing. Why didn't Knative buffer the request and spin up a new pod?
-<br><br>
-<b>Options:</b><br>
-A) The developer bypassed the Knative Activator, which is dynamically inserted into the ingress routing table when the service scales to zero to hold connections.<br>
-B) The Knative Autoscaler only monitors requests that pass through the queue-proxy sidecar, which had already terminated.<br>
-C) The Istio Ingress Gateway is strictly required to hold connections for Knative services during cold starts.<br>
-D) Knative Services do not support ClusterIP routing and only listen on NodePort or LoadBalancer interfaces.
-<br><br>
-<b>Correct Answer: A</b>
-<br><br>
-<b>Explanation:</b> When a Knative Service is scaled to zero, the ingress routing table is updated to point to the Activator instead of non-existent application pods. The Activator is the component responsible for buffering the request and triggering the scale-up. By bypassing the ingress layer and hitting the pod IP directly, the developer bypassed the Activator entirely, resulting in an immediate connection failure. Because the target pod does not actually exist yet, the request falls into a routing black hole within the cluster network.
-</details>
-
-<details>
-<summary><b>Question 10: Runtime Cold Start Risks</b></summary>
-<b>Scenario:</b> When migrating a set of HTTP-triggered, synchronous microservices to Knative Serving on a bare-metal cluster, which language/framework combination will present the highest operational risk regarding cold start latency under unpredictable traffic patterns?
-<br><br>
-<b>Options:</b><br>
-A) Go (compiled statically).<br>
-B) Rust (compiled dynamically).<br>
-C) Node.js (Express framework).<br>
-D) Java (Spring Boot framework, JIT compiled).
-<br><br>
-<b>Correct Answer: D</b>
-<br><br>
-<b>Explanation:</b> JIT-compiled languages like Java (especially with heavy frameworks like Spring Boot) suffer from extreme cold starts due to JVM initialization and framework bootstrapping. Statically compiled languages (Go, Rust) and interpreted languages (Node.js) have significantly faster startup times, making them less risky for scale-to-zero serverless environments. The JVM requires significant CPU cycles and memory to load classes, perform bytecode verification, and compile hot paths before the application can accept its first request. In a serverless environment, this delay forces the Knative Activator to buffer incoming traffic for tens of seconds, drastically increasing the risk of dropped connections and SLA breaches.
-</details>
-
-## Further Reading
-
-*   [Knative Serving Documentation](https://knative.dev/docs/serving/)
-*   [KEDA Official Documentation](https://keda.sh/docs/)
-*   [Knative Kourier Ingress Setup](https://knative.dev/docs/install/installing-istio/#installing-kourier)
-*   [Fission Architecture Overview](https://fission.io/docs/architecture/)
-*   [CloudEvents Specification](https://cloudevents.io/)
+- [ ] Kourier networking layer configured and routing traffic.
+- [ ] Magic DNS resolving to the LoadBalancer IP.
+- [ ] Hello-world service reachable with expected payload.
+- [ ] Service scales to zero after idle period and cold-starts on demand.
 
 ## Next Module
 
-Ready to dive deeper into the operational realities of these platforms? Now that you have constructed a functional serverless environment on your bare-metal nodes, it is time to secure it. In the next module, we will explore advanced traffic management, enforcing zero-trust networking between serverless functions, and implementing mutual TLS utilizing service meshes.
+Ready to secure the serverless platform you built? The next module covers advanced traffic management, zero-trust networking between functions, and mutual TLS with service meshes so that scale-to-zero endpoints do not become unauthenticated lateral movement paths inside your bare-metal fabric.
 
 [Continue with Zero-Trust Architecture ->](/on-premises/security/module-6.8-zero-trust-architecture/)
 
 ## Sources
 
-- [Knative Project Overview](https://www.cncf.io/projects/knative/) — Best high-level source for Knative's CNCF status and major components before diving into Serving and Eventing details.
-- [KEDA Project Overview](https://www.cncf.io/projects/keda/) — Concise authoritative overview of KEDA's role as an event-driven autoscaler and its CNCF maturity.
-- [CloudEvents Core Specification](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md) — Grounds the event-format and interoperability claims behind Knative Eventing.
-- [faasd Repository](https://github.com/openfaas/faasd) — Useful for the module's single-host and edge-style alternatives to full Kubernetes-based serverless stacks.
-- [Fission Repository](https://github.com/fission/fission) — Backs the warm-pool and cold-start trade-off discussion for an alternative Kubernetes-native FaaS framework.
+- [Knative CNCF Project Page](https://www.cncf.io/projects/knative/) — Authoritative CNCF Graduated status (September 11, 2025) and component overview.
+- [KEDA CNCF Project Page](https://www.cncf.io/projects/keda/) — Graduated status (August 22, 2023) and event-driven autoscaling role.
+- [Knative Serving Documentation](https://knative.dev/docs/serving/) — Core Serving concepts, installation, and operations.
+- [Knative Eventing Documentation](https://knative.dev/docs/eventing/) — Brokers, Triggers, and event sources.
+- [Knative Concurrency and Autoscaling](https://knative.dev/docs/serving/autoscaling/concurrency/) — Soft/hard concurrency limits and target utilization.
+- [Knative net-kourier Repository](https://github.com/knative/net-kourier) — Lightweight ingress implementation for bare-metal clusters.
+- [Contour Knative Integration Guide](https://projectcontour.io/docs/main/guides/knative/) — Alternative ingress when Contour already exists.
+- [KEDA Documentation](https://keda.sh/docs/) — ScaledObject, ScaledJob, and scaler catalog.
+- [KEDA Prometheus Scaler](https://keda.sh/docs/2.20/scalers/prometheus/) — Verified PromQL trigger metadata for external metrics.
+- [MetalLB Project Site](https://metallb.io/) — Bare-metal LoadBalancer implementation required for Knative VIPs.
+- [CloudEvents Specification](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md) — Event envelope standard used by Knative Eventing.
+- [OpenFaaS Documentation](https://www.openfaas.com/) — Licensing, deployment models, and faasd edge option.
+- [Fission Architecture](https://fission.io/docs/architecture/) — Warm-pool design and component responsibilities.
+- [Kubernetes Forensic Container Checkpointing](https://kubernetes.io/blog/2022/12/05/forensic-container-checkpointing-alpha/) — CRIU-based checkpoint/restore maturity through Kubernetes 1.35.


### PR DESCRIPTION
## On-premises Wave 4 batch 3 (#1881) — final 3 operations modules

Completes the on-premises **operations (7.x)** chapter. Cross-family reviewed, every finding ground-checked against the live file and web-verified.

| Module | Work | Author | Reviewer | Verdict |
|---|---|---|---|---|
| **7.4** observability | review-flip (already T0/5040w) | — | opus 4.8 | APPROVE_WITH_NITS → illustrative TLS caveats applied |
| **7.7** self-hosted-registry | expand 2098→**5159w** + structural rebuild | codex gpt-5.5 | cursor composer-2.5 | NEEDS_CHANGES → fixed |
| **7.9** serverless-bare-metal | expand 1764→**5053w** | cursor auto | codex gpt-5.5 | NEEDS_CHANGES → fixed |

### Verifier-blind defects caught + fixed (all web-verified)
- **7.7**: cosign sign/verify missing `--allow-http-registry` for the plain-HTTP Harbor lab (Step 5 would fail); obsolete `chartmuseum`/`notary` chart stanzas (ChartMuseum removed Harbor v2.8.0, Notary deprecated v2.8); signature-storage reframed onto OCI 1.1 referrers; Docker Compose host reqs scoped to the Compose path; 1.26 in-tree cred-provider precision.
- **7.9**: CRIU checkpoint claimed "Stable in 1.32" → still **Beta as of 1.35** (KEP-2008); electricity "$200–800/yr per kW" → **~$1,200–1,900** (EIA ~14¢/kWh, dated); KEDA RabbitMQ deprecated bare `queueLength` → `mode`+`value`+host; KEDA 2.19→**2.20** (k8s 1.33–1.35); Knative lab v1.14.0→**v1.22.1** + net-kourier org move; `scale-to-zero-grace-period` semantics; CronJob "holds memory between runs" corrected.

### Gates
- All 3 `verify_module.py` **T0/passed**; build green in PRIMARY (**2171 pages**, 0 errors); no bitnami images.

Closes the operations chapter of #1881.

🤖 Generated with [Claude Code](https://claude.com/claude-code)