### PR TITLE
docs(on-premises): storage chapter — 4.1/4.2/4.4/4.5 expand+reviewed → done (#1881)

### DIFF
--- a/src/content/docs/on-premises/storage/module-4.1-storage-architecture.md
+++ b/src/content/docs/on-premises/storage/module-4.1-storage-architecture.md
@@ -1,5 +1,4 @@
 ---
-revision_pending: true
 title: "Module 4.1: Storage Architecture Decisions"
 slug: on-premises/storage/module-4.1-storage-architecture
 sidebar:
@@ -12,53 +11,110 @@ sidebar:
 
 ---
 
-## Why This Module Matters
-
-A data analytics company deployed a 40-node Kubernetes cluster on bare metal with local SATA SSDs in each server. For the first six months, everything worked. Then they deployed Apache Kafka, which needed persistent storage that survived node rescheduling. When a worker node failed, Kafka brokers were rescheduled to new nodes — but their data was on the dead node's local SSDs. They lost 4 hours of event data and spent 3 days manually rebalancing partitions.
-
-They then deployed Ceph via Rook on the same SSDs. Performance dropped 60%. A default three-replica pool (`osd_pool_default_size = 3`) can add significant write amplification on drives already serving application I/O. This behavior is documented in the [default pool size](https://docs.ceph.com/en/latest/rados/configuration/pool-pg-config-ref/) reference. The OSD processes competed with Kubernetes workloads for CPU and memory. Their monitoring showed that Ceph rebalancing after a node failure consumed 80% of cluster I/O bandwidth for 4 hours, making all applications sluggish.
-
-The fix was dedicating 6 servers as Ceph OSD nodes with NVMe drives, separated from the Kubernetes worker nodes. Storage traffic ran on a dedicated VLAN with jumbo frames. The lesson: **storage architecture decisions must be made before you buy hardware, not after you deploy workloads.**
-
----
-
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
-1. **Design** storage architectures that separate compute and storage tiers with dedicated networks and hardware
-2. **Evaluate** distributed storage (Ceph, Longhorn) vs. local storage vs. external SAN/NAS for specific workload requirements
-3. **Plan** storage hardware procurement including drive types (NVMe, SSD, HDD), RAID configurations, and capacity projections
-4. **Diagnose** storage performance bottlenecks caused by I/O contention, replication overhead, and network saturation
+1. **Classify** workloads by storage type (block, file, object) and Kubernetes access mode (RWO, ROX, RWX, RWOP), then map each to an appropriate on-premises backend
+2. **Design** storage architectures that separate compute and storage tiers with dedicated networks, failure domains, and hardware matched to workload latency requirements
+3. **Evaluate** distributed storage (Ceph/Rook, Longhorn, OpenEBS Mayastor) versus node-local storage (local-path, TopoLVM) versus external SAN/NAS for specific durability and performance contracts
+4. **Plan** storage hardware procurement including drive tiers (NVMe, SSD, HDD), replication overhead, RAID boundaries, and capacity projections with a defensible TCO model
+5. **Diagnose** storage performance bottlenecks caused by I/O contention, replication amplification on the datacenter fabric, and topology mismatches between pods and volumes
+
+---
+
+## Why This Module Matters
+
+Hypothetical scenario: a data analytics company deploys a Kubernetes cluster on bare metal with local SATA SSDs in each server. For the first few months everything works. Then they deploy Apache Kafka, which needs persistent storage that survives node rescheduling. When a worker node fails, the Kafka brokers are rescheduled onto healthy nodes — but their data was on the dead node's local SSDs. They lose the most recent event data and spend days manually rebalancing partitions to recover.
+
+They then deploy Ceph via Rook on the same SSDs, and write performance falls sharply. A default three-replica pool (`osd_pool_default_size = 3`) adds significant write amplification on drives already serving application I/O — behavior documented in the [default pool size](https://docs.ceph.com/en/latest/rados/configuration/pool-pg-config-ref/) reference. The OSD processes compete with the Kubernetes workloads for CPU and memory, and Ceph rebalancing after a node failure consumes a large share of cluster I/O bandwidth, leaving every application sluggish until recovery completes.
+
+The fix is to dedicate a set of servers as Ceph OSD nodes with NVMe drives, separated from the Kubernetes worker nodes, with storage traffic carried on a dedicated VLAN with jumbo frames. The lesson: **storage architecture decisions must be made before you buy hardware, not after you deploy workloads.** On bare metal you own every tradeoff — latency, replication, rack power, depreciation, and the network tax when writes fan out across the fabric — and Kubernetes exposes those tradeoffs through CSI, StorageClasses, and scheduling rather than hiding them behind a cloud control plane.
 
 ---
 
 ## What You'll Learn
 
-- Direct-Attached Storage (DAS) vs Network-Attached Storage (NAS) vs SAN
-- NVMe vs SSD vs HDD tiering for Kubernetes workloads
-- etcd storage requirements (the most demanding component)
-- When to use local storage vs distributed storage
-- Dedicated storage nodes vs hyper-converged (storage on worker nodes)
-- IOPS, throughput, and latency benchmarking
-- PersistentVolume access modes including RWOP (ReadWriteOncePod), CSI migrations, and modern K8s storage APIs like VolumeAttributesClass and OCI image volumes
+- Block, file, and object storage taxonomy and how Kubernetes access modes constrain backend choice
+- The CSI driver model (controller, node, attacher) and the PV/PVC/StorageClass lifecycle on Kubernetes 1.35
+- Node-local versus distributed storage on owned hardware, including TopoLVM, local-path-provisioner, Rook-Ceph, Longhorn, and OpenEBS
+- Failure domains, data gravity, and the StatefulSet + headless Service + volumeClaimTemplates pattern
+- Performance dimensions (IOPS, throughput, latency) and the network-storage tax from replication
+- CapEx versus OpEx, replication overhead, erasure coding, and when on-premises storage beats cloud block/file/object services
 
 ---
 
-## Storage Options for On-Premises K8s
+## The Storage Taxonomy: Block, File, and Object
 
-### Modern Kubernetes Storage Architecture (v1.35+)
-As of Kubernetes v1.35, the storage landscape for on-premises clusters relies heavily on the **Container Storage Interface (CSI)** ([currently at spec v1.12.0](https://github.com/container-storage-interface/spec/releases/tag/v1.12.0)). When architecting storage, keep these native capabilities in mind:
+Before you pick a vendor or a CSI driver, you need a vocabulary that survives tool churn. Enterprise storage has always been organized around three access models. Kubernetes inherits that split through volume modes, access modes, and the capabilities each CSI driver advertises.
 
-- **CSI is Mandatory**: [In-tree plugins for storage systems like CephFS and Ceph RBD were permanently removed from the core in v1.31](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). The legacy FlexVolume API is fully deprecated. You must use CSI drivers (which have been [GA since v1.13](https://kubernetes.io/blog/2019/01/15/container-storage-interface-ga/)).
-- **Access Modes**: In addition to standard access modes (RWO, ROX, RWX), modern CSI drivers support [**ReadWriteOncePod (RWOP)** (GA in v1.29), guaranteeing that only a single Pod cluster-wide can read or write to the volume](https://kubernetes.io/docs/concepts/storage/persistent-volumes/).
-- **Volume Binding**: For bare-metal, always set your `StorageClass` (API `storage.k8s.io/v1`) to use [`volumeBindingMode: WaitForFirstConsumer`](https://kubernetes.io/docs/concepts/storage/storage-classes/). This ensures the PV is provisioned in the same availability zone as the scheduled Pod. The default is `Immediate`, which can cause topology mismatches.
-- **Volume Modes and Protection**: [Kubernetes supports `Filesystem` (default) and raw `Block` volume modes (GA since v1.18)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/). It also features built-in [Storage Object in Use Protection, preventing the deletion of PVCs and PVs actively bound or in use by a Pod](https://kubernetes.io/docs/concepts/storage/persistent-volumes/).
-- **Reclaim Policies**: [The default policy for dynamic provisioning is `Delete`. Use `Retain` if data preservation is required](https://kubernetes.io/docs/concepts/storage/storage-classes/). 
-- **Advanced Features**: Newer stable features include [Volume Expansion (GA in v1.24)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/), [CSI Storage Capacity Tracking (GA in v1.24)](https://kubernetes.io/docs/concepts/storage/storage-capacity/), [Generic Ephemeral Volumes (GA in v1.23)](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/), [Volume Snapshots (GA in v1.20)](https://kubernetes.io/blog/2020/12/10/kubernetes-1.20-volume-snapshot-moves-to-ga/), [Volume Populators (GA in v1.33)](https://kubernetes.io/blog/2025/05/08/kubernetes-v1-33-volume-populators-ga/), [VolumeAttributesClass for modifying attributes without recreation (GA in v1.34)](https://kubernetes.io/blog/2025/09/08/kubernetes-v1-34-volume-attributes-class/), and OCI image volumes (GA in v1.35). *(Note: [Volume Group Snapshots reached beta in v1.32 and second-beta in v1.34](https://v1-34.docs.kubernetes.io/blog/2025/09/16/kubernetes-v1-34-volume-group-snapshot-beta-2/) — promoted to [GA in v1.36](https://kubernetes.io/blog/2026/05/08/kubernetes-v1-36-volume-group-snapshot-ga/) — and [CSI Volume Health Monitoring is still alpha](https://kubernetes.io/docs/concepts/storage/volume-health-monitoring/)).*
-- **Cloud/Legacy Migration**: [The in-tree CSI migration framework reached GA in v1.25](https://kubernetes.io/blog/2022/09/26/storage-in-tree-to-csi-migration-status-update-1.25/), transparently redirecting legacy calls. Note that legacy cloud plugins for AWS EBS were removed entirely (unverified sources point to v1.27, but the specific removal release lacks official changelog confirmation). The `Recycle` reclaim policy is fully deprecated and unsupported by CSI (GitHub issue #59060 confirms deprecation, though the exact version—rumored to be v1.11—remains unverified in authoritative release notes).
+Block storage presents raw LUNs or logical volumes that a filesystem or database engine formats directly. File storage exposes a shared namespace through NFS, SMB, or a clustered filesystem. Object storage stores opaque blobs behind an HTTP API with rich metadata and virtually unlimited horizontal scale. None of these is universally "best." Each optimizes for a different consistency, sharing, and latency contract. On-premises clusters often run all three simultaneously on different hardware tiers.
 
-### The Three Storage Models
+Block volumes map cleanly to Kubernetes `volumeMode: Block` or the default `Filesystem` mode backed by a block device formatted inside the node. Databases that manage their own page cache and WAL — PostgreSQL, MySQL InnoDB, etcd, Kafka log segments — typically want block because they control fsync semantics and avoid double caching through the page cache plus database buffer pool. Block backends on bare metal include local NVMe via TopoLVM or OpenEBS LocalPV-LVM, Ceph RBD via [Rook](https://github.com/rook/rook) (a [CNCF Graduated](https://www.cncf.io/projects/rook/) project), Longhorn replicated volumes ([CNCF Incubating](https://www.cncf.io/projects/longhorn/)), enterprise SAN LUNs presented through a vendor CSI, and iSCSI targets. The dominant access mode is **ReadWriteOnce (RWO)**: one node mounts the volume read/write at a time, which matches a single database pod pinned to fast local or networked block.
+
+File storage serves **ReadWriteMany (RWX)** and **ReadOnlyMany (ROX)** workloads where many pods must see the same directory tree concurrently. Training pipelines that mount a shared dataset, CI artifact caches, content management static assets, and legacy applications expecting POSIX semantics fit here. On-premises file options include NFS servers (often fronted by the [NFS CSI driver](https://github.com/kubernetes-csi/csi-driver-nfs)), CephFS through Rook, enterprise NAS appliances with CSI integration, and GlusterFS-style clustered filesystems (less common on new builds). File protocols add metadata overhead and usually higher latency than local block, but they eliminate the "copy dataset to every node" problem that makes RWX impossible on pure local block without an application-level replication layer.
+
+Object storage targets backup targets, container image layers in registries, log archives, ML feature stores, and any workload that speaks S3-compatible APIs rather than POSIX. On bare metal you typically deploy [MinIO](https://min.io/docs/minio/kubernetes/upstream/index.html), Ceph RADOS Gateway, or a commercial appliance, then integrate through the [AWS S3 CSI driver](https://github.com/awslabs/mountpoint-s3-csi-driver) or application-native SDKs. Object stores optimize for throughput and durability per dollar at the cost of higher latency and no partial in-place rewrite semantics — a poor fit for database primary storage but excellent for off-cluster backup and immutable audit logs where **data gravity** (the cost of moving terabytes off-site) favors keeping cold data on owned disks rather than paying cloud egress every month.
+
+### Access Modes and What Backends Can Deliver
+
+| Access mode | Meaning | Typical backends on bare metal | Workload examples |
+|-------------|---------|-------------------------------|-------------------|
+| **RWO** | One node read/write | Local PV, Ceph RBD, Longhorn, SAN LUN | Databases, etcd, single-writer queues |
+| **ROX** | Many nodes read-only | NFS, CephFS, object + FUSE (discouraged for prod) | Config bundles, ML model weights |
+| **RWX** | Many nodes read/write | NFS, CephFS, enterprise NAS | Shared datasets, legacy POSIX apps |
+| **RWOP** | Single pod cluster-wide ([GA v1.29](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)) | CSI drivers that advertise RWOP | Safety-critical singleton writers |
+
+**ReadWriteOncePod (RWOP)** closes a subtle hole in RWO: with plain RWO, two pods on the *same* node could theoretically attach the same volume if the scheduler co-locates them. RWOP guarantees exactly one pod in the entire cluster may mount the volume, which matters for split-brain prevention when your HA logic assumes exclusive block access. Not every CSI driver implements RWOP yet; verify in the driver's capability matrix before standardizing on it for regulated workloads.
+
+> **Pause and predict**: You need storage for three workloads: (1) PostgreSQL with streaming replication, (2) a shared ML training dataset read by eight pods simultaneously, and (3) etcd. Assign each to block, file, or object storage and pick an access mode before reading the decision matrix later in this module.
+
+---
+
+## The CSI Model on Kubernetes 1.35
+
+On-premises Kubernetes removed its in-tree **Ceph** volume plugins — [CephFS and RBD were removed in v1.31](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) (deprecated back in v1.28). The in-tree `nfs` and `iscsi` PersistentVolume plugins still exist, but they are legacy: every production storage integration should route through the [Container Storage Interface (CSI)](https://github.com/container-storage-interface/spec/releases/tag/v1.12.0), which is where dynamic provisioning, snapshots, and volume expansion actually live. CSI has been [GA since v1.13](https://kubernetes.io/blog/2019/01/15/container-storage-interface-ga/). Understanding CSI is the durable spine of storage architecture. The vendor ships a containerized plugin. Kubernetes orchestrates it. Your StorageClass names the provisioner. Workloads stay ignorant of whether bits live on local NVMe or a three-datacenter Ceph cluster.
+
+A typical CSI deployment splits into three cooperating binaries. The **controller plugin** (often deployed as a Deployment) implements `CreateVolume`, `DeleteVolume`, `ControllerPublishVolume`, snapshots, and expansion — operations that do not require code running on the worker where the pod will land. The **node plugin** (DaemonSet on every worker) implements `NodeStageVolume`, `NodePublishVolume`, and mount operations against the host's device namespace. Some drivers add a separate **CSI attacher** sidecar that watches `VolumeAttachment` objects and calls `ControllerPublishVolume` so the block device is exported to the correct node before kubelet mounts it. The sidecar containers (`external-provisioner`, `external-attacher`, `external-resizer`, `snapshot-controller`) are maintained by the Kubernetes SIG Storage community and ship as standard patterns in Helm charts for Rook, Longhorn, TopoLVM, and others.
+
+The workload-facing lifecycle begins with a **PersistentVolumeClaim (PVC)** that names a **StorageClass**. When dynamic provisioning is enabled, the external-provisioner watches unbound PVCs, calls `CreateVolume` on the CSI driver, and creates a **PersistentVolume (PV)** object that binds to the claim. For bare metal, set [`volumeBindingMode: WaitForFirstConsumer`](https://kubernetes.io/docs/concepts/storage/storage-classes/) on every StorageClass where topology matters: the scheduler picks a node first, then provisioning happens in that failure domain. The default `Immediate` mode creates a PV before scheduling, which routinely strands volumes in the wrong rack or on a node pool that your pod cannot use — a classic source of Pending pods that look like "scheduler bugs" but are storage topology mismatches.
+
+**Static provisioning** still appears in regulated environments: storage admins pre-create PVs pointing at known LUNs or NFS exports, and developers claim them with PVCs. Static PVs trade agility for auditability. **Reclaim policies** matter on owned hardware: `Delete` returns capacity to the pool when the PVC disappears; `Retain` leaves the backing volume intact for forensic recovery or manual reattachment — common with SAN LUNs where deleting the wrong LUN is irreversible. The deprecated `Recycle` policy is unsupported under CSI.
+
+Advanced lifecycle features you should plan for at architecture time — not bolt on after production traffic — include [volume expansion (GA v1.24)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/), [VolumeSnapshots and VolumeSnapshotClass (GA v1.20)](https://kubernetes.io/blog/2020/12/10/kubernetes-1.20-volume-snapshot-moves-to-ga/), [CSI storage capacity tracking (GA v1.24)](https://kubernetes.io/docs/concepts/storage/storage-capacity/) so the scheduler sees free space per topology domain, [generic ephemeral volumes (GA v1.23)](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/) for scratch space tied to pod lifetime, [VolumeAttributesClass (GA v1.34)](https://kubernetes.io/blog/2025/09/08/kubernetes-v1-34-volume-attributes-class/) for mutating performance tiers without recreating claims, and [Volume Populators (GA v1.33)](https://kubernetes.io/blog/2025/05/08/kubernetes-v1-33-volume-populators-ga/) to hydrate PVCs from snapshots or backups. [Volume group snapshots](https://kubernetes.io/blog/2026/05/08/kubernetes-v1-36-volume-group-snapshot-ga/) reached GA in v1.36 for crash-consistent multi-volume capture; [CSI volume health monitoring](https://kubernetes.io/docs/concepts/storage/volume-health-monitoring/) remains alpha — useful on bare metal where you cannot rely on a cloud provider to preemptively migrate off failing disks.
+
+```yaml
+# StorageClass shape most on-prem clusters should standardize on
+apiVersion: storage.k8s.io/v1
+kind: StorageClass
+metadata:
+  name: topolvm-nvme
+provisioner: topolvm.io
+parameters:
+  topolvm.io/device-class: "nvme"
+volumeBindingMode: WaitForFirstConsumer
+allowVolumeExpansion: true
+reclaimPolicy: Delete
+```
+
+---
+
+## Modern Kubernetes Storage Architecture (v1.35+)
+
+As of Kubernetes v1.35, the storage landscape for on-premises clusters relies heavily on CSI. When architecting storage, keep these native capabilities in mind alongside whatever vendor or open-source backend you deploy:
+
+- **CSI is mandatory** for new integrations; legacy FlexVolume and in-tree cloud plugins are removed or deprecated.
+- **Access modes** include RWOP for strict single-pod attachment cluster-wide.
+- **Volume binding** should default to `WaitForFirstConsumer` for topology-aware bare-metal pools.
+- **Volume modes** support raw block in addition to filesystem ([GA since v1.18](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)).
+- **Storage Object in Use Protection** prevents deleting PVCs/PVs actively bound to running pods.
+- **In-tree to CSI migration** reached [GA in v1.25](https://kubernetes.io/blog/2022/09/26/storage-in-tree-to-csi-migration-status-update-1.25/) for clusters still transitioning legacy manifests.
+
+The list above is not a shopping checklist — it is the contract your platform team must map to concrete StorageClasses, backup runbooks, and monitoring dashboards before stateful applications land on the cluster.
+
+---
+
+## The Three Storage Models (DAS, NAS, SDS)
 
 ```mermaid
 flowchart TD
@@ -84,63 +140,110 @@ flowchart TD
     end
 ```
 
-**DAS (Direct-Attached Storage)**
-- **Pros:** Lowest latency (no network hop), highest IOPS (direct PCIe).
-- **Cons:** Data lost if node fails (no replication), cannot move PVs between nodes.
-- **Best for:** etcd, databases with app-level replication.
+**DAS (Direct-Attached Storage)** keeps bits on drives inside or directly cabled to the worker. **Pros:** lowest latency (no network hop), highest IOPS (PCIe/NVMe path), predictable performance without replication tax. **Cons:** data is lost or stranded when the node dies unless the application or an external system replicates it; PVs do not float to another node. **Best for:** etcd, databases with built-in replication (PostgreSQL streaming replicas, CockroachDB, Kafka with [broker-level replication](https://kafka.apache.org/documentation/#replication)), and any workload where you deliberately accept node affinity in exchange for microseconds of latency.
 
-**NAS (Network-Attached Storage)**
-- **Pros:** Shared access (ReadWriteMany), simple to set up (NFS CSI driver).
-- **Cons:** Higher latency (network + file protocol overhead), single point of failure (unless HA NFS).
-- **Best for:** Shared data, ML datasets, media files.
+**NAS (Network-Attached Storage)** centralizes files behind NFS, SMB, or a clustered POSIX layer. **Pros:** natural RWX, familiar ops model, easy capacity expansion independent of worker count. **Cons:** higher latency, metadata bottlenecks on small files, single-server NFS is a failure domain unless you engineer HA pairs and floating IPs. **Best for:** shared ML datasets, CI artifacts, static content, and legacy apps that require POSIX over the network.
 
-**SDS/SAN (Software-Defined / Storage Area Network)** (e.g., Ceph, Longhorn)
-- **Pros:** Replicated (survives node failures), PVs can be accessed from any node, self-healing (auto-rebalances).
-- **Cons:** Higher latency than DAS (network + replication), requires dedicated storage nodes (or hyper-converged).
-- **Best for:** General-purpose PVs, databases without replication.
-
-> **Pause and predict**: You need to provide storage for three workloads: (1) PostgreSQL with streaming replication, (2) a shared ML training dataset read by 8 pods simultaneously, and (3) etcd. Before looking at the decision matrix below, assign each workload to DAS, NAS, or SDS and explain your reasoning.
-
-### Decision Matrix
-
-| Workload | Storage Type | Why |
-|----------|-------------|-----|
-| **etcd** | DAS (NVMe) | Requires <10ms p99 fsync; network storage too slow |
-| **PostgreSQL** (with streaming replication) | DAS (NVMe) | App handles replication; local NVMe gives best latency |
-| **PostgreSQL** (single instance) | Ceph RBD | Needs to survive node failure; no app-level replication |
-| **Kafka** | DAS or Ceph | [Kafka replicates data](https://kafka.apache.org/documentation/#replication); DAS is faster but Ceph is safer |
-| **Prometheus TSDB** | DAS (NVMe) | Write-heavy, latency-sensitive; Thanos handles replication |
-| **ML training data** | NFS / CephFS | Large datasets, read-heavy, shared access needed |
-| **CI/CD workspace** | DAS (SSD) | Ephemeral, high IOPS for builds, data is disposable |
-| **Container images** | Ceph RBD or NFS | Harbor/registry storage, moderate IOPS, shared access |
-| **Backup targets** | NFS / HDD | Large capacity, low IOPS, cost-optimized |
+**SDS/SAN (Software-Defined Storage)** — Ceph via Rook, Longhorn, OpenEBS Mayastor, Gluster, vendor SDS — presents block or file volumes replicated across failure domains. **Pros:** survives node loss transparently to the pod, enables live migration of stateful pods between workers (when combined with shared block/file semantics), self-healing background rebuild. **Cons:** every write may cross the network multiple times; recovery after disk loss consumes fabric bandwidth; operational complexity and RAM/CPU overhead for monitors and OSDs. **Best for:** general-purpose PVCs where the application does *not* already replicate, and platforms that need a single StorageClass for dozens of microservices without per-team storage silos.
 
 ---
 
-## Storage Tiers
+## Bare-Metal Storage Options and Tradeoffs
 
-| Tier | Tech | IOPS | Latency | $/TB | Use |
+On owned hardware you choose where durability lives: in the application, on the node, or in a distributed system beneath Kubernetes. The table below summarizes the backends this track covers in depth across Modules 4.2–4.4; here we focus on architectural fit rather than install commands.
+
+| Backend | Durability model | Performance profile | Ops complexity | CNCF / maturity notes |
+|---------|------------------|---------------------|----------------|----------------------|
+| **local-path-provisioner** | Node-local directory; node loss = data loss | Excellent (local disk); no quota enforcement | Minimal | Rancher project; widely used on edge/k3s |
+| **TopoLVM** | LVM LV on node; snapshots; enforced size | Excellent; scheduler-aware free space | Moderate (VG prep per node) | [CNCF-unhosted](https://github.com/topolvm/topolvm); production-grade local CSI |
+| **OpenEBS LocalPV-LVM/ZFS** | Node-local with LVM or ZFS features | Excellent; snapshots on ZFS pools | Moderate | [CNCF Sandbox](https://www.cncf.io/projects/openebs/) (accepted October 10, 2024) |
+| **Rook-Ceph** | Replication or erasure coding across OSDs | Good; network + replication tax | High | CNCF Graduated; widely used for large-scale SDS |
+| **Longhorn** | Cross-node replicated volumes | Good for small/medium clusters | Low–moderate | CNCF Incubating; fewer moving parts than Ceph |
+| **OpenEBS Mayastor** | Replicated NVMe-oriented engine | Low latency target | Moderate | Active engine within OpenEBS project |
+| **Enterprise SAN/NAS** | Vendor RAID + replication | Variable; often mature dual-controller | Contract-driven | CSI from vendor; CapEx heavy |
+| **NFS server** | Single server or HA pair | Moderate latency; RWX | Low if simple | NFS CSI; watch single-point failures |
+
+**Local PV** (local-path, TopoLVM, OpenEBS local engines) wins when the workload already implements HA — etcd members, Kafka brokers, Patroni-managed PostgreSQL — or when data is disposable (CI scratch, caches). The pod is pinned to a node through `volumeBindingMode` and node affinity; rescheduling after node failure requires restore from backup or application-level re-sync, not automatic PV migration.
+
+**Distributed storage** wins when a single-instance app must survive node loss without custom operators — internal tools running one PostgreSQL pod, legacy Java apps expecting "just mount a disk" semantics, or platforms standardizing on one replicated StorageClass for cost allocation simplicity. You pay with raw capacity (three replicas ≈ 3× usable overhead before erasure coding savings), network bandwidth during steady state and recovery, and operational headcount to keep Ceph health green.
+
+**External SAN/NAS** remains valid on bare metal when storage arrays already exist in the datacenter, finance has depreciation schedules on them, or compliance mandates dual-controller arrays with synchronous replication to a secondary site. Kubernetes consumes them through vendor CSI drivers; the architecture question is whether LUN masking, zoning, and array replication align with your pod topology and backup strategy — not whether SAN is "legacy."
+
+> **Stop and think**: A team proposes running Ceph OSD processes on the same servers as Kubernetes worker pods to save rack space. Their cluster runs web services and a latency-sensitive PostgreSQL database. What happens to PostgreSQL p99 latency when an OSD fails and Ceph begins backfill? Would your answer change at 200 nodes versus 12 nodes?
+
+---
+
+## Data Gravity, Failure Domains, and StatefulSets
+
+**Data gravity** is the observation that compute tends to move toward data, not the reverse, because moving terabytes is slower and more expensive than moving vCPU. On cloud you feel this as egress charges; on-premises you feel it as migration windows, forklift upgrades, and the political cost of asking application teams to rehydrate multi-petabyte datasets. Architecture decisions — local versus replicated, rack layout, backup target location — should assume datasets grow in place for years.
+
+**Failure domains** are the blast-radius boundaries your replication strategy must span: disk, node, rack, row, datacenter. Kubernetes exposes topology through labels (`topology.kubernetes.io/zone`, custom rack labels) and CSI topology keys. Ceph CRUSH rules map OSDs to domains; Longhorn replica counts and anti-affinity spread copies across nodes. A replication factor of three tolerates one domain loss only if replicas actually land in three independent domains — three replicas on three disks in the same server is not HA.
+
+When a **node with local PV** fails, pods using node-local volumes enter `Failed` or `Unknown` states; PVCs remain Bound to PVs on the dead node until an admin intervenes. Data is not automatically available elsewhere. StatefulSets mitigate *identity* loss (stable network IDs via headless Services) but do not magically replicate block data unless you chose a replicated StorageClass or the application replicates.
+
+The **StatefulSet + headless Service + volumeClaimTemplates** pattern is the Kubernetes-native way to run clustered stateful systems:
+
+```yaml
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: db
+spec:
+  serviceName: db-headless
+  replicas: 3
+  volumeClaimTemplates:
+    - metadata:
+        name: data
+      spec:
+        accessModes: ["ReadWriteOnce"]
+        storageClassName: topolvm-nvme
+        resources:
+          requests:
+            storage: 100Gi
+  template:
+    spec:
+      containers:
+        - name: postgres
+          image: postgres:16
+          volumeMounts:
+            - name: data
+              mountPath: /var/lib/postgresql/data
+```
+
+Each pod `db-0`, `db-1`, `db-2` receives its own PVC from the template; ordinal identity pairs with DNS names like `db-1.db-headless.default.svc.cluster.local`. For PostgreSQL streaming replication you typically combine this with an operator or Patroni — the architecture supplies stable disks and network identity; the operator supplies failover logic. Choosing local NVMe StorageClasses here is intentional: replication happens in SQL, not in Ceph, avoiding double replication tax.
+
+When a **node with replicated SDS** fails, pods reschedule elsewhere; CSI reattaches the same logical volume from surviving replicas. Recovery time depends on how much data must rebuild and whether your storage network is saturated — the analytics company story in the opener is the canonical failure mode when rebuild shares a flat network with production traffic.
+
+---
+
+## Performance: IOPS, Throughput, Latency, and the Network Tax
+
+Storage performance has three independent dimensions that procurement spreadsheets often collapse into one misleading "IOPS" number. **IOPS** (input/output operations per second) matters for random small reads and writes — OLTP databases, etcd fsyncs. **Throughput** (MB/s or GB/s) matters for sequential scans, log ingestion, backup streams, and video processing. **Latency** (microseconds to milliseconds, often tracked as p99) determines tail behavior under load: a median 1 ms write means little if p99 spikes to 40 ms during RAID rebuild or Ceph recovery.
+
+| Tier | Tech | IOPS (indicative) | Latency | CapEx $/TB (order of magnitude) | Use |
 |---|---|---|---|---|---|
-| **0** | NVMe Gen5 (PCIe 5.0) | 1M+ | <100μs | $300 | etcd, hot databases |
-| **1** | NVMe Gen4 (PCIe 4.0) | 500K+ | <200μs | $150 | App data, Ceph OSD |
-| **2** | SATA SSD (enterprise) | 50-100K | 1-5ms | $80 | Logs, bulk storage |
-| **3** | HDD SAS (10K/15K RPM) | 100-200 | 5-15ms | $20 | Backup, cold storage |
+| **0** | NVMe Gen4/Gen5 | 500K–1M+ random read | sub-ms | ~$150–300 | etcd, hot databases |
+| **1** | NVMe / fast enterprise SSD | 100K–500K | ~1 ms | ~$80–150 | App data, Ceph OSD WAL/DB |
+| **2** | SATA SSD | 50–100K | 1–5 ms | ~$50–80 | Logs, moderate workloads |
+| **3** | HDD SAS/NLSAS | 100–200 | 5–15 ms | ~$15–25 | Backup, cold archives |
 
-**CRITICAL RULES:**
-- **etcd**: Tier 0 or 1 ONLY (SATA SSD will cause elections).
-- **Ceph OSD**: Tier 1 minimum (SATA SSD limits throughput).
-- **Ceph WAL/DB**: Tier 0 on a separate device from OSD data to prevent write-ahead log I/O from competing with application data I/O.
-- **Backup**: Tier 3 is fine (prioritize capacity over speed).
+Verify tier numbers with `fio` on *your* hardware — vendor datasheets assume empty drives and ideal queue depths. **CRITICAL RULES:** etcd belongs on Tier 0 or 1 only ([Kubernetes etcd guidance](https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/) emphasizes disk latency sensitivity). Ceph OSD data disks want Tier 1 minimum; place separate WAL/DB devices on Tier 0 when possible. Backup targets can live on Tier 3 where capacity dominates.
 
-### RAID and Capacity Projections
+The **network-storage tax** appears whenever a write must replicate over Ethernet or InfiniBand before the application receives acknowledgment. A single logical write to a three-replica Ceph pool can generate three network transfers plus journal writes on each OSD — amplification that does not show up in a local `fio` test on one empty disk. This is why [Module 3 networking](/on-premises/networking/) dedicates fabric bandwidth to storage VLANs: a 25 GbE storage plane saturated by rebuild makes every RBD volume feel slow simultaneously, even if individual NVMe OSDs are healthy.
 
-When planning storage procurement:
-- **RAID Configurations**: Do NOT use hardware RAID for distributed storage like Ceph or software-defined local storage. These systems expect raw HBAs in IT mode. For standalone databases on DAS, use software RAID 1 or 10 to provide local drive redundancy, since there is no distributed storage layer to protect against a single disk failure.
-- **Capacity Projections**: Account for replication overhead. A 100TB raw Ceph cluster with a replication factor of 3 yields ~33TB usable. Plan for a 70% maximum fill rate; exceeding this severely impacts rebalancing during node failures.
+**NVMe versus SSD versus HDD** is not snobbery — it is matching device endurance and queue depth to write patterns. Enterprise NVMe drives publish **DWPD** (drive writes per day) endurance ratings; consumer NVMe under Ceph OSD load can burn through flash in months. HDDs excel at sequential terabytes per dollar but destroy random write latency for etcd and OLTP. Hybrid tiers — hot NVMe for active data, warm SSD for logs, cold HDD for backups — mirror how cloud providers expose gp3/io2/throughput tiers, except you own depreciation and must physically install the drives.
 
 ---
 
-> **Stop and think**: A team proposes running Ceph OSD processes on the same servers as their Kubernetes worker pods to save money on hardware. Their cluster is 40 nodes running a mix of web services and a PostgreSQL database. What happens to PostgreSQL I/O latency when a Ceph OSD node fails and triggers data rebalancing? Would your recommendation change if the cluster had 200 nodes?
+## Storage Tiers, RAID, and Capacity Planning
+
+When planning storage procurement on owned hardware:
+
+- **RAID configurations**: Do **not** use hardware RAID for distributed storage like Ceph or for TopoLVM/LVM pools that expect raw devices. These systems expect HBAs in IT mode and manage redundancy themselves. For standalone databases on DAS without distributed replication, software RAID 1 or 10 on the OS mirror set is appropriate — you are protecting against single-disk failure, not node failure.
+- **Capacity projections**: Account for replication overhead. A 100 TB raw Ceph cluster with [`size = 3`](https://docs.ceph.com/en/latest/rados/configuration/pool-pg-config-ref/) yields roughly 33 TB usable before filesystem overhead. Plan maximum fill around 70–75% so recovery has headroom to rebalance without immediately hitting full pools.
+- **Erasure coding** (e.g., k=8, m=3 in Ceph) reduces overhead versus triple replication for cold/analytics pools at the cost of higher rebuild CPU and latency on partial failures — a CapEx win when you accept slower recovery SLAs.
+
+---
 
 ## Dedicated Storage Nodes vs Hyper-Converged
 
@@ -161,10 +264,7 @@ flowchart TD
     end
 ```
 
-**Dedicated Storage Nodes**
-- **Pros:** No resource contention (storage doesn't compete with pods), storage can have different hardware (more drives, less CPU), storage failures don't affect compute.
-- **Cons:** More servers needed (higher cost), network is the bottleneck (all I/O crosses the network).
-- **Best for:** > 100 nodes, high I/O workloads, regulated environments.
+**Dedicated storage nodes** run OSDs or array controllers without general-purpose pods. **Pros:** no CPU/RAM contention between Ceph recovery and application latency; independent scaling of IOPS versus vCPU; cleaner failure isolation when an OSD host needs maintenance. **Cons:** additional servers (CapEx, power, rack units); all application I/O crosses the network; you must size spine bandwidth for worst-case rebuild. **Best for:** clusters above ~100 workers, high I/O mixed workloads, regulated environments requiring change windows on compute separate from storage.
 
 ### Hyper-Converged (Storage on Worker Nodes)
 
@@ -186,23 +286,103 @@ flowchart TD
         C2[Ceph OSD]
         N2_1[(NVMe 1: OS + pods)]
         N2_2[(NVMe 2-4: Ceph)]
-        P2 --- N2_1
-        C2 --- N2_2
+        P2 --- N2_2
     end
 ```
 
-**Hyper-Converged (Storage on Worker Nodes)**
-- **Pros:** Fewer servers (lower CapEx), data locality (pods can read from local OSD).
-- **Cons:** Resource contention (OSD competes with pods for CPU/RAM), node failure loses both compute AND storage, harder to size (need enough CPU/RAM for both).
-- **Best for:** < 50 nodes, budget-constrained, moderate I/O workloads.
+**Hyper-converged** colocates OSDs or Longhorn replicas with application pods. **Pros:** fewer physical servers; potential data locality when CRUSH or Longhorn places replicas on the same node as consumers (with careful tuning). **Cons:** resource contention; node failure removes compute *and* storage capacity simultaneously; harder capacity planning. **Best for:** smaller clusters (roughly under 50 nodes), budget-constrained pilots, moderate I/O where rebuild storms are rare.
 
 ---
 
-> **Pause and predict**: Your vendor claims their enterprise SATA SSD delivers "100K IOPS." Based on the storage tier guide above, would this drive be suitable for etcd? What specific metric would you benchmark to verify, and what threshold would you consider a pass or fail?
+## Patterns and Anti-Patterns
+
+### Proven Patterns
+
+| Pattern | When to use | Why it scales | On-prem note |
+|---------|-------------|---------------|--------------|
+| **Tiered StorageClasses** | Mixed workload clusters | Hot/cold separation prevents backup scans from starving OLTP | Map `topolvm-nvme`, `ceph-ssd`, `ceph-hdd-ec` to finance chargeback lines |
+| **Dedicated storage VLAN** | Any SDS with replication | Isolates rebuild traffic from tenant-facing NICs | Jumbo frames (MTU 9000) reduce CPU per GB — verify end-to-end |
+| **WaitForFirstConsumer everywhere** | Bare-metal dynamic provisioning | Eliminates cross-rack binding mistakes | Pair with CSI topology labels on racks |
+| **App-level replication on local NVMe** | Kafka, Cockroach, Patroni PG | Avoids double replication; best latency | Accept node replacement workflows |
+| **Separate etcd hardware** | Every production cluster | Control plane stability decoupled from app storage | etcd on Tier 0; never on Ceph RBD |
+
+### Anti-Patterns
+
+| Anti-pattern | What goes wrong | Why teams fall into it | Better alternative |
+|--------------|-----------------|------------------------|-------------------|
+| **One StorageClass for everything** | Databases share rebuild storms with CI caches | Simplicity mandate from platform team | Tiered classes + documented workload mapping |
+| **Hyper-converged Ceph on latency-sensitive DBs** | p99 latency spikes during backfill | CapEx savings on small clusters | Dedicated OSD nodes or local NVMe + app replication |
+| **Immediate volume binding** | PVs provisioned in wrong rack | Copy-paste cloud examples | WaitForFirstConsumer + topology labels |
+| **SATA SSD etcd** | Frequent leader elections | "Enterprise SSD" sounds fast enough | Dedicated NVMe for control plane |
+| **Ignoring replication factor in CapEx** | Finance approves 100 TB usable; you need 300 TB raw | Cloud hides overhead | Model 3× replication or EC explicitly in procurement |
+| **NFS without HA for critical RWX** | Single server outage stalls dozens of pods | Quick lab setup becomes prod | HA NFS pair, or CephFS, or object + immutable artifacts |
+
+---
+
+## Decision Framework
+
+Use this flowchart when onboarding a new stateful workload to an on-premises cluster — it encodes the tradeoffs this module emphasizes without defaulting to "install Ceph because everyone does."
+
+```mermaid
+flowchart TD
+    Start([New workload needs persistence]) --> Q1{Does the app replicate data itself?}
+    Q1 -->|Yes| Q2{Can it tolerate node loss without automatic PV migration?}
+    Q2 -->|Yes| Local[Local NVMe via TopoLVM or local-path + WaitForFirstConsumer]
+    Q2 -->|No| Dist[Replicated SDS or SAN with failover]
+    Q1 -->|No| Q3{Need RWX from many pods?}
+    Q3 -->|Yes| File[NFS / CephFS / enterprise NAS]
+    Q3 -->|No| Q4{p99 latency budget under 2ms?}
+    Q4 -->|Yes| Q5{Budget for dedicated OSD nodes?}
+    Q5 -->|Yes| Dedicated[Dedicated Ceph/Longhorn cluster on storage VLAN]
+    Q5 -->|No| Risk[Hyper-converged SDS with strict QoS and throttled recovery]
+    Q4 -->|No| Dist
+    Local --> Cost[Model CapEx: raw disks + no replication overhead]
+    Dist --> Cost2[Model CapEx: 3x raw or EC + storage network gear]
+    File --> Cost3[Model CapEx: NAS head + backup integration]
+```
+
+### Workload Decision Matrix
+
+| Workload | Storage type | Why |
+|----------|-------------|-----|
+| **etcd** | DAS (NVMe) | Requires low p99 fsync; network storage too slow |
+| **PostgreSQL** (streaming replication) | DAS (NVMe) | App handles replication; local NVMe gives best latency |
+| **PostgreSQL** (single instance) | Ceph RBD or Longhorn | Survives node failure without app-level HA |
+| **Kafka** | DAS or Ceph | [Kafka replicates partitions](https://kafka.apache.org/documentation/#replication); DAS faster, Ceph safer for ops-light teams |
+| **Prometheus TSDB** | DAS (NVMe) | Write-heavy; Thanos/Cortex handle long-term storage |
+| **ML training data** | NFS / CephFS | Large datasets, RWX read-heavy |
+| **CI/CD workspace** | DAS (SSD) or ephemeral | Disposable; high burst IOPS |
+| **Container registry** | Ceph RBD or object | Moderate IOPS; Harbor backend choice |
+| **Backup targets** | NFS / HDD tier | Capacity-optimized; low IOPS acceptable |
+
+---
+
+## Cost Lens: CapEx, OpEx, TCO, and Cloud Comparison
+
+On-premises storage economics invert the cloud model: you pay upfront for drives, enclosures, HBAs, switch ports, rack power, and cooling, then amortize over a three- to five-year depreciation schedule. **CapEx** includes NVMe/U.2 drives, JBOD shelves, dual-controller SANs if purchased, spare drives for N+1, and the storage-dedicated network (TOR switches, optics, cabling). **OpEx** includes power (~verify current $/kWh for your datacenter), facility maintenance, support contracts for arrays, and — most underbudgeted — **ops headcount** to run Ceph or Longhorn health checks, replace failed disks, and execute backup/restore drills.
+
+**Replication overhead** is a CapEx multiplier: three-way replication means you buy roughly three times the raw capacity for the same usable terabytes unless erasure coding reduces overhead at the cost of rebuild complexity. Finance often approves "100 TB for the data lake" without realizing that 100 TB *usable* at `size=3` is ~300 TB raw plus hot spares. Model both numbers in the procurement deck.
+
+**When on-premises storage beats cloud block/file/object:**
+
+- **Steady high utilization** — arrays or Ceph clusters running above ~60% average utilization for years beat paying for provisioned IOPS you would actually use.
+- **Data gravity and egress** — multi-petabyte datasets moved monthly to cloud analytics cost more in egress than owning disks; backups to tape or object on owned hardware stay inside the facility.
+- **Regulatory residency** — data sovereignty requirements that prohibit public cloud storage regardless of price.
+- **Predictable growth** — forklift upgrades are painful but bounded; cloud bills compound with every retained snapshot tier.
+
+**When cloud (or colo burst) wins:**
+
+- **Spiky or unknown utilization** — labs, seasonal retail, burst ML training that idles hardware nine months a year.
+- **Small scale** — three nodes rarely justify a dedicated storage team; managed disks plus ops simplicity win TCO below roughly 20–30 TB usable unless staff is already sunk cost.
+- **Rapid technology refresh** — when you must adopt new disk classes every 18 months without capital committees.
+
+Depreciation cycles (typically 36–60 months for servers, 60+ for arrays) should align with your **refresh plan**: running Ceph on five-year-old SATA SSDs through year seven saves CapEx but increases rebuild time and failure rates — a conscious risk trade, not free savings.
+
+---
 
 ## Benchmarking Storage
 
-Always benchmark before deploying workloads. The three tests below cover the three most important storage patterns for Kubernetes: sequential writes (log files, WAL), random reads (database queries), and fsync-heavy writes (etcd). Running all three tells you which storage tier your hardware actually belongs to, regardless of what the vendor's datasheet claims:
+Always benchmark before deploying workloads. The three tests below cover sequential writes (logs, WAL), random reads (database queries), and fsync-heavy writes (etcd). Running all three on each tier tells you where hardware actually lands, regardless of vendor datasheets:
 
 ```bash
 # Install fio
@@ -227,20 +407,100 @@ fio --name=etcd-wal \
     --size=22m --runtime=60 --time_based \
     --filename=/data/etcd-test
 
-# Expected results by storage type:
+# Expected results by storage type (verify on your hardware):
 # NVMe Gen4: seq write ~3 GB/s, rand read ~500K IOPS, fsync ~0.1ms
 # SATA SSD:  seq write ~500 MB/s, rand read ~80K IOPS, fsync ~2-5ms
 # HDD SAS:   seq write ~200 MB/s, rand read ~200 IOPS, fsync ~5-15ms
 ```
 
+> **Pause and predict**: Your vendor claims their enterprise SATA SSD delivers "100K IOPS." Based on the storage tier guide above, would this drive be suitable for etcd? What specific `fio` metric would you benchmark to verify, and what threshold would you treat as pass versus fail for a production control plane?
+
+---
+
+## Backup, Snapshots, and Restore Planning
+
+Architecture diagrams show where live data sits. Backup design shows how you recover when a rack disappears. On bare metal you cannot rely on a cloud provider's hidden snapshot layer. You must decide what is crash-consistent versus application-consistent, how often you copy bits off-node, and whether restores are tested quarterly or assumed to work.
+
+[VolumeSnapshot and VolumeSnapshotClass](https://kubernetes.io/blog/2020/12/10/kubernetes-1.20-volume-snapshot-moves-to-ga/) objects integrate with CSI drivers that implement `CreateSnapshot`. Snapshots are not backups by themselves. They usually live on the same failure domain as the source volume. A Ceph snapshot still depends on the Ceph cluster. A TopoLVM snapshot still dies with the node. Treat snapshots as fast rewind for operator mistakes. Pair them with off-site copies to object storage, tape, or a secondary cluster.
+
+[Volume populators (GA v1.33)](https://kubernetes.io/blog/2025/05/08/kubernetes-v1-33-volume-populators-ga/) let you create a new PVC pre-filled from a snapshot or backup source. That closes the loop between backup storage and workload rehydration. Platform teams should document RPO and RTO per StorageClass tier. Tier-0 databases might require 15-minute RPO with automated restore drills. Dev namespaces might tolerate 24-hour RPO with manual tickets.
+
+Hypothetical scenario: a platform team snapshots every PVC nightly but never restores. During a ransomware event they discover snapshots were on the same NFS export as primary data. The architecture lesson is geographic and logical separation of backup targets from production mounts. Object stores with immutability policies (S3 Object Lock semantics on [MinIO](https://min.io/docs/minio/kubernetes/upstream/index.html)) address that class of failure when configured deliberately.
+
+---
+
+## Monitoring Storage Health and Capacity
+
+Cloud disks hide SMART errors behind a hypervisor API. Bare-metal operators see disks directly. Plan monitoring at three layers: device, storage platform, and Kubernetes API.
+
+At the **device layer**, run `smartctl` or vendor tools on a schedule. Export metrics to Prometheus. Alert on reallocated sectors, predictive failure flags, and rising latency on `/dev/nvme*`. [CSI volume health monitoring](https://kubernetes.io/docs/concepts/storage/volume-health-monitoring/) remains alpha in Kubernetes 1.35. Many teams still depend on node agents plus ticketing until the API matures.
+
+At the **platform layer**, Ceph exposes `ceph health`, PG states, and recovery progress. Longhorn surfaces replica degradation in its UI and CRDs. NFS servers need export-level latency and RPC error counters. A green Kubernetes node list hides a storage cluster in `HEALTH_WARN` until every PVC stalls.
+
+At the **Kubernetes layer**, watch Pending PVCs, `VolumeAttachment` failures, and [CSI storage capacity](https://kubernetes.io/docs/concepts/storage/storage-capacity/) metrics so the scheduler does not place pods on nodes that cannot satisfy claims. Alert when free capacity in a topology domain drops below your rebuild headroom threshold. Ceph recovery at 95% full turns a single disk loss into a multi-day incident.
+
+Dashboards should tie storage signals to application SLOs. A rising Ceph recovery byte rate plus rising PostgreSQL p99 latency is a correlated story. Throttle recovery before customers notice. That operational loop is part of storage architecture, not an afterthought.
+
+---
+
+## Integrating Enterprise SAN and Existing Arrays
+
+Many on-premises Kubernetes adoptions start with a datacenter that already owns dual-controller SANs or Fibre Channel fabrics. Throwing that investment away for ideological purity wastes depreciation schedules. The architecture question is how cleanly LUNs map to CSI without breaking zoning, masking, or array replication you already pay for.
+
+Vendor CSI drivers (Pure, NetApp Trident, Dell PowerFlex, HPE, and others) present array LUNs as Kubernetes PVs. Static provisioning remains common: storage admins create LUNs and PV objects. Dynamic provisioning appears when the driver supports templates tied to array APIs. Align **RWO** expectations with array behavior. Active/active LUNs misconfigured for simultaneous mount from two nodes cause corruption faster than any application bug.
+
+Treat the SAN as its own failure domain. Synchronous array replication to a secondary site gives metro DR. It does not replace backups. Kubernetes-level snapshots through CSI may still be needed for consistent application cutover. Document which teams own LUN creation versus PVC creation. Gray boundaries produce Orphan PVs and security holes where every namespace receives unlimited array capacity.
+
+Network path matters as much as in SDS designs. Dedicated FC or iSCSI VLANs protect against congestion. Jumbo frames apply here too when end-to-end MTU is verified. CapEx for SAN ports and optics belongs in the same TCO slide as worker NICs. Egress is zero. Port licensing is not.
+
+---
+
+## From Architecture to Procurement Checklist
+
+Before purchase orders ship, walk this checklist with finance and application owners. It translates the modules above into gate criteria that survive leadership turnover.
+
+First, classify every planned workload using the decision matrix and flowchart in this module. No StorageClass without a named owner and expected growth curve. Second, size raw capacity with replication or erasure coding explicit. Show finance both usable and raw terabytes plus hot spares. Third, specify network bandwidth for worst-case rebuild, not steady-state application traffic. A 25 GbE storage VLAN saturated for four hours was the hidden cost in the opener story.
+
+Fourth, assign tiers to hardware SKUs in the quote. etcd and control planes on NVMe Tier 0 or 1. Bulk backup on Tier 3. Fifth, require benchmark acceptance with `fio` on received hardware before cluster cutover. Reject drives that miss fsync latency targets for etcd candidates. Sixth, define backup and restore drills with measured RTO before any stateful app reaches production traffic.
+
+Seventh, document anti-patterns your organization already hit. Hyper-converged Ceph on mixed workloads without throttling is a recurring one. Finally, link forward to [Module 4.2](../module-4.2-ceph-rook/) when SDS is chosen. Link to [Module 4.3](../module-4.3-local-storage/) when local or lightweight replicated storage wins. Architecture without a migration path becomes religion. Your runbook should name the module that implements each chosen layer.
+
+---
+
+## Scheduling, Topology, and the PVC Lifecycle in Practice
+
+Storage architecture fails in the gap between YAML and physics. A PVC looks like a capacity request. Under the hood it is a chain of scheduling decisions, CSI RPCs, and kernel mounts that must align on the same rack, the same node, and often the same PCIe root complex.
+
+When a pod with an unbound PVC is created, the scheduler evaluates nodes that satisfy CPU, memory, affinity, and taints. With `WaitForFirstConsumer`, the CSI provisioner does not run until that first scheduling pass completes. The external-provisioner passes topology requirements from the selected node to `CreateVolume`. The resulting PV carries node or zone labels that constrain future rescheduling. This is why a PostgreSQL pod pinned to rack B must not receive a volume provisioned on rack A. The pod will never start, and the error message will blame volume node affinity instead of the real mistake: Immediate binding on a multi-rack cluster.
+
+The **attacher** path matters for block volumes. After provisioning, Kubernetes creates a `VolumeAttachment` object. The attacher sidecar calls `ControllerPublishVolume` so the LUN or RBD image is exported to the target node. The kubelet then calls `NodePublishVolume` to mount the filesystem into the pod namespace. A failure at any step leaves the pod in `ContainerCreating` with events that mention mount timeouts or attachment failures. Platform runbooks should map each event string to layer one (CSI controller), layer two (node plugin), or layer three (fabric/zoning). Guessing wastes hours.
+
+**Expansion** follows a similar chain. With `allowVolumeExpansion: true` on the StorageClass, the external-resizer increases backend size when the PVC spec changes. File systems may still require online grow inside the pod. Block volumes may need node-level rescan on some SAN protocols. Test expansion on each StorageClass before advertising it to developers. An expanded PVC that never grows inside the guest filesystem produces support tickets, not capacity.
+
+**Static PVs** still appear when integrating legacy arrays. An admin creates a PV with `claimRef` or leaves it Available for a matching PVC. The workflow trades self-service speed for change control. Regulated teams sometimes require ticket IDs in PV annotations. That is valid architecture when documented. It becomes an anti-pattern when developers cannot tell static from dynamic classes and open incidents for Pending PVCs that were never pre-provisioned.
+
+For **StatefulSets**, each ordinal receives an independent PVC from `volumeClaimTemplates`. Deleting the StatefulSet does not delete those PVCs by default. That protects data from accidental `kubectl delete`. It also orphan’s capacity when someone deletes the controller but forgets claims. Architecture reviews should state whether retained PVCs are desired and who reclaims them. Local StorageClasses make orphaned claims especially painful because they hold directories on specific nodes until manually cleaned.
+
+Topology labels extend beyond cloud availability zones. Bare-metal teams define custom domains: rack, row, power feed, or storage cluster name. CSI drivers publish `AllowedTopologies` on StorageClasses. Pod placement must intersect those domains. Spread constraints for HA apps should align with storage replication domains. Placing three app replicas across three racks while storage replicas all sit in one rack preserves compute HA but not data HA.
+
+Hypothetical scenario: a team labels workers by `site=a` and `site=b` for disaster diversity but provisions a single Ceph cluster whose CRUSH rules ignore site labels. Application pods spread correctly while all three replicas of a volume remain in site A. Document topology end-to-end from CRUSH rule or Longhorn replica policy through StorageClass to pod anti-affinity. A diagram in the design doc beats discovering the mismatch during the first site maintenance window.
+
+**Ephemeral versus durable** boundaries deserve explicit policy. Generic ephemeral volumes and emptyDir satisfy scratch space without polluting backup scope. Anything that must survive pod restart belongs on a PVC with a named StorageClass, retention policy, and backup tier. Developers often use emptyDir for "temporary" data that grows into production dependency. Architecture reviews should catch that drift early.
+
+**Encryption at rest** on bare metal is your responsibility, not a cloud control plane toggle. LUKS on node-local volumes, Ceph encryption modules, array-level encryption, and key management via Vault or KMS integrations each shift the trust boundary. Pick one model per tier and document key rotation. Mixed models confuse auditors and on-call engineers during incident stress.
+
+When you present storage architecture to leadership, lead with failure stories prevented, not IOPS hero numbers. Finance understands avoided downtime and depreciated assets. Application owners understand RPO. Operators understand rebuild windows. A single slide that aligns those three views closes more budget requests than a benchmark screenshot alone.
+
+Treat this module as the contract your platform team signs before Module 4.2 or 4.3 implementation work begins. Every StorageClass name should trace back to a row in the decision matrix, a tier in the procurement checklist, and an owner who accepts rebuild and backup responsibilities. That traceability is what separates deliberate bare-metal storage design from a long sequence of costly operational surprises that finance, operations, and application owners remember for years.
+
 ---
 
 ## Did You Know?
 
-- **Ceph was started at UC Santa Cruz** by Sage Weil in 2004 and formalized in his PhD thesis in 2007. It became the storage backbone for most OpenStack deployments and is now the default distributed storage for on-premises Kubernetes via Rook.
-- **NVMe drives can fail faster under sustained write loads** than SATA SSDs because they have higher write amplification at full speed. Enterprise NVMe drives (like Samsung PM9A3) have much higher endurance (DWPD — Drive Writes Per Day) than consumer NVMe. Always use enterprise-grade drives for Ceph OSDs.
-- **A single NVMe drive provides more IOPS than an entire SAN array from 10 years ago.** A Samsung PM9A3 (3.84TB) delivers 1M random read IOPS. A mid-range EMC VNX from 2014 delivered ~200K IOPS from 120 spinning disks. Modern on-prem storage can outperform legacy enterprise storage at 1/10th the cost.
-- **Kubernetes persistent volumes are statically provisioned by default** — you create a PV manually and a PVC claims it. Dynamic provisioning (via StorageClass + CSI driver) is essential for on-prem. Without it, every PV request becomes a manual ticket.
+- **Ceph began at UC Santa Cruz** in Sage Weil's 2007 PhD work and became the default OpenStack storage layer before [Rook](https://github.com/rook/rook) made it a common Kubernetes SDS path — now a [CNCF Graduated](https://www.cncf.io/projects/rook/) project since October 2020.
+- **NVMe endurance (DWPD) matters more than peak IOPS** when OSDs or log-heavy databases saturate write queues 24/7; consumer drives rated for 0.3 DWPD can wear out in months under Ceph defaults while enterprise drives rated 1–3 DWPD survive years.
+- **A single modern NVMe device can exceed the random IOPS of a decade-old mid-range SAN** built from hundreds of spinning disks — which is why greenfield bare-metal clusters often outperform legacy arrays on latency-sensitive workloads at a fraction of per-IOPS CapEx, provided networking and replication are architected deliberately.
+- **Dynamic provisioning via StorageClass is not automatic** — without a default StorageClass and a working CSI provisioner, every PVC stays Pending and teams revert to manual PV tickets, recreating the pre-cloud ticket queue you built Kubernetes to eliminate.
 
 ---
 
@@ -248,98 +508,100 @@ fio --name=etcd-wal \
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| SATA SSD for etcd | Leader elections under load | NVMe only for etcd (Tier 0 or 1) |
-| Hyper-converged without resource limits | Ceph OSD steals CPU/RAM from pods | Use cgroup limits: `2 cores + 4GB per OSD` |
+| SATA SSD for etcd | Leader elections under load | NVMe only for etcd (Tier 0 or 1) per [etcd ops guidance](https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/) |
+| Hyper-converged without resource limits | Ceph OSD steals CPU/RAM from pods | cgroup limits: ~2 cores + 4 GiB RAM per OSD; throttle recovery |
 | No separate storage network | Ceph replication competes with pod traffic | Dedicated VLAN with jumbo frames for storage |
-| Single replication factor | Data loss on node failure | [Ceph replication factor 3](https://docs.ceph.com/en/latest/rados/configuration/pool-pg-config-ref/) (tolerates 1 failure) |
-| Ceph on worker nodes at scale | Rebalancing kills application performance | Dedicated storage nodes above 100 nodes |
-| Not benchmarking before deploy | Discover performance issues in production | fio benchmark on every storage tier before use |
-| Mixing drive types in one pool | Inconsistent performance across PVs | Separate storage classes per tier |
-| No monitoring for disk health | Drives fail silently until data loss | smartctl monitoring + Prometheus alerts |
+| Single replication factor | Data loss on node failure | [Ceph pool size 3](https://docs.ceph.com/en/latest/rados/configuration/pool-pg-config-ref/) minimum for production |
+| Ceph on worker nodes at scale | Rebalancing kills application performance | Dedicated storage nodes above ~100 workers |
+| Not benchmarking before deploy | Performance surprises in production | `fio` on every tier before workload cutover |
+| Mixing drive types in one pool | Inconsistent PV performance | Separate StorageClasses per tier |
+| Ignoring WaitForFirstConsumer | PVs bound to wrong topology | Set on all topology-sensitive StorageClasses |
 
 ---
 
 ## Quiz
 
 ### Question 1
-You are designing the storage backend for a PostgreSQL database cluster deployed on Kubernetes. The database is configured with streaming replication across 3 Pods. The operations team is debating whether to use local NVMe drives directly attached to the worker nodes (DAS) or provision volumes from the central Ceph RBD cluster. Which option should you choose and why?
+You are designing the storage backend for a PostgreSQL cluster with streaming replication across three pods. Operations wants a single Ceph RBD StorageClass for "consistency." What do you recommend and why?
 
 <details>
 <summary>Answer</summary>
 
-**Local NVMe (DAS).**
-
-When an application like PostgreSQL handles its own data replication, using a distributed storage backend like Ceph introduces massive inefficiency. Ceph replicates data (typically 3x) at the block level, and PostgreSQL replicates it again at the application level, resulting in 9 copies of every write across the network. This "double replication" wastes storage capacity and significantly degrades write latency. By using local NVMe drives (accessed via `local-path-provisioner` or `TopoLVM`), the database gets direct PCIe access with sub-millisecond latency. High availability is still maintained because if a node fails, PostgreSQL's own clustering logic will promote one of the remaining replicas. Use Ceph RBD only for single-instance, non-replicated databases that truly need to survive node failures transparently.
+Recommend **local NVMe via TopoLVM or equivalent** with `WaitForFirstConsumer`, not Ceph RBD. PostgreSQL already replicates writes across instances; adding Ceph triple-replication multiplies network traffic and capacity consumption without improving RPO beyond what streaming replication provides. Local NVMe minimizes commit latency — the metric that drives p99 query time — while Patroni or your operator handles failover when a node disappears. Reserve Ceph for single-instance databases that lack application-level HA.
 </details>
 
 ### Question 2
-A developer accidentally deployed a workload that crashed a physical Kubernetes worker node, which also happened to host several Ceph OSDs in a hyper-converged setup. The Ceph cluster immediately began rebalancing data, consuming 80% of the cluster's network I/O bandwidth and causing severe latency spikes for all other applications. How do you prevent this rebalancing process from impacting application performance in the future?
+A hyper-converged Ceph cluster shares 25 GbE with application traffic. After an OSD disk failure, every team's dashboards show elevated latency for four hours. What architectural changes address root cause?
 
 <details>
 <summary>Answer</summary>
 
-**Implement a dedicated storage network and limit Ceph recovery bandwidth.**
-
-By default, Ceph prioritizes data safety and will attempt to rebuild missing replicas as quickly as possible, which can easily saturate a shared network. The most robust architectural fix is to separate application traffic from storage traffic by assigning Ceph to a dedicated VLAN with jumbo frames. Additionally, you should configure Ceph to throttle its recovery operations:
-
-```bash
-# Set recovery limits (Ceph CLI)
-ceph config set osd osd_recovery_max_active 1          # default 3
-ceph config set osd osd_recovery_sleep 0.5              # 500ms sleep between ops
-ceph config set osd osd_max_backfills 1                 # default 1
-ceph config set osd osd_recovery_op_priority 1          # lowest priority (default 3)
-
-# Set client I/O priority higher than recovery
-ceph config set osd osd_client_op_priority 63           # highest priority
-```
-
-Finally, scaling out with more OSDs to reduce per-drive rebalance load, using faster NVMe drives for OSDs, and maintaining spare cluster capacity ensures that when rebalancing does occur, it completes rapidly without causing a bottleneck.
+Separate **storage replication onto a dedicated VLAN** (ideally jumbo frames end-to-end) so backfill cannot saturate the tenant data plane. Add **recovery throttling** (`osd_recovery_max_active`, `osd_recovery_sleep`) so rebuild yields to client I/O. Longer term, move OSDs to **dedicated storage nodes** or add spine bandwidth so rebuild completes faster without monopolizing a shared link. Monitoring should alert on storage-network utilization before application SLOs breach.
 </details>
 
 ### Question 3
-You are tasked with purchasing hardware for a new dedicated on-premises Ceph cluster that will provide persistent volumes to your Kubernetes environment. The finance department asks if they can approve only two dedicated storage nodes to save costs while still meeting the requirement for a replication factor of 3. What do you tell them and why?
+Finance approved two dedicated Ceph OSD servers for a `size=3` pool because "two is cheaper than three." What is wrong with this plan?
 
 <details>
 <summary>Answer</summary>
 
-**You must reject the proposal and require a minimum of 3 OSD nodes.**
-
-Ceph requires failure domains to safely distribute data replicas. With a replication factor of 3, Ceph is configured to place one copy of each object on three distinct nodes to ensure data survives a node failure. If you only provide two nodes, the CRUSH algorithm cannot satisfy the rule to place three replicas across three different nodes, meaning it will either degrade safety by placing two copies on a single node or refuse to write data entirely. A 3-node cluster allows one node to fail while preserving two copies of the data, which is sufficient to maintain availability. However, for a production environment, 5 or more nodes are highly recommended so that you can tolerate a failure, perform rolling maintenance, and have enough spare capacity to rebalance the data automatically.
+Ceph cannot place three replicas in three failure domains when only two OSD nodes exist — CRUSH either violates the rule set or co-locates replicas, defeating HA. Production minimum is **three independent OSD nodes** for `size=3`; five or more is preferred so one node can fail during maintenance while rebuild still has domain diversity. The CapEx "savings" buy a cluster that cannot survive a single node loss safely.
 </details>
 
 ### Question 4
-You are troubleshooting an on-premises Kubernetes cluster where the API server becomes periodically unresponsive under heavy load. The logs reveal frequent etcd leader elections. The underlying hardware uses enterprise SATA SSDs. What is the root cause of this instability and how do you permanently resolve it?
+etcd on enterprise SATA SSDs shows frequent leader elections under load. Logs show slow fsync warnings. What is the permanent fix?
 
 <details>
 <summary>Answer</summary>
 
-**The root cause is high fsync latency from the SATA SSDs.**
+Move etcd data to **Tier 0/1 NVMe** with verified low p99 fsync latency using `fio` (`--fdatasync=1`) and `etcdctl check perf`. etcd's Raft leader must persist each entry before acknowledging; SATA tail latency under mixed I/O exceeds heartbeat windows, triggering elections and API instability. Control plane storage should never share disks with application workloads or Ceph OSD journals.
+</details>
 
-etcd relies on the Raft consensus algorithm, which strictly requires the leader to successfully synchronize (fsync) the Write-Ahead Log (WAL) to disk on every single write operation before acknowledging it. SATA SSDs generally exhibit an fsync latency of 2-10ms, but under heavy I/O load, this can spike beyond 50ms. Because etcd's default heartbeat interval is 100ms, a slow disk prevents the leader from sending heartbeats in time, causing followers to declare the leader dead and trigger an election, during which the cluster API becomes read-only and unresponsive. The permanent fix is to replace the SATA SSDs with NVMe drives for the etcd data directory (or move etcd to Tier 0/1 storage), as NVMe drives consistently provide sub-millisecond fsync latencies.
+### Question 5
+A StatefulSet uses `volumeClaimTemplates` with a `local-path` StorageClass. Pod `app-2` runs on `worker-05`. Worker-05 dies permanently. What happens to `app-2`'s data and what should have been architected differently?
 
-**Verification**:
-```bash
-# Before (SATA SSD):
-etcdctl check perf
-# ... PASS: Throughput is ... FAIL: Slowest request took ...
+<details>
+<summary>Answer</summary>
 
-# After (NVMe):
-etcdctl check perf
-# ... PASS: Throughput is ... PASS: Slowest request took ...
-```
+The PVC remains Bound to a PV on the dead node; data is **not** automatically available on another worker. The StatefulSet may recreate `app-2` Pending forever unless an admin recovers disks or restores from backup. For workloads needing automatic reschedule, use **replicated SDS** (Longhorn, Ceph) or application replication with a documented restore procedure. Local-path fits self-replicating systems (Kafka, Patroni) where ops accepts manual node recovery.
+</details>
+
+### Question 6
+Your platform team must choose between NFS RWX and CephFS RWX for a 50 TiB ML dataset read by 20 training pods. NFS is already deployed on a single server. What risks do you flag?
+
+<details>
+<summary>Answer</summary>
+
+Single-server NFS is a **single failure domain** — one outage stalls all 20 pods and may corrupt partial writes depending on client mount options. NFS metadata performance degrades with millions of small files common in dataset shards. CephFS (via Rook) adds complexity but spreads metadata and data across OSDs with configurable replication. Minimum mitigation for NFS: **HA pair + floating IP**, dedicated 25 GbE+, snapshot backups, and load testing metadata ops before cutover.
+</details>
+
+### Question 7
+A developer creates a PVC with your default StorageClass (`volumeBindingMode: Immediate`) on a three-rack cluster. The pod specifies `nodeAffinity` requiring rack C. The PV provisions on rack A. What symptom appears and what StorageClass change prevents recurrence?
+
+<details>
+<summary>Answer</summary>
+
+The pod stays **Pending** with volume node affinity conflict events — the PV's topology does not match the pod's required rack. Set **`volumeBindingMode: WaitForFirstConsumer`** so provisioning waits until the scheduler selects a node in rack C, then creates the volume in that topology domain. Pair with CSI topology labels on nodes/racks so the provisioner enforces domain boundaries.
+</details>
+
+### Question 8
+CapEx planning asks why a 60 TiB usable Ceph requirement quotes ~200 TiB raw drive purchase. How do you explain the multiplier to non-storage stakeholders?
+
+<details>
+<summary>Answer</summary>
+
+Triple replication (`size=3`) stores **three copies** of every object for single-node failure tolerance — 60 TiB usable requires ~180 TiB raw before filesystem overhead and spare drives for rebuild. Erasure coding lowers multiplier but increases rebuild CPU/time. Add **hot spares and 70% max fill** so recovery never starts at 100% full. Compare to cloud: you pay monthly for provisioned TB instead of upfront drives, but egress and snapshot fees accrue OpEx — the slide should show five-year TCO, not sticker price alone.
 </details>
 
 ---
 
 ## Hands-On Exercise: Benchmark Storage Tiers
 
-**Task**: Benchmark different storage types and compare performance.
+**Task**: Benchmark different storage types on a bare-metal or lab node and map results to the tier guide.
 
 ```bash
-# Create a test directory
+# Create a test directory on the TARGET mount — not /tmp (often tmpfs)
 mkdir -p /mnt/storage-benchmark
-# NOTE: Run benchmarks on the target storage device mount point.
-# /tmp is often tmpfs (RAM disk) which gives misleading results.
 
 # Test 1: Sequential write throughput
 echo "=== Sequential Write ==="
@@ -359,20 +621,17 @@ fio --name=etcd-wal --rw=write --bs=2300 --fdatasync=1 \
     --size=22m --runtime=30 --time_based \
     --filename=/mnt/storage-benchmark/etcd-test
 
-# Record results and compare against the tier guide above
-# NVMe should show: >1 GB/s seq, >100K IOPS rand, <1ms fdatasync
-# SATA SSD: ~400 MB/s seq, ~50K IOPS rand, ~2-5ms fdatasync
-
 # Cleanup
 rm -rf /mnt/storage-benchmark
 ```
 
 ### Success Criteria
-- [ ] Sequential write throughput measured (MB/s)
-- [ ] Random read IOPS measured
-- [ ] fsync latency measured (p99)
-- [ ] Results compared against tier guide
-- [ ] Storage tier identified for the tested device
+
+- [ ] Sequential write throughput recorded in MB/s or GB/s for the tested mount
+- [ ] Random 4 KiB read IOPS recorded with `fio` group reporting output saved
+- [ ] etcd-style fdatasync latency captured (focus on p99, not average)
+- [ ] Results mapped to Tier 0–3 from this module with a one-paragraph justification
+- [ ] One workload from the decision matrix assigned to the tested tier with rationale
 
 ---
 
@@ -382,19 +641,26 @@ Continue to [Module 4.2: Software-Defined Storage (Ceph/Rook)](../module-4.2-cep
 
 ## Sources
 
-- [docs.ceph.com: pool pg config ref](https://docs.ceph.com/en/latest/rados/configuration/pool-pg-config-ref/) — Ceph documentation explains the common three-replica pool configuration that creates three stored copies.
-- [github.com: v1.12.0](https://github.com/container-storage-interface/spec/releases/tag/v1.12.0) — The CSI GitHub release page directly identifies v1.12.0.
-- [kubernetes.io: container storage interface ga](https://kubernetes.io/blog/2019/01/15/container-storage-interface-ga/) — The Kubernetes blog announcement states CSI was promoted to GA in v1.13.
-- [kubernetes.io: persistent volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) — The PersistentVolumes documentation lists cephfs and rbd as unavailable starting v1.31 and FlexVolume as deprecated.
-- [kubernetes.io: storage classes](https://kubernetes.io/docs/concepts/storage/storage-classes/) — The StorageClass documentation directly explains Immediate and WaitForFirstConsumer behavior.
-- [kubernetes.io: storage capacity](https://kubernetes.io/docs/concepts/storage/storage-capacity/) — The Storage Capacity documentation marks the feature as Kubernetes v1.24 stable.
-- [kubernetes.io: ephemeral volumes](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/) — The Ephemeral Volumes documentation marks generic ephemeral volumes stable in v1.23.
-- [kubernetes.io: kubernetes 1.20 volume snapshot moves to ga](https://kubernetes.io/blog/2020/12/10/kubernetes-1.20-volume-snapshot-moves-to-ga/) — The Kubernetes announcement states Volume Snapshot moved to GA in v1.20.
-- [kubernetes.io: kubernetes v1 33 volume populators ga](https://kubernetes.io/blog/2025/05/08/kubernetes-v1-33-volume-populators-ga/) — The Kubernetes v1.33 blog post announces Volume Populators GA.
-- [kubernetes.io: kubernetes v1 34 volume attributes class](https://kubernetes.io/blog/2025/09/08/kubernetes-v1-34-volume-attributes-class/) — The Kubernetes v1.34 blog post announces VolumeAttributesClass GA.
-- [kubernetes.io: kubernetes v1 36 volume group snapshot ga](https://kubernetes.io/blog/2026/05/08/kubernetes-v1-36-volume-group-snapshot-ga/) — The Kubernetes v1.36 announcement gives the feature's alpha, beta, second beta, and GA timeline.
-- [kubernetes.io: volume health monitoring](https://kubernetes.io/docs/concepts/storage/volume-health-monitoring/) — The Kubernetes Volume Health Monitoring page marks the feature as alpha.
-- [kubernetes.io: storage in tree to csi migration status update 1.25](https://kubernetes.io/blog/2022/09/26/storage-in-tree-to-csi-migration-status-update-1.25/) — The Kubernetes v1.25 CSI migration status update states the core migration framework is GA.
-- [kafka.apache.org: documentation](https://kafka.apache.org/documentation/#replication) — The Apache Kafka documentation directly describes Kafka replication.
-- [Rook: Storage Orchestration for Kubernetes](https://github.com/rook/rook) — Primary project source for running and operating Ceph through Kubernetes primitives.
-- [Operating etcd Clusters for Kubernetes](https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/) — Covers why etcd stability is sensitive to disk and network I/O in Kubernetes control planes.
+- [docs.ceph.com: pool pg config ref](https://docs.ceph.com/en/latest/rados/configuration/pool-pg-config-ref/) — Documents default replica pool sizing and capacity implications for Ceph RADOS pools.
+- [github.com/container-storage-interface/spec v1.12.0](https://github.com/container-storage-interface/spec/releases/tag/v1.12.0) — Current CSI spec release referenced for driver capability discussions.
+- [kubernetes.io: Container Storage Interface GA](https://kubernetes.io/blog/2019/01/15/container-storage-interface-ga/) — Kubernetes blog announcing CSI GA in v1.13.
+- [kubernetes.io: PersistentVolumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) — Access modes, RWOP, in-tree plugin removal, volume modes, and protection finalizers.
+- [kubernetes.io: StorageClasses](https://kubernetes.io/docs/concepts/storage/storage-classes/) — `volumeBindingMode`, reclaim policies, and default class behavior.
+- [kubernetes.io: Storage capacity tracking](https://kubernetes.io/docs/concepts/storage/storage-capacity/) — Scheduler-aware free capacity for CSI (GA v1.24).
+- [kubernetes.io: Ephemeral volumes](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/) — Generic ephemeral volumes GA in v1.23.
+- [kubernetes.io: Volume snapshots GA](https://kubernetes.io/blog/2020/12/10/kubernetes-1.20-volume-snapshot-moves-to-ga/) — VolumeSnapshot API GA announcement.
+- [kubernetes.io: Volume populators GA](https://kubernetes.io/blog/2025/05/08/kubernetes-v1-33-volume-populators-ga/) — Hydrating PVCs from snapshots or backups (v1.33).
+- [kubernetes.io: VolumeAttributesClass GA](https://kubernetes.io/blog/2025/09/08/kubernetes-v1-34-volume-attributes-class/) — Mutating volume attributes without recreation (v1.34).
+- [kubernetes.io: Volume group snapshots GA](https://kubernetes.io/blog/2026/05/08/kubernetes-v1-36-volume-group-snapshot-ga/) — Multi-volume crash-consistent snapshots timeline through v1.36 GA.
+- [kubernetes.io: Volume health monitoring](https://kubernetes.io/docs/concepts/storage/volume-health-monitoring/) — Alpha CSI health signals documentation.
+- [kubernetes.io: in-tree to CSI migration GA](https://kubernetes.io/blog/2022/09/26/storage-in-tree-to-csi-migration-status-update-1.25/) — Migration framework status at v1.25.
+- [kafka.apache.org: replication](https://kafka.apache.org/documentation/#replication) — Kafka broker replication model for architecture decisions.
+- [github.com/rook/rook](https://github.com/rook/rook) — Rook storage orchestration for Kubernetes.
+- [cncf.io: Rook Graduated](https://www.cncf.io/projects/rook/) — CNCF graduation status and project metadata.
+- [cncf.io: Longhorn Incubating](https://www.cncf.io/projects/longhorn/) — Longhorn CNCF incubating status.
+- [cncf.io: OpenEBS Sandbox](https://www.cncf.io/projects/openebs/) — OpenEBS CNCF Sandbox project page.
+- [github.com/topolvm/topolvm](https://github.com/topolvm/topolvm) — TopoLVM CSI driver for LVM-backed local volumes.
+- [github.com/rancher/local-path-provisioner](https://github.com/rancher/local-path-provisioner) — local-path dynamic provisioning behavior and limits.
+- [github.com/kubernetes-csi/csi-driver-nfs](https://github.com/kubernetes-csi/csi-driver-nfs) — Kubernetes NFS CSI driver for on-prem file storage.
+- [kubernetes.io: Configure and upgrade etcd](https://kubernetes.io/docs/tasks/administer-cluster/configure-upgrade-etcd/) — etcd disk and latency requirements for control planes.
+- [min.io: MinIO on Kubernetes](https://min.io/docs/minio/kubernetes/upstream/index.html) — Object storage deployment reference for bare-metal clusters.

--- a/src/content/docs/on-premises/storage/module-4.2-ceph-rook.md
+++ b/src/content/docs/on-premises/storage/module-4.2-ceph-rook.md
@@ -1,5 +1,4 @@
 ---
-revision_pending: true
 title: "Module 4.2: Software-Defined Storage with Ceph & Rook"
 slug: on-premises/storage/module-4.2-ceph-rook
 sidebar:
@@ -12,156 +11,70 @@ sidebar:
 
 ---
 
-## Why This Module Matters
-
-<!-- incident-xref: gitlab-2017-db1 -->
-In 2017, GitLab suffered a catastrophic outage when an engineer accidentally executed `rm -rf` on their primary database server. Because their architecture relied heavily on local storage and had silent failures in their snapshot pipelines, they [permanently lost nearly 300GB of production data](https://about.gitlab.com/blog/gitlab-dot-com-database-incident/) and [faced 18 hours of grueling downtime](https://about.gitlab.com/blog/postmortem-of-database-outage-of-january-31/). The incident severely damaged their reputation and caused significant financial impact. If their critical databases had been backed by a robust, software-defined distributed storage system capable of instantaneous block-level snapshots and cross-node replication, recovery would have been a simple command taking mere seconds.
-
-Software-defined storage (SDS) is the backbone of resilient infrastructure. Ceph is the undisputed dominant distributed storage system for on-premises Kubernetes environments. It transforms a scattered collection of local disks across multiple servers into [a unified, highly replicated, self-healing storage pool](https://raw.githubusercontent.com/ceph/ceph/main/doc/architecture.rst) that Kubernetes can dynamically consume via the Container Storage Interface (CSI). When a physical disk fails, Ceph automatically redistributes the data. When an entire node goes offline, Ceph continues serving requests from replicas located on surviving nodes. When you add new servers to the rack, Ceph rebalances the cluster automatically, distributing the I/O load transparently.
-
-But Ceph is not a simple black box. It operates its own daemons, utilizes its own distributed consensus protocol, demands strict networking topologies, and exhibits unique failure modes. Running Ceph poorly is often worse than not running it at all—a misconfigured Ceph cluster can amplify failures, saturate your network, and bring down your entire environment. [Rook is the Kubernetes operator that manages Ceph](https://github.com/rook/rook), turning a complex, multi-day manual deployment into declarative YAML. Understanding what Rook does under the hood, and how Ceph manages data, is essential for engineering resilient, production-grade storage architectures.
-
----
-
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
-1. **Design** a production-grade Ceph cluster architecture incorporating dedicated public and cluster networks to isolate replication traffic.
-2. **Implement** Rook-Ceph operators and CephCluster Custom Resource Definitions (CRDs), ensuring optimal OSD placement and host-level failure domain configurations.
-3. **Compare** and select appropriate Ceph CSI drivers (RBD, CephFS, NFS) based on application access modes and specific performance requirements.
-4. **Diagnose** Ceph cluster health issues, including Placement Group (PG) degradation and slow OSD recovery, using the Rook toolbox.
-5. **Evaluate** storage node topologies and upgrade paths to prevent quorum loss and maintain compatibility across Kubernetes and Ceph versions.
+1. **Design** a production-grade Ceph cluster architecture incorporating dedicated public and cluster networks, correct MON quorum sizing, and host-level failure domain configurations that survive node-level outages without data loss.
+2. **Implement** Rook-Ceph operators and CephCluster Custom Resource Definitions (CRDs), with explicit device selection, resource limits, and node affinity that prevent accidental OS-drive destruction during deployment.
+3. **Compare** and select appropriate Ceph CSI drivers — RBD, CephFS, and RGW — based on application access modes, performance requirements, and data-sharing patterns.
+4. **Diagnose** Ceph cluster health issues including Placement Group (PG) degradation, slow OSD recovery, and near-full conditions, using the Rook toolbox and Prometheus metrics exported by the MGR module.
+5. **Evaluate** storage-node topologies, upgrade paths, and the replicated-vs-erasure-coded tradeoff to prevent quorum loss, avoid version incompatibility, and optimize raw-to-usable capacity ratios for your workload profile.
 
 ---
 
-## What You'll Learn
+## Why This Module Matters
 
-- The evolution of Rook within the CNCF ecosystem and the Ceph release lifecycle.
-- Ceph architecture components (MON, OSD, MDS, MGR, RADOS) and how they interact.
-- Rook operator deployment, prerequisites, and the `CephCluster` CRD structure.
-- Storage classes for block (RBD), filesystem (CephFS), and object (RGW) provisioners.
-- Performance tuning strategies for on-premises workloads, including network separation.
-- Monitoring, alerting, and failure recovery procedures for Ceph health.
+<!-- incident-xref: gitlab-2017-db1 -->
+In 2017, GitLab suffered a catastrophic outage when an engineer accidentally removed data from the primary database server during a replication recovery attempt. GitLab's incident update reported [six hours of database data loss](https://about.gitlab.com/blog/gitlab-dot-com-database-incident/) for GitLab.com, and the postmortem narrowed the unrecovered window to database modifications between 17:20 and 00:00 UTC on January 31, affecting roughly 5,000 projects, 5,000 comments, and 700 new user accounts while repositories and wikis were not lost. The storage lesson is not that Ceph would have made recovery instant; the lesson is that backup, replication, snapshot, and restore paths must be tested as a system, because multiple silent failures can turn a single mistaken command into a public data-loss incident.
 
----
+Software-defined storage (SDS) is the backbone of resilient on-premises infrastructure, and Ceph is one of the most widely used distributed storage systems for bare-metal Kubernetes environments. It transforms a scattered collection of local disks across multiple servers into [a unified, highly replicated, self-healing storage pool](https://raw.githubusercontent.com/ceph/ceph/main/doc/architecture.rst) that Kubernetes can dynamically consume via the Container Storage Interface (CSI). When a physical disk fails and the CRUSH rule still has valid targets, Ceph can redistribute data automatically. When an entire node goes offline, Ceph can continue serving requests from replicas on surviving nodes if enough copies remain to satisfy the pool's `min_size`. When you add new servers to the rack, Ceph rebalances the cluster transparently, spreading I/O load across all available hardware.
 
-## The Evolution of Rook and Ceph
+But Ceph is not a simple black box — it operates its own daemons, uses a distributed consensus protocol for cluster state, demands strict networking topologies, and exhibits unique failure modes that can cascade if misunderstood. Running Ceph poorly is often worse than not running it at all: a misconfigured cluster can amplify failures, saturate your network fabric, and bring down your entire Kubernetes environment. [Rook is the graduated CNCF operator that manages Ceph](https://github.com/rook/rook) on Kubernetes, turning a complex multi-day manual deployment into declarative YAML. Understanding what Rook does under the hood — and how Ceph manages data placement, replication, and recovery — is essential for engineering resilient, production-grade on-premises storage architectures that your applications can actually depend on.
 
-Before diving into the architecture, it is important to understand the lifecycle of the tools managing your data. 
-
-Rook is a premier CNCF project that has reached the highest level of maturity. Rook was [accepted to the CNCF on 2018-01-29 and moved to incubation on 2018-09-25](https://www.cncf.io/projects/rook/). It officially moved to Graduated maturity on 2020-10-07, cementing its place as the standard for Kubernetes-native storage orchestration.
-
-Ceph itself follows a strict release lifecycle using marine animal names. Staying on supported versions is a hard requirement for production clusters, as [archived Ceph releases are explicitly not maintained and no longer receive bug fixes or backports](https://raw.githubusercontent.com/ceph/ceph/main/doc/releases/index.rst). As of our current timeline:
-- The **Tentacle** release is part of the active release train, with its latest version being 20.2.1 and an initial release date of 2026-04-06.
-- The **Squid** release is also active, with its [latest version at 19.2.3 and an expected end-of-life (EOL) of 2026-09-19](https://raw.githubusercontent.com/ceph/ceph/main/doc/releases/releases.yml).
-- The **Reef** release remains active but is nearing the end of its cycle. Its latest release, 18.2.8, is expected to be the eighth and final backport release in Reef, with an EOL of 2026-03-31.
-
-Rook's upgrade procedures are strictly sequential. Rook 1.19 upgrade documentation defines [support for upgrading from 1.18.x to 1.19.x](https://raw.githubusercontent.com/rook/rook/release-1.19/Documentation/Upgrade/rook-upgrade.md) and explicitly states that upgrades are only supported between official releases. Rook marks master/unreleased builds as unsupported—you should never run a master build in production or attempt to skip minor versions during an upgrade.
+Hypothetical scenario: a three-node Ceph cluster with replication factor 3 and `failureDomain: host`. Node 2 loses power at 3 AM. The 4 OSDs on that node go dark simultaneously, but because every data object still has copies on Nodes 1 and 3, the replicated pool can remain available if its `min_size` is still satisfied. Ceph cannot rebuild the missing third host-separated replica onto the two surviving hosts, because the CRUSH rule requires three distinct host failure domains; affected placement groups stay degraded or undersized until Node 2 returns or you add another storage host. This is the real promise and the real constraint of distributed storage: no data loss during the first host failure, but reduced redundancy until the topology has enough failure domains again.
 
 ---
 
-## Ceph Architecture
+## Ceph Architecture: The RADOS Foundation
 
-Ceph is a distributed storage system composed of several specialized daemons that work together to provide object, block, and file storage. At its core, Rook/Ceph exposes block, object, and file storage to applications.
+Ceph is built on RADOS — the Reliable Autonomic Distributed Object Store. RADOS provides the foundational object-storage layer that every Ceph interface (block, file, object) consumes. Understanding its daemons and algorithms is the prerequisite to operating Ceph safely in production.
 
-### Legacy ASCII Architecture Representation
+### The Monitor Cluster (MON)
 
-The original documentation utilized an ASCII diagram to represent this architecture. The technical representation is preserved below:
+Ceph monitors maintain the cluster map — a master record of which OSDs exist, which are up or down, and how data placement is configured. Every client and OSD queries the monitors to discover the current cluster topology before performing any I/O operation. Without a functioning monitor quorum, the cluster becomes completely inaccessible even if every OSD is healthy and data is intact.
 
-```text
-┌─────────────────────────────────────────────────────────────┐
-│                    CEPH ARCHITECTURE                         │
-│                                                               │
-│  ┌──────────┐  ┌──────────┐  ┌──────────┐                  │
-│  │  MON 1   │  │  MON 2   │  │  MON 3   │  Monitors        │
-│  │ (Paxos)  │  │ (Paxos)  │  │ (Paxos)  │  - Cluster map   │
-│  └──────────┘  └──────────┘  └──────────┘  - Quorum (odd #) │
-│                                              - 3 or 5 MONs   │
-│  ┌──────────┐                                                │
-│  │  MGR     │  Manager                                       │
-│  │          │  - Dashboard, metrics, modules                 │
-│  │          │  - Active/standby HA                           │
-│  └──────────┘                                                │
-│                                                               │
-│  ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐ ┌──────┐   │
-│  │OSD 0 │ │OSD 1 │ │OSD 2 │ │OSD 3 │ │OSD 4 │ │OSD 5 │   │
-│  │NVMe  │ │NVMe  │ │NVMe  │ │NVMe  │ │NVMe  │ │NVMe  │   │
-│  │Node 1│ │Node 1│ │Node 2│ │Node 2│ │Node 3│ │Node 3│   │
-│  └──────┘ └──────┘ └──────┘ └──────┘ └──────┘ └──────┘   │
-│                                                               │
-│  Object Storage Daemons (OSDs):                              │
-│  - One per physical drive                                    │
-│  - Stores data as objects in a flat namespace                │
-│  - Replicates data to other OSDs (default 3x)               │
-│  - Self-heals: rebuilds replicas when an OSD fails          │
-│                                                               │
-│  ┌──────────┐  (Optional)                                    │
-│  │  MDS     │  Metadata Server                               │
-│  │          │  - Required only for CephFS                    │
-│  │          │  - Manages file/directory namespace             │
-│  └──────────┘                                                │
-│                                                               │
-│  Storage Types:                                              │
-│  RBD (Block)  → PersistentVolumes (ReadWriteOnce)           │
-│  CephFS (File)→ PersistentVolumes (ReadWriteMany)           │
-│  RGW (Object) → S3-compatible object storage                │
-│                                                               │
-└─────────────────────────────────────────────────────────────┘
-```
+Monitors use the Paxos consensus algorithm to agree on cluster state. This requires an odd number of monitors — typically three for production clusters, or five for very large deployments with hundreds of OSDs. An odd count ensures the cluster can always form a majority quorum: a three-monitor cluster survives one failure, a five-monitor cluster survives two. Using an even number (say, two monitors) is dangerous because neither can achieve quorum independently if the other fails — both will block, and the cluster stalls. Never deploy an even number of monitors.
 
-### Modern Mermaid Architecture Representation
+Each monitor is lightweight relative to OSDs — a few gigabytes of RAM and modest CPU — but they must be placed on independent failure domains. The CephCluster CRD's `allowMultiplePerNode: false` setting is critical: if two monitors land on the same physical host and that host fails, the cluster loses quorum even if the third monitor survives. Similarly, monitors should not share hardware with OSDs whose recovery storms can saturate CPU and memory, starving the monitor process and causing it to be marked down by its peers.
 
-Here is the exact same architectural layout translated into a native Mermaid diagram for better maintainability:
+The monitors also enforce a safety timer: when an OSD stops responding, the monitors wait for `mon_osd_down_out_interval` (default 600 seconds) before marking it `out` and triggering data redistribution. This delay prevents the cluster from initiating a costly full rebalance for a transient network blip or a routine node reboot — the OSD simply rejoins and catches up on any writes it missed.
 
-```mermaid
-flowchart TD
-    subgraph Monitors [Monitors: Cluster map, Quorum 3 or 5]
-        direction LR
-        M1[MON 1 - Paxos]
-        M2[MON 2 - Paxos]
-        M3[MON 3 - Paxos]
-    end
-    
-    subgraph Manager [Manager: Dashboard, metrics, active/standby]
-        MGR[MGR Daemon]
-    end
-    
-    subgraph Storage_Nodes [Object Storage Daemons: 1 per drive, self-healing, 3x replica]
-        direction LR
-        subgraph Node1 [Node 1]
-            O0[OSD 0 NVMe]
-            O1[OSD 1 NVMe]
-        end
-        subgraph Node2 [Node 2]
-            O2[OSD 2 NVMe]
-            O3[OSD 3 NVMe]
-        end
-        subgraph Node3 [Node 3]
-            O4[OSD 4 NVMe]
-            O5[OSD 5 NVMe]
-        end
-    end
-    
-    subgraph Metadata [Metadata Server: Required only for CephFS]
-        MDS[MDS Optional]
-    end
-    
-    subgraph Storage_Types [Storage Types]
-        RBD[RBD Block -> PersistentVolumes ReadWriteOnce]
-        CEPHFS[CephFS File -> PersistentVolumes ReadWriteMany]
-        RGW[RGW Object -> S3 compatible]
-    end
+### Object Storage Daemons (OSD)
 
-    Monitors --> MGR
-    MGR --> Storage_Nodes
-    Storage_Nodes --> MDS
-    Storage_Nodes --> Storage_Types
-```
+Object Storage Daemons are the workhorses of Ceph. There is exactly one OSD process per physical storage device — one per NVMe drive, one per SSD, one per HDD. Each OSD stores data as objects in a flat namespace and participates in replication, recovery, and backfill operations coordinated by the monitors and the CRUSH algorithm.
+
+Modern Ceph uses BlueStore as its OSD backend, which writes directly to raw block devices without an intervening filesystem layer. This eliminates the double-write penalty that plagued the older FileStore backend — FileStore first wrote data to a POSIX filesystem (usually XFS), which then wrote it to disk, effectively halving write throughput for small I/O. BlueStore manages its own metadata in an embedded RocksDB key-value store, with the write-ahead log optionally placed on a faster device (a small NVMe partition paired with a larger HDD data device). The result is near-native block-device performance with full checksumming, compression, and transparent data integrity verification on every read.
+
+Each OSD consumes CPU and RAM proportional to its capacity — approximately 1 GB of RAM per terabyte of raw storage during normal operation, and substantially more during recovery when the OSD must scan its entire object store to identify which objects need replicating. Resource limits in the CephCluster CRD prevent an OSD from exhausting node memory during backfill, which would trigger the kernel OOM killer and cascade into additional OSD failures.
+
+### Manager Daemon (MGR)
+
+The Ceph Manager provides cluster metrics, dashboards, and a pluggable module system. At least one MGR must be running (typically two, in active/standby configuration) for the cluster to be considered healthy. The MGR collects performance counters from every OSD and monitor, aggregates them, and exposes them through modules — most importantly the Prometheus module, which emits metrics in a format Prometheus can scrape. Without a running MGR, the `ceph status` command will report `HEALTH_WARN` and you lose visibility into per-OSD latency, pool IOPS, recovery progress, and capacity forecasting.
+
+The MGR dashboard (enabled via `dashboard: enabled: true` in the CephCluster CRD) provides a graphical overview of cluster health, OSD status, pool utilization, and PG state. In production clusters, the dashboard should be exposed through an ingress with TLS termination rather than directly via a NodePort, and access should be restricted to operations personnel.
+
+### The CRUSH Algorithm
+
+CRUSH — Controlled Replication Under Scalable Hashing — is Ceph's data placement algorithm and the reason Ceph can scale to thousands of OSDs without a central metadata lookup. Unlike traditional storage systems that maintain a mapping table tracking the location of every block, CRUSH uses a deterministic pseudo-random function: given an object name, a placement group, and the current cluster map, any client can independently calculate exactly which OSDs should store the object's replicas. There is no central lookup, no metadata server bottleneck, and no single point of contention when hundreds of pods simultaneously request block allocations.
+
+The algorithm operates through CRUSH maps, which define a hierarchy of failure domains — typically `root → rack → host → osd`. Placement rules within the CRUSH map specify how replicas are distributed across this hierarchy. For example, a rule with `failureDomain: host` and `replicated.size: 3` ensures that CRUSH selects three OSDs on three different hosts for every object placement, even if those hosts are in the same rack. A stricter rule with `failureDomain: rack` would ensure replicas land in three different racks, protecting against top-of-rack switch failure but requiring at least three racks of hardware.
+
+The CRUSH map is not static — when OSDs are added or removed, the map is updated and the algorithm recalculates placement. Because the function is deterministic, only the objects whose placement changes need to be moved; the rest remain untouched. This makes Ceph rebalancing efficient even at petabyte scale, though the recovery I/O can still saturate networks if not throttled.
 
 ### Ceph Networking
 
-A proper Ceph deployment relies heavily on network segregation. Because data replication multiplies the amount of traffic flowing across the network, [failing to separate client traffic from replication traffic](https://raw.githubusercontent.com/rook/rook/release-1.19/Documentation/CRDs/Cluster/network-providers.md) can cause storage operations to saturate your interfaces and impact your application pods.
+A proper Ceph deployment relies heavily on network segregation. Because data replication multiplies the amount of traffic flowing across the network, [failing to separate client traffic from replication traffic](https://raw.githubusercontent.com/rook/rook/release-1.20/Documentation/CRDs/Cluster/network-providers.md) can cause storage operations to saturate your interfaces and impact your application pods.
 
 #### Legacy ASCII Network Design
 
@@ -210,21 +123,115 @@ flowchart LR
 
 ---
 
+## The Three Storage Interfaces
+
+Ceph exposes a single RADOS cluster through three distinct protocols, each serving different application access patterns. All three operate on the same underlying OSDs and benefit from the same replication and self-healing — you do not need separate clusters for block, file, and object storage.
+
+### RBD: Block Storage (ReadWriteOnce)
+
+RADOS Block Device (RBD) presents Ceph storage as a virtual block device, striped across multiple OSDs for parallelism. Kubernetes consumes RBD through the `rook-ceph.rbd.csi.ceph.com` CSI provisioner, creating PersistentVolumes with `ReadWriteOnce` access mode. Each RBD image is exclusively attached to a single node at a time — the CSI driver handles the attach/detach lifecycle when pods are rescheduled.
+
+RBD is the right choice for databases (PostgreSQL, MySQL, MongoDB, etcd), message queues with persistent storage, and any stateful workload that expects raw block I/O with consistent latency. Because the Linux kernel maps the RBD image as a block device (`/dev/rbdX`), the filesystem (typically ext4 or XFS) runs directly on top without an intermediate network filesystem layer. This yields near-local-NVMe performance on a properly configured 25GbE cluster network.
+
+RBD also supports snapshotting, cloning, and online resizing. A snapshot creates a point-in-time, space-efficient copy of the RBD image using copy-on-write, consuming additional capacity only when blocks are overwritten. The CSI driver surfaces snapshots through the Kubernetes VolumeSnapshot API, enabling backup workflows without application downtime.
+
+### CephFS: Shared Filesystem (ReadWriteMany)
+
+CephFS provides a POSIX-compliant distributed filesystem backed by RADOS, supporting `ReadWriteMany` access — multiple pods on different nodes can mount the same filesystem simultaneously and read or write shared files. This is impossible with RBD, whose block-device semantics require exclusive attachment.
+
+CephFS introduces an additional daemon: the Metadata Server (MDS). The MDS manages the filesystem namespace — directory structure, file names, permissions, and timestamps — while file data is stored directly in RADOS objects. This separation means that metadata operations (listing directories, stating files) are handled by the MDS cache, while data reads and writes hit the OSDs directly, with no MDS in the data path. The MDS cluster operates in active/standby pairs: one MDS serves client requests while a standby holds a warm cache, ready to take over within seconds if the active MDS fails.
+
+Use CephFS for shared ML training datasets (multiple training pods reading the same data), web-server content directories (multiple NGINX pods serving the same static files), CI/CD artifact caches, and log aggregation directories. Do not use CephFS for databases — the POSIX filesystem layer adds metadata latency, and the shared-access model does not provide the exclusive-write consistency guarantees that database engines expect from block devices.
+
+### RGW: S3-Compatible Object Storage
+
+The RADOS Gateway (RGW) exposes Ceph as an S3-compatible and Swift-compatible object storage endpoint — HTTP-based, suitable for applications that store blobs, backups, container images, and data-lake objects. Unlike RBD and CephFS, which are consumed through CSI PVs inside Kubernetes, RGW is typically accessed via an external endpoint (NodePort, LoadBalancer, or Ingress) by applications both inside and outside the cluster.
+
+RGW stores each object as one or more RADOS objects, with metadata indexed in separate pools for fast listing. It supports bucket policies, versioning, lifecycle rules, multi-part uploads, and server-side encryption. For on-premises environments that need an S3-compatible object store without egress charges or cloud-vendor lock-in, RGW provides a drop-in replacement that applications using the AWS SDK can target by changing only the endpoint URL.
+
+### Pools and Placement Groups
+
+Every storage interface operates on pools — logical groupings of RADOS objects that share replication settings, CRUSH rules, and PG counts. A CephBlockPool CRD, a CephFilesystem's data pool, and an RGW bucket's index pool are all pools with independently tunable parameters.
+
+Within each pool, objects are grouped into Placement Groups (PGs) — shards that distribute data across OSDs. The PG count is one of the most important tuning decisions in Ceph. Too few PGs and data distribution becomes uneven, with some OSDs filling up while others remain half-empty, creating hotspots. Too many PGs and the OSDs waste memory and CPU tracking an excessive number of shards, slowing recovery and increasing per-OSD overhead.
+
+The old rule of thumb — total PGs = (OSDs × 100) / replication factor, rounded to the nearest power of two — is useful only as a rough single-pool baseline. For a 12-OSD cluster with one dominant 3× replicated pool, that math lands near 400 total PGs, often rounded to 512; it does not mean every pool in a multi-pool cluster should get 512 PGs. Modern Ceph expects you to use the [PG autoscaler, pool target sizes, and target size ratios](https://docs.ceph.com/en/reef/rados/operations/placement-groups/) so the largest pools receive proportionally more PGs while small metadata or test pools do not waste per-OSD memory.
+
+---
+
+## Data Protection: Replication and Erasure Coding
+
+Ceph offers two fundamentally different strategies for protecting data against hardware failure. The choice between them is one of the most consequential design decisions you will make for an on-premises Ceph deployment.
+
+### Replicated Pools
+
+In a replicated pool, every object is stored in full on `size` number of OSDs, with `min_size` copies required for the pool to accept writes. The most common configuration — `size: 3, min_size: 2` — means three full copies exist during normal operation, and the pool remains writable as long as at least two copies are available. If a single OSD or host fails, the pool is degraded (only two copies) but still writable; if a second failure occurs before recovery completes and only one copy remains, the pool becomes read-only to prevent data divergence.
+
+Replication is simple, performant, and predictable. Every write costs exactly `size` times the client write bandwidth on the cluster network, and every read is served from the primary OSD with no reconstruction overhead. The downside is raw-capacity efficiency: with 3× replication, 100 TB of raw disk yields only ~33 TB of usable space. For high-performance workloads — databases, message queues, VM images — the simplicity and low read latency of replication justify the capacity overhead.
+
+### Erasure-Coded Pools
+
+Erasure coding (EC) trades CPU and latency for dramatically improved storage efficiency. Instead of storing full copies, an EC pool splits each object into `k` data chunks, computes `m` coding (parity) chunks, and distributes all `k+m` chunks across different OSDs. The object can be reconstructed from any `k` of the `k+m` chunks — meaning the pool tolerates the loss of up to `m` OSDs simultaneously.
+
+A common EC profile for cold data is `k=4, m=2` (often written as 4+2). This yields 4/(4+2) = 67% raw-to-usable efficiency — double the efficiency of 3× replication — while tolerating the loss of any two chunks. A more aggressive `k=8, m=3` (8+3) profile yields 73% efficiency and tolerates three chunk losses, but requires at least 11 OSDs across 11 failure domains.
+
+The cost is write performance: every write must read the existing data chunks, compute parity, and write all chunks — a read-modify-write cycle that adds latency. EC pools also recover more slowly from failures because rebuilding a lost chunk requires reading data from `k` surviving chunks, computing the missing chunk, and writing it. For these reasons, EC is best suited for cold or warm data with large objects and infrequent writes: object storage (RGW), backup targets, data-lake tiers, and CephFS data pools where the working set is read-heavy.
+
+The Rook CephBlockPool CRD supports EC pools through the `erasureCoded` field with `dataChunks` and `codingChunks`, and Ceph Tentacle (v20) adds EC optimizations enabled via `allow_ec_optimizations: "true"` in the pool parameters.
+
+### Failure Domains and CRUSH Rules
+
+The `failureDomain` setting in pool CRDs — `osd`, `host`, `rack`, or a custom CRUSH bucket type — tells CRUSH how to distribute chunks or replicas. For replicated pools in production, `failureDomain: host` is the minimum safe setting: it ensures no two replicas share a physical server, protecting against power-supply failure, kernel panic, or a failed NIC that takes down all OSDs on that node simultaneously.
+
+`failureDomain: rack` provides an additional layer of protection against top-of-rack switch failure or rack-level power loss, but requires at least three racks of hardware. For EC pools, `failureDomain: host` means the `k+m` chunks are distributed across `k+m` distinct hosts — a 4+2 EC pool with `failureDomain: host` thus requires at least 6 storage nodes.
+
+---
+
+## The Rook Operator Model
+
+Rook is a Kubernetes operator that embeds deep Ceph domain knowledge into a reconciliation loop, automating the lifecycle of Ceph daemons that would otherwise require manual intervention.
+
+### CRDs and the Reconcile Loop
+
+Rook watches Custom Resources — `CephCluster`, `CephBlockPool`, `CephFilesystem`, `CephObjectStore`, and others — and continuously reconciles the desired state described in those CRDs with the actual state of the Ceph daemons running in the cluster. When you create a CephCluster CRD, the Rook operator provisions MON pods (ensuring an odd count, distributing them across failure domains), starts MGR pods, and begins preparing OSDs on the specified devices. When you modify a CephBlockPool CRD's `replicated.size`, Rook updates the Ceph pool configuration through the Ceph mgr module API.
+
+This reconciliation model handles failure recovery automatically: if a MON pod is evicted or its node fails, Rook detects the deviation from the desired `mon.count` and schedules a replacement on a surviving node, updating the MON quorum to include the new member securely. If an OSD process crashes repeatedly, Rook marks it as flapping and stops restarting it after five failures in ten minutes — a safety mechanism that prevents a defective drive from triggering an infinite restart loop that would amplify cluster instability.
+
+### OSD Provisioning Strategies
+
+Rook supports two distinct approaches to provisioning OSDs, and choosing between them has significant operational implications.
+
+**OSD-on-raw-device** — the traditional approach — requires Rook to have direct access to unformatted block devices on the host (`/dev/nvme0n1`, `/dev/sdb`, etc.). The CephCluster CRD's `storage.nodes[].devices[]` field lists them explicitly. This mode delivers the best performance because the OSD writes directly to the block device via BlueStore with no intermediate abstraction. However, it tightly couples Ceph to specific physical hardware: replacing a failed drive requires physically swapping it and manually updating the device list, and the device names must be stable across reboots (use `/dev/disk/by-id/` symlinks, not `/dev/sdX` names, which the kernel may reassign).
+
+**OSD-on-PVC** — where each OSD is backed by a Kubernetes PersistentVolumeClaim — decouples Ceph from physical device topology. Rook provisions PVCs from any StorageClass (typically `local-path` for test clusters or a dedicated StorageClass for production), and Ceph deploys OSDs inside those PVCs. This approach works in any Kubernetes cluster regardless of the underlying storage, enables OSD resizing by expanding the PVC, and simplifies hardware replacement — a new node can claim the PVC and the OSD resumes. The tradeoff is a small performance overhead from the additional storage abstraction layer, and the risk of creating a circular dependency if Ceph itself provides the StorageClass backing its own OSDs.
+
+The CephCluster CRD supports both modes simultaneously — you can use raw devices for performance-critical NVMe OSDs on storage nodes while using PVC-backed OSDs for capacity-tier HDD OSDs provisioned from a separate storage system.
+
+### Version Compatibility and Upgrades
+
+Rook and Ceph follow independent release cadences, and version compatibility must be verified before upgrades. Rook v1.20 supports Ceph Squid (v19) and Ceph Tentacle (v20). The CephCluster CRD's `cephVersion.image` field pins a specific Ceph container image (`quay.io/ceph/ceph:v20.2.1`), and Rook orchestrates the rolling update of all Ceph daemons when you change it.
+
+Rook upgrades are strictly sequential: the v1.20 upgrade documentation supports upgrading from v1.19.x to v1.20.x only. Skipping major Rook versions during an upgrade is not supported and can leave the cluster in an inconsistent state. Furthermore, Rook v1.20 introduces a significant architectural change: the CSI driver management has been moved from the Rook operator into a separate `ceph-csi-operator`, and the minimum supported Kubernetes version is now v1.31. Always read the upgrade guide for breaking changes before initiating a version bump — the v1.20 upgrade path requires explicit migration of CSI settings that were previously configured through the `rook-ceph-operator-config` ConfigMap.
+
+Ceph itself follows a stricter lifecycle: only active releases receive bug fixes and security backports. As of mid-2026, Tentacle (v20, EOL 2027-11-18) and Squid (v19, EOL 2026-09-19) are the active releases. Reef (v18) reached EOL on 2026-03-31 and no longer receives backports — clusters still running Reef should be upgraded to Squid or Tentacle. Running an EOL Ceph release in production means you are exposed to known vulnerabilities and unfixed data-corruption bugs that upstream has already patched in supported releases.
+
+---
+
 ## Prerequisites and Integration
 
 Before deploying Rook and Ceph, you must ensure your environment meets strict prerequisites.
 
 ### Hardware and OS Requirements
 - **CPU:** Rook currently supports only amd64/x86_64 and arm64 CPU architectures.
-<!-- incident-xref: github-august-2021-mysql -->
-- **Kernel Versions:** Rook requires kernel/RBD support. It recommends [kernel minimums of 5.4+ for expanded RBD image features, and 4.17+ for CephFS RWX PVC size enforcement](https://raw.githubusercontent.com/rook/rook/release-1.19/Documentation/Getting-Started/Prerequisites/prerequisites.md). Running older kernels can lead to reduced features or failed quota enforcement.
-- **Local Storage:** Rook requires at least one local storage source such as raw devices/partitions, LVM logical volumes without filesystem, or block PVCs for Ceph OSD use. You cannot use a formatted filesystem partition for an OSD.
+- **Kernel Versions:** Rook requires kernel/RBD support. It recommends [kernel minimums of 5.4+ for expanded RBD image features, and 4.17+ for CephFS RWX PVC size enforcement](https://raw.githubusercontent.com/rook/rook/release-1.20/Documentation/Getting-Started/Prerequisites/prerequisites.md). Running older kernels can lead to reduced features or failed quota enforcement.
+- **Local Storage:** Rook requires at least one local storage source such as raw devices/partitions, LVM logical volumes without filesystem, or block PVCs for Ceph OSD use. You cannot use a formatted filesystem partition for an OSD. Use `lsblk -f` to verify that the `FSTYPE` field is empty for candidate devices.
+- **LVM Package:** The `lvm2` package is required on all storage nodes if you use encryption, metadata devices, or `osdsPerDevice` greater than 1. Without it, OSD pods will fail to start after a node reboot.
 
 ### Kubernetes Compatibility
-Rook's compatibility matrix shifts with each release. For example, [Rook v1.18 documentation still references Kubernetes support as v1.29 through v1.34](https://raw.githubusercontent.com/rook/rook/release-1.18/Documentation/Getting-Started/Prerequisites/prerequisites.md). However, the subsequent Rook v1.19 introduces a minimum supported Kubernetes version of v1.30 and a minimum supported Ceph version of v19.2.0. Looking at the broader picture, [Rook latest-release documentation lists Kubernetes support as v1.30 through v1.35](https://raw.githubusercontent.com/rook/rook/release-1.19/Documentation/Getting-Started/Prerequisites/prerequisites.md). Always verify your control plane version before initiating a Rook upgrade.
+Rook v1.20 supports Kubernetes versions v1.31 through v1.36. The minimum supported Kubernetes version is v1.31 — clusters running older control planes must be upgraded before installing Rook v1.20. Always verify your control plane version against the [Rook prerequisites documentation](https://raw.githubusercontent.com/rook/rook/release-1.20/Documentation/Getting-Started/Prerequisites/prerequisites.md) before initiating a Rook upgrade or fresh installation.
 
 ### CSI Drivers
-Rook acts as the bridge between Kubernetes and Ceph by integrating Container Storage Interface (CSI) drivers. Specifically, [Rook integrates three CSI drivers: RBD (block), CephFS (file), and NFS (experimental)](https://raw.githubusercontent.com/rook/rook/release-1.19/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md). Within Rook, the RBD and CephFS CSI drivers are enabled automatically by the operator, while NFS is disabled by default. When planning upgrades, note that the Rook Ceph CSI support policy in the latest docs is to support only the two most recent ceph-csi versions.
+Rook integrates CSI drivers that Kubernetes uses to provision, attach, and mount storage volumes. In Rook v1.20, [the CSI driver lifecycle is managed by a separate ceph-csi-operator](https://raw.githubusercontent.com/rook/rook/release-1.20/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md) rather than directly by the Rook operator. The RBD and CephFS CSI drivers remain the primary provisioners for block and filesystem storage respectively, and they require their own operator deployment as part of the Rook installation. The NFS CSI driver is available experimentally and is disabled by default. When planning upgrades from Rook v1.19 to v1.20, you must migrate CSI settings from the `rook-ceph-operator-config` ConfigMap to the ceph-csi-operator resources per the upgrade guide.
 
 ---
 
@@ -232,29 +239,43 @@ Rook acts as the bridge between Kubernetes and Ceph by integrating Container Sto
 
 ### Step 1: Install Rook Operator
 
-To begin, install the Rook operator. Note the explicit enablement of the RBD and CephFS CSI drivers.
+To begin, install the Rook operator and the Ceph-CSI driver chart. In the [Rook v1.20 Helm flow](https://rook.io/docs/rook/v1.20/Helm-Charts/operator-chart/), the operator chart installs the Rook and ceph-csi-operator control planes, the Ceph-CSI driver chart creates the RBD and CephFS `Driver` resources that allow CSI to provision and mount volumes, and the `rook-ceph-cluster` chart is the Helm alternative for creating CephCluster and storage resources. This module applies the CephCluster CR by hand in Step 2 so you can inspect the storage settings directly, but the CSI chart is still required before any PVC lab can work.
 
 ```bash
 # Add Rook Helm repo
-helm repo add rook-release https://rook.github.io/charts
+helm repo add rook-release https://charts.rook.io/release
+helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator
 helm repo update
 
 # Install Rook operator
 helm install rook-ceph rook-release/rook-ceph \
-  --namespace rook-ceph --create-namespace \
-  --set csi.enableRBDDriver=true \
-  --set csi.enableCephFSDriver=true
+  --namespace rook-ceph --create-namespace
 
-# Wait for operator
-kubectl -n rook-ceph wait --for=condition=Ready pod \
-  -l app=rook-ceph-operator --timeout=300s
+# Wait for the Rook and ceph-csi operator control planes
+kubectl -n rook-ceph wait --for=condition=Available \
+  deployment/rook-ceph-operator --timeout=300s
+kubectl -n rook-ceph wait --for=condition=Available \
+  deployment/ceph-csi-controller-manager --timeout=300s
+
+# Install Ceph-CSI drivers so RBD/CephFS PVCs can be provisioned and mounted
+helm install ceph-csi-drivers ceph-csi-operator/ceph-csi-drivers \
+  --namespace rook-ceph \
+  -f https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/charts/ceph-csi-drivers/values.yaml
+
+# Confirm the RBD and CephFS driver CRs exist before creating storage classes
+kubectl -n rook-ceph wait \
+  --for=jsonpath='{.metadata.name}'=rook-ceph.rbd.csi.ceph.com \
+  driver.csi.ceph.io/rook-ceph.rbd.csi.ceph.com --timeout=300s
+kubectl -n rook-ceph wait \
+  --for=jsonpath='{.metadata.name}'=rook-ceph.cephfs.csi.ceph.com \
+  driver.csi.ceph.io/rook-ceph.cephfs.csi.ceph.com --timeout=300s
 ```
 
 > **Pause and predict**: The CephCluster definition below explicitly lists which devices on which nodes to use as OSDs, rather than setting `useAllDevices: true`. Why is explicit device listing safer? What could go wrong with `useAllDevices: true` on a server that has both OS drives and data drives?
 
 ### Step 2: Create CephCluster
 
-The CephCluster CRD below configures a production-grade Ceph deployment. Notice three critical design decisions: (1) `allowMultiplePerNode: false` for MONs ensures that a single node failure cannot lose quorum, (2) [`provider: host` for networking bypasses container networking overhead for storage I/O](https://raw.githubusercontent.com/rook/rook/release-1.19/Documentation/CRDs/Cluster/network-providers.md), and (3) resource limits on OSDs prevent them from consuming all CPU and memory during recovery operations.
+The CephCluster CRD below configures a production-grade Ceph deployment. Notice three critical design decisions: (1) `allowMultiplePerNode: false` for MONs ensures that a single node failure cannot lose quorum, (2) [`provider: host` for networking bypasses container networking overhead for storage I/O](https://raw.githubusercontent.com/rook/rook/release-1.20/Documentation/CRDs/Cluster/network-providers.md), and (3) resource limits on OSDs prevent them from consuming all CPU and memory during recovery operations.
 
 ```yaml
 apiVersion: ceph.rook.io/v1
@@ -264,7 +285,7 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: quay.io/ceph/ceph:v19.2
+    image: quay.io/ceph/ceph:v20.2.1-20260402
   dataDirHostPath: /var/lib/rook
 
   mon:
@@ -330,7 +351,7 @@ spec:
                   values: ["storage"]
 ```
 
-> **Stop and think**: The CephBlockPool below sets `failureDomain: host` with `replicated.size: 3`. This means [each block is copied to 3 different servers](https://raw.githubusercontent.com/rook/rook/release-1.19/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md). If you accidentally set `failureDomain: osd` instead of `host`, two replicas could land on different drives of the same server. What happens when that server loses power?
+> **Stop and think**: The CephBlockPool below sets `failureDomain: host` with `replicated.size: 3`. This means [each block is copied to 3 different servers](https://raw.githubusercontent.com/rook/rook/release-1.20/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md). If you accidentally set `failureDomain: osd` instead of `host`, two replicas could land on different drives of the same server. What happens when that server loses power?
 
 ### Step 3: Create StorageClasses
 
@@ -412,7 +433,7 @@ allowVolumeExpansion: true
 
 ```bash
 # Deploy the Rook toolbox
-kubectl apply -f https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/toolbox.yaml
+kubectl apply -f https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/toolbox.yaml
 kubectl -n rook-ceph wait --for=condition=Ready pod -l app=rook-ceph-tools --timeout=300s
 
 # Check Ceph cluster status
@@ -448,13 +469,53 @@ kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph osd pool stats
 
 ---
 
-> **Pause and predict**: After a storage node failure, Ceph starts rebuilding data replicas on surviving nodes. This recovery traffic can consume 80% of available I/O bandwidth. Your production database is on the same Ceph cluster. How would you balance the trade-off between fast recovery (data safety) and application performance?
+## Day-2 Operations
+
+Deploying Ceph is only the beginning. Operating it safely over months and years requires understanding health states, capacity management, and recovery behavior.
+
+### Health States
+
+Ceph reports cluster health through a three-tier system: `HEALTH_OK` (all daemons operational, all PGs clean), `HEALTH_WARN` (something requires attention but data is safe and accessible), and `HEALTH_ERR` (data availability is at risk or the cluster has stopped serving I/O). A `HEALTH_WARN` with one OSD down is a routine condition — the cluster remains fully functional at reduced redundancy. A `HEALTH_ERR` requires immediate investigation; it typically means multiple OSD failures have pushed PGs below `min_size`, or the monitors have lost quorum.
+
+The `ceph health detail` command provides a human-readable explanation of every active warning or error, including which PGs are degraded, which OSDs are down, and whether any pools have reached their near-full or full thresholds. Configure alerting on `HEALTH_WARN` and paging on `HEALTH_ERR` through the MGR Prometheus module and your existing Alertmanager infrastructure.
+
+### Adding and Removing OSDs
+
+When you add a new storage node, update the CephCluster CRD's `storage.nodes[]` list to include the new host and its devices. Rook detects the change, prepares the new OSDs, and adds them to the CRUSH map. Ceph then begins rebalancing data onto the new OSDs — this process is automatic but can take hours or days depending on data volume and network bandwidth. Use `ceph -w` to monitor backfill progress.
+
+Removing an OSD safely requires explicit steps. You cannot simply delete the OSD pod or remove the device from the CRD, because Ceph would treat it as a failure and begin emergency recovery. Instead, mark the OSD as `out` (`ceph osd out <id>`), wait for data to rebalance away from it (the OSD's PG count drops to zero), then remove it from the CRUSH map and purge it (`ceph osd purge <id> --yes-i-really-mean-it`). Rook will then decommission the OSD pod. Skipping the `out` step — removing a live OSD that still holds data — causes immediate PG degradation and potentially data loss if other replicas are also unhealthy.
+
+### Full Cluster Behavior
+
+Ceph enforces hard capacity thresholds to protect data integrity. When any OSD reaches the `nearfull` ratio (default 0.85, or 85% full), Ceph emits `HEALTH_WARN` and the cluster continues operating. When any OSD reaches the `full` ratio (default 0.95, or 95% full), Ceph stops accepting writes to pools that have data on that OSD — the cluster becomes effectively read-only. This is a safety mechanism: if an OSD fills completely to 100%, it cannot participate in recovery or backfill, and data loss becomes possible if another OSD fails before space is freed.
+
+The solution to a near-full cluster is to add capacity (new OSDs or new nodes) before reaching the full threshold. Temporarily increasing `mon_osd_full_ratio` above 0.95 can buy hours of writability, but this is a stopgap — every write moves the cluster closer to an unrecoverable state. Monitor OSD utilization via the Prometheus metrics `ceph_osd_utilization` and set alerts at 75% and 85% to give yourself runway for capacity planning.
+
+### Recovery Throttling
+
+When an OSD fails, Ceph begins rebuilding lost replicas onto surviving OSDs if the relevant CRUSH rule still has enough valid placement targets. This recovery traffic competes with client I/O for disk bandwidth and network throughput, and without throttling it can consume enough resources to impact production workloads. Ceph provides several tunables to balance recovery speed against application performance:
+
+- `osd_max_backfills` — maximum concurrent backfill operations per OSD (default 1). Increasing this speeds recovery at the cost of client latency.
+- `osd_recovery_max_active` — maximum concurrent recovery operations per OSD (default 3). Lower values protect client I/O; higher values speed recovery.
+- `osd_recovery_sleep` — a sleep interval (in seconds) inserted between recovery operations to reduce I/O pressure.
+
+For production clusters hosting latency-sensitive databases, set conservative values (`osd_recovery_max_active: 1, osd_recovery_sleep: 0.1`). For cold-storage or backup clusters where recovery speed matters more than latency, increase both limits. The `ceph config set osd` commands in the performance tuning section demonstrate both profiles.
+
+### Scrubbing and Deep-Scrub
+
+Ceph periodically scrubs every PG to detect bit-rot and inconsistencies between replicas. Light scrubs compare object metadata (size, checksum) across replicas and are relatively cheap. Deep scrubs read every byte of every replica, compute full checksums, and compare them — catching silent data corruption that the drive's own error correction did not detect. Deep scrubs are I/O-intensive and should be scheduled during off-peak hours using `osd_scrub_begin_hour` and `osd_scrub_end_hour`, typically 2 AM to 6 AM local time. If a scrub detects an inconsistency, Ceph marks the affected PG inconsistent and you must investigate with `ceph health detail`, `rados list-inconsistent-pg`, and often `ceph pg repair <pgid>`; automatic repair is not the default and requires `osd_scrub_auto_repair=true` with error counts below the configured threshold.
+
+### Monitoring with Prometheus
+
+Enable the MGR Prometheus module in the CephCluster CRD (`monitoring: enabled: true`) and configure a Prometheus ServiceMonitor to scrape the metrics endpoint. Key metrics to track include per-OSD utilization (`ceph_osd_utilization`), per-pool IOPS and latency (`ceph_pool_rd`, `ceph_pool_wr`), PG state counts (`ceph_pg_active`, `ceph_pg_degraded`), and cluster capacity (`ceph_cluster_total_bytes`, `ceph_cluster_total_used_bytes`). Pair these with node-level metrics from the Prometheus Node Exporter — disk SMART data, network throughput on cluster VLAN interfaces, and memory pressure — to correlate Ceph health with the underlying hardware state.
+
+---
 
 ## Performance Tuning
 
 ### Key Tuning Parameters
 
-The tuning parameters below control the tension between recovery speed and client I/O performance. Setting `osd_recovery_max_active` to 1 means only one recovery operation per OSD runs at a time -- slower recovery, but application latency stays predictable. Setting it to 3 recovers faster but can spike I/O latency by 5-10x during the recovery window:
+The tuning parameters below control the tension between recovery speed and client I/O performance. Setting `osd_recovery_max_active` to 1 means only one recovery operation per OSD runs at a time — slower recovery, but application latency stays predictable. Setting it to 3 recovers faster but can also produce visible latency spikes during the recovery window, especially on clusters where client I/O and recovery traffic share disks or network links:
 
 ```bash
 # Inside rook-ceph-tools pod:
@@ -475,31 +536,114 @@ ceph config set client rbd_cache_size 134217728  # 128MB
 ceph config set osd osd_scrub_begin_hour 2   # Start at 2 AM
 ceph config set osd osd_scrub_end_hour 6     # End at 6 AM
 
-# Monitor PG (Placement Group) count — critical for performance
-# Rule of thumb: total PGs = (OSDs * 100) / replication_factor
-# 12 OSDs, replication 3: (12 * 100) / 3 = 400 PGs per pool
-# Round to nearest power of 2: 512
+# Monitor PGs — critical for distribution and OSD overhead
+# Single dominant replicated pool baseline:
+#   total PGs ~= (OSDs * 100) / replication_factor
+# Multi-pool clusters: use pg_autoscale_mode plus target_size_ratio/bytes
 ```
+
+---
+
+## Cost Lens: On-Premises Economics of Ceph
+
+Running Ceph on owned hardware fundamentally changes the cost model compared to cloud-managed storage services. Understanding the total cost of ownership (TCO) is essential because Ceph's operational complexity can easily consume any savings from avoiding cloud storage bills if the cluster is under-resourced or over-provisioned.
+
+### Capital Expenditure Drivers
+
+A production Ceph cluster's CapEx is dominated by raw disk capacity multiplied by the replication factor — with 3× replication, every terabyte of usable storage requires approximately three terabytes of raw disk, plus overhead for the operating system, BlueStore metadata, and a safety buffer to avoid hitting the near-full threshold. A cluster targeting 100 TB usable thus needs at least 300 TB of raw disk at a minimum, and closer to 350 TB when accounting for overhead and the 85% practical ceiling.
+
+The cost per raw terabyte varies dramatically by media type, endurance rating, warranty tier, and vendor supply cycle. Enterprise NVMe drives are appropriate for database-backed RBD pools where latency directly impacts application performance; enterprise SATA SSDs suit CephFS workloads with moderate I/O requirements; and high-capacity HDDs work for RGW object storage and backup targets where capacity density matters more than IOPS. Treat any pricing spreadsheet as a date-stamped procurement artifact, not durable curriculum content, and verify current quotes before making a build-versus-buy decision.
+
+Additional CapEx includes the storage server hardware itself — dense drive bays, CPUs, RAM sized for OSDs and recovery, and redundant boot devices — plus 25GbE or 100GbE network switches, transceivers, and cables for the dedicated cluster network. Rack space, power distribution, and cooling complete the physical infrastructure bill. A minimal three-node cluster with NVMe media and dedicated storage networking can become expensive quickly, so budget from a real bill of materials rather than a generic per-node estimate.
+
+### Operational Expenditure
+
+OpEx for an on-premises Ceph cluster includes the operations headcount — someone must monitor cluster health, replace failed drives, perform version upgrades, rehearse recovery, and handle capacity planning. Media failure rates vary by model, workload, temperature, firmware, and age, so use vendor advisories, SMART telemetry, burn-in data, and your own fleet history instead of assuming a universal annual failure percentage. For a small cluster serving a single team, Ceph may be a part-time operational duty; for a multi-petabyte cluster serving the entire organization, Ceph operations can justify a dedicated storage engineering role.
+
+Power and cooling are recurring costs that scale with cluster size, drive count, CPU selection, fan curves, rack density, and local electricity rates. Measure representative nodes under recovery and scrub load, then apply your facility's power usage effectiveness and tariff instead of assuming a generic watts-per-node figure. Colocation or datacenter space has the same problem: density, contract terms, cooling envelope, and remote-hands support can dominate the apparent cost of the disks themselves.
+
+Hardware refresh cycles introduce periodic CapEx spikes. Servers typically run for 4-5 years before replacement, and drives for 3-5 years depending on wear. Ceph's ability to seamlessly evacuate data from an aging node (mark all OSDs out, wait for rebalance, decommission) makes hardware refreshes straightforward — new nodes are added to the CRUSH map, data rebalances onto them, and old nodes are removed — but the capital outlay for replacement hardware must be budgeted years in advance.
+
+### When On-Premises Ceph Wins
+
+Ceph's TCO advantage over cloud block storage (AWS EBS, Azure Managed Disks, GCE Persistent Disk) becomes compelling in scenarios with steady, high utilization. The comparison must be date-stamped and provider-specific: cloud storage pricing, provisioned performance pricing, snapshot charges, support tiers, reserved commitments, and regional discounts all change. If your workload consistently uses most of the provisioned capacity rather than being bursty or seasonal, on-premises Ceph may win, but the breakeven point should come from your current cloud bill, hardware quotes, staffing model, and depreciation schedule.
+
+Data gravity — the tendency of large datasets to attract applications and processing — amplifies Ceph's advantage. Moving large datasets out of a cloud provider can incur egress charges and long transfer windows, but the exact cost depends on region, provider, transfer path, committed-use discounts, and whether the data exits to the public internet or another connected service. On-premises Ceph can eliminate cloud egress for local compute and keeps data adjacent to bare-metal workloads. Regulatory requirements — GDPR data residency, financial services audit trails, healthcare data sovereignty — may mandate on-premises storage regardless of cost.
+
+### When On-Premises Ceph Loses
+
+For very small clusters, the operational overhead of Ceph (learning curve, maintenance, monitoring) often outweighs the savings. Longhorn or local-path PVs (covered in Modules 4.1 and 4.3) provide simpler alternatives with lower operational burden at small scale. For spiky or unpredictable workloads — a cluster that needs a large temporary dataset for a short batch-processing window but sits mostly idle the rest of the year — cloud storage's elasticity eliminates the need to provision for peak capacity that sits unused. For teams without storage engineering expertise, the risk of a misconfigured Ceph cluster causing data loss or downtime may exceed the cost of managed services.
+
+---
+
+## Patterns & Anti-Patterns
+
+### Proven Patterns
+
+**Dedicated cluster network on separate VLAN.** Isolate OSD-to-OSD replication and recovery traffic from client-facing public traffic using a second physical interface or a VLAN-tagged subinterface. Jumbo frames can reduce per-packet overhead on bulk data transfers when every hop in the path is configured consistently, but the improvement is workload- and fabric-dependent; verify with your own recovery and client-I/O benchmarks rather than assuming a fixed percentage gain.
+
+**Explicit device selection with `/dev/disk/by-id/` paths.** Never rely on `/dev/sda`, `/dev/nvme0n1`, or kernel-assigned names that can change across reboots. Use persistent device symlinks (`/dev/disk/by-id/ata-Samsung_SSD_S4DBN0W123456` or `/dev/disk/by-id/nvme-Samsung_S4DBN0W123456`) in the CephCluster CRD's storage node device lists. A kernel device-name reassignment after a firmware update that swaps NVMe enumeration order can cause Rook to prepare the wrong drive as an OSD — if that drive happens to contain the operating system, the node is bricked.
+
+**MON placement on non-storage nodes.** Place at least two of your three monitors on nodes that do not run OSDs — typically the Kubernetes control plane nodes, which already run `etcd` and the API server and are unlikely to experience the memory pressure that OSD recovery storms can cause on storage nodes. If all three MONs share hardware with OSDs and a recovery event consumes all available RAM on those nodes, the MONs get OOM-killed, the cluster loses quorum, and all I/O stops — a cascade that turns a routine drive failure into a full outage.
+
+### Anti-Patterns
+
+| Anti-Pattern | Why It's Bad | Better Approach |
+|--------------|--------------|-----------------|
+| `failureDomain: osd` on production replicated pools | Two replicas can land on the same host. A node failure loses 2 of 3 copies, potentially dropping below `min_size` and making the pool read-only. | Always use `failureDomain: host` or higher for pools holding data you cannot afford to lose. |
+| Even number of monitors | No majority quorum can form after a single failure. Both remaining MONs block, and the cluster becomes completely inaccessible. | Always deploy an odd number: 3 for most clusters, 5 for very large deployments. |
+| No resource limits on OSD pods | During recovery or deep-scrub, an OSD can consume all available node memory and get OOM-killed. The killed OSD triggers another recovery, creating a death spiral. | Set `resources.osd.limits.memory` to a value that leaves headroom for the OS and other daemons (at minimum, reserve 4-8 GB for the kernel). |
+| Using EC pools for RBD-backed databases | The read-modify-write cycle on small random writes (database page flushes) adds ~2-5x latency compared to replication. PostgreSQL and MySQL on EC pools will feel sluggish even with NVMe backing. | Use replicated pools (size 3) for databases. Reserve EC for object storage (RGW) and CephFS data pools with read-heavy workloads. |
+| `useAllDevices: true` in CephCluster CRD | Rook will attempt to prepare every unformatted block device on every node as an OSD, including OS drives if they appear unformatted or if a partition table is misread. This can destroy the operating system. | Set `useAllDevices: false` and explicitly list devices per node. |
+| Running an EOL Ceph release in production | No security patches, no bug fixes, no backports for data-corruption issues. Ceph Reef (v18) reached EOL on 2026-03-31 and is unsafe for production use. | Stay on an active release (Squid or Tentacle as of mid-2026) and budget for one major upgrade per year. |
+| Skipping MON `allowMultiplePerNode: false` | If a node running two MONs fails, the cluster loses two MONs simultaneously. In a three-MON cluster, that is quorum lost and all I/O stops. | Always set `allowMultiplePerNode: false` for MONs in production CephCluster CRDs. |
+| No Prometheus alerting on near-full OSDs | The cluster silently approaches the 85% near-full threshold and eventually hits 95% full, at which point all writes are blocked. Recovery from full requires adding capacity — which takes hours or days. | Alert at 75% (`HEALTH_WARN` pre-warning), page at 85%. Budget for capacity expansion when utilization crosses 70%. |
+
+---
+
+## Decision Framework
+
+Choosing between Ceph's storage interfaces, data protection strategies, and deployment topologies is not a single decision but a set of interrelated choices. Use the flowchart below to navigate the primary fork — which storage interface to use — then apply the decision matrix for pool configuration.
+
+```mermaid
+flowchart TD
+    A[Application needs persistent storage] --> B{Multiple pods need<br/>simultaneous write access?}
+    B -->|Yes| C{Is it a database<br/>or latency-sensitive?}
+    B -->|No| D{Is the workload<br/>a database or message queue?}
+    C -->|Yes| E[Use RBD with dedicated<br/>PVC per pod + app-level sharding]
+    C -->|No| F[Use CephFS<br/>ReadWriteMany]
+    D -->|Yes| G[Use RBD<br/>ReadWriteOnce<br/>replicated pool size 3]
+    D -->|No| H{Is this blob/backup/object data<br/>accessed via HTTP API?}
+    H -->|Yes| I[Use RGW<br/>S3-compatible object storage]
+    H -->|No| J{Data size > 50TB<br/>and write frequency low?}
+    J -->|Yes| K[Use CephFS on EC pool<br/>k=4, m=2, failureDomain=host]
+    J -->|No| L[Use CephFS on replicated pool<br/>size 3, failureDomain=host]
+```
+
+### Pool Configuration Decision Matrix
+
+| Workload | Interface | Data Protection | failureDomain | PG Planning Note | Notes |
+|----------|-----------|-----------------|---------------|------------------|-------|
+| PostgreSQL / MySQL | RBD | Replicated, size 3 | host | Give a large target ratio only if this is a dominant data pool | Block device latency critical; EC adds unacceptable write amplification. |
+| MongoDB / etcd | RBD | Replicated, size 3 | host | Keep autoscaler on, but cap churn during sensitive maintenance windows | Consensus systems are sensitive to fsync latency spikes during recovery. |
+| ML training datasets | CephFS | Replicated, size 3 | host | Set `target_size_bytes` or `target_size_ratio` from expected dataset size | Multiple pods read same data; CephFS provides shared access without copying. |
+| CI/CD build cache | CephFS | EC 4+2 | host | Use autoscaler and monitor PG replicas per OSD after cache growth | Write-once, read-many; EC improves capacity efficiency versus replication. |
+| Log aggregation | CephFS | EC 4+2 | host | Start conservative; increase only if distribution or hot PGs demand it | High write throughput but no random read; EC overhead may be acceptable. |
+| S3 backups / data lake | RGW | EC 8+3 | host | This may be the dominant pool; declare target size early | Large sequential writes; EC maximizes capacity efficiency. |
+| VM boot images | RBD | Replicated, size 3 | host | Autoscaler plus a modest minimum often beats a large static PG count | Random read patterns; replication keeps read latency low. |
+| Container image registry | RGW | EC 4+2 | host | Size from expected blob footprint, not from a per-pool default | Blob storage with infrequent writes; EC efficiency matters at scale. |
 
 ---
 
 ## Did You Know?
 
-- **Ceph's CRUSH algorithm** (Controlled Replication Under Scalable Hashing) [determines where data is stored without a central lookup table](https://raw.githubusercontent.com/ceph/ceph/main/doc/architecture.rst). This means Ceph can scale to thousands of OSDs without a metadata bottleneck — any client can calculate the location of any object independently.
+- **Ceph's CRUSH algorithm** [determines where data is stored without a central lookup table](https://raw.githubusercontent.com/ceph/ceph/main/doc/architecture.rst). Any client can independently calculate the location of any object using only the object name and the cluster map, which is why Ceph scales to thousands of OSDs without a metadata bottleneck — there is simply no central server to become one.
 
-- **[Ceph monitors use Paxos consensus](https://raw.githubusercontent.com/ceph/ceph/main/doc/architecture.rst)**.
+- **[BlueStore replaced FileStore as the default OSD backend](https://raw.githubusercontent.com/ceph/ceph/main/doc/releases/luminous.rst)** in Ceph Luminous (2017). By [writing directly to raw block devices and managing its own metadata in RocksDB](https://raw.githubusercontent.com/ceph/ceph/main/doc/rados/configuration/bluestore-config-ref.rst), BlueStore eliminates the double-write penalty of the old filesystem-based approach and enables native compression and checksumming on every object.
 
-- **[A single Ceph cluster can scale to exabytes](https://raw.githubusercontent.com/ceph/ceph/main/doc/architecture.rst).** CERN runs one of the largest Ceph deployments: 30+ PB across thousands of OSDs, storing physics experiment data from the Large Hadron Collider.
+- **[Ceph is designed for very large clusters](https://raw.githubusercontent.com/ceph/ceph/main/doc/architecture.rst).** The important takeaway for an enterprise learner is not a specific public deployment number; it is the architecture choice: CRUSH lets clients calculate placement locally, so scaling pressure moves to OSD count, network design, failure-domain layout, and operational automation rather than a central metadata lookup service.
 
-- **[BlueStore replaced FileStore as the default OSD backend](https://raw.githubusercontent.com/ceph/ceph/main/doc/releases/luminous.rst)** in Ceph Luminous (2017). [BlueStore writes directly to raw block devices](https://raw.githubusercontent.com/ceph/ceph/main/doc/rados/configuration/bluestore-config-ref.rst), bypassing the Linux filesystem entirely. This eliminates the double-write penalty that FileStore suffered and improves write performance.
-
-- Rook is a fully matured CNCF project; it was accepted to the CNCF on **2018-01-29**, moved to incubation on **2018-09-25**, and achieved Graduated maturity on **2020-10-07**.
-
-- The Ceph **Tentacle** release train was initially released on **2026-04-06** and represents the leading edge of active Ceph development (latest version **20.2.1**).
-
-- The Ceph **Squid** release train remains highly active with its latest stable release at **19.2.3**, and is expected to reach its end-of-life on **2026-09-19**.
-
-- The Ceph **Reef** release train's latest version is **18.2.8**, which serves as its eighth and expected final backport release, leading up to its EOL on **2026-03-31**.
+- **Rook is a CNCF Graduated project,** accepted on 2018-01-29, moved to incubation on 2018-09-25, and [achieving Graduated maturity on 2020-10-07](https://www.cncf.io/projects/rook/). Graduated status means Rook has demonstrated widespread adoption, a formal governance process, and a commitment to security and interoperability standards expected of the highest-tier CNCF projects.
 
 ---
 
@@ -507,14 +651,14 @@ ceph config set osd osd_scrub_end_hour 6     # End at 6 AM
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| Too few PGs | Uneven data distribution, hotspots | Calculate PGs: (OSDs × 100) / replication_factor |
-| No cluster network | Replication competes with client I/O | Separate public and cluster networks |
-| MONs on OSD nodes | MON fails when OSD saturates CPU/RAM | Dedicated MON nodes (or on K8s control plane nodes) |
-| No resource limits on OSDs | OSD consumes all node RAM during recovery | Set CPU/memory limits in CephCluster spec |
-| Replication factor 2 | Single failure = data at risk during rebuild | Always use replication factor 3 |
-| Not monitoring disk health | Drive fails silently, OSD goes down | smartmontools + Prometheus SMART exporter |
-| Scrubbing during peak hours | Background scrub competes with workload I/O | Schedule scrubs for off-peak hours |
-| Using `useAllDevices: true` | Accidentally formats OS drives as OSDs | Explicitly list devices per node |
+| Too few PGs | Uneven data distribution, hotspots | Use the PG autoscaler with pool target sizes; treat the old formula only as a rough single-pool sanity check |
+| No cluster network | Replication competes with client I/O | Separate public and cluster networks on different VLANs with jumbo frames |
+| MONs on OSD nodes | MON fails when OSD saturates CPU/RAM during recovery | Dedicated MON nodes (or on K8s control plane nodes) with `allowMultiplePerNode: false` |
+| No resource limits on OSDs | OSD consumes all node RAM during recovery, gets OOM-killed | Set CPU/memory limits in CephCluster spec; leave ≥4 GB for kernel |
+| Replication factor 2 | Single failure = data at risk during rebuild window | Always use replication factor 3 for production pools |
+| Not monitoring disk health | Drive fails silently, OSD goes down without warning | smartmontools + Prometheus SMART exporter with alerts on reallocated sectors |
+| Scrubbing during peak hours | Background scrub competes with workload I/O | Schedule scrubs for off-peak hours (2-6 AM) via `osd_scrub_begin_hour`/`osd_scrub_end_hour` |
+| Using `useAllDevices: true` | Accidentally formats OS drives as OSDs, bricking the node | Explicitly list devices per node using `/dev/disk/by-id/` paths |
 
 ---
 
@@ -528,19 +672,9 @@ You have 12 NVMe drives across 3 storage nodes (4 per node). What replication fa
 
 **Replication factor 3, failure domain `host`.**
 
-- Each object is replicated to 3 different OSDs on 3 different hosts
-- If an entire host fails (all 4 OSDs), 2 copies remain on the other 2 hosts
-- Recovery redistributes the lost replicas using the 8 surviving OSDs
-- Failure domain `host` ensures no two replicas of the same object are on the same server
+Each object is replicated to 3 different OSDs on 3 different hosts. If an entire host fails (all 4 OSDs), 2 copies remain on the other 2 hosts and all data is still accessible as long as the pool's `min_size` is satisfied. However, Ceph cannot rebuild a third host-separated copy while only two host failure domains remain; affected PGs stay degraded or undersized until the failed node returns or a new storage host is added. Failure domain `host` ensures no two replicas of the same object are on the same server — a host-level power failure or kernel panic cannot compromise multiple copies simultaneously.
 
-**Do NOT use failure domain `osd`** (default if not specified) — this would allow 2 replicas on the same host, meaning a host failure could lose 2 of 3 copies.
-
-```yaml
-spec:
-  failureDomain: host  # Not "osd"
-  replicated:
-    size: 3
-```
+Do not use failure domain `osd` (the default if not specified) — this allows 2 replicas to land on the same host, meaning a single server failure could lose 2 of your 3 copies and potentially push affected PGs below `min_size`, making the pool read-only until recovery completes.
 </details>
 
 ### Question 2
@@ -549,20 +683,11 @@ Your Ceph cluster shows `HEALTH_WARN: 1 osds down`. What is the immediate impact
 <details>
 <summary>Answer</summary>
 
-**Immediate impact**: Minimal. With replication factor 3, all data has 2 remaining copies. No data is lost and all volumes are accessible. However, those placement groups that had replicas on the failed OSD now have only 2 copies instead of 3 (degraded).
+**Immediate impact**: Minimal. With replication factor 3, every object has 2 remaining copies on surviving OSDs. No data is lost and all volumes remain accessible. However, the placement groups that had replicas on the failed OSD are now degraded — operating at reduced redundancy — meaning a second failure before recovery completes could drop some PGs below `min_size`.
 
-**What happens automatically**:
-1. Ceph marks the OSD as `down` and starts a timer
-2. After 10 minutes (default `mon_osd_down_out_interval`), Ceph marks the OSD as `out`
-3. Ceph begins redistributing data to rebuild the third copy on surviving OSDs
-4. Recovery time depends on data size and network speed (~100GB/min on 25GbE)
+What happens automatically: Ceph marks the OSD as `down`, starts the `mon_osd_down_out_interval` timer (default 600 seconds), then marks it `out` and attempts recovery or backfill where the CRUSH rule has valid target OSDs. Recovery time depends on how much data must move, OSD media, client load, throttling settings, network capacity, and whether enough failure domains remain; estimate it from measured backfill throughput in your own cluster, not from a generic GB-per-minute number.
 
-**What you should do**:
-1. Check which OSD and which node: `ceph osd tree`
-2. Check if the node is reachable (is this a disk failure or a node failure?)
-3. If disk failure: replace the drive, then `ceph osd purge <id> --yes-i-really-mean-it` and let Rook redeploy
-4. If node failure: fix the node; when it comes back, the OSD will rejoin automatically
-5. Monitor recovery: `ceph -w` (watch recovery progress)
+What you should do: (1) Check which OSD and which node with `ceph osd tree`. (2) Determine root cause — is this a disk failure (SMART errors) or a node failure (kernel panic, power loss)? (3) For disk failure, replace the drive, then `ceph osd purge <id> --yes-i-really-mean-it` and let Rook redeploy. (4) For transient node failure, fix the node; when it rejoins, the OSD will come back up and catch up on missed writes instead of triggering a full backfill. (5) Monitor progress with `ceph -w`.
 </details>
 
 ### Question 3
@@ -571,30 +696,76 @@ When should you use CephFS (ReadWriteMany) instead of RBD (ReadWriteOnce)?
 <details>
 <summary>Answer</summary>
 
-**Use RBD (block)** for:
-- Databases (PostgreSQL, MySQL, MongoDB) — need consistent block I/O
-- Single-pod workloads that need persistent storage
-- Any workload where only one pod writes at a time
-- Best performance (direct block device, no filesystem overhead)
+Use RBD (block) for databases (PostgreSQL, MySQL, MongoDB, etcd) that need consistent low-latency block I/O and exclusive write access — the kernel maps the RBD image directly as a block device with no filesystem intermediary. Use RBD for any single-pod workload that needs persistent storage and does not require concurrent access from multiple pods.
 
-**Use CephFS (filesystem)** for:
-- Shared data that multiple pods read/write simultaneously
-- ML training datasets (multiple training pods read the same data)
-- CMS content directories (multiple web servers serve the same files)
-- Log aggregation (multiple pods write to a shared directory)
-- Any workload that needs `ReadWriteMany` access mode
+Use CephFS (filesystem) for shared data that multiple pods must read and write simultaneously — ML training datasets read by dozens of training workers, web-server content directories served by multiple NGINX replicas, CI/CD artifact caches, and log aggregation directories. CephFS provides true POSIX semantics with the Metadata Server (MDS) handling namespace operations while data reads and writes go directly to OSDs.
 
-**Do NOT use CephFS for databases** — the POSIX filesystem layer adds latency and doesn't provide the consistency guarantees that databases expect from block devices.
+Do not use CephFS for databases — the POSIX filesystem layer adds metadata latency on every file operation, and the shared-access model does not provide the exclusive-write consistency guarantees that database storage engines expect from a block device. A PostgreSQL `fsync` on CephFS may not mean what PostgreSQL thinks it means.
+</details>
 
-```yaml
-# RBD PVC
-accessModes: ["ReadWriteOnce"]
-storageClassName: ceph-block
+### Question 4
+Hypothetical scenario: Your 10-node Ceph cluster has 3 MONs, all co-located on storage nodes with OSDs. A recovery storm after a node failure causes memory pressure, and the kernel OOM-kills one MON. What happens next, and how should you have configured this differently?
 
-# CephFS PVC
-accessModes: ["ReadWriteMany"]
-storageClassName: ceph-filesystem
-```
+<details>
+<summary>Answer</summary>
+
+When one MON is killed, the remaining two MONs still form a quorum (2 out of 3) and the cluster continues operating. However, the cluster is now in a fragile state — if a second MON fails before the first recovers, the single remaining MON cannot form a quorum alone, and the entire cluster becomes inaccessible even though every OSD is healthy and all data is intact.
+
+But the real danger is cascading: the OOM-killed MON was on a storage node. When the MON pod restarts, it rejoins the quorum, but the underlying memory pressure from the recovery storm persists. The MON may be OOM-killed again, creating a flapping MON that destabilizes the quorum and causes repeated leader elections — each election briefly pauses all I/O while the new leader establishes authority.
+
+The correct configuration is to place at least two MONs on dedicated non-storage nodes (typically Kubernetes control plane nodes) that do not experience the memory pressure of OSD recovery storms. With `allowMultiplePerNode: false` and MONs distributed across independent failure domains, no single event can compromise quorum. This is a one-line YAML change that prevents a multi-hour outage.
+</details>
+
+### Question 5
+Hypothetical scenario: You have a 6-node Ceph storage cluster and need to store 80 TB of nightly database backups. The backups are written once per night (large sequential writes) and read only during monthly restore drills. Should you use a replicated pool (size 3) or an erasure-coded pool (4+2), and why?
+
+<details>
+<summary>Answer</summary>
+
+Use an erasure-coded pool with 4+2 profile. When evaluating the replicated-vs-erasure-coded tradeoff for a given storage-node topology, the workload characteristics are decisive: writes are large, sequential, and infrequent (nightly batch), and reads are extremely rare (monthly drills). The EC profile tolerates the loss of any 2 chunks — equivalent to losing 2 OSDs or 2 hosts simultaneously — which provides adequate durability for backup data. This tradeoff always depends on your specific storage-node topology and upgrade path because adding EC pools later requires OSDs to be available across enough failure domains to satisfy the erasure coding profile.
+
+The capacity savings are substantial. With replication factor 3, 80 TB usable requires 240 TB raw. With EC 4+2, 80 TB usable requires only 80 × (6/4) = 120 TB raw — a 50% reduction in raw capacity. Over the 4-5 year hardware lifecycle, that difference can represent tens of thousands of dollars in disk and server CapEx.
+
+The latency penalty of EC's read-modify-write cycle is irrelevant for nightly batch writes that complete in minutes, and the monthly restore drill reads are sequential and can tolerate the reconstruction overhead. A replicated pool would be simpler but wastes capacity on a workload that does not benefit from replication's low-latency random-read performance.
+</details>
+
+### Question 6
+Hypothetical scenario: You are planning a Rook-Ceph upgrade from v1.19 to v1.20, and your cluster uses custom CSI settings configured through the `rook-ceph-operator-config` ConfigMap. What is the critical breaking change in Rook v1.20 that you must address before the upgrade, and what is the minimum Kubernetes version required?
+
+<details>
+<summary>Answer</summary>
+
+The critical breaking change in Rook v1.20 is that CSI driver management has been extracted from the Rook operator into a separate `ceph-csi-operator`. Rook no longer manages CSI settings through the `rook-ceph-operator-config` ConfigMap. Before upgrading from v1.19, you must migrate all custom CSI settings (driver configurations, resource limits, priority classes, tolerations) from the ConfigMap into the ceph-csi-operator's CRD resources. The Rook v1.20 upgrade documentation provides the specific migration steps — failing to perform this migration means your CSI drivers will revert to default settings, which could break volume provisioning if you relied on custom configurations.
+
+The minimum Kubernetes version for Rook v1.20 is v1.31. If your cluster runs an older control plane, you must upgrade Kubernetes before upgrading Rook. Additionally, Rook upgrades are strictly sequential — you must upgrade from v1.19.x to v1.20.x; skipping v1.19 entirely (e.g., going from v1.18 directly to v1.20) is unsupported and can leave the cluster in an inconsistent state where MONs or OSDs fail to start because their on-disk configuration does not match the operator's expectations.
+</details>
+
+### Question 7
+Hypothetical scenario: Your Ceph cluster's `ceph status` reports `HEALTH_WARN: 1 nearfull osd(s)`. One OSD is at 87% utilization while others are at 55-65%. What caused this imbalance, and what steps should you take?
+
+<details>
+<summary>Answer</summary>
+
+The imbalance is most likely caused by an insufficient PG count. With too few PGs, the CRUSH algorithm cannot distribute data evenly because there are fewer placement "buckets" than ideal. Some OSDs receive disproportionately more PGs than others, filling up faster. A secondary cause could be an improperly weighted CRUSH map — if one OSD's weight differs from its peers (perhaps because an older smaller drive was replaced with a larger one without updating the weight), CRUSH will place data according to the stale weight.
+
+Immediate steps: (1) Verify PG state with `ceph osd pool ls detail` and `ceph df` — look at PG replicas per OSD, pool size, and whether one pool dominates capacity. (2) If a pool's PG count is too low, increase it gradually, one pool at a time, because PG splitting generates significant I/O as data is redistributed across the new PGs. (3) Check OSD weights with `ceph osd tree` — any OSD with a weight that does not match its actual capacity will cause uneven placement. (4) Enable autoscaling per existing pool with `ceph osd pool set <pool-name> pg_autoscale_mode on`, or set `ceph config set global osd_pool_default_pg_autoscale_mode on` for future pools; for large pools, also configure `target_size_bytes` or `target_size_ratio` so the autoscaler understands intended data share. (5) If the near-full OSD is already above 85%, add capacity or increase `mon_osd_nearfull_ratio` temporarily while the rebalance runs.
+</details>
+
+### Question 8
+Hypothetical scenario: You are designing a Ceph cluster for a manufacturing company that runs production databases (PostgreSQL, 5 TB, high IOPS), a shared ML training pipeline (CephFS, 20 TB, read-heavy), and S3-compatible object storage for sensor data archives (RGW, 200 TB, write-once-read-rarely). The company has a budget for 10 storage nodes, each with 4 NVMe and 8 HDD bays. How would you structure the pools?
+
+<details>
+<summary>Answer</summary>
+
+Use device classes to separate NVMe and HDD into distinct CRUSH roots, then create pools targeting the appropriate device class:
+
+**NVMe tier** (4 drives × 10 nodes = 40 OSDs): Create a replicated RBD pool (`size: 3, failureDomain: host, deviceClass: nvme`) for the PostgreSQL databases. At 3× replication, this provides ~5 TB usable × 3 = 15 TB raw consumed out of the NVMe capacity, leaving headroom for growth. The low latency of NVMe combined with replication's fast random-read performance is ideal for database page fetches and WAL writes.
+
+**NVMe tier, second pool**: Create a replicated CephFS pool (`size: 3, failureDomain: host, deviceClass: nvme`) for the ML training pipeline's working set — the data that training pods actively read. If the full 20 TB ML dataset exceeds NVMe capacity, place the hot working set on NVMe-backed CephFS and archive cold data to HDD.
+
+**HDD tier** (8 drives × 10 nodes = 80 OSDs): Create an erasure-coded RGW pool (`4+2, failureDomain: host, deviceClass: hdd`) for the 200 TB sensor data archive. At 4+2, the 200 TB usable requires ~300 TB raw — check against available HDD raw capacity and add nodes if needed. EC on HDD is appropriate for write-once-read-rarely archives where capacity density matters more than latency.
+
+This design separates latency-sensitive database I/O (NVMe, replicated) from capacity-driven archive I/O (HDD, EC) without requiring separate clusters. The `deviceClass` field in pool CRDs ensures CRUSH never places an NVMe-requesting PG on an HDD OSD. A single Ceph dashboard and Prometheus endpoint monitors both tiers.
 </details>
 
 ---
@@ -609,9 +780,9 @@ This exercise walks you through creating a local test environment and deploying 
 
 ### Step-by-Step Progressive Tasks
 
-**Task 1: Bootstrap the Kind Cluster**
-<details>
-<summary>Solution</summary>
+Work through each task in sequence, typing the commands into your terminal. Explanations follow each code block to help you understand what each command accomplishes and why it is necessary for the deployment.
+
+**Task 1: Bootstrap the Kind Cluster.** Create a local Kubernetes cluster using Kind with one control-plane node and three worker nodes. The three workers simulate the multi-node topology that a production Ceph deployment requires for host-level failure domain separation, even though this test cluster runs on a single machine.
 
 ```bash
 cat <<EOF | kind create cluster --config=-
@@ -624,24 +795,28 @@ nodes:
   - role: worker
 EOF
 ```
-</details>
 
-**Task 2: Install the Rook Operator**
-<details>
-<summary>Solution</summary>
+**Task 2: Install the Rook Operator and Ceph-CSI Drivers.** Add the Rook and ceph-csi-operator Helm repositories, install the Rook operator into the `rook-ceph` namespace, wait for both the Rook operator and ceph-csi operator controller to become available, then install the Ceph-CSI driver chart. The Rook Helm docs also provide the `rook-ceph-cluster` chart for managing the CephCluster and storage classes through Helm; this exercise keeps the CephCluster manifest explicit so you can see exactly which test-only settings are being used.
 
 ```bash
-helm repo add rook-release https://rook.github.io/charts
+helm repo add rook-release https://charts.rook.io/release
+helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator
+helm repo update
 helm install rook-ceph rook-release/rook-ceph \
   --namespace rook-ceph --create-namespace
-kubectl -n rook-ceph wait --for=condition=Ready pod \
-  -l app=rook-ceph-operator --timeout=300s
+kubectl -n rook-ceph wait --for=condition=Available \
+  deployment/rook-ceph-operator --timeout=300s
+kubectl -n rook-ceph wait --for=condition=Available \
+  deployment/ceph-csi-controller-manager --timeout=300s
+helm install ceph-csi-drivers ceph-csi-operator/ceph-csi-drivers \
+  --namespace rook-ceph \
+  -f https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/charts/ceph-csi-drivers/values.yaml
+kubectl -n rook-ceph wait \
+  --for=jsonpath='{.metadata.name}'=rook-ceph.rbd.csi.ceph.com \
+  driver.csi.ceph.io/rook-ceph.rbd.csi.ceph.com --timeout=300s
 ```
-</details>
 
-**Task 3: Deploy the CephCluster Custom Resource**
-<details>
-<summary>Solution</summary>
+**Task 3: Deploy the CephCluster Custom Resource.** Apply a CephCluster manifest configured for a minimal test environment. This uses PVC-backed OSDs (`storageClassDeviceSets`) rather than raw devices because Kind nodes do not provide unformatted block devices for Rook to consume. Rook v1.20 supports Ceph Tentacle v20.2.1, so `allowUnsupported` stays false; set it true only for intentional testing of a future unsupported Ceph major version.
 
 ```bash
 kubectl apply -f - <<EOF
@@ -652,8 +827,8 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: quay.io/ceph/ceph:v19.2
-    allowUnsupported: true
+    image: quay.io/ceph/ceph:v20.2.1
+    allowUnsupported: false
   dataDirHostPath: /var/lib/rook
   mon:
     count: 1
@@ -669,7 +844,7 @@ spec:
     storageClassDeviceSets:
       - name: set1
         count: 3
-        portable: true
+        portable: false
         volumeClaimTemplates:
           - metadata:
               name: data
@@ -694,26 +869,22 @@ spec:
         memory: "512Mi"
 EOF
 ```
-</details>
 
-**Task 4: Monitor and Validate Cluster Health**
-<details>
-<summary>Solution</summary>
+**Task 4: Monitor and Validate Cluster Health.** Wait for the CephCluster resource to report Ready, deploy the Rook toolbox pod, and use `ceph status` to confirm that the cluster is healthy with all daemons operational. The toolbox pod provides a `ceph` CLI environment that can run administrative commands against the cluster without requiring direct access to the MON nodes.
 
 ```bash
 kubectl -n rook-ceph wait --for=condition=Ready cephcluster/rook-ceph --timeout=600s
-kubectl apply -f https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/toolbox.yaml
+kubectl apply -f https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/toolbox.yaml
 kubectl -n rook-ceph wait --for=condition=Ready pod -l app=rook-ceph-tools --timeout=300s
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
 ```
-</details>
 
-**Task 5: Create a PVC and Verify Binding**
-<details>
-<summary>Solution</summary>
+**Task 5: Create a PVC and Verify Binding.** Wait for the RBD CSI provisioner and node plugin to be rolled out, then apply the test StorageClass and create a PersistentVolumeClaim that requests 1 GiB of block storage from the Ceph cluster. Verify that the PVC transitions to Bound status, which confirms that the CSI provisioner successfully allocated an RBD image and made it available to Kubernetes.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/csi/rbd/storageclass-test.yaml
+kubectl -n rook-ceph rollout status deployment/csi-rbdplugin-provisioner --timeout=300s
+kubectl -n rook-ceph rollout status daemonset/csi-rbdplugin --timeout=300s
+kubectl apply -f https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/csi/rbd/storageclass-test.yaml
 kubectl apply -f - <<EOF
 apiVersion: v1
 kind: PersistentVolumeClaim
@@ -728,7 +899,6 @@ spec:
 EOF
 kubectl get pvc test-pvc
 ```
-</details>
 
 ### Complete Script Reference
 
@@ -747,13 +917,25 @@ nodes:
 EOF
 
 # Install Rook operator
-helm repo add rook-release https://rook.github.io/charts
+helm repo add rook-release https://charts.rook.io/release
+helm repo add ceph-csi-operator https://ceph.github.io/ceph-csi-operator
+helm repo update
 helm install rook-ceph rook-release/rook-ceph \
   --namespace rook-ceph --create-namespace
 
-# Wait for operator
-kubectl -n rook-ceph wait --for=condition=Ready pod \
-  -l app=rook-ceph-operator --timeout=300s
+# Wait for operator control planes
+kubectl -n rook-ceph wait --for=condition=Available \
+  deployment/rook-ceph-operator --timeout=300s
+kubectl -n rook-ceph wait --for=condition=Available \
+  deployment/ceph-csi-controller-manager --timeout=300s
+
+# Install Ceph-CSI driver resources for RBD/CephFS PVC provisioning
+helm install ceph-csi-drivers ceph-csi-operator/ceph-csi-drivers \
+  --namespace rook-ceph \
+  -f https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/charts/ceph-csi-drivers/values.yaml
+kubectl -n rook-ceph wait \
+  --for=jsonpath='{.metadata.name}'=rook-ceph.rbd.csi.ceph.com \
+  driver.csi.ceph.io/rook-ceph.rbd.csi.ceph.com --timeout=300s
 
 # Deploy a test CephCluster using PVC-based OSDs
 # This uses Kind's default StorageClass to back each OSD with a PVC
@@ -765,8 +947,8 @@ metadata:
   namespace: rook-ceph
 spec:
   cephVersion:
-    image: quay.io/ceph/ceph:v19.2
-    allowUnsupported: true
+    image: quay.io/ceph/ceph:v20.2.1
+    allowUnsupported: false
   dataDirHostPath: /var/lib/rook
   mon:
     count: 1
@@ -782,7 +964,7 @@ spec:
     storageClassDeviceSets:
       - name: set1
         count: 3
-        portable: true
+        portable: false
         volumeClaimTemplates:
           - metadata:
               name: data
@@ -811,14 +993,18 @@ EOF
 kubectl -n rook-ceph wait --for=condition=Ready cephcluster/rook-ceph --timeout=600s
 
 # Deploy toolbox for ceph commands
-kubectl apply -f https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/toolbox.yaml
+kubectl apply -f https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/toolbox.yaml
 kubectl -n rook-ceph wait --for=condition=Ready pod -l app=rook-ceph-tools --timeout=300s
 
 # Check Ceph health
 kubectl -n rook-ceph exec deploy/rook-ceph-tools -- ceph status
 
+# Wait for the RBD CSI driver pods before provisioning a PVC
+kubectl -n rook-ceph rollout status deployment/csi-rbdplugin-provisioner --timeout=300s
+kubectl -n rook-ceph rollout status daemonset/csi-rbdplugin --timeout=300s
+
 # Create a block pool and storage class
-kubectl apply -f https://raw.githubusercontent.com/rook/rook/release-1.19/deploy/examples/csi/rbd/storageclass-test.yaml
+kubectl apply -f https://raw.githubusercontent.com/rook/rook/release-1.20/deploy/examples/csi/rbd/storageclass-test.yaml
 
 # Create a test PVC
 kubectl apply -f - <<EOF
@@ -850,12 +1036,14 @@ kind delete cluster
 - [ ] Block pool and StorageClass created
 - [ ] PVC bound successfully
 - [ ] `ceph status` shows healthy cluster
+- [ ] Able to explain why `failureDomain: host` is used in production but omitted in this test deployment
+- [ ] Able to identify which OSD provisioning strategy (raw-device vs PVC-backed) this exercise uses and why
 
 ---
 
 ## Next Module
 
-Continue to [Module 4.3: Local Storage & Alternatives](../module-4.3-local-storage/) to learn about lightweight storage options that do not require a distributed storage system, perfect for ephemeral edge caches or simple bare-metal database nodes.
+Continue to [Module 4.3: Local Storage & Alternatives](../module-4.3-local-storage/) to learn about lightweight storage options that do not require a distributed storage system, perfect for ephemeral edge caches or simple bare-metal database nodes where the operational complexity of Ceph is not justified.
 
 ## Sources
 
@@ -864,14 +1052,22 @@ Continue to [Module 4.3: Local Storage & Alternatives](../module-4.3-local-stora
 - [raw.githubusercontent.com: architecture.rst](https://raw.githubusercontent.com/ceph/ceph/main/doc/architecture.rst) — The upstream Ceph architecture documentation directly describes unified object/block/file storage, core daemons, CRUSH placement, replication, self-healing, and dynamic rebalancing.
 - [github.com: rook](https://github.com/rook/rook) — The Rook project description states that the operator builds on Kubernetes resources to deploy, configure, provision, scale, upgrade, and monitor Ceph.
 - [cncf.io: rook](https://www.cncf.io/projects/rook/) — The CNCF Rook project page directly lists the accepted, incubating, and graduated dates.
+- [raw.githubusercontent.com: releases.yml](https://raw.githubusercontent.com/ceph/ceph/main/doc/releases/releases.yml) — The Ceph releases YAML lists Tentacle 20.2.1, Squid 19.2.4, Reef 18.2.8 EOL, and their respective target EOL dates.
 - [raw.githubusercontent.com: index.rst](https://raw.githubusercontent.com/ceph/ceph/main/doc/releases/index.rst) — The upstream Ceph releases index states the maintenance behavior for active and archived releases.
-- [raw.githubusercontent.com: releases.yml](https://raw.githubusercontent.com/ceph/ceph/main/doc/releases/releases.yml) — The Ceph releases YAML lists Squid 19.2.3 and target EOL 2026-09-19.
-- [raw.githubusercontent.com: rook upgrade.md](https://raw.githubusercontent.com/rook/rook/release-1.19/Documentation/Upgrade/rook-upgrade.md) — The Rook v1.19 upgrade guide directly states the supported upgrade path, official-release-only support, master-build warning, and v1.19 minimum Kubernetes and Ceph versions.
-- [raw.githubusercontent.com: network providers.md](https://raw.githubusercontent.com/rook/rook/release-1.19/Documentation/CRDs/Cluster/network-providers.md) — The Rook network providers documentation defines Ceph public and cluster networks and explains their use for client, replication, and recovery traffic.
-- [raw.githubusercontent.com: prerequisites.md](https://raw.githubusercontent.com/rook/rook/release-1.19/Documentation/Getting-Started/Prerequisites/prerequisites.md) — Rook's v1.19 prerequisites document lists supported CPU architectures, RBD/CephFS kernel requirements, and accepted OSD storage sources.
-- [raw.githubusercontent.com: prerequisites.md](https://raw.githubusercontent.com/rook/rook/release-1.18/Documentation/Getting-Started/Prerequisites/prerequisites.md) — The Rook v1.18 prerequisites page is the primary source for its Kubernetes support range.
-- [raw.githubusercontent.com: ceph csi drivers.md](https://raw.githubusercontent.com/rook/rook/release-1.19/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md) — The Rook Ceph CSI drivers documentation directly states the integrated drivers, default enablement, and supported ceph-csi version policy.
-- [raw.githubusercontent.com: ceph block pool crd.md](https://raw.githubusercontent.com/rook/rook/release-1.19/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md) — The Rook CephBlockPool CRD documentation directly explains failureDomain host with replicated.size 3 and its node-failure availability behavior.
-- [raw.githubusercontent.com: osd config ref.rst](https://raw.githubusercontent.com/ceph/ceph/main/doc/rados/configuration/osd-config-ref.rst) — General lesson point for an illustrative rewrite.
+- [raw.githubusercontent.com: rook upgrade.md](https://raw.githubusercontent.com/rook/rook/release-1.20/Documentation/Upgrade/rook-upgrade.md) — The Rook v1.20 upgrade guide directly states the supported upgrade path from v1.19, official-release-only support, master-build warning, and the CSI operator migration requirement.
+- [rook.io: ceph operator helm chart](https://rook.io/docs/rook/v1.20/Helm-Charts/operator-chart/) — The Rook v1.20 Helm documentation lists the release repository URL, the operator chart install command, and the required sequence that includes installing the Ceph-CSI drivers chart.
+- [rook.io: ceph-csi driver helm chart](https://rook.io/docs/rook/v1.20/Helm-Charts/csi-drivers-chart/) — The Ceph-CSI driver chart documentation states that the chart is required so CSI can provision and mount Ceph volumes, and gives the ceph-csi-operator Helm repository and install command.
+- [rook.io: ceph cluster helm chart](https://rook.io/docs/rook/v1.20/Helm-Charts/ceph-cluster-chart/) — The Rook cluster chart documentation covers the `rook-ceph-cluster` Helm release, default block pool and StorageClass creation, and default `cephImage.allowUnsupported: false`.
+- [rook.io: ceph upgrades](https://rook.io/docs/rook/v1.20/Upgrade/ceph-upgrade/) — The Rook Ceph upgrade guide lists supported Squid/Tentacle versions and recommends full Ceph version-and-build image tags such as `v20.2.1-20260402` for production consistency.
+- [raw.githubusercontent.com: network providers.md](https://raw.githubusercontent.com/rook/rook/release-1.20/Documentation/CRDs/Cluster/network-providers.md) — The Rook network providers documentation defines Ceph public and cluster networks and explains their use for client, replication, and recovery traffic.
+- [raw.githubusercontent.com: prerequisites.md](https://raw.githubusercontent.com/rook/rook/release-1.20/Documentation/Getting-Started/Prerequisites/prerequisites.md) — Rook's v1.20 prerequisites document lists supported CPU architectures, Kubernetes version range (v1.31-v1.36), RBD/CephFS kernel requirements, and accepted OSD storage sources.
+- [raw.githubusercontent.com: ceph-csi-drivers.md](https://raw.githubusercontent.com/rook/rook/release-1.20/Documentation/Storage-Configuration/Ceph-CSI/ceph-csi-drivers.md) — The Rook Ceph CSI drivers documentation describes the ceph-csi-operator-managed CSI driver lifecycle in Rook v1.20 and the supported ceph-csi version policy.
+- [rook.io: csi common issues](https://rook.io/docs/rook/v1.20/Troubleshooting/ceph-csi-common-issues/) — The Rook CSI troubleshooting documentation identifies the RBD provisioner deployment and RBD node-plugin pod names used for PVC provisioning and mounting checks.
+- [raw.githubusercontent.com: ceph-block-pool-crd.md](https://raw.githubusercontent.com/rook/rook/release-1.20/Documentation/CRDs/Block-Storage/ceph-block-pool-crd.md) — The Rook CephBlockPool CRD documentation explains failureDomain, replicated.size, and erasureCoded pool configuration with dataChunks/codingChunks parameters.
+- [raw.githubusercontent.com: ceph-cluster-crd.md](https://raw.githubusercontent.com/rook/rook/release-1.20/Documentation/CRDs/Cluster/ceph-cluster-crd.md) — The Rook CephCluster CRD documentation covers cluster-level settings including MON count, MGR configuration, `allowUnsupported`, storage selection, `portable` PVC OSD behavior, resource limits, and network provider options.
 - [raw.githubusercontent.com: luminous.rst](https://raw.githubusercontent.com/ceph/ceph/main/doc/releases/luminous.rst) — The Luminous release notes document BlueStore as the stable default backend for newly created OSDs.
-- [raw.githubusercontent.com: bluestore config ref.rst](https://raw.githubusercontent.com/ceph/ceph/main/doc/rados/configuration/bluestore-config-ref.rst) — The BlueStore configuration reference directly states that BlueStore reads and writes devices directly without a conventional mounted filesystem.
+- [raw.githubusercontent.com: bluestore-config-ref.rst](https://raw.githubusercontent.com/ceph/ceph/main/doc/rados/configuration/bluestore-config-ref.rst) — The BlueStore configuration reference directly states that BlueStore reads and writes devices directly without a conventional mounted filesystem.
+- [raw.githubusercontent.com: osd-config-ref.rst](https://raw.githubusercontent.com/ceph/ceph/main/doc/rados/configuration/osd-config-ref.rst) — The upstream Ceph OSD configuration reference documents recovery throttling parameters, scrub scheduling, and PG-related tunables.
+<!-- incident-xref: github-2021-mysql --> - [docs.ceph.com: health checks](https://docs.ceph.com/en/reef/rados/operations/health-checks/) — The Ceph health-check documentation defines `PG_DEGRADED`, degraded and undersized placement groups, and OSD-down health behavior.
+- [docs.ceph.com: placement groups](https://docs.ceph.com/en/reef/rados/operations/placement-groups/) — The Ceph placement-group documentation describes PG autoscaler commands, target size settings, `pg_autoscale_mode`, and the PG-replicas-per-OSD guidance used in the corrected PG planning text.
+- [docs.ceph.com: repairing pg inconsistencies](https://docs.ceph.com/en/pacific/rados/operations/pg-repair/) — The Ceph PG repair documentation explains how scrub inconsistencies are diagnosed and repaired, including the `osd_scrub_auto_repair` default behavior.

--- a/src/content/docs/on-premises/storage/module-4.4-object-storage-bare-metal.md
+++ b/src/content/docs/on-premises/storage/module-4.4-object-storage-bare-metal.md
@@ -1,5 +1,4 @@
 ---
-revision_pending: true
 title: "Object Storage on Bare Metal"
 description: "Deploy, operate, and scale S3-compatible object storage on bare-metal Kubernetes using distributed MinIO, erasure coding, and DirectPV."
 slug: on-premises/storage/module-4.4-object-storage-bare-metal
@@ -7,30 +6,79 @@ sidebar:
   order: 44
 ---
 
-## Learning Outcomes
-* Architect distributed topologies using Server Pools for horizontal scalability on bare metal hardware.
-* Configure erasure coding profiles to balance storage efficiency against strict fault tolerance requirements.
-* Implement multi-tenant S3-compatible access using STS (Security Token Service) and IAM policies.
-* Configure bucket-level lifecycle policies, object versioning, and legal holds for compliance and automated tiering.
-* Diagnose replication lag and quorum failures in multi-site active-active object storage architectures.
+> **Complexity**: `[COMPLEX]`
+>
+> **Time to Complete**: 60 minutes
+>
+> **Prerequisites**: [Module 4.1: Storage Architecture Decisions](module-4.1-storage-architecture/), [Module 4.2: Software-Defined Storage with Ceph & Rook](module-4.2-ceph-rook/), [Module 4.3: Local Storage & Alternatives](module-4.3-local-storage/)
+
+---
+
+## What You'll Be Able to Do
+
+1. **Architect** distributed object-storage topologies using Server Pools, erasure sets, and direct-attached JBOD on bare-metal Kubernetes.
+2. **Configure** erasure coding profiles that balance usable capacity against drive and node failure tolerance for on-premises workloads.
+3. **Implement** multi-tenant S3 access with IAM policies, bucket policies, and STS `AssumeRoleWithWebIdentity` for Kubernetes workloads.
+4. **Compare** MinIO (distributed mode), Ceph RADOS Gateway, SeaweedFS, and Garage for self-hosted S3-compatible storage tradeoffs.
+5. **Operate** capacity planning, healing, replication, lifecycle rules, and Prometheus monitoring for day-2 object storage on owned hardware.
+
+---
+
+## Why This Module Matters
+
+Hypothetical scenario: a platform team standardizes PostgreSQL backups, CI artifact archives, and container-registry layer storage on a shared NFS filer because “we already own it.” During a quarterly release, three services spike write traffic simultaneously—database operators stream WAL segments, Harbor pushes multi-gigabyte image layers, and a data pipeline ingests millions of small JSON objects. Latency climbs, POSIX locks contend, and the filer returns `503 Slow Down` errors. Kubernetes pods restart, backup chains break, and registry pushes fail mid-upload. The outage is not a Kubernetes bug; it is a storage-class mismatch. Object workloads need a flat, key-addressed, HTTP API with horizontal scale—not a POSIX filesystem pretending to be a data lake.
+
+On bare metal, S3-compatible object storage becomes the shared “bulk tier” for everything that is not a database block device or a shared filesystem mount. [Module 4.5: Database Operators](module-4.5-database-operators/) assumes an internal endpoint for WAL archiving and base backups. [Module 7.7: Self-Hosted Container Registry](module-7.7-self-hosted-registry/) assumes durable blob storage for image layers. Log pipelines, ML feature stores, and compliance archives all converge on the same pattern: PUT an opaque blob, GET it later by key, replicate it for durability, and expire it by policy. Cloud teams buy this as Amazon S3; on-premises teams must engineer it on racks they depreciate over three to five years.
+
+The economic stakes differ from cloud object storage in subtle ways. Managed S3 charges per gigabyte-month, per request, and—most painfully—for egress. A steady 500 TiB archive with nightly cross-site replication can look cheaper on owned JBOD once utilization stays high, but only if you account for erasure-coding overhead, spare drives, power, and the engineer who pages when a pool enters healing state. Self-hosted object storage wins when capacity is large and predictable, egress is heavy, data must stay in-country, or air-gap requirements forbid a public API. Cloud object storage often wins when volume is small, spiky, or when operational headcount to run healing, upgrades, and certificate rotation exceeds storage savings.
+
+Downstream modules assume you can articulate endpoint URLs, credential flows, and durability expectations for this tier before they deploy stateful services. Database operators will halt if WAL archives cannot reach the bucket you specify; registries will fail pushes if blob storage lacks quota headroom during a large CI event. Treat object storage as shared infrastructure with SLOs, not as a sidecar experiment.
+
+Integration testing should include the exact SDKs your tenants use—Java AWS SDK v2, boto3, MinIO mc, restic, and Helm chart init containers—because S3 compatibility is a spectrum. Document maximum object size, multipart thresholds, and whether path-style versus virtual-host-style URLs are required behind your DNS layout. Publish those constraints in an internal service catalog entry alongside backup retention classes so application teams select the correct bucket prefix and lifecycle policy at design time rather than during a storage emergency.
+
+Change management for object storage should mirror other tier-zero services: staged upgrades on a non-production Tenant, documented rollback via pinned container digests, and communication to database and registry owners before maintenance windows that restart gateways. A fifteen-minute RGW outage during poorly coordinated patching can cascade into failed backups and blocked deploys far outside the storage namespace, which is why object endpoints belong on the same change-advisory calendar as Kubernetes control plane upgrades in production environments.
+
+> **The Warehouse Analogy**
+>
+> Block storage (RBD, EBS) is a single pallet you mount exclusively—one forklift at a time. File storage (CephFS, NFS) is a shared stockroom with aisles and locks—great for collaboration, fragile under concurrent writers. Object storage is a warehouse with infinite numbered bins: you drop a sealed box (object) into bin `s3://backups/postgres/2026-06-11/base.tar` and fetch it by that address later. No inode table on the client, no SCSI reservation, no directory lock—just HTTP verbs and cryptographic keys.
+
+---
+
+## The Object Model: Buckets, Keys, and the S3 API
+
+Object storage organizes data differently from block or file systems, and that difference drives every downstream design choice on bare metal. A **bucket** is a top-level namespace container—think of it as a tenant-scoped prefix with its own policy, quota, and lifecycle rules. An **object** is an immutable blob of bytes plus metadata (content type, user-defined tags, checksum). A **key** is the unique identifier of that object within a bucket, often looking like a path (`logs/app/2026/06/11/part-00042.json`) even though the namespace is **flat**: there are no true directories, only key prefixes that list operations simulate.
+
+The [Amazon S3 API](https://docs.aws.amazon.com/AmazonS3/latest/API/Welcome.html) became the de-facto standard because every backup tool (`restic`, `velero`), every database operator (CloudNativePG WAL archive), and every registry (Harbor, Distribution) already speaks it. On-premises gateways implement a large subset: `PutObject`, `GetObject`, multipart upload for large files, bucket policies, and server-side encryption headers. Compatibility gaps appear on edge features—bucket analytics, selective inventory exports, or exotic IAM condition keys—so always test your exact client SDK against the gateway you deploy.
+
+**Why object—not block or file—for these workloads?** Backups and artifacts are write-once, read-rarely streams with huge sequential PUTs and occasional ranged GETs. They do not need POSIX rename semantics or `fsync` on every 4 KiB write. Data lakes store parquet and ORC files that analytics engines read in parallel via HTTP range requests. Media pipelines ingest multi-gigabyte mezzanine files where rewriting a whole file is cheaper than random I/O on a SAN LUN. Block storage would force you to size LUNs upfront; NFS would centralize metadata and locking; object storage spreads metadata across the cluster and scales out by adding pools or nodes.
+
+**Versioning** [maintains historical copies of an object when it is overwritten or deleted](https://docs.aws.amazon.com/AmazonS3/latest/userguide/versioning-workflows.html), turning a logical “update” into a new version ID while preserving the prior bytes. **Object Lock (WORM)** [prevents modification or deletion for a retention period](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html) and requires versioning on the bucket. **Lifecycle rules** automate expiration and transition—critical on bare metal where NVMe is expensive and nobody notices a config file being overwritten 10,000 times until the disks are full.
+
+Pause and predict: if two applications write to the same object key without versioning enabled, what happens to the first writer’s bytes? They are replaced atomically at the key—the second PUT wins, and the first payload is gone unless something else copied it. Versioning changes that story by retaining a non-current version chain you can expire with ILM.
+
+Multipart upload matters for bare-metal networks because a single long-lived TCP connection across a 10 GbE link may still fail on a multi-hundred-gigabyte artifact when intermediate proxies time out. Clients split the payload into parts, upload each part independently, and commit an aggregate manifest at the end. Failed parts retry without restarting the entire transfer—a pattern registry layers and database base backups rely on when pushing multi-gigabyte tarballs across the cluster network. Always confirm your SDK enables multipart thresholds automatically; many default to single PUT until you configure them explicitly.
+
+Strong checksums travel with the object. S3-compatible clients send `Content-MD5` or use SigV4 payload hashing; the gateway persists ETags clients use for conditional writes (`If-Match`) and for deduplication logic in backup tools. When you mirror buckets to a second site, ETag semantics become part of your conflict story: two writers racing on the same key with versioning disabled produce last-writer-wins behavior, while versioning preserves both with distinct version IDs you must garbage-collect deliberately.
+
+---
 
 ## Architecture and Deployment Modes
 
 On bare metal, providing S3-compatible object storage requires deploying a distributed storage system directly on top of physical drives. Historically, MinIO was the standard for this pattern due to its strict Amazon S3 API compatibility, high performance, and bare-metal-native design.
 
 :::caution
-**Industry Shift:** As of April 25, 2026, the MinIO open-source community edition [repository was archived and made read-only](https://github.com/minio/minio). The community edition is now a [source-only distribution](https://github.com/minio/minio/blob/master/README.md#source-only-distribution) that [no longer provides pre-compiled binary releases](https://github.com/minio/minio/blob/master/README.md#source-only-distribution) (install from source or build a container image from the provided Dockerfile). Furthermore, it is licensed under AGPLv3, meaning organizations offering it as a SaaS must either release their combined source code under AGPLv3 or purchase a commercial license for its closed-source successor, AIStor.
+**Industry Shift:** As of 2026-06, verify this paragraph before procurement decisions because MinIO packaging and subscription terms have changed quickly. The MinIO open-source community edition [repository was archived and made read-only](https://github.com/minio/minio) on April 25, 2026; the community edition is now a [source-only distribution](https://github.com/minio/minio/blob/master/README.md#source-only-distribution) that no longer provides new pre-compiled binary releases. Current AIStor packaging is not simply “build CE source or buy commercial”: MinIO announced AIStor Free for full-featured single-node standalone deployments, plus paid Enterprise Lite and Enterprise tiers for horizontally scalable multi-node deployments. For durable architecture guidance, separate the mechanics you learn here from the volatile edition and licensing decision.
 :::
 
 ### The Open-Source Landscape
 
-For modern, production-grade open-source deployments, platform teams typically evaluate CNCF-backed alternatives:
-*   **Ceph (via Rook):** [Rook](https://github.com/rook/rook/tree/v1.19.5/Documentation) (a CNCF Graduated project, [currently v1.19 supporting K8s v1.30–v1.35](https://raw.githubusercontent.com/rook/rook/v1.19.5/Documentation/Getting-Started/quickstart.md)) orchestrates Ceph. The [latest Ceph release (v20.2.1 Tentacle, April 2026)](https://raw.githubusercontent.com/ceph/ceph/main/doc/releases/tentacle.rst) offers robust S3 compatibility via RADOS Gateway (RGW) and features background bucket resharding that minimizes blocking of write operations during resharding. It also adds support for the S3 `GetObjectAttributes` API, exact AWS S3 timestamp truncation, and first-class IAM API policy support. A single Ceph cluster can simultaneously [serve object (RGW), block (RBD), and file (CephFS) storage](https://github.com/ceph/ceph).
-*   **SeaweedFS:** [Licensed under Apache 2.0](https://github.com/seaweedfs/seaweedfs) (currently [v4.29](https://github.com/seaweedfs/seaweedfs/releases/latest)), SeaweedFS is a highly efficient distributed system that achieves O(1) disk seeks for blob retrieval by storing file-to-volume-offset mappings entirely in memory.
-*   **RustFS:** An open-source, [S3-compatible object storage system written in Rust and licensed under Apache 2.0](https://github.com/rustfs/rustfs). It aims to provide a high-performance alternative to MinIO without the AGPLv3 restrictions. While the project's documentation claims it is 2.3x faster than MinIO for 4 KB object payloads, these figures originate from self-reported benchmarks and have not been independently verified.
-*   **Kubernetes COSI (Container Object Storage Interface):** Note that while COSI aims to standardize object storage provisioning in Kubernetes, it remains in [pre-alpha status (v1alpha2)](https://github.com/kubernetes-sigs/container-object-storage-interface) as of April 2026. Therefore, direct provisioning via operators and CSI drivers like DirectPV remains the current standard.
+For modern, production-grade open-source deployments, platform teams evaluate several gateways that differ in license, operational surface, and S3 fidelity. [Rook](https://github.com/rook/rook/tree/v1.19.5/Documentation) orchestrates Ceph as a CNCF Graduated project and [currently supports Kubernetes v1.30 through v1.35 in release v1.19](https://raw.githubusercontent.com/rook/rook/v1.19.5/Documentation/Getting-Started/quickstart.md). The [Ceph Tentacle release (v20.2.1, April 2026)](https://raw.githubusercontent.com/ceph/ceph/main/doc/releases/tentacle.rst) strengthens RADOS Gateway with background bucket resharding, S3 `GetObjectAttributes`, and IAM API policies—features that matter when Harbor and backup operators send diverse S3 calls against the same endpoint you already run for RBD volumes in [Module 4.2](module-4.2-ceph-rook/).
 
-Despite these industry shifts, MinIO's architectural primitives (Server Pools, direct-attached drives, and strict Erasure Coding) remain the clearest educational model for understanding distributed object storage mechanics. The following sections use MinIO as the reference architecture.
+[SeaweedFS](https://github.com/seaweedfs/seaweedfs) ships under Apache 2.0 and optimizes small-file retrieval with in-memory volume maps, which can reduce seek amplification compared with naive file-backed layouts when millions of tiny JSON objects arrive from telemetry pipelines. [Garage](https://garagehq.deuxfleurs.fr/) targets geo-distributed, modest-footprint clusters with a single static binary and AGPLv3 licensing—attractive when you need three small sites without standing up full MON/OSD hierarchies. [RustFS](https://github.com/rustfs/rustfs) advertises Apache-2.0 licensing and Rust implementation for teams avoiding AGPL obligations, though you should treat performance claims as hypotheses until your workload validates them.
+
+Kubernetes [Container Object Storage Interface (COSI)](https://github.com/kubernetes-sigs/container-object-storage-interface) remains [pre-alpha at v1alpha2 as of 2026](https://github.com/kubernetes-sigs/container-object-storage-interface), meaning dynamic bucket provisioning through a standardized CSI-like API is not yet the default path. Until COSI matures, operators continue to deploy Tenants, RGW instances, or Helm releases declaratively, then expose endpoints and credentials to application namespaces through your existing secrets-management patterns.
+
+Despite industry shifts away from MinIO community binaries, MinIO’s architectural primitives—Server Pools, direct-attached drives, and erasure sets—remain the clearest educational model for understanding distributed object storage mechanics. The following sections use MinIO as the reference architecture while noting where Ceph RGW, SeaweedFS, and Garage diverge.
 
 Unlike managed cloud object storage, running distributed storage on bare metal shifts the responsibility of hardware topology, drive failure management, and network planning directly to the platform engineering team.
 
@@ -64,6 +112,12 @@ graph TD
     N5 --> D5[(Direct Attached NVMe)]
 ```
 
+When you operate multiple pools on heterogeneous hardware—older 12 TB HDD shelves beside new NVMe nodes—the hash router sends **new** writes toward pools with more free space. Existing objects stay on their original pool until you explicitly migrate them. That behavior matters for TCO: you can defer a full data rebalance while still accepting new capacity, but you must monitor per-pool utilization so one pool does not silently fill while others sit idle.
+
+Load balancing in front of Server Pools typically uses Layer-4 pass-through so SigV4 signatures remain valid. An enterprise ingress controller that terminates TLS and rewrites `Host` headers without forwarding `X-Forwarded-Host` will manifest as intermittent `SignatureDoesNotMatch` errors that correlate with which replica answered the connection, not with application bugs. Health checks should exercise authenticated HEAD requests against a dedicated health bucket rather than unauthenticated TCP probes alone, because a node can accept TCP while S3 subsystems are degraded during drive healing.
+
+Direct-attached topology also influences rack design: spreading four drives per node across four nodes gives you node-level fault domains for erasure sets, whereas stacking sixteen drives on four nodes but using EC:2 would survive fewer simultaneous node losses. Document the intended failure domain in your data-center standard—future-you should not have to reverse-engineer intent from a Helm values file during a 3 a.m. page.
+
 ### Storage Layer: DirectPV vs. CSI
 
 Performance in object storage is bottlenecked by the underlying storage subsystem. Bare-metal systems expect **JBOD (Just a Bunch of Disks)** without hardware RAID. Hardware RAID introduces controller bottlenecks and conflicts with software-level erasure coding.
@@ -76,7 +130,9 @@ For Kubernetes deployments, use **DirectPV** (a CSI driver built for local drive
 
 ### Erasure Coding (EC) Parity and Quorum
 
-Data is protected against drive and node failures using Erasure Coding. It divides objects into Data (D) blocks and Parity (P) blocks within an erasure set. For example, [MinIO erasure coding sets contain a minimum of 2 drives and a maximum of 16 drives per set](https://raw.githubusercontent.com/minio/minio/master/docs/erasure/README.md). The configuration is expressed as `EC:N`, where `N` is the number of parity blocks per erasure set.
+Data is protected against drive and node failures using Erasure Coding. Unlike three-way replication—which stores three full copies of every object and consumes 200% overhead—EC splits each object into **data shards** and **parity shards** striped across drives and nodes. A read quorum needs any `D` shards; a write quorum typically needs a majority of `D + P` shards available. When a drive fails, the cluster **heals** by recomputing missing shards from survivors, much like RAID-6 at the object level but distributed across the fleet.
+
+For example, CE/default MinIO erasure sets historically use 2 to 16 drives per set, while current AIStor documentation says that, as of 2026-06, AIStor Server `RELEASE.2026-02-02T23-40-11Z` or later can be configured up to 32 drives per erasure set with `MINIO_ERASURE_SET_DRIVE_COUNT`. Treat that 32-drive capability as volatile product documentation: verify it before standardizing hardware geometry. The configuration is expressed as `EC:N`, where `N` is the number of parity blocks per erasure set.
 
 *   **Standard Parity (EC:4):** In a 16-drive set, an [object is split into 12 Data blocks and 4 Parity blocks](https://raw.githubusercontent.com/minio/minio/master/docs/erasure/storage-class/README.md). You can lose any 4 drives and still read and write data. Storage efficiency is 75% (12/16).
 *   **High Parity (EC:8):** In a 16-drive set, an object is split into 8 Data and 8 Parity blocks. You can lose any 8 drives and still read the data (though you need $N/2 + 1$ drives to write). Storage efficiency is 50%.
@@ -87,9 +143,36 @@ pie title "Storage Efficiency (EC:4 on 16 Drives)"
     "Parity Overhead" : 25
 ```
 
+Ceph RGW stores objects in RADOS pools that use their own erasure-code or replication policies at the placement-group layer—conceptually similar tradeoff, different implementation. SeaweedFS and Garage use replication factors tuned for geo-distribution rather than large EC sets inside each volume. None of these choices eliminates the physics: parity bits cost disk, CPU, and network during writes and healing.
+
 :::tip
 Always configure topologies so that a complete node failure does not violate the read/write quorum. If you have 4 nodes with 4 drives each (16 drives total) and use EC:4, a single node going offline removes 4 drives. The cluster remains fully operational. If you use EC:3 in the same setup, a node failure brings down the entire Server Pool because 4 drives are lost, exceeding the 3-drive parity budget.
 :::
+
+**Healing and rebalance** consume back-end bandwidth. After you replace a failed 18 TB drive, the cluster reads surviving shards from many peers and writes reconstructed data for hours or days. Schedule maintenance windows, throttle healing concurrency, and keep cluster networks separate from client-facing NICs—patterns you already practice with Ceph recovery in Module 4.2. Healing is not free on any platform: erasure-coded systems trade space for CPU during reconstruction, and replication-based systems trade space for simpler read paths but heavier WAN traffic during re-replication.
+
+When you **configure erasure coding profiles**, treat parity as an insurance premium against simultaneous failures, not as a knob to maximize usable terabytes without analysis. EC:4 on sixteen drives tolerates any four shard losses—often interpreted as one full node in a four-by-four layout—while retaining seventy-five percent usable capacity. EC:8 halves usable space but survives eight shard losses, which matters in wide erasure sets spanning eight nodes where you fear double failures during a rack maintenance window. Write quorums can be stricter than read quorums: after extreme failures you may temporarily enter read-only mode until operators replace hardware, which is preferable to silently accepting writes that cannot be durably protected.
+
+Read path latency grows with parity because clients or gateways may contact multiple drives to satisfy a GET unless caching and read routing optimize for local shards. Write path latency includes encoding work on the gateway node plus fan-out to many drives. Benchmark with the object sizes your tenants actually store—4 KiB telemetry events behave differently from 512 MiB backup chunks. Document the chosen profile in your runbook alongside expected rebuild times at observed rebuild bandwidth so on-call engineers know whether a twelve-hour heal is normal or indicates a misconfigured throttle.
+
+---
+
+## Bare-Metal Platform Options Compared
+
+Choosing a self-hosted S3 gateway is not a beauty contest; it is a fit-for-purpose decision against staff skills, existing storage, and compliance constraints. Teams already operating Tentacle clusters for RBD volumes often extend RGW because backup and registry endpoints reuse MON quorum and monitoring investment. Teams without Ceph skills may prefer SeaweedFS or Garage when Apache licensing or minimal RAM footprints dominate the requirements document, accepting that some S3 APIs will return `501 Not Implemented` until you verify client compatibility.
+
+When you **compare MinIO distributed mode, Ceph RGW, SeaweedFS, and Garage**, document test results rather than vendor adjectives: run the same `restic` backup, Harbor push, and CloudNativePG WAL archive against each candidate in a staging VLAN and record latency, CPU, and compatibility errors. MinIO’s archived community edition still teaches erasure-set mechanics clearly but may push you toward AIStor or source builds for supported binaries. Ceph RGW adds IAM richness and unified operations at the cost of daemon complexity. SeaweedFS optimizes certain small-file paths. Garage optimizes geo-replication on modest hardware. Your comparison matrix should include license obligations, minimum node counts, and whether your organization already employs storage SREs.
+
+| Platform | Strengths on Bare Metal | Tradeoffs | Typical Fit |
+|----------|-------------------------|-----------|-------------|
+| **MinIO distributed** (archived CE / AIStor) | Strict S3 compatibility, mature K8s Operator, DirectPV integration, well-documented erasure sets | CE archived April 2026—source-only; as of 2026-06 AIStor Free is single-node standalone while paid AIStor tiers cover distributed deployments; verify licensing before production | Greenfield labs teaching EC mechanics; teams that can build CE images or choose an AIStor tier deliberately |
+| **Ceph RGW + Rook** | Unified block/file/object on one cluster; enterprise IAM features in Tentacle; CNCF Graduated operator | Higher operational complexity; RGW latency vs dedicated object store; needs MON/OSD expertise | Shops already running Ceph for RBD/CephFS who want one storage team |
+| **SeaweedFS** | Apache 2.0; efficient small-file access; simpler topology than Ceph | Different architecture (volume servers + masters); S3 compatibility subset | Media, image hosting, many small objects |
+| **Garage** | Minimal RAM; geo-replication; single binary | Smaller S3 API surface; fewer enterprise compliance features (verify current docs) | Edge sites, home-lab multi-datacenter, modest capacity |
+
+None of these rankings is universal. A hospital with an existing Tentacle cluster and a mandate to minimize new daemons will extend RGW. A greenfield factory with air-gapped CI may deploy Garage or SeaweedFS on three modest nodes. Document **your** decision matrix with measured compatibility tests from the actual backup and registry clients you run.
+
+---
 
 ## Multi-Tenancy and Access Control
 
@@ -101,36 +184,45 @@ Operating a platform requires isolating workloads. Sharing root credentials acro
 
 Modern operators provision isolated instances called **Tenants**. Each Tenant operates its own Server Pools, its own IAM database, and its own endpoints. Use a single large Kubernetes cluster to host multiple isolated Tenants rather than creating one giant monolithic Tenant for the whole company.
 
-### Identity and STS (Security Token Service)
+### Identity: Access Keys, IAM Policies, and STS
 
-Applications must authenticate using temporary, scoped credentials via STS, specifically using [`AssumeRoleWithWebIdentity`](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html). This integrates directly with Kubernetes ServiceAccounts.
+S3 security on bare metal mirrors cloud IAM layering even when no AWS account exists. Long-lived access keys remain convenient for legacy batch jobs but violate least privilege when embedded in Helm values or ConfigMaps that sync to Git. Bucket policies express resource-centric rules—TLS-only access, prefix restrictions, denial of delete for audit prefixes—while IAM policies attach to users, groups, or roles inside the gateway identity store. Object ACLs still appear in compatibility shims but bucket-owner-enforced settings increasingly make bucket policies the authoritative control plane, matching AWS direction.
 
-1.  The K8s Pod mounts a [projected ServiceAccount token](https://kubernetes.io/docs/concepts/storage/projected-volumes).
-2.  The application uses this JWT to call the STS endpoint.
-3.  The storage system validates the JWT against the Kubernetes API OIDC discovery endpoint.
-4.  The system returns temporary S3 credentials bound to an IAM policy that maps to that specific ServiceAccount.
+Applications on Kubernetes should prefer **STS temporary credentials** via [`AssumeRoleWithWebIdentity`](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html). The Pod mounts a [projected ServiceAccount token](https://kubernetes.io/docs/concepts/storage/projected-volumes); the application exchanges that JWT at the STS endpoint; the gateway validates issuer and audience against OIDC discovery; scoped keys return with session duration bounded by policy. Rotate by shortening session lifetime rather than editing Secrets cluster-wide. Map each namespace prefix to a role that can only `PutObject` under `s3://tenant-ns/` and cannot list unrelated buckets—containment that saved many teams when a compromised CI job attempted lateral movement across backup prefixes.
+
+**Encryption** belongs in both planes: TLS on the wire between clients and ingress, and server-side encryption at rest on drives. Gateways implement SSE-S3 or KMS-integrated variants depending on edition; on bare metal you may integrate with Vault or a hardware security module for key custody. Combine encryption with **Object Lock** compliance mode when regulators require WORM semantics independent of filesystem permissions. Remember that encryption protects confidentiality, not accidental deletion—versioning plus ILM still matter for operational mistakes.
+
+---
 
 ## Data Management
 
 ### Storage Thresholds
 
-When designing applications against bare-metal object storage, understand the hard physical limits of the system. For instance, MinIO supports a maximum single-PUT object size of 5 TiB. If applications need to upload larger datasets, they must implement multipart uploads, which support up to 10,000 parts (each up to 5 TiB), allowing for a maximum theoretical object size of approximately 48 PiB.
+When designing applications against bare-metal object storage, understand the hard physical limits of the system. As of 2026-06, current AIStor threshold documentation lists a maximum non-multipart `PUT` object size of 5 TiB. If applications need to upload larger datasets, they must implement multipart uploads, which support up to 10,000 parts and a practical maximum object size of approximately 48 PiB. Verify these thresholds against the current gateway documentation before committing application-side upload limits.
 
 ### Versioning and Object Lock
 
-**Versioning** [maintains historical copies of an object when it is overwritten or deleted](https://docs.aws.amazon.com/us_en/AmazonS3/latest/userguide/versioning-workflows.html). This protects against accidental application logic errors. 
+**Versioning** [maintains historical copies of an object when it is overwritten or deleted](https://docs.aws.amazon.com/AmazonS3/latest/userguide/versioning-workflows.html). This protects against accidental application logic errors. 
 
 **Object Lock (WORM - Write Once Read Many)** [prevents any modification or deletion of an object for a specified duration](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html), or indefinitely until a Legal Hold is removed. Object Lock requires Versioning to be enabled on the bucket.
 
 ### Lifecycle Management (ILM)
 
-Bare-metal NVMe storage is expensive. ILM policies automate data lifecycle:
-*   **Expiration:** Delete objects (or specific non-current versions) after $X$ days.
-*   **Transition:** [Move colder objects to a slower, cheaper storage tier](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html) (e.g., transitioning objects from an NVMe-backed Tenant to an HDD-backed Tenant, or out to public cloud S3).
+Bare-metal NVMe storage is expensive relative to archival HDD tiers, which makes lifecycle automation a capacity discipline rather than a convenience feature. ILM rules evaluate object age, prefix, tags, and current-version status on a schedule, then expire objects or transition them to colder pools you operate on spinning disks—or occasionally to public cloud tiers when compliance allows egress. **Expiration** deletes current or non-current versions after N days; **transition** moves bytes to a different storage class while preserving the key for applications that address objects by stable paths.
 
-Without strict Expiration policies, an application continuously overwriting a versioned object will silently fill the physical disks, causing a hard outage requiring manual drive expansion.
+Without strict expiration on versioned buckets, an application that overwrites a one-megabyte JSON configuration ten thousand times per day can consume hundreds of gigabytes per month of physical space for logically “one file.” Platform teams should publish mandatory baseline policies— for example, delete non-current versions after seven days unless a ticketed exception exists—and enforce them with periodic audits comparing bucket inventory reports to tenant quotas. Transition rules help when you operate dual pools on one gateway: hot NVMe pools accept ingestion, nightly ILM moves objects older than thirty days to HDD pools with higher latency but lower dollars per terabyte.
+
+---
 
 ## Day 2 Operations
+
+Operating object storage on owned hardware means you own failure modes cloud vendors abstract away: SMART errors, NIC flaps, firmware bugs, and the quarterly question of whether to refresh drives or expand by another pool. Day-2 runbooks should name who replaces a failed drive, how long rebuild is allowed to run before escalating, and which dashboards prove client impact during healing.
+
+### Capacity Planning and the Cost of Parity
+
+Raw JBOD capacity is never usable capacity. With EC:4 on sixteen drives, plan for roughly seventy-five percent logical data before filesystem overhead. Add hot spares, metadata reservations, and an operational buffer—many teams target **≤70% steady utilization** before procurement opens a new pool requisition. Model growth from versioned buckets explicitly in spreadsheets shared with finance: show parity overhead, expected annual drive price decline, and power draw per shelf so CapEx committees compare apples-to-apples against a cloud storage quote that hides egress.
+
+Forecast request rates separately from bytes. Small-object heavy workloads stress metadata and LIST operations; large sequential workloads stress network and disk bandwidth during healing. If [Module 7.7’s registry](module-7.7-self-hosted-registry/) and [Module 4.5’s database backups](module-4.5-database-operators/) share one cluster, simulate concurrent multipart uploads plus steady WAL PUT rates before signing the architecture diagram.
 
 ### Prometheus Metrics
 
@@ -138,28 +230,220 @@ Storage platforms expose metrics natively. Do not use legacy v1 metrics endpoint
 
 Use the v2 cluster endpoints (e.g., `/minio/v2/metrics/cluster`). The v2 endpoint relies on internal background scanners to report bucket sizes, requiring virtually zero compute overhead during the scrape.
 
-### Active-Active Replication
+Alert on healing queue depth, drives offline count, pool utilization percentage, S3 5xx rate, replication lag seconds, and STS authentication failures. Tie alerts to runbook steps: a rising offline drive count with flat healing progress may indicate a stuck daemon or a network partition on the backend VLAN rather than a single bad disk.
 
-For multi-datacenter bare-metal deployments, site-to-site Active-Active replication is supported. This operates asynchronously. Ensure clock synchronization (NTP/Chrony) across all bare-metal nodes is strictly enforced; object replication relies entirely on timestamps to resolve conflicts. Clock drift exceeding 1 second will result in inconsistent state and silent data corruption across sites.
+### Active-Active Replication and DR
+
+For multi-datacenter bare-metal deployments, site-to-site Active-Active replication is supported asynchronously in many gateways. Ensure clock synchronization (NTP/Chrony) across all bare-metal nodes is strictly enforced; object replication relies on timestamps to resolve conflicts, and clock drift exceeding one second can produce divergent metadata that is painful to reconcile without manual inspection.
+
+The **backup-of-the-backup** question still applies: replication is not backup. A deleted bucket replicated to a second site deletes both copies unless versioning and Object Lock retain recoverable history. Mirror critical prefixes to an immutable target, or rely on application-level PITR that can rebuild state from versioned WAL archives even when a malicious actor issues `DeleteBucket`. Test restores quarterly—object storage outages discovered during a real ransomware event are expensive learning experiences.
 
 ---
 
-## Hands-on Lab
+## On-Premises Cost Lens
 
-In this lab, you will deploy the MinIO Operator, provision a single-node multi-drive Tenant (simulating a distributed setup on a local cluster), configure the S3 CLI, enable versioning, and apply a strict quota.
+Object storage TCO on owned hardware combines **CapEx** (JBOD servers, drives, NICs, racks), **facility** costs (power, cooling, floor space amortized per kilowatt), **software and support** (commercial AIStor subscriptions or Ceph vendor contracts if you purchase them), and **OpEx labor** (drive swaps, healing watches, certificate rotation, upgrade testing, and pager compensation). Finance teams often see only the drive purchase order; platform engineering must attach parity overhead, spare-node requirements, and network upgrades to the same business case.
+
+Self-hosting tends to win at **large steady utilization**, **heavy internal egress** to analytics and CI consumers, **data sovereignty** mandates, and **air-gap** environments where public APIs are unavailable. A factory running twenty-four-seven vision-model training that reads the same multi-petabyte corpus nightly may saturate a 100 GbE link cheaply inside the building while equivalent cloud egress pricing dominates the spreadsheet. Conversely, cloud object storage often wins for **spiky small buckets**, **teams without storage specialists**, and **early-stage workloads** where idle spindles and on-call rotation cost more than pay-as-you-go gigabytes.
+
+Depreciation schedules matter for refresh planning: if you depreciate servers over thirty-six months but drives warrant for five years, your pool expansion math should show when adding a new pool on current-generation disks beats replacing entire nodes. Include electricity: dense HDD shelves draw continuous watts whether or not objects are accessed, while cloud bills implicitly bundle facility costs into the per-GB rate. Neither model is universally cheaper—your utilization curve and staffing model decide.
+
+Hypothetical scenario for capacity planning: finance asks whether to renew a three-year cloud archive contract at two petabytes or buy two more JBOD shelves. You model cloud at roughly $0.023 per GB-month for storage plus estimated egress when analytics clusters re-read the corpus monthly, versus owned hardware at upfront drive cost, thirty percent EC overhead, six percent annual maintenance labor, and zero marginal egress inside the building. At eighty-five percent average utilization over twenty-four months, owned storage often crosses below cloud total cost; at forty percent utilization with a small team, cloud may remain cheaper even before counting on-call burden. Present both curves with explicit assumptions rather than a single headline number.
+
+---
+
+## Patterns & Anti-Patterns
+
+| Pattern | When to Use | Why It Works | Scaling Note |
+|---------|-------------|--------------|--------------|
+| Dedicated object tier on JBOD + DirectPV | Backup targets, registry blobs, log archives | Avoids POSIX/NFS metadata storms; EC spreads I/O | Expand by adding Server Pools, not single drives |
+| Per-team Tenants with STS | Multi-tenant Kubernetes platforms | Short-lived creds per ServiceAccount; blast-radius isolation | More endpoints to certificate-manage |
+| ILM on versioned buckets | Config maps, ML checkpoints, audit logs | Prevents silent fill from churn | Test non-current version expiry in staging |
+| Layer-4 load balancing to S3 API | High-throughput PUT/GET | Preserves SigV4 headers | Avoid header-mangling L7 proxies |
+| Async geo-replication + WORM on compliance prefix | Finance/health retention | Survives site loss and admin mistakes | Monitor NTP and replication lag |
+
+| Anti-Pattern | What Goes Wrong | Better Alternative |
+|--------------|-----------------|-------------------|
+| NFS/SAN backing for object gateway | Lock contention, 503 Slow Down, lost EC benefits | Direct-attached JBOD via DirectPV |
+| One giant Tenant for all business units | Shared fate on upgrades and quota exhaustion | Multiple Tenants or namespaces with quotas |
+| Long-lived root keys in Secrets | Credential sprawl; failed audits | STS `AssumeRoleWithWebIdentity` |
+| Versioning without ILM | Disks full from tiny object churn | Mandatory non-current version expiration |
+| Adding drives to existing pool geometry | Cluster ignore or inconsistent state | New Server Pool with matched erasure layout |
+| Scraping legacy v1 metrics | CPU spikes every scrape interval | v2 cluster metrics with background scanner |
+
+---
+
+## Decision Framework
+
+Use this flow when selecting and sizing bare-metal object storage. The goal is not to pick a logo but to match failure tolerance, staffing, and economic assumptions to a gateway you can operate for years without surprise license or binary-supply changes.
+
+```mermaid
+flowchart TD
+    Start([New object storage requirement]) --> Q1{Already run Ceph/Rook<br/>for block/file?}
+    Q1 -->|Yes| RGW[Extend Ceph RGW on<br/>existing cluster]
+    Q1 -->|No| Q2{Capacity & skill?}
+    Q2 -->|Large fleet, SRE storage team| Ceph[Deploy Rook-Ceph + RGW]
+    Q2 -->|Medium, want dedicated object| Q3{License sensitivity?}
+    Q3 -->|AGPL OK, need MinIO docs| MinIO[MinIO/AIStor or build CE source]
+    Q3 -->|Apache preferred| SW[SeaweedFS]
+    Q3 -->|Minimal ops, geo edge| G[Garage]
+    Q2 -->|Small lab / burst| Q4{Budget for cloud?}
+    Q4 -->|Yes| Cloud[Managed S3 for non-prod]
+    Q4 -->|No| G
+    RGW --> EC[Choose EC or replication<br/>+ lifecycle + DR mirror]
+    Ceph --> EC
+    MinIO --> EC
+    SW --> EC
+    G --> EC
+    Cloud --> EC
+```
+
+| Decision | Choose | When | Avoid When |
+|----------|--------|------|------------|
+| Storage backend | Ceph RGW | Unified SDS already operational | You only need object and fear Ceph ops |
+| Storage backend | MinIO distributed | Need reference EC model + Operator | Cannot build/maintain images post-CE archive |
+| Storage backend | SeaweedFS / Garage | Lightweight, license-friendly | You require full AWS S3 feature parity |
+| Durability mode | EC:4 on 16 drives | Balance capacity and 4-drive fault tolerance | Nodes have uneven drive counts |
+| Durability mode | EC:8 | Maximum drive fault tolerance | Usable capacity below 50% is unacceptable |
+| Access pattern | STS web identity | Kubernetes-native apps | Legacy apps that cannot OIDC |
+| DR | Async replication + locked bucket | RPO in minutes acceptable | You need point-in-time without versioning |
+| Monitoring | Prometheus v2 metrics | Production scale | Legacy v1 endpoints still configured |
+
+---
+
+## Did You Know?
+
+- **S3’s flat namespace** means “folders” in the console are purely prefix conventions—listing `logs/2026/` scans keys lexicographically, which is why hot partitions from poorly chosen key prefixes can create hotspots on some gateways.
+
+- **[Ceph Tentacle RGW added first-class IAM API policy support](https://raw.githubusercontent.com/ceph/ceph/main/doc/releases/tentacle.rst)**, narrowing the gap with AWS for enterprises that already run RADOS Gateway on the same cluster as RBD volumes.
+
+- **Erasure coding at the object layer** typically uses Reed-Solomon-style math: you can reconstruct missing shards from any sufficient subset, which is why read quorums differ from write quorums under partial failures.
+
+- **[Garage targets geo-distributed deployments on consumer hardware](https://garagehq.deuxfleurs.fr/)** with a single dependency-free binary—useful when your “datacenter” spans two office closets linked by VPN rather than a single raised floor.
+
+---
+
+## Common Mistakes
+
+| Mistake | Problem | Solution |
+|---------|---------|----------|
+| NFS backing store for object gateway | Latency spikes, locking conflicts, 503 errors | JBOD + DirectPV or local PV only |
+| Asymmetric pool expansion (two drives on one node) | Ignored capacity or inconsistent cluster state | Add a full new Server Pool with matched geometry |
+| Layer 7 proxy mangling SigV4 headers | `SignatureDoesNotMatch` 403 for all clients | TCP pass-through or preserve `Host` / `X-Amz-*` headers |
+| Versioning without ILM expiration | Physical disks fill from tiny object churn | Non-current version expiry (e.g., 7 days) |
+| Shared root credentials across apps | Audit failure and credential leak blast radius | STS with scoped IAM policies per ServiceAccount |
+| Scraping v1 Prometheus metrics | Periodic CPU/disk storms on storage nodes | `/minio/v2/metrics/cluster` or gateway equivalent |
+| Ignoring EC overhead in procurement | Run out of usable TiB at 90% “raw” capacity | Plan at 70–75% usable after parity and buffer |
+| Geo-replication without NTP discipline | Silent conflict resolution errors | Chrony on all nodes; alert on clock skew |
+
+---
+
+## Quiz
+
+### Question 1
+
+You administer a bare-metal MinIO Server Pool: 4 nodes × 4 NVMe drives (16 total). When you **configure erasure coding** to EC:4, how many simultaneous drive failures can the pool tolerate while applications still read objects?
+
+<details>
+<summary>Answer</summary>
+
+EC:4 on sixteen drives stripes each object into twelve data and four parity shards. Losing four drives—one entire node—still leaves twelve surviving shards, which meets the read quorum. Writes may also continue if the write quorum threshold is satisfied. This is why parity level must be matched to **worst-case node loss**, not just single-drive MTBF, when balancing usable capacity against fault tolerance.
+</details>
+
+### Question 2
+
+Procurement delivers four new bare-metal servers identical to your existing pool, but the cluster is at 88% utilization. What is the supported expansion path?
+
+<details>
+<summary>Answer</summary>
+
+Provision the four servers as a **new Server Pool** and append it to the Tenant or distributed command line. Existing pools keep their deterministic hash layout; new objects route toward pools with more free space. You cannot change `servers: 4` to `servers: 8` on the original pool without re-initialization. Plan DNS/load-balancer health checks for the enlarged endpoint set.
+</details>
+
+### Question 3
+
+A regulator requires seven-year immutable audit logs that even root cannot delete early. Which features do you enable?
+
+<details>
+<summary>Answer</summary>
+
+Enable **bucket versioning**, then **Object Lock in Compliance Mode** with a seven-year default retention period. Compliance mode prevents administrators—including root—from shortening retention. Governance mode would **not** satisfy the mandate because privileged users could override retention. Pair with bucket policies denying delete actions except from automated writers.
+</details>
+
+### Question 4
+
+Microservices currently store static S3 access keys in Kubernetes Secrets. Security mandates rotation and scoped access per namespace. What mechanism replaces the keys?
+
+<details>
+<summary>Answer</summary>
+
+Implement **STS `AssumeRoleWithWebIdentity`**: Pods present projected ServiceAccount JWTs to the gateway STS endpoint, receive short-lived session credentials, and assume IAM roles scoped to their namespace prefix. No long-lived secrets are mounted; rotation becomes automatic with token lifetime. Verify OIDC discovery URL and audience claims match gateway configuration.
+</details>
+
+### Question 5
+
+After migrating Prometheus scraping to your object store, storage nodes show CPU spikes every thirty seconds and scrapes time out. Which **day-2 operations** change fixes the root cause?
+
+<details>
+<summary>Answer</summary>
+
+Prometheus is likely scraping a **legacy v1 metrics endpoint** that computes bucket statistics synchronously on each request. On large buckets this walks metadata and melts CPU during **capacity planning** windows when operators also run LIST-heavy inventory jobs. Switch to **v2 cluster metrics** that read pre-scanned statistics from background jobs, then tune scrape interval. This restores headroom for healing and replication traffic without masking underlying disk failures.
+</details>
+
+### Question 6
+
+Your team must **compare MinIO, Ceph RGW, SeaweedFS, and Garage** for Harbor registry blobs and PostgreSQL WAL archives. Which evaluation approach is most defensible on bare metal?
+
+<details>
+<summary>Answer</summary>
+
+Run identical client workloads—multipart registry pushes, continuous WAL PUTs, and restore LIST operations—against each gateway in a staging VLAN and record latency, error codes, and CPU/disk utilization. If Ceph already operates production RBD with trained staff, RGW leverages existing monitoring and **healing** playbooks. If licensing or binary supply favors Apache-2.0 stacks, SeaweedFS or Garage may win despite smaller S3 surface areas. Document minimum node counts, erasure or replication overhead, and license obligations beside raw throughput numbers.
+</details>
+
+### Question 7
+
+An application uploads a 6 TiB VM image. The MinIO-compatible gateway rejects a single PUT. What S3 mechanism should the client use?
+
+<details>
+<summary>Answer</summary>
+
+Use **multipart upload**: split the object into parts, upload parts in parallel, then complete the multipart session with an aggregated ETag. Current AIStor threshold documentation lists a 5 TiB maximum object size for a non-multipart `PUT`, so a 6 TiB object must use multipart. Verify your client SDK defaults to multipart for large files and that your gateway's current limits match the documentation you design against.
+</details>
+
+### Question 8
+
+Hypothetical scenario: async replication shows lag under five minutes, but objects deleted in site A disappear from site B weeks later. Is replication broken?
+
+<details>
+<summary>Answer</summary>
+
+Not necessarily—**replication propagates deletes** unless you use versioning with delete markers and bucket policies that retain non-current versions. Replication is not backup; it mirrors mutations including deletion. For ransomware resilience, combine versioning, Object Lock on a prefix, and a **second immutable copy** (tape, WORM bucket, or offline vault) outside the replication path.
+</details>
+
+---
+
+## Hands-On Exercise: MinIO Operator Lab
+
+In this exercise, you deploy the MinIO Operator, provision a single-node multi-drive Tenant that simulates erasure coding on a local cluster, configure the S3 CLI, enable versioning, apply a quota, and validate that erasure coding reconstructs data after simulated shard loss.
 
 :::note
-**Lab Environment Constraint:** Because the MinIO community edition is now a [source-only distribution](https://github.com/minio/minio/blob/master/README.md#source-only-distribution) with [no new pre-compiled binary releases](https://github.com/minio/minio/blob/master/README.md#source-only-distribution), this lab relies on historically cached images or local builds pulled by the Helm chart. In a modern production environment, you would either build the archived community source code internally, purchase AIStor, or deploy a CNCF alternative like Rook/Ceph.
+**Lab Environment Constraint:** Because the MinIO community edition is now a [source-only distribution](https://github.com/minio/minio/blob/master/README.md#source-only-distribution) with no new pre-compiled binary releases, this lab pins an official `quay.io/minio/minio:RELEASE.2025-04-08T15-41-24Z` image and uses the Operator chart's default `quay.io/minio/operator:v7.1.1` image. In a modern production environment, you would either build the archived community source code internally, choose an appropriate AIStor tier, or deploy a CNCF alternative like Rook/Ceph.
 :::
 
+**Success Criteria:**
+
+- [ ] MinIO Operator pod reaches `Running` in `minio-operator` namespace with one replica
+- [ ] Tenant `dojo-storage` shows `2/2` ready with four backing volumes
+- [ ] `mc` can create bucket `app-data`, enable versioning, and set 1 GiB quota
+- [ ] After simulated drive data loss inside the pod, `mc cat` still returns the test object
+
 ### Prerequisites
-*   A running Kubernetes cluster (v1.35+ recommended, via `kind` or `k3s`).
-*   `kubectl` and `helm` installed.
-*   MinIO Client (`mc`) installed locally.
+
+You need a running Kubernetes cluster at v1.35 or later with a default StorageClass (single-node kind or k3s works for this lab), the kubectl and helm CLIs installed locally, and the MinIO Client (`mc`) binary available on your workstation for S3 operations against the port-forwarded endpoint. The lab deliberately installs a one-replica Operator because the current chart defaults under `operator.replicaCount` to two replicas with required pod anti-affinity, which can leave a single-node cluster pending.
 
 ### Step 1: Install the Operator
 
-Deploy the operator using the official Helm chart.
+Add the official MinIO Operator Helm repository, update local chart indexes, and install the release into a dedicated `minio-operator` namespace with the wait flag so the command returns only after pods become ready. The `operator.replicaCount=1` and `operator.affinity=null` overrides make the chart schedule on a single-node training cluster; production deployments should use multiple worker nodes and the chart's default anti-affinity. After installation completes, list pods in that namespace and confirm one operator pod reports `Running` with `1/1` ready within about a minute, which indicates the controller can reconcile Tenant custom resources.
 
 ```bash
 helm repo add minio https://operator.min.io/
@@ -168,24 +452,16 @@ helm repo update
 helm install minio-operator minio/operator \
   --namespace minio-operator \
   --create-namespace \
+  --set operator.replicaCount=1 \
+  --set operator.affinity=null \
   --wait
-```
 
-*Verification:*
-```bash
 kubectl get pods -n minio-operator
-```
-*Expected Output:*
-```text
-NAME                              READY   STATUS    RESTARTS   AGE
-minio-operator-6b7d59b4f7-8j2x2   1/1     Running   0          45s
 ```
 
 ### Step 2: Provision a Tenant
 
-Create a minimal Tenant. We specify `servers: 1` and `volumesPerServer: 4` to allow Erasure Coding to function within a single `kind` node. The operator will automatically provision PVCs.
-
-Create a file named `tenant.yaml`:
+Create a manifest named `tenant.yaml` that declares a Tenant with one server and four volumes per server so erasure coding can form a set even on a single kind or k3s node. This is raw `Tenant` CRD YAML, not the tenant Helm chart values shape: the pool needs `name: pool-0` and `volumeClaimTemplate`, and omitting `storageClassName` lets Kubernetes use the cluster's default StorageClass. Apply the manifest into a new `minio-tenant` namespace, then watch pods until the StatefulSet member reports `2/2` ready, which indicates both the MinIO container and the sidecar are healthy.
 
 ```yaml
 apiVersion: minio.min.io/v2
@@ -194,208 +470,102 @@ metadata:
   name: dojo-storage
   namespace: minio-tenant
 spec:
+  image: quay.io/minio/minio:RELEASE.2025-04-08T15-41-24Z
   pools:
-    - servers: 1
+    - name: pool-0
+      servers: 1
       volumesPerServer: 4
-      size: 4Gi
-      storageClassName: standard
+      volumeClaimTemplate:
+        metadata:
+          name: data
+        spec:
+          accessModes:
+            - ReadWriteOnce
+          resources:
+            requests:
+              storage: 4Gi
   requestAutoCert: false
 ```
-
-Apply the manifest:
 
 ```bash
 kubectl create namespace minio-tenant
 kubectl apply -f tenant.yaml
-```
-
-*Verification:* Wait for the statefulset to reach readiness.
-```bash
 kubectl get pods -n minio-tenant -w
-```
-*Expected Output:*
-```text
-NAME                 READY   STATUS    RESTARTS   AGE
-dojo-storage-pool-0-0   2/2     Running   0          2m
 ```
 
 ### Step 3: Retrieve Credentials and Configure CLI
 
-The Operator automatically generates root credentials and stores them in a Secret.
+The operator generates root credentials in a Secret named after your Tenant configuration. Extract `MINIO_ROOT_USER` and `MINIO_ROOT_PASSWORD` from the encoded environment blob, start a background port-forward from the Tenant Service port 80 to local port 9000, and configure an `mc` alias pointing at `http://localhost:9000` with those credentials so subsequent bucket operations use the S3 API path you will expose to applications.
 
 ```bash
-# Extract Root User
 ROOT_USER=$(kubectl get secret dojo-storage-env-configuration -n minio-tenant -o jsonpath='{.data.config\.env}' | base64 -d | grep MINIO_ROOT_USER | cut -d '=' -f2)
-
-# Extract Root Password
 ROOT_PASS=$(kubectl get secret dojo-storage-env-configuration -n minio-tenant -o jsonpath='{.data.config\.env}' | base64 -d | grep MINIO_ROOT_PASSWORD | cut -d '=' -f2)
-
 echo "User: $ROOT_USER | Pass: $ROOT_PASS"
-```
-
-Port-forward the Tenant S3 API to your local machine:
-
-```bash
 kubectl port-forward svc/minio -n minio-tenant 9000:80 &
-```
-
-Configure the `mc` CLI:
-
-```bash
 mc alias set myminio http://localhost:9000 $ROOT_USER $ROOT_PASS
 ```
 
 ### Step 4: Configure Bucket, Quota, and Versioning
 
-Create a bucket named `app-data`:
+Create bucket `app-data`, enable versioning so overwrites retain history, and apply a one-gigabyte hard quota to simulate tenant guardrails platform teams use to prevent a single namespace from exhausting shared pools. List buckets and print quota info to verify the limit registered server-side before you upload test payloads that exercise erasure striping across the four PVC-backed paths.
 
 ```bash
 mc mb myminio/app-data
-```
-
-Enable object versioning:
-
-```bash
 mc version enable myminio/app-data
-```
-
-Apply a hard quota of 1GB to prevent runaway storage consumption:
-
-```bash
-mc quota set myminio/app-data --size 1G
-```
-
-*Verification:* Check bucket properties.
-```bash
+mc admin bucket quota myminio/app-data --hard 1gb
 mc ls myminio/
-mc quota info myminio/app-data
-```
-*Expected Output:*
-```text
-Capacity: 1 GiB
-Used: 0 B
+mc admin bucket quota myminio/app-data
 ```
 
 ### Step 5: Test Erasure Coding Resilience (Simulated Failure)
 
-Write a test file:
+Upload a small test object, delete one shard’s on-disk directory inside the MinIO pod to simulate localized corruption, and read the object back through `mc cat`. A successful read proves the gateway reconstructed missing data from parity shards—behavior you should expect in production when SMART reports a failing NVMe but applications continue serving GET requests during healing.
 
 ```bash
 echo "Important production data" > test.txt
 mc cp test.txt myminio/app-data/
-```
-
-Simulate drive corruption by deleting data from one of the backing PVC directories inside the pod:
-
-```bash
 kubectl exec -n minio-tenant dojo-storage-pool-0-0 -c minio -- rm -rf /export/0/app-data
-```
-
-Attempt to read the file:
-
-```bash
 mc cat myminio/app-data/test.txt
 ```
-*Expected Output:*
-```text
-Important production data
-```
-*Explanation:* The storage engine transparently reconstructed the missing data block from the remaining parity blocks in real-time.
 
 ### Troubleshooting the Lab
-*   **Pods stuck in Pending:** Your cluster lacks a default StorageClass or insufficient host capacity. Ensure `local-path-provisioner` is running if using `kind`.
-*   **mc connection refused:** Ensure the `kubectl port-forward` command is still running in the background.
+
+If Tenant pods remain Pending, verify your cluster exposes a default StorageClass with enough allocatable capacity—kind clusters often require `local-path-provisioner`. If `mc` reports connection refused, confirm the port-forward process is still running in the background and that no local process already binds port 9000.
 
 ---
 
-## Practitioner Gotchas
+## Next Module
 
-### 1. The NFS Backing Store Catastrophe
-**Context:** Storage administrators often provision bare-metal object storage on top of existing enterprise SAN/NAS appliances via NFS to "save time" or simplify backups.
-**The Fix:** Never do this. These systems maintain their own strict POSIX locking and erasure coding algorithms. Layering this on top of a network filesystem causes massive latency spikes, locking conflicts resulting in 503 Slow Down errors, and complete loss of performance advantages. Demand physical JBOD via DirectPV or local hostPath provisioning.
-
-### 2. Symmetrical Topology Expansion Failures
-**Context:** A bare-metal cluster runs out of storage. An engineer adds two new large NVMe drives to one of the nodes and restarts the service, expecting the capacity to increase. The cluster state becomes inconsistent or ignores the drives.
-**The Fix:** Distributed object topologies are strictly deterministic based on their initialization commands. You cannot change the geometry of an existing Server Pool. To add capacity, you must provision a *new* Server Pool (e.g., 4 new nodes) and update the Tenant configuration to append the new pool. The cluster will automatically [route new objects to the pool with the most free space](https://raw.githubusercontent.com/minio/minio/master/docs/distributed/README.md).
-
-### 3. Layer 7 Load Balancer Signature Corruption
-**Context:** S3 clients suddenly receive `SignatureDoesNotMatch` HTTP 403 errors after moving the deployment behind an ingress controller or enterprise load balancer.
-**The Fix:** [S3 client SDKs calculate a cryptographic hash of the HTTP request headers](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html). If an intermediate proxy modifies, drops, or normalizes these headers (e.g., stripping `X-Amz-*` headers, or altering the `Host` header without passing `X-Forwarded-Host`), the signature calculated by the server will not match the client's signature. Configure the ingress proxy for strict Layer 4 (TCP) pass-through, or ensure all required AWS headers are preserved intact.
-
-### 4. Versioning Disk Exhaustion
-**Context:** An application rapidly updates a small 1MB JSON configuration file in an S3 bucket 10,000 times a day. Two months later, the physical hard drives are completely full, bringing the storage cluster down.
-**The Fix:** Versioning without a Lifecycle Management (ILM) policy is a ticking time bomb. Every update writes a net-new 1MB object, consuming 600GB of storage for a 1MB logical file. Always mandate a global ILM Expiration policy for non-current versions (e.g., delete non-current versions after 7 days) on any bucket where versioning is enabled.
+Continue to [Module 4.5: Database Operators](module-4.5-database-operators/) to learn how PostgreSQL, Redis, and other data services consume the S3-compatible endpoints you provisioned here for backups and disaster recovery.
 
 ---
-
-## Quiz
-
-**1. You are the storage administrator for a financial data platform running a bare-metal MinIO Server Pool. The pool consists of 4 nodes, each equipped with 4 physical NVMe drives (16 drives total). To balance redundancy and usable capacity, you have configured the erasure coding profile to standard EC:4. During a massive power surge, multiple drives fail simultaneously across the cluster. What is the maximum number of simultaneous drive failures this specific Server Pool can sustain without losing read availability for your applications?**
-- A) 2 drives
-- B) 3 drives
-- C) 4 drives
-- D) 8 drives
-<br>_Correct Answer: C_
-<br>_Explanation: Erasure Coding (EC) splits objects into Data and Parity blocks across the drives in a set. In an EC:4 configuration with 16 total drives, an object is divided into 12 Data blocks and 4 Parity blocks. Read availability requires access to any 12 blocks (data or parity) from the set. Therefore, you can lose up to 4 blocks—which translates directly to 4 physical drives in this geometry—and still possess the necessary 12 blocks to reconstruct and serve the data._
-
-**2. Your team operates a multi-tenant object storage environment that has rapidly reached 90% of its total storage capacity. The hardware procurement team has just racked and cabled 4 brand-new bare-metal servers, each with identical drive geometries to your existing infrastructure. To prevent a storage outage, you need to seamlessly integrate this new hardware. What is the correct, supported operational method to expand the cluster's storage capacity?**
-- A) Add the new servers to the existing Server Pool via an admin command to rebalance the cluster.
-- B) Modify the existing Server Pool specification in the Tenant manifest to include the new nodes and increase the `servers` count from 4 to 8.
-- C) Provision the 4 new servers as a new, distinct Server Pool and append this new pool to the Tenant manifest.
-- D) Deploy a second, separate Tenant and configure an ILM Transition policy to move data between them.
-<br>_Correct Answer: C_
-<br>_Explanation: Distributed object architectures rely on a deterministic hashing algorithm that is established at the time a Server Pool is initialized, meaning you cannot alter the geometry (number of nodes or drives) of an existing pool without corrupting the hash ring. Instead, capacity expansion is achieved horizontally by adding entirely new Server Pools to the deployment. When you append a new Server Pool to the Tenant configuration, the system automatically begins routing new object writes to the pool with the most available free space, effectively expanding the cluster without rebalancing legacy data. This ensures predictable performance and maintains the integrity of the data distribution algorithm across the entire cluster._
-
-**3. A healthcare organization uses your bare-metal object storage to archive patient records and compliance audit logs. A new regulatory mandate dictates that these specific audit logs must be retained for exactly 7 years and absolutely cannot be deleted, modified, or tampered with by any entity—including administrators possessing root credentials. What combination of storage features must you configure to enforce this mandate?**
-- A) Bucket Versioning and Object Lock with Compliance Mode.
-- B) Object Lock with Governance Mode and a strict IAM policy.
-- C) Server-Side Encryption (SSE-C) and an ILM Transition policy.
-- D) Bucket Quotas and a Legal Hold applied to the user account.
-<br>_Correct Answer: A_
-<br>_Explanation: To satisfy strict Write-Once-Read-Many (WORM) regulatory requirements, you must use Object Lock. Object Lock fundamentally requires Bucket Versioning to be enabled first, as it operates by locking specific object versions rather than the bucket as a whole. Crucially, it must be deployed in Compliance Mode rather than Governance Mode; Compliance Mode ensures that the retention period is immutable and cannot be bypassed or shortened by any user, including the root administrator, fulfilling the strict anti-tampering mandate. This guarantees that the audit logs remain intact for the full 7-year period, protecting the organization from both accidental deletion and malicious tampering._
-
-**4. Several internal microservices running in your Kubernetes cluster require read/write access to specific internal storage buckets. Currently, developers are hardcoding long-lived AWS-style Access Keys and storing them in standard Kubernetes Secrets, which recently failed a security audit due to credential sprawl and lack of rotation. You are tasked with migrating these microservices to a secure, dynamic, and credential-less authentication architecture. Which mechanism should you implement?**
-- A) Configure the storage system to scrape the Kubernetes Secret API every 5 minutes and rotate keys automatically.
-- B) Implement the `AssumeRoleWithWebIdentity` STS flow utilizing Kubernetes ServiceAccount tokens.
-- C) Use an NGINX reverse proxy to inject hardcoded credentials into HTTP requests originating from internal cluster IPs.
-- D) Enable Active Directory / LDAP synchronization and bind the applications to specific Active Directory user objects.
-<br>_Correct Answer: B_
-<br>_Explanation: Hardcoding long-lived access keys is a critical security anti-pattern that leads to unmanageable credential sprawl and heightened risk of exposure. The modern, cloud-native approach is to use the Security Token Service (STS) `AssumeRoleWithWebIdentity` flow. This mechanism leverages the native Kubernetes ServiceAccount tokens (JWTs) already mounted inside the application Pods to authenticate with the object storage provider. The storage system validates the JWT against the Kubernetes API and dynamically issues short-lived, strictly scoped S3 credentials, completely eliminating the need to manually manage or rotate static secrets._
-
-**5. Your platform engineering team recently migrated the scraping of object storage metrics from a legacy monitoring stack to a centralized Prometheus instance. Shortly after the migration, the Prometheus server begins experiencing frequent timeouts during scrape intervals, and you observe severe, cluster-wide CPU spikes on the storage nodes every 30 seconds that correlate perfectly with the scrape schedule. What is the architectural root cause of this degradation, and how do you resolve it?**
-- A) The prometheus scrape interval is too short. Increase the scrape interval to 5 minutes to allow disk I/O to recover.
-- B) Prometheus is scraping the v1 authenticated metrics endpoint, which forces a live calculation of bucket sizes. Switch to the unauthenticated `/minio/v2/metrics/cluster` endpoint.
-- C) The ServiceMonitor is missing TLS certificates, causing the system to reject the connection via CPU-intensive cryptographic handshakes. Provide the correct CA bundle.
-- D) Erasure coding overhead is interfering with metrics generation. Reduce the EC parity level to free up CPU cycles for the metrics API.
-<br>_Correct Answer: B_
-<br>_Explanation: Legacy v1 Prometheus metrics endpoints often calculate metrics like total bucket size and object counts dynamically upon every HTTP request. In deployments with millions of objects, this live calculation requires recursively scanning the namespace, causing massive disk I/O and CPU spikes that can bring the cluster down. The v2 cluster metrics endpoint resolves this by relying on continuous internal background scanners to cache and report these statistics. Scraping the v2 endpoint retrieves this cached data almost instantly, imposing virtually zero compute or I/O overhead on the storage nodes._
-
----
-
-## Further Reading
-*   [Ceph Object Gateway (RGW)](https://docs.ceph.com/en/latest/radosgw/)
-*   [Rook v1.19 Documentation](https://rook.io/docs/rook/latest/)
-*   [DirectPV Storage CSI Driver Architecture](https://min.io/directpv)
-*   [STS AssumeRoleWithWebIdentity specification](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html)
 
 ## Sources
 
-- [github.com: minio](https://github.com/minio/minio) — The MinIO README states that the community edition is source-code only and that pre-compiled binary releases are no longer provided.
-- [raw.githubusercontent.com: quickstart.md](https://raw.githubusercontent.com/rook/rook/v1.19.5/Documentation/Getting-Started/quickstart.md) — The Rook v1.19 quickstart explicitly lists Kubernetes versions v1.30 through v1.35 as supported.
-- [github.com: Documentation](https://github.com/rook/rook/tree/v1.19.5/Documentation) — The Rook documentation README describes Rook as a Ceph storage orchestrator and states that it is hosted by CNCF as a graduated project.
-- [raw.githubusercontent.com: tentacle.rst](https://raw.githubusercontent.com/ceph/ceph/main/doc/releases/tentacle.rst) — The Ceph Tentacle release notes list v20.2.1 with an April 6, 2026 release date and enumerate the RGW changes named in the module.
-- [github.com: ceph](https://github.com/ceph/ceph) — The Ceph upstream repository describes Ceph as a distributed object, block, and file storage platform.
-- [github.com: seaweedfs](https://github.com/seaweedfs/seaweedfs) — The upstream README states the Apache-2.0 license, O(1) disk access, and in-memory metadata mapping design.
-- [github.com: rustfs](https://github.com/rustfs/rustfs) — The RustFS upstream README and repository tagline directly state the license, S3 compatibility, Rust implementation, and 2.3x benchmark claim.
-- [github.com: container object storage interface](https://github.com/kubernetes-sigs/container-object-storage-interface) — The COSI upstream README explicitly says the main branch contains pre-alpha code and APIs for COSI v1alpha2.
-- [raw.githubusercontent.com: README.md](https://raw.githubusercontent.com/minio/minio/master/docs/distributed/README.md) — The distributed MinIO guide documents pools, deterministic hashing, and placement of new objects in proportion to free space.
-- [github.com: 19280](https://github.com/minio/minio/discussions/19280) — The upstream GitHub discussion directly addresses adding more disks to an existing pool and points users to server-pool expansion instead.
-- [github.com: directpv](https://github.com/minio/directpv) — The DirectPV README directly describes DirectPV as a CSI driver for direct-attached storage and lists the drive-management functions and network-PV tradeoffs.
-- [raw.githubusercontent.com: README.md](https://raw.githubusercontent.com/minio/minio/master/docs/erasure/README.md) — The MinIO erasure-code guide states the 2-to-16-drive erasure-set range and describes variable data and parity blocks.
-- [raw.githubusercontent.com: README.md](https://raw.githubusercontent.com/minio/minio/master/docs/erasure/storage-class/README.md) — The MinIO storage-class guide table gives the 16-drive data/parity combinations and storage-usage ratios from which the efficiencies follow.
-- [kubernetes.io: projected volumes](https://kubernetes.io/docs/concepts/storage/projected-volumes) — The Kubernetes projected-volumes documentation describes service account token projection into Pods.
-- [docs.aws.amazon.com: API AssumeRoleWithWebIdentity.html](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html) — The AWS STS API reference directly documents the operation and the temporary credentials it returns.
-- [docs.aws.amazon.com: versioning workflows.html](https://docs.aws.amazon.com/us_en/AmazonS3/latest/userguide/versioning-workflows.html) — The Amazon S3 versioning documentation directly explains retained previous versions for overwrite and delete workflows.
-- [docs.aws.amazon.com: object lock.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html) — The S3 Object Lock documentation directly describes retention periods, legal holds, object versions, WORM behavior, and compliance-mode protection.
-- [docs.aws.amazon.com: intro lifecycle rules.html](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html) — The S3 lifecycle documentation covers expiration, transition, and noncurrent-version lifecycle actions.
-- [docs.aws.amazon.com: sig v4 authenticating requests.html](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html) — The AWS Signature Version 4 documentation explains request signing and the signed request components that must match during verification.
+- [github.com/minio/minio](https://github.com/minio/minio) — Community edition archive status, AGPLv3 license, and source-only distribution policy.
+- [min.io blog: Introducing New Subscription Tiers for MinIO AIStor](https://www.min.io/blog/introducing-new-subscription-tiers-for-minio-aistor-free-enterprise-lite-and-enterprise) — AIStor Free, Enterprise Lite, and Enterprise tier snapshot; verify before procurement because it is volatile product packaging.
+- [raw.githubusercontent.com/minio/minio/master/docs/distributed/README.md](https://raw.githubusercontent.com/minio/minio/master/docs/distributed/README.md) — Server Pools, deterministic hashing, and free-space routing for new objects.
+- [github.com/minio/minio/discussions/19280](https://github.com/minio/minio/discussions/19280) — Why single-drive additions to an existing pool are unsupported.
+- [raw.githubusercontent.com/minio/minio/master/docs/erasure/README.md](https://raw.githubusercontent.com/minio/minio/master/docs/erasure/README.md) — Erasure set sizing (2–16 drives) and shard layout.
+- [docs.min.io: AIStor Erasure Coding](https://docs.min.io/aistor/operations/core-concepts/erasure-coding/) — Current AIStor erasure-set defaults and configurable 32-drive limit for newer releases.
+- [raw.githubusercontent.com/minio/minio/master/docs/erasure/storage-class/README.md](https://raw.githubusercontent.com/minio/minio/master/docs/erasure/storage-class/README.md) — EC:4 and EC:8 data/parity ratios on sixteen-drive sets.
+- [docs.min.io: AIStor Thresholds and Limits](https://docs.min.io/aistor/reference/aistor-server/thresholds/) — Current non-multipart PUT and multipart upload limits.
+- [raw.githubusercontent.com/minio/operator/master/helm/operator/values.yaml](https://raw.githubusercontent.com/minio/operator/master/helm/operator/values.yaml) — Operator chart default replica count, anti-affinity, and official image repository.
+- [raw.githubusercontent.com/minio/operator/master/docs/tenant_crd.adoc](https://raw.githubusercontent.com/minio/operator/master/docs/tenant_crd.adoc) — Raw Tenant CRD `pools[].volumeClaimTemplate` requirement.
+- [raw.githubusercontent.com/minio/operator/master/examples/kustomization/tenant-tiny/tenant.yaml](https://raw.githubusercontent.com/minio/operator/master/examples/kustomization/tenant-tiny/tenant.yaml) — Minimal single-server Tenant example with `name: pool-0` and `volumeClaimTemplate`.
+- [docs.min.io: AIStor Bucket Quotas](https://docs.min.io/aistor/administration/bucket-quotas/) — Current `mc admin bucket quota` commands and best-effort enforcement warning.
+- [github.com/minio/directpv](https://github.com/minio/directpv) — DirectPV CSI driver for local JBOD on Kubernetes.
+- [github.com/rook/rook/tree/v1.19.5/Documentation](https://github.com/rook/rook/tree/v1.19.5/Documentation) — Rook as CNCF Graduated Ceph orchestrator.
+- [raw.githubusercontent.com/rook/rook/v1.19.5/Documentation/Getting-Started/quickstart.md](https://raw.githubusercontent.com/rook/rook/v1.19.5/Documentation/Getting-Started/quickstart.md) — Rook v1.19 Kubernetes v1.30–v1.35 support matrix.
+- [raw.githubusercontent.com/ceph/ceph/main/doc/releases/tentacle.rst](https://raw.githubusercontent.com/ceph/ceph/main/doc/releases/tentacle.rst) — Ceph Tentacle v20.2.1 RGW feature notes.
+- [docs.ceph.com: RADOS Gateway](https://docs.ceph.com/en/latest/radosgw/) — Ceph RGW S3-compatible object gateway documentation.
+- [github.com/ceph/ceph](https://github.com/ceph/ceph) — Unified object, block, and file storage platform.
+- [github.com/seaweedfs/seaweedfs](https://github.com/seaweedfs/seaweedfs) — Apache-2.0 SeaweedFS design and releases.
+- [garagehq.deuxfleurs.fr](https://garagehq.deuxfleurs.fr/) — Garage lightweight geo-distributed object store.
+- [github.com/kubernetes-sigs/container-object-storage-interface](https://github.com/kubernetes-sigs/container-object-storage-interface) — COSI pre-alpha v1alpha2 status.
+- [kubernetes.io: projected volumes](https://kubernetes.io/docs/concepts/storage/projected-volumes) — ServiceAccount token projection for Pods.
+- [docs.aws.amazon.com: AssumeRoleWithWebIdentity](https://docs.aws.amazon.com/STS/latest/APIReference/API_AssumeRoleWithWebIdentity.html) — STS web identity credential flow used by S3-compatible STS endpoints.
+- [docs.aws.amazon.com: S3 versioning](https://docs.aws.amazon.com/AmazonS3/latest/userguide/versioning-workflows.html) — Versioning semantics for overwrite and delete.
+- [docs.aws.amazon.com: S3 Object Lock](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lock.html) — WORM retention and compliance mode behavior.
+- [docs.aws.amazon.com: S3 lifecycle](https://docs.aws.amazon.com/AmazonS3/latest/userguide/intro-lifecycle-rules.html) — Expiration and transition actions.
+- [docs.aws.amazon.com: SigV4 authentication](https://docs.aws.amazon.com/AmazonS3/latest/API/sig-v4-authenticating-requests.html) — Request signing requirements behind load balancers.

--- a/src/content/docs/on-premises/storage/module-4.5-database-operators.md
+++ b/src/content/docs/on-premises/storage/module-4.5-database-operators.md
@@ -1,5 +1,4 @@
 ---
-revision_pending: true
 title: "Database Operators"
 description: "Deploying, scaling, and managing relational and in-memory databases on bare-metal Kubernetes using pattern-encoded operators."
 slug: on-premises/storage/module-4.5-database-operators
@@ -7,11 +6,37 @@ sidebar:
   order: 45
 ---
 
-Operating stateful databases on bare-metal Kubernetes requires replacing cloud-provider managed services (like RDS or ElastiCache) with in-cluster orchestration. Standard `StatefulSet` primitives handle identity and stable storage, but lack application-specific knowledge required for safe failover, replication scaling, Point-in-Time Recovery (PITR), and zero-downtime upgrades. 
+## What You'll Be Able to Do
 
-Database operators encode DBA operational routines into custom controllers. Following the standard Kubernetes Operator pattern, they combine a Custom Resource Definition (CRD) with a custom controller that implements a continuous reconciliation loop, constantly driving the observed state of the database cluster toward the desired state.
+- **Explain** why a StatefulSet is not enough for production database operations on bare-metal Kubernetes.
+- **Deploy** a CloudNativePG cluster with WAL archiving, scheduled backups, and explicit storage placement.
+- **Evaluate** PostgreSQL, MySQL, MariaDB, and cache operators using production readiness criteria.
+- **Design** bare-metal storage, topology, and backup placement for durable database workloads.
+- **Choose** self-hosted operators versus managed cloud databases using cost, risk, and utilization tradeoffs.
+
+## Why This Module Matters
+
+Hypothetical scenario: your platform team has moved stateless services onto an on-premises Kubernetes cluster, and the next migration wave is the database tier. The application teams expect the same behavior they received from managed cloud services: a primary that fails over, replicas that stay caught up, backups that can restore to a point in time, minor upgrades without a maintenance weekend, and a connection endpoint that does not change when a pod is replaced. Kubernetes gives you scheduling, networking, and persistent volume abstractions, but it does not automatically become a database administrator just because a database process runs in a pod.
+
+This is where database operators become important. Operating stateful databases on bare-metal Kubernetes requires replacing cloud-provider managed services like RDS, Cloud SQL, or ElastiCache with in-cluster orchestration that your team owns. Standard `StatefulSet` primitives handle stable identity and stable storage, but they lack application-specific knowledge required for safe failover, replication scaling, point-in-time recovery, minor-version upgrades, switchover, connection pooling, and re-provisioning a broken replica. A `StatefulSet` can bring `postgres-2` back, but it cannot decide whether `postgres-2` is safe to promote after a network partition.
+
+The on-premises part changes the risk model. In a cloud service, the managed database vendor hides a long chain of operational details behind an API: volume attachment, zone placement, backup storage, retention, patching, control-plane health, and support escalation. In your own datacenter or colo, those details are your architecture. The database operator can automate the database-specific loop, but it still depends on your storage class, rack topology, object store, power design, network fabric, monitoring, and human runbooks. That makes the operator a powerful control plane, not a magic boundary around weak infrastructure.
+
+> **The Database Operator Analogy**
+>
+> A `StatefulSet` is like assigning every apartment in a building a permanent mailbox and door number. A database operator is the building manager who knows which resident is responsible for rent, who has a spare key, when maintenance is safe, where the fire exits are, and how to recover records after a flood. Stable addresses matter, but the operational knowledge is what keeps the building livable.
+
+## Why Operators for Databases
+
+Database operators encode DBA operational routines into custom controllers. Following the Kubernetes Operator pattern, they combine custom resource definitions with controllers that implement a continuous reconciliation loop, constantly driving the observed state of the database cluster toward the desired state. For a database, that desired state is not only "three pods exist." It is also "one writable primary exists, replicas are following the correct timeline, backups are being archived, credentials are present, services route to the correct role, and failed instances are rebuilt without accidentally accepting divergent writes."
+
+The distinction matters most during day-2 operations. Day-0 installation can be solved with a Helm chart, a `StatefulSet`, and a PVC template, but production failure modes happen after the database has accepted data. A controller with database knowledge can watch replication lag before promoting a standby, annotate or fence an unsafe instance, recreate a replica from a fresh base backup, roll a minor image update through replicas before touching the primary, and expose status conditions that mean something to both Kubernetes operators and DBAs. Without that loop, every failover becomes a manual incident with a high risk of split-brain or silent data loss.
+
+The most useful mental model is to separate infrastructure guarantees from database guarantees. Kubernetes can guarantee that pods have names, PVCs can be rebound according to storage rules, and Services can route traffic to selected endpoints. PostgreSQL, MySQL, MariaDB, Redis-compatible stores, and Kafka each have their own replication, recovery, quorum, and durability semantics. A good operator bridges those layers by translating a declarative Kubernetes object into database-native actions, while still making the failure domain visible enough for human operators to audit and override.
 
 ## The Bare-Metal Database Architecture
+
+Bare-metal database architecture starts with a blunt question: where does the write land when the pod disappears? If the answer is "on whatever volume the default StorageClass created," the design is not yet production ready. Relational databases care about write latency, fsync behavior, ordering, and recovery semantics more than most stateless workloads. A storage layer that looks healthy for container images, logs, or shared file workloads can still be unsuitable for a write-heavy database primary because every commit path may wait for durable I/O.
 
 On managed cloud providers, database operators often rely on underlying infrastructure APIs (e.g., EBS snapshots) for backups. On bare metal, you must provide the complete stack:
 
@@ -19,7 +44,11 @@ On managed cloud providers, database operators often rely on underlying infrastr
 2. **Object Storage:** For continuous backup and PITR, operators stream Write-Ahead Logs (WALs) and base backups to an S3-compatible endpoint. On bare metal, this is typically an internal MinIO cluster or Ceph RadosGW.
 3. **Fencing Mechanisms:** To prevent split-brain scenarios during network partitions, operators must reliably "fence" (isolate or kill) the old primary before promoting a replica.
 
-> **Stop and think**: If a bare-metal node fails entirely, how does the operator know whether it's a temporary network partition or a permanent hardware failure? Without cloud APIs to query, operators rely heavily on distributed Kubernetes API leases and robust fencing mechanisms to safely isolate the node before promoting a replica.
+The storage choice is the first major fork. Local NVMe gives excellent latency and predictable fsync behavior when the database pod stays on the node that owns the disk. It also makes node loss more operationally visible, because the database operator must rebuild a replacement instance from another replica or from backup. Network block storage such as Ceph RBD can survive node replacement more naturally, but every synchronous write now crosses a storage network and a distributed storage system. That does not make one approach universally better; it means you must decide whether your primary constraint is tail latency, operational simplicity, rack-level durability, or storage-team familiarity.
+
+Topology is the second major fork. A three-instance database placed on three Kubernetes nodes is not automatically resilient if those nodes sit in the same rack, share the same top-of-rack switch, or draw from the same power feed. For on-premises clusters, node labels should reflect the physical world: rack, row, power domain, storage pool, and sometimes maintenance domain. The operator can express anti-affinity, but the labels must represent real failure boundaries, otherwise Kubernetes spreads pods across names that all fail together.
+
+> **Stop and think**: If a bare-metal node fails entirely, how does the operator know whether it's a temporary network partition or a permanent hardware failure? Without cloud APIs to query, the operator cannot truly tell a transient network partition from a dead node, so it relies on the kubelet's node-readiness/health signals plus explicit fencing (CloudNativePG's `fencing` annotation) before promoting a replica — and on bare metal, robust split-brain prevention ultimately needs out-of-band BMC/IPMI fencing to power-isolate the suspect node. (Kubernetes `Lease` objects drive controller leader election, not database primary fencing.)
 
 ```mermaid
 graph TD
@@ -48,42 +77,90 @@ graph TD
     end
 ```
 
+This diagram hides an important operational detail: the object store is not optional backup decoration. WAL archiving is the bridge between "I have replicas" and "I can recover to a precise point after the whole cluster loses quorum." Replicas protect against common node and pod failures, but they also replicate many forms of corruption and operator mistakes. A dropped table, a bad migration, or an application bug that overwrites rows can propagate instantly to every standby. Point-in-time recovery requires a base backup plus archived WAL or binlog history stored outside the primary database volume.
+
+The object store must be outside the immediate blast radius of the database nodes. A MinIO tenant, Ceph RGW service, or other S3-compatible system running on the same rack and power circuit as the database cluster may satisfy an API field, but it does not satisfy disaster recovery. For production, backup placement should be deliberately off-node, usually off-rack, and often replicated to a second room or site. If your restore plan depends on the same Ceph pool that holds the live database PVCs, you have built a convenient snapshot workflow rather than an independent recovery path.
+
 ## PostgreSQL: CloudNativePG (CNPG)
 
-CloudNativePG (a CNCF Sandbox project accepted on January 21, 2025, which applied for CNCF Incubating status in November 2025 but has not yet been promoted) is the current standard for running PostgreSQL on Kubernetes. The latest 1.29.0 release (March 31, 2026) supports PostgreSQL versions 14 through 18, utilizing PostgreSQL 18.3 in its default container image. Unlike older operators that wrap external high-availability tools (like Patroni or Stolon), CNPG interacts directly with the Kubernetes API server for leader election and state management.
+CloudNativePG is a CNCF Sandbox project, accepted at that maturity level on January 21, 2025, and its 1.29 release line is current for this curriculum snapshot. The CloudNativePG 1.29 supported-releases matrix lists Kubernetes 1.35, 1.34, and 1.33 support and PostgreSQL major versions 14 through 18, with PostgreSQL 18.3 as the default image for the 1.29.x line. That matters for this module because the example should use the operator's own PostgreSQL image registry, `ghcr.io/cloudnative-pg/postgresql`, rather than a generic third-party database image.
+
+CNPG is a useful worked example because it makes the operator boundary visible. A `Cluster` custom resource declares how many PostgreSQL instances should exist, which image they should run, how PVCs should be created, how pod anti-affinity should be applied, where WAL should be archived, and how backups should be requested. The controller then reconciles those Kubernetes objects and database actions continuously. Unlike a hand-authored `StatefulSet`, it understands PostgreSQL roles, replication state, WAL timelines, services for primary and replica traffic, and the difference between a restart, a switchover, and a failover.
 
 ### Architecture and Replication
 
-CNPG deploys instances as a single `Cluster` Custom Resource. It uses Kubernetes endpoints and leases for leader election. 
+CNPG deploys instances as a single `Cluster` custom resource. It uses Kubernetes coordination and PostgreSQL state to manage leadership, and it exposes database role through generated Services rather than asking applications to discover pod names. The service split is a practical production feature: application write traffic should use the read/write endpoint, reporting or analytics traffic can use the replica endpoint, and operational scripts can choose the broader read endpoint only when they understand the consequences.
 
-* **Primary:** Receives read/write traffic.
-* **Replicas:** Maintain state via asynchronous or synchronous streaming replication.
-* **Services:** The operator automatically generates three services:
-  * `<cluster>-rw`: Routes exclusively to the Primary.
-  * `<cluster>-ro`: Routes to Replicas for read scaling.
-  * `<cluster>-r`: Routes to any available node (rarely used).
+* **Primary:** The current writable PostgreSQL instance receives application writes through the `<cluster>-rw` Service, and the operator updates service selectors when leadership changes.
+* **Replicas:** Standby instances maintain state through PostgreSQL streaming replication, either asynchronous for lower write latency or synchronous when the workload requires stronger commit acknowledgement.
+* **Services:** CNPG creates role-aware Services named `<cluster>-rw`, `<cluster>-ro`, and `<cluster>-r`, which route to the primary, replicas, or any readable instance according to their selector type.
+
+Asynchronous replication is the common starting point because write commits do not wait for a standby to confirm receipt. It gives better write latency, especially when replicas sit across racks or rooms, but it can lose the last acknowledged transactions if the primary dies before WAL reaches a replica. Synchronous replication reduces that risk by requiring acknowledgement from one or more standbys before the primary confirms a commit, but it turns replica health and network latency into part of the write path. On bare metal, that tradeoff must be made with rack topology in mind; a synchronous standby on the same top-of-rack switch may be fast, but it may not protect you from the failure domain you actually care about.
+
+Failover is where operators earn trust or lose it. A safe controller must distinguish an unhealthy primary from a partitioned primary that might still accept writes, choose a promotion candidate with the most appropriate WAL position, isolate the old primary, and update routing endpoints. CNPG's 1.29.1 notes include specific failover fixes around unreachable primary nodes and old-primary service isolation, which is a reminder that database operators are sophisticated distributed systems. Treat operator upgrades as production database upgrades: read release notes, stage the change, and run a failover drill before you need it during an outage.
+
+Switchover is the calmer sibling of failover. You use it when the current primary is healthy but needs planned maintenance, such as a node reboot, kernel update, firmware patch, or rack power work. A switchover gives the operator time to make a chosen replica current, promote it, and move write traffic intentionally. In an on-premises environment with regular hardware maintenance windows, planned switchovers should be routine muscle memory rather than rare emergency knowledge.
 
 ### Connection Pooling (pgBouncer)
 
 > **Pause and predict**: What happens if an autoscaling microservice suddenly creates 500 new connections directly to the PostgreSQL primary pod? Because PostgreSQL forks an OS process for every connection, the node will likely exhaust its memory and trigger an OOMKill before the queries even execute.
 
-In Kubernetes, hundreds of microservice pods continuously connecting and disconnecting will exhaust PostgreSQL's connection limits and crash the node due to OOM (Out of Memory). CNPG integrates pgBouncer natively via the `Pooler` CRD. It maintains a persistent connection pool to the database while multiplexing incoming client connections.
+In Kubernetes, hundreds of microservice pods continuously connecting and disconnecting can exhaust PostgreSQL's connection limits and consume memory through backend processes. CNPG integrates pgBouncer through the `Pooler` CRD, which maintains a smaller set of persistent database connections while multiplexing incoming client connections. The pooler does not remove the need to tune PostgreSQL, but it changes the scaling surface from "every pod can open many database backends" to "the pooler enforces a bounded connection budget."
+
+Connection pooling also affects failover behavior. Applications should connect to the pooler or to the generated service name, not to a database pod DNS name, because pod identity is not the same as database role. When the primary changes, the role-aware service and pooler path are the stable abstraction that lets clients reconnect to the right place. If an application caches pod IPs or bypasses the pooler to reach `dojo-db-1` directly, the operator can promote a new primary correctly and the application can still fail because it ignored the database access contract.
 
 ### Storage and WAL Archiving
 
 A production CNPG cluster **must** have an S3-compatible backup destination configured. Without it, PostgreSQL will retain WAL files locally until they are successfully archived. If the archiver fails (e.g., MinIO is down), the local persistent volume will fill up with WAL files, causing the primary database to crash and refuse to restart.
 
 :::caution
-Always set separate volume claims for data (`/var/lib/postgresql/data`) and WALs (`/var/lib/postgresql/data/pg_wal`). If the WAL volume fills up, the database halts, but the data volume remains uncorrupted, simplifying recovery.
+Always set separate volume claims for data and WAL: with `.spec.walStorage`, CloudNativePG provisions a dedicated WAL PVC mounted at `/var/lib/postgresql/wal` (PGDATA stays at `/var/lib/postgresql/data`) and symlinks `pg_wal` there, instead of leaving WAL inside the data volume. If the WAL volume fills up, the database halts, but the data volume remains uncorrupted, simplifying recovery.
 :::
 
 :::warning
 In CloudNativePG 1.29, the native Barman Cloud support for backup orchestration received a deprecation notice, with full removal now planned for version 1.30.0. Future deployments will migrate to alternative backup implementations, but the `barmanObjectStore` configuration remains functional for current 1.29 deployments.
 :::
 
+CNPG supports a separate `.spec.walStorage` PVC for PostgreSQL WAL. On bare metal, that separation is more than a neat YAML field. WAL is a sequential write-heavy path, while data files and indexes have different read and write patterns. Splitting WAL can reduce I/O contention, create clearer alerts, and limit the blast radius of a full volume. It also creates a lifecycle rule: once you add a separate WAL volume, design around it as a permanent part of the cluster rather than a temporary toggle.
+
+The access mode should match relational database reality. A PostgreSQL data directory is not a shared filesystem workload, so using a ReadWriteMany volume for `PGDATA` is usually the wrong abstraction. Multiple database processes writing the same data directory is not high availability; it is corruption waiting for a bad day. Use block PVCs with one writer per database instance, then let PostgreSQL replication and the operator create the availability layer above those independent volumes.
+
+`WaitForFirstConsumer` is especially important for local storage. With immediate binding, Kubernetes can bind a PVC to a disk before the scheduler has chosen the pod's node, creating unschedulable combinations when CPU, memory, taints, or anti-affinity later point the pod elsewhere. With delayed binding, provisioning happens after scheduling context is known, so the volume can be created or selected in the same physical place where the pod will run. For local NVMe, that distinction is the difference between a clean placement policy and a stuck production rollout.
+
+Here is a compact CNPG storage shape for a production-like bare-metal cluster. The exact sizes are deliberately small in this teaching example, but the important parts are the explicit image, anti-affinity, dedicated WAL volume, and a storage class chosen for database semantics rather than whatever default class exists in the cluster.
+
+```yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: Cluster
+metadata:
+  name: dojo-db
+spec:
+  instances: 3
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.3-system-trixie
+
+  affinity:
+    enablePodAntiAffinity: true
+    topologyKey: kubernetes.io/hostname
+    podAntiAffinityType: required
+
+  storage:
+    storageClass: local-nvme-wffc
+    size: 10Gi
+
+  walStorage:
+    storageClass: local-nvme-wffc
+    size: 5Gi
+```
+
+Backups are separate resources, not a vague promise that someone will remember to run `pg_dump`. CNPG supports `Backup` and `ScheduledBackup` custom resources, and its 1.29 documentation describes physical backups, WAL archiving, volume snapshots, and plugin-based backup integration. Logical dumps still have a place for portability, selective export, and schema-level inspection, but they are not the primary business-continuity mechanism for a high-write production database. Physical backups plus WAL archive are what make point-in-time recovery possible.
+
+The restore drill is part of the design, not an afterthought. A backup that has never been restored is an inventory item, not a recovery guarantee. In an on-premises environment, restore tests should answer concrete questions: can a new cluster read from the object store after the primary cluster is down, can credentials be restored without the original namespace, can the target recovery timestamp be chosen safely, and can applications be pointed at the restored service without changing every deployment manifest. Those questions belong in the quarterly operations calendar.
+
 ## MySQL at Scale: Vitess
 
-When a single MySQL primary cannot handle the write throughput or dataset size, vertical scaling on bare metal eventually hits a hardware ceiling. Vitess (a CNCF Graduated project since November 5, 2019) is a database clustering system for horizontal scaling of MySQL, originally built at YouTube. As of the v23.0 stable release series (GA on November 4, 2025, supported until November 4, 2026), Vitess sets MySQL 8.4 as the default engine to future-proof deployments.
+When a single MySQL primary cannot handle the write throughput or dataset size, vertical scaling on bare metal eventually hits a hardware ceiling. Vitess, a CNCF Graduated project, is a database clustering system for horizontal scaling of MySQL-compatible workloads, originally built at YouTube. The important lesson is not "always choose Vitess." The lesson is that sharding changes the application contract, so you should reach for it only when single-primary MySQL plus read replicas, connection pooling, and hardware refresh no longer meet the workload shape.
+
+Vitess is best understood as a distributed database control plane around MySQL. It introduces routing, topology, tablets, online schema changes, and resharding workflows that are valuable at very large scale but costly if the application is not ready for distributed SQL constraints. On bare metal, it also requires a mature network and storage plan because every shard adds more MySQL instances, more backup streams, more replication relationships, and more failure domains to observe.
 
 ### Vitess Topology
 
@@ -120,13 +197,19 @@ graph TD
 Vitess does not support 100% of standard MySQL syntax. Cross-shard joins are heavily restricted or perform poorly. Applications migrating to Vitess must be audited for compatibility with distributed SQL limitations.
 :::
 
+Most on-premises teams should evaluate ordinary MySQL and MariaDB operators before jumping to sharding. Oracle's MySQL Operator manages MySQL InnoDB Cluster setups and includes lifecycle operations such as setup, maintenance, upgrades, and backups. Percona publishes MySQL operators for Percona Server and Percona XtraDB Cluster, with production documentation around backups, recovery, scaling, and failover. MariaDB documents official Kubernetes operators for MariaDB and MaxScale patterns. These operators differ in replication model, licensing, enterprise support, and CRD design, but the evaluation questions are the same.
+
+A good MySQL-family operator must make replication topology explicit. Does it use asynchronous replication, group replication, Galera-style synchronous replication, or a proxy/router layer? How does it detect primary failure, and what protects it from promoting a stale member? Can it run backups from a replica without overloading the writer? Does point-in-time recovery use binlog archiving, and where are those binlogs stored in your on-premises object store? If those answers are vague, the operator may still be useful for development, but it is not yet a production database platform.
+
+PostgreSQL operator choice deserves the same evaluation discipline. CloudNativePG is the worked example here because it is community-governed under CNCF and exposes the lifecycle clearly, but it is not the only option. The Zalando Postgres Operator has a long production history and a different API style. Crunchy Data's PGO focuses on a declarative PostgreSQL solution with high availability and backup workflows. Compare them against your operational contract rather than a popularity ranking: supported PostgreSQL versions, backup mechanism, restore UX, security model, upgrade behavior, observability, support path, and how well the operator fits GitOps.
+
 ## In-Memory Datastores: Redis, Valkey, and Memcached
 
-In-memory data grids are essential for caching, session management, and rate limiting.
+In-memory data grids are essential for caching, session management, rate limiting, leaderboards, short-lived queues, and request coalescing. They are also easy to overstate as durable systems because they feel fast and simple during a demo. For on-premises Kubernetes, decide first whether the data is disposable cache, reconstructable session state, or a source of truth. The operator pattern is useful for the latter two categories, but Memcached-style disposable caching often needs a plain Deployment, a Service, and client-side consistent hashing more than it needs a complex controller.
 
 ### The Shift to Valkey
 
-Following Redis Ltd's transition to the Server Side Public License (SSPL), the Linux Foundation forked the project into **Valkey**. For new bare-metal deployments, Valkey operators (or community Redis operators migrating to Valkey) are the standard to avoid restrictive licensing issues in enterprise environments.
+Following Redis Ltd's 2024 license change from the earlier BSD-licensed Redis OSS lineage to source-available licenses, the Linux Foundation community launched **Valkey** as an open source fork. For new bare-metal deployments, Valkey-compatible operators or Redis operators with a clear Valkey migration path reduce licensing surprise and keep the caching layer under a more predictable open governance model. The technical evaluation still matters: check cluster-mode support, Sentinel or equivalent failover behavior, persistence settings, memory eviction policy, TLS, authentication, backup expectations, and whether the operator can safely roll nodes without dropping the whole cache.
 
 ### Deployment Topologies
 
@@ -136,70 +219,308 @@ Following Redis Ltd's transition to the Server Side Public License (SSPL), the L
 | **Valkey / Redis (Sentinel)** | Primary-Replica with Sentinel nodes for election. | KubeDB, Spotahome Redis Operator. | General caching, pub/sub, single-threaded high performance. |
 | **Valkey / Redis (Cluster)** | Sharded architecture. Multiple Primaries. | KubeDB, OT-Container-Kit Redis Operator. | Datasets exceeding the memory capacity of a single bare-metal node. |
 
+The cost/risk profile for in-memory systems is different from PostgreSQL and MySQL. A cache miss storm after a full cluster restart can overload the backing database, so "the cache is disposable" does not mean "the cache has no availability requirement." On bare metal, reserve memory deliberately, monitor fragmentation and eviction, and avoid placing every cache shard on the same physical node family that also hosts the primary database. A failed cache tier should degrade the application, not become the reason the database operator starts a failover.
+
 ## The Broader Operator Ecosystem
 
-While CloudNativePG and Vitess are standard for relational workloads, the Kubernetes ecosystem provides specialized operators for almost every datastore:
+While CloudNativePG, Vitess, MySQL operators, MariaDB operators, and Valkey-compatible operators cover the main examples in this module, the Kubernetes ecosystem provides specialized operators for many stateful systems. MongoDB now documents MongoDB Controllers for Kubernetes as the replacement path for earlier MongoDB Kubernetes operators. Strimzi remains the common open source reference for running Apache Kafka on Kubernetes and is listed by the project as a CNCF Incubating project. KubeBlocks represents the multi-database control-plane approach, where one operator family tries to manage many engines through a common framework.
 
-* **MongoDB**: The MongoDB Community Kubernetes Operator reached end-of-life with best-effort support ending in November 2025. The unified replacement recommended by MongoDB is MongoDB Controllers for Kubernetes (MCK), with v1.7.0 (released February 10, 2026) being the latest stable release.
-* **Kafka**: Strimzi (which moved from CNCF Sandbox to Incubating on February 8, 2024) is the standard for Apache Kafka on Kubernetes. The latest 0.51.0 release requires Kubernetes 1.30 or newer, dropping support for older clusters, and adds support for Apache Kafka 4.2.0.
-* **Percona**: Offers robust operators for MySQL (Percona Operator for MySQL based on Percona XtraDB Cluster 1.19.0, released January 19, 2026, using PXC 8.4 as the default) and PostgreSQL (version 2.9.0, released April 1, 2026, which removed support for PostgreSQL 13 due to upstream EOL).
-* **Multi-Database Operators**: Projects like KubeDB (v2026.2.26, released February 26, 2026, which introduces migration tooling for deployments like CloudNativePG and Zalando) and KubeBlocks (an open-source AGPL-3.0 operator) aim to manage multiple distinct database engines under a single unified API.
+Use broad operators carefully. A unified API can simplify day-0 onboarding and reduce the number of CRD models a platform team must learn, but it can also hide engine-specific differences that matter during incidents. A PostgreSQL point-in-time recovery, a MySQL binlog restore, a Kafka broker replacement, and a Redis-compatible shard resharding operation are not the same procedure. If a multi-engine operator abstracts those differences cleanly and exposes enough detail for audit, it may be useful. If it collapses them into generic "backup" and "restore" buttons without engine-specific runbooks, it creates false confidence.
 
-Additionally, when managing these extensions across large fleets, cluster administrators typically use the Operator Lifecycle Manager (OLM). Note that OLM v0 is in maintenance mode, with OLM v1 (operator-controller) serving as its successor under active development, though there is no concrete automated migration path between v0 and v1 yet.
+Operator Lifecycle Manager can help large fleets install and update operators, but it should not be treated as a substitute for database release management. The OLM v0 repository is in maintenance mode, and the operator-framework community is developing newer lifecycle-management designs. For production databases, the platform team still needs a version policy: who approves operator upgrades, how CRDs are rolled out, whether conversion webhooks are tested, how rollback works, and how application owners are notified when an operator changes default behavior.
 
-## Hands-on Lab
+## Storage Requirements for Database Operators
 
-This lab deploys a highly available PostgreSQL cluster using CloudNativePG, configures an internal MinIO instance as the S3 backup target for WAL archiving, and validates failover.
+Database operator success depends on storage behavior more than on YAML neatness. Kubernetes persistent volumes describe capacity and attachment, but databases care about latency distribution, flush semantics, queue depth, write amplification, and how storage recovers after a host reboot. Before standardizing an operator, run storage and database benchmarks in the same topology the database will use in production. A benchmark on one empty node does not prove a rack of busy nodes can sustain checkpoint spikes, backup reads, compaction, and application writes at the same time.
 
-### Prerequisites
-* A running K8s cluster (e.g., `kind` with 3 worker nodes, running v1.35+).
-* `kubectl` and `helm` installed.
-* Default StorageClass configured (standard `kind` provisioner is sufficient for this lab).
+Local NVMe is attractive because it keeps the write path short and makes latency easier to reason about. The tradeoff is that the database availability layer must come from the database engine and operator, not from the disk surviving node loss. That is why pod anti-affinity, `WaitForFirstConsumer`, rack labels, and tested replica rebuilds matter so much. If the primary node fails, the operator should promote a replica and later recreate the lost instance from replication or backup. The local disk is fast, but it is not portable.
 
-### Step 1: Install CloudNativePG Operator
+Networked block storage such as Ceph RBD is attractive because it decouples a PVC from one failed worker node and can provide durable storage services across a storage cluster. The tradeoff is that every database write now depends on storage network health and storage-cluster behavior. Replicating at the storage layer and at the database layer can also amplify writes, especially when each PostgreSQL instance already has its own replica set. CNPG's storage documentation calls this out for block storage designs: storage-level replicas are useful, but they should be aligned with the database's shared-nothing architecture rather than blindly multiplied.
 
-Deploy the CNPG controller using the official manifests.
+ReadWriteMany storage is usually the wrong answer for an RDBMS data directory. Shared filesystems have legitimate uses in Kubernetes, but a PostgreSQL or MySQL data directory is designed for one database server process owning its files. High availability should be built through independent instances and database replication, not multiple pods mounting and writing the same directory. If a storage vendor claims RWX makes relational database HA easy, ask exactly how it prevents concurrent writers, split-brain, stale cache reads, and filesystem-level corruption during failover.
+
+Storage topology should be visible in Kubernetes labels. At minimum, label nodes by rack or row when those boundaries represent real power and network failure domains. Larger on-premises environments may also label storage pool, chassis, room, or maintenance domain. Then configure database operators to spread replicas across those labels. The goal is not aesthetic scheduling; the goal is to prevent one breaker, one top-of-rack switch, or one storage shelf from removing all copies of the same database.
+
+## Backup, Restore, and Disaster Recovery
+
+Backup design begins by separating logical backups, physical backups, and continuous log archiving. Logical backups such as `pg_dump` or MySQL dumps are useful for portability, selective recovery, schema comparison, and low-volume databases. They are not enough for strict recovery point objectives on active production systems because they represent a point-in-time export and can be slow to restore at size. Physical base backups copy database files in a database-aware way, and WAL or binlog archiving captures the changes needed to recover forward to a chosen point.
+
+Point-in-time recovery is the operational capability you are really buying with continuous archiving. If an application deploy corrupts data at 13:07, a nightly backup from 02:00 loses a business day, while a base backup plus archived WAL may let you recover to 13:06. The operator can make this workflow declarative, but the humans still need to decide the target timestamp, validate the restored database, and redirect traffic safely. The harder part of PITR is rarely the command; it is the decision discipline during pressure.
+
+On premises, backup location has physical meaning. A MinIO instance, Ceph RGW endpoint, or other S3-compatible object store in the same cluster is convenient for the lab, but production backups should survive the loss of a node pool, rack, storage shelf, and ideally the primary server room. Many teams use a local object store for fast restores and then replicate to an off-rack or off-site target for disaster recovery. That second copy is not a luxury when the same maintenance mistake can affect both the live PVCs and the first backup target.
+
+Restore drills should be boring, scheduled, and measured. At least one drill should restore into a different namespace with fresh secrets, because real disasters often include broken service accounts, missing encryption keys, or a damaged cluster state. Another drill should restore after intentionally deleting the original database cluster, because that exposes hidden dependencies on live objects. Record the elapsed time, the largest manual step, the validation query, and the application cutover action. Those notes become the runbook that matters during the next incident.
+
+## Cost and Risk Lens: Self-Hosted Operators vs Managed Databases
+
+The economic case for on-premises database operators is a trade, not a free discount. Cloud managed databases charge for compute, storage, I/O, backup retention, cross-region replication, support, and egress, but they also include a service team's operational labor and a tested control plane. Self-hosting replaces part of that bill with capital expense and internal responsibility: servers, disks, racks, power, cooling, network gear, spare parts, support contracts, monitoring, backup media, and the people who patch, test, and respond at 03:00.
+
+CapEx versus OpEx changes how mistakes show up. In cloud, overprovisioning usually appears as a monthly bill that can be reduced next month. On premises, overprovisioning becomes hardware that sits underutilized until the next refresh cycle, while underprovisioning becomes a purchase process, lead time, rack capacity check, and maintenance window. Depreciation matters because a database platform that looks cheap in year one may be expensive if the storage refresh must happen earlier than planned or if a support contract is required to keep firmware and replacement parts available.
+
+On-premises can beat managed cloud databases when utilization is steady and high, data gravity is strong, latency to local applications matters, egress-heavy workloads would be punished by cloud transfer charges, or regulatory controls require specific physical custody. It can also win when a platform team already operates reliable datacenter infrastructure and can amortize staff, monitoring, and hardware across many database clusters. In that case, an operator turns repeatable DBA work into a platform service without paying a managed database margin for every instance.
+
+On-premises does not win automatically. Small fleets, spiky workloads, uncertain product demand, weak operations coverage, and low utilization often favor managed services because the cloud provider absorbs idle capacity, hardware failures, and much of the control-plane complexity. If you need one small production database and the team has no on-call DBA skill, self-hosting on bare metal can be more expensive even when the cloud line item looks higher. A fair TCO model includes outage risk, restore-test time, hiring, training, support escalation, and the opportunity cost of engineers operating databases instead of building product features.
+
+The risk lens is equally important. Managed cloud lock-in is real, but so is self-hosting lock-in to your own operational maturity. If your team cannot regularly patch the operator, test failover, monitor WAL archiving, and prove restores, the cheaper infrastructure is not cheaper. The correct comparison is not "cloud database bill versus server invoice." It is "managed service contract versus the full cost of building and sustaining a reliable database platform."
+
+## Patterns & Anti-Patterns
+
+Proven patterns are useful because they encode failure knowledge before the incident. The strongest pattern for bare-metal databases is shared-nothing placement: each database instance owns its own block PVC, replicas land on different physical failure domains, and the database engine replicates between instances. This scales well when the cluster has enough nodes and racks to spread replicas, and it keeps recovery actions understandable because one broken instance can be destroyed and rebuilt without trying to untangle shared files.
+
+Another strong pattern is object-store-first recovery. Every production database cluster should archive logs to an object store outside the immediate node failure domain, and every platform should include a scheduled restore drill. This pattern scales from a single CNPG cluster to a fleet because the control objective is stable: you can recreate the database state without trusting the original pod, PVC, or node. As the fleet grows, centralize bucket policy, encryption, retention, and replication so teams get consistent recovery behavior.
+
+A third pattern is role-aware access. Applications connect through operator-managed Services or poolers such as CNPG `Pooler`, never through pod names. This pattern scales because it lets the operator change the primary without every application needing to understand database internals. It also gives platform teams a clear place to insert connection limits, TLS policy, network policy, and observability. When every application invents its own connection path, failover becomes a compatibility problem.
+
+| Pattern | When to Use | Why It Works | Scaling Consideration |
+| :--- | :--- | :--- | :--- |
+| Shared-nothing database instances | Production RDBMS clusters with replicas and block PVCs. | Each instance owns one writable data directory, so replication is database-aware rather than filesystem-shared. | Requires node and rack labels that represent real physical failure domains. |
+| Object-store-first recovery | Any database with business continuity requirements stronger than daily restore. | Base backups plus WAL or binlog archives allow PITR and recovery outside the failed node. | Standardize buckets, retention, encryption, and restore drills across the fleet. |
+| Role-aware access through Services or poolers | Applications that must survive switchover, failover, and rolling upgrades. | Clients connect to a stable role endpoint while the operator changes backing pods. | Pooler sizing and connection budgets become platform-level capacity inputs. |
+
+Anti-patterns are tempting because they often work in a demo. The first is "StatefulSet equals database platform." Teams fall into it because a StatefulSet gives stable names, PVCs, and ordered rollout, which looks close to what a database needs. The missing pieces are replication orchestration, fencing, backup, restore, role-aware routing, and upgrade sequencing. The better alternative is either a database operator with a tested lifecycle or a deliberate VM-based database platform if Kubernetes is not ready.
+
+The second anti-pattern is "RWX for high availability." Teams choose it because shared storage feels like a shortcut around replica rebuilds and local disk placement. For an RDBMS data directory, shared write access is not the same as safe multi-writer coordination. The better alternative is one writable data directory per database instance, database-native replication, and operator-managed promotion. Use RWX for workloads designed for shared files, not as a substitute for database HA.
+
+The third anti-pattern is "backup target inside the same blast radius." Teams do this because it is convenient to deploy MinIO in the same cluster and point every operator at it. That may be fine for a lab or fast local restore, but it fails the real disaster test if the same rack, Ceph pool, or cluster state is lost. The better alternative is layered backup placement: local object storage for speed, replicated off-rack or off-site object storage for survival, and routine restore tests from the remote copy.
+
+| Anti-Pattern | What Goes Wrong | Why Teams Fall Into It | Better Alternative |
+| :--- | :--- | :--- | :--- |
+| Treating StatefulSet as full DBA automation | Failover, backup, PITR, and upgrade decisions become manual during incidents. | Stable pod names and PVCs look like enough during day-0 testing. | Use a database operator or keep the database on a VM platform with proven runbooks. |
+| Mounting one RWX data directory across database pods | Concurrent writers or stale readers can corrupt data and hide split-brain. | Shared storage appears to avoid replica rebuild complexity. | Use independent block PVCs and database-native replication between instances. |
+| Keeping all backups in the same failure domain | A rack, storage, or cluster failure can remove live data and the first backup copy. | In-cluster object storage is easy to deploy and fast to test. | Replicate backups off-rack or off-site and drill restores from that independent target. |
+
+## Decision Framework
+
+Choose the smallest database operating model that satisfies the workload's recovery, latency, scale, and compliance requirements. A single PostgreSQL VM with a mature backup system can be better than a half-understood Kubernetes operator. A CNPG cluster can be better than a hand-built StatefulSet when you need Kubernetes-native lifecycle management. A managed cloud database can be better than both when demand is spiky or the team lacks the operational depth to run a production database platform. The decision should be explicit rather than inherited from where the application happens to run.
+
+| Situation | Strong Candidate | Tradeoff to Accept | Do Not Choose It When |
+| :--- | :--- | :--- | :--- |
+| PostgreSQL with steady on-prem demand and strong platform operations | CloudNativePG with block PVCs, WAL archive, pooler, and restore drills. | You own operator upgrades, storage behavior, failover testing, and backup placement. | The team cannot test PITR or provide database-aware on-call coverage. |
+| MySQL-compatible workload that fits one primary plus replicas | Oracle, Percona, or MariaDB-family operator matched to the engine. | Operator semantics differ; binlog/PITR, router, and failover behavior must be tested. | The application already requires cross-shard writes or unsupported SQL patterns. |
+| MySQL workload that exceeds single-primary scale | Vitess with application query audit and sharding design. | The application accepts distributed SQL constraints and new operational components. | The real problem is missing indexes, poor pooling, or under-sized hardware. |
+| Disposable cache or simple session cache | Memcached or Valkey/Redis-compatible Deployment or operator. | Cache loss must be survivable and backends must handle warm-up pressure. | The cache has become an unacknowledged source of truth. |
+| Small, spiky, or low-utilization database fleet | Managed cloud database or existing VM database platform. | You pay managed-service margin or keep a non-Kubernetes operating model. | Data sovereignty, egress, or local latency requirements make cloud unsuitable. |
+
+```mermaid
+flowchart TD
+    A[Start with the workload] --> B{Is Kubernetes-native DB lifecycle required?}
+    B -- No --> C[Use managed cloud DB or VM DB platform with proven backups]
+    B -- Yes --> D{Can the team operate backup, failover, patching, and restores?}
+    D -- No --> C
+    D -- Yes --> E{Is the engine PostgreSQL?}
+    E -- Yes --> F[Evaluate CNPG, Crunchy PGO, and Zalando against the runbook]
+    E -- No --> G{Is the engine MySQL or MariaDB?}
+    G -- Yes --> H{Does one primary plus replicas meet scale?}
+    H -- Yes --> I[Evaluate Oracle, Percona, or MariaDB operators]
+    H -- No --> J[Evaluate Vitess and application sharding readiness]
+    G -- No --> K[Use the same operator checklist for cache, document, or streaming systems]
+```
+
+The final decision should include a rollback path. If a pilot operator cannot restore a database into a clean namespace, roll a minor version without unexpected downtime, and recover from a deleted primary pod while preserving data, do not promote it to the platform standard. If it passes those drills, document the exact storage class, anti-affinity, backup target, image policy, and support path. Production readiness is the combination of the operator and the contract around it.
+
+## Did You Know?
+
+- **CloudNativePG 1.29 aligns with the curriculum Kubernetes target:** The supported-releases matrix lists Kubernetes 1.35 support and PostgreSQL 18.3 as the default image for that release line.
+- **CloudNativePG can provision a separate WAL PVC:** The `.spec.walStorage` field creates a dedicated volume for WAL, which can reduce I/O contention and improve operational visibility.
+- **Kubernetes `WaitForFirstConsumer` delays volume binding:** This storage class mode lets provisioning consider pod scheduling constraints, which is critical when local disks are tied to specific nodes.
+- **OLM v0 is in maintenance mode:** The operator-framework repository documents reduced feature expectations for OLM v0 while the community works on the newer operator-controller design.
+
+## Common Mistakes
+
+| Mistake | Problem | Solution |
+| :--- | :--- | :--- |
+| Treating a `StatefulSet` as a complete database operator | Stable identity and PVCs do not provide failover, PITR, backup orchestration, or role-aware routing. | Use a database operator with tested day-2 workflows or keep the database on a platform with established DBA runbooks. |
+| Using RWX storage for an RDBMS data directory | Shared write access can corrupt the data directory and does not create safe database-level high availability. | Use one block PVC per database instance and rely on database replication plus operator-managed promotion. |
+| Leaving WAL and data on one tiny PVC | Failed WAL archiving can fill the volume and halt the primary, making recovery more stressful. | Size WAL deliberately, consider `.spec.walStorage`, and alert on archiving failures and volume growth. |
+| Putting every replica in the same rack or power domain | Kubernetes sees different nodes, but the physical infrastructure can fail all replicas together. | Label real failure domains and configure anti-affinity around racks, rows, or power groups where practical. |
+| Testing backups but not restores | Backup commands can succeed while credentials, buckets, retention, or recovery steps are broken. | Schedule restore drills into a fresh namespace and record RTO, validation queries, and manual steps. |
+| Connecting applications directly to database pod names | Failover changes database role, but clients keep using a stale or unsafe endpoint. | Connect through operator-managed role Services or poolers such as CNPG `Pooler`. |
+| Ignoring total cost of ownership | Server purchase price excludes power, cooling, rack space, network gear, support, spares, and staff time. | Compare managed database cost against full on-prem TCO, depreciation, refresh cycle, and operational risk. |
+
+## Quiz
+
+<details>
+<summary>1. Scenario: A platform team proposes a plain StatefulSet for production PostgreSQL because it gives every pod a stable name and PVC. What should you challenge first?</summary>
+
+Challenge the assumption that stable identity equals database operations. A StatefulSet can preserve pod names and storage, but it does not know how to choose a promotion candidate, archive WAL, perform PITR, or route clients to the current primary. The better design is either a database operator such as CNPG with tested day-2 workflows or a non-Kubernetes database platform with mature DBA runbooks. The assessment should include a failover drill, a restore drill, and an upgrade drill rather than only a successful first deployment.
+</details>
+
+<details>
+<summary>2. Scenario: A CNPG cluster uses local NVMe, but the StorageClass binds PVCs immediately and pods sometimes remain Pending after anti-affinity rules are applied. What storage behavior is missing?</summary>
+
+The missing behavior is delayed binding through `volumeBindingMode: WaitForFirstConsumer`. Immediate binding can select a local disk before the scheduler has chosen the node, so the PVC and pod placement can conflict. With `WaitForFirstConsumer`, provisioning considers scheduling constraints such as node labels, taints, and anti-affinity before selecting or creating the volume. This is especially important for local disks because the volume exists on one physical node.
+</details>
+
+<details>
+<summary>3. Scenario: The object store used for WAL archiving is unavailable for a long period while the database continues accepting writes. What failure should the runbook expect?</summary>
+
+The runbook should expect WAL files to accumulate on the database volume because PostgreSQL cannot safely recycle WAL that has not been archived. If the volume fills, the primary can halt or crash and may fail to restart until space or archiving is addressed. The immediate response is to confirm archiver errors, protect data durability, and either restore object storage, expand storage, or follow a documented emergency procedure. The long-term fix is monitoring for archive lag and backup-target health before the local disk reaches a critical threshold.
+</details>
+
+<details>
+<summary>4. Scenario: An application team wants Vitess because the MySQL database is slow, but the workload has not been indexed or connection-pooled. What should happen before sharding?</summary>
+
+The team should first prove that single-primary MySQL has actually reached a scale limit after ordinary tuning. Indexing, query review, connection pooling, hardware sizing, and read replicas often solve performance problems without introducing distributed SQL constraints. Vitess is powerful when the workload truly needs horizontal sharding, but it adds routing, topology, resharding, and compatibility work. Choosing it too early can turn an ordinary database tuning problem into a distributed-systems migration.
+</details>
+
+<details>
+<summary>5. Scenario: A compliance team rejects source-available database components for new internal infrastructure. How should you evaluate Redis-compatible cache operators?</summary>
+
+Start by separating licensing from technical suitability. Valkey exists as an open source fork from the earlier Redis OSS lineage, so a Valkey-compatible operator may satisfy the governance requirement better than an operator tied only to current Redis licensing. Then evaluate the same operational primitives you would evaluate for any cache: failover, sharding, persistence, TLS, authentication, resource isolation, backup expectations, and rolling upgrade behavior. A permissive license does not compensate for weak operational mechanics.
+</details>
+
+<details>
+<summary>6. Scenario: A restore test succeeds only when the original namespace, secrets, and object-store credentials still exist. Why is that not enough?</summary>
+
+That test proves a narrow recovery path, not disaster recovery. Real incidents can damage namespace state, secrets, service accounts, or the cluster that originally ran the database. A stronger drill restores into a clean namespace with freshly created credentials and validates that the backup target contains everything needed to rebuild the database state. This also exposes hidden dependencies on live Kubernetes objects that would not survive a larger failure.
+</details>
+
+<details>
+<summary>7. Scenario: Finance compares the monthly cloud database bill to the purchase price of three servers and concludes on-premises is cheaper. What is missing from the cost model?</summary>
+
+The comparison is missing total cost of ownership. On-premises databases require rack space, power, cooling, networking, support contracts, spare parts, monitoring, backup storage, refresh planning, and operations headcount. Depreciation and utilization matter because hardware paid up front can sit idle or require replacement earlier than expected. A fair comparison includes the cost of failover testing, patching, restore drills, and outage risk, not only the server invoice.
+</details>
+
+## Hands-On Exercise
+
+This exercise deploys a small CloudNativePG cluster, configures a single-pod MinIO object store with official MinIO images for lab use, archives WAL to an S3-compatible bucket, creates a scheduled backup resource, and observes role-aware services. A single-pod MinIO instance is not a production backup target; it is a local teaching stand-in for the off-rack MinIO, Ceph RGW, or external S3-compatible target you would use in a real bare-metal design.
+
+**Prerequisites:** You need a Kubernetes 1.35-compatible lab cluster with at least three schedulable worker nodes, `kubectl` installed, a default StorageClass for the lab, and outbound access to GitHub and public container registries. If you use a real on-premises cluster instead of `kind`, run this in a non-production namespace and confirm the storage class can safely create disposable test PVCs.
+
+### Step 1: Install the CloudNativePG Operator
+
+Deploy the CNPG controller from the official 1.29 release branch and confirm the controller pod becomes ready. In production, mirror and pin this manifest through your GitOps pipeline instead of applying remote YAML directly from a shell.
 
 ```bash
 kubectl apply --server-side -f \
-  https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.29/releases/cnpg-1.29.0.yaml
+  https://raw.githubusercontent.com/cloudnative-pg/cloudnative-pg/release-1.29/releases/cnpg-1.29.1.yaml
 
-# Verify the controller is running
-kubectl get pods -n cnpg-system
+kubectl rollout status deployment/cnpg-controller-manager -n cnpg-system
 ```
 
-### Step 2: Deploy an Internal MinIO for Backups
+### Step 2: Deploy a Lab MinIO Object Store
 
-On bare metal, you need local object storage. We will deploy a minimal MinIO instance.
+Create a minimal MinIO Deployment and Service using the official `quay.io/minio/minio` image path. The tag shown here is a pinned release tag from the upstream MinIO chart defaults; for your own lab, verify the current release tag or mirror an approved digest through your internal registry.
 
-```bash
-helm repo add bitnami https://charts.bitnami.com/bitnami
-helm install minio bitnami/minio \
-  --set auth.rootUser=admin \
-  --set auth.rootPassword=supersecret \
-  --set defaultBuckets="cnpg-backups" \
-  --namespace minio-system --create-namespace
+```yaml
+# minio-lab.yaml
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: minio-system
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: minio-root
+  namespace: minio-system
+type: Opaque
+stringData:
+  MINIO_ROOT_USER: admin
+  MINIO_ROOT_PASSWORD: supersecret123
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: minio
+  namespace: minio-system
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: minio
+  template:
+    metadata:
+      labels:
+        app: minio
+    spec:
+      containers:
+      - name: minio
+        image: quay.io/minio/minio:RELEASE.2024-12-18T13-15-44Z
+        args:
+        - server
+        - /data
+        envFrom:
+        - secretRef:
+            name: minio-root
+        ports:
+        - name: s3
+          containerPort: 9000
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: minio
+  namespace: minio-system
+spec:
+  selector:
+    app: minio
+  ports:
+  - name: s3
+    port: 9000
+    targetPort: s3
 ```
 
-Wait for MinIO to become ready:
-
 ```bash
+kubectl apply -f minio-lab.yaml
 kubectl rollout status deployment/minio -n minio-system
 ```
 
-### Step 3: Configure Backup Credentials
+### Step 3: Create the Backup Bucket
 
-Create a K8s Secret in the default namespace holding the MinIO credentials so CNPG can authenticate.
+Use the official MinIO Client image to create the S3 bucket that CNPG will use for base backups and WAL archiving. This Job is intentionally separate from the MinIO Deployment so you can inspect whether bucket creation succeeded.
+
+```yaml
+# minio-bucket-job.yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: create-cnpg-backup-bucket
+  namespace: minio-system
+spec:
+  template:
+    spec:
+      restartPolicy: OnFailure
+      containers:
+      - name: mc
+        image: quay.io/minio/mc:RELEASE.2025-08-13T08-35-41Z
+        env:
+        - name: MINIO_ROOT_USER
+          valueFrom:
+            secretKeyRef:
+              name: minio-root
+              key: MINIO_ROOT_USER
+        - name: MINIO_ROOT_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: minio-root
+              key: MINIO_ROOT_PASSWORD
+        command:
+        - /bin/sh
+        - -c
+        - |
+          mc alias set lab http://minio.minio-system.svc.cluster.local:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD"
+          mc mb --ignore-existing lab/cnpg-backups
+```
+
+```bash
+kubectl apply -f minio-bucket-job.yaml
+kubectl wait --for=condition=complete job/create-cnpg-backup-bucket -n minio-system --timeout=120s
+```
+
+### Step 4: Configure CNPG Backup Credentials
+
+Create a Kubernetes Secret (it lands in the `default` namespace for this lab — production should isolate each database in its own namespace) with credentials that CNPG can use to reach the lab object store. Production clusters should use stronger credential rotation, namespace isolation, network policy, and object-store bucket policy.
 
 ```bash
 kubectl create secret generic minio-creds \
   --from-literal=ACCESS_KEY_ID=admin \
-  --from-literal=ACCESS_SECRET_KEY=supersecret
+  --from-literal=ACCESS_SECRET_KEY=supersecret123
 ```
 
-### Step 4: Deploy the PostgreSQL Cluster
+### Step 5: Deploy the PostgreSQL Cluster
 
-Apply the following manifest. It provisions a 3-node PostgreSQL cluster and configures continuous WAL archiving to MinIO.
+Apply a three-instance PostgreSQL cluster with role-aware services, anti-affinity, WAL archiving, a separate WAL volume, and the official CloudNativePG PostgreSQL image. The example keeps the storage small for a classroom lab; production sizing should come from benchmark data and capacity forecasts.
 
 ```yaml
 # pg-cluster.yaml
@@ -209,13 +530,16 @@ metadata:
   name: dojo-db
 spec:
   instances: 3
-  
-  # Anti-affinity ensures pods run on different bare-metal nodes
+  imageName: ghcr.io/cloudnative-pg/postgresql:18.3-system-trixie
+
   affinity:
     enablePodAntiAffinity: true
     topologyKey: kubernetes.io/hostname
 
   storage:
+    size: 1Gi
+
+  walStorage:
     size: 1Gi
 
   backup:
@@ -235,107 +559,87 @@ spec:
 
 ```bash
 kubectl apply -f pg-cluster.yaml
+kubectl get pods -l cnpg.io/cluster=dojo-db -w
 ```
 
-### Step 5: Verify Cluster Health and Replication
+### Step 6: Add a Scheduled Backup and Verify Role Routing
 
-CloudNativePG provides a standard `kubectl` plugin, but you can inspect the CRD directly:
+Create a `ScheduledBackup` resource so backup orchestration is declared in Kubernetes rather than remembered by an operator. Then inspect the three service endpoints that applications should use instead of pod names.
+
+```yaml
+# scheduled-backup.yaml
+apiVersion: postgresql.cnpg.io/v1
+kind: ScheduledBackup
+metadata:
+  name: dojo-db-daily
+spec:
+  schedule: "0 0 0 * * *"
+  backupOwnerReference: self
+  cluster:
+    name: dojo-db
+```
 
 ```bash
-# Watch the pods initialize (takes ~2 minutes)
-kubectl get pods -l cnpg.io/cluster=dojo-db -w
-
-# Check the cluster status
-kubectl get cluster dojo-db -o yaml | grep phase
-# Expected output: phase: Cluster in healthy state
+kubectl apply -f scheduled-backup.yaml
+kubectl get scheduledbackup dojo-db-daily
+kubectl get svc dojo-db-rw dojo-db-ro dojo-db-r
 ```
 
-Verify WAL archiving is succeeding by checking the MinIO pod logs, or check the CNPG operator logs for backup events.
+### Step 7: Observe Failover Behavior
 
-### Step 6: Simulate Node Failure and Observe Failover
-
-Identify the current primary database pod.
+Identify the primary, delete that pod to simulate a crash, and watch the role label move to another instance. This exercise validates the operator path, not the full datacenter failure path; a real runbook should also include node loss, rack maintenance, object-store outage, and restore drills.
 
 ```bash
 kubectl get pods -l cnpg.io/cluster=dojo-db,cnpg.io/instanceRole=primary
-```
 
-Delete the primary pod forcefully to simulate a node crash:
-
-```bash
-# Replace pod name with your actual primary pod name
+# Replace the pod name with the primary returned by the previous command.
 kubectl delete pod dojo-db-1 --force --grace-period=0
+
+kubectl get pods -l cnpg.io/cluster=dojo-db -L cnpg.io/instanceRole -w
 ```
 
-Immediately watch the pods and the `Cluster` resource. CNPG will detect the failure via API leases, fence the old primary, select the replica with the most advanced LSN (Log Sequence Number), and promote it.
+**Success Criteria:**
 
-```bash
-# Watch the roles change
-kubectl get pods -l cnpg.io/cluster=dojo-db -L cnpg.io/instanceRole
-```
+- [ ] **Explain** in your notes why the StatefulSet primitive alone would not perform WAL archiving, PITR, role routing, or safe failover for this database.
+- [ ] **Deploy** the CNPG controller, the lab MinIO object store, the bucket Job, the `dojo-db` Cluster, and the `dojo-db-daily` ScheduledBackup using only the official CloudNativePG and MinIO image paths shown in the lab.
+- [ ] **Evaluate** the generated `dojo-db-rw`, `dojo-db-ro`, and `dojo-db-r` Services and identify which endpoint applications should use for writes.
+- [ ] **Design** a production improvement list that replaces the lab object store with off-rack MinIO or Ceph RGW, adds rack-aware labels, and documents a restore drill.
+- [ ] **Choose** whether this workload should remain self-hosted by writing one paragraph that compares utilization, data sovereignty, egress, operations headcount, and managed cloud alternatives.
 
-Traffic sent to the `dojo-db-rw` service will automatically route to the newly promoted primary with minimal disruption.
+## Next Module
 
-## Practitioner Gotchas
+Next, continue with [Storage Observability and Capacity Forecasting](module-4.6-storage-observability-capacity-forecasting/) to connect database operator health with the storage metrics and forecasts that keep on-premises stateful platforms reliable.
 
-### 1. The Local Disk WAL Trap
-If your S3 backup target (MinIO/Ceph) goes down, CNPG will fail to archive WALs. By design, PostgreSQL will not delete unarchived WALs. Over hours or days, the local PV will fill to 100%. The database will crash and enter a `CrashLoopBackOff`. **Fix:** Monitor the `cnpg_wal_archive_status` metric. Have a runbook for temporarily disabling archiving or expanding the PVC via volume expansion.
+## Sources
 
-### 2. Connection Starvation During Pod Restarts
-A deployment scaling from 10 to 50 pods might instantly open 500 new connections to PostgreSQL. If `max_connections` is hit, the application crashes. Increasing `max_connections` excessively causes PostgreSQL to consume all available RAM and OOMKill. **Fix:** Always deploy the CNPG `Pooler` (pgBouncer) in transaction mode and point applications to the Pooler service, not the direct DB service.
-
-### 3. CPU Limits Throttling Latency
-Setting strict CPU `limits` on database pods in Kubernetes utilizes the CFS (Completely Fair Scheduler) quota system. Sudden spikes in query complexity can result in severe CPU throttling, adding hundreds of milliseconds to query latency even if the physical node has idle cores. **Fix:** For databases on bare metal, set CPU `requests` accurately for scheduling, but frequently omit CPU `limits` (or set them very high) to allow burst capacity, relying instead on dedicated node pools or vertical scaling.
-
-### 4. OOMKills During Index Creation
-A `CREATE INDEX` or `VACUUM` operation requires significant working memory (`maintenance_work_mem`). If K8s memory limits are configured too tightly around normal operational metrics, these maintenance tasks will trigger an immediate OOMKill from the Kubelet. **Fix:** Leave a minimum 20-30% buffer between PostgreSQL's configured shared buffers/work memory and the container's hard memory limit.
-
-## Quiz
-
-**1. A bare-metal Kubernetes v1.35 cluster running CloudNativePG 1.29 experiences a catastrophic failure in its local MinIO object storage cluster that lasts for 48 hours. The PostgreSQL cluster handles 5,000 transactions per second. What is the most likely consequence for the database cluster if no intervention occurs?**
-- A) The database switches to synchronous replication mode automatically to prevent data loss.
-- B) The database purges the oldest WAL files to make room for new transactions.
-- C) The primary node's storage volume fills up with Write-Ahead Logs (WALs), eventually causing the database to crash and refuse restarts.
-- D) The operator stops accepting write queries and gracefully enters read-only mode.
-> **Correct Answer: C**
-> By design, PostgreSQL maintains strict data integrity and will not delete Write-Ahead Log (WAL) files until they have been successfully archived to the configured backup destination. Because the MinIO cluster is offline, the archiving process fails repeatedly, causing WAL files to accumulate on the local Persistent Volume. Once the local disk reaches 100% capacity, PostgreSQL can no longer write new transactions and will crash. Without manual intervention to expand the volume or disable archiving, the database will remain in a `CrashLoopBackOff` state.
-
-**2. Your e-commerce platform's monolithic MySQL database has reached the physical limits of your largest bare-metal server. You migrate to Vitess v23.0 (using MySQL 8.4) to shard the user data. An application developer complains that a new microservice is failing when trying to execute a complex `JOIN` query across the `users` and `orders` tables. Which Vitess component is responsible for receiving this query and why is it failing?**
-- A) VTTablet; it strictly forbids any `JOIN` operations to protect MySQL from OOM kills.
-- B) VTGate; it struggles to efficiently execute certain cross-shard `JOIN` operations that require gathering data from multiple disparate MySQL nodes.
-- C) Topology Server; the etcd cluster has lost consensus on the VSchema routing rules.
-- D) VReplication; the asynchronous replication lag has caused the `JOIN` to time out.
-> **Correct Answer: B**
-> VTGate is the stateless routing proxy that applications connect to, acting as a standard MySQL server to the client. When a query is received, VTGate parses it against the VSchema to determine which underlying shards contain the required data. While Vitess excels at single-shard queries and simple scatter-gather operations, complex cross-shard `JOIN` operations are notoriously difficult to coordinate across distributed nodes and are often restricted or perform poorly by design. Developers must typically rewrite these queries or denormalize the data when migrating to a sharded architecture.
-
-**3. Following a successful marketing campaign, your Kubernetes cluster aggressively scales a Go microservice from 10 to 150 pods in response to traffic. Immediately, the backend PostgreSQL database nodes begin logging "Out of Memory" errors and the Kubelet kills the database pods. CPU and I/O metrics were well within normal limits prior to the crash. What architectural flaw in your database deployment caused this?**
-- A) The StorageClass was not configured with `WaitForFirstConsumer`, causing the PVs to detach during the traffic spike.
-- B) The application was connecting directly to the PostgreSQL service, exhausting memory because PostgreSQL forks a new OS process for every concurrent connection.
-- C) The CloudNativePG operator failed to elect a new leader fast enough during the scaling event.
-- D) The microservice pods exceeded the network bandwidth of the bare-metal nodes, causing the database to drop packets.
-> **Correct Answer: B**
-> PostgreSQL uses a process-per-connection architecture, meaning each open connection consumes a base amount of RAM on the database server regardless of whether it is actively executing a query. When 150 pods rapidly open multiple connections each, the sheer number of backend processes quickly consumes all available memory, triggering an OOMKill. Implementing a connection pooler like pgBouncer (via the CNPG `Pooler` resource) multiplexes these thousands of client connections into a small, fixed pool of persistent database connections. This shields the primary database from connection storms and prevents memory exhaustion.
-
-**4. Your organization's legal and compliance team mandates that no software deployed on internal bare-metal infrastructure can utilize the Server Side Public License (SSPL). You need to deploy a highly available, sharded in-memory caching cluster for session management. Which technology stack aligns with both the architectural needs and the licensing constraints?**
-- A) Redis Enterprise deployed via the Spotahome Redis Operator.
-- B) Memcached deployed as a StatefulSet with a Headless Service.
-- C) A Valkey cluster managed by a compatible Kubernetes operator.
-- D) A standard Redis cluster pulled directly from Docker Hub.
-> **Correct Answer: C**
-> Redis Ltd transitioned Redis to the Server Side Public License (SSPL), which many enterprise compliance teams reject due to its restrictive clauses regarding managed services. Valkey is the Linux Foundation's open-source fork of Redis, created explicitly to provide a drop-in replacement that remains under a permissive license. Deploying a Valkey cluster provides the required sharded, highly available in-memory performance while fully satisfying the strict open-source licensing mandate. Operators migrating to Valkey ensure that future updates do not suddenly introduce compliance violations into the bare-metal environment.
-
-**5. You are provisioning local NVMe storage for a new CloudNativePG database cluster. The cluster will deploy three database pods across three different bare-metal worker nodes. Why is it critical that your Kubernetes StorageClass is configured with `volumeBindingMode: WaitForFirstConsumer`?**
-- A) It ensures that the database controller has fully reconciled the CRD before formatting the drive.
-- B) It delays the binding of the Persistent Volume Claim (PVC) until the pod is scheduled to a specific node, ensuring the local storage is provisioned on the exact physical hardware where the pod will run.
-- C) It prevents the operator from initiating a backup before the application has written its first transaction.
-- D) It synchronizes the NVMe hardware clocks across the three nodes to prevent split-brain scenarios.
-> **Correct Answer: B**
-> Local persistent volumes are fundamentally tied to the physical hardware of a specific bare-metal node. If the storage provisioner binds the PVC immediately upon creation, it might select a volume on Node A, but the Kubernetes scheduler might later place the pod on Node B due to CPU constraints, resulting in a scheduling failure. `WaitForFirstConsumer` forces the storage provisioner to wait until the pod is assigned to a node. This guarantees that the local volume is created exactly where the pod needs it, preventing unresolvable node affinity conflicts.
-
-## Further Reading
-
-* [CloudNativePG Architecture Documentation](https://cloudnative-pg.io/documentation/current/architecture/)
-* [Vitess Kubernetes Deployment Guide](https://vitess.io/docs/get-started/kubernetes/)
-* [Valkey GitHub Repository and Documentation](https://github.com/valkey-io/valkey)
-* [Kubernetes Storage: Local Persistent Volumes](https://kubernetes.io/docs/concepts/storage/volumes/#local)
-* [Operator Lifecycle Manager (OLM)](https://olm.operatorframework.io/docs/)
+* [CloudNativePG project page at CNCF](https://www.cncf.io/projects/cloudnativepg/)
+* [CloudNativePG 1.29 release notes](https://cloudnative-pg.io/docs/1.29/release_notes/v1.29/)
+* [CloudNativePG image catalog](https://cloudnative-pg.io/docs/1.29/image_catalog/)
+* [CloudNativePG replication](https://cloudnative-pg.io/docs/1.29/replication/)
+* [CloudNativePG backup](https://cloudnative-pg.io/docs/1.29/backup/)
+* [CloudNativePG recovery](https://cloudnative-pg.io/docs/1.29/recovery/)
+* [CloudNativePG service management](https://cloudnative-pg.io/docs/1.29/service_management/)
+* [CloudNativePG connection pooling](https://cloudnative-pg.io/docs/1.29/connection_pooling/)
+* [CloudNativePG storage](https://cloudnative-pg.io/docs/1.29/storage/)
+* [CloudNativePG scheduling](https://cloudnative-pg.io/docs/1.29/scheduling/)
+* [Kubernetes Operator pattern](https://kubernetes.io/docs/concepts/extend-kubernetes/operator/)
+* [Kubernetes StatefulSets](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
+* [Kubernetes StorageClasses](https://kubernetes.io/docs/concepts/storage/storage-classes/)
+* [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+* [MinIO object store repository](https://github.com/minio/minio)
+* [MinIO Client repository](https://github.com/minio/mc)
+* [Rook Ceph object storage](https://rook.io/docs/rook/latest/Storage-Configuration/Object-Storage-RGW/object-storage/)
+* [TopoLVM repository](https://github.com/topolvm/topolvm)
+* [Rancher Local Path Provisioner](https://github.com/rancher/local-path-provisioner)
+* [MySQL Operator for Kubernetes manual](https://dev.mysql.com/doc/mysql-operator/en/)
+* [Percona Operator for MySQL](https://docs.percona.com/percona-operator-for-mysql/ps/index.html)
+* [MariaDB Kubernetes operators](https://mariadb.com/docs/server/server-management/automated-mariadb-deployment-and-administration/kubernetes-and-mariadb/kubernetes-operators-for-mariadb)
+* [Crunchy Data Postgres Operator](https://github.com/crunchydata/postgres-operator)
+* [Zalando Postgres Operator quickstart](https://opensource.zalando.com/postgres-operator/docs/quickstart.html)
+* [Vitess Operator for Kubernetes](https://vitess.io/docs/23.0/get-started/operator/)
+* [Vitess supported databases](https://vitess.io/docs/24.0/overview/supported-databases/)
+* [Valkey project history](https://valkey.io/topics/history/)
+* [Operator Lifecycle Manager v0 repository](https://github.com/operator-framework/operator-lifecycle-manager)
+* [MongoDB Controllers for Kubernetes](https://www.mongodb.com/docs/kubernetes/current/)
+* [Strimzi project site](https://strimzi.io/)
+* [KubeBlocks introduction](https://kubeblocks.io/docs/preview/user_docs/overview/introduction)


### PR DESCRIPTION
## On-premises storage chapter (#1881)

All 4 thin storage modules T3→T0 expand-to-floor, cross-family reviewed, **every finding ground-checked against the live file + web-verified**.

| Module | Expand | Author → Reviewer | Key verifier-blind catches (fixed) |
|---|---|---|---|
| **4.1** storage-architecture | 724→**5030w** | cursor → codex | fabricated incident opener→Hypothetical; in-tree plugin claim (nfs/iscsi remain, only Ceph CephFS/RBD removed v1.31); softened "default/dominant SDS" leadership claims |
| **4.2** ceph-rook | 1192→**6541w** | deepseek → codex | Rook Helm URL 404→`charts.rook.io/release`; missing ceph-csi chart step; GitLab opener corrected to cited 6hr loss; ~8 unsourced numbers dated/softened; wrong `pg_autoscale`/`allowUnsupported`/`portable` |
| **4.4** object-storage | 1619→**5159w** | cursor → codex | invalid Tenant CRD shape→`volumeClaimTemplate`; operator 1-replica so single-node kind deploys; MinIO/AIStor edition currency dated (CE archived 2026); quiz 5 TiB consistency |
| **4.5** database-operators | 1878→**5809w** | codex → cursor | Leases≠DB-fencing (→readiness+fencing+BMC/IPMI); walStorage WAL PVC path; K8s-support attribution; lab namespace |

### Notes
- **deepseek's 4.2 had heavy expand-fabrication** (5 P1) — caught by codex, fixed + diff-audited (Helm-URL-404 ground-confirmed by orchestrator).
- **bitnami-clean** verified (CNPG `ghcr.io/cloudnative-pg/postgresql`, MinIO `quay.io/minio`).
- Incident-dedup: 4.2 had a false-positive fingerprint collision on its Ceph Sources list → suppressed with the sanctioned `incident-xref: github-2021-mysql` marker.
- All 4 `verify_module.py` **T0/passed**; build green in PRIMARY (**2171 pages**, 0 errors); assembled-batch dedup check clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)