### PR TITLE
docs(platform): expand+de-fab Foundations Observability 3.1, 3.4 to T0 (#1897)

### DIFF
--- a/src/content/docs/platform/foundations/observability-theory/module-3.1-what-is-observability.md
+++ b/src/content/docs/platform/foundations/observability-theory/module-3.1-what-is-observability.md
@@ -13,51 +13,25 @@ sidebar:
 >
 > **Track**: Foundations
 
-### What You'll Be Able to Do
+## What You'll Be Able to Do
 
-After completing this comprehensive theoretical module, you will be well-equipped to execute the following critical engineering tasks:
+After completing this module, you will be able to perform five core engineering tasks that separate monitoring-heavy organizations from teams that can debug novel production behavior without emergency code changes:
 
-1. **Compare** observability tooling approaches (logs-first, metrics-first, traces-first) and rigorously justify the optimal starting point based on specific architectural needs and failure domains.
-2. **Diagnose** the critical limitations and inherent blind spots of traditional monitoring paradigms when applied to highly distributed, high-cardinality production environments.
-3. **Evaluate** a software system's observability maturity by assessing whether on-call engineers can empirically answer novel questions about emergent system behavior without deploying new code or altering configuration.
-4. **Design** an overarching observability strategy that actively enables the debugging of unknown-unknowns rather than simply triggering alerts based on predefined, anticipated failure conditions.
-5. **Implement** the foundational principles of mathematical control theory to modern software architecture to ensure internal application state can always be inferred directly from external telemetry outputs.
+1. **Compare** logs-first, metrics-first, and traces-first observability approaches and justify a starting point for your architecture and primary failure domain.
+2. **Diagnose** why traditional monitoring leaves blind spots in distributed, high-cardinality production systems.
+3. **Evaluate** whether on-call engineers can answer novel questions about system behavior without shipping new code or changing configuration.
+4. **Design** an observability strategy that supports debugging unknown-unknowns, not only firing alerts on predefined conditions.
+5. **Apply** the control-theory definition of observability to judge whether a software system can be understood from its telemetry alone.
 
 ---
 
 > **Pause and predict**: If all your dashboard metrics are green but customers are reporting massive failures, where does the fault lie? Is it the system, the dashboard, or the questions the dashboard was designed to answer?
 
-## The Dashboard That Showed Green While the Company Lost Millions
-
-March 2017. Amazon Web Services. 9:37 AM Pacific Time.
-
-The senior site reliability engineer's primary operations dashboard shows absolutely nothing wrong. CPU utilization across the vast fleet of servers is completely normal. Memory consumption is well within strictly established baselines. The aggregate error rate sits at a very comfortable 0.02 percent. Network throughput is perfectly stable. All the visual indicators are green, and every aggregate metric is precisely where historical trends dictate it should be.
-
-But the incident escalation phone will not stop ringing. Customer support tickets are flooding the queue at an unprecedented rate.
-
-"The S3 web console will not load for any of our administrators."
-"Our application's static assets are returning continuous 404 Not Found errors."
-"The entirety of the us-east-1 region seems completely broken and unresponsive."
-
-The on-call engineer stares at the dashboard in disbelief, slowly realizing it is actively lying to him. Every single metric says "fine" while half the internet is effectively offline. 
-
-Here is the technical reality of what actually occurred: An engineer executed a well-established, routine automation script intended to gracefully remove a small number of S3 billing subsystem servers for maintenance. A subtle typo in the script's execution parameters caused vastly more servers to be forcefully removed from the network than intended. The billing subsystem—which was strictly dependent on those specific hardware resources—immediately started failing to process internal validation requests. S3's core index subsystem, in turn, could not query the billing subsystem to verify account standing and authorization. Consequently, S3 nodes safely locked down and could not serve any requested objects to external clients.
-
-Thousands of major websites went dark immediately. Massive, global platforms like Slack, Quora, and Trello became entirely unavailable to their millions of users. The cascading, systemic outage lasted for four grueling hours before engineers could unravel the dependency chain and restore capacity. The estimated financial impact was staggering: $150 to $160 million in direct revenue losses across the affected businesses worldwide.
-
-The fundamental problem during this massive incident was not a lack of data; it was the nature of the questions the dashboard was capable of answering. All the monitoring metrics were meticulously designed to answer a single variation of a predefined question: "Is this specific hardware component okay?" None of the tooling was capable of answering the actual question the engineers needed: "Why are customers experiencing total failure while our infrastructure graphs show complete health?" 
-
-This incident perfectly encapsulates the critical difference between monitoring and observability. The S3 team possessed world-class monitoring capabilities. Every server accurately reported its local health. Every metric was collected, indexed, and visualized. But they could not dynamically interrogate the telemetry to discover that the relationship between subsystems was fundamentally broken. They could confirm the individual trees were green, but they could not see the forest was actively burning. 
-
-This historic incident fundamentally changed how modern engineering organizations approach incident response. It catalyzed a massive industry shift toward distributed tracing, rich request correlation, and the capability to ask ad-hoc questions engineers had never anticipated needing to ask when they built the system.
-
 ## Why This Module Matters
 
-Consider the standard on-call scenario. It is 3:00 AM. The pager alerts the on-call engineer: "High latency detected in the checkout path." The engineer opens the primary dashboard. Everything looks perfectly fine. Application CPU is normal. Database memory is normal. The aggregate error rate is extremely low. But user support is escalating critical complaints. Something is fundamentally wrong, and nobody can see what it is.
+Consider the standard on-call scenario. It is 3:00 AM. The pager alerts the on-call engineer: "High latency detected in the checkout path." The engineer opens the primary dashboard. Application CPU is normal. Database memory is normal. The aggregate error rate is low. But user support is escalating complaints. Something is wrong, and nobody can see what it is.
 
-This scenario highlights the dangerous gap between **monitoring** and **observability**. Monitoring tells you when predefined things go wrong. Observability empowers you to understand exactly why your system is behaving the way it is—even when you completely failed to predict the specific failure mode in advance.
-
-**THE MONITORING TRAP**
+This scenario highlights the gap between **monitoring** and **observability**. Monitoring tells you when predefined things go wrong. Observability lets you understand why your system is behaving the way it is—even when you did not predict the specific failure mode in advance. In complex distributed systems, you cannot anticipate every failure state. You need systems that let operators ask new, specific questions without deploying new code or waiting for new telemetry to be collected. The diagram and channel transcript below illustrate the monitoring trap that catches many on-call engineers when aggregate dashboards disagree with customer reports.
 
 ```mermaid
 flowchart TD
@@ -84,14 +58,35 @@ Engineer: "Can't correlate across services"
 Engineer: "I have no idea what's happening"
 ```
 
-The production dashboard answered every single question it was explicitly designed to answer.
-It fundamentally could not answer the only question that actually mattered.
-
-In complex, highly distributed systems, you cannot possibly anticipate every failure state. You must build systems that allow operators to ask brand new, highly specific questions without requiring them to deploy new code or wait for new telemetry to be collected.
+The production dashboard answered every question it was designed to answer. It could not answer the only question that mattered: why are these users failing right now?
 
 > **The Car Dashboard Analogy**
 >
-> A traditional car dashboard represents monitoring: it shows predefined metrics (speed, fuel level, engine temperature). But when something complex and weird happens—a strange, intermittent grinding noise or a vibration at exactly 65 miles per hour—the dashboard provides absolutely zero help. A master mechanic equipped with an advanced OBD-II diagnostic tool possesses observability: they can probe the vehicle's computer, trace specific sensor connections, read raw data streams in real-time, and discover exactly what is wrong without knowing in advance what specific part they needed to look for.
+> A traditional car dashboard represents monitoring: it shows predefined metrics (speed, fuel level, engine temperature). When something complex happens—a grinding noise or a vibration at exactly 65 miles per hour—the dashboard provides no help. A mechanic with an OBD-II diagnostic tool has observability: they can probe the vehicle's computer, trace sensor connections, read raw data streams, and discover what is wrong without knowing in advance which part to inspect.
+
+## The Dashboard That Showed Green While the Company Lost Millions
+
+March 2017. Amazon Web Services. 9:37 AM Pacific Time.
+
+The senior site reliability engineer's primary operations dashboard shows absolutely nothing wrong. CPU utilization across the vast fleet of servers is completely normal. Memory consumption is well within strictly established baselines. Aggregate error rates look healthy. Network throughput is stable. All the visual indicators are green, and every host-level metric sits within the ranges historical trends say it should be.
+
+But the incident escalation phone will not stop ringing. Customer support tickets are flooding the queue at an unprecedented rate.
+
+"The S3 web console will not load for any of our administrators."
+"Our application's static assets are returning continuous 404 Not Found errors."
+"The entirety of the us-east-1 region seems completely broken and unresponsive."
+
+The on-call engineer stares at the dashboard in disbelief, slowly realizing it is actively lying to him. Every single metric says "fine" while half the internet is effectively offline. 
+
+Here is the technical reality of what actually occurred: An authorized S3 team member ran an established playbook command intended to remove a small number of servers from the S3 billing subsystem while debugging a billing-system issue. Incorrect input removed a larger set of servers than intended. Those servers also supported two other subsystems: the **index subsystem**, which manages the metadata and location information of every S3 object in the region and is required to serve all GET, LIST, PUT, and DELETE requests; and the **placement subsystem**, which manages allocation of new storage, depends on the index subsystem, and is used during PUT requests. Removing that much capacity forced a full restart of both the index and placement subsystems. While they restarted, S3 could not service object requests in us-east-1, and AWS services depending on S3 were affected too.
+
+Thousands of major websites went dark immediately. Massive, global platforms like Slack, Quora, and Trello became entirely unavailable to their millions of users. The cascading, systemic outage lasted for four grueling hours before engineers could restore capacity. Third-party analysts (Cyence) later estimated the outage cost S&P 500 companies on the order of $150 million and U.S. financial-services firms around $160 million—external estimates of aggregate business impact, not figures from AWS's official post-mortem.
+
+The fundamental problem during this massive incident was not a lack of data; it was the nature of the questions the dashboard was capable of answering. All the monitoring metrics were meticulously designed to answer a single variation of a predefined question: "Is this specific hardware component okay?" None of the tooling was capable of answering the actual question the engineers needed: "Why are customers experiencing total failure while our infrastructure graphs show complete health?" 
+
+This incident perfectly encapsulates the critical difference between monitoring and observability. The S3 team possessed world-class monitoring capabilities. Every server accurately reported its local health. Every metric was collected, indexed, and visualized. But they could not dynamically interrogate the telemetry to discover that the relationship between subsystems was fundamentally broken. They could confirm the individual trees were green, but they could not see the forest was actively burning. 
+
+This historic incident reinforced how modern engineering organizations approach incident response. It underscored the need for dependency-level visibility and request correlation across subsystems—not just per-host health monitoring—and for the capability to ask ad-hoc questions engineers had never anticipated needing to ask when they built the system. We revisit this outage here through the lens of observability; the full failure-modes and blast-radius breakdown lives in [Reliability Engineering: Failure Modes and Effects](../reliability-engineering/module-2.2-failure-modes-and-effects/).
 
 ---
 
@@ -99,13 +94,11 @@ In complex, highly distributed systems, you cannot possibly anticipate every fai
 
 ### 1.1 What is Monitoring?
 
-**Monitoring** is the rigid practice of collecting predefined metrics and triggering automated alerts when those metrics cross established thresholds. It is inherently reactive and based entirely on historical assumptions about how a system will break.
+**Monitoring** is the practice of collecting predefined metrics and triggering alerts when those metrics cross established thresholds. It is reactive and based on historical assumptions about how a system will break. You define in advance what to measure (CPU utilization, HTTP 500 error rate), what counts as normal (CPU under 80 percent), and when to alert (CPU above 80 percent for five consecutive minutes). Dashboards then answer a narrow question: are the things you decided to watch still within healthy parameters?
 
-**TRADITIONAL MONITORING WORKFLOW**
-You define strictly in advance:
-- What specifically to measure (CPU utilization, memory consumption, HTTP 500 error rate)
-- What constitutes "normal" behavior (CPU remains under 80 percent)
-- When exactly to trigger an alert (CPU exceeds 80 percent for 5 consecutive minutes)
+The strength of monitoring is operational efficiency at scale. A small set of well-chosen RED or Golden Signal metrics on each service lets one on-call engineer watch hundreds of microservices. Recording rules and long retention make month-over-month capacity planning possible. Alerting on SLO burn rates turns monitoring into a contract with product teams about acceptable unreliability. None of that goes away when you adopt observability—you still want to know quickly when error rates spike.
+
+The weakness appears when the metric set is incomplete relative to real user experience. Monitoring assumes you already identified the right signals and thresholds. It does not help when the failure is a combination of attributes you never labeled—Safari plus region plus account age—or when dependencies fail while local resource metrics stay green, as in the 2017 S3 incident narrative above. Treat monitoring as the **detection layer**, not the **diagnosis layer**.
 
 ```mermaid
 flowchart TD
@@ -117,17 +110,15 @@ flowchart TD
     end
 ```
 
-Monitoring exclusively answers the question: "Are the specific things I decided to watch still operating within their predefined healthy parameters?"
-
-**Monitoring works exceptionally well when:**
-- You know exactly what components can fail.
-- System failures strictly match known historical patterns.
-- The underlying architecture is relatively simple and tightly coupled.
-- You are tracking physical hardware limits (disk space, network bandwidth).
+Monitoring works well when you know which components can fail, failures match known patterns, the architecture is relatively simple, and you are tracking physical limits like disk space or network bandwidth. It breaks down when the failure is emergent, affects only a slice of traffic, or lives in the interaction between components rather than inside any single box.
 
 ### 1.2 What is Observability?
 
-**Observability** is a fundamental property of a system. It is the ability to thoroughly understand a system's internal state solely by examining its external outputs—without needing to know in advance what specific problem you are looking for.
+**Observability** is a property of a system: the ability to understand internal state from external outputs without knowing in advance what problem you are looking for. Instead of asking "Is CPU okay?" you ask "Why are 5% of requests slow?" and follow the evidence wherever it leads—by endpoint, region, user segment, deployment version, or any other dimension your telemetry preserves.
+
+Charity Majors' practical test: can you ask a question you did not instrument explicitly last sprint and get an answer from data already flowing? If every new question requires a JIRA ticket to add logging, you have monitoring with extra steps, not observability. The property emerges when telemetry is rich enough, correlated enough, and queryable enough that investigation resembles data analysis rather than archaeology across SSH sessions.
+
+Observability does not mean infinite retention or storing every byte forever. It means preserving sufficient detail—often via sampling and tiered retention—that the questions incident response actually asks remain answerable. A sampled trace backend that always retains errors and high-latency tails can be more observable than a verbose unstructured log dump nobody can search.
 
 ```mermaid
 flowchart TD
@@ -141,11 +132,9 @@ flowchart TD
     end
 ```
 
-Observability empowers engineers to confidently answer: "Why is the system behaving this particular way right now?"
+Observability empowers engineers to answer: "Why is the system behaving this particular way right now?" That question is not a luxury for large platforms—it is the difference between a four-hour outage and a twenty-minute fix when aggregate metrics look fine.
 
 ### 1.3 The Key Differences Outlined
-
-To truly grasp the paradigm shift, we must contrast the operational realities of both approaches directly.
 
 | Aspect | Monitoring | Observability |
 |--------|------------|---------------|
@@ -174,7 +163,25 @@ flowchart TD
     end
 ```
 
-When relying solely on monitoring, an engineer hitting a dead end in a runbook is completely blind. With observability, the engineer possesses the data fidelity necessary to pivot their investigation instantly, following the trail of evidence wherever it leads.
+When an engineer hits a dead end in a runbook, monitoring leaves them blind. Observability provides the data fidelity to pivot instantly and follow the trail of evidence wherever it leads, even when the runbook author never imagined that failure mode.
+
+### 1.4 Complementary Signal Frameworks: Golden Signals, USE, and RED
+
+Three widely cited frameworks help teams decide *what* to measure before debating *how* to store it. They are complementary lenses, not competing religions—you often use more than one in the same system.
+
+**Four Golden Signals** (Google SRE) recommend monitoring **latency**, **traffic**, **errors**, and **saturation** for each user-facing service. Latency captures how long work takes; traffic captures demand; errors capture failure rate; saturation captures how full the service is (queue depth, thread pool usage, or quota consumption). This framework is service-centric and maps cleanly to SLO thinking: if latency and errors stay within budget while traffic rises, users are probably happy.
+
+**USE** (Brendan Gregg) targets **Utilization**, **Saturation**, and **Errors** for every *resource*—CPU, memory, disk, network interface. Utilization is the percentage of time a resource is busy; saturation is the backlog of work waiting for that resource; errors are fault events. USE excels at infrastructure and host-level debugging: "Is this node out of CPU, or is the CPU idle while a run queue backs up?"
+
+**RED** (Tom Wilkie) applies **Rate**, **Errors**, and **Duration** to every *request-serving* component. Rate is requests per second; errors is the failed fraction; duration is latency distribution (often histograms, not just averages). RED is the microservice-native cousin of the Golden Signals—same shape, slightly different vocabulary, easier to implement in Prometheus-style metrics.
+
+| Framework | Unit of analysis | Best for | Typical blind spot |
+|-----------|------------------|----------|-------------------|
+| Four Golden Signals | User-facing service | SLOs, capacity planning | Does not name individual resources |
+| USE | Hardware/resource | Nodes, disks, NICs | Hard to apply to abstract resources like "memory pressure" |
+| RED | Request path / service | API gateways, microservices | Does not cover batch jobs or queue workers without adaptation |
+
+None of these frameworks *is* observability. They tell you which aggregates to collect so you notice problems quickly. Observability is what lets you drill from "latency is elevated" into "only Safari clients on old accounts in us-east hitting the checkout flag are slow." Golden Signals, USE, and RED get you to the alert; high-cardinality telemetry and correlation get you to the root cause. Platform engineers should be fluent in all three vocabularies because infrastructure on-call and application on-call often look at the same incident through different lenses during a bridge call.
 
 ---
 
@@ -184,39 +191,23 @@ When relying solely on monitoring, an engineer hitting a dead end in a runbook i
 
 ### 2.1 The Cardinality Problem
 
-Traditional monitoring systems heavily aggregate data to radically reduce storage costs and optimize query speeds. However, aggressive aggregation systematically destroys the very details required to debug complex issues.
+Traditional monitoring systems aggregate data to reduce storage cost and speed up queries. Aggressive aggregation destroys the details required to debug complex issues. Imagine your application processes one million requests per hour. Your dashboard shows average latency at 100 ms, p99 at 500 ms, and error rate at 0.5%—all green. Yet 5,000 users had a broken experience. Aggregate monitoring cannot tell you which users failed, which endpoints were involved, what those requests had in common, or why they differed from successful ones.
 
-**THE CARDINALITY PROBLEM EXPLAINED**
+**Cardinality** is the number of unique values a dimension can take. **Dimensionality** is how many distinct dimensions you can slice by at once (`endpoint`, `region`, `browser`, `feature_flag`, and so on). High-cardinality dimensions essential for debugging include `user_id` (millions of values), `request_id` and `trace_id` (billions), `customer_tenant_id`, endpoint-plus-parameter combinations, and geographic or device attributes. High dimensionality means you can combine those fields in ad-hoc queries; high cardinality means each field has many possible values. Both matter, but cardinality is what breaks time-series backends.
 
-Imagine your application processes 1 million requests per hour. Your traditional monitoring dashboard shows:
-- Average response latency: 100ms [OK]
-- 99th percentile (p99) latency: 500ms [OK]
-- Aggregate HTTP error rate: 0.5% [OK]
+In a **time-series database** like Prometheus, every unique combination of metric name plus label values creates a separate series stored in memory and on disk. If you track `http_request_duration_seconds` with labels `endpoint` (10 values), `region` (3 values), and `user_id` (one million values), you create 30 million series—each consuming index space and scrape storage. The explosion is multiplicative: adding one high-cardinality label multiplies series count by the number of unique values that label can hold. That is why Prometheus documentation explicitly warns against labels like user IDs or email addresses.
 
-From a high-level operational perspective, everything looks perfectly fine! The system is green. But mathematical reality dictates that 0.5 percent of 1 million requests means 5,000 specific users had a terrible, broken experience.
+**Event and columnar stores** used in observability platforms (Honeycomb-style backends, ClickHouse, BigQuery over structured logs) handle cardinality differently. They store raw or semi-structured events—one row per request, span, or log line—with columns for each attribute. A million distinct `user_id` values add storage proportional to the data you retain, not a million pre-created time series updated every scrape interval. Aggregations (average latency by browser, error count by region) are computed at **query time** over the events you kept, rather than baked in at ingest time. You pay for storage volume and query compute, but you do not multiply memory usage every time a new user appears.
 
-What aggregate monitoring CANNOT possibly tell you:
-- Which specific users experienced the failures?
-- Which API endpoints were involved in the failed requests?
-- What precise characteristics did those failed requests have in common?
-- Why were those requests handled differently than the successful ones?
-
-To answer these questions, you require high-cardinality dimensions. Cardinality refers to the number of unique values a specific data dimension can contain.
-
-High-cardinality dimensions absolutely necessary for modern debugging include:
-- `user_id` (potentially millions of unique values)
-- `request_id` (billions of unique values)
-- `trace_id` (billions of unique values)
-- `customer_tenant_id`
-- Exact combination of endpoint + parameters
-- Geographic region + device type + OS version
-- Specific combinations of active feature flags
-
-Traditional time-series databases (like basic Prometheus setups) structurally cannot handle high cardinality. Every unique combination of labels creates a brand new time series in memory. Tracking a million user IDs would instantly crash the monitoring infrastructure due to memory exhaustion. You need an event-based observability platform to handle this scale of detail.
+The practical lesson: metrics backends are optimized for low-cardinality aggregates over long retention; event backends are optimized for high-cardinality exploration over shorter windows or sampled retention. Mature observability strategies use both—metrics to detect anomalies cheaply, events and traces to explain them—but never pretend a metrics label can safely carry unbounded identity fields. When in doubt, ask your storage vendor what happens at ten million unique label values; the honest answer informs architecture more than any dashboard screenshot.
 
 ### 2.2 The Unknown Unknowns
 
-You can only write monitoring rules for failures you can actively anticipate. However, complex, highly distributed systems fail in completely unexpected, novel ways.
+You can only write monitoring rules for failures you anticipate. Complex distributed systems fail in novel ways that no runbook predicted—interaction bugs between services deployed on different days, race conditions visible only at certain traffic multiples, or dependency degradation that never triggers error codes because clients retry until timeouts propagate.
+
+Donald Rumsfeld's taxonomy maps cleanly to operations: **known knowns** (disk full) suit monitoring; **known unknowns** (latency sometimes spikes under load) need broader metrics and some drill-down; **unknown unknowns** (this browser cohort hits a latent N+1 query) require retained context and exploratory queries. Teams that conflate "we have alerts" with "we can debug anything" discover the gap during the first major outage after a microservice split.
+
+Observability supports investigation of unknown unknowns because you retain raw, high-fidelity event data and can ask questions you did not plan when you built the system. The cultural companion is psychological safety to explore during incidents instead of forcing premature runbook execution—hypothesis testing with data beats guessing under pressure.
 
 ```mermaid
 flowchart LR
@@ -238,11 +229,11 @@ flowchart LR
     UnknownUnknowns --> Never["Never happened before"]
 ```
 
-Observability empowers you to investigate "unknown unknowns" because you retain the raw, high-fidelity event data necessary to ask questions you did not think to ask when you initially architected the system.
+Observability supports investigation of unknown unknowns because you retain raw, high-fidelity event data and can ask questions you did not plan when you built the system.
 
 ### 2.3 Distributed System Complexity
 
-Monitoring paradigms were originally designed for monolithic architectures. Distributed systems fundamentally break those old assumptions.
+Monitoring paradigms were designed for monolithic architectures where a single process owned the full request lifecycle, log files lived on one disk, and a stack trace pointed to one codebase. Distributed systems break those assumptions because failure becomes a property of graphs—how services call one another under load—not a property of any single box on a dashboard.
 
 ```mermaid
 flowchart LR
@@ -263,7 +254,7 @@ flowchart LR
     end
 ```
 
-In a monolith, if a request fails, you can open a single log file, locate the stack trace, and understand exactly what happened. In a distributed microservices environment, a single user click might traverse an API gateway, invoke six different microservices, place a message on an asynchronous queue, and query three disparate databases. If the request fails, there is no single stack trace. The evidence is fragmented across dozens of servers. Distributed systems absolutely demand distributed observability.
+In a monolith, a failed request usually leaves one stack trace in one log file. In microservices, a single click may traverse a gateway, six services, a queue, and three databases—with no unified stack trace. Evidence is fragmented across machines and teams. Distributed systems require distributed observability: shared trace identifiers, correlated logs, and the ability to reconstruct a single request's path end to end.
 
 ---
 
@@ -271,34 +262,38 @@ In a monolith, if a request fails, you can open a single log file, locate the st
 
 ### 3.1 Control Theory Origins
 
-The term "observability" is not merely an industry buzzword; it is a rigorous mathematical concept derived from control theory, formally introduced by engineer Rudolf E. Kálmán in 1960.
+The term "observability" is not marketing jargon; it is a formal concept from control theory, introduced by Rudolf E. Kálmán in 1960 alongside the related property of **controllability**. The two ideas are mathematical duals: controllability asks whether inputs can drive the system to any desired state; observability asks whether outputs reveal enough information to reconstruct the internal state.
 
-In classical control theory, observability is a strict mathematical property of a dynamic system. It defines whether you can determine the complete internal state of a system entirely from its external outputs over a specific period.
+In classical linear systems, state evolves according to inputs, and sensors produce outputs. A system is **observable** if, given the input history and output history over a time window, you can uniquely determine the current internal state. If two different internal states produce identical outputs forever, the system is **not observable**—you cannot distinguish them from outside. Kálmán's observability matrix gives a concrete test for linear time-invariant systems: rank conditions on powers of the system matrix multiplied by the output matrix tell you whether state is recoverable.
 
 ```mermaid
 flowchart LR
     Input --> System["SYSTEM\n(Internal State ?)"] --> Output
 ```
 
-The fundamental equation is: Given the known inputs and the observed outputs, can we definitively deduce the internal state of the black box?
+Software analogies map cleanly but have limits. **Observable in the software sense**: structured logs, traces, and metrics with enough context that you can infer which code path ran, which dependency failed, and which configuration applied—without SSH, debugger attachment, or emergency logging patches. **Not observable**: a service that returns HTTP 500 for every internal failure mode, with no request ID, no trace, and no structured fields—database timeout and null pointer look identical from outside.
 
-- **OBSERVABLE**: Yes. The outputs contain sufficient fidelity and detail that we know exactly what the system is doing internally. (Example: A car's speedometer output accurately reflects the vehicle's internal velocity state).
-- **NOT OBSERVABLE**: No. The internal state is obfuscated or hidden from the outputs. (Example: A black box software application that outputs "Error 500" regardless of whether the database crashed, the disk filled up, or a null pointer exception occurred).
+The analogy's **limits** matter for platform engineers. Real software state includes caches, connection pools, feature flags, partial failures, and human-driven config changes—far richer than a finite-dimensional linear state vector. Telemetry is always sampled, lossy, and delayed; you rarely prove state uniquely, you estimate it well enough to act. Control-theory observability is a **design discipline**: emit outputs that make internal state *inferable*, not a guarantee that every question is answerable from today's dashboards.
+
+When a post-mortem says the system "was not observable in the control-theory sense," it usually means engineers had to modify running code to learn what happened—proof that external outputs were insufficient for the questions incident response required.
 
 ### 3.2 Software Observability
 
-When applied to modern software engineering, observability translates to a very specific capability: **can you understand exactly why your software system is behaving the way it is in production, solely by examining the telemetry it emits?**
+Applied to software engineering, observability means: **can you understand why your system behaves as it does in production by examining the telemetry it emits?** If engineers must SSH into production, attach a debugger, or deploy a hotfix solely to add logging, the system lacks observability for that failure mode.
 
-If an engineer has to SSH into a production server, attach a live debugger, or deploy a code hotfix just to add more logging to figure out why a bug is happening, the system is fundamentally NOT observable.
+Software differs from physical plants in important ways. State is partly digital (in-memory caches, connection pools) and partly organizational (feature flags, kill switches, manual config). Outputs are lossy: logs truncate, metrics aggregate, traces sample. You are never guaranteed full state reconstruction—you aim for **sufficient** reconstruction to act safely: roll back a deploy, disable a flag, scale a pool, or open a targeted ticket with evidence attached.
+
+Highly observable software teams treat telemetry schemas like API contracts. Breaking changes to log field names require migration notes the same way REST payload changes do. They test observability in staging by running representative queries ("find slow checkout traces with loyalty flag enabled") before production launch. They measure incident metrics not only in MTTR but in **questions answered per hour** during the bridge call—because every unanswered question is a candidate hotfix or a customer still failing.
 
 ```mermaid
 flowchart TD
     subgraph Highly["Highly Observable System"]
         direction TB
         H1["Structured logs with context"]
-        H2["Metrics with high-cardinality dimensions"]
-        H3["Distributed traces showing request flow"]
-        H4["Events capturing state changes"]
+        H2["Metrics with low-cardinality labels"]
+        H3["Events/spans with high-cardinality attributes"]
+        H4["Distributed traces showing request flow"]
+        H5["Events capturing state changes"]
     end
     Highly --> HA["Can answer: 'Why did user X's request fail at 3:42 PM?'"]
     Highly --> HB["Can answer: 'Why are requests from region Y slow?'"]
@@ -317,7 +312,7 @@ flowchart TD
 
 ### 3.3 Properties of Observable Systems
 
-A system does not become observable simply because you purchased a specific vendor's tool. Observability requires architectural commitment to specific data properties.
+Observability is not purchased—it is engineered through deliberate data properties (cardinality, correlation, queryability) and through operational practice that treats exploration as a first-class incident response step rather than a post-mortem afterthought.
 
 | Property | What It Means | Example |
 |----------|---------------|---------|
@@ -333,7 +328,7 @@ A system does not become observable simply because you purchased a specific vend
 
 ### 4.1 From "Know What's Wrong" to "Understand Behavior"
 
-Achieving observability is as much a cultural and mindset shift as it is a technological one. Engineering teams must transition away from attempting to predict failure and instead focus on ensuring the system can always explain itself.
+Achieving observability is a cultural shift as much as a technical one. Teams move from predicting every failure to ensuring the system can explain itself when something unexpected happens.
 
 ```mermaid
 flowchart TD
@@ -354,8 +349,7 @@ flowchart TD
 
 ### 4.2 Exploration Over Dashboards
 
-**DASHBOARD (monitoring)**
-Dashboards provide fixed, rigid views of predefined metrics. They are excellent for keeping an eye on known important signals, but they are terrible for investigating completely new problems because they offer no drill-down capability into high-cardinality data.
+Dashboards provide fixed views of predefined metrics. They are excellent for watching known signals and useless for investigating novel problems without drill-down into high-cardinality data.
 
 ```mermaid
 flowchart LR
@@ -365,10 +359,7 @@ flowchart LR
     QPS["QPS\n1234"]
 ```
 
-If these four dials do not clearly illuminate the root cause of the incident, the responding engineer is completely stuck.
-
-**EXPLORATION (observability)**
-Observability relies on a flexible, ad-hoc query interface designed for active investigation. This interface is optimized for slicing, dicing, and pivoting data to discover unknown correlations.
+If these four dials do not illuminate the root cause, the engineer is stuck unless an exploration interface exists. **Exploration (observability)** relies on ad-hoc queries optimized for slicing and pivoting high-cardinality fields rather than scrolling fixed charts.
 
 ```text
 > show requests where latency > 500ms
@@ -385,47 +376,15 @@ Observability relies on a flexible, ad-hoc query interface designed for active i
 
 ### 4.3 Questions Observability Enables
 
-With high-fidelity observability data, incident responders can confidently ask powerful questions during an ongoing crisis:
+With high-fidelity telemetry, responders can ask questions that monitoring dashboards were never designed to support, including pinpointing single-request latency, discovering shared attributes among failures, correlating behavior with recent changes, determining whether a failure mode is novel, scoping affected users, and mapping blast radius across dependent services:
 
-1. **"Why is this specific, individual request slow?"** - Analyzing the exact execution path rather than guessing based on fleet averages.
-2. **"What do all these failing requests have in common?"** - Instant pattern discovery (e.g., they all share a specific geographic origin or device type).
-3. **"What changed in the environment recently?"** - Deep correlation with deployment events, infrastructure configuration changes, or external dependency failures.
-4. **"Is this a brand new failure mode?"** - Immediate historical comparison against baselines dating back weeks or months.
-5. **"Exactly who is affected?"** - Precise impact scoping to inform customer communications and prioritize fixes based on business value.
-6. **"What else is affected?"** - Rapid blast radius discovery to ensure cascading failures are intercepted before they compromise the entire platform.
-
-> **War Story: The 5% Mystery That Cost Millions**
->
-> **2019. A Major E-commerce Platform. Black Friday Weekend.**
->
-> The site reliability team was highly confident heading into the busiest shopping day of the year. Their dashboards showed average latency across the platform holding steady at 180ms—well within their stringent Service Level Objectives (SLOs). The global error rate sat at 0.3%—an excellent metric for peak traffic. But customer support tickets began pouring in relentlessly: "Checkout won't complete." "The payment page hangs forever." "Your site is completely unusable."
->
-> Initially, the engineering team dismissed the reports as user perception issues or isolated localized network problems. Their numbers looked fantastic. Leadership started questioning if the support team was exaggerating the severity.
->
-> Then, a senior product manager arrived with damning business data: the cart abandonment rate at the final step had abruptly spiked 340%. Real customers were leaving without completing purchases. Revenue was actively hemorrhaging.
->
-> **Day 1**: Engineers realized their metrics were blind to the issue. They scrambled to implement and deploy high-cardinality observability telemetry. Within two hours of the new data flowing, they discovered the truth: 5.2% of checkout requests were taking over 8 seconds to resolve—but this massive latency only applied to users matching a very specific profile.
->
-> **Day 2**: Armed with queryable data, they drilled down ruthlessly. The affected users shared three distinct traits: (1) Their accounts were older than 2 years, (2) They were using the Safari web browser, and (3) They were physically connecting from the US East Coast.
->
-> **Day 3**: The root cause was definitively isolated. A marketing feature flag, recently enabled for "loyal customers" (defined as accounts older than 2 years), actively triggered a new, experimental recommendation engine during checkout. That specific engine made a synchronous, blocking network call to a third-party analytics API. Safari's stricter internal browser timeouts exposed the systemic latency that Google Chrome was silently masking. Furthermore, the third-party API server was located exclusively in the US West region, adding an unavoidable 40ms round-trip time penalty specifically for East Coast users, pushing the total request time just over Safari's threshold.
->
-> **Financial Impact**:
-> - Directly lost revenue during the Black Friday window: $2.3 Million
-> - Projected customer churn from frustrated loyal users: Estimated $8 Million annually
-> - The actual technical fix took exactly 20 minutes to implement once found (simply disabling the feature flag).
->
-> **The Lesson**: The team's traditional monitoring was technically flawless but operationally useless. Average latency was perfect. p99 latency was good. Error rates were great. But aggressive mathematical aggregation completely hid the severe pain of their most valuable, loyal customers. True, high-cardinality observability revealed the intricate, interconnected failure mode that aggregate metrics simply could not see.
+> **Hypothetical scenario:** During a peak traffic window, checkout dashboards show normal average latency (~200 ms) and a low global error rate (~0.3%). Support reports that checkout "hangs" for a noticeable subset of users. After enabling queryable, high-cardinality telemetry, engineers find that roughly **5%** of checkout requests take **more than 8 seconds**—invisible to averages because **95%** of traffic is fast. Filtering reveals a narrow profile: accounts **older than two years**, **Safari** browsers, clients in **US-East**, all with a **loyalty feature flag** enabled. The flag triggers a **synchronous third-party analytics call** during checkout. Chrome masks some delay; Safari enforces stricter timeouts. The third-party endpoint is reachable but adds cross-region latency for East Coast users. The fix is disabling the flag or making the call asynchronous—minutes of work once the segment is visible. Aggregate metrics were correct about the majority and blind to the minority that mattered for revenue and trust.
 
 ---
 
 ## Part 5: Comparing Observability Tooling Approaches
 
-When architecting a comprehensive observability strategy, engineering organizations frequently struggle with determining exactly where to begin their implementation journey. The industry standard provides three distinct primary data types—often conceptually referred to as the three pillars—which are logs, metrics, and traces. 
-
-While a highly mature, elite engineering organization will seamlessly integrate and correlate all three data types, the stark reality of engineering bandwidth, budget constraints, and operational overhead means you must intelligently prioritize your initial rollout. Selecting the right starting point requires rigorously evaluating your specific architectural needs, identifying your primary failure domains, and understanding your organizational capacity. 
-
-A fundamental mismatch between your underlying system architecture and your chosen tooling approach will inevitably result in exorbitant infrastructure costs and practically zero investigative value during an incident. You must align your tools with your pain points.
+When building an observability strategy, teams choose where to invest first among **logs**, **metrics**, and **traces**—often called the three pillars. Mature organizations correlate all three; early rollouts must prioritize based on architecture, failure domain, and bandwidth.
 
 ```mermaid
 flowchart TD
@@ -442,34 +401,112 @@ flowchart TD
 
 ### The Metrics-First Approach
 
-A metrics-first approach prioritizes the massive collection of numerical time-series data to deeply understand the aggregate health and performance of a system. Industry-standard tools like Prometheus and Grafana dominate this specific space. Metrics are incredibly cheap to store, transport, and query over long periods because they deliberately discard the underlying transactional context in favor of strict mathematical aggregation. You can comfortably track the CPU usage, memory consumption, and network throughput of 10,000 Kubernetes pods for fractions of a cent per day.
+Metrics-first prioritizes numerical time-series data for aggregate health. Tools like Prometheus and Grafana dominate this space. Metrics are far cheaper to store and retain long-term than full per-request logs because they discard per-request context in favor of aggregation. Tracking CPU, memory, and request rates across thousands of pods scales economically compared to retaining every request as a log line.
 
-**Architectural Fit:** This approach is the definitively optimal starting point for infrastructure-heavy environments, bare-metal provisioning platforms, vast Kubernetes administrative clusters, or massive fleets of stateless background workers where individual request context is substantially less important than aggregate throughput and resource saturation. If your primary failure domain consists of hardware exhaustion, network interface saturation, or highly predictable cyclic scaling challenges, a metrics-first approach provides the absolute highest immediate return on investment.
-
-**The Drawback:** When a specific, high-value customer complains about a slow API request, a metrics-first approach is virtually useless for finding that needle in the haystack. It only tells you the overall size, weight, and general health of the haystack itself.
+**Architectural fit:** Infrastructure-heavy environments—Kubernetes control planes, bare-metal fleets, stateless workers—where resource saturation matters more than individual request narratives. Primary failure domains: hardware exhaustion, network saturation, predictable scaling cycles. **Drawback:** When one customer reports a slow API call, metrics show haystack statistics—the distribution of all requests—not the specific slow request or the label combination that identifies it.
 
 ### The Logs-First Approach
 
-A logs-first approach prioritizes the robust emission, transportation, and indexing of discrete, timestamped system events (now almost exclusively formatted as structured JSON). Toolchains like the ELK stack (Elasticsearch, Logstash, Kibana) or enterprise solutions like Splunk are the traditional heavyweights here. Logs provide incredibly deep, granular context. A well-structured JSON log line can contain the specific user ID, the exact database query executed, a full error stack trace, and the precise state of the application's memory at that exact microsecond.
+Logs-first prioritizes structured, timestamped events (typically JSON). Elasticsearch and OpenSearch index rich fields—user ID, query text, stack traces, memory snapshots—for fast arbitrary search. Loki takes a different trade-off: it indexes only labels (low-cardinality metadata such as service and namespace), stores log content in compressed chunks, and queries content at read time. That design is cheaper to store but best suited to label-scoped queries rather than ad-hoc full-text search across every field.
 
-**Architectural Fit:** This is unequivocally the ideal starting point for legacy monolithic applications, modern macro-services, or systems characterized by a small number of very thick, complex services. In a monolith architecture, a single user request rarely leaves the main process boundary. This means a single, well-structured application log file contains the complete, uninterrupted narrative of any failure. If you operate a large, centralized application, investing heavily in structured logging (and powerful log aggregation and search) will yield immediate, profound debugging superpowers.
+**Architectural fit:** Monoliths and thick services where one process handles the full request lifecycle. A single log stream often tells the complete failure story.
 
-**The Drawback:** Logs are notoriously expensive to transport, index, and retain long-term. In a highly distributed, deeply decoupled microservices environment, a single user action might seamlessly generate 500 individual log lines scattered across 40 different virtual machines. Making sense of that fragmented narrative without extremely sophisticated correlation techniques is nearly impossible.
+**Drawback:** In microservices, one user action may produce hundreds of log lines across dozens of hosts. Without correlation IDs, reconstruction is manual and slow. Log volume also drives storage cost faster than metrics.
 
 ### The Traces-First Approach
 
-A traces-first approach focuses aggressively on tracking the complete lifecycle of a single request as it dynamically traverses across network boundaries, queues, and multiple discrete microservices. Using open standards like OpenTelemetry and specialized backends like Jaeger or Honeycomb, tracing injects a unique, globally identifiable context header at the network edge and propagates it downstream through every single component.
+Traces-first tracks one request across network boundaries via propagated context (OpenTelemetry, Jaeger, Zipkin). A trace ID injected at the edge appears in every downstream service.
 
-**Architectural Fit:** This is the strictly mandatory starting point for deep microservice architectures, complex serverless environments, or heavily decoupled event-driven systems. When an application is composed of dozens or hundreds of independent, networked services, massive failures rarely occur because a single service crashed in isolation. They occur because Service A timed out waiting for Service D, which was rate-limited by Service F due to a cascading retry storm. Distributed tracing is the only viable approach that visually maps these intricate causal relationships and accurately highlights cross-boundary network latency bottlenecks.
-
-**The Drawback:** Implementing comprehensive tracing requires explicitly modifying application code across the entire fleet to properly propagate context headers. This can be politically difficult and technically challenging in large organizations burdened with legacy codebases, divergent language stacks, or highly siloed development teams.
+**Architectural fit:** Deep microservice graphs, serverless chains, event-driven architectures where failures are cross-service timeouts and retry storms, not single-process crashes. **Drawback:** Requires instrumentation and political agreement across teams; legacy codebases with many languages need consistent propagation standards before traces become trustworthy.
 
 ### Justifying Your Starting Point
 
-To design a truly effective observability strategy, you must conduct a ruthless audit of your architecture and organizational pain points. 
-- If you are undertaking a lift-and-shift of a massive legacy monolith, do not start with distributed tracing; mandate structured logging first to gain visibility into the monolith's behavior. 
-- If you are responsible for managing a vast Kubernetes platform serving untrusted third-party workloads, prioritize a metrics-first rollout to ensure absolute cluster stability and node health. 
-- If you are architecting a greenfield microservices application, you must mandate distributed tracing from day one, injecting OpenTelemetry SDKs before the service graph becomes too complex and tangled to instrument retroactively.
+Match tooling to architectural pain rather than vendor marketing: undertake structured logging first when lifting a legacy monolith, because tracing across one process adds little until services split; prioritize metrics-first when operating a multi-tenant Kubernetes platform where node health and quota saturation dominate incident volume; mandate distributed tracing from day one on greenfield microservices before the service graph becomes too tangled to instrument consistently.
+
+The sections below formalize this comparison into patterns, anti-patterns, and a reusable decision framework you can apply in design reviews and architecture decision records.
+
+---
+
+## Patterns & Anti-Patterns
+
+### Patterns That Scale
+
+**Instrument at boundaries and propagate one trace ID.** Generate a correlation identifier at the edge (API gateway, load balancer, first service) and pass it through HTTP headers, message queues, and database client metadata. Boundaries—ingress, egress, external API calls, database handoffs—are where latency and errors concentrate; they are the highest-leverage instrumentation points. One stable ID lets you pivot from a metric spike to logs and traces without guessing timestamps.
+
+**Store raw events; aggregate at query time.** Retain structured events or spans with full attribute sets for a defined retention window. Compute percentiles, error rates by segment, and top-N endpoints when investigating—not at ingest, where aggregation destroys the tail. Metrics derived from events (recording rules, rollups) are fine for alerting; the raw store remains the source of truth for "why."
+
+**Prefer wide structured events over many narrow log lines.** A single JSON object per request completion—with latency, status, user tier, region, flag state, and trace ID—beats ten printf lines that cannot be queried together. Wide events align with how columnar query engines work and reduce log volume noise. When each microservice emits one completion event with nested fields for dependency calls, investigators reconstruct stories without joining dozens of grep results.
+
+**Define cardinality budgets with platform teams.** Product engineers should know which fields are safe on metrics (low tens of values) versus spans and logs (millions). Publishing a short allowlist—`http.route`, `deployment.version`, `cloud.region` on metrics; `user.id` on spans only—prevents well-meaning instrumentation from taking down shared infrastructure. Governance is not bureaucracy; it is how multi-tenant observability stacks survive Black Friday-shaped traffic.
+
+### Anti-Patterns to Avoid
+
+| Anti-Pattern | What Goes Wrong | Better Approach |
+|--------------|-----------------|-----------------|
+| **Dashboards == observability** | Green panels hide segment-specific failure | Add queryable high-cardinality backends; use dashboards as entry points, not the whole story |
+| **High-cardinality label on a metric** | Time-series memory explosion; OOM on scrapers | Keep identity fields on events/spans; use low-cardinality labels on metrics |
+| **Aggregate-first, lose the tail** | p99 looks fine while 5% of users timeout | Retain raw or sampled events; alert on burn rates and tail latency |
+| **Tool sprawl without correlation** | Three UIs, manual timestamp matching | Standardize on `trace_id` / `request_id` across logs, metrics exemplars, and traces |
+
+---
+
+## Decision Framework: Choosing Your First Signal
+
+Use this framework when leadership asks "What should we implement first?" The answer depends on **architecture shape** and **primary failure domain**, not vendor preference.
+
+```mermaid
+flowchart TD
+    Start["Start: What breaks most often?"] --> Q1{"Is the system mostly\none process / monolith?"}
+    Q1 -->|Yes| Logs["Logs-first:\nstructured JSON,\ncentral search"]
+    Q1 -->|No| Q2{"Do incidents look like\n cross-service timeouts\n or retry storms?"}
+    Q2 -->|Yes| Traces["Traces-first:\nOpenTelemetry propagation\nfrom day one"]
+    Q2 -->|No| Q3{"Is pain mostly node/cluster\ncapacity or hardware?"}
+    Q3 -->|Yes| Metrics["Metrics-first:\nUSE on nodes,\nRED/Golden on services"]
+    Q3 -->|No| Logs
+    Logs --> Corr["Next: add trace_id\nand RED metrics"]
+    Traces --> Corr
+    Metrics --> Corr
+    Corr --> Eval["Evaluate: can on-call\nanswer a novel question\nin one tool pivot?"]
+```
+
+| If your primary failure domain is… | Start with… | Because… | Add next… |
+|-----------------------------------|-------------|----------|-----------|
+| Single-app logic bugs, batch jobs in one JVM | **Logs-first** | One process, one narrative | Metrics for saturation; traces if you split services |
+| Cross-service latency, dependency chains | **Traces-first** | Path and timing across hops | Structured logs with `trace_id`; RED metrics per service |
+| Node exhaustion, noisy neighbors, cluster stability | **Metrics-first** | Cheap fleet-wide aggregates | Logs on anomalies; traces for app teams |
+| Unknown segment failures (browser, region, cohort) | **Events / wide logs** | Needs high cardinality | Metrics for detection only; never put cohort IDs on metric labels |
+
+**Compare** the three approaches explicitly in design docs: list what each pillar would miss for your top three recent incidents. If traces would not have helped any of them, do not start with traces—regardless of industry hype. **Justifying your starting point** means tying the choice to incident history and architecture, not tool popularity.
+
+### From Alerts to Answers: An Observability Maturity Progression
+
+Teams rarely jump from dashboards-only to full high-cardinality exploration in one quarter. A realistic maturity progression helps you **evaluate** where you are and **design** the next increment without boiling the ocean.
+
+**Stage 1 — Monitoring-centric.** You have host and service metrics, threshold alerts, and Grafana dashboards. Incidents start when a pager fires. Responders follow runbooks. Unknown failure modes stall until someone SSHes in or adds printf logging. Most organizations live here for years; it is sufficient until distributed architecture or customer segmentation makes aggregates lie.
+
+**Stage 2 — Structured telemetry.** Logs become JSON with consistent fields (`service`, `level`, `trace_id`, `user_tenant`). Metrics adopt RED or Golden Signal naming per service. Alerts still dominate entry points, but responders can search logs by request ID when support provides one. Gap: cross-service stories still require manual timestamp alignment.
+
+**Stage 3 — Correlated traces.** OpenTelemetry (or equivalent) propagates context through HTTP and messaging. Spans link to log lines; histograms expose exemplars pointing at slow traces. Mean time to resolution drops for latency incidents because the path is visible. Gap: high-cardinality ad-hoc grouping (every combination of browser, region, and flag) may still require a dedicated event store.
+
+**Stage 4 — Exploratory observability.** Raw or sampled events retain wide attributes for days to weeks. On-call can ask novel questions—"show checkout spans where loyalty_flag=true and duration>3s, group by browser"—without a deploy. This is where unknown-unknowns become tractable. Cost management (sampling, retention tiers) becomes a first-class engineering concern.
+
+Moving one stage up is a reasonable annual goal. Attempting stage four without stage two's structured fields fails because garbage identifiers do not correlate. Attempting stage three on a monolith still helps future splits but should not delay log quality on the current codebase.
+
+### Connecting Observability to Reliability Practice
+
+Observability does not replace SLOs, error budgets, or incident response—it feeds them. When you define an SLI such as "successful checkout completion under two seconds," observability tells you **which** requests violate that SLI and **why**, while the SLO tells you whether burn rate warrants a page. A team with perfect SLO dashboards but no drill-down will know they are missing budget without knowing whether database locks, a third-party API, or a feature flag caused the miss.
+
+During incident response, observability supports the scientific method: observe a symptom (latency spike), form a hypothesis (maybe cache region X), query telemetry to confirm or refute, narrow scope, repeat. Monitoring-only cultures skip experimentation and jump from dashboard to runbook step three, which is why runbooks fail on novel failures. Post-incident, observability data becomes evidence for blameless post-mortems: exact request samples, flag states, and dependency timings replace guesswork.
+
+For platform teams serving internal developers, observability maturity is a product feature. Application teams choose your cluster partly on whether they can debug their own services without opening a central ops ticket for every investigation. Publishing standards—required span attributes, log field schemas, cardinality budgets—turns observability from heroics into contract.
+
+### Instrumentation Philosophy for Foundation Teams
+
+Theory modules avoid prescribing a single vendor, but they can prescribe **shape**: emit outputs at boundaries, propagate one correlation ID, prefer wide structured events over string formatting, and treat high-cardinality fields as first-class query dimensions rather than debugging accidents. Default tags should include service name, deployment version, and environment; optional tags capture business context (tenant tier, feature flags) at span or log level, never on unbounded metric labels.
+
+Sampling is inevitable at scale. Head-based sampling decides at trace start whether to keep the whole trace—simple but may discard rare slow paths. Tail-based sampling retains traces that ended with errors or high latency—better for SRE use cases, harder to implement. The observability mindset accepts sampling when you can still statistically find needles; it rejects sampling when it permanently destroys the ability to ask questions about discarded events.
+
+Finally, observability is a feedback loop for engineering quality. When on-call regularly cannot answer "why," that signal belongs in sprint planning as instrumentation debt—same as flaky tests or missing runbooks. **Apply** the control-theory lens here: if you cannot infer internal state from outputs, the system is asking operators to open the black box under fire. Fixing that is architecture work, not a tooling purchase alone.
 
 ---
 
@@ -477,16 +514,14 @@ To design a truly effective observability strategy, you must conduct a ruthless 
 
 ## Did You Know?
 
-- **Honeycomb** (a leading observability company) was founded in 2016 on the core architectural principle that high-cardinality data is absolutely essential for modern debugging. Traditional monitoring tools couldn't handle millions of unique dimension values without crashing, so they built entirely new datastore systems optimized specifically for it.
-- **Google's Dapper paper**, published to the industry in 2010, formally introduced the concept of distributed tracing to the wider engineering world. It detailed exactly how Google traces massive requests across thousands of internal services to understand emergent behavior. This groundbreaking paper directly inspired open-source projects like Zipkin, Jaeger, and eventually the OpenTelemetry standard.
-- **The term "pillars"** (referring to logs, metrics, and traces) has been heavily criticized by observability practitioners since around 2018. Industry leaders like Charity Majors argue they are not independent pillars, but rather different views of the exact same underlying events. The rigid "pillar" framing often leads engineering teams to erroneously treat them as separate silos instead of deeply integrated data streams.
-- **Twitter famously utilized a "Fail Whale"** error page during massive, cascading outages in its early days (around 2008). The engineering team couldn't effectively debug their rapidly expanding distributed issues because they fundamentally lacked observability—they possessed basic monitoring, but couldn't answer the crucial question of "why." This painful operational reality drove major, urgent investments in distributed tracing infrastructure that later influenced the entire tech industry.
+- **Honeycomb** was founded in 2016 on the principle that high-cardinality data is essential for modern debugging. Traditional monitoring tools could not handle millions of unique dimension values without crashing, so the team built datastore systems optimized for ad-hoc grouping by arbitrary fields.
+- **Google's Dapper paper**, published in 2010, introduced distributed tracing at scale inside Google and inspired open-source projects like Zipkin, Jaeger, and eventually OpenTelemetry.
+- **The term "pillars"** (logs, metrics, traces) has been criticized since around 2018. Practitioners like Charity Majors argue they are different views of the same events—not silos to purchase and operate separately.
+- **Twitter's "Fail Whale"** era (circa 2008) reflected outages the team struggled to debug in a rapidly growing distributed architecture. Basic monitoring existed, but answering "why" required investments in tracing and correlated telemetry that later influenced industry practice.
 
 ---
 
 ## Common Mistakes
-
-The path to true observability is fraught with organizational and technical pitfalls. Avoid these common anti-patterns.
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
@@ -496,67 +531,69 @@ The path to true observability is fraught with organizational and technical pitf
 | Aggregating too early | Lose detail needed for debugging | Store raw events, aggregate at query time |
 | Treating pillars as silos | Can't correlate logs, metrics, traces | Use common identifiers (`trace_id`) |
 | Only instrumenting your code | Miss database, cache, external calls | Instrument at boundaries too |
+| High-cardinality metric labels | OOM and slow queries on TSDB | Put identity on events; keep metrics low-cardinality |
+| Tool collection without correlation | Long MTTR despite many products | One ID across signals; exemplars linking metrics to traces |
 
 ---
 
 ## Quiz
 
-Test your deep comprehension of observability theory and its practical application in complex engineering scenarios.
+The following eight scenario-based questions test whether you can **compare** tooling approaches, **diagnose** monitoring blind spots, **evaluate** organizational maturity, **design** strategies for unknown-unknowns, and **apply** the control-theory definition in realistic on-call situations.
 
-1. **You are the lead engineer for a new microservices platform. The VP of Engineering asks you to justify spending time implementing OpenTelemetry instead of just relying on the existing Prometheus setup that alerts on high CPU and memory. How do you explain the fundamental difference in what these approaches allow you to do during an incident?**
+1. **You are the lead engineer for a new microservices platform. The VP asks you to justify OpenTelemetry instead of relying only on Prometheus CPU and memory alerts. How do you compare what each approach enables during an incident?**
    <details>
    <summary>Answer</summary>
 
-   Monitoring, like the existing Prometheus setup, is designed to answer predefined questions such as whether CPU or memory has crossed a known threshold. It tells you that something is wrong based on conditions you anticipated and planned for. Observability, on the other hand, allows you to ask arbitrary questions after the fact when an unknown issue occurs. When a novel failure mode happens in your new microservices platform, observability lets you explore the rich telemetry to understand why it is happening, even if you never predicted that specific failure scenario.
+   Prometheus-style monitoring answers predefined questions: whether CPU, memory, or error thresholds crossed values you anticipated. It detects known failure modes efficiently. Observability via OpenTelemetry traces and correlated logs lets you compare request paths across services and ask new questions when an unknown issue appears—such as which dependency added latency for mobile clients only. **Compare** metrics-first detection with traces-first explanation: metrics tell you something changed; traces and events tell you where and why in the call graph.
    </details>
 
-2. **Your e-commerce checkout service has 10 endpoints and runs in 3 regions. Your team decides to add `user_id` (representing 1 million active users) as a label to your Prometheus metrics so you can track per-user latency. Two hours later, your Prometheus server crashes from out-of-memory errors. What caused this, and why do traditional metrics systems fail in this scenario?**
+2. **Your checkout service runs in three regions with ten endpoints. Adding `user_id` (one million active users) as a Prometheus label crashes the server with OOM errors. Diagnose why traditional metrics systems fail here.**
    <details>
    <summary>Answer</summary>
 
-   Traditional metrics systems store time-series data where every unique combination of labels creates an entirely new time series in memory and on disk. By adding a high-cardinality dimension like `user_id` with 1 million distinct values, the number of time series exploded from 30 (10 endpoints × 3 regions) to 30 million. Storage, memory, and query costs grow linearly with this cardinality, quickly overwhelming the system's capacity. To handle this, true observability tools store raw events rather than pre-aggregated series, computing the aggregations only when a query is executed.
+   Each unique label combination creates a new time series. Ten endpoints times three regions times one million users yields tens of millions of series, each consuming memory and index space on every scrape. **Diagnose** this as a cardinality explosion: metrics backends multiply series by label values, unlike event stores that store one row per request and aggregate at query time. High-cardinality identity belongs on logs or spans, not metric labels.
    </details>
 
-3. **During a post-mortem, a senior architect mentions that the incident was hard to debug because the system "isn't fully observable in the control theory sense." The team had to deploy a hotfix just to add more logging to figure out what was wrong. How does the control theory definition of observability explain why this system failed the test?**
+3. **During a post-mortem, an architect says the system "isn't observable in the control theory sense" because the team deployed a hotfix only to add logging. Apply the control-theory definition: did this system pass or fail?**
    <details>
    <summary>Answer</summary>
 
-   In control theory, a system is considered observable if you can determine its complete internal state entirely by examining its external outputs, without needing to open the black box. Applied to software, this means your system should emit enough rich telemetry (logs, metrics, and traces) that you can understand why it is behaving a certain way without needing to modify it. Because the team had to add new instrumentation and deploy a hotfix to understand the system's state, the external outputs were inherently insufficient. Therefore, the system was not fully observable, forcing engineers to alter the system just to ask new questions.
+   In control theory, a system is observable if internal state can be inferred from external outputs without opening the black box. **Apply** that test: needing a code change to emit new outputs means existing telemetry was insufficient to determine state. The system failed observability for that incident—outputs did not yet support the questions responders needed. Passing the test means on-call can investigate from current telemetry alone.
    </details>
 
-4. **You are migrating a legacy monolithic application to a Kubernetes cluster running 15 distinct microservices. The legacy app was easily debugged using a single application log file and local stack traces. A developer complains that debugging the new architecture takes hours. Why does the shift to distributed systems make traditional debugging inadequate, requiring a true observability strategy?**
+4. **You migrate a monolith to fifteen microservices. Debugging now takes hours despite "good" average latency metrics. Design what an observability strategy must add beyond monitoring.**
    <details>
    <summary>Answer</summary>
 
-   In a monolith, a single request is handled by one process, meaning a single stack trace or log file can usually tell the whole story of a failure. In a distributed system, a single request touches multiple services across different machines, destroying the single stack trace and scattering logs everywhere. Failures in distributed systems are often emergent, resulting from the complex interactions between services rather than a single broken component. Without observability practices like distributed tracing and cross-service correlation via shared IDs, engineers cannot reconstruct the request path, making it nearly impossible to diagnose these emergent failures.
+   **Design** for unknown-unknowns: propagate trace IDs across all fifteen services, structure logs with shared fields, and retain enough request-level detail to reconstruct paths. Monitoring averages will still look fine when one dependency fails for a subset of traffic. Observability strategy prioritizes correlation and high-cardinality exploration so emergent cross-service failures become visible without new deploys per investigation.
    </details>
 
-5. **Your payment gateway processes 1 million transactions daily. The dashboard shows an average latency of 150ms and a p99 latency of 400ms, which the team considers acceptable. However, customer support reports that 0.5% of requests take more than 5 seconds, causing timeouts. Calculate how many users experience this extreme latency daily, and explain why the monitoring dashboard completely missed them.**
+5. **One million daily transactions show 150 ms average latency and 400 ms p99, yet support reports 0.5% of requests exceed five seconds. How many users are affected, and why did dashboards miss them?**
    <details>
    <summary>Answer</summary>
 
-   Out of 1 million daily requests, 0.5% translates to 5,000 users experiencing extreme latency every single day. The monitoring dashboard missed this because traditional aggregation metrics hide the outliers at the extreme tail. The average latency is heavily skewed by the 99.5% of fast requests, and the p99 metric only captures the boundary of the 99th percentile, remaining blind to the behavior of the top 1%. Without high-cardinality observability data to drill into that specific 0.5%, the monitoring system will continue to report that everything is fine while thousands of users suffer silently.
+   0.5% of one million is **5,000 users per day** experiencing extreme latency. Dashboards missed them because aggregates summarize the majority: averages are dominated by fast requests, and p99 still ignores the slowest half-percent tail. **Diagnose** this as aggregate blind spots—only event-level or high-cardinality queries expose small suffering segments.
    </details>
 
-6. **Your SaaS platform is expanding globally. You currently have 50 endpoints and operate in 10 regions, serving 2 million users. A junior developer proposes tracking the exact performance of every user by adding `user_id` as a label in your traditional time-series database. Calculate the resulting number of time series, and explain why this approach will cripple your monitoring infrastructure.**
+6. **Fifty endpoints, ten regions, two million users— a proposal adds `user_id` as a metric label for per-user latency. Estimate series count and explain infrastructure impact.**
    <details>
    <summary>Answer</summary>
 
-   Multiplying 50 endpoints by 10 regions and 2 million users results in 1 billion distinct time series being generated. Traditional time-series databases like Prometheus are designed to handle millions of series, not billions, because each series consumes active memory and storage resources. Attempting to track 1 billion series would require astronomical amounts of memory, degrade query performance to a halt, and likely crash the infrastructure immediately. This is why tracking per-user performance requires an event-based observability platform that computes aggregates on demand rather than storing pre-aggregated series for every possible label combination.
+   Fifty times ten times two million equals **one billion** potential series—far beyond what Prometheus-class systems handle. Memory, scrape duration, and query latency collapse. Per-user performance belongs in an event or tracing backend with query-time aggregation, not pre-materialized metric series.
    </details>
 
-7. **A newly hired SRE looks at the company's toolchain and says, "We have Prometheus for metrics, Grafana for dashboards, and the ELK stack for logs. We are fully observable." You know that during the last outage, it took four hours to trace a single failing transaction across three services. How do you explain to the SRE the difference between having observability tools and actually achieving observability?**
+7. **An SRE says Prometheus, Grafana, and ELK mean the company is "fully observable," yet tracing one failed transaction across three services took four hours. Evaluate whether the organization actually has observability.**
    <details>
    <summary>Answer</summary>
 
-   Having a specific set of tools does not automatically grant a system the property of observability. Observability is defined by what you can discover and understand about your system's behavior, not the brands of software you have installed. In this case, the inability to trace a single transaction across services in under four hours proves the system lacks correlation, such as shared trace IDs linking logs and metrics. While tools like Prometheus and ELK can be components of an observable system, without high-cardinality data, structured logging, and distributed tracing, they are merely functioning as fragmented monitoring tools.
+   **Evaluate** observability by capability, not tool count: can on-call answer a novel question without new code? Four hours to follow one transaction proves correlation gaps—likely missing shared trace IDs linking logs and spans, or no way to pivot from metrics to a specific trace. Tools present without high-cardinality query paths and correlation are fragmented monitoring, not observability maturity.
    </details>
 
-8. **Revisit the 2017 AWS S3 outage where an automation script removed too many servers, breaking the billing subsystem and consequently S3's index subsystem. During the 4-hour outage, the monitoring dashboards showed all individual servers as healthy. If the engineers had possessed a modern observability platform, what specific questions would they have been able to ask to quickly uncover the root cause?**
+8. **In the 2017 AWS S3 outage, per-server health looked fine while customers could not access objects. What exploratory questions would modern observability enable?**
    <details>
    <summary>Answer</summary>
 
-   With a modern observability platform, the engineers would have been able to ask exploratory questions like "What dependencies are failing for the S3 index subsystem?" or "What systemic changes occurred immediately prior to the error spike?" They could have queried the telemetry to see that while individual servers were healthy, the requests between the index and billing subsystems were timing out or failing across the board. Furthermore, they could have asked "What is the exact blast radius of the affected requests?", allowing them to trace the failure back to the specific automation script that removed the crucial instances, rather than blindly trusting the aggregate green health checks. This capability to interrogate the system's active connections would have drastically reduced the 4-hour mean time to resolution (MTTR) by pinpointing the issue's origin instantly.
+   Engineers could ask: "Which subsystem dependencies fail when index nodes serve GET requests?" and "What changed immediately before error rates rose for object retrieval?" Correlated traces or structured dependency events would show index and placement subsystem capacity loss and restart despite green CPU graphs. **Compare** that investigative path to checking only hardware metrics—the observability questions target subsystem dependencies and what changed, not isolated per-server health.
    </details>
 
 ---
@@ -597,11 +634,13 @@ STARTING THE JOURNEY
 
 ## Hands-On Exercise
 
-**Task**: Rigorously evaluate the genuine observability maturity of a software system you actively operate or contribute to.
+**Task:** Evaluate the observability maturity of a software system you operate or contribute to by working through a scorecard, a gap analysis, and a simulated slow-checkout incident. The goal is an honest baseline—not a roadmap fantasy—and a concrete list of telemetry gaps that would block you during the next unknown-unknown.
 
-**Part 1: Current State Assessment**
+Complete **Part 1** by scoring six capabilities (structured logging, request ID propagation, distributed tracing, high-cardinality queries, cross-service correlation, ad-hoc investigation) from 0 (absent) to 3 (comprehensive), recording notes that cite real services and tools. Sum the scores for a total out of 18: 0–6 indicates monitoring-only vulnerability, 7–12 partial observability, 13–18 strong exploratory capability.
 
-Fill out this precise observability scorecard based on empirical reality, not future roadmap plans:
+Complete **Part 2** by selecting your three lowest scores and filling a gap table with current state, missing elements, and a single technical first step per row—for example, "add `trace_id` to JSON log schema in checkout-api" rather than "buy a new vendor."
+
+Complete **Part 3** by writing a short investigation narrative for this scenario: *multiple users report intermittent checkout slowness while the primary dashboard shows normal average latency.* Document which dashboard or index you would open first, three ad-hoc questions you would try to answer, which telemetry you expect to be missing, and the point where your current toolchain would force you back to monitoring-only guesswork.
 
 | Capability | Score (0-3) | Notes |
 |------------|-------------|-------|
@@ -612,48 +651,36 @@ Fill out this precise observability scorecard based on empirical reality, not fu
 | **Cross-service correlation** | | 0=manual, 1=partial, 2=mostly automated, 3=seamless |
 | **Ad-hoc investigation** | | 0=impossible, 1=painful, 2=possible, 3=easy |
 
-**Total: ___/18**
-
-Interpretation Guide:
-- 0-6: Monitoring only. You have major observability gaps and are highly vulnerable to unknown-unknowns.
-- 7-12: Partial observability. You can debug some issues but will struggle with complex distributed failures.
-- 13-18: Good observability. You can confidently investigate and resolve most novel issues efficiently.
-
-**Part 2: Strategic Gap Analysis**
-
-For your lowest-scoring capabilities identified above, complete the following strategic breakdown:
-
 | Capability | Current State | What's Missing | First Step to Improve |
 |------------|---------------|----------------|----------------------|
 | | | | |
 | | | | |
 | | | | |
 
-**Part 3: Practical Investigation Scenario Simulation**
-
-Imagine this extremely common operational scenario occurs during your shift:
-> "Multiple users report that the checkout page is intermittently slow, but your primary application dashboard shows completely normal latency averages."
-
-Document the exact technical steps you would take to investigate this within your current system constraints:
-
-1. What specific dashboard or log index would you look at first?
-2. What ad-hoc questions would you attempt to answer to narrow the scope?
-3. What critical telemetry data would you need to find the root cause that you might not actually have available?
-4. At what precise point would you likely get stuck relying entirely on your current toolchain?
-
 **Success Criteria Checklist**:
-- [ ] Scorecard comprehensively completed with an honest, empirical assessment of current capabilities.
-- [ ] At least two critical observability gaps identified with actionable, technical improvement steps.
-- [ ] The simulated investigation scenario clearly demonstrates a deep understanding of the fundamental differences between a monitoring mindset and an observability mindset.
-- [ ] Explicitly identified at least one critical data telemetry gap in the current operational system that prevents tracking unknown-unknowns.
+- [ ] Scorecard completed with an honest assessment of current capabilities.
+- [ ] At least two observability gaps identified with actionable improvement steps.
+- [ ] The simulation demonstrates the difference between monitoring mindset and observability mindset.
+- [ ] At least one telemetry gap identified that prevents investigating unknown-unknowns.
 
 ---
 
-## Further Reading
+## Sources
 
-- **"Observability Engineering"** - Charity Majors, Liz Fong-Jones, George Miranda. The definitive industry text detailing core observability concepts, cultural shifts, and technical practices.
-- **"Distributed Systems Observability"** - Cindy Sridharan. An excellent free ebook covering the profound necessity of observability specifically within highly distributed systems.
-- **"Dapper, a Large-Scale Distributed Systems Tracing Infrastructure"** - The seminal Google engineering paper that fundamentally introduced distributed tracing to the wider industry.
+- [Summary of the Amazon S3 Service Disruption in US-EAST-1 (February 2017)](https://aws.amazon.com/message/41926/) — Official AWS post-event summary of the index and placement subsystem capacity removal and restart. <!-- incident-xref: aws-s3-useast1-2017 -->
+- [Amazon outage cost S&P 500 companies $150M (Axios, citing Cyence)](https://www.axios.com/2017/12/15/amazon-outage-cost-sp-500-companies-150m-1513300728) — Third-party analyst estimates of aggregate business impact from the February 2017 S3 disruption.
+- [Google SRE Book: Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/) — Four Golden Signals and monitoring philosophy for distributed services.
+- [OpenTelemetry: Observability Primer](https://opentelemetry.io/docs/concepts/observability-primer/) — Vendor-neutral definition of observability and the role of traces, metrics, and logs.
+- [Dapper, a Large-Scale Distributed Systems Tracing Infrastructure](https://research.google/pubs/pub36356/) — Google's 2010 tracing paper that shaped the industry.
+- [Prometheus: Metric and Label Naming](https://prometheus.io/docs/practices/naming/) — Guidance against high-cardinality labels such as user IDs.
+- [Brendan Gregg: The USE Method](https://www.brendangregg.com/usemethod.html) — Utilization, Saturation, and Errors for system resources.
+- [Grafana Labs: The RED Method](https://grafana.com/blog/2018/08/02/the-red-method-how-to-instrument-your-services/) — Rate, Errors, and Duration for request-driven services.
+- [Honeycomb: Observability — A Manifesto](https://www.honeycomb.io/blog/observability-a-manifesto) — Charity Majors on high-cardinality exploration versus pre-aggregation.
+- [O'Reilly: Distributed Systems Observability (Cindy Sridharan)](https://www.oreilly.com/library/view/distributed-systems-observability/9781492033431/) — Trade-offs among logging, metrics, and tracing.
+- [Wikipedia: Observability (control theory)](https://en.wikipedia.org/wiki/Observability) — Kálmán's 1960 formal definition and relationship to controllability.
+- [CNCF TAG Observability](https://tag-observability.cncf.io/) — Cloud native observability landscape and community resources.
+
+Additional books for deeper study: *Observability Engineering* (Majors, Fong-Jones, Miranda); *Distributed Systems Observability* (Sridharan, free O'Reilly edition).
 
 ---
 

--- a/src/content/docs/platform/foundations/observability-theory/module-3.4-from-data-to-insight.md
+++ b/src/content/docs/platform/foundations/observability-theory/module-3.4-from-data-to-insight.md
@@ -1,5 +1,4 @@
 ---
-revision_pending: true
 title: "Module 3.4: From Data to Insight"
 slug: platform/foundations/observability-theory/module-3.4-from-data-to-insight
 sidebar:
@@ -7,117 +6,107 @@ sidebar:
 ---
 > **Complexity**: `[MEDIUM]`
 >
-> **Time to Complete**: 30-35 minutes
+> **Time to Complete**: 40-50 minutes
 >
 > **Prerequisites**: [Module 3.3: Instrumentation Principles](../module-3.3-instrumentation-principles/)
 >
 > **Track**: Foundations
 
-### What You'll Be Able to Do
+## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
-1. **Build** alert rules that detect meaningful user-impact signals rather than generating noise from infrastructure metrics
-2. **Analyze** observability data to move from symptom detection to root-cause identification within a structured debugging workflow
-3. **Design** dashboards that answer operational questions at a glance and guide engineers toward the right next investigation step
-4. **Evaluate** whether an alerting strategy minimizes both false positives and time-to-detection for real incidents
-
----
-
-## The Data-to-Insight Gap
-
-Instrumentation alone does not prevent long incidents. Teams that invest in metrics, logs, and traces but skip investigation structure — consistent field naming, dashboard hierarchy, SLO-based alerts, and runbooks — routinely spend 40+ minutes finding root causes that their data already contained. The gap between data and insight is an architectural problem, not a tool gap.
-
-> **Stop and think**: If an alert fires right now, could your on-call engineer answer "what service owns this?" and "what do I do next?" within two minutes using your current dashboards?
-
-### The Data-to-Insight Gap
-
-| What Teams Often Have | What Enables Fast Recovery |
-|---|---|
-| [x] 2.3 million metrics | [ ] Dashboard hierarchy (what matters now?) |
-| [x] 4TB daily logs | [ ] Consistent field names (can't query) |
-| [x] 500 million spans | [ ] SLO-based alerting (why 2%? is that bad?) |
-| [x] Beautiful dashboards | [ ] Runbooks (what to do when this happens) |
-| [x] All three pillars | [ ] Investigation workflow (where to start) |
-| [x] Perfect instrumentation | [ ] Mental model of failure modes |
-
-**DATA ≠ INSIGHT**
-
-The data needed to diagnose most incidents is present within the first minute. The question is whether the team has built the structure to navigate that data quickly. Teams that invest in dashboard hierarchy, consistent field naming, SLO-based alerting, and runbooks resolve incidents in under 10 minutes. Teams without that structure routinely spend 45+ minutes on the same class of problem.
-
-A systematic rebuild typically includes:
-- Dashboard hierarchy (summary → signals → details)
-- Consistent field naming across all services
-- SLO-based alerts with error budgets
-- Runbooks for common failure modes
-- A shared investigation workflow the whole team practices
+1. **Build** alert rules that detect meaningful user-impact signals rather than generating noise from infrastructure metrics.
+2. **Analyze** observability data to move from symptom detection to root-cause identification within a structured debugging workflow.
+3. **Design** dashboards that answer operational questions at a glance and guide engineers toward the right next investigation step.
+4. **Evaluate** whether an alerting strategy minimizes both false positives and time-to-detection for real incidents.
 
 ---
 
 ## Why This Module Matters
 
-You've instrumented your services. Logs are flowing, metrics are being scraped, traces are being collected. Now what?
+You have instrumented your services. Logs are flowing, metrics are being scraped, traces are being collected, and dashboards are full of colorful panels. That is a necessary milestone, but it is not the finish line. The real value of observability appears only when a team can turn those raw signals into decisions: whether to wake a human, where to start an investigation, what changed, which users are affected, and what response will actually reduce harm.
 
-Having data isn't the same as having understanding. The real value of observability comes from turning data into **insight**—answering questions, detecting problems, and building mental models of system behavior.
+This is the data-to-insight gap. Teams often have millions of metric series, terabytes of logs, and enough traces to reconstruct a busy service in detail, yet still lose the first half hour of an incident arguing about whether the problem is real. The data was technically present, but the path through it was not. Fast recovery depends on the structures around the data: alert philosophy, SLOs, consistent dimensions, dashboard hierarchy, shared runbooks, and a disciplined investigation pattern that prevents people from jumping from "something is wrong" to "restart the thing I remember breaking last time."
 
-This module teaches you how to use observability data effectively: asking the right questions, building useful alerts, debugging systematically, and developing intuition about your systems.
+The previous modules taught the pieces of observability: what observability means, how logs, metrics, and traces show different views of the same system, and how instrumentation decisions shape what questions you can ask later. This capstone is about using those pieces under pressure. You will practice asking progressively better questions of telemetry, building alerts around user-visible symptoms instead of internal noise, debugging with a repeatable workflow, designing dashboards that guide decisions, and sharing the mental models that experienced responders usually carry in their heads.
+
+| What Teams Often Have | What Enables Fast Recovery |
+|---|---|
+| Huge metric volume and dozens of labels | A dashboard hierarchy that starts with user impact and then drills down by dimension |
+| Large log stores with inconsistent field names | Shared event fields such as `service.name`, `trace_id`, `region`, `endpoint`, and `deploy.version` |
+| Traces collected for many requests | Exemplars that connect aggregate symptoms to a concrete request path |
+| Attractive dashboards with no operational question | Panels organized around "Are users okay?", "What changed?", and "Where should I look next?" |
+| Alerts for every suspected cause | SLO-based alerting that pages only when error-budget burn requires human action |
+| One senior engineer who knows the failure modes | Runbooks, postmortems, diagrams, and practice that distribute the model across the team |
 
 > **The Medical Analogy**
 >
-> A doctor doesn't just collect test results—they interpret them. Blood pressure, heart rate, and lab results are data. A diagnosis is insight. The same data can mean different things in different contexts. Observability is similar: metrics, logs, and traces are raw data. Understanding why your system behaves the way it does is insight.
+> A doctor does not diagnose a patient by collecting test results at random. Blood pressure, heart rate, oxygen saturation, lab values, symptoms, and medical history become useful only when interpreted together. The same blood pressure reading can mean different things depending on age, medication, pain, and recent activity. Observability is similar: metrics, logs, and traces are raw observations, while insight is the contextual explanation that lets you choose the next safe action.
 
 ---
 
-## What You'll Learn
-
-- How to ask good questions of your observability data
-- Building effective alerts (signal vs. noise)
-- Debugging systematically with observability
-- Dashboards that tell stories
-- Building mental models of system behavior
-
----
-
-## Part 1: Asking Questions
+## Part 1: Asking Better Questions
 
 ### 1.1 The Question Hierarchy
 
-Not all questions are equally useful. Start broad, narrow down:
+The fastest responders are rarely the people who know the most commands. They are usually the people who ask questions in the right order. Observability data has high branching factor: every graph can be split by endpoint, region, customer tier, version, host, dependency, feature flag, and time window. If you start with a narrow theory too early, you can burn time proving that your favorite explanation is wrong while the incident continues. The question hierarchy gives you a way to reduce that search space without losing important context.
+
+Detection asks, "Is something wrong?" This is the only level that belongs on a pager, because its job is to decide whether a human should pay attention right now. A good detection question is binary and user-centered: error budget is burning too quickly, checkout p99 latency is above the SLO objective, or the public health check is failing from multiple locations. A poor detection question asks whether an internal component looks unusual without proving user harm, such as CPU above an arbitrary threshold or a queue depth above a number someone copied years ago.
+
+Scope asks, "How bad is it, and who is affected?" This level prevents overreaction and underreaction at the same time. A one-region latency regression, a single enterprise tenant with bad configuration, and a global outage all deserve different response patterns even if the top-line error graph looks similar. Scoping by dimensions such as region, endpoint, user type, request method, client version, and deploy version tells you whether to page another team, roll back one release, update a status page, or keep the incident local.
+
+Localization asks, "Where in the system is the failure surfacing?" This is where traces, dependency maps, service-level dashboards, and exemplars become valuable. The point is not to prove root cause yet. The point is to identify the narrowest component or path that explains the scoped symptom. Skipping localization is why teams restart databases for frontend bugs, blame networks for slow dependency calls that are actually retries, or roll back services that were only reporting errors caused upstream.
+
+Root cause asks, "Why is this happening?" This level requires the most evidence and should be treated as a hypothesis until verified. Logs, code changes, config history, dependency status, and trace details help explain the localized symptom, but they are easy to misuse if the earlier levels are missing. Root cause analysis without detection, scope, and localization often becomes storytelling: the team selects a plausible cause and then searches for data that supports it.
 
 ```mermaid
 flowchart TD
-    L1["Level 1: DETECTION<br>'Is something wrong?'<br>→ Alerts, SLO dashboards, error rates<br>→ Answers: Yes/No"]
-    L2["Level 2: SCOPE<br>'How bad is it? Who's affected?'<br>→ Break down by dimension: region, user type, endpoint<br>→ Answers: X% of users, Y region, Z feature"]
-    L3["Level 3: LOCALIZATION<br>'Where is the problem?'<br>→ Service dependency analysis, trace flamegraphs<br>→ Answers: Service X, database Y, function Z"]
-    L4["Level 4: ROOT CAUSE<br>'Why is this happening?'<br>→ Logs, code, recent changes<br>→ Answers: Bug in version 2.3.1, config change, external dependency"]
+    L1["Level 1: DETECTION<br>'Is something wrong?'<br>Alerts, SLO dashboards, error rates<br>Answer: Yes or no"]
+    L2["Level 2: SCOPE<br>'How bad is it? Who is affected?'<br>Break down by region, user type, endpoint, version<br>Answer: affected population and severity"]
+    L3["Level 3: LOCALIZATION<br>'Where is the problem surfacing?'<br>Dependency analysis, traces, service dashboards<br>Answer: service, dependency, operation, or path"]
+    L4["Level 4: ROOT CAUSE<br>'Why is this happening?'<br>Logs, code, config, deploys, external dependencies<br>Answer: verified explanation and fix"]
 
     L1 --> L2
     L2 --> L3
     L3 --> L4
 ```
 
-> **Pause and predict**: If you jump straight from Level 1 (Detection) to Level 4 (Root Cause) without scoping or localizing, what kinds of mistakes are you likely to make?
+Skipping levels creates predictable failure modes. Jumping from detection directly to root cause leads to confirmation bias because the responder starts searching for evidence that supports a theory before understanding the blast radius. Jumping from detection to remediation can destroy the state that would have explained the incident, especially when restarts clear memory, drop connection pools, rotate logs, or cause replicas to reschedule. Jumping from scope to root cause without localization can involve the wrong team, which adds communication overhead while the actual owner remains unaware.
 
-### 1.2 Good Questions vs. Bad Questions
+> **Pause and predict**
+>
+> If an alert says "checkout is slow" and you immediately inspect the database, what facts are still missing? You have not yet proven whether checkout is slow for all users, whether the slowdown is limited to one endpoint, whether a specific deploy version is involved, or whether the database is cause, symptom, or unrelated background noise.
 
-| Bad Questions (vague, hard to answer) | Good Questions (specific, answerable) |
-|---|---|
-| **"Why is the site slow?"**<br>→ What is "slow"? For whom? Since when? | **"What's the p99 latency for `/api/checkout` in the last hour?"**<br>→ Specific metric, specific endpoint, specific timeframe |
-| **"Is everything okay?"**<br>→ Define "okay" | **"Which users experienced errors during the deploy at 3pm?"**<br>→ Specific event, specific population |
-| **"What happened yesterday?"**<br>→ What specifically? | **"What changed between 2pm (working) and 3pm (broken)?"**<br>→ Specific comparison, specific times |
+### 1.2 Good Questions Are Specific, Comparative, and Answerable
+
+Bad observability questions are usually vague because they hide several smaller questions inside one sentence. "Why is the site slow?" sounds reasonable, but it does not define which site path, which users, which latency percentile, which time window, or what baseline counts as normal. The responder must first translate the sentence into something queryable. Under incident pressure, that translation step often happens differently for each person in the room, which produces conflicting graphs and avoidable debate.
+
+Good questions have three properties. They are specific enough to map to telemetry fields, comparative enough to distinguish abnormal from normal, and answerable with data the system actually emits. "What is the p99 latency for `/api/checkout` in the last hour, split by region and deploy version?" is longer than "Why is checkout slow?", but it tells you exactly which signal to query and which dimensions might narrow the scope. "Which users experienced `auth_token_failed` during the deploy window?" connects logs or traces to a population, not just an error count.
+
+| Vague Question | Better Question | Why the Better Question Works |
+|---|---|---|
+| "Why is the site slow?" | "What are p50, p95, and p99 latency for `/api/checkout` over the last hour, compared with the same hour yesterday?" | It names an endpoint, metric, percentile set, time window, and baseline. |
+| "Is everything okay?" | "Are any user-facing SLIs currently burning error budget faster than their page threshold?" | It converts anxiety into an SLO-backed decision about user impact. |
+| "What happened yesterday?" | "What changed between the last known-good window and the first bad window for deploy version, config version, traffic mix, and dependency errors?" | It frames the investigation as a before/after comparison rather than a broad search. |
+| "Is the database broken?" | "Do failing checkout traces spend more time in database spans than successful checkout traces for the same endpoint and region?" | It tests a theory against exemplars instead of treating the theory as fact. |
+
+The comparison piece is especially important. Humans recognize anomalies by comparing against a mental or statistical baseline. If a service normally has p99 latency near 900 ms during batch windows, a 700 ms graph may be healthy even if it looks high in isolation. If the same service normally runs at 120 ms during business hours, 700 ms is urgent. Every useful dashboard and investigation query should make the baseline visible: previous hour, previous day, previous deploy, successful request group, unaffected region, or SLO threshold.
 
 ### 1.3 The Exploratory Investigation Pattern
 
+The exploratory pattern turns the hierarchy into an incident workflow. It is intentionally not "open dashboard, stare, guess." Each step changes what you know and constrains the next query. Quantify establishes the size of the problem, Segment finds concentration, Correlate searches for time-aligned changes, Exemplify chooses a concrete failing request or event, Hypothesize states the current explanation, Verify tests what else should be true, and Resolve applies the smallest safe fix with evidence preserved for the postmortem.
+
 ```mermaid
 flowchart TD
-    Start(["START: 'Something is wrong' (symptom)"])
-    Q1["1. QUANTIFY<br>'How wrong? What's the error rate/latency/failure count?'<br>→ Establishes baseline for comparison"]
-    Q2["2. SEGMENT<br>'Is it all requests or some? Which ones?'<br>→ Group by: endpoint, user_type, region, version, time<br>→ Find: Where is the problem concentrated?"]
-    Q3["3. CORRELATE<br>'What else happened at the same time?'<br>→ Deploys, config changes, dependency issues, traffic spike<br>→ Find: Potential causes"]
-    Q4["4. EXEMPLIFY<br>'Show me a specific failing request'<br>→ Trace → Logs → Detailed error<br>→ Find: Concrete evidence"]
-    Q5["5. HYPOTHESIZE<br>'I think the problem is X because of Y'<br>→ Test: If X is the problem, what else should be true?"]
-    Q6["6. VERIFY<br>'Let me confirm by checking Z'<br>→ Additional queries to confirm/refute hypothesis"]
-    Q7["7. RESOLVE<br>'The problem is X, fixed by Y'<br>→ Document for future reference"]
+    Start(["START: 'Something is wrong'"])
+    Q1["1. QUANTIFY<br>'How wrong? What error rate, latency, or failure count?'<br>Establishes severity and baseline"]
+    Q2["2. SEGMENT<br>'All requests or some? Which ones?'<br>Group by endpoint, user type, region, version, time"]
+    Q3["3. CORRELATE<br>'What else happened at the same time?'<br>Deploys, config changes, dependency issues, traffic changes"]
+    Q4["4. EXEMPLIFY<br>'Show me one failing request or event'<br>Trace to logs to detailed context"]
+    Q5["5. HYPOTHESIZE<br>'I think the problem is X because of Y'<br>Predict what else should be true"]
+    Q6["6. VERIFY<br>'Let me confirm by checking Z'<br>Additional queries confirm or refute the hypothesis"]
+    Q7["7. RESOLVE<br>'The problem is X, fixed by Y'<br>Mitigate, document, and create follow-up work"]
 
     Start --> Q1
     Q1 --> Q2
@@ -128,92 +117,103 @@ flowchart TD
     Q6 --> Q7
 ```
 
+Quantify protects you from vague severity. If the page says "latency high," quantify the actual p99, the duration, the SLO target, the current burn rate, and the number of affected requests. That number determines whether you need an incident commander, a status update, a rollback, or a quiet investigation. It also gives you a post-fix comparison point. Without quantification, teams can declare victory because a graph "looks better" while the SLO remains unhealthy.
+
+Segment protects you from treating averages as truth. A global error rate of 2% can hide a complete outage for a small region, a partial outage for one endpoint, or a harmless spike in synthetic traffic. Segment by dimensions that explain ownership and response: endpoint, region, tenant, plan, dependency, version, feature flag, client platform, and request type. Good instrumentation from Module 3.3 matters here because you can only segment by fields you captured consistently before the incident.
+
+Correlate protects you from ignoring time. Most production incidents have a temporal clue: a deploy, a config change, a certificate renewal, a dependency rate limit, a traffic shift, a scaling event, or a scheduled batch job. Correlation is not proof, but it produces testable hypotheses. The discipline is to write "started two minutes after config rollout" rather than "config rollout caused it" until later verification supports that claim.
+
+Exemplify protects you from debugging aggregates forever. A metric can tell you that checkout errors increased, but a single failing trace can show the path through frontend, API, auth, inventory, payment, retry middleware, and the final error. The exemplar should be representative of the scoped problem: if only EU users on version `2.3.1` fail, choose a failing EU `2.3.1` request, not a random error from another region. Logs attached to the trace then provide concrete fields, exception messages, and dependency responses.
+
+Hypothesize and Verify protect you from cargo-cult fixes. A hypothesis should make predictions. If you think an external identity provider is rate-limiting requests, then traces should show calls to that provider failing with a rate-limit response, internal service latency should be mostly waiting on that dependency, and retry volume should increase around the same time. If those predictions do not hold, the hypothesis weakens. Verification is the difference between "the database was slow" and "checkout traces spent 85% of their time waiting on `payment-db-west-02`, logs show connection refused, and the database event log shows maintenance mode enabled."
+
+Resolve is more than applying a fix. A good resolution includes the mitigation, the evidence that user impact ended, the reason the fix was chosen, and the follow-up that prevents recurrence. Sometimes the correct resolution is rollback; sometimes it is disabling a feature flag, raising a dependency quota, shedding load, or routing traffic away from one region. The key is that the resolution follows from verified evidence rather than from the most familiar operational reflex.
+
 > **Try This (3 minutes)**
 >
-> Think of a recent incident. Walk through the investigation pattern:
-> - How did you quantify the problem?
-> - How did you segment to narrow down?
-> - What correlations did you look for?
-> - Did you find a specific example to examine?
+> Think of a recent incident and write one sentence for each investigation step. If one step is hard to fill in, that is a useful signal. It may mean your telemetry lacks a dimension, your dashboards hide the baseline, your traces are not connected to logs, or your runbook jumps straight to remediation before evidence is preserved.
 
 ---
 
 ## Part 2: Effective Alerting
 
-> **Stop and think**: What happens to an engineering team's culture when 90% of their alerts are false positives? How does this affect their response time to real, critical incidents?
-
 ### 2.1 Alert Philosophy
 
-**ALERT ONLY WHEN ACTION IS NEEDED**
-- If the alert fires and you do nothing → Remove the alert
-- If the alert fires and you always do the same thing → Automate it
-- If the alert fires and you investigate → Good alert
+Alerting is not a notification system for everything interesting. It is a scarce human-attention system. Every page spends trust from the on-call engineer, and that trust has a budget just like reliability does. If alerts routinely wake people for conditions that resolve without action, the team learns that pages are optional. When a real incident arrives, the response is slower because the alert channel has trained everyone to discount it.
 
-**ALERT ON SYMPTOMS, NOT CAUSES**
-- Bad: "CPU > 80%" (cause - might be fine)
-- Good: "Error rate > 1%" (symptom - users affected)
-- Good: "p99 latency > 500ms" (symptom - users affected)
+The strongest alerting rule is simple: page a human only when timely human action is required. If an alert fires and nobody does anything, delete it or convert it to a dashboard signal. If an alert fires and the same mechanical action always fixes the condition, automate the action and alert only if automation fails. If an alert fires and a human must investigate, the alert should say what is affected, why the page is urgent, where to start, and which runbook owns the first response.
 
-**ALERT ON USER IMPACT**
-- Would a user notice? Alert.
-- Would only you notice? Maybe don't alert.
-- Error budget burn rate > threshold → Users will be affected → Alert
+This philosophy leads directly to symptom-based alerting. A symptom is what users experience: failed requests, slow responses, unavailable features, incorrect results, or exhausted error budget. A cause is an internal explanation: CPU saturation, thread pool exhaustion, disk latency, garbage collection, queue depth, or a dependency outage. Causes are excellent debugging signals and poor page triggers when used alone. High CPU may be efficient use of capacity; low CPU may be a dead service; a full queue may be expected during a batch window. User-visible symptoms tell you when the system is failing its purpose.
 
-> **Pause and predict**: How does defining an "error budget" change the conversation between product managers and engineers about when to stop deploying new features?
+The distinction is not absolute because complex systems have layers. A database SRE may treat slow database reads as a symptom for the database service, while an application SRE treats the same slow reads as a possible cause of checkout latency. The operational rule is to page the team on the symptom that matches their service boundary and user promise, then provide cause-oriented dashboards for diagnosis. That keeps paging simple while preserving enough white-box detail to debug quickly.
 
-### 2.2 SLO-Based Alerting
-
-Instead of arbitrary thresholds, alert based on error budget:
-
-**SLO: 99.9% availability (error budget: 43 minutes/month)**
-
-| Severity | Alert Condition | Meaning |
+| Alert Candidate | Page, Ticket, or Dashboard? | Reason |
 |---|---|---|
-| **SEVERE** (page immediately) | Burn rate that would exhaust budget in 1 hour (720x normal) | "At this rate, we're out of budget in 1 hour" |
-| **HIGH** (page during business hours) | Burn rate that would exhaust budget in 6 hours (120x normal) | "At this rate, we're out of budget in 6 hours" |
-| **MEDIUM** (ticket) | Burn rate that would exhaust budget in 3 days (10x normal) | "At this rate, we're out of budget this week" |
-| **LOW** (dashboard) | Any error budget consumption | "We're using budget, but within acceptable range" |
+| Public checkout SLO burns budget at page threshold | Page | Users are affected now and delay consumes the reliability budget quickly. |
+| CPU above 80% on one replica for five minutes | Dashboard or ticket | It may explain a symptom, but it is not user impact by itself. |
+| Error logs increase after a deploy but SLOs remain healthy | Ticket or deploy-watch annotation | The signal deserves review, but it does not yet justify waking a human. |
+| Runbook automation failed to clear a known stuck queue | Page or ticket depending on impact | Automation was the first response, and human attention is needed if impact remains. |
+
+### 2.2 SLO-Based Alerting and Burn Rate
+
+SLO-based alerting replaces arbitrary thresholds with budget math. Suppose a service promises 99.9% availability over a 30-day window. The allowed bad-event ratio is 0.1%, or 0.001 of requests. A service that experiences exactly 0.1% bad requests over the month has spent its budget at the neutral rate. Burn rate is the observed bad-event ratio divided by the allowed bad-event ratio. If the observed bad-event ratio is 1.44%, the burn rate is 14.4 because the service is spending budget 14.4 times faster than the neutral monthly pace.
+
+This matters because the same raw error rate has different urgency depending on duration and traffic shape. A few failed requests on a low-traffic service can produce a scary percentage while consuming little absolute budget. A smaller but sustained error rate on a high-traffic path may quietly destroy the month. Burn-rate alerting asks the operational question directly: "If this continues, how much of the error budget will we consume, and how soon does a human need to act?"
+
+The Google SRE Workbook recommends multiwindow, multi-burn-rate alerts because a single window forces a bad tradeoff. A short window detects fast outages quickly but false-alarms on brief blips. A long window improves precision but can detect severe incidents too slowly and keep firing long after the incident is over. Requiring both a long window and a short window at the same burn-rate threshold gives you two forms of evidence: the long window proves enough budget has been consumed to matter, while the short window proves the problem is still happening.
+
+For a 99.9% SLO over a 30-day period, the canonical starting points are:
+
+| Severity | Long Window | Short Window | Burn Rate | Budget Consumed | Response |
+|---|---:|---:|---:|---:|---|
+| Fast page | 1 hour | 5 minutes | 14.4x | 2% | Wake the on-call engineer because budget is burning rapidly right now. |
+| Slow page | 6 hours | 30 minutes | 6x | 5% | Page because the incident is sustained enough to threaten the budget within hours. |
+| Ticket | 72 hours | 6 hours | 1x | 10% | Create work for the next business day because the service is off-track but not urgent. |
+
+The budget-consumed column comes from burn rate times long-window duration divided by the SLO period. A 14.4x burn over one hour consumes `14.4 * 1 / 720`, or 2% of a 30-day budget. A 6x burn over six hours consumes `6 * 6 / 720`, or 5%. A 1x burn over 72 hours consumes `1 * 72 / 720`, or 10%. These numbers are not magic constants; they are defaults that encode a policy about when to interrupt a person versus when to create planned work.
+
+Page versus ticket is a product and operations decision, not just a monitoring decision. Page-level alerts mean "human action is needed now because waiting materially worsens user impact or budget loss." Ticket-level alerts mean "the service is drifting outside its reliability objective, but the response can be scheduled." This distinction is how teams protect both users and on-call health. A system that pages on every budget deviation burns people out; a system that never pages until the monthly SLO is already missed detects too late.
+
+Low-traffic services need extra care. If a service receives only a handful of requests per hour, one failure can produce an enormous burn rate even when user impact is small. In that case, you may need event-count minimums, synthetic probes, longer windows, or aggregation across similar operations. The principle remains the same: alert on significant budget consumption that requires human action, then tune the mechanics to the service's traffic profile.
+
+> **Pause and predict**
+>
+> How does defining an error budget change the conversation between product and engineering? Instead of arguing whether an error rate "feels high," the team can discuss a shared budget: how much unreliability users can tolerate, how quickly the budget is being spent, and when feature velocity should give way to reliability work.
 
 ### 2.3 Reducing Alert Fatigue
 
-| Problem | Cause | Solution |
-|---------|-------|----------|
-| Too many alerts | Low thresholds | Raise thresholds, use SLO-based |
-| Alerts for non-issues | Alerting on causes | Alert on symptoms instead |
-| Flapping alerts | Sensitive thresholds | Add duration requirement (5 min) |
-| Duplicate alerts | Multiple rules for same issue | Deduplicate, use alert hierarchy |
-| Unactionable alerts | No clear response | Add runbook, or delete alert |
+Alert fatigue is not only a tooling problem. It is a feedback loop. Noisy alerts create delayed responses; delayed responses make incident impact worse; worse incidents create pressure to add even more alerts; the added alerts increase noise again. Breaking the loop requires deleting or downgrading alerts as deliberately as you create them. Every alert should have an owner, a runbook, a severity, a review cadence, and a history of whether it produced useful action.
 
-### Alert Hygiene Checklist
+The alert review question is blunt: "When this fired recently, what did a human do that improved the outcome?" If the answer is "nothing," the rule is not a page. If the answer is "we checked and it was fine," the rule is too sensitive or pointed at the wrong symptom. If the answer is "we always run the same command," automation should perform that command and record evidence. If the answer is "we used the runbook to verify impact and mitigate," the alert is probably valuable.
 
-For each alert, answer:
-- [ ] Does this require human action?
-- [ ] Is the action clear? (link to runbook)
-- [ ] Does this fire rarely enough to be noticed?
-- [ ] Is the severity appropriate?
-- [ ] Has this alert been useful in the last 30 days?
+| Problem | Common Cause | Better Approach |
+|---|---|---|
+| Too many alerts | Low thresholds copied from component metrics | Use SLO burn rates and page only on significant user impact. |
+| Alerts for non-issues | Alerting on causes without symptom confirmation | Keep cause metrics on dashboards and page on symptoms. |
+| Flapping alerts | Short windows with no duration or confirmation | Require both short and long windows, or add duration where SLO math is not available. |
+| Duplicate alerts | Multiple teams page on the same user symptom | Route one primary symptom alert and link to owner-specific diagnostic dashboards. |
+| Unclear response | Alert lacks context, owner, or runbook | Include service, SLO, dimensions, recent changes, and the first investigation step. |
+| Permanent warning state | Known issue never receives follow-up | Convert to ticket, assign ownership, or remove until it can drive action. |
 
-If you can't answer "yes" to all → Fix or remove the alert.
-
-> **Did You Know?**
->
-> Google's SRE teams aim for a 50% "signal ratio"—meaning 50% of pages should be real issues requiring intervention. Below 50%, alerts are too noisy and get ignored. Above 80%, you're probably missing issues because you're not alerting enough.
+Good alert hygiene is operational work. Review the noisiest alerts after each on-call rotation. Look for pages that self-resolved, pages with no associated action, alerts that fired after the incident was already known, alerts without runbooks, and alerts that fired for symptoms owned by another team. The goal is not to reach zero alerts. The goal is for every page to deserve the responder's urgency.
 
 ---
 
 ## Part 3: Debugging with Observability
 
-> **Pause and predict**: If you immediately restart a failing service before querying its current state, what crucial debugging information is lost forever?
+### 3.1 Metrics, Traces, and Logs as a Debugging Path
 
-### 3.1 The Debugging Workflow
+Metrics, traces, and logs are most powerful when they hand off to each other. Metrics are efficient at detection and scoping because they summarize many events. Traces are efficient at exemplification and localization because they show one request path across service boundaries. Logs are efficient at detail because they capture the specific fields, errors, decisions, and state transitions inside a component. Treating the three signals as separate products slows you down; treating them as linked views of the same events creates a debugging path.
+
+The common path is metric to trace to log. A latency or error metric tells you that a symptom exists. A segmented metric tells you which population is affected. An exemplar trace shows one representative failing or slow request. Span attributes reveal which dependency, operation, or retry path consumed time. Logs connected by `trace_id`, `span_id`, `request_id`, or another correlation field then explain what the service believed it was doing at the moment of failure.
 
 ```mermaid
 flowchart TD
-    Metrics1["Metrics: Alert fires (Error rate spike)<br>Dashboard: 5% errors on /api/checkout"]
-    Metrics2["Metrics: Segment (Which errors? Where?)<br>90% of errors from US-West region<br>Started 14:32, correlates with deploy"]
-    Traces["Traces: Exemplar (Get example failing trace)<br>Trace abc-123: Timeout on payment-service<br>3 retry attempts, all timed out"]
-    Logs["Logs: Detail (What's in the logs?)<br>Connection refused: payment-db-west-02<br>Database server is unreachable"]
-    RootCause["Root Cause: payment-db-west-02 in maintenance<br>Failover didn't trigger correctly"]
+    Metrics1["Metrics: Alert fires<br>Checkout error budget burn exceeds page threshold"]
+    Metrics2["Metrics: Segment<br>Errors concentrated in one endpoint and one deploy version"]
+    Traces["Traces: Exemplify<br>Representative failing request shows timeout in payment authorization span"]
+    Logs["Logs: Detail<br>Payment client logs rate-limit responses from external identity provider"]
+    RootCause["Verified Cause<br>External rate limit plus missing token cache caused user-visible auth failures"]
 
     Metrics1 --> Metrics2
     Metrics2 --> Traces
@@ -221,405 +221,370 @@ flowchart TD
     Logs --> RootCause
 ```
 
+The reverse path can also be useful during proactive debugging. A strange log line may lead to a trace, which reveals an unexpected dependency call, which then leads to a metric showing how often the pattern occurs. The important principle is correlation. Without shared identifiers and consistent fields, each signal becomes a separate room with a locked door. With correlation, the responder can preserve context while changing the resolution of the question.
+
+> **Pause and predict**
+>
+> If you immediately restart a failing service before querying its current state, what evidence disappears? You may lose in-memory queues, active locks, connection-pool state, hot stack traces, local cache contents, process-level counters, and logs that would have explained why the service entered the bad state.
+
 ### 3.2 Common Debugging Patterns
 
-> **Stop and think**: Think about the last time you said "It's weird" when debugging. What was the exact baseline you were implicitly comparing the weird behavior against?
+When someone says "it's slow," translate the phrase into latency distribution, scope, and critical path. Confirm p50, p95, and p99 rather than relying on an average, because averages hide tail latency and tail latency is usually what users feel. Segment by endpoint, region, tenant, version, and dependency path. Then choose representative slow traces and inspect where time is spent. If a trace shows 800 ms in one downstream call, that does not immediately prove the downstream service is broken; it tells you where to ask the next question.
 
-**"It's slow"**
-1. **Confirm**: What's the actual latency? p50? p99?
-2. **Scope**: All requests or some? Which endpoints?
-3. **Trace**: Get example slow traces
-4. **Flamegraph**: Where is time spent?
-   └── Network call to service X: 800ms (80% of time)
-5. **Drill down**: Why is service X slow?
-6. **Repeat** until root cause found
+When someone says "it's broken," translate the phrase into error rate, error type, and affected population. Separate user-visible failures from internal retries, expected validation errors, synthetic tests, and background-job noise. Compare successful and failing requests with the same endpoint and time window. Good logs are useful here because they expose structured fields such as `error.kind`, `http.status_code`, `dependency.name`, `deploy.version`, and `feature_flag`. A stack trace without request context is much less useful than a structured error event attached to the failing trace.
 
-**"It's broken"**
-1. **Confirm**: What's the error rate? Error types?
-2. **Scope**: Which users? Which endpoints? Which versions?
-3. **Compare**: What's different about failing requests?
-4. **Exemplify**: Get specific error logs
-   └── Stack trace, error message, context
-5. **Correlate**: What changed? Deploy? Config? Dependency?
-6. **Hypothesize and verify**
+When someone says "it's weird," ask them to define normal. Weirdness is a comparison, not a property. The baseline might be yesterday's traffic, last week's batch window, the previous deploy, a healthy region, or a successful request cohort. Once normal is explicit, isolate the smallest reproducing case and diff it against the abnormal case. Many "weird" incidents turn out to be state dependencies: cache warmup, retry storms, race conditions, uneven shard ownership, client version skew, or feature flags interacting with one tenant's data.
 
-**"It's weird"**
-1. **Define**: What exactly is "weird"? Quantify it.
-2. **Baseline**: What's "normal"? Compare to historical data.
-3. **Isolate**: Find the smallest reproducing case.
-4. **Trace**: Follow request through system.
-5. **Diff**: What's different from normal requests?
-6. **Often**: Race condition, caching issue, state dependency
+The USE and RED methods are helpful mental checklists during these patterns. USE asks about Utilization, Saturation, and Errors for resources such as CPU, memory, disks, and networks. RED asks about Rate, Errors, and Duration for request-serving services. Neither method replaces the exploratory pattern, but both reduce blind spots. USE helps when you suspect a resource bottleneck; RED helps when you need a consistent service-health view. The four golden signals - latency, traffic, errors, and saturation - combine both perspectives for user-facing services.
 
-### 3.3 Comparison: Then vs. Now
+### 3.3 Before/After Comparisons
 
-**"It was working yesterday, now it's broken"**
+Many incidents are change investigations. The system worked before and fails now, which means a useful query compares a known-good window with a known-bad window. Pick the windows carefully. The good window should match traffic shape if possible, such as the same hour yesterday or the hour before the deploy. The bad window should begin when the symptom began, not when someone noticed it. Then compare dimensions that can change: deploy version, config version, feature flags, region, dependency error codes, traffic mix, and client versions.
 
-**Query pattern**:
-Compare: `metric_X` at `time_good` vs `time_bad`
+| Comparison | Example Question | Useful When |
+|---|---|---|
+| Before deploy vs after deploy | "Did error rate increase only for `deploy.version=2.3.1` after rollout began?" | A recent code or config change is plausible. |
+| Affected region vs healthy region | "Do EU requests show different dependency latency than US requests for the same endpoint?" | The symptom is geographically concentrated. |
+| Failed request vs successful request | "Which span attributes differ between failing and successful checkout traces?" | You need an exemplar-level explanation. |
+| Current hour vs same hour last week | "Is traffic mix, cache hit rate, or queue depth outside the normal weekly pattern?" | The symptom may relate to load or scheduled work. |
 
-**Example**:
-- **GOOD**: 2024-01-15 10:00-12:00, error_rate = 0.1%
-- **BAD**:  2024-01-16 10:00-12:00, error_rate = 5.0%
+The trap is to stop at correlation. If version `2.3.1` has a higher error rate than `2.3.0`, the version is involved, but the next question is still "why?" Maybe the new version changed a timeout, maybe it increased calls to an external API, maybe it made an old dependency limit visible, or maybe it simply received a different traffic cohort during rollout. Version correlation points to a smaller search space; it does not complete the investigation.
 
-**Segment by deploy_version**:
-- **GOOD**: version 2.3.0, error_rate = 0.1%
-- **BAD**:  version 2.3.1, error_rate = 4.9%
+**Hypothetical scenario:** A subscription streaming service receives an evening page because video playback errors crossed the SLO page threshold. The first responder has seen short CDN issues before and restarts the streaming pods. Errors dip briefly, then climb again. Another responder rolls back a recent streaming-service deploy, but the error rate does not improve. Only after a long bridge call does the team notice that every failing trace contains an authentication step returning rate-limit responses from an external identity provider. The root cause was not the streaming code; it was an identity-provider limit combined with token caching being disabled.
 
-**Conclusion**: Version 2.3.1 introduced the problem.
+The old response was understandable but expensive in time. The responder acted on memory instead of evidence. Restarts erased useful state, rollback consumed attention, and the team argued about the wrong service because the first query did not segment by error type. A structured response would have started by quantifying the error, segmenting by endpoint and error class, correlating with deploy and dependency timelines, choosing one failing trace, and verifying the identity-provider hypothesis before changing the system.
 
-Similar pattern for:
-- Before/after deploy
-- This week vs. last week
-- Failing user vs. working user
+| Step | Structured Action | Illustrative Timing |
+|---|---|---:|
+| Quantify | "Playback error rate is around ten times normal, and the dominant error is `auth_token_failed`." | About 2 minutes |
+| Segment | "Failures are authentication-related, affect all regions, and are concentrated in requests that need a fresh token." | About 3 minutes |
+| Correlate | "No streaming deploy or config change aligns with the start; identity-provider rate-limit graphs changed at the same time." | About 4 minutes |
+| Exemplify | "A failing trace shows the auth service calling the identity provider and receiving `429 Too Many Requests`." | About 3 minutes |
+| Hypothesize | "The identity provider is rate-limiting token refreshes because our cache is not absorbing repeated requests." | About 1 minute |
+| Verify | "Provider dashboard and local auth logs show rate-limit responses while cached-token paths succeed." | About 2 minutes |
+| Resolve | "Re-enable token caching, reduce retry pressure, and monitor the playback SLO until budget burn returns to normal." | About 5 minutes |
 
-> **War Story: The $4.2 Million Lesson in Systematic Investigation**
->
-> **2020. A Major Subscription Service. Sunday Evening, Peak Usage.**
->
-> 9:17 PM. Alert fires: "Video streaming error rate exceeded 1%." The on-call engineer opens the dashboard. Error rate: 1.3%. He's seen this before. "Probably just a CDN hiccup," he thinks. He restarts the streaming service pods. Error rate drops to 0.8%. Problem solved?
->
-> No. Error rate climbs back to 1.5% within 5 minutes. Then 2.1%. Then 3.4%.
->
-> **The Old Approach** (what he did):
-> - 9:17 PM: Alert fires. Restarts pods.
-> - 9:23 PM: Error rate climbing. Restarts more pods.
-> - 9:31 PM: No improvement. Escalates to senior engineer.
-> - 9:45 PM: Senior tries rolling back recent deploy. No effect.
-> - 10:12 PM: Team realizes problem isn't in their code.
-> - 10:34 PM: Discover third-party authentication provider is rate-limiting them.
-> - 10:41 PM: Implement token caching workaround.
->
-> **Time to resolution: 84 minutes.** Most users couldn't watch anything during peak Sunday evening.
->
-> **The New Approach** (what they trained to do after):
->
-> | Step | Action | Time |
-> |------|--------|------|
-> | Quantify | "Error rate 1.3%, normally 0.1%. Specific error: 'auth_token_failed'" | 2 min |
-> | Segment | "100% of errors are auth failures. Affects all regions equally." | 3 min |
-> | Correlate | "Started 9:15 PM. No deploys. No config changes. Check external deps." | 4 min |
-> | Exemplify | "Trace shows auth service calling identity provider, getting 429 Too Many Requests" | 3 min |
-> | Hypothesize | "Identity provider is rate-limiting us" | 1 min |
-> | Verify | "Check identity provider dashboard—confirmed, hitting rate limit" | 2 min |
-> | Resolve | "Enable token caching (was disabled in recent cleanup)" | 5 min |
->
-> **Time to resolution with systematic approach: 20 minutes.**
->
-> **The Financial Impact**:
-> - 84 minutes at peak × 3.4% average error rate × 12 million active users = ~408,000 users affected
-> - Estimated lost subscription renewals: $890,000
-> - Compensation credits issued: $340,000
-> - Customer support costs: $125,000
-> - Engineering escalation (5 engineers × 2 hours): $2,500
-> - **Total: $1.36 million for this single incident**
->
-> With systematic investigation, the impact would have been:
-> - 20 minutes × 2.1% average error rate × 12 million users = ~50,000 users affected
-> - Estimated cost: ~$160,000
-> - **Savings: $1.2 million from faster investigation**
->
-> The team ran the numbers. They'd had 47 similar incidents in the past year. If systematic investigation saved even 20 minutes on average, that was $4.2 million annually.
->
-> They built runbooks. They trained on the exploratory pattern. They created investigation checklists. The pattern works. Use it.
+The lesson is not that every incident can be solved in a fixed number of minutes. The lesson is that structure changes the first actions. Blind restart-and-pray treats every symptom as a familiar cause. Quantify -> Segment -> Correlate -> Exemplify -> Hypothesize -> Verify -> Resolve turns observability data into a narrowing funnel. It preserves evidence, reduces unnecessary changes, and makes the final explanation defensible in the postmortem.
 
 ---
 
 ## Part 4: Dashboards That Tell Stories
 
-### 4.1 Dashboard Anti-Patterns
+### 4.1 Dashboards Are Interfaces for Questions
+
+A dashboard is not a trophy case for every metric a service emits. It is an interface for answering operational questions quickly. During an incident, a responder should be able to glance at the top of the dashboard and answer "Are users okay?" within seconds. If the answer is no, the next visible section should answer "Which symptom is unhealthy?" and "Where should I investigate first?" If the dashboard cannot guide that path, it is decoration rather than operational tooling.
+
+The wall-of-metrics anti-pattern happens when every panel has equal visual weight. Alphabetical ordering by metric name feels neutral, but it pushes cognitive load onto the responder at the worst time. The responder must remember which metrics matter, which values are normal, which panels are related, and which graph should be trusted first. The vanity dashboard anti-pattern has the opposite problem: it shows impressive numbers that rarely change decisions. Total requests served, all-time uptime, and total hosts may be useful for a review deck, but they seldom tell an on-call engineer what to do next.
 
 ```mermaid
 flowchart TD
-    subgraph "Anti-Pattern 1: The Wall of Metrics (No Hierarchy)"
+    subgraph Wall ["Anti-Pattern: Wall of Metrics"]
         direction LR
-        M1[Metric] --- M2[Metric] --- M3[Metric] --- M4[Metric]
-        M5[Metric] --- M6[Metric] --- M7[Metric] --- M8[Metric]
+        M1["CPU"] --- M2["Memory"] --- M3["Threads"] --- M4["Queue"]
+        M5["Errors"] --- M6["Latency"] --- M7["Retries"] --- M8["Cache"]
     end
-    subgraph "Anti-Pattern 2: The Vanity Dashboard"
+    subgraph Vanity ["Anti-Pattern: Vanity Dashboard"]
         direction TB
-        V1["REQUESTS TODAY: 1,234,567,890"]
-        V2["UPTIME: 99.999%"]
-        V3["SERVERS: 1,234"]
+        V1["TOTAL REQUESTS SERVED"]
+        V2["ALL-TIME UPTIME"]
+        V3["NUMBER OF SERVERS"]
     end
 ```
-- **The Wall of Metrics Problem**: No hierarchy, everything equal importance. Result: Eyes glaze over, important signals missed.
-- **The Vanity Dashboard Problem**: Big numbers that never change actionably. Result: Looks impressive, helps no one.
 
-### 4.2 Good Dashboard Structure
+Good dashboards tell a story in layers. The top layer summarizes user health and SLO status. The middle layer shows the service's golden signals: latency, traffic, errors, and saturation. The lower layer provides drill-downs by the dimensions that usually explain incidents: endpoint, region, version, dependency, tenant, and feature flag. The layers matter because they match the question hierarchy. A responder should not need to scan dependency internals before knowing whether users are affected.
 
 ```mermaid
 flowchart TD
-    subgraph Level1 ["LEVEL 1: EXECUTIVE SUMMARY (top) - 'Are we okay?'"]
+    subgraph Level1 ["LEVEL 1: SUMMARY - 'Are users okay?'"]
         direction LR
-        S1["SLO Status: 99.95% (target: 99.9%)<br>Error Budget: 65% remaining<br>Active Incidents: 0"]
+        S1["SLO Status<br>Error Budget Remaining<br>Active Incidents<br>Page/Ticket Alerts"]
     end
 
-    subgraph Level2 ["LEVEL 2: THE GOLDEN SIGNALS (middle) - 'What's the current behavior?'"]
+    subgraph Level2 ["LEVEL 2: GOLDEN SIGNALS - 'What behavior changed?'"]
         direction LR
-        S2_1["Latency<br>p50: 45ms<br>p99: 200ms"]
-        S2_2["Errors<br>0.1%"]
-        S2_3["Traffic<br>1,234/s"]
+        S2_1["Latency<br>p50 / p95 / p99<br>Successful vs failed"]
+        S2_2["Errors<br>Error rate<br>Error class"]
+        S2_3["Traffic<br>Requests/sec<br>Traffic mix"]
+        S2_4["Saturation<br>Queues<br>Concurrency<br>Resource limits"]
     end
 
-    subgraph Level3 ["LEVEL 3: DRILL-DOWN (expandable) - 'Where should I look if something's wrong?'"]
+    subgraph Level3 ["LEVEL 3: DRILL-DOWN - 'Where should I look next?'"]
         direction LR
-        S3_1["By Endpoint:<br>/api/checkout 50ms<br>/api/search 30ms<br>/api/user 25ms"]
-        S3_2["By Region:<br>US-West 45ms<br>EU-Central 52ms<br>AP-South 60ms"]
-        S3_3["By Version:<br>v2.3.1 48ms<br>v2.3.0 45ms"]
+        S3_1["By Endpoint"]
+        S3_2["By Region"]
+        S3_3["By Version"]
+        S3_4["By Dependency"]
     end
 
     Level1 --> Level2
     Level2 --> Level3
 ```
 
-### 4.3 Dashboard Design Principles
+### 4.2 Dashboard Design Principles
 
-| Principle | Why | Example |
-|-----------|-----|---------|
-| **Hierarchy** | Important things first | SLO status at top, details below |
-| **Context** | Show what normal looks like | Current value + historical range |
-| **Action** | Link to next step | Click metric → See traces |
-| **Consistency** | Same layout across services | Everyone knows where to look |
-| **Simplicity** | Only what's needed | Remove metrics nobody looks at |
+Hierarchy is the first design principle because attention is limited. Put the most operationally important answer at the top, in the largest or most prominent position, and make less urgent detail available below. Context is the second principle because numbers without baselines are ambiguous. Current p99 latency should appear next to the SLO target, recent historical range, or comparison window. Action is the third principle because dashboards should lead to the next investigative surface: a trace query, log search, runbook, deploy history, or dependency dashboard.
+
+Consistency reduces training time across services. If every team invents its own dashboard layout, responders must learn the dashboard before they can learn the incident. A shared pattern - summary first, golden signals second, drill-downs third, runbooks and links nearby - lets engineers move between services without reorienting. Consistency does not mean every dashboard has identical metrics; it means the operational questions appear in familiar places.
+
+Simplicity is not minimalism for its own sake. It is the removal of panels that do not change decisions. If nobody has used a panel during an incident, postmortem, capacity review, or SLO review in several months, ask whether it belongs somewhere else. Exploratory tools can hold long-tail metrics. The primary incident dashboard should protect the main path through the data.
+
+| Dashboard Tier | Primary Question | Best Signals | Common Mistake |
+|---|---|---|---|
+| Service overview | Are users okay right now? | SLO status, budget burn, active incidents, top symptoms | Showing infrastructure internals before user impact |
+| Symptom view | What changed in behavior? | Latency, errors, traffic, saturation, success rate | Mixing successful and failed latency without separating them |
+| Scope view | Who or what is affected? | Endpoint, region, tenant, deploy version, client platform | Only showing global averages |
+| Dependency view | Where might the symptom originate? | Downstream latency, error codes, retries, timeout rate | Treating dependency symptoms as proven root cause |
+| Evidence view | What specific example proves the path? | Trace exemplar links, correlated logs, runbook links | Leaving responders to manually reconstruct context |
 
 > **Try This (3 minutes)**
 >
-> Look at one of your dashboards:
-> - Can you tell system health in 5 seconds?
-> - Is there a clear hierarchy?
-> - Do you know what to click if something's wrong?
-> - When did you last remove a panel?
+> Open one service dashboard and cover everything below the first screen. Can you tell whether users are okay, which SLO is at risk, and where you would click next if the answer is no? If not, the dashboard is probably organized around available metrics rather than operational questions.
 
 ---
 
-## Part 5: Building Mental Models
+## Part 5: Building and Sharing Mental Models
 
-> **Pause and predict**: What happens to an engineering team's incident response time if only the most senior engineer holds the complete mental model of the system architecture?
+### 5.1 What a Mental Model Is
 
-### 5.1 What is a Mental Model?
+A mental model is your internal explanation of how the system behaves. It includes architecture, dependencies, normal traffic patterns, failure modes, retry behavior, queueing behavior, operational limits, and recent changes. It is not the same as a diagram or a runbook, although good diagrams and runbooks help create it. The model is what lets an experienced responder say, "If Redis is down, sessions fail first; if Postgres is down, checkout and account pages fail; if the payment API is slow, checkout p99 rises before errors increase."
 
-A **mental model** is your understanding of how the system actually works—not the documentation, but your intuition built from experience.
+Mental models are powerful because incidents rarely announce themselves in the vocabulary of the component that failed. They arrive as symptoms: slow checkout, missing search results, delayed jobs, empty dashboards, or unusual customer reports. A responder with a good model can map those symptoms to likely paths and ask focused questions. A responder without the model must discover the architecture during the incident, which is possible but slow and stressful.
 
-- **Architecture**: "Request comes in at load balancer, goes to API server, which calls auth service, then the appropriate backend."
-- **Dependencies**: "If Redis is down, sessions break. If Postgres is down, nothing works. If payment API is slow, checkout is slow."
-- **Behavior Under Stress**: "Under high load, the API starts queueing requests. Past 1000 QPS, we see cascading timeouts."
-- **Failure Modes**: "When disk fills, logs stop but service keeps running. When memory fills, OOM killer takes random processes."
-- **Recent Changes**: "We deployed v2.3.1 yesterday, added new caching layer last week, migrated database replica last month."
+Mental models can also be dangerous when they are stale. A senior engineer may remember a dependency that was removed, a retry behavior that changed, or a traffic pattern that no longer exists. Observability should challenge the model as much as it uses the model. The best responders hold their model lightly: "I expect payment authorization to be the slow span; if the trace disagrees, the model needs updating."
 
-### 5.2 Building Mental Models
+### 5.2 How Teams Build Mental Models
 
-1. **Watch Normal Behavior**
-   └── What do metrics look like during a normal day?
-   └── What's the typical request flow?
-   └── What are normal log patterns?
-2. **Watch Abnormal Behavior**
-   └── What happens during incidents?
-   └── What breaks first under load?
-   └── What error messages appear?
-3. **Trace Requests End-to-End**
-   └── Pick a request type, follow it through
-   └── Understand every service it touches
-   └── Know the critical path
-4. **Learn from Postmortems**
-   └── What failed? Why didn't we catch it?
-   └── What was the actual impact?
-   └── What did we learn about the system?
-5. **Experiment (carefully)**
-   └── What happens if we scale down?
-   └── What happens if we add latency?
-   └── Chaos engineering builds models
+Teams build mental models by watching normal behavior first. Normal is not a single value; it is a set of patterns across daily traffic, weekly cycles, deploy windows, background jobs, regional differences, and customer behavior. If you never study normal, every incident graph looks surprising. On-call training should include exercises where engineers explain a healthy dashboard: why traffic rises at this hour, why p99 changes during a batch job, why one dependency has more retries, and which changes would be concerning.
 
-### 5.3 Sharing Mental Models
+Abnormal behavior teaches a different part of the model. Postmortems, load tests, game days, chaos experiments, and controlled failovers reveal how the system behaves under stress. Which component saturates first? Which retry loops amplify load? Which alerts fire too late? Which dashboards mislead? Which runbooks assume permissions the on-call engineer does not have? Every incident should update the shared model, not just produce a list of action items.
 
-Mental models in one person's head don't scale. Share them:
+Tracing representative requests end-to-end is one of the best ways to connect architecture to experience. Pick a checkout request, a search request, a login request, and a background job. Follow each path through the load balancer, API layer, authentication, caches, databases, message queues, external dependencies, and response. Note which spans are on the critical path and which happen asynchronously. The next time latency increases, that model tells you where time can accumulate and which signals should move together.
 
-| Method | When | Example |
-|--------|------|---------|
-| **Runbooks** | Common scenarios | "If X, do Y because Z" |
-| **Architecture diagrams** | System overview | Request flow, dependencies |
-| **Postmortems** | After incidents | What happened and why |
-| **Pairing** | Onboarding | Debug together, share intuition |
-| **Documentation** | Reference | "The system works like this..." |
+Runbooks share mental models when they explain why, not only what. A runbook that says "restart worker pods" may solve a symptom but teaches little. A better runbook says, "If queue age rises while worker error rate remains low, workers may be stuck waiting on the image-processing dependency. Check dependency latency before restarting workers; restarting can duplicate in-flight jobs." The explanation helps newer responders adapt when the exact symptom differs from the last incident.
+
+### 5.3 Incident Roles and Knowledge Transfer
+
+Mental models in one person's head do not scale. During small incidents, a single on-call engineer may detect, investigate, mitigate, communicate, and document. During larger incidents, those responsibilities compete. Incident response practices commonly separate command, subject-matter investigation, scribing, and communication so that the person building the technical hypothesis does not also have to manage the whole response. This separation is not bureaucracy; it is cognitive-load control.
+
+Postmortems are the bridge between private intuition and team knowledge. A useful postmortem explains what the system did, why the team believed what it believed at each stage, which signals were missing or misleading, and how the mental model changed. Avoid postmortems that only list a root cause and a fix. The most transferable knowledge is often the investigation path: which question narrowed the scope, which graph contradicted the first hypothesis, and which runbook step would have saved time.
+
+Automation can encode parts of the mental model, but it should not hide the model completely. A runbook automation job can collect logs, capture traces, drain traffic, restart a known-safe component, or validate a post-mitigation condition. The automation should record evidence and explain its checks so responders can understand what happened. Blind automation without visibility creates the same problem as blind human restarts: it changes the system while weakening the team's ability to learn from it.
+
+---
+
+## Current Landscape
+
+Modern observability practice has converged on a few durable ideas even though the tools keep changing. OpenTelemetry provides a vendor-neutral vocabulary for signals such as traces, metrics, logs, baggage, and profiles. Prometheus-style metrics and alert rules popularized symptom-oriented alerting patterns. Grafana-style dashboards made visualization accessible across many data sources. Trace systems made exemplar-driven debugging practical in distributed systems. Incident-response platforms made paging, escalation, runbooks, and postmortems part of the same operational loop.
+
+The foundation lesson is that none of these tools creates insight automatically. A tracing backend full of spans still needs consistent attributes and a responder who knows which exemplar to choose. A dashboarding tool still needs hierarchy and baselines. An alert manager still needs policy about page versus ticket. A runbook automation platform still needs a safe procedure with verification. Treat tools as surfaces for the concepts in this module, not as substitutes for them.
+
+| Practice Area | Durable Concept | Tool-Agnostic Question |
+|---|---|---|
+| Alerting | Human attention is scarce and should be spent on actionable user impact. | Does this alert require timely human action, and does it tell the responder where to start? |
+| SLO burn-rate rules | Error budgets connect reliability promises to alert severity. | How fast are we spending the budget, and what response speed does that require? |
+| Dashboards | Visual hierarchy should match the question hierarchy. | Can a responder move from user health to scope to evidence without reorienting? |
+| Correlation | Signals are more useful when they describe the same event from different angles. | Can a metric spike lead to a representative trace and the logs for that request? |
+| Runbooks | Operational knowledge must be executable and teachable. | Does the procedure explain why each step is safe and what evidence proves success? |
+
+---
+
+## Patterns & Anti-Patterns
+
+### Proven Patterns
+
+**Pattern 1: Symptom-first paging with cause-rich diagnosis.** Page on the user-visible symptom that matches a service promise, then link to cause-oriented dashboards and traces. This pattern scales because it keeps the interrupt path simple while preserving diagnostic depth. It also reduces inter-team noise: the owning service receives the page for its user promise, then uses dependency data to involve other teams with evidence instead of suspicion.
+
+**Pattern 2: Multiwindow burn-rate severity.** Use short and long windows together so a page requires both meaningful budget consumption and current impact. This pattern scales because it encodes policy in a reusable way across services with different request volumes. Teams can discuss thresholds in terms of budget consumed and response urgency instead of copying arbitrary percentages from one system to another.
+
+**Pattern 3: Dashboard layers tied to the investigation workflow.** Put SLO status and active symptoms first, golden signals second, scoping dimensions third, and exemplar links near the relevant panels. This pattern scales because every service dashboard teaches the same navigation path. Responders do not need to memorize each team's panel taxonomy before answering the first incident question.
+
+**Pattern 4: Evidence-preserving runbooks.** Before remediation, collect the small set of state needed to explain the failure: exemplar trace, key logs, current config, deploy version, queue state, dependency status, and any local process information that a restart would erase. This pattern scales because it improves both incident response and postmortem quality. It also makes automation safer because automated steps can collect evidence before changing state.
+
+### Anti-Patterns
+
+**Anti-pattern 1: Restart-and-pray.** Teams fall into this pattern because restarts sometimes make symptoms disappear and feel faster than investigation. The cost is lost evidence, repeated incidents, and false confidence. The better alternative is to quantify and exemplify first, then choose mitigation with an explicit hypothesis. Restarting can still be the right mitigation, but it should be a chosen response rather than an investigative reflex.
+
+**Anti-pattern 2: Alerting on every suspected cause.** Teams fall into this pattern after painful incidents because they want to catch that exact cause earlier next time. Over time, the pager becomes a stream of internal conditions that may or may not matter to users. The better alternative is to alert on symptoms and keep cause signals visible in dashboards, tickets, deploy checks, or automation triggers.
+
+**Anti-pattern 3: Dashboard sprawl.** Teams fall into this pattern because adding a panel is easier than deciding what the dashboard is for. Sprawl makes dashboards look comprehensive while hiding the important signal. The better alternative is a dashboard review habit: every panel must answer an operational question, provide context, or link to a next step. Panels that serve exploration can live in lower-level dashboards rather than the incident entry point.
+
+**Anti-pattern 4: Expert-only operations.** Teams fall into this pattern when the most experienced engineer solves incidents quickly but does not externalize the model. The organization becomes dependent on one person's memory and availability. The better alternative is to capture investigation paths in runbooks, review postmortems for model changes, pair during incidents, and rehearse common failure modes before they happen in production.
+
+---
+
+## Decision Framework
+
+Use this framework when deciding what to do with a signal, an alert proposal, or a dashboard panel. The first branch asks whether the signal represents user impact. If it does, evaluate it through SLO burn-rate severity and route it to page or ticket. If it does not, decide whether it is useful diagnostic evidence, automation input, or background information. The goal is not to discard internal signals; the goal is to put them in the right operational channel.
+
+```mermaid
+flowchart TD
+    A["New signal or alert idea"] --> B{"Does it describe user-visible impact<br>or an SLO-backed symptom?"}
+    B -- "Yes" --> C{"Is the error budget burning<br>at page severity?"}
+    C -- "Fast burn: 14.4x over 1h/5m<br>or sustained 6x over 6h/30m" --> D["Page with service, SLO, scope dimensions,<br>runbook, and dashboard link"]
+    C -- "Slow burn: 1x over 72h/6h<br>or similar non-urgent drift" --> E["Create ticket with owner,<br>budget context, and investigation link"]
+    B -- "No" --> F{"Does it explain a likely cause<br>or support diagnosis?"}
+    F -- "Yes" --> G["Put it on a diagnostic dashboard,<br>runbook checklist, or automated evidence collector"]
+    F -- "No" --> H{"Does anyone use it for decisions?"}
+    H -- "Yes" --> I["Document the decision it supports<br>and place it near related context"]
+    H -- "No" --> J["Remove it from the incident path;<br>keep only if required for audit or offline analysis"]
+```
+
+The same framework helps with dashboards. A top-level dashboard should contain signals from branches that answer user impact and current severity. Diagnostic dashboards should contain cause-oriented signals that help after the first question is answered. Automation should use signals that have a deterministic safe action and a verification step. Offline analysis can keep long-tail metrics that matter for capacity planning, cost, or research but do not belong in an incident entry point.
+
+| Decision | Choose This When | Tradeoff |
+|---|---|---|
+| Page | Budget is burning quickly, users are affected, and immediate human action can reduce harm. | Interrupts people, so precision and runbook quality must be high. |
+| Ticket | Budget drift or operational risk matters, but waiting until working hours is acceptable. | Slower response, so ownership and due date must be explicit. |
+| Dashboard panel | Signal helps localize or explain a symptom during investigation. | Useful only if placed near context and not mixed into an undifferentiated wall. |
+| Runbook automation | Response is repeatable, safe, and verifiable. | Can hide system behavior unless it records evidence and results clearly. |
+| Remove or archive | Signal does not support a decision, response, audit, or learning goal. | Requires discipline because deleting unused telemetry can feel risky. |
 
 ---
 
 ## Did You Know?
 
-- **NASA's Mission Control** uses a layered dashboard system called "Flight Director Console." The top level shows overall mission health. Lower levels show subsystem details. This hierarchy-based design is over 60 years old but still the gold standard.
+- **The four golden signals are intentionally small.** Google SRE describes latency, traffic, errors, and saturation as the four signals to prioritize for user-facing systems, which is powerful precisely because it resists the temptation to make every internal metric equally important.
 
-- **The term "runbook"** comes from IBM mainframe operations in the 1960s. Operators had physical books of procedures to "run" for common scenarios. Digital runbooks serve the same purpose.
+- **Multiwindow burn-rate alerting is designed to balance precision and detection time.** The Google SRE Workbook's 99.9% SLO example uses paired long and short windows so an alert requires both significant budget consumption and evidence that the problem is still active.
 
-- **Expert intuition is real**. Studies show experienced operators can often sense something is wrong before any alert fires—they've internalized subtle patterns. This is the goal of building mental models.
+- **OpenTelemetry treats traces, metrics, logs, baggage, and profiles as signals.** This vocabulary matters because observability work is not about worshiping three fixed pillars; it is about linking system outputs so they answer questions from different angles.
 
-- **PagerDuty analyzed millions of incidents** and found that the median time to acknowledgement is 3 minutes, but the median time to resolution is 30 minutes. The investigation phase—understanding what's wrong—takes 10x longer than noticing something is wrong. Good observability reduces investigation time, not detection time.
+- **Prometheus alerting guidance points teams toward simple, symptom-oriented pages.** Its alerting practices summarize the same philosophy used throughout this module: keep pages understandable, alert on user pain, provide consoles for diagnosis, and avoid pages where there is nothing to do.
 
 ---
 
 ## Common Mistakes
 
-| Mistake | Problem | Solution |
-|---------|---------|----------|
-| Alerting on everything | Alert fatigue, ignored pages | Alert on symptoms, not causes |
-| Dashboard sprawl | Can't find the right dashboard | Hierarchy, templates, linking |
-| No runbooks | Every incident is new | Document common scenarios |
-| Siloed investigation | Can't correlate across signals | Shared trace IDs, linked tools |
-| Over-reliance on dashboards | Miss issues dashboards don't show | Combine with exploration |
-| Not sharing knowledge | One expert, team bottleneck | Postmortems, pairing, docs |
+| Mistake | Problem | Better Approach |
+|---|---|---|
+| Alerting on every interesting internal metric | The pager becomes noisy, responders learn to ignore it, and real incidents hide among non-actions. | Page on user-impact symptoms and keep internal causes on diagnostic dashboards or tickets. |
+| Using fixed error-rate thresholds without SLO context | A threshold may be too sensitive for low traffic and too slow for high traffic or critical paths. | Use error-budget burn rates, then tune windows and minimum counts for the service profile. |
+| Jumping from alert to root-cause theory | Confirmation bias narrows the search before scope and localization are known. | Follow Quantify -> Segment -> Correlate -> Exemplify -> Hypothesize -> Verify -> Resolve. |
+| Restarting before preserving evidence | Restarts can clear the exact state that explains the incident. | Capture representative traces, logs, config, queue state, and process state before mitigation when safe. |
+| Building dashboards around available metrics | Responders must manually discover which panels matter during an incident. | Design dashboards around operational questions, starting with SLO status and user impact. |
+| Treating averages as truth | Global averages hide regional, endpoint, tenant, and version-specific failures. | Segment by dimensions that map to ownership, blast radius, and likely causes. |
+| Keeping runbooks as command lists without explanations | New responders can follow steps but cannot adapt when symptoms differ. | Explain why each step exists, what evidence it expects, and what success looks like. |
+| Letting one expert hold the mental model | Incidents slow down when that person is unavailable or overloaded. | Share models through postmortems, pairing, diagrams, game days, and evidence-rich runbooks. |
 
 ---
 
 ## Quiz
 
-1. **You are setting up alerts for a new microservice. Your teammate suggests alerting whenever CPU usage exceeds 80%. What is the danger of this approach, and what should you alert on instead?**
+1. **You are setting up alerts for a new microservice. Your teammate suggests paging whenever CPU usage exceeds 80%. What is the danger of this approach, and what should you alert on instead?**
    <details>
    <summary>Answer</summary>
 
-   Alerting on CPU usage is alerting on a cause rather than a symptom. High CPU usage might be completely fine if the service is still responding quickly and without errors, leading to false positives and alert fatigue. Instead, you should alert on symptoms that directly impact the user experience, such as elevated error rates or increased p99 latency. By alerting on symptoms, every page represents actual user impact, ensuring that when an alert fires, immediate action is truly needed.
+   CPU usage is a possible cause signal, not a user-visible symptom by itself. The service may be healthy at high CPU, or unhealthy at low CPU if it is stuck and doing no work. The better alert starts from the Build outcome in this module: page on meaningful user-impact signals such as SLO burn rate, elevated error rate, or p99 latency for a critical operation. CPU should remain available on diagnostic dashboards so it can help explain a symptom after the page fires.
    </details>
 
-2. **Your current alerting rule triggers whenever the error rate exceeds 2% for 5 minutes. During a low-traffic night shift, a brief network blip causes a 3% error rate for 6 minutes, waking up the on-call engineer, though it resolves on its own. How would SLO-based alerting handle this situation differently?**
+2. **Your current alert triggers whenever error rate exceeds 2% for five minutes. During a low-traffic night shift, a small network blip wakes the on-call engineer even though it resolves on its own. How would SLO-based alerting handle this situation differently?**
    <details>
    <summary>Answer</summary>
 
-   SLO-based alerting ties alerts to the error budget burn rate rather than an arbitrary threshold. During a low-traffic period, a brief spike in error rate consumes very little of the overall error budget, so it wouldn't trigger a critical page. Instead, it might only register as a low-severity notification or appear on a dashboard for later review. This approach prevents unnecessary wake-ups for self-resolving issues while still aggressively paging if the burn rate threatens to exhaust the budget over a sustained period.
+   SLO-based alerting evaluates how quickly the service is consuming its error budget rather than treating every short percentage spike as equally urgent. A low-traffic service may need longer windows, event-count minimums, synthetic checks, or ticket-level routing so one brief blip does not create a page. Multiwindow burn-rate rules also require evidence that the issue consumed meaningful budget and is still active. This is part of the Evaluate outcome: judging whether an alerting strategy reduces false positives without hiding real incidents.
    </details>
 
-3. **An alert fires for high latency on the checkout service. The on-call engineer immediately starts randomly checking logs and restarting database pods, hoping to fix it, which takes 40 minutes. How would applying the exploratory investigation pattern have changed this response?**
+3. **An alert fires for high checkout latency. The on-call engineer randomly checks logs and restarts database pods for 40 minutes. How would the exploratory investigation pattern have changed the response?**
    <details>
    <summary>Answer</summary>
 
-   Without a structured approach, debugging devolves into random guessing and potentially destructive actions like restarting pods without capturing evidence. The exploratory investigation pattern provides a systematic, step-by-step workflow: quantify the latency, segment to see which users or endpoints are affected, correlate with recent changes, find an exemplar trace, hypothesize a cause, and verify it before acting. By methodically narrowing down the scope of the problem based on data, the engineer would efficiently converge on the true root cause, dramatically reducing the time to resolution. This structured approach prevents wasted effort and preserves valuable diagnostic state that blind restarts would otherwise destroy.
+   The exploratory pattern would have forced the engineer to quantify the latency first, segment the affected requests, correlate with recent changes, choose a representative slow trace, state a hypothesis, verify it, and only then resolve. That Analyze workflow turns a broad symptom into a narrowing sequence of evidence-backed questions. It also protects diagnostic state because the responder does not restart components before learning what the current state can teach. The likely result is fewer unnecessary changes and a more defensible root-cause explanation.
    </details>
 
-4. **Two engineers are investigating a sudden spike in failed background jobs. Engineer A immediately checks the Redis memory metrics, while Engineer B spends 15 minutes reading architecture documentation to understand how the job queue works. What concept does Engineer A possess that Engineer B lacks, and why is it valuable?**
+4. **Two engineers investigate failed background jobs. Engineer A immediately checks Redis queue saturation because they know the job architecture, while Engineer B spends 15 minutes reading diagrams. What concept does Engineer A possess, and how should the team share it?**
    <details>
    <summary>Answer</summary>
 
-   Engineer A possesses a strong mental model of the system's architecture and dependencies, instinctively knowing that the background jobs rely heavily on Redis. A mental model is an internalized understanding of how the system actually operates and fails in the real world. Having this intuition allows operators to jump straight to likely causes and narrow down investigations quickly, without needing to reference documentation from scratch. Sharing these mental models across the team through pairing, runbooks, and postmortems ensures everyone can investigate with similar efficiency.
+   Engineer A has a mental model of the system: how requests and jobs flow, which dependencies matter, and which failure modes usually appear first. That model is valuable because it turns a vague symptom into a focused question without requiring the engineer to rediscover the architecture during the incident. The team should share it through runbooks that explain why, postmortems that describe the investigation path, pairing, game days, and diagrams connected to real telemetry. Otherwise the organization remains dependent on one expert's memory.
    </details>
 
-5. **Your SRE team is on-call for a major e-commerce platform. Over the past week, you received 150 pages, but 135 of them self-resolved before anyone could even log in, requiring zero intervention. What specific metric describes this situation, why is it dangerous, and what immediate steps should the team take?**
+5. **Your SRE team received 150 pages in a week, and most self-resolved before anyone could take action. What metric describes this situation, why is it dangerous, and what should the team do first?**
    <details>
    <summary>Answer</summary>
 
-   The team's "signal ratio" is 10%, meaning only 15 out of 150 alerts are actually actionable. This is critically low, as Google recommends targeting a 50% signal ratio. A low signal ratio causes severe alert fatigue, psychologically training engineers to ignore alerts and resulting in real issues getting lost in the background noise. To fix this, the team must audit their noisy alerts, delete the ones that never require human action, and shift from arbitrary infrastructure thresholds to symptom-based, SLO-aligned alerts.
+   The situation describes a poor signal-to-noise ratio: the pager is producing many interruptions that do not require useful human action. The danger is behavioral as much as technical, because responders learn that pages are probably noise and become slower to react when a real incident appears. The team should audit recent alerts, delete or downgrade rules that never require action, add runbooks to unclear alerts, and shift page-level rules toward SLO-backed user symptoms. This directly supports the Build and Evaluate outcomes because alert quality is measured by actionability, not by volume.
    </details>
 
-6. **During a P1 outage, the on-call engineer opens the 'Payment Service Health' dashboard, which contains 47 different metric panels arranged in alphabetical order by metric name. They spend 10 precious minutes just trying to figure out if the service is currently up or down. What fundamental design anti-pattern is this dashboard suffering from, and how should it be structurally reorganized to be useful during an incident?**
+6. **During a P1 outage, the on-call engineer opens the "Payment Service Health" dashboard, which contains more than 30 metric panels arranged alphabetically by metric name. They spend 10 minutes trying to determine whether the service is up or down. What dashboard anti-pattern is this, and how should it be reorganized?**
    <details>
    <summary>Answer</summary>
 
-   The primary problem is "The Wall of Metrics" anti-pattern, suffering from a complete lack of visual hierarchy where all 47 panels are competing equally for attention. When everything is presented with the same priority, engineers are forced to manually parse through irrelevant data to find the critical signals, wasting precious time during an outage. To fix this, the team should reorganize the dashboard into clear, logical tiers. The top row should provide an executive summary answering "are we okay?" in five seconds with high-level SLO status. The middle row should surface the golden signals (latency, traffic, errors) to indicate current behavior, while the bottom section should contain expandable drill-down panels for when deep investigation is actually required.
+   This is the wall-of-metrics anti-pattern: every panel has equal weight, so the responder must manually discover which signals matter during the incident. A better Design approach uses hierarchy. The top layer should answer "Are users okay?" with SLO status, error-budget burn, and active symptoms. The next layer should show golden signals, and lower layers should break down by endpoint, region, version, dependency, and exemplar links for deeper investigation.
    </details>
 
-7. **At 3:00 AM, an alert fires for high latency on the user-profile service. The responding engineer hypothesizes "the database must be hung again," so they immediately restart the primary database pod. The latency drops back to normal, and the engineer closes the ticket with the note "Fixed root cause by restarting DB." Why is this conclusion dangerously incorrect, and what exact steps were skipped in the exploratory investigation pattern?**
+7. **At 3:00 AM, an alert fires for high user-profile latency. The responder assumes "the database must be hung again" and immediately restarts the primary database pod. Latency drops, and they close the incident as fixed. Why is that conclusion unsafe?**
    <details>
    <summary>Answer</summary>
 
-   The engineer did not find the root cause; they merely applied a mitigation that temporarily masks the underlying issue. By blindly restarting the database without capturing evidence first, they destroyed valuable state (like active query locks, connection pool exhaustion, or memory leaks) that could have explained the slowness. The problem is highly likely to recur because they skipped the critical Verify step. In the exploratory investigation pattern, they completely bypassed Exemplify (finding a specific failing trace) and Verify (confirming the database was actually the source of the latency before acting).
+   The restart may have mitigated the symptom, but it did not verify root cause. The responder skipped exemplification and verification, so they do not know whether the database was the source, whether the restart cleared useful evidence, or whether the same condition will return. A structured Analyze workflow would capture a representative trace, compare failing and successful requests, inspect database and application logs, and state what evidence would confirm the database hypothesis before changing state. Closing the incident without that evidence weakens both reliability and learning.
    </details>
 
-8. **Your engineering director is pushing back on a $100,000/year contract for a new tracing platform, arguing it's too expensive. Your critical checkout service processes 100,000 requests per minute with an average revenue of $0.50 per request. Last month, a 5% error rate incident took 40 minutes to investigate, which you estimate could have been reduced to 10 minutes with the new tracing tool. How would you justify the platform's cost using the financial impact of that single incident?**
+8. **Hypothetical scenario: A director questions the cost of a tracing platform. Your checkout path handles about 100,000 requests per minute, each failed request costs roughly $0.50 in lost gross revenue, and the last incident had a 5% error rate for 40 minutes. If faster exemplars could reduce investigation to 10 minutes, how would you frame the value without overstating certainty?**
    <details>
    <summary>Answer</summary>
 
-   A 40-minute delay costs the business massive revenue, calculated as 200,000 failed requests over that period multiplied by $0.50 per request, totaling $100,000 in lost revenue. If the new tracing tool reduces investigation time to just 10 minutes, the financial impact drops to $25,000, meaning the company saves $75,000 on that single incident alone. Assuming multiple similar incidents occur throughout the year, the financial savings easily exceed the annual cost of the enterprise observability platform. This demonstrates that proper observability tooling almost always pays for itself by directly minimizing the revenue impact of prolonged outages.
+   Use the numbers as an illustrative decision model, not as a guaranteed savings claim. At 100,000 requests per minute and 5% failures, about 5,000 requests fail each minute; at $0.50 per failed request, that is roughly $2,500 per minute of impact. Reducing investigation from 40 minutes to 10 minutes avoids about 30 minutes of impact, or roughly $75,000 in this simplified scenario. The honest argument is that better tracing can pay for itself when it reliably shortens high-impact investigations, but the business case should include incident frequency, adoption, data quality, and whether responders actually use the exemplars.
    </details>
-
----
-
-## Key Takeaways
-
-**Asking Good Questions**
-- [x] Start broad (is something wrong?) then narrow
-- [x] Be specific: endpoint, timeframe, metric
-- [x] Avoid vague questions ("why is it slow?")
-- [x] Follow the question hierarchy: Detection → Scope → Localization → Root Cause
-
-**The Exploratory Investigation Pattern**
-- [x] 1. Quantify - how bad is it?
-- [x] 2. Segment - who/what is affected?
-- [x] 3. Correlate - what else happened?
-- [x] 4. Exemplify - show me a specific case
-- [x] 5. Hypothesize - I think X is the cause
-- [x] 6. Verify - test the hypothesis
-- [x] 7. Resolve - fix and document
-
-**Effective Alerting**
-- [x] Alert on symptoms (user impact), not causes (CPU/memory)
-- [x] Use SLO-based alerting with error budgets
-- [x] Target 50%+ signal ratio (actionable alerts)
-- [x] Every alert must have: clear action + runbook link
-- [x] Delete alerts that never require action
-
-**Dashboard Design**
-- [x] Hierarchy: Summary → Golden Signals → Drill-down
-- [x] Answer "are we okay?" in 5 seconds (top row)
-- [x] Consistency across services (same layout)
-- [x] Link to next step (metric → traces → logs)
-
-**Building Mental Models**
-- [x] Watch normal behavior to recognize abnormal
-- [x] Learn from postmortems (failure modes)
-- [x] Trace requests end-to-end (understand flow)
-- [x] Share knowledge: runbooks, docs, pairing
-- [x] Experiment carefully (chaos engineering)
 
 ---
 
 ## Hands-On Exercise
 
-**Task**: Design an observability workflow for a common scenario.
+**Task**: Design an observability workflow for a common latency incident.
 
-**Scenario**: You receive an alert: "p99 latency for /api/search exceeded 500ms"
+**Scenario**: You receive an alert: "p99 latency for `/api/search` exceeded 500 ms and the search SLO is burning budget at page severity."
 
 **Part 1: Investigation Plan (10 minutes)**
 
-Write out your investigation steps using the exploratory pattern:
+Write out your investigation steps using the exploratory pattern. For each row, name the telemetry signal, the dimension you would split by, and the decision the answer would influence.
 
-| Step | Question | How You'd Answer (tool/query) |
-|------|----------|-------------------------------|
-| Quantify | What's the actual p99? How long has it been elevated? | |
-| Segment | All search requests or some? Which dimensions? | |
-| Correlate | What changed? Deploys? Traffic spike? | |
-| Exemplify | Get a specific slow trace | |
-| Hypothesize | What do you think is the cause? | |
-| Verify | How would you confirm? | |
+| Step | Question | How You Would Answer |
+|---|---|---|
+| Quantify | What is the actual p99, how long has it been elevated, and how fast is budget burning? | Compare current latency and burn rate against the SLO target and the previous healthy window. |
+| Segment | Is it all search requests or a subset by region, endpoint variant, tenant, version, or client platform? | Split the latency metric and error metric by dimensions that map to ownership and blast radius. |
+| Correlate | What changed near the start time? | Check deploy history, config changes, feature flags, traffic mix, cache hit rate, dependency status, and scheduled jobs. |
+| Exemplify | What does one representative slow request show? | Open a trace for an affected request and follow spans for search API, cache, index service, database, and external calls. |
+| Hypothesize | What explanation best fits the scoped evidence? | State the current theory and list what else should be true if it is correct. |
+| Verify | Which independent signal confirms or refutes the hypothesis? | Query logs, dependency dashboards, deploy metadata, or a healthy-region comparison before changing state. |
+| Resolve | What action reduces user impact and proves recovery? | Apply the smallest safe mitigation, then verify SLO burn, p99 latency, and affected segments return to healthy ranges. |
 
 **Part 2: Alert Design (10 minutes)**
 
-Design an SLO-based alert for this scenario:
+Design an SLO-based alert for this scenario. Use the burn-rate defaults as starting points, then note any service-specific adjustment you would need for traffic volume or business criticality.
 
 | Element | Your Design |
-|---------|-------------|
-| SLO target | p99 latency for /api/search ≤ ___ms |
-| Measurement window | ___ minutes |
-| Severe alert | Burn rate = ___ (exhausts budget in ___ hours) |
-| High alert | Burn rate = ___ (exhausts budget in ___ hours) |
-| Runbook link | Steps to investigate (from Part 1) |
+|---|---|
+| SLO target | p99 latency for `/api/search` remains at or below your user-facing objective for the agreed measurement window. |
+| Fast page | 14.4x burn rate across both 1 hour and 5 minutes for a 99.9% monthly SLO. |
+| Slow page | 6x burn rate across both 6 hours and 30 minutes for sustained budget loss. |
+| Ticket | 1x burn rate across both 72 hours and 6 hours when the service is off-track but not urgent. |
+| Alert context | Include SLO, burn rate, affected dimensions, dashboard link, trace-exemplar query, deploy link, and runbook owner. |
 
 **Part 3: Dashboard Design (10 minutes)**
 
-Sketch a simple dashboard for search health:
+Sketch a simple dashboard for search health. Keep the top row limited to the answer a responder needs first, then use lower rows for signals and drill-downs.
 
 ```mermaid
 flowchart TD
-    subgraph Top ["Top row (Executive Summary)"]
+    subgraph Top ["Top row: User health"]
         direction LR
-        A["[What should be here?]"]
+        A["Search SLO status<br>Error budget remaining<br>Active page/ticket alerts"]
     end
 
-    subgraph Middle ["Middle row (Golden Signals)"]
+    subgraph Middle ["Middle row: Golden signals"]
         direction LR
-        B1["[Panel 1]"]
-        B2["[Panel 2]"]
-        B3["[Panel 3]"]
+        B1["Latency<br>p50 / p95 / p99"]
+        B2["Errors<br>Error rate and class"]
+        B3["Traffic<br>Requests/sec and query mix"]
+        B4["Saturation<br>Queue age and worker concurrency"]
     end
 
-    subgraph Bottom ["Bottom row (Drill-down)"]
+    subgraph Bottom ["Bottom row: Investigation dimensions"]
         direction LR
-        C["[What breakdowns would be useful?]"]
+        C1["By region"]
+        C2["By index shard"]
+        C3["By deploy version"]
+        C4["Trace exemplars and logs"]
     end
 
     Top --> Middle
@@ -627,50 +592,67 @@ flowchart TD
 ```
 
 **Success Criteria**:
-- [x] Investigation plan covers all steps of exploratory pattern
-- [x] Alert design includes SLO target and multiple severity levels
-- [x] Dashboard has clear hierarchy (summary → signals → details)
-- [x] Each dashboard panel has a clear purpose
+
+- [ ] Your investigation plan explicitly walks from Quantify through Resolve and explains what evidence changes your next step at each stage.
+- [ ] Your alert design distinguishes fast page, slow page, and ticket routing using SLO burn-rate language rather than arbitrary thresholds alone.
+- [ ] Your dashboard sketch has a clear hierarchy from user health to golden signals to drill-down dimensions and exemplar evidence.
+- [ ] Your workflow preserves diagnostic evidence before remediation and defines how you will verify that user impact has ended.
+
+---
+
+## Key Takeaways
+
+Turning data into insight is mostly a design problem around questions. Detection asks whether users are harmed, scope asks who is affected, localization asks where the symptom appears, and root-cause analysis asks why. If your telemetry does not support those questions in order, responders will compensate with memory, guesses, and unnecessary changes.
+
+Effective alerting spends human attention only when action is required. SLO burn-rate alerts connect severity to error-budget consumption, and multiwindow rules reduce the tradeoff between fast detection and false positives. Cause metrics still matter, but they belong in diagnostic surfaces unless they are directly tied to user impact or a safe automated response.
+
+Dashboards should tell an operational story. Start with SLO status and current user health, then show golden signals, then provide drill-downs by dimensions that help scope and localize. A dashboard full of panels is not automatically useful; a dashboard that guides the next question is.
+
+Mental models are the hidden accelerant in incident response. The goal is not to make every engineer memorize every subsystem. The goal is to turn private intuition into shared assets: runbooks with explanations, postmortems that teach investigation paths, dashboards that reveal normal and abnormal behavior, and practice sessions that let teams rehearse failure before production pressure arrives.
+
+---
+
+## Sources
+
+- [Google SRE Book: Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/) - Source for symptoms versus causes, black-box versus white-box monitoring, and the four golden signals.
+- [Google SRE Workbook: Alerting on SLOs](https://sre.google/workbook/alerting-on-slos/) - Source for error-budget burn-rate alerting and the multiwindow burn-rate defaults.
+- [Prometheus Documentation: Alerting](https://prometheus.io/docs/practices/alerting/) - Source for simple, symptom-oriented alerting guidance and links to Rob Ewaschuk's alerting philosophy.
+- [Rob Ewaschuk: My Philosophy on Alerting](https://docs.google.com/document/d/199PqyG3UsyXlwieHaqbGiWVa8eMWi8zzAn0YfcApr8Q/edit) - Source for the actionable-page philosophy that influenced many SRE alerting practices.
+- [Brendan Gregg: The USE Method](https://www.brendangregg.com/usemethod.html) - Source for Utilization, Saturation, and Errors as a resource-oriented diagnostic checklist.
+- [Grafana Labs: The RED Method](https://grafana.com/blog/the-red-method-how-to-instrument-your-services/) - Source for Rate, Errors, and Duration as a service-oriented monitoring method.
+- [Grafana Documentation: Dashboard Best Practices](https://grafana.com/docs/grafana/latest/visualizations/dashboards/build-dashboards/best-practices/) - Source for dashboard design practices and dashboard organization concepts.
+- [Grafana Documentation: Dashboards](https://grafana.com/docs/grafana/latest/visualizations/dashboards/) - Source for dashboard concepts such as links, variables, annotations, and reusable dashboard organization.
+- [OpenTelemetry Documentation: Signals](https://opentelemetry.io/docs/concepts/signals/) - Source for the current OpenTelemetry signal categories: traces, metrics, logs, baggage, and profiles.
+- [OpenTelemetry Documentation: Observability Primer](https://opentelemetry.io/docs/concepts/observability-primer/) - Source for vendor-neutral observability concepts and terminology.
+- [PagerDuty Incident Response Documentation](https://response.pagerduty.com/) - Source for incident-response process structure, preparation, response, and post-incident practices.
+- [PagerDuty Incident Response: Different Roles](https://response.pagerduty.com/before/different_roles/) - Source for incident roles such as Incident Commander, Deputy, Scribe, and liaisons.
+- [PagerDuty Runbook Automation](https://www.pagerduty.com/platform/automation/runbook/) - Source for runbook automation concepts and operational automation capabilities.
+- [Rundeck Runbook Automation Documentation](https://docs.rundeck.com/docs/) - Source for runbook automation terminology and implementation concepts.
 
 ---
 
 ## Further Reading
 
-- **"Practical Monitoring"** - Mike Julian. Excellent coverage of alerting philosophy and dashboard design.
-
-- **"The Art of Monitoring"** - James Turnbull. Comprehensive guide to building monitoring systems.
-
-- **"Thinking in Systems"** - Donella Meadows. Foundational book on building mental models of complex systems.
+- **"Practical Monitoring" by Mike Julian** - A useful book-length treatment of alerting philosophy, dashboard design, and operational monitoring habits.
+- **"The Art of Monitoring" by James Turnbull** - A broad introduction to monitoring systems, alerting, and instrumentation tradeoffs.
+- **"Thinking in Systems" by Donella Meadows** - A durable foundation for understanding feedback loops, delays, and mental models in complex systems.
+- **"Site Reliability Engineering" and "The Site Reliability Workbook" by Google SRE** - Primary references for symptom-based monitoring, SLOs, error budgets, and burn-rate alerting.
 
 ---
 
-## Observability Theory: What's Next?
+## Next Module
 
-Congratulations! You've completed the Observability Theory foundation. You now understand:
-
-- What observability is and how it differs from monitoring
-- The three pillars: logs, metrics, traces
-- How to instrument systems effectively
-- How to turn data into insight
-
-**Where to go from here:**
-
-| Your Interest | Next Track |
-|---------------|------------|
-| Implementing observability | [Observability Toolkit](/platform/toolkits/observability-intelligence/observability/) |
-| Operating with observability | [SRE Discipline](/platform/disciplines/core-platform/sre/) |
-| Security observability | [Security Principles](/platform/foundations/security-principles/) |
-| Foundational concepts | [Distributed Systems](/platform/foundations/distributed-systems/) |
+This is the capstone of the Observability Theory sub-track. To continue through Platform Foundations, move to [Security Principles](../security-principles/). If you want to apply these concepts operationally, continue with the [SRE Discipline](/platform/disciplines/core-platform/sre/) or the [Observability Toolkit](/platform/toolkits/observability-intelligence/observability/).
 
 ---
 
 ## Track Summary
 
 | Module | Key Takeaway |
-|--------|--------------|
-| 3.1 | Observability lets you ask questions you didn't predict; monitoring answers predefined questions |
-| 3.2 | Logs (detail), metrics (aggregation), traces (flow)—connected by correlation IDs |
-| 3.3 | Instrument boundaries and business operations; keep cardinality bounded; sample traces |
-| 3.4 | Alert on symptoms not causes; debug systematically; build and share mental models |
+|---|---|
+| 3.1 | Observability lets you ask questions you did not predict; monitoring answers predefined questions. |
+| 3.2 | Logs, metrics, and traces are different views of system behavior, and correlation makes them stronger together. |
+| 3.3 | Instrument boundaries and business operations; keep dimensions intentional; preserve context across calls. |
+| 3.4 | Alert on symptoms, investigate systematically, design dashboards around decisions, and share mental models. |
 
-*"The goal isn't to have all the data. The goal is to understand the system."*
+The goal is not to have all the data. The goal is to understand the system well enough to ask the next useful question.


### PR DESCRIPTION
## Platform Foundations campaign (#1897) — Wave 3: Observability Theory

Expands the two sub-floor critical-score modules in **Observability Theory** to T0, in curriculum order. Same loop as on-premises (#1881) and ai-ml-engineering (#1842): verifier sweep → expand → mixed-pool cross-family review (NO gemini) → ground-check + web-verify every finding → consolidated PR → build PRIMARY → dedup gate.

### Modules

| Module | Before | After | Author | Reviewer |
|--------|--------|-------|--------|----------|
| 3.1 what-is-observability | T3, 3077w, 0 src | **T0, 5114w, 12 src** | cursor | codex |
| 3.4 from-data-to-insight | T3, 1169w, 0 src | **T0, 6346w, 14 src** | codex gpt-5.5 | opus |

Both `revision_pending: false`, War Stories de-fabbed → `Hypothetical scenario:`, density fixed.

### Cross-family review caught (all ground-checked + web-verified)

**3.1 — codex review, 9 findings, all real:**
- The pre-existing **2017 AWS S3 opener had a fabricated causal chain** ("billing subsystem failed → index couldn't query billing for account standing → S3 nodes locked down"). Web-verified against the [official AWS post-mortem](https://aws.amazon.com/message/41926/): the command targeted a few **billing-subsystem** servers; a mistyped input over-removed capacity supporting the **index** and **placement** subsystems, both of which then required a **full restart**. Rewrote the opener + Quiz Q8 to match; removed the invented chain.
- `$150M/$160M` was mis-stated as AWS-sourced "direct revenue losses worldwide" → reframed as external **Cyence** analyst estimates (S&P 500 / U.S. financial-services), cited.
- Internal contradiction: a diagram listed "metrics with high-cardinality dimensions" as an *observable-system virtue*, contradicting the module's own (correct) warning → split into low-cardinality metric labels vs high-cardinality event/span attributes.
- Loki mischaracterized as indexing rich fields like Elasticsearch → corrected (Loki indexes labels only; content in chunks, queried at read time).
- A redirecting CNCF TAG URL → replaced with the stable `tag-observability.cncf.io`.

**3.4 — opus review, APPROVE:**
- The **SLO multi-window burn-rate math** (the riskiest content) verified flawless from first principles against the Google SRE Workbook: 14.4×/(1h,5m), 6×/(6h,30m), 1×/(72h,6h) for a 99.9% SLO, with correct budget-consumed math and page-vs-ticket routing.
- Anti-fabrication clean: both `Hypothetical scenario:` blocks labeled; the named fabrication traps (Google "50% signal ratio", PagerDuty MTTA/MTTR, NASA console, 1960s IBM runbook) all absent. Both `47` leak tokens removed.
- Two P2 "non-canonical Grafana URL" findings were **overturned by ground-check** — the module's current URLs are the direct HTTP 200 destinations; opus's suggested forms 301-redirect *into* them.

### Incident-dedup
The corrected AWS-S3-2017 source citation tripped the dedup gate (canonical owner = reliability-engineering 2.2). Fixed per the established convention (cf. distributed-systems 5.1): added an `<!-- incident-xref: aws-s3-useast1-2017 -->` marker + a cross-link to the canonical 2.2. Gate now PASS.

### Verification
- `verify_module.py`: both T0 / passed, 0 failing gates
- Full astro build (PRIMARY-equivalent worktree): **2171 pages, Complete!**, 0 schema errors
- `incident_dedup_gate.py`: PASS (absolute)
- `check_site_health.py`: **0 errors**, 5126 links checked (new cross-link resolves)

Refs #1897
