### PR TITLE
docs(platform): expand+flip Foundations Distributed Systems 5.1-5.5 to T0 (#1897)

### DIFF
--- a/src/content/docs/platform/foundations/distributed-systems/module-5.1-what-makes-systems-distributed.md
+++ b/src/content/docs/platform/foundations/distributed-systems/module-5.1-what-makes-systems-distributed.md
@@ -12,7 +12,7 @@ sidebar:
 >
 > **Track**: Foundations
 
-### What You'll Be Able to Do
+## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
@@ -26,38 +26,414 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-In February 2017, a single mistyped command took the AWS S3 index in US-East-1 offline, <!-- incident-xref: aws-s3-useast1-2017 --> cascading into a four-hour outage across hundreds of internet services. The full breakdown is covered in [Failure Modes and Effects](../reliability-engineering/module-2.2-failure-modes-and-effects/).
+In February 2017, an authorized operator working from an established AWS S3 playbook entered an incorrect input while removing a small number of servers from a billing subsystem in US-East-1. The over-broad removal did not directly "take the index offline" in one step; it removed more servers than intended, and the removed servers also supported the index and placement subsystems. Those two large subsystems then required full restarts, and because they held very large amounts of metadata and had not been fully restarted in years, recovery took several hours. <!-- incident-xref: aws-s3-useast1-2017 --> The way one subsystem's failure rippled into hundreds of dependent services is exactly the failure-mode taxonomy and blast-radius analysis taught in [Failure Modes and Effects](../reliability-engineering/module-2.2-failure-modes-and-effects/); this module uses the outage only as the doorway into distributed-systems thinking.
 
-For the next four hours, S3 in US-East-1 was essentially offline. However, the true impact of this outage was not just that files couldn't be downloaded; it was the catastrophic cascade of failures across the entire internet. Hundreds of other AWS services depended inherently on S3 to function. Websites couldn't load assets, continuous integration pipelines halted, and IoT devices went dark. Ironically, the AWS Service Health Dashboard itself was hosted on S3 and could not be updated to reflect that S3 was down, leaving customers entirely in the dark. S&P 500 companies collectively lost an estimated $150 million during this single four-hour window.
+The important lesson is not that humans make mistakes, because every operating model must assume that they do. The lesson is that a distributed system turns a local action into a system-wide experiment. A billing maintenance command affected metadata lookup, storage placement, dashboards, build systems, websites, and devices that were not part of the original operator's mental model. External analysts at Cyence, widely reported at the time, estimated that S&P 500 companies lost roughly $150 million during the interruption, but that number was not an AWS-reported figure and should be read as an outside economic estimate rather than a precise service metric.
 
-This cascade revealed what distributed systems engineers have known for decades but what the broader industry frequently forgets: even the simplest web application running in the cloud is a complex distributed system. These systems are bound by hidden dependencies, plagued by partial failures, and subject to emergent behaviors that no single individual can fully predict. When you scale beyond a single machine, the laws of physics and logic change. This module will teach you exactly how they change, why these systems fail in such spectacular ways, and how you can architect applications that embrace this chaos rather than attempting to hide from it.
+That is what makes distributed systems different from ordinary programming. A single process on one machine can still be complicated, but its failure is usually local and its state is usually inspectable from one place. A cloud service is a conversation among machines, networks, clocks, queues, caches, databases, load balancers, controllers, and people. The application presents one coherent experience to the user, while underneath that experience there are independent components that can be slow, unreachable, stale, overloaded, partitioned, or correct in isolation but wrong in combination.
+
+The central analogy for this module is a stage performance with the curtain down. The audience sees one play, but the production depends on actors, lighting, sound, props, ticketing, stage management, and building power all coordinating without the audience seeing the machinery. A distributed system is similar: the user sees "save file" or "place order," while the system is quietly routing messages across many independently failing parts. Good architecture does not pretend the backstage is simple; it designs the performance so one missed cue does not collapse the whole show.
+
+We accept this complexity because the alternatives are worse for modern workloads. One large machine can be easier to reason about, but it has a finite ceiling for CPU, memory, storage, blast-radius isolation, and geographic reach. Distributed systems let us scale beyond one box, survive some component failures, place work near users, separate teams by service boundary, and evolve parts of a system without replacing the whole. The price is that we must design for uncertainty instead of treating uncertainty as an exception.
 
 ---
 
 ## Did You Know?
 
-- **The $150 Million Typo:** The AWS S3 outage of 2017 cost S&P 500 companies an estimated $150 million, proving that a single human error in a distributed control plane can cascade globally.
-- **Physical Speed Limits:** The speed of light in a vacuum is 299,792 km/s, but in fiber optic glass, it slows to roughly 200,000 km/s. This means the absolute physical minimum round-trip time between New York and London is approximately 56 milliseconds, regardless of how much money you spend on bandwidth.
-- **The CAP Theorem Origins:** Eric Brewer first presented the CAP Theorem as a conjecture in the year 2000 at the Symposium on Principles of Distributed Computing (PODC). It was formally proven mathematically by Nancy Lynch and Seth Gilbert of MIT in 2002.
-- **Consensus in Kubernetes:** The brain of every Kubernetes cluster, `etcd`, relies on the Raft consensus algorithm. Raft was published in 2014 by Diego Ongaro and John Ousterhout specifically to be more understandable than the notoriously complex Paxos algorithm.
+- **The external $150 million estimate:** Analysts at Cyence estimated that S&P 500 companies lost roughly $150 million during the 2017 AWS S3 disruption. Treat that as a third-party economic estimate, not as an AWS-reported loss number or an exact causal accounting.
+- **Physical speed limits:** Light travels about 299,792 km/s in vacuum, but signals in fiber are commonly approximated around 200,000 km/s. New York and London are roughly 5,600 km apart in a straight line, so a perfect fiber path would still have a round-trip floor near 56 ms before routers, queues, encryption, or real cable routes add delay.
+- **The CAP theorem origins:** Eric Brewer presented CAP as a conjecture at PODC 2000, and Seth Gilbert with Nancy Lynch later formalized the result in 2002. The practical reading is narrower than the slogan: during a partition, a shared-data system must decide how it trades consistency against availability.
+- **Consensus in Kubernetes:** The Kubernetes control plane stores cluster state in `etcd`, and `etcd` uses Raft to replicate state among members. Raft was published by Diego Ongaro and John Ousterhout in 2014 with understandability as an explicit design goal compared with Paxos.
 
 ---
 
 ## Part 1: Defining Distributed Systems
 
-Before we can solve the problems of distributed systems, we must precisely define what they are. In the early days of computing, a system was a single mainframe. If it failed, everything stopped. Today, a system is a collection of hundreds or thousands of independent nodes working together to create the illusion of a single, cohesive entity.
+Before we can solve distributed-systems problems, we need a precise definition of what kind of system we are talking about. A distributed system is a collection of independent computational components that coordinate by sending messages across a network and present themselves as one coherent system to users or clients. The components may be physical servers, virtual machines, containers, processes, controllers, databases, message brokers, or managed cloud services. What matters is not the packaging; what matters is that no single process owns all state, all decisions, and all timing.
 
 ### 1.1 What is a Distributed System?
 
+Leslie Lamport's famous joke-definition captures the emotional truth: "A distributed system is one in which the failure of a computer you didn't even know existed can render your own computer unusable." The quote is funny because it is unfair in exactly the way production feels unfair. Your application can be correct, your database schema can be valid, and your deployment can be green, yet a remote dependency, DNS resolver, certificate authority, control-plane quorum, routing table, or object-store subsystem can still decide whether your user gets a working product.
+
+A **node** is one participant in the system. In a Kubernetes cluster, a worker node is literally called a node, but the concept is broader than Kubernetes. A node can be an API server process, a database replica, a queue consumer, an object-storage metadata service, a sidecar proxy, or a browser tab participating in a collaborative editor. A node has local memory, local disk or durable storage access, local clocks, local CPU scheduling, and local observations. It does not automatically know what every other node knows.
+
+**Message passing** is the act of coordinating by sending information between nodes. A message might be an HTTP request, a gRPC call, a database replication record, a Raft append entry, a DNS query, a queue event, or a Kubernetes watch notification. The sender can put bytes on the wire, but it cannot force the receiver to process them on time, process them once, process them in order, or process them at all. Once communication crosses a process and network boundary, the sender has only evidence, not certainty.
+
+The **single coherent system** is the illusion we build for users. A shopper clicks "buy" once and expects one order. A developer runs `kubectl apply` and expects the cluster to converge toward the declared state. A reader opens a document and expects one current version, even if replicas, caches, and search indexes are involved. The art of distributed systems is maintaining that illusion without lying to yourself about the independent parts underneath it.
+
+A single mainframe or one large database server is easier to reason about because most important state changes happen inside one failure domain. The process can lock memory, write to local disk, and decide an order of events without asking a remote peer. If the machine fails, the failure is often obvious: the whole service stops. This simplicity is valuable, and many systems should stay single-process or single-database as long as their requirements allow it.
+
+Distributed architecture becomes attractive when a single failure domain is no longer acceptable or sufficient. Scale pushes data and work across multiple machines. Fault tolerance demands that one failed component not erase the service. Geography pushes replicas closer to users and into different regions. Organizational growth pushes teams to own separate deployable units. Those are legitimate reasons to distribute a system, but each one buys capability by spending cognitive budget.
+
+The first discipline, then, is to recognize when distribution has entered the room. A web server and a database are already a distributed system because the application can succeed while the database is slow, or the database can commit while the web server times out. A service with a cache is distributed because cache state and database state can diverge. A Kubernetes controller and the API server are distributed because the controller observes desired state, acts, and later learns whether the API server and cluster accepted the change.
+
+### 1.2 The Boundary Test
+
+Use a boundary test when you are unsure whether a design is distributed: can one part keep running while another part is unavailable, slow, stale, or partitioned? If yes, distributed-systems behavior is present. The boundary may be a network hop, a process boundary, a data-replication boundary, a queue boundary, a cache boundary, or a human-approval boundary. The key question is not whether there are multiple computers; the key question is whether the system can have multiple partial views of reality at the same time.
+
+This matters because distributed failures are rarely polite. They do not arrive as one clean exception with a perfect root cause attached. They arrive as increased latency, missing acknowledgments, duplicate events, old cache entries, leader elections, half-open TCP connections, delayed DNS changes, clock skew, overloaded retry queues, or a metrics dashboard that is still green because the broken path is not the one the dashboard checks. You diagnose such systems by asking what each participant could observe locally, not by assuming the system has one global truth that everyone sees instantly.
+
+### 1.3 Distribution Should Be Intentional
+
+The strongest distributed-systems design decision is sometimes to avoid distributing a concern at all. A modular monolith with one database may be the right architecture while a product is still discovering its invariants, while one team owns most changes, or while traffic fits comfortably inside one failure domain. Keeping code in one deployable unit does not mean ignoring architecture. It means preserving local reasoning until the organization, scale, or reliability requirement can pay for the added coordination cost.
+
+Accidental distribution is common because cloud platforms make the mechanical act of creating services easy. A team can add a queue, cache, function, database replica, service mesh, and regional failover path with a few configuration changes, but every addition creates a new place where reality can diverge. The queue can accept messages while consumers are broken. The cache can serve old data while the database is correct. The failover region can be reachable while its credentials, schema, or feature flags are not ready for real traffic.
+
+Intentional distribution starts with a reason that can survive an incident review. "We split this service because this team owns a separate invariant and needs independent release control" is a stronger reason than "the class was getting large." "We replicate this data because users in another region need a bounded recovery objective" is stronger than "multi-region sounds safer." When the reason is explicit, the design can name the trade-off it is accepting instead of discovering that trade-off during an outage.
+
+---
+
+## Part 2: The Eight Fallacies of Distributed Computing
+
+The eight fallacies of distributed computing are false assumptions often associated with L. Peter Deutsch, James Gosling, and the Sun Microsystems engineering culture that shaped early networked software. They are not a formal theorem, and they are not a checklist to memorize for trivia. They are a compact way to diagnose the assumptions hidden inside architecture diagrams. When an incident surprises a team, one of these fallacies is often quietly present.
+
+Use the fallacies as design-review prompts rather than slogans. For each remote dependency, ask what happens if the network is slow, unavailable, expensive, hostile, changing, owned by another team, or different from the path you tested. The answer does not always need a complex mechanism. Sometimes it is a timeout, sometimes a cached fallback, sometimes a queue, sometimes an explicit error, and sometimes a decision not to make the call in the user path at all. The value is that the assumption becomes visible before production traffic tests it for you.
+
+### 2.1 The Network Is Reliable
+
+The first fallacy says the network is reliable. In a local program, a function call either returns or throws inside one process. In a distributed system, a remote call can be lost before it reaches the server, processed by the server while the response is lost, delayed behind other traffic, rejected by a load balancer, reset by a proxy, or accepted by a server that crashes before writing durable state. "Request failed" is not a single fact; it is a family of possibilities.
+
+Cloud-native systems often violate this fallacy through optimistic service-to-service calls. Service A calls Service B and assumes that an HTTP 200 means success while any timeout means no work happened. That assumption is dangerous because the timeout belongs to the caller's local clock, not to the remote side's state. The safe design treats the network as an unreliable transport and gives every side effect a way to be retried, reconciled, or observed later.
+
+### 2.2 Latency Is Zero
+
+The second fallacy says latency is zero. Developers fall into this trap when they replace a local method call with a remote service call and keep the same mental model. A local call may take nanoseconds or microseconds; a cross-zone or cross-region call pays serialization, kernel scheduling, queueing, routing, TLS, proxy, and server time. Even when the median is excellent, the tail can dominate the user's experience because one slow dependency can hold the whole request open.
+
+The cloud-native manifestation is the chatty microservice chain. A page request calls a profile service, which calls an entitlement service, which calls a billing service, which calls a feature-flag service, which calls a database several times. Each hop looks reasonable in isolation, but the end-to-end path becomes an N-plus-one network pattern. Good designs batch, cache carefully, move computation near data, collapse unnecessary hops, and set latency budgets before service boundaries become permanent.
+
+### 2.3 Bandwidth Is Infinite
+
+The third fallacy says bandwidth is infinite. Network capacity is large enough that small tests hide the problem, then production traffic reveals it through replication lag, slow image pulls, overloaded service meshes, expensive cross-zone transfer, or backups that saturate links during recovery. Bandwidth is also shared: your service is not the only system using the same node, network interface, zone fabric, NAT gateway, or observability pipeline.
+
+A common cloud-native example is treating logs, metrics, traces, and replication streams as free. Teams add high-cardinality labels, full request bodies, debug logs, and cross-region replication without budgeting for volume. During an incident, the observability pipeline can become part of the load spike, and the replication stream can compete with user traffic. Designing for finite bandwidth means reducing unnecessary payloads, applying backpressure, sampling thoughtfully, and knowing which traffic can be shed first.
+
+### 2.4 The Network Is Secure
+
+The fourth fallacy says the network is secure. Private address space, cluster networking, and internal DNS can create a false sense of safety. A request that came from "inside" may still come from a compromised workload, an over-permissioned service account, a stale credential, a misconfigured proxy, or a tenant path that should never have reached the target. Distributed systems multiply trust decisions because every boundary is a potential policy boundary.
+
+In Kubernetes, this fallacy shows up when teams rely only on namespace separation or on the idea that "only our services can reach this endpoint." Secure distributed design authenticates callers, authorizes actions, encrypts sensitive paths, rotates credentials, records audit trails, and assumes that topology will change. The network can help enforce policy, but it should not be the only reason a dangerous operation is accepted.
+
+### 2.5 Topology Does Not Change
+
+The fifth fallacy says topology does not change. Real systems reschedule pods, rotate nodes, replace instances, rebalance shards, move leaders, update DNS, add replicas, remove replicas, and shift traffic during deploys. Even if the application code stays still, the runtime graph around it moves. A design that depends on fixed addresses, fixed replica counts, or fixed leader placement is brittle before it reaches production scale.
+
+Kubernetes makes topology change routine. A Deployment rollout replaces pods gradually. A Service endpoint list changes as readiness probes pass or fail. The API server offers watches so clients can observe changes, but a watch is not magic global memory; clients still need reconnection logic and resource-version handling. Treat topology as data that changes over time, not as a diagram frozen during the design review.
+
+### 2.6 There Is One Administrator
+
+The sixth fallacy says there is one administrator. In a small system, one team may control code, infrastructure, network policy, credentials, dashboards, and deployment cadence. In a real platform, different teams own the application, cluster, cloud account, identity provider, CI system, database, security policy, and incident process. A distributed system is also a distributed organization.
+
+This fallacy appears when a service assumes another team will coordinate every breaking change manually. It also appears when a platform team rolls out a policy change without considering application-owned retries, clients, or data migrations. Good distributed designs use explicit contracts, versioned APIs, deprecation windows, ownership metadata, runbooks, and observable compatibility signals. The architecture should not require perfect cross-team timing to remain correct.
+
+### 2.7 Transport Cost Is Zero
+
+The seventh fallacy says transport cost is zero. Transport cost includes money, CPU, memory, sockets, file descriptors, TLS handshakes, serialization, connection pools, load-balancer capacity, and operational attention. A single remote call can be cheap; millions of remote calls per minute across zones or regions can become a material cost center and a reliability risk.
+
+Cloud-native teams often discover this fallacy through synchronous fan-out. An API endpoint fans out to twenty services, each service emits traces and logs, and every hop crosses a mesh proxy that performs encryption and policy checks. The transport layer is doing useful work, but it is not free. Design reviews should ask how many network calls a user action creates, how those calls scale with data size, and whether a lower-cost asynchronous path would meet the product need.
+
+### 2.8 The Network Is Homogeneous
+
+The eighth fallacy says the network is homogeneous. Real networks differ by region, zone, cloud provider, device, proxy path, MTU, DNS behavior, packet-loss profile, rate limit, and policy. Even inside one cluster, traffic between two pods on the same node behaves differently from traffic that crosses nodes, zones, gateways, or egress controls. Homogeneity is a comforting fiction that disappears under load or during migration.
+
+Hybrid and multi-cloud systems make this fallacy visible quickly. One path may have low latency but strict egress controls. Another may have higher latency but more capacity. A managed database endpoint may behave differently from a self-hosted service behind a Kubernetes Service. Robust systems measure path behavior, expose dependency latency by route, test failover paths before they are needed, and avoid assuming that every network hop has the same semantics.
+
+The eight fallacies are a diagnostic lens. When you diagnose a distributed architecture, ask which fallacy would make the design look simpler than it is. When you evaluate a production incident, ask which fallacy made the failure surprising. When you design a new service boundary, ask what the system must still do when that fallacy is false, because in production it eventually will be.
+
+---
+
+## Part 3: Partial Failure
+
+Partial failure is the defining property of distributed systems. In a single process, many failures are total from the user's point of view: the process crashes, the request stops, or the machine is unavailable. In a distributed system, some parts keep working while others fail. The database primary may be healthy while a replica lags. The API may accept writes while the search index is stale. A queue may keep receiving messages while consumers are stuck. The load balancer may reach one zone while another zone is isolated.
+
+Partial failure is hard because it creates ambiguity. If you call another service and do not receive a response, you do not know whether the request never arrived, arrived and failed validation, arrived and committed, committed but lost its response, or is still waiting behind other work. The caller's timeout is a local decision to stop waiting. It is not proof that the remote side is dead, and it is not proof that the remote side did nothing.
+
+This uncertainty is why perfect failure detection is impossible in ordinary asynchronous networks. A detector can suspect a node after a timeout, but slow and dead can look identical from a distance. If messages can be delayed arbitrarily, no observer can always distinguish a crashed node from a node whose messages are merely late. Practical systems use timeouts, heartbeats, leases, and quorum protocols anyway, but they treat those mechanisms as engineering approximations with trade-offs.
+
+Gray failures make the situation worse. A gray failure is not a clean crash; it is a component that is alive enough to pass some checks while broken for meaningful work. A pod might answer TCP connections but hang on database calls. A disk might respond slowly only under write pressure. A service might return success while silently dropping background events. A dependency might be reachable from one zone and unreachable from another. Health checks reduce blind spots, but they cannot prove that every user path is healthy.
+
+Hypothetical scenario: imagine a checkout system with three services: cart, payment, and email. The payment service commits a charge, but the response to checkout times out after two seconds. Checkout retries immediately without an idempotency key, so the payment service sees a second valid request and creates a second charge. Nobody intended a double charge, and no single component "malfunctioned" according to its local logic. The distributed failure was the gap between a committed side effect and a caller that could not observe it.
+
+Partial failure also changes how you model user-visible state. A single-process program can often return either success or failure, but a distributed workflow may need states such as accepted, pending, retrying, committed-but-not-notified, needs-reconciliation, or degraded. Those states can feel awkward in a product conversation, yet they are more honest than pretending every workflow is instantaneous and binary. If the system cannot represent uncertainty, operators and users will discover uncertainty anyway through duplicate tickets, manual database fixes, or inconsistent dashboards.
+
+State machines are useful because they make uncertainty explicit. Instead of writing a checkout flow as a long chain of synchronous calls, you can record an order as accepted, attach an idempotency key, enqueue payment, mark payment as authorized when confirmed, and then enqueue email as a separate effect. That design still has failures, but each failure leaves a durable state that can be retried or inspected. The architecture becomes easier to operate because the system remembers where it was when communication became ambiguous.
+
+The response to partial failure is not despair; it is design. Use idempotent operations when a caller may retry. Store request identifiers so duplicate attempts map to one logical effect. Make state transitions observable so operators can reconcile uncertain outcomes. Prefer asynchronous workflows when the user does not need every downstream effect before receiving a response. Place bulkheads between dependencies so one slow subsystem does not consume every thread, connection, or worker in the caller.
+
+Module 5.4, [Partial Failure and Timeouts](module-5.4-partial-failure-and-timeouts/), goes deeper into timeout selection, retry storms, jitter, and circuit breakers. For now, the important mental model is that partial failure is not an edge case. It is the normal failure mode of systems whose parts can disagree about what just happened.
+
+---
+
+## Part 4: The Network Is Not Reliable
+
+A network partition occurs when some nodes cannot communicate with other nodes, even though at least one side may still be running. Partitions can be clean, where two groups cannot reach each other in either direction, but they can also be asymmetric. Node A may reach Node B while Node B cannot reach Node A through the expected path. One availability zone may reach the database while another zone cannot. A service mesh policy may block traffic in one direction while health checks use a different path and stay green.
+
+Packet loss and reordering add more uncertainty. TCP hides some loss and ordering problems by retransmitting and presenting an ordered byte stream, but that does not make distributed operations reliable. Retransmission takes time, connection pools can fill, proxies can reset connections, deadlines can expire, and application-level retries can duplicate work. UDP-based protocols, DNS behavior, load balancers, queues, and streaming systems each have their own delivery semantics that must be understood rather than assumed.
+
+Timeouts are guesses because they encode a trade-off between waiting too long and giving up too early. A short timeout improves caller responsiveness and frees resources quickly, but it can mark healthy work as failed during a latency spike. A long timeout reduces false suspicion, but it can trap threads, sockets, and users behind a dependency that is not recovering. The right timeout depends on downstream latency distribution, caller budget, retry policy, resource limits, and the business value of waiting.
+
+Retries are useful only when the operation is safe to repeat or when the caller can prove that a previous attempt did not commit. The usual production answer is idempotency: give each logical operation a stable key, store the result under that key, and return the same result for duplicate attempts. Idempotency does not mean "the function has no side effects." It means repeated delivery of the same logical request produces one logical outcome.
+
+```python
+from dataclasses import dataclass, field
+
+
+@dataclass
+class PaymentGateway:
+    receipts_by_key: dict[str, str] = field(default_factory=dict)
+    first_call_timed_out: bool = False
+
+    def charge(self, idempotency_key: str, amount_cents: int) -> str:
+        if idempotency_key in self.receipts_by_key:
+            return self.receipts_by_key[idempotency_key]
+
+        receipt = f"receipt-{len(self.receipts_by_key) + 1}"
+        self.receipts_by_key[idempotency_key] = receipt
+
+        if not self.first_call_timed_out:
+            self.first_call_timed_out = True
+            raise TimeoutError("client timed out after the remote side committed")
+
+        return receipt
+
+
+def charge_with_retry(gateway: PaymentGateway, key: str, amount_cents: int) -> str:
+    for _attempt in range(3):
+        try:
+            return gateway.charge(key, amount_cents)
+        except TimeoutError:
+            continue
+    raise RuntimeError("payment status is unknown and must be reconciled")
+
+
+gateway = PaymentGateway()
+request_key = "checkout-1000"
+
+print(charge_with_retry(gateway, request_key, 5000))
+print(charge_with_retry(gateway, request_key, 5000))
+```
+
 ```text
-DISTRIBUTED SYSTEM DEFINITION
-═══════════════════════════════════════════════════════════════
+receipt-1
+receipt-1
+```
 
-A distributed system is one where:
-- Components run on multiple networked computers
-- Components coordinate by passing messages
-- The system appears as a single coherent system to users
+The example is intentionally small, but the production principle is large. The first call creates the receipt and then simulates a lost response. The retry uses the same idempotency key, so the gateway returns the existing receipt instead of creating a second charge. A real implementation would persist the key durably, scope it to the actor and operation, expire it carefully, and expose reconciliation paths for cases where the caller exhausts retries without learning the outcome.
 
-Leslie Lamport's definition:
-"A distributed system is one in which the failure of a computer
-you didn't even know existed can
+Backoff and jitter matter because retries can become a second outage. If every caller retries immediately after a shared dependency becomes slow, the dependency receives more traffic precisely when it has less capacity. Exponential backoff spreads attempts over time, and jitter prevents a synchronized wave of clients from retrying together. Module 5.4 will focus on those mechanics, but you should already connect them to the bigger theme: the network is not reliable, so the caller must be polite, bounded, and repeatable.
+
+---
+
+## Part 5: CAP and the Consistency-Availability Trade-off
+
+CAP is one of the most quoted and most misquoted ideas in distributed systems. In its practical form, CAP says that when a network partition prevents some nodes from communicating, a shared-data system cannot simultaneously provide a fully consistent answer and remain available to every request on every side of the partition. Partition tolerance is not a feature you "pick" in a real distributed system; partitions are a condition the environment can impose. The live design choice during a partition is how you trade consistency against availability.
+
+Availability in CAP also has a stricter meaning than many architecture conversations use. It is not "the status page is green" or "most users can still do something." In the formal model, availability means every request to a non-failing node eventually receives a response. That is why a CP system can look unavailable during a partition even though the service is making a deliberate safety choice: a node that cannot coordinate may refuse a write rather than accept a value that could violate consistency. In product language, this is often a controlled refusal rather than a crash.
+
+The sloppy slogan "pick two of three" hides the time dimension. When there is no partition, many systems can provide useful consistency and useful availability together. During a partition, however, a system that preserves strong consistency may reject or delay some operations until it can coordinate with the required nodes. That is the CP posture: preserve consistency under partition by sacrificing some availability. A system that preserves availability may accept operations on both sides and reconcile later. That is the AP posture: preserve availability under partition by accepting weaker consistency.
+
+Neither posture is morally superior. CP is appropriate when accepting conflicting writes would violate an invariant that the business cannot repair. Examples include granting the same scarce resource twice, accepting a withdrawal that breaks an account invariant, or changing security policy without a single authoritative order. AP is appropriate when temporary divergence is acceptable and availability matters more than immediate agreement. Examples include shopping carts, like counters, telemetry ingestion, local-first collaboration, recommendations, and workloads where conflicts can be merged or compensated.
+
+Consensus protocols such as Raft and Paxos are common tools for CP decisions because they use quorum agreement to keep replicas in one ordered history. Module 5.2, [Consensus and Coordination](module-5.2-consensus-and-coordination/), explains how those protocols coordinate leaders, logs, and quorums. Eventually consistent replication and conflict-resolution strategies are common AP tools because they let writes continue in more places and converge later. Module 5.3, [Eventual Consistency](module-5.3-eventual-consistency/), explains read-your-writes, causal consistency, version vectors, last-writer-wins hazards, and CRDT-style approaches.
+
+PACELC extends the conversation by pointing out that even when there is no partition, replicated systems often trade latency against consistency. A system can wait for remote replicas to acknowledge a write before responding, which improves consistency but adds latency. Or it can respond after a local write and replicate asynchronously, which improves latency but allows stale reads and conflict windows. CAP is the emergency-room framing for partitions; PACELC reminds you that normal operation also contains trade-offs.
+
+The most useful CAP question is not "is this database CP or AP?" The better question is "which operations require which guarantees under which failure modes?" One product may use CP coordination for account ownership, AP replication for activity feeds, asynchronous events for email, and cached reads for public catalog pages. Distributed-system design is often a per-invariant decision, not a single label stamped on the whole architecture.
+
+Read paths deserve the same care as write paths. A system may accept writes through a CP leader but serve reads from followers, caches, or search indexes that lag behind the leader. That can be a good design if the product labels freshness honestly or if stale reads do not break user expectations. It is a bad design if a user changes a security setting, receives a success message, and another page immediately shows the old permission as if the write did not happen. Consistency is not one switch; it is a promise attached to a particular operation and user expectation.
+
+---
+
+## Decision Framework: CP vs AP
+
+Use this framework when you compare CP and AP architectural patterns for a specific business requirement. Start with the invariant, not with the technology. Ask what must never be temporarily false, what can be corrected later, who is harmed by rejection versus stale acceptance, and whether the system has a reliable merge or compensation path after a partition heals.
+
+| Requirement | Prefer CP when... | Prefer AP when... | Design consequence |
+|---|---|---|---|
+| Scarce resource ownership | Two actors must never own the same resource at the same time. | Temporary duplicate claims can be detected and resolved without serious harm. | CP usually needs consensus, leases, or a single authoritative writer. |
+| Money or entitlement change | A wrong acceptance creates legal, financial, or security exposure. | Temporary local acceptance can be reversed or limited safely. | CP favors rejecting some requests during partition instead of accepting unsafe state. |
+| User-facing read latency | Users can tolerate waiting for an authoritative answer. | Users value fast local reads more than perfectly fresh data. | AP often pairs asynchronous replication with visible freshness or conflict handling. |
+| Telemetry and events | Losing or duplicating data would corrupt an invariant. | Approximate, delayed, or duplicate-tolerant data is acceptable. | AP ingestion can buffer locally and reconcile downstream with deduplication. |
+| Collaboration and offline work | Conflicts cannot be merged meaningfully. | Users can work locally and conflicts have domain-specific merge rules. | AP designs need versioning, conflict display, or CRDT-like structures. |
+
+The framework deliberately separates business truth from implementation taste. A team may prefer a fast AP database, but if the invariant is "only one active cluster leader can mutate this state," the design probably needs CP coordination. A team may prefer strong consistency everywhere, but if the workload is high-volume metrics ingestion, forcing every write through a quorum may spend latency and availability on precision the product does not need.
+
+---
+
+## Patterns & Anti-Patterns
+
+Patterns are recurring design moves that make distributed systems survivable. Anti-patterns are recurring shortcuts that make a system appear simpler by hiding uncertainty until production reveals it. The goal is not to apply every pattern everywhere. The goal is to match the pattern to the failure mode and to know which anti-pattern a design review should challenge immediately.
+
+| Pattern | Why it helps | Example application |
+|---|---|---|
+| Design for partial failure | Keeps one unhealthy dependency from turning into a total outage. | A checkout path accepts the order, queues email, and lets email recover independently. |
+| Make operations idempotent | Allows safe retry after ambiguous timeout or lost response. | Payment, order creation, and provisioning APIs store a client request key. |
+| Use bulkheads | Limits blast radius by isolating resources for different dependencies or tenants. | Separate worker pools prevent slow search indexing from consuming checkout workers. |
+| Embrace asynchrony | Removes unnecessary synchronous coupling from user-facing paths. | A user upload returns after durable storage, while thumbnails and search indexing run later. |
+| Apply timeouts, backoff, and jitter | Bounds waiting and prevents synchronized retry storms. | Clients retry transient failures with capped exponential backoff and randomized delay. |
+
+| Anti-pattern | Why it is dangerous | Better approach |
+|---|---|---|
+| Assuming the network is reliable | Converts lost, delayed, or duplicated messages into corrupt user-visible state. | Treat every remote side effect as ambiguous until confirmed or reconciled. |
+| Building synchronous chains across many services | Makes end-to-end availability the product of every hop in the chain. | Collapse unnecessary calls, cache carefully, batch, or move work to asynchronous flows. |
+| Creating a distributed monolith | Keeps tight coupling while adding deployment, network, and ownership failure modes. | Draw service boundaries around stable ownership and data invariants, not around nouns alone. |
+| Ignoring clock skew | Makes event ordering, lease expiry, and last-writer-wins behavior unsafe. | Use monotonic clocks for durations and logical or version-based ordering for causality. |
+| Retrying without idempotency | Turns transient failures into duplicate charges, duplicate jobs, or duplicate state changes. | Store operation keys and make duplicate requests return the original logical result. |
+
+One practical review habit is to ask for the failure story of each service boundary. If the boundary exists only because it looks tidy on a diagram, it may be a distributed monolith boundary. If the boundary exists because a team owns a durable invariant, the contract is versioned, and failure behavior is explicit, the distribution is more likely to pay for itself.
+
+---
+
+## Common Mistakes
+
+| Mistake | Problem | Solution |
+|---|---|---|
+| Treating an HTTP timeout as proof that no work happened | The remote service may have committed the side effect before the response was lost. | Use idempotency keys, reconciliation reads, and clear unknown-outcome handling. |
+| Splitting services before defining data ownership | The system gains network failure modes while teams still fight over the same invariants. | Define the authoritative owner for each state transition before creating a service boundary. |
+| Calling many services synchronously in one user request | One slow or unavailable dependency can stall the entire request path. | Budget latency per hop, batch calls, cache carefully, or move noncritical work behind a queue. |
+| Assuming health checks prove user-path health | A component can pass a shallow probe while failing a real dependency or data path. | Use readiness checks, synthetic transactions, and dependency-specific observability. |
+| Using retries without backoff or jitter | Clients can amplify load and prevent a recovering dependency from stabilizing. | Cap retries, add exponential backoff, add jitter, and stop retrying when the caller deadline is spent. |
+| Treating CAP as "pick two forever" | The real trade-off happens during partitions, while normal operation also has latency-consistency choices. | Decide per invariant how the system behaves during partition and how it trades latency against freshness otherwise. |
+| Relying on wall clocks for distributed ordering | Clock skew can make a later write appear earlier or expire a lease incorrectly. | Use monotonic clocks for durations and logical versions, consensus, or causality tracking for ordering. |
+| Hiding partial failure from users and operators | Ambiguous state becomes harder to reconcile when the system pretends everything is fine. | Expose pending, retrying, degraded, and unknown states with clear operational paths. |
+
+---
+
+## Quiz
+
+1. **Scenario:** A checkout API times out while calling the payment service. The payment service may have charged the customer, but the API did not receive the response. What should the checkout API do before retrying?
+
+   <details>
+   <summary>Answer</summary>
+
+   The checkout API should implement idempotent operations and retry mechanisms by sending the same stable request key with each attempt. That design handles transient network failures because the payment service can return the original receipt instead of creating a second charge. This answer probes the outcome to implement idempotent operations and also reinforces that a timeout is not proof that the remote side did nothing.
+
+   </details>
+
+2. **Scenario:** A team proposes a user request path that calls twelve services in sequence before returning a page. Each service has good median latency in isolation. What distributed-systems fallacy should you diagnose first?
+
+   <details>
+   <summary>Answer</summary>
+
+   You should diagnose the eight fallacies of distributed computing, especially "latency is zero" and "the network is reliable." The architecture hides a chatty synchronous chain where tail latency and partial failure compound across every hop. A better design would set an end-to-end latency budget, collapse unnecessary calls, batch data access, or move noncritical work to asynchronous paths.
+
+   </details>
+
+3. **Scenario:** During a zone-level network issue, half of a replicated inventory system cannot reach the other half. The business rule says one serialized item must never be sold to two customers. Should this operation prefer CP or AP behavior?
+
+   <details>
+   <summary>Answer</summary>
+
+   This operation should prefer CP behavior because the business requirement cannot safely tolerate conflicting ownership of the same scarce item. During a partition, a CP design may reject or delay writes that cannot reach quorum, sacrificing some availability to preserve consistency. This answer probes the outcome to compare CP and AP architectural patterns by starting from the invariant rather than from database branding.
+
+   </details>
+
+4. **Scenario:** A metrics pipeline accepts duplicate events and deduplicates them later by event ID. During a partition, local collectors can keep buffering and accepting events. Why might AP behavior be acceptable here?
+
+   <details>
+   <summary>Answer</summary>
+
+   AP behavior can be acceptable because the business requirement values continued ingestion and can tolerate temporary divergence. The system has a merge path: duplicate events are identified later by event ID, and delayed events can still contribute to aggregate views. This does not mean consistency is irrelevant; it means the chosen consistency model matches a workload where availability and low-latency local acceptance matter more than immediate global agreement.
+
+   </details>
+
+5. **Scenario:** A service's readiness probe returns success because the process can answer HTTP, but real requests hang whenever they need the database. What kind of failure is this, and how should you evaluate the architecture?
+
+   <details>
+   <summary>Answer</summary>
+
+   This is a gray failure, a form of partial failure where the component is alive enough to pass some checks but broken for meaningful work. You should evaluate the architecture by identifying which components introduce distributed-system challenges such as partial failure, dependency-specific health, and ambiguous user-path state. Better readiness checks and synthetic transactions can reduce the blind spot, but they still cannot create perfect failure detection.
+
+   </details>
+
+6. **Scenario:** A platform team wants to split a large service into five microservices because smaller repositories feel cleaner. The same team will still own all data, releases, and invariants. What risk should you call out?
+
+   <details>
+   <summary>Answer</summary>
+
+   The risk is a distributed monolith: the design adds network communication, partial failure, deployment ordering, and operational overhead without gaining independent ownership or clearer invariants. You should design service boundaries that account for the unreliability of network communication between components and only distribute when the boundary pays for itself. A better first step may be modularizing the codebase while keeping one deployable service until ownership and data boundaries are real.
+
+   </details>
+
+7. **Scenario:** A product manager asks why a cross-region write cannot be both instantly visible everywhere and always accepted during a wide-area partition. How would you explain the trade-off without using the sloppy "pick two" phrase?
+
+   <details>
+   <summary>Answer</summary>
+
+   Explain that partition tolerance is not a menu option once the system spans unreliable networks; a partition can be imposed by the environment. During that partition, the system must choose whether to preserve consistency by rejecting or delaying some operations, or preserve availability by accepting operations that may need later reconciliation. PACELC adds that even without a partition, the system often trades lower latency against stronger consistency when deciding how many replicas must acknowledge a write before the user sees success.
+
+   </details>
+
+---
+
+## Hands-On Exercise
+
+In this exercise, you will observe partial failure in a local Kubernetes cluster. The point is not that Kubernetes makes the problem disappear; the point is that Kubernetes gives you controllers and Services that can mask one pod failure while the distributed system converges. You will create a three-replica Deployment, expose it through a Service, delete one pod, and watch the Service remain available while the ReplicaSet creates a replacement.
+
+**Prerequisites:** A working local Kubernetes cluster such as kind or another disposable test cluster, plus `kubectl` configured for that cluster. Use a namespace dedicated to the lab so cleanup is safe.
+
+```bash
+kubectl create namespace ds-lab
+kubectl -n ds-lab create deployment catalog --image=nginx:1.27-alpine --replicas=3
+kubectl -n ds-lab expose deployment catalog --port=80 --target-port=80
+kubectl -n ds-lab rollout status deployment/catalog
+kubectl -n ds-lab get pods -l app=catalog -o wide
+```
+
+Now remove one running pod and immediately observe both the pod list and the Service path. A Service gives clients one stable name, while EndpointSlices and readiness determine which pod IPs receive traffic.
+
+```bash
+POD_NAME="$(kubectl -n ds-lab get pod -l app=catalog -o jsonpath='{.items[0].metadata.name}')"
+kubectl -n ds-lab delete pod "$POD_NAME" --wait=false
+kubectl -n ds-lab get pods -l app=catalog -w
+```
+
+In a second terminal, probe the Service while the replacement pod is being created. If your cluster is slow to pull images, wait for at least two pods to be Ready before judging the Service behavior.
+
+```bash
+kubectl -n ds-lab run catalog-probe \
+  --image=curlimages/curl \
+  --rm -it --restart=Never \
+  -- http://catalog.ds-lab.svc.cluster.local
+
+kubectl -n ds-lab get endpointslice \
+  -l kubernetes.io/service-name=catalog \
+  -o wide
+```
+
+Clean up the namespace after you finish. The cleanup command removes the Deployment, Service, pods, and temporary probe pod created for this exercise.
+
+```bash
+kubectl delete namespace ds-lab
+```
+
+**Success Criteria:**
+
+- [ ] The initial Deployment reaches three Ready replicas behind one Service name.
+- [ ] Deleting one pod creates a visible partial failure while at least part of the system keeps serving.
+- [ ] The ReplicaSet creates a replacement pod and the Service returns to three healthy endpoints.
+- [ ] You can explain why the client saw one Service even though the backing pod set changed.
+
+---
+
+## Sources
+
+- [Designing Data-Intensive Applications](https://dataintensive.net/)
+- [Time, Clocks, and the Ordering of Events in a Distributed System](https://lamport.azurewebsites.net/pubs/time-clocks.pdf)
+- [Paxos Made Simple](https://lamport.azurewebsites.net/pubs/paxos-simple.pdf)
+- [In Search of an Understandable Consensus Algorithm](https://raft.github.io/raft.pdf)
+- [L. Peter Deutsch on the Fallacies of Distributed Computing](https://se-radio.net/2021/07/episode-470-l-peter-deutsch-on-the-fallacies-of-distributed-computing/)
+- [Brewer's Conjecture and the Feasibility of Consistent, Available, Partition-Tolerant Web Services](https://users.ece.cmu.edu/~adrian/731-sp04/readings/GL-cap.pdf)
+- [CAP Twelve Years Later: How the Rules Have Changed](https://sites.cs.ucsb.edu/~rich/class/cs293b-cloud/papers/brewer-cap.pdf)
+- [Consistency Tradeoffs in Modern Distributed Database System Design](https://www.cs.umd.edu/~abadi/papers/abadi-pacelc.pdf)
+- [Timeouts, retries and backoff with jitter](https://aws.amazon.com/builders-library/timeouts-retries-and-backoff-with-jitter/)
+- [Google SRE Book: Addressing Cascading Failures](https://sre.google/sre-book/addressing-cascading-failures/)
+- [Kubernetes API Concepts](https://kubernetes.io/docs/reference/using-api/api-concepts/)
+- [etcd Performance](https://etcd.io/docs/v3.6/op-guide/performance/)
+- [Eventually Consistent](https://www.allthingsdistributed.com/2007/12/eventually_consistent.html)
+- [Jepsen Consistency Models](https://jepsen.io/consistency/models)
+
+---
+
+## Next Module
+
+Next, continue to [Module 5.2: Consensus and Coordination](module-5.2-consensus-and-coordination/), where we study how distributed systems use quorums, leaders, and replicated logs to make a group of unreliable nodes agree on one ordered history.

--- a/src/content/docs/platform/foundations/distributed-systems/module-5.2-consensus-and-coordination.md
+++ b/src/content/docs/platform/foundations/distributed-systems/module-5.2-consensus-and-coordination.md
@@ -12,9 +12,9 @@ sidebar:
 >
 > **Track**: Foundations
 
-### What You'll Be Able to Do
+## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+After completing this module, you will be able to apply consensus theory to production architecture reviews, evaluate coordination stores under failure, and debug leader-election behavior using the durable outcomes below.
 
 1. **Explain** how Raft and Paxos achieve consensus and why the FLP impossibility theorem constrains all consensus protocols
 2. **Evaluate** consensus-based systems (etcd, ZooKeeper, Consul) by analyzing their quorum requirements, failure tolerance, and split-brain prevention
@@ -23,40 +23,17 @@ After completing this module, you will be able to:
 
 ---
 
-**November 24, 2014. A routine database migration at a major financial services company triggers one of the most expensive consensus failures in banking history.**
-
-The company operated a distributed trading system with five database nodes using Paxos-based replication. During the migration, a network misconfiguration caused three nodes to become unreachable from each other—but each could still reach some of the remaining two nodes. The Paxos implementation had a subtle bug: under this specific partition pattern, two different nodes each believed they had achieved quorum.
-
-**For 45 minutes, the trading system had two leaders accepting conflicting writes.** One leader processed $127 million in buy orders. The other processed $89 million in sell orders for the same securities. When the partition healed and the nodes attempted to reconcile, the conflict was irreconcilable—the audit log showed trades that couldn't have both happened.
-
-**The total cost: $23 million in immediate losses from voided trades, $31 million in regulatory fines for order book integrity violations, and $180 million in customer lawsuit settlements.** The root cause wasn't the network—it was a consensus algorithm implementation that hadn't been tested against byzantine partition scenarios.
-
-This module teaches consensus: how distributed systems reach agreement, why it's deceptively hard, and why getting it wrong can cost more than most companies earn in a year.
-
----
-
 ## Why This Module Matters
 
-How do you get multiple computers to agree on something? It sounds simple—until network partitions split them, messages get lost, and nodes crash mid-decision. Yet agreement is essential: which node is the leader? Is this transaction committed? What's the current configuration?
+How do you get multiple computers to agree on something? The question sounds simple until a network partition splits them, messages get lost, and nodes crash mid-decision. Agreement still matters: which node is the leader, whether a transaction committed, and what the current configuration is. **Consensus** is the foundation of reliable distributed systems. Without it, you cannot run consistent replicated databases, reliable leader election, or fault-tolerant coordination in production.
 
-**Consensus** is the foundation of reliable distributed systems. Without it, you can't have consistent replicated databases, reliable leader election, or fault-tolerant coordination. Understanding consensus helps you choose the right tools and understand their limitations.
+This module explores how distributed systems reach agreement, which algorithms engineers use, where the trade-offs live, and when consensus is worth its cost. You will learn why Paxos and Raft exist, how quorums prevent split brain, why distributed locks need fencing tokens, and when a lease or optimistic concurrency check is the better tool. The goal is not to memorize protocol steps, but to recognize consensus problems in architecture reviews and choose coordination mechanisms that match your consistency needs.
 
-This module explores how distributed systems reach agreement—the algorithms, the trade-offs, and where you'll encounter consensus in practice.
+Strong coordination shows up in places that are easy to overlook. Service meshes elect control-plane leaders. Databases elect primaries. CI systems elect build executors. Each case needs an answer to the same question: who may mutate shared state right now? Weak coordination hides in caches and analytics pipelines where duplicates or delay are tolerable. Learning to classify workloads into those buckets keeps platforms fast without sacrificing safety on the metadata path.
 
 > **The Committee Analogy**
 >
-> Imagine a committee that must vote on decisions, but members are in different cities and can only communicate by mail. Letters get lost. Some members don't respond. The committee must still make decisions. How do they ensure everyone agrees on what was decided? This is the consensus problem—made harder because there's no chairperson everyone trusts.
-
----
-
-## What You'll Learn
-
-- What consensus means and why it's hard
-- Key consensus algorithms (Paxos, Raft)
-- How leader election works
-- Distributed locks and coordination
-- How etcd and ZooKeeper implement consensus
-- When you need consensus (and when you don't)
+> Imagine a committee that must vote on decisions, but members are in different cities and can only communicate by mail. Letters get lost, some members do not respond, and the committee must still make decisions. How do they ensure everyone agrees on what was decided when there is no chairperson everyone trusts? That is the consensus problem, and every production control plane faces a version of it.
 
 ---
 
@@ -64,21 +41,11 @@ This module explores how distributed systems reach agreement—the algorithms, t
 
 ### 1.1 What is Consensus?
 
-```
-CONSENSUS DEFINITION
-═══════════════════════════════════════════════════════════════
+**Consensus** means getting multiple nodes to agree on a single value or on an ordered log of values. Formally, a consensus protocol aims for three properties. **Agreement** requires that all non-faulty nodes decide on the same value. **Validity** requires that the decided value was proposed by some node rather than invented by the protocol. **Termination** requires that every non-faulty node eventually decides rather than waiting forever.
 
-Consensus: Getting multiple nodes to agree on a single value.
+These three properties sound modest, yet they are difficult to satisfy together when networks are unreliable and nodes fail independently. Consensus is not about one RPC succeeding; it is about a group converging on one outcome despite partial failure. That distinction matters when you design Kubernetes control planes, payment ledgers, or configuration stores.
 
-REQUIREMENTS
-─────────────────────────────────────────────────────────────
-1. AGREEMENT: All non-faulty nodes decide on the same value
-2. VALIDITY: The decided value was proposed by some node
-3. TERMINATION: All non-faulty nodes eventually decide
-
-SOUNDS SIMPLE, BUT...
-─────────────────────────────────────────────────────────────
-```
+Single-value consensus decides one proposal, such as which node is primary. Replicated log consensus decides an ordered sequence of operations, which is what state machines require. Database replication, configuration stores, and distributed locks all reduce to ordered logs sooner or later. When someone says "we need strong consistency," translate that statement into whether they need one agreed value now or a durable history forever.
 
 ```mermaid
 flowchart TD
@@ -86,114 +53,48 @@ flowchart TD
     B[Node B proposes Y] --> N
     N --> DA{Node A<br>decides ?}
     N --> DB{Node B<br>decides ?}
-    
+
     classDef note fill:#f9f9f9,stroke:#333,stroke-width:1px;
     Note[What if A doesn't hear from B?<br>What if B crashes mid-decision?<br>What if the network partitions?]:::note
 ```
 
+When Node A and Node B propose different values, the network may deliver some messages and drop others. A may decide while B still waits, or both may decide differently if the protocol is wrong. Correct consensus algorithms eliminate those outcomes by requiring majorities, monotonic terms, or prepared proposal numbers before any decision becomes binding.
+
+Engineers sometimes confuse "everyone received the message" with "everyone agreed on the same decision." Broadcast alone is insufficient because recipients may process messages in different orders or miss retries. Consensus protocols add voting rounds, persistent promises, and leader serialization so that agreement survives retransmissions and crashes.
+
 ### 1.2 Why Consensus is Hard
 
-```
-THE FLP IMPOSSIBILITY RESULT
-═══════════════════════════════════════════════════════════════
+In 1985, Fischer, Lynch, and Paterson published the **FLP impossibility result**. They proved that in a fully asynchronous model, where messages can take arbitrarily long and there are no reliable timeouts, no deterministic algorithm can guarantee consensus if even one process may crash. The proof exposes a cruel ambiguity: when you stop hearing from a peer, you cannot tell whether the peer crashed or is merely slow.
 
-Fischer, Lynch, and Paterson proved (1985):
+If you wait forever for the missing vote, you may violate termination because a crashed peer never responds. If you proceed without the missing vote, you may violate agreement because the slow peer might still be alive and decide differently. If you use a timeout, you are no longer in a purely asynchronous model; you are making a timing bet. FLP does not say consensus is impossible in practice. It says you cannot have a protocol that guarantees termination in every possible schedule without stepping outside strict asynchrony.
 
-    In an asynchronous system where even ONE node might crash,
-    there is NO algorithm that guarantees consensus.
+Real systems sidestep the theorem with partial synchrony assumptions, randomized backoff, and failure detectors implemented as timeouts. Paxos, Raft, and Zab all rely on those practical ingredients. They prioritize safety first: they would rather stop accepting writes than accept conflicting ones. Liveness returns when the network stabilizes and enough nodes can talk again.
 
-ASYNCHRONOUS = No timing assumptions
-    - Messages can take arbitrarily long
-    - You can't tell if a node crashed or is just slow
+Partial synchrony does not mean synchronized clocks across datacenters. It means there exists some period after an unknown but finite time when messages arrive within predictable bounds long enough for leaders to renew authority and for majorities to respond. Consensus implementations exploit those stable windows. During severe instability they pause, which operators experience as elevated latency or write unavailability rather than as corrupted state.
 
-THE PROBLEM
-─────────────────────────────────────────────────────────────
-You're waiting for Node B's vote. No response.
+> **Stop and think**: If consensus cannot be guaranteed in all situations, how do systems like Kubernetes run reliably every day? What assumptions do they make that the FLP theorem does not?
 
-Option 1: Wait forever
-    Problem: If B crashed, you never decide (no termination)
+### 1.3 Quorums and Fault Tolerance
 
-Option 2: Proceed without B
-    Problem: B might be alive and decide differently (no agreement)
+Most consensus systems use **quorums**: any two quorums overlap, so two different majorities cannot make independent decisions. For `n` nodes, a quorum is typically `floor(n/2) + 1`. A cluster of three nodes tolerates one failure because the remaining two form a majority. A cluster of five tolerates two failures because three nodes still form a majority.
 
-Option 3: Use timeouts
-    Problem: You might timeout a live node, or wait for a dead one
+Engineers often choose odd-sized clusters because even sizes waste a node without increasing fault tolerance. Four nodes still require three for a quorum, same as three nodes, but you pay for an extra machine. The rule of thumb for tolerating `f` simultaneous failures is `2f + 1` nodes. That formula appears in etcd sizing guides, ZooKeeper deployment notes, and every Raft implementation review.
 
-There's no perfect solution. Every algorithm makes trade-offs.
+Quorums also define what happens during partitions. A minority partition cannot commit new writes because it cannot assemble a quorum. That behavior feels like an outage to clients pinned to the minority side, but it prevents split brain. Availability and consistency trade off here: the majority partition stays writable while the minority stops, which is the safe choice for coordination stores.
 
-PRACTICAL IMPLICATIONS
-─────────────────────────────────────────────────────────────
-FLP says: Can't guarantee consensus in all cases.
-Reality: Consensus is highly probable with good algorithms.
+When you size a cluster, count failure domains rather than only node counts. Three nodes in one rack tolerate one machine failure but not rack power loss. Five nodes spread across three zones tolerate zone loss only if quorums cannot form inside a lost zone alone. Placement and quorum math must be designed together, otherwise you will discover gaps during the first real partition instead of during a tabletop exercise.
 
-Algorithms like Paxos and Raft work in practice because:
-- True asynchrony is rare (most messages arrive quickly)
-- Random backoff prevents live-lock
-- Timing assumptions usually hold
-```
+### 1.4 Consensus Use Cases
 
-> **Stop and think**: If it's mathematically impossible to guarantee consensus in all situations, how do systems like Kubernetes run reliably in production every day? What assumptions do they make that the FLP theorem doesn't?
+Consensus shows up wherever a group must pick one answer. **Leader election** asks which node is authoritative right now. **Distributed locks** ask which client may enter a critical section. **Replicated state machines** ask which operation happened in which order across replicas. **Atomic commit** asks whether a distributed transaction should commit or abort as a unit.
 
-### 1.3 Consensus Use Cases
+Kubernetes uses etcd, a Raft-backed store, to record desired cluster state. Controller-manager and scheduler components elect leaders through Lease objects so only one active controller mutates shared resources at a time. Kafka and Hadoop historically relied on ZooKeeper, which uses the Zab protocol, for similar coordination. The tool names differ, but the underlying need is the same: strong agreement under failure.
 
-```
-WHERE YOU NEED CONSENSUS
-═══════════════════════════════════════════════════════════════
-
-LEADER ELECTION
-─────────────────────────────────────────────────────────────
-"Who is the leader?"
-
-Only one node should be leader at a time.
-All nodes must agree on who it is.
-If leader fails, elect a new one.
-
-    Examples:
-    - Kubernetes controller-manager
-    - Database primary
-    - Message queue broker
-
-DISTRIBUTED LOCKS
-─────────────────────────────────────────────────────────────
-"Who holds the lock?"
-
-Only one client can hold a lock at a time.
-All nodes must agree on current holder.
-If holder crashes, lock must be released.
-
-    Examples:
-    - Preventing duplicate processing
-    - Coordinating batch jobs
-    - Resource allocation
-
-REPLICATED STATE MACHINES
-─────────────────────────────────────────────────────────────
-"What is the current state?"
-
-All replicas apply the same operations in the same order.
-Must agree on operation ordering.
-
-    Examples:
-    - etcd (Kubernetes configuration)
-    - Replicated databases
-    - Configuration management
-
-ATOMIC COMMIT
-─────────────────────────────────────────────────────────────
-"Should this transaction commit?"
-
-All participants must agree: commit or abort.
-Can't have some commit and some abort.
-
-    Examples:
-    - Distributed transactions
-    - Two-phase commit
-    - Saga coordination
-```
+Atomic commit across microservices is another face of consensus. Two-phase commit asks every participant to prepare and then commit or abort together. Saga patterns relax all-or-nothing guarantees with compensating transactions. The consensus question still appears at the coordinator: did everyone agree on the outcome? If your business cannot tolerate divergent commit decisions, you need either consensus or a human reconciliation process.
 
 > **Try This (2 minutes)**
 >
-> Think of systems you use. Where is consensus happening?
+> Think of systems you use. Where is consensus happening, and what breaks if it fails?
 >
 > | System | Consensus For | What if it Fails? |
 > |--------|---------------|-------------------|
@@ -207,34 +108,9 @@ Can't have some commit and some abort.
 
 ### 2.1 Paxos: The Original
 
-```
-PAXOS (Leslie Lamport, 1989)
-═══════════════════════════════════════════════════════════════
+Leslie Lamport introduced **Paxos** in the late 1980s as the first proven solution to consensus in asynchronous networks with crash failures. Paxos is famous for being correct and for being difficult to teach. Many production systems borrow Paxos ideas even when engineers implement Raft instead for clarity.
 
-The first proven consensus algorithm.
-Famous for being difficult to understand.
-Basis for many production systems.
-
-ROLES
-─────────────────────────────────────────────────────────────
-PROPOSERS: Suggest values (can be multiple)
-ACCEPTORS: Vote on values (majority must agree)
-LEARNERS: Learn the decided value
-
-BASIC PAXOS (Single Value)
-─────────────────────────────────────────────────────────────
-Phase 1: PREPARE
-    Proposer → Acceptors: "Prepare proposal number N"
-    Acceptors → Proposer: "Promise to not accept < N"
-                          (plus any already-accepted value)
-
-Phase 2: ACCEPT
-    If majority promised:
-    Proposer → Acceptors: "Accept value V with number N"
-    Acceptors → Learners: "Accepted V"
-
-    If majority accept: Consensus reached!
-```
+Paxos assigns three roles. **Proposers** suggest values. **Acceptors** vote on proposals and remember promises. **Learners** observe the chosen value once acceptors agree. Basic Paxos decides a single value in two phases. In the prepare phase, a proposer sends a proposal number and collects promises from a majority of acceptors not to accept older numbers. In the accept phase, the proposer sends a value with that number; if a majority accepts, consensus is reached.
 
 ```mermaid
 sequenceDiagram
@@ -259,40 +135,15 @@ sequenceDiagram
     Note over L: Consensus: X
 ```
 
-```
-WHY IT'S COMPLEX
-─────────────────────────────────────────────────────────────
-- Multiple proposers can conflict
-- Must handle old proposals
-- Single-decree Paxos decides ONE value
-- Multi-Paxos for sequences (even more complex)
-```
+Multi-Paxos extends the idea to a sequence of log entries, which is what databases need, but the bookkeeping grows quickly. Competing proposers, stale proposal numbers, and learner notification all add operational complexity. That complexity is one reason Diego Ongaro and John Ousterhout designed Raft as an understandable alternative with equivalent safety properties for replicated logs.
+
+Lamport's later paper [Paxos Made Simple](https://lamport.azurewebsites.net/pubs/paxos-simple.pdf) reframed the algorithm for practitioners, yet operational teams still prefer implementations with clear leader roles and explicit logs. Google Chubby, Spanner's Paxos groups, and numerous legacy systems prove Paxos at scale, but onboarding cost remains high. When you read about "Paxos-based" storage, ask whether the system uses single-decree Paxos, Multi-Paxos, or a derivative such as Zab that borrows Paxos-style quorums with different messaging shapes.
 
 ### 2.2 Raft: Understandable Consensus
 
-```
-RAFT (Diego Ongaro, 2014)
-═══════════════════════════════════════════════════════════════
+**Raft**, published in 2014, reorganizes consensus around a strong leader. Instead of symmetric proposers competing at all times, Raft elects one leader that orders client requests and replicates them to followers. Consensus decomposes into leader election, log replication, and safety rules that keep logs consistent.
 
-Designed for understandability.
-Equivalent to Paxos but easier to implement.
-Used by etcd, Consul, CockroachDB.
-
-KEY INSIGHT
-─────────────────────────────────────────────────────────────
-Instead of symmetric nodes, use a leader.
-Leader orders all decisions.
-Consensus becomes: "elect leader" + "follow leader"
-
-THREE SUB-PROBLEMS
-─────────────────────────────────────────────────────────────
-1. LEADER ELECTION: Choose a leader
-2. LOG REPLICATION: Leader replicates log to followers
-3. SAFETY: Ensure consistency despite failures
-
-NODE STATES
-─────────────────────────────────────────────────────────────
-```
+Raft nodes are followers by default. If followers stop receiving heartbeats from a leader, they start an election. A candidate requests votes; if it wins a majority, it becomes the new leader. The leader accepts client writes, appends them to its log, and replicates entries to followers. Under Raft §5.4.2, a leader may commit an entry from its **current term** directly once a majority has replicated it; entries from **prior terms** become committed only **indirectly**, when a current-term entry at a higher index commits and pulls them along — a leader cannot treat a replicated-on-majority old-term entry as safely committed on its own. Only then may the leader treat an operation as durable.
 
 ```mermaid
 stateDiagram-v2
@@ -304,58 +155,33 @@ stateDiagram-v2
     Candidate --> Follower: discovers higher term
 ```
 
-**State Transitions:**
-- **Start**: All nodes are Followers
-- **Timeout**: Follower becomes Candidate, requests votes
-- **Majority**: Candidate becomes Leader
-- **Failure**: Leader times out, new election
+This state machine is easier to teach than Paxos because there is one obvious writer at a time. etcd, Consul, CockroachDB, and many other systems implement Raft or a close variant for replicated logs.
 
-### 2.3 Raft Deep Dive
+Followers are passive except during elections. Candidates gather votes. Leaders accept client traffic and replicate entries. The simplicity is intentional: most engineering time goes into snapshotting, compaction, and operational tooling rather than into proving liveness for exotic proposer races. When you debug Raft, ask which role a node believes it holds and whether its term matches the cluster majority.
 
-```
-RAFT: LEADER ELECTION
-═══════════════════════════════════════════════════════════════
+### 2.3 Raft Deep Dive: Leader Election
 
-TERMS
-─────────────────────────────────────────────────────────────
-Time divided into terms (epochs).
-Each term has at most one leader.
-Term number increases monotonically.
+Raft divides time into **terms**, numbered monotonically. Each term has at most one leader. When a follower times out, it increments its term, votes for itself, and asks peers for votes. Peers grant at most one vote per term and refuse candidates whose logs lag behind theirs. That log-completeness rule prevents a stale node from winning leadership with missing entries.
 
-    Term 1: Node A is leader
-    Term 2: Node A fails, Node B elected
-    Term 3: Node B fails, Node C elected
-```
+Split votes happen when multiple candidates start elections simultaneously. Raft mitigates split votes with **randomized election timeouts**, typically spread across a few hundred milliseconds. Randomness makes it likely that one candidate wins before others restart the race. Fixed identical timeouts across nodes can cause election storms where no candidate reaches a majority for minutes.
 
-> **Pause and predict**: If a network partition splits a 5-node cluster into a group of 3 and a group of 2, what will happen to the leader if it was in the group of 2?
+Log completeness voting prevents a lagging node from truncating committed history if it wins an election. The rule compares the last log term and index between candidate and voter. Operators who restore old snapshots without understanding index continuity can accidentally elect nodes that force large reconciliations or reject valid candidates.
 
-```
-ELECTION PROCESS
-─────────────────────────────────────────────────────────────
-1. Follower doesn't hear from leader (timeout)
-2. Increments term, becomes candidate
-3. Votes for itself, requests votes from others
-4. Others vote if:
-   - Haven't voted this term
-   - Candidate's log is at least as up-to-date
-5. Majority votes → becomes leader
-6. No majority → timeout, new election with random delay
+During a partition, only the side with a quorum can elect a leader and commit entries. A stale leader on the minority side may still append incoming client requests to its own local log, but it cannot replicate them to a majority, so it never commits or acknowledges them. Clients talking only to the minority see timeouts, errors, or uncertainty rather than durable success, and those uncommitted entries are discarded when the partition heals. That behavior is safety working as designed, not a random glitch.
 
-SPLIT VOTE PREVENTION
-─────────────────────────────────────────────────────────────
-Random election timeouts (150-300ms).
-Unlikely two candidates timeout simultaneously.
-If they do, random backoff ensures one wins next round.
+Heartbeats are empty **AppendEntries** RPCs — they carry no log entries and are not written to the log — sent periodically to suppress unnecessary elections. Operators who set extremely aggressive election timeouts to "fail over faster" sometimes trigger flapping leadership during normal latency spikes. Tune timeouts against measured round-trip times inside the cluster, not against developer laptop benchmarks.
 
-RAFT: LOG REPLICATION
-═══════════════════════════════════════════════════════════════
+> **Pause and predict**: If a network partition splits a five-node cluster into groups of three and two, what happens to the leader if it lands in the group of two?
 
-Leader receives client requests.
-Appends to local log.
-Replicates to followers.
-Once majority acknowledge, entry is "committed."
-Leader notifies followers of commit.
-```
+### 2.4 Raft Deep Dive: Log Replication and Safety
+
+The leader serializes all writes. For each client request, the leader appends an entry to its local log, sends AppendEntries RPCs to followers, and waits for acknowledgments from a quorum. Once a quorum stores an entry from the leader's **current term**, the leader marks it committed and applies it to its state machine; older-term entries replicated on a majority commit only indirectly when a current-term entry above them commits (Raft §5.4.2). Followers learn commit indexes from the leader and apply the same entries in order.
+
+Raft's safety argument rests on two ideas. First, committed entries appear in every future leader's log because leaders are elected by majorities and majorities overlap. Second, if two logs diverge, the leader forces followers to discard uncommitted suffixes and match its log before accepting new entries. That reconciliation is why a rejoining node with stale data cannot overwrite the authoritative history.
+
+The **commit index** separates "stored on some nodes" from "safe to expose." Clients should not treat a write as durable until the leader commits it. Many outages trace back to clients ignoring that boundary or talking to endpoints that are not fault-aware.
+
+Snapshot and compaction are operational extensions of the same log model. etcd periodically snapshots state so logs do not grow without bound. Compaction deletes superseded entries while preserving safety for new leaders. Those maintenance operations still respect quorum rules; running them during unhealthy clusters can stall recovery if operators skip health checks.
 
 ```mermaid
 sequenceDiagram
@@ -369,47 +195,25 @@ sequenceDiagram
     L->>F2: Append X
     F1-->>L: ACK
     F2-->>L: ACK
-    Note over L: COMMITTED! (majority)
+    Note over L: COMMITTED (majority)
     L-->>C: Success
     L->>F1: Commit notify X
     L->>F2: Commit notify X
 ```
 
-```
-LOG CONSISTENCY
-─────────────────────────────────────────────────────────────
-Leader's log is authoritative.
-Followers must match leader.
-If mismatch, leader sends earlier entries until sync.
-```
+### 2.5 Membership Changes
 
-> **War Story: The $4.2 Million etcd Split-Brain**
->
-> **June 2019. A fintech startup's Kubernetes cluster loses $4.2 million in a single weekend due to an etcd misconfiguration.**
->
-> The company ran a payment processing platform on Kubernetes. Their 3-node etcd cluster sat in a single availability zone—violating every high-availability best practice. When the network switch serving Node A failed, the cluster split: Node A was isolated, while Nodes B and C remained connected.
->
-> **The timeline of disaster:**
-> - **Friday 6:42 PM**: Network switch fails, partitioning Node A
-> - **Friday 6:42 PM**: Nodes B and C detect missing heartbeat, start election
-> - **Friday 6:43 PM**: Node B wins election with term 42 (majority: B+C = 2/3)
-> - **Friday 6:43 PM - Sunday 2:00 AM**: System operates normally on B+C
-> - **Friday 6:42 PM - Sunday 2:00 AM**: Node A continues receiving writes from misconfigured clients
->
-> **The critical failure**: Some microservices had been configured with Node A's IP directly, bypassing the load balancer. These services kept writing to Node A, which accepted writes despite having no quorum—**the etcd version had a bug where stale leaders accepted reads but not writes, except through a deprecated API the microservices used**.
->
-> **When the network healed Sunday morning:**
-> - Node A rejoined with term 41 (stale)
-> - Node A's 33 hours of writes were rejected—term 42 > term 41
-> - 142,000 payment records existed only on Node A
-> - Node A's data was overwritten by B+C's authoritative log
->
-> **The cost:**
-> - $3.1 million in customer refunds for lost payment confirmations
-> - $1.2 million in emergency engineering (weekend rates, consultants)
-> - $400,000 in regulatory penalties for payment processing failures
->
-> **The fix**: The company moved to 5-node etcd across 3 availability zones, enforced all traffic through a load balancer with health checks, and implemented etcd endpoint monitoring that alerts on quorum loss within 30 seconds.
+Changing cluster membership is dangerous because overlapping majorities from old and new configurations could decide different values. Raft handles this with **joint consensus**: a transitional configuration requires majorities of both old and new sets before committing membership changes. After the joint phase completes, the cluster shrinks to the new configuration alone.
+
+Operators feel this during etcd scale-up and scale-down events. Rushing node removal without following the documented steps can shrink quorums unexpectedly. Treat membership changes as planned operations with verified quorum health, not as casual autoscaling.
+
+Read paths deserve the same skepticism as write paths during partitions. A stale member may serve lagging data unless the client requests linearizable reads through the leader or uses verified indexes. Many "mystery bugs" after failover are stale reads rather than lost writes. Document which APIs guarantee linearizability and which tolerate lagging followers so application teams do not guess under pressure.
+
+> **Hypothetical scenario:** Imagine a three-node etcd cluster running in a single availability zone for a Kubernetes platform. A top-of-rack switch failure isolates one node while the other two remain connected. The pair detects missed heartbeats, holds an election, and elects a new leader at term N+1 with a quorum of two. The isolated node still believes it is leader at the older term N and may append client requests to its local log from clients configured with its IP directly instead of the cluster endpoint list, but it cannot replicate those entries to a majority, so it never commits or acknowledges them.
+
+When the partition heals, the stale node rejoins and discovers the higher term N+1. Raft discards the uncommitted entries from term N because they never reached a quorum. Operators see "lost" configuration changes that existed only on the minority side. The lesson is twofold: minority partitions must not be treated as writable, and clients must use fault-aware endpoints rather than pinning to a single member IP. The term numbers here are illustrative, but the mechanics match real Raft behavior documented in etcd operations guides.
+
+Monitoring should alert when etcd loses quorum or when clients bypass endpoint lists. Healthy servers cannot fix misconfigured writers that keep sending traffic to an isolated member. Include client configuration verification in consensus incident runbooks alongside server health checks.
 
 ---
 
@@ -417,115 +221,56 @@ If mismatch, leader sends earlier entries until sync.
 
 ### 3.1 Why Leaders?
 
-```
-WHY USE LEADERS?
-═══════════════════════════════════════════════════════════════
-
-LEADERLESS (all nodes equal)
-─────────────────────────────────────────────────────────────
-    Every request needs coordination
-    Complex conflict resolution
-    Higher latency (wait for quorum)
-    No single point of failure
-
-LEADER-BASED
-─────────────────────────────────────────────────────────────
-    Leader orders all operations
-    Simple decision making
-    Lower latency (leader decides alone)
-    Must handle leader failure
-
-COMPARISON
-─────────────────────────────────────────────────────────────
-```
+Leaderless designs allow any replica to accept writes, which can improve availability during partitions at the cost of conflict resolution. Leader-based designs route writes through one node, which simplifies ordering and shrinks the coordination problem to "who is leader?" rather than "how do we merge every write?"
 
 | Feature | Leaderless | Leader-based |
 |---------|------------|--------------|
 | **Writes** | Any node | Leader only |
 | **Coordination** | Every write | Leader election |
-| **Latency** | Higher | Lower |
-| **Availability** | Higher | Lower (election) |
+| **Latency** | Depends on consistency level, quorum size, and locality | Often lower for single-leader steady-state writes |
+| **Availability** | Higher | Lower during election |
 | **Complexity** | Complex reads | Complex failover |
 | **Examples** | Cassandra | etcd, ZooKeeper |
 
+Latency is not a universal ordering: leaderless designs may win on local quorum-one writes or tunable consistency, while leader-based paths pay round trips to one coordinator but simplify ordering. Compare designs using your consistency target, quorum layout, conflict handling, and geographic placement — not a blanket "leaderless is always slower" rule.
+
+Leader election introduces a brief unavailability window when the leader fails, but it makes steady-state performance predictable. For control planes and metadata stores, that trade-off is usually correct.
+
+Dual leaders on a minority partition are prevented by quorum voting, not by good intentions. Application-level "leader flags" stored in local memory do not participate in consensus and can lie after partitions heal. Always anchor leadership in a quorum-backed lease or log entry.
+
 ### 3.2 Leader Election Mechanisms
 
-```
-LEADER ELECTION APPROACHES
-═══════════════════════════════════════════════════════════════
+Simple algorithms like **bully election** pick the highest numeric ID and work on LANs with stable membership. They are not partition tolerant: split groups may each declare a leader. Consensus-based election through Raft or Zab elects leaders with quorum support, which prevents dual leaders in minority partitions.
 
-BULLY ALGORITHM
-─────────────────────────────────────────────────────────────
-Highest ID wins. Simple but not partition-tolerant.
+**Lease-based leadership** adds time bounds. A leader must renew a lease periodically; if renewal stops, others may take over. Leases convert "leader died" into "leader failed to prove liveness within N seconds." That pattern appears in Kubernetes Lease objects and in Chubby-style lock services.
 
-    Node 1 (ID=1): "I want to be leader"
-    Node 2 (ID=2): "I have higher ID, step aside"
-    Node 3 (ID=3): "I have highest ID, I'm leader"
+External coordination stores let application components delegate hard consensus to etcd or ZooKeeper. Your service watches a key or lease, runs leader callbacks, and exits cleanly on loss of leadership. That separation keeps application code simpler while benefiting from battle-tested replication.
 
-CONSENSUS-BASED (Raft/Paxos)
-─────────────────────────────────────────────────────────────
-Nodes vote. Majority wins. Partition-tolerant.
-
-    - Requires quorum for election
-    - Leader has "lease" (term)
-    - New election on leader failure
-
-LEASE-BASED
-─────────────────────────────────────────────────────────────
-Leader holds time-limited lease. Must renew.
-
-    Leader acquires lease (e.g., 15 seconds)
-    Leader renews every 5 seconds
-    If leader crashes, lease expires
-    Others can acquire after expiry
-
-    # Kubernetes leader election uses leases
-    kubectl get leases -n kube-system
-
-EXTERNAL COORDINATION
-─────────────────────────────────────────────────────────────
-Use external system (etcd, ZooKeeper) for coordination.
-
-    Component → etcd: "I'm leader" (with lease)
-    etcd: "OK, you're leader until lease expires"
-    Other components: Watch etcd for current leader
-```
+Compare bully election only in teaching exercises or strictly trusted LANs. In cloud environments, partitions happen during routine maintenance. Consensus-backed leases cost more latency but buy the property you actually need: at most one acknowledged leader at a time for a given term.
 
 ### 3.3 Kubernetes Leader Election
 
-```
-KUBERNETES LEADER ELECTION
-═══════════════════════════════════════════════════════════════
+Kubernetes components such as kube-controller-manager and kube-scheduler use **Lease** objects in the `coordination.k8s.io/v1` API. The active leader creates or renews a Lease; followers watch the Lease and attempt takeover when renewals stop. Lease duration, renew deadline, and retry period define how quickly failover happens versus how sensitive the cluster is to short pauses.
 
-HOW IT WORKS
-─────────────────────────────────────────────────────────────
-Uses Lease objects in etcd.
-Leader creates/renews lease.
-Others watch lease, take over if expired.
-
-EXAMPLE: CONTROLLER-MANAGER
-─────────────────────────────────────────────────────────────
-# View current leader
+```bash
 kubectl get lease kube-controller-manager -n kube-system -o yaml
+```
 
+```yaml
 apiVersion: coordination.k8s.io/v1
 kind: Lease
 metadata:
   name: kube-controller-manager
   namespace: kube-system
 spec:
-  holderIdentity: master-1_abc123    # Current leader
-  leaseDurationSeconds: 15           # Lease validity
-  renewTime: "2024-01-15T10:30:00Z"  # Last renewal
+  holderIdentity: control-plane-node-1_abc123
+  leaseDurationSeconds: 15
+  renewTime: "2026-01-15T10:30:00Z"
+```
 
-IMPLEMENTATION FOR YOUR APPS
-─────────────────────────────────────────────────────────────
-# Using client-go leader election
+Application controllers can use client-go leader election with the same Lease mechanism. Callbacks separate **OnStartedLeading** work from **OnStoppedLeading** cleanup, which prevents split-brain writes if your process continues after losing the lease.
 
-import (
-    "k8s.io/client-go/tools/leaderelection"
-)
-
+```go
 leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
     Lock: &resourcelock.LeaseLock{
         LeaseMeta: metav1.ObjectMeta{
@@ -538,14 +283,18 @@ leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
     RetryPeriod:   2 * time.Second,
     Callbacks: leaderelection.LeaderCallbacks{
         OnStartedLeading: func(ctx context.Context) {
-            // I'm the leader, do leader work
+            // Leader work here
         },
         OnStoppedLeading: func() {
-            // I'm no longer leader
+            // Stop writers; release resources
         },
     },
 })
 ```
+
+Treat leader loss as a normal event. Long garbage-collection pauses or network blips can delay renewal; your process must stop mutating shared state when leadership ends even if it still feels healthy locally.
+
+In Kubernetes 1.35, Lease-based leader election remains the standard path for in-tree and custom controllers. The coordination API is stable, but your callbacks must still be non-blocking enough to renew before `renewTime` drifts past `leaseDurationSeconds`. Watch dashboards for rising workqueue depth during leader transitions; those spikes often indicate controllers that assume leadership is permanent.
 
 ---
 
@@ -553,35 +302,11 @@ leaderelection.RunOrDie(ctx, leaderelection.LeaderElectionConfig{
 
 ### 4.1 Distributed Locks
 
-```
-DISTRIBUTED LOCKS
-═══════════════════════════════════════════════════════════════
+A local mutex protects in-process critical sections because the operating system releases locks when a process exits. A **distributed lock** protects shared resources across machines, but there is no shared OS to clean up after crashes. Lock services must combine consensus with time bounds so locks eventually expire when holders die.
 
-PURPOSE
-─────────────────────────────────────────────────────────────
-Ensure only one process does something at a time.
-Coordinate access to shared resources.
+The naive pattern stores a lock key in etcd or Redis with a TTL. That helps, but TTL alone does not make locks safe. If a holder pauses longer than the TTL, another client can acquire the lock while the first still believes it holds exclusivity.
 
-LOCAL LOCK (single machine)
-─────────────────────────────────────────────────────────────
-    mutex.Lock()
-    // Critical section
-    mutex.Unlock()
-
-    Simple. Process crashes → OS releases lock.
-
-DISTRIBUTED LOCK (multiple machines)
-─────────────────────────────────────────────────────────────
-    // Acquire lock from coordination service
-    lock.Acquire("resource-x")
-    // Critical section
-    lock.Release("resource-x")
-
-    Complex. Process crashes → Who releases lock?
-
-THE PROBLEM WITH DISTRIBUTED LOCKS
-─────────────────────────────────────────────────────────────
-```
+Lock granularity matters as much as correctness. One global lock for an entire batch pipeline creates an availability bottleneck. Fine-grained locks per shard reduce contention but multiply fencing requirements. Prefer idempotent shard workers with lease-based claim keys when possible, and reserve exclusive locks for resources that truly cannot be shared.
 
 ```mermaid
 sequenceDiagram
@@ -596,131 +321,50 @@ sequenceDiagram
     B->>S: Acquire lock
     S-->>B: Lock granted
     Note over A: GC pause ends
-    Note over A, B: Client A thinks it still has lock!<br>Both A and B in critical section!
+    Note over A, B: Both may enter critical section
 ```
 
-> **Stop and think**: Why does a distributed lock need a TTL (time-to-live) in the first place? What would happen if a client acquired a lock without a TTL and then crashed permanently before releasing it?
+Martin Kleppmann's analysis of Redlock explains why fencing is required for correctness. A lock service can only hint at exclusivity; the storage layer must reject stale writers.
 
-```
-SOLUTION: FENCING TOKENS
-─────────────────────────────────────────────────────────────
-Lock server issues incrementing token with each acquisition.
-Resource checks token, rejects stale tokens.
+### 4.2 Fencing Tokens
 
-    Client A gets lock with token 33
-    Client A pauses
-    Lock expires, Client B gets lock with token 34
-    Client A wakes, tries to write with token 33
-    Resource rejects: 33 < 34 (stale)
-```
+**Fencing tokens** are monotonically increasing numbers issued with each lock acquisition. Writers attach the token to every mutating request. The shared resource rejects requests whose token is older than the highest token it has seen. Even if Client A wakes late and still believes it holds the lock, its stale token cannot corrupt data.
 
-### 4.2 Coordination Patterns
+This pattern shifts correctness from the unreliable client to the storage layer, which you control. Databases and object stores can store the latest fencing token alongside each record. Any payment, inventory, or shard migration API that relies on distributed locks should understand fencing before production load arrives.
 
-```
-COORDINATION PATTERNS
-═══════════════════════════════════════════════════════════════
+Redlock-style designs attempt to survive Redis node failures by quorum acquisition across independent Redis masters, but Kleppmann's critique shows that without fencing at the resource, clock drift and long pauses still break safety. If you cannot plumb fencing tokens into the storage layer, treat the lock as a performance hint rather than a correctness guarantee and choose idempotent workflows instead.
 
-DISTRIBUTED QUEUE
-─────────────────────────────────────────────────────────────
-Multiple workers, one task at a time.
+### 4.3 Coordination Patterns
 
-    /tasks/task-001 → Worker A claims
-    /tasks/task-002 → Worker B claims
-    /tasks/task-003 → Worker C claims
+Beyond locks, coordination services implement **queues**, **barriers**, and **service discovery**. Workers claim tasks by creating ephemeral nodes or conditional keys. Barriers let N workers signal readiness before a batch step proceeds. Service registration publishes instance endpoints that disappear automatically when sessions end.
 
-    Workers watch for new tasks, claim by creating ephemeral node.
+These patterns reuse the same primitives: consistent writes, watches or long polls, and ephemeral keys tied to session lifetime. The difference is semantics, not infrastructure. Choosing the wrong pattern, such as using a lock where a queue suffices, adds latency without improving correctness.
 
-BARRIER (RENDEZVOUS)
-─────────────────────────────────────────────────────────────
-Wait until N nodes are ready, then proceed.
+Barriers coordinate phased work such as rolling restarts or batch ETL starts. Queues decouple producers and consumers while preserving at-most-one claim semantics when implemented with compare-and-swap or ephemeral nodes. Service discovery publishes membership that should disappear automatically when processes crash. Each pattern maps cleanly to watches in etcd or ZooKeeper, but the error handling differs when sessions expire during long-running jobs.
 
-    Worker 1: Create /barrier/worker-1
-    Worker 2: Create /barrier/worker-2
-    Worker 3: Create /barrier/worker-3
+### 4.4 etcd and ZooKeeper
 
-    All watch /barrier. When count = N, all proceed.
-
-    Use case: Coordinated restart, batch processing start.
-
-SERVICE DISCOVERY
-─────────────────────────────────────────────────────────────
-Services register, clients find them.
-
-    Service A: Create /services/api/instance-1 (ephemeral)
-    Service A: Create /services/api/instance-2 (ephemeral)
-
-    Client: List /services/api → [instance-1, instance-2]
-
-    If service crashes, ephemeral node deleted automatically.
-
-CONFIGURATION DISTRIBUTION
-─────────────────────────────────────────────────────────────
-Central config, all nodes watch.
-
-    Admin: Write /config/feature-flags = {"new-ui": true}
-    All nodes: Watch /config/feature-flags
-    Change detected → All nodes update simultaneously
-```
-
-### 4.3 etcd and ZooKeeper
-
-```
-etcd vs ZooKeeper
-═══════════════════════════════════════════════════════════════
-
-SIMILARITIES
-─────────────────────────────────────────────────────────────
-Both provide:
-- Distributed key-value store
-- Strong consistency (linearizable)
-- Watch mechanism (change notifications)
-- TTL/leases (automatic expiration)
-- Used for coordination, not data storage
-
-DIFFERENCES
-─────────────────────────────────────────────────────────────
-```
+Both etcd and ZooKeeper provide strongly consistent coordination stores with watch mechanisms and lease support. They are optimized for small, critical metadata rather than application data volumes.
 
 | Feature | etcd | ZooKeeper |
 |---------|------|-----------|
 | **Protocol** | gRPC | Custom binary |
-| **Consensus** | Raft | Zab (Paxos-like) |
-| **Data model** | Flat key-value | Hierarchical (tree) |
-| **API** | Simple KV | ZNodes (like files) |
-| **Watches** | Efficient (stream) | One-time triggers |
-| **Typical use** | Kubernetes | Kafka, Hadoop |
-| **Language** | Go | Java |
+| **Consensus** | Raft | Zab (atomic broadcast) |
+| **Data model** | Flat key-value | Hierarchical znodes |
+| **API** | Simple KV + watches | Tree operations |
+| **Typical use** | Kubernetes | Kafka, Hadoop legacy stacks |
 
-```
-etcd EXAMPLE
-─────────────────────────────────────────────────────────────
-# Set a key
+```bash
 etcdctl put /myapp/config '{"version": 2}'
-
-# Get a key
 etcdctl get /myapp/config
-
-# Watch for changes
 etcdctl watch /myapp/config
-
-# Set with TTL (lease)
 etcdctl lease grant 60
 etcdctl put /myapp/leader "node-1" --lease=<lease-id>
-
-ZOOKEEPER EXAMPLE
-─────────────────────────────────────────────────────────────
-# Create a znode
-create /myapp/config '{"version": 2}'
-
-# Get a znode
-get /myapp/config
-
-# Watch (one-time)
-get /myapp/config -w
-
-# Ephemeral node (deleted when session ends)
-create -e /myapp/leader "node-1"
 ```
+
+ZooKeeper clients create ephemeral znodes that disappear when sessions expire, which is how early Hadoop ecosystems implemented leader election and membership. Modern Kubernetes stacks standardize on etcd, but ZooKeeper remains relevant where ecosystems already embed it.
+
+Consul uses Raft internally and targets service mesh and multi-datacenter discovery scenarios. The comparison table is not a winner-take-all ranking; it is a map of which protocol and data model your ecosystem already expects. Migrating Kafka off ZooKeeper toward KRaft, for example, changes operational assumptions that used to hide inside znode hierarchies.
 
 ---
 
@@ -728,152 +372,104 @@ create -e /myapp/leader "node-1"
 
 ### 5.1 Consensus is Expensive
 
-```
-THE COST OF CONSENSUS
-═══════════════════════════════════════════════════════════════
+Every committed write in Raft crosses the leader and a quorum of followers. That implies at least two network round trips and serializes writes through one node. Geographic distribution amplifies latency; a quorum spanning regions may measure hundreds of milliseconds per write.
 
-LATENCY
-─────────────────────────────────────────────────────────────
-Every write requires:
-    1. Client → Leader
-    2. Leader → Followers (parallel)
-    3. Followers → Leader (acknowledgments)
-    4. Leader → Client (commit confirmation)
+Throughput also caps out earlier than in leaderless stores. A single Raft leader might sustain tens of thousands of small writes per second on good hardware, while an in-memory cache without consensus can exceed that by an order of magnitude. You pay for linearizable agreement with latency, throughput, and operational complexity.
 
-    Minimum: 2 round trips
-    With geographic distribution: 100s of milliseconds
+Availability requires quorum maintenance. A three-node cluster survives one failure; a five-node cluster survives two. Adding nodes increases fault tolerance but also increases coordination work. Even-sized clusters should be avoided unless you have a documented reason.
 
-THROUGHPUT
-─────────────────────────────────────────────────────────────
-All writes go through leader.
-Leader is bottleneck.
-Can't horizontally scale writes.
-
-    Single leader: ~10,000-50,000 writes/second typical
-    Compare to Redis: ~100,000+ writes/second (no consensus)
-
-AVAILABILITY
-─────────────────────────────────────────────────────────────
-Requires quorum (majority).
-3 nodes: 1 can fail
-5 nodes: 2 can fail
-7 nodes: 3 can fail
-
-    More nodes = better fault tolerance
-    More nodes = slower consensus (more coordination)
-
-COMPLEXITY
-─────────────────────────────────────────────────────────────
-Consensus algorithms are hard to implement correctly.
-Subtle bugs can cause data loss.
-Use battle-tested implementations (etcd, ZooKeeper).
-```
+Benchmark claims about writes per second vary with value size, fsync policy, and network latency. Treat numbers as order-of-magnitude guidance. The enduring lesson is structural: consensus writes are serialized through a leader and acknowledged by majorities, so they will not behave like horizontally sharded application databases no matter how fast the hardware becomes.
 
 ### 5.2 When You Need Consensus
 
-```
-YOU NEED CONSENSUS WHEN
-═══════════════════════════════════════════════════════════════
+Reach for consensus when mistakes are expensive and ordering must be global. Leader election, strongly consistent configuration, distributed locks with fencing, and atomic commit decisions fit that profile. If two leaders or two lock holders would corrupt user data or violate regulation, consensus or an equivalent strong coordination layer belongs in the design.
 
-[YES] LEADER ELECTION
-    Only one leader at a time, all must agree.
-    Alternative: Live with multiple (might cause duplicates)
+Platform metadata is the classic sweet spot. Kubernetes object counts stay far smaller than application payload volumes, yet errors propagate cluster-wide. That asymmetry justifies etcd on the control plane while application data lives elsewhere. Copy the pattern before you copy the tool.
 
-[YES] DISTRIBUTED LOCKS (if correctness matters)
-    Only one holder, must be certain.
-    Alternative: Optimistic locking with conflicts
+When in doubt, prototype failure modes before benchmarking happy-path throughput. A system that survives leader loss and partition recovery usually beats a faster system that corrupts state silently during the first maintenance window.
 
-[YES] CONFIGURATION CHANGES
-    All nodes must see same config.
-    Alternative: Eventual propagation (brief inconsistency)
+Document quorum layout and client endpoints in the same runbook entry so on-call engineers do not rediscover placement math during an outage. Include expected election pause duration so product owners understand brief write unavailability during controlled failover.
 
-[YES] TRANSACTION COMMIT
-    All participants agree: commit or abort.
-    Alternative: Sagas (compensating transactions)
+You probably do not need consensus for caches, metrics, high-volume event streams, or shopping carts where business rules tolerate merge and retry. Eventual consistency, CRDTs, and idempotent workers often deliver better user experience at lower cost for those workloads.
 
-[YES] TOTAL ORDERING
-    All nodes process operations in same order.
-    Alternative: Partial ordering or eventual consistency
-
-YOU PROBABLY DONT NEED CONSENSUS WHEN
-═══════════════════════════════════════════════════════════════
-
-[NO] CACHING
-    Stale data is acceptable.
-    Use TTLs instead.
-
-[NO] METRICS/LOGGING
-    Approximate counts are fine.
-    Eventual consistency is enough.
-
-[NO] USER PREFERENCES
-    Minor inconsistency is tolerable.
-    Conflict-free data types (CRDTs) work well.
-
-[NO] SHOPPING CART
-    Merge conflicts on checkout.
-    Eventual consistency with conflict resolution.
-```
+The test is whether two concurrent writers can create an irreconcilable business state. If the worst case is a duplicated metric point or a cart line merged at checkout, consensus is overkill. If the worst case is two leaders mutating the same shard or two payments capturing the same invoice, consensus or fencing belongs on the critical path.
 
 ### 5.3 Alternatives to Consensus
 
+**Leases** grant temporary authority without a full round of replication for every decision, as long as holders renew promptly. **Optimistic concurrency** reads a version, computes an update, and writes only if the version unchanged, retrying on conflict. **CRDTs** merge concurrent updates without coordination for data types that support commutative operations. **Single-writer sharding** assigns each key range to one authoritative node, avoiding cross-shard consensus for the common case.
+
+Optimistic concurrency appears in Kubernetes resource updates through resourceVersion checks. A controller reads an object, computes a patch, and submits it expecting the same resourceVersion. If another writer changed the object first, the API rejects the patch and the controller retries. That pattern provides safety without a global lock as long as conflicts are rare enough that retries stay cheap.
+
+These alternatives trade strict global ordering for performance and availability. The design task is to match the tool to the business invariant, not to default to etcd because it is familiar.
+
+Martin Kleppmann's treatment of consensus in *Designing Data-Intensive Applications* emphasizes that coordination is a scarce resource. Every strong decision consumes time on a critical path shared by the entire system. Platform teams should publish guidance about which namespaces may create Lease objects, which services may hold global locks, and which data belongs in eventually consistent stores instead. Without that guardrail, every new microservice adds another hidden dependency on the coordination layer.
+
+---
+
+## Patterns
+
+1. **Quorum-first sizing** — Run odd-sized clusters across failure domains so losing one zone still leaves a majority; document `2f+1` capacity before deployment.
+2. **Endpoint lists, not member IPs** — Clients talk to load-balanced or DNS-backed etcd endpoints so partitions do not pin traffic to an isolated member that can append locally but never commit or acknowledge writes.
+3. **Term-aware leadership** — Treat higher terms as authoritative; automate stale leader detection instead of trusting local role flags after network heals.
+4. **Fenced writes** — Pair distributed locks with monotonic fencing tokens checked by the storage layer, not only by clients.
+5. **Joint membership changes** — Expand or shrink consensus clusters using documented joint-configuration flows rather than abrupt node removal.
+
+Each pattern above addresses a failure mode that appears repeatedly in postmortems. Quorum sizing fights split brain. Endpoint lists fight misconfigured clients. Term awareness fights stale leaders. Fencing fights pause-induced double writers. Joint configuration fights overlapping majorities during membership churn. Adopting one pattern without the others still leaves holes.
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Fails | Better Approach |
+|--------------|--------------|-----------------|
+| Consensus for telemetry | Writes bottleneck on the leader | Use metrics pipelines with eventual consistency |
+| Even-sized etcd clusters | Pay for a node without extra fault tolerance | Prefer 3, 5, or 7 members |
+| TTL locks without fencing | Paused clients corrupt shared state after expiry | Issue fencing tokens validated by resources |
+| Fixed election timeouts | Split votes stall failover for minutes | Randomize timeouts per node within a safe band |
+| Rolling your own Raft | Subtle bugs cause silent data loss | Use etcd, Consul, or proven libraries |
+| Cross-region quorum on every write | Latency and partitions dominate uptime | Regional consensus with async replication for data plane |
+
+Anti-patterns often arrive as reasonable shortcuts. A team stores high-volume metrics in etcd because it is already there. Another pins automation to node IP addresses because DNS once failed in staging. Another skips fencing because TTL locks worked in demos. Each shortcut removes a guardrail that consensus systems assume, and production load eventually finds the gap.
+
+---
+
+## Decision Framework
+
+Choosing coordination machinery is a design decision, not a default import. Start from the invariant you must protect, then map that invariant to consensus, leases, or nothing. The flowchart below summarizes the most common branch points platform engineers use when reviewing service proposals.
+
+Use this flowchart when choosing coordination mechanisms for a new service, and validate the chosen path with failure-mode questions before implementation begins.
+
+```mermaid
+flowchart TD
+    Start([Need coordination?]) --> Q1{Must all nodes agree<br>on one order or leader?}
+    Q1 -->|Yes| Q2{Write volume low<br>and latency OK?}
+    Q1 -->|No| Q3{Can merges or retries<br>fix conflicts?}
+    Q2 -->|Yes| Consensus[Use consensus store<br>etcd / ZooKeeper / Consul]
+    Q2 -->|No| Reshard[Reshard or regionalize;<br>consensus only for metadata]
+    Q3 -->|Yes| Eventual[Eventual consistency,<br>CRDTs, or queues]
+    Q3 -->|No| Q4{Need exclusive access<br>to a resource?}
+    Q4 -->|Yes| Lock[Lease + fencing token<br>on the resource]
+    Q4 -->|No| Local[Local locks or<br>single-writer shard]
 ```
-ALTERNATIVES TO CONSENSUS
-═══════════════════════════════════════════════════════════════
 
-EVENTUAL CONSISTENCY
-─────────────────────────────────────────────────────────────
-Changes propagate asynchronously.
-All nodes converge to same state... eventually.
+Ask three questions in design reviews: What invariant breaks if two actors proceed at once? What is the cost of a wrong decision versus a delayed decision? Can we prove liveness with our timeout and quorum layout? Honest answers route you to consensus, leases, or nothing.
 
-    Pro: Higher availability, lower latency
-    Con: Temporary inconsistency
+Document the decision in architecture notes so future teams do not optimize away etcd without understanding which invariant they are weakening. Many outages begin when a faster datastore replaces a coordination store but nobody updates the failure model.
 
-CONFLICT-FREE REPLICATED DATA TYPES (CRDTs)
-─────────────────────────────────────────────────────────────
-Data structures that merge automatically.
-No coordination needed.
-
-    Examples:
-    - G-Counter: Only grows (add, never subtract)
-    - LWW-Register: Last-write-wins by timestamp
-    - OR-Set: Observed-remove set
-
-    Pro: No coordination, always available
-    Con: Limited operations, eventual consistency
-
-OPTIMISTIC CONCURRENCY
-─────────────────────────────────────────────────────────────
-Assume no conflicts. Detect and retry if wrong.
-
-    Read record with version V
-    Make changes
-    Write "if version still V"
-    If version changed, retry
-
-    Pro: No locks, high concurrency
-    Con: Retries under contention
-
-SINGLE LEADER (NO CONSENSUS)
-─────────────────────────────────────────────────────────────
-One designated leader (not elected).
-Simple but single point of failure.
-
-    Pro: Simple, no consensus needed
-    Con: Manual failover, downtime during failure
-```
+When you present this framework to stakeholders, translate technical branches into business language. "Must all nodes agree" becomes "would duplicate leaders corrupt money or safety?" "Write volume low" becomes "is this metadata or customer traffic?" Shared vocabulary prevents teams from accidentally shipping strong-consistency requirements into high-throughput paths.
 
 ---
 
 ## Did You Know?
 
-- **Paxos was rejected twice** by academic journals because reviewers found it too hard to understand. Lamport eventually published it as a "part-time parliament" allegory to make it more accessible.
+- **Paxos publication history**: Leslie Lamport's Paxos work was initially considered difficult to review; his later "Paxos Made Simple" paper reframed the algorithm for broader audiences and remains a standard reference.
+- **Raft's design goal**: Diego Ongaro and John Ousterhout designed Raft for understandability and evaluated it with user studies comparing comprehension against Paxos in the 2014 USENIX ATC paper.
+- **Chubby's blast radius**: Google's Chubby lock service influenced many coordination designs; the original OSDI paper describes how widespread dependencies on a lock service can amplify outages.
+- **etcd's Kubernetes role**: etcd became Kubernetes' backing store for cluster state; its Raft-backed API is on the critical path for nearly every control-plane change in modern clusters.
 
-- **Raft's name** comes from "Reliable, Replicated, Redundant, And Fault-Tolerant." It was specifically designed to be understandable—the paper includes a user study showing people learn Raft faster than Paxos.
+Leslie Lamport's work on logical clocks and ordering underpins many coordination designs even when teams implement Raft instead of Paxos directly. Understanding happens-before relationships helps you interpret why consensus logs are append-only authorities rather than mutable shared files.
 
-- **Google's Chubby** (Paxos-based lock service) was so critical that when it went down for 15 minutes, more Google services failed than when a major datacenter lost power. Dependencies on coordination services can be dangerous.
-
-- **etcd started at CoreOS** in 2013 as a simple key-value store for CoreOS's distributed init system. When Kubernetes adopted it as its brain, etcd became one of the most critical pieces of infrastructure in cloud-native computing—now running in production at virtually every major tech company.
+The next module explores what to do when you deliberately choose weaker consistency. Keep the consensus mental model in mind: eventual consistency is not "no rules," it is a different set of guarantees with different recovery tools.
 
 ---
 
@@ -881,94 +477,82 @@ Simple but single point of failure.
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| Using consensus for everything | Slow, complex, bottleneck | Consensus only when needed |
-| Wrong quorum size | 2 of 4 nodes isn't majority | Use odd numbers (3, 5, 7) |
-| Ignoring leader election time | Brief unavailability on failover | Design for election pauses |
-| Distributed locks without fencing | Stale clients corrupt data | Use fencing tokens |
-| Rolling your own consensus | Subtle bugs, data loss | Use battle-tested implementations |
-| Consensus across datacenters | High latency, frequent elections | Prefer regional consensus |
+| Using consensus for everything | Slow writes and leader bottlenecks | Reserve consensus for metadata and strong invariants |
+| Wrong quorum size | Even counts waste nodes without gain | Size clusters as odd `2f+1` groups |
+| Ignoring election pauses | Failover looks like mysterious unavailability | Budget leader transition time in SLOs |
+| Distributed locks without fencing | Stale holders write after lease expiry | Validate monotonic fencing tokens at storage |
+| Pinning clients to one etcd member | Isolated member appends locally but never commits or acknowledges without a quorum | Use endpoint lists and health-aware routing |
+| Rolling your own consensus | Rare edge cases lose data silently | Adopt etcd, ZooKeeper, or mature libraries |
+| Global quorum for app data | Cross-region latency dominates | Keep consensus regional; replicate data asynchronously |
+| Skipping joint configuration | Membership changes create dual majorities | Follow Raft joint-consensus procedures |
 
 ---
 
 ## Quiz
 
-1. **Scenario**: You are tasked with building a highly reliable distributed database where three nodes must agree on the order of transactions. During testing, you notice that if the network becomes heavily congested, the system completely halts and refuses to commit new transactions. Why is this behavior actually expected rather than a bug?
+1. **Scenario**: You are building a replicated database where three nodes must agree on transaction order. Under heavy network congestion the system halts and refuses new commits. Why is that expected rather than a bug?
    <details>
    <summary>Answer</summary>
-
-   This behavior is expected due to the constraints of the FLP impossibility theorem, which states that in an asynchronous system where even one node might fail, no algorithm can guarantee consensus. Because the system cannot distinguish between a node that has crashed and one that is simply slow to respond due to network congestion, it must make a trade-off. In this scenario, the database has prioritized safety (agreement and validity) over liveness (termination). Practical consensus algorithms like Raft and Paxos accept that they cannot guarantee termination in all possible faulty states, choosing instead to pause operations rather than risk data corruption or split-brain scenarios.
+   This behavior reflects the FLP impossibility result and the safety-first design of practical consensus. In an asynchronous network you cannot distinguish a crashed node from a slow one, so algorithms like Raft prioritize agreement and validity over guaranteed termination. Halting commits prevents split brain or conflicting orders. When congestion clears and quorums can form again, liveness typically returns without sacrificing the safety properties you relied on when choosing consensus.
    </details>
 
-2. **Scenario**: In a 5-node etcd cluster powering a production Kubernetes environment, the current leader node suffers a hardware failure and abruptly dies. Walk through the exact mechanism the remaining four nodes use to recover and agree on the cluster's next state.
+2. **Scenario**: A five-node etcd cluster loses its leader to hardware failure. Describe how the remaining nodes elect a replacement and resume safe replication.
    <details>
    <summary>Answer</summary>
-
-   When the leader dies, the remaining follower nodes will eventually stop receiving heartbeat messages, triggering an election timeout on one or more of them. The first node to time out increments its current term number and transitions to a candidate state, voting for itself and sending request-vote messages to the other nodes. The remaining nodes will grant their vote if they haven't voted in this term and if the candidate's log is at least as up-to-date as their own. Once the candidate receives a majority of votes, it assumes the role of leader and immediately begins sending heartbeats to establish its authority. This process ensures the cluster safely transitions to a new leader without any single point of failure disrupting the overall consensus.
+   Followers stop receiving heartbeats and eventually exceed their election timeouts. One follower increments its term, becomes a candidate, votes for itself, and requests votes from peers. Peers grant votes if they have not voted in the new term and if the candidate's log is at least as up to date as theirs. When the candidate receives a majority, it becomes leader, sends heartbeats to establish authority, and resumes AppendEntries replication. Committed entries from the old leader remain safe because majorities overlap across terms.
    </details>
 
-3. **Scenario**: You are implementing a distributed lock using a simple Redis key with a TTL. A developer asks why you can't just delete the key when the process finishes instead of worrying about fencing tokens. Explain the fundamental flaw in relying solely on TTLs and deletion for distributed locks.
+3. **Scenario**: A developer proposes Redis TTL locks without fencing for inventory updates. Explain the flaw and the fix.
    <details>
    <summary>Answer</summary>
-
-   Relying solely on a TTL and deletion is fundamentally flawed because it assumes a perfectly synchronous environment where processes never freeze and networks never delay. If a process acquires a lock but experiences a massive garbage collection pause, the TTL will expire on the server while the process is completely unaware. When a second process inevitably acquires the now-free lock, both processes will eventually attempt to execute their critical sections concurrently, leading to silent data corruption. Fencing tokens are required because they shift the ultimate validation from the unreliable client processes to the storage layer itself. By ensuring the resource rejects any writes from a client holding a stale, older token, the system remains safe even when distributed lock guarantees temporarily break down.
+   TTL locks assume holders always run forward in real time. Garbage collection pauses, VM freezes, or long network partitions can expire a lock while the holder still believes it is exclusive. A second client then acquires the lock and both mutate inventory. Fencing tokens fix this by requiring the storage layer to reject writes with tokens older than the highest token it has seen, even if a stale client wakes up late.
    </details>
 
-4. **Scenario**: A junior engineer proposes using etcd (which relies on Raft consensus) to store the high-volume clickstream events and real-time user metrics for a popular e-commerce website, arguing that "we need to ensure we never lose a click." Explain why this architectural choice will fail in production and what pattern should be used instead.
+4. **Scenario**: A team wants etcd for high-volume clickstream ingestion because they "cannot lose clicks." Why will that fail, and what should they use?
    <details>
    <summary>Answer</summary>
-
-   Using a consensus-based system like etcd for high-volume clickstream data will quickly bottleneck the system and lead to severe performance degradation. Every write in a Raft cluster must go through the single leader node and be replicated to a majority of followers before it can be acknowledged, which introduces significant latency and caps the maximum throughput. Consensus algorithms prioritize strict linearizability and correctness over high availability and write throughput, making them entirely unsuited for transient, high-volume data like metrics. Instead, the team should use an eventually consistent system or a distributed message queue designed for high throughput. In these alternative systems, occasional data loss or reordering in clickstream analytics is an acceptable trade-off for the massive performance gains required at e-commerce scale.
+   etcd optimizes for consistent metadata, not firehose ingestion. Every write traverses a single Raft leader and waits for quorum acknowledgment, capping throughput and adding latency unsuitable for click volumes. Losing an occasional analytic event is usually acceptable compared to losing payment metadata. Use a partitioned log or stream processor with at-least-once delivery and idempotent consumers instead of a consensus store for telemetry.
    </details>
 
-5. **Scenario**: You are configuring a new Raft-based service and set the election timeout to a fixed 200ms across all 5 nodes. During a network blip that drops the leader, the cluster completely fails to elect a new leader for several minutes, continuously timing out. What configuration error caused this cascading failure, and how does the protocol natively solve this?
+5. **Scenario**: All five Raft nodes use an identical 200 ms election timeout. After a leader failure, elections loop for minutes. What went wrong and how does Raft mitigate it?
    <details>
    <summary>Answer</summary>
-
-   Setting a fixed, identical election timeout across all nodes virtually guarantees a persistent split-vote scenario during recovery. When the leader fails, all followers will time out at exactly the same moment, transition to candidates, and vote for themselves, preventing anyone from achieving a majority. This cycle will repeat indefinitely because they will all restart their candidate timers simultaneously, completely halting cluster operations. The Raft protocol natively solves this by requiring randomized election timeouts (for example, a random value between 150ms and 300ms) for each individual node. This randomness ensures that one node will reliably time out before the others, allowing it to request and win the necessary votes before competing candidates can even emerge.
+   Identical timeouts synchronize candidates so they split votes repeatedly and nobody wins a majority. Raft requires randomized election timeouts spread across a range so one follower times out first, wins votes, and becomes leader before others restart competing elections. Operators should never copy one timeout value to every node without jitter.
    </details>
 
-6. **Scenario**: Your global infrastructure team deploys a 7-node etcd cluster spread evenly across three datacenters: 3 nodes in US-East, 2 in EU-West, and 2 in AP-South. The transatlantic fiber cable is cut, completely isolating the US-East datacenter from the other two. Will the Kubernetes control planes in any of these regions continue to function, and why?
+6. **Scenario**: A seven-node etcd cluster spans three datacenters with three, two, and two nodes. Transatlantic links fail, isolating the three-node site. Which partitions remain writable and why?
    <details>
    <summary>Answer</summary>
-
-   Yes, the cluster will continue to function, but only the partition containing EU-West and AP-South will be able to accept writes and make progress. A 7-node cluster requires a quorum of 4 nodes to achieve consensus and confirm any state changes. The US-East datacenter only has 3 nodes, so it cannot form a quorum and will degrade to a read-only state, safely rejecting all new configuration changes to prevent a split-brain. However, the connected partition of EU-West and AP-South contains 4 nodes in total, giving them the exact majority needed to elect a new leader and continue processing writes. This demonstrates why careful distribution of nodes across fault domains is critical; if US-East had contained 4 nodes instead, the loss of a single datacenter would have taken down the entire global cluster.
+   A seven-node cluster needs four nodes for a quorum. The isolated site of three cannot commit writes because it lacks a majority and should reject new mutations to stay safe. The remaining four nodes can elect a leader and continue because they still form a quorum. This layout shows why node placement across fault domains must be counted against quorum math, not just total node count.
    </details>
 
-7. **Scenario**: A distributed lock has a 15-second TTL and a 5-second renewal heartbeat. Client A acquires the lock, but exactly 2 seconds later experiences a severe 20-second garbage collection pause. Walk through the exact timeline of events that leads to a split-brain state, and explain how a fencing token neutralizes this specific timeline.
+7. **Scenario**: Client A holds a fifteen-second lock with five-second renewals but enters a twenty-second GC pause at second two. Trace the split-brain timeline and how fencing neutralizes it.
    <details>
    <summary>Answer</summary>
-
-   At T=0, Client A acquires the lock and begins processing, but at T=2 it enters a severe 20-second garbage collection pause. Because Client A is frozen, it cannot send the required 5-second renewal heartbeats, causing the lock server to expire the lock at T=15. At T=16, Client B acquires the newly available lock and begins legitimately writing to the shared resource. When Client A wakes up at T=22, it has no knowledge of the pause and still believes it holds the exclusive lock, resulting in both clients actively mutating the resource. A fencing token neutralizes this exact timeline because the shared resource would reject Client A's writes at T=22, recognizing that its associated token is older than the token currently being used by Client B.
+   Client A stops renewing during the pause, so the lock expires around second fifteen. Client B acquires the lock and receives a higher fencing token. Client A resumes at second twenty-two believing it still holds the lock, but the resource rejects A's stale token while accepting B's writes. Fencing makes the storage layer authoritative instead of trusting client clocks or lock memory.
    </details>
 
-8. **Scenario**: Your organization is migrating a legacy Java-based Hadoop data lake and a modern Go-based Kubernetes microservices platform into a unified architecture. The architecture board wants to standardize on a single coordination service—either ZooKeeper or etcd—for both platforms to reduce operational overhead. Defend why standardizing on a single tool might be a mistake in this specific context.
+8. **Scenario**: An organization wants one coordination service for Hadoop on ZooKeeper and Kubernetes on etcd. Argue against forced unification.
    <details>
    <summary>Answer</summary>
-
-   Standardizing on a single coordination service in this mixed environment ignores the native integrations and architectural assumptions of the respective ecosystems. The legacy Hadoop and Java stack relies heavily on ZooKeeper's hierarchical znode data model and has deep, battle-tested client libraries specifically built around those semantics. Conversely, the modern Kubernetes ecosystem is fundamentally designed around etcd's flat key-value store and highly efficient gRPC watch streams. Forcing Hadoop to use etcd, or Kubernetes to use ZooKeeper, would require building complex translation layers that introduce latency and significantly increase the risk of consensus-related outages. The operational overhead of running both services is far lower than the engineering cost and operational risk of fighting the native design patterns of these two major platforms.
+   Hadoop ecosystems embed ZooKeeper's hierarchical znode semantics and session models, while Kubernetes integrates deeply with etcd's gRPC watches and Lease-based leader election. Forcing either stack to emulate the other adds translation layers, latency, and failure modes without removing operational components. Running both coordination systems is often cheaper than fighting each platform's native integration points and risk profile.
    </details>
 
 ---
 
 ## Hands-On Exercise
 
-**Task**: Explore consensus and coordination in Kubernetes.
+This exercise connects Raft terminology to objects you can inspect in a Kubernetes lab cluster. You will read etcd health and leadership signals, observe Lease renewals used for control-plane leader election, and compare strong coordination with weaker configuration propagation delays.
 
-**Part 1: Observe etcd Consensus (10 minutes)**
+**Part 1 — etcd cluster state (10 minutes).** Run the commands below against a kind, minikube, or other cluster where etcd is reachable. Replace the pod name if your control plane uses a different identifier.
 
 ```bash
-# If you have etcd access (e.g., kind cluster)
-# List etcd members
-kubectl exec -it -n kube-system etcd-<node> -- etcdctl member list
-
-# Check etcd health
-kubectl exec -it -n kube-system etcd-<node> -- etcdctl endpoint health
-
-# Watch etcd statistics
-kubectl exec -it -n kube-system etcd-<node> -- etcdctl endpoint status --write-out=table
+kubectl exec -it -n kube-system etcd-control-plane -- etcdctl member list
+kubectl exec -it -n kube-system etcd-control-plane -- etcdctl endpoint health
+kubectl exec -it -n kube-system etcd-control-plane -- etcdctl endpoint status --write-out=table
 ```
 
-Record cluster status:
+Fill in the table from `endpoint status` output so you can explain which member is leader, which Raft term is active, and how far the log index has progressed during your session.
 
 | Node | Is Leader | Raft Term | Raft Index |
 |------|-----------|-----------|------------|
@@ -976,25 +560,16 @@ Record cluster status:
 | | | | |
 | | | | |
 
-**Part 2: Observe Leader Election (10 minutes)**
+**Part 2 — Lease-based leader election (10 minutes).** Kubernetes control-plane components renew Lease objects instead of embedding custom Raft clients. Inspect renew timestamps to see liveness in action.
 
 ```bash
-# View current leaders
 kubectl get leases -n kube-system
-
-# Watch leader lease for controller-manager
 kubectl get lease kube-controller-manager -n kube-system -o yaml
-
-# Observe holder identity and renew time
-# Note: renewTime updates regularly while leader is healthy
 ```
 
-**Part 3: Implement Simple Coordination (15 minutes)**
-
-Create a ConfigMap that multiple pods watch:
+**Part 3 — Configuration propagation (15 minutes).** The manifest below creates a shared ConfigMap and a watcher pod. Patching the ConfigMap shows that not every Kubernetes object provides etcd-linearizable watch semantics with instant delivery.
 
 ```yaml
-# coordination-config.yaml
 apiVersion: v1
 kind: ConfigMap
 metadata:
@@ -1022,20 +597,13 @@ spec:
 ```
 
 ```bash
-# Create the resources
 kubectl apply -f coordination-config.yaml
-
-# Watch the output
 kubectl logs -f watcher-1
-
-# In another terminal, update the config
 kubectl patch configmap shared-config -p '{"data":{"feature-flag":"true"}}'
-
-# Observe: Does the watcher see the change?
-# (Note: ConfigMap volume updates have propagation delay)
 ```
 
-**Success Criteria**:
+**Success Criteria** — confirm each item before closing the exercise:
+
 - [ ] Observed etcd cluster state and leader
 - [ ] Understood lease-based leader election
 - [ ] Saw configuration propagation delay
@@ -1043,31 +611,38 @@ kubectl patch configmap shared-config -p '{"data":{"feature-flag":"true"}}'
 
 ---
 
-## Further Reading
+## Key Takeaways
 
-- **"In Search of an Understandable Consensus Algorithm"** - Diego Ongaro. The Raft paper, specifically designed to be readable.
+Before moving on, confirm that you can explain each bullet below without peeking at notes, because the next modules assume you can reason about consistency trade-offs confidently.
 
-- **"Designing Data-Intensive Applications"** - Martin Kleppmann. Chapters 8-9 cover consensus, distributed transactions, and coordination.
-
-- **"The Raft Visualization"** - raft.github.io. Interactive visualization of Raft consensus.
+- [ ] **Consensus properties**: Agreement, validity, and termination define the problem; FLP limits pure asynchronous guarantees
+- [ ] **Quorum math**: Majorities overlap; use `2f+1` odd-sized clusters for `f` failures
+- [ ] **Raft mechanics**: Terms, leader election, log replication, and commit indexes enforce one authoritative history
+- [ ] **Partition behavior**: Minorities cannot commit or acknowledge writes; clients need fault-aware endpoints
+- [ ] **Lock safety**: TTL alone is insufficient; fencing tokens protect shared resources from stale holders
+- [ ] **Cost awareness**: Consensus serializes writes; use it for metadata and invariants, not firehose data
+- [ ] **Alternatives**: Leases, optimistic concurrency, CRDTs, and sharding reduce coordination when strong global order is unnecessary
 
 ---
 
-## Key Takeaways
+## Sources
 
-Before moving on, ensure you understand:
-
-- [ ] **Consensus fundamentals**: Getting nodes to agree on a single value with agreement (same value), validity (proposed value), and termination (eventual decision)
-- [ ] **FLP impossibility**: In asynchronous systems, consensus can't be guaranteed with even one failure. Practical algorithms work because true asynchrony is rare
-- [ ] **Raft mechanics**: Leader election via majority vote, log replication to followers, terms to prevent split-brain, random timeouts to break ties
-- [ ] **Quorum math**: Majority = floor(n/2) + 1. For 5 nodes, need 3. For 7 nodes, need 4. Use odd numbers to avoid ties
-- [ ] **Leader election trade-offs**: Leader-based is simpler and faster but requires failover. Leaderless is more available but more complex
-- [ ] **Distributed lock dangers**: GC pauses, network delays can cause client to think it holds expired lock. Fencing tokens are essential
-- [ ] **Consensus cost**: Every write requires 2 round trips through leader. Limited to ~10-50K writes/sec. Don't use for high-throughput data
-- [ ] **When to avoid consensus**: Caching, metrics, logs, shopping carts—anywhere eventual consistency is acceptable. Save consensus for leader election, strong locks, transaction commits
+- Diego Ongaro and John Ousterhout, [In Search of an Understandable Consensus Algorithm (Raft)](https://raft.github.io/raft.pdf)
+- Raft project, [Raft consensus website](https://raft.github.io/)
+- Leslie Lamport, [Paxos Made Simple](https://lamport.azurewebsites.net/pubs/paxos-simple.pdf)
+- Fischer, Lynch, and Paterson, [Impossibility of Distributed Consensus with One Faulty Process](https://www.cs.princeton.edu/courses/archive/fall09/cos518/papers/flp.pdf) — see also [Lamport publications index](https://lamport.azurewebsites.net/pubs/pubs.html) for related work
+- Martin Kleppmann, [Designing Data-Intensive Applications](https://dataintensive.net/)
+- Martin Kleppmann, [How to do distributed locking](https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html)
+- etcd documentation, [etcd.io docs](https://etcd.io/docs/latest/)
+- Apache ZooKeeper, [ZooKeeper Internals (Zab)](https://zookeeper.apache.org/doc/current/zookeeperInternals.html)
+- Mike Burrows et al., [The Chubby lock service for loosely-coupled distributed systems](https://static.googleusercontent.com/media/research.google.com/en//archive/chubby-osdi06.pdf)
+- Kyle Kingsbury, [Jepsen: etcd 3.4.3 analysis](https://jepsen.io/analyses/etcd-3.4.3)
+- Kubernetes documentation, [Leases](https://kubernetes.io/docs/concepts/architecture/leases/)
+- Kubernetes API reference, [Lease (coordination.k8s.io/v1)](https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/lease-v1/)
+- Kubernetes documentation, [Control plane node communication](https://kubernetes.io/docs/concepts/architecture/control-plane-node-communication/)
 
 ---
 
 ## Next Module
 
-[Module 5.3: Eventual Consistency](../module-5.3-eventual-consistency/) - When you don't need strong consistency, and how to make eventual consistency work.
+[Module 5.3: Eventual Consistency](../module-5.3-eventual-consistency/) — When you do not need strong consistency, and how to make eventual consistency work in production.

--- a/src/content/docs/platform/foundations/distributed-systems/module-5.3-eventual-consistency.md
+++ b/src/content/docs/platform/foundations/distributed-systems/module-5.3-eventual-consistency.md
@@ -6,30 +6,33 @@ sidebar:
 ---
 > **Complexity**: `[MEDIUM]`
 >
-> **Time to Complete**: 30-35 minutes
+> **Time to Complete**: 35-40 minutes
 >
 > **Prerequisites**: [Module 5.2: Consensus and Coordination](../module-5.2-consensus-and-coordination/)
 >
 > **Track**: Foundations
 
-### What You'll Be Able to Do
+## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
-1. **Evaluate** the CAP Theorem trade-offs for a given distributed service and justify choosing eventual consistency over strong consistency (or vice versa).
-2. **Design** eventually consistent data flows using conflict resolution strategies (last-write-wins, vector clocks, CRDTs) appropriate for the data model.
-3. **Implement** read-your-writes and causal consistency guarantees on top of eventually consistent datastores when user experience demands it.
-4. **Analyze** consistency anomalies in production to determine whether they indicate a design flaw or acceptable convergence delay.
+1. **Explain** the CAP Theorem trade-off and the full consistency spectrum from linearizability through eventual consistency, including when and why each level makes sense for a given workload.
+2. **Contrast** strong versus eventual consistency models and reason about which is appropriate for a specific service based on its latency, availability, and correctness requirements.
+3. **Reason** about replication topologies and quorum tuning — including the `W + R > N` overlap rule, synchronous versus asynchronous trade-offs, and leader versus leaderless architectures.
+4. **Diagnose and resolve** write conflicts using the appropriate tool: last-write-wins (and its pitfalls), version vectors for concurrency detection, merge functions, and Conflict-Free Replicated Data Types (CRDTs).
+5. **Apply** session guarantees — including read-your-writes, monotonic reads, and causal consistency — to build acceptable user experiences on top of eventually consistent stores.
 
 ---
 
 ## Why This Module Matters
 
-December 26, 2012. Amazon's retail website experiences intermittent failures during the busiest shopping week of the year—and the root cause is surprisingly simple: they chose the wrong consistency model for their inventory system. Amazon's engineers had originally designed a strongly consistent inventory system. Every purchase required immediate confirmation from all database replicas before the customer saw "Order Confirmed." This worked perfectly at normal load, providing a flawless, real-time view of stock levels across the entire global infrastructure.
+In 2007, a team at Amazon published a paper that changed how the industry thought about distributed data. The problem they were solving was deceptively simple: a shopping cart. Users add items from multiple devices — a phone on the bus, a laptop at home, a tablet on the couch — and those additions must never be lost, even when network links between data centers are slow, noisy, or temporarily severed. If a customer adds a book on one device and a pair of headphones on another, both items had better appear at checkout time, regardless of which replica served which write or in what order those writes propagated through the system.
 
-But on the day after Christmas, with millions of gift card recipients flooding the site, the synchronous replication became a severe bottleneck. Database replicas could not keep up with the distributed lock contention. Write latency spiked to over thirty seconds, and shopping carts started timing out. For forty-nine minutes, an estimated $66,000 per minute in potential revenue was lost—not because servers were offline, but because the system was waiting for perfect consistency that customers did not actually need.
+The Amazon Dynamo paper — authored by DeCandia, Hastorun, Jampani, Kakulapati, Lakshman, Pilchin, Sivasubramanian, Vosshall, and Vogels — introduced a radical idea for its time: give up on strong consistency. Let replicas diverge temporarily, accept writes on any node, and resolve conflicts at read time or during background synchronization. The shopping cart became a mergeable data structure: concurrent additions from different devices combine via set union rather than overwriting each other, so no item is ever silently lost because of a replication race. The paper demonstrated that you could build a highly available, always-writable key-value store by embracing eventual consistency as a first-class design principle, not a bug to be tolerated.
 
-The irony of the situation was profound: customers do not need to know the exact, global inventory count at the millisecond they click buy. They only need to know if they are permitted to purchase the item. Amazon's post-incident analysis led to a fundamental architecture shift. They mandated the use of eventual consistency everywhere possible, reserving strong consistency strictly for the final financial transaction. This module explores eventual consistency: what it means, when to use it, how to design for it, and the patterns that make it practical in high-scale environments.
+That paper became the blueprint for an entire generation of distributed databases — Cassandra, Riak, Voldemort, and later DynamoDB all trace their lineage to its ideas. What made Dynamo's approach durable was not the specific implementation but the recognition that consistency is not a binary property. It is a spectrum, and choosing where to sit on that spectrum is one of the most consequential architectural decisions you will make when designing any system that spans more than one machine. Pick a level stronger than necessary, and you waste latency and throughput on coordination nobody actually needs. Pick a level too weak, and you silently corrupt application state in ways that can be astronomically expensive to repair after the fact.
+
+This module teaches you how to make that decision with confidence. You will learn the theoretical underpinnings — CAP, PACELC, the consistency spectrum — and the practical mechanics: replication topologies, quorum tuning, conflict detection with version vectors, and conflict elimination with CRDTs. By the end, you will be able to look at a distributed service's requirements and decide whether it needs linearizability, causal consistency, or plain eventual consistency, and you will know exactly what engineering trade-off you are making with each choice.
 
 ---
 
@@ -37,21 +40,25 @@ The irony of the situation was profound: customers do not need to know the exact
 
 ### 1.1 The CAP Theorem Defined
 
-To understand eventual consistency, we must first explicitly define the **CAP Theorem**. Formulated by computer scientist Eric Brewer, the CAP Theorem dictates that any distributed data store can provide only two of the following three guarantees simultaneously:
+The **CAP Theorem** was first articulated by Eric Brewer in a 2000 keynote. Gilbert and Lynch later formalized it with a proof published in ACM SIGACT News in 2002. The theorem states that a distributed data store can provide at most two of the following three guarantees simultaneously:
 
-1. **Consistency (C)**: Every read receives the most recent write or an error. In a perfectly consistent system, all nodes see the exact same data at the exact same time.
-2. **Availability (A)**: Every request receives a non-error response, regardless of the individual health of the nodes. However, there is no guarantee that the response contains the most recent write.
-3. **Partition Tolerance (P)**: The system continues to operate despite an arbitrary number of messages being dropped or delayed by the network between nodes.
+1. **Consistency (C)**: Every read receives the most recent write or an error. In linearizable (strongly consistent) terms, the system behaves as though there is only a single copy of the data, and all operations appear to execute atomically at a single point on a global timeline. No client ever sees stale data, and the system preserves the illusion that the distributed nodes are a single machine.
+2. **Availability (A)**: Every request to a non-failing node receives a non-error response. The system continues serving reads and writes even when some nodes are unreachable due to network partitions or crashes. However, there is no guarantee that the response reflects the most recent write — the system may return stale data because it prioritizes staying online over staying correct.
+3. **Partition Tolerance (P)**: The system continues to operate correctly despite an arbitrary number of messages being dropped, delayed, or reordered by the network between nodes. A partition, in this context, means any situation where some nodes cannot communicate with others — not just a clean fiber cut, but also congestion-induced packet loss, misconfigured firewalls, or the asymmetric reachability problems that plague real-world networks.
 
-In modern distributed architectures, network partitions are inevitable. Hardware fails, connections drop, and latency spikes. Therefore, Partition Tolerance is not optional; it is a physical reality of the network. This forces architects to choose between Consistency and Availability during a partition:
-- Choosing **CP (Consistency + Partition Tolerance)** means shutting down nodes that cannot synchronize, thereby compromising availability to prevent stale reads.
-- Choosing **AP (Availability + Partition Tolerance)** means allowing nodes to serve potentially stale data, thereby compromising strict consistency to keep the system online.
+In practice, network partitions are not an edge case — they are a physical certainty in any system that spans more than one machine. Ethernet cables get unplugged, switches fail, BGP routes flap, and latency spikes can be functionally indistinguishable from lost packets for the duration of a timeout window. Because partitions are inevitable, **Partition Tolerance is not optional** for any distributed system that aspires to real-world reliability. This forces architects into a hard choice: during a partition, do you preserve Consistency or Availability?
 
-Eventual consistency is the deliberate architectural choice of Availability over strict Consistency.
+Choosing **CP (Consistency + Partition Tolerance)** means refusing to serve writes — or in some designs, even reads — from nodes that cannot reach a quorum. The system sacrifices availability on the altar of correctness, ensuring that no client ever observes stale or conflicting data but potentially leaving users staring at error pages during a network outage. Choosing **AP (Availability + Partition Tolerance)** means allowing nodes to serve requests with potentially stale data, thereby compromising strict consistency to keep the system online and responsive. Eventual consistency is the deliberate architectural commitment to the AP side of this trade-off: you accept that readers may temporarily see old values in exchange for lower latency, higher throughput, and resilience in the face of network degradation.
 
-### 1.2 The Consistency Spectrum
+### 1.2 PACELC: The Trade-off When There Is No Partition
 
-Consistency is not a binary choice between "perfect" and "broken." It exists on a spectrum of guarantees provided by the distributed system.
+CAP addresses the system's behavior *during* a partition, but what about the vast majority of operational time — the 99.9% of seconds when the network is healthy and all nodes can communicate? Daniel Abadi's **PACELC** extension, published in 2012, fills this gap with an elegantly simple formulation: if there is a **P**artition, choose between **A**vailability and **C**onsistency; **E**lse, when the system is **L**atency-sensitive and the network is intact, choose between **L**atency and **C**onsistency.
+
+This is a profound insight because it reveals that even in the complete absence of failures, strong consistency imposes a real and measurable cost on every operation. A linearizable system must coordinate every write across replicas — typically via consensus (see Module 5.2) or synchronous replication to a quorum — which adds a network round-trip penalty to every single operation. That round-trip might be hundreds of microseconds within a single availability zone, but it becomes tens or hundreds of milliseconds across continental distances. PACELC forces you to ask a question that CAP alone cannot answer: is that extra latency justified by the correctness guarantees it buys? For a payment ledger, almost certainly yes — the correctness invariant (no double-spend, no overdraft) is worth every millisecond. For a social media "like" counter, almost certainly no — nobody will notice or care if a like count is off by one for three seconds. PACELC gives you the vocabulary and the analytical framework to explain those choices to your team, your product manager, and your future self who will inherit this architecture.
+
+### 1.3 The Consistency Spectrum in Depth
+
+Consistency is not binary. It is a spectrum, and each level trades away some degree of coordination in exchange for performance. Understanding the full range is essential because picking a level stronger than necessary wastes latency and throughput on every operation, while picking a level too weak can corrupt application state in ways that are expensive or impossible to undo after the fact. The spectrum runs from the strongest guarantee to the weakest, and every step downward relaxes a specific constraint that the level above enforces.
 
 ```mermaid
 flowchart LR
@@ -61,11 +68,17 @@ flowchart LR
     Se --> E[Eventual<br/>Consistency<br/>Weakest]
 ```
 
-- **Linearizability (Strongest)**: Operations appear to execute atomically at a single point in time. All clients see operations in real-time order. Systems like etcd and Google Spanner provide this, but at the cost of high latency and reduced availability during network partitions.
-- **Sequential Consistency**: Operations appear in some total order consistent with the program order. The real-time aspect is relaxed, but every client agrees on the sequence of events.
-- **Causal Consistency**: Causally related operations are seen in order. Concurrent operations may be seen in any order. If writing Y depends on reading X, everyone who sees Y must have also seen X.
-- **Session Consistency**: Within a single user session, a client sees a consistent view of the database. This provides guarantees like read-your-writes and monotonic reads.
-- **Eventual Consistency (Weakest)**: Only guarantees eventual convergence. There are no ordering guarantees for concurrent operations. This offers the maximum availability and the lowest possible latency.
+**Linearizability** is the gold standard of consistency models. Every operation appears to execute instantaneously at some point between its invocation and its completion, and that point falls on a single global timeline that all clients agree on. A read that begins after a write completes must see that write — there is no window where one client observes the new value while another still sees the old one. Systems that provide linearizability, such as etcd (via the Raft consensus algorithm) and Google Spanner (via TrueTime atomic clocks), pay for it with higher latency and reduced write availability during partitions. Linearizability is what makes a distributed lock safe and what prevents a bank balance from being overdrawn by concurrent withdrawals at different ATMs. It is also, by a wide margin, the most expensive consistency model to implement and operate at scale.
+
+**Sequential Consistency**, formalized by Leslie Lamport in his landmark 1979 paper "How to Make a Multiprocessor Computer That Correctly Executes Multiprocess Programs," relaxes the real-time constraint. Operations from all clients appear in some total order consistent with each client's program order — meaning no client sees its own operations reordered — but there is no guarantee that a write visible to client A is immediately visible to client B. The real-time freshness guarantee of linearizability is gone, but the ordering contract remains intact. Treat sequential consistency as a formal reasoning model, not as a description of commodity CPU hardware: x86 is commonly described as Total Store Order, while ARM and RISC-V permit still weaker reorderings unless software uses fences or atomic operations. Sequential consistency provides a useful mental bridge between the absolute certainty of linearizability and the more relaxed models that distributed systems typically adopt.
+
+**Causal Consistency** goes further: operations that are causally related must be seen in causal order by every replica, but concurrent (causally independent) operations may appear in any order across different replicas. If Alice posts a photo and then comments on it, the comment is causally dependent on the post — no replica should ever show the comment without the photo. But if two users independently "like" the same photo at roughly the same time, those likes have no causal relationship and can be ordered arbitrarily. Causal consistency is the weakest model that still preserves the intuitive "cause before effect" expectation that humans rely on to make sense of the world. Causal consistency is often the sweet spot for collaborative applications where users interact with each other's content.
+
+**Session Guarantees** — including read-your-writes, monotonic reads, consistent prefix, and writes-follow-reads — operate within the scope of a single user session. They provide a pragmatic middle ground: strong enough for most application user interfaces, where users reasonably expect to see the effects of their own actions, but weak enough to scale horizontally without the global coordination that consensus demands. They were formalized by Terry, Demers, Petersen, et al. in their 1994 paper "Session Guarantees for Weakly Consistent Replicated Data," and they remain the most widely deployed form of consistency above plain eventual in production systems today.
+
+**Eventual Consistency** is the weakest guarantee on the spectrum. It promises only that if no new updates are made, all replicas will eventually converge to the same state. There is no bound on how long convergence takes, no ordering guarantee for concurrent writes, and no protection against stale reads — a client reading from a lagging replica may see data that is seconds, minutes, or in pathological cases even hours out of date. What eventual consistency offers in return is maximum availability, minimum write latency, and the simplest operational model for wide-area replication. It is the default consistency model of DNS, of CDN cache invalidation, and of the Amazon Dynamo lineage of databases, and it powers a surprising fraction of the internet infrastructure that billions of people interact with every day.
+
+> **Stop and think**: If linearizability guarantees that every read sees the latest write, what specific latency price are you paying? How many network round-trips does a linearizable write require compared to an eventually consistent one, and what happens to that cost as you add more replicas or spread them across wider geographic distances?
 
 ---
 
@@ -73,12 +86,13 @@ flowchart LR
 
 ### 2.1 Defining Eventual Convergence
 
-**Eventual Consistency** is formally defined as: *"If no new updates are made to a given data item, eventually all accesses to that item will return the last updated value."*
+Formally, **eventual consistency** guarantees: *if no new updates are made to a given data item, eventually all accesses to that item will return the last updated value.* The definition, originating from Werner Vogels's influential 2009 ACM Queue article "Eventually Consistent," has three critical implications that every architect must internalize before choosing this model for a production system.
 
-The key properties are:
-1. **Eventual Convergence**: All replicas will eventually reach the identical state. 
-2. **No Temporal Guarantee**: There is no mathematical bound on how long convergence takes. It could be milliseconds under normal conditions, or minutes during a severe network partition.
-3. **Stale Reads**: Clients may read old values during the propagation phase. Two different clients querying two different replicas simultaneously might see entirely different data.
+1. **Eventual Convergence**: All replicas will eventually reach an identical state. No acknowledged write is permanently lost, assuming the system's durability guarantees hold — writes are persisted to disk before the acknowledgement is returned. The path to convergence, however, may involve background processes like read-repair, anti-entropy sweeps, or gossip protocols that operate asynchronously and at their own pace. These mechanisms are statistical, not deterministic: they improve the probability that a given read will see fresh data, but they make no absolute guarantees about any particular read operation.
+
+2. **No Temporal Bound**: There is no mathematical or operational guarantee on how long convergence will take. Under normal conditions with healthy networks and light load, it may be milliseconds — fast enough that users perceive the system as instant. During a severe partition, with saturated inter-DC links and backlogged replication queues containing millions of pending writes, convergence could take minutes or longer. The system makes no promise, and your application must not rely on any assumed convergence window, because the moment you bake an assumption like "replication finishes within 500 milliseconds" into your business logic is the moment your system will encounter a network event that violates that assumption.
+
+3. **Stale Reads Are Normal and Expected**: During the propagation window — the interval between a write being acknowledged and all replicas receiving it — different clients querying different replicas may observe entirely different versions of the same data item. This is not a bug or a transient failure state; it is the expected behavior of the consistency model. The question is not whether staleness will occur, but whether your application logic can tolerate it when it does. For a product catalog, showing yesterday's price for three seconds is probably fine. For a payment ledger, showing yesterday's balance is absolutely not.
 
 ```mermaid
 sequenceDiagram
@@ -105,20 +119,23 @@ sequenceDiagram
     Note over R: X=2
 ```
 
-> **Stop and think**: If eventual consistency means data can be stale, how long is "eventually"? What factors might delay convergence in a real network?
+> **Stop and think**: If eventual consistency means data can be stale, how long is "eventually"? What factors — network bandwidth between data centers, replication queue depth, partition duration, the sheer volume of writes generated during a peak traffic event — might delay convergence in a real deployment?
 
-### 2.2 Trade-offs of Eventual Consistency
+### 2.2 Anti-Entropy and Read-Repair
 
-Opting for eventual consistency drastically changes the performance profile of your application.
+Eventual consistency does not happen by magic or by waiting long enough. Two specific mechanisms drive replica convergence in production systems, and understanding how they work is essential to reasoning about the consistency behavior your users will actually experience.
 
-**Advantages:**
-- **Lower Latency**: Writes can be acknowledged immediately by a single node without waiting for network coordination.
-- **Higher Availability**: The system can continue accepting reads and writes even if the majority of the network is partitioned.
-- **Scalability**: Nodes can operate highly independently, making horizontal scaling much simpler.
+**Anti-entropy** is a background process that continuously compares replicas and synchronizes any missing updates. A common and efficient implementation uses Merkle trees: each replica builds a hash tree over its key range — hashing contiguous blocks of keys, then hashing those hashes together — and periodically exchanges these tree structures with its peers. Where the trees diverge, the replicas know that some keys in that subtree differ, and they exchange only those specific keys rather than the entire dataset. This is bandwidth-efficient and scalable, but it operates on its own schedule — typically every few minutes — and provides no guarantee that any particular read, executed between anti-entropy sweeps, will see the latest write. Anti-entropy is the safety net, not the primary consistency mechanism.
 
-**Disadvantages:**
-- **Application Complexity**: Developers must write code that gracefully handles stale data and unexpected state transitions.
-- **Conflict Resolution**: Because nodes accept writes independently, concurrent updates to the same record will create data conflicts that must be programmatically resolved.
+**Read-repair** opportunistically corrects stale data during normal read operations. When a coordinator reads from multiple replicas to satisfy a quorum read (or a probabilistic read in a leaderless system), it may notice that one of the replicas returned an older version than the others. Rather than silently accepting the inconsistency, the coordinator can push the newer version to the lagging replica — repairing it — before returning the freshest result to the client. Read-repair provides a statistical improvement in consistency for data that is actively being accessed: the more often a key is read, the more likely it is to be repaired. However, cold data — records that nobody has queried in hours or days — may remain inconsistent indefinitely until an anti-entropy sweep eventually catches them. This is a deliberate design choice: repair effort is concentrated on the data that users care about right now.
+
+### 2.3 The Full Trade-off Landscape
+
+Choosing eventual consistency reshapes the performance profile of your application in ways that go beyond the simple "faster but stale" summary. The effects cascade through latency, availability, scalability, and — most critically — application complexity.
+
+**Advantages.** Write latency drops dramatically because a single node can acknowledge the write locally without coordinating with peers — no consensus rounds, no quorum waits, no cross-DC round-trips. Availability increases because the system can accept writes even when a majority of nodes are partitioned from each other; any reachable node can process the request and the system stays online. Horizontal scalability becomes simpler because nodes operate with high independence, minimizing cross-node coordination overhead that grows super-linearly with cluster size in strongly consistent systems. These are genuine engineering wins, and they explain why the Dynamo model became dominant for large-scale internet services.
+
+**Disadvantages.** Application complexity shifts from the database to the developer, and this is a cost that compounds over time. Every developer working on the service must understand the consistency model and code defensively against it. Stale reads must be detected or tolerated; conflict resolution logic must be written, tested, and maintained for every data type that permits concurrent writes; and certain application invariants — uniqueness constraints, foreign key relationships, atomic multi-item updates — become either impossible in the general case or require expensive compensating transactions implemented at the application layer. This is not a one-time cost. Every new feature, every schema migration, and every new team member must account for the fact that the database makes weaker promises than they were taught to expect in their undergraduate databases course.
 
 ---
 
@@ -126,7 +143,7 @@ Opting for eventual consistency drastically changes the performance profile of y
 
 ### 3.1 Synchronous vs Asynchronous Replication
 
-How data moves between nodes defines the consistency boundary of the system.
+How data propagates between replicas after a write is acknowledged is the single largest lever you can pull when tuning a distributed system's consistency, durability, and latency profile. The choice between synchronous and asynchronous replication has first-order effects on every property your users care about, and understanding the trade-off at a mechanical level — what actually happens inside the system when a write arrives — is essential to making the right choice.
 
 ```mermaid
 sequenceDiagram
@@ -163,15 +180,17 @@ sequenceDiagram
     end
 ```
 
-> **Pause and predict**: If you use asynchronous replication and the primary node crashes before replicating to followers, what happens to the most recent writes?
+**Synchronous replication** blocks the write acknowledgment until every designated replica has confirmed that it has durably persisted the update. Every replica is in lockstep: no read from any replica can ever be stale, and no acknowledged write can be lost if the primary fails — at least one other node has the data on durable storage. The cost is latency measured by the slowest replica in the set. If you have replicas in three availability zones and one zone experiences a brief network hiccup, every write in the cluster stalls for the duration of that hiccup. This is why synchronous replication is almost never deployed with more than a small number of replicas within a single availability zone. Systems that need strong guarantees across regions typically use consensus-based approaches rather than naive synchronous replication.
 
-- **Synchronous**: The write blocks until all replicas acknowledge the update. This guarantees strong consistency but introduces high latency. If one replica is slow, the entire system slows down.
-- **Asynchronous**: The write returns success the moment the primary node persists the data. This provides ultra-low latency, but if the primary fails before background replication occurs, data is permanently lost.
-- **Semi-Synchronous (Quorum)**: The write blocks until a specific subset (usually a majority) of nodes acknowledge the update. This offers a tunable middle ground between latency and durability.
+**Asynchronous replication** acknowledges the write to the client the moment the primary node has persisted it locally. Replication to followers happens in the background, decoupled from the client's request-response lifecycle and invisible to the user who submitted the write. This delivers the lowest possible write latency — the client waits for exactly one disk write and zero network round-trips to replicas — but it introduces a durability gap that every architect must reckon with. If the primary crashes before the background replication completes, the acknowledged writes sitting in its local write-ahead log are permanently lost. The window of vulnerability is typically small — milliseconds to seconds under normal conditions — but it is real. Asynchronous replication alone cannot satisfy durability requirements for financial or safety-critical data.
+
+**Semi-synchronous (quorum) replication** occupies the middle ground. The primary blocks the write acknowledgement until a configurable subset of replicas — typically a simple majority, but sometimes a weighted subset based on node health or geographic proximity — has confirmed the write. The remaining replicas catch up asynchronously in the background. This provides a tunable dial: raise the quorum for stronger durability and consistency guarantees, lower it for faster response times during degraded conditions. Most production deployments of leader-based replication, including MySQL Group Replication and PostgreSQL synchronous replication with `synchronous_commit = remote_write`, use some form of quorum rather than all-or-nothing synchronous replication.
+
+> **Pause and predict**: If you use asynchronous replication and the primary node crashes before replicating to any follower, every write since the last replication event is lost. How would you detect this loss after the primary recovers? What information would the followers need to identify the gap?
 
 ### 3.2 Topologies: Leader and Leaderless
 
-Replication can be organized into different architectural topologies, each handling conflicts differently.
+Replication can be organized into fundamentally different architectural topologies, and the choice of topology determines not only the system's performance characteristics but also where and how conflicts manifest — and who is responsible for resolving them.
 
 ```mermaid
 flowchart TD
@@ -193,106 +212,113 @@ flowchart TD
     end
 ```
 
-- **Single-Leader**: All writes route to one primary node. This simplifies conflict resolution (the leader dictates the order of operations) but creates a severe bottleneck for write-heavy workloads.
-- **Multi-Leader**: Multiple nodes can accept writes, often deployed across different geographic regions to minimize latency. This requires complex bidirectional synchronization and guaranteed conflict resolution logic, as two regions might update the same record simultaneously.
-- **Leaderless**: Any node can accept a write. Clients typically write to multiple nodes simultaneously and read from multiple nodes simultaneously. Conflicts are resolved at read-time by the client or a coordinating proxy.
+**Single-Leader** replication funnels all writes through one designated primary node. This is the simplest model to reason about and the most widely deployed in relational databases: the leader defines the authoritative write order, and followers apply updates in that exact sequence from the leader's write-ahead log or binary log. Conflict resolution is trivial because there is exactly one source of truth for each data item — the leader's current state. The architectural price is a write bottleneck: all write throughput is gated by the leader's capacity, and a failover dependency exists because writes are unavailable from the moment the leader crashes until a new leader is elected and promoted. Leader election (see Module 5.2) can be automated with consensus, but the failover window is never zero — there is always a gap where the system is read-only or fully unavailable.
 
-### 3.3 Consistency Tuning and Quorums
+**Multi-Leader** replication allows multiple nodes to accept writes independently, typically deployed across different geographic regions so that users in each region experience local-latency writes rather than cross-continental round-trips. This is a powerful pattern for globally distributed applications — a user in Tokyo and a user in London can both update their profiles simultaneously without either waiting for a trans-Pacific network round-trip — but it introduces the hardest problem in distributed systems: concurrent writes to the same data item from different leaders create conflicts that must be resolved. The resolution strategy — whether last-write-wins, application-level merge, or CRDT — becomes a first-class architectural concern, not an implementation detail you can defer to later sprints.
 
-In quorum-based systems (like Cassandra or DynamoDB), consistency is tunable on a per-request basis using three variables:
-- **N**: Total number of replicas storing the data.
-- **W**: Write quorum (number of nodes that must acknowledge a write).
-- **R**: Read quorum (number of nodes that must respond to a read).
+**Leaderless** replication, pioneered by Amazon Dynamo and adopted by Cassandra, Riak, and DynamoDB in its eventually consistent modes, lets any node accept a write from any client at any time. Clients typically send writes to multiple nodes simultaneously — enough to satisfy a write quorum — and read from multiple nodes to satisfy a read quorum. Conflicts are detected at read time by comparing version vectors and resolved either by the client (in Dynamo's original design, the shopping cart merge logic ran in the application) or by a coordinating proxy within the database cluster. The leaderless model eliminates the single point of failure and the leader-election latency gap entirely, but it pushes conflict detection and resolution onto every read path, making reads more expensive and more complex than in leader-based systems.
+
+### 3.3 Hinted Handoff and Sloppy Quorums
+
+In a leaderless system, what happens when a node that should receive a write is temporarily down or unreachable? The naive answer — reject the write and return an error — would sacrifice the very availability that leaderless replication was designed to achieve. **Hinted handoff**, a technique introduced in the Dynamo paper, provides a more graceful degradation path. When the coordinator determines that one of the designated replica nodes for a key is unreachable, it selects a substitute node — one that is healthy but not among the canonical home replicas for that key — and writes the data there. The write is tagged with a "hint" metadata field indicating which node the data was originally intended for. The coordinator proceeds as though the write succeeded against the full replica set. When the intended node eventually recovers and rejoins the cluster, the substitute node detects this (via gossip or periodic health checks), forwards the hinted data to the now-healthy original node, and deletes the local copy of the hint.
+
+This is a **sloppy quorum**: the write and read quorums may be satisfied by nodes that are not the canonical home replicas for the key, increasing availability during transient failures at the cost of a temporarily weakened consistency guarantee. During the handoff window — the interval between the substitute receiving the hinted write and the original node receiving the forwarded data — a read that queries the canonical replicas but misses the substitute node may not see the hinted write, even if the read quorum overlaps with the write quorum under normal circumstances. Sloppy quorums are not linearizable, but they keep the system accepting writes during conditions that would cause strict quorums to fail entirely. DynamoDB's eventual consistency mode, Cassandra's `ANY` consistency level, and Riak's `sloppy_quorum` all rely on variations of this technique, and it represents a conscious choice to prioritize availability over correctness during transient infrastructure failures.
+
+### 3.4 Consistency Tuning and Quorum Math
+
+In quorum-based systems, consistency is not a binary switch but a continuous dial — tunable on a per-request or even per-operation basis by adjusting three parameters that every developer operating a Dynamo-style database should be able to reason about in their sleep.
+
+- **N**: Total number of replicas that store the data item. This is typically set at the keyspace or table level and remains fixed for the lifetime of the data.
+- **W**: Write quorum — the number of replicas that must acknowledge a write before it is considered successful and durable. The coordinator waits for W acknowledgements, then returns success to the client.
+- **R**: Read quorum — the number of replicas that must respond to a read before the result is returned to the client. The coordinator typically reads from multiple replicas and returns the version with the highest version vector.
 
 ```mermaid
 flowchart LR
-    subgraph Strong Consistency W+R > N
+    subgraph Quorum Overlap W+R > N
         W[Write] --> A1[Node A]
         W --> B1[Node B]
         A1 -.->|overlap| R[Read]
         B1 -.-> R
     end
-    subgraph Eventual Consistency W+R <= N
+    subgraph No Guaranteed Overlap W+R <= N
         W2[Write] --> A2[Node A]
         B2[Node B] -.->|no overlap| R2[Read]
     end
 ```
 
-To guarantee strong consistency, you must ensure that read and write operations always overlap. The formula is `W + R > N`. If you write to 2 out of 3 nodes, and read from 2 out of 3 nodes, physics guarantees that at least one node in your read group possesses the latest write.
+The governing equation is `W + R > N`. When this inequality holds in a strict quorum system, the read and write quorums are mathematically guaranteed to overlap by at least one node. That overlap provides **quorum consistency** for completed writes: a read quorum intersects the quorum that acknowledged the write, so the read path has a chance to discover that completed write if version selection chooses the causally newest value. This is a useful read-after-write guarantee, but it is not the same thing as global linearizability. Concurrent writes, sloppy quorums, hinted handoff, stale repair state, and timestamp-based version selection can still produce histories that do not behave like a single copy of the data. Reserve the word **linearizability** for systems that serialize operations through consensus or an equivalent single-copy mechanism, such as etcd using Raft or Spanner using its transaction protocol.
 
-Setting `W + R <= N` results in Eventual Consistency. This is faster and more fault-tolerant, but allows stale reads if the read hits the nodes that missed the write.
+When `W + R <= N`, there is no guaranteed overlap between the read and write quorums, and the system operates with eventual consistency. A read may query a set of replicas that happens to exclude every node that received the latest write, returning stale data. The system is faster because fewer nodes must respond to each operation, and it is more available during partitions because a write only needs W reachable nodes, which might be as few as 1. But the probability of a stale read is non-zero, and for workloads with high write throughput or frequent network instability, that probability can become uncomfortably high.
+
+**Typical configurations in production.** The most common safe default sets `W = R = (N+1)/2` — a majority quorum for both reads and writes, rounded up. With `N=3`, this means `W=R=2`, giving `W+R=4 > 3`, so every completed write quorum intersects every later read quorum under strict quorum assumptions while tolerating the loss of any single node. With `N=5`, `W=R=3` gives `W+R=6 > 5`, tolerating the loss of up to two nodes. This configuration balances latency (you wait for a bare majority, not all N nodes) with fault tolerance (writes remain available as long as at least W nodes are reachable). For read-heavy workloads where eventual consistency is acceptable and write latency is the primary bottleneck, many teams set `R=1, W=N`. Reads are blazingly fast — a single local node responds — while writes require acknowledgement from every replica, maximizing completed-write overlap at the cost of write latency and write availability. For write-heavy workloads, the inverse — `R=N, W=1` — provides fast writes at the cost of slow reads that must consult every replica to discover the freshest completed write. Each configuration represents a deliberate trade-off, and the right choice depends entirely on the access patterns, latency budgets, and correctness requirements of the specific service.
 
 ---
 
-## Part 4: Conflict Resolution and Vector Clocks
+## Part 4: Conflict Resolution and Version Vectors
 
 ### 4.1 The Inevitability of Conflicts
 
-When availability is prioritized, conflicts are unavoidable. They primarily occur due to:
-1. **Concurrent Writes**: Two users modify the same data attribute at the exact same millisecond.
-2. **Network Partitions**: A connection severs between Data Center A and Data Center B. Both centers continue accepting localized writes. When the connection heals, the divergent datasets must be reconciled.
-3. **Offline Mode**: A mobile application allows local edits while in an airplane. Upon reconnecting, those edits conflict with server-side changes made by other users.
+When a system prioritizes availability — accepting writes on any reachable node without first establishing global consensus on the current state — conflicts become not a possibility but a statistical certainty at sufficient scale. They arise from three primary scenarios. Every distributed system architect must design for all three from day one. Retrofitting conflict resolution into an existing data model is orders of magnitude harder than building it in from the start.
 
-> **Pause and predict**: If a system uses "Last-Write-Wins" (LWW) based on timestamps, what happens if two servers have their system clocks out of sync by 5 minutes?
+1. **Concurrent Writes**: Two clients, unaware of each other's existence, modify the same key at roughly the same instant. Neither operation "happened before" the other in Lamport's precise sense — they are causally independent events, and the system has no basis for deciding which one expresses the user's true intent. The system must choose between discarding one update, merging them programmatically, or surfacing the conflict to a human operator.
+
+2. **Network Partitions**: A connection between two data centers severs — fiber cut, BGP misconfiguration, DDoS saturation. Both centers continue accepting localized writes to the same keyset because they are designed for availability. When the link eventually heals, potentially hours later, the divergent histories spanning thousands or millions of writes must be reconciled. This is the "split-brain" scenario, and it is the hardest conflict resolution problem in practice because the semantic distance between the two divergent states can be enormous — for instance, one side may have deleted a record that the other side updated with dozens of new field values.
+
+3. **Offline Operation**: A mobile device allows local edits while completely disconnected from the network — an airplane, a subway tunnel, a rural area with no coverage. When it reconnects hours or days later, those local edits may conflict with changes made on the server or on other devices during the offline window. This is the canonical use case for CRDTs and merge-based conflict resolution, because the conflict window is measured in hours or days rather than milliseconds, making the probability of a genuine conflict close to 100% for any actively edited data.
+
+> **Pause and predict**: If a system uses "Last-Write-Wins" (LWW) based on wall-clock timestamps to resolve conflicts, what happens when two servers have their system clocks out of sync by five minutes — a common occurrence when NTP is misconfigured or temporarily unreachable? Which write "wins," and is that outcome correct from the user's perspective?
 
 ### 4.2 Conflict Resolution Strategies
 
-When divergent data merges, the system must decide which data survives.
+When divergent data converges — whether at read time, during anti-entropy, or when a partition heals — the system needs a deterministic policy for deciding what the merged state should be. The choice of strategy is arguably the single most important architectural decision in an eventually consistent design, because it determines whether concurrent user actions are silently discarded or intelligently combined.
 
-- **Last-Write-Wins (LWW)**: The system discards all updates except the one with the highest wall-clock timestamp. It is simple but highly prone to data loss, especially if servers suffer from clock drift.
-- **Merge Functions**: The system provides conflicting values to custom business logic. For example, merging two shopping cart arrays by taking the union of both lists.
-- **Operational Transformation (OT)**: The system mathematically transforms operations based on concurrent state changes. This is heavily utilized in collaborative text editors to adjust character index insertions dynamically.
+**Last-Write-Wins (LWW)** is the simplest possible strategy: discard every version except the one with the highest timestamp, and call that the truth. It requires no application logic, no domain knowledge, and no special data structures — it is just a comparison operator applied at write time. This simplicity is seductive, but it is catastrophically prone to silent data loss. Every concurrent write except exactly one is discarded without warning, without logging, and without any notification to the user who submitted it. Clock skew between servers — which is inevitable in any real deployment — can cause an older write to "win" over a newer one if the older server's clock is ahead. LWW is appropriate only for data where true concurrent writes are architecturally impossible (single-writer workloads) or where any discarded write is genuinely and permanently acceptable — cached derived values, idempotent status flags, or append-only logs where timestamps are monotonic by construction.
 
-### 4.3 Version Vectors
+**Merge Functions** represent the next level of sophistication. Instead of discarding conflicts, the system surfaces conflicting values to a custom application-provided function that understands the semantics of the data and decides the merged result. For a shopping cart, the merge function takes the set union of items from both versions — both the book and the headphones appear at checkout. For a distributed counter, it sums the divergent increments rather than picking a winner. For a calendar, it might keep both conflicting appointments and alert the user to resolve the conflict manually. Merge functions give the application developer full semantic control over conflict resolution, but they come with a significant engineering cost. A merge function must be written, tested, and maintained for every data type in the system. Incorrect merge logic — a function that drops a field or miscalculates a derived value — produces data corruption. This corruption is indistinguishable from a bug in the conflict resolution process itself.
 
-To reliably detect conflicts without relying on fragile system clocks, distributed databases use **Version Vectors**. A version vector is an array of counters, maintaining a specific index for every node in the cluster.
+**Operational Transformation (OT)** is used primarily in collaborative text editing and represents an entirely different approach. Instead of merging conflicting states, OT mathematically transforms concurrent operations so that they can be applied in any order and still produce an identical document state. If two users insert characters at different positions, OT adjusts the insertion indices to account for the fact that the other user's concurrent insert shifted the character positions. OT is extremely powerful — it powers Google Docs, Etherpad, and numerous other collaborative editors — but it is notoriously difficult to implement correctly. The transformation functions must be proven correct for every possible pair of concurrent operations, and the proof is non-trivial even for simple text operations.
 
-When Node A updates a record, it increments its own counter: `[NodeA: 1, NodeB: 0]`.
-When Node B independently updates the same record, it increments its counter: `[NodeA: 0, NodeB: 1]`.
+### 4.3 Version Vectors and Concurrency Detection
 
-When these nodes synchronize, the system compares the vectors. If one vector has equal or higher values across every single node index, it strictly dominates, meaning it is a newer revision. However, if the vectors show independent increments (Node A is higher in its slot, Node B is higher in its slot), the system mathematically proves a concurrent write occurred. A conflict is flagged for programmatic resolution.
+To reliably detect conflicts without relying on fragile and skew-prone wall-clock timestamps, distributed databases use **version vectors** — sometimes called **vector clocks** when used in the context of causal ordering rather than data versioning. The distinction is subtle but worth understanding: version vectors track per-replica data versions as monotonically increasing counters (version A evolved from counter 1 to counter 2 to counter 3), while vector clocks track per-process logical timestamps for ordering events in a causal history. In database literature and implementation, the terms are often used interchangeably, and the mechanism is identical: an array of counters, one per node in the cluster, that collectively encode what each replica has seen.
 
-### 4.4 War Story: The $8.2 Million Shopping Cart Bug
+When a client reads from a replica, it receives not just the data but also the current version vector — a snapshot of the causal history that produced this particular value. When the client later writes back, it includes that version vector with the write. The database compares the incoming vector against the current state to determine whether the write is a clean descendant or a concurrent conflict.
 
-**Black Friday 2018. A major electronics retailer discovers their shopping carts are "eating" high-value items—and the timing couldn't be worse.**
+If the incoming vector is strictly greater than or equal to the current vector in every position — meaning every node's counter in the incoming vector is at least as high as the corresponding counter in the current vector — the write is a **descendant**. It represents a later state based on having observed the current data, and it can be applied without conflict because no concurrent writes occurred in the interval between the read and the write. But if neither vector dominates the other — Node A's counter is higher in one slot while Node B's counter is higher in another — the system has detected a **concurrent write**. Two clients made independent updates based on the same parent version, and neither observed the other's changes before submitting their own. This is a genuine conflict that requires resolution.
 
-The company had implemented eventually consistent shopping carts using last-write-wins (LWW) conflict resolution. The theory was sound: shopping carts are a classic eventual consistency use case. But the implementation had a fatal flaw.
+Consider a concrete example with three nodes. Node A writes to a key and records version vector `[A:1, B:0, C:0]`. Node B independently writes to the same key and records `[A:0, B:1, C:0]`. When these vectors are compared, neither dominates. Node A's vector has a higher value in the A slot, and Node B's vector has a higher value in the B slot. The system correctly identifies this as a concurrent write conflict and invokes the configured resolution strategy — merge function, CRDT, or flagging for human review. Without version vectors, this conflict would be invisible to the system, and a naive LWW policy would silently discard one of the two writes, with no warning and no audit trail.
 
-**The bug**: When a user added an item on their phone, then added a different item on their laptop before the phone's write replicated, the laptop's write included only its local cart state. Last-write-wins meant the phone's item disappeared.
+### 4.4 Hypothetical Scenario: The Shopping Cart That Forgot
 
-**Timeline of the disaster:**
-- **Wednesday before Black Friday**: QA notices occasional "missing item" reports but can't reproduce.
-- **Black Friday 6:00 AM**: Doors open, traffic spikes 40x normal.
-- **Black Friday 8:15 AM**: Customer complaints surge—"I added a TV but it's gone".
-- **Black Friday 9:00 AM**: Engineering traces bug to LWW conflict resolution.
-- **Black Friday 10:30 AM**: Hotfix deployed—all cart writes now merge (union) instead of replace.
-- **Black Friday 6:00 PM**: Final tally: 127,000 carts affected, 23,000 abandoned purchases.
+Consider an e-commerce platform that uses eventually consistent shopping carts with a naive last-write-wins (LWW) conflict resolution strategy. The reasoning at design time seemed defensible: shopping carts are a textbook eventual-consistency use case, after all, and LWW is trivial to implement and requires no domain-specific logic. Here is what actually goes wrong in production.
 
-**The cost:**
-- $4.8 million in lost sales (abandoned carts with high-value items).
-- $2.1 million in emergency discounts to affected customers.
-- $1.3 million in overtime engineering and customer service.
+**The bug.** A user adds a laptop to their cart on their phone during the morning commute, when the cellular connection is spotty and the write lands on one replica. They then add a monitor to the same cart on their laptop at work, before the phone's write has finished replicating to the replica that serves the laptop. The laptop's local replica contains only the monitor — it never received the laptop addition because replication is still in flight. When the laptop's write propagates, LWW sees a newer timestamp on the laptop's write and overwrites the cart, silently discarding the laptop. The user arrives at checkout, sees a monitor but no laptop, assumes the system lost their item, and abandons the purchase. The platform lost a sale not because of infrastructure failure, but because the conflict resolution strategy treated a set as a scalar value.
 
-**The fix**: The team replaced their cart data structure with a CRDT-style design:
+This scenario illustrates the core problem: **the root cause.** LWW treats each write as a complete replacement of the cart's state, with no awareness that the cart is semantically a *set* — a collection of independently added items that are not in competition with each other. Concurrent additions should combine (union), not compete (last-writer-wins). The timestamp on the laptop's write says "this write happened later in wall-clock time," but wall-clock time cannot express the semantic relationship between two independent additions made on different devices by the same user. The system chose the wrong primitive for the data type.
+
+**The fix.** Replace the single-value cart with a mergeable data structure, modeled after the approach described in the Amazon Dynamo paper. Instead of storing the cart as a flat list that is overwritten on every write, the system stores each item as an independently tagged entry with a unique identifier. The merge operation is set union over the add-tombstone structure.
+
 ```javascript
-// Before: Single value, LWW
-cart = {items: ["tv", "laptop"]}  
-// After: OR-Set style, merges correctly
+// Before: Single value, LWW — concurrent additions LOST
+cart = {items: ["laptop"]}   // phone's write
+cart = {items: ["monitor"]}  // laptop's write overwrites — laptop LOST
+
+// After: OR-Set style — concurrent additions MERGE
 cart = {
-  adds: {"tv": uuid1, "laptop": uuid2},
+  adds: {"laptop": "uuid-1", "monitor": "uuid-2"},
   removes: {}
-}  
+}
 ```
 
-**The lesson**: Eventual consistency requires thinking about conflict resolution at design time, not after the bug reports come in. "Last-write-wins" is almost never what you actually want for user data.
+With the OR-Set approach, every addition carries a unique identifier that is independent of wall-clock time and replica identity. When the system receives conflicting cart states — one with the laptop, one with the monitor — it computes the union of the `adds` maps (minus any items whose UUIDs appear in the `removes` tombstone set), producing a cart that contains both items. No addition is ever silently dropped, regardless of the order in which writes arrive or the relative skew of the replicas' clocks. This is precisely the design choice that the Dynamo paper describes: the shopping cart is modeled as a data type whose merge operation is set union. Conflicts are resolved by combining concurrent additions rather than choosing a winner. The lesson is not specific to shopping carts. Any time your data model contains independently created items that should accumulate rather than replace each other — a playlist, a collaborative to-do list, a set of tags on a document — the merge strategy should be union. LWW is the wrong tool for the job.
 
 ---
 
 ## Part 5: Practical Consistency Patterns and CRDTs
 
-### 5.1 Read-Your-Writes Guarantees
+### 5.1 Session Guarantees: Read-Your-Writes and Beyond
 
-Even in an eventually consistent architecture, the minimum acceptable baseline for user experience is often "Read-Your-Writes." If a user updates their profile and refreshes the page, they expect to see the new data immediately, regardless of replication lag.
+Even in an architecture that embraces eventual consistency at the storage layer, users expect a coherent experience within their own session — the sequence of interactions they perform with your application over the course of minutes or hours. If a user updates their profile photo and immediately refreshes the page, they should see the new photo, not the old one, regardless of which replica happens to serve the refresh request. This expectation is formalized as **read-your-writes consistency**, one of four session guarantees identified by Terry, Demers, Petersen, et al. in their foundational 1994 paper on session guarantees for weakly consistent replicated data. The paper demonstrated that even without global strong consistency, a system can provide a local, per-session consistency model that is sufficient for the vast majority of user-facing application logic.
 
 ```mermaid
 sequenceDiagram
@@ -306,70 +332,191 @@ sequenceDiagram
     NB-->>U: Return stale data!
 ```
 
-**Implementation Solutions:**
-1. **Sticky Sessions**: Load balancers route all requests from a specific user to the exact same node that processed their writes. 
-2. **Version-Based Reads**: The client application remembers the version number of its last write. Subsequent read requests include an "at least version V" header. If the serving node is lagging, it blocks the read until background replication catches up to version V.
+The diagram above illustrates the core problem. The user writes to Node A, but their next read request — perhaps due to load-balancer routing or a connection drop and reconnect — lands on Node B, which has not yet received the replication. Node B returns stale data, and from the user's perspective, the system appears to have lost their write. The user's trust in the application erodes instantly, and unlike a backend consistency metric, this erosion is invisible to monitoring dashboards.
 
-### 5.2 Monotonic Reads
+**Implementation strategies for read-your-writes** represent a spectrum of complexity and coverage. Sticky sessions (session affinity) are the simplest: configure the load balancer to route all requests from a given user session to the same replica that handled their writes, using a cookie or a header-based routing rule. This requires no database-level support and works immediately, but it breaks when the pinned replica fails, when the user switches devices, or when an operational task like a rolling restart shifts the user to a different node. Version-tagged reads are more robust: the client remembers the version vector or logical timestamp from its last write, and all subsequent reads include a "read at least version V" directive. If the serving replica is behind, it either blocks until it catches up — adding latency but preserving the guarantee — or returns an error telling the client to retry against a more current replica. This approach works across devices because the version hint can be stored in a cookie, a mobile app's local state, or a user's session record, but it requires the database to support conditional reads. Quorum reads with a write timestamp offer a third path: the client reads from a quorum of replicas (R > 1) and selects the result whose version is at least as recent as the client's last known write, discarding stale results from lagging nodes. This provides read-your-writes without any sticky-session dependency and without blocking, but it adds latency from the multi-replica read.
 
-Monotonic reads guarantee that once a user has observed a specific state of the system, they will never observe an older, stale state on subsequent requests. Time must never appear to go backwards.
+**Monotonic reads** guarantee that time never appears to move backward for a user. Once a user has observed a particular version of the data — say, version 7 of a document — every subsequent read from that user's session must return version 7 or later. The user should never see version 6 again after having seen version 7, because that temporal rewind is deeply disorienting and undermines trust. Implementation again relies on the client carrying a high-watermark version token and the database rejecting or redirecting reads that would return a version older than the token.
 
-> **Stop and think**: How would a jarring "rewind in state" (like seeing a deleted item reappear temporarily) affect user trust in an application?
+**Causal consistency** extends these guarantees across users, creating a shared causal order that multiple users can rely on. If Alice posts a photo and Bob comments on it, Bob's comment is causally dependent on Alice's post — the comment would not exist without the post, and it makes no sense to display the comment without the post. Systems implement causal consistency by including dependency metadata with every write. Bob's comment carries an explicit reference to Alice's post, and any replica that receives Bob's comment before Alice's post will suppress the comment from read results, holding it in a pending queue until the causal dependency — Alice's post — has been locally replicated. This ensures that no user anywhere in the world ever sees a reply before the message it replies to, a comment before the post it comments on, or a "like" on content that hasn't loaded yet.
 
-Achieving this typically requires enforcing session affinity or passing high-watermark version tokens in client cookies, ensuring the backend rejects any read operation from a node trailing the client's known timeline.
+### 5.2 Conflict-Free Replicated Data Types (CRDTs)
 
-### 5.3 Causal Consistency
+**Conflict-Free Replicated Data Types (CRDTs)** — formalized by Shapiro, Preguiça, Baquero, and Zawirski in their 2011 paper "A Comprehensive Study of Convergent and Commutative Replicated Data Types" — are specialized data structures designed from their mathematical foundations to be merged across distributed replicas without coordination, without conflict, and without data loss. They achieve this remarkable property by ensuring that the merge operation satisfies three algebraic laws that collectively guarantee deterministic convergence regardless of message ordering or duplication.
 
-Causal consistency ensures that operations logically dependent on one another are ordered correctly across all replicas. For example, if Alice posts "I got a promotion!" and Bob comments "Congratulations!", Bob's comment has a causal dependency on Alice's post. 
+The three laws are **commutativity**, **associativity**, and **idempotence**. Commutativity means that the order in which merges are applied does not affect the final result: `merge(a, b) == merge(b, a)`. Replicas can exchange state in any sequence, and the end state is always identical. Associativity means that grouping of merge operations does not matter: `merge(a, merge(b, c)) == merge(merge(a, b), c)`. This enables incremental, pairwise synchronization — Replica A can sync with Replica B, then later with Replica C, and arrive at the same state as if all three synchronized simultaneously. Idempotence means that applying the same merge multiple times produces no additional effect: `merge(a, a) == a`. This makes CRDTs safe against duplicate message delivery, retry storms, and the "at-least-once" delivery semantics that are the norm in distributed messaging systems.
 
-Without causal consistency tracking, replication lag could cause a third user to see the comment before the original post arrives. To prevent this, data payloads include dependency arrays. A replica receiving Bob's comment will hold it in a suppressed queue until Alice's post successfully replicates locally, preserving logical sanity for end users.
+CRDTs come in two families that represent different points on the bandwidth-versus-simplicity spectrum. **State-based CRDTs (CvRDTs)** have each replica periodically transmit its entire local state to its peers. The receiving replica merges the incoming state with its own using the CRDT's merge function, and the system converges. State-based CRDTs are simpler to implement and naturally tolerate message loss — if a state transmission is dropped, the next periodic transmission will repair any gap. The trade-off is bandwidth: state transmission is proportional to the state size, which can be prohibitive for large data structures. **Operation-based CRDTs (CmRDTs)** have each replica broadcast only the operations it performed — "increment counter by 1," "add element X to set" — rather than its full state. The receiving replicas apply these operations locally. Operation-based CRDTs use dramatically less bandwidth. However, they require reliable causal broadcast to ensure that every replica receives every operation in causal order. This infrastructure requirement is non-trivial.
 
-### 5.4 Conflict-Free Replicated Data Types (CRDTs)
+**Common CRDT implementations in production.** Each of the following data structures satisfies the commutativity, associativity, and idempotence laws that guarantee conflict-free convergence:
 
-**Conflict-Free Replicated Data Types (CRDTs)** are specialized data structures mathematically guaranteed to merge seamlessly across distributed nodes without human intervention or data loss. They rely on operations being commutative (order does not matter), associative (grouping does not matter), and idempotent (repeating the operation is safe).
+- **G-Counter (Grow-only Counter)**: Each node maintains its own local counter and never touches another node's counter. To read the total value, the system sums all node-local counters. The merge function takes the element-wise maximum of each node's counter across the merging vectors, ensuring that no increment from any node is ever lost. The limitation is that G-Counters can only increase — there is no decrement operation.
 
-**Common CRDT Implementations:**
-- **G-Counter (Grow-only counter)**: Every node maintains its own local counter. To read the total value, the system sums the mathematical `max()` of all individual node counters. No increments are ever lost during concurrent updates.
-- **PN-Counter (Positive-Negative counter)**: Consists of two internal G-Counters—one tracking increments, one tracking decrements. The true value is the total increments minus the total decrements.
-- **OR-Set (Observed-Remove set)**: Allows adding and removing items continuously. Every addition is tagged with a unique cryptographic UUID. Removing an item means tombstoning its specific UUID. This allows nodes to deterministically resolve concurrent adds and removes of the same item name.
+- **PN-Counter (Positive-Negative Counter)**: Composed internally of two G-Counters — one tracking all increments, one tracking all decrements. The value is `sum(increments) - sum(decrements)`. Both sub-counters are grow-only, which makes the PN-Counter itself a valid CRDT even though it supports both addition and subtraction at the API level. This is the CRDT equivalent of an integer that can go up and down, as long as the increments and decrements are themselves monotonic within their respective counters.
+
+- **OR-Set (Observed-Remove Set)**: Items are added with unique identifiers, typically UUIDs. Removal does not delete an item; instead, it adds the item's UUID to a tombstone set. An element is considered present in the set if its UUID appears in the add-set but not in the tombstone-set. The concurrent add and remove of the same element is resolved deterministically: both the add with its UUID and the tombstone for that UUID are preserved, and the element is considered removed because the tombstone takes precedence. This means that once an item is removed, it can be re-added (with a new UUID, representing a genuinely new addition), but the original addition's UUID remains tombstoned forever.
+
+- **LWW-Register (Last-Write-Wins Register)**: Each write to the register is tagged with a timestamp and a replica identifier for deterministic tiebreaking. The merge operation selects the write with the highest timestamp, using the replica ID as a tiebreaker when timestamps are equal. Unlike a naive LWW database write, the LWW-Register CRDT makes the tiebreaking rule explicit, deterministic, and auditable, and it preserves the complete version history so that no write is technically lost — it is simply superseded in the merged view. This makes the LWW-Register suitable for use cases where "the most recent value" is genuinely the right semantic, such as a "last modified by" field on a document.
+
+The transformative insight behind CRDTs is that they eliminate conflicts at the data structure level rather than at the application level. If your application can express its mutable state in terms of CRDTs — counters, sets, registers, maps — you get automatic, mathematically proven conflict resolution without writing a single line of application-level merge logic and without the risk of an incorrectly implemented merge function silently corrupting data. The trade-off is expressiveness. CRDTs cover a surprisingly wide range of real-world use cases — collaborative text editing, distributed counters, presence tracking, shopping carts, playlists, and configuration management — but they cannot express arbitrary application invariants such as uniqueness constraints across records or multi-item atomic updates. For those invariants, you still need consensus, and you must pay the latency and availability cost that consensus demands.
+
+---
+
+## Patterns and Anti-Patterns
+
+### Patterns
+
+1. **Mergeable Data Model First**: Design your data types to support deterministic merge before you write a single line of application-level conflict resolution code. If a counter can be a G-Counter, if a collection can be an OR-Set, if a field can be an LWW-Register — use the CRDT. The merge logic is mathematically proven correct by the CRDT's algebraic structure, and you will never find yourself debugging a lost-update bug at 3 AM because a hand-rolled merge function mishandled an edge case you didn't anticipate.
+
+2. **Tune Quorum Per Operation, Not Per Database**: Every operation in a service has its own consistency requirements, and they are rarely uniform. A product catalog page view can use `R=1` for sub-millisecond reads with eventual consistency. A shopping cart "add item" operation can use `W=2, R=2` on a 3-node cluster for read-your-writes without blocking on all replicas. A payment confirmation should use `W=3, R=3` — or better, a dedicated strongly consistent store — for linearizability. The database's tunable quorum knobs exist precisely so that you can apply the weakest consistency that still satisfies each operation's specific correctness requirements.
+
+3. **Read-Repair Aggressively**: Every read in an eventually consistent system is an opportunity to improve consistency for free. When your read coordinator notices version discrepancies across the replicas it queried — one replica returned version 5, another returned version 7 — it should push version 7 to the lagging node before returning the result to the client. This converts the probability of reading stale data into a self-healing mechanism that accelerates convergence for data that users actively access.
+
+4. **Version Vectors Over Timestamps**: Whenever you need to detect concurrent writes or establish causal ordering, use version vectors or hybrid logical clocks (HLCs) rather than wall-clock timestamps. Clocks skew — NTP can drift by tens or hundreds of milliseconds, virtual machine time can jump forward or backward during live migration, and leap seconds introduce discontinuities that no NTP configuration can fully paper over. Version vectors are a logical construct that tracks what each replica has actually observed, and they are immune to every one of these problems by design.
+
+### Anti-Patterns
+
+| Anti-Pattern | Why It's Harmful | Better Approach |
+|---|---|---|
+| LWW for mutable user data | Silent data loss on every concurrent write; no warning, no audit trail, no recovery path | Merge functions for domain types, CRDTs for counters/sets/registers, or strong consistency for operations where correctness is non-negotiable |
+| Assuming "eventually" means seconds | Network partitions can last minutes or hours; there is no bound on convergence, and your code must not assume one | Design for arbitrary convergence delay; surface staleness indicators to users if data freshness matters to their workflow |
+| Strong consistency everywhere by default | Every operation pays the latency and availability cost of consensus or quorum, even for data where occasional staleness is imperceptible | Audit each operation's requirements; start with eventual consistency and escalate to stronger models only where correctness demands it |
+| Ignoring conflict resolution until production | Conflicts surface as data corruption — duplicated records, lost updates, inconsistent derived values — that may be impossible to retroactively correct without data migration | Design the conflict resolution strategy as part of the data model specification; test concurrent-write scenarios in CI with randomized message delays |
+| Clock-based ordering for correctness-critical decisions | NTP skew, leap seconds, and VM time jumps cause the wrong write to "win" in LWW, producing incorrect application state with no error signal | Use version vectors or hybrid logical clocks; never rely on wall-clock timestamps for anything that affects data correctness |
+| No monitoring of replication lag | Stale reads go undetected; users report bugs that engineering cannot reproduce because the lag has healed by the time anyone investigates | Export per-replica lag metrics — seconds behind the leader, pending replication queue depth — and alert when lag exceeds application-defined thresholds |
+| Treating eventual consistency as "good enough for everything" | Some operations — payment processing, inventory decrement, distributed lock acquisition — genuinely require linearizability | Use the Decision Framework below to classify each operation; never apply eventual consistency to operations where stale data could cause financial loss or safety hazards |
+
+---
+
+## Decision Framework
+
+Use this flowchart to select a consistency level when designing a new distributed service or evaluating an existing operation's consistency requirements:
+
+```mermaid
+flowchart TD
+    Start[Start: Define Operation Requirements] --> Q1{Would stale data cause<br/>financial loss, safety hazard,<br/>or irreversible user harm?}
+    Q1 -->|Yes| Strong[Strong Consistency<br/>Linearizable / CP]
+    Q1 -->|No| Q2{Must a user always see<br/>their own writes immediately<br/>within the same session?}
+    Q2 -->|Yes| Session[Session Consistency<br/>Read-Your-Writes]
+    Q2 -->|No| Q3{Does one operation<br/>causally depend on the<br/>result of another?}
+    Q3 -->|Yes| Causal[Causal Consistency<br/>Track dependencies]
+    Q3 -->|No| Q4{Can concurrent writes<br/>to the same key cause<br/>data loss?}
+    Q4 -->|Yes| CRDTorMerge[CRDTs or Merge Functions<br/>Design conflict resolution]
+    Q4 -->|No| Eventual[Eventual Consistency<br/>AP / W+R <= N]
+
+    style Strong fill:#f96,stroke:#333
+    style Session fill:#fc9,stroke:#333
+    style Causal fill:#ffb,stroke:#333
+    style CRDTorMerge fill:#bfb,stroke:#333
+    style Eventual fill:#bdf,stroke:#333
+```
+
+**Quick reference matrix for common workload types.** Use this table to map specific operational requirements to the appropriate consistency model:
+
+| Workload | Recommended Model | Rationale |
+|---|---|---|
+| Payment / financial write | Linearizable (CP) | Correctness is non-negotiable; double-charging or overdraft is unacceptable at any latency |
+| User profile update | Read-your-writes | User must see their own change immediately after refresh; other users can see it eventually |
+| Social media feed | Eventual (AP) | Few-seconds staleness in a feed is imperceptible and acceptable to users |
+| Collaborative document editing | CRDT or OT | Concurrent edits from multiple users must merge without any data loss |
+| Inventory count (available quantity) | Causal or strong | Overselling is a real business cost with customer-service and reputational consequences |
+| Analytics / metrics dashboard | Eventual (AP) | Approximate values with low latency are sufficient; exact counts are rarely needed in real-time dashboards |
+| Distributed lock acquisition | Linearizable (CP) | Two holders of the same lock is a safety violation that can corrupt arbitrary application state |
+| Shopping cart (add items) | CRDT (OR-Set) | Concurrent additions from multiple devices must accumulate, never overwrite each other |
 
 ---
 
 ## Did You Know?
 
-- Amazon's shopping cart was one of the first famous eventually consistent systems. Their 2007 Dynamo paper showed how eventual consistency enables high availability and became the blueprint for Cassandra, Riak, and DynamoDB.
-- Conflict-Free Replicated Data Types (CRDTs) were independently discovered multiple times. The mathematical foundations existed long before distributed systems, but applying them directly to database replication was a major breakthrough formalized in 2011.
-- The global Domain Name System (DNS) is eventually consistent by design. When you update a DNS record, it can take up to 48 hours for the Time-To-Live (TTL) caches to propagate worldwide, yet the internet functions reliably because most applications tolerate stale routing data.
-- Figma utilizes CRDTs to power its real-time collaborative design engine. Multiple designers can edit the same file simultaneously, and their changes merge automatically without conflicts, ensuring no work is ever overwritten during concurrent edits.
+- Amazon's Dynamo paper (DeCandia et al., SOSP 2007) introduced the shopping-cart-as-mergeable-set pattern — treating the cart not as a scalar value but as a collection whose merge is set union — and became the architectural blueprint for Cassandra, Riak, Voldemort, and DynamoDB. The paper explicitly argues that the "add to cart" operation must never be lost under any circumstance, which drove the design of the entire conflict resolution subsystem.
+- Conflict-Free Replicated Data Types (CRDTs) have deep mathematical roots in lattice theory and order theory from abstract algebra, fields that predate distributed computing by decades. Shapiro et al.'s 2011 paper bridged the gap between pure mathematics and practical database engineering by showing that any data structure whose state space forms a monotonic semilattice — where the merge operation is the least upper bound in the lattice — naturally converges without coordination. This connection between algebraic structure and distributed consistency is one of the most elegant results in computer science.
+- The global Domain Name System (DNS) is arguably the world's largest eventually consistent system, serving billions of queries per day across hundreds of thousands of recursive resolvers. When you update a DNS record, the change can take up to the TTL duration to propagate to every resolver worldwide — 24 to 48 hours for high-TTL records — yet the internet functions reliably because every application that relies on DNS is designed to tolerate transient inconsistencies in name-to-address mappings.
+- Session guarantees were formalized in 1994 as a practical middle layer between single-copy consistency and fully weak replication. The key insight was that many user-facing applications do not need every replica to agree immediately; they need each user session to feel coherent, so guarantees like read-your-writes and monotonic reads can preserve trust without forcing every operation through global coordination.
 
 ---
 
 ## Common Mistakes
 
 | Mistake | Problem | Solution |
-|---------|---------|----------|
-| Assuming immediate consistency | Read stale data, confused users | Implement read-your-writes |
-| Last-write-wins without thought | Silent data loss | Use merge functions or CRDTs |
-| Ignoring conflict resolution | Conflicts surface as bugs later | Design conflict strategy upfront |
-| Clock-based ordering | Clock skew causes wrong order | Use logical clocks or version vectors |
-| No causal ordering | Comments before posts, replies before questions | Track causality explicitly |
-| Over-engineering consistency | Complexity without benefit | Start eventual, add consistency where needed |
+|---|---|---|
+| Assuming immediate consistency after a write | Users see stale data and lose trust in the application; bugs are non-deterministic and hard to reproduce | Implement read-your-writes via sticky sessions, version-tagged reads, or quorum reads with write timestamps |
+| Using last-write-wins without analyzing the data model | Silent data loss on every concurrent write; no warning, no recovery, and no audit trail to even know it happened | Use merge functions for domain types that have natural merge semantics; use CRDTs for counters, sets, and registers |
+| Ignoring conflict resolution during the design phase | Conflicts surface as production data corruption — duplicated records, lost updates, inconsistent derived values — that may require a data migration to fix | Define the conflict resolution strategy as part of the data model specification; write it down before the first line of persistence code |
+| Relying on wall-clock timestamps for correctness-critical ordering | Clock skew between nodes causes the wrong write to "win" in LWW, producing incorrect application state with no error signal | Use version vectors or hybrid logical clocks; never trust NTP for anything that affects data correctness |
+| No causal ordering enforcement for dependent operations | Users see comments before parent posts, replies before original questions, "likes" on content that hasn't loaded | Embed causal dependencies in write payloads; suppress delivery of dependent operations until all causal predecessors are locally replicated |
+| Over-engineering consistency for every operation in a service | Every operation pays the latency and availability cost of consensus or quorum, even when staleness would be acceptable or imperceptible | Use tunable quorums per operation; audit each endpoint and apply the weakest consistency that satisfies its specific correctness requirements |
+| No replication lag monitoring | Stale reads go undetected for weeks; users experience bugs that engineering cannot reproduce because the lag window has closed by the time anyone investigates | Export per-replica lag metrics — seconds behind, pending queue depth — and set alerts based on application-defined staleness thresholds |
+
+---
+
+## Quiz
+
+1. **You are designing a globally distributed user profile service for a social media app. You choose eventual consistency to keep latency low. When explaining the system guarantees to the product manager, what exactly are you promising about the data state?**
+   <details>
+   <summary>Answer</summary>
+   Eventual consistency guarantees that if no new updates occur, all replicas will eventually converge to identical data. It does not, by itself, guarantee that every acknowledged write is durable under every failure mode. That durability promise depends on the write path: quorum acknowledgement, durable local persistence, fsync policy, replication factor, and repair behavior all matter. In a safely configured service, you can promise that acknowledged writes are persisted according to the system's documented durability contract and will eventually propagate to other replicas, but an asynchronous single-primary design can still lose an acknowledged write if the primary fails before replication. Eventual consistency also does NOT guarantee when convergence happens (it could take milliseconds or minutes) or what intermediate stale states a user might read during propagation. Ultimately, you are promising that the system will prioritize availability over returning the strict, globally correct data on every read — a trade-off that makes sense for user profiles where occasional staleness is acceptable but slow page loads driven by cross-region consensus latency are not.
+   </details>
+
+2. **Two users in a collaborative document editor are working offline. User A changes the title to "Draft 1", and User B changes it to "Final Draft". When both reconnect, the system uses version vectors to detect a conflict. How does this mechanism identify that neither change should automatically overwrite the other?**
+   <details>
+   <summary>Answer</summary>
+   Version vectors track the causal history of data rather than wall-clock time. Each node maintains a counter array representing the updates it has seen from every replica. When User A and User B edit offline, they both fork from the same baseline version vector, incrementing their own node's counter without observing the other's increment. Upon reconnecting, the system compares their vectors element by element and finds that neither vector strictly dominates the other across all dimensions — A's vector has a higher counter in A's slot, B's in B's slot. Because neither client observed the other's operation before submitting their own, the system mathematically proves that a concurrent write occurred, flags it as a conflict, and invokes the configured resolution strategy rather than silently discarding one user's work.
+   </details>
+
+3. **You are migrating a distributed "like" counter for a video streaming service from a simple integer column to a CRDT (G-Counter). How does the mathematical structure of the CRDT guarantee that concurrent "likes" from different regions will merge perfectly without dropping counts?**
+   <details>
+   <summary>Answer</summary>
+   A G-Counter CRDT works by having every node independently track only its own local increments in a per-node counter, rather than mutating a shared global integer that multiple nodes compete to update. Because the merge function uses the mathematical `max()` operation across each node's position in the counter array, the operations become commutative (order does not matter), associative (grouping does not matter), and idempotent (applying the same merge twice has no effect). This means the order in which regional synchronizations arrive is irrelevant to the final count, and applying the same sync payload twice — due to a retry or duplicate message — will not double-count any likes. By eliminating the mutable shared integer and replacing it with a monotonic per-node counter structure, concurrent increments merge safely and deterministically without requiring locks, consensus, or conflict resolution code.
+   </details>
+
+4. **Your e-commerce architecture review board is debating the consistency models for two microservices: the Product Catalog and the Payment Ledger. What consistency models should you apply to each, and why?**
+   <details>
+   <summary>Answer</summary>
+   The Product Catalog should use Eventual Consistency, while the Payment Ledger requires Strong (Linearizable) Consistency. For the catalog, high availability and low read latency directly impact user experience and conversion rates; if a user sees a product description from an hour ago or a price that is off by a few cents, the business impact is negligible and the user is unlikely to notice. Conversely, the payment ledger handles financial state, where correctness is absolutely critical — a stale read or a lost write on a payment ledger could result in double-charging a customer, shipping goods without confirmed payment, or violating regulatory audit requirements. The latency cost of strong consistency — waiting for quorum acknowledgement or consensus rounds — is an acceptable and necessary trade-off for the ledger because the alternative is financial error, which is unacceptable at any latency.
+   </details>
+
+5. **Your database cluster has 5 nodes (N=5). You are deploying a read-heavy microservice where every read should overlap with a completed write quorum, but the workload does not require consensus-grade linearizability for concurrent writes. What read (R) and write (W) quorum values should you configure, and how does this affect write availability during a node failure?**
+   <details>
+   <summary>Answer</summary>
+   In a strict quorum model, the overlap rule is `W + R > N`. To prioritize high read availability and fast reads while preserving completed-write/read-quorum overlap, you can set `R=1` and `W=5`, giving `W+R=6 > 5`. By reading from just 1 node, read latency is extremely low — a single local node responds — but writing requires acknowledgement from all 5 nodes so that every possible one-node read quorum intersects the completed write quorum. The major drawback is fault tolerance: if even a single node goes down, `W=5` becomes unsatisfiable and write operations will block or fail until the node recovers. This is not a substitute for consensus-backed linearizability; concurrent writes still need version vectors, merge logic, or a single-copy serialization mechanism. It is a quorum-overlap trade-off that makes sense only when read speed matters more than write availability and when the application can tolerate the remaining conflict-resolution semantics.
+   </details>
+
+6. **A social media platform stores user posts with eventual consistency. User A posts "Hello", then immediately comments "First!" on their own post. Another user B refreshes their feed and sees the comment "First!" but not the original "Hello" post. What specific consistency property is violated, and how would you architecturally prevent it?**
+   <details>
+   <summary>Answer</summary>
+   This scenario violates **Causal Consistency**, as a causally dependent event (the comment) was made visible to a reader before its cause (the original post) had been replicated to that reader's replica. This happens when the comment — typically a smaller payload that replicates faster — arrives at a secondary node before the larger post payload completes replication. To prevent this, you should implement explicit causal dependency tracking in the write protocol. The comment object would include the post ID in a `dependencies` list (e.g., `deps: [post_id]`), and the receiving replica, upon receiving the comment, would check whether the referenced post has been locally replicated. If not, the replica would hold the comment in a suppressed pending queue and refuse to serve it to any client until the causal dependency — the original post — has been fully replicated and is available for read. This preserves the intuitive "cause before effect" ordering that users expect from any social application.
+   </details>
+
+7. **You are implementing a collaborative document editor. User A inserts "Hello" at position 0. User B inserts "World" at position 0 (concurrently, before seeing A's edit). After syncing, what mechanism prevents the document state from being scrambled or losing data?**
+   <details>
+   <summary>Answer</summary>
+   Systems prevent data scrambling using either Operational Transformation (OT) or Replicated Growable Array CRDTs. If using OT, when User A's replica receives B's concurrent insert operation, the transformation engine algorithmically adjusts the index of B's insert to account for the length of the string that A inserted — shifting B's insertion point from position 0 to position 5 (after "Hello") — so both strings are preserved in the correct relative order. If using a CRDT-based approach, every inserted character is assigned a globally unique, immutable identifier composed of a site identifier and a monotonic counter, rather than relying on fragile absolute indices. Because each character's identity is anchored to its unique ID and its position relative to neighboring character IDs, the insertions will sort deterministically across all replicas, producing either "HelloWorld" or "WorldHello" consistently everywhere, without any data loss or corruption.
+   </details>
+
+8. **You are monitoring a distributed cache system that uses a G-Counter CRDT to track video page views across 3 regional nodes. The G-Counter has the following state across the nodes. Calculate the total count. Then, Node B handles 5 more page views locally and subsequently syncs with Node A. What is Node A's new state, and why does this prevent data loss?**
+   ```text
+   Node A: {A: 10, B: 3, C: 7}
+   Node B: {A: 8,  B: 3, C: 5}
+   Node C: {A: 10, B: 2, C: 7}
+   ```
+   <details>
+   <summary>Answer</summary>
+   The true total count initially is the sum of the element-wise maximums across all nodes: `max(10,8,10) + max(3,3,2) + max(7,5,7) = 10 + 3 + 7 = 20`. When Node B handles 5 additional local page views, it increments only its own counter (the B component), producing the new vector `{A: 8, B: 8, C: 5}`. When Node B synchronizes this updated vector with Node A, the merge function independently computes the element-wise maximum for each node's position: Node A's state becomes `{A: max(10,8), B: max(3,8), C: max(7,5)}` = `{A: 10, B: 8, C: 7}`. The total is now `10 + 8 + 7 = 25`, correctly reflecting all 5 additional views. Because the merge uses the mathematical `max()` function — which is commutative, associative, and idempotent — the 5 new views are safely merged without duplication, and none of Node C's previously recorded 7 views are affected by the merge.
+   </details>
 
 ---
 
 ## Hands-On Exercise
 
-**Task**: Explore eventual consistency behavior and conflict resolution mechanics.
+**Task**: Explore consistency behavior and conflict resolution mechanics. You will use Kubernetes ConfigMaps as a strongly consistent baseline, then use a sequential overwrite as an analogy for last-write-wins risk before designing a CRDT-based counter that avoids overwrite-style data loss.
 
-**Task 1: Environment Setup & Strong Consistency Observation**
-Run the following commands to create and modify a ConfigMap, observing how Kubernetes (which uses strongly consistent etcd) handles reads immediately after writes. Note: Kubernetes commands require a cluster running v1.35+.
+**Task 1: Environment Setup and Strong Consistency Observation**. Run the following commands to create and modify a ConfigMap, observing how Kubernetes (which uses strongly consistent etcd) handles reads immediately after writes. Kubernetes v1.35+ is assumed for these commands.
 
 ```bash
 # Create a ConfigMap
 kubectl create configmap test-data --from-literal=value=1
 
-# Immediately read from different nodes
-# (Results may vary based on your cluster setup)
+# Immediately read back through the Kubernetes API server / etcd path
 kubectl get configmap test-data -o jsonpath='{.data.value}'
 
 # Update the ConfigMap
@@ -377,17 +524,16 @@ kubectl patch configmap test-data -p '{"data":{"value":"2"}}'
 
 # Read again immediately - you should see consistent results
 # (Kubernetes uses etcd with strong consistency)
+kubectl get configmap test-data -o jsonpath='{.data.value}'
 ```
 <details>
-<summary>Solution & Explanation</summary>
-Because Kubernetes v1.35+ relies on etcd, which implements the Raft consensus algorithm, writes are strongly consistent. The read operation immediately following the patch will reliably return "2". You will not observe eventual consistency or stale reads here, setting a baseline for contrast.
+<summary>Solution and Explanation</summary>
+Kubernetes stores API objects in etcd, and etcd uses Raft to provide a strongly consistent control-plane data store. A `kubectl get` request goes through the Kubernetes API server to that control-plane storage path; it is not reading arbitrary copies from worker nodes. The read operation immediately after the patch should return "2". You will not observe eventual consistency or stale reads in this configuration — this serves as a CP baseline for contrast when you later work with eventually consistent systems.
 </details>
 
-**Task 2: Prepare Conflict Scenarios**
-Create two separate YAML files representing concurrent edits to the same ConfigMap.
+**Task 2: Prepare an Overwrite Analogy**. Create two separate YAML files that represent two actors wanting different final values for the same ConfigMap field. These manifests are an analogy for overwrite-style conflict resolution, not a claim that Kubernetes resolves genuine concurrent writes with last-write-wins semantics.
 
 ```yaml
-# Create two versions of a ConfigMap in different files
 # version-a.yaml
 apiVersion: v1
 kind: ConfigMap
@@ -405,12 +551,11 @@ data:
   setting: "value-from-B"
 ```
 <details>
-<summary>Solution & Explanation</summary>
-You have prepared two manifests targeting the exact same resource (`conflict-test`). In a distributed system lacking strict locking, multiple actors might submit these changes to the control plane simultaneously.
+<summary>Solution and Explanation</summary>
+You have prepared two manifests targeting the exact same Kubernetes resource (`conflict-test`). Kubernetes itself protects object updates with optimistic concurrency: if a client submits a write carrying a stale `resourceVersion`, the API server rejects it with an HTTP 409 Conflict rather than silently choosing a winner by timestamp. In the next task you are not intentionally sending a stale precondition; you are applying two ordinary updates in sequence, which makes the result a controlled overwrite demonstration rather than a real Kubernetes concurrent-update race.
 </details>
 
-**Task 3: Trigger and Analyze Last-Write-Wins**
-Apply both versions rapidly to simulate a concurrent write or network partition resolution.
+**Task 3: Trigger and Analyze a Sequential Overwrite**. Apply both ConfigMap versions in sequence. Use the result as an analogy for why LWW-style overwrite policies are dangerous in eventually consistent systems, while remembering that Kubernetes is accepting two ordinary updates in order, not asking etcd to merge concurrent histories by timestamp.
 
 ```bash
 # Apply version A
@@ -422,143 +567,48 @@ kubectl apply -f version-b.yaml
 # Which value won?
 kubectl get configmap conflict-test -o jsonpath='{.data.setting}'
 
-# Kubernetes uses last-write-wins (based on resourceVersion)
+# This is an overwrite analogy, not Kubernetes using resourceVersion as LWW
 ```
 <details>
-<summary>Solution & Explanation</summary>
-Kubernetes handles conflict collisions using a form of Last-Write-Wins (LWW) based on the `resourceVersion` state and the sequence of API processing. The second command overwrites the first, and the value will predictably be "value-from-B". The data from version A is silently discarded, demonstrating the high risk of LWW in collaborative architectures.
+<summary>Solution and Explanation</summary>
+The surviving value should be "value-from-B" because you deliberately sent version B after version A without a stale-`resourceVersion` precondition. Kubernetes did not use `resourceVersion` as a last-write-wins tie-breaker, and etcd did not choose the newest update by wall-clock timestamp. `resourceVersion` is Kubernetes' optimistic-concurrency token: a stale conditional update is rejected with HTTP 409 Conflict. The lesson is narrower and more precise: if an API operation is allowed to replace a field without a merge policy or precondition, the later accepted update can overwrite prior state. Eventually consistent systems that use LWW make that overwrite behavior their conflict-resolution rule, which is why LWW is dangerous for data where both concurrent values carry meaning.
 </details>
 
-**Task 4: Design a CRDT Counter Architecture**
-On paper, design a distributed "like" counter for a cluster with 3 regional nodes. Users can route requests to any node. How do you structure the data to prevent lost increments when the nodes synchronize?
+**Task 4: Design a CRDT Counter Architecture**. On paper (or in a text file), design a distributed "like" counter for a cluster with 3 regional nodes. Users must be able to submit likes to any node, and no like should ever be lost when nodes synchronize their state. What data structure do you use, and how does the merge operation work?
 <details>
-<summary>Solution & Explanation</summary>
-You should design a G-Counter (Grow-only Counter). Each of the 3 nodes must maintain a map tracking only its own local increments (e.g., `NodeA: 5, NodeB: 0, NodeC: 2`). When nodes synchronize, the merge function takes the mathematical `max()` for each node's key. The total like count is the sum of these maximums. Because operations are commutative and associative, no concurrent increments are ever lost or overwritten.
+<summary>Solution and Explanation</summary>
+You should design a G-Counter (Grow-only Counter) CRDT. Each of the 3 nodes maintains a map tracking only its own local increments — for example, `{NodeA: 5, NodeB: 0, NodeC: 2}` after some period of operation. When nodes synchronize, the merge function computes the element-wise `max()` for each node's key in the counter vector. The total global like count is the sum of these per-node maximum values. Because the `max()` operation is commutative (order does not matter), associative (grouping does not matter), and idempotent (applying the same merge twice has no effect), no concurrent increment from any node is ever lost or double-counted, regardless of the order in which replicas exchange state or whether messages are duplicated in transit.
 </details>
 
-**Success Criteria**:
-- [ ] Successfully executed ConfigMap creation and patching
-- [ ] Observed strong consistency guarantees within Kubernetes v1.35+
-- [ ] Simulated a concurrent write conflict
-- [ ] Analyzed the data loss inherent in Last-Write-Wins resolution
-- [ ] Architected a theoretical CRDT to prevent such data loss
+**Success Criteria**. Review your work against this checklist to confirm you have completed every objective:
+- [ ] Successfully executed ConfigMap creation and patching, observing strongly consistent reads
+- [ ] Used two ConfigMap versions to demonstrate a sequential overwrite against a strongly consistent API server
+- [ ] Explained why Kubernetes `resourceVersion` is optimistic concurrency, not a silent LWW timestamp mechanism
+- [ ] Architected a theoretical G-Counter CRDT that prevents such data loss in a multi-node system
+- [ ] Explained how the mathematical properties of the merge function (commutativity, associativity, idempotence) guarantee correctness
 
 ---
 
-## Quiz
+## Sources
 
-1. **You are designing a globally distributed user profile service for a social media app. You choose eventual consistency to keep latency low. When explaining the system guarantees to the product manager, what exactly are you promising about the data state?**
-   <details>
-   <summary>Answer</summary>
-   Eventual consistency guarantees two things: first, that if no new updates occur, all replicas will eventually converge to identical data. Second, there will be no permanent data loss for acknowledged writes. It does NOT guarantee when convergence happens (it could take milliseconds or minutes) or what intermediate stale states a user might read during propagation. Ultimately, you are promising that the system will prioritize availability over returning the strict, globally real-time correct data on every read.
-   </details>
-
-2. **Two users in a collaborative document editor are working offline. User A changes the title to "Draft 1", and User B changes it to "Final Draft". When both reconnect, the system uses version vectors to detect a conflict. How does this mechanism identify that neither change should automatically overwrite the other?**
-   <details>
-   <summary>Answer</summary>
-   Version vectors track the causal history of data rather than wall-clock time. Each node maintains a counter array representing the updates it has seen. When User A and User B edit offline, they both fork from the same baseline version vector, incrementing their own local node counter without seeing the other's increment. Upon reconnecting, the system compares their vectors and finds that neither vector strictly dominates the other across all elements. Because neither has seen the other's operation, the system flags it as a true concurrent write conflict requiring a merge strategy.
-   </details>
-
-3. **You are migrating a distributed "like" counter for a video streaming service from a simple integer column to a CRDT (G-Counter). How does the mathematical structure of the CRDT guarantee that concurrent "likes" from different regions will merge perfectly without dropping counts?**
-   <details>
-   <summary>Answer</summary>
-   A G-Counter CRDT works by having every node independently track only its own increments in a local variable, rather than mutating a shared global integer. Because the merge function uses the mathematical `max()` operation across each node's array of counts, the operations become commutative, associative, and idempotent. This means the order in which region synchronizations arrive doesn't matter, and applying the same sync payload twice won't duplicate counts. By eliminating the need to lock and modify a single scalar value, concurrent increments merge safely and deterministically without data loss.
-   </details>
-
-4. **Your e-commerce architecture review board is debating the consistency models for two microservices: the Product Catalog and the Payment Ledger. What consistency models should you apply to each, and why?**
-   <details>
-   <summary>Answer</summary>
-   The Product Catalog should use Eventual Consistency, while the Payment Ledger requires Strong Consistency. For the catalog, high availability and low read latency are critical for user experience; if a user sees stale pricing or an old image for a few seconds, the business impact is minimal. Conversely, the payment ledger handles financial state, where correctness is absolutely critical. A stale read on a payment ledger could result in double-charging or shipping goods without confirmed payment. This makes the latency costs of strong consistency, such as waiting for quorum or consensus, an acceptable and necessary trade-off.
-   </details>
-
-5. **Your database cluster has 5 nodes (N=5). You are deploying a new microservice that requires high availability for reads, but writes must be strictly strongly consistent. What read (R) and write (W) quorum values should you configure, and how does this affect system latency during a node failure?**
-   <details>
-   <summary>Answer</summary>
-   For strict strong consistency, you must satisfy the quorum rule `W + R > N`. To prioritize high availability and fast reads, you should set `R=1` and `W=5`. By reading from just 1 node, read latency is extremely low, but writing requires an acknowledgement from all 5 nodes to guarantee overlap. The major drawback is fault tolerance: if even a single node goes down, your write operations will block or fail entirely. This configuration heavily penalizes write latency and write availability to ensure readers never wait and always see the latest data.
-   </details>
-
-6. **A social media platform stores user posts with eventual consistency. User A posts "Hello", then immediately comments "First!" on their own post. Another user B refreshes their feed and sees the comment "First!" but not the original "Hello" post. What specific consistency property is violated, and how would you architecturally prevent it?**
-   <details>
-   <summary>Answer</summary>
-   This scenario violates **Causal Consistency**, as a dependent event (the comment) was made visible before its cause (the original post). This happens when the comment replicates to a secondary node faster than the post itself. To prevent this, you should implement explicit causal dependency tracking. The comment object would include the post ID in a dependencies list (e.g., `deps: [post_id]`), and the receiving replica would hold the comment in a pending state, refusing to serve it to clients until the required parent post has successfully replicated locally.
-   </details>
-
-7. **You're implementing a collaborative document editor. User A inserts "Hello" at position 0. User B inserts "World" at position 0 (concurrently, before seeing A's edit). After syncing, what mechanism prevents the document state from being scrambled or losing data?**
-   <details>
-   <summary>Answer</summary>
-   Systems prevent this using either Operational Transformation (OT) or Replicated Growable Array CRDTs. If using OT, when User A receives B's operation, the system algorithmically transforms the index of B's insert to account for the length of "Hello", shifting it so both strings are preserved. If using a CRDT, every inserted character is assigned a unique, immutable ID (comprising a timestamp and node ID) rather than relying on absolute indices. Because the edits are anchored to surrounding character IDs, they will sort deterministically across all clients, resulting in either "HelloWorld" or "WorldHello" consistently everywhere without data loss.
-   </details>
-
-8. **You are monitoring a distributed cache system that uses a G-Counter CRDT to track video page views across 3 regional nodes. The G-Counter has the following state across the nodes. Calculate the total count. Then, Node B handles 5 more page views locally and subsequently syncs with Node A. What is Node A's new state, and why does this prevent data loss?**
-   ```text
-   Node A: {A: 10, B: 3, C: 7}
-   Node B: {A: 8,  B: 3, C: 5}
-   Node C: {A: 10, B: 2, C: 7}
-   ```
-   <details>
-   <summary>Answer</summary>
-   The true total count initially is the sum of the maximums of each component across all nodes: `max(10,8,10) + max(3,3,2) + max(7,5,7) = 10 + 3 + 7 = 20`. When Node B increments its local counter by 5, its state becomes `{A: 8, B: 8, C: 5}`. When Node B synchronizes this new vector to Node A, the merge function independently takes the highest known value for each node's key. Node A's state updates to `{A: max(10,8), B: max(3,8), C: max(7,5)}`, resulting in `{A: 10, B: 8, C: 7}`. This mathematical max function ensures increments are safely merged without duplication, preserving the operations from both regions.
-   </details>
+- [Dynamo: Amazon's Highly Available Key-value Store — DeCandia et al., SOSP 2007](https://www.allthingsdistributed.com/files/amazon-dynamo-sosp2007.pdf)
+- [Eventually Consistent — Werner Vogels, ACM Queue 2009](https://queue.acm.org/detail.cfm?id=1466448)
+- [Brewer's Conjecture and the Feasibility of Consistent, Available, Partition-Tolerant Web Services — Gilbert & Lynch, 2002](https://dl.acm.org/doi/10.1145/564585.564601)
+- [Designing Data-Intensive Applications — Martin Kleppmann, O'Reilly 2017 (Chapters 5 and 9)](https://dataintensive.net/)
+- [A Comprehensive Study of Convergent and Commutative Replicated Data Types — Shapiro, Preguiça, Baquero, Zawirski, 2011](https://hal.inria.fr/inria-00555588/document)
+- [CRDT.tech — Interactive CRDT explanations and references](https://crdt.tech/)
+- [Jepsen: Consistency Models — Kyle Kingsbury](https://jepsen.io/consistency)
+- [x86-TSO: A Rigorous and Usable Programmer's Model for x86 Multiprocessors — Sewell et al., CACM 2010](https://www.cl.cam.ac.uk/~pes20/weakmemory/cacm.pdf)
+- [Arm Developer: The Memory Model](https://developer.arm.com/documentation/100941/0101/The-memory-model)
+- [RISC-V Unprivileged ISA: RVWMO Memory Consistency Model](https://docs.riscv.org/reference/isa/unpriv/rvwmo.html)
+- [Session Guarantees for Weakly Consistent Replicated Data — Terry, Demers, Petersen, et al., 1994](https://dl.acm.org/doi/10.1109/PDIS.1994.331722)
+- [Highly Available Transactions: Virtues and Limitations — Peter Bailis et al., VLDB 2014](https://www.bailis.org/papers/hat-vldb2014.pdf)
+- [Kubernetes API Concepts: Resource Versions](https://kubernetes.io/docs/reference/using-api/api-concepts/)
+- [Spanner: Google's Globally-Distributed Database — Corbett et al., OSDI 2012](https://static.googleusercontent.com/media/research.google.com/en//archive/spanner-osdi2012.pdf)
+- [Distributed Systems for Fun and Profit — Mikito Takada](https://book.mixu.net/distsys/)
 
 ---
 
-## Key Takeaways
+## Next Module
 
-Before moving on, ensure you understand:
-
-- [ ] **The CAP Theorem**: You cannot have both strict Consistency and full Availability during a network Partition. Eventual consistency is the architectural choice of AP over CP.
-- [ ] **Eventual consistency guarantee**: If updates stop, all replicas converge to the same state. No bound on "when"—but usually milliseconds in practice.
-- [ ] **The consistency spectrum**: Linearizability → Sequential → Causal → Session → Eventual. Stronger means more latency and less availability.
-- [ ] **Quorum math**: `W + R > N` for strong consistency. Tuning W and R fundamentally trades consistency for performance.
-- [ ] **Replication trade-offs**: Synchronous is strong but slow. Asynchronous is fast but eventual. Multi-leader is available but causes conflicts.
-- [ ] **Conflict resolution strategies**: Last-write-wins (simple, lossy), merge functions (semantic), version vectors (detect conflicts), CRDTs (conflict-free by design).
-- [ ] **CRDTs eliminate conflicts**: Commutative, associative, and idempotent operations. Examples include G-Counter, PN-Counter, and OR-Set. Use them when available, but note their limited expressiveness.
-- [ ] **Read-your-writes is essential**: Even with eventual consistency, users should see their own updates. Implement via sticky sessions, quorum reads, or version tracking.
-- [ ] **Design for conflict upfront**: "Last-write-wins" is almost never what you want for complex user data.
-
----
-
-## Track Complete: Distributed Systems
-
-Congratulations! You've completed the Distributed Systems foundation. You now understand:
-
-- Why distribution is hard: latency, partial failure, no global clock.
-- Consensus: how nodes agree, and when you absolutely need it.
-- Eventual consistency: when immediate agreement isn't necessary and how to scale.
-- Conflict resolution: handling concurrent updates intelligently.
-
-**Where to go from here:**
-
-| Your Interest | Next Track |
-|---------------|------------|
-| Platform building | [Platform Engineering Discipline](/platform/disciplines/core-platform/platform-engineering/) |
-| Reliability | [SRE Discipline](/platform/disciplines/core-platform/sre/) |
-| Kubernetes deep dive | [CKA Certification](/k8s/cka/) |
-| Observability tools | [Observability Toolkit](/platform/toolkits/observability-intelligence/observability/) |
-
----
-
-## Foundations Complete!
-
-You've now completed all five Foundations tracks:
-
-| Track | Key Takeaway |
-|-------|--------------|
-| Systems Thinking | See the whole system, not just components |
-| Reliability Engineering | Design for failure, measure what matters |
-| Observability Theory | Understand through metrics, logs, traces |
-| Security Principles | Defense in depth, least privilege, secure defaults |
-| Distributed Systems | Consensus when needed, eventual when possible |
-
-These foundations prepare you for the Disciplines and Toolkits tracks, where you'll apply these concepts to real-world practices and tools.
-
-*"A distributed system is one in which the failure of a computer you didn't even know existed can render your own computer unusable."* — Leslie Lamport
-
----
-
-### Key Links
-- [Module 5.2: Consensus and Coordination](../module-5.2-consensus-and-coordination/)
-- [Platform Engineering Discipline](/platform/disciplines/core-platform/platform-engineering/)
-- [SRE Discipline](/platform/disciplines/core-platform/sre/)
-- [CKA Certification](/k8s/cka/)
-- [Observability Toolkit](/platform/toolkits/observability-intelligence/observability/)
+[Module 5.4: Partial Failure and Timeouts](../module-5.4-partial-failure-and-timeouts/) — where you will learn how distributed systems degrade under stress, why "the network is reliable" is the deadliest of the eight fallacies of distributed computing, and how timeouts, retries, and backoff strategies let you build systems that remain resilient when components inevitably fail.

--- a/src/content/docs/platform/foundations/distributed-systems/module-5.4-partial-failure-and-timeouts.md
+++ b/src/content/docs/platform/foundations/distributed-systems/module-5.4-partial-failure-and-timeouts.md
@@ -568,7 +568,7 @@ kubectl get lease kube-controller-manager -n kube-system -o yaml
 
 # Note leaseDurationSeconds, renewTime, and holderIdentity
 # Re-run after ~30 seconds and compare renewTime
-kubectl get lease kube-controller-manager -n kube-system -o jsonpath='{.spec.holderIdentity}{"\n"}{.spec.leaseDurationSeconds}{"\n"}{.status.renewTime}{"\n"}'
+kubectl get lease kube-controller-manager -n kube-system -o jsonpath='{.spec.holderIdentity}{"\n"}{.spec.leaseDurationSeconds}{"\n"}{.spec.renewTime}{"\n"}'
 ```
 
 <details>
@@ -584,7 +584,7 @@ Readiness and liveness probes are another form of timeout policy. They decide wh
 # Pick any running pod in your cluster
 kubectl get pods -A | head -5
 
-# Replace with a pod name from your cluster
+# Dump probe config across all kube-system pods (no name needed — this lists them)
 kubectl get pod -n kube-system -o yaml | rg -n "livenessProbe|readinessProbe|timeoutSeconds|periodSeconds|failureThreshold" -A2
 ```
 
@@ -646,7 +646,7 @@ Before moving on, ensure you understand:
 
 ---
 
-## Further Reading
+## Sources
 
 - Martin Kleppmann, [Designing Data-Intensive Applications](https://dataintensive.net/) - replication, consistency, fault tolerance, and the design trade-offs behind reliable data systems.
 - AWS Builders Library, [Timeouts, retries, and backoff with jitter](https://aws.amazon.com/builders-library/timeouts-retries-and-backoff-with-jitter/) - practical guidance on timeout selection, idempotency, retry amplification, and jitter.
@@ -666,12 +666,13 @@ Before moving on, ensure you understand:
 
 Partial failure is the foundation for the remaining distributed-systems mental models. When you see a remote call time out, think in terms of uncertainty, delivery semantics, idempotency, retry budgets, and overload protection. These habits apply directly to platform operations: Kubernetes controllers retry reconciliation, service meshes enforce deadlines, queues redeliver messages, and user-facing APIs must protect downstream systems when the tail gets slow.
 
-Continue into the Platform Disciplines tracks when you want to apply these mental models to SRE, platform engineering, GitOps, and observability practice.
+The next module turns from *whether* a remote call succeeded to *when* events actually happened. [Module 5.5: Clock Skew and Ordering](../module-5.5-clock-skew-and-ordering/) explains why wall-clock timestamps are untrustworthy across machines, and how logical clocks recover a usable ordering of events without a shared "now."
 
 ### Key Links
 
 - [Module 5.1: What Makes Systems Distributed](../module-5.1-what-makes-systems-distributed/)
 - [Module 5.2: Consensus and Coordination](../module-5.2-consensus-and-coordination/)
 - [Module 5.3: Eventual Consistency](../module-5.3-eventual-consistency/)
+- [Module 5.5: Clock Skew and Ordering](../module-5.5-clock-skew-and-ordering/)
 - [SRE Discipline](/platform/disciplines/core-platform/sre/)
 - [Platform Engineering Discipline](/platform/disciplines/core-platform/platform-engineering/)

--- a/src/content/docs/platform/foundations/distributed-systems/module-5.5-clock-skew-and-ordering.md
+++ b/src/content/docs/platform/foundations/distributed-systems/module-5.5-clock-skew-and-ordering.md
@@ -446,7 +446,7 @@ This is the final distributed-systems foundation lesson currently available in t
 
 ---
 
-## Further Reading
+## Sources
 
 - **[Leslie Lamport, "Time, Clocks, and the Ordering of Events in a Distributed System"](https://lamport.azurewebsites.net/pubs/time-clocks.pdf)** - The foundational paper for happens-before, logical clocks, and why distributed ordering cannot start with physical clock assumptions.
 - **[Martin Kleppmann, "Designing Data-Intensive Applications"](https://dataintensive.net/)** - The clearest practitioner treatment of replication, clocks, consistency guarantees, and the hazards of timestamp-based conflict resolution.


### PR DESCRIPTION
Wave 5 of the **Platform Foundations** campaign (#1897), processed in curriculum order. Brings the Distributed Systems sub-track (5 critical-score modules) to T0 + score-cleared.

## Modules

| Module | Before | After | Author → Reviewer |
|---|---|---|---|
| 5.1 what-makes-systems-distributed | T3 309w 0src | **T0 5214w 14src** | codex → cursor |
| 5.2 consensus-and-coordination | T3 856w 0src | **T0 5184w 14src** | cursor → codex |
| 5.3 eventual-consistency | T3 1369w 0src | **T0 7123w 15src** | deepseek → cursor |
| 5.4 partial-failure-and-timeouts | T0 (flip) | **T0 5603w** | opus review |
| 5.5 clock-skew-and-ordering | T0 (flip) | **T0 5156w** | opus review |

## Verifier-blind defects the review layer caught (all ground-checked + web-verified)

- **5.1** — opener repeated the AWS-S3-2017 fabrication (corrected last session in 3.1): `$150M` stated as fact + "mistyped command took the index offline". Corrected to the accurate post-mortem causal chain (billing-subsystem removal → over-broad → index+placement restart, multi-hour recovery); `$150M` reframed as an external Cyence estimate (not AWS-reported). Kept the `incident-xref` marker; post-mortem NOT cited in `## Sources` (dedup gate). cursor R1 also caught that the line-29 cross-link falsely claimed reliability 2.2 *hosts* the full S3 case study (2.2 is a labeled hypothetical + registry owner only) — reworded to 2.2's actual failure-mode-taxonomy/blast-radius teaching.
- **5.2** — de-fabbed the `$4.2M etcd Split-Brain` War Story → `Hypothetical scenario:`. codex R1 caught real Raft errors: commit-safety missing the current-term rule (§5.4.2), "heartbeats are noop writes" (they're empty AppendEntries), and "minority partition accepts writes" (it appends locally but can never commit/ack without a quorum). Fixed at all occurrences.
- **5.3** — de-fabbed the `$8.2M Shopping Cart` War Story → `Hypothetical Scenario:` (Amazon Dynamo cited for the real mergeable-cart design). cursor R1 caught a **fabrication** (false "Google Docs abandoned OT" — removed) and a **K8s factual error** (`resourceVersion` is optimistic concurrency → HTTP 409, not silent LWW — hands-on reframed as an explicit overwrite *analogy*); also quorum≠linearizability, x86 TSO/weak-memory, and a quiz durability overstatement.
- **5.4** — opus caught a Lease jsonpath bug (`.status.renewTime` → `.spec.renewTime`; Lease has no status subresource) and a missing forward-nav to 5.5.
- **5.4 + 5.5** — renamed `## Further Reading` → `## Sources`. This is the real score-clearing fix: the heuristic scorer (`local_api.py`) caps score at 1.5 without a literal `## Sources` block — that is *why* these two T0 modules were on the critical-score list, not a stale flag.

## Verification

- Build (full astro, worktree): **2171 pages, Complete!**, 0 schema errors.
- `incident_dedup_gate.py` (run from worktree): **PASS**.
- `check_site_health.py`: **0 errors** (8 pre-existing warnings, none in distributed-systems).
- Every module re-verified **T0** after its fix pass. Cross-family reviewers: opus / codex / cursor (NO gemini — retired). Every reviewer finding ground-checked both ways.

Refs #1897