### PR TITLE
feat(uk): re-wire uk_sync.py translation dispatch gemini-cli → agy (#1911)

### DIFF
--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -19,6 +19,7 @@ import signal
 import shutil
 import subprocess
 import sys
+import tempfile
 import threading
 import time
 from datetime import UTC, datetime
@@ -26,6 +27,7 @@ from pathlib import Path
 
 import psutil
 
+from agent_runtime.adapters.agy import AgyAdapter
 from agent_runtime.env_sanitize import build_agent_env
 from agent_runtime.redact import redact_text
 from ai_agent_bridge._prompts import build_review_message
@@ -506,6 +508,80 @@ def dispatch_gemini_with_retry(prompt: str, model: str = GEMINI_DEFAULT_MODEL,
         return False, output
 
     return False, output
+
+
+AGY_TRANSLATE_MODEL = "gemini-3.1-pro-high"
+
+_AGY_FILE_WRITE_SUFFIX = (
+    "\n\nWrite your COMPLETE Ukrainian translation as raw Markdown to this "
+    "absolute file path and write NOTHING to stdout: {out_path}. Do NOT abridge, "
+    "summarize, or omit any section — reproduce every paragraph, table row, "
+    "list item, and quiz Q&A. If the source has a `## Sources` section, "
+    "translate and include it."
+)
+
+
+def dispatch_agy_translate(prompt: str, *, timeout: int = 600) -> tuple[bool, str]:
+    """Translate via agy CLI; read Ukrainian output from a temp file, not stdout.
+
+    agy returns a prose summary on stdout. The caller contract matches
+    ``dispatch_gemini_with_retry``: ``(ok, translated_text)``.
+    """
+    adapter = AgyAdapter()
+
+    def _run_once() -> tuple[bool, str]:
+        with tempfile.TemporaryDirectory() as td:
+            out_path = os.path.join(td, "translation.md")
+            full_prompt = prompt + _AGY_FILE_WRITE_SUFFIX.format(out_path=out_path)
+            cwd = Path(td)
+            plan = adapter.build_invocation(
+                prompt=full_prompt,
+                mode="danger",
+                cwd=cwd,
+                model=AGY_TRANSLATE_MODEL,
+                task_id=None,
+                session_id=None,
+                tool_config=None,
+            )
+            env = build_agent_env(provider="agy", overrides=_AGENT_ENV_OVERRIDES)
+            t0 = time.time()
+            try:
+                result = subprocess.run(
+                    plan.cmd,
+                    capture_output=True,
+                    text=True,
+                    cwd=str(plan.cwd),
+                    env=env,
+                    timeout=timeout,
+                )
+            except subprocess.TimeoutExpired:
+                elapsed = time.time() - t0
+                _log("agy-translate", AGY_TRANSLATE_MODEL, prompt, "", False, elapsed, "TIMEOUT")
+                print(f"agy translation timed out after {timeout}s", file=sys.stderr)
+                return False, "TIMEOUT"
+            except FileNotFoundError:
+                elapsed = time.time() - t0
+                _log("agy-translate", AGY_TRANSLATE_MODEL, prompt, "", False, elapsed, "CLI not found")
+                print("agy CLI not found.", file=sys.stderr)
+                return False, "agy CLI not found"
+
+            elapsed = time.time() - t0
+            out_file = Path(out_path)
+            if out_file.is_file():
+                text = out_file.read_text()
+                if text.strip():
+                    _log("agy-translate", AGY_TRANSLATE_MODEL, prompt, text, True, elapsed)
+                    return True, text
+
+            err = redact_text((result.stderr or result.stdout or "no file written").strip())
+            _log("agy-translate", AGY_TRANSLATE_MODEL, prompt, "", False, elapsed, err)
+            return False, err or "no file written"
+
+    ok, output = _run_once()
+    if ok:
+        return True, output
+    print("agy translation failed — retrying once", file=sys.stderr)
+    return _run_once()
 
 
 _CLAUDE_TEXT_ONLY_DISALLOWED = (

--- a/scripts/uk_sync.py
+++ b/scripts/uk_sync.py
@@ -3,7 +3,7 @@
 
 One tool for all Ukrainian translation work. Detects stale translations,
 finds missing files, translates new modules, and fixes incomplete ones.
-Uses Gemini + MCP RAG for translation with Ukrainian quality verification.
+Uses agy (gemini-3.1-pro-high) for translation with Ukrainian quality verification.
 
 Usage:
     .venv/bin/python scripts/uk_sync.py status                    # full report
@@ -38,10 +38,9 @@ REPORT_FILE = REPO_ROOT / ".pipeline" / "uk-sync-report.json"
 sys.path.insert(0, str(REPO_ROOT / "scripts"))
 
 from checks import ukrainian
-from dispatch import GEMINI_WRITER_MODEL, dispatch_gemini_with_retry
+from dispatch import dispatch_agy_translate
 
 CHUNKED_THRESHOLD = 40_000  # chars — modules above this use section-by-section translation
-CHUNKED_MODEL = GEMINI_WRITER_MODEL  # pro for quality on section-by-section
 BATCH_LIMIT = 15_000  # chars — pack adjacent sections into batches up to this size
 
 
@@ -522,7 +521,7 @@ def _translate_chunked(en_path: Path, en_content: str, en_commit: str, en_file: 
         en_file=en_file,
     )
     print(f"    [1/{total_batches}] Preamble + {first_h2[:40]} ({len(merged_content)} chars)...")
-    ok, output = dispatch_gemini_with_retry(prompt, model=CHUNKED_MODEL, mcp=True, timeout=600)
+    ok, output = dispatch_agy_translate(prompt, timeout=600)
 
     if not ok or not output.strip():
         print("    ✗ Preamble translation failed")
@@ -584,7 +583,7 @@ def _translate_chunked(en_path: Path, en_content: str, en_commit: str, en_file: 
             section_heading=batch_keys[0],  # first heading for context
             section_body=batch_content,  # full batch content
         )
-        ok, output = dispatch_gemini_with_retry(prompt, model=CHUNKED_MODEL, mcp=True, timeout=300)
+        ok, output = dispatch_agy_translate(prompt, timeout=300)
 
         if not ok or not output.strip():
             print(f"    ✗ Batch failed: {batch_headings} — aborting module")
@@ -632,7 +631,7 @@ def translate_new_module(en_path: Path) -> bool:
             en_file=en_file,
         )
 
-        ok, output = dispatch_gemini_with_retry(prompt, mcp=True, timeout=600)
+        ok, output = dispatch_agy_translate(prompt, timeout=600)
 
         if not ok or not output.strip():
             print(f"  ✗ Translation failed")


### PR DESCRIPTION
Epic #1911 AC #1 — the bulk Ukrainian-translation lane.

## What
- `scripts/dispatch.py`: new `dispatch_agy_translate(prompt, *, timeout)` — drives agy via `AgyAdapter` (danger mode, temp-dir as `--add-dir` root, **absolute** out-path so agy writes in-place, not to its sandbox mirror), reads the translation from the file (agy returns a summary on stdout), returns `(ok, text)` to match the old gemini contract. Retry-once.
- `scripts/uk_sync.py`: swap the 3 `dispatch_gemini_with_retry` call-sites → `dispatch_agy_translate`. Chunking / truncation-guards / frontmatter / assembly **unchanged**.

## Why this shape
Empirically: agy writes in-place only for absolute paths inside `--add-dir`; it has a ~3k-word output cap (silently abridges larger single calls). The existing chunker (`BATCH_LIMIT` 15k chars ≈ 2.2k words/batch) keeps each call under the cap.

## Validation (orchestrator, real module)
`uk_sync.py translate modern-devops/1.5-platform-engineering` (7586w EN) → **7557 UK words** (ratio 0.996, complete), **27/27 headings** (incl. Sources + Next Module), 17 sections → 6 batches, 0 Russicism letters. `uk_sync` imports clean.

Refs #1911

🤖 Generated with [Claude Code](https://claude.com/claude-code)