### PR TITLE
feat(uk): full-read calque review — module 0.2 (clean), board 2/51 (#1934)

### DIFF
--- a/src/content/docs/uk/prerequisites/zero-to-terminal/module-0.2-what-is-a-terminal.md
+++ b/src/content/docs/uk/prerequisites/zero-to-terminal/module-0.2-what-is-a-terminal.md
@@ -6,6 +6,12 @@ sidebar:
 revision_pending: false
 en_commit: "e75b3670185808314327c0642a490984a327c752"
 en_file: "src/content/docs/prerequisites/zero-to-terminal/module-0.2-what-is-a-terminal.md"
+calque_review:
+  reviewed_at: "2026-06-13"
+  detector_version: "v1"
+  status: "clean"
+  flags_resolved: 0
+  content_sha: "b4acb9b17115a769fce0880b1d5430eba72d70a90ef211cdf5092451e8733065"
 ---
 > **Складність**: `[ШВИДКО]` - Абсолютний новачок
 >


### PR DESCRIPTION
## What
Second page of the full-read UK calque review (issue #1934): `module-0.2-what-is-a-terminal.md`.

**Full-read reviewed — clean.** Every sentence read in context. The s139 translation is strong; the one borderline phrase (`скопіювати один в один`) was MCP-verified as a **legitimate Ukrainian idiom** (Фразеологічний словник, with literary citations from Панас Мирний / Стельмах) — NOT a Russicism, so it was correctly left untouched (avoiding over-editing). No calques found. Stamped `calque_review: status=clean, flags_resolved=0`.

Board: prerequisites calque-reviewed **2 / 51**.

## Method note
This confirms the emerging pattern: the s139 prerequisites translations are high quality (they were hand-fixed during re-translation), so the full read mostly **certifies** pages clean and occasionally catches a real calque (as on 0.1). The dashboard stamp is the proof each page was actually read sentence-by-sentence, not assumed.

## Verification
- `npm run build` green; UK russicism gate exit 0; stamp round-trips (`status` reads `clean`, not stale).

## Learner check
> **Передумови**: Жодних. Серйозно, жодних. Якщо ви можете прочитати це речення, ви готові.

Part of #1934 (epic #1911).
