### PR TITLE
docs(on-premises): clear revision_pending on 8.1/8.2 (#1881)

### DIFF
--- a/src/content/docs/on-premises/resilience/module-8.1-multi-site-dr.md
+++ b/src/content/docs/on-premises/resilience/module-8.1-multi-site-dr.md
@@ -1,5 +1,5 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 8.1: Multi-Site & Disaster Recovery"
 slug: on-premises/resilience/module-8.1-multi-site-dr
 sidebar:

--- a/src/content/docs/on-premises/resilience/module-8.2-hybrid-connectivity.md
+++ b/src/content/docs/on-premises/resilience/module-8.2-hybrid-connectivity.md
@@ -1,5 +1,5 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 8.2: Hybrid Cloud Connectivity"
 slug: on-premises/resilience/module-8.2-hybrid-connectivity
 sidebar:


### PR DESCRIPTION
Frontmatter bookkeeping follow-up to #1895: 8.1 Multi-Site DR and 8.2 Hybrid Connectivity were expanded to T0 + cross-family reviewed in #1895, so clear the stale `revision_pending: true` banner. No content/render change. Refs #1881.

## Learner check

> DR is like fire insurance combined with an evacuation drill. The policy matters, but the practiced route out of the building matters just as much. A backup is the policy; a tested restore path is the evacuation route.

(verbatim from the touched module `8.1-multi-site-dr` — the Insurance Analogy callout)

🤖 Generated with [Claude Code](https://claude.com/claude-code)