### PR TITLE
feat(analytics): add GoatCounter to all pages

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -81,6 +81,19 @@ export default defineConfig({
       title: 'KubeDojo',
       tagline: 'Free, comprehensive cloud native education',
       disable404Route: true,
+      // GoatCounter — privacy-friendly analytics (no cookies). Injected into the
+      // <head> of every page via the default Starlight Head (kept by our custom
+      // src/components/Head.astro override, which renders <Default>).
+      head: [
+        {
+          tag: 'script',
+          attrs: {
+            'data-goatcounter': 'https://kube-dojo.goatcounter.com/count',
+            src: '//gc.zgo.at/count.js',
+            async: true,
+          },
+        },
+      ],
       expressiveCode: {
         shiki: {
           langAlias: {

--- a/src/layouts/Homepage.astro
+++ b/src/layouts/Homepage.astro
@@ -29,6 +29,10 @@ const aimlHref = t.lang === 'uk' ? '/ai-ml-engineering/' : `${p}/ai-ml-engineeri
   <meta name="description" content={t.description} />
   <link rel="canonical" href={t.canonical} />
   <link rel="shortcut icon" href="/favicon.svg" type="image/svg+xml" />
+  <!-- GoatCounter — privacy-friendly analytics (no cookies). This custom homepage
+       layout does not render the Starlight Head, so the script is added directly
+       here; all Starlight content pages get it via the head[] config in astro.config.mjs. -->
+  <script is:inline data-goatcounter="https://kube-dojo.goatcounter.com/count" async src="//gc.zgo.at/count.js"></script>
   <style>
     :root {
       --kube-blue: #326CE5;


### PR DESCRIPTION
Adds the GoatCounter (privacy-friendly, cookieless) analytics snippet for `kube-dojo.goatcounter.com` to every page.

**Two injection points** (the site has both Starlight content pages and a custom homepage layout):
- `astro.config.mjs` — Starlight `head[]` config → injects `count.js` into the `<head>` of all **2168** Starlight content pages (rendered by the default Starlight Head, which our `src/components/Head.astro` override keeps via `<Default>`).
- `src/layouts/Homepage.astro` — the custom homepage layout (en + uk homepages) doesn't render the Starlight Head, so the loader is added there directly with `is:inline` (so Astro emits the external script verbatim, no bundling).

**Verified locally** (CI has no full astro build): `npm run build` green (2171 pages); the script renders in `<head>` on all **2170** rendered pages. The only pages without it are `<meta http-equiv=refresh>` redirect stubs (they bounce to the real page, which carries it) and `/test/` (a build-debug page).

**No Subresource Integrity** (`integrity`/`crossorigin`): GoatCounter's `count.js` is a vendor-updated loader served from their CDN, and the official snippet omits SRI — pinning a hash would silently break analytics on every upstream update. Matches the snippet provided.

Merging deploys to GitHub Pages → analytics live.

🤖 Generated with [Claude Code](https://claude.com/claude-code)