### PR TITLE
docs(platform): expand+de-fab Foundations Systems Thinking 1.1-1.4 to T0 (#1897)

### DIFF
--- a/src/content/docs/platform/foundations/systems-thinking/module-1.1-what-is-systems-thinking.md
+++ b/src/content/docs/platform/foundations/systems-thinking/module-1.1-what-is-systems-thinking.md
@@ -3,197 +3,166 @@ title: "Module 1.1: What is Systems Thinking?"
 slug: platform/foundations/systems-thinking/module-1.1-what-is-systems-thinking
 sidebar:
   order: 2
+revision_pending: false
 ---
-> **Complexity**: `[MEDIUM]` | **Time**: 35-45 minutes | **Prerequisites**: None (entry point to Platform track)
+> **Complexity**: `[MEDIUM]` | **Time**: 50-65 minutes | **Prerequisites**: None (entry point to Platform track)
 
-### What You'll Be Able to Do
+## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
-1. **Analyze** a system failure by mapping interconnected components rather than investigating services in isolation
-2. **Explain** how emergent properties arise from component interactions and why they cannot be predicted from individual parts alone
-3. **Apply** systems thinking frameworks (stocks-and-flows, boundaries, leverage points) to real infrastructure architectures
-4. **Diagnose** incidents by zooming out to identify upstream and downstream dependencies before restarting individual services
+1. **Analyze** a system failure by mapping relationships, shared resources, delays, and feedback loops instead of investigating services in isolation.
+2. **Explain** how emergent behavior arises from component interactions, and why healthy components can still create unhealthy system behavior.
+3. **Apply** systems thinking frameworks such as boundaries, stocks and flows, feedback loops, delays, and leverage points to infrastructure architectures.
+4. **Diagnose** incidents by moving from events to patterns, structures, and mental models before choosing a corrective action.
+5. **Evaluate** tradeoffs between local optimization and whole-system outcomes when designing platform services, reliability controls, and operational processes.
 
 ---
 
-## The 3 AM Incident
+## Why This Module Matters
 
-*Tuesday, 2:47 AM. The on-call engineer's phone explodes with alerts.*
+**Hypothetical scenario:** A payment alert wakes the on-call engineer before dawn. The payment service dashboard looks ordinary: CPU is low, memory is stable, logs show no new exception pattern, and the most recent deployment happened earlier in the week. The immediate fix seems obvious, so the engineer restarts the payment pods, watches latency drop, and closes the incident as a transient service problem.
 
-"Payment service latency increased." Standard stuff. They check the dashboards—CPU at 23%, memory looks fine, no error spikes in the logs. Weird.
+A little later, the same alert fires again. The restart works again, but only for a short time. Adding replicas helps briefly, then the symptom returns. A code-level investigation finds nothing because the payment service is not the origin of the behavior. The service is waiting behind locks and saturated database connections caused by a reporting workload that shares the same transactional database. The visible symptom lives in one service, but the cause lives in the relationship between workloads, schedules, database isolation, and the team's assumption that batch traffic and interactive traffic can safely share the same resource.
 
-They do what any reasonable engineer would do at 3 AM: restart the service. Latency drops immediately. Back to sleep.
+That shift in attention is the heart of systems thinking. Component thinking asks, "Which part is broken?" Systems thinking asks, "What pattern is the whole system producing, what relationships produce that pattern, and where can we intervene without creating a worse side effect?" Both modes are useful. A dead pod, expired certificate, or malformed deployment often needs direct component repair. The mistake is treating every production surprise as if it must have one broken part and one local fix.
 
-3:52 AM. Same alert. Latency is back.
+Platform engineering is full of systems whose most important behavior does not belong to any single component. Kubernetes self-healing emerges from controllers comparing desired state with observed state. Tail latency emerges from fan-out, retries, queues, locks, noisy neighbors, and resource contention. Reliability emerges from service code, dependency behavior, operational practice, and user demand arriving at the same time. Observability emerges from instrumentation, context propagation, sampling policy, storage, query habits, and team literacy. In each case, the behavior operators care about is created by interaction.
 
-Restart again. Works again. Sleep again.
+Systems thinking matters because platform teams are often asked to fix symptoms whose causes cross ownership boundaries. An application team sees slow checkout. A database team sees acceptable average query time. A networking team sees packet loss within tolerance. A platform team sees autoscaling behaving as configured. Users still experience a broken system. The systems thinker is the person who can connect those truths without pretending any one dashboard is the whole story.
 
-4:23 AM. **Again.**
-
-Now they're annoyed. They add more replicas. Check the code for memory leaks. Review recent deployments. Nothing. The service is *fine*. But the system is broken.
-
-At 6 AM, exhausted and frustrated, they finally do what should have been done hours earlier: zoom out. Instead of staring at the payment service, they look at what's *around* it.
-
-That's when they see it. A batch job—completely unrelated to payments—started running at 2:30 AM. It's processing end-of-day reports. It's hammering the shared database with massive analytical queries. Those queries are holding locks that block the payment service's small, fast transactions.
-
-The payment service was *perfect*. It was the victim of a system-level problem that couldn't be seen by looking at individual components.
-
-**This is systems thinking.** The ability to see the whole, not just the parts. To understand that behavior emerges from relationships, not components. To stop playing whack-a-mole with symptoms and start solving actual problems.
-
-This scenario plays out in engineering teams every day. This module will teach you how to avoid it.
-
-> **Stop and think**: How often does your team play "whack-a-mole" with production issues? Can you recall an incident where the root cause was entirely disconnected from the service that triggered the alert?
+The goal of this module is not to give you a new vocabulary for sounding abstract in incident reviews. The goal is practical: make better troubleshooting decisions, design safer platform services, and choose interventions that improve the whole system rather than merely moving pain from one team or component to another. You will learn when to zoom in, when to zoom out, and how to move between those levels deliberately.
 
 ---
 
 ## What You'll Learn
 
-- Why looking at components in isolation is a trap
-- How behavior *emerges* from interactions (not from parts)
-- The iceberg model for seeing below the surface
-- The vocabulary that will change how you troubleshoot
-- How to apply this to your next incident (starting tonight)
+Systems thinking starts with a simple but demanding habit: treat the system as a living arrangement of relationships, not a pile of boxes. A box diagram can be useful, but a systems view asks what flows between the boxes, what accumulates, what gets delayed, what feeds back, what is hidden outside the diagram boundary, and what purpose the arrangement actually serves.
+
+By the end of this module, "the payment service is slow" should no longer feel like a complete diagnosis. It should feel like an event at the surface of a larger system. You should be able to ask what changed upstream, what queues or pools are accumulating pressure, what workload shares the same bottleneck, what retry or autoscaling loop may be amplifying the symptom, and what belief allowed the structure to exist in the first place.
+
+You will also learn a disciplined way to avoid two common extremes. One extreme is local heroics: restart, scale, rollback, repeat. The other is vague abstraction: everything is connected, so nothing is actionable. Good systems thinking sits between those extremes. It uses models to find better action, not to avoid action.
 
 ---
 
 ## Part 1: The Problem with Component Thinking
 
-### The Mechanic vs. The Engineer
+### The Mechanic vs. The Systems Engineer
 
-Here's an analogy that helped me understand this:
+A useful analogy is the difference between replacing a part and understanding a traffic network. If a bicycle tire is punctured, component thinking works well: find the hole, patch the tube, inflate the tire, and ride. The part has a clear boundary, the failure is local, and the same fix usually produces the same outcome. Many infrastructure tasks are like this. A container image tag is wrong, a secret expired, a node is out of disk, or a manifest has an invalid field.
 
-A **mechanic** fixes cars by testing parts until they find the broken one. Alternator dead? Replace it. Brake pads worn? New ones. This works because cars are *complicated* but not *complex*—the same input always produces the same output.
+A production platform is more like a city's traffic network during bad weather. One stalled vehicle can matter, but the larger behavior comes from intersections, signal timing, driver choices, road capacity, emergency routes, weather, and feedback from navigation apps redirecting many drivers at once. Clearing one lane may help or may simply move congestion to the next bottleneck. The system's behavior depends on how parts influence one another over time.
 
-An **engineer** understands how the car actually works. They know that a weak alternator doesn't just fail—it causes the battery to drain, which causes the car to run lean, which damages the catalytic converter, which triggers the check engine light. They see the cascade.
-
-Most ops teams are mechanics. They replace parts (restart services, scale pods, rollback deployments) until the alert goes away. Sometimes that's enough. But for complex systems, you need to be an engineer.
+Component thinking becomes dangerous when it is used on complex behavior. It narrows attention to the part named by the alert, which is often only the place where pain became visible. A checkout timeout may be caused by a pricing service, a fraud provider, a shared cache, a slow database query, a retry storm, an overloaded logging pipeline, or a scheduler delay. The checkout service may be healthy by every local metric and still be part of an unhealthy checkout system.
 
 ```mermaid
 flowchart TD
-    subgraph Mechanic ["MECHANIC APPROACH"]
-        M1["Alert fires"] --> M2["Check the broken thing"]
-        M2 --> M3["Restart it"]
-        M3 --> M4["Alert clears → Done! (until next time)"]
+    subgraph ComponentThinking ["Component Thinking"]
+        A1["Alert names a service"] --> A2["Inspect that service"]
+        A2 --> A3["Restart, scale, or roll back"]
+        A3 --> A4["Symptom clears or moves"]
     end
 
-    subgraph Engineer ["ENGINEER APPROACH"]
-        E1["Alert fires"] --> E2["What is the pattern? When did this start?"]
-        E2 --> E3["What changed in the system? What is connected?"]
-        E3 --> E4["What is the actual cause?"]
-        E4 --> E5["Fix the cause → Problem actually solved"]
+    subgraph SystemsThinking ["Systems Thinking"]
+        B1["Alert names a symptom"] --> B2["Map the path, dependencies, and shared resources"]
+        B2 --> B3["Look for patterns, delays, stocks, and feedback loops"]
+        B3 --> B4["Change the structure that produces the symptom"]
     end
 ```
 
-### What is a System?
+The systems engineer still knows how to replace parts. The difference is sequencing. First, decide whether the problem is local, relational, or systemic. If a pod is crash-looping because it cannot parse configuration, a direct fix is appropriate. If three services are timing out even though each service is individually under its CPU limit, a relationship is likely involved. If the same class of incident recurs across teams, the structure or mental model is probably the more important target.
 
-A **system** is a set of interconnected elements organized to achieve a purpose.
+### What Is a System?
 
-Three key parts:
+A **system** is an organized set of elements, interconnections, and purposes. The elements are the things you can name: pods, services, databases, queues, controllers, people, runbooks, dashboards, and deployment pipelines. The interconnections are the ways those elements affect one another: network calls, shared storage, ownership handoffs, retry behavior, alert routing, incident escalation, and policy. The purpose is what the whole arrangement is trying to accomplish, whether or not that purpose is written down.
 
-| Part | What It Is | Example |
-|------|------------|---------|
-| **Elements** | The things you can point at | Pods, services, databases, queues |
-| **Interconnections** | How elements affect each other | Network calls, shared resources, data flows |
-| **Purpose** | Why the system exists | Process payments, serve users, store data |
-
-Here's the crucial insight: **you can understand every element perfectly and still not understand the system.**
+That last phrase matters. A declared purpose might be "serve checkout reliably." The actual purpose revealed by behavior might be "ship features quickly unless checkout is visibly on fire." A platform can claim to prioritize reliability while rewarding teams only for deployment speed. A monitoring system can claim to reduce downtime while paging people on low-signal alerts until real incidents are missed. Systems thinking pays attention to the purpose the system enacts, not only the purpose people state.
 
 ```mermaid
 flowchart LR
-    subgraph ComponentView ["COMPONENT VIEW (tells you nothing)"]
-        direction TB
-        CA["Service A"]
-        CB["Service B"]
-        CDB[/"Database"/]
+    subgraph Elements ["Elements"]
+        E1["API service"]
+        E2["Worker pool"]
+        E3["Database"]
+        E4["On-call rotation"]
     end
 
-    subgraph SystemsView ["SYSTEMS VIEW (tells you everything)"]
-        direction TB
-        SA["Service A"] -->|"Calls"| SB["Service B"]
-        SB -->|"Queries"| SDB[/"Database"/]
-        SDB -.->|"Feedback Loops"| SA
+    subgraph Interconnections ["Interconnections"]
+        I1["Requests"]
+        I2["Queues"]
+        I3["Locks"]
+        I4["Alerts and handoffs"]
     end
+
+    subgraph Purpose ["Purpose"]
+        P1["Complete user work safely within a deadline"]
+    end
+
+    Elements --> Interconnections --> Purpose
 ```
 
-> **Did You Know?** The word "system" comes from Greek *systema*, meaning "organized whole." The ancient Greeks understood something we keep forgetting: the whole is fundamentally different from the sum of its parts. Aristotle wrote about this 2,400 years ago. We're still learning the same lesson.
+The crucial insight is that you can understand every element and still misunderstand the system. A service owner may know every endpoint. A database owner may know every index. A platform owner may know every autoscaling rule. None of those facts alone explains what happens when a sale event sends user traffic through the checkout path while a background reconciliation job fills the same connection pool and a retry policy multiplies the load.
+
+### Boundaries Decide What You Can See
+
+Every system model has a boundary. The boundary says what is inside the model and what is outside. A tight boundary can make a problem easier to reason about, but it can also hide the actual cause. A wide boundary can reveal important relationships, but it can also become too large to act on. Systems thinking is not "include everything." It is choosing a boundary that explains the behavior you are trying to change.
+
+For a payment timeout, a narrow boundary might include only the payment deployment and its pods. That boundary is appropriate if the pods are crashing. If the pods are waiting on a database, the boundary must include the database, connection pool, schema locks, and other workloads sharing the database. If the issue appears only after promotions, the boundary may need to include marketing calendars, traffic forecasts, release timing, rate limits, and customer behavior.
+
+A practical boundary test is to ask, "Could something outside this diagram change the behavior inside it without changing any code inside it?" If the answer is yes, the boundary may be too tight. A DNS provider, identity provider, payment processor, object store, feature flag service, or human approval process can all change user-visible behavior while the application repository remains untouched.
+
+Boundary choices also shape accountability. If the boundary stops at a team line, the organization may blame the owning team for symptoms created by shared infrastructure. If the boundary includes the shared resource and the policy that allowed unsafe sharing, the intervention can become structural rather than personal. This is one reason systems thinking is closely tied to blameless incident analysis: it changes the unit of analysis from a person or component to the conditions that made the outcome likely.
 
 ### Emergence: Where System Behavior Lives
 
-**Emergence** is when a system exhibits properties that none of its individual parts possess.
-
-This is the most important concept in this entire module. Read it again.
-
-Your brain is made of neurons. No single neuron is conscious—it's just an electrochemical switch. But 86 billion of them connected in the right way, and suddenly you're reading this sentence and thinking about it. Consciousness *emerges*.
-
-In distributed systems:
-
-- **Individual service metrics**: Service A: 50ms, Service B: 40ms, Service C: 30ms
-- **System behavior**: p99 latency of 2000ms, random timeouts, cascade failures
-
-Where did the 2000ms come from? Where did the cascades come from? Not from any individual service. They emerged from the interactions—retries that amplify load, connection pools that exhaust, locks that contend.
+**Emergence** means the whole system exhibits behavior that its individual elements do not exhibit alone. A Kubernetes Deployment controller is just a controller loop, a ReplicaSet is just a desired replica count, a Pod is just a workload unit, and a Service is just stable networking over changing endpoints. Together, they create self-healing behavior: delete a pod and the system works to return to desired state. No single pod contains "self-healing" as a property. The behavior emerges from the control loop and the relationships among objects.
 
 ```mermaid
 sequenceDiagram
-    participant User
-    participant A as Service A
-    participant B as Service B
-    participant C as Service C
+    participant U as User
+    participant A as API
+    participant B as Backend
+    participant D as Database
 
-    Note over A, C: What dashboards show: "Everything is fine" (50ms, 40ms, 30ms)
-    
-    User->>A: Request
-    A->>B: Call
-    B-->>A: Timeout
-    A->>B: Retry
-    B-->>A: Success (eventually)
-    
-    A->>C: Call
-    Note right of C: Slow because B's retries<br/>exhausted shared connection pool
-    C-->>A: Timeout
-    A-->>User: Failed Request (2-second latency)
-    
-    Note over User, C: What users experience: "Your system is broken"
+    U->>A: Request
+    A->>B: Call with deadline
+    B->>D: Query waits behind lock
+    A->>B: Retry after timeout
+    B->>D: More waiting work
+    D-->>B: Slow response
+    B-->>A: Late response
+    A-->>U: User-visible timeout
 ```
 
-> **Thought Exercise (2 minutes)**
->
-> Think of a behavior in your system that only exists when components interact.
->
-> Examples:
-> - Shopping cart totals (product service + cart service + pricing rules)
-> - Search ranking (search service + recommendation engine + user history)
-> - Cascading failures (any service + retry logic + shared resources)
->
-> Where does that behavior "live"? Not in any single service's code.
+In that sequence, each component may be doing something locally reasonable. The API uses a timeout to avoid waiting forever. The backend retries because transient failures happen. The database lock exists because another workload needs consistency. The user-visible failure emerges when those individually reasonable behaviors interact under load. A component dashboard can tell you the local facts, but it will not automatically explain the emergent pattern.
 
-### Why Reductionism Fails
+Emergence is why average metrics can mislead. A service can have a healthy average latency while a small slice of requests waits behind a shared lock. A database can have acceptable total CPU while one hot table blocks a critical path. A cluster can have enough aggregate capacity while the scheduler cannot place pods that need a scarce resource. A system view asks where the user journey crosses queues, locks, rate limits, and fan-out points, because those are where local health can become global pain.
 
-**Reductionism** is the scientific approach of understanding something by breaking it into parts and studying each part separately.
+This does not mean emergent behavior is mystical or impossible to analyze. It means the behavior is located in relationships and time. To study it, you need traces, dependency maps, queue depth, saturation, timelines, and incident narratives that include what changed before the alert. You need to observe the system in motion, not only inspect component inventory.
 
-It works brilliantly for complicated machines. Want to understand a car engine? Take it apart. Study each piece. Reassemble. Done.
+### Why Reductionism Fails in Complex Systems
 
-It fails catastrophically for complex systems. Here's why:
+Reductionism is the habit of understanding something by breaking it into parts and studying each part separately. It is powerful when the parts have stable relationships and predictable behavior. It is less reliable when the parts adapt, contend, queue, retry, degrade, and influence one another through delayed feedback. Distributed systems have both kinds of problems, which is why experienced operators move between reductionist and systemic views instead of choosing one forever.
 
-| Aspect | Complicated (car engine) | Complex (distributed system) |
-|--------|--------------------------|------------------------------|
-| **Behavior** | Predictable from parts | Emergent, surprising |
-| **Cause & Effect** | Linear, traceable | Circular, networked |
-| **Analysis** | Take apart, study pieces | Must observe whole in motion |
-| **Fixing** | Replace broken part | Change relationships |
-| **Same input** | Same output | Different output each time |
+The table below is a useful distinction, but it is not a moral ranking. A complicated system has many parts, yet the same input usually produces the same output if the environment is controlled. A complex system has interactions that can produce surprising outcomes even when the parts are known. Your platform has complicated pieces, such as manifests, binaries, network rules, and database schemas. It also has complex behavior, such as overload, incident response, cascading failure, and organizational drift.
 
-This is why "works on my machine" is such a meme. Your laptop isn't the system. The system includes the network, other services, the database state, the load from other users, and a hundred other interacting factors.
+| Aspect | Complicated Problem | Complex System Problem |
+|--------|---------------------|------------------------|
+| Behavior | Mostly predictable from parts | Often emerges from interactions |
+| Cause and effect | Usually linear and traceable | Often circular, delayed, and networked |
+| Best first move | Inspect the suspect part | Map relationships and time sequence |
+| Fix style | Repair or replace a component | Change boundaries, feedback, or incentives |
+| Risk of local optimization | Usually limited | Can make the whole system worse |
 
-> **The Optimization Trap**
->
-> Here's a counterintuitive truth: optimizing individual components often makes the system *worse*.
->
-> Example: You make Service A 10x faster. Congratulations! Now it hammers the database 10x harder, causing lock contention that slows Services B and C. Global latency *increases*. Users are angrier than before.
->
-> This is called **suboptimization**—winning locally while losing globally. It's one of the most common mistakes in distributed systems.
+The trap is local optimization. If Service A becomes faster without backpressure, it may send more traffic to a shared database and slow Services B and C. If an autoscaler reacts aggressively to short spikes, it may create capacity oscillation. If every client retries independently, the system may amplify the very failure it is trying to survive. Local improvement is valuable only when it is aligned with the constraint and purpose of the whole system.
 
-> **Pause and predict**: If optimizing a single component can sometimes make the system slower, what is the safest way to approach performance tuning in a microservices architecture?
+### The First Decision: Zoom In or Zoom Out
+
+When an incident starts, you rarely know whether the right move is local repair or system mapping. The first decision is therefore a diagnostic one: zoom in if evidence points to a discrete broken component, and zoom out if the symptom crosses boundaries, recurs after local fixes, or contradicts component dashboards. This decision should be explicit because teams often zoom in by habit.
+
+Useful zoom-in signals include a fresh deployment tightly correlated with the symptom, a clear crash loop, a config parse error, a certificate expiration, a failed health check on one dependency, or an error message that names a specific missing resource. Useful zoom-out signals include repeated recurrence after restart, multiple services degrading at once, symptoms tied to time of day or workload mix, queue depth rising while CPU looks normal, or user complaints that do not match service averages.
+
+The discipline is to keep both views available. If a rollback restores service, still ask why the system allowed the change to create broad impact. If a systemic map identifies a shared database bottleneck, still inspect the slow query or lock that consumed the resource. Systems thinking is not a replacement for debugging. It is the frame that tells you which debugging path is likely to matter.
 
 ---
 
@@ -201,246 +170,213 @@ This is why "works on my machine" is such a meme. Your laptop isn't the system. 
 
 ### Seeing Below the Surface
 
-Most troubleshooting happens at the surface level. An alert fires, we react. Another alert, another reaction. We're playing an endless game of whack-a-mole.
-
-The iceberg model teaches us to look deeper:
+The iceberg model is a systems thinking tool for moving from visible events to deeper causes. The event is what triggered attention: an alert, a timeout, a failed deployment, a missed SLO, or a user report. Below that event are patterns over time, structures that create those patterns, and mental models that make those structures seem natural. The Donella Meadows Project describes the model as a way to connect events with patterns, structures, and mental models rather than treating each incident as isolated.
 
 ```mermaid
 flowchart TD
-    subgraph Visible [VISIBLE - What we react to]
-        E["EVENTS<br/>'Payment service is slow right now'<br/>Response: Restart it, scale it up<br/>Mindset: REACTIVE"]
-    end
-    
-    subgraph Invisible [INVISIBLE - Below the surface]
-        P["PATTERNS<br/>'Payment is slow every Monday 6-9 AM'<br/>Response: Create runbook, schedule extra pods<br/>Mindset: ADAPTIVE"]
-        S["STRUCTURES<br/>'Batch job shares database with payments'<br/>'No resource isolation between workloads'<br/>Response: Separate resources, add limits<br/>Mindset: REDESIGN"]
-        M["MENTAL MODELS<br/>'All workloads can safely share infrastructure'<br/>'Batch jobs do not affect real-time traffic'<br/>Response: New policies, architecture reviews<br/>Mindset: TRANSFORM"]
-    end
-    
-    E --> P
-    P --> S
-    S --> M
+    E["Events: checkout timed out during a sale"] --> P["Patterns: checkout slows during every large promotion"]
+    P --> S["Structures: synchronous inventory lookup, shared database pool, no priority isolation"]
+    S --> M["Mental Models: real-time inventory is always required before showing checkout"]
 ```
 
-> **Stop and think**: Which level of the iceberg does your team spend most of its time in? What would need to change to move one level deeper?
+The model is useful because each level suggests a different class of action. Event-level action restores service. Pattern-level action prepares for recurrence. Structure-level action changes the design that creates recurrence. Mental-model action changes the assumptions that keep recreating the design. A mature team can operate at all four levels, but it should know which level it is addressing at any moment.
 
-### Each Level Explained
+### Event Level: What Happened?
 
-**Event level** (what happened?):
-- "The payment service is slow right now."
-- Response: Restart, scale up, add more resources
-- Limitation: You'll be doing this forever
+The event level is where production work usually begins. "Checkout timed out." "The queue is growing." "The deployment failed." "The cluster is out of allocatable memory." Event-level response is necessary because users are waiting and the system may be losing money, trust, or data. Restarting, rolling back, failing over, shedding load, disabling a feature flag, or adding temporary capacity can be exactly the right short-term action.
 
-**Pattern level** (what's been happening?):
-- "This happens every Monday morning."
-- Response: Schedule extra capacity, create runbooks
-- Limitation: You're managing the problem, not solving it
+The limitation is that event-level work usually resets the symptom without changing the conditions that produced it. If a service is restarted every Monday, the restart is not the lesson. It is a clue. If a runbook says "scale the worker pool when the report job runs," the runbook may be useful, but the system is still designed to create manual work. The event level is where you buy time, not where you finish learning.
 
-**Structure level** (what's causing this?):
-- "The batch job and payment service share a database with no isolation."
-- Response: Resource quotas, separate databases, connection pooling
-- Limitation: Fixes this problem, but similar ones will appear
+### Pattern Level: What Has Been Happening?
 
-**Mental model level** (what beliefs allow this to exist?):
-- "We assumed production workloads don't need resource isolation."
-- Response: New architecture principles, design review processes
-- Impact: Prevents entire *categories* of problems
+The pattern level asks whether the event is part of a repeated shape. Does it happen at the same time of day, during the same workload, after the same deployment step, near the same traffic threshold, or whenever a particular dependency is slow? Pattern analysis turns "random" into "not yet explained." It also protects teams from overfitting to the most recent event.
 
----
+Good pattern questions are concrete. What changed before the first occurrence? What was different between occurrences and non-occurrences? Which metrics moved together? Which user journeys were affected and which were not? Did the symptom start after a traffic mix change, data growth, ownership handoff, new retry policy, or cost reduction? The answer is rarely in one chart. It usually appears when timelines are layered.
 
-## War Story: The Monday Mystery (Extended Cut)
+### Structure Level: What Arrangement Produces the Pattern?
 
-*I want to tell you about the incident that taught me the iceberg model—the hard way.*
+The structure level looks for the architecture, policy, process, or resource relationship that makes the pattern likely. A structure might be a shared database without workload isolation, a queue with no age-based alerting, an autoscaler that reacts to delayed metrics, an incident process that requires too many approvals, or a deployment pipeline that batches risky changes because releases feel expensive.
 
-A fintech company had "random" payment failures every Monday. They weren't truly random, of course, but nobody had connected the dots. Every Monday morning, the on-call engineer would get paged, restart some services, add some pods, and things stabilize. They wrote a runbook. They scheduled extra capacity for Mondays. They were **world-class at managing the symptom**.
+Structure-level fixes are more durable than event-level fixes because they change the conditions. Moving analytical traffic to a read replica, adding connection-pool limits, separating priority queues, making retries bounded, adding backpressure, or changing rollout policy can prevent repeated events. These changes often require coordination because the structure usually crosses team lines. That coordination is part of the work, not a distraction from the work.
 
-For eight months.
+### Mental Model Level: What Belief Keeps Recreating the Structure?
 
-One day, a new engineer—fresh out of university, hadn't learned to accept dysfunction yet—asked an innocent question:
+The mental model level asks what people believed when they created or tolerated the structure. "Batch jobs are harmless if they run at night." "Services are independent if they have separate repositories." "Average latency is enough." "Retries make systems more reliable." "If a team owns a service, the service's incidents are that team's problem." These beliefs are not usually foolish. They were often reasonable in an earlier context and became unsafe as scale, coupling, or user expectations changed.
 
-**"Why only Mondays?"**
+Mental-model work can feel abstract, but it has practical outputs. It changes review checklists, platform defaults, SLO definitions, capacity policies, incident templates, and design principles. For example, replacing "all production workloads can share the main database if they are careful" with "interactive and analytical workloads require explicit isolation" prevents a category of incidents. That is a higher-leverage intervention than teaching every on-call engineer to restart faster.
 
-The senior engineers looked at each other. Nobody knew. They'd always just... dealt with it.
+### The Iceberg Model in a Platform Review
 
-The new engineer started digging. She pulled metrics from the past year. She correlated payment failures with everything she could find: deployment schedules, traffic patterns, marketing campaigns, infrastructure changes.
+**Hypothetical scenario:** A platform team reviews a recurring checkout slowdown before the next sale event. At the event level, the team records that checkout latency exceeded the user deadline during promotions. At the pattern level, it notices the issue appears only when a marketing campaign and an inventory reconciliation job overlap. At the structure level, it finds that checkout synchronously calls inventory, inventory shares a database pool with reconciliation, and neither workload has priority isolation.
 
-And there it was. At exactly 2:30 AM every Sunday night, CPU usage on one database server spiked. By 6 AM Monday, the spike ended—but the damage was done. Connection pools exhausted. Queries backed up. Payment timeouts cascading.
+At the mental-model level, the team finds two assumptions. The product assumption is that checkout must confirm exact inventory before continuing, even though the business can tolerate a small reconciliation flow after purchase. The infrastructure assumption is that batch jobs are safe if they are scheduled away from normal peak traffic, even though campaigns create new peaks. The fix is no longer "add more pods." The fix becomes a design change: isolate the reconciliation workload, cache inventory reads for the checkout path, and define which data must be exact before payment.
 
-The culprit? A "Weekly Analytics Summary" batch job. Created two years ago. When the company was small. Processing a few thousand transactions. Now processing millions. What used to take 30 minutes now took 4 hours—and it was still growing.
-
-Nobody owned this job anymore. The engineer who wrote it had left. It ran on the same database as real-time payments because, at the time, "it's just a small report."
-
-**The Fix:**
-
-| Level | What They Did |
-|-------|--------------|
-| Event | (What they'd been doing) Restart services, add pods |
-| Pattern | Added Monday runbook, scheduled extra capacity |
-| Structure | Moved batch job to replica database, added connection pool limits |
-| Mental Model | New policy: "No analytical workloads on transactional databases. Ever." |
-
-The Monday pages stopped. Not because they got better at responding—because they eliminated the cause.
-
-**Total time to fix once they understood the problem**: 2 hours.
-**Time they'd spent managing the symptom over 8 months**: ~200 engineer-hours.
-
-> **Lesson**: The question "why only Mondays?" was worth hundreds of hours. The right question at the right level changes everything.
+That example shows why the iceberg model is not just for postmortems. It is also a design review tool. Before building a new platform service, ask what events will get attention, what patterns you expect over time, what structures could create harmful patterns, and what assumptions are hidden in the design. If the team cannot name the assumptions, the system will still have them; they will simply be harder to challenge later.
 
 ---
 
 ## Part 3: Systems Thinking Vocabulary
 
-To see systems clearly, you need the right words. These terms will become essential to how you troubleshoot and communicate.
+### Elements, Interconnections, Purpose
 
-### The Essential Terms
+The basic vocabulary of systems thinking gives teams a shared way to describe behavior. Elements are the visible pieces. Interconnections are the ways those pieces affect one another. Purpose is the outcome the whole system is organized to produce. In infrastructure work, the interconnections are often more important than the elements because they define how pressure moves.
 
-| Term | Definition | Example |
-|------|------------|---------|
-| **System** | Interconnected elements with a purpose | Your entire production stack |
-| **Boundary** | What's in vs. out of the system | Your services vs. AWS infrastructure |
-| **Stock** | Accumulation within the system | Queue depth, connection count, error budget |
-| **Flow** | Rate of change to a stock | Requests/second, pod creation rate |
-| **Feedback** | When a system's output influences its input | Autoscaler: high CPU → more pods → lower CPU |
-| **Delay** | Time between cause and effect | Metric collection lag, autoscaler reaction time |
+A service catalog lists elements. A dependency map begins to show interconnections. A trace shows one request moving through interconnections over time. A queue depth chart shows accumulation. An incident timeline shows how actions and delays changed the system. A good platform review uses all of these views because no single artifact tells the whole story.
 
-### Stocks and Flows: The Bathtub Model
+### Stocks and Flows
 
-The easiest way to understand stocks and flows is to think of a bathtub:
+A **stock** is something that accumulates. A **flow** is the rate at which that stock increases or decreases. Queue depth is a stock. Incoming requests and completed requests are flows. Error budget is a stock. Bad events consume it, and it is replenished directly as the rolling SLO window advances and old failures age out of the window. Connection count is a stock. New checkouts increase it and completed work decreases it.
+
+The bathtub analogy is still the simplest way to remember this. Water in the tub is the stock. Water from the faucet is inflow. Water down the drain is outflow. If inflow exceeds outflow, the stock rises even if both flows look normal by themselves. In a platform, a queue can grow while CPU is moderate because the constraint is a lock, external dependency, thread pool, or downstream quota rather than raw compute.
 
 ```mermaid
-flowchart TD
-    Inflow["INFLOW (faucet)<br/>10 liters/min"] --> Tub
-    
-    subgraph TubGroup [ ]
-        Tub["STOCK: Water<br/>(liters in tub)<br/>Current: 50L"]
-    end
-    
-    Tub --> Outflow["OUTFLOW (drain)<br/>8 liters/min"]
+flowchart LR
+    In["Inflow: work arriving"] --> Stock["Stock: queued work, open connections, error budget consumed"]
+    Stock --> Out["Outflow: work completed, connections released, budget recovered by time window"]
 ```
-*Rules: If INFLOW > OUTFLOW, stock rises. If INFLOW < OUTFLOW, stock falls. If INFLOW == OUTFLOW, stock is stable. Right now: 10 in, 8 out → Tub is filling at 2L/min → Overflow coming!*
 
-Now apply this to your systems:
+Stocks are powerful because they carry memory. A system can look healthy at the inflow and outflow edges while the accumulated stock tells a different story. If requests arrive slightly faster than they complete, the queue may grow quietly until latency suddenly crosses a user deadline. If retries add new inflow while old work is still queued, the stock grows faster. If humans are the constrained stock, such as open incident actions or unreviewed changes, burnout and delay can accumulate even when each individual request seems small.
 
-```mermaid
-flowchart TD
-    Inflow["INFLOW: Incoming requests<br/>1000 req/sec"] --> Queue
-    
-    subgraph QueueGroup [ ]
-        Queue["STOCK: Queue depth<br/>Current: 5000 requests"]
-    end
-    
-    Queue --> Outflow["OUTFLOW: Processed requests<br/>800 req/sec"]
-```
-*You can't fix latency by looking at inflow or outflow alone. The STOCK determines latency. 5000 queued ÷ 800/sec = 6.25 seconds. The only ways to reduce latency: 1. Reduce inflow (rate limiting), 2. Increase outflow (more capacity), 3. Accept the backlog will drain eventually.*
+### Feedback Loops
 
-> **Stop and think**: Look at the bathtub model. Can you identify the "stocks" and "flows" in the most critical service you maintain?
+A **feedback loop** occurs when a system's output influences future input. A balancing loop pushes the system toward a target. A thermostat turns heat on when a room is cold and off when it is warm. A Kubernetes controller observes actual state and works toward desired state. A rate limiter rejects some requests when demand exceeds policy. These loops are stabilizing when they are tuned to the real system.
 
-### Delays: The Hidden Cause of Chaos
+A reinforcing loop amplifies change. Retries can be a reinforcing loop during overload: slow responses cause timeouts, timeouts cause retries, retries add load, added load causes slower responses. Cache stampedes can do the same thing: many callers miss the cache, all hit the database, the database slows, requests time out, and callers retry. Google SRE's cascading failure guidance describes cascading failure as a failure that grows through positive feedback, which is exactly the pattern systems thinkers look for during incidents.
 
-Delays are everywhere in distributed systems:
+Feedback loops are not good or bad by themselves. They are design tools. The question is whether the loop moves the system toward its purpose under realistic delays and saturation. A retry loop with backoff, jitter, retry budgets, and idempotency can improve resilience. A retry loop with immediate retries, no budget, and side effects can turn a minor fault into a larger outage.
 
-| Delay | Typical Duration |
-|-------|------------------|
-| Metric collection | 10-60 seconds |
-| Alerting pipeline | 30-120 seconds |
-| Autoscaler reaction | 1-5 minutes |
-| DNS propagation | Seconds to hours |
-| Human response | Minutes to hours |
-| Rolling deployment | Minutes to hours |
+### Delays
 
-**Why delays matter**: They cause oscillation and overshoot.
+A **delay** is time between cause and effect. Delays are easy to underestimate because dashboards often display a value as if it represents the present. Metrics may be scraped periodically, processed through an alerting pipeline, and viewed after a human opens a dashboard. Autoscalers react after metric windows, control-loop intervals, scheduling, image pulls, readiness checks, and warm-up. Deployment impact may appear only after caches expire or long-lived connections drain.
+
+Delays create overshoot. If an autoscaler adds pods based on a spike that has already ended, the system may over-provision. If it removes pods based on a quiet period just before demand returns, it may under-provision. Kubernetes documentation describes the HorizontalPodAutoscaler as a controller that periodically adjusts desired scale based on observed metrics. The word "periodically" is operationally important: the controller reacts to measured history, not perfect future demand.
 
 ```mermaid
 sequenceDiagram
-    participant L as Load
-    participant A as Autoscaler
-    participant P as Pods
+    participant Demand
+    participant Metrics
+    participant HPA as Autoscaler
+    participant Pods
 
-    Note over L, P: ACT 1: The Spike
-    L->>A: Load increases
-    A->>P: "Need more pods!" (Delay starts)
-    
-    Note over L, P: ACT 2: The Overshoot
-    L->>L: Load drops back to normal
-    P-->>A: New pods finally ready
-    Note over A, P: We now have way too many pods!
-    
-    Note over L, P: ACT 3: The Oscillation
-    A->>P: "Need fewer pods!" (Delay starts)
-    L->>L: Load spikes again
-    P-->>A: Pods terminated
-    Note over A, P: We now have too few pods! (Repeat)
+    Demand->>Metrics: Traffic rises
+    Metrics->>HPA: Aggregated signal arrives later
+    HPA->>Pods: Desired replicas increase
+    Pods-->>Pods: Scheduling and readiness take time
+    Demand->>Metrics: Traffic changes again
+    Pods-->>HPA: Capacity arrives after the original signal
 ```
 
-> **Did You Know?** The famous "thundering herd" problem is a delay-induced catastrophe. A cache expires. All requests hit the database simultaneously. The database slows down. Requests time out and retry. More load. More timeouts. More retries. The delay between cache miss and successful refill creates a feedback loop that amplifies the original problem exponentially.
+Delays also affect humans. An alert may fire after customers have already complained. A postmortem action may be assigned after the team has lost context. A quarterly architecture review may notice a reliability pattern months after the first warning signs. Systems thinking includes people and process because human delays are part of the production system.
+
+### Leverage Points
+
+A **leverage point** is a place where a small change can produce a large shift in system behavior. Donella Meadows' leverage point work is a foundational systems thinking reference because it warns that the obvious intervention is not always the powerful one. Changing a number, such as a timeout or replica count, can help. Changing information flow, incentives, rules, goals, or mental models can be more powerful when the recurring problem is structural.
+
+In platform work, low-leverage interventions often fight symptoms. Add more dashboard panels. Add more pods. Increase a timeout. Create another runbook step. Those changes may be necessary during response, but they rarely change the pattern. Higher-leverage interventions change defaults and relationships: make dangerous retries hard to configure, provide a standard idempotency library, isolate batch and interactive workloads by default, require ownership for shared resources, or change SLO reviews so user journeys matter more than component averages.
+
+Leverage is contextual. Separating databases may be high leverage for a workload-isolation problem and irrelevant for a deployment-risk problem. Adding tracing may be high leverage when dependency paths are unknown and low leverage when the known bottleneck is a contract with an external provider. Systems thinking does not choose the fanciest intervention. It chooses the intervention that changes the feedback loop producing the unwanted behavior.
+
+### Coupling and Slack
+
+**Coupling** describes how strongly one part of a system depends on another. Tight coupling is not automatically bad; synchronous calls are useful when the caller truly needs the answer before continuing. The risk is that tight coupling allows failure, delay, and demand spikes to travel quickly. A checkout flow that synchronously calls pricing, tax, inventory, fraud, payment, and email has many places where one slow component can consume the user's deadline.
+
+**Slack** is spare capacity or flexibility that absorbs variation. Queue capacity, retry budgets, error budgets, manual fallback paths, cached reads, and human on-call bandwidth are all forms of slack. Too little slack makes the system brittle. Too much slack can hide waste or delay necessary design changes. The systems question is not "should we remove all slack?" It is "where does slack protect the system's purpose, and where does it hide a structure that should change?"
+
+Coupling and slack interact. A tightly coupled path needs more careful deadlines, isolation, and fallback because variation travels directly to the user. A loosely coupled path can often absorb delay with queues, reconciliation, and eventual consistency. A platform engineer should be able to explain which dependencies are on the critical path, which are asynchronous, and how much slack each path has before user-visible behavior changes.
 
 ---
 
 ## Part 4: Applying Systems Thinking
 
-### The Questions That Change Everything
+### A Practical Troubleshooting Frame
 
-When troubleshooting or designing systems, systems thinkers ask different questions:
+When a production symptom appears, start with a clear statement of user impact, then map the path that produces that impact. The map does not need to be beautiful. It needs to show the user journey, synchronous dependencies, asynchronous work, shared resources, queues, retry loops, rate limits, and ownership boundaries. If the map has only boxes and no flows, it is not yet a systems map.
 
-| Normal Question | Systems Thinking Question |
-|-----------------|---------------------------|
-| "Which service is broken?" | "What changed in the system as a whole?" |
-| "Who deployed what?" | "What feedback loops are active?" |
-| "What's the error?" | "What's the pattern over time?" |
-| "How do I fix this?" | "What structure enables this problem?" |
-| "Is this service healthy?" | "Is the system achieving its purpose?" |
+After mapping the path, place the symptom on the map and ask where pressure could accumulate before it becomes visible. Is there a queue that can grow? A connection pool that can saturate? A lock that can serialize work? A cache that can expire for many keys at once? A provider quota that can reject bursts? A human approval step that can delay recovery? These stocks often explain why the visible service is not the origin of the problem.
 
-### A Systems Thinking Troubleshooting Session
+Next, build a timeline. Systems thinking is temporal. A dependency graph says what can influence what, but the timeline says what actually changed. Include deployments, feature flags, traffic changes, batch jobs, provider incidents, schema migrations, on-call actions, autoscaling events, and alert times. The goal is not to find a single guilty event. The goal is to identify the sequence of interactions that produced the pattern.
 
-**Scenario**: Users report intermittent slowness. Dashboards show all services green.
+Finally, choose an intervention at the right level. If the event is still active, stabilize the system. If the pattern is known but the structure cannot change immediately, add guardrails and runbooks. If the structure is unsafe, redesign the relationship. If the same unsafe structure keeps appearing, change the mental model through standards, defaults, and review criteria.
 
-**Component approach** (what most people do):
-1. Check each service's CPU, memory, errors
-2. Everything looks fine
-3. Blame the network
-4. Add more logging
-5. Wait for it to happen again
-6. Still confused
+### The Questions That Change the Conversation
 
-**Systems approach**:
+Systems thinkers ask different questions from component troubleshooters. Instead of "Which service is broken?", ask "Where does the user journey cross a shared constraint?" Instead of "Who deployed?", ask "What changed in demand, dependency behavior, data shape, or control loops?" Instead of "Why did the alert fire?", ask "What pattern made this alert likely?" Instead of "How do we stop this page?", ask "What structure makes this page necessary?"
 
-**Step 1: Map the System** (Draw connections, not just boxes)
+Those questions are not softer than technical debugging. They are more precise about the level of analysis. A restart answers an event. A capacity forecast answers a pattern. Workload isolation answers a structure. A new platform default answers a mental model. A mature incident review should be able to name which question each action item answers.
+
+### Worked Example: Intermittent Slowness with Green Dashboards
+
+**Hypothetical scenario:** Users report intermittent slowness in a document-processing application. The API, worker, cache, and database dashboards all show acceptable averages. A component-oriented investigation checks each service, finds no obvious error spike, and concludes the issue may be "the network." A systems-oriented investigation starts by mapping the request path and notices that slow requests all require a cache miss, a metadata lookup, and a document conversion job.
+
 ```mermaid
 flowchart LR
     User --> API
     API --> Cache
-    Cache --> ServiceA[Service A]
-    Cache --> ServiceB[Service B]
-    Cache --> ServiceC[Service C]
-    ServiceB --> DB[(Database)]
-    ServiceC --> DB
-    
-    classDef highlight fill:#f9f,stroke:#333,stroke-width:2px;
-    class ServiceB,ServiceC,DB highlight;
+    Cache --> Metadata["Metadata service"]
+    Metadata --> DB[(Shared database)]
+    API --> Queue["Conversion queue"]
+    Queue --> Workers["Worker pool"]
+    Workers --> ObjectStore["Object storage"]
+    Workers --> DB
 ```
 
-**Step 2: Identify Feedback Loops**
-- Cache misses → DB load → Slower queries → More timeouts → More retries → More DB load... (Reinforcing loop)
-- Rate limiter → Rejected requests → Less load → Faster response... (Balancing loop)
+The map reveals two stocks: conversion queue depth and database connections. It also reveals a reinforcing loop: cache misses increase database reads, slow reads delay API responses, clients retry, retries increase cache and database demand, and worker status updates compete for the same database connections. The service averages are green because most requests hit the cache and avoid the slow path. The user impact is concentrated in a smaller path whose tail latency is hidden by averages.
 
-**Step 3: Look for Stocks**
-- Queue depths? Growing.
-- Connection pool? 100% utilized!
-- Error budget? Almost gone.
+The event-level fix is to shed duplicate retries and temporarily increase worker capacity. The pattern-level fix is to alert on cache-miss latency and queue age, not only service averages. The structure-level fix is to separate read pools from worker update pools and add bounded retries with jitter. The mental-model fix is to stop treating "service average latency" as proof that the user journey is healthy. Each level produces a different action, and all of them may be needed.
 
-**Step 4: Check the Delays**
-- How old are these metrics? 60 seconds old.
-- Autoscaler cooldown? 5 minutes.
-- When did the pattern start? Yesterday at 3 PM.
+### Decision Framework: Where Should You Intervene?
 
-**Step 5: Go Deeper Than Events**
-- Is this a pattern? Yes—happens during peak hours.
-- What structure enables it? Shared DB connection pool with no limits.
-- What mental model? "Services are independent."
+A systems intervention should be judged by the behavior it changes, the side effects it may create, and the level at which it operates. Increasing capacity is often fast and reversible, but it may hide an unbounded demand problem. Adding a retry can improve resilience to transient faults, but it may amplify overload. Splitting a database can improve isolation, but it adds operational cost and consistency questions. Changing a platform default can prevent many incidents, but it requires migration support and clear ownership.
 
-**Root cause found**: Service B and C share a database connection pool. During peak load, Service B takes all connections for a slow analytics query. Service C starves. Timeouts cascade.
+Use four prompts before committing to a fix. First, what stock or flow will this change? Second, what feedback loop will it strengthen or weaken? Third, what delay could make the intervention overshoot? Fourth, who or what will feel the side effect? If you cannot answer those questions, the fix may still be necessary during an emergency, but it should not be mistaken for a durable solution.
 
-**Fix**: Per-service connection pool limits.
+The safest durable interventions usually make the desired behavior easier than the dangerous behavior. For example, a standard HTTP client that includes deadlines, retry budgets, idempotency support, and telemetry makes safe calls easier than custom retry loops. A platform-provided queue with age alerts and dead-letter handling makes asynchronous work safer than every team inventing its own worker pattern. A deployment template that includes progressive rollout and automatic rollback makes careful release behavior the default instead of a heroic habit.
+
+### Systems Thinking in Design Reviews
+
+Design reviews often overemphasize component inventory: service names, database choices, API endpoints, and deployment manifests. A systems review adds questions about behavior over time. What happens when a dependency is slow rather than down? What work accumulates when consumers lag? What retries exist at each layer? Which operations are idempotent? What is the user deadline? What is the fallback behavior? What shared resource could become the real bottleneck?
+
+It also asks what the design will teach future teams. If the platform makes it easy to create synchronous chains across many services, teams will build long critical paths. If the platform makes it easy to run analytical jobs against transactional stores, teams will share unsafe resources. If the platform exposes only component dashboards, teams will optimize components. The platform's defaults become the organization's mental model in executable form.
+
+This is why systems thinking belongs in Platform Foundations. Platform teams do not merely run clusters. They shape the constraints, defaults, and information flows through which other teams build systems. A platform that encodes good systems thinking can prevent classes of incidents before application teams know the vocabulary. A platform that encodes poor assumptions will reproduce the same incidents across many services, even when each team is competent.
+
+### Systems Thinking and Observability
+
+Observability is the evidence layer for systems thinking. Metrics show stocks, flows, saturation, and trends. Logs show local facts and decisions. Traces show relationships across service boundaries and expose where time is spent. OpenTelemetry's tracing model relies on context propagation so spans from different services can be assembled into one trace. That is a technical implementation of a systems idea: the behavior belongs to the path, not only to the individual span.
+
+The caution is that observability data can still reinforce component thinking if it is organized only around services. A dashboard per service is useful, but it should be complemented by user-journey dashboards, dependency views, queue age, saturation, and SLO burn. If the checkout journey is failing, the first dashboard should show checkout as users experience it, then let operators drill down into components. Starting with components makes it too easy to declare every part healthy while the whole remains unhealthy.
+
+Observability also has feedback effects. If alerts reward fast restarts, teams will get better at restarts. If dashboards expose recurring structures, teams will redesign structures. If postmortems ask only "what broke?", teams will find broken parts. If postmortems ask "what made this outcome likely?", teams will find system conditions. The measurements you choose change the behavior of the people operating the system.
+
+### A Short Practice Loop
+
+Use this loop during your next design review or incident review. State the system purpose in user terms. Draw the boundary and name what is outside it. Identify the main stocks and flows. Mark feedback loops, especially retries, autoscalers, queues, and human escalation. Mark delays. Ask what pattern over time the current structure is likely to produce. Then choose the lowest-risk intervention that changes the unwanted pattern without damaging the system's purpose.
+
+The loop can be done quickly. A rough diagram on a shared document is often enough to change the conversation. The value is not the artifact; it is the shift from debating isolated components to reasoning about relationships. Over time, that habit becomes part of how the team reads incidents, writes runbooks, designs platform APIs, and evaluates reliability work.
+
+---
+
+## Did You Know?
+
+- **The iceberg model is a systems thinking teaching tool, not just a management metaphor.** The Donella Meadows Project describes it as a way to connect events with patterns, structures, and mental models so teams can see what keeps producing visible symptoms.
+- **Kubernetes controllers are practical systems thinking in code.** The Kubernetes controller documentation describes controllers as loops that watch cluster state and make changes to move actual state toward desired state.
+- **Cascading failure is a feedback problem.** Google SRE's chapter on cascading failures explains how an initial failure can grow when load shifts or retries increase pressure on remaining components.
+- **Distributed tracing exists because service-local views are incomplete.** OpenTelemetry's tracing documentation emphasizes context propagation so spans from multiple services can be correlated into a single request path.
+
+## Sources
+
+- [Systems Thinking Resources - The Donella Meadows Project](https://donellameadows.org/systems-thinking-resources/)
+- [Leverage Points: Places to Intervene in a System](https://donellameadows.org/archives/leverage-points-places-to-intervene-in-a-system/)
+- [How Complex Systems Fail](https://how.complexsystems.fail/)
+- [Addressing Cascading Failures - Google SRE Book](https://sre.google/sre-book/addressing-cascading-failures/)
+- [Handling Overload - Google SRE Book](https://sre.google/sre-book/handling-overload/)
+- [Timeouts, retries and backoff with jitter - AWS Builders' Library](https://aws.amazon.com/builders-library/timeouts-retries-and-backoff-with-jitter/)
+- [The Tail at Scale - Google Research](https://research.google/pubs/the-tail-at-scale/)
+- [Dapper, a Large-Scale Distributed Systems Tracing Infrastructure - Google Research](https://research.google/pubs/dapper-a-large-scale-distributed-systems-tracing-infrastructure/)
+- [Horizontal Pod Autoscaling - Kubernetes](https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/)
+- [Deployments - Kubernetes](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/)
+- [Controllers - Kubernetes](https://kubernetes.io/docs/concepts/architecture/controller/)
+- [Traces - OpenTelemetry](https://opentelemetry.io/docs/concepts/signals/traces/)
 
 ---
 
@@ -448,221 +384,121 @@ flowchart LR
 
 | Mistake | Why It Hurts | What To Do Instead |
 |---------|--------------|-------------------|
-| **Treating symptoms** | Problem recurs, wastes time | Use iceberg model—go deeper |
-| **Optimizing components** | Can make system worse | Optimize for system-level goals |
-| **Ignoring delays** | Causes oscillation, overshoot | Map delays explicitly |
-| **Tight system boundaries** | Miss external dependencies | Include what affects behavior |
-| **Looking for THE root cause** | Complex systems have multiple causes | Look for contributing factors |
-| **Assuming independence** | Services affect each other | Map connections and shared resources |
+| Treating the alerting service as the cause | The alert often names where pain surfaced, not where it originated | Map the user journey and shared resources before choosing a fix |
+| Optimizing one component in isolation | A faster component can overload a downstream constraint or starve peers | Optimize against the whole-system goal and current bottleneck |
+| Ignoring stocks such as queues and pools | Accumulated work can hide until latency suddenly crosses a deadline | Track queue age, pool saturation, backlog, and error budget burn |
+| Treating retries as free reliability | Retries can amplify overload and duplicate side effects | Use idempotency, retry budgets, backoff, jitter, and load shedding |
+| Drawing boundaries around team ownership | Organizational boundaries can hide technical causes and shared constraints | Choose boundaries based on behavior, not reporting lines |
+| Stopping at a single root cause | Complex incidents usually require multiple contributing conditions | Identify interacting factors and the structure that connected them |
+| Writing action items only at the event level | Restart runbooks and extra capacity may leave the pattern intact | Add structure-level or mental-model changes when recurrence is likely |
 
 ---
 
 ## Quiz
 
-### Question 1
-**Scenario:** Your company's checkout flow involves a Cart Service, a Pricing Service, and a Payment Service. Recently, users are experiencing 5-second delays during checkout. You check the dashboards for Cart, Pricing, and Payment, and all three services report average response times under 50ms with no errors. Your manager suggests putting a dedicated team on each service to optimize their individual performance to fix the delay. Is this the right approach?
-
 <details>
-<summary>Show Answer</summary>
+<summary>Hypothetical scenario: A checkout service reports low CPU and low error rate, but users still see checkout timeouts during promotions. What systems-thinking question should you ask first?</summary>
 
-**No, this approach relies on component-level optimization rather than systems thinking.**
-
-In a complex distributed system, behavior emerges from the interactions between components, not the components themselves. The 5-second delay does not exist within the Cart, Pricing, or Payment services in isolation; it arises from how they communicate, such as network retries, connection pool exhaustion, or locking on a shared database. Optimizing the individual services without understanding their interconnections might actually make the problem worse (e.g., a faster Cart service could overwhelm a shared database). To solve this, you must map the system boundaries and look for delays or bottlenecks in the spaces *between* the services.
+Start by asking where the checkout journey crosses shared resources, queues, locks, synchronous dependencies, or retry loops. Low CPU on the named service only tells you that one element is not saturated in that dimension. The timeout may emerge from a database pool, inventory call, fraud provider, cache miss path, or client retry behavior. Systems thinking begins by mapping the path that produces user impact rather than accepting the alert label as the system boundary.
 </details>
 
-### Question 2
-**Scenario:** You deploy a new microservice that automatically retries failed network requests up to 3 times. During testing, it works perfectly. However, in production during a minor network blip, this retry logic causes a massive spike in traffic that takes down an entirely unrelated legacy database. You are tasked with writing the incident report. How does the concept of "emergence" explain why this wasn't caught in component testing?
-
 <details>
-<summary>Show Answer</summary>
+<summary>Hypothetical scenario: Restarting a service clears an alert for a short time, but the same alert returns later. Which iceberg levels have been addressed, and which remain?</summary>
 
-**Emergence explains that the cascading failure is a property of the entire system, not the individual retry logic.**
-
-When you tested the microservice in isolation, the retry logic behaved exactly as designed: it made the service more resilient to transient faults. However, when integrated into the broader production environment, the interaction between the retries, the network blip, and the shared database's limited connection pool created a completely new, unpredictable behavior—a cascading failure. Emergent properties cannot be predicted by looking at a component alone because they are born from the relationships and feedback loops across the system. This is why troubleshooting complex systems requires looking at the system in motion, rather than examining isolated parts.
+The restart addresses the event level because it temporarily changes the immediate condition that triggered the alert. The returning symptom suggests the pattern, structure, or mental model remains unchanged. A pattern-level investigation would ask when recurrence happens, while a structure-level investigation would look for shared resources, workload schedules, or control loops that recreate the symptom. A mental-model investigation would ask what assumption allowed that structure to seem acceptable.
 </details>
 
-### Question 3
-**Scenario:** Every Friday afternoon, your team's CI/CD pipeline backs up, delaying deployments by hours. The team's current solution is to manually cancel non-essential builds (Event level) and scale up the runner pool on Friday mornings (Pattern level). If you apply the Iceberg Model, what would a "Mental Model" level solution look like, and why is it more effective?
-
 <details>
-<summary>Show Answer</summary>
+<summary>What is emergence, and why does it make component-only testing insufficient?</summary>
 
-**A Mental Model solution would challenge the underlying assumption that all deployments must happen at the end of the week, which fundamentally eliminates the problem.**
-
-Addressing events (canceling builds) or patterns (scaling runners) only manages the symptoms and requires continuous ongoing effort. By digging down to the Mental Model, you might discover the team believes "deployments are risky, so they should be grouped together on Fridays," which creates the structural bottleneck in the first place. Changing this belief to "deployments should be small, continuous, and safe at any time" would lead to a steady, even flow of CI/CD pipeline usage throughout the week. This approach is far more impactful because resolving a flawed mental model permanently prevents the entire category of problems from recurring.
+Emergence is system behavior created by interactions among elements rather than by one element alone. Component-only testing can prove that a service behaves correctly in isolation, but it cannot reveal every effect of retries, queues, shared pools, locks, delays, and user traffic interacting in production. This is why integration tests, load tests, traces, and incident timelines matter. They expose behavior that belongs to the relationship between components.
 </details>
 
-### Question 4
-**Scenario:** You configure a Kubernetes Horizontal Pod Autoscaler (HPA) to scale up your application when CPU exceeds 70%. During a traffic spike, the HPA triggers a scale-up. However, it takes 3 minutes for the new pods to become ready. By the time they start, the traffic spike has ended, leaving the cluster heavily over-provisioned. The HPA then scales down, but another traffic spike hits just as the pods terminate. Why does this specific sequence lead to system oscillation?
+<details>
+<summary>Hypothetical scenario: A team wants to make one API service ten times faster. What systems tradeoff should they evaluate before celebrating?</summary>
+
+They should evaluate whether the faster service will increase pressure on a downstream constraint such as a database, queue, rate limit, or external provider. Local speed can improve user experience when the optimized service is the true bottleneck, but it can also move congestion to a more fragile part of the system. The team should measure whole-journey latency, saturation, and error budget impact before and after the change. Systems thinking treats local optimization as a hypothesis about the whole system, not an automatic win.
+</details>
 
 <details>
-<summary>Show Answer</summary>
+<summary>Hypothetical scenario: An autoscaler adds capacity after a traffic spike has already passed, then removes capacity just before the next spike. Which systems concept explains this behavior?</summary>
 
-**The delay between the autoscaler's decision and the actual realization of capacity creates a mismatch between current state and current demand.**
+The key concept is delay. The autoscaler reacts to observed metrics after collection, aggregation, decision, scheduling, and readiness delays. If demand changes faster than the control loop can respond, the corrective action may arrive after the condition that triggered it has changed. That mismatch can cause overshoot and oscillation unless the system uses stabilization windows, predictive signals, slower scale-down, or other damping mechanisms.
+</details>
 
-In distributed systems, whenever there is a delay between cause and effect (such as the 3 minutes it takes for pods to boot), the system's corrective actions are essentially reacting to outdated information. By the time the new pods are ready, the initial condition (the traffic spike) has already changed, leading to an overshoot where there are too many resources. This overshoot triggers a corrective scale-down, which also suffers from delays, subsequently causing an undershoot when demand returns. Without accounting for these delays—such as by implementing predictive scaling, smoothing metrics, or adding stabilization windows—the system will continuously bounce between extremes instead of reaching equilibrium.
+<details>
+<summary>Why is a system boundary a design choice rather than an objective fact?</summary>
+
+A boundary is chosen to explain or change a behavior, so different questions require different boundaries. A pod crash may need a narrow boundary around one deployment, while recurring checkout latency may need a boundary that includes traffic sources, synchronous dependencies, shared databases, queues, retries, and human release practices. Boundaries that follow team ownership can be convenient but misleading. The useful boundary is the one that includes the relationships capable of producing the observed behavior.
+</details>
+
+<details>
+<summary>Hypothetical scenario: A postmortem action item says, "Add more dashboard panels for each service." When is this low leverage, and what might be higher leverage?</summary>
+
+It is low leverage if the recurring problem is that teams cannot see the user journey or shared bottlenecks across services. More component panels may deepen the same component-focused mental model that missed the issue. A higher-leverage action might add journey-level SLO dashboards, tracing across the critical path, queue-age alerts, or design rules for shared resource isolation. The better intervention changes the information flow or structure that made the incident hard to understand.
 </details>
 
 ---
 
 ## Hands-On Exercise
 
-### Part A: Observe Emergence in Kubernetes (15 minutes)
+### Part A: Model a Stock, Flow, Delay, and Feedback Loop
 
-**Objective**: See how system behavior emerges from component interactions.
+This exercise uses a small local simulation instead of a live cluster so you can focus on systems behavior without needing special infrastructure. You will model a request queue where incoming work, processing capacity, and retries interact. The numbers are intentionally a toy model; the lesson is how the shape changes when a feedback loop adds more work during overload.
 
-```bash
-# Create namespace
-kubectl create namespace systems-lab
-
-# Deploy interconnected services
-cat <<EOF | kubectl apply -f -
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: backend
-  namespace: systems-lab
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app: backend
-  template:
-    metadata:
-      labels:
-        app: backend
-    spec:
-      containers:
-      - name: backend
-        image: nginx:alpine
-        ports:
-        - containerPort: 80
----
-apiVersion: v1
-kind: Service
-metadata:
-  name: backend
-  namespace: systems-lab
-spec:
-  selector:
-    app: backend
-  ports:
-  - port: 80
----
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: frontend
-  namespace: systems-lab
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app: frontend
-  template:
-    metadata:
-      labels:
-        app: frontend
-    spec:
-      containers:
-      - name: frontend
-        image: curlimages/curl:latest
-        command: ["/bin/sh", "-c"]
-        args:
-          - |
-            while true; do
-              curl -s -o /dev/null -w "%{http_code}\n" http://backend/
-              sleep 1
-            done
-EOF
-
-# Watch the system
-kubectl get pods -n systems-lab -w
-```
-
-**Now break something and watch the system respond:**
+Create the simulation file:
 
 ```bash
-# In another terminal, kill a backend pod
-kubectl delete pod -n systems-lab -l app=backend \
-  $(kubectl get pod -n systems-lab -l app=backend -o jsonpath='{.items[0].metadata.name}') \
-  --wait=false
+cat > /tmp/systems-thinking-queue.py <<'PY'
+backlog = 0
+capacity = 80
+base_arrivals = [60, 70, 120, 140, 120, 90, 70, 60]
+retry_fraction_when_backlogged = 0.25
+
+print("minute arrivals retries processed backlog")
+for minute, arrivals in enumerate(base_arrivals, start=1):
+    retries = int(backlog * retry_fraction_when_backlogged) if backlog else 0
+    total_arrivals = arrivals + retries
+    processed = min(capacity, backlog + total_arrivals)
+    backlog = backlog + total_arrivals - processed
+    print(f"{minute:>6} {arrivals:>8} {retries:>7} {processed:>9} {backlog:>7}")
+PY
+
+.venv/bin/python /tmp/systems-thinking-queue.py
 ```
 
-**What to observe:**
-- Frontend continues working (load balances to surviving backend)
-- New backend pod is created automatically
-- System self-heals without human intervention
+Read the output as a systems map. The stock is backlog. The inflow is new arrivals plus retries. The outflow is processed work. The feedback loop appears when backlog causes retries, and retries increase future backlog. The system can become worse even after base arrivals drop because the stock carries memory from previous minutes.
 
-**This is emergence.** The self-healing behavior doesn't exist in any individual pod. It emerges from the interactions between Deployment controller, ReplicaSet, Service, and kube-proxy.
+Now change `retry_fraction_when_backlogged` to `0.0` and run the script again. The difference shows why retries are not automatically good or bad. A retry policy changes a feedback loop. In a real service, you would combine retries with deadlines, budgets, backoff, jitter, idempotency, and load shedding so the loop helps during transient faults without amplifying overload.
 
-**Clean up:**
-```bash
-kubectl delete namespace systems-lab
-```
+### Part B: Apply the Iceberg Model to a Platform Problem
 
-### Part B: Apply the Iceberg Model (20 minutes)
+Use a recurring issue from your environment, or use this explicitly labeled teaching prompt: **Hypothetical scenario:** "The checkout page becomes slow during large promotions, but all individual service dashboards show acceptable averages." Fill in each iceberg level with one or two concrete observations, then write one action item for each level. The point is not to create the perfect answer; it is to practice separating event response from structural prevention.
 
-Pick a recurring issue in your environment (or use this hypothetical):
-
-> "The checkout page is slow during sales events."
-
-Apply the iceberg model:
-
-| Level | Analysis |
-|-------|----------|
-| **Event** | What happens? |
-| **Pattern** | When? How often? What correlates? |
-| **Structure** | What architecture/config enables this? |
-| **Mental Model** | What assumption allowed this structure? |
-
-**Example answer:**
-
-| Level | Answer |
-|-------|--------|
-| **Event** | Checkout timeouts during Black Friday |
-| **Pattern** | Happens every sale event. Correlates with >10x traffic. |
-| **Structure** | Checkout service calls inventory synchronously. No caching. Single DB. |
-| **Mental Model** | "Real-time inventory is always required" (but is it for checkout display?) |
+| Level | Guiding Question | Example Analysis |
+|-------|------------------|------------------|
+| Event | What happened this time? | Checkout exceeded the user deadline during a promotion |
+| Pattern | What has been happening over time? | Slowdowns correlate with promotion traffic and inventory reconciliation |
+| Structure | What arrangement creates the pattern? | Checkout synchronously reads inventory through a shared database pool |
+| Mental Model | What belief made the structure seem acceptable? | Exact inventory was assumed to be required before every checkout step |
 
 **Success Criteria:**
-- [ ] Observed pod deletion and automatic recovery in Part A
-- [ ] Can explain what "emergence" you witnessed
-- [ ] Completed iceberg analysis for Part B
-- [ ] Identified at least one mental model that enables the problem
 
----
-
-## Did You Know?
-
-- **Systems thinking was born in biology**, not engineering. Ludwig von Bertalanffy developed General Systems Theory in the 1930s to understand living organisms as integrated wholes, not collections of parts.
-
-- **The Apollo program** was one of the first engineering projects to formally apply systems thinking. With 2 million parts and 400,000 people, NASA couldn't understand the spacecraft by studying components—they had to see the whole.
-
-- **W. Edwards Deming**, the quality management guru, estimated that **94% of problems are caused by the system, not the individual workers**. When something goes wrong, the structure almost always matters more than the person.
-
-- **Jeff Bezos** attributes Amazon's success to "working backwards from the customer"—a systems thinking approach. Instead of building components and hoping they create good outcomes, he defines the desired system behavior first.
+- [ ] You can identify the stock, inflow, outflow, delay, and feedback loop in the local simulation.
+- [ ] You can explain why backlog can keep growing after the original demand spike drops.
+- [ ] You completed an iceberg analysis with event, pattern, structure, and mental-model levels.
+- [ ] You wrote at least one structure-level action item that would reduce recurrence rather than only improving response speed.
 
 ---
 
 ## Further Reading
 
-- **"Thinking in Systems: A Primer"** by Donella Meadows — The foundational text. Readable, profound, and changed how I see everything.
+Start with Donella Meadows if you want the durable theory, then read Google SRE and AWS Builders' Library material when you want production examples. Meadows gives you the language of systems, stocks, flows, feedback, and leverage. The SRE and AWS sources show how those ideas appear in overload, cascading failure, retries, throttling, and tail latency in large software systems.
 
-- **"How Complex Systems Fail"** by Richard Cook — An 18-point paper that every engineer should read. Takes 10 minutes. Will change your career.
-
-- **"The Fifth Discipline"** by Peter Senge — Systems thinking applied to organizations. Explains why your team keeps having the same problems.
-
-- **"Drift into Failure"** by Sidney Dekker — How systems gradually drift toward catastrophe while every individual decision seems reasonable.
+For a short safety-oriented companion, read Richard Cook's "How Complex Systems Fail" and pay attention to the argument that complex systems usually contain multiple latent problems before an incident. That framing is useful during postmortems because it pushes the team away from asking which person or component failed and toward asking how normal work exposed a combination of weaknesses.
 
 ---
 
 ## Next Module
 
-[Module 1.2: Feedback Loops](../module-1.2-feedback-loops/) — Understanding reinforcing and balancing feedback, and why your autoscaler sometimes makes things worse.
-
----
-
-*"To understand is to perceive patterns."* — Isaiah Berlin
-
-*"You can't understand a system by taking it apart. You can only understand it by seeing it in motion."* — Adapted from Russell Ackoff
+[Module 1.2: Feedback Loops](../module-1.2-feedback-loops/) builds on this foundation by separating reinforcing loops from balancing loops and showing why retries, autoscalers, queues, and organizational incentives can either stabilize a platform or amplify failure.

--- a/src/content/docs/platform/foundations/systems-thinking/module-1.2-feedback-loops.md
+++ b/src/content/docs/platform/foundations/systems-thinking/module-1.2-feedback-loops.md
@@ -3,6 +3,7 @@ title: "Module 1.2: Feedback Loops"
 slug: platform/foundations/systems-thinking/module-1.2-feedback-loops
 sidebar:
   order: 3
+revision_pending: false
 ---
 > **Complexity**: `[MEDIUM]`
 >
@@ -14,7 +15,7 @@ sidebar:
 
 ### What You'll Be Able to Do
 
-After completing this module, you will be able to:
+When you finish this module, you will be able to identify reinforcing and balancing feedback loops in production systems, diagnose runaway cascades caused by positive feedback, design damping mechanisms that interrupt destructive cycles, and evaluate whether a system's feedback loops will stabilize or amplify under failure conditions. The numbered capabilities below map directly to the hands-on exercise and quiz.
 
 1. **Identify** reinforcing and balancing feedback loops in production systems and predict their behavior under load
 2. **Diagnose** runaway cascades caused by positive feedback loops such as retry storms, autoscaler thrashing, and connection pool exhaustion
@@ -25,71 +26,67 @@ After completing this module, you will be able to:
 
 ## The Black Friday Meltdown
 
-*November 29th, 2019. 10:47 AM Eastern Time.*
+**Hypothetical scenario:** The following narrative is a composite teaching example. It combines patterns documented in post-mortems across e-commerce and retail platforms during high-traffic events, but it does not describe one specific public incident. The timeline below uses approximate clock times to show how quickly reinforcing loops can escalate—not as a claim about any particular company's outage.
 
-The ShopMart engineering team is watching dashboards with coffee in hand. Black Friday traffic is building—already 3x normal load, heading toward 10x by afternoon. The autoscaler is doing its job, spinning up new pods. Everything looks green.
+The engineering team for a large online retailer is watching dashboards with coffee in hand. Black Friday traffic is building—already several times normal load, heading toward a much larger peak by afternoon. The autoscaler is doing its job, spinning up new pods. Everything looks green on the surface-level health checks.
 
-10:52 AM. Someone notices something odd. Database connection count is climbing faster than traffic. Not by a little—exponentially. Traffic up 20%, connections up 400%.
+Within minutes, someone notices something odd. Database connection count is climbing faster than traffic. Not by a little—exponentially. Traffic might be up modestly, but connections are multiplying far faster than request volume would explain.
 
-The senior DBA pulls up query logs. Queries are taking 3x longer than normal. Nothing has changed in the code. The database itself isn't maxed out—CPU at 40%, memory fine.
+The senior DBA pulls up query logs. Queries are taking several times longer than normal. Nothing has changed in the application code. The database itself is not maxed out on CPU or memory—the bottleneck is connection hold time, not raw compute capacity.
 
-10:58 AM. The first timeouts start appearing. Payment service can't reach the database. It retries. All instances retry simultaneously—thousands of retries per second.
+The first timeouts start appearing. The payment service cannot reach the database reliably. It retries. All instances retry simultaneously—creating thousands of retry attempts per second across the fleet.
 
-11:04 AM. The circuit breaker finally trips, but it's too late. The database connection pool is completely exhausted. New pods are spinning up (autoscaler sees high latency), but each new pod tries to grab connections from an empty pool. More pods, more connection attempts, more failures.
+The circuit breaker finally trips, but by then it is too late. The database connection pool is completely exhausted. New pods are spinning up because the autoscaler sees high latency, but each new pod tries to grab connections from an empty pool. More pods means more connection attempts, more failures, and more load on an already saturated database.
 
-11:12 AM. Complete outage. The site displays "temporarily unavailable" to 400,000 shoppers.
+Within roughly twenty minutes, the checkout path is effectively unavailable. Shoppers see error pages instead of completed purchases.
 
-**The root cause?** A single slow query. One poorly indexed query that normally took 50ms started taking 500ms under load. Connections held 10x longer meant connection pool filled 10x faster. Which meant more queuing. Which meant even longer waits. Which meant more timeouts. Which meant retries. Which added more load. Which made queries even slower.
+**The root cause?** A single slow query. One poorly indexed query that normally took tens of milliseconds started taking hundreds of milliseconds under load. Connections held ten times longer meant the connection pool filled ten times faster. That meant more queuing, which meant even longer waits, which meant more timeouts, which meant retries, which added more load, which made queries even slower.
 
 > **Stop and think**: If a system is perfectly stable under normal load, what makes it suddenly collapse under higher load rather than just slowing down proportionally?
 
-A **feedback loop** turned a minor performance issue into a complete system collapse in under 25 minutes.
-
----
-
-## Why This Module Matters
-
-Every production outage has a story. But if you look closely at the worst ones—the cascading failures, the death spirals, the "everything went wrong at once" disasters—they share a common element: **feedback loops** that amplified small problems into catastrophic failures.
-
-Understanding feedback loops is understanding the DNA of system behavior.
-
-A system with well-designed feedback loops is antifragile—it stabilizes under stress, recovers from failures, and gets stronger with use. A system with poorly designed feedback loops is a time bomb—stable in normal conditions, catastrophic when stressed.
-
-This module teaches you to:
-- Recognize feedback loops before they bite
-- Predict which loops will help and which will harm
-- Design systems that use feedback safely
-- Break dangerous loops before they cascade
-
-> **The Thermostat Principle**
->
-> Your home thermostat is a perfect feedback loop. Temperature drops below setpoint → heater turns on → temperature rises → heater turns off. This is a **balancing loop**—it opposes change, maintaining stability.
->
-> Now imagine if your thermostat were wired backwards: temperature drops → heater turns *off*. That's a **reinforcing loop**—it amplifies change. Your house would freeze.
->
-> Most production incidents are just thermostats wired backwards. The system is trying to help, but its corrective actions make things worse. This module teaches you to spot backwards thermostats before they freeze your production systems.
+A **feedback loop** turned a minor performance issue into a complete system collapse in under half an hour. The system did not fail because traffic exceeded designed capacity in a linear way—it failed because the system's own corrective and retry mechanisms amplified a small slowdown into a runaway cascade.
 
 ---
 
 ## What You'll Learn
 
-- The two fundamental types of feedback loops
-- Why delays turn helpful loops into destructive oscillations
-- The six most dangerous feedback patterns in distributed systems
-- How to design systems that use feedback safely
-- Techniques for breaking loops once they start
+- The two fundamental types of feedback loops and how to classify any loop you encounter in production
+- Why delays turn helpful balancing loops into destructive oscillations—and how to measure total loop delay
+- The six most dangerous feedback patterns in distributed systems, with breaking strategies for each
+- How to design systems that use feedback safely, including damping, jitter, and circuit breakers
+- Techniques for breaking loops once they start, plus a checklist for pre-deployment loop analysis
+
+---
+
+## Why This Module Matters
+
+Every production outage has a story. But if you look closely at the worst ones—the cascading failures, the death spirals, the "everything went wrong at once" disasters—they share a common element: **feedback loops** that amplified small problems into catastrophic failures. The initial trigger is often mundane: a slow query, a cache miss, a pod that takes too long to start. The catastrophe comes from how the system responds to that trigger.
+
+Understanding feedback loops is understanding the DNA of system behavior. When you can map the loops in an architecture, you stop asking "which service broke?" and start asking "which relationship is amplifying stress right now?" That shift—from component blame to loop diagnosis—is one of the highest-leverage skills in platform engineering.
+
+A system with well-designed feedback loops is antifragile in the practical sense: it stabilizes under stress, recovers from failures, and learns from load. A system with poorly designed feedback loops is a time bomb—stable in normal conditions, catastrophic when stressed. Many teams discover this only during their first major traffic spike or regional outage.
+
+This module teaches you to recognize feedback loops before they bite, predict which loops will help and which will harm, design systems that use feedback safely, and break dangerous loops before they cascade. You will work through reinforcing and balancing loops, delay-induced oscillation, six common failure patterns in distributed systems, and concrete design principles you can apply in YAML, code, and architecture reviews.
+
+> **The Thermostat Principle**
+>
+> Your home thermostat is a perfect feedback loop. Temperature drops below setpoint → heater turns on → temperature rises → heater turns off. This is a **balancing loop**—it opposes change, maintaining stability around a target.
+>
+> Now imagine if your thermostat were wired backwards: temperature drops → heater turns *off*. That is a **reinforcing loop**—it amplifies change. Your house would freeze while the control system confidently "corrected" in the wrong direction.
+>
+> Most production incidents are just thermostats wired backwards. The system is trying to help, but its corrective actions make things worse. This module teaches you to spot backwards thermostats before they freeze your production systems.
 
 ---
 
 ## Part 1: The Two Types of Feedback Loops
 
-All feedback loops fall into two categories. Master this distinction and you'll understand half of all production incidents.
+All feedback loops fall into two categories. Master this distinction and you will understand a large fraction of production incidents. Every loop you map on a whiteboard during an outage review will be either reinforcing (amplifying change) or balancing (opposing change). The vocabulary comes from systems dynamics and control theory, but the production patterns are concrete: retries, autoscaling, rate limits, and cache behavior all express one of these two forms.
 
 ### 1.1 Reinforcing Loops: The Amplifiers
 
-**Reinforcing loops** amplify change. Whatever direction the system is moving, reinforcing loops push it further. They're called "positive feedback" not because they're good (they usually aren't), but because they *add to* the existing trend.
+**Reinforcing loops** amplify change. Whatever direction the system is moving, reinforcing loops push it further. They are called "positive feedback" not because they are good (they usually are not in production), but because they *add to* the existing trend. If latency is rising, a reinforcing loop makes latency rise faster. If errors are increasing, a reinforcing loop increases errors at an accelerating rate.
 
-Think of a microphone placed in front of a speaker. Sound enters the mic → gets amplified → comes out the speaker → enters the mic louder → gets amplified more. Without intervention, you get that ear-piercing screech within seconds.
+Think of a microphone placed in front of a speaker. Sound enters the mic, gets amplified, comes out the speaker, enters the mic louder, and gets amplified more. Without intervention, you get that ear-piercing screech within seconds. The loop has no target and no inversion—it only amplifies.
 
 > **Pause and predict**: What happens if a system has a reinforcing loop but no balancing loop to counteract it?
 
@@ -103,35 +100,37 @@ flowchart TD
     end
 ```
 
-**Timeline of a real incident:**
+**Illustrative timeline (hypothetical):** The table below shows how a reinforcing retry loop can escalate quickly. Numbers are rounded for teaching; real systems vary by retry policy, timeout settings, and downstream capacity.
 
-| Time | Latency | Timeouts | Load |
+| Time | Latency | Timeouts | Effective Load |
 |---|---|---|---|
-| t=0:00 | 200ms | 0/sec | 1000 req/s |
-| t=0:30 | 500ms | 50/sec | 1050 req/s |
-| t=1:00 | 2000ms | 400/sec | 1400 req/s |
-| t=1:30 | 5000ms | 1200/sec | 2200 req/s |
-| t=2:00 | DEAD | ALL | 4000+ req/s |
+| t=0:00 | 200ms | 0/sec | baseline |
+| t=0:30 | 500ms | low | modest increase |
+| t=1:00 | 2000ms | moderate | noticeable increase |
+| t=1:30 | 5000ms | high | large increase |
+| t=2:00 | service degraded | very high | runaway |
 
-*From "a little slow" to "completely dead" in 2 minutes.*
+*Illustrative escalation: from "a little slow" to "effectively dead" can happen in minutes when reinforcing loops dominate and no circuit breaker or backoff breaks the cycle.*
 
-**The mathematics of reinforcing loops are terrifying.** If each loop iteration increases load by just 10%, after 10 iterations you're at 2.6x original load. After 20 iterations, 6.7x. After 30, 17x. This is exponential growth—and it happens fast.
+**The mathematics of reinforcing loops are terrifying in practice.** If each loop iteration increases effective load by even a modest percentage, growth compounds quickly. Ten percent per iteration doubles effective load in roughly seven iterations; twenty percent per iteration does it in fewer than four. This is exponential growth—and in distributed systems the "iterations" can happen every few hundred milliseconds when retries and timeouts are aggressive.
 
-**Common reinforcing loops in production:**
+**Common reinforcing loops in production** include retry storms (failure triggers retries, retries add load, load causes more failure), cache stampedes (synchronized cache expiry causes simultaneous database hits), connection pool exhaustion (slow queries hold connections, pool fills, more requests wait and retry), memory pressure spirals (swapping slows processing, which increases memory pressure), and alert fatigue in human systems (too many alerts lead to ignoring alerts, which leads to missed incidents and more reactive monitoring). Each pattern has the same signature: a small deviation triggers responses that enlarge the deviation.
 
 | Loop | How It Works | Why It's Dangerous |
 |------|--------------|-------------------|
-| **Retry storms** | Failure → retry → more load → more failure | Can 10x load in minutes |
+| **Retry storms** | Failure → retry → more load → more failure | Can multiply load rapidly |
 | **Cache stampede** | Cache expires → all hit DB → DB slows → cache stays empty | Synchronized devastation |
 | **Connection pool exhaustion** | Slow queries → connections held → pool fills → more waiting | Everything stops |
 | **Memory pressure** | Swapping → slower processing → more memory pressure | Gradual then sudden death |
 | **Alert fatigue** | Too many alerts → ignored → more incidents → more alerts | Human systems fail too |
 
+When you review an architecture diagram, mark every path where "problem → automatic response → more of the same problem" can occur. Those paths are reinforcing loops waiting for the right stress level.
+
 ### 1.2 Balancing Loops: The Stabilizers
 
-**Balancing loops** oppose change. They push the system back toward a target or equilibrium. They're called "negative feedback" because they *subtract from* the current trend.
+**Balancing loops** oppose change. They push the system back toward a target or equilibrium. They are called "negative feedback" because they *subtract from* the current trend—not because they are negative in the emotional sense, but because they counteract deviation from a goal.
 
-Your body temperature is maintained by balancing loops. Too hot → you sweat → cooling → temperature drops. Too cold → you shiver → heat generation → temperature rises. The target is 37°C, and your body fights any deviation.
+Your body temperature is maintained by balancing loops. Too hot → you sweat → cooling → temperature drops toward target. Too cold → you shiver → heat generation → temperature rises. The target is roughly 37°C, and your body continuously fights deviation. Production autoscaling works the same way at a systems level: high CPU → add pods → load per pod drops → CPU returns toward target.
 
 ```mermaid
 flowchart TD
@@ -143,32 +142,25 @@ flowchart TD
     R --> M
 ```
 
-This is a **BALANCING** loop: it opposes change.
-High CPU → action → lower CPU. Low CPU → action → higher CPU. System stabilizes around target.
+This is a **balancing** loop: it opposes change. High CPU triggers action that lowers CPU; low CPU triggers action that raises CPU. The system stabilizes around a target rather than running away from it.
 
-**Common balancing loops in production:**
+**Common balancing loops in production** include autoscaling (high load → add capacity → lower load per instance), rate limiting (too many requests → reject excess → manageable load), circuit breakers (failures rise → stop calling failing dependency → failures drop on the caller side), backpressure (queue full → slow producers → queue drains), and garbage collection (memory fills → GC runs → memory freed). These mechanisms are essential—but as Part 2 explains, they fail when delays are misaligned with evaluation speed.
 
 | Loop | How It Works | What It Protects |
-|------|--------------|-----------------|
+|------|--------------|-------------------|
 | **Autoscaling** | High load → add capacity → lower load | Performance |
 | **Rate limiting** | Too many requests → reject excess → manageable load | Availability |
 | **Circuit breakers** | Failures rise → stop calling → failures drop | Dependencies |
 | **Backpressure** | Queue full → slow producers → queue drains | Memory |
 | **Garbage collection** | Memory fills → GC runs → memory freed | Stability |
 
-> **Did You Know?**
->
-> - Your body contains over **200 feedback loops** maintaining temperature, blood sugar, blood pressure, pH levels, and more. Engineers who study biology often build more resilient systems.
->
-> - The **steam engine governor** (1788) was one of the first mechanical feedback loops. When the engine sped up, weights flew outward and closed the steam valve. James Watt's governor made the Industrial Revolution possible.
->
-> - **Predator-prey cycles** in nature are feedback loops. Rabbits increase → foxes increase (more food) → rabbits decrease (more predation) → foxes decrease (less food) → rabbits increase again. Ecologists mapped these loops in the 1920s; they're now used to model cloud services.
+Biological and industrial systems offer useful parallels for platform engineers. Your body maintains temperature, blood sugar, and blood pressure through hundreds of active feedback loops—stability is something organisms *do*, not something they passively enjoy. The steam engine governor (1788) was an early mechanical balancing loop: as engine speed increased, centrifugal weights closed a steam valve, preventing runaway rotation and making factory power predictable. Ecological predator-prey cycles—prey rise, predators rise, prey fall, predators fall—were mapped by ecologists in the early twentieth century and mirror queue-and-consumer dynamics in message-driven services today.
 
 ### 1.3 Identifying Loop Types: The Polarity Test
 
-Quick technique: Count the inversions. An **inversion** is when an increase in one thing causes a *decrease* in another (or vice versa).
+Quick technique for classifying loops during incident reviews: count the **inversions**. An inversion is when an increase in one variable causes a *decrease* in another (or vice versa) somewhere in the loop. Reinforcing loops have an even number of inversions (often zero). Balancing loops have an odd number of inversions (typically one).
 
-> **Stop and think**: Can a system have both reinforcing and balancing loops at the same time? Which one usually wins?
+> **Stop and think**: Can a system have both reinforcing and balancing loops at the same time? Which one usually wins under stress?
 
 ```mermaid
 flowchart LR
@@ -185,45 +177,39 @@ flowchart LR
     end
 ```
 
-Quick test: Start with "A increases" and follow the loop.
-If A ends up increasing more → Reinforcing
-If A ends up decreasing back → Balancing
+**How to apply the polarity test:** Start with "A increases" and follow the causal chain around the loop. If A ends up increasing more without an opposing force, the loop is reinforcing. If A ends up decreasing back toward a setpoint, the loop is balancing. When multiple loops interact, the loop with the shortest effective delay often dominates early in an incident; reinforcing loops with fast iteration can overwhelm slower balancing loops before autoscaling or human intervention catches up.
 
-**Practice examples:**
+The polarity test below walks through three production-style examples so you can practice classifying loops as reinforcing or balancing before you encounter them in a live incident review.
 
-1. **Rate limiting:** Requests ↑ → Rejections ↑ → *Accepted requests* ↓ → Load ↓
-   - One inversion (more rejections = fewer accepted) = **Balancing**
+For **rate limiting**, requests increase, rejections increase, and accepted requests decrease, which reduces load on backends—one inversion, so this is a **balancing** loop when viewed from the server's perspective (though client-side immediate retries can create a reinforcing loop on the client).
 
-2. **Cache miss cascade:** Misses ↑ → DB queries ↑ → DB latency ↑ → Cache timeout ↑ → Misses ↑
-   - Zero inversions = **Reinforcing**
+For **cache miss cascade**, cache misses increase, database queries increase, database latency increases, cache timeouts cause more misses—zero inversions around the failure path, so this is **reinforcing**.
 
-3. **Pod eviction:** Memory ↑ → Eviction ↑ → *Running pods* ↓ → *Load per pod* ↑ → Memory ↑
-   - Two inversions = **Reinforcing** (eviction makes things worse!)
+For **pod eviction under memory pressure**, memory use increases, evictions increase, running pods decrease, load per remaining pod increases, memory per pod increases—two inversions, which is even, so the eviction response can behave as **reinforcing** under certain conditions: evicting pods to "help" the cluster can concentrate load and worsen memory pressure on survivors.
+
+Real architectures rarely have a single loop. During an outage you often see HPA trying to balance CPU while retry logic reinforces load on the database. Your job is to identify which loop is winning *right now* and break or damp the dangerous one first. A practical review habit is to draw two columns on a whiteboard—reinforcing on the left, balancing on the right—and place every automatic response you find into one column before you change any configuration. If the left column fills faster than the right during stress, your architecture is biased toward amplification.
+
+### 1.4 Stock-and-Flow View of Loops
+
+Feedback loops are easier to reason about when you name the **stock** (something that accumulates) and the **flow** (something that changes the stock). Connection pool occupancy is a stock; incoming requests and connection releases are flows. Queue depth is a stock; enqueue and dequeue rates are flows. Reinforcing loops often appear when a flow increases the stock and a higher stock increases the same flow—retries increase in-flight work, which increases latency, which increases retries. Balancing loops appear when a flow opposes stock growth—rate limiting reduces accepted requests when the queue stock grows too large.
+
+When you diagram a loop for an incident review, write the stock in the center and label each arrow with its delay. Teams that skip the stock-and-flow step often misclassify loops because they focus on services (components) instead of accumulated pressure (connections held, messages waiting, memory used). The stock perspective also clarifies **where to intervene**: you can sometimes break a reinforcing loop by draining a stock (purge a poison queue), capping a stock (max pool size with fast reject), or slowing a flow (backoff on retries) without redeploying application code.
 
 ---
 
 ## Part 2: Delays—Why Good Loops Go Bad
 
-Here's the dirty secret of feedback loops: **balancing loops can become destructive when delays are too long.** A well-intentioned stabilizing mechanism can oscillate wildly, causing more damage than if it didn't exist at all.
+Here's the dirty secret of feedback loops: **balancing loops can become destructive when delays are too long relative to how fast the controller reacts.** A well-intentioned stabilizing mechanism can oscillate wildly, causing more damage than if it didn't exist at all. Autoscaling is the canonical example: it is designed to stabilize load, but with the wrong timing it creates perpetual over-provisioning and under-provisioning cycles.
+
+Delay is not a minor tuning detail—it defines whether a balancing loop feels smooth or chaotic. Control engineers express this with concepts like phase lag and overshoot; platform engineers feel it as "we scaled to a hundred pods and then immediately scaled back down while users still couldn't check out."
 
 ### 2.1 The Shower Problem
 
-Everyone has experienced this. Hotel shower. Unfamiliar controls.
+Everyone has experienced this. Hotel shower. Unfamiliar controls. You turn up the hot because the water feels cold, but nothing changes immediately because hot water is still traveling through the pipes. You turn up more, still cold, turn up even more—and then scalding hot water arrives all at once because all your adjustments hit together. You yank toward cold, but hot water is still in the pipe, so you overshoot to freezing, crank colder, and repeat until you give up.
 
-1. Water is cold
-2. Turn up the hot
-3. Still cold (water still in pipes)
-4. Turn up more
-5. Still cold (patience running thin)
-6. Turn up even more
-7. **SCALDING HOT** (all adjustments hit at once)
-8. Yank it to cold
-9. Still hot (pipe delay again)
-10. Crank it colder
-11. **FREEZING**
-12. Repeat until you give up
+This is a **balancing loop with delay**. The loop is trying to stabilize temperature toward your comfort target, but the delay between your action and the measured result causes overshoot in both directions. The longer the delay relative to how fast you adjust, the worse the oscillation. Production autoscaling exhibits the same human-visible frustration at cluster scale: metrics say "add capacity," you add capacity, metrics still say "add capacity" because new capacity is not ready yet, you add more, and eventually you flood the system with idle or half-ready pods.
 
-This is a **balancing loop with delay**. The longer the delay relative to how fast you adjust, the worse the oscillation. The loop is trying to stabilize temperature, but the delay causes overshoot in both directions.
+The shower problem teaches an operational lesson: **when feedback feels "laggy," slow down your control actions.** In software, that means longer evaluation intervals, stabilization windows, and smoothed metrics—not faster reactions to stale measurements.
 
 ### 2.2 Autoscaler Oscillation: A Story in Three Graphs
 
@@ -255,9 +241,13 @@ sequenceDiagram
     Note over HPA, Pods: Oscillation continues indefinitely
 ```
 
+The sequence diagram shows a balancing loop fighting itself. HPA measures CPU, compares to target, and adds pods—but pod readiness delay means the measurement does not reflect the effect of previous scale-up decisions for several minutes. Each 15-second evaluation sees "still high CPU" and adds more pods. When pods finally become ready, CPU drops sharply and HPA aggressively scales down, potentially undershooting before traffic fills the reduced fleet. Without stabilization windows and alignment between evaluation period and provisioning delay, the cluster breathes in and out indefinitely, wasting cost and churning connections, caches, and warm JVM heaps.
+
+To fix oscillation you need at least one of: slower scale-up decisions relative to startup delay, faster provisioning (smaller images, pre-warmed pools), better signals (queue depth or request latency rather than CPU alone), or explicit damping (stabilization windows, max scale step per period).
+
 ### 2.3 The Delay Inventory
 
-Every feedback loop contains delays. Knowing your delays is essential for tuning loops correctly.
+Every feedback loop contains delays. Knowing your delays is essential for tuning loops correctly. Incident post-mortems often reveal that teams knew autoscaling existed but never summed metric scrape interval, query aggregation window, HPA evaluation period, pod schedule time, image pull, init container, readiness probe, and dependency warmup into a single "time until my scale-up helps" figure.
 
 | Delay Type | Typical Duration | Where It Lurks |
 |------------|-----------------|----------------|
@@ -271,42 +261,39 @@ Every feedback loop contains delays. Knowing your delays is essential for tuning
 | **Deployment pipeline** | 300-3600s | Build + test + deploy |
 | **Cache invalidation** | Variable | TTL or explicit purge |
 
-**The total loop delay** is the sum of all delays in the loop. If your HPA evaluates every 15 seconds but pods take 3 minutes to start, your effective loop delay is 3+ minutes.
+**The total loop delay** is the sum of all delays in the loop path from disturbance to corrective effect visible in the metric the controller uses. If your HPA evaluates every 15 seconds but pods take several minutes to become ready and serve traffic, your effective loop delay is dominated by startup time—not evaluation interval. Controllers that react faster than the plant can respond (in control-theory terms) will overshoot.
 
-> **War Story: The Autoscaler That Destroyed Itself (Extended Version)**
+> **Hypothetical scenario:** A logistics company runs an order-tracking system on Kubernetes. They configure an HPA to scale based on a custom metric: messages in the processing queue. Scaling on queue depth is a reasonable idea— it ties capacity to actual backlog rather than proxy metrics alone.
 >
-> A logistics company ran their order tracking system on Kubernetes. They configured an HPA to scale based on a custom metric: messages in the processing queue. Clever idea—scale based on actual work, not just CPU.
+> The metric comes from their message broker, scraped by Prometheus every 30 seconds, aggregated over one minute for smoothing. Total measurement delay is on the order of one to two minutes from queue state change to metric availability.
 >
-> The metric came from their message broker, scraped by Prometheus every 30 seconds, aggregated over 1 minute for smoothing. Total delay: about 2 minutes from queue state to metric availability.
+> The HPA evaluates every 15 seconds. Every evaluation looks at somewhat stale queue data and may add pods. During a traffic burst, queue depth jumps. For roughly two minutes, each evaluation still sees "queue growing" and adds more pods before fresh metrics reflect earlier scale-up effects.
 >
-> The HPA evaluated every 15 seconds. So every 15 seconds, it would look at 2-minute-old data and make scaling decisions.
+> By the time accurate metrics arrive, the fleet may be several times larger than needed for the actual backlog. Each pod opens multiple database connections. Connection demand exceeds pool limits. Pods fail health checks. A node autoscaler, seeing failing pods, may add nodes—each hosting more pods that compete for the same saturated connection pool.
 >
-> One Thursday, a burst of orders came in. Queue depth jumped. The 2-minute-old metric showed "queue growing." HPA added 5 pods. Fifteen seconds later, still seeing "queue growing" (stale metric). Added 5 more. This continued for 2 minutes until fresh metrics arrived.
+> The database, overwhelmed with connection attempts and queries, times out. Queue processing slows. The queue grows. The HPA, now seeing accurate metrics of a growing queue, tries to add more pods—reinforcing the failure while attempting to balance backlog.
 >
-> By then, they had 47 pods for a queue that 8 pods could handle. But it got worse.
->
-> Each pod needed 3 database connections. 47 pods × 3 connections = 141 connections. Their connection pool max was 100. Pods started failing health checks. The node autoscaler, seeing failing pods, added more nodes to "help." Each new node started more pods. More pods meant more connection attempts against a saturated pool.
->
-> The database, overwhelmed with connection attempts, started timing out actual queries. The queue processing slowed. The queue grew. The HPA saw the growing queue (in now-accurate metrics) and tried to add more pods.
->
-> At the peak, they had 400+ pods failing to start across 12 nodes, their database completely unresponsive, and zero orders being processed.
->
-> The fix took three changes:
-> 1. Increased HPA evaluation interval to exceed metric delay (3 minutes)
-> 2. Added stabilization windows (5 minutes before scale-down)
-> 3. Set connection pool limits as pod resource constraints
->
-> Total outage: 47 minutes. Revenue impact: $230,000. The fix: 3 lines of YAML.
+> Recovery required aligning control speed with measurement and provisioning delay: increasing HPA evaluation interval to exceed metric delay, adding scale-down stabilization windows, and tying connection pool sizing to known downstream limits rather than unconstrained pod count.
+
+This scenario is hypothetical, but its ingredients—custom metrics, scrape delay, aggressive evaluation, connection pool limits, and node-level reactions—appear repeatedly in real post-mortems. The fix is usually not "remove autoscaling" but "slow the loop until the plant can keep up." Document your total delay in runbooks so on-call engineers do not tighten HPA intervals during an outage in the mistaken belief that faster reaction equals faster recovery.
+
+### 2.4 Measuring Total Loop Delay in Practice
+
+To measure total loop delay for an autoscaling path, walk the causal chain on paper and add conservative estimates. Start when user traffic increases. Add metric scrape interval, PromQL evaluation range, HPA sync period, scheduler queue time, image pull duration, init container time, readiness probe failure budget until Ready=True, and any application warmup before the new replica accepts production share. If that sum is five minutes, an HPA that evaluates every fifteen seconds will make many decisions before the first scale-up helps—each decision may add more replicas or trigger downstream saturation.
+
+The same exercise applies to human loops: page delivery latency, time to open dashboard, time to identify loop type, time to apply mitigation, time for mitigation to affect user-visible metrics. Organizational loops fail for the same mathematical reason as HPA oscillation: the controller reacts faster than the system can respond. Runbooks that say "scale up immediately" without noting startup delay can accidentally instruct engineers to reinforce oscillation during incidents.
 
 ---
 
 ## Part 3: The Six Deadly Loops
 
-These patterns cause the majority of cascading failures in distributed systems. Learn to recognize them instantly.
+These patterns cause a large share of cascading failures in distributed systems. Learn to recognize them instantly during architecture review and incident response. Each pattern below includes a reinforcing or mis-tuned balancing mechanism, typical triggers, and practical breaking strategies. None of these are exotic—they are the default failure modes of retries, caches, pools, Kubernetes eviction, alerting, and capacity planning done without loop awareness. When you read public post-mortems, practice mapping the narrative to one or more of these six patterns; over time you will notice that authors use different vendor names but describe the same causal shapes repeatedly.
+
+The list is deliberately finite. You do not need fifty named antipatterns to run production—you need reliable recognition of the small set that recurs because our tools (retries, caches, pools, schedulers, pagers, budgets) all implement feedback. Mastery looks like sketching the loop on a whiteboard in the first ten minutes of an incident and choosing a breaker that matches the pattern, not restarting random pods until the graph looks quieter for a moment.
 
 ### 3.1 The Retry Storm
 
-**Pattern:** Failure triggers retries, retries add load, load causes more failures.
+**Pattern:** Failure triggers retries, retries add load, load causes more failures. Retry logic is often added to improve reliability for transient errors, but without backoff, jitter, and budgets it becomes one of the fastest reinforcing loops in production.
 
 ```mermaid
 flowchart LR
@@ -315,15 +302,11 @@ flowchart LR
     C --> D[Death Spiral\n+3000 retries\n100% failure]
 ```
 
-**Breaking the loop:**
-- Exponential backoff: Each retry waits longer
-- Jitter: Randomize backoff to prevent synchronization
-- Retry budgets: Limit total retries per time window
-- Circuit breakers: Stop retrying after threshold
+**Breaking the loop** requires treating retries as a scarce resource: exponential backoff so each retry waits longer and gives the dependency time to recover; jitter so retries desynchronize across clients; retry budgets limiting total retries per time window; and circuit breakers that stop calling a failing dependency after a threshold so the caller fails fast instead of amplifying load. Google SRE guidance and the broader microservices literature emphasize that retries multiply traffic—if ten clients each retry three times on timeout, you have up to forty attempts per original request under worst-case alignment.
 
 ### 3.2 The Thundering Herd
 
-**Pattern:** Synchronized events cause coordinated resource access.
+**Pattern:** Synchronized events cause coordinated resource access. The herd is not malicious—it is often the result of sensible design choices like fixed cache TTLs, cron schedules, or mobile app daily resets that align millions of clients to the same clock.
 
 ```mermaid
 sequenceDiagram
@@ -346,15 +329,11 @@ sequenceDiagram
     Note over D: DYING - Cannot recover
 ```
 
-**Breaking the loop:**
-- Jittered TTLs: `TTL = 3600 + random(-300, 300)` seconds
-- Single-writer pattern: One request populates cache, others wait
-- Cache warming: Refresh before expiration
-- Request coalescing: Deduplicate identical in-flight requests
+**Breaking the loop** uses jittered TTLs so expirations spread over time (`TTL = base + random offset`), single-writer or request-coalescing patterns so one backend query repopulates cache while others wait, proactive cache warming before expiry for known hot keys, and stale-while-revalidate semantics so clients can serve slightly old data while refresh happens in the background. The goal is to convert a spike into a slope the database can absorb.
 
 ### 3.3 The Connection Pool Death Spiral
 
-**Pattern:** Slow operations hold connections longer, exhausting the pool.
+**Pattern:** Slow operations hold connections longer, exhausting the pool, which causes more waiting, timeouts, and retries—each retry needing a connection that is not available. Connection pools are balancing mechanisms (limit concurrency to protect the database) that become reinforcing failure paths when hold times increase.
 
 ```mermaid
 flowchart TD
@@ -365,35 +344,27 @@ flowchart TD
     E --> C
 ```
 
-**Breaking the loop:**
-- Connection timeouts: Release connections if held too long
-- Query timeouts: Kill queries that exceed threshold
-- Pool sizing: Size based on downstream capacity, not demand
-- Bulkheading: Separate pools for different operation types
+**Breaking the loop** requires query and connection timeouts so stuck work releases resources, pool sizing based on downstream capacity rather than frontend demand alone, bulkheads separating pools for critical vs. batch traffic, and admission control at the edge so you reject work before opening connections you cannot service. Michael Nygard's stability patterns in *Release It!* treat pools as bulkheads—when the bulkhead fills, the system must shed load, not queue indefinitely.
 
 ### 3.4 The Eviction Cascade
 
-**Pattern:** Resource pressure causes evictions, evictions redistribute load, causing more pressure.
+**Pattern:** Resource pressure causes evictions, evictions redistribute load onto remaining pods, which increases per-pod pressure and triggers more evictions. Kubernetes memory limits and OOM kills are balancing loops at the node level that can behave as reinforcing cascades at the workload level.
 
 ```mermaid
 flowchart TD
-    A[10 Pods: 10% load each, 400MB memory] --> B[Memory leak in Pod 3 hits 512MB limit]
+    A[10 Pods: 470MB each of a 512MB limit, already 92 percent full] --> B[Memory leak pushes Pod 3 to the 512MB limit]
     B --> C[Pod 3 OOMKilled and Evicted]
-    C --> D[9 Pods: 11% load each, 440MB memory]
-    D --> E[Pod 2 hits limit and is OOMKilled]
-    E --> F[8 Pods: More load, more memory]
+    C --> D[9 surviving Pods absorb the evicted load: now about 522MB each, over the 512MB limit]
+    D --> E[Pod 2 crosses the limit and is OOMKilled]
+    E --> F[8 Pods: per-pod memory climbs further]
     F --> G[Cascade accelerates until cluster collapse]
 ```
 
-**Breaking the loop:**
-- PodDisruptionBudgets: Limit concurrent evictions
-- Proper resource requests: Ensure headroom
-- Horizontal scaling: Add pods before eviction, not after
-- Memory leak detection: Alert before OOM
+**Breaking the loop** uses PodDisruptionBudgets to limit concurrent evictions, realistic resource requests and limits with headroom, horizontal scaling before memory saturation rather than after, and memory leak detection with alerts before OOM. Eviction is a signal that the scheduler and kubelet are "helping"—but concentrating traffic on fewer pods can accelerate failure unless scale-out keeps pace.
 
 ### 3.5 The Alert Storm
 
-**Pattern:** Incidents generate alerts, alerts overwhelm responders, overwhelmed responders miss alerts, more incidents.
+**Pattern:** Incidents generate alerts, alerts overwhelm responders, overwhelmed responders miss or mute alerts, real incidents go unnoticed, post-incident reviews add more monitoring, and the cycle repeats. Human attention is part of the system; alert pipelines are feedback loops too.
 
 ```mermaid
 flowchart TD
@@ -407,15 +378,11 @@ flowchart TD
     I --> F
 ```
 
-**Breaking the loop:**
-- Alert on symptoms, not causes (user impact, not internal metrics)
-- Every alert must be actionable
-- Regular alert review: Delete alerts nobody acts on
-- On-call feedback: Track alert-to-incident ratio
+**Breaking the loop** means alerting on user-visible symptoms and SLO burn rather than every internal metric fluctuation, requiring every alert to be actionable with a linked runbook, regular alert review to delete alerts nobody acts on, and tracking alert-to-incident ratio as a quality metric. Google SRE's alerting guidance distinguishes pages (wake a human) from tickets (fix later)—if everything pages, nothing pages effectively.
 
 ### 3.6 The Capacity Planning Spiral
 
-**Pattern:** Under-provisioning causes incidents, incidents cause over-provisioning, budgets cut, under-provisioning.
+**Pattern:** Under-provisioning causes incidents, incidents cause over-provisioning and budget scrutiny, budgets cut capacity, next peak under-provisions again. This is an organizational balancing loop with annual period and strong political delay.
 
 ```mermaid
 flowchart TD
@@ -430,26 +397,32 @@ flowchart TD
     I --> D
 ```
 
-**Breaking the loop:**
-- Load testing: Know your actual limits
-- Autoscaling: Match capacity to demand
-- Cost attribution: Show cost vs. revenue at traffic levels
-- Chaos engineering: Prove you can handle expected peaks
+**Breaking the loop** requires load testing to know actual limits, autoscaling to match capacity to demand dynamically, cost attribution that shows spend versus revenue at traffic levels, and chaos or game-day exercises that prove peak handling before marketing announces the peak. Without measured headroom, capacity debates oscillate between fear and waste. Finance and engineering should share the same graph: traffic percentile, utilization, error rate, and cost per successful request—when those series diverge, the organizational loop is already running.
+
+### 3.7 Combining Patterns: The Perfect Storm
+
+Individual deadly loops are teachable in isolation; real outages combine them. A cache stampede increases database latency, which triggers retry storms, which exhausts connection pools, which causes health check failures, which prompts HPA or node autoscaler to add capacity that cannot obtain connections. Each pattern alone might be survivable; together they form a reinforcing **meta-loop** where each mitigation attempt (more pods, more retries, more alerts) feeds the next failure mode.
+
+During incident response, prioritize **stopping amplification** before **restoring capacity**. Opening circuit breakers, enabling aggressive load shedding, and disabling nonessential retries often feel counterintuitive because they increase visible errors temporarily—but they break the meta-loop so balancing mechanisms can work again. Adding capacity into an active reinforcing loop frequently worsens outcomes because new replicas participate in the same retry and connection behavior as failing ones.
 
 ---
 
 ## Part 4: Designing with Feedback in Mind
 
+Designing for feedback loops means asking, for every automatic response in your system, what happens if the response arrives too late, too aggressively, or while a reinforcing loop is already running. The principles below are not abstract—they map directly to HPA behavior blocks, retry libraries, cache clients, and circuit breaker middleware. Good design reviews treat feedback like security: assume loops will activate under stress and document how you detect and break them before launch, not after the first Black-Friday-scale event.
+
+Platform teams often inherit loops from application defaults—generous retry counts, optimistic pool sizes, aggressive HPA targets—without tracing combined behavior. Your checklist in section 4.2 is the minimum bar; pairing it with load tests that *intentionally* slow a dependency (fault injection on database latency, cache flush, pod startup delay) reveals loops that steady-state monitoring never shows.
+
 ### 4.1 Principles for Safe Feedback Loops
 
-**Principle 1: Match loop speed to delay**
-
-If your system changes faster than your feedback loop can respond, you'll oscillate. The loop evaluation period should exceed the total delay.
+**Principle 1: Match loop speed to delay.** If your system changes faster than your feedback loop can respond effectively, you will oscillate or overshoot. The loop evaluation period should generally exceed the dominant delay in the loop, or you must use heavy damping. For Kubernetes HPA, that means stabilization windows, scale policies with max step sizes, and metrics that reflect user-visible backlog rather than instantaneous CPU spikes alone.
 
 ```yaml
 # Kubernetes HPA with proper stabilization
 apiVersion: autoscaling/v2
 kind: HorizontalPodAutoscaler
+metadata:
+  name: my-app-hpa
 spec:
   scaleTargetRef:
     apiVersion: apps/v1
@@ -483,9 +456,7 @@ spec:
       selectPolicy: Max                 # Use whichever allows more scaling
 ```
 
-**Principle 2: Add damping to prevent oscillation**
-
-Damping slows down responses, trading speed for stability. Like shock absorbers on a car.
+**Principle 2: Add damping to prevent oscillation.** Damping slows down responses, trading speed for stability—like shock absorbers on a car. Instead of reacting to every metric sample, require sustained deviation, moving averages over multiple samples, and cooldown periods between scale actions.
 
 ```python
 # Bad: React to every measurement
@@ -514,7 +485,9 @@ class DampedScaler:
 
         avg_cpu = sum(self.measurements) / len(self.measurements)
 
-        # Require sustained deviation
+        # Require sustained deviation (need a full 5-sample window first)
+        if len(self.measurements) < 5:
+            return  # Not enough history to confirm a sustained trend
         if all(m > 70 for m in self.measurements[-5:]):
             add_pods(2)  # Smaller increments
             self.last_scale_time = time.time()
@@ -523,9 +496,7 @@ class DampedScaler:
             self.last_scale_time = time.time()
 ```
 
-**Principle 3: Break reinforcing loops with circuit breakers**
-
-Don't let failure amplify failure. Insert breaks in the loop.
+**Principle 3: Break reinforcing loops with circuit breakers.** Do not let failure amplify failure. Insert breaks in the loop so callers fail fast and shed load instead of retrying into a dying dependency. Circuit breakers implement a state machine: closed (normal), open (reject calls), half-open (probe recovery).
 
 ```python
 class CircuitBreaker:
@@ -557,12 +528,14 @@ class CircuitBreaker:
             raise
 
 # Usage: Breaks the retry storm loop
-@circuit_breaker(failure_threshold=5, recovery_timeout=30)
+payment_breaker = CircuitBreaker(failure_threshold=5, recovery_timeout=30)
+
 def call_payment_service(order):
-    return http_client.post("/payments", order)
+    # Route the call through the breaker rather than calling http_client directly
+    return payment_breaker.call(http_client.post, "/payments", order)
 ```
 
-**Principle 4: Add jitter to prevent synchronization**
+**Principle 4: Add jitter to prevent synchronization.** Synchronized timers turn benign periodic work into thundering herds. Randomize cache TTLs, retry delays, and cron offsets so correlated clients desynchronize over time.
 
 ```python
 # Bad: All caches expire at exactly the same time
@@ -586,13 +559,11 @@ def retry_with_backoff(func, max_retries=5):
     raise MaxRetriesExceeded()
 ```
 
+**Principle 5: Make loops observable.** If you cannot see loop behavior in metrics, you cannot tune it. Track retry rates, pool utilization, cache hit ratio, HPA desired versus ready replicas, circuit breaker state, and queue depth alongside user-facing latency and error rate. During incidents, plot these on the same timeline to see reinforcing loops accelerate.
+
 ### 4.2 The Feedback Loop Checklist
 
-Before deploying any system with feedback mechanisms, answer these questions:
-
-### Feedback Loop Analysis Checklist
-
-For each feedback loop in your system:
+Before deploying any system with feedback mechanisms, walk through the checklist below for **each feedback loop** in the architecture—name the elements, classify reinforcing versus balancing behavior, and document delays before you rely on autoscaling or retries under load.
 
 - [ ] **IDENTIFICATION**
   - What are the elements in the loop?
@@ -619,17 +590,25 @@ For each feedback loop in your system:
   - What metrics show loop behavior?
   - How would you detect a runaway loop?
 
+When two loops interact—HPA plus retries plus connection pools—document the combination explicitly. The deadliest outages often come from benign loops that turn reinforcing only when combined under load. Schedule a quarterly "loop review" alongside dependency mapping: for each new feature flag, retry policy, or autoscaling metric, ask which of the six deadly patterns it could activate and what breaker you added at design time.
+
+### 4.3 Decision Framework: Stabilize or Amplify?
+
+Use this framework when triaging live loop behavior or reviewing designs. **Step one—classify:** Is the dominant loop reinforcing or balancing? Count inversions or follow the trend: are errors/latency/queue depth accelerating (reinforcing) or returning toward target (balancing)? **Step two—measure delay:** What is total loop delay versus evaluation interval? If evaluation is faster than delay, expect overshoot even from well-intentioned automation. **Step three—choose intervention:** For reinforcing dominance, break the loop (circuit breaker, shed load, disable retries, add jitter) before adding capacity. For balancing oscillation, slow the controller (stabilization windows, larger evaluation period, smoothed metrics) before removing the balancer entirely.
+
+**Step four—verify observability:** After mitigation, you should see the accelerating metric flatten within one to two loop delays. If it keeps accelerating, you have not broken the reinforcing path—you have only shifted load. **Step five—post-incident:** Update architecture docs with the loop diagram and the measured delays so the next reviewer inherits stock-and-flow context instead of folklore about "that one time we scaled to a hundred pods."
+
 ---
 
 ## Did You Know?
 
-- **Audio engineers** use feedback loops intentionally. Electric guitar sustain comes from controlled feedback between the pickups and amplifier. Jimi Hendrix was a master of feedback control.
+- **Audio engineers** use feedback loops intentionally. Electric guitar sustain comes from controlled feedback between the pickups and amplifier. Jimi Hendrix was a master of feedback control—the same physics that destroys microphone setups creates musical expression when bounded.
 
-- **The 2010 Flash Crash** (stock market dropped 9% in 5 minutes) was caused by algorithmic trading feedback loops. One algorithm sold, prices dropped, other algorithms sold in response, prices dropped more. Circuit breakers now halt trading when prices move too fast.
+- **The 2010 Flash Crash** saw major U.S. equity indices drop sharply within minutes before partially recovering. Subsequent regulatory analysis attributed part of the volatility to automated trading strategies interacting in reinforcing sell-pressure loops. Market circuit breakers now halt trading when prices move too fast—a deliberate loop breaker at financial system scale.
 
-- **Climate feedback loops** worry scientists. Ice melts → less reflection → more heat absorption → more melting. Some loops are self-reinforcing with century-long delays—we might have already triggered them without knowing.
+- **Climate feedback loops** worry scientists because some processes are self-reinforcing with long delays—ice melt reduces reflectivity, which increases heat absorption, which accelerates melt. Century-scale delays mean triggering may precede visible consequences, a cautionary tale for infrastructure teams who ignore slow-burn reinforcing loops until sudden collapse.
 
-- **The Federal Reserve** manages feedback loops constantly. Raise interest rates → less borrowing → less spending → lower inflation. But with 12-18 month delays, it's like steering a supertanker through a narrow channel.
+- **The Federal Reserve** manages economic feedback loops constantly. Raising interest rates reduces borrowing and spending, which lowers inflation—but with delays often measured in quarters or years, policy is like steering a supertanker. Platform capacity and pricing decisions have similar delayed feedback between investment, utilization, outages, and budget cuts.
 
 ---
 
@@ -651,39 +630,65 @@ For each feedback loop in your system:
 
 1. **Scenario: Your e-commerce checkout service has a default timeout of 5 seconds. During a database slowdown, requests start taking 8 seconds. The payment processing pods automatically retry failed requests up to 3 times immediately. What type of feedback loop is this, and what will happen to the database?**
    <details>
-   <summary>Answer</summary>
+   <summary>Question</summary>
 
-   This is a **reinforcing loop** (specifically, a retry storm). The database is already slow due to load or locking. When the checkout service times out and immediately retries 3 times, it multiplies the load on the database by 4. This additional load makes the database even slower, causing more timeouts, which cause even more retries. The loop will amplify the failure until the database or the payment service completely collapses.
+   This is a **reinforcing loop** (specifically, a retry storm). The database is already slow due to load or locking. When the checkout service times out and immediately retries three times, it multiplies the load on the database by up to four for each timed-out request. This additional load makes the database even slower, causing more timeouts, which cause even more retries. The loop amplifies the failure until the database or the payment service collapses unless you add backoff, jitter, circuit breaking, or admission control.
    </details>
 
 2. **Scenario: You configure a HorizontalPodAutoscaler (HPA) to maintain 70% CPU utilization. It evaluates metrics every 15 seconds. However, your application pods take 4 minutes to start up and become ready because they need to download a large machine learning model. After a spike in traffic, you notice the number of pods fluctuating wildly between 10 and 100 every few minutes, while CPU usage bounces between 10% and 100%. What is causing this behavior?**
    <details>
-   <summary>Answer</summary>
+   <summary>Question</summary>
 
-   This oscillation is caused by a **balancing loop with a severe delay**. The HPA sees high CPU and adds pods to counteract the load. Because the pods take 4 minutes to start, the CPU metric remains high during the next 15-second evaluation, prompting the HPA to add even more pods. By the time the pods finally start, the HPA has over-provisioned massively, dropping CPU to near zero and triggering an aggressive scale-down. The system oscillates wildly because the corrective action takes longer to take effect than the HPA's evaluation interval.
+   This oscillation is caused by a **balancing loop with a severe delay mismatch**. The HPA sees high CPU and adds pods to counteract the load, but pods take four minutes to start, so CPU remains high at each 15-second evaluation and the HPA keeps adding pods. When pods finally become ready, CPU drops sharply and triggers aggressive scale-down. The corrective action takes longer to affect the measured metric than the controller's evaluation interval, producing classic overshoot oscillation. Fix by aligning evaluation and stabilization with startup delay, limiting scale steps, or using a signal that reflects ready capacity.
    </details>
 
-3. **Scenario: You launch a new popular mobile game. At exactly midnight, the daily quests reset for all players. Every player's app simultaneously requests the new quests from the backend. The backend checks a Redis cache, but the quest data for the new day hasn't been cached yet. The backend then queries the database. Within seconds, the database crashes. What pattern is this, and how does it create a reinforcing loop?**
+3. **Scenario: You launch a new popular mobile game. At exactly midnight, the daily quests reset for all players. Every player's app simultaneously requests the new quests from the backend. The backend checks a Redis cache, but the quest data for the new day has not been cached yet. The backend then queries the database. Within seconds, the database is overwhelmed. What pattern is this, and how does it create a reinforcing loop?**
    <details>
-   <summary>Answer</summary>
+   <summary>Question</summary>
 
-   This is the **thundering herd** pattern, which creates a destructive reinforcing loop. The simultaneous cache misses cause a massive spike in database queries that overwhelms the database backend. The database slows down significantly, causing those queries to time out and fail to populate the cache. Because the queries time out, subsequent requests from the apps also miss the cache and hit the database directly. This keeps the database overwhelmed and ensures the cache remains empty indefinitely.
+   This is the **thundering herd** pattern, which creates a destructive reinforcing loop. Simultaneous cache misses cause a massive spike in database queries that overwhelms the backend. The database slows down, queries time out before populating the cache, and subsequent requests also miss and hit the database directly. The cache stays empty or cold while load remains high, so the herd self-sustains until you add jitter, warming, request coalescing, or stale-while-revalidate semantics to break synchronization.
    </details>
 
 4. **Scenario: To fix the daily quest crash from the previous scenario, you decide to cache the daily quests for 24 hours. However, you notice that exactly 24 hours later, the database crashes again. Your senior engineer suggests adding "jitter" to the cache TTL. Why is jitter the correct solution here?**
    <details>
-   <summary>Answer</summary>
+   <summary>Question</summary>
 
-   Jitter is the correct solution because it breaks the synchronization of the **thundering herd**. If all cache entries have an exact TTL of 24 hours (86,400 seconds), they will all expire at exactly the same time the next day, causing another simultaneous wave of database queries. By adding a random jitter value (e.g., between -30 and +30 minutes), the cache expirations are spread out over a wide time window. This converts a massive, instantaneous spike in load into a manageable, distributed stream of requests. The database can then comfortably repopulate the cache without becoming overwhelmed.
+   Jitter breaks synchronization of the thundering herd. If all cache entries expire at exactly 24 hours, they expire together the next day and recreate the simultaneous miss wave. Adding random jitter (for example, plus or minus tens of minutes) spreads expirations over a time window, converting an instantaneous spike into a manageable stream of refreshes the database can handle while keeping cache effectiveness high.
+   </details>
+
+5. **Scenario: During an incident, you disable retries entirely on the API gateway to stop load amplification. Error rates at the gateway drop, but checkout success rate for end users falls sharply because transient blips that retries used to mask now surface as hard failures. What balancing loop did you weaken, and what should you do instead?**
+   <details>
+   <summary>Question</summary>
+
+   Retries implement a crude **balancing loop** against transient failures— they recover from short glitches without user-visible errors. Disabling them removed that stabilizer but did not fix the reinforcing loop caused by aggressive immediate retries downstream. Instead, keep retries with exponential backoff, jitter, per-client budgets, and circuit breakers on failing dependencies so you retain recovery for transient errors without multiplying load during sustained outages.
+   </details>
+
+6. **Scenario: Your team's on-call rotation receives hundreds of Slack alerts per day, most from non-customer-facing metrics. Engineers start muting channels. A production outage lasts an hour before anyone notices. Map this to a feedback loop type and name two organizational fixes.**
+   <details>
+   <summary>Question</summary>
+
+   This is a **reinforcing loop in the human attention subsystem**: incidents and noisy monitoring increase alert volume, which reduces attention and increases missed incidents, which leads to adding more alerts after post-mortems. Fixes include alerting on SLO burn and user-visible symptoms only, and instituting regular alert review with deletion of non-actionable rules plus tracking alert-to-incident ratio so noise is visible to leadership before muting becomes culture.
+   </details>
+
+7. **Scenario: During architecture review you apply the polarity test to classify a loop: load increases, latency increases, retries increase, load increases further—zero inversions around the cycle. A memory leak then causes OOMKill evictions that concentrate traffic on surviving pods. Name both loop types involved and explain which classification step you used.**
+   <details>
+   <summary>Question</summary>
+
+   The retry path is a **reinforcing loop** (zero inversions—each step amplifies load). Eviction under fixed replica count behaves as a **reinforcing loop** from the application perspective (two inversions, even count). You classified them using the **fundamental two-type framework**: count inversions around the causal cycle, determine even versus odd, and predict amplify-versus-stabilize behavior before choosing circuit breakers versus HPA tuning.
+   </details>
+
+8. **Conceptual: You are reviewing Part 3 of this module—the six deadly feedback patterns in distributed systems. A teammate proposes fixing connection pool exhaustion by doubling the pool size without adding query timeouts or circuit breakers. Which of the six patterns are they partially addressing, and why is their fix incomplete as a breaking strategy?**
+   <details>
+   <summary>Question</summary>
+
+   Doubling the pool addresses **connection pool death spiral** symptoms by delaying exhaustion, but without query timeouts, circuit breakers, or bulkheads the reinforcing path remains: slow queries still hold connections longer, retries still multiply load, and a larger pool can eventually saturate the database with more concurrent work. Effective breaking strategies for this pattern include connection and query timeouts, pool sizing tied to downstream capacity, bulkheads, and admission control—not pool size alone.
    </details>
 
 ---
 
 ## Hands-On Exercise
 
-**Task**: Analyze feedback loops in a production architecture.
-
-**Scenario**: You're reviewing this API service architecture:
+**Task:** Analyze feedback loops in a production architecture. **Scenario:** You are reviewing the API service architecture shown below, which includes an HPA-managed API tier, a Redis cache with fixed TTL, fixed-interval retries, and a PostgreSQL pool with no circuit breaker. Your goal is to map loops, find dangerous combinations, and propose concrete configuration fixes.
 
 ```mermaid
 flowchart LR
@@ -694,29 +699,10 @@ flowchart LR
     API -->|Pool: 50| DB[(PostgreSQL)]
 ```
 
-**Your Analysis**:
-
-1. **Identify all feedback loops** (20 minutes)
-
-   List every loop you can find. For each one:
-   - Elements in the loop
-   - Type (reinforcing/balancing)
-   - Total delay in the loop
-   - What triggers it
-   - What goes wrong
-
-2. **Find dangerous combinations** (10 minutes)
-
-   Which loops could trigger together? Which balancing loops might fight each other?
-
-3. **Propose fixes** (15 minutes)
-
-   For each dangerous loop, propose a concrete fix with configuration examples.
-
-**Expected Findings**:
+Work through three phases in order. First, spend roughly twenty minutes listing every feedback loop you can find—for each loop, document the elements, type (reinforcing or balancing), total delay, trigger conditions, and failure mode. Second, spend ten minutes identifying which loops could fire together and whether any balancing loops might fight each other under spike load. Third, spend fifteen minutes proposing a concrete fix per dangerous loop with YAML or policy snippets that break the reinforcing path.
 
 <details>
-<summary>Click to see answer</summary>
+<summary>Click to see expected findings</summary>
 
 **Reinforcing Loops (Dangerous)**:
 
@@ -724,7 +710,7 @@ flowchart LR
    - Path: Timeout → Retry → More load → Slower responses → More timeouts
    - Delay: 1 second (fixed, no jitter)
    - Trigger: Any slowdown
-   - Problem: 3 retries with no jitter means 3x load when slow
+   - Problem: 3 retries with no jitter means up to 4x load when slow
 
 2. **Cache Stampede**
    - Path: Cache expires → All miss → DB overload → Timeouts → Cache not populated → More misses
@@ -759,7 +745,7 @@ flowchart LR
 **Dangerous Combinations**:
 
 1. Cache stampede + Retry storm + Connection exhaustion:
-   - Cache expires → DB hit → DB slow → Connections held → Pool full → Timeouts → Retries → 3x load on full pool → Complete failure
+   - Cache expires → DB hit → DB slow → Connections held → Pool full → Timeouts → Retries → amplified load on full pool → Complete failure
 
 2. HPA oscillation + Retry storm:
    - CPU high → Scale up → New pods retry → More load → CPU still high → Scale up more → Overshoot
@@ -802,30 +788,37 @@ pool:
 
 </details>
 
-**Success Criteria**:
-- [ ] Identified at least 4 reinforcing loops
-- [ ] Identified at least 2 balancing loops
-- [ ] Documented delays for each loop
-- [ ] Found at least 2 dangerous combinations
-- [ ] Proposed fixes with specific configurations
-- [ ] Explained why each fix breaks the loop
+You have succeeded when you can demonstrate all of the following:
+
+- [ ] Identified at least four reinforcing loops with documented delays and triggers
+- [ ] Identified at least two balancing loops and noted where delay mismatch could invert their effect
+- [ ] Found at least two dangerous combinations and explained why fixes must break paths—not just add capacity
+- [ ] Proposed configuration changes (backoff, jitter, circuit breakers, HPA behavior) tied to specific loops
 
 ---
 
-## Further Reading
+## Sources
 
-- **"Thinking in Systems"** by Donella Meadows - Chapter 2 covers feedback loops with beautiful clarity. Essential reading.
-
-- **"Release It!"** by Michael Nygard - Chapters on stability patterns (circuit breakers, timeouts, bulkheads) are all about managing feedback loops in production.
-
-- **"How Complex Systems Fail"** by Richard Cook - 18 short points on why feedback loops in complex systems create surprising failures. Takes 10 minutes to read, provides a lifetime of insight.
-
-- **"Control Theory for Engineers"** - Any introductory text. Understanding PID controllers will transform how you tune autoscalers.
-
-- **"Feedback Control for Computer Systems"** by Philipp K. Janert - Applies control theory directly to software systems. Dense but invaluable.
+- [Thinking in Systems: A Primer (Donella Meadows)](https://www.chelseagreen.com/product/thinking-in-systems/) — Primary reference for reinforcing and balancing loops, delays, and system behavior.
+- [Site Reliability Engineering (Google SRE Book)](https://sre.google/sre-book/table-of-contents/) — Cascading failures, overload control, and retry discipline in large-scale production systems.
+- [Site Reliability Workbook — Alerting on SLOs](https://sre.google/workbook/alerting-on-slos/) — Actionable alerting guidance to avoid alert-storm reinforcing loops in on-call workflows.
+- [Kubernetes Horizontal Pod Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) — Official documentation for HPA metrics, behavior, and stabilization windows.
+- [Kubernetes HorizontalPodAutoscaler v2 behavior](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/#configurable-scaling-behavior) — Scale-up/scale-down policies and stabilization configuration referenced in Part 4.
+- [Release It! Design and Deploy Production-Ready Software (Michael Nygard)](https://pragprog.com/titles/mnee2/release-it-second-edition/) — Stability patterns including circuit breakers, bulkheads, and timeouts as loop breakers.
+- [Feedback Control for Computer Systems (Philipp K. Janert, O'Reilly)](https://www.oreilly.com/library/view/feedback-control-for/9781449362638/) — Control-theory framing for tuning software feedback mechanisms.
+- [How Complex Systems Fail (Richard Cook, PDF)](https://www.adaptivecapacitylabs.com/HowComplexSystemsFail.pdf) — Foundational essay on failure dynamics in complex operational systems.
+- [SEC Concept Release on Equity Market Structure (2010)](https://www.sec.gov/rules-regulations/2010/02/concept-release-equity-market-structure) — Regulatory review of automated and high-frequency trading and the feedback effects of automated market-making.
+- [AWS Architecture Blog — Exponential Backoff And Jitter](https://aws.amazon.com/blogs/architecture/exponential-backoff-and-jitter/) — Canonical practical guidance on desynchronizing retries to prevent thundering herds and retry storms.
+- [Prometheus scrape configuration](https://prometheus.io/docs/prometheus/latest/configuration/configuration/#scrape_config) — Metric collection intervals as a component of total feedback loop delay in autoscaling paths.
 
 ---
 
 ## Next Module
 
 [Module 1.3: Mental Models for Operations](../module-1.3-mental-models-for-operations/) - Build practical mental models for understanding production systems: leverage points, stock-and-flow diagrams, and the frameworks that experienced operators use instinctively.
+
+---
+
+## Further Reading
+
+For deeper study beyond the linked sources above, start with Donella Meadows' *Thinking in Systems* (Chapter 2 on feedback loops), Michael Nygard's *Release It!* (stability patterns), Richard Cook's *How Complex Systems Fail*, and Philipp K. Janert's *Feedback Control for Computer Systems*. The Google SRE books connect these concepts to alerting, overload handling, and cascading failures at organizational scale.

--- a/src/content/docs/platform/foundations/systems-thinking/module-1.3-mental-models-for-operations.md
+++ b/src/content/docs/platform/foundations/systems-thinking/module-1.3-mental-models-for-operations.md
@@ -1,6 +1,7 @@
 ---
 title: "Module 1.3: Mental Models for Operations"
 slug: platform/foundations/systems-thinking/module-1.3-mental-models-for-operations
+revision_pending: false
 sidebar:
   order: 4
 ---
@@ -12,11 +13,9 @@ sidebar:
 >
 > **Track**: Foundations
 
-### What You'll Be Able to Do
+## What You'll Be Able to Do
 
-After completing this module, you will be able to:
-
-1. **Apply** at least five mental models (constraint theory, queue theory, Swiss cheese, OODA loop, Cynefin) to operational decision-making
+1. **Apply** the three core operational mental models — leverage points, stock-and-flow diagrams, and causal loop diagrams — to decisions during live incidents
 2. **Evaluate** which mental model best fits a given incident scenario and explain why others fall short
 3. **Diagnose** production incidents faster by selecting the appropriate reasoning framework before diving into logs
 4. **Compare** competing hypotheses during incidents using structured mental models rather than intuition alone
@@ -25,22 +24,15 @@ After completing this module, you will be able to:
 
 ## The Incident That Revealed Everything
 
-*Tuesday, 4:23 PM. An e-commerce platform's checkout is down.*
+**Hypothetical scenario:**
 
-The war room is packed. Engineers stare at dashboards. The CTO is asking for updates every five minutes. Everyone has a theory.
+*A mid-afternoon outage at a production e-commerce platform. Checkout is down. The incident channel is flooded. Engineers stare at dashboards showing conflicting signals. Management is asking for status every few minutes. Multiple theories are flying—database connections maxed out, cache miss rate spiking, a recent deploy rolled back. Someone suggests restarting everything, but that has already been tried twice without effect.*
 
-"It's the database—connections are maxed out."
-"No, it's the cache miss rate—look at this spike."
-"We should just restart everything."
-"We already tried that. Twice."
+Hours into the incident, a team member asks a question nobody had considered: "What is *supposed* to happen when checkout gets slow?"
 
-Three hours in, someone junior asks a question nobody else thought to ask: "What's *supposed* to happen when checkout gets slow?"
+The answer reveals the entire failure chain. The frontend retries on timeout. Each retry adds load. More load means more timeouts. More timeouts mean more retries. The database was never the root cause—it was being crushed by a retry storm that had been amplifying since the initial trigger.
 
-Silence. Then: "The frontend retries... oh no."
-
-Within minutes, they draw a diagram on a whiteboard. Frontend retries on timeout. Each retry adds load. More load means more timeouts. More timeouts mean more retries. The database was fine—it was being crushed by a retry storm that had been amplifying for hours.
-
-The fix took 30 seconds: disable retries. The outage had lasted three hours because nobody had the right mental model to see what was happening.
+The fix is nearly instantaneous once the loop is identified: disable retries. The outage persisted because nobody had the right mental model to see the feedback structure governing the system's behavior.
 
 > **Stop and think**: If the database was perfectly healthy, what system behavior actually brought it down in this scenario?
 
@@ -48,24 +40,19 @@ The fix took 30 seconds: disable retries. The outage had lasted three hours beca
 
 ## Why This Module Matters
 
-You've got 20 metrics dashboards, 500 alerts, and a system doing something unexpected. Where do you focus? What do you change? How do you know if your fix will help or make things worse?
+You have twenty metrics dashboards, hundreds of alerts, and a production system doing something unexpected. Where do you focus? What do you change? How do you know whether your fix will help or make things catastrophically worse? Raw telemetry data does not give you answers—it gives you measurements. The gap between measurement and effective action is bridged by mental models.
 
-Raw data doesn't give you answers. **Mental models** do.
+Mental models are compressed representations of how complex systems behave. They are thinking tools, distilled patterns that help you navigate situations where the full detail of the system exceeds what any one person can hold in their head at once. They are not the territory—your actual production system contains orders of magnitude more detail—but they are maps that let you orient quickly, identify leverage, and avoid the most common traps. The right mental model lets you see patterns others overlook and find solutions that address the structural cause rather than the surface symptom.
 
-Mental models are thinking tools—compressed wisdom about how systems behave. They're not the territory (your actual system), but they're maps that help you navigate it. The right mental model helps you see patterns others miss and find solutions that actually work.
+This module equips you with three essential frameworks drawn from the systems thinking tradition, each addressing a distinct operational need. First, Donella Meadows' hierarchy of leverage points provides a ranked ordering of where to intervene in a system for maximum effect relative to effort. Understanding this hierarchy counteracts the instinct to reach for the most obvious (and usually weakest) intervention during an incident. Second, stock-and-flow diagrams give you a visual language for understanding accumulation—why queues grow, why memory fills up, and why error budgets deplete over time. Third, causal loop diagrams reveal the feedback structures that make systems resistant to change or prone to runaway amplification.
 
-This module gives you three essential frameworks:
-1. **Leverage Points**: Where to intervene for maximum effect
-2. **Stock-and-Flow Diagrams**: What's accumulating and why
-3. **Causal Loop Diagrams**: How variables influence each other
-
-These aren't abstract theory. They're the tools used by the best SREs and operators to understand and influence production systems under pressure.
+These are not abstract academic constructs. The best SREs and platform engineers use these frameworks—whether explicitly drawn on a whiteboard or implicitly internalized—to understand production systems under pressure, to design interventions that last, and to communicate their reasoning to others during incidents. When you cannot see the feedback loops driving your system's behavior, you are flying blind regardless of how many dashboards you have.
 
 > **The Map Analogy**
 >
-> A subway map isn't geographically accurate—it's schematically useful. The London Underground map famously distorts distances and directions, but it's perfect for planning your journey.
+> A transit map is not geographically accurate—it is schematically useful. The iconic London Underground map deliberately distorts distances and directions, compressing outer stations and expanding the dense central core, yet it is exactly the right tool for planning a journey across the network. A topographically precise map would overwhelm you with irrelevant detail and make route planning significantly harder.
 >
-> Mental models work the same way. A stock-and-flow diagram doesn't capture every aspect of your system, but it helps you see where things accumulate and why. "All models are wrong, but some are useful." Your job is to know which model is useful when.
+> Mental models work the same way. A stock-and-flow diagram of your request pipeline does not capture every configuration knob, every network hop, or every caching layer. But it does help you see where work accumulates and why. The statistician George Box captured this tradeoff precisely: "All models are wrong, but some are useful." Your professional judgment lies in knowing which simplified model is useful for the problem at hand, and when to switch to a different one.
 
 ---
 
@@ -83,15 +70,11 @@ These aren't abstract theory. They're the tools used by the best SREs and operat
 
 ### 1.1 The Counterintuitive Truth
 
-When something goes wrong, there's usually an obvious fix: add more servers, increase the timeout, bump the memory limit. These fixes feel good. They're fast. They're tangible.
+When a production system degrades, there is almost always an obvious fix waiting to be applied: add more replicas, increase the timeout, bump the memory limit, scale out the database. These fixes feel productive because they are fast, they are tangible, and they produce an immediate, visible change in a dashboard number. They are also, in the majority of cases, the wrong intervention—or at least a dramatically suboptimal one. Understanding why requires grappling with the concept of leverage.
 
-They're also usually wrong.
+Leverage points are places in a system where a modest change can produce a disproportionately large result. Donella Meadows, the systems thinker and lead author of the landmark "Limits to Growth" study, identified twelve such points and ordered them from least to most effective in her 1997 essay "Places to Intervene in a System." Her framework has become foundational across disciplines from ecology to economics to software operations because it provides a ranking that is simultaneously intuitive in hindsight and almost never followed in practice. The central counterintuitive insight of her hierarchy is this: the most obvious and accessible interventions are almost always the weakest, while the most transformative interventions require questioning assumptions so fundamental that most organizations never consider them.
 
-> **Pause and predict**: Before reading further, think about the last incident you handled. Did your team's fix involve changing a number (like a timeout) or changing a rule?
-
-**Leverage points** are places in a system where a small change can produce big results. Donella Meadows, the systems thinker behind "Limits to Growth," identified 12 leverage points, ranked from least to most effective.
-
-The counterintuitive insight: **the most obvious interventions are usually the weakest**.
+The accompanying diagram organizes the twelve leverage points into two tiers—weak interventions that feel productive but rarely solve the underlying problem, and strong interventions that require more effort but produce lasting structural change:
 
 ```mermaid
 flowchart TD
@@ -124,9 +107,21 @@ flowchart TD
     class L8,L7,L6,L5,L4,L3,L2,L1 strong;
 ```
 
+The weak tier—levels 12 through 9—corresponds to interventions that change numbers, sizes, flows, and delays. These are the parameters of the system, the quantities you can adjust with a configuration change or a resource allocation. They are weak because they operate within the existing structure of the system rather than changing that structure. Increasing a timeout from five to ten seconds does not change the fact that timeouts exist and that slow responses will accumulate; it merely changes the threshold at which accumulation begins. Increasing a connection pool from fifty to a hundred connections does not change the fact that connections are a finite resource subject to contention; it merely changes the ceiling.
+
+The strong tier—levels 8 through 1—operates differently. These interventions change the feedback structure, the information flows, the rules, the goals, and ultimately the paradigms that govern the system. Adding a circuit breaker changes the system's feedback dynamics by introducing a mechanism that detects and responds to failure patterns. Adding distributed tracing changes what information the system reveals about itself, enabling entirely new categories of diagnosis and improvement. Changing a team's goal from "ship features quickly" to "ship features that meet their reliability SLO" does not change any parameter at all, yet it fundamentally alters every decision the team makes. The pattern is consistent across every domain where the hierarchy has been applied: the highest-leverage interventions change what the system is trying to do and how it perceives itself, not just how fast or how large it operates.
+
+> **Did You Know?**
+>
+> - Most incident response stays at leverage point 12—tweaking numbers. "Increase replicas." "Raise the timeout." "Bump the memory limit." These interventions are easy to apply and easy to justify, but they rarely solve the underlying structural problem. They buy time, not solutions, and the bill for that time compounds with every recurrence.
+>
+> - **Netflix's Chaos Engineering** program operates at level 6 (information): by intentionally injecting failures into production, they reveal how their system actually behaves under stress—information that would otherwise remain hidden until a real outage forces the revelation. The chaos experiments are not the intervention; the information they produce is.
+>
+> - **Google's SRE model** operates at level 3: by making reliability a shared goal between development and operations, enforced through error budgets, it changes what the entire organization optimizes for. This is not a parameter tweak—it is a redefinition of what success means.
+
 ### 1.2 Leverage Points in Action
 
-Let's apply this framework to a real scenario: **"The API is consistently slow."**
+Applying the hierarchy to a concrete operational scenario makes the ranking tangible. Consider the recurring problem: **"The API is consistently slow."** Engineers have been living with this for weeks, applying quick fixes that help temporarily but do not last. The table below evaluates potential interventions at each leverage level for this scenario:
 
 | Leverage Level | Intervention | Why This Level | Effectiveness |
 |----------------|--------------|----------------|---------------|
@@ -140,59 +135,37 @@ Let's apply this framework to a real scenario: **"The API is consistently slow."
 | **5** (Rules) | "All queries must have timeout" | Changes the game | **Strong—prevents accumulation** |
 | **3** (Goals) | "Optimize for P99, not throughput" | Changes what matters | **Very strong—realigns all decisions** |
 
-Notice the pattern: **interventions at levels 12-11 are what everyone tries first, but levels 7-5 are where the real solutions live.**
+Notice the pattern that emerges from this analysis: **interventions at levels 12–11 are what everyone reaches for first, because they are low-risk and immediately visible, but levels 7–5 are where the real solutions reside.** The gap between these tiers explains why so many incident postmortems produce action items like "increased the timeout" and "added monitoring for X" while the underlying pattern recurs predictably. The team applied a weak-leverage intervention and mistook the temporary relief for a solution. Organizational incentives often reinforce this trap: a parameter change can be deployed in minutes with minimal review, while changing a rule or adding an information flow requires coordination, design, and sometimes uncomfortable conversations about why the current approach is insufficient.
 
-> **Did You Know?**
->
-> - Most incident response stays at leverage point 12—tweaking numbers. "Increase replicas." "Raise the timeout." "Bump the memory limit." These interventions are easy, but they rarely solve the underlying problem. They buy time, not solutions.
->
-> - **Netflix's Chaos Engineering** operates at level 6 (information): by intentionally injecting failures, they reveal how their system actually behaves under stress—information that would otherwise remain hidden until an outage.
->
-> - **Google's SRE model** operates at level 3: by making reliability a shared goal between dev and ops (error budgets), they changed what teams optimize for.
+A systems-thinking approach to incident response means consciously pausing before applying the obvious fix and asking: at what leverage level am I about to intervene, and is there a higher-leverage alternative worth the additional effort? The answer is not always to reach for the highest level—sometimes a parameter tweak is exactly what the moment demands. But the question must be asked explicitly, because the default instinct under pressure is to reach for what is easy, not what is effective.
 
 ### 1.3 Finding High-Leverage Interventions
 
-When you're in an incident or designing a system, ask these questions in order:
+When you are in the middle of an incident or designing a system, a structured question sequence can surface higher-leverage interventions that intuition alone would overlook. Work through these questions in order, from most urgent to most fundamental:
 
 ### The High-Leverage Question Sequence
 
-1. **REINFORCING LOOPS (Level 7)**: *"Where's the amplification?"*
-   - Is there a retry storm?
-   - Is something filling up and making things worse?
-   - Is success breeding more success (or failure breeding failure)?
-   - *Breaking a reinforcing loop is almost always high leverage.*
+1. **REINFORCING LOOPS (Level 7)**: *"Where's the amplification?"* Is there a retry storm feeding on itself? Is something filling up and making the situation progressively worse? Is success breeding more success, or is failure breeding more failure in a way that accelerates? Breaking an active reinforcing loop is almost always the highest-leverage immediate action because it stops the damage from compounding. In the retry storm scenario from the opener, the reinforcing loop was the only thing sustaining the outage—the database was healthy, but the loop made it appear broken.
 
-2. **INFORMATION GAPS (Level 6)**: *"Who doesn't have information they need?"*
-   - Can the on-call see what's happening?
-   - Does the autoscaler know about the real load?
-   - Can developers see the production impact of their code?
-   - *Adding visibility enables all other improvements.*
+2. **INFORMATION GAPS (Level 6)**: *"Who does not have the information they need to act correctly?"* Can the on-call engineer see what is actually happening, or are they guessing from aggregate metrics? Does the autoscaler know about the real load arriving at each pod, or is it reacting to a lagging indicator? Can developers see the production impact of the code they are shipping? Adding information flow enables every other improvement because it replaces assumptions with evidence.
 
-3. **RULES (Level 5)**: *"What rule prevents the obvious solution?"*
-   - Why can't we deploy the fix now?
-   - Why do we retry on every error?
-   - Why don't we have that circuit breaker?
-   - *Often the barrier is a rule nobody remembers making.*
+3. **RULES (Level 5)**: *"What rule prevents the obvious solution from being implemented?"* Why can the fix not be deployed right now? Why does every error trigger a retry? Why is there no circuit breaker in place? Often the barrier is a rule that was established long ago for a context that no longer applies—a deployment freeze policy from a previous incident, a retry-everything default from a library, or a standard operating procedure that nobody has questioned.
 
-4. **GOALS (Level 3)**: *"What is the system actually optimizing for?"*
-   - Is the team measured on features shipped or reliability?
-   - Does the business prioritize speed or stability?
-   - What gets celebrated vs. what gets punished?
-   - *Changing goals changes everything downstream.*
+4. **GOALS (Level 3)**: *"What is the system actually optimizing for, as measured by what gets rewarded and what gets penalized?"* Is the team measured primarily on features shipped or on reliability sustained? Does the business prioritize speed to market or stability of the existing service? What behaviors are celebrated in team meetings, and what behaviors lead to uncomfortable conversations? Changing the goal changes everything downstream because it redirects every individual decision toward a different objective.
 
 **Worked Example:**
 
-> **SCENARIO: Frequent production incidents (3-4 per week)**
+> **SCENARIO: Frequent production incidents disrupting the team's velocity**
 >
 > * **Team's first instinct (Level 12)**: "Add more on-call engineers"
->   * **Problem**: More people doing the same broken process. Incidents keep happening at the same rate.
-> * **Better intervention (Level 8)**: "Add PagerDuty escalation policies"
->   * **Improvement**: Better balancing loop for incident response.
->   * **Problem**: Doesn't prevent incidents, just handles them better.
-> * **High-leverage intervention (Level 6)**: "Replay production traffic in staging before every deploy"
->   * **Impact**: New information flow catches issues before production. Incidents drop from 4/week to 1/month.
-> * **Highest-leverage intervention (Level 3)**: "Team goal changes from 'ship features' to 'ship reliable features' - with error budget enforcing the balance"
->   * **Impact**: Changes what the whole system optimizes for. Incidents become rare because preventing them is now valued.
+>   * **Problem**: More people responding to the same broken processes. The incidents continue at the same underlying rate while the response team grows larger, burning out more engineers over time.
+> * **Better intervention (Level 8)**: "Add structured escalation policies and incident commander rotation"
+>   * **Improvement**: A stronger balancing loop for incident response coordination and handoff.
+>   * **Problem**: Does nothing to prevent incidents from occurring—only handles them more smoothly once they are underway.
+> * **High-leverage intervention (Level 6)**: "Replay production traffic patterns against staging before every deploy"
+>   * **Impact**: A new information flow catches regressions before they reach production. Incidents that would have been discovered by users are instead discovered by automated testing, dramatically reducing the frequency of unplanned work.
+> * **Highest-leverage intervention (Level 3)**: "Team goal redefined from 'ship features rapidly' to 'ship features that meet their reliability SLO, with the error budget as the mechanism for deciding when to prioritize velocity over stability'"
+>   * **Impact**: Changes what the entire team optimizes for at a fundamental level. Preventing incidents becomes valued work rather than overhead. The quality of every decision—from architecture to code review to testing investment—improves because the goal structure now incentivizes reliability.
 
 ---
 
@@ -200,7 +173,7 @@ When you're in an incident or designing a system, ask these questions in order:
 
 ### 2.1 The Bathtub Model
 
-Imagine a bathtub. The water level is the **stock**—it's what you can measure at a point in time. The faucet is the **inflow**—water entering. The drain is the **outflow**—water leaving.
+The simplest and most powerful starting point for stock-and-flow thinking is an everyday object: a bathtub. The water level in the tub at any moment is the **stock**—a quantity you can measure at a point in time, expressed in gallons. The faucet is the **inflow**—water entering the tub at a certain rate, expressed in gallons per minute. The drain is the **outflow**—water leaving the tub, also a rate. The fundamental dynamic is elegantly simple: if inflow exceeds outflow, the stock rises. If outflow exceeds inflow, the stock falls. If they are equal, the stock is stable.
 
 ```mermaid
 flowchart TD
@@ -211,11 +184,13 @@ flowchart TD
     class WaterLevel stock;
 ```
 
-Simple, right? But this model explains why queue depths grow, why memory fills up, why connection pools exhaust, and why incidents cascade.
+This model is disarmingly trivial to describe and yet profoundly underutilized in operational practice. It explains why queue depths grow unboundedly, why memory fills up and triggers OOM kills, why connection pools exhaust, and why incidents cascade when a reinforcing loop amplifies an inflow. The insight that transforms bathtub thinking from obvious to operationally useful is recognizing that stocks, flows, and the relationships between them are what your monitoring dashboards are actually measuring—you are simply not accustomed to reading them through this lens. Queue depth is a stock. Request rate is an inflow. Processing rate is an outflow. Latency is the stock divided by the outflow rate. Every metric in your observability stack can be classified as a stock or a flow, and understanding which is which tells you what to watch when the system degrades.
+
+A critical property of stock-and-flow systems is that **stocks change the time shape of flows**. A large stock acts as a buffer, absorbing fluctuations in inflow so that outflow can remain steady. If your request queue can hold a thousand items, a brief spike in incoming requests does not immediately translate to dropped traffic—the queue absorbs the excess and drains gradually. This buffering property is simultaneously a design tool and a diagnostic hazard: it smooths out problems, which means the system can be degrading for minutes or hours before any alert fires, because the stock level is rising silently within the buffer zone. When the alert finally triggers, the degradation has been underway for far longer than the alert duration suggests.
 
 ### 2.2 Stocks and Flows in Operations
 
-> **Stop and think**: Where does "technical debt" fit in the stock-and-flow model? What is the inflow, and what is the outflow?
+Translating the bathtub model into operational terms yields a diagnostic lens that applies across virtually every subsystem you manage. The table below maps common operational stocks to their inflows and outflows:
 
 | Stock (What accumulates) | Inflow (What adds) | Outflow (What removes) | Why It Matters |
 |--------------------------|-------------------|----------------------|----------------|
@@ -227,9 +202,13 @@ Simple, right? But this model explains why queue depths grow, why memory fills u
 | **On-call fatigue** | Alerts, pages | Rest time | Fatigue → burnout → turnover |
 | **Backlog items** | Feature requests | Completed features | Backlog bloat → priority chaos |
 
+The error budget row deserves particular attention because it is a deliberately designed stock-and-flow system. The stock of budget accumulates steadily during periods of reliable operation—the SLO is being met, so time passing adds to the available budget. Incidents draw down the budget, and if the drawdown rate exceeds the accumulation rate over the SLO's measurement window, the budget is exhausted. When the budget is exhausted, deployments stop. This mechanism transforms an abstract reliability target into a concrete, accumulating quantity that both development and operations teams can reason about. It is an information-flow intervention (level 6) embedded in a stock-and-flow structure, and it works precisely because it makes the accumulation of risk visible and quantifiable.
+
+> **Stop and think**: Where does "technical debt" fit in the stock-and-flow model? What is the inflow, and what is the outflow? The inflow is every shortcut, every skipped test, every "we'll fix it later" decision made under schedule pressure. The outflow is the deliberate refactoring and remediation work that reduces the accumulated debt. The stock of debt rises whenever inflow outpaces outflow, and the stock itself has a compounding effect: the more debt accumulates, the slower every subsequent change becomes, which in turn reduces the rate at which outflow (remediation) can occur. This is a reinforcing feedback loop embedded within what initially appears to be a simple stock-and-flow structure.
+
 ### 2.3 Drawing Stock-and-Flow Diagrams
 
-**Example: Request Processing Pipeline**
+Drawing the system explicitly, even in a rough sketch, surfaces dynamics that are invisible when you stare at individual metric dashboards. The following diagram models a request processing pipeline as a stock-and-flow system:
 
 ```mermaid
 flowchart TD
@@ -248,60 +227,31 @@ flowchart TD
 
 **What This Diagram Reveals:**
 
-1. If incoming (100/s) = processing (100/s): Queue stable at 50.
-2. If database slows (processing drops to 40/s):
-   - Queue grows by 60 items/second.
-   - Queue full in ~16 seconds.
-   - Then requests start dropping.
-3. Retries add 3/s to inflow when failing:
-   - Effective inflow becomes 103/s.
-   - If failures increase, retries increase.
-   - This is a reinforcing loop hiding in the diagram!
-4. The queue is your BUFFER:
-   - Small queue = fast response, but fragile.
-   - Large queue = can absorb bursts, but high latency.
-   - Choose based on your SLO.
+The diagram exposes four dynamics that a raw request-rate dashboard would not communicate. First, when incoming rate (100/s) equals processing rate (100/s), the queue is stable at its current level—a steady-state equilibrium that can persist indefinitely. Second, when the downstream database slows and processing drops to 40/s, the queue grows by 60 items per second, reaching its maximum capacity of 1000 in approximately sixteen seconds, after which requests begin receiving 503 responses. Third, the retry path introduces a hidden inflow: 5/s of requests fail, 60% of those retry (adding 3/s to inflow), making the effective inflow 103/s even when the nominal arrival rate has not changed. Fourth, the queue itself is a buffer whose size represents a deliberate tradeoff between resilience (larger buffers absorb larger spikes) and latency (items waiting in the queue experience additional delay proportional to queue depth divided by processing rate). Selecting the right buffer size is not a capacity-planning exercise—it is an SLO-level design decision that shapes how the system degrades under load.
+
+The retry path in this diagram is especially instructive because it shows how a stock-and-flow diagram can reveal a reinforcing loop that would otherwise be hidden. The retry arrow feeds back into the inflow, meaning that failures increase the effective arrival rate, which increases failures, and so on. This is the same pattern from the opening scenario, now rendered as a visual structure rather than a narrative. When you draw stock-and-flow diagrams, trace every connection back to its source and ask whether it might create a feedback path. Loops that emerge from supposedly linear pipelines are among the most dangerous failure modes in production systems precisely because nobody drew the diagram.
 
 ### 2.4 Using Stock-and-Flow for Incident Diagnosis
 
-**Incident: Latency increasing over time**
-
-The mental model immediately tells you what to check:
+The stock-and-flow lens provides a systematic approach to diagnosing the most common incident pattern: a metric that is growing over time, such as climbing latency, an expanding queue, or rising memory consumption.
 
 ### Stock-and-Flow Incident Diagnosis
 
-**SYMPTOM**: Queue depth (stock) is growing. Latency = Queue Depth / Processing Rate. Growing queue = growing latency.
+When a stock is growing—queue depth expanding, latency climbing, memory consumption trending upward—the diagnosis always reduces to a single question with exactly two possibilities. The symptom is straightforward: queue depth (the stock) is growing, and latency equals queue depth divided by processing rate, so a growing queue means growing latency. The diagnosis is equally straightforward: inflow exceeds outflow. This framework guarantees there are no other branches to consider, which means you can eliminate entire categories of hypotheses rapidly and focus your investigation on the remaining possibilities.
 
-**DIAGNOSIS**: Inflow > Outflow. Two possibilities:
+**Possibility A: Inflow has increased.** The rate at which work arrives has gone up. Check whether there has been a traffic spike by consulting the load balancer request rate and comparing it to the baseline for this time of day—common causes include a marketing campaign driving unexpected traffic, viral content sharing, or a deliberate attack. Check for a retry storm by examining error rate and retry rate metrics simultaneously; if errors triggered retries which triggered more errors, the inflow increase is being generated internally rather than externally. Check whether a scheduled batch job has started by examining cron schedules and job queue metrics; nightly ETL jobs and report generation are frequent culprits in periodic latency spikes. Check whether the system is catching up after a period of downtime by looking for a recent gap in processing metrics; recovering systems often face a backlog that looks like an inflow spike.
 
-**POSSIBILITY A: INFLOW INCREASED**
-* **Traffic spike?** → Check: Load balancer request rate. Cause: Marketing campaign, viral content, attack.
-* **Retry storm?** → Check: Error rate and retry metrics. Cause: Downstream failure triggering retries.
-* **Batch job started?** → Check: Cron schedules, job queues. Cause: Nightly ETL, report generation.
-* **Backlog processing?** → Check: Was there recent downtime? Cause: System catching up on missed work.
+**Possibility B: Outflow has decreased.** The rate at which work is being processed has dropped. Check whether there are fewer workers available by examining pod counts, node status, and recent deployment events—evictions, failed deployments, and node failures all reduce processing capacity. Check whether individual requests are taking longer to process by examining request latency breakdowns; a slow database, a degraded dependency, or CPU throttling will increase per-request duration, which reduces effective throughput even if no workers are lost. Check for resource contention by examining CPU, memory, network, and disk I/O saturation; a noisy neighbor on shared infrastructure or a resource limit being hit can throttle processing without triggering a clear failure signal. Check for lock contention by examining database lock metrics and mutex wait times; blocking queries and deadlocks can stall processing at near-zero throughput while every metric except the lock wait time looks normal.
 
-**POSSIBILITY B: OUTFLOW DECREASED**
-* **Fewer workers?** → Check: Pod count, node status. Cause: Eviction, failed deployment, node failure.
-* **Slower processing?** → Check: Request latency breakdown. Cause: Database slow, dependency slow, CPU throttle.
-* **Resource contention?** → Check: CPU, memory, network, disk I/O. Cause: Noisy neighbor, resource limits hit.
-* **Lock contention?** → Check: Database locks, mutex waits. Cause: Blocking queries, deadlocks.
-
-*Check each systematically. The answer is always: inflow went up OR outflow went down (or both).*
-
-> **War Story: The Invisible Stock**
+> **Hypothetical scenario: The Invisible Stock**
 >
-> A team spent three weeks debugging "random" latency spikes. They had dashboards for everything: CPU, memory, network, database. All looked fine during spikes.
+> A team spent weeks debugging intermittent latency spikes that appeared on no standard dashboard. CPU was within limits. Memory was stable. Network throughput was unremarkable. Database query times were normal. Every observable metric said the system was healthy, and yet clients were experiencing failures that left no trace in the application logs.
 >
-> Finally, someone thought to check the TCP layer. Linux has a **listen queue**—a stock of pending connections waiting to be accepted. The application was accepting connections slower than they arrived during traffic bursts.
+> Eventually, someone checked the operating system level. Linux maintains a **listen queue**—a stock of pending TCP connections waiting to be accepted by the application process. When the application accepts connections more slowly than they arrive during a traffic burst, this queue fills up. The kernel parameter `net.core.somaxconn` controls its maximum size, and the default on many systems is modest. When the queue fills completely, the kernel silently drops new connection attempts. No application-level error. No log entry. No metric in the standard observability stack. Just clients experiencing connection failures that the server never saw.
 >
-> The listen queue (controlled by `net.core.somaxconn`) had a max of 128. When it filled, the kernel dropped connections silently. No errors, no logs, no metrics—just "random" client failures.
+> Once the team recognized the problem as a stock-and-flow dynamic—a hidden stock with an inflow exceeding its outflow and a hard ceiling—the solution became clear. First, increase the buffer ceiling by raising `net.core.somaxconn` to provide headroom during bursts. Second, increase the outflow rate by configuring additional accept workers or tuning the application's accept loop. Third, and most importantly, add monitoring for the queue depth that had previously been invisible, so the next time the stock began to rise, the team would see it before it hit the ceiling.
 >
-> Once they visualized it as a stock-and-flow problem, the fix was obvious:
-> 1. Increase the buffer (`net.core.somaxconn=4096`)
-> 2. Increase outflow (more accept workers)
-> 3. Add monitoring for the queue depth they'd never measured
->
-> **Lesson**: Every system has stocks you don't see. Stock-and-flow thinking helps you find them.
+> **Lesson**: Every production system contains stocks you are not currently measuring. Stock-and-flow thinking helps you hypothesize their existence and find them before they find you.
 
 ---
 
@@ -309,21 +259,19 @@ The mental model immediately tells you what to check:
 
 ### 3.1 The Grammar of Causation
 
-Causal loop diagrams show how variables influence each other. They're the X-ray vision of systems thinking—revealing connections that dashboards hide.
+Causal loop diagrams provide a visual notation for representing how variables in a system influence one another. Where dashboards show you isolated metrics, causal loop diagrams show you the structure of causation that connects those metrics. They are the X-ray vision of systems thinking, revealing the feedback architecture that determines whether a disturbance will be dampened, amplified, or ignored by the system.
+
+Before you can map a real system, you need the notation itself—a small grammar that, once learned, lets you diagram any feedback structure you encounter in production:
 
 ### Causal Loop Notation
 
-**POSITIVE (+) LINK: Same direction**
-When A increases, B increases. When A decreases, B decreases.
-*Examples:* Load (+)→ Latency (More load = more latency). Users (+)→ Revenue (More users = more revenue). Failures (+)→ Retries (More failures = more retries).
+The grammar of causal loop diagrams consists of exactly two link types and two loop types, and mastering this small vocabulary unlocks the ability to model any feedback structure encountered in production.
 
-**NEGATIVE (-) LINK: Opposite direction**
-When A increases, B decreases. When A decreases, B increases.
-*Examples:* Pods (-)→ CPU per pod (More pods = less CPU each). Cache hits (-)→ DB load (More cache hits = less DB load). Circuit open (-)→ Requests (Breaker open = fewer requests).
+The first link type is the **positive (+) link**, which describes variables that move in the same direction. When variable A increases, variable B increases; when A decreases, B decreases. Operations examples abound: higher load produces higher latency (Load (+)→ Latency), more users generate more revenue (Users (+)→ Revenue), and more failures trigger more retries (Failures (+)→ Retries). The positive sign describes the mathematical relationship between the variables, not whether the resulting outcome is desirable—a reinforcing death spiral is composed entirely of positive links.
 
-**LOOP TYPES: Count the negative links**
-* **REINFORCING (R)**: Even number of (-) links (0, 2, 4...). Amplifies change, creates exponential growth or collapse, unstable without limits.
-* **BALANCING (B)**: Odd number of (-) links (1, 3, 5...). Opposes change, creates stability or oscillation, seeks equilibrium.
+The second link type is the **negative (−) link**, which describes variables that move in opposite directions. When variable A increases, variable B decreases; when A decreases, B increases. In operations: more pods reduce the CPU load per pod (Pods (−)→ CPU per pod), higher cache hit rates reduce database load (Cache hits (−)→ DB load), and an open circuit breaker reduces the number of requests reaching the protected service (Circuit open (−)→ Requests). Each negative link represents a dampening or opposing force within the system.
+
+The behavior of an entire loop—whether it amplifies change or resists it—is determined by a simple parity check applied to the closed path. Count the number of negative links in the loop. If the count is even (zero, two, four, and so on), the loop is **reinforcing (R)**: it amplifies change in whatever direction it is currently moving, producing exponential growth or collapse, and it is unstable by nature because it has no self-limiting mechanism. If the count is odd (one, three, five, and so on), the loop is **balancing (B)**: it opposes change, driving the system toward a goal state or equilibrium, creating stability but also risking oscillation if significant delays are present. This counting rule is deterministic; given any closed loop of causal links, its polarity can be established by counting the negative signs without ambiguity or judgment. Causal loop diagrams are therefore testable models whose implications can be checked against observed system behavior, not subjective opinion diagrams.
 
 ### 3.2 Mapping Real Systems
 
@@ -339,7 +287,8 @@ flowchart TD
         Retries -- "(+)" --> Load
     end
 ```
-*Reading the Loop: Load ↑ → Latency ↑ → Timeouts ↑ → Retries ↑ → Load ↑ (more!). All links are positive (+) = 0 negative links = REINFORCING. This loop has no natural stopping point. It will grow exponentially until something breaks.*
+
+Reading the loop from any starting point reveals the same dynamic: Load increases → Latency increases → Timeouts increase → Retries increase → Load increases further. Every link is positive, meaning the variables move together at each step. With zero negative links (an even number), the loop is reinforcing. It has no natural limit and no internal mechanism to stop itself. Left unchecked, it accelerates until an external limit is encountered—typically a resource ceiling at which the system fails rather than merely degrading. This is why circuit breakers exist: they insert a negative link into the reinforcing loop, converting it from a self-amplifying spiral into a structure that can detect runaway behavior and break the cycle.
 
 **Example 2: Autoscaling (the Savior)**
 
@@ -353,9 +302,10 @@ flowchart TD
         Pods -- "(-)" --> CPU
     end
 ```
-*Reading the Loop: CPU ↑ → Decision: scale up → Pods ↑ → CPU per pod ↓. One negative link (more pods = less CPU) = BALANCING. This loop opposes change. High CPU triggers more pods, which reduces CPU. System seeks equilibrium. BUT: If there are delays, it can oscillate!*
 
-**Example 3: The Complex Reality**
+This loop operates differently. When CPU usage rises, the comparison against the target triggers a decision to scale up, which increases the pod count. More pods reduce the CPU usage per pod. The loop contains one negative link (Pods (−)→ CPU), making the count odd and the loop balancing. It opposes change rather than amplifying it—high CPU triggers corrective action that brings CPU back down. However, the word "balancing" should not be mistaken for "benign." Balancing loops with delays can overshoot and oscillate. If the autoscaler takes two minutes to detect the CPU change and three minutes to bring new pods online, it may add capacity after the spike has passed and then remove it just as the next spike arrives, creating a cycle of overcorrection and undercorrection that is entirely predictable from the loop structure.
+
+**Example 3: The Complex Reality.** Real production systems combine multiple loops that interact, and the combined behavior can differ dramatically from what any individual loop would produce in isolation. Consider a system that simultaneously contains a retry storm, an autoscaler, and a circuit breaker—three loops whose interactions determine whether the system degrades gracefully or collapses:
 
 ```mermaid
 flowchart TD
@@ -371,54 +321,31 @@ flowchart TD
     CircuitState -- "(-)" --> Load
 ```
 
-*Three Loops Interacting:*
-* **R1 (Retry Storm)**: Load → Latency → Timeouts → Retries → Load. DANGEROUS: Exponential growth toward failure.
-* **B2 (Autoscaler)**: Load → Latency → Pods → Latency. PROTECTIVE: Adds capacity to handle load. BUT: Has delays, might oscillate.
-* **B3 (Circuit Breaker)**: Timeouts → Circuit opens → Load drops → Latency drops. PROTECTIVE: Breaks the retry storm. FASTEST: Acts immediately when failures spike.
+*Three Loops Interacting:* The retry storm loop R1 (Load → Latency → Timeouts → Retries → Load) is reinforcing with no negative links, and its natural behavior is exponential growth toward failure—it represents the failure mode the system is vulnerable to whenever retry logic is present without adequate protection. The autoscaler loop B2 (Load → Latency → Pods → Latency) is balancing with one negative link where Pods negatively affects Latency, adding capacity in response to increased load as the system's primary adaptive mechanism for handling sustained traffic growth, though its response is subject to delays that can cause oscillation. The circuit breaker loop B3 (Timeouts → Circuit opens → Load drops → Latency drops) is also balancing with one negative link where Circuit State negatively affects Load, and it acts faster than the autoscaler because it operates on immediate failure signals rather than lagging utilization metrics—its action of shedding load is instantaneous once the breaker trips.
 
-*Analysis: B3 (circuit breaker) protects against R1 (retry storm). B2 (autoscaler) handles sustained load. Without B3, R1 can overwhelm B2's ability to respond.*
+*Combined analysis: B3 (circuit breaker) directly counteracts R1 (retry storm) by inserting negative feedback where R1 has only positive feedback. B2 (autoscaler) handles sustained load growth but responds too slowly to prevent a retry storm from overwhelming the system. Without B3, R1 can accelerate faster than B2 can respond, consuming all available resources before additional pods come online. This interaction pattern—a fast reinforcing loop overwhelming a slow balancing loop—is one of the most common failure architectures in production systems and can be identified during design review simply by drawing the loops and comparing their response times.*
 
 ### 3.3 Using Causal Loops for Design
 
-Before building any feature that involves feedback, draw the loops:
+Before implementing any feature that involves feedback—retry logic, autoscaling, caching, rate limiting, circuit breaking, load shedding—draw the causal loop diagram. A few minutes of diagramming will surface interactions that would take hours of incident debugging to discover empirically:
 
 ### Causal Loop Design Checklist
 
-1. **IDENTIFY ALL LOOPS**
-   * [ ] What feedback mechanisms exist?
-   * [ ] Are they reinforcing or balancing?
-   * [ ] Are there hidden loops you haven't considered?
+1. **IDENTIFY ALL LOOPS**: What feedback mechanisms exist in the design, and what feedback mechanisms might emerge from interactions between components that were designed independently? Are the loops reinforcing or balancing? Are there hidden loops—paths through the system that connect back to earlier stages in ways the component designers did not anticipate?
 
-2. **ASSESS EACH LOOP**
-   * [ ] What triggers it?
-   * [ ] What delays are involved?
-   * [ ] What limits exist?
-   * [ ] What happens at the limits?
+2. **ASSESS EACH LOOP**: What conditions trigger each loop into action? What delays exist between when the trigger condition occurs and when the loop's corrective action takes effect? What limits exist on the loop's behavior—resource ceilings, rate limits, saturation points? What happens when the loop encounters those limits—does it degrade gracefully, oscillate, or fail catastrophically?
 
-3. **CHECK LOOP INTERACTIONS**
-   * [ ] Can reinforcing loops overpower balancing ones?
-   * [ ] Can balancing loops fight each other?
-   * [ ] Is there a sequence where loops activate?
+3. **CHECK LOOP INTERACTIONS**: Can a reinforcing loop overpower a co-existing balancing loop by acting faster? Can multiple balancing loops, each correct in isolation, fight each other by pulling the system toward different goal states? Is there a sequence in which loops activate that produces a different outcome than any loop would produce alone?
 
-4. **DESIGN SAFETY MECHANISMS**
-   * [ ] Every reinforcing loop needs a circuit breaker.
-   * [ ] Every balancing loop needs appropriate delays.
-   * [ ] Every loop needs observability.
+4. **DESIGN SAFETY MECHANISMS**: Every reinforcing loop needs a circuit breaker—a mechanism that detects runaway behavior and inserts a negative link to dampen it before it reaches a resource ceiling. Every balancing loop needs delays that are short enough relative to the dynamics it is controlling to prevent sustained oscillation. Every loop needs observability—metrics and traces that reveal whether it is behaving as designed, because loops that operate silently are loops that will surprise you.
 
-> **Gotcha: Fighting Autoscalers**
+> **Hypothetical scenario: Fighting Autoscalers**
 >
-> A team had two autoscalers: HPA scaling on CPU, and a custom controller scaling on queue depth. Both were balancing loops. Both were "correct."
+> A team deployed two autoscaling mechanisms. The Horizontal Pod Autoscaler (HPA) scaled the service on CPU utilization using the standard Kubernetes metrics pipeline. A custom controller scaled the same service on queue depth, monitoring the pending request count and adding pods when the queue grew beyond a configurable threshold. Both mechanisms were balancing loops. Both were "correct" in the sense that each, operating alone, would converge to its respective target.
 >
-> But they fought each other:
-> 1. Queue grows → Custom scaler adds pods
-> 2. More pods → Queue drains fast → CPU drops
-> 3. Low CPU → HPA removes pods
-> 4. Fewer pods → Queue grows
-> 5. Repeat
+> In production, they fought each other. When traffic increased, the queue grew, triggering the custom controller to add pods. Additional pods drained the queue rapidly, which caused per-pod CPU utilization to drop below the HPA's target threshold. The HPA, seeing low CPU, removed pods. Fewer pods meant the queue grew again, restarting the cycle. The system oscillated continuously—not because either loop was wrong, but because they had different goal states (queue depth versus CPU utilization) and different response times, creating a tug-of-war that neither could win.
 >
-> The system oscillated continuously. Neither loop was wrong—they just had different goals (queue depth vs. CPU) and different response times.
->
-> **Lesson**: When designing systems, map ALL the loops. Individual loops can be correct but collectively dysfunctional.
+> **Lesson**: When designing systems with multiple feedback mechanisms, map the complete set of loops and verify that they do not have conflicting goal states. Individual loops can be correct in isolation and dysfunctional in combination. The only way to detect this before production is to draw the complete diagram and trace the interactions.
 
 ---
 
@@ -426,28 +353,27 @@ Before building any feature that involves feedback, draw the loops:
 
 ### 4.1 The Unified Framework
 
-When an incident occurs, use all three models in sequence:
+The three mental models presented in this module are not alternatives from which you choose one. They are layers of analysis that build on each other, providing a structured sequence for approaching any incident that involves system degradation. The framework orders them by the questions they answer, moving from what is happening to why it is happening to what to do about it:
 
 ### Mental Model Incident Framework
 
 **STEP 1: STOCK-AND-FLOW (What's accumulating?)**
-*"Something is growing that shouldn't be."*
-* **Ask**: What stocks are changing? Is inflow > outflow? Where's the bottleneck?
-* **Quick checks**: Queue depths, connection pool usage, memory trends, error counts.
+
+*"Something is growing that should not be growing, or depleting faster than it should."* Begin by identifying the stocks that are changing: queue depths, connection pool usage, memory consumption, error counts, error budget remaining. For each stock that is trending in an undesirable direction, determine whether the cause is increased inflow, decreased outflow, or both. Locate the bottleneck—the point in the system where inflow exceeds outflow capacity, causing accumulation upstream. This step answers the most operationally urgent question: what is the immediate dynamic driving the degradation, and what metrics confirm or refute each hypothesis?
 
 **STEP 2: CAUSAL LOOPS (Why is it accumulating?)**
-*"What's driving the accumulation?"*
-* **Ask**: Is there a reinforcing loop amplifying the problem? Is a balancing loop broken or overwhelmed? What feedback is missing?
-* **Quick checks**: Retry rates (retry storm?), autoscaler behavior (fighting or oscillating?), circuit breaker states.
+
+*"What feedback structure is driving and sustaining the accumulation identified in Step 1?"* Draw the loops connecting the affected stocks and flows. Is there a reinforcing loop amplifying the problem? Is a balancing loop that normally maintains stability broken, overwhelmed, or fighting another balancing loop? What feedback is missing—what information would a component need to avoid making the situation worse, and who does not have it? This step moves from description to explanation, revealing the structural cause beneath the surface symptom.
 
 **STEP 3: LEVERAGE POINTS (Where to intervene?)**
-*"What's the highest-leverage fix?"*
-* **Ask**: Can we break a reinforcing loop? Can we add information? Do we need to change a rule? Or just tune a parameter?
-* **Quick checks**: What's the immediate need (stop bleeding)? What's the root cause fix? What prevents this from recurring?
+
+*"What is the highest-leverage intervention given the loop structure revealed in Step 2?"* Can you break a reinforcing loop immediately by inserting a negative link, such as enabling a circuit breaker or disabling retries? Can you add an information flow that reveals the problem earlier, such as a dashboard for a previously unmonitored queue? Can you change a rule that prevents the system from self-correcting? The leverage hierarchy provides a clear priority order: aim as high as the incident's urgency permits, starting from level 7 (breaking reinforcing loops) and moving upward toward level 3 (changing goals) for long-term remediation.
+
+This sequence is cumulative. Stock-and-flow analysis identifies the candidate culprits. Causal loop analysis confirms or eliminates structural explanations. Leverage point analysis ranks the available interventions. Together, they form a complete reasoning chain from observation to action, one that can be communicated to and debated with other engineers because each step is transparent and the model at each step is explicit.
 
 ### 4.2 Worked Example: Database Connection Exhaustion
 
-**Incident**: "All pods reporting database connection timeouts"
+**Incident**: "All pods reporting database connection timeouts. The connection pool is saturated."
 
 > **Stop and think**: Before jumping to a fix, what is the highest leverage point you can affect in this system?
 
@@ -461,8 +387,8 @@ flowchart TD
     classDef stock fill:#d4e6f1,stroke:#2874a6,stroke-width:2px;
     class Pool stock;
 ```
-*Inflow (50/s) > Outflow (20/s) = Stock was growing. Stock hit max (200) = New queries can't get connections.*
-*Why is outflow only 20/s when it should be 50/s? Queries are taking 10x longer than normal (1s vs 100ms). Connections held 10x longer. Pool saturated with slow queries.*
+
+The stock is active connections, and it has hit its ceiling. Inflow (50 queries per second requesting connections) exceeds outflow (20 queries per second completing and releasing connections). The outflow is abnormally low because individual queries are taking far longer to execute than normal—a query that should complete in 100ms is instead taking several seconds. The connections are being held open for the duration of these slow queries, saturating the pool and blocking new work. The immediate mechanism is clear: slow queries → connections held longer → pool fills → new requests blocked. But the mechanism does not explain why queries are slow, which is what causal loop analysis addresses.
 
 **Step 2: Causal Loop Analysis**
 
@@ -476,7 +402,8 @@ flowchart TD
         Held -- "(+)" --> Queries
     end
 ```
-*Reading: More concurrent queries → more lock contention. More contention → slower queries. Slower queries → connections held longer. Connections held → more concurrent queries (waiting). This is REINFORCING. It has no natural stopping point. The database will get slower and slower until it dies.*
+
+The root cause is a reinforcing loop. More concurrent queries increase lock contention within the database. Increased contention slows every query, which means connections are held longer. Longer-held connections mean more concurrent queries are active at any given moment. This drives more contention, and the cycle accelerates. All four links are positive, yielding zero negative links and a reinforcing polarity. The loop has no internal braking mechanism—once contention passes a threshold, the database degrades progressively until it is effectively unavailable. The latency increase is not caused by a single slow query; it is caused by the interaction of all queries competing for the same locks, a systemic effect invisible to per-query analysis.
 
 **Step 3: Leverage Point Analysis**
 
@@ -490,35 +417,37 @@ flowchart TD
 | **6** (Information) | Add slow query logging + APM | **High**—shows which queries are slow |
 | **5** (Rules) | "All queries must have timeout" | **Very high**—prevents accumulation |
 
+Notice that the most obvious intervention—increasing the pool size (level 12)—is the worst possible action. More concurrent connections would increase lock contention, making every query slower and accelerating the death spiral. This is a general property of the leverage hierarchy: low-level interventions applied to problems driven by reinforcing loops are not merely ineffective; they are often actively harmful because they increase the load on the very mechanism that is failing.
+
 **Action Plan**:
 
 **IMMEDIATE (next 5 minutes):**
-* **Kill long-running queries** (break the loop now): Command to kill queries running > 30 seconds.
-* **Reduce connection pool temporarily** (counterintuitive!): Fewer concurrent queries = less contention = faster queries. Pool: 200 → 50.
+
+Terminate the longest-running queries to break the contention loop now. The command to kill queries running beyond a threshold (e.g., 30 seconds) immediately frees connections and reduces contention, allowing the system to recover. Counterintuitively, consider temporarily reducing the connection pool size: fewer concurrent queries means less lock contention, which means faster query completion for the remaining connections. A smaller pool operating at higher throughput can outperform a larger pool paralyzed by contention.
 
 **SHORT-TERM (next hour):**
-* **Add query timeouts** (change rules): Every query gets a 5-second timeout, no exceptions.
-* **Identify the slow queries** (add information): Enable slow query log, threshold = 500ms.
+
+Add mandatory query timeouts at the application level: every query receives a deadline (e.g., 5 seconds), and queries that exceed it are cancelled rather than allowed to hold connections indefinitely. This is a rule change (level 5) that prevents any single query from saturating a connection for longer than the timeout duration. Identify the specific slow queries by enabling the database's slow query log with a threshold of 500ms, providing the information (level 6) needed to determine whether the fix is a missing index, a suboptimal query plan, or a schema design issue.
 
 **MEDIUM-TERM (next sprint):**
-* **Add circuit breaker on database calls** (break reinforcing loop): If 5 failures in 30 seconds, return cached/default value.
-* **Add read replica for heavy queries** (structural change): Route reporting queries to replica.
+
+Add a circuit breaker on database calls: if a configurable number of failures or timeouts occurs within a window, the circuit opens and subsequent calls return a cached or default response rather than adding to the database's load. This breaks the reinforcing loop at level 7. Add a read replica for reporting and analytics queries that do not require real-time consistency, structurally separating heavy read traffic from the write path (level 10).
 
 **LONG-TERM (next quarter):**
-* **Add database connection observability** (information flow): Dashboard showing active connections, query times, lock waits.
-* **Change team goal** (highest leverage): "Every query must be explainable and have an index". Review before merge, not after incident.
+
+Build a dedicated database observability dashboard showing active connections, query latency distribution, lock wait times, and connection pool saturation. This information flow (level 6) makes the contention spiral visible before it reaches the connection pool ceiling. Change the team's development goal: "Every query introduced in a pull request must be explainable and have an appropriate index, verified during code review." This is a goal change (level 3) that prevents the accumulation of un-indexed queries rather than reacting to their effects after deployment.
 
 ---
 
 ## Did You Know?
 
-- **Donella Meadows** was lead author of "Limits to Growth" (1972), which used system dynamics to model global resource depletion. Her leverage points framework came from decades of modeling complex systems, distilled into a few pages that changed how a generation thought about intervention.
+- **Donella Meadows** was the lead author of "Limits to Growth" (1972), which used system dynamics computer models to simulate global resource depletion under different policy scenarios. Her leverage points framework—distilled into a short article decades later—came from a career spent modeling complex systems and observing that interventions at different points in a system's structure produce radically different outcomes for the same amount of effort.
 
-- **Jay Forrester**, who invented system dynamics at MIT in the 1950s, originally developed it to understand why GE's factories had boom-bust hiring cycles. He discovered that feedback delays were causing oscillation—the exact same pattern we see in modern autoscalers.
+- **Jay Forrester**, who invented the field of system dynamics at MIT in the 1950s, originally developed the methodology to understand a puzzle at General Electric: why their factories experienced cycles of labor shortage and oversupply despite stable product demand. He discovered that the delays built into hiring and layoff decisions were creating an oscillating feedback loop—the exact same mathematical structure that causes modern autoscalers to oscillate when their response delays exceed the natural frequency of traffic variation.
 
-- **The London cholera epidemic of 1854** was solved by John Snow using stock-and-flow thinking, though he didn't call it that. He mapped where people were dying (stock of deaths) and traced inflow (water sources) to a single contaminated pump. Removing the pump handle stopped the epidemic.
+- **The London cholera epidemic of 1854** was resolved by John Snow using what we would now recognize as stock-and-flow reasoning. He mapped the stock of deaths geographically, traced the inflow pathway to a contaminated water pump on Broad Street, and convinced authorities to remove the pump handle. The epidemic stopped. Snow did not know about bacteria—germ theory was decades away—but his map of accumulation made the cause visible.
 
-- **Modern epidemiology** is pure stock-and-flow thinking: susceptible → infected → recovered, with rates for infection and recovery. COVID-19 models used the same mathematics we use for queue depth and error budgets.
+- **Modern epidemiology** is built on stock-and-flow mathematics. The classic SIR model—Susceptible, Infected, Recovered—tracks how populations move between these stocks at rates determined by infection probability and recovery time. The differential equations governing these transitions are structurally identical to the mathematics governing queue depth, error budget accumulation, and connection pool dynamics in production systems.
 
 ---
 
@@ -538,45 +467,73 @@ flowchart TD
 
 ## Quiz
 
-1. **During a major Black Friday event, the checkout service starts dropping requests. The on-call engineer's first instinct is to double the connection pool size, but the incident commander instead asks to enable a circuit breaker that will drop 10% of traffic immediately. Why is the incident commander's approach considered higher leverage?**
+1. **An e-commerce platform experiences a checkout outage during a high-traffic sales event. The on-call engineer's first instinct is to quadruple the connection pool size to handle the surge. The incident commander instead proposes immediately enabling a circuit breaker that will shed 10% of all incoming traffic for the next five minutes. Using the leverage points hierarchy, explain why the incident commander's approach is likely the higher-leverage intervention and what makes the engineer's approach potentially harmful in this scenario.**
    <details>
    <summary>Answer</summary>
 
-   The incident commander's approach operates at a higher leverage point (Level 7: breaking a reinforcing loop) compared to the engineer's approach (Level 11: increasing buffer sizes). Doubling the connection pool only delays the inevitable by providing a larger buffer to fill up, which is a weak intervention. In contrast, the circuit breaker actively prevents the system from entering a death spiral by breaking the reinforcing loop of retries and resource exhaustion. By shedding load early, the system can recover and process the remaining 90% of traffic successfully, rather than crashing entirely. This demonstrates why the most effective interventions often feel counterintuitive or punitive in the moment.
+   The incident commander is operating at level 7 by breaking the reinforcing loop that is likely causing the outage—a retry storm or contention spiral where each failed request generates additional load that causes more failures. The circuit breaker inserts a negative link into this reinforcing loop, immediately reducing the effective load on the system and giving it space to recover. The engineer's approach of quadrupling the connection pool operates at level 11 (buffer sizing), which is a weak intervention in Meadows' hierarchy. Worse, it can be actively harmful: if the root cause is a contention spiral, more concurrent connections will increase lock contention inside the database, making every query slower and accelerating the death spiral rather than stopping it. This counterintuitive property—that the obvious fix worsens the problem—is characteristic of reinforcing loops and is precisely why the leverage hierarchy ranks parameter changes at the bottom.
    </details>
 
-2. **You are investigating an alert for 'High API Latency'. Looking at the dashboard, you see the active request queue has grown from a steady 50 items to over 800 items in the last five minutes. Walk through the diagnostic branching process you would use to determine the cause of this accumulation.**
+2. **Your monitoring alerts for a payment processing service: the active request queue has grown from a steady baseline of approximately 50 items to over 700 items in the span of four minutes, and latency is climbing in proportion. Diagnose this incident faster by selecting the appropriate reasoning framework before diving into the logs: walk through the complete stock-and-flow diagnostic branching process you would use to determine the root cause, specifying which metrics you would check for each branch and what each finding would imply.**
    <details>
    <summary>Answer</summary>
 
-   A growing queue depth indicates a fundamental imbalance where the inflow of requests exceeds the outflow (processing rate). To diagnose this, you must first investigate if the inflow has increased unexpectedly by checking metrics like load balancer request rates for traffic spikes or retry storms. If the inflow is normal, you must investigate if the outflow has decreased by checking for issues like node failures, CPU throttling, or downstream database latency. By systematically isolating whether the faucet was turned up or the drain got clogged, you eliminate half of the potential root causes immediately. This structured approach prevents engineers from guessing and directs them to the exact metrics needed to confirm the hypothesis.
+   To diagnose this incident, start by selecting the appropriate reasoning framework—stock-and-flow analysis—before diving into the logs, because the growing queue is fundamentally a question of inflow versus outflow. A growing queue depth indicates that the inflow of requests exceeds the outflow of processed requests. The diagnostic process branches into two mutually exclusive and collectively exhaustive possibilities. First, investigate whether inflow has increased above baseline by checking the load balancer's request rate—a spike here suggests external traffic growth, potentially from a marketing campaign, viral content, or an attack. Also check the retry rate and error rate simultaneously; if errors triggered client-side or internal retries, the increased inflow is being generated internally by a feedback mechanism rather than externally by users. Second, if inflow is normal, investigate whether outflow has decreased by checking the pod count and node status for recent evictions, failed deployments, or node failures that reduced worker capacity. Additionally, examine per-request latency breakdowns to identify whether a downstream dependency—the database, a payment gateway, an authentication service—has slowed down, increasing per-request duration and thus reducing effective throughput. This systematic branching eliminates entire categories of hypotheses with each check, focusing the investigation on the specific metrics that will confirm or refute the remaining possibilities.
    </details>
 
-3. **Your team implements a new caching layer. When cache hit rates are high, database load drops, which makes cache population queries faster, encouraging more cache usage. However, when the cache is cold, database load spikes, making cache population fail, leading to more cache misses. What type of causal loop is this, and how can you mathematically prove it using link polarities?**
+3. **Your team implements a new caching layer in front of a database. During normal operation, cache hit rates are high, which reduces database load, which speeds up cache population queries, which encourages even more cache usage. However, after a cache flush, the database is immediately overwhelmed, which makes cache population queries fail, which keeps the cache cold, which means all queries continue to hit the overloaded database. Classify this feedback structure using causal loop notation: draw the links, count the polarities, and determine whether the loop is reinforcing or balancing. Explain what makes the system stable in one direction and fragile in the other.**
    <details>
    <summary>Answer</summary>
 
-   This scenario describes a reinforcing loop, which amplifies change and leads to either exponential success or a death spiral. You can prove this mathematically by mapping the variables and counting the negative links: Cache Misses (+) -> DB Load (+) -> Cache Population Failure (+) -> Cache Misses. Since all links are positive (moving in the same direction), the total count of negative links is zero (an even number), confirming it is a reinforcing loop. If it were a balancing loop, it would contain an odd number of negative links and naturally seek equilibrium, rather than spiraling out of control when stressed.
+   The loop is reinforcing, and the clean way to prove it is to count the negative links around the cycle. Trace it as Cache Hit Rate → DB Load → Cache Population Speed → Cache Hit Rate. More cache hits *reduce* database load, so that link is negative; lower database load lets population queries run *faster*, so that link is also negative (load down, speed up); and faster cache population *raises* the cache hit rate, a positive link. Two negative links is an even number, so the loop is reinforcing. You can confirm the result by tracing the same structure in the failure direction: more cache misses raise database load, higher load makes population queries fail, and failed population keeps the cache cold and misses high—every link positive, zero negatives, still reinforcing. The loop is symmetric: it amplifies in whichever direction it is currently moving. During normal operation, high cache hit rates create a virtuous reinforcing cycle of low database load and fast cache population. After a flush, the same loop becomes a vicious cycle of database overload and cache population failures. This symmetry is characteristic of reinforcing loops—they do not have a preferred direction, they amplify whatever momentum the system currently has. Stability in one direction does not guarantee stability in the other; in fact, the same loop structure that produces excellent steady-state performance creates catastrophic fragility when disturbed.
    </details>
 
-4. **A team has experienced three database exhaustion incidents this month. Leadership wants to rewrite the data access layer in Rust for better performance. Instead, the Staff Engineer suggests spending a week adding distributed tracing and query attribution headers. Why is the Staff Engineer's proposal likely to be a much higher-leverage intervention than the rewrite?**
+4. **A team facing recurring database incidents is debating how to choose the right mental model for diagnosing their problem. One engineer wants to apply stock-and-flow analysis by examining connection pool metrics. Another argues they should use causal loop diagrams because the issue might involve feedback dynamics. A third suggests starting with the leverage points hierarchy to identify where to intervene. Using what you have learned about when each mental model is most appropriate, explain which model (or combination) you would apply first to this situation and justify why the order matters for effective diagnosis.**
    <details>
    <summary>Answer</summary>
 
-   Adding information flow is a Level 6 leverage point because it changes how the system and its operators perceive reality, enabling better decisions across the board. A rewrite without observability might just recreate the same bottlenecks faster, as the team still wouldn't know *which* queries are causing the exhaustion. By adding tracing and attribution, the team gains the missing feedback loop needed to identify the exact problematic query patterns. This visibility will likely reveal that a simple index or a minor code change can solve the problem, saving months of unnecessary rewrite effort. Information interventions are powerful because they permanently improve the team's ability to navigate the system.
+   The correct approach is to apply the models in sequence rather than choosing one in isolation: start with stock-and-flow analysis because it answers the most operationally urgent question—what is accumulating and why is the connection pool saturating? This step identifies the immediate dynamic (inflow exceeding outflow) and the metric to watch. Then apply causal loop analysis to determine whether the saturation is driven by a reinforcing feedback loop such as a contention spiral, which would explain why the problem escalates rather than stabilizes. Only after understanding the stock-and-flow dynamic and the causal structure should you apply the leverage points hierarchy to rank possible interventions—because the hierarchy's effectiveness depends on knowing which loops are active and what level of intervention the loop structure demands. Choosing the right model at the right time is essential: using stock-and-flow alone risks treating a symptom without understanding the feedback that will recreate it, and using causal loops alone risks identifying a loop structure without knowing which stock to monitor during remediation. The models are complementary layers of analysis, not competing alternatives, and the situation dictates the sequence.
+   </details>
+
+5. **Apply the mental models from this module to a practical incident scenario. You are designing a new service that will call a downstream payment gateway with a known characteristic: under load, it slows down progressively rather than failing cleanly, and its response time can stretch from a typical 200ms to over 30 seconds during peak periods. Draw the causal loop that would develop if your service implements simple timeout-and-retry logic without additional protection. Then propose two design-level interventions at different leverage levels and explain which is higher leverage and why this analysis would change how you approach similar real-world integration risks.**
+   <details>
+   <summary>Answer</summary>
+
+   The timeout-and-retry loop: Load on gateway (+)→ Gateway Latency (+)→ Timeouts in your service (+)→ Retries (+)→ Load on gateway. All links are positive, making this a reinforcing loop with no natural limiting mechanism. During peak periods, the gateway's progressive slowdown triggers timeouts, which trigger retries, which add more load to an already overloaded gateway, driving latency even higher and triggering more timeouts. The loop accelerates until either the gateway collapses completely or your service exhausts its own resources. Two interventions at different levels: first, a circuit breaker (level 7) that monitors the failure rate and opens when it exceeds a threshold, stopping all calls to the gateway for a configurable cooldown period. This breaks the reinforcing loop by inserting a negative link. Second, information flow (level 6) in the form of latency histogram metrics with attribution by calling endpoint, so the team can see which specific operations are driving the retry load. The circuit breaker is the higher-leverage intervention for immediate protection because it directly counteracts the amplification mechanism. The information intervention is higher leverage for long-term improvement because it enables root-cause fixes—and unlike the circuit breaker, which only protects during incidents, the information is valuable during normal operation as well. This analysis has practical application to real integration design: whenever you connect to a service that degrades rather than fails, you must design the interaction as a feedback system rather than a simple call, anticipating the reinforcing loop that retry logic will create and inserting a balancing mechanism before the first incident.
+   </details>
+
+6. **During an incident review, a team identifies that their Kubernetes Horizontal Pod Autoscaler and a custom queue-depth autoscaler were fighting each other: the queue scaler added pods when the queue grew, draining the queue and dropping CPU, which caused the HPA to remove pods, which made the queue grow again. Both scalers were individually correctly configured. Classify this as a systems dynamics failure pattern and explain what property of the system design—independent of the specific scaler configurations—caused the conflict.**
+   <details>
+   <summary>Answer</summary>
+
+   This is a case of two balancing loops with different, fixed goal states competing to control the same variable—a recognized failure pattern in control systems, and distinct from instability inside a single loop. The HPA's goal state is a target CPU utilization; the queue scaler's goal state is a target queue depth. These goals are correlated but not identical—a system with low CPU can still have a growing queue if requests are I/O-bound, and a system with high CPU can have a draining queue if workers are CPU-saturated. Because the scalers optimize for different metrics, their corrective actions pull the system in opposing directions. The structural cause is not misconfiguration but the presence of two independent control loops operating on the same controlled variable (pod count) with different setpoints. This pattern cannot be fixed by tuning either scaler's parameters because the conflict is architectural, not parametric. The solution is either to consolidate into a single scaling mechanism with a unified metric (such as scaling on a composite signal) or to establish a hierarchy where one scaler defers to the other when their recommendations conflict.
+   </details>
+
+7. **An observability platform team adds a new metric: the fill level of the operating system's TCP listen queue (whose maximum size is set by `net.core.somaxconn`). No application-level dashboards previously showed this metric, and no alert was configured for it. Two weeks later, the metric reveals that the queue fills to capacity during every deployment rollout, silently dropping client connections for approximately 30 seconds each time. Using the leverage points hierarchy, explain what category of intervention the addition of this metric represents, and why it enables higher-leverage interventions that were previously impossible.**
+   <details>
+   <summary>Answer</summary>
+
+   Adding the TCP listen queue depth metric is a level 6 intervention: it adds an information flow where none previously existed. Before the metric was available, the connection drops during deployments were invisible to the operations team—the kernel was silently discarding connections with no application-level error, log entry, or alert. The addition of this single metric enables a cascade of higher-leverage interventions that were previously impossible because the problem was undetectable. With the metric in place, the team can now configure an alert on queue saturation (level 8, strengthening a balancing feedback loop that notifies humans when the stock approaches its ceiling). They can tune kernel parameters like `somaxconn` and `tcp_max_syn_backlog` (level 12) with confidence because they can observe the effect. They can redesign the deployment process to drain connections gracefully before shutting down old pods (level 10, changing the structure of flows). And they might reconsider their deployment SLO to include a "no dropped connections" objective (level 3, changing goals). The metric itself is modest, but it unlocks the entire leverage hierarchy above it by converting an invisible system behavior into visible evidence.
+   </details>
+
+8. **A platform team is debating whether to invest effort in adding distributed tracing or in writing a comprehensive runbook for every known failure mode. Applying the leverage points hierarchy and the stock-and-flow framework, argue which investment provides higher leverage and why, considering both immediate incident response and long-term system improvement.**
+   <details>
+   <summary>Answer</summary>
+
+   Distributed tracing is a level 6 intervention (information flows), while runbooks are essentially documentation of known procedures—valuable but operating at the level of response tactics rather than system structure. Tracing provides higher leverage for two reasons. First, it addresses unknown failure modes: a runbook can only document what the team already knows about, while tracing reveals patterns and dependencies that were previously invisible, enabling the discovery of failure modes the team has not yet encountered. Second, tracing changes the system's information architecture permanently: once instrumented, every future incident benefits from richer observability without additional investment, and every team member gains the ability to trace a request end-to-end regardless of their familiarity with the specific service. Runbooks decay as the system evolves and must be continuously maintained; tracing instrumentation, properly implemented, becomes part of the system's self-description. From a leverage perspective, the runbook is a low-leverage intervention—it improves the response to a known problem without changing the system's ability to detect or prevent similar problems. The tracing investment moves the system up the leverage hierarchy and compounds in value over time, while the runbook's value erodes.
    </details>
 
 ---
 
 ## Hands-On Exercise
 
+This exercise has two parts. Part A lets you observe stock-and-flow dynamics directly in a live Kubernetes cluster by creating and draining a job queue. Part B asks you to apply all three mental models—stock-and-flow, causal loops, and leverage points—to analyze a realistic web application architecture with known issues. Together they provide concrete practice in translating the conceptual frameworks from this module into operational reasoning.
+
 ### Part A: Observe Stocks and Flows in Kubernetes (15 minutes)
 
-**Objective**: See stocks and flows in action using a Kubernetes Job queue.
+The objective of this exercise is to see stocks and flows in action using a Kubernetes Job queue as a simplified model of a production work pipeline. You will need a running Kubernetes cluster—kind, minikube, or any accessible cluster will work. The exercise proceeds through five steps that each illustrate a different aspect of stock-and-flow dynamics.
 
-**Prerequisites**: A running Kubernetes cluster (kind, minikube, or any cluster)
-
-**Step 1: Create a job processing system**
+**Step 1: Create a job processing system.** Start by creating a dedicated namespace and submitting ten Kubernetes Jobs that will serve as the work queue. These jobs simulate variable-duration work items by sleeping for a random interval:
 
 ```bash
 # Create namespace
@@ -603,7 +560,7 @@ EOF
 done
 ```
 
-**Step 2: Watch the stock (pending jobs) drain**
+**Step 2: Watch the stock drain as jobs are processed.** With the jobs submitted, monitor the queue (the stock of pending work) and the pods (the workers processing that work). Open two terminal windows and run these watch commands simultaneously:
 
 ```bash
 # Watch jobs - this shows the "stock" of work
@@ -613,20 +570,16 @@ kubectl get jobs -n stocks-lab -w
 kubectl get pods -n stocks-lab -w
 ```
 
-**Step 3: Observe the dynamics**
+**Step 3: Observe the dynamics by counting stock levels over time.** Use a watch loop that reports pending and completed job counts each second, giving you a real-time view of how the stock drains as workers process the queue:
 
 ```bash
 # Count pending vs completed (stock levels)
 watch -n 1 'echo "Pending: $(kubectl get jobs -n stocks-lab --no-headers 2>/dev/null | grep -c "0/1"); echo "Completed: $(kubectl get jobs -n stocks-lab --no-headers 2>/dev/null | grep -c "1/1")"'
 ```
 
-**What to observe:**
-- **Stock**: Number of pending jobs (accumulation)
-- **Inflow**: Jobs being created (we created 10, then will add more)
-- **Outflow**: Jobs completing (depends on processing time and worker capacity)
-- **Flow rate**: How fast does the stock drain?
+As you watch the numbers change, identify each element in the stock-and-flow model: the pending job count is your stock, job creation is the inflow, and job completion is the outflow. Note how the flow rate determines how fast the stock drains and how the random sleep durations introduce variability in the outflow rate.
 
-**Step 4: Create a flow imbalance**
+**Step 4: Create a flow imbalance by spiking the inflow.** With the original jobs still processing, add ten more jobs quickly to overwhelm the processing capacity and observe the pending stock grow as inflow exceeds outflow:
 
 ```bash
 # Add 10 more jobs quickly (spike in inflow)
@@ -635,9 +588,9 @@ kubectl create job task-$i -n stocks-lab --image=busybox -- sh -c "echo Processi
 done
 ```
 
-Watch how the pending stock grows when inflow exceeds outflow capacity.
+Watch the pending count climb until the new jobs begin completing, at which point the stock should peak and then resume draining. This is the exact dynamic that occurs in production when a traffic spike arrives faster than the system can process it.
 
-**Step 5: Clean up**
+**Step 5: Clean up by deleting the namespace.** Remove all resources created during the exercise:
 
 ```bash
 kubectl delete namespace stocks-lab
@@ -647,7 +600,7 @@ kubectl delete namespace stocks-lab
 
 ### Part B: Analyze a System Using All Three Models (25 minutes)
 
-**Scenario**: You operate a web application with this architecture:
+This part asks you to work through a realistic operational scenario using all three frameworks from the module in sequence. You operate a web application with users routed through a load balancer to API pods managed by a Horizontal Pod Autoscaler, backed by a database and a Redis cache. The system exhibits three recurring issues: latency spikes that occur every hour on the hour, occasional cascading failures during traffic spikes, and periodic drops in cache hit rate from 95% down to 60%.
 
 ```mermaid
 flowchart LR
@@ -657,36 +610,11 @@ flowchart LR
     API --> Redis["Redis Cache"]
 ```
 
-**Current issues:**
-- Latency spikes every hour (on the hour)
-- Occasional cascading failures during traffic spikes
-- Cache hit rate drops from 95% to 60% periodically
+**Section 1: Stock-and-Flow Diagram (10 minutes).** Draw a diagram that includes at least two stocks—consider the request queue, the database connection pool, and the cache entry set—along with their inflows and outflows, and show how these stocks are connected through the request processing path. Then answer two diagnostic questions: which stock is most likely related to the hourly latency spikes (think about what resets on an hourly cycle), and what happens to each stock when traffic spikes?
 
-**Your Analysis:**
+**Section 2: Causal Loop Diagram (10 minutes).** Draw a diagram that includes at least three feedback loops: the retry storm loop (reinforcing), the autoscaling loop (balancing), and the cache behavior loop that explains the hit rate fluctuations. Mark each link as (+) or (−) and label each loop as R or B. Then identify which loop interactions explain the cascading failures—specifically, how a reinforcing loop can overwhelm the protective balancing loops.
 
-**Section 1: Stock-and-Flow Diagram (10 minutes)**
-
-Draw a diagram including:
-- At least 2 stocks (request queue, connection pool, cache entries)
-- Inflows and outflows for each
-- How stocks are connected
-
-Answer these questions:
-- What stock is related to the hourly latency spikes?
-- What happens when traffic spikes?
-
-**Section 2: Causal Loop Diagram (10 minutes)**
-
-Draw a diagram including:
-- The retry storm loop (reinforcing)
-- The autoscaling loop (balancing)
-- The cache behavior loop
-
-Mark each link as (+) or (−). Label each loop as R or B.
-
-**Section 3: Leverage Point Analysis (5 minutes)**
-
-For "cascading failures during traffic spikes," list interventions:
+**Section 3: Leverage Point Analysis (5 minutes).** For the cascading failure scenario, list at least one intervention at each of the following leverage levels and explain the expected impact of each:
 
 | Level | Intervention | Expected Impact |
 |-------|--------------|-----------------|
@@ -696,7 +624,7 @@ For "cascading failures during traffic spikes," list interventions:
 | 6 | | |
 | 5 | | |
 
-**Success Criteria**:
+**Success criteria for this exercise.** Complete Part A by creating the job queue, observing it drain, and watching what happens when inflow exceeds outflow capacity. For Part B, produce a stock-and-flow diagram with clearly labeled accumulation points, a causal loop diagram with at least two identified loops and correct polarity markings, a leverage point analysis with interventions ranked at the correct levels, and an explanation of why the hourly latency spikes occur—the hint is that cache entries have a time-to-live that expires on a regular cycle.
 - [ ] Part A: Created and observed job queue draining
 - [ ] Part A: Observed what happens when inflow > outflow
 - [ ] Part B: Stock-and-flow diagram with clear accumulation points
@@ -706,17 +634,30 @@ For "cascading failures during traffic spikes," list interventions:
 
 ---
 
+## Sources
+
+1. [Places to Intervene in a System](https://donellameadows.org/archives/leverage-points-places-to-intervene-in-a-system/) — Donella Meadows, 1997. The original essay defining the twelve leverage points and their hierarchy.
+2. [Thinking in Systems: A Primer](https://www.chelseagreen.com/product/thinking-in-systems/) — Donella Meadows, 2008. The posthumously published book-length treatment, with detailed chapters on leverage points and system traps.
+3. [Handling Overload](https://sre.google/sre-book/handling-overload/) — Chapter from the Google SRE Book covering retry storms, circuit breakers, load shedding, and the feedback dynamics of overloaded systems.
+4. [Embracing Risk](https://sre.google/sre-book/embracing-risk/) — Chapter from the Google SRE Book introducing error budgets as a mechanism for balancing reliability and velocity through measurable risk tolerance.
+5. [Business Dynamics: Systems Thinking and Modeling for a Complex World](https://www.mhprofessional.com/business-dynamics-9780072389152) — John Sterman, 2000. Comprehensive textbook on stock-and-flow modeling with applications across engineering, management, and public policy.
+6. [The Fifth Discipline](https://en.wikipedia.org/wiki/The_Fifth_Discipline) — Peter Senge, 1990. Foundational text applying causal loop diagrams to organizational behavior and team dynamics, introducing the concept of the learning organization.
+7. [System Dynamics](https://en.wikipedia.org/wiki/System_dynamics) — Jay Forrester originated this discipline at MIT in the 1950s. The methodology emerged from studying factory hiring cycles at General Electric, where Forrester discovered that feedback delays were causing oscillation—the same pattern seen in modern autoscalers.
+8. [Principles of Chaos Engineering](https://principlesofchaos.org/) — Community-authored reference defining the practice of using controlled failure injection to reveal information about system behavior under stress, an application of leverage point 6 (information flows).
+9. [Drift into Failure: From Hunting Broken Components to Understanding Complex Systems](https://www.routledge.com/Drift-into-Failure-From-Hunting-Broken-Components-to-Understanding-Complex/Dekker/p/book/9781409422211) — Sidney Dekker, 2011. Applies systems thinking to incident analysis, arguing that failures emerge from normal system dynamics rather than component breakage.
+10. [Resilience Engineering: Concepts and Precepts](https://www.routledge.com/Resilience-Engineering-Concepts-and-Precepts/Hollnagel-Woods-Leveson/p/book/9780754649045) — Hollnagel, Woods, and Leveson, 2006. Foundational text on designing systems that sustain required capability under both expected and unexpected conditions.
+11. [Resilience Engineering in Practice: A Guidebook](https://www.routledge.com/Resilience-Engineering-in-Practice-A-Guidebook/Hollnagel-Paries-Woods-Wreathall/p/book/9781472420749) — Hollnagel, Pariès, Woods, and Wreathall, 2013. Practitioner-oriented follow-up with operational patterns for applying resilience engineering principles to production systems.
+12. [An Introduction to General Systems Thinking](https://www.amazon.com/Introduction-General-Systems-Thinking-ebook/dp/B004VS9AUS) — Gerald Weinberg, 1975. Classic text connecting systems thinking principles to software engineering practice, with particular emphasis on the limits of models.
+
+---
+
 ## Further Reading
 
-- **"Thinking in Systems: A Primer"** - Donella Meadows. Chapters 5-6 on leverage points and system traps are essential. Short, clear, and will change how you think.
-
-- **"Places to Intervene in a System"** - Donella Meadows (original article). Free online, even shorter than the book.
-
-- **"Business Dynamics"** - John Sterman. Academic but thorough. The definitive text on stock-and-flow modeling.
-
-- **"An Introduction to Systems Thinking"** - Barry Richmond. Practical guide with lots of diagram examples.
-
-- **"The Fifth Discipline"** - Peter Senge. Applies systems thinking to organizations. Relevant if you're trying to change team behavior.
+- **"Thinking in Systems: A Primer"** - Donella Meadows. Chapters 5-6 on leverage points and system traps are essential. Short, clear, and will permanently change how you interpret system behavior.
+- **"Places to Intervene in a System"** - Donella Meadows (original article). Available online at the Donella Meadows Project. Even shorter than the book and denser with actionable insight.
+- **"Business Dynamics"** - John Sterman. The definitive academic text on stock-and-flow modeling and system dynamics, with extensive operational examples.
+- **"An Introduction to Systems Thinking"** - Barry Richmond. A practical guide with numerous diagram examples and exercises for building systems thinking fluency.
+- **"The Fifth Discipline"** - Peter Senge. Applies systems thinking to organizational behavior and team dynamics. Relevant for engineers who need to influence how their organization makes decisions about reliability investment.
 
 ---
 

--- a/src/content/docs/platform/foundations/systems-thinking/module-1.4-complexity-and-emergent-behavior.md
+++ b/src/content/docs/platform/foundations/systems-thinking/module-1.4-complexity-and-emergent-behavior.md
@@ -425,7 +425,7 @@ Chaos Engineering deliberately introduces failures to discover weaknesses before
 4. **Run experiments continuously**: Systems drift. Regular chaos experiments detect this drift.
 5. **Build confidence, not heroics**: The goal is a boring incident response because you've seen it before.
 
-Netflix's Chaos Monkey, described in the [Principles of Chaos Engineering](https://principlesofchaos.org/), was among the early tools that randomly terminates production instances so teams design for survivability rather than assuming instance permanence. The tool does not merely test resilience—it forces resilient design by making instance loss routine. For a deeper KubeDojo treatment, see [Chaos Principles](../../disciplines/reliability-security/chaos-engineering/module-1.1-chaos-principles/).
+Chaos engineering tools that randomly terminate production instances, described in the [Principles of Chaos Engineering](https://principlesofchaos.org/), push teams to design for survivability rather than assuming instance permanence. Making instance loss routine does not merely test resilience—it forces resilient design. KubeDojo covers the specific tools and the discipline in depth in [Chaos Principles](../../disciplines/reliability-security/chaos-engineering/module-1.1-chaos-principles/).
 
 **Common Chaos Experiments:**
 

--- a/src/content/docs/platform/foundations/systems-thinking/module-1.4-complexity-and-emergent-behavior.md
+++ b/src/content/docs/platform/foundations/systems-thinking/module-1.4-complexity-and-emergent-behavior.md
@@ -3,6 +3,7 @@ title: "Module 1.4: Complexity and Emergent Behavior"
 slug: platform/foundations/systems-thinking/module-1.4-complexity-and-emergent-behavior
 sidebar:
   order: 5
+revision_pending: false
 ---
 > **Complexity**: `[COMPLEX]`
 >
@@ -12,9 +13,9 @@ sidebar:
 >
 > **Track**: Foundations
 
-### What You'll Be Able to Do
+## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+After completing this module, you will be able to apply complexity thinking to production systems in four concrete ways:
 
 1. **Distinguish** between complicated systems (predictable, decomposable) and complex systems (emergent, non-linear) in real infrastructure
 2. **Analyze** how simple component interactions produce emergent behaviors that cannot be predicted from specifications alone
@@ -25,17 +26,11 @@ After completing this module, you will be able to:
 
 ## The Perfect Storm That Nobody Saw Coming
 
-*July 8, 2015. The New York Stock Exchange halts trading at 11:32 AM.*
+On [July 8, 2015](https://www.nyse.com/market-status/history), the New York Stock Exchange suspended trading for several hours after a software configuration problem during a routine deployment. That same morning, [United Airlines grounded flights nationwide](https://www.bbc.co.uk/news/technology-33449693) because of a failed network router, and the Wall Street Journal website suffered a separate technical outage. Three high-profile failures within hours looked coordinated to observers watching social media, even though post-incident reporting from each organization described independent causes with no shared attacker or shared root dependency.
 
-Engineers scramble. Is it a cyberattack? A hardware failure? The systems look... fine. Dashboards green. No errors. No crashes.
+Engineers at each company faced a familiar pattern: dashboards that looked mostly healthy, symptoms that did not map cleanly to a single broken component, and public pressure to name one villain quickly. The NYSE incident involved software behavior during an update. United's outage traced to router configuration. The WSJ disruption involved its own delivery stack. None of these stories required a conspiracy to be terrifying—they required only the ordinary complexity of large socio-technical systems failing in parallel while humans searched for narrative simplicity.
 
-Meanwhile, United Airlines grounds all flights nationwide. Same morning. Different company. Different systems. Complete coincidence.
-
-And The Wall Street Journal's website goes down. Same morning.
-
-Three unrelated failures, all hitting within hours of each other, creating a day the internet will never forget. Conspiracy theories explode. "China is attacking!" "This is coordinated!"
-
-The truth was stranger: each failure was independently caused by mundane issues. NYSE had a software glitch during a routine update. United had a network router problem. WSJ had a technical issue with their content delivery. No coordination. No attack. Just three independent complex systems failing in ways that seemed impossible—until they happened.
+This clustering effect is one reason operators study complexity theory instead of treating every incident as an isolated bug hunt. When several critical systems wobble on the same day, your brain wants one explanation. Complex systems often deliver many small explanations that combine into a day that feels impossible until you read the timelines carefully.
 
 > **Stop and think**: Before reading further, consider the last major incident you experienced. Did it have one clear cause, or was it a combination of seemingly unrelated, small factors?
 
@@ -49,11 +44,7 @@ You've done everything right. Code is tested. Deployment is automated. Monitorin
 
 This isn't a failure of engineering—it's the **nature of complex systems**. They behave in ways that can't be predicted from their components alone. They adapt, they surprise, and they fail in novel ways.
 
-Understanding complexity changes how you approach operations:
-- You stop trying to prevent all failures (impossible)
-- You start building systems that handle failure gracefully
-- You stop asking "why did this fail?"
-- You start asking "how did this ever work?"
+Understanding complexity changes how you approach operations. You stop trying to prevent all failures, because that goal is impossible in coupled systems with humans in the loop. You start building systems that handle failure gracefully, measuring success by recovery time and customer impact rather than by a fantasy of zero incidents. You stop asking only "why did this fail?" as if a single story could capture the whole mechanism. You start asking "how did this ever work?"—which surfaces latent dependencies, unwritten compensations, and adaptations that were carrying the system until they could not.
 
 > **The Weather Analogy**
 >
@@ -69,7 +60,7 @@ Understanding complexity changes how you approach operations:
 - The Cynefin framework for decision-making in different domains
 - Richard Cook's essential insights on how complex systems fail
 - Why your system is always partially broken (and that's normal)
-- How to design for resilience instead of robustness
+- How robustness and resilience complement each other in complex systems
 
 ---
 
@@ -77,7 +68,7 @@ Understanding complexity changes how you approach operations:
 
 ### 1.1 The Two Types of Hard Problems
 
-Not all difficult problems are the same. A Boeing 747 is **complicated**. A flock of birds is **complex**. Understanding the difference will transform how you approach production systems.
+Not all difficult problems are the same. A commercial jet engine is **complicated**. A flock of birds is **complex**. Understanding the difference will transform how you approach production systems.
 
 | Complicated | Complex |
 |-------------|---------|
@@ -86,11 +77,11 @@ Not all difficult problems are the same. A Boeing 747 is **complicated**. A floc
 | Experts **can** understand fully | No one **can** understand fully |
 | **Best practice** exists | **Good practice** emerges |
 | Can be **designed** top-down | Must be **evolved** |
-| Example: Airplane engine | Example: Air traffic control system |
+| Example: Jet engine | Example: Air traffic control system |
 
 ```mermaid
 graph TD
-    subgraph Complicated [Complicated System: Airplane Engine]
+    subgraph Complicated [Complicated System: Jet Engine]
         direction LR
         A[Fuel] --> B[Combustion] --> C[Turbine] --> D[Thrust]
     end
@@ -106,55 +97,54 @@ graph TD
     end
 ```
 
-**Complicated Systems (Airplane Engine):**
-- Relationships are FIXED
-- Expert mechanics can predict every behavior
-- Same input = Same output (always)
-- Built from a blueprint
-- Can be disassembled, understood, and reassembled
-- Failure modes are KNOWN and FINITE
-- **You CAN fully understand a complicated system.**
+**Complicated systems** like a commercial jet engine have fixed relationships among parts that expert mechanics can model with high fidelity. The same input produces the same output under equivalent conditions, failure modes are enumerable, and the artifact can be disassembled, inspected, and reassembled from a blueprint. You can fully understand a complicated system in the operational sense that matters for maintenance: there is a right answer discoverable by analysis.
 
-**Complex Systems (Your Production Environment):**
-- Relationships change DYNAMICALLY
-- No one understands full system behavior
-- Same input ≠ Same output (depends on state)
-- Emerges from evolution, not design
-- Cannot be fully modeled or predicted
-- Failure modes are UNKNOWN and INFINITE
-- **You CANNOT fully understand a complex system. And that's not a failure—it's fundamental.**
+**Complex systems** such as your production environment change relationships dynamically as code, traffic, configuration, and human behavior shift. No one understands full system behavior in advance, identical inputs can produce different outcomes depending on hidden state, and failure modes are open-ended rather than finite. Complexity emerges from evolution and interaction, not from a single design document. You cannot fully understand a complex system—and that limitation is fundamental physics of coupling, not a personal failure of your team.
 
 ### 1.2 Why Production Systems Are Complex
 
-Your Kubernetes cluster is complex, not just complicated. Here's why:
+Your Kubernetes cluster is complex, not just complicated, because production coupling shows up in five recurring patterns that reinforce one another.
 
-**1. Non-linear interactions**
+Non-linear interactions mean a slow database does not merely make queries slower—it can exhaust connection pools, trigger timeouts, provoke retries, and thereby make the database slower still until the effect is wildly disproportionate to the original trigger. Feedback loops are everywhere: autoscalers respond to load, retries respond to failures, circuit breakers respond to errors, caches respond to traffic shapes, and each loop interacts with the others in ways nobody fully designed ahead of time. Constant adaptation is unavoidable because users change behavior, traffic shifts, code ships daily, dependencies update, and teams rotate; the system you operate today is not the system you operated yesterday even if the architecture diagram stayed the same.
 
-A slow database doesn't just make database queries slow—it causes connection pool exhaustion, which causes timeouts, which causes retries, which makes the database slower. The effect is wildly disproportionate to the cause.
+Human-system coupling means operators are not outside observers. Their decisions change the system, and the system's alerts and dashboards change which decisions feel urgent. Humans are part of the control loop, which is why runbooks, on-call fatigue, and incident rituals matter as much as CPU limits. Multiple timescales stack on top of one another: millisecond network jitter interacts with second-level retries, minute-level autoscaling, hourly batch work, daily deploy rhythms, weekly maintenance, and quarterly capacity plans—all simultaneously—so an incident that looks like a "database problem" may be a cross-scale interaction problem. A latency spike that lasts two hundred milliseconds can trigger retry logic measured in seconds, which changes queue depth over minutes, which changes autoscaling decisions over tens of minutes, which changes cost and capacity over days. Operators who debug only one timescale often fix a symptom while the cross-scale interaction remains.
 
-**2. Feedback loops everywhere**
+### 1.3 Worked Example: From Slow Query to Site-Wide Degradation
 
-Autoscalers respond to load. Retries respond to failures. Circuit breakers respond to errors. Caches respond to traffic patterns. Each feedback loop interacts with others in ways nobody designed.
+Consider a payment API backed by a relational database that begins running ten percent slower because of a missing index after a migration. At first, nothing pages. Latency dashboards show a gentle upward slope. Error rates remain below the alert threshold because most requests still complete within the configured timeout. This is the dangerous middle phase of complex failure: the system is already compensating, and your green dashboards are recording the compensation rather than the underlying stress.
 
-**3. Constant adaptation**
+The next link in the chain is connection pooling. Slower queries hold connections longer, so the pool saturates even though query throughput has not doubled. Upstream services start waiting for pool slots, which increases their latency, which triggers client retries configured to improve reliability. Retries multiply load on the database at the exact moment the database is least able to absorb it. A cache layer that was masking read pressure now sees more write-related invalidation traffic because checkout attempts are being retried. An autoscaler adds pods to stateless services, which increases concurrent database connections and makes pool exhaustion worse.
 
-Users change behavior. Traffic patterns shift. Code changes daily. Dependencies update. Team members join and leave. The system you have today isn't the system you had yesterday.
+No single team owns this story end to end. The database team sees slow queries. The application team sees timeouts. The platform team sees elevated pod counts. The business team sees checkout complaints that do not align cleanly with error-rate graphs. That fragmentation is not an organizational accident; it is what complexity looks like in a microservice architecture. The emergent behavior—checkout feels broken while many service-level indicators look merely elevated—is not written in any one repository.
 
-**4. Human-system coupling**
+The operator move is not to ask which chart is "wrong." It is to trace interactions: pool wait time, retry rate, downstream concurrency, and user-visible success rate must be interpreted together. Complexity-aware debugging starts from the hypothesis that several individually understandable mechanisms are amplifying one another.
 
-Operators make decisions that affect the system. The system's behavior affects operator decisions. Alerts change behavior. Dashboards focus attention. The humans are part of the system.
+### 1.4 Decision Framework: Complicated or Complex?
 
-**5. Multiple timescales**
+When you face a production surprise, the first architectural question is not "which service is broken?" but "what kind of problem is this?" The table below is a practical decision aid. It is not a personality test for your organization; it is a way to avoid applying a blueprint where you need experiments, or running experiments while the site is fully down.
 
-Millisecond network issues interact with second-level retries, minute-level autoscaling, hourly batch jobs, daily deployment patterns, weekly maintenance windows, and quarterly infrastructure changes. All happening simultaneously.
+| Signal | Lean complicated | Lean complex |
+|--------|------------------|--------------|
+| Relationship between change and effect | Repeatable in staging | Changes with load, time, or user segment |
+| Expert analysis | Converges on one mechanism | Produces multiple plausible stories |
+| Fix confidence | Patch or rollback should work | Need safe-to-fail probes first |
+| Metric pattern | One dominant anomaly | Several mild anomalies that correlate oddly |
+| Human role | Implement known fix | Coordinate learning across teams |
 
-> **Did You Know?**
->
-> - **The 2003 Northeast Blackout** (55 million people without power) started with a software bug in an alarm system. The bug meant operators didn't see warnings. But the same bug had existed for years without causing blackouts. What changed? A combination of factors—high temperatures, tree branches touching power lines, operator shift changes—that had never occurred together before. This is complex system failure: multiple small issues combining in novel ways.
->
-> - **Ant colonies** build bridges, farm fungus, wage wars, and manage complex supply chains—without any ant understanding the bigger picture. Each ant follows simple rules; complexity emerges. Your microservices work the same way: simple services creating complex system behavior that nobody designed.
->
-> - **The 2010 Flash Crash** (stock market dropped 9% in 5 minutes, then recovered) was caused by algorithmic trading systems interacting in unexpected ways. Each algorithm was "correct." Together, they created chaos.
+If the situation is complicated, invest in analysis and controlled change. If the situation is complex, invest in observability for learning, bounded experiments, and explicit time limits so you do not confuse learning with infinite data gathering. If the situation is chaotic, stabilize first—then classify again, because chaos often collapses into complex or complicated once the immediate bleeding stops.
+
+### 1.5 Historical Anchor: When Many Small Failures Align
+
+The [2003 Northeast blackout](https://en.wikipedia.org/wiki/Northeast_blackout_of_2003) left tens of millions of people without power after a sequence of equipment and software issues interacted across multiple utilities. A software bug in an alarm system meant operators did not see some warnings they needed. That bug had existed for years without causing catastrophe on its own. What changed was context: high load, vegetation contact with lines, maintenance timing, and operator handoffs combined into a pattern the system had never experienced before. This is the Swiss Cheese pattern in the wild—many layers with latent holes, usually misaligned, occasionally aligned all at once.
+
+That incident is useful for platform engineers even if you never touch power grids, because it demonstrates how "we knew about that bug" is not the same as "that bug was safe." Latent failures wait for partners. Your muted alert, your oversized timeout, your skipped integration test, and your deferred capacity purchase are often harmless—until the day they are not.
+
+
+### 1.6 Coupling Budgets and Architectural Tradeoffs
+
+Platform architects sometimes talk about "blast radius" as if it were a property of a single service. In complex systems, blast radius is an emergent property of coupling choices: synchronous chains, shared mutable state, global caches, and implicit dependencies all increase the number of pathways through which a local fault becomes a customer-visible surprise. A coupling budget is the intentional limit on how many hidden dependencies a feature may introduce before it must be redesigned with explicit boundaries, contracts, and degradation behavior.
+
+Evaluating architectural decisions through a complexity lens asks different questions than a feature checklist. Instead of only "Can we ship it this quarter?" ask "What new interaction loops does this create?" and "If this dependency slows by ten times, what amplifies?" and "Which metrics will show emergent failure before users abandon checkout?" These questions do not slow good engineering—they prevent the kind of fast shipping that later produces slow, scary incidents whose narratives only make sense in hindsight.
 
 ---
 
@@ -186,7 +176,7 @@ graph TD
 
 ### 2.2 Why the Order of Actions Matters
 
-Each domain requires a different approach. Using the wrong approach is worse than doing nothing.
+Each domain requires a different response pattern, and using the wrong pattern is often worse than doing nothing because it burns time while the system state evolves. The table above is a map, not a mandate: your job during incidents is to reclassify quickly as evidence arrives, then announce the domain shift to the bridge so everyone stops arguing from incompatible playbooks.
 
 | Domain | Characteristics | Response Strategy | Common Mistake |
 |--------|-----------------|-------------------|----------------|
@@ -200,41 +190,23 @@ Each domain requires a different approach. Using the wrong approach is worse tha
 
 ### 2.3 Cynefin in Operations: Real Examples
 
-**CLEAR: Disk Space Alert**
-* **Sense:** See the alert.
-* **Categorize:** This is a known issue with a known fix.
-* **Respond:** Run the disk cleanup playbook.
-> **Danger:** Don't overcomplicate it! If you start analyzing why logs grew so much, you're treating a clear problem as complicated. First: fix it. Then: investigate (separate action).
+For a **clear** disk-space alert, sense the signal, categorize it against a known playbook, and respond with the documented cleanup steps. The danger is overcomplicating a solved problem: if you launch a deep log-growth investigation before freeing space, you are borrowing complicated-domain latency for a clear-domain task. Fix first, learn second as a separate deliberate action.
 
-**COMPLICATED: Performance Degradation**
-* **Sense:** Gather data (metrics, traces, logs).
-* **Analyze:** Have experts examine the evidence (profile code paths, check query plans, examine network latency).
-* **Respond:** Implement the fix that analysis reveals.
-> **Danger:** Analysis paralysis! If you're still analyzing after 30 minutes while users are affected, you've waited too long. Set a time limit. Act with the best available information.
+For **complicated** performance degradation, gather metrics, traces, and logs; analyze with domain experts who can interpret query plans, profiles, and network paths; then implement the fix the evidence supports. The danger is analysis paralysis while users remain impacted—set explicit time boxes and be willing to act on the best current hypothesis when the clock expires.
 
-**COMPLEX: Mystery Failures** (Users complain checkout fails but metrics look fine)
-* **Probe:** Run safe-to-fail experiments (Canary with verbose logging, test different user segments).
-* **Sense:** Observe patterns that emerge ("Oh, it only happens on mobile Safari" or "It correlates with CDN cache age").
-* **Respond:** Amplify what works, dampen what doesn't.
-> **Danger:** Premature convergence! Saying "I bet it's the database" and attempting an immediate fix is treating a complex problem as complicated. Run experiments first. Let patterns emerge.
+For **complex** mystery failures where checkout complaints do not match global error rates, run safe-to-fail probes such as canaries with verbose tracing or segment-specific tests, sense the patterns that emerge (mobile Safari only, CDN cache age correlation, specific region skew), and respond by amplifying what works while dampening what fails. The danger is premature convergence: declaring "it must be the database" and shipping a risky change without learning context treats complexity as if it were merely complicated.
 
-**CHAOTIC: Complete Outage** (Site is completely down, everything is red)
-* **Act:** Do something immediately to stabilize (Roll back the last deployment, restart critical services, fail over to backup region).
-* **Sense:** What effect did the action have?
-* **Respond:** Iterate until stable.
-> **Danger:** Analysis during chaos! "Let's understand what's happening first..." NO. The site is down. Users are angry. Revenue is lost. ACT FIRST. Understand later. A wrong action that provides information is better than perfect analysis while everything burns.
+For **chaotic** complete outage when the site is down and indicators are red everywhere, act immediately to stabilize—rollback, restart critical paths, failover, or shed load—then sense the effect, then iterate. The danger is analysis during chaos: waiting for perfect understanding while customers and revenue burn converts an urgent stabilization problem into a prolonged disaster. A coarse action that produces observable learning beats elegant analysis with no remediation attempt.
 
-> **War Story: The 45-Minute Analysis Meeting**
+> **Hypothetical scenario: The analysis meeting during a total outage**
 >
-> A team treated every incident as "complicated"—spending time analyzing before acting. During a major outage, they gathered for 45 minutes examining dashboards, discussing theories, debating root causes. The CTO finally walked in and asked, "Is the site still down?" Yes. "What have you tried?" Nothing. "Why?" "We're still analyzing."
+> A team treats every incident as "complicated" and spends the first phase of response gathering evidence before acting. During a major outage, they convene a bridge call and spend most of an hour examining dashboards, debating theories, and asking for one more chart. A leader finally asks whether the customer-facing site is still down. It is. They ask what remediation has been attempted. Nothing yet—the team is still analyzing. The crashed process was visible in monitoring within the first few minutes, but the group kept treating uncertainty as a reason to delay action rather than as a signal to stabilize first.
 >
-> The fix? Restart a crashed process. Five seconds. The analysis had revealed the process was crashed in minute three. They'd spent 42 more minutes confirming it was definitely crashed.
->
-> **They treated a chaotic situation (site down) as complicated (analyze then act).** Domain misrecognition is dangerous. When the building is on fire, don't form a committee to study fire.
+> The eventual fix is restarting a single process and takes seconds. The expensive part was domain misrecognition: they treated a chaotic situation (total outage, unclear cause, high urgency) with a complicated-domain playbook (analyze thoroughly, then respond). **When the building is on fire, you extinguish or evacuate first; the architectural review can wait.**
 
 ### 2.4 Domain Transitions
 
-Situations can shift between domains. Understanding these transitions helps you respond appropriately.
+Situations can shift between domains as stabilization progresses, and recognizing those transitions prevents the common failure mode of applying yesterday's correct strategy to today's changed context.
 
 ```mermaid
 graph LR
@@ -254,10 +226,27 @@ graph LR
     end
 ```
 
-**Common stuck states:**
-* **COMPLICATED → still COMPLICATED**: "We need more data" (forever). Set time limits. Decide with imperfect information.
-* **COMPLEX → forced to COMPLICATED**: Management demands a single "root cause" when there isn't one. Educate stakeholders on complexity.
-* **CHAOTIC → still CHAOTIC**: Stabilize one thing, something else breaks. Triage. Fix the biggest impact first.
+
+### 2.5 Operating Cynefin Under Incident Pressure
+
+During incidents, domain classification is a leadership skill as much as a technical one. Teams under stress gravitate toward familiar habits: senior engineers want to analyze, managers want a single owner, executives want a confident sentence for status page updates. Cynefin gives you language to resist those defaults when they do not fit the situation. The goal is not to win a framework debate on the bridge call; the goal is to pick a response pattern that matches how much certainty you actually have.
+
+In the Clear domain, speed and standardization win. Disk cleanup, certificate renewal, and known dependency version bumps should not spawn novel investigation every time. The danger is complacency: a playbook written three years ago may assume architecture that no longer exists. Schedule periodic playbook drills, not because the task is hard, but because the environment changed while the document stayed still.
+
+In the Complicated domain, expertise and measurement win, but time bounds matter. Analysis that continues for an hour while user impact persists is often a sign that you have slipped from complicated toward complex or chaotic without updating your strategy. A practical rule many teams adopt is to alternate between twenty-minute investigation windows and explicit decision points: what will we try next if this window does not produce an actionable hypothesis?
+
+In the Complex domain, experiments must be safe-to-fail. That phrase is overloaded in industry slides, so make it concrete. A safe-to-fail probe changes one variable, has a reversible or bounded blast radius, produces observable learning even when it "fails," and is documented so the next responder is not guessing what you tried. Canary traffic with extra tracing, shadow reads against a new dependency, or temporarily routing internal users through an alternate path are probes. "Restart everything in production and see" is not a probe; it is a high-risk gamble that destroys learning context.
+
+In the Chaotic domain, the first obligation is stabilization, not understanding. Stabilization actions include rollback, failover, feature disablement, traffic shedding, and capacity isolation. These actions may feel crude. They are supposed to. Chaotic domains reward coarse moves that reduce the number of simultaneous unknowns. Once user-visible function returns, you almost always transition into Complex or Complicated work: now you can run probes, compare timelines, and rebuild a narrative with fewer moving parts.
+
+### 2.6 Communicating Uncertainty to Stakeholders
+
+Complex systems create a communication trap: leadership asks for certainty because certainty is comforting, and engineers provide narrow technical facts because those are the only statements they can defend. The gap between "we do not know yet" and "the database is slow" is where incidents go politically wrong. Practice translating domains into business language. Clear and Complicated updates can include expected time-to-recover ranges when the fix path is known. Complex updates should emphasize what you are learning, what you ruled out, and what bounded experiment runs next. Chaotic updates should state what stabilization action is in flight and when the next customer-facing checkpoint will occur.
+
+A useful template for complex incidents is: **impact**, **stabilization status**, **working hypotheses**, **next safe experiment**, **decision time**. That template prevents the two worst failure modes: false confidence early, and endless "still investigating" language with no decision clock.
+
+
+**Common stuck states** appear in almost every long-running organization. Teams can remain in complicated mode forever by insisting they "need more data" without time limits or decision clocks. Leaders can force complex incidents into complicated RCA templates that demand a single root cause when several contributing factors remain visible only in hindsight. Incident bridges can remain chaotic because each stabilization attempt fixes one symptom while another dependency fails, which means triage must explicitly prioritize customer impact over completeness.
 
 ---
 
@@ -267,14 +256,7 @@ graph LR
 
 Dr. Richard Cook's "How Complex Systems Fail" is three pages that will change how you think about operations. Here are the key insights, applied to production systems:
 
-**PRINCIPLE 1: Complex systems are intrinsically hazardous**
-Your production system is inherently dangerous. Not because you built it wrong—because it's complex. This isn't failure. This is physics. Accept it. Don't fight it. Design for it.
-
-**PRINCIPLE 2: Complex systems are heavily defended against failure**
-Your system has multiple layers of defense: redundancy, monitoring, alerting, failover, backups, circuit breakers, retries. These defenses work—that's why catastrophic failures are rare.
-
-**PRINCIPLE 3: Catastrophe requires multiple failures**
-Single points of failure are myths. The real danger is multiple defenses failing simultaneously in ways nobody anticipated.
+Cook's first three principles establish the baseline. **Complex systems are intrinsically hazardous**—not because your team built them incorrectly, but because coupling, humans, and time create inherent risk that must be designed for rather than denied. **Complex systems are heavily defended against failure** through redundancy, monitoring, alerting, failover, backups, circuit breakers, retries, and operational habit; those defenses usually work, which is why catastrophes are rare and therefore surprising. **Catastrophe requires multiple failures** aligning: the popular single-root-cause story hides the Swiss Cheese reality that several layers must fail together in a way nobody anticipated.
 
 ```mermaid
 graph LR
@@ -286,8 +268,7 @@ graph LR
 ```
 *The Swiss Cheese Model: Each defense layer has holes. Most days, they don't align. Some days, they do.*
 
-**PRINCIPLE 4: Complex systems contain changing mixtures of latent failures**
-Your system has bugs right now. It has misconfigurations. It has race conditions. It has capacity limits waiting to be hit. It works **despite** these problems, not because they're absent.
+**Principle 4** states that complex systems contain changing mixtures of latent failures—bugs, misconfigurations, race conditions, and capacity cliffs that exist right now while the service appears healthy because compensations and margins absorb them.
 
 ```mermaid
 graph LR
@@ -300,22 +281,16 @@ graph LR
         B2 ===|Rarely| F2((Actually Failed))
     end
 ```
-*The question isn't "is anything wrong?" but "what's wrong that we're compensating for?"*
+
+The useful post-incident question is not whether anything is wrong right now, but which latent problems are currently being compensated for by automation, operator habit, or slack capacity that could disappear during the next change window.
 
 > **Stop and think**: If your system is currently running without active incidents, does that mean it is completely healthy? Or is it just compensating for hidden failures?
 
-**PRINCIPLE 5: Complex systems run in degraded mode**
-"Normal operation" includes partial failures. The metrics you're seeing right now probably include a slow query, a flaky connection, a service that's about to run out of memory. The system works because humans and automated systems compensate.
-
-**PRINCIPLE 6: Catastrophe is always just around the corner**
-Safety margins exist. But they erode. Small pressures—ship faster, cut costs, do more with less—gradually consume safety margins until there's none left.
-
-**PRINCIPLE 7: Post-accident attribution is fundamentally wrong**
-"Root cause" is a myth. Assigning blame to a single cause obscures the system conditions that allowed the incident.
+**Principles 5 through 7** describe lived operations. Systems run in degraded mode where "normal" includes partial failures that humans and automation continuously work around. Catastrophe remains nearby because safety margins erode under everyday pressures to ship faster, spend less, and defer cleanup. Post-accident attribution to a single root cause is fundamentally misleading because it hides the system conditions, incentives, and adaptations that made the outcome possible.
 
 ### 3.2 The Myth of Root Cause
 
-Complex system failures don't have a single "root cause." They have multiple contributing factors that combine in novel ways.
+Complex system failures rarely have a single root cause; they accumulate through multiple contributing factors that only look inevitable after the fact, which is why post-incident learning must widen the lens instead of narrowing it to the last change deployed.
 
 ```mermaid
 graph TD
@@ -335,9 +310,10 @@ graph TD
         style I2 fill:#ff9999
     end
 ```
-*Individually harmless factors combine to create catastrophe.*
 
-The deployment bug existed for weeks. The alert was muted months ago. The timing was random. The load spike was normal for that time. NONE of these alone would cause an incident. TOGETHER, they did.
+Individually harmless factors can combine through ordinary coupling to produce catastrophe that no single team would have shipped on purpose.
+
+The deployment bug existed for weeks without triggering pages, the alert had been muted months earlier during a noisy weekend, the traffic spike was normal for that hour, and the timing aligned so that none of these factors looked harmful in isolation yet together they produced customer-visible failure.
 
 ### 3.3 Drift into Failure
 
@@ -365,6 +341,32 @@ graph TD
 | "Increase timeout from 5s to 30s" | "It fixes the immediate problem" | Slow failures propagate |
 | "Add one more feature before the refactor" | "Just this once" | Technical debt compounds |
 
+
+### 3.4 Principles 8 Through 18: Cook's Remaining Insights
+
+Cook's remaining principles are short on the page and enormous in operations practice. **Hindsight biases post-accident assessments of human performance** (Principle 8) warns that knowing the outcome poisons how investigators reconstruct what practitioners could reasonably have seen. **Human operators have dual roles: as producers and as defenders against failure** (Principle 9) explains why outsiders overemphasize either shipping or safety depending on whether an accident just happened. **All practitioner actions are gambles** (Principle 10) reminds you that successful outcomes are also uncertain bets, not proof that risk was absent.
+
+**Actions at the sharp end resolve all ambiguity** (Principle 11) means production pressure, incomplete policy, and organizational ambiguity get resolved by whoever is on call—not by the architecture diagram. **Human practitioners are the adaptable element of complex systems** (Principle 12) is why runbook workarounds, alert fatigue, and "temporary" firewall rules persist for years: people continuously restructure work to keep production moving. **Human expertise in complex systems is constantly changing** (Principle 13) means your team always mixes veterans, trainees, and turnover; expertise is a resource, not a fixed asset.
+
+**Change introduces new forms of failure** (Principle 14) is the principle most relevant to platform engineering teams shipping controllers, operators, and autoscaling policies. New automation can eliminate familiar failure modes while creating rare, high-consequence pathways nobody designed for—controllers that reconcile every few seconds can amplify a misconfiguration into a cluster-wide event before a human finishes reading the first page of symptoms. **Views of "cause" limit the effectiveness of defenses against future events** (Principle 15) argues that blame-focused remedies often increase coupling without reducing the next accident's likelihood.
+
+**Safety is a characteristic of systems and not of their components** (Principle 16) means you cannot buy safety as a feature bolted onto one service. **People continuously create safety** (Principle 17) describes how routine compensations and well-rehearsed adaptations keep operations failure-free most of the time. **Failure free operations require experience with failure** (Principle 18) closes the loop: near-misses, game days, and calibrated exposure to hazard teach operators where the edge of tolerable performance lies.
+
+Treat Cook's paper as a checklist during post-incident review, not as philosophy. Ask: which defenses were supposed to catch this, which were bypassed, which latent conditions existed before the trigger, and which adaptations made the incident harder to see? Those four questions consistently produce systemic improvements that "find the bug and patch it" misses.
+
+### 3.5 Emergence in Distributed Platforms
+
+Emergence is not mysticism; it is what happens when components follow local rules and global behavior is not a simple sum. Kubernetes desired-state reconciliation is a canonical example. No single Pod object "knows" about cluster health, yet the cluster exhibits self-healing behavior when controllers, schedulers, kubelet, and CNI plugins interact. That emergence is valuable until it emergently works against you: for example, rapid pod restart loops that increase load on a failing dependency, or autoscaling that adds replicas that all hammer the same broken backend.
+
+Observability for emergent behavior requires **system-level signals**, not only component greens. User journeys, saturation, queue depth, retry rates, and cross-service correlation often reveal emergent failure earlier than per-service CPU graphs. When symptoms appear in user experience before they appear in infrastructure metrics, you are often watching complexity rather than a simple component fault.
+
+### 3.6 Tradeoffs: How Much Complexity Can You Afford?
+
+Every feature coupling, shared library, synchronous call, and global cache increases the interaction surface where emergence can hide. Platform teams sometimes reduce complexity by enforcing asynchronous boundaries, idempotent interfaces, bulkheads, and explicit ownership of failure modes. Those patterns do not eliminate complexity—users, data, and time still interact—but they channel interactions into places where probes and circuit breakers can operate.
+
+The tradeoff is velocity versus interaction density. Tight coupling ships features faster until the day emergent failure makes every change feel risky. Loose coupling feels slower until the day a dependency fails and only one domain degrades. Complexity thinking helps you choose where to pay coupling costs intentionally rather than accidentally.
+
+
 Each decision seems small. Each is locally rational. Together, they erode safety margins until failure is inevitable.
 
 ---
@@ -373,8 +375,7 @@ Each decision seems small. Each is locally rational. Together, they erode safety
 
 ### 4.1 Resilience vs Robustness—A Critical Distinction
 
-**Robustness** = Resist known failures
-**Resilience** = Adapt to any failure
+**Robustness** means resisting known failures within designed limits, while **resilience** means adapting when the failure mode was not predicted or when multiple stresses combine in novel ways.
 
 ```mermaid
 graph TD
@@ -398,31 +399,19 @@ graph TD
     end
 ```
 
-Robustness handles known failures perfectly, but collapses on the unknown. Resilience handles everything imperfectly, surviving what you didn't anticipate. **For complex systems: ALWAYS choose resilience.**
+Robustness handles known failures well within designed limits, but can collapse when stress exceeds those limits. Resilience adapts imperfectly to novel or combined stresses, preserving partial function rather than all-or-nothing failure. **For complex systems, you need both:** robust controls for known failure modes (timeouts, validation, capacity limits) plus resilient adaptation for the unknown (graceful degradation, fallbacks, learning loops). Neither alone is sufficient.
 
 ### 4.2 The Four Resilience Capabilities
 
-Resilience engineering identifies four capabilities that enable systems to adapt:
+Resilience engineering identifies four capabilities that enable systems to adapt under uncertainty, and mature teams instrument all four instead of treating resilience as a synonym for redundancy.
 
-**1. RESPOND: Address disturbances as they occur**
-* **Question:** "What can we do when things go wrong?"
-* **Good:** Circuit breakers, graceful degradation, failover.
-* **Bad:** Rigid systems with no alternatives (e.g., throwing a Timeout Error when the DB is slow instead of returning cached data).
+**Respond** addresses disturbances as they occur by asking what the system can do when things go wrong. Good implementations include circuit breakers, graceful degradation, and failover paths; weak implementations throw hard errors to users when a dependency slows, even though a cached or partial response would preserve core function.
 
-**2. MONITOR: Know what's happening in the system**
-* **Question:** "What should we look for?"
-* **Good:** Business metrics, user experience, leading indicators.
-* **Bad:** Only infrastructure metrics (CPU, memory, disk).
+**Monitor** asks what signals reveal emerging trouble before catastrophe. Business metrics, user-journey success, saturation, and retry rates are leading indicators; CPU-only dashboards often stay green while customers suffer.
 
-**3. ANTICIPATE: Identify potential future issues**
-* **Question:** "What might go wrong?"
-* **Good:** Chaos engineering, load testing, gamedays, threat modeling.
-* **Bad:** "It's never failed before."
+**Anticipate** asks what might go wrong before customers discover it. Chaos experiments, load tests, game days, and threat modeling surface latent interactions; assuming "it never failed before" is not anticipation—it is hope.
 
-**4. LEARN: Improve from experience**
-* **Question:** "How do we get better?"
-* **Good:** Blameless postmortems, systemic analysis, studying successes (Safety-II).
-* **Bad:** Categorizing issues as "human error" and moving on.
+**Learn** asks how the organization improves after surprises. Blameless postmortems, systemic contributing-factor analysis, and Safety-II study of everyday success encode adaptation into culture; labeling incidents "human error" and closing tickets guarantees repetition.
 
 ### 4.3 Chaos Engineering—Practicing Failure Before It Happens
 
@@ -436,6 +425,8 @@ Chaos Engineering deliberately introduces failures to discover weaknesses before
 4. **Run experiments continuously**: Systems drift. Regular chaos experiments detect this drift.
 5. **Build confidence, not heroics**: The goal is a boring incident response because you've seen it before.
 
+Netflix's Chaos Monkey, described in the [Principles of Chaos Engineering](https://principlesofchaos.org/), was among the early tools that randomly terminates production instances so teams design for survivability rather than assuming instance permanence. The tool does not merely test resilience—it forces resilient design by making instance loss routine. For a deeper KubeDojo treatment, see [Chaos Principles](../../disciplines/reliability-security/chaos-engineering/module-1.1-chaos-principles/).
+
 **Common Chaos Experiments:**
 
 | Experiment | What It Tests | Tools |
@@ -447,15 +438,29 @@ Chaos Engineering deliberately introduces failures to discover weaknesses before
 | **CPU/memory stress** | Autoscaling, resource limits, throttling | stress-ng |
 | **DNS failure** | Fallback mechanisms, caching | Block DNS queries |
 
-> **Did You Know?**
->
-> Netflix's **Chaos Monkey** <!-- incident-xref: netflix-chaos-monkey --> was one of the first chaos engineering tools (2011). It randomly terminates production instances. The logic: if engineers know their instances will be killed randomly, they design systems that survive instance death. The tool doesn't test resilience—it **forces** resilient design. For the full Netflix Chaos Monkey case study, see [Chaos Principles](../../disciplines/reliability-security/chaos-engineering/module-1.1-chaos-principles/).
-
 ### 4.4 Safety-I vs Safety-II
 
 Traditional safety (**Safety-I**) focuses on what goes wrong. It counts errors, eliminates causes, and asks "Why did this fail?"
 
 Resilience engineering (**Safety-II**) also studies what goes right. It recognizes that most operations succeed despite latent failures. Operators constantly work around issues to keep the system running. By asking "Why does this usually work?" we can learn from successful adaptations and amplify them.
+
+### 4.5 Observability for Edge-of-Chaos Operations
+
+Systems at the "edge of chaos" sit between rigid order and total disorder: enough structure to function, enough coupling that small perturbations can produce large effects. That is where many revenue-critical platforms live during growth phases. Observability design for this regime prioritizes **leading indicators** and **interaction metrics** over static thresholds on individual machines.
+
+Leading indicators include retry amplification, pool wait time, queue age, error budget burn relative to traffic, and saturation of shared resources such as connection pools, thread pools, and API rate limits. Interaction metrics include cross-service traces that show fan-out depth, correlation between deploy times and tail latency shifts, and segment-specific failure rates when global aggregates look acceptable. Dashboards that only turn red when a single service crosses a threshold will systematically miss complex degradation.
+
+Alert design should encode domain thinking. Clear-domain alerts can page with runbook links. Complicated-domain alerts should attach recent change context and key dependency graphs. Complex-domain alerts should often route to learning workflows: ticket plus experiment template, not only "fix immediately" paging, because premature fixes can worsen emergent loops. This does not mean ignoring user pain; it means pairing customer-impact alerts with explicit stabilization timers.
+
+### 4.6 Game Days and Organizational Learning
+
+Chaos engineering is not only tooling; it is a social technology for building shared mental models. Game days that include product, support, and leadership participants often teach more about complexity than engineering-only drills, because customer communication and business tradeoffs are part of the system. Scenarios should include partial failures where metrics disagree, latent misconfigurations that only appear under load, and dependencies that are "healthy" by health check but unusable by real traffic.
+
+Document outcomes as **conditions**, not hero stories. "We discovered retries doubled write load during simulated partition" is reusable. "Alice saved the day" is not a control. Safety-II thinking applies: study why routine operations succeed despite latent flaws, and encode those successful adaptations into guardrails without punishing the people who improvised responsibly.
+
+### 4.7 Putting It Together: An Edge-of-Chaos Checklist
+
+Before you leave this module, walk through a checklist on a service you operate today. First, classify recent surprises with Cynefin: which were clear, complicated, complex, or chaotic, and did the team's actions match the domain? Second, list latent partners: muted alerts, retry policies changed under pressure, undeployed fixes, documentation drift, and dependencies nobody owns on-call. Third, identify one respond/monitor/anticipate/learn gap you could close this sprint without waiting for a major rewrite. Fourth, choose one architectural coupling you would not add again if you were designing the service fresh. Complexity thinking is not an excuse for fatalism; it is a disciplined way to prioritize where surprise will hurt most and where learning will pay the highest interest.
 
 ---
 
@@ -512,7 +517,35 @@ Resilience engineering (**Safety-II**) also studies what goes right. It recogniz
    <details>
    <summary>Answer</summary>
 
-   Team A built a robust system, while Team B built a resilient system. **WHY?** A robust system (Team A) is designed like a fortress to resist known failures up to a specific threshold, but when it encounters unexpected stress (like a database slow down that pushes past its rigid limits), it fails catastrophically (crashing the frontend). A resilient system (Team B) is designed to adapt and bend like a reed; it accepts that failures will happen and degrades gracefully (returning stale data) rather than collapsing completely. For complex systems, resilience is always preferred over robustness. This allows users to keep interacting with the application, preserving trust even during degraded operations.
+   Team A built a robust system, while Team B built a resilient system. **WHY?** A robust system (Team A) is designed like a fortress to resist known failures up to a specific threshold, but when it encounters unexpected stress (like a database slow down that pushes past its rigid limits), it fails catastrophically (crashing the frontend). A resilient system (Team B) is designed to adapt and bend like a reed; it accepts that failures will happen and degrades gracefully (returning stale data) rather than collapsing completely. For complex systems, robustness and resilience are complementary: Team A's rigid timeout is a reasonable robust guard for known latency bounds, while Team B's fallback adds resilient adaptation when those bounds are exceeded. The best design combines both—strict limits where you understand the failure mode, graceful degradation where you do not.
+   </details>
+
+5. **Your platform team must evaluate two architectural decisions for a new checkout service through the lens of complexity theory. Design A synchronously calls five downstream services on every request to maximize data freshness. Design B uses asynchronous boundaries, bulkheads, and cached fallbacks that may serve slightly stale prices during dependency trouble. Which design better reduces blast radius of unexpected interactions, and why?**
+   <details>
+   <summary>Answer</summary>
+
+   Design B better reduces blast radius of emergent failures when you **evaluate architectural decisions** using **complexity theory**. **WHY?** Synchronous fan-out creates dense interaction graphs where one slow or failing dependency can stall the entire request path and amplify retries across the mesh. Asynchronous boundaries and bulkheads constrain how failures propagate, while cached fallbacks preserve partial user value during degradation. Design A may look simpler and fresher in demos, but it increases coupling density—the number of ways simple local rules can interact to produce surprising global outcomes. Complexity-aware architecture prefers controlled coupling and explicit degradation paths over maximal freshness with hidden interdependence.
+   </details>
+
+6. **During an incident, metrics show database CPU at normal levels, yet checkout latency spikes and support tickets rise. An engineer proposes, "Database looks fine—must be frontend." What complexity-aware investigation steps should come next instead of jumping to that conclusion?**
+   <details>
+   <summary>Answer</summary>
+
+   Treat the situation as complex until proven otherwise. **WHY?** Emergent degradation often appears first in user journeys while component greens remain misleading. Next steps should include tracing checkout end-to-end, measuring pool wait time and retry rates, comparing segments (device, region, account type), and correlating with recent deploys or flag changes. The database may be "fine" by CPU while suffering lock contention, connection starvation, or hot keys. Premature convergence on frontend blame repeats the complicated-domain mistake on a complex symptom set.
+   </details>
+
+7. **A leadership sponsor asks for a guarantee that chaos testing will prevent the next outage. What honest answer aligns with Safety-I and Safety-II thinking?**
+   <details>
+   <summary>Answer</summary>
+
+   Chaos testing cannot guarantee prevention of novel emergent failures. **WHY?** Safety-I methods reduce known failure modes, but complex systems generate new interaction patterns as code, traffic, and human behavior change. Chaos experiments and game days improve anticipation and learning—they reveal latent weaknesses, train response, and validate degradation paths—but resilience is continuous adaptation, not a one-time certificate. The honest promise is faster learning, smaller blast radius, and better recovery, not permanent immunity from surprise.
+   </details>
+
+8. **Two latent conditions exist in production: an alert muted last month and a retry policy doubled during a previous incident. Neither alone caused customer impact until today's traffic mix shifted. Which models from this module explain why the incident occurred, and what remediation style fits?**
+   <details>
+   <summary>Answer</summary>
+
+   Swiss Cheese, latent failure mixtures, and drift into failure explain the incident. **WHY?** Each condition was harmless alone but aligned today: muted alert removed early signal, elevated retries amplified load under a new traffic shape. Remediation should address systemic conditions—restore alert hygiene, revisit retry budgets with load testing, document contributing factors without single-blame RCA, and add monitors on retry amplification and user-journey success. Fixing only today's trigger without treating the latent partners invites recurrence when another alignment occurs.
    </details>
 
 ---
@@ -521,11 +554,9 @@ Resilience engineering (**Safety-II**) also studies what goes right. It recogniz
 
 ### Part A: Simple Chaos Experiment (15 minutes)
 
-**Objective**: Experience how a resilient system handles failure and observe emergence.
+This exercise uses a minimal Kubernetes deployment so you can observe emergent self-healing without reproducing a full production stack. You need a running Kubernetes v1.35+ cluster (kind, minikube, or managed). The learning goal is to experience how controllers, schedulers, and replicated pods produce system-level recovery behavior that no individual Pod manifest encodes explicitly.
 
-**Prerequisites**: A running Kubernetes v1.35+ cluster (kind, minikube, or managed)
-
-**Step 1: Create a resilient deployment**
+1. **Create a resilient deployment** by applying the manifest below, which creates three nginx replicas with readiness and liveness probes in a dedicated namespace.
 
 ```bash
 # Create a namespace for this experiment
@@ -580,7 +611,7 @@ spec:
 EOF
 ```
 
-**Step 2: Verify all pods are running**
+2. **Verify all pods are running** and wait until each replica reports `Running` and `1/1 Ready`.
 
 ```bash
 kubectl get pods -n chaos-lab -w
@@ -588,14 +619,14 @@ kubectl get pods -n chaos-lab -w
 # Press Ctrl+C to stop watching
 ```
 
-**Step 3: In a second terminal, watch pod events continuously**
+3. **In a second terminal, watch pod events continuously** so you can observe recovery dynamics while injecting failure.
 
 ```bash
 # Keep this running to observe the emergent behavior
 kubectl get pods -n chaos-lab -w
 ```
 
-**Step 4: Inject chaos—kill a pod**
+4. **Inject chaos by deleting one pod** and watch how the Deployment controller recreates capacity.
 
 ```bash
 # Delete a pod (the first one in the list)
@@ -604,47 +635,31 @@ echo "Killing pod: $POD"
 kubectl delete pod -n chaos-lab $POD --wait=false
 ```
 
-**Observe in terminal 2:**
-- The pod enters Terminating state
-- A new pod is created almost immediately (by the Deployment controller)
-- The new pod progresses: Pending → ContainerCreating → Running
+In terminal 2 you should see the pod enter `Terminating`, a replacement pod appear almost immediately, and the new pod progress through `Pending`, `ContainerCreating`, and `Running` without manual intervention.
 
-**Step 5: Inject more chaos—kill multiple pods**
+5. **Inject stronger chaos by deleting two pods at once** to see how the same control loop responds under larger perturbation.
 
 ```bash
 # Delete 2 pods simultaneously
-kubectl delete pod -n chaos-lab -l app=resilience-test --wait=false \
+kubectl delete pod -n chaos-lab --wait=false \
   $(kubectl get pod -n chaos-lab -l app=resilience-test -o jsonpath='{.items[0].metadata.name} {.items[1].metadata.name}')
 ```
 
-**Step 6: Observe emergent behavior**
+6. **Observe emergent behavior** across both experiments: the cluster maintains desired replica count without human action, recreation timing varies with scheduler and node conditions, and you cannot predict exactly which pod names will appear even though the system-level outcome stabilizes.
 
-Notice how:
-- The system maintains desired state (3 replicas) without human intervention
-- Pod recreation time varies (depends on scheduler, node resources, image cache)
-- You can't predict exactly which pods will be created when
-- The system-level behavior (self-healing) emerges from component interactions
-
-**Step 7: Clean up**
+7. **Clean up** when finished so the experiment does not consume cluster resources.
 
 ```bash
 kubectl delete namespace chaos-lab
 ```
 
-**What You Experienced:**
-- **Emergence**: System-level self-healing that no single pod possesses
-- **Feedback loop**: Deployment controller detects actual ≠ desired → creates pods
-- **Complexity**: Exact recovery timing is unpredictable
-- **Resilience**: System degrades (fewer pods) but recovers automatically
+What you experienced is emergence in miniature: system-level self-healing that no single pod possesses, a feedback loop where the Deployment controller detects actual state diverging from desired state and creates replacements, unpredictable timing at the pod level coupled with reliable recovery at the service level, and resilience that tolerates brief degradation while converging back toward the declared replica count.
 
 ---
 
 ### Part B: Complex Systems Analysis (25 minutes)
 
-**Task**: Apply complex systems thinking to a recent incident (or use the provided scenario).
-
-**Scenario** (if you don't have a recent incident):
-> "Users report checkout is failing intermittently. Error rates are elevated but below the alert threshold. Some team members can reproduce it, others can't. The issue started sometime in the last few days but nobody knows exactly when."
+Apply complex systems thinking to a recent incident from your organization, or use the hypothetical scenario below if you do not have a suitable recent example. **Hypothetical scenario:** users report checkout failing intermittently; error rates are elevated but remain below alert thresholds; some engineers reproduce the issue while others cannot; symptoms began within the last few days but the exact start time is unclear.
 
 **Section 1: Cynefin Classification (10 minutes)**
 
@@ -676,14 +691,9 @@ Instead of finding "root cause," list all potential contributing factors:
 | | Environment (load, time, dependencies) | | |
 | | Timing (sequence, coincidence) | | |
 
-Answer:
-- Which factors individually seem harmless?
-- What combination might have created the incident?
-- What latent failures might still exist even after "fixing" this?
+Write short answers explaining which factors individually seem harmless, which combination might have created the incident, and which latent failures might remain even after a narrow fix.
 
-**Section 3: Resilience Improvements (5 minutes)**
-
-For the scenario, identify one improvement for each resilience capability:
+**Section 3: Resilience Improvements (5 minutes)** — for the scenario, identify one improvement for each resilience capability in the table below and note which capability gap would have made the intermittent checkout failure visible earlier.
 
 | Capability | Current Gap | Proposed Improvement |
 |------------|-------------|---------------------|
@@ -691,6 +701,8 @@ For the scenario, identify one improvement for each resilience capability:
 | **Monitor** | | |
 | **Anticipate** | | |
 | **Learn** | | |
+
+Complete Part B successfully when you can explain the Cynefin domain with evidence, name at least five contributing factors across categories, and propose resilience improvements for all four capabilities.
 
 **Success Criteria**:
 - [ ] Part A: Successfully killed and observed pod recovery
@@ -702,33 +714,38 @@ For the scenario, identify one improvement for each resilience capability:
 
 ---
 
+## Sources
+
+- [How Complex Systems Fail](https://how.complexsystems.fail/) — Richard Cook's eighteen principles on safety and failure in complex socio-technical systems.
+- [Drift into Failure (Sidney Dekker)](https://www.routledge.com/Drift-into-Failure-From-Hunting-Broken-Components-to-Understanding-Complex-Systems/Dekker/p/book/9781409422211) — Dekker's account of how systems drift toward failure through locally rational decisions.
+- [The Cynefin Framework](https://cynefin.io/wiki/Cynefin) — Dave Snowden's sense-making model for matching response strategy to context.
+- [Thinking in Systems: A Primer](https://www.chelseagreen.com/product/thinking-in-systems/) — Donella Meadows on stocks, flows, feedback, and leverage points in complex systems.
+- [Google SRE Book — Handling Overload](https://sre.google/sre-book/handling-overload/) — Client-side throttling, load shedding, and protecting dependencies under stress.
+- [Google SRE Book — Addressing Cascading Failures](https://sre.google/sre-book/addressing-cascading-failures/) — Retry amplification, cascading failure patterns, and mitigation patterns for production.
+- [Principles of Chaos Engineering](https://principlesofchaos.org/) — Foundational chaos-engineering principles for building confidence in turbulent production conditions.
+- [2015 NYSE trading suspension](https://www.nyse.com/market-status/history) — NYSE market-status history documenting the July 8, 2015 trading suspension discussed in the module opener.
+- [United Airlines ground stop (2015)](https://www.bbc.co.uk/news/technology-33449693) — Reporting on the same-day United Airlines computer disruption from independent infrastructure failure.
+- [Northeast blackout of 2003](https://en.wikipedia.org/wiki/Northeast_blackout_of_2003) — Overview of the multi-factor cascade referenced in the module's historical anchor section.
+- [Safety-II (Erik Hollnagel)](https://www.hollnagel.com/safety-ii) — Foundational Safety-II perspective on studying everyday success in safety-critical work.
+- [Emergence (Stanford Encyclopedia of Philosophy)](https://plato.stanford.edu/entries/properties-emergent/) — Philosophical and scientific background on emergent properties in complex wholes.
+
 ## Further Reading
 
-- **"How Complex Systems Fail"** - Richard Cook. Free online, 3 pages. Read it today. It will change how you think about operations.
+For book-length depth beyond the canonical sources above, seek full texts on resilience engineering, human factors, and organizational learning. Cook's three-page essay remains the highest leverage starting point; Dekker and Meadows provide complementary lenses on drift and system structure; Rosenthal and Jones extend chaos engineering from philosophy into practice.
 
-- **"Drift into Failure"** - Sidney Dekker. How systems gradually migrate toward catastrophe through locally rational decisions.
+---
 
-- **"Thinking, Fast and Slow"** - Daniel Kahneman. Understanding cognitive biases helps explain operator decisions during incidents.
+## Next Module
 
-- **"Chaos Engineering"** - Casey Rosenthal & Nora Jones. Practical guide to building resilience through controlled experiments.
-
-- **"The Field Guide to Understanding Human Error"** - Sidney Dekker. Why "human error" is the start of the investigation, not the conclusion.
-
-- **"Cynefin Framework Introduction"** - Dave Snowden (videos on YouTube). Best explained by its creator.
+You have completed the Systems Thinking foundation sequence. Continue into [Reliability Engineering](/platform/foundations/reliability-engineering/) to translate complexity awareness into measurable reliability practice—failure modes, redundancy, SLOs, and error budgets—or explore [Observability Theory](/platform/foundations/observability-theory/) if understanding system behavior through signals is your immediate need.
 
 ---
 
 ## Systems Thinking: What's Next?
 
-Congratulations! You've completed the Systems Thinking foundation.
+Congratulations—you have completed the Systems Thinking foundation. You now have a vocabulary for discussing complex systems, mental models for analyzing behavior under pressure, frameworks such as Cynefin for choosing response strategies, and a practical understanding of why complex systems fail and how to design for resilience instead of brittle perfection.
 
-**You now have:**
-- A vocabulary for discussing complex systems
-- Mental models for analyzing system behavior
-- Frameworks for deciding how to respond to different situations
-- Understanding of why complex systems fail and how to design for resilience
-
-**Where to go from here:**
+Use the table below to choose your next track based on what you want to practice first.
 
 | Your Interest | Next Track |
 |---------------|------------|


### PR DESCRIPTION
## Platform Foundations campaign — Wave 1: Systems Thinking (Refs #1897)

First wave of the platform-foundations quality campaign. All four **Systems Thinking** modules were genuine T3 (thin prose + unlabeled fabrication), confirmed by a `verify_module.py` sweep. Each was expanded to T0 and de-fabricated, then cross-family reviewed.

| Module | Before | After | Author → Reviewer |
|---|---|---|---|
| 1.1 what-is-systems-thinking | 1886w T3 | **T0 5971w** | codex → opus (APPROVE) |
| 1.2 feedback-loops | 1609w T3 | **T0 5001w** | cursor → codex |
| 1.3 mental-models-for-operations | 1668w T3 | **T0 6453w** | deepseek → opus |
| 1.4 complexity-and-emergent-behavior | 1972w T3 | **T0 5318w** | cursor → codex |

### What changed per module
- **All four**: expanded prose to ≥5000 body words, density gates met, sources raised to 12 (`[title](url)`), quizzes to 7-8 scenario questions; `War Story:` openers relabeled `Hypothetical scenario:`; `47` magic numbers + invented metrics/companies ($230k/ShopMart) removed; `revision_pending: false`.
- **1.2**: fixed eviction-cascade arithmetic (was 444MB < 512MB limit), added a 5-sample window guard to the damping example, replaced 3 dead source URLs + corrected an SEC mislabel, fixed circuit-breaker usage + HPA metadata.
- **1.3**: corrected a learning-outcome/content contract violation (LO1 promised 5 models the module doesn't teach), removed a left-in reasoning artifact + sign error in Q3, fixed misattributed archetypes in Q6, trimmed 2 duplicate paragraphs, corrected somaxconn/runbook labels.
- **1.4**: fixed a non-runnable `kubectl delete` (selector + explicit names), replaced 2 dead opener sources, corrected Cook "How Complex Systems Fail" principle attribution, softened an over-absolute "always choose resilience" claim to complementary framing, reordered Part-4 subsections (4.4→4.7).

### Verification
- All 4 pass `verify_module.py` at **T0** (independently re-run).
- Every reviewer finding ground-checked against the live file (dead URLs curl-verified, replacements confirmed 200).
- `npm run build` green in PRIMARY: **2171 pages, 0 schema errors**.
- Anti-fabrication clean: all narratives carry `Hypothetical scenario:`; no incident-dedup collisions across the four.

Refs #1897

🤖 Generated with [Claude Code](https://claude.com/claude-code)
