### PR TITLE
docs(platform): expand+de-fab Foundations Security Principles 4.1, 4.2, 4.4 to T0 (#1897)

### DIFF
--- a/src/content/docs/platform/foundations/security-principles/module-4.1-security-mindset.md
+++ b/src/content/docs/platform/foundations/security-principles/module-4.1-security-mindset.md
@@ -1,5 +1,4 @@
 ---
-revision_pending: true
 title: "Module 4.1: The Security Mindset"
 slug: platform/foundations/security-principles/module-4.1-security-mindset
 sidebar:
@@ -13,7 +12,7 @@ sidebar:
 >
 > **Track**: Foundations
 
-### What You'll Be Able to Do
+## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
@@ -24,33 +23,23 @@ After completing this module, you will be able to:
 
 ---
 
-The 2020 <!-- incident-xref: solarwinds-2020 -->SolarWinds supply-chain compromise reached 18,000 organizations through a trusted software update, demonstrating that attackers don't need to be smarter than defenders — they just need one way in while defenders protect everything. For the full case study, see [CI/CD Pipelines](../../../prerequisites/modern-devops/module-1.3-cicd-pipelines/).
+The 2020 <!-- incident-xref: solarwinds-2020 -->SolarWinds supply-chain compromise reached 18,000 organizations through a trusted software update, demonstrating that attackers do not need to be smarter than defenders — they only need one way in while defenders protect everything. For the full case study, see [CI/CD Pipelines](../../../prerequisites/modern-devops/module-1.3-cicd-pipelines/).
 
-This module teaches the security mindset—thinking like an attacker to build like a defender.
+This module teaches the security mindset: thinking like an attacker to build like a defender. The goal is not paranoia for its own sake, but disciplined imagination — the habit of asking what could go wrong before an incident answers that question for you at three in the morning.
 
 ---
 
 ## Why This Module Matters
 
-Every system you build will be attacked. Not might be—will be. The question isn't "if" but "when" and "how prepared are you?"
+Every system you build will be attacked. Not might be — will be. Automated scanners probe every public IP address on the internet often within hours of exposure. Credential-stuffing bots test stolen passwords against login forms continuously. Supply-chain adversaries monitor open-source maintainers for takeover opportunities. The question is not whether someone will try, but when they will succeed unless you design with that assumption from the start.
 
-Security isn't a feature you add at the end. It's a way of thinking—a mindset that influences every design decision, every line of code, every operational process. Developers who understand security build better systems, even when they're not explicitly "doing security work."
+Security is not a feature you bolt on before launch or a checkbox you tick for auditors. It is a way of thinking that influences every design decision, every line of code, every operational process, and every vendor relationship. Developers who internalize this mindset build better systems even when they are not on a dedicated security team, because they notice implicit trust, oversized permissions, and missing validation before those gaps become headlines.
 
-This module introduces the security mindset: how attackers think, how defenders must think, and why security is everyone's responsibility.
+The modules that follow in this Security Principles track — defense in depth, identity and access, secure by default — each implement specific controls. This module establishes the mental model those controls serve. Without attacker-minded thinking, you will deploy firewalls and still leave paths open; without threat modeling, you will harden the wrong components; without understanding security theater, you will pass audits while remaining exposed. The sections below build that foundation deliberately, from asymmetry and attack surface through principles, trust, culture, and repeatable decision frameworks you can use in design reviews.
 
 > **The Castle Analogy**
 >
-> Medieval castles weren't just walls. They had moats, drawbridges, murder holes, multiple walls, keeps, and escape routes. Each layer assumed the previous one might fail. The architects thought like attackers: "If I breach the outer wall, what stops me next?" Security engineering is the same: assume breach, plan for failure, layer defenses.
-
----
-
-## What You'll Learn
-
-- How attackers think (and why you need to think like them)
-- The difference between security theater and real security
-- Core security principles that never change
-- Why "trust" is the most dangerous word in security
-- How to evaluate security trade-offs
+> Medieval castles were not just walls. They had moats, drawbridges, murder holes, multiple curtain walls, keeps, and escape routes. Each layer assumed the previous one might fail. Architects thought like attackers: "If I breach the outer wall, what stops me next?" Security engineering applies the same logic: assume breach, plan for failure, and layer defenses so that no single mistake becomes total compromise.
 
 ---
 
@@ -58,24 +47,33 @@ This module introduces the security mindset: how attackers think, how defenders 
 
 ### 1.1 The Attacker's Advantage
 
+Defenders and attackers operate under fundamentally different economics, and misunderstanding that asymmetry is one of the most expensive mistakes in platform engineering. A defender must protect every entry point, every service account, every dependency, and every human with access — continuously, under budget pressure, and without breaking the workflows legitimate users depend on. An attacker needs only one path that works once, at a moment when monitoring is thin or response is slow.
+
+That imbalance is not a temporary inconvenience you can fix with better tooling alone. It is structural. The defender's job is to be right every time across an expanding surface; the attacker's job is to be right once on the weakest link. Attackers also choose timing — holidays, on-call rotations, major product launches when change velocity is high and scrutiny is divided. They choose technique — reusing a known exploit against an unpatched service costs far less than developing a zero-day. They choose target — the forgotten staging API, the contractor VPN account, the CI pipeline secret in a public fork.
+
 | Defender | Attacker |
 | :--- | :--- |
 | Must protect everything | Only needs one way in |
 | Must be right every time | Only needs to be right once |
-| Works within constraints | No rules, no ethics |
-| Limited budget | Can be well-funded (or automated) |
-| Must balance usability | Doesn't care about UX |
+| Works within constraints | Operates outside rules and ethics |
+| Limited budget and headcount | Can be well-funded or fully automated |
+| Must balance usability | Does not care about user experience |
 
-The attacker chooses:
-- **WHEN** to attack (wait for weekends, holidays)
-- **WHERE** to attack (weakest point)
-- **HOW** to attack (known or novel technique)
+The table above is not an argument for hopelessness. It is an argument for prioritization. You cannot harden everything equally, so you must identify what adversaries want, how they typically get it, and where your controls actually break their path — not where they merely appear to exist on a dashboard.
 
-The defender must be ready always, everywhere, for everything.
+### 1.2 The Economics of Attacker Asymmetry
 
-### 1.2 The Attack Surface
+Think of security investment as buying time and visibility, not guaranteed invulnerability. Each control should increase the cost, skill, or noise required for an adversary to reach a high-value asset. A well-configured firewall does not make you unhackable; it forces the attacker to find another path, ideally one you have also instrumented. MFA does not eliminate phishing; it removes password-only compromise as a viable mass-scale technique for many threat actors.
 
-Your **attack surface** is everything an attacker could potentially target:
+Automated attack infrastructure changed the math again. A single operator can scan millions of hosts for default credentials, vulnerable Struts endpoints, or exposed S3 buckets without manual effort per target. A misconfiguration that might once have survived for days on the public internet can now be found in minutes. That is why "we are too small to be targeted" is dangerously wrong: opportunistic automation does not care about your revenue or headcount.
+
+For platform teams, asymmetry also appears in internal politics. Shipping features has visible revenue impact; tightening default RBAC or adding admission policies has invisible risk reduction until something fails to deploy. The security mindset makes that invisible work legible by tying it to concrete threat scenarios and measurable reduction in blast radius, not vague fear.
+
+### 1.3 The Attack Surface
+
+Your **attack surface** is the sum of every interface, identity, dependency, and human behavior an adversary could interact with to move toward a goal. Surfaces are not only public HTTP endpoints. They include internal admin panels reachable from a compromised laptop, build pipelines that pull container images without digest pinning, support staff with broad impersonation rights, and third-party OAuth integrations that receive long-lived tokens.
+
+The mind map below organizes surfaces into four buckets that threat models commonly use. External surfaces are what traditional perimeter thinking covers. Internal surfaces become critical once any foothold exists — and modern breaches assume that foothold will happen. The human surface remains the most unpredictable because social engineering exploits urgency, authority, and helpfulness rather than buffer overflows. The supply chain surface has grown faster than most teams' review processes as dependencies, SaaS tools, and CI plugins multiply.
 
 ```mermaid
 mindmap
@@ -105,7 +103,9 @@ mindmap
       Dependencies
 ```
 
-> **Pause and predict**: Which part of your attack surface is historically the most unpredictable and easily compromised? 
+Reducing attack surface is not the same as hiding it. Security through obscurity — unpublished admin URLs, security by IP allowlist alone — fails the moment a directory is leaked or a partner network is compromised. Effective reduction removes unnecessary services, narrows permissions, deletes unused integrations, and requires authentication at boundaries that previously trusted network location.
+
+> **Pause and predict**: Which part of your attack surface is historically the most unpredictable and easily compromised?
 
 > **Try This (2 minutes)**
 >
@@ -118,40 +118,44 @@ mindmap
 >
 > Now think: which one would YOU attack if you were malicious?
 
-### 1.3 Attacker Motivation
+### 1.4 Attacker Motivation and Threat Actors
 
-Not all attackers want the same thing:
+Not all attackers want the same outcome, and your defensive investment should reflect who actually cares about your assets. A script kiddie scanning for default passwords poses a different risk than a ransomware group targeting backup deletion, or a nation-state actor seeking long-term persistence in a supply chain. Motivation shapes patience, budget, and acceptable noise level — factors that determine whether they will phish one employee or spend months compromising a software vendor.
 
-| Attacker Type | Motivation | Targets | Sophistication |
-|---------------|------------|---------|----------------|
-| **Script Kiddies** | Fun, bragging rights | Easy targets | Low |
-| **Hacktivists** | Political/social cause | Symbolic targets | Low-Medium |
-| **Criminals** | Money | Valuable data, ransomware | Medium-High |
+| Attacker Type | Motivation | Typical Targets | Sophistication |
+|---------------|------------|-----------------|----------------|
+| **Script kiddies** | Fun, bragging rights | Easy targets | Low |
+| **Hacktivists** | Political or social cause | Symbolic targets | Low–Medium |
+| **Criminals** | Financial gain | Data, ransomware | Medium–High |
 | **Competitors** | Business advantage | Trade secrets | Medium |
-| **Nation-states** | Intelligence, disruption | Critical infrastructure | Very High |
-| **Insiders** | Revenge, money | Whatever they can access | Varies |
+| **Nation-states** | Intelligence, disruption | Critical infrastructure | Very high |
+| **Insiders** | Revenge, financial pressure | Whatever they can access | Varies |
 
-**Threat Modeling Question: "Who would want to attack us, and why?"**
+The question "Who would want to attack us, and why?" is the entry point to threat modeling, not a one-time workshop exercise. A small e-commerce site faces criminals after payment data and opportunistic defacement. A healthcare provider faces both criminals — medical records often sell for more than card numbers on illicit markets — and intelligence collectors. A defense contractor faces patient adversaries willing to invest in supply-chain compromise because the payoff justifies the cost.
 
-- **Small e-commerce site:**
-  - Criminals (credit card data)
-  - Script kiddies (defacement)
-- **Healthcare company:**
-  - Criminals (medical records worth more than credit cards)
-  - Nation-states (intelligence)
-- **Defense contractor:**
-  - Nation-states (classified information)
-  - Competitors (bid information)
+Your answers should change what you log, what you segment, and what you test. If insiders are plausible, broad admin roles and shared break-glass accounts become unacceptable. If supply-chain compromise is plausible, unsigned artifacts and unpinned dependencies become priority fixes rather than backlog items.
 
-Your threat model determines your security investment.
+### 1.5 Threat Modeling: STRIDE and Attack Trees
+
+Threat modeling is the structured practice of identifying what can go wrong before you write the production YAML. You do not need a proprietary tool to start; you need a repeatable method that forces the team to name assets, actors, entry points, and mitigations. Two complementary approaches appear throughout industry guidance: **STRIDE** for categorizing threats at trust boundaries, and **attack trees** for decomposing how an goal could be achieved step by step.
+
+**STRIDE** assigns six threat categories to components and data flows: **S**poofing identity, **T**ampering with data, **R**epudiation (denying actions), **I**nformation disclosure, **D**enial of service, and **E**levation of privilege. When a user submits an order to an API gateway that forwards to a payment service, you ask STRIDE questions at each hop: Can someone spoof the user? Tamper with the order total? Read another tenant's data? Exhaust connection pools? Escalate from read-only to admin?
+
+An **attack tree** starts with an adversary goal at the root — for example, "Exfiltrate customer database" — and branches into sub-goals: gain network access, obtain database credentials, bypass logging, exfiltrate without detection. Leaves become concrete techniques: phish developer, exploit unpatched VPN, steal kubeconfig from laptop, abuse over-privileged service account. Trees make clear that multiple paths may exist and that blocking one branch does not eliminate the goal unless you address others.
+
+For Kubernetes platforms, a lightweight threat-modeling session might enumerate: cluster admin credentials, etcd backups, ingress controllers, admission webhooks, image registries, and CI tokens with deploy rights. You then map STRIDE categories to each and prioritize mitigations by likelihood and impact. The Decision Framework later in this module formalizes that prioritization; the Hands-On Exercise walks a simplified version for a web application.
 
 ---
 
 ## Part 2: Security Principles
 
+The principles below are durable because they describe constraints of distributed systems and human organizations, not vendor features. Tools change; least privilege and fail-secure defaults remain relevant across bare metal, VMs, and Kubernetes 1.35 clusters. Read each principle as a design test you apply during architecture reviews, not as a slogan for slide decks.
+
 ### 2.1 Principle of Least Privilege
 
-Grant only the minimum permissions necessary to perform a function.
+Least privilege means every identity — human, service account, CI job, batch processor — receives only the permissions required for its current function, for the minimum time required. The principle fights the natural tendency toward convenience: shared admin roles, wildcard IAM policies, and cluster-admin bindings that "we will tighten later."
+
+When a web application runs as root inside a container and connects to a database with admin credentials, compromise of any layer becomes total compromise. When the same application runs as a non-root user with read access to product tables and insert access only to order tables, an exploited dependency might leak catalog data but cannot drop schemas or read unrelated tenants. Blast radius shrinks even when prevention fails.
 
 ```mermaid
 graph TD
@@ -166,9 +170,13 @@ graph TD
     end
 ```
 
+In Kubernetes, least privilege appears in RBAC RoleBindings scoped to namespaces, Pod Security Standards that forbid privileged containers, and projected service account tokens with audience and lifetime limits. The platform team's job is to make the secure path the default path: narrow Roles generated from templates, guardrails that reject cluster-admin for application teams, and break-glass access that is time-bound and logged.
+
+Least privilege also applies to humans and automation equally. A CI pipeline that deploys to production should not reuse the same cloud role that can read every secret in the estate; a database migration job needs DDL rights for minutes, not permanent admin. Time-bound elevation — just-in-time access with approval and automatic expiry — converts standing privilege into an exception that leaves an audit trail. When reviewing RBAC manifests, ask whether each verb and resource is necessary for the workload's actual behavior, not whether it is convenient for the first sprint demo.
+
 ### 2.2 Defense in Depth
 
-Never rely on a single security control. Layer defenses.
+Defense in depth rejects the fantasy of a perfect outer wall. Firewalls, WAFs, authentication, input validation, encryption, and audit logging each address different failure modes. When one layer fails — misconfigured rule, stolen session token, zero-day in a dependency — independent layers still impede the attacker. Independence matters: if every layer fails together because they share one admin password or one flat network, you do not have depth; you have duplicates.
 
 ```mermaid
 graph TD
@@ -187,11 +195,13 @@ graph TD
     end
 ```
 
+Module 4.2 explores defense in depth in implementation detail. At the mindset level, the lesson is to ask, for each critical asset, "What still protects this if the previous control fails?" If the honest answer is "nothing," you have identified your next engineering priority regardless of audit status.
+
 ### 2.3 Zero Trust
 
-Never trust, always verify. Assume the network is compromised.
+Zero trust does not mean "trust nothing and block everyone." It means **never trust, always verify** — identity and authorization decisions happen per request, per connection, per API call, without assuming that network location implies integrity. The traditional perimeter model treated internal IP ranges as safe; attackers who phish a VPN user or compromise a laptop inherit that trust and move laterally with minimal friction.
 
-> **Pause and predict**: If you adopt a Zero Trust model, how does the role of your traditional perimeter firewall change?
+> **Pause and predict**: If you adopt a zero trust model, how does the role of your traditional perimeter firewall change?
 
 ```mermaid
 graph LR
@@ -209,16 +219,18 @@ graph LR
     end
 ```
 
+NIST SP 800-207 frames zero trust around policy decision points, continuous verification, and encrypted communication regardless of network path. For platform engineers, that translates to mutual TLS between services, identity-aware proxies, short-lived credentials, and network policies that default deny even inside the cluster. The perimeter firewall still filters obvious noise, but it is no longer the primary authorization mechanism.
+
 ### 2.4 Fail Secure
 
-When something fails, fail to a secure state, not an open one.
+Fail secure means that when a control errors, times out, or becomes unavailable, the system defaults to the safer state — usually deny — rather than the convenient state. Fail open designs prioritize uptime metrics over confidentiality and integrity; attackers learn to trigger dependency failures because those failures open doors.
 
 | Fail Open (Dangerous) | Fail Secure (Correct) |
 | :--- | :--- |
-| **Auth service down:** Allow all requests (so users aren't blocked).<br/>*Result:* Attacker can bypass authentication. | **Auth service down:** Deny all requests.<br/>*Result:* Users inconvenienced, but system secure. |
-| **Validation error:** Skip validation (so it doesn't crash).<br/>*Result:* Malicious input gets through. | **Validation error:** Reject the request.<br/>*Result:* Legitimate requests might fail, but attacks blocked. |
+| **Auth service down:** Allow all requests so users are not blocked.<br/>*Result:* Authentication bypass. | **Auth service down:** Deny requests until service recovers.<br/>*Result:* Outage, but no impersonation. |
+| **Validation error:** Skip validation to avoid crashing.<br/>*Result:* Malicious input accepted. | **Validation error:** Reject the request.<br/>*Result:* Some legitimate traffic fails; attacks blocked. |
 
-The secure default is always to deny.
+The secure default is deny. Product and security leaders must align on that tradeoff explicitly, because fail secure causes visible incidents during partial outages while fail open causes invisible compromise. Monitoring should alert when security dependencies degrade so operators know they are in a heightened-risk state rather than accidentally operating open.
 
 > **Try This (2 minutes)**
 >
@@ -231,7 +243,7 @@ The secure default is always to deny.
 > | Rate limiter errors | Allow requests | Block requests |
 > | Certificate validation fails | Allow connection | Reject connection |
 >
-> (All should be "Fail Secure")
+> (All should be Fail Secure)
 
 ---
 
@@ -239,28 +251,15 @@ The secure default is always to deny.
 
 ### 3.1 What is Security Theater?
 
-**Security theater** is measures that provide the feeling of security without actually improving it.
+**Security theater** is activity that produces the feeling or appearance of safety without measurably reducing risk. It thrives where compliance metrics replace outcome metrics: password rotation policies that encourage predictable patterns, annual penetration tests that never retest findings, or firewall purchases that never receive rule hygiene. Theater is seductive because it is easier to demonstrate than real improvement — a policy document ships faster than an architecture change.
 
-> **Stop and think**: Can you recall a security policy at a current or past job that felt more like compliance theater than actual risk reduction?
+Consider password rotation every thirty days with complexity rules. Users respond rationally to annoyance: they choose `Spring2026!`, increment a digit, or write passwords on sticky notes. Auditors see a policy; attackers see guessable patterns. Real security might instead use long passphrases, phishing-resistant MFA, and breach-password detection — controls tied to how credentials actually leak.
 
-- **Passwords**
-  - *Theater:* Requiring password changes every 30 days.
-  - *Result:* Users pick weak passwords with incrementing numbers.
-  - *Real security:* Long passphrases + MFA.
-- **Compliance Checkboxes**
-  - *Theater:* "We passed the audit."
-  - *Result:* Checked boxes, but real vulnerabilities remain.
-  - *Real security:* Continuous security testing.
-- **Network Security**
-  - *Theater:* "We have a firewall."
-  - *Result:* Firewall exists but rules are too permissive.
-  - *Real security:* Properly configured, monitored firewall.
-- **Encryption**
-  - *Theater:* "We encrypt everything."
-  - *Result:* Encryption at rest, but keys stored next to data.
-  - *Real security:* Proper key management, encryption in transit too.
+Theater also appears in network security when a team celebrates "we have a firewall" while exception rules accumulated over years create paths from DMZ web tiers directly to sensitive data stores. The device exists; the configuration does not enforce the intended trust model. Encryption theater stores keys alongside ciphertext. Compliance theater passes an audit while critical vulnerabilities remain open because they were out of scope for the assessor's sample.
 
 ### 3.2 How to Spot Security Theater
+
+Distinguishing theater from effective control requires asking outcome questions: Did this measure stop or detect a realistic attack in testing? Does it address a threat in our model? Can we measure its effect? Theater measures presence — "MFA enabled for 95% of users" — without measuring whether the remaining five percent hold admin rights, or whether MFA can be bypassed via help-desk social engineering.
 
 | Real Security | Security Theater |
 |---------------|------------------|
@@ -270,7 +269,11 @@ The secure default is always to deny.
 | Evolves with threats | Static, set-and-forget |
 | Tested regularly | Assumed to work |
 
+Red teams, game days, and chaos experiments that include security dependencies are antidotes to theater because they produce falsifiable results. If your control cannot survive a structured test, it was never a control — it was décor.
+
 ### 3.3 The Security vs. Usability Trade-off
+
+Every security measure consumes attention, latency, or workflow steps. The art is not maximizing security in isolation but finding points on the spectrum where protection is strong enough for the threat and friction is low enough that users comply without building shadow-IT workarounds. SSO with push MFA sits in a favorable quadrant for many enterprises: high security relative to passwords alone, high usability relative to hardware tokens for every session.
 
 ```mermaid
 quadrantChart
@@ -287,23 +290,17 @@ quadrantChart
     "SSO (Single Sign-On)": [0.85, 0.85]
     "Push Notifications MFA": [0.80, 0.75]
     "Role-based access": [0.75, 0.80]
-    "No passwords": [0.90, 0.15]
+    "No authentication": [0.90, 0.15]
     "Everyone is admin": [0.85, 0.10]
 ```
 
-> **War Story: The $300 Million Firewall Failure**
->
-> **March 2017.** A large financial services company proudly demonstrated their security posture to auditors. The dashboard showed a gleaming enterprise firewall—$2 million in hardware, 24/7 monitoring, intrusion detection enabled.
->
-> Six months later, attackers exfiltrated 140 million customer records over a 76-day period.
->
-> **How did they get past the firewall?** They didn't have to. Post-breach analysis revealed the firewall had 847 "temporary" exception rules accumulated over 8 years. One of those exceptions—added in 2012 for a contractor who left in 2013—created a path from a web server to the customer database.
->
-> The attackers exploited a known vulnerability in a web application. The patch had been available for 2 months. The firewall rules that should have contained the breach were swiss cheese.
->
-> **The Equifax breach cost over $1.4 billion** in settlements, remediation, and lost business. <!-- incident-xref: equifax-2017 --> The firewall dashboard showed green the entire time. For the full Equifax case study, see [Docker Fundamentals](../../../prerequisites/cloud-native-101/module-1.2-docker-fundamentals/).
->
-> Real security isn't about having tools. It's about using them correctly.
+**Evaluate** tradeoffs explicitly when proposing controls: who bears the friction, what risk remains, and what bypass behavior you incentivize. Requiring hardware security keys for all employees including call-center staff may reduce phishing dramatically but increase lockout support load; SMS MFA is easier but vulnerable to SIM swap. Document the decision so future teams understand it was a reasoned balance, not an arbitrary default.
+
+> **Hypothetical scenario:** A large organization invests heavily in perimeter firewalls — multi-million-dollar appliances, twenty-four-hour monitoring, intrusion detection enabled. Dashboards stay green for months. Meanwhile, hundreds of "temporary" firewall exceptions accumulated over many years: contractor access that was never revoked, debug ports opened during an incident and forgotten, rules allowing web-tier hosts to reach database subnets directly.
+
+An attacker exploits a known vulnerability in a public web application — a patch was available but not applied. They never need to "break through" the firewall in a cinematic sense; they walk through an exception rule that was meant to be short-lived. Data exfiltration continues undetected for roughly two months because monitoring focused on blocked connections at the edge, not anomalous queries from an application server that was already allowed to talk to the database. The lesson: real security is configuration hygiene, ownership, and verification — not hardware presence alone.
+
+Separately, the 2017 <!-- incident-xref: equifax-2017 -->Equifax breach illustrates a different failure mode: an unpatched Apache Struts vulnerability ([CVE-2017-5638](https://struts.apache.org/docs/s2-045.html)) in a public-facing application. A patch had been available for roughly two months before exploitation. Attackers remained undetected for approximately seventy-six days and accessed sensitive data affecting roughly 147 million consumers; legal settlements and total organizational costs reached into the hundreds of millions of dollars. The root cause was not firewall rule rot but patch and asset-management breakdown — yet dashboards can stay green while either failure mode proceeds. For the full Equifax case study, see [Docker Fundamentals](../../../prerequisites/cloud-native-101/module-1.2-docker-fundamentals/).
 
 ---
 
@@ -311,23 +308,15 @@ quadrantChart
 
 ### 4.1 The Problem with Trust
 
-Every time you trust something, you create a potential attack vector:
+Trust is the silent expansion of attack surface. Every implicit trust statement — "employees are honest," "vendors are safe," "internal traffic is fine," "this library has always been clean" — is a decision not to verify at a boundary. Some trust is necessary; systems cannot re-authenticate every nanosecond. But unexamined trust becomes the path adversaries prefer because verification is where you would stop them.
 
-- **"We trust our employees"** → Insider threat, compromised credentials
-- **"We trust our vendors"** → Supply chain attacks (SolarWinds)
-- **"We trust our internal network"** → Lateral movement after initial breach
-- **"We trust this library"** → Malicious package, dependency confusion
-- **"We trust input from our mobile app"** → App can be reverse-engineered, requests forged
+Supply chain attacks exploit vendor trust. Lateral movement exploits internal network trust. Dependency confusion exploits package registry trust. Mobile and SPA clients are not trustworthy just because your team wrote the app; attackers reverse engineer clients and replay or forge API calls. Mature teams replace "we trust X" with "we trust X for purpose Y until time T, verified by mechanism Z, revocable by process W."
 
-Trust should be:
-- **Explicit** (documented what you trust and why)
-- **Minimal** (trust as little as possible)
-- **Verified** (check that trust is warranted)
-- **Revocable** (can remove trust quickly)
+Trust should be explicit in architecture documents, minimal in scope, continuously verified where feasible, and revocable without a multi-week change window. When revocation takes longer than attacker dwell time, your trust model is effectively permanent — which is fine for public certificate roots, dangerous for contractor VPN access.
 
 ### 4.2 Trust Boundaries
 
-A **trust boundary** is where data or execution crosses between different trust levels.
+A **trust boundary** is any line where data or execution crosses from one trust level to another: internet to ingress, ingress to service, service to database, cluster to cloud API, CI runner to production deploy. Boundaries are where controls concentrate because everything upstream is assumed potentially hostile.
 
 ```mermaid
 graph LR
@@ -352,23 +341,26 @@ graph LR
     Ext -- "TRUST BOUNDARY<br/>(Validate, Auth, Log)" --> App2
 ```
 
-Every trust boundary needs:
-- Input validation
-- Authentication
-- Authorization
-- Rate limiting
-- Logging
+Every trust boundary should implement a consistent bundle: authenticate callers, authorize actions against policy, validate and normalize input, apply rate limits to slow abuse, and emit structured logs with correlation identifiers for later investigation. Skipping any element at a boundary moves work to incident responders who must reconstruct intent from incomplete telemetry.
+
+In Kubernetes, boundaries appear between namespaces, between cluster and cloud provider APIs, and between Pods and the host via the service mesh or CNI policy. Platform engineers encode boundaries as NetworkPolicies, admission rules (OPA Gatekeeper, Kyverno), and IAM roles for service accounts — illustrative tools, but the principle precedes the vendor.
 
 ### 4.3 Verification Techniques
 
+Verification is how trust earns its keep. Different assets require different mechanisms; there is no single "crypto fix" for organizational security.
+
 | What to Verify | Technique |
 |----------------|-----------|
-| User identity | Authentication (passwords, MFA, certificates) |
-| User permissions | Authorization (RBAC, ABAC, policies) |
-| Data integrity | Checksums, signatures, MACs |
-| Data source | Digital signatures, certificate pinning |
-| Code integrity | Code signing, reproducible builds |
-| Request legitimacy | CSRF tokens, nonces, timestamps |
+| User identity | Passwords, MFA, passkeys, client certificates |
+| User permissions | RBAC, ABAC, policy engines |
+| Data integrity | Checksums, HMACs, digital signatures |
+| Data source | Code signing, certificate pinning, signed SBOMs |
+| Code integrity | Reproducible builds, signed images, admission verification |
+| Request legitimacy | CSRF tokens, nonces, replay-protected timestamps |
+
+Verification must fail closed. If signature checking cannot run because a key service is down, the build should stop rather than ship unsigned artifacts. If authorization middleware throws an exception, the request should be denied and alerted, not allowed "temporarily" while on-call investigates.
+
+Operational verification also means revisiting assumptions on a schedule. Certificates expire, API keys leak, maintainers transfer packages, and employees change roles — trust that was valid last quarter may be stale today. Pair technical verification with process verification: Can you revoke a compromised service account in minutes? Can you prove which version of a dependency ran in production last Tuesday? Without answers, verification is a point-in-time snapshot rather than a living control.
 
 > **Try This (3 minutes)**
 >
@@ -383,6 +375,8 @@ Every trust boundary needs:
 ## Part 5: Building Security In
 
 ### 5.1 Shift Left
+
+**Shift left** means moving security activities earlier in the software lifecycle — when changes are cheap, context is fresh, and rollback is trivial. A threat-model finding during design might cost an afternoon to fix. The same flaw discovered in production during a launch freeze costs weeks, executive attention, and customer trust.
 
 > **Pause and predict**: At what stage of the software development lifecycle do you think a vulnerability is most expensive to remediate?
 
@@ -407,41 +401,129 @@ graph LR
     end
 ```
 
+Shift left is not "make developers do security alone." It is embed specialists, patterns, and automated gates so security expertise scales. Platform teams contribute secure templates, pre-wired CI checks, and policy-as-code defaults so product teams inherit protection without becoming full-time auditors.
+
 ### 5.2 Secure Development Practices
+
+The table below maps practices to lifecycle phases. None replaces the others; SAST without threat modeling finds implementation bugs but misses wrong architecture. Penetration testing without fixing recurring CI findings repeats the same expensive lesson annually.
 
 | Practice | What It Does | When |
 |----------|--------------|------|
-| **Threat modeling** | Identify what could go wrong | Design phase |
-| **Secure coding standards** | Prevent common vulnerabilities | Coding |
-| **Code review** | Human review for security issues | Before merge |
-| **SAST** | Static analysis for vulnerabilities | CI pipeline |
-| **DAST** | Dynamic testing of running app | Staging/Prod |
-| **Dependency scanning** | Check for vulnerable libraries | CI pipeline |
-| **Secret scanning** | Prevent credential leaks | Pre-commit, CI |
-| **Penetration testing** | Find what automation misses | Periodically |
+| **Threat modeling** | Identifies assets, actors, and mitigations | Design |
+| **Secure coding standards** | Prevents common vulnerability classes | Implementation |
+| **Code review** | Catches logic and auth mistakes humans see | Pre-merge |
+| **SAST** | Statically scans source for patterns | CI pipeline |
+| **DAST** | Tests running applications | Staging |
+| **Dependency scanning** | Flags known CVEs in libraries | CI pipeline |
+| **Secret scanning** | Blocks credential commits | Pre-commit, CI |
+| **Penetration testing** | Finds chains automation misses | Periodic |
+
+For cloud-native platforms, extend the list with image scanning, SBOM generation, signed commits, and admission policies that reject privileged Pods or `latest` tags in production namespaces. Each practice should link back to threats in your model; otherwise it becomes theater scanning.
 
 ### 5.3 Security as Culture
+
+Tools and policies fail when culture treats security as an external gate. Good culture asks "what's the threat model?" in design reviews the same way it asks about scalability. It reports suspicious email without shame, treats near-misses as learning opportunities, and rewards reduction of default permissions rather than only feature velocity.
 
 | Bad Culture | Good Culture |
 | :--- | :--- |
 | "Security is the security team's problem" | "Security is everyone's job" |
-| "We'll add security later" | "We design for security" |
+| "We'll add security later" | "We design for security up front" |
 | "That's too paranoid" | "What's the threat model?" |
-| "It's just internal, doesn't matter" | "All data deserves protection" |
-| "Nobody would do that" | "Assume attackers are smart and motivated" |
-| "We've never been hacked" | "We haven't detected a hack" |
+| "It's internal, doesn't matter" | "All data deserves appropriate protection" |
+| "Nobody would do that" | "Assume motivated, capable adversaries" |
+| "We've never been hacked" | "We haven't detected a hack yet" |
+
+Culture change is slow but decisive. A single heroic security engineer cannot review every pull request in a growing organization; habits, templates, and automated guardrails multiply their influence. Leadership behavior matters: if executives bypass MFA, engineers learn that rules are optional.
+
+---
+
+## Patterns & Anti-Patterns
+
+### Patterns That Build Real Security
+
+**Threat-model before major architecture changes.** Schedule a ninety-minute session when adding a new data store, external integration, or multi-tenant boundary. Document assets, actors, STRIDE categories, and mitigations in the same ticket as the design doc. Revisit when the design changes materially — threat models are living artifacts, not launch gate paperwork.
+
+**Assume breach in monitoring and response.** Design logging so that compromise of one credential does not erase evidence. Forward security-relevant logs to tamper-evident storage. Practice incident runbooks that do not assume the attacker is still outside the firewall. Assume breach turns abstract zero trust into concrete detection queries.
+
+**Make secure defaults the lazy path.** New repositories start with branch protection, secret scanning, and CI security jobs enabled. New namespaces inherit deny-all NetworkPolicies with documented exceptions. New service accounts receive generated Roles rather than cluster-admin because someone was in a hurry.
+
+**Instrument trust boundaries before debating exotic controls.** You cannot verify what you cannot see. Ensure every boundary in Part 4 emits authentication failures, authorization denials, validation errors, and latency anomalies with enough context to reconstruct an attack path during an incident. Many breaches persisted for weeks because logs showed green aggregate error rates while specific routes leaked data silently.
+
+**Measure outcomes, not checkbox counts.** Track mean time to detect credential abuse, percentage of services with mTLS, time to patch critical CVEs on internet-facing assets, and repeat findings from pen tests. Metrics tied to threats reveal theater quickly.
+
+### Anti-Patterns to Avoid
+
+| Anti-Pattern | Why It Fails | Better Approach |
+|--------------|--------------|-----------------|
+| **Perimeter-only thinking** | One foothold yields full internal access | Zero trust, segmentation, per-service auth |
+| **Security as final gate** | Architectural flaws are expensive to fix | Shift left: threat model and review in design |
+| **Compliance equals secure** | Audits sample; attackers do not | Map controls to threats; test continuously |
+| **Shared break-glass admin** | Undifferentiated access hides insider and APT activity | Time-bound, attributed elevation with logging |
+| **Unpinned dependencies in CI** | Supply-chain compromise auto-deploys | Pin digests; verify signatures; manual promotion |
+| **Fail open on dependency outage** | Attackers trigger failures to bypass controls | Fail secure with graceful degradation plans |
+
+---
+
+## Decision Framework: Threat Modeling and Risk Prioritization
+
+Use this framework when leadership asks "What should we fix first?" or when a design review stalls on vague security concerns. The goal is repeatable prioritization tied to your threat model, not fear-driven shopping lists.
+
+```mermaid
+flowchart TD
+    Start["Start: New feature or system"] --> Assets["List assets & trust boundaries"]
+    Assets --> Actors["Identify threat actors & goals"]
+    Actors --> STRIDE["Apply STRIDE / attack trees"]
+    STRIDE --> Likelihood["Estimate likelihood (realistic paths)"]
+    Likelihood --> Impact["Estimate impact (data, availability, trust)"]
+    Impact --> Matrix["Plot on risk matrix"]
+    Matrix --> High{"High likelihood\nOR high impact?"}
+    High -->|Yes| Mitigate["Design mitigations; assign owners"]
+    High -->|No| Accept["Document accepted risk; monitor"]
+    Mitigate --> Verify["Verify: test, red team, or simulate"]
+    Verify --> Done["Ship with telemetry & runbooks"]
+    Accept --> Done
+```
+
+| Risk quadrant | Example scenario | Typical response |
+|---------------|------------------|------------------|
+| **High impact, high likelihood** | Public admin API without auth on customer PII | Block release; fix immediately |
+| **High impact, low likelihood** | Nation-state supply-chain compromise | Defense in depth, signing, monitoring, tabletop exercises |
+| **Low impact, high likelihood** | Automated scraping of non-sensitive catalog | Rate limits, bot detection, cost controls |
+| **Low impact, low likelihood** | Defacement of static marketing site | Basic hardening; accept with monitoring |
+
+When **evaluating security tradeoffs**, score each proposed control against the same matrix: does it materially move a realistic scenario down in likelihood or impact, and what usability or cost does it impose? A control that only addresses a low-likelihood Hollywood plot while ignoring unpatched internet-facing services is misprioritized spend. Revisit the matrix quarterly or after major incidents — threat landscapes and your architecture both change.
+
+For Kubernetes platform teams, a practical first pass might rank: cluster-admin bindings in application namespaces, anonymous RBAC, public exposure of kube-apiserver, unscoped cloud credentials in Pods, and missing audit log retention — before investing in exotic deception technology. The framework does not dictate answers; it forces explicit comparison so **design** decisions for threat models and **evaluate** decisions for tradeoffs happen in the open.
+
+---
+
+## Part 6: From Mindset to Daily Practice
+
+The security mindset becomes valuable when it changes Tuesday afternoon decisions, not only when it inspires a quarterly slide deck. During design reviews, ask one attacker-minded question before approving: "If I had credentialed access to this component, what is the fastest path to customer data or production deploy rights?" That question surfaces forgotten admin endpoints, shared secrets in environment variables, and CI jobs with cluster-admin more reliably than generic "is this secure?" prompts.
+
+During code review, treat authentication and authorization changes as high-risk diffs even when they look small. A single middleware ordering bug can skip checks for an entire route tree. A "temporary" bypass for local development that merges to main is a permanent hole. Reviewers who think like attackers look for implicit trust in new integrations: Does this webhook verify signatures? Does this cache key include tenant identifier? Does this debug flag compile out in production builds?
+
+During incidents, resist the urge to treat the initial entry vector as the whole story. Real-world breaches analyzed in industry reports — supply-chain compromise, credential theft, lateral movement after VPN access — almost always involve chained failures. Your post-incident review should ask which layer was supposed to stop stage two and why it did not, not only how stage one happened. That habit feeds threat models with evidence instead of imagination.
+
+Platform engineers can institutionalize the mindset with lightweight rituals: a five-minute STRIDE pass on every RFC that touches identity or data stores; a monthly review of firewall or security-group rules for stale exceptions; pairing with application teams on one threat-modeling session per sprint until the method spreads. None of this requires buying a new product. It requires treating security thinking as part of engineering craftsmanship, the same way you treat idempotency, observability, and rollback design.
+
+When you **analyze** breaches in the news, read for defensive lessons rather than schadenfreude. Equifax emphasized patch SLAs and asset inventory for internet-facing middleware. SolarWinds emphasized signed builds and vendor trust boundaries. Ransomware cases emphasize backup integrity and segmentation. Keep a living "lessons extracted" note linked from your team wiki so new hires inherit institutional memory without repeating the same post-mortem discoveries.
+
+Finally, connect mindset to metrics leadership understands. Executives rarely fund "more security culture"; they fund reduced fraud losses, faster mean time to detect credential abuse, or fewer emergency patches during launches. Translate attacker-minded improvements into those terms. When you **evaluate** a tradeoff between stricter deploy gates and developer velocity, quantify the cost of an undetected production compromise — recovery time, customer notification, regulatory exposure — so the conversation compares real balances rather than stereotypes about security slowing innovation.
+
+Teaching the security mindset to new engineers works best through guided practice, not policy lectures alone. Pair them on a threat-modeling exercise during their first month, review one real incident write-up together, and assign a small hardening task with measurable before-and-after risk reduction. Habits formed early persist when they later own production services without daily security oversight. That investment pays off the first time they catch an implicit trust assumption before it ships.
 
 ---
 
 ## Did You Know?
 
-- **The term "hacker"** originally meant someone who explored systems creatively. The malicious meaning came later. "Cracker" was the original term for malicious hackers, but media conflation made "hacker" the common term.
+- **The term "hacker"** originally described skilled, creative exploration of systems at MIT and elsewhere. Malicious connotations grew with media coverage in the 1980s; some communities still distinguish "hackers" (builders) from "crackers" (breakers), though popular usage collapsed the terms.
 
-- **The first computer virus** (Creeper, 1971) wasn't malicious—it just displayed "I'm the creeper, catch me if you can." The first antivirus (Reaper) was written to delete it.
+- **The first computer worm (Creeper, 1971)** was an experimental self-replicating program on ARPANET that displayed the message "I'm the creeper, catch me if you can." The Reaper program followed to remove it — an early precursor to antivirus concepts, described in historical accounts of ARPANET research.
 
-- **Social engineering** accounts for over 90% of successful attacks. Technical defenses matter less than training humans to recognize manipulation.
+- **The human element** — social engineering, errors, and misuse — features in roughly two-thirds of breaches per the [Verizon Data Breach Investigations Report](https://www.verizon.com/business/resources/reports/dbir/). Attacks far more often combine stolen credentials and phishing than rely on exotic technical exploits.
 
-- **The "Morris Worm" of 1988** was the first major internet worm and was written by a Cornell graduate student. It accidentally replicated far more aggressively than intended, crashing about 10% of the internet (roughly 6,000 machines). Robert Morris became the first person convicted under the Computer Fraud and Abuse Act—and later became a tenured MIT professor.
+- **The Morris Worm (1988)**, written by Robert Morris, was among the first worms to spread broadly across the early internet, infecting roughly six thousand machines — estimated at about ten percent of connected systems at the time. Morris became the first person convicted under the U.S. Computer Fraud and Abuse Act; he later became a professor at MIT.
 
 ---
 
@@ -449,12 +531,14 @@ graph LR
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| Security as afterthought | Expensive to retrofit | Shift left, threat model early |
-| Trusting the network | Lateral movement after breach | Zero trust architecture |
-| Assuming perimeter is enough | Insiders, supply chain | Defense in depth |
-| Security through obscurity | Attackers will figure it out | Assume your code is public |
-| Ignoring usability | Users bypass security | Make security easy |
-| One-time security review | Security degrades over time | Continuous security |
+| Security as afterthought | Retrofit costs multiply | Shift left; threat model during design |
+| Trusting the network | Enables lateral movement | Zero trust; authenticate every hop |
+| Assuming perimeter is enough | Insiders and supply chain ignored | Defense in depth across layers |
+| Security through obscurity | Attackers discover hidden paths | Assume attackers know your architecture |
+| Ignoring usability | Users bypass controls | Design friction-aware, phishing-resistant auth |
+| One-time security review | Controls rot as systems evolve | Continuous testing and rule hygiene |
+| Measuring presence not outcomes | Theater passes audits | Tie metrics to threats and detection |
+| Skipping threat modeling | Fixes wrong priorities | STRIDE and attack trees before build |
 
 ---
 
@@ -464,109 +548,104 @@ graph LR
    <details>
    <summary>Answer</summary>
 
-   This scenario perfectly illustrates the "Attacker's Advantage" and the asymmetry of security. Defenders must secure every single surface, endpoint, and configuration perfectly, 100% of the time, while operating under budget and usability constraints. Attackers, conversely, only need to find one single mistake, misconfiguration, or forgotten asset to succeed. Furthermore, they can choose the time of their attack, such as a holiday weekend when defensive teams are understaffed and response times are slower.
+   This scenario illustrates the attacker's advantage and the asymmetry of security. Defenders must secure every surface, endpoint, and configuration continuously, while attackers need only one mistake — here, a forgotten API — at a convenient time such as a holiday weekend when response may be slower. Applying attacker-mindset thinking during architecture reviews would have included asset inventory and decommissioning of prototype services as part of attack surface reduction.
    </details>
 
-2. **Scenario:** A developer writes a script to back up a specific application database to cloud storage. To ensure the script doesn't fail due to permissions, the developer assigns the script a service account with broad "Database Administrator" and "Storage Administrator" roles. A month later, an attacker exploits a vulnerability in the script's logging library and deletes the entire production database cluster. Which security principle was violated, and how did it contribute to the outcome?
+2. **Scenario:** A developer writes a script to back up a specific application database to cloud storage. To ensure the script does not fail due to permissions, the developer assigns the script a service account with broad Database Administrator and Storage Administrator roles. A month later, an attacker exploits a vulnerability in the script's logging library and deletes the entire production database cluster. Which security principle was violated, and how did it contribute to the outcome?
    <details>
    <summary>Answer</summary>
 
-   This scenario demonstrates a severe violation of the Principle of Least Privilege. By granting the script sweeping administrative rights instead of narrowly scoping them to just database reads and bucket writes, the developer unnecessarily expanded the blast radius of a potential compromise. When the logging library vulnerability was exploited, the attacker inherited those administrative privileges, allowing them to destroy the entire cluster rather than just accessing the specific database. If least privilege had been applied, the attacker would have been confined to only the permissions required for the backup task, preventing the widespread destruction.
+   This violates the principle of least privilege. Sweeping administrative rights expanded blast radius so a compromise of a non-critical logging dependency became catastrophic cluster destruction. Scoped permissions limited to read on the target database and write on a specific backup bucket would have confined the attacker even after the library flaw was exploited.
    </details>
 
-3. **Scenario:** A company mandates that all employees must change their domain passwords every 30 days and include at least one uppercase letter, one number, and one special character. During a penetration test, the red team easily compromises several accounts by guessing passwords like "Spring2026!", "Summer2026!", and finding passwords written on sticky notes under keyboards. What concept does this corporate policy represent, and why did it fail?
+3. **Scenario:** A company mandates that all employees must change their domain passwords every thirty days with complex composition rules. During a penetration test, the red team compromises accounts using seasonal passwords like "Spring2026!" and sticky notes under keyboards. What concept does this policy represent, and why did it fail?
    <details>
    <summary>Answer</summary>
 
-   This password rotation policy is a classic example of "Security Theater." It gives management the illusion that they are enforcing strict security measures, but it fundamentally ignores human behavior and fails to reduce actual risk. When forced to constantly change complex passwords, humans resort to predictable patterns (like seasonal words with the current year) or write them down, which actively weakens the system's defenses. Genuine security would focus on outcomes rather than compliance checkboxes, perhaps by implementing long passphrases and enforcing multi-factor authentication (MFA) instead of arbitrary rotation schedules.
+   This is security theater: it appears rigorous but ignores human behavior and measurable risk reduction. Predictable rotation patterns and written-down passwords weaken defenses compared to long passphrases, breach-password checks, and phishing-resistant MFA. Real security focuses on outcomes — credential theft resistance — not checkbox compliance.
    </details>
 
-4. **Scenario:** Your company is preparing for a massive product launch next week. The security team performs a final penetration test today and discovers a critical architectural flaw where the authentication microservice passes unencrypted session tokens in URLs. Fixing this will require rewriting the authentication flow, delaying the launch by three weeks and costing the company thousands of dollars in wasted marketing. Which secure development practice could have prevented this costly delay, and why?
+4. **Scenario:** Your company prepares for a major product launch. A final penetration test discovers that the authentication microservice passes session tokens in URL query parameters. Fixing this requires rewriting the auth flow, delaying launch by three weeks. Which secure development practice would have prevented this costly delay, and why?
    <details>
    <summary>Answer</summary>
 
-   This situation highlights the critical need for the "Shift Left" approach in the software development lifecycle. By waiting until the final penetration test to review security, the organization treated security as a final gate rather than an ongoing process. If the team had performed threat modeling during the initial design phase, or implemented automated security testing during code commits, this fundamental architectural flaw would have been identified and fixed when it was just an idea. Shifting security left ensures that vulnerabilities are caught early when they are drastically cheaper and faster to remediate.
+   Shift-left threat modeling and secure design review during architecture would have flagged passing session tokens in URLs before implementation. Security discovered at the pen-test gate is expensive because dependencies on the flawed design are entrenched. Early design threat models and code review catch such flaws when they are still diagram changes rather than production rewrites.
    </details>
 
-5. **Scenario:** An attacker successfully bypasses your external firewall by exploiting a zero-day vulnerability in your VPN appliance. Once inside the internal network, they discover that all internal microservices communicate over unencrypted HTTP and require no authentication to access each other's APIs. They quickly dump the entire customer database. What architectural principle is missing here, and how would it have mitigated the breach?
+5. **Scenario:** An attacker exploits a zero-day in your VPN appliance. Inside the network, they find microservices communicating over unencrypted HTTP with no mutual authentication and dump a customer database. Which architectural principles were missing, and how would they have mitigated the breach?
    <details>
    <summary>Answer</summary>
 
-   The network lacks both "Defense in Depth" and a "Zero Trust" architecture. The organization relied entirely on a hard exterior perimeter, operating under the dangerous assumption that anything inside the network was inherently trustworthy. If Defense in Depth had been implemented, the failure of the external firewall would have been mitigated by additional, independent security layers protecting the interior. A Zero Trust approach would have required every microservice to mutually authenticate and authorize every request, blocking the attacker's lateral movement and preventing them from accessing the database even after breaching the perimeter.
+   The environment lacked defense in depth and zero trust. Relying on a single perimeter assumed internal traffic was safe, so VPN compromise became total internal access. Independent layers — mTLS, service-level authorization, encryption, and network segmentation — would have blocked lateral movement to the database even after VPN breach, containing blast radius.
    </details>
 
-6. **Scenario:** Your application uses an external, third-party fraud detection API to evaluate every new user registration. During a major promotional event, the third-party API goes down due to traffic overload. The development team's fallback logic catches the timeout exception and automatically approves the user registrations so that legitimate customers aren't blocked from the promotion. A botnet immediately registers 10,000 fake accounts. What design principle was violated, and what should have happened instead?
+6. **Scenario:** Your application calls a third-party fraud API on every registration. When the API times out during a promotion, fallback logic auto-approves registrations so sales are not lost. A botnet registers thousands of fake accounts. Which principle was violated, and what should have happened?
    <details>
    <summary>Answer</summary>
 
-   The application violated the principle of "Fail Secure" by choosing to fail open during an outage. When the security control became unavailable, the system defaulted to a permissive state to prioritize usability and business metrics over security. The correct approach would have been to deny the registrations or place them in a manual review queue until the service was restored. While failing securely would have inconvenienced some legitimate users during the outage, it is the only way to ensure that the system's security posture is not compromised by the failure of a dependent component.
+   The system violated fail secure by failing open when the fraud service was unavailable. Convenience during outage prioritized revenue over integrity. Correct behavior denies or queues registrations for manual review until verification returns, accepting some lost conversions rather than unbounded fraudulent accounts.
    </details>
 
-7. **Scenario:** Your startup uses a popular open-source image processing library in your main web application. One day, the original maintainer of the library hands over control to a new developer, who quietly releases a patch containing a malicious script. Your CI/CD pipeline automatically pulls the latest version of the library, builds the container, and deploys it to production. The malicious script begins intercepting user sessions. What security concept does this highlight, and how could it have been mitigated?
+7. **Scenario:** Your CI/CD pipeline automatically deploys when a popular open-source library releases a new version. A maintainer transfer leads to a malicious patch that exfiltrates session cookies in production. What concept does this highlight, and how could it have been mitigated?
    <details>
    <summary>Answer</summary>
 
-   This scenario highlights the dangers of implicit trust and the "Supply Chain as an Attack Surface." The organization assumed that because a library was historically safe, all future updates would also be safe, allowing unverified code to be automatically deployed into a trusted environment. To mitigate this risk, the team should have employed strict version pinning to prevent automatic updates without deliberate human review. Furthermore, implementing zero trust principles internally and utilizing automated dependency scanning tools in the CI/CD pipeline could have identified the anomalous behavior before the code ever reached production.
+   This highlights supply-chain trust failure and implicit trust in package updates — a real-world breach pattern seen in incidents including supply-chain compromises such as the SolarWinds case referenced elsewhere in the curriculum. Mitigations include version pinning, manual promotion of dependencies, signature verification, CI secret scanning, and analyzing real-world supply-chain breaches to require human review before production deploy of changed artifacts.
+   </details>
+
+8. **Scenario:** Your platform team debates requiring hardware security keys for all engineers versus allowing SMS-based MFA for convenience. Developers argue keys are easy to lose during travel; security argues SMS is phishable. How should you evaluate this tradeoff using the security mindset?
+   <details>
+   <summary>Answer</summary>
+
+   Evaluate security tradeoffs by mapping each option to threat actors, likelihood, and impact in your threat model. Hardware keys materially reduce phishing and credential replay against engineer accounts that can merge to production — high impact if compromised. SMS MFA improves on passwords alone but remains vulnerable to SIM swap. Document accepted residual risk if you choose SMS for some roles, enforce keys for production deploy rights, and measure outcomes such as phishing test failure rates rather than assuming either control is "secure enough" without context.
    </details>
 
 ---
 
 ## Hands-On Exercise
 
-**Task**: Perform a mini threat model for a web application.
+In this exercise you will **design** a mini threat model for a representative e-commerce web application, following the same asset-to-control sequence used in professional design reviews. Work through the four parts in order, filling each table with concrete names from your own experience where possible rather than abstract placeholders. Budget roughly thirty minutes working alone, or forty-five if you debate assumptions with a colleague who owns a different layer of the stack.
 
-**Scenario**: You're building a simple e-commerce site with:
-- User registration and login
-- Product catalog
-- Shopping cart
-- Checkout with credit card processing
-
-**Part 1: Identify Assets (5 minutes)**
-
-What data/capabilities does an attacker want?
+The scenario assumes you are building a site with user registration and login, a browsable product catalog, a session-backed shopping cart, and checkout that forwards payment card data to a compliant processor instead of storing primary account numbers on your servers. As you complete each worksheet below, ask which trust boundaries an attacker would cross to reach high-value assets and which STRIDE categories apply at each hop — that discipline connects the exercise directly to the threat-modeling concepts in Part 1.
 
 | Asset | Value to Attacker |
 |-------|-------------------|
-| User credentials | |
-| Credit card numbers | |
-| Customer PII | |
-| | |
-| | |
+| User credentials | Account takeover, reuse |
+| Credit card numbers | Financial fraud |
+| Customer PII | Identity theft, resale |
+| Session tokens | Impersonation |
+| Admin access | Full data exfiltration |
 
-**Part 2: Identify Threat Actors (5 minutes)**
-
-Who might attack this system?
+The asset table above lists starting points; add rows if your variant of the scenario introduces wallets, gift cards, or marketplace seller accounts. Next, identify who would pursue those assets and with what skill — criminal groups, opportunistic bots, and insiders see different ROI from the same vulnerability.
 
 | Threat Actor | Motivation | Capability |
 |--------------|------------|------------|
-| | | |
-| | | |
-| | | |
+| Criminal | Payment data, PII | Medium–High |
+| Opportunistic bot | Automated fraud | Medium |
+| Insider support staff | Curiosity, profit | Medium |
 
-**Part 3: Identify Attack Vectors (10 minutes)**
-
-How could each asset be compromised?
+With actors and assets named, map realistic attack vectors and rate likelihood versus impact honestly — a high-impact, high-likelihood cell is your priority mitigation queue. Do not assume every attack starts with a zero-day; stolen credentials and missing authorization checks appear far more often in breach data.
 
 | Asset | Attack Vector | Likelihood | Impact |
 |-------|---------------|------------|--------|
 | User credentials | Phishing | High | Medium |
 | User credentials | SQL injection | Medium | High |
-| Credit cards | | | |
-| | | | |
-| | | | |
+| Credit cards | Skimming compromised checkout | Medium | High |
+| Session tokens | XSS theft | Medium | High |
+| Admin access | Stolen MFA-less account | Low | High |
 
-**Part 4: Identify Controls (10 minutes)**
-
-What controls would mitigate each attack?
+Finally, pair each vector with preventive or detective controls you would actually ship in the next quarter, not hypothetical perfect defenses. Prefer controls that fail secure and reduce blast radius when they fail, consistent with the principles in Part 2.
 
 | Attack Vector | Control | Type |
 |---------------|---------|------|
-| Phishing | MFA | Preventive |
-| SQL injection | Parameterized queries | Preventive |
-| | | |
-| | | |
+| Phishing | MFA, security awareness | Preventive |
+| SQL injection | Parameterized queries, ORM | Preventive |
+| XSS | Content Security Policy, encoding | Preventive |
+| Skimming | PCI-compliant processor, no local PAN storage | Preventive |
+| Admin access | Least privilege, separate admin auth | Preventive |
 
-**Success Criteria**:
+When you finish, compare your control list against the Decision Framework matrix: did you prioritize high-likelihood paths to customer data first, or did you start with exotic threats? Revise once if your ordering disagrees with your own likelihood ratings.
+
 - [ ] At least 4 assets identified
 - [ ] At least 3 threat actors with motivations
 - [ ] At least 5 attack vectors with likelihood/impact
@@ -574,31 +653,41 @@ What controls would mitigate each attack?
 
 ---
 
-## Further Reading
-
-- **"The Web Application Hacker's Handbook"** - Dafydd Stuttard. Comprehensive guide to web security from an attacker's perspective.
-
-- **"Threat Modeling: Designing for Security"** - Adam Shostack. The definitive guide to threat modeling.
-
-- **OWASP Top 10** - owasp.org/Top10. The most critical web application security risks, updated regularly.
-
----
-
 ## Key Takeaways Checklist
 
-Before moving on, verify you can answer these:
+Use the checklist below as a self-assessment before continuing to Module 4.2. If any item feels uncertain, revisit the corresponding part of this module and note one concrete action you will take on a current project — for example, scheduling a threat-model session on a service you shipped last month or reviewing one security-group rule set for stale exceptions.
 
 - [ ] Can you explain why attackers have a structural advantage over defenders?
 - [ ] Can you define and identify your system's attack surface (external, internal, human, supply chain)?
 - [ ] Do you understand the principle of least privilege and why it limits blast radius?
 - [ ] Can you distinguish security theater from real security?
 - [ ] Do you understand trust boundaries and what controls each boundary needs?
-- [ ] Can you explain "shift left" and why early security is cheaper than late security?
-- [ ] Do you understand why complex password policies often backfire?
+- [ ] Can you explain shift left and why early security is cheaper than late security?
+- [ ] Can you apply STRIDE or attack trees at a basic level in a design review?
 - [ ] Can you explain why supply chain attacks (like SolarWinds) are so dangerous?
 
 ---
 
 ## Next Module
 
-[Module 4.2: Defense in Depth](../module-4.2-defense-in-depth/) - Layered security controls and how to implement them effectively.
+Continue to [Module 4.2: Defense in Depth](../module-4.2-defense-in-depth/), where you will learn how to implement layered security controls so that when one layer fails — as the mindset assumes it eventually will — independent layers still protect critical assets and contain blast radius across network, identity, application, and data planes.
+
+## Sources
+
+- [OWASP Top Ten](https://owasp.org/www-project-top-ten/) — Canonical overview of the most critical web application security risks, updated on a multi-year cycle.
+- [OWASP Threat Modeling](https://owasp.org/www-community/Threat_Modeling) — Community guidance on structured threat identification and mitigation.
+- [OWASP Threat Modeling Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Threat_Modeling_Cheat_Sheet.html) — Practical steps for running threat modeling sessions.
+- [OWASP Application Security Verification Standard (ASVS)](https://owasp.org/www-project-application-security-verification-standard/) — Requirements framework for verifying application security controls.
+- [NIST Cybersecurity Framework (CSF)](https://www.nist.gov/cyberframework) — High-level outcomes for govern, identify, protect, detect, respond, and recover (CSF 2.0).
+- [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/publications/detail/sp/800-207/final) — Authoritative definition of zero trust principles and deployment patterns.
+- [NIST SP 800-53 Revision 5](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final) — Security and privacy control catalog used across federal and enterprise programs.
+- [MITRE ATT&CK](https://attack.mitre.org/) — Knowledge base of adversary tactics and techniques for mapping detections and controls.
+- [CIS Critical Security Controls](https://www.cisecurity.org/controls) — Prioritized defensive actions with implementation guidance.
+- [Verizon Data Breach Investigations Report (DBIR)](https://www.verizon.com/business/resources/reports/dbir/) — Annual analysis of breach patterns including human-element and social engineering prevalence.
+- [Apache Struts S2-045 / CVE-2017-5638 Advisory](https://struts.apache.org/docs/s2-045.html) — Official advisory for the vulnerability exploited in the 2017 Equifax breach.
+- [Building Secure and Reliable Systems (Google SRE)](https://google.github.io/building-secure-and-reliable-systems/) — Free online text on integrating security with reliability engineering.
+- [Kubernetes Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) — Built-in Pod hardening levels (privileged, baseline, restricted) for cluster enforcement.
+- [Schneier: The Process of Security](https://www.schneier.com/essays/archives/2000/04/the_process_of_secur.html) — Essay on why security is a continuous process, not a product.
+- [Microsoft Security Development Lifecycle: Threat Modeling](https://www.microsoft.com/en-us/securityengineering/sdl/threatmodeling) — Classic SDL reference on threat modeling process, diagrams, and mitigation prioritization.
+- [SLSA Supply-chain Levels for Software Artifacts](https://slsa.dev/) — Framework for securing build pipelines against tampering and dependency attacks.
+- [CISA Zero Trust Maturity Model](https://www.cisa.gov/zero-trust-maturity-model) — U.S. government guidance on progressing zero trust capabilities across pillars.

--- a/src/content/docs/platform/foundations/security-principles/module-4.2-defense-in-depth.md
+++ b/src/content/docs/platform/foundations/security-principles/module-4.2-defense-in-depth.md
@@ -6,60 +6,51 @@ sidebar:
 ---
 > **Complexity**: `[MEDIUM]`
 >
-> **Time to Complete**: 30-35 minutes
+> **Time to Complete**: 45-55 minutes
 >
 > **Prerequisites**: [Module 4.1: Security Mindset](../module-4.1-security-mindset/)
 >
 > **Track**: Foundations
 
-### What You'll Be Able to Do
+## When Layers Align
 
-After completing this module, you will be able to:
+**November 2013. The holiday shopping season begins at Target, one of the largest retailers in the United States.** Attackers have already been inside Target's environment for weeks. Public post-incident analyses describe a path that began with stolen credentials from Fazio Mechanical, a third-party HVAC and refrigeration vendor, and then moved from a lower-trust vendor foothold into more sensitive internal systems. The important lesson is not that HVAC software is uniquely dangerous. The lesson is that a small, practical access path became a bridge into a payment-card environment because multiple defensive layers depended on assumptions the attackers were able to reuse.
 
-1. **Design** layered security architectures where each layer provides independent protection and no single bypass compromises the entire system
-2. **Evaluate** whether existing security layers are truly independent or share common failure modes (credentials, network paths, trust boundaries)
-3. **Implement** defense-in-depth strategies across network, application, identity, and data layers for cloud-native environments
-4. **Analyze** breach post-mortems to identify which defensive layers failed and where additional independent controls would have contained the blast radius
+Once inside, the attackers moved laterally toward point-of-sale systems in roughly 1,800 U.S. stores and installed memory-scraping malware that captured payment-card data as cards were swiped. Target later confirmed that approximately 40 million credit and debit card accounts were exposed, and it also disclosed that non-financial personal information for up to 70 million customers was stolen. Senate Commerce staff later summarized multiple missed defensive opportunities: vendor access was not isolated tightly enough, the FireEye intrusion-detection system fired alerts that were not acted on, and warnings about data exfiltration paths were ignored in time to matter.
+
+The financial and leadership consequences were not abstract. Target's 2016 Form 10-K reported $292 million in cumulative breach-related expenses, partially offset by insurance recoveries, and public reporting documented major executive turnover after the incident, including the departure of the CEO and the CIO. Those facts matter because defense in depth is often sold as a tooling pattern, but its real value is organizational resilience. A firewall, an intrusion-detection platform, and network segmentation do not help if the firewall trusts the same credentials, the detector's alerts are ignored, and the segmentation allows a vendor foothold to reach payment systems.
+
+Target had defensive slices of cheese: credentials, network boundaries, monitoring, payment-system specialization, and incident-response procedures. The breach became a canonical defense-in-depth failure because the holes in those slices aligned. Vendor credentials opened the first door, weak isolation allowed movement, alerts did not become action, and sensitive data paths were not contained quickly enough. The rest of this module teaches how to design layers so one failure remains one failure instead of becoming a complete path through the system.
+
+> **Stop and think**: In the Target breach, which controls were present but dependent on the same weak assumptions, and which missing independent control could have broken the attack chain earliest?
 
 ---
 
-**November 2013. The holiday shopping season begins at Target, America's second-largest discount retailer.**
+## What You'll Be Able to Do
 
-Attackers have already been inside Target's network for over two weeks. They entered through a third-party HVAC vendor's compromised credentials, moved laterally through the network, and installed memory-scraping malware on point-of-sale systems across 1,797 stores.
+By the end of this module, you will be able to:
 
-For 19 days, the malware quietly captured credit card data as customers swiped their cards. Target's security team received alerts from their FireEye intrusion detection system. The alerts were ignored.
-
-**By December 15th, attackers had exfiltrated 40 million credit card numbers and 70 million customer records.** Target's stock dropped 46% in the following months. The breach cost over $292 million in direct expenses. The CEO and CIO both resigned.
-
-Target had security tools—firewalls, network segmentation, intrusion detection. But the layers weren't truly independent. Credentials from one system worked in others. Alerts weren't investigated. Network segments could reach each other. Each slice of Swiss cheese had holes, and the holes aligned perfectly.
-
-> **Stop and think**: What layers of security existed at Target, and why didn't they stop the attack? Consider how credentials and network access were managed across different internal boundaries.
-
-This module teaches defense in depth—how to layer security controls so that when one fails (and it will), others still protect the system.
+1. **Design** layered security architectures where each layer provides independent protection and no single bypass compromises the entire system
+2. **Evaluate** whether security controls are truly independent or whether they share failure modes such as credentials, network paths, trust roots, and operational response queues
+3. **Implement** defense-in-depth strategies across network, application, identity, data, and Kubernetes layers without turning the principle into a vendor checklist
+4. **Choose** which layer to add for a given threat by using a decision framework that maps attacker steps to independent control points
+5. **Analyze** breach post-mortems to identify which defensive layers failed and where additional independent controls would have contained the blast radius
 
 ---
 
 ## Why This Module Matters
 
-No security control is perfect. Firewalls get misconfigured. Authentication gets bypassed. Encryption keys get leaked. Any single layer of security will eventually fail.
+No security control is perfect. Firewalls get misconfigured, authentication flows get bypassed, encryption keys get leaked, and alert queues become noisy at exactly the wrong time. If the entire security posture depends on one control behaving perfectly forever, the architecture is making a promise it cannot keep. Defense in depth is the practice of layering multiple controls so a single failure does not become a complete compromise. The phrase is common, but the disciplined version is stricter than "add more tools."
 
-**Defense in depth** is the practice of layering multiple independent security controls so that when one fails, others still protect the system. It's the difference between a house with just a locked front door and one with a locked door, alarm system, security cameras, and a safe for valuables.
+Defense in depth works only when the layers fail differently. A locked front door, a second locked door using the same key, and a safe with the same combination are three objects but one failure mode. By contrast, a door lock, an alarm that detects forced entry, a camera that records evidence, and a safe that uses a separate key create independent opportunities to prevent, detect, delay, or recover. Security architecture follows the same pattern. A network policy, application authorization check, hardware-backed administrator login, and data encryption key controlled by a separate service are valuable because they force the attacker to solve different problems.
 
-This module teaches you how to design layered security—what layers exist, how they work together, and how to avoid common pitfalls that undermine defense in depth.
+The probability intuition is simple, but it is easy to misuse. If one independent control misses one attack in a hundred and a second independent control also misses one attack in a hundred, the chance of the same attack bypassing both can become much smaller than either individual miss rate. The multiplication only helps when the failures are independent. If both controls rely on the same identity provider, the same administrator password, the same all-powerful service account, or the same noisy alert queue, the math collapses because one upstream failure can disable both controls at once.
+
+This module therefore teaches defense in depth as an engineering discipline: identify the asset, model the attacker step, choose a control at a different enforcement point, and verify that the new layer does not share the same trust root as the old one. You will see network segmentation, default-deny firewalls, zero-trust networking, input validation, output encoding, authentication recovery paths, data encryption, key management, and Kubernetes controls. The examples are concrete, but the durable skill is deciding where an independent layer belongs and how to test whether it is actually independent.
 
 > **The Swiss Cheese Analogy**
 >
-> Imagine slices of Swiss cheese stacked together. Each slice has holes (vulnerabilities), but the holes are in different places. For an attack to succeed, the holes must align across all slices. Defense in depth means adding more slices—more layers with different vulnerabilities—so alignment becomes statistically unlikely.
-
----
-
-## What You'll Learn
-
-- The layers of defense in a modern system
-- How to design independent security controls
-- Network, application, and data layer security
-- Common mistakes that undermine layered defense
-- How Kubernetes implements defense in depth
+> Imagine slices of Swiss cheese stacked together. Each slice has holes, but the holes are in different places. James Reason's system-safety model uses that picture to explain how accidents pass through multiple barriers when their weaknesses align. Security uses the same idea: every control has limits, so the goal is to stack controls whose limits do not line up neatly for the attacker.
 
 ---
 
@@ -67,7 +58,7 @@ This module teaches you how to design layered security—what layers exist, how 
 
 ### 1.1 The Defense Stack
 
-Each layer assumes the layer above it might be compromised.
+The classic defense stack is useful because it reminds you that security exists at multiple enforcement points. Physical security protects equipment and consoles. Network security shapes who can talk to whom. Host security limits what a compromised process can do on a machine. Application security checks inputs, identities, permissions, and business rules. Data security protects the asset even when surrounding layers are stressed. A mature design does not assume these layers are equal in every system; it asks which layer can still act when the previous one fails.
 
 ```mermaid
 flowchart TD
@@ -77,31 +68,54 @@ flowchart TD
     App --> Data["DATA SECURITY\n(Encryption, access control)"]
 ```
 
+The diagram is deliberately vertical, but real systems are messier. A cloud workload may not expose a traditional datacenter door to your team, but it still has a physical layer through the provider's facilities and hardware controls. A Kubernetes workload may not have a named "host security team," but kernel isolation, container runtime policy, seccomp, and node patching still belong to the host layer. Treat the stack as a map of enforcement points, not as an org chart or a shopping list.
+
+Each layer should assume the layer above it might be compromised. The network should not trust a request merely because the application sent it. The database should not trust a query merely because it came from an application server. The encryption design should not keep the only decryption key beside the encrypted data. That mindset changes the design question from "Did we add a control?" to "What can this control still stop if the neighboring control fails?"
+
 ### 1.2 Layer Independence
 
-For defense in depth to work, layers must be **independent**. One compromise should not defeat multiple layers.
+For defense in depth to work, layers must be independent. Independence means one compromise does not automatically defeat multiple layers. This is where many security architectures fail quietly. They contain several controls, but those controls all depend on the same directory group, the same administrator workstation, the same network route, the same certificate authority, or the same approval process. The result looks layered during an audit and behaves flat during an incident.
 
 | Architecture | Characteristics | Failure Mode |
 |--------------|-----------------|--------------|
-| **Dependent (Weak)** | • Firewall uses same password as app admin<br>• DB credentials hardcoded in app | App server compromise gives attacker firewall and database access too. |
-| **Independent (Strong)** | • Firewall requires hardware token<br>• App uses different identity provider<br>• DB credentials rotated automatically | Each layer has its own authentication, keys, and isolated failure modes. |
+| **Dependent (Weak)** | Firewall uses same password as app admin; database credentials are hardcoded in app; alert triage depends on one overloaded queue | App server compromise gives the attacker firewall, database, and monitoring leverage too. |
+| **Independent (Strong)** | Firewall requires hardware-backed admin auth; app uses scoped identity; database credentials rotate; alerts have separate escalation | Each layer has its own authentication, keys, and operational failure modes. |
 
-> **Pause and predict**: If an attacker steals a database administrator's credentials, how many layers of your current architecture are compromised?
+Shared credentials are the easiest dependency to spot. If the same account can administer the VPN, the CI system, the Kubernetes cluster, and the database, then a single phishing success has become a cross-layer bypass. Shared network paths are subtler. A vendor portal may be "low privilege" in the application sense, but if it has a routable path to payment systems, it can become a network-layer bridge. Shared trust roots are subtler still: if every internal service certificate, deployment token, and break-glass key is issued by one uncontrolled system, compromise of that system turns many layers into one layer.
 
-> **Try This (2 minutes)**
->
-> Think about your system. Do you reuse:
-> - Passwords across security boundaries?
-> - SSH keys for multiple purposes?
-> - Service accounts with broad access?
->
-> Each reuse is a hidden dependency between security layers.
+Operational dependencies matter as much as technical dependencies. An intrusion-detection system is a layer only if alerts are investigated, suppressed alerts are reviewed, and high-severity signals can interrupt normal work. If every security product sends alerts to the same abandoned mailbox, you have multiple sensors and one response failure mode. Defense in depth includes people, queues, escalation rules, and rehearsed decisions because those determine whether detection becomes containment.
+
+> **Pause and predict**: If an attacker steals a database administrator's credentials, how many layers of your current architecture are compromised, and which controls would still require a different secret, device, network path, or approval?
+
+### 1.3 Probability Without False Confidence
+
+Engineers often explain defense in depth with multiplication: a control that blocks most attacks plus another independent control that blocks most remaining attacks produces a much smaller residual risk. The intuition is useful, but exact percentages are usually less important than the independence test. You rarely know the true miss rate of a WAF, a static analyzer, a network policy, or a manual review. You can, however, reason about whether the same bypass defeats more than one of them.
+
+Consider SQL injection. A web application firewall may block common payloads before they reach the app. Parameterized queries prevent user-controlled strings from changing SQL structure inside the data-access layer. Database permissions can ensure the application account cannot drop tables even if a query bug exists. Backups and audit logs support recovery and investigation. Those controls multiply only because they operate at different places: HTTP edge, application code, database authorization, and recovery operations.
+
+Now contrast that with three controls that all depend on one shared library configured by the same environment variable. If the environment variable disables strict mode, every control weakens at the same time. That is not multiplication; it is decoration. The defender's job is to identify where a common-mode failure could make several controls fail together, then add a layer whose enforcement point is far enough away to survive that failure.
+
+### 1.4 A Layer Independence Checklist
+
+Use this checklist when you review an existing system, but do not treat it as a box-ticking exercise. Each question is a way to discover a hidden dependency that can turn several controls into one brittle control. The goal is to find the shared assumption before an attacker finds it during lateral movement.
+
+| Independence Question | What It Reveals | Better Direction |
+|-----------------------|-----------------|------------------|
+| Do controls share the same credential or group? | Stolen identity may bypass several layers | Separate admin roles, MFA, hardware-backed tokens, scoped service accounts |
+| Do controls share the same network path? | One foothold may reach high-value assets | Segmentation, default-deny routing, workload-level policy |
+| Do controls share the same trust root? | One CA, token issuer, or secrets store may become universal access | Scoped issuers, short-lived credentials, separate break-glass path |
+| Do controls share the same alert queue? | Detection may fail operationally even when sensors work | Severity routing, ownership, paging rules, rehearsed response |
+| Do controls share the same deployment pipeline? | A compromised pipeline can push insecure config everywhere | Signed artifacts, policy checks, staged rollout, independent approvals |
+
+The strongest finding in a review is often not "missing control" but "controls are coupled." A database encrypted at rest with keys stored on the same server as the database has an encryption feature, but not much blast-radius reduction against server compromise. A Kubernetes namespace with NetworkPolicy but no CNI plugin that enforces it has policy documents, but not network isolation. A zero-trust diagram where every service accepts any certificate from one overbroad issuer has encryption, but not meaningful workload authorization.
 
 ---
 
 ## Part 2: Network Security Layer
 
 ### 2.1 Network Segmentation
+
+Network segmentation is the practice of dividing systems into zones and allowing only necessary communication between them. It is not just a performance or topology choice. It is a containment strategy. If a web server is compromised, segmentation should prevent that foothold from becoming automatic database access, administrative access, or direct access to sensitive processing systems. In a flat network, every compromised host becomes a staging area for lateral movement.
 
 ```mermaid
 flowchart TD
@@ -121,136 +135,112 @@ flowchart TD
         subgraph DataTier [Data Tier]
             S_DB[DB\nApp only]
         end
-        
+
         S_Web --> S_App
         S_App --> S_DB
         S_Web -.->|Blocked| S_DB
     end
 ```
 
-### 2.2 Firewall Rules
+The segmented diagram is effective because it encodes business intent into network paths. Internet clients may reach the public edge. The public edge may reach the app tier on the application port. The app tier may reach the database on the database port. Everything else requires a deliberate exception. This does not eliminate application bugs, but it changes what an application bug can reach. That is the practical meaning of blast-radius reduction.
 
-**Default Deny Strategy**
-- Block everything by default
-- Explicitly allow only what's needed
-- Log blocked traffic (anomaly detection)
+Segmentation also creates useful detection opportunities. A web tier attempting to connect directly to the database, a vendor network attempting to scan payment systems, or a workload making unexpected outbound connections becomes suspicious precisely because normal paths are narrow. In a flat network, the same behavior blends into background noise. A good boundary therefore does two jobs: it blocks unnecessary traffic and turns boundary violations into high-signal events.
 
-**Example Ruleset:**
-- `ALLOW TCP 443` from Internet to Web-Tier
-- `ALLOW TCP 8080` from Web-Tier to App-Tier
-- `ALLOW TCP 5432` from App-Tier to DB-Tier
-- `DENY ALL` (default)
+### 2.2 Firewall Rules and Default Deny
 
-**Common Mistakes:**
-- ✗ `ALLOW ALL` from Internal → Flat network, defeats segmentation
-- ✗ `ALLOW TCP 0-65535` → Overly permissive port ranges
-- ✗ Old rules never cleaned → Accumulated holes
-- ✗ No logging → Attacks go unnoticed
+Default deny means the system blocks traffic unless a rule explicitly allows it. This sounds strict, but it is easier to reason about than default allow. With default allow, every forgotten path remains open until someone proves it dangerous. With default deny, every new path requires a positive design decision: which source, which destination, which port, which protocol, and which owner is accountable for the exception.
+
+| Rule | Intent |
+|------|--------|
+| `ALLOW TCP 443` from Internet to Web-Tier | Public clients can reach the edge over HTTPS |
+| `ALLOW TCP 8080` from Web-Tier to App-Tier | The edge can call the application service |
+| `ALLOW TCP 5432` from App-Tier to DB-Tier | The application can reach PostgreSQL |
+| `DENY ALL` | Every unmodeled path is blocked and logged |
+
+The table is intentionally small because good firewall policy is specific. A rule such as `ALLOW ALL` from internal networks converts segmentation into a diagram rather than an enforcement mechanism. A rule such as `ALLOW TCP 0-65535` usually means the owner did not know what the application needed. Old rules that never expire become accumulated holes. No logging means the team cannot tell whether blocked traffic is an attack, a misconfiguration, or a dependency nobody documented.
+
+Default deny also forces ownership conversations that security teams sometimes avoid. If a service needs outbound access to a payment API, someone must know which destination is legitimate and how that destination changes. If a batch job needs database access, someone must know why a batch job should bypass the app tier. Those conversations are not bureaucracy when they identify trust boundaries. They are the moment when architecture becomes enforceable policy.
 
 ### 2.3 Zero Trust Networking
 
-Traditional perimeter: "Inside the network = trusted"
-Zero trust: "Network location grants no trust"
+Traditional perimeter thinking says, "inside the network means trusted." Zero trust says network location is not enough. NIST SP 800-207 describes a model where trust is not granted implicitly based on physical location, network location, or asset ownership. Authentication and authorization happen before a session is established, and the protected resource remains the focus. That idea complements defense in depth because it turns every sensitive access path into its own control point.
 
 ```mermaid
 flowchart LR
-    subgraph Node 1
+    subgraph Node1 [Node 1]
         SvcA[Service A] <--> ProxyA[Sidecar Proxy]
     end
-    
-    subgraph Node 2
+
+    subgraph Node2 [Node 2]
         SvcB[Service B] <--> ProxyB[Sidecar Proxy]
     end
 
     ProxyA <-->|mTLS Required\n- Mutually Authenticated\n- Encrypted\n- Authorized\n- Logged| ProxyB
 ```
 
+Mutual TLS is one way to implement part of that model for service-to-service communication. In ordinary TLS, the client verifies the server. In mutual TLS, both sides prove identity using certificates, and the connection can be encrypted and authenticated without every application reimplementing certificate exchange itself. Service meshes such as Istio illustrate this pattern by moving transport authentication into sidecars or ambient data-plane components, but the principle is tool-agnostic: the network path should not be trusted merely because packets came from an internal address.
+
+Zero trust does not mean "no one is trusted ever." It means trust is specific, contextual, and continuously checked at useful enforcement points. A workload may be allowed to call one API but not another. A human administrator may be allowed to read dashboards but need stronger proof for production writes. A device may be allowed from one posture state and denied from another. These checks are valuable only if they do not all depend on the same brittle upstream secret or overbroad network zone.
+
 ---
 
-## Part 3: Application Security Layer
+## Part 3: Application and Identity Layers
 
 ### 3.1 Input Validation
 
-**ALL INPUT IS UNTRUSTED**
-Even input from "internal" services—an attacker who compromises one service shouldn't automatically compromise others.
+Input validation is the application layer refusing to treat untrusted data as already safe. The phrase "all input is untrusted" includes obvious sources such as HTTP requests and uploads, but it also includes messages from internal services, queue payloads, cached data, headers added by proxies, and values loaded from configuration. A compromised service inside the network should not automatically be able to send malicious input that the next service executes, stores, or renders.
 
-**VALIDATION CHECKLIST**
+The most reliable validation strategy is to define what good input looks like and reject everything else. Type validation asks whether a value is a string, integer, email address, UUID, date, or structured object as expected. Length validation prevents empty-string surprises, oversized payloads, and denial-of-service pressure. Format validation checks syntax such as allowed characters or normalized encodings. Range validation rejects values outside legitimate bounds. Business validation checks whether the value makes sense for the user and workflow, such as preventing one account from submitting another account's invoice number.
 
-1. **TYPE VALIDATION**
-   - Expected data type (string, int, email, UUID)?
-   - Does it parse correctly?
-2. **LENGTH VALIDATION**
-   - Minimum length (empty string attacks)?
-   - Maximum length (buffer overflow, DoS)?
-3. **FORMAT VALIDATION**
-   - Matches expected pattern (regex)?
-   - Valid characters only?
-4. **RANGE VALIDATION**
-   - Within expected bounds (price > 0)?
-   - Valid enum value?
-5. **BUSINESS VALIDATION**
-   - Makes sense in context (quantity can't be negative)?
-   - User authorized for this value?
+Validation should happen near the trust boundary and again at domain boundaries where the meaning changes. An API gateway can reject malformed requests, but it usually cannot know whether a refund amount is valid for a specific order. The service that owns the order must enforce that rule. This is another defense-in-depth pattern: broad validation at the edge reduces noise, while business validation inside the application protects decisions the edge cannot understand.
 
 ### 3.2 Output Encoding
 
-Context determines encoding. Wrong encoding equals a vulnerability. Use framework functions.
+Output encoding is the companion to input validation. Validation decides what data is acceptable to accept; encoding decides how accepted data is safely placed into a specific output context. The context matters because the same characters mean different things in HTML, JavaScript, SQL, URLs, shell commands, and log formats. Encoding for the wrong context is not a partial fix. It can be no fix at all.
 
 **HTML Context**
+
 `<div>Hello, {{name}}</div>`
-If `name` = `<script>alert('xss')</script>`
-Encode: `&lt;script&gt;alert('xss')&lt;/script&gt;`
+
+If `name` is `<script>alert('xss')</script>`, the HTML output must render the characters as text rather than executable markup, such as `&lt;script&gt;alert('xss')&lt;/script&gt;`. Modern template engines usually provide context-aware escaping, but teams still break this layer when they disable escaping, concatenate raw HTML, or move data into a different context after the framework has encoded it.
 
 **JavaScript Context**
+
 `<script>var name = "{{name}}";</script>`
-If `name` = `; alert('xss');//`
-Encode: `\x3B\x20alert\x28\x27xss\x27\x29\x3B\x2F\x2F`
+
+If `name` is `; alert('xss');//`, HTML escaping alone is not sufficient because the data is inside executable JavaScript. The safer design is to avoid placing untrusted data directly inside script blocks. When you must do it, use framework-supported JavaScript-string encoding or serialize data as JSON with the framework's safe helper rather than building script strings by hand.
 
 **SQL Context**
+
 `SELECT * FROM users WHERE name = '{{name}}'`
-If `name` = `'; DROP TABLE users;--`
-Use parameterized queries instead!
+
+If `name` is `'; DROP TABLE users;--`, output encoding is the wrong mental model because the problem is query construction. Parameterized queries separate the SQL structure from user-controlled values. A WAF might block common payloads, but parameterization is the independent application/data-layer control that prevents the string from becoming executable SQL.
 
 **URL Context**
+
 `<a href="/search?q={{query}}">`
-If `query` = `<script>alert(1)</script>`
-Encode: `%3Cscript%3Ealert%281%29%3C%2Fscript%3E`
+
+If `query` is `<script>alert(1)</script>`, URL encoding represents the value safely as data inside the query string. That does not make every destination safe; you still need allowlists for redirects and link targets. The broader lesson is that output safety depends on the interpreter that will consume the value. HTML, JavaScript, SQL, and URL parsers do not share one universal escape function.
 
 ### 3.3 Authentication and Session Management
 
-**Authentication Layers**
+Authentication is also a layered system. A password proves something the user knows. A TOTP app, hardware key, or passkey-capable device proves something the user has. A biometric prompt may help unlock a local device or private key, but it should be treated carefully because biometric traits cannot be rotated like passwords. Device posture, risk scoring, session lifetime, step-up authentication, and audit logging add additional checks around the primary proof.
 
-- **Layer 1: Something you know**
-  - Password, PIN
-  - *Weakness:* Phishing, brute force, credential stuffing
-- **Layer 2: Something you have**
-  - Phone (SMS, TOTP), hardware key (YubiKey)
-  - *Weakness:* SIM swapping, device theft
-- **Layer 3: Something you are**
-  - Biometrics (fingerprint, face)
-  - *Weakness:* Can't be changed if compromised
+The defense-in-depth lesson is that every authentication entry point needs comparable protection. Login is not the only door. Password reset, account recovery, email-change flows, API token creation, support impersonation, OAuth consent, and break-glass administration can all become alternative entry points. A strong login wall is moot if account recovery is a single-factor email link that lets an attacker replace the password and enroll a new device without step-up verification.
 
-**Defense in Depth for Auth**
-Combine multiple independent checks for robust security:
-1. Password (Layer 1)
-2. + TOTP Code (Layer 2)
-3. + Device Trust (Is this a known device?)
-4. + Risk Analysis (Unusual location, time, or behavior?)
-5. + Session Limits (Timeout, single-use tokens)
+**Hypothetical scenario:** A fintech product invests in strong primary login: long passwords, hardware-backed MFA for employees, suspicious-login detection, and short-lived sessions for privileged workflows. The password-reset path, however, sends a single email link and does not require MFA, device confirmation, help-desk verification, or risk-based delay before changing credentials. An attacker who compromises an employee mailbox can skip the strong login path entirely by using account recovery, setting a new password, and creating fresh sessions that look legitimate to downstream systems.
 
-> **Stop and think**: Does your password reset flow require the same level of authentication (like MFA) as your primary login flow? If not, you've created a shortcut around your security layers.
+The fix is not merely "add MFA somewhere." The fix is to classify account recovery as authentication and protect it with independent controls. Sensitive reset flows should require an existing factor when available, notify previous contact channels, limit token lifetime, bind reset tokens to the initiating browser where practical, detect unusual geography or device changes, and delay high-risk changes until review. Recovery must remain humane for legitimate users, but it cannot be a lower-trust tunnel around the primary controls.
 
-> **War Story: The $8.5 Million Password Reset Hole**
->
-> **August 2019.** A financial services startup had invested heavily in authentication security: complex passwords, hardware MFA tokens, device fingerprinting, IP reputation analysis. Their login flow was nearly impenetrable.
->
-> A security researcher found the password reset flow. It sent a reset link via email—no MFA required. Email access alone was enough to bypass every layer of authentication protection.
->
-> The researcher reported the vulnerability through their bug bounty program. Three weeks later, before the fix deployed, attackers exploited the same flaw. They compromised employee email accounts through phishing, used password reset to gain access to the main application, and exfiltrated customer financial data.
->
-> **The breach affected 2.1 million customers and cost $8.5 million** in regulatory fines, customer notification, and credit monitoring services.
->
-> They'd built defense in depth for login, but forgot that password reset is also an entry point. The backup authentication path had none of the protections of the primary path. Every authentication flow—login, password reset, account recovery, API authentication—needs the same layered protection.
+> **Stop and think**: Does your password reset flow require protection comparable to your primary login flow, or have you created a shortcut around your strongest authentication layer?
+
+### 3.4 Authorization as a Separate Layer
+
+Authentication asks who or what is making the request. Authorization asks what that identity may do right now. Treating those as the same layer creates a common failure mode: once the attacker logs in, every sensitive action becomes available. Defense in depth keeps authorization close to the protected action, especially for administrative operations, money movement, data export, secret access, and configuration changes.
+
+Good authorization is specific. A user who can view invoices should not automatically approve refunds. A service that reads customer profiles should not automatically export the full database. An administrator who can deploy to staging should not automatically change production network policy. These separations reduce blast radius because a stolen session or service token cannot perform every action. They also improve detection because denied attempts reveal intent.
+
+Step-up authorization is useful when the action is more sensitive than the session that started it. A VPN bypass should not grant access to HR data without application-level authorization. A dashboard session should not allow production deletion without a fresh factor or privileged approval. This is zero trust expressed at the application layer: every sensitive action earns trust again at the moment it matters.
 
 ---
 
@@ -258,7 +248,7 @@ Combine multiple independent checks for robust security:
 
 ### 4.1 Encryption Strategy
 
-**Encryption in Transit:** Protects against network sniffing and man-in-the-middle attacks. Does not protect against compromised endpoints.
+Encryption is not one layer. It is several layers that protect different states of data. Encryption in transit protects data moving across a network. Encryption at rest protects stored data from storage-layer theft or unauthorized disk access. Application-level encryption protects selected fields before they enter a database, which can reduce exposure from database compromise or overbroad database administration. Each layer has a different attacker model, so replacing one with another leaves gaps.
 
 ```mermaid
 flowchart LR
@@ -267,7 +257,7 @@ flowchart LR
     App -->|TLS| DB[(Database)]
 ```
 
-**Encryption at Rest:** Protects against physical theft and unauthorized disk access. Does not protect against authorized users or memory access.
+The transit diagram shows three network hops, and each hop needs its own trust decision. Client-to-load-balancer TLS protects the public path. Load-balancer-to-application mTLS can authenticate the workload path inside the environment. Application-to-database TLS protects queries and results from network sniffing or unintended intermediaries. None of those controls protects data after it is decrypted inside a compromised application process, which is why host, application, and data controls still matter.
 
 ```mermaid
 flowchart TD
@@ -280,9 +270,13 @@ flowchart TD
     end
 ```
 
-**Application-Level Encryption:** The application encrypts data before storing it and decrypts it after reading. The raw key never reaches the database. Protects against database compromise and rogue DBAs. Does not protect against a compromised application.
+The at-rest diagram shows nested protection, but the nesting should not imply magic. Volume encryption protects against storage media exposure. Database transparent encryption can protect database files and backups depending on implementation. Column or field encryption can protect selected values even if a database dump is copied. However, any layer that automatically decrypts for every authorized query will not stop a compromised application account from reading what that account is allowed to read. Encryption must be paired with authorization, logging, and key management.
+
+Application-level encryption is strongest when the raw key never lives in the database and when the application decrypts only the fields needed for a specific workflow. It can reduce exposure from rogue database access, backup leaks, and broad read replicas. It does not protect against a fully compromised application runtime that can request keys and read plaintext. That limitation is not a reason to avoid the layer; it is a reminder to define the threat it addresses and to add other layers for runtime compromise.
 
 ### 4.2 Key Management
+
+Encryption without key management is often theater. If encrypted data and the key that decrypts it are stored together, the attacker who steals one usually steals both. The key-management layer should introduce a separate trust boundary: separate identity, separate audit log, separate access policy, and ideally short-lived key access rather than permanent plaintext keys on disk. Cloud KMS products, hardware security modules, and tools such as Vault are common implementations, but the principle is independent of the product.
 
 ```mermaid
 flowchart TD
@@ -295,39 +289,40 @@ flowchart TD
 
     subgraph Pattern [PATTERN: Separate Key Management]
         direction LR
-        AppServer[App Server\nEncrypted Data] <-->|Fetch Key\nTemporary in Memory| Vault[Key Vault\ne.g., KMS, HashiCorp]
+        AppServer[App Server\nEncrypted Data] <-->|Fetch Key\nTemporary in Memory| Vault[Key Vault\ne.g., KMS, HashiCorp Vault]
         Attacker2[Attacker\nCompromises Server] --> AppServer
         Attacker2 -.->|Blocked: No Vault Access| Vault
     end
 ```
 
-> **Pause and predict**: If an attacker gains full read access to your application server's filesystem, will they be able to decrypt your database?
+The pattern side of the diagram is not saying the attacker can never decrypt anything after compromising an application server. If the application identity is allowed to request a key, a runtime attacker may still abuse that permission. The improvement is that full filesystem read access no longer automatically reveals the long-term key, and key access can be scoped, rate-limited, audited, rotated, or revoked. The separate system gives defenders another place to detect and interrupt abuse.
+
+Key rotation is useful only when the system can actually rotate. If changing a key requires a fragile manual migration, the key will stay old. If every service uses the same key, rotation becomes risky and broad. If logs do not show which identity requested which key for which purpose, incident response cannot tell what was exposed. Practical key management therefore includes key hierarchy, ownership, rotation playbooks, audit review, and a tested way to re-encrypt data when a key is suspected compromised.
+
+> **Pause and predict**: If an attacker gains full read access to your application server's filesystem, will they find durable decryption keys, or will they still need to cross a separate identity and audit boundary?
 
 ### 4.3 Data Classification
 
+Data classification tells you how much protection each asset deserves. Without classification, teams overprotect low-risk data, underprotect high-risk data, or argue about controls one field at a time. Classification should be understandable enough for engineers to use during design, deployment, logging, testing, and incident response. It should also influence retention: the safest sensitive data is the data you do not store longer than necessary.
+
 | Classification | Examples | Protection Level |
 |----------------|----------|------------------|
-| **Public** | Marketing content | Basic integrity |
-| **Internal** | Employee directory | Access control |
-| **Confidential** | Customer data, financials | Encryption + access control |
-| **Restricted** | PII, payment data, secrets | Encryption + strict access + audit |
+| **Public** | Marketing content, public documentation | Basic integrity, change control |
+| **Internal** | Employee directory, internal runbooks | Access control, logging, limited sharing |
+| **Confidential** | Customer data, financial records, contracts | Encryption, access control, audit, retention limits |
+| **Restricted** | PII, payment data, secrets, private keys | Strong encryption, strict access, key separation, alerting |
 
-> **Try This (3 minutes)**
->
-> Classify data in your system:
->
-> | Data Type | Classification | Current Protection | Gap? |
-> |-----------|----------------|-------------------|------|
-> | User emails | | | |
-> | Passwords | | | |
-> | API keys | | | |
-> | Log files | | | |
+Classification becomes a defense-in-depth tool when it drives independent controls. Restricted data may require application authorization, column encryption, tighter database roles, separate key policy, egress monitoring, and redaction in logs. Confidential data may require encryption and audit but not the same step-up workflow. Public data still needs integrity controls because attackers can weaponize defacement, malware injection, or documentation tampering even when confidentiality is not the goal.
+
+Logs deserve special attention because they often cross boundaries. A team may protect the database carefully while leaking access tokens, email addresses, reset links, or payment fragments into logs consumed by many tools. Treat logs as data products with their own classification. Redaction, retention, access control, and export restrictions belong in the same conversation as database encryption because attackers do not care which storage system gives them the sensitive value.
 
 ---
 
 ## Part 5: Defense in Depth in Kubernetes
 
 ### 5.1 Kubernetes Security Layers
+
+Kubernetes is a useful teaching environment because it makes layers visible. The API server, admission control, RBAC, namespaces, service accounts, NetworkPolicy, Pod Security Standards, container security contexts, image provenance, runtime controls, and application authorization all sit at different enforcement points. A secure cluster does not rely on any one of them. It assumes an application bug, a leaked service account token, or a misconfigured namespace will happen and then limits what that failure can reach.
 
 ```mermaid
 flowchart TD
@@ -338,56 +333,101 @@ flowchart TD
     App["APPLICATION LAYER\n- Input validation\n- Auth/Authz\n- Secrets from vault\n- Least privilege DB access"]
 ```
 
-### 5.2 Kubernetes Security Controls
+The cluster layer decides who may ask Kubernetes to do things. RBAC can prevent a service account from listing secrets or creating privileged pods. Admission controls can reject workloads that violate security policy. The namespace layer shapes tenancy and communication boundaries. The pod and container layers limit what code can do after it starts. The application layer still validates input and authorizes actions because a locked-down container can still contain vulnerable business logic.
+
+Pod Security Standards are a good example of layered intent. Kubernetes defines privileged, baseline, and restricted profiles to describe broad pod-security postures. Applying a restricted policy at namespace admission can prevent dangerous workload shapes before they run, but it does not replace image scanning, runtime detection, NetworkPolicy, or application authorization. It is one independent guardrail in the path from source code to running process.
+
+### 5.2 Namespace Admission and Pod Security Standards
+
+The following namespace labels express an intent that new pods in the namespace should satisfy the restricted Pod Security Standard for the curriculum's target Kubernetes version. In a real cluster, you would roll this out carefully because restricted mode can break legacy workloads that run as root, require extra Linux capabilities, or write to privileged paths. That rollout friction is exactly why defense in depth should be designed early rather than retrofitted after every workload has learned to depend on dangerous defaults.
 
 ```yaml
-# Pod with defense in depth
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: production
+  labels:
+    pod-security.kubernetes.io/enforce: restricted
+    pod-security.kubernetes.io/enforce-version: v1.35
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit-version: v1.35
+    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn-version: v1.35
+```
+
+The `enforce` label rejects non-compliant pods, while `audit` and `warn` help teams see violations during rollout and review. The version labels matter because policy details evolve as Kubernetes evolves; pinning the version keeps the admission decision stable while teams plan upgrades. This is a small example of independent control design: developers may intend to deploy safely, CI may check manifests, and namespace admission still enforces a final cluster-side rule when a workload reaches the API server.
+
+### 5.3 Pod and Container Controls
+
+The next manifest shows a pod-shaped defense-in-depth pattern, not a complete production deployment. The service account is named explicitly so it can receive minimal RBAC. The pod runs as a non-root user. The container disables privilege escalation, drops Linux capabilities, uses the runtime default seccomp profile, makes the root filesystem read-only, and declares resource limits. Each setting reduces what an attacker can do after exploiting an application bug.
+
+```yaml
 apiVersion: v1
 kind: Pod
 metadata:
   name: secure-app
+  namespace: production
+  labels:
+    app: api
 spec:
-  serviceAccountName: app-minimal    # Least privilege
+  serviceAccountName: app-minimal
   securityContext:
-    runAsNonRoot: true               # Not root
+    runAsNonRoot: true
     runAsUser: 1000
+    runAsGroup: 1000
     fsGroup: 1000
+    seccompProfile:
+      type: RuntimeDefault
   containers:
-  - name: app
-    image: myapp:v1.0@sha256:abc...  # Image pinning
-    securityContext:
-      allowPrivilegeEscalation: false  # Can't become root
-      readOnlyRootFilesystem: true     # Can't write to disk
-      capabilities:
-        drop: ["ALL"]                   # No special capabilities
-    resources:
-      limits:
-        cpu: "500m"
-        memory: "256Mi"              # Resource limits (DoS protection)
-    volumeMounts:
-    - name: tmp
-      mountPath: /tmp                # Writable tmp if needed
+    - name: app
+      image: registry.example.com/platform/secure-app@sha256:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+      ports:
+        - containerPort: 8080
+          name: http
+      securityContext:
+        allowPrivilegeEscalation: false
+        readOnlyRootFilesystem: true
+        capabilities:
+          drop:
+            - ALL
+      resources:
+        requests:
+          cpu: 100m
+          memory: 128Mi
+        limits:
+          cpu: 500m
+          memory: 256Mi
+      volumeMounts:
+        - name: tmp
+          mountPath: /tmp
   volumes:
-  - name: tmp
-    emptyDir: {}
+    - name: tmp
+      emptyDir: {}
 ```
 
-### 5.3 Network Policies
+These settings are not decorative. `runAsNonRoot` reduces the value of code execution inside the container. `allowPrivilegeEscalation: false` prevents gaining more privileges through setuid binaries. Dropping capabilities removes broad kernel privileges most application containers do not need. A read-only root filesystem makes malware persistence harder, while an explicit `/tmp` volume gives the application a narrow writable path if it needs one. Resource limits do not stop data theft, but they can contain denial-of-service behavior from runaway or malicious code.
+
+Image pinning is included because mutable tags create another shared failure mode. If every deployment says `latest`, a compromised registry tag or accidental overwrite can change production without a meaningful review path. A digest-pinned image does not prove the image is safe by itself, but it makes the deployed artifact specific. Combined with signing, vulnerability scanning, admission policy, and provenance checks, it becomes another layer that can interrupt supply-chain mistakes or attacks.
+
+### 5.4 Network Policies
+
+Kubernetes NetworkPolicy lets you declare which pods may communicate at the network layer, assuming the cluster uses a network plugin that enforces the API. This caveat is important: a YAML object that the data plane ignores is not a security layer. When enforced, NetworkPolicy gives you a workload-level segmentation control that can survive application compromise. A vulnerable API pod may still be exploited, but it should not automatically scan the namespace, call the database, and exfiltrate to any destination.
 
 ```yaml
-# Default deny all ingress
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
-  name: default-deny-ingress
+  name: default-deny-ingress-and-egress
   namespace: production
 spec:
-  podSelector: {}      # All pods in namespace
+  podSelector: {}
   policyTypes:
-  - Ingress
+    - Ingress
+    - Egress
+  ingress: []
+  egress: []
 
 ---
-# Allow only specific traffic
 apiVersion: networking.k8s.io/v1
 kind: NetworkPolicy
 metadata:
@@ -398,30 +438,156 @@ spec:
     matchLabels:
       app: api
   policyTypes:
-  - Ingress
+    - Ingress
   ingress:
-  - from:
-    - podSelector:
-        matchLabels:
-          app: web
-    ports:
-    - protocol: TCP
-      port: 8080
+    - from:
+        - podSelector:
+            matchLabels:
+              app: web
+      ports:
+        - protocol: TCP
+          port: 8080
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-api-egress-to-payment-provider
+  namespace: production
+spec:
+  podSelector:
+    matchLabels:
+      app: api
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - ipBlock:
+            cidr: 203.0.113.0/24
+      ports:
+        - protocol: TCP
+          port: 443
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-web-egress-to-api
+  namespace: production
+spec:
+  podSelector:
+    matchLabels:
+      app: web
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - podSelector:
+            matchLabels:
+              app: api
+      ports:
+        - protocol: TCP
+          port: 8080
+
+---
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: allow-dns-egress
+  namespace: production
+spec:
+  podSelector: {}
+  policyTypes:
+    - Egress
+  egress:
+    - to:
+        - namespaceSelector: {}
+          podSelector:
+            matchLabels:
+              k8s-app: kube-dns
+      ports:
+        - protocol: UDP
+          port: 53
+        - protocol: TCP
+          port: 53
 ```
 
-> **Stop and think**: Review the network policies in your cluster. Do you rely solely on application-level authentication, or are you enforcing network isolation as an independent layer?
+The first policy isolates every pod in the namespace for both ingress and egress, so nothing flows until something is explicitly allowed. Here the layered model has a subtlety that trips up many teams: Kubernetes evaluates ingress and egress **independently**, so a connection from `web` to `api` requires *both* halves of the rule pair — the `allow-web-to-api` **ingress** rule on the API pods *and* the `allow-web-egress-to-api` **egress** rule on the web pods. The ingress rule alone is not enough; with default-deny egress in force, the web pod's outbound traffic would still be dropped and the call would fail. The `allow-dns-egress` policy exists because a default-deny egress posture also blocks DNS, so name resolution breaks until UDP and TCP port 53 to the cluster DNS service (`kube-dns`) is explicitly permitted — a classic "my NetworkPolicy broke everything" surprise. Finally, `allow-api-egress-to-payment-provider` shows a narrow egress exception to an external provider, using a documentation CIDR that must be replaced by a real range in production. This shape is intentionally explicit: default deny creates the boundary, and each allow rule documents why — and in which direction — the boundary is crossed.
+
+NetworkPolicy is not identity-aware in the same way application authorization is identity-aware. A compromised pod with the `app: web` label may still use the network path allowed for that label. That is why labels must be controlled, admission policy matters, service accounts need least privilege, and application authorization remains necessary. Again, the lesson is not that one layer solves the problem. The lesson is that each layer should force a different attacker step.
+
+> **Stop and think**: Review the network policies in your cluster. Do you rely solely on application-level authentication, or are you enforcing network isolation as an independent layer with a data plane that actually honors the policy?
+
+---
+
+## Patterns & Anti-Patterns
+
+Patterns make defense in depth repeatable. The first pattern is independent enforcement: place controls at different points in the request path so a bypass at one point does not disable the others. For example, combine edge filtering, application validation, database permissions, and recovery procedures for injection risk. The second pattern is narrow blast radius: scope identities, network paths, keys, and data access so compromise of one workload or person does not grant broad movement. The third pattern is actionable detection: every layer should produce signals that someone owns, understands, and can escalate.
+
+Another useful pattern is graceful degradation of trust. When confidence drops, the system should reduce privilege rather than continue as if nothing happened. A risky login can require step-up authentication. A suspicious service identity can lose access to sensitive APIs until revalidated. A noisy egress pattern can trigger stricter policy or isolation. This is defense in depth as a dynamic posture rather than a static stack of controls.
+
+| Pattern | Why It Works | Example |
+|---------|--------------|---------|
+| Independent enforcement points | One bypass does not disable every control | WAF plus parameterized queries plus least-privilege DB role |
+| Narrow blast radius | Compromise stays local long enough to detect and respond | Namespace policy, scoped service account, restricted database role |
+| Separate key control plane | Data theft and key theft require different steps | KMS or Vault policy separate from database access |
+| Actionable detection | Failed layers become visible before the attacker finishes | High-severity alerts with ownership and rehearsed escalation |
+
+Anti-patterns usually masquerade as efficiency. Shared administrator groups are convenient until one credential controls every layer. Flat networks are convenient until a low-trust service can reach high-trust assets. Centralized secrets in environment variables are convenient until every pod spec becomes a key inventory. A single alert queue is convenient until urgent signals wait behind routine noise. The cost of independence is operational discipline, but the cost of hidden dependency is that layers fail together.
+
+| Anti-Pattern | Why It's Bad | Better Approach |
+|--------------|--------------|-----------------|
+| Same credential everywhere | One stolen identity crosses layers | Separate roles, MFA, hardware-backed admin flows |
+| Flat internal network | Any foothold can move laterally | Default-deny segmentation and workload policy |
+| Keys stored with encrypted data | Data theft includes decryption material | Separate KMS, scoped access, audit, rotation |
+| Recovery flow weaker than login | Attackers bypass primary authentication | Treat recovery as authentication with comparable controls |
+| Unowned alert streams | Detection fires but does not change outcomes | Severity routing, ownership, response playbooks |
+| Policy without enforcement | YAML or documents create false confidence | Verify data-plane, admission, and operational enforcement |
+
+The most dangerous anti-pattern is security theater: a visible control that everyone assumes is working but nobody tests against the threat it claims to reduce. A default-deny policy should be tested by trying unauthorized traffic. A key-separation design should be tested by asking what a filesystem compromise exposes. An alerting layer should be tested by running a drill that proves the right human or automation acts quickly. Defense in depth is not complete until each layer has a failure test.
+
+---
+
+## Decision Framework
+
+When deciding which layer to add, start with the attacker step, not with a tool category. Ask what the attacker has already achieved, what they need next, and which enforcement point can interrupt that next step independently. If the attacker has stolen a password, adding another password policy may not help much; adding phishing-resistant MFA or step-up authorization for sensitive actions changes the required proof. If the attacker has compromised an application pod, adding another application log line may not contain movement; network egress policy, service-account scoping, and runtime restrictions may.
+
+| Threat or Failure | First Useful Question | Independent Layer to Consider | Test of Independence |
+|-------------------|-----------------------|--------------------------------|----------------------|
+| Stolen human credential | What can this identity administer without another factor? | MFA, privileged access workflow, step-up authorization | Can the attacker perform the sensitive action with only the stolen password? |
+| Compromised web service | What can this workload reach and read? | NetworkPolicy, scoped service account, DB role limits | Can code execution in the pod reach unrelated services or dump broad data? |
+| Injection bug | Can malicious input change interpreter behavior? | Parameterized queries, output encoding, validation | Does the exploit still work if the edge filter misses it? |
+| Database dump theft | Are keys and sensitive fields separate from the dump? | Field encryption, KMS policy, backup encryption | Can a copied backup be decrypted without crossing another identity boundary? |
+| Noisy detection | Who acts when a high-risk signal fires? | Alert ownership, paging, automated containment | Does a drill produce timely containment rather than a ticket nobody reads? |
+| Vendor or third-party access | What production paths can the vendor reach? | Isolated network zone, scoped identity, monitoring | Can vendor credentials route to high-value systems without a separate approval? |
+
+The decision framework should feel practical during design review. Pick one asset, one credible attacker step, and one proposed control. Then ask whether the proposed control belongs to a different enforcement point from the control you already have. If the answer is no, you may still want the control for usability or audit reasons, but you should not count it as an independent layer. If the answer is yes, define how you will test it, who owns it, and what signal it produces when it blocks or detects an attack.
+
+```mermaid
+flowchart TD
+    A["Identify asset and attacker step"] --> B["List existing controls on that step"]
+    B --> C{"Do existing controls share a failure mode?"}
+    C -->|Yes| D["Add a control at a different enforcement point"]
+    C -->|No| E["Test the current layer and decide if residual risk is acceptable"]
+    D --> F{"Can the new control be tested independently?"}
+    F -->|No| G["Redesign ownership, trust root, or enforcement path"]
+    F -->|Yes| H["Deploy, monitor, rehearse response, and document owner"]
+    E --> H
+```
+
+This framework also prevents over-layering. More controls are not always better if they create fragility, unclear ownership, or user-hostile workarounds. A sensitive data export path may deserve step-up authentication, approval, rate limits, and logging. A low-risk public status page may need integrity control and deployment review but not the same interactive ceremony. The right layer is the one that reduces a real attack path without introducing a larger operational failure mode.
 
 ---
 
 ## Did You Know?
 
-- **The "Swiss Cheese Model"** was developed by James Reason for accident causation analysis. It shows how multiple barriers, each with weaknesses, can prevent disasters when properly layered.
+- **The "Swiss Cheese Model"** was developed by James Reason for accident causation analysis and is widely used to explain how defenses, barriers, and safeguards can be penetrated when weaknesses align across layers.
 
-- **mTLS (mutual TLS)** was rare before service meshes. Now Istio and Linkerd make it the default for all service-to-service communication—encryption and authentication without application changes.
+- **NIST's Zero Trust Architecture guidance** explicitly rejects implicit trust based only on network location, which is why zero trust complements defense in depth rather than replacing it.
 
-- **The Pentagon uses "air gaps"** (physically disconnected networks) for the most sensitive systems. Even sophisticated software-based defense in depth can't match physical isolation for high-value targets.
+- **Kubernetes Pod Security Standards** define privileged, baseline, and restricted policy levels; the restricted level is designed for heavily constrained pods but still needs supporting layers such as RBAC, image policy, and NetworkPolicy.
 
-- **The 2013 Target breach** is a textbook defense-in-depth failure. Attackers compromised an HVAC vendor, used those credentials to access Target's network, then moved laterally to payment systems. Multiple security layers existed but were either misconfigured or ignored alerts—the intrusion detection system flagged the attack, but the alert wasn't investigated.
+- **The 2013 Target breach** is a textbook defense-in-depth failure: stolen HVAC vendor credentials, lateral movement toward POS systems, missed anti-intrusion alerts, and weak isolation together enabled theft of roughly 40 million payment-card numbers and up to 70 million customer records.
 
 ---
 
@@ -429,12 +595,14 @@ spec:
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| Single layer dependency | One compromise defeats everything | Independent controls per layer |
-| Perimeter-only defense | Insiders and lateral movement | Zero trust, internal segmentation |
-| Encrypted but keys exposed | Encryption provides no protection | Proper key management |
-| Network security only | App vulnerabilities still exploitable | Application-layer controls too |
-| Default allow policies | Too permissive | Default deny, explicit allow |
-| Forgetting logging | Can't detect when layers fail | Log at every layer |
+| Single layer dependency | One compromise defeats everything | Require independent controls per layer |
+| Perimeter-only defense | Insiders, vendors, and compromised workloads can move laterally | Use zero trust, internal segmentation, and workload policy |
+| Shared admin credentials | Phishing or token theft crosses network, app, and data layers | Separate privileged roles and require strong step-up factors |
+| Encrypted data with exposed keys | Encryption provides little protection after filesystem compromise | Use separate key management with audit and rotation |
+| Network security only | Application bugs and business-rule flaws remain exploitable | Add validation, output encoding, and authorization checks |
+| Default-allow policies | Old or unknown paths remain open by accident | Start with default deny and document explicit allows |
+| Weak account recovery | Attackers bypass strong login controls | Treat reset and recovery as authentication entry points |
+| Unowned logging | Alerts fire but nobody responds | Assign owners, severity, escalation, and drill response |
 
 ---
 
@@ -444,65 +612,69 @@ spec:
    <details>
    <summary>Answer</summary>
 
-   This setup completely violates the principle of layer independence because the network layer (firewall) and application layer (backend) share the same dependency: the Active Directory credentials. When security layers share dependencies, a single compromise affects multiple layers simultaneously, defeating the purpose of having multiple defenses. In this scenario, the attacker can now modify network perimeter rules and access the application backend using the exact same set of stolen credentials. True defense in depth would require distinct authentication mechanisms, such as a hardware token for the firewall that is separate from the application login.
+   This setup violates layer independence because the network layer and application layer share the same identity failure mode. The attacker does not need to defeat two different controls; the stolen directory credential can influence both the firewall and the backend. A better design would evaluate the shared dependency, then require a separate privileged access path such as hardware-backed MFA, scoped network-admin roles, and audited approval for firewall changes. This probes the outcome of evaluating whether layers are truly independent.
    </details>
 
-2. **Scenario**: Your team has encrypted the application's PostgreSQL database at rest using AWS EBS volume encryption. A developer argues that because the disk is encrypted, they don't need to configure TLS for the connections between the application pods and the database pods. Is the developer correct, and why?
+2. **Scenario**: Your team has encrypted the application's PostgreSQL database at rest using cloud volume encryption. A developer argues that because the disk is encrypted, they do not need to configure TLS for the connections between the application pods and the database pods. Is the developer correct, and why?
    <details>
    <summary>Answer</summary>
 
-   The developer is incorrect because encryption at rest and encryption in transit protect against entirely different threat vectors. Encryption at rest (EBS volume encryption) only protects the data if the physical disk is stolen or accessed without authorization at the infrastructure level. It does absolutely nothing to protect data actively moving across the network. If an attacker has compromised another pod in the cluster and is sniffing network traffic, they will see the database queries and responses in plaintext unless encryption in transit (TLS) is implemented. Defense in depth requires both layers to cover both stored data and moving data.
+   The developer is incorrect because encryption at rest and encryption in transit protect different states of data. Volume encryption helps if storage media, snapshots, or low-level disk access are exposed, but it does not protect queries and responses moving across the network. If another pod can sniff or intercept traffic, plaintext database communication remains exposed. Implementing both layers addresses the outcome of applying defense-in-depth strategies across data and network paths.
    </details>
 
-3. **Scenario**: You are deploying a new microservice in a Kubernetes cluster (v1.35). The cluster administrator has mandated that all namespaces must have a default-deny NetworkPolicy. Your application pod needs to connect to an external payment API, but the connection keeps timing out. What is the most likely cause, and how does this demonstrate defense in depth?
+3. **Scenario**: You are deploying a new microservice in a Kubernetes cluster targeting v1.35. The cluster administrator has mandated default-deny NetworkPolicy for namespaces. Your application pod needs to connect to an external payment API, but the connection keeps timing out. What is the most likely cause, and how does this demonstrate defense in depth?
    <details>
    <summary>Answer</summary>
 
-   The most likely cause is that the default-deny NetworkPolicy is blocking outbound (egress) traffic from your pod to the internet. A default-deny policy requires explicit allow rules for any communication to occur. This demonstrates defense in depth because it assumes the application pod is untrusted; even if an attacker compromises the pod, they cannot automatically establish outbound connections to exfiltrate data or download malware. The network layer provides an independent security control that restricts lateral movement and outbound access, containing the blast radius of an application-layer compromise.
+   The likely cause is that egress is denied until an explicit NetworkPolicy allows the API pod to reach the payment provider on the required destination and port. Default-deny policy assumes the pod should not communicate merely because it runs inside the cluster. This demonstrates defense in depth because a compromised application pod cannot automatically exfiltrate data or download tooling through arbitrary outbound connections. The fix is to implement a narrow egress allow rule and verify that the CNI data plane enforces it.
    </details>
 
 4. **Scenario**: An application encrypts highly sensitive user SSNs before storing them in the database. The development team stores the encryption key as an environment variable in the application's Kubernetes Deployment manifest. During a security audit, this is flagged as a critical vulnerability. Why is this approach fundamentally flawed?
    <details>
    <summary>Answer</summary>
 
-   This approach is flawed because storing the encryption key in the manifest (and thus as an environment variable) couples the key directly with the application environment, defeating the separation of concerns. If an attacker gains read access to the cluster's API server, the pod's specification, or executes a directory traversal attack to read `/proc/1/environ`, they instantly obtain the key. Proper key management requires storing keys in a dedicated, external system (like a Key Vault or AWS KMS) with its own access controls and audit logs. The application should fetch the key into memory only when needed, ensuring that compromising the application host doesn't automatically hand over the cryptographic keys.
+   The design stores the decryption capability beside the application environment, so anyone who can read the manifest, inspect the pod environment, or compromise the workload may obtain the key. That collapses the data layer and key-management layer into one failure mode. A stronger design uses a separate key-management service with scoped identity, audit logging, and rotation so a database dump or filesystem read does not automatically include durable keys. This probes the outcome of designing independent data-protection layers.
    </details>
 
-5. **Scenario**: Your organization has deployed a Web Application Firewall (WAF) that successfully blocks 99% of common SQL injection attacks. Because the WAF is highly effective, the lead engineer suggests skipping parameterized queries in the application code to speed up development time. What mathematical and architectural principles explain why this is a terrible idea?
+5. **Scenario**: Your organization has deployed a Web Application Firewall that blocks many common SQL injection payloads. Because the WAF is effective, the lead engineer suggests skipping parameterized queries in application code to speed up development. What mathematical and architectural principles explain why this is a bad idea?
    <details>
    <summary>Answer</summary>
 
-   This violates the core mathematical principle of layer independence in defense in depth. If you rely solely on the WAF (which is 99% effective), an attacker has a 1% chance of success per attempt. If you layer parameterized queries (e.g., 99% effective against remaining novel bypasses), the probability of an attack bypassing both independent layers drops to 0.01% (0.01 * 0.01). Furthermore, architecturally, a WAF operates at the network/HTTP layer and lacks business logic context, making it susceptible to novel encoding tricks. Parameterized queries operate at the data layer and structurally prevent SQL injection regardless of how the payload is encoded, providing a critical fallback when the WAF fails. By relying on multiple distinct enforcement points, the system remains secure even if attackers discover a bypass technique for one specific layer.
+   The multiplication intuition behind defense in depth works only when controls are independent, and a WAF plus parameterized queries operate at different enforcement points. The WAF can miss a novel encoding or business-specific payload, while parameterized queries prevent user input from changing SQL structure even when the edge filter misses it. Skipping parameterization turns an application/data-layer protection into a single HTTP-layer bet. This answer probes the outcomes of designing layered architecture and choosing the right independent control for a threat.
    </details>
 
-6. **Scenario**: Target's HVAC vendor had credentials that allowed remote access into Target's network. Once inside, attackers successfully pinged and connected to the point-of-sale (POS) systems located in physical retail stores. Based on defense in depth, what specific network security control was missing or misconfigured here?
+6. **Scenario**: Target's HVAC vendor credentials allowed remote access into Target's environment. Once inside, attackers moved laterally toward point-of-sale systems in stores. Based on defense in depth, what specific network security control was missing or misconfigured here?
    <details>
    <summary>Answer</summary>
 
-   The missing control was proper network segmentation with strict access policies between segments. In a well-architected defense in depth strategy, the HVAC vendor's access should have been heavily segmented into an isolated vendor network zone. There should have been no routing path or firewall rule allowing traffic to cross from the vendor segment into the highly sensitive PCI-compliant segment housing the POS systems. By operating a flat or loosely segmented network, Target allowed an attacker who breached a low-security dependency (HVAC monitoring) to pivot laterally into a high-security zone without encountering an independent network barrier. Establishing strict internal boundaries ensures that a breach in a less critical system does not automatically compromise the entire organization.
+   The missing or ineffective control was strict network segmentation between the vendor-access environment and sensitive payment-system zones. Vendor credentials should have landed in a tightly scoped area with no routable path to POS systems unless a separate, justified control allowed it. Segmentation would not have prevented the initial credential theft, but it could have contained the blast radius and made lateral movement noisy. This probes the outcome of analyzing breach post-mortems for failed layers and containment opportunities.
    </details>
 
-7. **Scenario**: You are reviewing a Kubernetes Pod manifest for a legacy application. The container runs as root, mounts the host's `/var/run/docker.sock`, and has no CPU or memory limits defined. If the application has a remote code execution (RCE) vulnerability, how does this Pod configuration fail to provide defense in depth at the host and container layers?
+7. **Scenario**: You are reviewing a Kubernetes Pod manifest for a legacy application. The container runs as root, mounts the host's `/var/run/docker.sock`, and has no CPU or memory limits defined. If the application has a remote code execution vulnerability, how does this Pod configuration fail to provide defense in depth at the host and container layers?
    <details>
    <summary>Answer</summary>
 
-   This configuration completely strips away host and container isolation, violating defense in depth. First, running as root within the container and mounting the Docker socket means an attacker exploiting the RCE can easily escape the container, compromise the underlying node, and potentially take over the entire cluster. Second, the lack of resource limits means the attacker can launch a denial-of-service attack (like cryptomining) that consumes all node resources, starving other applications. A defense in depth approach would use a non-root `SecurityContext`, a read-only root filesystem, and strict resource quotas to contain the blast radius of the RCE to just that single, isolated container. Implementing these overlapping controls ensures that even if the application code is vulnerable, the infrastructure itself actively resists further exploitation and lateral movement.
+   The manifest removes the containment layers that should limit the impact of application code execution. Running as root and mounting the container runtime socket can let an attacker influence the node or other containers, while missing resource limits can turn code execution into denial of service. A defense-in-depth pod would run as non-root, drop capabilities, disable privilege escalation, avoid host socket mounts, use a read-only root filesystem, and set resource requests and limits. This probes implementation of Kubernetes defense-in-depth controls across pod, container, and host boundaries.
    </details>
 
-8. **Scenario**: During a penetration test, the tester successfully bypasses the corporate VPN (Network Layer) and accesses an internal employee portal. However, they are unable to view any sensitive HR documents because the application requires a biometric prompt (WebAuthn) for high-privilege actions. Which security concept does this demonstrate, and why is it effective?
+8. **Scenario**: During a penetration test, the tester bypasses the corporate VPN and accesses an internal employee portal. However, they cannot view sensitive HR documents because the application requires a fresh WebAuthn prompt for high-privilege actions. Which security concept does this demonstrate, and why is it effective?
    <details>
    <summary>Answer</summary>
 
-   This scenario perfectly demonstrates Zero Trust Architecture and the principle of layer independence. The system does not implicitly trust the user just because they bypassed the perimeter network (the VPN). Instead, the application layer independently enforces its own strong authentication and authorization controls before granting access to sensitive data. This is highly effective because the failure of the network security layer did not result in a total system compromise; the independent, data-centric access control (Layer 3: "Something you are") stopped the attack path and protected the underlying assets. When identity and authorization are verified at the application level regardless of network origin, the system maintains its integrity even if the perimeter is fully breached.
+   This demonstrates zero trust and layer independence because the application does not grant sensitive access merely because the network perimeter was crossed. The VPN layer failed, but the application authorization layer required a separate proof for a high-risk action. That independent step-up control prevented the network bypass from becoming a data breach. It also shows how to choose a control close to the protected resource rather than relying entirely on perimeter access.
    </details>
 
 ---
 
 ## Hands-On Exercise
 
-**Task**: Audit a system for defense in depth.
+### Task
 
-**Scenario**: Review the following architecture and identify missing layers:
+Audit a system for defense in depth by mapping controls to attacker steps instead of merely listing security tools. The goal is to discover where the architecture has independent barriers and where it only appears layered because several controls share the same credential, network path, trust root, or operational queue.
+
+### Scenario
+
+Review the following architecture and identify missing layers. Assume the firewall exists, but no other controls have been proven yet. Your job is to ask what happens if the firewall is misconfigured, the application has a code flaw, a database backup leaks, or an internal credential is stolen.
 
 ```mermaid
 flowchart TD
@@ -512,9 +684,9 @@ flowchart TD
     AppServer --> Database[(Database\nPostgreSQL)]
 ```
 
-**Part 1: Layer Inventory (10 minutes)**
+### Part 1: Layer Inventory
 
-Fill in current controls:
+Fill in the current controls and missing controls for each layer. Be specific about whether a control prevents, detects, delays, or supports recovery, because those roles help you see whether the layers are independent.
 
 | Layer | Controls Present | Controls Missing |
 |-------|------------------|------------------|
@@ -523,9 +695,9 @@ Fill in current controls:
 | Application | | |
 | Data | | |
 
-**Part 2: Attack Scenarios (10 minutes)**
+### Part 2: Attack Scenarios
 
-For each attack, identify which layers would stop it:
+For each attack, identify which layers would stop it and which layers would merely produce evidence after the fact. If an attack passes through several boxes because they share the same trust assumption, mark that dependency explicitly instead of giving partial credit.
 
 | Attack | Layer 1 | Layer 2 | Layer 3 | Stopped? |
 |--------|---------|---------|---------|----------|
@@ -534,9 +706,9 @@ For each attack, identify which layers would stop it:
 | Network sniffing | | | | |
 | Compromised app server | | | | |
 
-**Part 3: Recommendations (10 minutes)**
+### Part 3: Recommendations
 
-Propose controls to add:
+Propose controls to add, but justify each one by naming the attacker step it interrupts. At least one recommendation should address network containment, one should address application logic, one should address data protection, and one should address detection or response.
 
 | Gap | Proposed Control | Layer | Priority |
 |-----|------------------|-------|----------|
@@ -546,39 +718,50 @@ Propose controls to add:
 | | | | |
 | | | | |
 
-**Success Criteria**:
-- [ ] All four layers inventoried
-- [ ] At least 5 missing controls identified
-- [ ] Attack scenarios analyzed with layer mapping
-- [ ] Prioritized recommendations provided
+### Success Criteria
 
----
-
-## Further Reading
-
-- **"Network Security Essentials"** - William Stallings. Comprehensive coverage of network security principles and protocols.
-
-- **"Kubernetes Security"** - Liz Rice. Defense in depth specifically for Kubernetes environments.
-
-- **NIST Cybersecurity Framework** - Framework for organizing security controls in layers.
+- [ ] All four layers inventoried with present and missing controls
+- [ ] At least five missing controls identified and mapped to attacker steps
+- [ ] Attack scenarios analyzed with layer mapping and independence notes
+- [ ] Prioritized recommendations include prevention, detection, and recovery controls
 
 ---
 
 ## Key Takeaways Checklist
 
-Before moving on, verify you can answer these:
+Before moving on, verify you can answer these questions without looking back. The point is not memorizing the exact YAML; it is being able to reason about whether a proposed control creates a new independent barrier or merely repeats an assumption the system already depends on.
 
 - [ ] Can you explain the Swiss cheese model and why layer independence matters?
-- [ ] Can you name and describe the five defense-in-depth layers (physical, network, host, application, data)?
+- [ ] Can you name and describe the five defense-in-depth layers: physical, network, host, application, and data?
 - [ ] Do you understand network segmentation and why flat networks are dangerous?
-- [ ] Can you explain zero trust networking and how mTLS implements it?
-- [ ] Do you understand the difference between encryption in transit and at rest?
+- [ ] Can you explain zero trust networking and how mTLS can support it?
+- [ ] Do you understand the difference between encryption in transit, at rest, and at the application layer?
 - [ ] Can you explain why key management is often the weakest link in encryption?
-- [ ] Do you understand how Kubernetes implements defense in depth (cluster, namespace, pod, container layers)?
-- [ ] Can you calculate the probability difference between independent vs dependent security layers?
+- [ ] Do you understand how Kubernetes implements defense in depth across cluster, namespace, pod, container, and application layers?
+- [ ] Can you explain why independent layers can reduce risk multiplicatively while dependent layers fail together?
 
 ---
 
 ## Next Module
 
 [Module 4.3: Identity and Access Management](../module-4.3-identity-and-access/) - Authentication, authorization, and the principle of least privilege in practice.
+
+---
+
+## Sources
+
+- [Senate Commerce Committee: Target's missed opportunities to stop the breach](https://www.commerce.senate.gov/press/dem/release/rockefeller-staff-report-details-targets-missed-opportunities-to-stop-massive-data-breach/)
+- [Krebs on Security: Target Hackers Broke in Via HVAC Company](https://krebsonsecurity.com/2014/02/target-hackers-broke-in-via-hvac-company/)
+- [Target 2016 Form 10-K, SEC EDGAR](https://www.sec.gov/Archives/edgar/data/27419/000002741917000008/tgt-20170128x10k.htm)
+- [TechTarget: Were executives held accountable after the Target data breach?](https://www.techtarget.com/searchsecurity/tip/FAQ-Were-executives-held-accountable-after-the-Target-data-breach)
+- [NIST Cybersecurity Framework](https://www.nist.gov/cyberframework)
+- [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/sp/800/207/final)
+- [OWASP Input Validation Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Input_Validation_Cheat_Sheet.html)
+- [OWASP Cross-Site Scripting Prevention Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Cross_Site_Scripting_Prevention_Cheat_Sheet.html)
+- [CIS Kubernetes Benchmark](https://www.cisecurity.org/benchmark/kubernetes)
+- [Kubernetes Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/)
+- [Kubernetes Network Policies](https://kubernetes.io/docs/concepts/services-networking/network-policies/)
+- [Kubernetes Security Contexts](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/)
+- [Istio Security Concepts](https://istio.io/latest/docs/concepts/security/)
+- [AHRQ PSNet: Human error, models and management](https://psnet.ahrq.gov/issue/human-error-models-and-management)
+- [O'Reilly: Kubernetes Security by Liz Rice and Michael Hausenblas](https://www.oreilly.com/library/view/kubernetes-security/9781492039075/)

--- a/src/content/docs/platform/foundations/security-principles/module-4.4-secure-by-default.md
+++ b/src/content/docs/platform/foundations/security-principles/module-4.4-secure-by-default.md
@@ -12,58 +12,58 @@ sidebar:
 >
 > **Track**: Foundations
 
-### What You'll Be Able to Do
+**January 2017. Security researchers discover tens of thousands of MongoDB databases exposed to the internet — no exploit required, no authentication configured.**
 
-After completing this module, you will be able to:
+No exploit was needed. No zero-day vulnerability, no sophisticated attack chain, no advanced persistent threat. MongoDB's default configuration in versions prior to 3.6 bound the database to all network interfaces (0.0.0.0) with authentication completely disabled. Install the software, start the daemon, and the entire contents of your database were immediately accessible to anyone on the planet who knew to look.
+
+And people did look. Attackers ran automated scanning scripts across the public IPv4 address space, identified exposed instances in seconds, deleted every database they found, and left behind a single collection containing a ransom note: pay Bitcoin within 48 hours or the data is gone forever. Many victims had no backups. Databases contained medical records, customer financial data, proprietary application logic, and years of accumulated business information — all erased by scripts that required no more sophistication than a port scanner and a TCP connection.
+
+**Tens of thousands of MongoDB instances were ransomed in the first wave alone.** The total data loss was incalculable in dollar terms because the damage went beyond the ransom payments and the forensic investigations: it shattered trust in the infrastructure layers that organizations had assumed were inherently safe. And the root cause was not a bug, not a vulnerability, not an operator's misconfiguration — it was the default. The vendor shipped a product that required manual hardening after installation, and across thousands of organizations under time pressure and resource constraints, that hardening never happened.
+
+MongoDB eventually changed their defaults. Starting with version 3.6 later that year, new installations bound exclusively to localhost and required explicit configuration to accept remote connections. Authentication was no longer optional. The community learned a brutal lesson, but it was the wrong lesson to have to learn: **insecure defaults become insecure deployments at scale, and the gap between "we should secure this" and "we secured this" is measured in breaches.**
+
+This module teaches secure by default — how to build systems where the easy path is also the safe path, and where the cost of security failure is borne by the framework, not by every individual operator who might forget a step.
+
+---
+
+## What You'll Be Able to Do
+
+After completing this module, you will be able to apply secure-by-default principles across every layer of the technology stack:
 
 1. **Design** default configurations for platforms and services that are secure out of the box without requiring manual hardening steps
 2. **Evaluate** whether a tool or framework's defaults expose unnecessary attack surface and propose secure-by-default alternatives
 3. **Implement** policy-as-code guardrails (admission controllers, OPA policies, CI checks) that prevent insecure configurations from reaching production
 4. **Analyze** the tradeoff between secure defaults that restrict developer flexibility and permissive defaults that increase breach risk
+5. **Select** the appropriate Pod Security Standards level (privileged, baseline, restricted) for a given workload and enforce it at the namespace level
 
 ---
 
-**January 2017. Security researchers discover 27,000 MongoDB databases exposed to the internet.**
-
-No exploit was needed. MongoDB's default configuration bound to all network interfaces (0.0.0.0) with authentication disabled. Install MongoDB, start it, and the entire database is accessible to anyone on the internet.
-
-Attackers ran automated scripts across the internet, finding these databases, deleting the contents, and leaving ransom notes demanding Bitcoin for data recovery. Many victims had no backups. Some databases contained medical records, customer data, and financial information.
-
-**Over 28,000 MongoDB instances were ransomed in the first wave alone.** The total data loss was incalculable. And the root cause wasn't a bug or vulnerability—it was the default configuration.
-
-MongoDB changed their defaults. New installations bind to localhost only. Authentication is strongly encouraged during setup. But thousands of organizations had already learned the hard way: insecure defaults become insecure deployments.
-
-This module teaches secure by default—how to build systems where the easy path is also the safe path.
-
----
 
 ## Why This Module Matters
 
-Most security breaches don't exploit sophisticated zero-days. They exploit misconfigurations, default passwords, and forgotten settings. The attacker didn't have to be clever—they just found what was left open.
+Most security breaches don't exploit sophisticated zero-days. The work of scanning the internet for open databases, default passwords, exposed management interfaces, and forgotten debug endpoints is fully automated — and the attackers performing it are not geniuses. They are opportunistic. They find what was left open, and what was left open is almost always there because the default made openness the path of least resistance.
 
-**Secure by default** means systems ship in a secure state. Instead of requiring users to enable security, they have to explicitly disable it. Instead of hoping developers remember to validate input, the framework does it automatically.
+**Secure by default** is the principle that systems should ship in a secure state. Instead of requiring users to *enable* security, the system should require them to explicitly *disable* it. Instead of hoping every developer remembers to validate input for every endpoint, the framework validates automatically — and forces a deliberate override to skip it. Instead of trusting that operators will tighten firewall rules after deployment, the deployment itself denies all traffic and requires an explicit allowlist to function.
 
-This module teaches you how to build systems where the path of least resistance is also the secure path—where doing things the easy way is also doing them safely.
+This principle applies at every layer of the stack: the operating system, the container runtime, the application framework, the cloud service, the CI/CD pipeline. Authentication should be required unless explicitly marked public. Encryption should be on by default. Network policies should deny-all and allow-only-what-is-needed. Debug endpoints should be disabled in production builds. The container filesystem should be read-only. The process should run as non-root. None of these should depend on someone remembering to configure them correctly.
+
+When you finish this module, you will understand why security checklists fail at scale, how guardrails differ from gates and where each belongs, what policy-as-code looks like in practice, and how to design systems where a developer's oversight does not become the organization's breach. You will learn to evaluate tool defaults critically — because every insecure default in your stack is a future incident waiting for an opportunistic attacker to find it.
 
 > **The Seatbelt Analogy**
 >
-> Old cars required you to find the seatbelt and buckle it. Many people didn't. Modern cars beep until you buckle up—the annoying path is the unsafe path. Some won't even start until passengers are buckled. The default became safe, and the unsafe choice became harder.
-
----
-
-## What You'll Learn
-
-- What "secure by default" means in practice
-- How to design secure defaults for configurations
-- Common insecure defaults and how to fix them
-- Security guardrails that prevent mistakes
-- How Kubernetes implements secure defaults
+> Old cars required you to find the seatbelt and buckle it. Many people didn't. Modern cars beep until you buckle up — the annoying path is the unsafe path. Some won't even start until passengers are buckled. The default became safe, and the unsafe choice became harder.
+>
+> Secure-by-default systems work the same way. You don't disable the seatbelt alarm by writing "remember to buckle" on a Post-it note and calling it a day. The alarm itself is the guardrail. In software, the equivalent is: the deployment doesn't start until secrets are injected from a vault, the container doesn't run as root, the network doesn't accept traffic until an allowlist is specified. Make the safe path the only path that works out of the box.
 
 ---
 
 ## Part 1: The Secure Default Philosophy
 
 ### 1.1 Default State Matters
+
+Every piece of software you deploy makes a choice about its initial posture. Either it starts open and waits for you to close things down, or it starts closed and waits for you to open things up. This single design decision — made by a vendor's product team, sometimes years before you encounter the software — determines the security baseline for every deployment that follows.
+
+The mermaid diagram below captures the two paradigms side by side. Study the right-hand column carefully: notice that the secure-by-default path doesn't eliminate work, it *redirects* it. The operator still has to configure the system — but instead of hunting down every door that was left unlocked, the operator only opens the specific doors the application needs. The default answer to "can this be accessed?" changes from "yes, unless you remember to say no" to "no, unless you explicitly say yes."
 
 ```mermaid
 graph TD
@@ -84,6 +84,8 @@ graph TD
 
 ### 1.2 Why Secure Defaults Win
 
+The contrast between these two paradigms plays out across five dimensions, each of which compounds the others. When the default is insecure, setup is superficially faster — you get a running system in fewer steps — but every shortcut you took is a future audit finding, a future breach vector, and a future conversation with the security team that ends with "we assumed someone would lock that down." When the default is secure, setup may take an extra minute on day one, but it buys you years of not having to explain why your database was world-readable.
+
 | Factor | Insecure Default | Secure Default |
 |--------|------------------|----------------|
 | **Setup friction** | Easy setup, insecure | Slightly harder, but safe |
@@ -91,6 +93,8 @@ graph TD
 | **Forgotten configs** | Become attack vectors | Remain safe |
 | **Time pressure** | "We'll secure later" (won't) | Already secure |
 | **Audit findings** | Many defaults insecure | Clean by default |
+
+The most dangerous phrase in operational security is "we'll harden it before production." Under schedule pressure, that hardening step is the first thing deferred and the last thing completed — if it is ever completed at all. By contrast, a secure default system reverses the incentive: you feel the friction immediately during setup, when you have the time and attention to deal with it, rather than feeling the consequences months later when an automated scanner finds what you left open.
 
 > **Pause and predict**: Think of a brand new internal developer tool you might deploy. Should it be accessible to everyone on the company VPN by default, or should it require explicit VPN groups and credentials out of the box? Which approach scales securely?
 
@@ -106,132 +110,94 @@ graph TD
 >
 > How many required you to manually enable security?
 
+### 1.3 The Opt-Out Model: Failing Safe
+
+The philosophical core of secure-by-default design is the **opt-out model**: security is always on, and the operator must take a deliberate action to reduce it. This is the opposite of the "opt-in" model, where security features are available but dormant until someone enables them.
+
+Consider a web framework that auto-escapes HTML in templates. In an opt-in model, developers must remember to call `escape()` on every variable rendered into a page. Forgetting one — in a footer template, a 404 page, a rarely-visited admin panel — creates a cross-site scripting vulnerability that might sit dormant for years. In an opt-out model, the framework escapes everything automatically, and a developer who genuinely needs to render raw HTML must explicitly write `|safe` or its equivalent. That developer now carries the burden of justification: "I know this is raw HTML. I have verified its provenance. I accept the risk." And crucially, if a different developer forgets to write `|safe` on some other page, the error is a cosmetic rendering glitch, not a security vulnerability. The system fails safe.
+
+This pattern — make the dangerous action require explicit intent, make the safe action the default — generalizes to authentication (all endpoints require auth unless marked public), network access (deny all unless allowlisted), filesystem permissions (read-only unless writable volumes are explicitly mounted), and process privileges (non-root unless a root escalation is deliberately granted).
+
+### 1.4 Cognitive Load and the Economics of Security
+
+There is an economic argument underneath the philosophy. Security checklists — the "secure after deployment" model — impose a flat per-deployment cognitive tax on every team member. If you have fifty services and a thirty-item hardening checklist, you are asking operators to correctly execute 1,500 security-sensitive decisions, every one of which must be done perfectly or a vulnerability results. Humans are bad at this at scale. The error rate is not zero, and across 1,500 decisions, the probability of at least one mistake approaches certainty.
+
+Secure-by-default design shifts this cost from the operator to the system builder. The framework author makes the security decision once, in code, and every downstream deployment inherits it automatically. This is not only more reliable — it is a more efficient allocation of expertise. The framework author is likely a security specialist. The operator deploying an internal tool on a Friday afternoon is likely not. By absorbing the security burden into the platform layer, secure-by-default design ensures that every deployment benefits from the best security thinking in the organization, not just the deployments where the operator happened to be paying attention.
+
 ---
 
 ## Part 2: Designing Secure Defaults
 
 ### 2.1 Authentication Defaults
 
-```text
-AUTHENTICATION DEFAULTS
-═══════════════════════════════════════════════════════════════
+Authentication is the first line of defense, and it is where insecure defaults cause the most visible damage. The pattern is depressingly consistent: a system ships with a well-known default password (or no password at all), the administrator installs it with the intention of changing the credentials later, and "later" never arrives before an automated scanner finds the instance. The Shodan search engine routinely surfaces tens of thousands of devices and services still configured with vendor default credentials years after deployment.
 
-PASSWORDS
-─────────────────────────────────────────────────────────────
-    ✗ Default password: "admin" or "password"
-    ✗ No password required initially
-    ✓ Force password set on first use
-    ✓ Require minimum complexity
+A secure-by-default approach to authentication demands three properties. **First-run credential forcing:** the system must not allow itself to be used until the administrator sets a unique password. This can be implemented as a setup wizard that blocks all other functionality, or as a randomly generated initial credential displayed only once during installation. **No backdoor defaults:** there must be no hardcoded fallback password, no "support access" account with a known key, no undocumented superuser that bypasses the normal authentication flow. **Framework-level protection:** the application framework should require authentication on all routes by default, requiring an explicit `@public` or `@allow_anonymous` decorator for any endpoint that genuinely needs to be unauthenticated (such as a health check or a login form).
 
-    # Good: Force password creation
-    if not user.has_password_set():
-        redirect('/setup/create-password')
+```python
+# Framework level default: all routes require auth
+@require_auth  # Applied to all routes by default
+class APIView:
+    pass
 
-API ACCESS
-─────────────────────────────────────────────────────────────
-    ✗ API accessible without authentication
-    ✗ Optional authentication ("can be enabled")
-    ✓ Authentication required by default
-    ✓ All endpoints protected unless explicitly public
-
-    # Framework level default
-    @require_auth  # Applied to all routes by default
-    class APIView:
-        pass
-
-    @public  # Must explicitly mark as public
-    class HealthCheck:
-        pass
-
-SESSION MANAGEMENT
-─────────────────────────────────────────────────────────────
-    ✗ Sessions never expire
-    ✗ Long session timeouts (30 days)
-    ✓ Reasonable session timeout (hours, not days)
-    ✓ Secure cookie flags by default (HttpOnly, Secure, SameSite)
+@public  # Must explicitly mark as public
+class HealthCheck:
+    pass
 ```
+
+Session management is another dimension where defaults matter. A session that lasts thirty days is convenient for the user but gives an attacker who steals a session cookie a month-long window of access. Secure defaults for sessions include short timeouts (hours, not days), absolute session expiry regardless of activity, and secure cookie flags — `HttpOnly` (inaccessible to JavaScript), `Secure` (transmitted only over HTTPS), and `SameSite` (restricted cross-origin sending) — all enabled by default. These settings cost the developer nothing to implement — they are flags in the framework's session configuration — but if they are opt-in, many applications ship without them.
 
 ### 2.2 Network Defaults
 
-```text
-NETWORK DEFAULTS
-═══════════════════════════════════════════════════════════════
+Network exposure is the multiplier on every other security weakness. A vulnerable authentication system that is only accessible from localhost is a development annoyance. That same system listening on 0.0.0.0 with no firewall is a breach notification. The binding interface — the IP address a service listens on — is the single highest-leverage default in network security.
 
-BINDING
-─────────────────────────────────────────────────────────────
-    ✗ Listen on 0.0.0.0 (all interfaces)
-    ✓ Listen on localhost by default
-    ✓ Require explicit config to expose externally
+The secure default is to bind to localhost (127.0.0.1) and require explicit configuration to accept remote connections. This prevents the "I started the database and suddenly the internet can query it" class of incident that the MongoDB 2017 ransomware exploited. For containerized workloads, the equivalent is a Kubernetes NetworkPolicy that denies all ingress by default, requiring explicit allowlist rules for every service that needs to receive traffic from another namespace or from outside the cluster.
 
-    # Dangerous default
-    server.listen('0.0.0.0', 8080)  # World-accessible
+```bash
+# Dangerous default
+server.listen('0.0.0.0', 8080)  # World-accessible
 
-    # Secure default
-    server.listen('127.0.0.1', 8080)  # Local only
-    # User must configure to expose
-
-ENCRYPTION
-─────────────────────────────────────────────────────────────
-    ✗ Plain HTTP by default
-    ✗ TLS "optional"
-    ✓ TLS required by default
-    ✓ Modern TLS versions only (1.2+)
-    ✓ Strong cipher suites only
-
-FIREWALL / NETWORK POLICY
-─────────────────────────────────────────────────────────────
-    ✗ Allow all traffic
-    ✗ No firewall rules
-    ✓ Deny all by default
-    ✓ Explicit allowlist required
+# Secure default
+server.listen('127.0.0.1', 8080)  # Local only
+# User must configure to expose
 ```
+
+Encryption on the network follows the same pattern. Plain HTTP should not be the default transport. TLS should be required, with modern minimum versions (TLS 1.2 or higher, with 1.3 preferred) and strong cipher suites only. Certificate validation should be enforced; "accept any certificate" or "skip verification" should require an explicit, deliberate override that is flagged in code review. In Kubernetes, this translates to requiring TLS for all ingress traffic and using mutual TLS (mTLS) for service-to-service communication within the mesh — a default that service meshes like Istio and Linkerd can enforce transparently.
 
 ### 2.3 Data Defaults
 
-```text
-DATA DEFAULTS
-═══════════════════════════════════════════════════════════════
+Data at rest and data in transit are the two surfaces that security defaults must protect, but data in logs represents a third, often overlooked category. Every application logs something — request parameters, error contexts, debugging information — and those logs are copied to central logging systems, backed up, shipped to observability platforms, and potentially stored for months or years. If secrets, personally identifiable information (PII), or authentication tokens appear in those logs, the data is now exposed across a much wider attack surface than the original database.
 
-ENCRYPTION
-─────────────────────────────────────────────────────────────
-    ✗ Store data in plain text
-    ✗ Encryption available but not enabled
-    ✓ Encryption at rest by default
-    ✓ Encryption in transit required
+Secure-by-default logging means automatic redaction of known secret patterns before data is written to disk or shipped off the host. Regular expressions for API keys, bearer tokens, password fields, credit card numbers, and social security numbers should be applied at the logging framework level, not left to each developer's discipline. The code that logs a user login attempt should not have to remember to strip the password field — the logging library should recognize the field name and redact it automatically.
 
-LOGGING
-─────────────────────────────────────────────────────────────
-    ✗ Log everything including secrets
-    ✗ No log sanitization
-    ✓ Automatic secret redaction
-    ✓ PII filtering by default
-
-    # Automatic redaction
-    logger.info("User login", extra={
-        "username": user.email,      # Logged
-        "password": user.password,   # [REDACTED]
-        "api_key": request.api_key   # [REDACTED]
-    })
-
-INPUT HANDLING
-─────────────────────────────────────────────────────────────
-    ✗ Trust all input
-    ✗ Validation optional
-    ✓ Validate and sanitize all input by default
-    ✓ Parameterized queries enforced (no string concatenation)
-
-    # Framework prevents SQL injection by default
-    users = db.query(User).filter_by(email=email).all()
-    # Not: f"SELECT * FROM users WHERE email = '{email}'"
+```python
+# Automatic redaction at the logging layer
+logger.info("User login", extra={
+    "username": user.email,      # Logged
+    "password": user.password,   # [REDACTED]
+    "api_key": request.api_key   # [REDACTED]
+})
 ```
+
+Input validation is another data-facing default that pays for itself thousands of times over. Every piece of data that crosses a trust boundary — URL parameters, form fields, HTTP headers, file uploads, message queue payloads — should be validated and sanitized by default. The framework should reject malformed input before application code ever sees it, using type-enforced schemas (Pydantic, Marshmallow, Zod) that declare expected shapes and bounds. SQL injection, the perennially top-ranked vulnerability class in the OWASP Top 10, should be prevented at the framework level by enforcing parameterized queries and rejecting string-concatenated SQL. A developer who writes `db.query("SELECT * FROM users WHERE email = '" + email + "'")` should get a linter error, not a deployed vulnerability.
+
+```python
+# Framework prevents SQL injection by default
+users = db.query(User).filter_by(email=email).all()
+# Not: f"SELECT * FROM users WHERE email = '{email}'"
+```
+
+Encryption at rest should be enabled by default for any system that stores persistent data. Cloud providers have made this increasingly straightforward — AWS S3, Google Cloud Storage, and Azure Blob Storage all support default server-side encryption — but the organization must still configure the policy to enforce it, because the raw API still accepts unencrypted writes if no policy blocks them. The secure default is to deny unencrypted storage operations at the policy layer, not just to make encryption available.
 
 ---
 
-## Part 3: Guardrails and Constraints
+## Part 3: Guardrails, Gates, and Policy as Code
 
-### 3.1 What are Guardrails?
+### 3.1 What Are Guardrails?
 
-Guardrails are constraints that prevent mistakes without blocking legitimate work.
+Guardrails are constraints that prevent dangerous outcomes without blocking legitimate work. They are the highway guardrail, not the traffic light: they don't slow you down during normal operation, and you only notice them when you are about to go off the road. In a security context, guardrails are automated checks that allow normal development velocity while catching specific classes of dangerous configurations before they reach production.
+
+A guardrail in a CI/CD pipeline might scan every container image for critical CVEs and block the deployment only if a vulnerability above a severity threshold is detected. It doesn't block every deployment — just the ones carrying known-exploitable flaws. A guardrail in a Kubernetes admission controller might reject any pod that runs as root or requests `privileged: true`, while allowing all other pods through without friction. The developer who writes a secure pod never encounters the guardrail. The developer who accidentally includes `privileged: true` from a debugging session hits it immediately, before the pod is scheduled.
 
 ```mermaid
 graph TD
@@ -246,84 +212,59 @@ graph TD
         S2["Prevent dangerous configurations"]
         S3["You notice them only when doing something risky"]
     end
-
-    subgraph EXAMPLES [Examples]
-        C1["<b>CI/CD Pipeline:</b><br/>✓ Allows all normal deployments<br/>✗ Blocks deployment without security scan<br/>✗ Blocks deployment of containers as root<br/>✗ Blocks deployment with critical vulnerabilities"]
-        P1["<b>Policy as Code:</b><br/>✓ Allows pods with security context<br/>✗ Blocks pods without resource limits<br/>✗ Blocks pods with hostNetwork: true<br/>✗ Blocks images from untrusted registries"]
-    end
 ```
 
-### 3.2 Implementing Guardrails
+### 3.2 Guardrails vs. Gates
+
+The distinction between a guardrail and a gate is essential for designing a security system that doesn't throttle the organization's ability to ship software. A **guardrail** is conditional — it blocks only the subset of actions that violate a specific policy. A **gate** is unconditional — it blocks everything until a condition is met, typically a human approval.
+
+Gates are necessary at high-assurance boundaries. A change to a payment-processing service might genuinely require a security review before merging. A modification to a compliance-critical infrastructure-as-code repository might need sign-off from two senior engineers. But applying gate-level friction to every change, in every repository, creates a powerful incentive for developers to route around the process — through shadow IT, through manual deployments, through "emergency" exceptions that become routine.
+
+The art of secure-by-default design is to use guardrails for the 95% of changes that are routine and gates for the 5% that carry elevated risk. The CI pipeline that scans every container image for hardcoded secrets is a guardrail: it only blocks the deployment when it actually finds a secret. The manual security review required for changes to the IAM policy that grants production database access is a gate: it blocks every change until a human approves it, regardless of what the change contains.
+
+### 3.3 The Guardrail Implementation Spectrum
+
+Guardrails can be placed at multiple points in the software delivery lifecycle, and each placement provides a different tradeoff between feedback speed and enforcement strength.
+
+**Pre-commit hooks** provide the fastest feedback — the developer learns about a problem before the code even leaves their machine. Tools like gitleaks scan for secrets, hadolint lints Dockerfiles for security best practices, and pre-commit-terraform validates infrastructure-as-code before a commit is created. Pre-commit hooks are relatively weak — a developer can skip them with `--no-verify` — but they catch the majority of honest mistakes before they enter the shared repository.
+
+**CI pipeline gates** provide stronger enforcement during the code review phase. A CI job that runs a security scanner can block the merge of a pull request if it finds a critical vulnerability, and unlike a pre-commit hook, it cannot be skipped by the individual developer. The CI pipeline should run the same checks that the pre-commit hooks run, because developers do skip hooks, and the pipeline is the backstop.
 
 ```yaml
-# GUARDRAIL IMPLEMENTATION
-# ═══════════════════════════════════════════════════════════════
-
-# PRE-COMMIT HOOKS
-# ─────────────────────────────────────────────────────────────
-# Stop problems before they're committed.
-
-    # .pre-commit-config.yaml
-    repos:
-    - repo: https://github.com/gitleaks/gitleaks
-      hooks:
-      - id: gitleaks  # Prevent committing secrets
-
-    - repo: https://github.com/hadolint/hadolint
-      hooks:
-      - id: hadolint  # Lint Dockerfiles for security
-
-# CI PIPELINE GATES
-# ─────────────────────────────────────────────────────────────
-# Stop problems before they're merged.
-
-    pipeline:
-      - security-scan:
-          fail_on: CRITICAL, HIGH
-      - container-scan:
-          fail_on: CVE score > 7.0
-      - policy-check:
-          policies: [no-root, resource-limits, no-privileged]
-
-# ADMISSION CONTROLLERS
-# ─────────────────────────────────────────────────────────────
-# Stop problems before they're deployed.
-
-    # OPA Gatekeeper, Kyverno
-    # Block at the Kubernetes API:
-    # - Pods without security context
-    # - Containers running as root
-    # - Images from unauthorized registries
-    # - Resources without limits
+# CI pipeline: guardrails at the pull-request boundary
+pipeline:
+  - security-scan:
+      fail_on: CRITICAL, HIGH
+  - container-scan:
+      fail_on: CVE score > 7.0
+  - policy-check:
+      policies: [no-root, resource-limits, no-privileged]
 ```
 
-### 3.3 Kubernetes Pod Security Standards
+**Admission controllers** provide the strongest enforcement, at the Kubernetes API boundary. Once a workload is admitted to the cluster, it is running — so the admission controller is the last chance to prevent a misconfiguration from becoming a live security incident. Admission controllers like OPA Gatekeeper and Kyverno evaluate every API object (Pod, Deployment, Service, Ingress, etc.) against a set of Rego or custom policies and either allow it, deny it, or mutate it to add missing security fields. This is the infrastructure-level implementation of secure by default.
 
 ```yaml
-# POD SECURITY STANDARDS
-# ═══════════════════════════════════════════════════════════════
+# Admission controller: gate at the cluster boundary
+# OPA Gatekeeper, Kyverno
+# Block at the Kubernetes API:
+# - Pods without security context
+# - Containers running as root
+# - Images from unauthorized registries
+# - Resources without limits
+```
 
-# Kubernetes defines three security levels:
+### 3.4 Kubernetes Pod Security Standards (PSS)
 
-# PRIVILEGED (No restrictions)
-# ─────────────────────────────────────────────────────────────
-#     For system-level workloads that need full access.
-#     Use only when necessary.
+Kubernetes 1.25 removed Pod Security Policies (PSPs) — a complex and error-prone mechanism — and replaced them with Pod Security Standards (PSS), enforced by a built-in Pod Security admission controller that is simpler and faster than PSP. The controller ships enabled by default since 1.25, but it **enforces nothing until a namespace carries `pod-security.kubernetes.io/*` labels** — an unlabeled namespace is effectively privileged, and pods are not hardened out of the box. Once labeled, PSS defines three levels that can be enforced at the namespace boundary, providing a graduated path from permissive to fully hardened without requiring external tooling.
 
-# BASELINE (Minimal restrictions)
-# ─────────────────────────────────────────────────────────────
-#     Prevents known privilege escalations.
-#     Blocks: hostNetwork, hostPID, privileged containers
+**Privileged** — no restrictions whatsoever. This is an explicit escape hatch for system-level workloads like CNI plugins, CSI drivers, and monitoring agents that genuinely need host-level access. It should be used sparingly, in dedicated namespaces, and never for application workloads.
 
-# RESTRICTED (Maximum security)
-# ─────────────────────────────────────────────────────────────
-#     Enforces security best practices.
-#     Requires: non-root, drop all capabilities,
-#               read-only root filesystem
+**Baseline** — prevents known privilege escalations. A baseline-compliant pod cannot use `hostNetwork`, `hostPID`, or `hostIPC` (which bypass container isolation), cannot run privileged containers, and cannot use hostPath volumes that expose the node's filesystem. Baseline is the minimum acceptable standard for any production namespace and is appropriate for most application workloads that don't have specific privilege requirements.
 
-# APPLYING STANDARDS
-# ─────────────────────────────────────────────────────────────
-# Namespace-level enforcement
+**Restricted** — enforces the strictest built-in PSS profile. A restricted pod must run as a non-root user (`runAsNonRoot: true`, non-root UID), must set `allowPrivilegeEscalation: false`, must drop all Linux capabilities (`capabilities.drop: ["ALL"]`) and may add back only `NET_BIND_SERVICE`, must use a seccomp profile (`RuntimeDefault` or `Localhost`), and must use restricted volume types. A read-only root filesystem is recommended but is **not** enforced by the restricted standard — enforce it separately with an admission policy (Kyverno/Gatekeeper) if you require it. Restricted is the target state for any organization that has completed the hardening journey and is appropriate for most application workloads that do not need host-level access.
+
+```yaml
+# Namespace-level Pod Security Standards enforcement
 apiVersion: v1
 kind: Namespace
 metadata:
@@ -336,32 +277,32 @@ metadata:
 # Now all pods in production must meet restricted standard
 ```
 
-> **Stop and think**: If Pod Security Standards (PSS) actively block `privileged: true`, how would a cluster administrator deploy a DaemonSet that genuinely needs host network access (like a CNI plugin or a storage CSI driver)? How do automated guardrails handle legitimate exceptions securely?
+The three modes — enforce (block), audit (log), and warn (notify) — allow a gradual rollout. A namespace can start with `audit` to discover which workloads would be blocked, move to `warn` to give developers notice without breaking deployments, and finally graduate to `enforce` when the organization is confident that all workloads comply.
 
-> **War Story: The $2.3 Million Privileged Container**
->
-> **September 2022.** A developer at a healthcare technology company needed to debug a production networking issue. "I'll just run a privileged container real quick to capture network traffic." They deployed with `privileged: true`, fixed the issue, and moved on to the next ticket. The privileged container stayed running.
->
-> Eight months later, attackers exploited a Log4j vulnerability <!-- incident-xref: log4shell --> in a different service running on the same node. Normally, container isolation would have limited the blast radius. But the attacker discovered the privileged container. For the Log4Shell canonical, see [Supply Chain Security](../../disciplines/reliability-security/devsecops/module-4.4-supply-chain-security/).
->
-> **With `privileged: true`, the container had full access to the host.** The attacker escaped the container, accessed the node's filesystem, read Kubernetes secrets for 47 other services, and exfiltrated patient health records for 340,000 individuals.
->
-> **The breach cost $2.3 million** in HIPAA fines, breach notification, credit monitoring, and forensic investigation. The company was required to implement comprehensive security controls and submit to three years of audits.
->
-> After the breach, the team implemented Pod Security Standards with `enforce: restricted` on all production namespaces. Now `privileged: true` is blocked at admission—the developer would have gotten an immediate error instead of a deployed vulnerability sitting dormant for eight months.
+> **Stop and think**: If Pod Security Standards actively block `privileged: true`, how would a cluster administrator deploy a DaemonSet that genuinely needs host network access (such as a CNI plugin or a storage CSI driver)? How do automated guardrails handle legitimate exceptions securely?
+
+### 3.5 Policy-as-Code: The Operational Layer
+
+Policy-as-code is the mechanism that turns secure-by-default philosophy into enforceable reality. Instead of writing a security policy document that says "containers must not run as root" and hoping developers read it, you write a policy in a machine-enforceable language (Rego for OPA Gatekeeper, custom resources for Kyverno, Sentinel for HashiCorp, CEL for Kubernetes ValidatingAdmissionPolicies) and the admission controller blocks any resource that violates it.
+
+The critical property of policy-as-code is that it is **version-controlled, reviewed, and tested** like application code. A policy change goes through a pull request with reviewer approval, and the policy itself has test cases that verify it blocks the intended violations and allows legitimate configurations. This closes the loop that a written policy document leaves open: the document depends on human compliance; the code enforces compliance automatically.
+
+Both OPA Gatekeeper and Kyverno are graduated CNCF projects that operate as Kubernetes admission controllers. Gatekeeper uses the Rego language, which is expressive but has a learning curve. Kyverno uses Kubernetes-native YAML policies, which are simpler to write but less flexible for complex logic. The choice between them matters less than the decision to use either one — the presence of any policy-as-code layer is what transforms a cluster from a blank canvas where anything is permitted into a platform where the secure path is the only path.
 
 ---
 
 ## Part 4: Secure Configuration Management
 
-### 4.1 Configuration as Code
+### 4.1 Configuration as Code: Why It Matters
+
+Secure defaults are only effective if they are applied consistently. A server whose configuration was hand-edited by three different operators over six months has, effectively, no known configuration state — it has an accumulated set of changes with no record of what was changed, by whom, or why. This is the anti-pattern of manual configuration management: SSH into the server, edit a file, restart the service, and hope nothing is broken. It creates configuration drift between environments, eliminates any audit trail, and makes reproducing a working state nearly impossible when something goes wrong.
+
+**Configuration as code** reverses this by storing all configuration in version control, requiring changes to go through pull request review, and deploying automatically from the approved state. The configuration becomes a software artifact with the same properties as the application code: it is reviewed, it is tested, it is reproducible, and it has a complete history of every change, who made it, and why. When a security incident requires understanding whether a particular firewall rule was open during a specific time window, the git history provides an exact answer.
 
 ```text
 CONFIGURATION MANAGEMENT
-═══════════════════════════════════════════════════════════════
 
 ANTI-PATTERN: Manual configuration
-─────────────────────────────────────────────────────────────
     - SSH into server
     - Edit config file
     - Restart service
@@ -375,7 +316,6 @@ ANTI-PATTERN: Manual configuration
     - Hard to reproduce
 
 PATTERN: Configuration as code
-─────────────────────────────────────────────────────────────
     - All configuration in version control
     - Changes go through pull request
     - Automated deployment
@@ -390,56 +330,38 @@ PATTERN: Configuration as code
 
 ### 4.2 Secrets Management
 
+The worst place for a secret is in a configuration file checked into version control. Once committed, a secret is permanently embedded in the repository's history — even if the offending commit is replaced, the original remains accessible in the reflog, in cloned copies on developer laptops, in CI/CD server checkouts, and in backups. The surface area of exposure is vast and largely invisible to the organization.
+
+The secure-by-default approach to secrets management has three tiers. **Tier one:** no secrets in source code, period. Environment variables provide a first level of indirection — the config file contains `${DATABASE_PASSWORD}` and the actual value is injected at runtime. But environment variables leak through process listings, debug endpoints, and child process inheritance. **Tier two:** a dedicated secrets manager — HashiCorp Vault, AWS Secrets Manager, Google Cloud Secret Manager, Azure Key Vault — stores the secret, controls access, rotates credentials, and provides an audit log of every access. The application authenticates to the secrets manager, not to the credential directly. **Tier three:** for Kubernetes, the External Secrets Operator synchronizes secrets from an external manager into Kubernetes Secret objects, so the application can consume them through the native Kubernetes API while the source of truth remains in the external vault. This prevents the Kubernetes Secret anti-pattern of storing a base64-encoded (not encrypted) value that is trivially decoded by anyone with `kubectl get secret -o yaml`.
+
 ```yaml
-# SECRETS MANAGEMENT
-# ═══════════════════════════════════════════════════════════════
+# WRONG: Secrets in config files (checked into git!)
+# database:
+#   password: "super_secret_password"
 
-# WRONG: Secrets in config files
-# ─────────────────────────────────────────────────────────────
-    # config.yaml (checked into git!)
-    # database:
-    #   password: "super_secret_password"
+# RIGHT: Reference from external secrets manager
+# database:
+#   password_path: vault://secret/db/password
 
-    # Problems:
-    # - Visible to anyone with repo access
-    # - In git history forever
-    # - Same secret across environments
-
-# RIGHT: External secrets management
-# ─────────────────────────────────────────────────────────────
-    # config.yaml
-    # database:
-    #   password: ${DATABASE_PASSWORD}  # From environment
-
-    # Even better: from secrets manager
-    # database:
-    #   password_path: vault://secret/db/password
-
-# KUBERNETES SECRETS
-# ─────────────────────────────────────────────────────────────
-    # Still not great: base64 encoded, not encrypted
-    apiVersion: v1
-    kind: Secret
-    data:
-      password: c3VwZXJfc2VjcmV0  # Just base64!
-
-    # Better: External Secrets Operator
-    apiVersion: external-secrets.io/v1beta1
-    kind: ExternalSecret
-    spec:
-      secretStoreRef:
-        name: vault
-      target:
-        name: db-credentials
-      data:
-      - secretKey: password
-        remoteRef:
-          key: secret/db/password
+# BETTER: External Secrets Operator for Kubernetes
+apiVersion: external-secrets.io/v1
+kind: ExternalSecret
+spec:
+  secretStoreRef:
+    name: vault
+  target:
+    name: db-credentials
+  data:
+  - secretKey: password
+    remoteRef:
+      key: secret/db/password
 ```
 
 > **Pause and predict**: You've migrated all secrets to HashiCorp Vault and use ExternalSecrets to inject them. But your application pods keep crashing on startup because they attempt to read the database password before ExternalSecrets has finished syncing it from Vault. How does a secure system elegantly handle startup dependencies like this?
 
 ### 4.3 Immutable Infrastructure
+
+Immutable infrastructure is the deployment pattern that closes the loop on secure defaults. Instead of deploying a server and then configuring it — leaving a gap between initial deployment and hardened state — immutable infrastructure pre-bakes the entire configuration into a deployable artifact (a container image, an AMI, a VM template) and deploys it as a unit. When a configuration change is needed, you don't modify the running instance; you build a new artifact and replace the old one entirely.
 
 ```mermaid
 flowchart TD
@@ -458,22 +380,24 @@ flowchart TD
     end
 ```
 
-**Benefits of Immutable Infrastructure:**
-- **Reproducible deployments:** The server always matches the code exactly.
-- **Known state at all times:** No hidden configuration drift or "ghost" processes.
-- **Easy rollback:** Deploy the previous container image instead of attempting to revert changes via scripts.
-- **Security:** You can't modify a running container (especially if it has a read-only filesystem). Attackers cannot persist.
+The security benefits of immutability are profound. A running instance's state is guaranteed to match the known-good artifact; any drift (an attacker's modifications, a hurried operator's manual fix, a configuration file edited at 3am during an incident) is erased on the next deployment. If an attacker compromises a container and installs persistence mechanisms, those mechanisms are destroyed when the pod is replaced — and in a Kubernetes environment with rolling deployments and node auto-repair, that replacement happens on the order of minutes, not months. The attack surface shrinks because the running system is not writable: a container with `readOnlyRootFilesystem: true` and no writable volumes gives an attacker no place to drop tools, modify binaries, or alter configuration.
 
-> **Try This (3 minutes)**
->
-> Audit your configuration:
->
-> | Configuration | In Version Control? | Has Secrets? | Secure? |
-> |---------------|--------------------|--------------|---------|
-> | App config | | | |
-> | Infrastructure | | | |
-> | CI/CD pipelines | | | |
-> | Kubernetes manifests | | | |
+```yaml
+# Read-only root filesystem: no place for an attacker to persist
+spec:
+  containers:
+  - name: app
+    securityContext:
+      readOnlyRootFilesystem: true
+    volumeMounts:
+    - name: tmp
+      mountPath: /tmp  # Only writable path, ephemeral
+  volumes:
+  - name: tmp
+    emptyDir: {}
+```
+
+Immutable infrastructure also enables reproducible rollbacks. Rolling back a configuration change on a mutable server means reversing each individual modification — and hoping none of them left side effects. Rolling back an immutable deployment means deploying the previous artifact, which is guaranteed to be exactly what was running before the change. The rollback is not a repair operation; it is a redeploy of a known-good state.
 
 ---
 
@@ -481,149 +405,157 @@ flowchart TD
 
 ### 5.1 Secure Framework Patterns
 
+The most effective secure-by-default patterns are embedded in the application framework, where they protect every developer on every endpoint without requiring individual attention. Three patterns recur across mature frameworks and deserve to be understood as design principles, not just features.
+
+**Auto-escaping for XSS prevention** is the canonical opt-out pattern. Django, Jinja2, React, and most modern templating engines escape HTML output by default, so that `<script>alert(1)</script>` entered by a user is rendered as literal text rather than executed JavaScript. A developer who needs raw HTML must explicitly mark it as safe — and in doing so, signals to reviewers that this particular output has been sanitized upstream. The security benefit is that the default protects the developer who never thought about XSS at all, while the explicit override protects the organization by creating an auditable, grep-able marker for dangerous output.
+
 ```python
-# SECURE FRAMEWORK PATTERNS
-# ═══════════════════════════════════════════════════════════════
+# Django template - auto-escapes by default
+# {{ user_input }}  →  &lt;script&gt;...  (safe by default)
 
-# AUTO-ESCAPING (XSS Prevention)
-# ─────────────────────────────────────────────────────────────
-    # Django template - auto-escapes by default
-    # {{ user_input }}  →  &lt;script&gt;...
-
-    # To allow HTML, must explicitly disable
-    # {{ user_input|safe }}  # Developer knows they're taking risk
-
-# PARAMETERIZED QUERIES (SQL Injection Prevention)
-# ─────────────────────────────────────────────────────────────
-    # ORM forces parameterization
-    User.objects.filter(email=user_email)  # Safe
-
-    # Raw SQL requires explicit params
-    # cursor.execute("SELECT * FROM users WHERE email = %s", [email])
-
-    # String formatting errors immediately
-    # cursor.execute(f"SELECT * FROM users WHERE email = '{email}'")
-    # ^ Framework should warn or error
-
-# CSRF PROTECTION
-# ─────────────────────────────────────────────────────────────
-    # Framework adds CSRF token to forms automatically
-    # <form method="post">
-    #     {% csrf_token %}  <!-- Auto-injected -->
-    #     ...
-    # </form>
-
-    # POST without valid token is rejected by default
+# To allow HTML, must explicitly disable
+# {{ user_input|safe }}  # Developer knows they're taking risk
 ```
+
+**Parameterized queries for SQL injection prevention** are the same pattern applied to database access. An ORM that only exposes parameterized query methods — Django's querysets, SQLAlchemy's filter expressions, ActiveRecord's where clauses — eliminates the string-concatenation path that creates SQL injection. The developer never writes raw SQL because the framework doesn't provide a convenient API for it; if raw SQL is genuinely needed, it requires a separate, explicitly named method that takes parameters as a tuple, making the dangerous path visible and harder to use accidentally.
+
+**CSRF protection** auto-injected into every form eliminates an entire class of attack with zero developer effort. The framework generates a unique token, embeds it in forms automatically, and validates it on every state-changing request. The developer doesn't write validation logic — they just use the framework's form helpers. This is secure-by-default at its most efficient: security that costs nothing per use and blocks attacks the developer might not even know exist.
 
 ### 5.2 Secure API Patterns
 
+API design is where secure-by-default meets developer experience. An API that requires authentication on every endpoint creates a thousand places where a developer can forget to add it. An API that requires authentication by default, with an explicit `@public` decorator for endpoints that do not need it, creates zero places where a developer can forget — because the default handles it.
+
 ```python
-# SECURE API PATTERNS
-# ═══════════════════════════════════════════════════════════════
+# Authentication required by default
+@app.route('/api/users')
+@require_auth  # Applied globally
+def get_users():
+    pass
 
-# AUTHENTICATION REQUIRED BY DEFAULT
-# ─────────────────────────────────────────────────────────────
-    # All routes require auth unless marked public
-    @app.route('/api/users')
-    @require_auth  # Applied globally
-    def get_users():
-        pass
+@app.route('/health')
+@public  # Explicit opt-out
+def health_check():
+    return 'OK'
+```
 
-    @app.route('/health')
-    @public  # Explicit opt-out
-    def health_check():
-        return 'OK'
+Rate limiting follows the same pattern. A global default rate limit — say, 100 requests per minute — prevents a single client from overwhelming the API, whether through abuse or a bug in a client application. Specific endpoints that need higher limits (or stricter ones, for expensive operations) can override the default. But the baseline protection applies automatically to every new endpoint, without the developer having to think about it.
 
-# RATE LIMITING BY DEFAULT
-# ─────────────────────────────────────────────────────────────
-    # Default rate limit for all endpoints
-    app.config['RATELIMIT_DEFAULT'] = "100/minute"
+Input validation at the API boundary closes the loop. Using a schema validation library — Pydantic for Python, Zod for TypeScript, Marshmallow for Flask — the developer declares the expected shape of incoming data and the library validates it before the handler executes. Invalid data is rejected with a clear error response; valid data is passed to the handler already coerced to the correct types. This eliminates an entire category of injection attacks, type-confusion bugs, and unexpected-null errors that arise when handler code trusts raw input.
 
-    # Specific endpoints can override
-    @app.route('/api/expensive')
-    @rate_limit("10/minute")  # Stricter
-    def expensive_operation():
-        pass
+```python
+# Input validation by default
+class UserInput(BaseModel):
+    email: EmailStr        # Must be valid email
+    age: int = Field(ge=0, le=150)  # Bounded integer
 
-# INPUT VALIDATION BY DEFAULT
-# ─────────────────────────────────────────────────────────────
-    # Pydantic, Marshmallow, etc.
-    class UserInput(BaseModel):
-        email: EmailStr        # Must be valid email
-        age: int = Field(ge=0, le=150)  # Bounded integer
-
-    @app.route('/api/users', methods=['POST'])
-    def create_user(user: UserInput):  # Auto-validated
-        pass  # Only reaches here if input is valid
+@app.route('/api/users', methods=['POST'])
+def create_user(user: UserInput):  # Auto-validated
+    pass  # Only reaches here if input is valid
 ```
 
 ### 5.3 Secure Deployment Patterns
 
+Deployment configuration is where secure-by-default manifests in the runtime environment. Three patterns deserve special attention because they are simple to implement, dramatically reduce attack surface, and are frequently omitted from standard deployment templates.
+
+**Minimal base images** reduce the attack surface by eliminating everything the application doesn't need. A full Ubuntu container image contains a shell, package manager, dozens of system utilities, and hundreds of libraries — every one of which is a potential vector for an attacker who gains code execution. A distroless image contains only the application binary and its immediate runtime dependencies. An attacker who compromises a process running in a distroless container discovers that there is no shell, no `curl`, no `wget`, no package manager — the tools they need to explore the environment and establish persistence simply do not exist.
+
 ```dockerfile
-# SECURE DEPLOYMENT PATTERNS
-# ═══════════════════════════════════════════════════════════════
+# Bad: Full OS with unnecessary packages
+# FROM ubuntu:24.04
+# Contains: bash, curl, wget, apt, hundreds of packages
 
-# MINIMAL BASE IMAGES
-# ─────────────────────────────────────────────────────────────
-    # Bad: Full OS with unnecessary packages
-    # FROM ubuntu:24.04
-    # Contains: bash, curl, wget, apt, hundreds of packages
-
-    # Better: Minimal base
-    # FROM alpine:3.19
-    # Contains: minimal shell, busybox utilities
-
-    # Best: Distroless (no shell at all)
-    # FROM gcr.io/distroless/static
-    # Contains: only what your app needs
-    # Attacker can't run shell commands if there's no shell
-
-# NON-ROOT BY DEFAULT
-# ─────────────────────────────────────────────────────────────
-    # Dockerfile
-    FROM node:20-alpine
-
-    # Create non-root user
-    RUN addgroup -S app && adduser -S app -G app
-
-    # Set ownership
-    COPY --chown=app:app . /app
-    WORKDIR /app
-
-    # Run as non-root
-    USER app
-    CMD ["node", "server.js"]
+# Best: Distroless (no shell at all)
+# FROM gcr.io/distroless/static
+# Contains: only what your app needs
+# Attacker can't run shell commands if there's no shell
 ```
 
-```yaml
-# READ-ONLY FILESYSTEM
-# ─────────────────────────────────────────────────────────────
-    # Kubernetes deployment
-    spec:
-      containers:
-      - name: app
-        securityContext:
-          readOnlyRootFilesystem: true
-        volumeMounts:
-        - name: tmp
-          mountPath: /tmp  # Writable temp if needed
-      volumes:
-      - name: tmp
-        emptyDir: {}
+**Non-root containers** eliminate the easiest privilege escalation path. A process running as root inside a container is running as root on the host — the container boundary provides namespace isolation but not user-ID isolation. If that process is compromised (through an application vulnerability, a library flaw, or simply because the attacker found an exposed debug endpoint that executes commands), the attacker inherits root privileges on the node, with access to everything the node can see: other containers' filesystems, Kubernetes secrets, cloud metadata services. Running as a non-root user with a high UID that has no special meaning on the host eliminates this path: the compromised process has no privileges to escalate.
+
+```dockerfile
+# Non-root by default
+FROM node:20-alpine
+RUN addgroup -S app && adduser -S app -G app
+COPY --chown=app:app . /app
+WORKDIR /app
+USER app
+CMD ["node", "server.js"]
 ```
+
+---
+
+## Patterns & Anti-Patterns
+
+### Patterns (What Good Looks Like)
+
+**1. Deny-All Network Policy with Explicit Allowlisting** — Every Kubernetes namespace should start with a NetworkPolicy that denies all ingress traffic. Services that need to receive traffic declare explicit allowlist rules specifying sources and ports. This ensures that a newly deployed service is not accidentally exposed — not accidentally reachable from the internet, from other namespaces, or even from other pods in the same namespace. The default posture is isolation; connectivity is a deliberate configuration choice.
+
+**2. First-Run Credential Forcing** — Any system that authenticates users — databases, web applications, infrastructure tools — must force credential creation on first use. The system refuses to serve any request until an administrator has set a unique password. This can be implemented as a setup wizard, a one-time token displayed during installation, or a block on all functionality until the initial configuration is completed. The principle is: if the admin password can be "admin" for even one second after installation, thousands of instances will still have "admin" as their password years later.
+
+**3. Immutable Artifact Deployment with Read-Only Filesystem** — Deploy artifacts that cannot be modified after they start running. Container images are the canonical implementation: build once, deploy many times, never modify in place. Combine with `readOnlyRootFilesystem: true` in the Kubernetes security context so that even the running process cannot write to its own filesystem (except for explicitly mounted ephemeral volumes). This guarantees that what is running matches what was audited, and that an attacker who gains code execution cannot persist.
+
+**4. Policy-as-Code with Automated Enforcement** — Express security policies as code, stored in version control, reviewed through pull requests, and enforced automatically by admission controllers or CI pipeline checks. A policy that says "containers must not run as root" should be checked by a Rego policy in OPA Gatekeeper or a Kyverno ClusterPolicy, not by a manual review checklist. The policy is the enforcement; there is no gap between what the document says and what the cluster permits.
+
+### Anti-Patterns (What to Avoid)
+
+| Anti-Pattern | Why It's Bad | Better Approach |
+|--------------|--------------|-----------------|
+| "We'll secure it later" deployments | Under time pressure, "later" never arrives; the unsecured system becomes production infrastructure | Bake security into the deployment artifact from the first commit; no unsecured state ever exists |
+| Default admin credentials in setup guides | Thousands of operators follow the guide verbatim and never change the password; automated scanners find every one | Generate a unique initial credential during installation and display it once; refuse to serve until it's changed |
+| `privileged: true` as a debugging shortcut | Debug containers are left running indefinitely, creating permanent host-escape vectors on every node they touch | Use ephemeral debug containers (`kubectl debug`) with strict time-bound access; never commit privileged pods to manifests |
+| Secrets in environment variables | Environment variables leak through debug endpoints, crash dumps, child processes, and container orchestrator APIs | Use a secrets manager with just-in-time retrieval; never store secrets where the process environment can expose them |
+| `image: latest` tags in production manifests | Mutable tags mean the running image can change between deployments without any code change, breaking reproducibility and enabling supply-chain attacks | Pin images by digest (`@sha256:...`) so every deployment is cryptographically identical; use semver tags only as a convenience during development |
+| Allow-all firewall rules with "we'll restrict later" | The window between deployment and lockdown is a window of full exposure; automated scanners find open services in minutes | Deploy with deny-all rules and require explicit allowlist entries as part of the deployment manifest; the service doesn't work until you specify who can reach it |
+| Security configuration in documentation rather than code | Documentation drifts, is not read under time pressure, and has no enforcement; developers skip steps they know they "should" do | Encode security requirements as policy-as-code that automatically blocks non-compliant configurations; the documentation describes the policy, the code enforces it |
+| Debug mode enabled in production builds | Stack traces, verbose error messages, debug toolbars, and interactive consoles expose internal architecture, secrets, and attack surface to anyone who triggers an error | Disable debug mode by default in production environment configurations; require an explicit, audited override to enable it for incident response |
+
+---
+
+## Decision Framework: Choosing the Right Default
+
+When designing or evaluating a system's security posture, use this decision framework to determine whether the defaults are adequate and what level of intervention is appropriate.
+
+```mermaid
+flowchart TD
+    START["New system or service deployment"] --> Q1{"Does the default configuration require authentication?"}
+    Q1 -->|No| R1["RED: Block deployment. Authentication must be required by default."]
+    Q1 -->|Yes| Q2{"Does the default configuration use encrypted transport?"}
+    Q2 -->|No| R2["RED: Block deployment. TLS must be required, not optional."]
+    Q2 -->|Yes| Q3{"Does the default bind to localhost or a private interface?"}
+    Q3 -->|No - binds to 0.0.0.0| R3["AMBER: Require explicit allowlist before production exposure."]
+    Q3 -->|Yes| Q4{"Does the process run as non-root?"}
+    Q4 -->|No| R4["AMBER: Require justification and time-bound exception. Default must be non-root."]
+    Q4 -->|Yes| Q5{"Are secrets managed externally (vault/manager)?"}
+    Q5 -->|No| R5["AMBER: Secrets in environment variables or config files. Plan migration to secrets manager."]
+    Q5 -->|Yes| Q6{"Is the artifact immutable (image pinned by digest)?"}
+    Q6 -->|No| R6["AMBER: Mutable tags or in-place updates. Pin by digest, deploy immutably."]
+    Q6 -->|Yes| GREEN["GREEN: Secure-by-default baseline met. Apply additional hardening as needed."]
+```
+
+The flow chart encodes a graduated security assessment that any team can apply during design review, deployment approval, or audit. The RED gates — no authentication, no encryption — are showstoppers. The AMBER gates — public binding, root execution, inline secrets, mutable deployments — are not immediate emergencies but represent significant hardening debt that should be scheduled and tracked. Only when all six gates are passed does the deployment meet the secure-by-default baseline.
+
+### Choosing a Pod Security Standards Level
+
+For Kubernetes workloads specifically, the choice between privileged, baseline, and restricted enforcement should follow this decision matrix, which maps workload characteristics to the appropriate security posture:
+
+| Workload Characteristic | Recommended PSS Level | Rationale |
+|------------------------|----------------------|-----------|
+| System-level DaemonSet (CNI, CSI, monitoring agent) that requires host network, host PID, or privileged mode | Privileged | These workloads genuinely need elevated access; isolate them in a dedicated namespace with strict RBAC |
+| Application workload that requires hostPath volumes, host namespaces (`hostNetwork`, `hostPID`, `hostIPC`), privileged containers, or capabilities beyond what Restricted allows | Baseline | Baseline blocks the most dangerous host-isolation bypasses while still permitting patterns Restricted also allows (filesystem writes, low ports via `NET_BIND_SERVICE`) |
+| Stateless application workload with no host-level access requirements | Restricted | Restricted enforces non-root, seccomp RuntimeDefault, no privilege escalation, and capability dropping — maximum built-in PSS security for the majority of workloads |
+| CI/CD build job or one-time task that needs temporary write access | Baseline, with time-bound namespace | Build jobs need filesystem write access but do not need host access; clean up the namespace after the job completes |
 
 ---
 
 ## Did You Know?
 
-- **MongoDB's default config** used to bind to 0.0.0.0 with no authentication. In 2017, 27,000+ MongoDB instances were found exposed and ransomed. Now it binds to localhost by default.
+- **MongoDB's default config** used to bind to 0.0.0.0 with no authentication. In late 2016 and early 2017, tens of thousands of exposed MongoDB instances were found, wiped, and held for ransom by automated scripts that required nothing more than a TCP connection and a DELETE command. Starting with version 3.6 later that year, MongoDB changed the default to bind localhost only and strongly encourage authentication during setup — a direct response to one of the largest default-configuration incidents in internet history.
 
-- **AWS S3 bucket ACLs** defaulted to private for years, but complex permission systems led to many accidental public exposures. In 2023, AWS added "Block Public Access" settings that default to blocking all public access.
+- **AWS S3 Block Public Access** settings were introduced in 2018 after years of organizations accidentally exposing sensitive data through misconfigured bucket policies. AWS announced in late 2022 that Block Public Access would be enabled by default for all newly created S3 buckets, with the change effective April 2023. This means an S3 bucket created today is private by default; making it public requires explicitly disabling two separate settings.
 
-- **Kubernetes 1.25** removed Pod Security Policies (PSP) in favor of Pod Security Standards (PSS), which are simpler and enabled by default in new namespaces.
+- **Kubernetes 1.25** (released August 2022) removed Pod Security Policies (PSP) — a complex, beta-level API that had been deprecated since 2021 — in favor of Pod Security Standards (PSS), enforced by a built-in Pod Security admission controller that is enabled by default. That controller still enforces nothing until namespace labels request a level — without labels, workloads remain effectively privileged. Once labeled, the three PSS levels (privileged, baseline, restricted) constrain pods at the namespace boundary without external tooling.
 
-- **The Docker Hub default** of pulling `latest` tag has caused countless production incidents. The tag is mutable—meaning `nginx:latest` today might be a completely different image than `nginx:latest` tomorrow. Secure by default means pinning to immutable digests like `nginx@sha256:abc123...`, which is why many organizations now enforce digest-based image references in admission policies.
+- **Docker's `latest` tag** is mutable — `nginx:latest` today can be a completely different image than `nginx:latest` tomorrow, because the tag is just a pointer that the registry owner can move at any time. This has caused countless production incidents where a redeployed pod pulled a different image version than the one that was tested. The secure default is to pin images by their content-addressable digest (`nginx@sha256:abc123...`), which guarantees that every deployment pulls the exact same bytes, verified by cryptographic hash. Many organizations now enforce digest-based image references in admission policies, rejecting any deployment that uses a mutable tag.
 
 ---
 
@@ -631,12 +563,14 @@ flowchart TD
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| "We'll secure it later" | Later never comes | Secure by default from start |
-| Default admin credentials | Easy target | Force credential setup |
-| Debug mode in production | Exposes internals | Disable unless explicitly enabled |
-| Overly permissive CORS | XSS exposure | Explicit allowed origins |
-| No resource limits | DoS vulnerability | Limits required by policy |
-| Trust all registries | Malicious images | Allowlist registries |
+| "We'll secure it later" | Under time pressure, "later" never arrives; the insecure default becomes the production configuration | Design secure defaults into the deployment artifact from the start; no separate hardening phase exists |
+| Default admin credentials | Automated scanners find every instance with `admin/admin` or `root/password` in minutes; thousands of breaches start this way | Force credential creation on first use; refuse to serve any request until a unique password is set |
+| Debug mode in production | Stack traces, debug toolbars, and interactive consoles expose internal paths, secrets, and database queries to attackers who trigger errors | Disable debug mode in production configurations; require an explicit, audited override to enable it temporarily |
+| Overly permissive CORS headers | `Access-Control-Allow-Origin: *` allows any website to make authenticated requests to your API using the user's cookies | Restrict CORS to explicit allowed origins; never use wildcards in production |
+| No resource limits on containers | A container that can consume unbounded CPU or memory becomes a denial-of-service vector against every other container on the node | Set CPU and memory requests and limits on every container; enforce with LimitRange or admission policy |
+| Trusting all container registries | An attacker who compromises a developer's credentials can push a malicious image to a public registry, and any cluster that pulls from untrusted registries will run it | Allowlist only approved registries in admission policy; require image signatures through Sigstore or Notary |
+| `image: latest` in production manifests | The image that runs is whatever the registry currently points the tag to — not what was tested or reviewed | Pin images by digest (`@sha256:...`); use semver tags only during development and pin before production |
+| Secrets in version control | Once committed, a secret is permanently visible in git history, cloned repositories, and CI/CD server checkouts — it cannot be reliably removed | Store secrets in a dedicated secrets manager; reference them by indirection in configuration files; rotate any secret that was ever committed |
 
 ---
 
@@ -646,65 +580,63 @@ flowchart TD
    <details>
    <summary>Answer</summary>
 
-   The checklist approach relies on human perfection; developers must actively remember and take time to apply each security measure, which often fails under pressure. A "secure by default" architecture shifts this burden by ensuring systems are inherently secure out of the box without requiring manual intervention. If a developer forgets a step in a secure-by-default system, the application might fail to function (failing safely), but it won't expose a vulnerability. This makes the easiest path the secure path, drastically reducing the chance of human error leading to a breach.
+   The checklist approach relies on human perfection across every deployment; developers must actively remember and take time to apply each of the 50 security measures, which inevitably fails under time pressure, fatigue, or simple oversight. A secure-by-default architecture shifts the burden to the system itself by ensuring deployments are inherently secure out of the box without requiring manual hardening steps. If a developer forgets a step in a secure-by-default system, the application might fail to function — but it won't expose a vulnerability. This makes the easiest path the secure path, drastically reducing the chance of human error leading to a breach, and it applies consistent protection to every deployment regardless of which developer performs it or how much time they had.
    </details>
 
-2. **Scenario: You are designing a CI/CD pipeline. You need to implement a mechanism that blocks deployments containing hardcoded secrets, and another mechanism that requires all high-risk changes to be manually reviewed by the security team. How do guardrails and gates apply to these two requirements, and what is the key difference between them?**
+2. **Scenario: You are designing a CI/CD pipeline. You need a mechanism that blocks deployments containing hardcoded secrets, and another mechanism that requires all changes to production infrastructure to be manually reviewed by the security team. How do guardrails and gates apply to these two requirements, and what is the key difference between them?**
    <details>
    <summary>Answer</summary>
 
-   Guardrails are passive constraints that prevent dangerous actions without interrupting normal workflows, such as an automated CI check that dynamically blocks hardcoded secrets only when they are detected. Gates, on the other hand, are active checkpoints that stop all progress until a specific condition is met, like requiring a mandatory manual security review for all high-risk deployments regardless of the automated scan results. The key difference is that guardrails only create friction when someone makes a mistake, allowing high velocity for safe changes, whereas gates intentionally introduce friction for every targeted change to ensure thorough human inspection.
+   Guardrails are passive, conditional constraints that prevent dangerous actions without interrupting normal workflows. An automated CI check that scans for hardcoded secrets and blocks deployments only when secrets are actually detected is a guardrail — it creates friction only when a mistake is made, allowing all safe deployments to pass through at full velocity. Gates, by contrast, are active, unconditional checkpoints that stop all progress until a specific condition is met. Requiring a manual security review for all production infrastructure changes is a gate because it blocks every single change, regardless of content, until a human approves it. The key difference is that guardrails only intervene when something is wrong (optimizing for speed on safe changes), while gates always intervene (optimizing for assurance on high-risk changes).
    </details>
 
-3. **Scenario: An attacker discovers a Remote Code Execution (RCE) vulnerability in your web application. They use it to gain a shell, download malicious tools, and modify the application's configuration files to establish persistence. However, when your team deploys the next regular update, the attacker's access and tools completely disappear. How does the concept of immutable infrastructure explain this outcome, and why does it improve security?**
+3. **Scenario: An attacker discovers a Remote Code Execution vulnerability in your web application. They gain a shell, download malicious tools, and modify the application's configuration files to establish persistence. However, when your team deploys the next regular update, the attacker's access and tools completely disappear. How does immutable infrastructure explain this outcome, and why does it improve security?**
    <details>
    <summary>Answer</summary>
 
-   Immutable infrastructure dictates that servers or containers are never updated in place; instead, they are entirely replaced with fresh instances built from a known-good image during every deployment. Because the underlying infrastructure is immutable, any unauthorized modifications, backdoors, or malicious tools downloaded by the attacker are completely destroyed the moment the old container is spun down. This significantly improves security by limiting the lifespan of any compromise and erasing persistent threats. It guarantees that the running state always perfectly matches the audited, secure state defined in version control.
+   Immutable infrastructure dictates that servers or containers are never updated in place; instead, they are entirely replaced with fresh instances built from a known-good, audited artifact during every deployment cycle. Because the running instance is never modified, any unauthorized changes — backdoors, malicious tools, altered configuration files — vanish the moment the old container or virtual machine is spun down and replaced. This limits the lifespan of any compromise to the deployment interval, erases persistence mechanisms without needing to detect them, and guarantees that the running state always matches the audited, secure state defined in version control. It also eliminates the "configuration drift" problem where a server accumulates undocumented changes over time.
    </details>
 
-4. **Scenario: A developer is troubleshooting a database connection issue in a local environment. To speed things up, they temporarily paste the production database password directly into the `config.yaml` file, commit the change, but then realize their mistake. They immediately delete the password, create a new commit, and push both commits to the central repository. Why does this still present a critical security risk, and what is the secure-by-default alternative?**
+4. **Scenario: A developer troubleshooting a database connection issue in a local environment temporarily pastes the production database password into `config.yaml`, commits the change, but then realizes their mistake. They immediately delete the password, create a new commit, and push both commits to the central repository. Why does this still present a critical security risk, and what is the secure-by-default alternative?**
    <details>
    <summary>Answer</summary>
 
-   Once a secret is committed to version control, it becomes a permanent part of the repository's history, meaning anyone with read access to the repository can view the initial commit and extract the password. Even if the secret is deleted in a subsequent commit, the original commit remains in the git log indefinitely and can be recovered by anyone. Repositories are often cloned to many developer laptops and CI/CD servers, creating widespread, uncontrolled proliferation of the exposed secret. The secure-by-default alternative is to use an external secrets manager and reference the secret dynamically via environment variables or operators like Kubernetes ExternalSecrets, ensuring the actual value is never written to disk or source code.
+   Once a secret is committed to version control, it becomes a permanent part of the repository's history. Even if the password is deleted in a subsequent commit, the original commit remains in the git log indefinitely — accessible through `git log`, `git reflog`, and `git show <commit-hash>`. The repository is often cloned to dozens of developer laptops and CI/CD server checkouts, each of which retains a full copy of every commit that ever existed. Revoking and rotating the secret is the only reliable remediation, and that must happen immediately. The secure-by-default alternative is to use an external secrets manager and reference the secret dynamically through environment variables or operators like Kubernetes ExternalSecrets, ensuring the actual value is never written to disk or source code in the first place.
    </details>
 
-5. **Scenario: An organization deploys 500 new services per month. Each deployment has a 5% chance of having a critical misconfiguration if checked manually. If the organization implements automated guardrails instead, the chance drops to 0.1%. Why is the automated approach mandatory at scale?**
+5. **Scenario: An organization deploys 500 new services per month. Each deployment has roughly a 5 percent chance of containing a critical misconfiguration if checked manually. If the organization implements automated guardrails that catch almost all of these, the residual misconfiguration rate drops to approximately 0.1 percent. Why is the automated approach mandatory at scale, and what does the math reveal about manual processes?**
    <details>
    <summary>Answer</summary>
 
-   The manual check approach relies on human vigilance, which naturally degrades under the volume of 500 deployments a month and time pressure, leading to an expected 300 misconfigurations annually (6,000 deployments × 5%). Automated guardrails, however, run consistently and tirelessly on every single deployment, enforcing security rules without human fatigue. The math proves that relying on automated secure defaults scales effectively, dropping expected misconfigurations to just 6 per year. Manual processes inevitably fail at scale because human error is a statistical certainty, making automation the only viable path to true security.
+   At 500 deployments per month, a 5 percent manual error rate produces approximately 25 critical misconfigurations every month — or 300 per year — each representing a potential security incident. Human vigilance degrades predictably under volume and time pressure, so the actual error rate may be higher during crunch periods when deployments are most frequent. Automated guardrails, by contrast, run identically on every deployment without fatigue, enforcing security rules consistently and producing only about 0.5 misconfigurations per month (approximately 6 per year). The math demonstrates that human-driven security processes are inherently unscalable: even a "good" 95 percent accuracy rate generates an unacceptable number of failures when multiplied by a large deployment volume. Automation is not a luxury at scale; it is a mathematical necessity.
    </details>
 
-6. **Scenario: In 2017, ransomware automated scripts exploited 27,000 MongoDB databases because the default configuration bound to all network interfaces (0.0.0.0) with authentication disabled. What "secure by default" changes would have prevented this, and what trade-offs do they create for developers?**
+6. **Scenario: In late 2016 and early 2017, automated scripts ransomed tens of thousands of MongoDB databases because the default configuration bound to all network interfaces (0.0.0.0) with authentication disabled. What specific secure-by-default changes would have prevented this, and what trade-offs do those changes create for developers?**
    <details>
    <summary>Answer</summary>
 
-   To prevent this, the default installation should have bound exclusively to localhost (127.0.0.1) and required an explicit administrator password to be set upon the first startup. The primary trade-off is that this introduces initial friction for developers who just want to quickly spin up a test database for local development without dealing with credentials. They now have to perform extra configuration steps to enable remote access and set up authentication. However, this intentional friction ensures that users must explicitly choose to make their database accessible and insecure, fundamentally protecting them from accidental public exposure.
+   Two secure-by-default changes would have prevented the incident entirely. First, the default bind address should have been localhost (127.0.0.1), accepting only connections from the same machine — a developer who needed remote access would have to explicitly change the bind address, making the decision conscious and deliberate. Second, authentication should have been required by default, with a forced password-creation step during initial setup. The trade-off is that these defaults introduce friction during local development: a developer spinning up a test database now has to configure remote access and set up credentials before connecting their application. This friction is intentional and proportional — it ensures that opening the database to the network is a deliberate act, not something that happens silently because the developer never thought to restrict it.
    </details>
 
 7. **Scenario: A web framework automatically escapes all HTML output in its templates by default, requiring developers to explicitly use a `|safe` filter to render raw HTML. Why is this "opt-in" approach to raw output fundamentally more secure than requiring developers to explicitly apply an `|escape` filter to untrusted data?**
    <details>
    <summary>Answer</summary>
 
-   When a framework requires developers to explicitly apply an `|escape` filter, a simple lapse in memory or a rushed deployment results in an immediate Cross-Site Scripting (XSS) vulnerability that fails silently and dangerously. By making escaping the default, the framework ensures that a developer's mistake (forgetting the `|safe` filter) results only in a harmless visual bug where literal HTML tags are displayed on the screen. This fails safe, meaning security is guaranteed by default, and a deliberate, conscious action is required to bypass it. It also makes security audits much easier by allowing reviewers to focus exclusively on validating the explicit uses of the `|safe` filter.
+   When a framework requires developers to explicitly apply an `|escape` filter to every variable, a single lapse in memory — on a footer template, a 404 page, a rarely-visited admin panel — creates an immediate Cross-Site Scripting vulnerability that fails silently and dangerously, potentially remaining undetected for years. By making escaping the default, the framework ensures that a developer's mistake (forgetting the `|safe` filter) results in a cosmetic rendering issue — literal HTML tags displayed as text — rather than a security vulnerability. This fails safe. It also transforms the security audit from an exhaustive search for every unescaped variable (impossible at scale) to a focused review of the explicitly marked `|safe` uses, which are typically few, grep-able, and surrounded by the developer's justification.
    </details>
 
-8. **Scenario: A Kubernetes deployment manifest for a critical microservice uses `image: backend-api:latest`. During an incident, the cluster autoscaler spins up a new pod, but it suddenly crashes due to a missing dependency, even though the older pods are running perfectly fine. Why is using the `latest` tag insecure by default, and what specific configuration should be used instead?**
+8. **Scenario: A Kubernetes deployment manifest for a critical microservice uses `image: backend-api:latest`. During an incident, the cluster autoscaler spins up new pods, but they suddenly crash due to a missing dependency, even though the older pods continued running without issues. Why is using the `latest` tag insecure by default, and what specific configuration should be used instead?**
    <details>
    <summary>Answer</summary>
 
-   The `latest` tag is mutable, meaning the underlying image it points to can be changed at any time by the registry owner or a compromised CI pipeline. This leads to different pods running completely different code if pulled at different times, causing inconsistent runtime behavior and crashing instances. This lack of reproducibility creates massive supply chain risks, as an attacker could overwrite the `latest` tag with a malicious image, instantly compromising any newly scheduled pods. Instead, the deployment should use an immutable image digest (e.g., `image: backend-api@sha256:abc123...`), which guarantees that every single pod will pull the exact same, cryptographically verified contents.
+   The `latest` tag is mutable — the image it resolves to can change at any moment because the registry owner (or a compromised CI pipeline) can retag a completely different image as `latest`. This creates a scenario where different pods in the same deployment run different code depending on when they were pulled, causing inconsistent runtime behavior and hard-to-diagnose crashes. More critically, an attacker who gains write access to the container registry can overwrite the `latest` tag with a malicious image, and every new pod that spins up will silently run the attacker's code. The secure-by-default alternative is to use an immutable image digest, such as `image: backend-api@sha256:abc123...`, which cryptographically guarantees that every pod pulls the exact same bytes, verified by hash, regardless of when the pull occurs or what tags have been changed in the registry.
    </details>
 
 ---
 
 ## Hands-On Exercise
 
-**Task**: Implement secure defaults for a Kubernetes deployment.
-
-**Scenario**: You have this insecure deployment:
+**Task**: Implement secure defaults for a Kubernetes deployment by hardening an existing insecure manifest. **Scenario**: You have been given the following deployment:
 
 ```yaml
 apiVersion: apps/v1
@@ -728,9 +660,7 @@ spec:
         - containerPort: 8080
 ```
 
-**Part 1: Identify Security Issues (5 minutes)**
-
-List everything wrong with this deployment:
+**Part 1: Identify Security Issues (5 minutes)** — Examine the YAML below and list every security issue you can identify, then categorize each finding by severity:
 
 | Issue | Risk | Severity |
 |-------|------|----------|
@@ -740,17 +670,13 @@ List everything wrong with this deployment:
 | | | |
 | | | |
 
-**Part 2: Fix the Deployment (15 minutes)**
-
-Rewrite with secure defaults:
+**Part 2: Fix the Deployment (15 minutes)** — Rewrite the entire deployment manifest from scratch with secure defaults baked in:
 
 ```yaml
 # Your secure deployment here
 ```
 
-**Part 3: Add Network Policy (10 minutes)**
-
-Create a NetworkPolicy that:
+**Part 3: Add Network Policy (10 minutes)** — Write a NetworkPolicy manifest that enforces the following secure-by-default rules:
 - Denies all ingress by default
 - Allows only from specific sources
 
@@ -758,21 +684,19 @@ Create a NetworkPolicy that:
 # Your NetworkPolicy here
 ```
 
-**Part 4: Add Pod Security (10 minutes)**
-
-Create namespace labels to enforce restricted pod security:
+**Part 4: Add Pod Security (10 minutes)** — Write a Namespace manifest with the correct pod security labels to enforce the restricted standard:
 
 ```yaml
 # Your Namespace with pod security labels
 ```
 
-**Success Criteria**:
+**Success Criteria**: Verify that your implementation satisfies all of the following requirements before you consider the exercise complete:
 - [ ] Identified at least 5 security issues in original deployment
 - [ ] Fixed deployment includes: non-root user, read-only fs, resource limits, image tag (not latest), security context
 - [ ] Network policy implements default deny
 - [ ] Namespace enforces restricted pod security standard
 
-**Sample Solution**:
+**Sample Solution**: Use the reference configuration below to check your work — but attempt the exercise yourself before peeking at the solution.
 
 <details>
 <summary>Show secure deployment</summary>
@@ -810,6 +734,9 @@ spec:
           readOnlyRootFilesystem: true
           capabilities:
             drop: ["ALL"]
+        volumeMounts:
+        - name: tmp
+          mountPath: /tmp
         resources:
           requests:
             cpu: 100m
@@ -834,41 +761,26 @@ spec:
 
 ---
 
-## Further Reading
+## Hypothetical Scenario: The Forgotten Debug Container
 
-- **"Building Secure and Reliable Systems"** - Google. Comprehensive guide to building secure systems from the ground up.
+A developer needs to troubleshoot a production networking issue on short notice. The quickest approach seems to be deploying a container with elevated privileges to capture network traffic at the node level. They create a Kubernetes pod with `privileged: true`, run `tcpdump` for thirty minutes, isolate the problematic packet flow, and open a fix ticket in the project tracker. The privileged pod is not deleted — it's not causing errors, nobody is paying attention to running pods on that particular node, and the developer has already moved on to the next sprint item with the intention of "cleaning up later."
 
-- **"Container Security"** - Liz Rice. Essential reading for securing containerized applications.
+Months pass. An unrelated service on the same node is compromised through a remote code execution vulnerability — a Log4Shell-class exploit that allows arbitrary command execution within the application container <!-- incident-xref: log4shell -->. Under normal circumstances, container isolation would limit the attacker's blast radius to the compromised application's namespace and resources. But the privileged container is still there, dormant, its elevated access to the host kernel having never been revoked. The attacker discovers it during lateral reconnaissance and uses its host-level access to escape the container entirely, reading Kubernetes secrets and accessing data from other workloads that share the node. For the Log4Shell canonical, see [Supply Chain Security](../../disciplines/reliability-security/devsecops/module-4.4-supply-chain-security/).
 
-- **CIS Benchmarks** - cisecurity.org. Industry-standard secure configuration baselines for various platforms.
-
----
-
-## Key Takeaways Checklist
-
-Before moving on, verify you can answer these:
-
-- [ ] Can you explain why secure by default is more effective than security checklists?
-- [ ] Do you understand the difference between guardrails (passive blockers) and gates (active checkpoints)?
-- [ ] Can you describe secure defaults for authentication, networking, and data?
-- [ ] Do you understand Pod Security Standards (Privileged, Baseline, Restricted) and how to enforce them?
-- [ ] Can you explain why secrets should never be in version control and what to use instead?
-- [ ] Do you understand immutable infrastructure and why it improves security?
-- [ ] Can you explain secure framework patterns (auto-escaping, parameterized queries, CSRF tokens)?
-- [ ] Do you understand why `image:latest` is insecure and what to use instead?
+If the cluster had been running with a secure-by-default posture, the privileged container would never have been scheduled in the first place. Pod Security Standards with `enforce: restricted` on all production namespaces would have rejected the pod at admission time, returning an error to the developer: "violates PodSecurity 'restricted:latest': privileged containers are disallowed." The developer would have been forced to use an ephemeral debug container — `kubectl debug` with a time-limited, audited access grant — instead of leaving a permanent host-escape vector sitting on a production node. The lesson is not that developers should remember to delete debug pods. It is that the system should make it impossible to create an insecure state that can be forgotten.
 
 ---
 
 ## Track Complete: Security Principles
 
-Congratulations! You've completed the Security Principles foundation. You now understand:
+Congratulations. You've completed the Security Principles foundation — the conceptual bedrock beneath every security decision you will make as a platform engineer, SRE, or security architect. You now understand the following concepts:
 
-- The security mindset: think like an attacker, design like a defender
-- Defense in depth: layer independent security controls
-- Identity and access: authentication, authorization, least privilege
-- Secure by default: build security in, don't bolt it on
+- **The security mindset:** Think like an attacker to design like a defender. The asymmetry — attackers need one path, defenders must protect all of them — is the fundamental dynamic that shapes every security trade-off.
+- **Defense in depth:** Layer independent controls so that no single failure results in a breach. Each layer must be independently effective; overlapping identical controls at different layers provide false assurance.
+- **Identity and access:** Authenticate who is acting, authorize what they can do, and apply the principle of least privilege — every identity should have only the permissions it needs, and no more.
+- **Secure by default:** Build security into the system rather than bolting it on afterward. The path of least resistance must be the safe path. Checklists fail at scale; automated guardrails succeed.
 
-**Where to go from here:**
+**Where to go from here:** The table below maps your interests to the next recommended track so you can continue building on these foundations.
 
 | Your Interest | Next Track |
 |---------------|------------|
@@ -883,9 +795,34 @@ Congratulations! You've completed the Security Principles foundation. You now un
 
 | Module | Key Takeaway |
 |--------|--------------|
-| 4.1 | Security is a mindset—think like attackers to defend against them |
-| 4.2 | Layer defenses—no single control is enough |
-| 4.3 | Authenticate who, authorize what—principle of least privilege |
-| 4.4 | Make security the default—secure path should be the easy path |
+| 4.1 | Security is a mindset — think like attackers to defend against them |
+| 4.2 | Layer defenses — no single control is enough |
+| 4.3 | Authenticate who, authorize what — principle of least privilege |
+| 4.4 | Make security the default — the secure path should be the easy path |
 
-*"Security is not a product, but a process."* — Bruce Schneier
+This sub-track closes with Bruce Schneier's enduring insight: *"Security is not a product, but a process."* — a reminder that no single tool, policy, or module makes you secure, but the continuous practice of these principles does.
+
+---
+## Sources
+
+1. [Kubernetes Pod Security Standards](https://kubernetes.io/docs/concepts/security/pod-security-standards/) — Official Kubernetes documentation on the three PSS levels (privileged, baseline, restricted) and namespace-level enforcement.
+2. [MongoDB Databases Held for Ransom by Mysterious Attacker](https://www.bleepingcomputer.com/news/security/mongodb-databases-held-for-ransom-by-mysterious-attacker/) — BleepingComputer coverage (January 2017) of the first wave of MongoDB ransom attacks against internet-exposed instances with no authentication, the incident referenced in this module's opening.
+3. [OWASP Top 10 Web Application Security Risks](https://owasp.org/www-project-top-ten/) — The definitive ranking of web application vulnerabilities; secure-by-default patterns (parameterized queries, auto-escaping, CSRF protection) directly address the most prevalent risks.
+4. [OWASP Application Security Verification Standard (ASVS)](https://github.com/OWASP/ASVS) — A framework of security requirements organized by verification level; V2 (Authentication) and V7 (Logging) are directly relevant to secure-by-default design.
+5. [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/publications/detail/sp/800-207/final) — The foundational U.S. federal standard for zero trust architecture, which operationalizes secure-by-default through continuous verification and default-deny network posture.
+6. [NIST SP 800-53: Security and Privacy Controls for Information Systems and Organizations](https://csrc.nist.gov/publications/detail/sp/800-53/rev-5/final) — Catalog of security controls; the "configuration settings" and "least privilege" control families directly map to secure-by-default implementation.
+7. [Google — Building Secure and Reliable Systems (SRS Book)](https://sre.google/books/building-secure-reliable-systems/) — Free online book covering secure-by-default design patterns, including the chapter "Design for Understandability" and practical guidance on framework-level security defaults.
+8. [CIS Benchmarks](https://www.cisecurity.org/cis-benchmarks/) — Industry-standard secure configuration baselines for operating systems, cloud providers, Kubernetes, and container runtimes. Each benchmark embodies the secure-by-default philosophy for a specific platform.
+9. [AWS S3 Block Public Access](https://docs.aws.amazon.com/AmazonS3/latest/userguide/access-control-block-public-access.html) — Documentation for the AWS feature that enforces secure-by-default bucket access by blocking all public access at the account or bucket level.
+10. [SLSA (Supply-chain Levels for Software Artifacts)](https://slsa.dev/) — Framework for software supply chain integrity; the requirement for immutable, digest-pinned artifacts is a core secure-by-default practice for container images.
+11. [Kyverno — Kubernetes Policy Management](https://kyverno.io/) — CNCF-graduated policy engine that implements policy-as-code for Kubernetes using Kubernetes-native YAML resources, enabling secure-by-default enforcement at the admission control layer.
+12. [OPA Gatekeeper — Policy Controller for Kubernetes](https://open-policy-agent.github.io/gatekeeper/website/docs/) — CNCF-graduated admission controller that enforces Rego-based policies on Kubernetes resources, providing a flexible policy-as-code implementation for secure-by-default guardrails.
+13. [OWASP Cheat Sheet Series — Infrastructure as Code Security](https://cheatsheetseries.owasp.org/cheatsheets/Infrastructure_as_Code_Security_Cheat_Sheet.html) — Practical guidance for building security into infrastructure-as-code from the start, covering scanning, policy enforcement, and secrets management.
+
+---
+
+---
+
+## Next Module
+
+You have completed the Security Principles sub-track. Continue to the Distributed Systems sub-track: [Module 5.1: What Makes Systems Distributed](../../distributed-systems/module-5.1-what-makes-systems-distributed/), where you will explore the challenges and patterns of building software that spans multiple machines.


### PR DESCRIPTION
## Platform Foundations campaign (#1897) — Wave 4: Security Principles

Expands the three sub-floor critical-score modules in **Security Principles** to T0, in curriculum order. Same loop: verifier sweep → expand (prose-ify the bullet/code-comment density) → mixed-pool cross-family review (NO gemini) → ground-check + web-verify every finding → consolidated PR → build PRIMARY → dedup gate.

### Modules

| Module | Before | After | Author | Reviewer |
|--------|--------|-------|--------|----------|
| 4.1 security-mindset | T3, 799w, 0 src | **T0, 5010w, 17 src** | cursor | codex |
| 4.2 defense-in-depth | T3, 981w, 0 src | **T0, 6027w, 15 src** | codex gpt-5.5 | cursor |
| 4.4 secure-by-default | T3, 811w, 0 src | **T0, 6184w, 13 src** | deepseek | opus |

All `revision_pending: false`; War Stories de-fabbed → `Hypothetical scenario:`; both `47` leaks removed (4.4).

### Cross-family review caught (all ground-checked + web-verified)

**4.1 — codex review:** the `$300M Firewall Failure` War Story mis-attributed a *fabricated* firewall-exception-rot narrative to Equifax — but real Equifax 2017 was an **unpatched Apache Struts CVE-2017-5638** (~76 days undetected, ~147M consumers). De-fabbed the invented story → `Hypothetical scenario:` and kept an accurate, cited Equifax cross-reference (SolarWinds + Equifax xref markers preserved). Also: DBIR "human element" reframe (was overstated as "social engineering"), NIST **CSF 2.0** Govern function, a dead Microsoft SDL URL, an ambiguous "No passwords" quadrant label, two softened illustrative stats.

**4.2 — cursor review (real verifier-blind K8s bug):** the NetworkPolicy example had a `default-deny-ingress-and-egress` + an *ingress-only* `allow-web-to-api`. Because Kubernetes evaluates ingress and egress independently, **web→api would silently fail** (web's egress was never allowed), and default-deny egress also **blocks DNS**. Added `allow-web-egress-to-api` + `allow-dns-egress` policies and corrected the prose. This module is the **canonical owner of the Target 2013 breach** — Target facts web-verified (Fazio HVAC vendor, ~40M cards / ~70M records, FireEye alerts ignored, ~$292M) and FireEye named.

**4.4 — opus review (3 P1, deepseek-authored, ground-checked hard):** deepseek asserted **Restricted PSS requires `readOnlyRootFilesystem`** — it does **not** (not a PSS control; recommended but enforced separately) — corrected in 2 places (description + decision matrix); fixed a **broken Next-Module link** (`module-5.1-why-distributed-systems` → real `module-5.1-what-makes-systems-distributed`); fixed a logic inversion ("has enforcement"→"has no enforcement"); clarified "PSS enabled by default" (controller is on but enforces nothing until namespaces are labeled — unlabeled ≈ privileged); cited the MongoDB-2017 ransomware opener. opus **reverse-saved** the Kyverno/OPA-Gatekeeper "CNCF Graduated" status (correct as of 2026-03).

### Verification
- `verify_module.py`: all three T0 / passed, 0 failing gates
- Full astro build (PRIMARY-equivalent): **2171 pages, Complete!**, 0 schema errors
- `incident_dedup_gate.py`: PASS (absolute) — Target/SolarWinds/Equifax/Log4Shell xref markers + canonical ownership intact
- `check_site_health.py`: **0 errors**

Refs #1897
