### PR TITLE
feat(content): Platform Disciplines wave 1 — FinOps 1.1/1.2/1.3 → T0 (#1953)

### DIFF
--- a/src/content/docs/platform/disciplines/business-value/finops/module-1.1-finops-fundamentals.md
+++ b/src/content/docs/platform/disciplines/business-value/finops/module-1.1-finops-fundamentals.md
@@ -8,17 +8,13 @@ sidebar:
 
 ## Prerequisites
 
-Before starting this module:
-- **Required**: Basic understanding of cloud computing (AWS, GCP, or Azure)
-- **Required**: Familiarity with on-demand cloud services (compute, storage, networking)
-- **Recommended**: Access to a cloud billing console (even a free-tier account)
-- **Recommended**: Spreadsheet skills for cost analysis
+This module assumes you already understand what compute, storage, and networking mean in a public cloud context — any major provider suffices. You should be comfortable reading a monthly invoice or cost export at a high level, even if you have never built a FinOps practice. Access to a billing console or sample Cost and Usage Report accelerates the hands-on exercise, and basic spreadsheet or command-line aggregation skills help you reproduce the analysis patterns on your own data.
 
 ---
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+When you finish this module, you can explain how FinOps connects engineering decisions to financial outcomes and apply that lens to real invoices. The following outcomes describe specific capabilities you will practice in the sections and assessments below:
 
 - **Design a FinOps practice with clear roles, responsibilities, and organizational reporting structures**
 - **Implement cloud cost visibility using tagging strategies and cost allocation frameworks**
@@ -27,51 +23,29 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-Your company just got its first six-figure cloud bill. The CTO is panicking. The VP of Engineering says "we need to optimize." The CFO wants to know *who* spent *what* and *why*.
+Your company just received its first six-figure cloud bill. The CTO is alarmed because infrastructure spend jumped faster than revenue. The VP of Engineering says the team must optimize immediately, but nobody can explain which product lines drove the increase. The CFO wants to know who spent what, and whether that spend produced measurable business value.
 
-Welcome to FinOps.
+Cloud computing inverted the economics of IT. Before cloud, you bought servers upfront as capital expenditure, and finance amortized those assets over three to five years. Procurement cycles were slow, but budgets were predictable. Engineers requested hardware months in advance; finance signed purchase orders once per quarter.
 
-Cloud computing flipped the economics of IT upside down. Before cloud, you bought servers upfront (CapEx), and the finance team amortized them over 3-5 years. Predictable. Boring. Safe.
+Now any developer with cloud credentials can provision compute, storage, and managed services in minutes. The invoice arrives weeks later, often with line items that finance cannot map to products or teams. Engineering speaks in requests, limits, and availability zones; finance speaks in cost centers, accruals, and variance reports. Without a shared language, both sides talk past each other while spend compounds.
 
-Now? Any developer with an AWS credential can spin up a $50,000/month machine learning cluster before lunch. The bill arrives 30 days later. Finance has no idea what `m6i.24xlarge` means, and Engineering has no idea what "accrual accounting" means.
+FinOps bridges this gap. It is a cultural practice — not a single tool — that brings financial accountability to the speed and elasticity of cloud. Engineers receive timely, actionable cost data so they can trade off performance, reliability, and price deliberately. Finance receives allocation coverage and unit economics so forecasts reflect how the business actually consumes infrastructure.
 
-**FinOps bridges this gap.** It's a cultural practice that brings financial accountability to cloud spending — giving engineers the data they need to make smart tradeoffs, and giving finance the visibility they need to sleep at night.
+> **Stop and think**: If an engineering team provisions a cluster that costs twice as much but enables releasing features twice as fast, is that optimization or waste? FinOps provides the framework to answer that question with evidence instead of opinion.
 
-> **Stop and think**: If an engineering team provisions a cluster that costs twice as much but enables releasing features twice as fast, is that an optimization or a waste? FinOps provides the framework to answer this.
+Without FinOps, cloud bills can grow faster than the business value they support. Teams hoard capacity just in case. Nobody knows the true cost of shipping a feature. Finance discovers overruns only after month-end close. With FinOps, teams own their spend, cost becomes a first-class engineering metric, and leadership decisions rest on unit economics rather than a single scary total.
 
-Without FinOps:
-- Cloud bills can grow faster than the business value they support
-- Teams hoard resources "just in case"
-- Nobody knows the true cost of a feature
-- Finance discovers overruns weeks after they happen
-
-With FinOps:
-- Teams own their spend and optimize proactively
-- Cost is a first-class engineering metric
-- Unit economics drive architectural decisions
-- Finance and Engineering speak the same language
+Hypothetical scenario: A product organization launches a successful campaign that doubles traffic over a weekend. Gross cloud spend rises sharply while cost per active user actually improves because autoscaling absorbed the spike without emergency hardware purchases. FinOps gives leadership the vocabulary to celebrate efficient growth instead of punishing the team that kept the service available. The opposite story — flat revenue with climbing unit cost — becomes visible early enough to investigate architecture and allocation before the quarter closes.
 
 ---
 
-## Did You Know?
+## Part 1: The FinOps Lifecycle — Inform, Optimize, Operate
 
-- **Cloud cost overruns and waste are common operational risks.** Idle and over-provisioned resources are common culprits when teams lack visibility and ownership.
+The FinOps Foundation defines a lifecycle with three phases that run as a continuous improvement loop, not a one-time project. Mature organizations execute all three phases simultaneously: you never finish informing, because new services and teams constantly appear; you never finish optimizing, because workloads and prices change; you never finish operating, because governance and culture require ongoing reinforcement.
 
-- **The FinOps Foundation ([part of The Linux Foundation](https://www.linuxfoundation.org/press/press-release/the-linux-foundation-brings-together-it-and-finance-teams-to-advance-cloud-financial-management-and-education)) has a large practitioner community** across many organizations. FinOps is now a recognized discipline with its own certification (FinOps Certified Practitioner), framework, and community — not just "someone looking at the bill."
+### Phase 1: Inform — See Where Money Goes
 
-- **Large streaming platforms may spend heavily on cloud infrastructure**, so their FinOps focus often shifts toward unit-cost efficiency such as cost per streaming hour. That's FinOps in action — not reducing spend, but maximizing *value per dollar spent*.
-
----
-
-## The FinOps Foundation Framework
-
-The FinOps Foundation defines a lifecycle with three phases. Think of it as a continuous improvement loop, not a one-time project.
-
-### Phase 1: Inform
-
-**Goal**: See what you're spending, who's spending it, and whether it aligns with business value.
-
-This is where most organizations start — and many never leave. Visibility is the foundation.
+The Inform phase answers one question: where is our money going, and does that spending align with business priorities? Most organizations begin here, and many stall because they treat visibility as a dashboard project instead of a data-quality discipline. Inform produces trusted allocation, baseline unit economics, and shared vocabulary between engineering and finance.
 
 ```mermaid
 graph LR
@@ -82,18 +56,17 @@ graph LR
     end
 ```
 
-Key activities in the Inform phase:
-- **Ingest billing data** from all cloud providers
-- **Tag resources** so costs can be attributed to teams, products, and environments
-- **Build dashboards** that show spend trends, anomalies, and forecasts
-- **Allocate shared costs** (networking, support, platform teams)
-- **Define unit economics** (cost per customer, cost per transaction)
+Ingesting billing data from every cloud account and service is the mechanical first step. Raw invoices and Cost and Usage Reports must land in a warehouse or cost tool with consistent granularity — hourly or daily, by resource, by tag, by region. Tagging strategy turns that raw feed into attributable spend: without labels, you see totals; with labels, you see owners. Dashboards and reports translate attributed data into trends, anomalies, and forecasts that teams review on a cadence.
 
-### Phase 2: Optimize
+Finance teams often receive consolidated invoices while engineering teams experience cost through accounts, subscriptions, or folders. Inform must reconcile those hierarchies so a single service owner does not appear under three different names in three exports. Standardize account naming, map subscriptions to cost centers, and document which organizational unit owns shared networking assets before you publish the first showback deck.
 
-**Goal**: Reduce waste and improve the cost efficiency of cloud resources.
+Inform also allocates shared costs — networking, support plans, platform engineering, security tooling — using rules everyone agrees on before the numbers appear in a chargeback report. Changing the key monthly destroys trust; document assumptions and revisit on a quarterly cadence. Finally, Inform defines unit economics: cost per customer, per transaction, or per API call. Those ratios become the north star that prevents panic when gross spend rises alongside healthy growth.
 
-Once you can see where the money goes, you can start making it go further.
+### Phase 2: Optimize — Spend Smarter, Not Just Less
+
+Optimize asks how to improve cost efficiency without breaking reliability or delivery speed. Visibility alone does not save money; informed engineering decisions do. Rightsizing matches provisioned capacity to measured utilization. Pricing model selection trades flexibility for discount through reservations, savings plans, or spot capacity where interruption tolerance exists.
+
+Optimize is where engineering judgment matters most. A smaller instance type might save money but violate latency SLOs during traffic spikes. FinOps practitioners bring data — utilization percentiles, throttling events, error budgets — so teams choose informed tradeoffs instead of defaulting to the largest available SKU because an incident once caused pain.
 
 ```mermaid
 graph LR
@@ -104,17 +77,11 @@ graph LR
     end
 ```
 
-Key activities in the Optimize phase:
-- **Rightsize instances** — match resources to actual utilization
-- **Select pricing models** — Reserved Instances, Savings Plans, Spot
-- **Eliminate waste** — unused resources, old snapshots, idle load balancers
-- **Architect for cost** — serverless, autoscaling, multi-tier storage
+Eliminating waste — idle instances, orphaned volumes, forgotten load balancers — often yields fast wins with low risk. Architectural changes — tiered storage, autoscaling, serverless for spiky work — compound savings over quarters. Optimize is iterative: each change shifts utilization patterns, which may invalidate yesterday's reservation strategy. That is why Optimize runs in parallel with Inform, not after it.
 
-### Phase 3: Operate
+### Phase 3: Operate — Sustain the Practice
 
-**Goal**: Build organizational processes that sustain cost optimization continuously.
-
-This is where FinOps becomes a *culture*, not just a project.
+Operate embeds cost discipline into how the organization works every day. Budgets and alerts translate forecasts into guardrails teams feel before month-end surprises. Automation enforces policies: scheduled shutdowns for non-production environments, tag enforcement at deploy time, approval workflows for expensive SKUs.
 
 ```mermaid
 graph LR
@@ -125,16 +92,13 @@ graph LR
     end
 ```
 
-Key activities in the Operate phase:
-- **Set budgets and alerts** per team, environment, and project
-- **Automate cost controls** — scheduled shutdowns, auto-rightsizing
-- **Establish governance** — approval workflows for expensive resources
-- **Regular reviews** — weekly cost standups, monthly business reviews
-- **Continuous improvement** — refine forecasts, update commitments
+Governance defines who can approve exceptions and how escalations work when a team exceeds budget. A mature Operate practice documents exception paths — who can approve a temporary GPU cluster for a training sprint, for how long, and with what post-hoc review — so urgency during incidents does not become permanent expensive footprint.
+
+Regular reviews — weekly engineering cost standups, monthly business reviews with finance — keep attention on unit economics instead of one annual scramble. Continuous improvement refines forecasts, revisits commitments, and updates allocation rules as the product portfolio evolves. Operate is also where you measure FinOps maturity honestly and publish next-quarter priorities based on gaps, not vanity scores.
 
 ### The Lifecycle in Motion
 
-These phases aren't sequential. A mature FinOps practice runs all three simultaneously:
+These phases are not a waterfall. A mature FinOps practice runs Inform, Optimize, and Operate as a single loop:
 
 ```mermaid
 graph TD
@@ -143,201 +107,141 @@ graph TD
     C -->|Continuous Loop| A
 ```
 
+When Inform exposes a tagging gap, Operate updates IaC policies. When Optimize rightsizes a service, Inform refreshes unit-cost dashboards. When Operate sets a budget alert, Optimize investigates the spike before it becomes structural waste. Treating any phase as "complete" is a category error: new services, acquisitions, and product lines continually reintroduce unknown spend that Inform must absorb.
+
+### What Each Phase Produces
+
+Inform delivers **trusted allocation** — tagged spend, shared-cost rules, allocation coverage metrics, and baseline unit economics. Optimize delivers **efficiency gains** — smaller footprints, better pricing-model fit, and architectural patterns that reduce waste without breaching SLOs. Operate delivers **sustainability** — budgets, forecasts, governance cadence, maturity scores, and cultural habits that survive reorganizations and leadership changes. Artifacts from each phase should be written down: allocation runbooks, commitment portfolios, and review agendas that new FinOps practitioners can inherit.
+
 ---
 
-## Cloud Billing 101
+## Part 2: FinOps Foundation Framework — Domains, Capabilities, and Personas
 
-### The Three Dimensions of Cloud Cost
+The [FinOps Foundation Framework](https://www.finops.org/framework/) organizes durable practice into domains, capabilities, and personas. Domains describe *what* you manage: understanding cloud usage and cost, performance tracking and benchmarking, real-time decision making, cloud rate optimization, and organizational alignment. Capabilities describe *how* you execute within each domain — for example allocation, budgeting, forecasting, workload optimization, and licensing strategy.
 
-Every cloud resource has a cost determined by three factors:
+Personas clarify who does what. Engineers and engineering managers consume allocation data and act on rightsizing recommendations. Finance and procurement own commitments, invoices, and variance analysis. Leadership sets guardrails and evaluates unit economics against business goals. Product managers connect feature investment to marginal infrastructure cost. A FinOps practitioner — sometimes a dedicated role, sometimes a coalition — coordinates tooling, cadence, and maturity assessments across those personas.
+
+Designing a FinOps practice means wiring those personas into reporting structures that do not collapse into a central team doing everyone else's optimization. Central teams provide standards, tooling, and training; engineering teams own workload-level decisions because they understand latency, redundancy, and release risk. Finance owns the chart of accounts mapping and commitment portfolio. Leadership owns policy: when to prioritize margin versus speed, and which unit metric is authoritative for a given product line.
+
+Reporting structures should make accountability obvious in every review deck. Engineering managers see their team's allocation trend and unit metric; finance sees commitment utilization and forecast variance; product sees marginal infrastructure cost of roadmap bets. When those views disagree, the FinOps practitioner investigates data quality first — duplicate tags, missing shared splits, stale forecasts — before declaring a team "out of control."
+
+### Maturity: Crawl, Walk, Run
+
+The framework describes maturity as crawl, walk, run — not a single maturity score for the whole company. An organization might *run* on reservation management while still *crawling* on Kubernetes allocation. Maturity assessments should score capabilities independently, publish gaps honestly, and sequence investments where low maturity blocks higher-value work.
+
+| Maturity stage | Typical signal | Example focus |
+|----------------|----------------|---------------|
+| **Crawl** | Reactive, invoice-driven | Export bills, basic tagging, executive dashboard |
+| **Walk** | Proactive team ownership | Showback, budgets, monthly reviews, RI/SP basics |
+| **Run** | Embedded in engineering flow | Chargeback, automated policies, unit economics in OKRs |
+
+Building a maturity assessment starts with capability checklists derived from the framework: allocation coverage percentage, forecast accuracy, commitment utilization, anomaly response time, and percentage of engineering teams receiving regular cost feedback. Reassess quarterly; celebrate crawl→walk progress on one capability instead of claiming FinOps is "done."
+
+### Domains in Practice
+
+**Understand cloud usage and cost** is the Inform backbone: ingestion, allocation, shared splits, and invoice reconciliation. **Quantify business value** connects those dollars to product outcomes — revenue per tenant, margin per order — so optimization debates reference value, not fear. **Optimize cloud rates and usage** covers rightsizing, commitment instruments, and architectural efficiency without confusing "cheaper" with "worse." **Manage the FinOps practice** covers personas, training, tooling standards, and the operating cadence that keeps finance and engineering aligned when priorities conflict.
+
+---
+
+## Part 3: Anatomy of a Cloud Bill
+
+A cloud invoice is not one number — it is a stack of meters, each with its own unit and pricing axis. Learning to read those line items is the foundation of Inform. Most provider bills group spend into compute, storage, networking (especially data transfer and egress), and managed services (databases, Kubernetes control planes, message queues, observability backends).
+
+Compute charges usually reflect instance hours, vCPU/memory size, and pricing model (on-demand, committed, spot). Storage bills combine capacity, access tier, and operations (PUT/LIST requests). Networking costs surprise teams because they are usage-based and cross-region: egress from a popular service to the public internet can dominate a seemingly small application. Managed services add their own SKUs — per-node cluster fees, per-GB ingestion, per-million API calls — that do not appear in simple VM spreadsheets.
+
+Every charge sits on three durable dimensions that behave the same way whether you read an AWS, GCP, or Azure export: what resource type metered the usage, how much was consumed, and which pricing model applied to that consumption window. Internalizing those dimensions lets you compare rows across services without memorizing every product code.
 
 | Dimension | Description | Example |
 |-----------|-------------|---------|
-| **Resource type** | What you're using | EC2 instance, S3 bucket, RDS database |
-| **Usage quantity** | How much/long you use it | 730 hours, 500 GB, 1M API calls |
-| **Pricing model** | How you pay | On-demand, Reserved, Spot |
+| **Resource type** | What you're using | Virtual machine, object bucket, managed database |
+| **Usage quantity** | How much or how long | Instance hours, stored gigabytes, API calls |
+| **Pricing model** | How you pay | On-demand, committed discount, interruptible capacity |
 
-Understanding these dimensions is the key to reading any cloud bill.
+Hypothetical scenario: A platform team sees a month-over-month jump from $120,000 to $158,000. Drilling into the bill reveals compute flat, storage up slightly, and networking egress doubling because a new analytics export copied production data cross-region nightly. Without line-item literacy, leadership might blame "too many servers" and miss the actual lever.
 
-### Pricing Models Explained
+### Managed Services and Hidden Meters
 
-#### On-Demand (Pay-As-You-Go)
+Managed databases, Kubernetes control planes, message buses, and observability backends bill on their own meters — vCPU and storage for databases, per-cluster hourly fees, per-million requests, per-gigabyte ingestion. These lines rarely appear in the same spreadsheet engineers use for VM counts, yet they compound silently as microservices multiply. FinOps Inform must include managed SKUs in the same allocation taxonomy as compute instances, tagging the projects that provisioned them or mapping shared platform cost explicitly.
 
-The default. [No commitment](https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/select-the-best-pricing-model.html). Maximum flexibility. Maximum price.
+Support plans, enterprise agreements, and marketplace purchases add another layer above raw infrastructure. Finance often recognizes these centrally while engineering attributes workload cost locally. Document which fees stay corporate overhead versus which pass through to product P&L so chargeback debates do not reopen settled accounting policy every month.
+
+### On-Demand, Committed, and Interruptible Pricing
+
+On-demand is the default pay-as-you-go model: no commitment, maximum flexibility, highest unit price. Committed discounts — Reserved Instances, Savings Plans, Committed Use Discounts — trade term and predictability for lower rates. Interruptible capacity (Spot, Preemptible VMs) trades availability guarantees for steep discounts on spare capacity.
+
+The durable principle is flexibility versus price, not memorizing every SKU name. Stable baselines belong on commitments once usage is observable. Bursty or experimental work stays on-demand or interruptible tiers with explicit fault-tolerance design. When in doubt, model three scenarios in a spreadsheet — on-demand only, partial commitment, full commitment — using your observed hourly usage before asking finance to sign a term.
+
+Interruptible workloads require engineering guarantees, not finance optimism. Stateless workers, queue consumers, and batch jobs that checkpoint progress can survive reclamation events; synchronous user-facing paths usually cannot. Document interruption tolerance in service catalogs so FinOps reviewers do not accidentally recommend spot tiers for tiers that lack HA design.
 
 ```text
-On-Demand Pricing:
+On-Demand Pricing (illustrative):
 ----------------------------------------
-m6i.xlarge (4 vCPU, 16 GB RAM)
+General-purpose instance (4 vCPU, 16 GB RAM)
 
-Price: $0.192/hour
-Monthly (730h): ~$140
-Annual: ~$1,681
-
-Pros: No commitment, scale up/down
-Cons: Most expensive per hour
+Price: billed per hour, no term
+Monthly (730h): moderate predictable baseline
+Pros: No commitment, scale freely
+Cons: Highest hourly rate
 ----------------------------------------
 ```
 
-**When to use**: Unpredictable workloads, short-term projects, development environments during business hours only.
-
-#### Reserved Instances (RIs)
-
-[Commit to 1 or 3 years of usage](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-reserved-instances.html) in exchange for a discount.
-
-```text
-Reserved Instance Pricing (m6i.xlarge):
-----------------------------------------
-Payment Options:
-
-1-Year No Upfront:    $0.125/hr (35%)
-1-Year All Upfront:   $0.114/hr (41%)
-3-Year No Upfront:    $0.089/hr (54%)
-3-Year All Upfront:   $0.072/hr (63%)
-
-Savings vs On-Demand: 35-63%
-Risk: Pay even if unused
-----------------------------------------
-```
-
-**When to use**: Stable, predictable workloads that run 24/7 — databases, core application servers, baseline capacity.
-
-#### Savings Plans
-
-AWS-specific. [Commit to a $/hour spend level, not specific instance types](https://docs.aws.amazon.com/savingsplans/latest/userguide/sp-ris.html).
-
-```text
-Savings Plans:
-----------------------------------------
-Commit: $10/hour for 1 year
-Flexibility: Any instance family/size
-Discount: Up to 72% vs On-Demand
-
-Compute SP: Any instance, any region
-EC2 SP: Specific family, any size
-
-Better than RIs for:
-- Teams that change instance types
-- Multi-region deployments
-- Workloads migrating to Graviton
-----------------------------------------
-```
-
-**When to use**: When you want RI-like savings but need flexibility to change instance types, sizes, or regions.
-
-#### Spot Instances
-
-[Use spare cloud capacity at up to 90% discount](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-best-practices.html). The catch? The cloud provider can reclaim them with 2 minutes' notice.
-
-```text
-Spot Instance Pricing (m6i.xlarge):
-----------------------------------------
-On-Demand:  $0.192/hr
-Spot:       $0.038/hr (80% savings)
-
-Warning - Interruption rate varies:
-  m6i.xlarge: ~5% monthly
-  c6i.2xlarge: ~3% monthly
-  r5.large: ~8% monthly
-
-Best for: Batch, CI/CD, stateless apps
-Bad for: Databases, stateful workloads
-----------------------------------------
-```
-
-> **Stop and think**: If Spot instances are up to 90% cheaper, why wouldn't you run your primary database on them? The risk of unpredictable termination makes them unsuitable for stateful workloads without robust external replication and failover mechanisms.
-
-**When to use**: Fault-tolerant, stateless workloads — batch processing, CI/CD, dev/test, data processing, machine learning training.
+Committed pricing (illustrative) shows the same shape across providers: one- or three-year terms, optional upfront payment, discounts that increase with commitment length and payment upfront. Interruptible pricing adds reclamation notice — often minutes — so only fault-tolerant workloads qualify.
 
 ### Pricing Model Comparison
 
-| Model | Savings | Commitment | Flexibility | Best For |
-|-------|---------|------------|-------------|----------|
-| On-Demand | 0% | None | Full | Spiky/unpredictable |
-| Reserved (1yr) | 35-41% | 1 year | Low | Stable baseline |
-| Reserved (3yr) | 54-63% | 3 years | Very low | Long-term core infra |
-| Savings Plans | 30-72% | 1-3 years | Medium | Flexible commitment |
-| Spot | 60-90% | None | Full (but interruptible) | Fault-tolerant batch |
+| Model | Savings (typical) | Commitment | Flexibility | Best For |
+|-------|-------------------|------------|-------------|----------|
+| On-Demand | Baseline | None | Full | Spiky or unknown usage |
+| Reserved / CUD (1yr) | Moderate | One year | Low | Stable baseline |
+| Reserved / CUD (3yr) | Higher | Multi-year | Very low | Long-lived core infra |
+| Savings Plans | Moderate–high | Term + $/hr commit | Medium | Mixed instance shapes |
+| Spot / Preemptible | High | None | Interruptible | Batch, CI, stateless burst |
+
+The table below captures a **landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.** Use it when you need indicative list prices during learning exercises, not as the basis for commitment contracts.
+
+| Provider | On-demand example | 1-year committed (indicative) | Spot / preemptible note |
+|----------|-------------------|----------------------------------|-------------------------|
+| AWS | m6i.xlarge ~$0.19/hr on-demand | RI/SP discounts vary by payment option | Spot reclamation ~2 min notice |
+| GCP | n2-standard-4 list pricing per hour | CUD % published per SKU | Preemptible termination at provider discretion |
+| Azure | D-series pay-as-you-go | Reservation % by term and region | Spot eviction policy varies by SKU |
 
 ---
 
-## CapEx vs OpEx: Why It Matters
+## Part 4: Allocation Hygiene — Tags, Coverage, and Shared Spend
 
-This isn't just an accounting detail. The CapEx-to-OpEx shift fundamentally changes how organizations plan and budget for technology.
+Cost allocation assigns each dollar of cloud spend to an owner: team, product, environment, or cost center. Tags (cloud provider labels) and Kubernetes labels are the primary hygiene mechanism. Untagged and shared spend is the root problem in most Inform failures — not missing dashboards.
 
-### Capital Expenditure (CapEx)
+Without allocation coverage targets, organizations debate tools forever while the underlying data stays opaque. Set a published goal — for example, ninety percent attributable spend within two quarters — and report progress monthly alongside gross spend. When leadership sees coverage stall, invest in enforcement and remediation instead of another dashboard SKU.
 
-```text
-Traditional Data Center (CapEx):
-----------------------------------------------
-Year 0: Buy $500,000 of servers
-Year 1: Depreciate $100K, use 20% capacity
-Year 2: Depreciate $100K, use 45% capacity
-Year 3: Depreciate $100K, use 70% capacity
-Year 4: Depreciate $100K, use 90% capacity
-Year 5: Depreciate $100K, need more capacity
+**Allocation coverage** is the percentage of gross spend that carries attributable labels after applying agreed rules. If only sixty percent of spend is tagged, forty percent is effectively invisible in showback reports. Finance sees a blob labeled "unallocated" or "shared infrastructure," and engineering teams argue about fairness instead of optimizing workloads.
 
-Total Cost: $500K + maintenance + power
-Utilization: Averaged 53% over 5 years
-Wasted: 47% of capacity
-----------------------------------------------
-```
+Shared costs — cluster control planes, NAT gateways, corporate VPNs, central logging — never map one-to-one to a single microservice. FinOps practice defines allocation keys upfront: proportional to CPU requests, per namespace, per egress gigabyte, or fixed splits documented in a runbook. Changing the key monthly destroys trust; document assumptions and revisit on a quarterly cadence.
 
-**Characteristics**:
-- Large upfront investment
-- Predictable annual depreciation
-- Assets appear on balance sheet
-- Long procurement cycles (weeks to months)
-- You pay whether you use it or not
+### Showback versus Chargeback
 
-### Operational Expenditure (OpEx)
+**Showback** publishes cost reports to engineering without moving money. It builds awareness and accountability with low political friction — ideal when maturity is crawl or walk. **Chargeback** actually bills internal teams, mirroring external invoices inside corporate accounting. It forces discipline but requires finance readiness, accurate allocation, and executive sponsorship.
 
-```text
-Cloud (OpEx):
-----------------------------------------------
-Month 1: $8,200  (launch, testing)
-Month 2: $11,400 (growing users)
-Month 3: $15,800 (marketing push)
-Month 4: $9,100  (optimized after review)
-Month 5: $12,600 (seasonal uptick)
-Month 6: $7,300  (rightsized instances)
+| Approach | Money moves? | Org readiness | Primary risk |
+|----------|--------------|---------------|--------------|
+| Showback | No | Crawl / Walk | Awareness without behavior change |
+| Chargeback | Yes | Walk / Run | Disputes if allocation untrusted |
+| Hybrid | Partial | Walk | Complexity without clear rules |
 
-Total: $64,400 for 6 months
-Pay for what you use, when you use it
-Scale up for peaks, scale down for troughs
-----------------------------------------------
-```
+Hypothetical scenario: Platform engineering runs shared Kubernetes clusters for twelve teams. Showback reports attribute node and storage costs by namespace labels; shared ingress and control-plane fees split by CPU request share. After two quarters of stable reports, finance pilots chargeback for production namespaces only, keeping sandboxes on showback until tagging compliance exceeds ninety-five percent.
 
-**Characteristics**:
-- No upfront investment
-- Variable monthly costs
-- Expenses on income statement (not balance sheet)
-- Instant provisioning (minutes)
-- You pay only for what you consume
+### Allocation Coverage as a KPI
 
-### Why Finance Cares
-
-| Concern | CapEx | OpEx (Cloud) |
-|---------|-------|--------------|
-| Budget predictability | High (fixed depreciation) | Low (variable monthly) |
-| Cash flow impact | Large upfront | Spread over time |
-| Tax treatment | Depreciated over years | Deducted immediately |
-| Financial planning | Annual cycle | Continuous forecasting |
-| Approval process | Board/CFO approval | Often decentralized |
-
-**The FinOps challenge**: Finance teams built processes for CapEx. Cloud (OpEx) breaks those processes. FinOps builds new ones.
+Publish **allocation coverage** on the same dashboard as gross spend. Define the metric precisely: tagged attributable spend divided by total spend after agreed exclusions (taxes, corporate support, one-time credits). When coverage rises from sixty to ninety percent, optimization conversations shift from "whose is this?" to "should this workload exist?" — a sign Inform maturity is working. Module 1.2 extends these ideas to namespace labels, idle cost, and the request-versus-usage gap inside Kubernetes.
 
 ---
 
-## Tagging: The Foundation of Cost Visibility
+## Part 5: Tagging — The Foundation of Cost Visibility
 
-[Tags are key-value pairs attached to cloud resources](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies.html). Without tags, your bill is a single number. With tags, it's a detailed breakdown by team, project, environment, and business unit.
+[Tags are key-value pairs attached to cloud resources](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies.html). Without them, your bill is a single opaque total. With consistent tags, the same export powers team dashboards, anomaly detection, and commitment planning. Before you debate showback versus chargeback, ask whether allocation coverage is high enough for anyone to trust the numbers.
 
-> **Pause and predict**: If you enforce tagging starting today, what happens to the visibility of the infrastructure created yesterday?
+> **Pause and predict**: If you enforce tagging starting today, what happens to visibility for infrastructure created yesterday? Untagged legacy assets remain a blind spot until you remediate them or park their spend in an explicit shared-cost bucket that leadership acknowledges in every review.
 
-### Why Tagging Fails (and How to Fix It)
-
-Most organizations start tagging and give up within 3 months. Here's why:
+Most organizations abandon tagging within a few months because enforcement is optional and retroactive cleanup is painful. The failure loop is predictable: leadership mandates tags, engineers forget during incidents, labels drift, finance stops trusting reports, and tagging is declared ineffective until the next invoice shock restarts the cycle.
 
 ```mermaid
 graph LR
@@ -347,9 +251,9 @@ graph LR
     D --> A
 ```
 
-### A Tagging Strategy That Works
+Breaking the cycle requires prevention at creation time — IaC hooks, policy-as-code, and deploy pipelines that reject untagged resources — plus a bounded remediation sprint for legacy assets.
 
-**Mandatory tags** ([enforce via policy](https://docs.aws.amazon.com/organizations/latest/userguide/enforce-required-tag-keys-iac.html) — block resource creation in IaC deployments without them):
+**Mandatory tags** should be few and stable; enforce them [via organization policy](https://docs.aws.amazon.com/organizations/latest/userguide/enforce-required-tag-keys-iac.html) so Terraform, CloudFormation, and Pulumi deployments cannot create noncompliant resources in the first place.
 
 | Tag Key | Example Values | Purpose |
 |---------|---------------|---------|
@@ -358,21 +262,10 @@ graph LR
 | `service` | `checkout-api`, `user-service` | Service-level costing |
 | `cost-center` | `CC-4521`, `CC-7803` | Finance mapping |
 
-**Recommended tags** (useful but not blocking):
-
-| Tag Key | Example Values | Purpose |
-|---------|---------------|---------|
-| `owner` | `jane.smith`, `team-payments` | Accountability |
-| `project` | `migration-v2`, `black-friday` | Project tracking |
-| `managed-by` | `terraform`, `helm`, `manual` | IaC compliance |
-| `expiry` | `2026-06-30` | Cleanup automation |
-
-### Enforcing Tags
-
-Tags only work if they're enforced. Here's a Terraform example using AWS:
+Recommended tags add accountability without blocking deploys: `owner`, `project`, `managed-by`, and `expiry` for automated cleanup. Kubernetes inherits the same discipline via namespace labels and annotations that downstream allocation tools map to cloud resource tags on nodes and volumes.
 
 ```hcl
-# AWS Organization Tag Policy
+# AWS Organization Tag Policy (illustrative excerpt)
 resource "aws_organizations_policy" "tag_policy" {
   name    = "mandatory-tags"
   type    = "TAG_POLICY"
@@ -418,25 +311,18 @@ resource "aws_organizations_policy" "tag_policy" {
 
 ---
 
-## Unit Economics: The North Star
+## Part 6: Unit Economics — The North Star
 
-Raw cloud spend is meaningless without context. Spending $200,000/month on cloud sounds alarming — until you learn you're serving 10 million customers and each one generates $5/month in revenue.
+Raw cloud spend is meaningless without business context. Spending $200,000 per month sounds alarming until you divide by ten million active customers and compare infrastructure cost to revenue per customer. **Unit economics** connects cloud cost to value-producing activity and prevents both false panic and false comfort.
 
-**Unit economics** connects cloud cost to business value.
+> **Pause and predict**: If your cloud bill rises fifty percent but unit cost per transaction falls ten percent, how should finance interpret the change?
 
-> **Pause and predict**: If your cloud bill increases by 50% next month, but your unit cost per transaction drops by 10%, how should finance interpret this change?
-
-### Common Unit Metrics
-
-| Business Type | Unit Metric | Example |
-|---------------|------------|---------|
-| SaaS | Cost per customer | $0.83/customer/month |
-| E-commerce | Cost per transaction | $0.012/order |
-| Streaming | Cost per stream hour | $0.0031/hour |
-| API platform | Cost per API call | $0.000042/call |
-| Gaming | Cost per daily active user | $0.15/DAU |
-
-### Calculating Unit Economics
+| Business Type | Unit Metric | Illustrative shape |
+|---------------|------------|-------------------|
+| SaaS | Cost per customer | Dollars per customer per month |
+| E-commerce | Cost per order | Cents per checkout |
+| Streaming | Cost per stream hour | Fractions of a cent per hour |
+| API platform | Cost per API call | Micro-dollars per request |
 
 ```text
 Step 1: Total cloud cost for the service
@@ -448,13 +334,183 @@ Step 2: Total business units processed
 Step 3: Divide
   → $42,000 / 3,200,000 = $0.013/order
 
-Step 4: Track the trend
-  → Last month: $0.015/order
-  → This month: $0.013/order
-  → Improving! Cost efficiency increased 13%
+Step 4: Track the trend month over month
 ```
 
-**Why this matters**: If your cost per order is $0.013 but your margin per order is $2.50, you know infrastructure is ~0.5% of revenue. That's healthy. If it's 15% of revenue, you have a problem.
+Shared Kubernetes clusters break naive attribution because many teams share nodes, ingress, and control-plane overhead. A service's unit cost depends on allocation rules from Inform, not only on its own Pod count. Module 1.2 addresses namespace- and label-based attribution; here, recognize that unit economics without allocation hygiene measures fiction.
+
+### Connecting Unit Economics to Product Decisions
+
+Product and engineering leaders should review unit cost when prioritizing roadmap items. A feature that doubles infrastructure cost per user while improving retention might be an excellent trade; a feature that raises unit cost without measurable value is a tax on margins. FinOps does not replace product judgment — it supplies the denominator finance and engineering can argue about with shared data instead of competing anecdotes from last month's invoice PDF.
+
+---
+
+## Part 7: CapEx versus OpEx — Why Finance Cares
+
+The shift from capital expenditure to operational expenditure is not accounting trivia — it changes who can spend, how fast budgets move, and which forecasts fail. CapEx bought depreciating assets with long procurement cycles. OpEx buys consumption with monthly variance tied directly to engineering activity.
+
+```text
+Traditional Data Center (CapEx):
+----------------------------------------------
+Year 0: Buy $500,000 of servers
+Year 1: Depreciate $100K, use 20% capacity
+Year 2: Depreciate $100K, use 45% capacity
+Year 3: Depreciate $100K, use 70% capacity
+Year 4: Depreciate $100K, use 90% capacity
+Year 5: Depreciate $100K, need more capacity
+
+Total Cost: $500K + maintenance + power
+Utilization: Averaged roughly half of purchased capacity over five years
+----------------------------------------------
+```
+
+```text
+Cloud (OpEx):
+----------------------------------------------
+Month 1: $8,200  (launch, testing)
+Month 2: $11,400 (growing users)
+Month 3: $15,800 (marketing push)
+Month 4: $9,100  (optimized after review)
+Month 5: $12,600 (seasonal uptick)
+Month 6: $7,300  (rightsized instances)
+
+Total: $64,400 for six months
+Pay for what you use, when you use it
+----------------------------------------------
+```
+
+| Concern | CapEx | OpEx (Cloud) |
+|---------|-------|--------------|
+| Budget predictability | High (fixed depreciation) | Lower (variable monthly) |
+| Cash flow impact | Large upfront | Spread over time |
+| Approval process | Board/CFO for large buys | Often decentralized to engineers |
+| Planning cycle | Annual | Continuous forecasting |
+
+FinOps builds new processes — tagging, showback, unit metrics, commitment governance — because legacy CapEx playbooks cannot explain a bill that changes every time someone scales a Deployment.
+
+---
+
+## Part 8: Forecasting, Budgets, and Anomaly Detection
+
+Operate-phase FinOps turns Inform data into forward-looking discipline. **Forecasting** projects spend from historical curves, planned launches, and known commitments. A forecast is not prophecy; it is a shared assumption finance and engineering can debate before money is spent. Start with tagged historical baselines, then layer growth scenarios: new region, doubled traffic, additional non-production environments for a release train.
+
+**Budgets** translate forecasts into guardrails. Account-level budgets catch runaway accounts; team-level budgets connect ownership to consequences. Alerts should fire on trends — projected month-end overrun at mid-month — not only after the invoice closes. Pair dollar thresholds with unit-metric thresholds so a growing business is not punished for serving more customers efficiently.
+
+**Anomaly detection** flags deviations from expected patterns: a sudden doubling of egress, a new untagged service family, a GPU instance type appearing in production without change approval. Automated detectors accelerate Inform; human review confirms whether the anomaly is attack, misconfiguration, or planned growth. Hypothetical scenario: A batch job misconfigured to sync logs cross-region triggers a networking spike. Anomaly alert routes to the owning team within hours instead of surfacing in finance's month-end variance deck.
+
+Effective forecasting requires the same allocation hygiene as showback. If thirty percent of spend is untagged, thirty percent of your forecast is fiction. Mature programs publish forecast accuracy metrics — mean absolute percentage error by team — alongside the forecast itself so credibility compounds.
+
+Budget owners should see unit metrics in the same view as dollar totals. A team under budget on dollars but over budget on cost per customer may still be harming margins. Conversely, a team over dollar budget while improving unit economics may deserve capacity for growth. Operate-phase reviews exist to disentangle those stories with data instead of rank by invoice slice alone.
+
+---
+
+## Part 9: Commitment Governance — Discounts Without Lock-In Regret
+
+Commitment-based discounts are a durable FinOps concept across every hyperscaler: trade flexibility for lower unit price over a term. The failure mode is not using commitments; it is buying the wrong shape too early and paying for unused reservation capacity — **utilization** becomes the Operate metric that matters as much as discount percentage.
+
+Governance starts after Inform establishes a stable baseline. Observe two to three months of hourly usage before converting on-demand baseline to reserved or savings-style commitments. Platform teams publish a **commitment portfolio**: which accounts hold which instruments, expiration dates, and coverage targets for steady-state compute. Finance owns renewal calendar; engineering owns shape accuracy.
+
+When workloads shift — Graviton migration, container density improvements, regional failover drills — commitment coverage drifts. Weekly utilization review asks: are we paying for capacity nobody schedules? If yes, Optimize changes shape or finance sells commitments on secondary markets where providers allow it. If utilization is healthy but on-demand spill remains high, additional commitment may be justified.
+
+Interruptible capacity sits outside the commitment portfolio but inside the same decision framework. Batch, CI, and fault-tolerant workers belong on spot or preemptible tiers with explicit interruption handling; never mix interruptible capacity into databases or single-replica stateful tiers without engineering sign-off documented in the architecture record.
+
+---
+
+## Part 10: Bringing Engineering Into FinOps Without Slowing Delivery
+
+FinOps fails when engineers experience it as procurement theater — another ticket queue blocking deploys. Successful programs embed cost signals where decisions already happen: pull request comments from IaC cost estimation, namespace dashboards linked from service runbooks, and post-incident reviews that include incremental cloud cost of mitigation choices.
+
+Engineers respond to metrics they can influence. Showing a team that their staging environment costs as much as a production slice motivates scheduled shutdowns more than a lecture from finance. Showing that rightsizing a Deployment improved cost per request without raising p95 latency proves FinOps protects velocity. Language matters: "cost efficiency" and "unit economics" land better than "cutting the bill."
+
+Leadership sets the tone. If executives reward only feature speed, teams hide over-provisioning. If executives reward reliability and unit cost jointly, teams ask platform for autoscaling and rightsizing guidance early in design. The FinOps practitioner brokers that tone — translating finance constraints into engineering SLO language and translating architectural tradeoffs into forecast updates finance can model.
+
+Training is part of Operate. New hires learn the tagging taxonomy alongside CI/CD conventions. FinOps office hours answer "why did my service double?" with data, not blame. Over quarters, cost awareness becomes as routine as security review — not because cloud is cheap, but because waste is an unforced error in a competitive product.
+
+### Kubernetes and the Next Layer of Inform
+
+Even perfect cloud tagging stops at the cluster boundary until you allocate inside Kubernetes. Nodes appear as EC2 lines; Pods do not. Platform teams running shared clusters on Kubernetes 1.35 should plan for namespace labels, resource requests, and allocation tooling as the next Inform milestone after account-level tagging stabilizes. This module establishes the finance and allocation vocabulary; Module 1.2 applies it to multi-tenant clusters where the request-versus-usage gap creates idle cost most organizations never see at the VM layer alone.
+
+---
+
+## Patterns and Anti-Patterns
+
+### Patterns That Work
+
+1. **Start with Inform data quality** — Fix tagging and allocation coverage before buying optimization tools. Dashboards on dirty data amplify confusion.
+2. **Publish unit economics alongside gross spend** — Leadership reviews cost per transaction every month, not only the total.
+3. **Match pricing model to workload shape** — Commit stable baselines; keep experimental and bursty work on flexible models.
+4. **Decentralize ownership, centralize standards** — Platform provides taxonomy and tooling; product teams act on their allocation.
+5. **Run the lifecycle loop on a cadence** — Weekly operational reviews for anomalies, monthly for commitments, quarterly for maturity reassessment.
+
+Patterns succeed when they are boring and repeated. A quarterly maturity reassessment that never changes priorities loses credibility; a monthly fifteen-minute team review that surfaces one actionable item builds the habit that makes Operate sustainable.
+
+### Anti-Patterns to Avoid
+
+| Anti-Pattern | Why It Fails | Better Approach |
+|--------------|--------------|-----------------|
+| Optimization before visibility | Savings cannot be attributed or sustained | Inform first: tags, coverage, shared rules |
+| Central FinOps team rightsizes every service | Lack of workload context | Enable teams with data and guardrails |
+| Commitment shopping day one | Locks wrong shape before usage stabilizes | Observe usage, then commit baseline |
+| Cost cutting as sole KPI | Stifles growth and reliability | Optimize unit economics and value |
+| Tool purchase replaces culture | Shelfware dashboards | Personas, cadence, and accountability |
+| Ignoring egress and managed SKUs | Misses fastest-growing line items | Full bill anatomy in reviews |
+
+---
+
+## Decision Framework — Pricing and Allocation Choices
+
+Use the flowchart below when choosing pricing models or allocation approaches for a workload or team. Start with usage predictability, then interruption tolerance, then instance shape stability — only after those axes are clear should you decide whether internal reporting stays at showback or advances to chargeback.
+
+```mermaid
+flowchart TD
+    START([New cost decision]) --> Q1{Usage predictable<br/>for 3+ months?}
+    Q1 -->|No| OD[On-demand or<br/>interruptible spot]
+    Q1 -->|Yes| Q2{Can tolerate<br/>interruption?}
+    Q2 -->|Yes| SPOT[Spot / preemptible<br/>with fallback]
+    Q2 -->|No| Q3{Instance shape<br/>stable?}
+    Q3 -->|Yes| RI[Reserved / CUD<br/>for baseline]
+    Q3 -->|No| SP[Savings Plan /<br/>flexible commit]
+    OD --> ALLOC{Need internal<br/>accountability?}
+    SPOT --> ALLOC
+    RI --> ALLOC
+    SP --> ALLOC
+    ALLOC -->|Awareness only| SB[Showback reports]
+    ALLOC -->|Budget transfer| CB[Chargeback with<br/>agreed keys]
+```
+
+The same decision logic applies across providers: predictability, interruption tolerance, and shape stability determine commitment depth; organizational maturity determines showback versus chargeback. Revisit the flowchart when workloads move regions, when you adopt Kubernetes bin-packing that changes node shapes, or when finance asks whether internal billing should begin — each trigger maps to a different branch, not a new ad hoc policy.
+
+---
+
+## Cost-Tooling Rosetta — Capability View
+
+The Rosetta table below is a **landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.** Compare tools by the capability you need for your current lifecycle phase rather than treating any column as a universal winner.
+
+| Capability | OpenCost | Kubecost | Cloud cost explorer (native) | Infracost |
+|------------|----------|----------|------------------------------|-----------|
+| Kubernetes allocation | Core focus | Core focus | Limited without add-ons | N/A (pre-deploy) |
+| Cloud bill integration | Via provider config | Supported | Native | N/A |
+| Showback / chargeback | Reports, APIs | Reports, policies | Account/label reports | N/A |
+| Rightsizing signals | Usage-based allocation | Recommendations | Provider advisors | N/A |
+| Idle / shared cost split | Allocation rules | Allocation rules | Tag-dependent | N/A |
+| CI cost estimation | Indirect | Varies | N/A | IaC pull-request estimates |
+| Anomaly detection | Varies by deployment | Supported | Native budgets/alerts | N/A |
+
+OpenCost provides a [vendor-neutral specification](https://opencost.io/docs/) for Kubernetes cost monitoring; Kubecost and other implementations expose similar allocation concepts with different packaging. Cloud provider explorers excel at invoice fidelity; Infracost addresses shift-left estimation before resources exist. Choose based on which capability gap blocks your Inform or Optimize phase today.
+
+No single product replaces the FinOps lifecycle. A native cost explorer may suffice for crawl-stage Inform on one cloud account. Kubernetes-heavy organizations eventually need allocation inside the cluster boundary. IaC estimation tools complement post-deploy monitoring by catching expensive templates before they merge. The Rosetta view keeps those roles distinct so you do not expect one dashboard to solve forecasting, allocation, rightsizing, and pre-merge estimation simultaneously.
+
+---
+
+## Did You Know?
+
+- **Cloud cost overruns and waste are common operational risks.** Idle and over-provisioned resources frequently appear when teams lack visibility, ownership, and consistent allocation — long before anyone needs an advanced optimization engine.
+
+- **The FinOps Foundation ([hosted by the Linux Foundation](https://www.linuxfoundation.org/press/press-release/the-linux-foundation-brings-together-it-and-finance-teams-to-advance-cloud-financial-management-and-education)) maintains a practitioner community, certification, and framework** — FinOps is a defined discipline with domains and capabilities, not an informal nickname for staring at invoices.
+
+- **Large streaming platforms may spend heavily on cloud infrastructure**, so mature FinOps programs often optimize cost per streaming hour rather than minimizing gross spend — efficiency relative to value matters more than the headline total.
+
+- **Data transfer and egress line items frequently represent a double-digit share of bills** in data-heavy architectures, yet many optimization programs focus only on compute instance sizes — full bill anatomy prevents misallocated effort.
 
 ---
 
@@ -462,73 +518,106 @@ Step 4: Track the trend
 
 | Mistake | Why It Happens | How to Fix It |
 |---------|---------------|---------------|
-| Treating FinOps as a one-time project | Leadership wants quick savings | Establish continuous review cadence |
-| Only looking at total spend | Aggregate numbers hide waste | Break down by team, service, environment |
-| Buying RIs/SPs too early | Premature commitment before understanding usage | Observe 2-3 months of usage patterns first |
-| No tagging enforcement | "We'll add tags later" | Enforce at resource creation, not retroactively |
-| Ignoring data transfer costs | Focus only on compute/storage | Data transfer is often 8-15% of total bill |
-| Cost optimization = cutting spend | Confusing efficiency with austerity | Focus on unit economics, not raw spend |
-| Centralized FinOps team does everything | One team can't optimize for 50 engineering teams | Decentralize ownership, centralize tooling |
-| Ignoring committed spend utilization | Buy RIs then forget to track usage | Monitor RI/SP utilization weekly |
+| Treating FinOps as a one-time project | Leadership wants quick savings | Establish continuous Inform–Optimize–Operate cadence |
+| Only looking at total spend | Aggregate numbers hide waste | Break down by team, service, environment, unit metric |
+| Buying RIs/SPs too early | Premature commitment before usage clarity | Observe two to three months of stable usage first |
+| No tagging enforcement | "We'll add tags later" | Enforce at resource creation via policy and IaC |
+| Ignoring data transfer costs | Focus only on compute and storage | Include networking in monthly reviews and allocation |
+| Cost optimization equals cutting spend | Confusing efficiency with austerity | Lead with unit economics and value alignment |
+| Centralized FinOps team does everything | One team cannot optimize fifty services | Decentralize ownership, centralize standards and tooling |
+| Ignoring committed spend utilization | Buy discounts then forget coverage | Monitor commitment utilization weekly |
+
+FinOps transforms cloud spending from an unpredictable cost center into a managed input for product and platform decisions. The Inform–Optimize–Operate lifecycle, allocation hygiene, pricing-model literacy, and unit economics give teams a shared language that survives vendor and tooling churn. Spending better — not blindly spending less — is the outcome that keeps cloud agility worth the invoice.
+
+When you continue to Module 1.2, you will apply these Inform foundations inside Kubernetes, where shared clusters hide cost behind abstractions until allocation tooling and labels make Pod-level spend visible. Carry forward the habits from this module: measure coverage, publish unit metrics, and treat every optimization proposal as a hypothesis you validate against business value.
 
 ---
 
 ## Quiz
 
 ### Question 1
-Your organization has just migrated its main application to the cloud. The CFO is concerned about upcoming bills and wants to establish a FinOps practice. You are tasked with leading this initiative. What three continuous phases should you implement to ensure long-term cost efficiency?
+Your organization has just migrated its main application to the cloud. The CFO wants a FinOps practice with defined roles for engineering, finance, and leadership. Which three continuous lifecycle phases should you implement, and how do personas map to them?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-**Inform, Optimize, Operate.** The Inform phase must be established first to give you visibility into spending across all your new cloud resources. Then, the Optimize phase allows you to systematically reduce waste and improve efficiency based on that data. Finally, the Operate phase builds sustainable processes, guardrails, and governance to maintain efficiency as the infrastructure grows. Crucially, these three phases run continuously as a never-ending cycle, not as a one-time implementation project.
+Implement **Inform, Optimize, and Operate** as a continuous loop. Engineers and engineering managers own workload decisions informed by allocation and unit metrics during Inform and Optimize. Finance owns invoices, commitments, and variance analysis across Inform and Operate. Leadership sets policies, guardrails, and unit-economic goals during Operate. A FinOps practitioner coordinates tooling and maturity assessments so reporting structures stay clear — nobody assumes a central team will optimize every service in isolation.
 </details>
 
 ### Question 2
-A workload runs 24/7 and has been stable for 8 months. It currently uses On-Demand instances costing $2,100/month. Which pricing model would you recommend and why?
+A workload runs twenty-four hours per day and has been stable for eight months on on-demand instances costing roughly $2,100 per month. Which pricing model would you recommend and why?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-You should recommend **Reserved Instances or Savings Plans** for this workload. With 8 months of stable usage data, this workload is a strong candidate for commitment-based pricing rather than on-demand. A 1-Year All Upfront RI could save approximately 41%, bringing the cost down to around $1,240/month and resulting in significant annual savings. However, if the engineering team suspects they might need to change instance types or scale across regions in the future, a Compute Savings Plan offers a similar financial benefit while preserving necessary architectural flexibility.
+Recommend **Reserved Instances, Committed Use Discounts, or Savings Plans** because eight months of stable usage demonstrates predictable baseline demand. Commitment-based models trade term and flexibility for lower unit rates. If instance family or region may change, a flexible savings-style commitment preserves optionality while still capturing discount. Keep burst or experimental components on on-demand or interruptible tiers rather than committing one hundred percent of volatile shape.
 </details>
 
 ### Question 3
-Your company's cloud bill is $180,000/month, but only 62% of resources have proper tags. Why is this a problem, and what would you do?
+Your company's cloud bill is $180,000 per month, but only sixty-two percent of resources have proper tags. Why is this an Inform-phase failure, and what would you do first?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-Without tags on 38% of resources, you cannot accurately attribute approximately $68,400/month to any specific team or project. This massive blind spot makes cost optimization nearly impossible because you cannot determine who owns the resources or whether they are actively needed for business value. To fix this, you must first implement tag enforcement policies that block the creation of new resources without mandatory tags. Then, you should organize a tagging remediation sprint to retroactively map existing untagged resources, aiming for a compliance target of 95% or higher within the next 60 days.
+With thirty-eight percent of spend unattributed, roughly $68,000 per month lacks trustworthy ownership in showback or chargeback reports — optimization targets become guesswork. This is an Inform data-quality failure, not an Optimize problem. First, enforce mandatory tags at creation through organization policies and IaC. Then run a bounded remediation sprint on legacy resources, tracking **allocation coverage** toward ninety-five percent before demanding chargeback. Without trusted attribution, finance and engineering will dispute numbers instead of improving unit economics.
 </details>
 
 ### Question 4
-Your startup recently shifted its infrastructure from an on-premises data center to a public cloud provider. The finance director is struggling to forecast the quarterly budget using their traditional spreadsheet models. How does the transition from CapEx to OpEx explain this difficulty, and what must the finance team change?
+Finance struggles to forecast quarterly cloud budget after migrating from owned data centers. How does the CapEx-to-OpEx shift explain the difficulty, and what FinOps capability helps?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-**CapEx** (Capital Expenditure) involves a large upfront purchase that is depreciated over years, making it highly predictable and planned. **OpEx** (Operational Expenditure) is a pay-as-you-go model that is inherently variable and immediate. The shift to cloud moves IT spending entirely from CapEx to OpEx, which invalidates forecasting models built around predictable annual depreciation schedules. Furthermore, in the cloud, any engineer can provision resources and generate expenses on demand without going through a traditional procurement pipeline. Finance teams must therefore transition from static annual budgeting cycles to continuous, dynamic forecasting, working closely with engineering teams to understand real-time utilization trends.
+CapEx spreads large upfront purchases over years of depreciation, producing predictable annual lines. OpEx bills reflect real-time consumption that engineers can change without procurement — variance appears monthly. Finance must shift from static annual cycles to continuous forecasting informed by tagged allocation, usage trends, and unit economics. Inform capabilities — ingestion, tagging, dashboards — plus Operate budgeting and review cadences give finance leading indicators instead of surprise month-end totals.
 </details>
 
 ### Question 5
-During a monthly review meeting, the VP of Engineering proudly announces that the cloud bill has remained steady at $300,000 per month for the past quarter. However, the FinOps practitioner argues that this number alone is insufficient to determine if the company is managing its cloud resources effectively. Why is raw spend inadequate for decision-making, and what framework should be used instead?
+The VP of Engineering reports flat $300,000 monthly cloud spend for three quarters. Why is raw spend alone insufficient, and which framework should leadership use?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-Raw spend alone is completely inadequate because it lacks business context and fails to indicate whether the infrastructure investment is actually efficient. For example, a stable $300,000 bill could be excellent news if the user base doubled during that quarter, or terrible news if the company lost half of its active customers. Instead, the organization must adopt unit economics, which ties the cloud spend to a specific business metric such as cost per customer or cost per transaction. This framework reveals the true efficiency of the cloud usage. If the cost per transaction decreases over time while the total spend remains flat, the organization is successfully optimizing its operations and supporting sustainable growth.
+Flat gross spend hides business context: customer count, transaction volume, or revenue may have moved sharply while the total stayed constant. Leadership should use **unit economics** — cost per customer, order, or API call — to judge efficiency. FinOps maturity assessments should track whether Inform produces those ratios reliably and whether Optimize actions improve them. A flat bill with collapsing unit volume is a crisis; a rising bill with improving unit cost may signal healthy growth.
+</details>
+
+### Question 6
+Platform leadership debates showback versus chargeback for Kubernetes namespaces. When is each appropriate, and what prerequisite must be true for chargeback?
+
+<details>
+<summary>Answer</summary>
+
+**Showback** fits crawl and early walk maturity: publish costs to build awareness without moving internal budget. **Chargeback** fits walk and run maturity when finance can absorb internal transfers and teams trust allocation keys for shared cluster overhead. Chargeback prerequisites include high allocation coverage, documented shared-cost splits, and executive sponsorship — otherwise disputes consume the FinOps program. Many organizations run years of showback before piloting chargeback on production only.
+</details>
+
+### Question 7
+Hypothetical scenario: A FinOps practitioner scores the organization as *run* on reservation management but *crawl* on Kubernetes allocation. What should the maturity assessment recommend next?
+
+<details>
+<summary>Answer</summary>
+
+The assessment should recommend sequencing investment into Kubernetes allocation — namespaces, labels, shared-cost rules — because container spend without attribution blocks trustworthy unit economics and chargeback. Maturity assessments must score capabilities independently per the FinOps Foundation framework, not award a single headline level. Publish the gap, assign owners across engineering and finance personas, and reassess next quarter. Optimizing commitments while Kubernetes spend remains opaque optimizes the wrong layer.
+</details>
+
+### Question 8
+During Analyze-phase review of a Cost and Usage Report, you see rising NAT gateway and cross-region egress charges while compute is flat. What optimization and Inform actions apply?
+
+<details>
+<summary>Answer</summary>
+
+This pattern suggests data movement architecture — not instance sizing — drives spend. Inform should attribute egress to services and teams using tagging and flow logs where available. Optimize should evaluate topology: colocate consumers, compress exports, use private connectivity, or tier analytics pipelines. Analyze spending patterns by **line item category** before launching a generic rightsizing initiative. FinOps connects billing literacy to targeted engineering changes instead of blanket cost cuts.
 </details>
 
 ---
 
 ## Hands-On Exercise: Analyze a Cloud Bill
 
-In this exercise, you'll analyze a simplified [AWS Cost and Usage Report (CUR)](https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html) to identify spending patterns, waste, and optimization opportunities.
+In this exercise, you'll analyze a simplified [AWS Cost and Usage Report (CUR)](https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html) to identify spending patterns, waste, and optimization opportunities. The workflow mirrors what FinOps practitioners do during Inform and Analyze reviews: aggregate by owner, quantify unattributed spend, compare environments, and narrate findings for stakeholders who will not read raw CSV rows.
+
+Real CUR files contain millions of rows and dozens of columns; this lab compresses the shape so you can practice the logic on a laptop in minutes. The same patterns apply when you load production exports into a warehouse, a spreadsheet, or a cost tool — only the scale changes. Pay attention to how untagged rows distort team rankings and how non-production environments contribute material spend without carrying production traffic.
 
 ### Setup
 
-Create a sample CUR dataset:
+The hands-on lab uses a simplified comma-separated export that mirrors the shape of a real [AWS Cost and Usage Report](https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html): one row per resource line with team, service, environment, and cost columns. Run the commands below from any Unix-like shell to create the dataset locally; no cloud account is required because the values are illustrative teaching data rather than live billing.
 
 ```bash
 mkdir -p ~/finops-lab && cd ~/finops-lab
@@ -566,9 +655,9 @@ echo "Sample CUR data created."
 
 ### Analysis Tasks
 
-Use standard command-line tools to answer these questions:
+Work through four analysis steps using standard command-line tools. Each step practices a different Inform or Analyze skill: attribution by owner, detection of untagged waste, environment mix review, and synthesis into an optimization narrative you could present in a weekly cost standup.
 
-**Task 1: Total spend by team**
+**Task 1 — Total spend by team.** Aggregate the `cost_usd` column grouped by the `team` field so you can see which organizational owners drive the largest share of monthly spend. The command below uses `awk` for a zero-dependency approach you can run on any laptop.
 
 ```bash
 cd ~/finops-lab
@@ -577,7 +666,8 @@ cd ~/finops-lab
 awk -F',' 'NR>1 {team[$2]+=$7} END {for(t in team) printf "%-12s $%9.2f\n", t, team[t] | "sort -t$ -k2 -rn"}' cloud_bill.csv
 ```
 
-Expected output (approximate):
+When the aggregation finishes, you should see `search` and `data` among the top spenders, with a large `untagged` row that flags an Inform hygiene problem worth escalating before any rightsizing work begins. Approximate expected totals:
+
 ```text
 data         $  1,242.24
 search       $  1,302.72
@@ -587,21 +677,21 @@ ml-team      $    725.06
 platform     $    350.60
 ```
 
-**Task 2: Identify the untagged resources**
+**Task 2 — Untagged resource inventory.** Filter rows where `team` equals `untagged` to list resources that cannot participate in showback or chargeback until someone claims ownership or finance assigns them to a shared platform bucket with documented rules.
 
 ```bash
 # Find untagged resources and their costs
 awk -F',' 'NR>1 && $2=="untagged" {printf "Resource: %-15s Env: %-10s Cost: $%.2f\n", $4, $5, $7}' cloud_bill.csv
 ```
 
-**Task 3: Non-production spend**
+**Task 3 — Environment mix.** Summarize spend by `environment` to quantify how much non-production capacity runs continuously. Persistent staging and development footprints are common Optimize targets when schedules or autoscaling policies are absent.
 
 ```bash
 # Calculate spend by environment
 awk -F',' 'NR>1 {env[$5]+=$7} END {for(e in env) printf "%-15s $%9.2f\n", e, env[e] | "sort -t$ -k2 -rn"}' cloud_bill.csv
 ```
 
-**Task 4: Optimization opportunities report**
+**Task 4 — Optimization narrative.** The shell script below combines the prior aggregates into a short report suitable for a FinOps review: totals, team and environment splits, tagging compliance percentage, and plain-language optimization opportunities including GPU utilization and always-on staging.
 
 ```bash
 cat > analyze_bill.sh << 'SCRIPT'
@@ -632,22 +722,18 @@ echo "  Untagged spend: \$$UNTAGGED ($PCT% of total)"
 echo ""
 
 echo "--- Optimization Opportunities ---"
-# ML GPU running only 186 of 744 hours = 25% utilization
 echo "  1. ML GPU (p3.2xlarge): Only 186/744 hours used (25% utilization)"
-echo "     → Use Spot instances or schedule start/stop = save ~\$400/mo"
+echo "     → Use Spot instances or schedule start/stop"
 echo ""
 echo "  2. Idle ML GPU (p3.2xlarge): 0 hours, still allocated"
-echo "     → Terminate immediately = save up to \$568/mo"
+echo "     → Terminate immediately"
 echo ""
 echo "  3. Staging instances running 24/7 (payments, search)"
-echo "     → Schedule business-hours only = save ~55% (~\$145/mo)"
+echo "     → Schedule business-hours only"
 echo ""
 echo "  4. Untagged resources: \$$UNTAGGED/mo with no owner"
-echo "     → Tag or terminate = potential savings \$$UNTAGGED/mo"
+echo "     → Tag or terminate"
 echo ""
-
-POTENTIAL="1,113"
-echo "ESTIMATED MONTHLY SAVINGS: ~\$$POTENTIAL (potential)"
 SCRIPT
 
 chmod +x analyze_bill.sh
@@ -655,6 +741,8 @@ bash analyze_bill.sh
 ```
 
 ### Success Criteria
+
+Complete the exercise when you have reproduced each analysis step and can explain which findings belong to Inform versus Optimize. Use the unchecked items below as your self-assessment checklist before moving to Module 1.2.
 
 You've completed this exercise when you:
 - [ ] Created the sample CUR dataset
@@ -666,56 +754,25 @@ You've completed this exercise when you:
 
 ---
 
-## Key Takeaways
+## Sources
 
-1. **FinOps is a cultural practice, not a tool** — it brings financial accountability to the speed of cloud
-2. **The lifecycle is continuous** — Inform, Optimize, Operate runs as a never-ending loop
-3. **Pricing models are levers** — matching the right model (On-Demand, RI, SP, Spot) to each workload saves 30-80%
-4. **Tags are the foundation** — without tags, you're flying blind on cost attribution
-5. **Unit economics matter more than total spend** — cost per customer tells you if you're efficient, raw spend doesn't
-
----
-
-## Further Reading
-
-**Books**:
-- **"Cloud FinOps"** — J.R. Storment & Mike Fuller (the definitive FinOps book, O'Reilly)
-- **"Cloud Cost Optimization Handbook"** — Google Cloud Architecture Center (free online)
-
-**Resources**:
-- **FinOps Foundation Framework** — finops.org/framework (the complete FinOps framework)
-- **AWS Cost and Usage Report** — docs.aws.amazon.com/cur (understand your AWS bill)
-- **FinOps Certified Practitioner** — finops.org/certification (professional certification)
-
-**Talks**:
-- **"FinOps: The Operating Model for Cloud"** — J.R. Storment (YouTube, KubeCon)
-- **"How Spotify Manages Cloud Costs"** — FinOps Summit (YouTube)
-
----
-
-## Summary
-
-FinOps transforms cloud spending from an unpredictable cost center into a managed business driver. By following the Inform-Optimize-Operate lifecycle, implementing robust tagging, choosing the right pricing models, and tracking unit economics, teams can reduce cloud waste while maintaining — or even improving — the speed and agility that cloud provides.
-
-The key insight is that FinOps is not about spending *less*. It's about spending *better*. A company that doubles its cloud bill while tripling its revenue has better FinOps than one that cuts spending 20% and stalls growth.
+- [FinOps Foundation Framework](https://www.finops.org/framework/) — Domains, capabilities, personas, and maturity guidance for cloud financial management.
+- [FinOps Foundation — What is FinOps](https://www.finops.org/introduction/what-is-finops/) — Definition of FinOps as a cultural practice bridging engineering, finance, and business.
+- [Linux Foundation — FinOps Foundation announcement](https://www.linuxfoundation.org/press/press-release/the-linux-foundation-brings-together-it-and-finance-teams-to-advance-cloud-financial-management-and-education) — Host organization and community context for the FinOps Foundation.
+- [AWS Well-Architected — Cost Optimization Pillar](https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/welcome.html) — Durable cost optimization principles for AWS workloads.
+- [AWS — Select the best pricing model](https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/select-the-best-pricing-model.html) — On-demand versus commitment pricing tradeoffs.
+- [AWS — Reserved Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-reserved-instances.html) — Commitment terms and billing mechanics for EC2 RIs.
+- [AWS — Savings Plans](https://docs.aws.amazon.com/savingsplans/latest/userguide/sp-ris.html) — Flexible hourly spend commitments.
+- [AWS — Spot Instance best practices](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-best-practices.html) — Interruptible capacity and workload suitability.
+- [AWS — Cost and Usage Reports](https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html) — Comprehensive billing export format for analysis.
+- [AWS Organizations — Tag policies](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies.html) — Tag definitions and enforcement scope.
+- [Google Cloud Architecture Framework — Cost optimization](https://cloud.google.com/architecture/framework/cost-optimization) — Cross-cutting cost principles on GCP.
+- [Azure Well-Architected — Cost optimization](https://learn.microsoft.com/en-us/azure/well-architected/cost-optimization/) — Microsoft guidance for cost-efficient Azure architectures.
+- [Kubernetes — Manage resources for containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) — Requests, limits, and resource model foundations for later allocation modules.
+- [OpenCost documentation](https://opencost.io/docs/) — Vendor-neutral Kubernetes cost monitoring specification and setup.
 
 ---
 
 ## Next Module
 
 Continue to [Module 1.2: Kubernetes Cost Allocation & Visibility](../module-1.2-k8s-cost-allocation/) to learn how to attribute cloud costs in multi-tenant Kubernetes clusters.
-
----
-
-*"The cloud bill is not a cost — it's a business metric."* — FinOps Foundation
-
-## Sources
-
-- [linuxfoundation.org: the linux foundation brings together it and finance teams to advance cloud financial management and education](https://www.linuxfoundation.org/press/press-release/the-linux-foundation-brings-together-it-and-finance-teams-to-advance-cloud-financial-management-and-education) — The Linux Foundation press release directly states that it would host the FinOps Foundation.
-- [docs.aws.amazon.com: select the best pricing model.html](https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/select-the-best-pricing-model.html) — AWS Well-Architected directly describes On-Demand as the default pay-as-you-go model with no long-term commitment.
-- [docs.aws.amazon.com: ec2 reserved instances.html](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-reserved-instances.html) — The EC2 Reserved Instances documentation directly states the one-year and three-year commitments and discounted billing model.
-- [docs.aws.amazon.com: sp ris.html](https://docs.aws.amazon.com/savingsplans/latest/userguide/sp-ris.html) — The Savings Plans guide directly describes the $/hour commitment, flexibility, eligible usage, and discount ceilings.
-- [docs.aws.amazon.com: spot best practices.html](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/spot-best-practices.html) — AWS Spot best practices directly state the discount ceiling, two-minute interruption notice, and workload suitability guidance.
-- [docs.aws.amazon.com: orgs manage policies tag policies.html](https://docs.aws.amazon.com/organizations/latest/userguide/orgs_manage_policies_tag-policies.html) — AWS Organizations tag policy documentation directly defines tags as key-value labels and describes their use for categorization.
-- [docs.aws.amazon.com: enforce required tag keys iac.html](https://docs.aws.amazon.com/organizations/latest/userguide/enforce-required-tag-keys-iac.html) — The AWS Organizations required-tag-key documentation directly describes required tag enforcement for CloudFormation, Terraform, and Pulumi IaC deployments.
-- [docs.aws.amazon.com: what is cur.html](https://docs.aws.amazon.com/cur/latest/userguide/what-is-cur.html) — AWS CUR documentation directly states that CUR contains comprehensive AWS cost and usage data and can break costs down by product, resource, and tags.

--- a/src/content/docs/platform/disciplines/business-value/finops/module-1.2-k8s-cost-allocation.md
+++ b/src/content/docs/platform/disciplines/business-value/finops/module-1.2-k8s-cost-allocation.md
@@ -3,100 +3,93 @@ title: "Module 1.2: Kubernetes Cost Allocation & Visibility"
 slug: platform/disciplines/business-value/finops/module-1.2-k8s-cost-allocation
 sidebar:
   order: 3
+revision_pending: false
 ---
 > **Discipline Module** | Complexity: `[MEDIUM]` | Time: 2.5h
 
-## Prerequisites
-
-Before starting this module:
-- **Required**: [Module 1.1: FinOps Fundamentals](../module-1.1-finops-fundamentals/) — FinOps lifecycle, pricing models, tagging
-- **Required**: Kubernetes basics — Pods, Deployments, Namespaces, Services
-- **Required**: Understanding of resource requests and limits
-- **Recommended**: Access to a local Kubernetes cluster (v1.35+ via kind or minikube)
-- **Recommended**: `kubectl` familiarity
-
----
-
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+Cost allocation is the translation layer between a shared Kubernetes platform and the people who make product, reliability, and budget decisions. After this module, you should be able to explain where Kubernetes spending comes from, choose a fair allocation method, and turn cost visibility into an operating signal that engineers can trust rather than a monthly accusation from finance.
 
-- **Implement Kubernetes cost allocation using namespace labels, resource quotas, and tools like Kubecost**
-- **Design chargeback and showback models that attribute cluster costs to teams and applications**
-- **Build cost allocation dashboards that give engineering teams visibility into their Kubernetes spending**
-- **Evaluate cost allocation accuracy across shared resources — control plane, networking, storage — in multi-tenant clusters**
+- **Allocate** Kubernetes compute, storage, network, idle, and shared overhead costs across namespaces, labels, pods, controllers, services, and teams.
+- **Explain** how requests, actual usage, limits, Quality of Service classes, bin packing, and cluster overhead create different cost signals.
+- **Design** showback and chargeback models that expose spend fairly in a multi-tenant cluster without destroying engineering trust.
+- **Build** cost dashboards and alerts that treat idle cost, allocation coverage, and unit economics as first-class platform signals.
+- **Evaluate** outputs from OpenCost, Kubecost, cloud-native cost explorers, and CI cost-estimation tools as evidence for decisions rather than as automatic policy.
 
 ## Why This Module Matters
 
-Your cloud bill says you spent $83,000 on Kubernetes last month. Great. But *which team* spent it? *Which microservice*? Is the staging namespace costing more than production? Is anyone using the resources they requested?
+Your cloud bill can tell you that a worker node, persistent volume, load balancer, or managed control plane incurred cost. It usually cannot tell you whether the underlying Kubernetes workload belonged to the checkout team, the search team, an abandoned staging environment, a shared observability stack, or spare node capacity waiting for a future burst. That gap is where many FinOps efforts stall: the organization knows Kubernetes is expensive, but the people who can change resource requests, replicas, schedules, and architecture cannot see the bill in the language they use every day.
 
-Traditional cloud cost tools see Kubernetes as a black box. They can tell you the cost of the EC2 instances running your cluster, but not the cost of individual workloads *inside* that cluster. It's like knowing your electricity bill but not knowing which appliance uses the most power.
+Kubernetes makes this harder because one node can host pods from many teams at the same time. A cloud billing export sees an instance or virtual machine; the Kubernetes API sees pods, labels, owners, namespaces, persistent volume claims, services, and controllers. Cost allocation connects those two views by mapping infrastructure cost to schedulable resources and then aggregating that cost into business dimensions such as team, product, environment, or feature. The goal is not accounting theater. The goal is to make waste visible at the decision point where it can be fixed.
 
-**This is the Kubernetes cost visibility problem.**
+The durable lesson is that Kubernetes cost allocation is a model, not a perfect measurement instrument. Every model makes choices about whether to allocate by request, actual usage, maximum of request and usage, idle capacity, storage, network, control-plane overhead, and shared platform services. Good FinOps practice makes those choices explicit, explains the tradeoffs, and improves the model as trust and data quality improve. Bad FinOps practice hides assumptions behind a dashboard and then asks teams to accept a bill they cannot reproduce.
 
-In a multi-tenant Kubernetes cluster shared by 12 teams running 200 microservices, you need to answer:
-- What does each team's workloads actually cost?
-- How much are we overpaying for resources nobody uses?
-- Should we charge team X for their resource consumption?
-- Are our namespace quotas aligned with actual business value?
+> **The Apartment Building Analogy**
+>
+> Think of a shared Kubernetes cluster as an apartment building with one utility bill. Each tenant has a lease, a meter, and access to shared spaces such as hallways, elevators, and lobby lighting. Request-based allocation is like charging tenants for the space they reserved; usage-based allocation is like charging only for measured electricity and water; shared-cost allocation is the rule for splitting the elevator and lobby. The important part is not pretending any one rule is morally perfect. The important part is choosing a rule everyone understands, publishing it, and revisiting it when tenant behavior or building design changes.
 
-Without solving this, FinOps stops at the infrastructure layer and never reaches the teams that actually make spending decisions. This module teaches you how to see inside the Kubernetes black box.
+## Prerequisites
 
----
+This module assumes you already understand the FinOps lifecycle from [Module 1.1: FinOps Fundamentals](../module-1.1-finops-fundamentals/), especially the Inform, Optimize, and Operate loop. You should also be comfortable reading a Kubernetes Pod or Deployment manifest, identifying a namespace, and explaining the difference between resource requests and limits. The hands-on exercise uses a local cluster and current curriculum examples assume Kubernetes 1.35 behavior for scheduling, resource requests, limits, Horizontal Pod Autoscaling, and Vertical Pod Autoscaling.
 
-## Did You Know?
-
-- **Studies from the CNCF and Datadog show that the average Kubernetes cluster runs at 13-18% CPU utilization** — meaning over 80% of requested compute capacity sits idle. In dollar terms, a cluster costing $50,000/month might have $40,000+ in wasted resources. The gap between what teams *request* and what they *use* is the single largest source of Kubernetes cost waste.
-
-- **OpenCost, the CNCF project for Kubernetes cost monitoring, was originally built by Kubecost** and donated to the CNCF in 2022. It provides a vendor-neutral, open-source specification for measuring Kubernetes costs that works across AWS, GCP, Azure, and on-premises clusters.
-
-- **A 2024 Flexera State of the Cloud survey found that 28% of cloud spend goes to Kubernetes**, yet only 31% of organizations have any Kubernetes-specific cost visibility tooling in place. The gap between spending and visibility is enormous.
+- **Required**: [Module 1.1: FinOps Fundamentals](../module-1.1-finops-fundamentals/)
+- **Required**: Kubernetes basics: Pods, Deployments, Namespaces, Services, labels, and selectors
+- **Required**: Resource requests and limits for CPU and memory
+- **Recommended**: Access to a local Kubernetes cluster through kind or minikube
+- **Recommended**: `kubectl`, `helm`, `jq`, and basic shell familiarity
 
 ---
 
-## The Kubernetes Cost Challenge
+## Part 1: The Kubernetes Cost Model
 
-### Why Cloud Bills Don't Show Kubernetes Costs
+### Why Cloud Bills Do Not Show Kubernetes Costs
 
-When you run Kubernetes on cloud infrastructure, the cloud provider bills you for:
-- **Compute**: EC2 instances (nodes), Fargate vCPU/memory
-- **Storage**: EBS volumes, EFS, S3
-- **Networking**: Load balancers, NAT gateways, data transfer
+Cloud billing systems are accurate at the infrastructure layer. They know about instances, disks, managed control planes, load balancers, NAT gateways, data transfer, snapshots, and provider-specific managed services. Kubernetes operates one layer above that. It schedules pods onto nodes, attaches volumes to workloads, exposes services through cloud integrations, and adds metadata that often matters more to the business than the provider resource name. Cost allocation starts by respecting both truths: the cloud bill is the financial source of record, and the Kubernetes API is the workload source of context.
 
-None of these line items mention Pods, Deployments, or namespaces. The cloud provider doesn't know (or care) that node `ip-10-0-1-42` is running 23 Pods from 7 different teams.
+The visibility problem appears whenever multiple teams share the same infrastructure. A node might run a payments API, a search indexer, a logging agent, a platform controller, and a short-lived batch job at the same time. The cloud provider can price the node, but it does not know which pod requested which share of CPU and memory unless a Kubernetes-aware allocation layer joins billing data with cluster state. That join is the heart of Kubernetes FinOps: convert raw infrastructure cost into workload-aligned cost without pretending that the raw bill already contains that answer.
 
 ```mermaid
 flowchart LR
     subgraph Cloud["Cloud Provider View"]
         direction TB
-        ec2["EC2 Instances<br/>• i-abc123 $142<br/>• i-def456 $142<br/>• i-ghi789 $285<br/><br/>Total: $569/mo<br/><br/>Per-team cost:<br/>???"]
+        ec2["Instances, disks, load balancers,<br/>data transfer, managed services<br/><br/>Financial source of record:<br/>what was billed"]
     end
     subgraph K8s["Kubernetes View"]
         direction TB
-        ns["Namespaces<br/>• payments<br/>• search<br/>• platform<br/>• ml-pipeline<br/>• staging<br/><br/>Per-team cost:<br/>We need to<br/>figure this out"]
+        ns["Namespaces, pods, controllers,<br/>labels, PVCs, services<br/><br/>Workload source of context:<br/>who used or reserved it"]
     end
-    Cloud -->|Cost Allocation Tooling| K8s
+    Cloud -->|Allocation model joins cost + metadata| K8s
 ```
 
-### The Cost Model
+The model needs three categories of input. First, it needs the cost of the infrastructure that backs the cluster, ideally from the billing export or provider cost API rather than a hand-maintained price table. Second, it needs Kubernetes resource data: which pods ran where, which resources they requested, which labels and owners they carried, and which volumes and services they used. Third, it needs organizational metadata: which labels represent team, product, environment, customer segment, or cost center, and how shared services should be split. If any category is weak, the allocation can still be useful, but its uncertainty must be visible.
 
-To allocate Kubernetes costs, you need to:
+### The Request-Usage Gap
 
-1. **Know the cost of each node** (from your cloud bill)
-2. **Know what each Pod requests** (from Kubernetes resource requests)
-3. **Divide node cost proportionally** across Pods
+Kubernetes schedules pods based on requests, not on future actual usage. When a container asks for CPU or memory, the scheduler uses that request to decide whether a node has enough allocatable capacity for the pod. That decision is conservative by design because the scheduler must protect reliability before it optimizes finance. A pod that requests far more CPU or memory than it normally uses can therefore block capacity for other workloads even when the node looks quiet in runtime metrics.
 
-This sounds simple. It's not.
+This request-usage gap is the core idle-cost mechanism in Kubernetes. If a pod requests one CPU but normally uses a small fraction of that request, the unused requested capacity is not automatically available to another pod from the scheduler's perspective. Enough over-requested pods force the cluster to run more nodes than the workload truly needs. The bill then shows more infrastructure; the runtime dashboard shows low utilization; the allocation model explains who reserved the capacity that made those nodes necessary.
 
----
+The same idea applies at the cluster level. A node can have unallocated capacity because no pod requested it, reserved-but-idle capacity because pods requested it but did not use it, or overhead capacity consumed by system components that make the cluster function. Those are different kinds of cost. Treating all of them as "waste" misses the reliability reason they exist, while hiding them entirely makes teams believe their service is cheaper than it really is. A good allocation report separates these categories so engineering and finance can have a precise conversation.
 
-## Requests vs Limits vs Actual Usage
+```mermaid
+flowchart LR
+    subgraph Node["One Kubernetes Node"]
+        direction TB
+        cap["Allocatable capacity"]
+        req["Reserved by pod requests"]
+        used["Actually used by containers"]
+        idle["Unallocated or reserved-but-idle slack"]
+        overhead["System and platform overhead"]
+    end
+    used --> req --> cap
+    idle --> cap
+    overhead --> cap
+```
 
-Understanding the difference between these three values is critical for Kubernetes cost allocation.
+### Requests, Limits, and Actual Usage
 
-### Resource Requests
-
-The **minimum** resources guaranteed to a Pod. The scheduler uses requests to decide which node a Pod runs on.
+Resource requests are the minimum resources Kubernetes reserves for a container when scheduling a pod. Limits are runtime ceilings enforced by the kubelet and container runtime. Actual usage is what the container consumed over time, usually observed through kubelet, cAdvisor, the Metrics API, Prometheus, or a cost tool that reads those signals. These three values answer different questions, and a FinOps model must avoid mixing them accidentally.
 
 ```yaml
 apiVersion: v1
@@ -110,33 +103,16 @@ spec:
     image: payments/api:v2.4
     resources:
       requests:
-        cpu: "500m"      # Guarantee me 0.5 CPU cores
-        memory: "512Mi"  # Guarantee me 512 MB RAM
+        cpu: "500m"      # Scheduler reserves half a CPU core
+        memory: "512Mi"  # Scheduler reserves 512 MiB of memory
+      limits:
+        cpu: "1000m"     # Runtime ceiling for CPU bursting
+        memory: "1Gi"    # Runtime ceiling before memory enforcement
 ```
 
-**For cost allocation**: Requests represent what you've *reserved*. Even if your Pod only uses 50m CPU, you're blocking 500m on the node. It's like reserving a table at a restaurant — you pay whether you eat or not.
+For allocation, requests are attractive because they represent reserved capacity and because teams can change them in the same manifests they already own. They also create a clear incentive: if a team reserves more capacity than it needs, its showback report makes the reservation visible. Usage is attractive because it reflects measured consumption and can feel fair to bursty workloads. It is also noisier, harder to forecast, and can remove the incentive to rightsize requests if teams are charged only for what they happened to use.
 
-> **Stop and think**: If a Pod requests 4 CPU cores but only uses 0.5 cores on average, what happens to the remaining 3.5 cores on that node? From the Kubernetes scheduler's perspective, those 3.5 cores are strictly reserved and unavailable to other workloads, even while they sit completely idle.
-
-### Resource Limits
-
-The **maximum** resources a Pod can use. If a Pod exceeds its CPU limit, it gets throttled. If it exceeds its memory limit, it gets OOM-killed.
-
-```yaml
-      resources:
-        requests:
-          cpu: "500m"
-          memory: "512Mi"
-        limits:
-          cpu: "1000m"    # Can burst up to 1 CPU core
-          memory: "1Gi"   # Hard ceiling: OOM-killed above 1 GB
-```
-
-**For cost allocation**: Limits represent *potential* burst usage. Some cost models charge based on limits because that's the maximum infrastructure impact.
-
-### Actual Usage
-
-What the Pod *really* uses, as measured by cAdvisor and the metrics server.
+Limits are a different signal again. CPU limits can throttle work when a container tries to exceed its ceiling, while memory limits can lead to termination when the process grows beyond the allowed memory. Charging by limits alone is usually too punitive for services that need burst headroom, but limits still matter in analysis because they reveal the blast radius a workload could create at runtime. In practice, allocation conversations often start with requests, then compare requests to p95 or p99 usage to identify rightsizing candidates without automatically applying every recommendation.
 
 ```mermaid
 flowchart LR
@@ -144,54 +120,50 @@ flowchart LR
         direction TB
         CL["Limit: 1000m"]
         CR["Request: 500m"]
-        CA["Actual: 120m"]
+        CA["Observed usage: 120m"]
     end
     subgraph Memory["Memory (MiB)"]
         direction TB
         ML["Limit: 1024 Mi"]
         MR["Request: 512 Mi"]
-        MA["Actual: 380 Mi"]
+        MA["Observed usage: 380 Mi"]
     end
-    CA -.->|76% of requested CPU is idle!| CR
-    MA -.->|26% of requested memory is idle!| MR
+    CA -.->|Reserved but idle CPU signal| CR
+    MA -.->|Memory headroom signal| MR
 ```
 
-### Which Value Should You Use for Cost Allocation?
+### Choosing the Allocation Basis
 
-| Method | Basis | Pros | Cons |
-|--------|-------|------|------|
-| Request-based | What's reserved | Simple, stable, predictable | Penalizes over-provisioning |
-| Usage-based | What's consumed | Reflects actual consumption | Volatile, hard to budget |
-| Max(request, usage) | Higher of the two | Fair for burst workloads | Complex to explain |
-| Weighted blend | 80% request + 20% usage | Balanced, incentivizes rightsizing | Arbitrary weights |
+There is no universal allocation basis because the model must match the behavior you want to encourage. Request-based allocation encourages teams to reserve responsibly and gives finance a more stable number. Usage-based allocation helps teams with bursty or event-driven workloads avoid paying for headroom they rarely use, but it can make budgets less predictable and can weaken request discipline. A max(request, usage) model protects against workloads that use more than they request, while a weighted model can intentionally balance reliability headroom with consumption.
 
-> **Pause and predict**: If you implemented a purely usage-based cost model, how would developers react? Would they care about their requests anymore? They likely wouldn't, resulting in massively over-provisioned clusters where teams request 10 CPUs "just in case" since they are only billed for the 0.5 CPUs they actually use.
+| Method | Basis | What It Encourages | Main Tradeoff |
+|--------|-------|--------------------|---------------|
+| Request-based | Reserved CPU and memory | Rightsized reservations and predictable reports | Can feel harsh to bursty workloads with legitimate headroom |
+| Usage-based | Observed CPU and memory | Consumption awareness and runtime efficiency | Can make budgets volatile and ignore scheduler pressure |
+| Max(request, usage) | Higher of reserved or observed | Honest requests and protection against under-requesting | Harder to explain to non-engineers |
+| Weighted blend | Agreed mix of reservation and usage | Balanced behavior across different workload shapes | Requires governance around the chosen weights |
 
-**Industry standard**: Most organizations start with **request-based allocation** because it's simple and incentivizes teams to rightsize their requests. If you request 4 CPU but use 0.3, you pay for 4 — which motivates you to reduce your request.
+Hypothetical scenario: a team runs a latency-sensitive API that requests 1000m CPU per replica but normally uses 250m, with short bursts during product launches. A pure request-based model will flag the unused reservation and push the team toward smaller requests, perhaps with more replicas or better autoscaling. A pure usage-based model will make the service look cheap most of the month, but it will not show that the cluster still needs enough reserved headroom to schedule the pods safely. The better conversation is not "which number is true"; it is "how much headroom is justified by reliability, and how do we make that justification visible?"
+
+### QoS, Bin Packing, and Cluster Overhead
+
+Kubernetes Quality of Service classes influence eviction behavior and operational risk, which means they indirectly affect cost decisions. A Guaranteed pod with equal requests and limits can be easier to reason about during pressure, but it can also reserve capacity very explicitly. A Burstable pod may be a practical compromise for many services because it reserves a baseline and allows headroom. A BestEffort pod carries no requests and is cheap in allocation models that depend only on requests, but it can be evicted first and can distort cost visibility if important workloads avoid requests to avoid showback.
+
+Bin packing is the cluster-level expression of request discipline. If workload requests fit together neatly, the scheduler can place more work on fewer nodes while preserving reliability. If requests are oversized, oddly shaped, or constrained by too many node selectors and affinity rules, the cluster may need additional nodes even when CPU or memory graphs appear low. Allocation reports should therefore show both workload-level reservation gaps and cluster-level idle capacity. A team can rightsize one deployment and still see little bill movement if fragmented requests, daemonset overhead, or node-pool constraints prevent nodes from being removed.
+
+Cluster overhead is not an accounting nuisance; it is part of the service cost. Core DNS, networking components, storage drivers, observability agents, policy controllers, service mesh sidecars, admission controllers, backup agents, and cost collectors all consume resources that business workloads rely on. Some overhead scales with the number of nodes, some with the number of pods, and some with organizational requirements such as audit retention or security scanning. Treating overhead as invisible platform cost makes application teams under-estimate their true unit economics, while dumping it on one platform namespace makes the platform team look artificially expensive.
 
 ---
 
-## Multi-Tenant Cost Attribution
+## Part 2: Allocation Dimensions and Metadata Contracts
 
-### Namespace-Based Allocation
+### Namespace, Label, Pod, Controller, and Team Views
 
-The simplest model: one namespace per team (or per service).
+A Kubernetes allocation report is useful only if it can be grouped by dimensions people recognize. Namespace is the simplest dimension because most clusters already use namespaces to separate teams, environments, or applications. It is also blunt. A shared namespace can contain workloads from multiple teams, and a single team can own workloads across production, staging, and batch namespaces. Namespace allocation is a good starting view, but it should not be the only view in a mature model.
 
-**Cluster**: 3 nodes × m6i.xlarge ($0.192/hr) = $420.48/month
-**Total cluster resources**: 12 vCPU, 48 GB RAM
+Labels provide the durable metadata contract. A label such as `team`, `product`, `environment`, `service`, or `cost-center` can follow a workload across namespaces and can support reports that finance, platform engineering, and product managers all understand. The danger is label drift: if different teams use `owner`, `team_name`, `squad`, and `group` for the same concept, the allocation model becomes a cleanup project instead of a teaching tool. FinOps teams should define a small mandatory label schema, validate it at admission or CI time, and publish examples that make the easy path the correct path.
 
-| Namespace | CPU Req | Memory Req | Allocated $ |
-|-----------|---------|------------|-------------|
-| payments | 3.0 CPU | 12 GB | $105.12/mo |
-| search | 4.5 CPU | 16 GB | $152.26/mo |
-| platform | 1.5 CPU | 8 GB | $68.81/mo |
-| monitoring| 1.0 CPU | 4 GB | $38.02/mo |
-| idle/unused| 2.0 CPU | 8 GB | $56.27/mo |
-| **Total** | **12.0 CPU**| **48 GB** | **$420.48/mo** |
-
-### Label-Based Allocation
-
-For more granularity, use Kubernetes labels to track costs at the service, feature, or team level — even within a shared namespace.
+Pod and controller views serve different purposes. Pod-level allocation is useful for debugging a spike or explaining why one replica set consumed more than expected during a rollout. Controller-level allocation is better for stable reporting because Deployments, StatefulSets, Jobs, and CronJobs represent ownership more clearly than individual pods. Team and product views are the business rollups that turn raw allocation into decision support. A good dashboard lets the viewer move between these layers without changing the underlying model.
 
 ```yaml
 apiVersion: apps/v1
@@ -203,187 +175,197 @@ metadata:
     app: checkout
     team: payments
     cost-center: "CC-4521"
-    feature: "checkout-v2"
+    product: "storefront"
+    environment: "production"
 spec:
   replicas: 3
+  selector:
+    matchLabels:
+      app: checkout
   template:
     metadata:
       labels:
         app: checkout
         team: payments
         cost-center: "CC-4521"
+        product: "storefront"
+        environment: "production"
+    spec:
+      containers:
+      - name: api
+        image: nginx:alpine
+        resources:
+          requests:
+            cpu: "300m"
+            memory: "512Mi"
+          limits:
+            cpu: "900m"
+            memory: "1Gi"
 ```
 
-### Handling Shared Costs
+The label contract should be boring on purpose. Require the few fields needed for allocation, ownership, and incident response; avoid asking every team to maintain a large taxonomy nobody audits. A practical contract might require `team`, `service`, `environment`, and `cost-center`, then allow optional labels for product, feature, customer segment, or compliance boundary. The right enforcement point depends on culture: some organizations start with CI warnings, some use admission policies, and some rely on namespace templates. The important point is that missing metadata becomes visible before the monthly report.
 
-Some costs don't belong to any single team:
+### Resource Quotas and Allocation Guardrails
 
-| Shared Cost | Examples | Allocation Strategy |
-|-------------|----------|-------------------|
-| Cluster overhead | kube-system, control plane | Proportional to each team's requests |
-| Monitoring | Prometheus, Grafana | Even split or proportional |
-| Networking | NAT Gateway, load balancers | Proportional to data transfer |
-| Platform team | CI/CD, service mesh | Even split across consuming teams |
-| Idle resources | Unallocated node capacity | Proportional or "tax" model |
+Resource quotas are not a cost allocation system, but they make allocation behavior visible earlier. A namespace quota can cap total requested CPU and memory, which forces teams to notice when a deployment consumes more reserved capacity than expected. LimitRanges can provide default requests and limits for containers that omit them, reducing the number of workloads that are impossible to allocate fairly. These controls should be paired with reports, not used as silent punishment, because a quota failure without context teaches frustration instead of FinOps discipline.
 
-**Shared Cost Allocation Example:**
-- Cluster cost: $420.48/mo
-- kube-system overhead: $38.50/mo
-- Monitoring stack: $52.00/mo
-- **Shared costs total: $90.50/mo**
+The useful pattern is to treat quotas as budget guardrails and allocation reports as feedback. When a namespace approaches its request quota, the team should be able to see which controllers are responsible, whether observed usage justifies the reservation, and whether the next action is rightsizing, horizontal scaling, architecture change, or a budget conversation. This turns a quota from an arbitrary platform rule into an early warning that connects cost, reliability, and ownership.
 
-```mermaid
-pie title "Shared Costs Distribution (Proportional to Requests)"
-    "payments (+ $22.63)": 25.0
-    "search (+ $33.94)": 37.5
-    "idle (+ $15.11)": 16.7
-    "platform (+ $11.31)": 12.5
-    "monitoring (+ $7.51)": 8.3
-```
+### Unit Economics and Allocation Dimensions
 
----
+Unit economics translates allocated platform cost into a business denominator. Cost per customer, cost per request, cost per order, cost per training job, cost per tenant, or cost per feature can be more useful than total namespace cost because it shows whether spend is scaling with value. A product whose monthly cluster cost rises while customer volume rises faster may be improving. A product whose cluster cost rises while the business denominator stays flat needs investigation even if the absolute bill is smaller.
 
-## Showback vs Chargeback
-
-Two models for communicating costs to teams:
-
-### Showback
-
-**"Here's what you cost"** — informational only. No money actually changes hands between departments.
+The allocation dimension determines whether unit economics can be calculated credibly. If every checkout workload carries `product=storefront` and every order event is counted in the same reporting period, cost per order can be a useful trend. If half the workloads are unlabeled or shared services are excluded, the metric becomes misleading. Start with a unit metric that has clean ownership and a stable denominator, then expand. Unit economics should reduce confusion, not create a precision costume for incomplete data.
 
 ```text
-Monthly Cost Report — Payments Team
-──────────────────────────────────────
-Namespace: payments
-Period: March 2026
+Illustrative unit-cost formulas:
 
-Compute (CPU):         $72.40
-Compute (Memory):      $32.72
-Storage (PVCs):        $18.90
-Network (LB):          $12.00
-Shared costs:          $22.63
-──────────────────────────────────────
-Total:                $158.65
-
-Optimization Opportunities:
-• checkout-api: CPU request 500m, usage avg 85m (-83%)
-• payment-worker: 2 idle replicas during off-peak
-• staging env: Running 24/7, used only business hours
-
-Estimated savings if optimized: $41/mo
+Cost per request  = allocated service cost / successful requests
+Cost per customer = allocated product cost / active customers
+Cost per job      = allocated batch cost / completed jobs
+Cost per feature  = allocated feature-label cost / business events for that feature
 ```
-
-**Pros**: Low friction, educational, non-threatening
-**Cons**: No financial consequence, easy to ignore
-
-### Chargeback
-
-**"Here's your bill"** — costs are deducted from the team's budget or charged to their cost center.
-
-```text
-Internal Invoice — Payments Team (CC-4521)
-──────────────────────────────────────
-Billing Period: March 2026
-
-Line Items:
-  Kubernetes compute (requests-based):    $105.12
-  Persistent volume claims (gp3):         $18.90
-  Load balancer (ALB shared):             $12.00
-  Shared platform overhead (25%):         $22.63
-  ──────────────────────────────────────
-  Subtotal:                              $158.65
-
-Adjustments:
-  Spot savings credit:                   -$14.20
-  ──────────────────────────────────────
-  Total charged to CC-4521:              $144.45
-```
-
-**Pros**: Real financial accountability, teams optimize proactively
-**Cons**: High friction, requires accurate data, can create perverse incentives
-
-> **Stop and think**: Why might implementing chargeback on day one of a FinOps initiative cause massive cultural resistance among engineering teams? If teams have never seen their costs before and suddenly face budget cuts based on un-optimized legacy configurations or missing labels, they will likely distrust the data and fight the FinOps program instead of collaborating.
-
-### Choosing a Model
-
-| Factor | Start with Showback | Move to Chargeback |
-|--------|--------------------|--------------------|
-| Data quality | Tagging < 85% | Tagging > 95% |
-| Cultural readiness | Teams new to FinOps | Teams understand cloud costs |
-| Cost accuracy | Within 20% | Within 5% |
-| Organization size | < 10 teams | > 10 teams |
-| Cloud maturity | 1-2 years cloud | 3+ years cloud |
-
-**Best practice**: Start with showback. Build trust in the data. Move to chargeback when teams accept the numbers as accurate and fair.
 
 ---
 
-## Kubernetes Cost Tooling
+## Part 3: Shared, Idle, and Overhead Costs
 
-### OpenCost
+### Why Shared Costs Must Stay Visible
 
-OpenCost is a CNCF project for Kubernetes cost monitoring. It provides a standard specification for measuring and allocating Kubernetes costs.
+Shared cost is the allocation category that exposes whether the organization is using FinOps as a trust-building practice or a blame mechanism. Some resources clearly belong to one workload, such as a pod's requested CPU or a persistent volume claim owned by one service. Other resources support everyone: control-plane fees, DNS, CNI components, node-local agents, observability pipelines, policy controllers, ingress infrastructure, NAT gateways, and unallocated node capacity. If you hide those costs, service teams under-estimate what their workloads really require. If you dump them randomly, teams stop trusting the report.
 
-**Architecture**:
+There are three common splitting methods. An even split is simple and politically easy when all tenants are similar, but it overcharges small teams and undercharges large ones. A request-weighted split charges teams in proportion to the capacity they reserve, which aligns well with scheduler pressure and works naturally with request-based allocation. A usage-proportional split can be useful for network egress or storage throughput where measured consumption is the fairness signal. The right method can differ by cost type, which is why the model should document the split rule next to the number.
+
+| Shared Cost | Examples | Durable Split Options | Fairness Question |
+|-------------|----------|-----------------------|-------------------|
+| Idle node capacity | Unallocated CPU and memory after scheduling | Request-weighted, node-pool-weighted, visible platform pool | Who caused the node to exist, and who benefits from the headroom? |
+| System components | DNS, CNI, CSI, kube-proxy, node agents | Request-weighted, pod-count-weighted, even split | Does overhead scale with requests, pods, nodes, or tenancy? |
+| Observability | Metrics, logs, tracing, dashboards, retention | Usage-proportional, request-weighted, service-tier split | Which teams generate the data and which teams require the retention? |
+| Control plane | Managed control-plane fees, API server overhead | Even split, request-weighted, cluster-level platform tax | Is the cluster a shared utility or a workload-specific environment? |
+| Network | Load balancers, NAT, cross-zone or internet egress | Usage-proportional where measurable | Which traffic source or consumer drives the charge? |
+
+Hypothetical scenario: a shared production cluster has a round internal monthly cost of 100 cost units. Workload requests account for 70 units, node idle capacity accounts for 15 units, platform agents account for 10 units, and shared networking accounts for 5 units. If the report shows only the 70 workload units, every team believes its service is cheaper than the cluster reality. If the report allocates all 30 shared units evenly, a small team may pay the same overhead as the largest tenant. If the report allocates idle and agents by request share while allocating network by measured transfer, the model is more complex, but each cost follows a defensible driver.
 
 ```mermaid
-flowchart TD
-    subgraph OpenCost ["OpenCost Architecture"]
-        direction TB
-        API["Cloud Pricing API<br/>(AWS/GCP/Azure)"]
-        K8s["Kubernetes Resource Metrics<br/>(cAdvisor, kubelet)"]
-        Engine["Cost Allocation Engine"]
-        Prom["Prometheus Metrics + REST API"]
-        
-        API --> Engine
-        K8s --> Engine
-        Engine --> Prom
-    end
+pie title "Illustrative Shared-Cost Split by Cost Driver"
+    "Direct workload requests" : 70
+    "Idle node capacity" : 15
+    "Platform agents" : 10
+    "Shared networking" : 5
 ```
 
-**Key features**:
-- Real-time cost allocation by namespace, deployment, pod, label
-- Cloud provider pricing integration (on-demand, spot, RI rates)
-- Support for CPU, memory, GPU, storage, and network costs
-- Prometheus metrics export for alerting and dashboards
-- Open-source, vendor-neutral (CNCF project)
+### Idle Cost Is a Signal, Not a Trash Can
 
-### Kubecost
+Idle cost deserves its own line because it can mean different things. Some idle capacity is deliberate reliability headroom for bursts, rollouts, node drains, and fault tolerance. Some idle capacity is fragmentation caused by oversized requests, incompatible node pools, affinity rules, or daemonset overhead. Some idle capacity is temporary because autoscalers need time to remove nodes after load drops. A useful report does not simply shame idle cost; it asks why the idle exists and whether it is justified by reliability, performance, or operational constraints.
 
-Kubecost is a commercial product (with a free tier) built on top of OpenCost. It adds:
+The most important distinction is unallocated idle versus reserved idle. Unallocated idle is node capacity no pod requested. It may indicate that cluster autoscaling can consolidate nodes, that a node pool has too much baseline capacity, or that system overhead prevents an otherwise empty node from disappearing. Reserved idle is capacity requested by workloads but not used. It points toward rightsizing, request policy, or workload architecture. Both contribute to the bill, but they require different owners and different fixes.
 
-- **Savings recommendations**: Specific rightsizing suggestions per workload
-- **Unified multi-cluster view**: Aggregate costs across clusters
-- **Alerting**: Budget alerts, anomaly detection
-- **Request sizing recommendations**: Based on actual usage patterns
-- **Network cost monitoring**: Pod-to-pod, cross-zone, internet egress
-- **Governance policies**: Enforce cost limits per namespace
+### Cost Allocation Formula
 
-### CAST AI, Spot.io, and Others
+The basic request-based formula is simple enough to teach, even though production systems add many refinements. Start with the hourly or monthly cost of a node, split that cost across resource dimensions, then allocate each pod's share based on requested resources on that node. Storage, GPU, and network charges should be modeled separately when they are material because their cost drivers differ from CPU and memory. The formula is a teaching device; the implementation should use real billing data and the cost tool's documented model.
 
-| Tool | Focus | Pricing | Best For |
-|------|-------|---------|----------|
-| OpenCost | Cost monitoring (open-source) | Free | Teams wanting CNCF-native visibility |
-| Kubecost | Cost management + optimization | Free tier + paid | Full-featured cost platform |
-| CAST AI | Automated optimization | Per-node pricing | Hands-off cluster optimization |
-| Spot.io (NetApp) | Spot management + cost | Per managed node | Heavy Spot instance users |
-| Vantage | Multi-cloud cost platform | Free tier + paid | Multi-cloud visibility |
-| Infracost | IaC cost estimation | Free + paid | Terraform cost in CI/CD |
+```text
+Pod CPU cost =
+  (pod_cpu_request / node_allocatable_cpu) * node_cpu_cost
+
+Pod memory cost =
+  (pod_memory_request / node_allocatable_memory) * node_memory_cost
+
+Pod direct allocation =
+  pod_cpu_cost + pod_memory_cost + pod_storage_cost + pod_network_cost
+
+Team allocation =
+  sum(pod direct allocation for team) + allocated shared costs
+```
+
+Hypothetical scenario: imagine a node whose internal monthly cost is modeled as 100 cost units, with 60 units assigned to CPU and 40 units assigned to memory for allocation purposes. A pod that reserves one quarter of the node's allocatable CPU receives 15 CPU cost units, and a pod that reserves one eighth of the node's allocatable memory receives 5 memory cost units. The pod's direct compute allocation is therefore 20 cost units before storage, network, and shared overhead. The exact weights should come from your chosen allocation method, but the reasoning should always be reproducible.
+
+### GPUs and Specialized Hardware
+
+Specialized hardware breaks simplistic CPU-memory assumptions. A GPU node, high-memory node, local-SSD node, or accelerator pool often exists because a small number of workloads require capabilities unavailable elsewhere. Allocating that node mostly by generic CPU and memory can hide the real cost driver. If a pod requests a GPU, the allocation model should treat the accelerator as a first-class resource and should show idle accelerator time separately from ordinary idle CPU.
+
+This is also where showback can teach architecture. A machine learning team may reasonably need expensive accelerators during training windows, but the allocation report can still show whether those accelerators are idle outside those windows, whether jobs queue efficiently, and whether batch scheduling would improve utilization. The FinOps lesson is not "never use expensive hardware." It is "make the scarce resource visible in the same business language as the value it produces."
 
 ---
 
-## Cost Allocation in Practice
+## Part 4: Showback, Chargeback, and Trust
+
+### Showback First
+
+Showback means "here is what your workloads cost" without moving money between budgets. It is the right starting point for most Kubernetes FinOps programs because the first objective is trust. Teams need time to see how labels map to reports, how requests map to allocation, how shared costs are split, and how to challenge numbers that look wrong. A showback report should invite correction. Missing labels, mis-owned namespaces, abandoned resources, and odd request settings are expected findings during the first cycles, not evidence that engineers are careless.
+
+```text
+Hypothetical scenario: Monthly Cost Report - Payments Team
+---------------------------------------------------------
+Namespace scope: payments
+Allocation model: request-based compute + explicit shared costs
+
+Compute requests:          100 cost units
+Persistent volumes:         20 cost units
+Load balancer share:        10 cost units
+Shared platform overhead:   30 cost units
+---------------------------------------------------------
+Total visible cost:        160 cost units
+
+Optimization prompts:
+- checkout-api reserves materially more CPU than observed p95 usage
+- payment-worker has replicas during a quiet overnight window
+- staging-like workloads should be reviewed for schedule and ownership
+```
+
+The report avoids two common mistakes. It does not present recommendations as automatic savings, and it does not hide the allocation model. "Optimization prompts" are questions for engineering review, not commands to cut capacity. A rightsizing recommendation can be wrong if the observation window missed a seasonal spike, if a service has strict cold-start behavior, or if memory usage is intentionally high before a batch flush. FinOps works when recommendations are treated as input to an engineering decision, not as autopilot.
+
+### Chargeback Later
+
+Chargeback means the allocation report drives real internal billing, budget transfer, or cost-center accounting. That can be useful in large organizations, but it raises the cost of every data-quality error. A mislabeled namespace under showback is an annoyance and a fix ticket. The same mislabeled namespace under chargeback is a budget dispute. That is why chargeback should follow a period of showback, label cleanup, model documentation, owner sign-off, and exception handling.
+
+```text
+Hypothetical scenario: Internal Allocation Notice - Payments Team
+----------------------------------------------------------------
+Billing period: monthly
+Allocation basis: requests for compute, ownership for storage,
+usage-proportional network, request-weighted platform overhead
+
+Line items:
+  Kubernetes compute reservation:      100 cost units
+  Persistent volume ownership:          20 cost units
+  Shared load balancer allocation:      10 cost units
+  Platform overhead allocation:         30 cost units
+  Adjustment for approved shared work: -10 cost units
+----------------------------------------------------------------
+  Total charged allocation:            150 cost units
+```
+
+Chargeback can also create perverse incentives if the model is too narrow. If teams are charged only for usage, they may inflate requests because reservation is free to them. If teams are charged only for requests, they may under-request and create reliability risk. If shared costs are invisible, teams may optimize their own services while shifting expense to the platform. The governance answer is to publish the model, monitor behavior changes, and adjust the model when it encourages the wrong outcome.
+
+### Choosing Showback or Chargeback
+
+The decision is cultural as much as technical. Showback fits an organization that is learning its metadata quality, has inconsistent ownership labels, or still needs engineering buy-in. Chargeback fits an organization with stable ownership, reproducible reports, finance processes that can handle disputes, and product teams that already use unit economics in planning. A hybrid model is common: showback for new teams and experimental environments, chargeback for mature product lines, and explicit platform-funded pools for work that benefits the whole organization.
+
+| Factor | Prefer Showback | Consider Chargeback |
+|--------|-----------------|---------------------|
+| Metadata quality | Ownership labels are incomplete or inconsistent | Required labels are enforced and audited |
+| Trust in model | Teams are still validating assumptions | Teams can reproduce and challenge reports |
+| Organizational maturity | Cost visibility is new to engineering | Product teams already manage cloud budgets |
+| Shared-cost policy | Split rules are still being negotiated | Split rules are documented and accepted |
+| Failure mode | Education and cleanup are the goal | Budget accountability is the goal |
+
+---
+
+## Part 5: Cost Monitoring as an Operating Signal
 
 ### The Cost Allocation Pipeline
 
+Cost allocation is not a one-time spreadsheet. It is a data pipeline that should run often enough for engineers to connect changes in manifests, deployments, traffic, and schedules with changes in cost. The pipeline collects infrastructure cost, maps nodes to Kubernetes resources, calculates direct pod costs, aggregates by durable dimensions, adds shared costs, and publishes reports or metrics. Each step needs observability because a silent break in billing ingestion or label collection can make the report look calm while the model is actually blind.
+
 ```mermaid
 flowchart TD
-    S1["Step 1: Collect Infrastructure Costs<br/>Cloud billing API → node costs per hour"]
-    S2["Step 2: Map Nodes to Resources<br/>Kubernetes API → pods per node, resource requests"]
-    S3["Step 3: Calculate Pod Costs<br/>Pod cost = (pod_requests / node_capacity) × node_cost"]
-    S4["Step 4: Aggregate by Dimension<br/>Sum pod costs by namespace, label, team, service"]
-    S5["Step 5: Add Shared Costs<br/>Distribute cluster overhead proportionally"]
-    S6["Step 6: Report<br/>Dashboards, reports, alerts, forecasts"]
+    S1["Step 1: Collect Infrastructure Costs<br/>Billing export or provider API -> node and service costs"]
+    S2["Step 2: Map Nodes to Resources<br/>Kubernetes API -> pods, owners, requests, labels"]
+    S3["Step 3: Calculate Direct Costs<br/>Pod cost from requests, usage, storage, network"]
+    S4["Step 4: Aggregate by Dimension<br/>Namespace, label, controller, team, product"]
+    S5["Step 5: Add Shared Costs<br/>Idle, system, control plane, observability, network"]
+    S6["Step 6: Operate the Signal<br/>Dashboards, alerts, reviews, forecasts, unit economics"]
 
     S1 --> S2
     S2 --> S3
@@ -392,130 +374,219 @@ flowchart TD
     S5 --> S6
 ```
 
-### Cost Allocation Formula
+Prometheus is often part of this pipeline because Kubernetes teams already use it for operational metrics, and tools such as OpenCost expose metrics and APIs that can be scraped or queried. The important design choice is not the brand of dashboard; it is whether cost metrics sit next to reliability and capacity metrics. A team reviewing a deployment should be able to see request changes, replica changes, p95 usage, error rate, latency, allocated cost, and idle share together. If cost lives in a separate finance portal, engineers will treat it as lagging commentary rather than an operating signal.
 
-For a request-based model:
+Cost can also participate in service-level thinking, but it should not be framed as an SLO that competes with reliability in a simplistic way. A better pattern is to define cost guardrails and review triggers: allocation coverage should stay complete enough to trust reports; idle cost should be explained by a known headroom or scaling policy; unit cost should be reviewed when it drifts away from traffic or customer growth; and anomaly alerts should route to the owner who can connect the spike to a deployment or incident. These signals do not replace reliability SLOs. They add the economic dimension that platform teams need to operate responsibly.
 
-```text
-Pod CPU cost = (pod_cpu_request / node_total_cpu) × node_cost × cpu_weight
+### Dashboard Views for Different Personas
 
-Pod Memory cost = (pod_memory_request / node_total_memory) × node_cost × memory_weight
+The FinOps Foundation framework emphasizes personas because the same cost data must support different decisions. Engineers need workload-level detail, request-to-usage gaps, and concrete links back to manifests. Product managers need unit economics and trend lines by customer, feature, or business capability. Finance needs allocation coverage, forecast confidence, budget variance, and a documented model. Platform teams need shared-cost drivers, cluster efficiency, node-pool fragmentation, and opportunities to improve the platform itself.
 
-Where:
-  cpu_weight = 0.65  (CPU is typically 65% of instance cost)
-  memory_weight = 0.35 (Memory is typically 35%)
+One dashboard rarely serves all of those needs. A better pattern is layered reporting over the same allocation model. The engineering view starts with namespaces, controllers, labels, requests, p95 usage, and optimization prompts. The platform view starts with node pools, idle cost, daemonset overhead, autoscaler behavior, and bin-packing constraints. The finance view starts with cost-center rollups, shared-cost policy, allocation coverage, and month-over-month variance. The product view starts with unit metrics and business context. The shared model keeps these views consistent while each persona sees the level of detail that matches its decisions.
 
-Example:
-  Node: m6i.xlarge (4 vCPU, 16 GB) = $0.192/hr = $140.16/mo
-  Pod requests: 500m CPU, 2 GB memory
+### Recommendations Are Inputs, Not Autopilot
 
-  CPU cost = (0.5 / 4) × $140.16 × 0.65 = $11.39/mo
-  Mem cost = (2 / 16) × $140.16 × 0.35 = $6.13/mo
+Rightsizing recommendations are useful because humans are bad at continuously comparing manifests with observed behavior across hundreds of workloads. They are dangerous when treated as automatic truth. A recommendation engine sees a historical window, a metric source, and a policy. It may not know that a service has a quarterly traffic pattern, that a batch job is intentionally quiet before a launch, that memory spikes during rare reconciliation events, or that a rollout needs headroom to avoid cascading retries.
 
-  Total pod cost = $17.52/mo
+The durable methodology is to treat recommendations as a queue of hypotheses. Review the observation window, compare p95 and p99 usage with requests, check whether the workload uses HPA or VPA (and never drive both from the same CPU or memory metric — that pits scaling out against scaling up; see Module 1.3 for the split-metric pattern), understand QoS and limit behavior, validate against incident history, and then apply changes gradually. If the workload is stateless and horizontally scalable, lowering requests and relying on HPA may be safe. If the workload is stateful or latency-sensitive, a conservative request with explicit headroom may be justified. The allocation report should preserve that nuance rather than reducing every recommendation to a promised saving.
+
+---
+
+## Part 6: Landscape Snapshot and Cost-Tooling Rosetta
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> OpenCost is listed by CNCF as an Incubating project and describes a vendor-agnostic methodology for measuring and allocating Kubernetes cluster costs to tenants. Kubecost is a commercial implementation of the same allocation concepts, now part of IBM's FinOps portfolio (acquired 2024) — verify its current packaging and naming when you reach IBM-branded docs. Kubernetes resource-management semantics remain centered on requests for scheduling and limits for runtime enforcement, while autoscaling behavior depends on the configured HPA, VPA, metrics pipeline, and provider environment. Cloud-native cost explorers, commercial FinOps platforms, and CI cost-estimation tools change feature sets frequently, so treat this snapshot as a refreshable map of capabilities rather than a ranking.
+
+The durable spine is capability-based. You need cost ingestion, Kubernetes metadata correlation, idle-cost attribution, shared-cost rules, showback and chargeback reporting, anomaly detection, rightsizing evidence, and pre-deployment cost awareness. Tools differ in packaging, integration depth, hosting model, and opinionated workflows. The mistake is choosing a tool first and letting its defaults become policy. Choose the policy first, then use tools to implement and audit it.
+
+| Durable Capability | OpenCost | Kubecost | Cloud-Native Cost Explorer | Infracost |
+|--------------------|----------|----------|----------------------------|-----------|
+| Kubernetes allocation | Provides open cost-allocation metrics and APIs for Kubernetes workloads | Builds allocation workflows and dashboards around Kubernetes concepts such as namespace, controller, service, and label | Provider tools can expose infrastructure and, for some managed Kubernetes services, split or container cost views | Not a runtime Kubernetes allocator; estimates infrastructure cost before deployment |
+| Idle-cost attribution | Exposes allocation data that can distinguish allocated and idle cost depending on configuration | Adds product workflows for idle, efficiency, and allocation views | Often strong for node or service spend, weaker for pod-level context unless provider-specific integrations are enabled | Flags cost changes in infrastructure-as-code rather than observing runtime idle |
+| Showback and chargeback | Supplies metrics/API foundations for reports you build or integrate | Provides reporting features designed for team and business rollups | Supports finance-facing bill views and account or tag-based allocation | Supports pull-request discussion before infrastructure changes reach the bill |
+| Rightsizing evidence | Can surface request, usage, and allocation signals for analysis | Provides recommendation workflows based on observed usage and requests | Provider recommendations can help at instance or managed-service level | Can catch expensive infrastructure changes before merge |
+| Anomaly and budget workflows | Usually integrated through Prometheus, alerting, or downstream systems | Product workflows may include alerts and budget features | Provider billing tools commonly support budgets, alerts, and anomaly workflows | CI comments and policies can prevent cost surprises before apply |
+| Metadata contract | Relies on Kubernetes labels, namespaces, and workload metadata | Uses Kubernetes concepts and organizational mappings | Relies heavily on cloud accounts, tags, labels, and provider billing dimensions | Relies on repository metadata, IaC structure, tags, and policy context |
+
+OpenCost and Kubecost are useful examples in this module because they make the Kubernetes allocation mechanics concrete. They are not the subject of the module. A cloud-native cost explorer may be enough for high-level account and service spend, but it often lacks the Kubernetes ownership context required for team-level showback in a shared cluster. A CI cost estimator such as Infracost helps before infrastructure changes are applied, but it does not replace runtime allocation because Kubernetes scheduling, idle cost, and shared overhead emerge after workloads run. These tools are peers in a workflow, not a ranked list.
+
+---
+
+## Patterns & Anti-Patterns
+
+Good FinOps patterns make cost visible without making engineers afraid to reserve reliability headroom. The strongest pattern is a written allocation policy that explains the basis for compute, memory, storage, network, idle, and shared costs in plain language. The second pattern is a small mandatory metadata contract enforced before deployment or shortly after. The third pattern is a recurring review loop where teams compare allocation, request-to-usage gaps, unit economics, and reliability outcomes before changing manifests.
+
+| Pattern | Why It Works | What It Looks Like |
+|---------|--------------|--------------------|
+| Policy before tooling | Prevents dashboard defaults from becoming accidental finance policy | A short allocation standard explains direct costs, shared costs, idle cost, and dispute handling |
+| Labels as a contract | Makes reports stable across namespaces, clusters, and teams | Required `team`, `service`, `environment`, and `cost-center` labels appear on workloads |
+| Shared costs shown explicitly | Builds trust by revealing platform overhead instead of hiding it | Reports show direct workload cost plus allocated idle, system, network, and observability cost |
+| Recommendations as review inputs | Protects reliability while still finding waste | Rightsizing tickets include p95/p99 evidence, owner context, and rollout safety notes |
+
+Anti-patterns usually come from chasing precision without trust or speed without context. A model that waits for perfect data never teaches anyone. A model that charges teams before labels are clean creates political resistance. A model that hides idle cost under a platform bucket makes application decisions look cheaper than they are. A model that ranks tools instead of capabilities goes stale and distracts from the operating practice.
+
+| Anti-Pattern | Why It Hurts | Better Approach |
+|--------------|--------------|-----------------|
+| Chargeback on day one | Turns metadata cleanup into a budget fight | Start with showback, document errors, and graduate mature scopes |
+| Usage-only allocation | Can remove incentives to rightsize requests | Include request pressure or max(request, usage) where scheduler capacity matters |
+| Hidden platform overhead | Makes services appear cheaper than their real support cost | Allocate overhead with explicit split rules and a visible platform line |
+| Tool-first governance | Lets product defaults define fairness | Define allocation policy, then configure tools to match it |
+| Promised savings from recommendations | Treats observed history as guaranteed future behavior | Review recommendations with workload owners and reliability evidence |
+| One giant dashboard for everyone | Forces every persona through the wrong level of detail | Build persona-specific views over one shared allocation model |
+
+---
+
+## Decision Framework
+
+Use this framework when a cost question becomes a policy question. It deliberately separates three decisions that often get blended together: how to communicate cost, how to reduce waste, and how to choose rate commitments. The first decision is organizational, the second is engineering, and the third is financial risk management. Mixing them produces bad outcomes, such as buying commitments before rightsizing or charging teams before they trust allocation.
+
+```mermaid
+flowchart TD
+    A["Cost question appears"] --> B{"Is ownership metadata trustworthy?"}
+    B -->|No| C["Use showback, fix labels, publish unknown/unallocated cost"]
+    B -->|Yes| D{"Will money move between budgets?"}
+    D -->|No| E["Use showback with team-level review and unit economics"]
+    D -->|Yes| F["Use chargeback only with documented split rules and dispute process"]
+
+    E --> G{"Is waste caused by over-requesting?"}
+    F --> G
+    C --> G
+    G -->|Yes| H["Rightsize requests using p95/p99 evidence and staged rollout"]
+    G -->|No| I{"Is waste caused by demand variation or idle nodes?"}
+    I -->|Demand variation| J["Tune HPA or event-driven autoscalers like KEDA, schedules, or workload architecture"]
+    I -->|Idle nodes| K["Review bin packing, node pools, cluster autoscaling, or Karpenter-like consolidation"]
+
+    H --> L{"Is baseline usage predictable after rightsizing?"}
+    J --> L
+    K --> L
+    L -->|No| M["Prefer on-demand flexibility or interruption-tolerant spot capacity where appropriate"]
+    L -->|Yes| N["Evaluate commitments as a rate decision, not a waste-fix decision"]
 ```
 
-### Handling GPUs
+| Decision | Choose This When | Avoid This When | Evidence to Review |
+|----------|------------------|-----------------|--------------------|
+| Showback vs chargeback | You need awareness first, or data quality is still improving | You need formal budget accountability and the model is already trusted | Label coverage, owner disputes, report reproducibility, finance process maturity |
+| Rightsize vs autoscale | Requests materially exceed observed p95/p99 usage | Demand changes faster than pod size can safely change | Usage window, SLO history, HPA/VPA settings, QoS class, rollout risk |
+| Cluster consolidation | Idle nodes remain after workload rightsizing | Node pools are constrained by hard tenancy, compliance, or hardware needs | Node-pool fragmentation, daemonset overhead, pod disruption budgets, affinity rules |
+| Commitment vs on-demand vs spot | Baseline usage is predictable after waste has been reduced | Usage is uncertain, seasonal, or interruption-sensitive | Historical baseline, business forecast, interruption tolerance, provider terms |
 
-GPU workloads require special handling because GPU costs dominate the node price:
+Commitment-based discounts are deliberately last in this framework. Reserved Instances, Savings Plans, committed use discounts, and similar provider programs trade flexibility for a lower rate on usage that actually materializes. Spot-style capacity trades interruption risk for a lower price on workloads that can tolerate replacement. Those are rate and risk decisions, not allocation decisions. If you buy commitments before fixing oversized requests and idle nodes, you may simply discount waste and make it harder to see.
 
-```text
-GPU Node: p3.2xlarge (8 vCPU, 61 GB, 1× V100 GPU) = $3.06/hr
+---
 
-Cost weights for GPU nodes:
-  cpu_weight = 0.08
-  memory_weight = 0.05
-  gpu_weight = 0.87    ← GPU dominates the cost
+## Did You Know?
 
-Pod requesting 1 GPU:
-  GPU cost = (1/1) × $2,233/mo × 0.87 = $1,943/mo
-  CPU cost = (2/8) × $2,233/mo × 0.08 = $44.66/mo
-  Mem cost = (8/61) × $2,233/mo × 0.05 = $14.64/mo
-  Total: ~$2,002/mo
-```
-
-> **Pause and predict**: If a team requests a GPU but leaves it idle for 20 hours a day, how does this impact the cluster's overall cost efficiency compared to idle CPU resources? Because GPUs are incredibly expensive and typically account for the vast majority of a node's cost, idle GPUs create a disproportionately massive financial waste compared to idle CPUs.
+- **Kubernetes scheduling uses requests**: The Kubernetes scheduler places pods using container resource requests, while the kubelet enforces limits at runtime. That is why request discipline affects both cost allocation and cluster capacity planning.
+- **Allocation is a named FinOps capability**: The FinOps Foundation describes allocation as apportioning costs to responsible categories, including shared elements, using account structures, tags, labels, and derived metadata.
+- **OpenCost is a CNCF Incubating project as of 2026-06**: CNCF lists OpenCost as accepted in 2022 and moved to Incubating maturity in 2024, which is a volatile fact that should be rechecked when refreshing this module.
+- **Autoscaling metrics and cost metrics answer different questions**: Metrics Server and HPA help Kubernetes adjust capacity for demand, while allocation tools connect resource and billing data to ownership and financial accountability.
 
 ---
 
 ## Common Mistakes
 
 | Mistake | Why It Happens | How to Fix It |
-|---------|---------------|---------------|
-| Ignoring idle resources in allocation | Only counting allocated pods | Include idle/unallocated capacity as a visible cost |
-| No namespace resource quotas | Teams request unlimited resources | Set quotas per namespace, review quarterly |
-| Charging by node count per team | Simplistic model | Use request-based proportional allocation |
-| Ignoring memory in cost model | CPU-only focus | Weight CPU and memory appropriately (65/35 or measure) |
-| Not accounting for DaemonSets | DaemonSets run on every node | Allocate DaemonSet cost as shared overhead |
-| Using only cloud-level tagging | Misses intra-cluster detail | Combine cloud tags with Kubernetes labels |
-| Quarterly cost reviews | Too infrequent to catch waste | Weekly automated reports, monthly deep reviews |
-| Perfectionism in cost model | Waiting for 100% accuracy | Start with 80% accuracy, iterate |
+|---------|----------------|---------------|
+| Treating the cloud bill as enough | Provider bills stop at infrastructure resources | Join billing data with Kubernetes namespaces, labels, owners, and resource requests |
+| Ignoring idle resources | Reports count only allocated pods and omit slack capacity | Show unallocated idle and reserved-but-idle capacity as separate visible lines |
+| Starting with chargeback | Finance wants accountability before engineering trusts the data | Run showback first, clean labels, document split rules, and add a dispute process |
+| Using only namespace allocation | Namespaces are easy but often mix teams, products, and environments | Add a small label contract and aggregate by team, product, service, and environment |
+| Hiding shared platform cost | Platform overhead feels hard to assign fairly | Split overhead by documented drivers such as requests, pod count, usage, or even share |
+| Treating recommendations as autopilot | Tool output looks precise and actionable | Review p95/p99 usage, workload seasonality, QoS, autoscaling, and rollout risk before applying changes |
+| Optimizing rates before reducing waste | Discounts are attractive and easier than engineering cleanup | Rightsize and explain baseline usage before commitments, reservations, or spot migration |
+| Building one dashboard for every persona | Finance, platform, product, and engineering need different views | Use one allocation model with persona-specific dashboards and shared definitions |
 
 ---
 
 ## Quiz
 
 ### Question 1
-**Scenario**: Your team deployed a new `recommendation-engine` Pod. The deployment manifest requests 1 CPU and 4 GB of memory. However, after running in production for a week, you observe it consistently uses only 200m CPU and 1.5 GB memory. In a request-based cost model, how much does this Pod "cost" relative to its actual usage, and how should your team respond?
+
+**Scenario**: Your team deployed a `recommendation-engine` workload that requests 1000m CPU and 4 GiB memory per replica. After a normal production week, p95 usage is closer to 250m CPU and 2 GiB memory, and the service has no known launch event in the next review window. In a request-based allocation model, what does this tell you, and what should the next engineering step be?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-The Pod is charged for its **requests** (1 CPU, 4 GB), not its actual usage (200m, 1.5 GB). This means you are paying for 1 CPU while using 200m (80% waste), and paying for 4 GB while using 1.5 GB (62.5% waste). In a request-based model, this allocation is completely intentional, as it reflects the resources you have reserved on the node that cannot be used by other workloads. By charging based on requests, the organization incentivizes teams to rightsize their deployments. To optimize costs, your team should update the resource requests closer to the actual usage—perhaps 300m CPU and 2 GB memory to allow for a small safety buffer—which would significantly reduce the financial chargeback for this workload.
+The workload is allocated cost for the reserved request, not only for the observed usage, because the scheduler treats requested capacity as capacity that must be available on a node. This exposes a request-to-usage gap that may be legitimate headroom or may be oversized reservation. The next step is not an automatic cut; the team should review p95 and p99 usage, SLO history, rollout behavior, and autoscaling configuration before lowering requests in a staged change. This probes the outcome to **explain** how requests, usage, limits, QoS, and bin packing create different cost signals.
 </details>
 
 ### Question 2
-**Scenario**: You are the FinOps liaison for the `payments` team. The shared cluster consists of 3 nodes costing $150/month each ($450 total). Your `payments` namespace currently requests 40% of the total cluster CPU capacity and 30% of the total memory. If the organization's cost allocation model uses a 65/35 weight split between CPU and memory, what will your team's monthly chargeback be?
+
+**Scenario**: A shared cluster has good namespace separation but inconsistent labels. Some workloads use `team`, others use `owner`, and several batch jobs have no business metadata. Finance asks for chargeback next month. What should you recommend?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-The payments team would be allocated **$164.25/month** out of the total $450 cluster cost, which represents about 36.5% of the overall cluster expense. Here is why: the model splits the node cost into compute and memory components based on the 65/35 weighting. The total CPU cost for the cluster is $450 × 0.65 = $292.50, and the payments team's 40% share of that is $117.00. The total memory cost is $450 × 0.35 = $157.50, and their 30% share equals $47.25. Combining the two ($117.00 + $47.25) gives the final monthly cost. This weighted approach ensures that workloads heavily leaning on either CPU or memory pay a fair proportion of the underlying infrastructure cost.
+Recommend showback first because chargeback would turn metadata cleanup into a budget dispute. The team should define a small mandatory label contract, publish unknown and unallocated cost explicitly, and let owners correct the data before money moves between budgets. Namespace reports can still be useful during this period, but they should be labeled as a coarse view rather than a final bill. This probes the outcome to **design** showback and chargeback models that preserve trust in a multi-tenant cluster.
 </details>
 
 ### Question 3
-**Scenario**: Your company is migrating to a large multi-tenant Kubernetes cluster. The CFO wants to immediately start billing each engineering team's cost center for their Kubernetes usage (a "chargeback" model) to enforce cost discipline. You advocate for starting with a "showback" model instead. What is the fundamental difference between these two approaches, and why is starting with showback the better strategy?
+
+**Scenario**: Your report shows direct workload cost by namespace, but it excludes DNS, CNI agents, observability collectors, managed control-plane cost, and unallocated node capacity. Product managers are using the report to compare feature profitability. What is wrong with the report?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-The fundamental difference is that **showback** is purely informational, whereas **chargeback** involves actual financial transactions where money is deducted from a team's budget. Showback says, "here is what your team's workloads cost," aiming to build awareness without financial penalties. You should start with showback because it builds trust in the new cost data, allows teams time to fix missing namespace tags, and gives them a grace period to rightsize their resource requests. If you implement chargeback on day one with inaccurate tags or vastly over-provisioned legacy requests, teams will feel unfairly penalized and resist the FinOps initiative. Chargeback should only be introduced once data accuracy exceeds 95% and teams understand how to optimize their deployments.
+The report hides shared and idle costs that are part of the real cost of running the product on the platform. Product managers will underestimate unit cost because the report makes shared platform services look free. The fix is to add explicit shared-cost lines with documented split rules, such as request-weighted overhead or usage-proportional network allocation where measurements exist. This probes the outcome to **allocate** direct and shared Kubernetes costs across teams and business dimensions.
 </details>
 
 ### Question 4
-**Scenario**: An engineering manager looks at the AWS Cost Explorer and sees that EC2 instances tagged with `k8s-cluster: prod` cost $12,000 last month. They ask you to break down how much of that $12,000 was spent by the `frontend` team versus the `data-science` team. Why can't you answer this question using just the cloud provider's billing tools?
+
+**Scenario**: A manager sees a provider cost explorer line for the production cluster's worker nodes and asks for cost per service. Why can the provider view be correct and still insufficient?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-Cloud provider billing tools lack visibility into the internal orchestration layer of Kubernetes. They track infrastructure resources like EC2 instances, EBS volumes, and load balancers, but they cannot see the Namespaces, Deployments, or Pods running inside those instances. Because a single EC2 worker node might simultaneously host Pods from the `frontend` team, the `data-science` team, and system-level daemonsets, the node's hourly cost cannot be natively divided by the cloud provider. To solve this, you must deploy Kubernetes-native cost tooling, such as OpenCost, which correlates the cloud pricing data for the node with the internal Kubernetes metrics for pod resource requests to accurately attribute costs to specific teams.
+The provider view is correct about what infrastructure was billed, but it does not contain enough Kubernetes ownership context to divide a shared node across pods, controllers, labels, and teams. A single node can host workloads from several services plus platform components, so the bill must be joined with Kubernetes metadata and resource signals. A Kubernetes-aware allocation model can then aggregate cost by namespace, label, controller, service, or team. This probes the outcome to **build** dashboards that expose Kubernetes spending in engineering language.
 </details>
 
 ### Question 5
-**Scenario**: After setting up OpenCost, you notice that 20% of your total cluster spend comes from the `kube-system` namespace, the Prometheus monitoring stack, and unallocated idle node capacity. The finance team wants to completely exclude these costs from the team reports since "they aren't business features." How should you handle these shared costs in your allocation model, and why?
+
+**Scenario**: A cost tool recommends lowering requests on a latency-sensitive API. The workload uses HPA, has strict p99 latency goals, and sometimes receives burst traffic after partner events. How should the team treat the recommendation?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-You should never hide shared costs; instead, they must be explicitly allocated and visible to the individual teams. The most common and fair strategy is proportional allocation, where the shared overhead is distributed based on each team's percentage of total resource requests. Hiding these costs creates a false sense of the true cost of running a service, which can lead to poor business decisions when evaluating the profitability of a product feature. By displaying the shared platform tax on their showback reports, teams gain a realistic understanding of the infrastructure burden. It also incentivizes teams to work collaboratively with the platform engineering group to optimize global tooling like logging and monitoring.
+The recommendation should be treated as evidence for review, not as an automatic change. The team should inspect the observation window, p95 and p99 usage, HPA targets, latency history, and whether partner events were represented in the data. A staged request reduction may still be appropriate, but the team should preserve reliability headroom that is justified by the workload's behavior. This probes the outcome to **evaluate** tooling outputs without mistaking recommendations for autopilot.
+</details>
+
+### Question 6
+
+**Scenario**: After rightsizing several deployments, the cluster still has idle nodes in one node pool. The team says cost allocation must be wrong because pod requests went down but the bill did not. What should you investigate next?
+
+<details>
+<summary>Answer</summary>
+
+Investigate bin packing and node-pool constraints before blaming the allocation model. Oversized requests are only one reason nodes stay alive; daemonset overhead, affinity rules, topology constraints, disruption budgets, special hardware pools, and autoscaler timing can all prevent consolidation. The report should distinguish reserved-but-idle workload capacity from unallocated node idle so the right owner can act. This reinforces the outcome to **explain** how requests, bin packing, and cluster overhead create different cost signals.
+</details>
+
+### Question 7
+
+**Scenario**: A finance stakeholder wants to buy long-term compute commitments because the Kubernetes bill is high. Engineering has not yet cleaned labels, rightsized requests, or identified idle node pools. What is the FinOps response?
+
+<details>
+<summary>Answer</summary>
+
+Commitments should come after the organization understands its baseline usage and removes obvious waste. Reserved capacity, savings plans, committed use discounts, and similar mechanisms reduce rates for usage that materializes, but they do not explain ownership or fix oversized requests. The FinOps response is to finish allocation, showback, rightsizing review, and baseline analysis first, then evaluate commitments for the predictable remainder. This connects allocation decisions to durable financial methodology without turning provider discounts into the subject of the module.
 </details>
 
 ---
 
-## Hands-On Exercise: OpenCost in a Local Cluster
+## Hands-On Exercise: Allocation Signals in a Local Cluster
 
-Deploy OpenCost to a local Kubernetes cluster and generate a cost allocation report.
+Deploy a small multi-namespace cluster, attach ownership labels, install OpenCost with Prometheus, and generate a simple allocation report. The local report uses illustrative internal rates because kind and minikube do not produce a real cloud bill. In a real environment, you would replace those rates with billing-export data or the pricing data used by your allocation tool.
 
 ### Prerequisites
 
 - `kind` or `minikube` installed
 - `kubectl` configured
 - `helm` v3 installed
+- `jq` installed for formatting API responses
 
 ### Step 1: Create a Cluster
 
 ```bash
-# Create a kind cluster with enough resources
 cat > /tmp/kind-finops.yaml << 'EOF'
 kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
@@ -530,16 +601,14 @@ kind create cluster --name finops-lab --config /tmp/kind-finops.yaml
 
 ### Step 2: Deploy Sample Workloads
 
-Create workloads that simulate multi-tenant usage:
+Create workloads that simulate multi-tenant usage and deliberately include different request shapes. The `ml-trainer` workload is intentionally over-requested for discussion purposes; do not copy these values into production without measurement.
 
 ```bash
-# Create namespaces for different teams
 kubectl create namespace payments
 kubectl create namespace search
 kubectl create namespace ml-pipeline
 kubectl create namespace staging
 
-# Payments team workloads
 kubectl apply -f - << 'EOF'
 apiVersion: apps/v1
 kind: Deployment
@@ -606,7 +675,6 @@ spec:
             memory: "256Mi"
 EOF
 
-# Search team workloads
 kubectl apply -f - << 'EOF'
 apiVersion: apps/v1
 kind: Deployment
@@ -673,7 +741,6 @@ spec:
             memory: "2Gi"
 EOF
 
-# ML pipeline workload (over-provisioned)
 kubectl apply -f - << 'EOF'
 apiVersion: apps/v1
 kind: Deployment
@@ -708,7 +775,6 @@ spec:
             memory: "8Gi"
 EOF
 
-# Staging workload (running 24/7 — waste candidate)
 kubectl apply -f - << 'EOF'
 apiVersion: apps/v1
 kind: Deployment
@@ -743,60 +809,59 @@ spec:
             memory: "512Mi"
 EOF
 
-echo "Workloads deployed. Waiting for pods..."
-kubectl get pods -A --field-selector=status.phase=Running | grep -v kube-system
+kubectl get pods -A --field-selector=status.phase=Running -L team,cost-center
 ```
 
-### Step 3: Deploy Prometheus + OpenCost
+### Step 3: Deploy Prometheus and OpenCost
 
 ```bash
-# Add Helm repos
 helm repo add prometheus-community https://prometheus-community.github.io/helm-charts
 helm repo add opencost https://opencost.github.io/opencost-helm-chart
 helm repo update
 
-# Install Prometheus (OpenCost dependency)
 helm install prometheus prometheus-community/prometheus \
   --namespace opencost-system \
   --create-namespace \
+  -f https://raw.githubusercontent.com/opencost/opencost/develop/kubernetes/prometheus/extraScrapeConfigs.yaml \
   --set server.persistentVolume.enabled=false \
   --set alertmanager.enabled=false \
   --set kube-state-metrics.enabled=true \
   --set prometheus-node-exporter.enabled=true \
   --set prometheus-pushgateway.enabled=false
 
-# Install OpenCost
 helm install opencost opencost/opencost \
   --namespace opencost-system \
   --set opencost.prometheus.internal.serviceName=prometheus-server \
   --set opencost.prometheus.internal.namespaceName=opencost-system \
   --set opencost.ui.enabled=true
 
-echo "Waiting for OpenCost to be ready..."
 kubectl rollout status deployment/opencost -n opencost-system --timeout=120s
 ```
 
+The `-f extraScrapeConfigs.yaml` flag is essential: it adds the scrape job that tells Prometheus to collect OpenCost's own metrics from port 9003. Without it OpenCost installs cleanly but its `/allocation` queries return empty or incomplete data, because the underlying cost metrics are never scraped — a silent failure that looks like a working install.
+
 ### Step 4: Query Cost Allocation
 
+Use OpenCost as the worked example for the allocation concept. The same learning goal applies if your organization uses another tool: ask which dimensions it can aggregate by, how it treats idle and shared cost, and how it connects to billing data.
+
 ```bash
-# Port-forward to OpenCost API
 kubectl port-forward -n opencost-system svc/opencost 9003:9003 &
 sleep 5
 
-# Query cost allocation by namespace (last 1 hour window)
-curl -s "http://localhost:9003/allocation/compute?window=1h&aggregate=namespace" | \
-  python3 -m json.tool
+curl -s "http://127.0.0.1:9003/allocation/compute?window=1h&aggregate=namespace" | jq '.'
 
-# Query cost allocation by label (team)
-curl -s "http://localhost:9003/allocation/compute?window=1h&aggregate=label:team" | \
-  python3 -m json.tool
+curl -s "http://127.0.0.1:9003/allocation/compute?window=1h&aggregate=label:team" | jq '.'
 ```
 
-### Step 5: Generate a Cost Report
+### Step 5: Generate a Simple Request-Based Report
+
+This local script does not replace OpenCost. It exists to make the request-based allocation concept tangible by summing namespace requests and applying round illustrative rates. Real production reports should use billing data and documented allocation rules.
 
 ```bash
 cat > /tmp/cost_report.sh << 'SCRIPT'
-#!/bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
+
 echo "============================================"
 echo "  Kubernetes Cost Allocation Report"
 echo "  Cluster: finops-lab"
@@ -804,83 +869,65 @@ echo "  Date: $(date +%Y-%m-%d)"
 echo "============================================"
 echo ""
 
-# Get resource requests by namespace
+namespaces="payments search ml-pipeline staging"
+
+cpu_request_millicores() {
+  kubectl get pods -n "$1" -o jsonpath='{range .items[*]}{range .spec.containers[*]}{.resources.requests.cpu}{"\n"}{end}{end}' | \
+    awk '
+      /m$/ { gsub("m", ""); total += $1; next }
+      $1 != "" { total += $1 * 1000 }
+      END { printf "%.0f", total }
+    '
+}
+
+memory_request_mib() {
+  kubectl get pods -n "$1" -o jsonpath='{range .items[*]}{range .spec.containers[*]}{.resources.requests.memory}{"\n"}{end}{end}' | \
+    awk '
+      /Gi$/ { gsub("Gi", ""); total += $1 * 1024; next }
+      /Mi$/ { gsub("Mi", ""); total += $1; next }
+      /Ki$/ { gsub("Ki", ""); total += $1 / 1024; next }
+      $1 != "" { total += $1 / 1024 / 1024 }
+      END { printf "%.0f", total }
+    '
+}
+
 echo "--- Resource Requests by Namespace ---"
-for ns in payments search ml-pipeline staging; do
-  cpu=$(kubectl get pods -n "$ns" -o json | \
-    python3 -c "
-import json,sys
-data=json.load(sys.stdin)
-total=0
-for pod in data.get('items',[]):
-  for c in pod['spec']['containers']:
-    req=c.get('resources',{}).get('requests',{}).get('cpu','0')
-    if 'm' in req: total+=int(req.replace('m',''))
-    else: total+=int(float(req)*1000)
-print(total)" 2>/dev/null || echo "0")
-
-  mem=$(kubectl get pods -n "$ns" -o json | \
-    python3 -c "
-import json,sys
-data=json.load(sys.stdin)
-total=0
-for pod in data.get('items',[]):
-  for c in pod['spec']['containers']:
-    req=c.get('resources',{}).get('requests',{}).get('memory','0')
-    if 'Gi' in req: total+=int(req.replace('Gi',''))*1024
-    elif 'Mi' in req: total+=int(req.replace('Mi',''))
-print(total)" 2>/dev/null || echo "0")
-
+for ns in $namespaces; do
+  cpu=$(cpu_request_millicores "$ns")
+  mem=$(memory_request_mib "$ns")
   printf "  %-15s CPU: %6sm  Memory: %6s Mi\n" "$ns" "$cpu" "$mem"
 done
 
 echo ""
-echo "--- Cost Estimation (assuming \$0.05/CPU-hr, \$0.007/GB-hr) ---"
-for ns in payments search ml-pipeline staging; do
-  cpu=$(kubectl get pods -n "$ns" -o json | \
-    python3 -c "
-import json,sys
-data=json.load(sys.stdin)
-total=0
-for pod in data.get('items',[]):
-  for c in pod['spec']['containers']:
-    req=c.get('resources',{}).get('requests',{}).get('cpu','0')
-    if 'm' in req: total+=int(req.replace('m',''))
-    else: total+=int(float(req)*1000)
-print(total)" 2>/dev/null || echo "0")
+echo "--- Illustrative Cost Estimate (internal rates only) ---"
+echo "Assumption: 0.05 cost units per CPU-hour and 0.007 cost units per GiB-hour"
+for ns in $namespaces; do
+  cpu=$(cpu_request_millicores "$ns")
+  mem=$(memory_request_mib "$ns")
+  cpu_cost=$(awk -v cpu="$cpu" 'BEGIN { printf "%.2f", cpu / 1000 * 0.05 * 730 }')
+  mem_cost=$(awk -v mem="$mem" 'BEGIN { printf "%.2f", mem / 1024 * 0.007 * 730 }')
+  total_cost=$(awk -v cpu="$cpu_cost" -v mem="$mem_cost" 'BEGIN { printf "%.2f", cpu + mem }')
 
-  mem=$(kubectl get pods -n "$ns" -o json | \
-    python3 -c "
-import json,sys
-data=json.load(sys.stdin)
-total=0
-for pod in data.get('items',[]):
-  for c in pod['spec']['containers']:
-    req=c.get('resources',{}).get('requests',{}).get('memory','0')
-    if 'Gi' in req: total+=int(req.replace('Gi',''))*1024
-    elif 'Mi' in req: total+=int(req.replace('Mi',''))
-print(total)" 2>/dev/null || echo "0")
-
-  cpu_cost=$(echo "scale=2; $cpu / 1000 * 0.05 * 730" | bc)
-  mem_cost=$(echo "scale=2; $mem / 1024 * 0.007 * 730" | bc)
-  total_cost=$(echo "scale=2; $cpu_cost + $mem_cost" | bc)
-
-  printf "  %-15s CPU: \$%7s  Memory: \$%7s  Total: \$%7s/mo\n" \
+  printf "  %-15s CPU: %7s  Memory: %7s  Total: %7s cost units/mo\n" \
     "$ns" "$cpu_cost" "$mem_cost" "$total_cost"
 done
 
 echo ""
-echo "--- Optimization Flags ---"
-echo "  ml-pipeline: 2000m CPU requested for 1 replica — verify utilization"
-echo "  staging: 3 replicas running 24/7 — consider business-hours scheduling"
-echo "  search: 4 search-api replicas — check if HPA could reduce baseline"
+echo "--- Review Prompts ---"
+echo "  ml-pipeline: high CPU and memory requests for one replica; verify p95 and p99 usage"
+echo "  staging: replicas run continuously; verify whether schedule matches business need"
+echo "  search: multiple replicas; compare request baseline with HPA and traffic pattern"
 SCRIPT
 
 chmod +x /tmp/cost_report.sh
 bash /tmp/cost_report.sh
 ```
 
-### Step 6: Cleanup
+### Step 6: Interpret the Output
+
+The report should make two ideas visible. First, ownership labels allow the same workloads to be grouped by namespace or team, which is the metadata foundation for showback. Second, request-based estimates can flag likely over-reservation before you have a perfect production cost model. The output is not a promise of savings; it is a prompt for workload owners to compare requests with observed usage and reliability needs.
+
+### Step 7: Cleanup
 
 ```bash
 kind delete cluster --name finops-lab
@@ -889,51 +936,38 @@ kind delete cluster --name finops-lab
 ### Success Criteria
 
 You've completed this exercise when you:
+
 - [ ] Created a multi-namespace Kubernetes cluster with labeled workloads
 - [ ] Deployed Prometheus and OpenCost
-- [ ] Queried OpenCost API for namespace-level cost allocation
-- [ ] Generated a cost report showing per-namespace resource requests and estimated costs
-- [ ] Identified at least 2 optimization opportunities (ML over-provisioning, staging 24/7)
+- [ ] Queried the OpenCost API for namespace-level and team-label allocation
+- [ ] Generated a request-based report showing per-namespace CPU and memory reservations
+- [ ] Identified at least two optimization review prompts without treating them as guaranteed savings
 
 ---
 
-## Key Takeaways
+## Sources
 
-1. **Cloud bills can't see inside Kubernetes** — you need tools like OpenCost/Kubecost to allocate cluster costs to teams and services
-2. **Requests drive cost allocation** — what you *reserve* is what you pay for, not what you *use*
-3. **The request-usage gap is the biggest savings opportunity** — most clusters run at 13-18% utilization
-4. **Start with showback, graduate to chargeback** — build trust in data before charging teams
-5. **Shared costs must be visible** — hiding kube-system and monitoring costs creates mistrust
-
----
-
-## Further Reading
-
-**Projects**:
-- **OpenCost** — opencost.io (CNCF project, open-source Kubernetes cost monitoring)
-- **Kubecost** — kubecost.com (commercial Kubernetes cost management)
-
-**Articles**:
-- **"Kubernetes Cost Monitoring with OpenCost"** — CNCF blog
-- **"Understanding Kubernetes Resource Requests and Limits"** — learnk8s.io
-- **"The Definitive Guide to Kubernetes Cost Allocation"** — Kubecost blog
-
-**Talks**:
-- **"Real World Cost Optimization in Kubernetes"** — KubeCon EU (YouTube)
-- **"OpenCost: The Open Source Standard for K8s Cost"** — CNCF webinar
-
----
-
-## Summary
-
-Kubernetes cost allocation is the critical bridge between cloud bills and team accountability. By combining cloud pricing data with Kubernetes resource metrics, tools like OpenCost can attribute every dollar to a namespace, deployment, or label. The key is choosing the right allocation model (request-based is the industry standard), making shared costs transparent, and starting with showback before graduating to chargeback. Once teams can see what they spend, they naturally optimize.
-
----
+- [FinOps Framework Overview](https://www.finops.org/framework/)
+- [Allocation FinOps Framework Capability](https://www.finops.org/framework/capabilities/allocation/)
+- [FinOps Personas](https://www.finops.org/framework/personas/)
+- [Understand Usage and Cost Domain](https://www.finops.org/framework/domains/understand-usage-cost/)
+- [OpenCost Specification](https://opencost.io/docs/specification/)
+- [OpenCost API](https://opencost.io/docs/integrations/api/)
+- [OpenCost API Examples](https://opencost.io/docs/integrations/api-examples/)
+- [OpenCost CNCF Project](https://www.cncf.io/projects/opencost/)
+- [Kubernetes Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+- [Kubernetes Horizontal Pod Autoscaling](https://kubernetes.io/docs/concepts/workloads/autoscaling/horizontal-pod-autoscale/)
+- [Kubernetes Vertical Pod Autoscaling](https://kubernetes.io/docs/concepts/workloads/autoscaling/vertical-pod-autoscale/)
+- [Kubernetes Resource Metrics Pipeline](https://kubernetes.io/docs/tasks/debug/debug-cluster/resource-metrics-pipeline/)
+- [Kubecost Allocation API](https://www.ibm.com/docs/en/kubecost/self-hosted/2.x?topic=apis-allocation-api)
+- [Amazon EKS Cost Monitoring with Kubecost](https://docs.aws.amazon.com/eks/latest/userguide/cost-monitoring-kubecost-bundles.html)
+- [Infracost Documentation](https://www.infracost.io/docs/)
+- [AWS Well-Architected Cost Optimization Pillar](https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/welcome.html)
+- [Google Cloud Committed Use Discounts](https://docs.cloud.google.com/compute/docs/instances/signing-up-committed-use-discounts)
+- [Azure Well-Architected Cost Optimization](https://learn.microsoft.com/en-us/azure/well-architected/cost-optimization/)
+- [Karpenter Concepts](https://karpenter.sh/docs/concepts/)
+- [Karpenter Disruption](https://karpenter.sh/docs/concepts/disruption/)
 
 ## Next Module
 
-Continue to [Module 1.3: Workload Rightsizing & Optimization](../module-1.3-rightsizing/) to learn how to identify and fix over-provisioned workloads.
-
----
-
-*"You can't optimize what you can't measure."* — Peter Drucker (paraphrased)
+Continue to [Module 1.3: Workload Rightsizing & Optimization](../module-1.3-rightsizing/) to learn how to turn allocation evidence into safe resource changes.

--- a/src/content/docs/platform/disciplines/business-value/finops/module-1.3-rightsizing.md
+++ b/src/content/docs/platform/disciplines/business-value/finops/module-1.3-rightsizing.md
@@ -1,5 +1,5 @@
 ---
-title: "Module 1.3: Workload Rightsizing & Optimization"
+title: "Module 1.3: Workload Rightsizing &amp; Optimization"
 slug: platform/disciplines/business-value/finops/module-1.3-rightsizing
 sidebar:
   order: 4
@@ -8,7 +8,7 @@ sidebar:
 
 ## Prerequisites
 
-Before starting this module:
+Ensure you have the following prerequisite knowledge and cluster access before beginning the content below:
 - **Required**: [Module 1.2: Kubernetes Cost Allocation](../module-1.2-k8s-cost-allocation/) — Cost visibility and attribution
 - **Required**: Understanding of Kubernetes resource requests and limits
 - **Required**: Familiarity with Deployments, Pods, and container resource management
@@ -19,7 +19,7 @@ Before starting this module:
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+After completing this module, you will have the skills and practical knowledge to accomplish the following outcomes:
 
 - **Implement resource rightsizing recommendations using VPA, Goldilocks, or custom analysis scripts**
 - **Design rightsizing workflows that validate changes in staging before applying to production workloads**
@@ -28,36 +28,60 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-In Module 1.2, you learned that the average Kubernetes cluster runs at 13-18% CPU utilization. That means for every dollar you spend on compute, roughly 82-87 cents buys unused capacity.
+In Module 1.2, you learned that the gap between requested and used resources is the largest single source of Kubernetes compute waste. Most production workloads use a small fraction of what they request — sometimes as little as 10-20%. This means the majority of provisioned capacity is sitting idle, paid for but never consumed.
 
-Why does this happen? Because engineers are *rational*.
+Why does this happen? Because engineers setting resource requests face an asymmetric risk: **request too little and the application crashes at 3 AM. Request too much and nothing visible goes wrong.** The cost is absorbed by a cloud bill that arrives weeks later and is read by a different team. The outage fires a PagerDuty alert that wakes up the engineer who set the request. The incentive structure is perfectly aligned to produce over-provisioning.
 
-When a developer sets resource requests, they face an asymmetric risk: **request too little and the app crashes at 3 AM. Request too much and... nothing bad happens.** The cost is invisible, the outage is a PagerDuty alert. So developers round up. Way up.
+> **Hypothetical scenario — illustrative numbers only**
+>
+> Consider a mid-size platform team running 80 services across a production cluster. A typical service requests 1000m CPU but actually uses 250m at p95. The difference — 750m of idle CPU reservation per replica — prevents the scheduler from placing other workloads on that node. Multiplied across six replicas and eighty services, the locked-but-unused capacity represents a substantial fraction of the cluster's total compute power. That capacity costs money every hour, whether the CPU cycles are consumed or not. This is not a theoretical edge case — it is the default state of nearly every Kubernetes cluster that has not been systematically rightsized.
+>
+> ```mermaid
+> graph TD
+>     subgraph "The Developer's Dilemma"
+>         A["'My app uses ~200m CPU normally, but once last<br>quarter it spiked to 800m during peak traffic.<br>I'll request 1000m to be safe.'"]
+>         B["Actual usage (p95): 250m CPU<br>Requested: 1000m CPU<br>Wasted: 750m CPU per replica"]
+>         C["Multiply by replica count, then by<br>service count across the cluster"]
+>         D["The cumulative idle reservation<br>is the cluster's single largest cost"]
+>     end
+>     A --> B
+>     B --> C
+>     C --> D
+> ```
 
-```mermaid
-graph TD
-    subgraph "The Developer's Dilemma"
-        A["'My app uses ~200m CPU normally, but once last<br>quarter it spiked to 800m during Black Friday.<br>I'll request 1000m to be safe.'"]
-        B["Actual usage (p95): 250m CPU<br>Requested: 1000m CPU<br>Wasted: 750m CPU (75%)"]
-        C["Annual waste per replica: ~$270<br>× 6 replicas: ~$1,620/year<br>× 80 similar services: ~$129,600/year"]
-        D["That's one senior engineer's salary in waste."]
-    end
-    A --> B
-    B --> C
-    C --> D
-```
+Rightsizing is the systematic practice of aligning resource requests with actual observed usage. It is the single highest-return FinOps activity for Kubernetes because it requires no architectural changes, no application rewrites, and no new infrastructure — only the discipline to measure, recommend, apply, and verify. Rightsizing turns the developer's rational over-provisioning into a managed process where safety margins are explicit, data-driven, and continuously updated rather than set once and forgotten.
 
-**Rightsizing** is the practice of aligning resource requests with actual usage. It's the single highest-ROI FinOps activity for Kubernetes — and this module shows you exactly how to do it.
+Within the FinOps Foundation's lifecycle model, rightsizing sits squarely in the **Optimize** phase — the phase where teams act on the visibility gained during Inform to reduce waste and improve efficiency. But the Inform phase is what makes Optimize possible: you cannot rightsize what you cannot measure, and you cannot sustain rightsizing without the allocation and showback mechanisms covered in Module 1.2. Once rightsized, the Operate phase takes over, with continuous monitoring and automated enforcement ensuring that the gains are not eroded by the next deployment or the next traffic surge. Rightsizing is therefore not an isolated activity but the bridge between cost visibility and sustained cost efficiency — it is where the data gathered during Inform is converted into the operational practices that define Operate.
+
+The durable methodology this module teaches — observe usage, generate a recommendation, apply with explicit headroom, then re-observe — applies regardless of which tools you use to implement it. Whether you run VPA, query Prometheus by hand, or use a commercial cost platform, the underlying loop is the same. Master the loop, and you can rightsize any Kubernetes workload on any infrastructure.
 
 ---
 
-## Did You Know?
+## Rightsizing Fundamentals
 
-- **Google's internal research showed that container resource requests are typically set 5-10x higher than actual usage** across most workloads. This isn't laziness — it's rational risk aversion. Nobody gets fired for over-provisioning, but under-provisioning causes visible outages.
+### The Rightsizing Loop
 
-- **The Vertical Pod Autoscaler (VPA) was created specifically to solve rightsizing**. Originally developed by Google, it's now a Kubernetes autoscaler project that observes actual resource consumption over time and recommends (or automatically applies) right-sized resource requests.
+Rightsizing is not a one-time project. It is a continuous four-phase cycle that must be embedded in platform operations:
 
-- **Memory rightsizing is trickier than CPU rightsizing.** If you under-provision CPU, the container gets throttled (slow but alive). If you under-provision memory, the container gets OOM-killed (dead). This asymmetry means memory requests should include a larger safety margin — typically 15-25% above peak observed usage.
+1. **Observe** — Collect actual resource consumption data over a meaningful time window (minimum 7 days, ideally 30+ days to capture weekly and monthly cycles). CPU usage is measured in millicores consumed per second; memory usage is measured as the working set — the pages actively referenced by the container, not including inactive file cache. Observation answers the question: what does this workload actually use?
+
+2. **Recommend** — Apply a statistical model to the observed data to produce a suggested resource request. The model must account for the shape of the usage distribution: a workload that spikes to 2000m for five seconds once per hour needs a different recommendation than one that runs steadily at 200m. The recommendation is a starting point, not a command. Any tool that produces a number without explaining its methodology and confidence should be treated with scepticism.
+
+3. **Apply with headroom** — Take the recommendation and add an explicit, documented safety margin. CPU typically gets 10-20% headroom above p95 or p99 usage because CPU throttling is graceful: the container slows down but stays alive. Memory typically gets 20-30% headroom above p99 usage because memory OOM-kill is catastrophic: the container dies, potentially corrupting state. The margin is not an afterthought — it is the explicit engineering decision that balances cost against reliability.
+
+4. **Re-observe** — After applying new requests, monitor the workload for at least 72 hours. Watch for OOM-kills, CPU throttling, latency regressions, and changes in the workload's own usage pattern (new requests can change how the application behaves — a container given more memory may use more memory due to larger caches or GC heuristics). Usage patterns also drift over time as code changes, traffic grows, and dependencies evolve. Re-observe continuously; re-recommend on a monthly cadence.
+
+This loop is the durable spine of rightsizing. Every tool in the ecosystem — VPA, Kubecost, cloud-native cost explorers, custom Prometheus scripts — implements some subset of it. Understanding the loop means you can evaluate any tool on whether it helps you observe, recommend, apply, or re-observe, and you can fill the gaps with your own automation where needed.
+
+A critical insight that distinguishes mature rightsizing practices from superficial ones is that the re-observe phase is not merely a safety check — it is where the organisational learning happens. Each cycle through the loop generates data about how workloads actually behave under different resource profiles. Over multiple cycles, teams accumulate a statistical profile of their fleet: which workloads are bursty and need p99 sizing, which are stable and can use p95, which grow predictably with traffic and need capacity planning rather than reactive rightsizing, and which are inherently unpredictable and should be treated as exceptions. This institutional knowledge is the real output of sustained rightsizing, and it is far more valuable than any single round of cost reduction. A team that has run the rightsizing loop for six months can make resource decisions with confidence; a team that runs it once and declares victory learns nothing that survives the next deployment.
+
+### The Bin-Packing Effect
+
+Rightsizing individual workloads produces a second-order benefit that is often larger than the direct savings: improved bin-packing efficiency. When a pod requests 1000m CPU but uses 250m, the Kubernetes scheduler reserves the full 1000m on the node where the pod is placed. The remaining 750m is unavailable to any other workload, even though it sits idle. This fragmentation spreads across the cluster: nodes appear full (no allocatable capacity remaining) while actually running at low utilization.
+
+When you rightsize that pod to request 300m CPU, the scheduler now has 700m of previously-locked capacity available for other workloads. Across a cluster of dozens of nodes, the cumulative effect can be dramatic — you may find that rightsizing enables you to remove nodes entirely, or to defer a cluster expansion that would otherwise have been necessary. This is bin-packing: fitting more workloads onto the same set of nodes by eliminating wasted reservations.
+
+Bin-packing interacts with node sizing. Larger nodes (e.g. 16 vCPU, 64Gi) provide more flexibility for the scheduler to pack diverse workloads but create larger "stranding" losses when a single large pod prevents scheduling on an otherwise empty node. Smaller nodes reduce stranding but increase the overhead of the control plane and operating system per unit of workload. The optimal node size for bin-packing efficiency is context-dependent and should be measured, not guessed — but tighter resource requests always improve bin-packing regardless of node size, because they reduce the size of the "holes" the scheduler must work around.
 
 ---
 
@@ -65,7 +89,7 @@ graph TD
 
 ### The Request-Usage Gap
 
-The first step in rightsizing is finding where the biggest gaps exist between what's requested and what's used.
+The first step in rightsizing is finding where the biggest gaps exist between what's requested and what's used. This requires comparing two sources of data: the resource requests declared in pod specifications (what the scheduler reserves) and the actual resource consumption reported by the metrics pipeline (what the container really uses).
 
 ```bash
 # Quick check: resource requests vs actual usage
@@ -81,7 +105,7 @@ payments   payment-worker-5b6c7-jkl89 worker     8m          42Mi
 payments   payment-worker-5b6c7-mno01 worker     5m          38Mi
 ```
 
-Compare against requests:
+Compare the instantaneous snapshot against the declared resource requests to quantify the gap between reserved and used capacity:
 
 ```
 payment-api:
@@ -95,9 +119,11 @@ payment-worker:
   Gap:       93m CPU (93%), 88Mi memory (69%)
 ```
 
+Note that `kubectl top` provides only an instantaneous snapshot. A single measurement tells you nothing about whether the workload spikes at particular times of day, during deployments, or under specific traffic patterns. Point-in-time data is useful for a quick sanity check but dangerous as the basis for a rightsizing decision. For that, you need historical data.
+
 ### Using Prometheus Queries
 
-For historical analysis over days or weeks (not just a point-in-time snapshot):
+For robust rightsizing decisions, you need historical analysis over days or weeks rather than relying on a single point-in-time snapshot from `kubectl top`:
 
 ```promql
 # Average CPU usage vs requests over 7 days, by container
@@ -129,9 +155,11 @@ sum by (namespace, pod) (
 ) < 0.10
 ```
 
+The last query is the one you run when you need to identify the biggest wins quickly. It surfaces workloads where the request-usage gap is so large that rightsizing is nearly risk-free — if a pod uses 8% of its requested CPU averaged over a full hour, reducing its request by 50% still leaves ample headroom. These are the workloads you rightsize first, both because the savings are largest and because the risk of disruption is lowest.
+
 ### The Rightsizing Matrix
 
-Categorize workloads based on their usage patterns:
+Categorize workloads based on their usage patterns using the matrix below to prioritise rightsizing action across the cluster:
 
 | Category | CPU Usage vs Request | Memory Usage vs Request | Action |
 |----------|---------------------|------------------------|--------|
@@ -149,13 +177,15 @@ Categorize workloads based on their usage patterns:
 
 ### What VPA Does
 
-VPA watches actual resource consumption over time and adjusts (or recommends) resource requests accordingly.
+VPA is a Kubernetes project that automates the observe-and-recommend phases of the rightsizing loop. It watches actual resource consumption over time — typically using the metrics-server or Prometheus as a data source — and produces three numbers for each container: a lower bound (the minimum request that would avoid starvation), a target (the recommended value), and an upper bound (the maximum likely to be needed). Optionally, VPA can also apply its recommendations automatically by evicting pods and recreating them with updated resource requests.
 
 ```mermaid
 graph LR
     A["Observe<br>usage<br>metrics<br>(Recommender)"] --> B["Calculate<br>optimal<br>requests<br>(Recommender)"]
     B --> C["Apply<br>new<br>requests<br>(Updater — optional)"]
 ```
+
+Understanding what VPA actually does — and does not do — is essential before trusting it with production workloads. VPA analyses historical usage and fits a statistical model to produce a recommendation. It does not understand your application's architecture, does not know about upcoming traffic events, and does not account for the fact that changing resource requests can change the workload's behaviour (a container given more memory may use more memory). Its recommendations are valuable inputs to a human decision — they should not be treated as autopilot for production-critical services.
 
 ### VPA Components
 
@@ -167,6 +197,8 @@ graph LR
 
 ### VPA Update Modes
 
+The mode you choose determines how much trust you place in VPA's recommendations and how much control you retain over the application process:
+
 | Mode | Behavior | Use Case |
 |------|----------|----------|
 | `Off` | Only generates recommendations, applies nothing | **Start here** — review before changing anything |
@@ -174,27 +206,37 @@ graph LR
 | `Auto` | Evicts and recreates pods with updated requests | Fully automated rightsizing |
 | `Recreate` | Same as Auto (legacy name) | Avoid, use Auto instead |
 
-**Best practice**: Always start with `Off` mode to review recommendations before trusting VPA to change anything automatically.
+**Best practice**: Always start with `Off` mode. Let VPA collect at least 7 days of usage data — ideally a full 30 days to capture monthly billing and traffic cycles — before reviewing its first recommendations. Only after engineering teams have reviewed the recommendations, compared them against their own understanding of the workload, and built confidence in VPA's accuracy should you consider graduating to more automated modes.
+
+### Why Recommendations Are Input, Not Autopilot
+
+VPA's recommendation model has known limitations that every operator must understand. It analyses a historical time series and fits a statistical distribution, typically computing percentiles from the observed data. This means VPA is backward-looking by design: it can only recommend based on what has happened, not what will happen. If your application has a seasonal traffic pattern (month-end billing, holiday shopping, quarterly close), VPA trained on off-peak data will under-recommend and leave you vulnerable when peak arrives.
+
+VPA also does not account for application-level semantics. A Go service with a fixed goroutine pool may genuinely need 500m CPU to serve peak traffic even though it averages 100m; VPA will see 100m and recommend 120m, and your service will degrade under load. A JVM application may need 2Gi of heap even though its working set appears to be 800Mi, because garbage collection behaviour changes when the heap is constrained. VPA sees memory bytes, not GC pause times or OOM-kill risk. Its recommendation is a data point, not a decision. The human operator brings the context that the statistical model lacks.
 
 ### VPA Limitations
 
-Before you go all-in on VPA, know the gotchas:
+Before committing to VPA as your primary rightsizing mechanism, understand the following known limitations that affect every deployment:
 
-1. **VPA and HPA conflict on CPU/memory** — Don't use both to scale the same metric. VPA adjusts requests; HPA adjusts replicas. If both try to respond to CPU, they fight.
+1. **VPA and HPA conflict on CPU/memory** — Don't use both to scale the same metric. VPA adjusts requests; HPA adjusts replicas. If both try to respond to CPU, they fight: VPA increases the per-pod CPU request, which reduces the utilisation percentage that HPA uses to decide whether to scale, which causes HPA to scale down, which concentrates load on fewer pods, which increases per-pod CPU usage, which causes VPA to increase requests further. The result is a thrashing loop that degrades both cost efficiency and reliability. The safe pattern is strict metric separation: VPA on memory only, HPA on CPU only.
 
-2. **VPA evicts pods to update** — In Auto mode, VPA kills running pods to apply new resource values. This means brief disruption. Use PodDisruptionBudgets.
+2. **VPA evicts pods to update** — In Auto mode, VPA terminates running pods and lets the Deployment controller recreate them with the new resource values. Each eviction causes a brief disruption window during which the old pod is terminating and the new pod is starting. For stateless services with multiple replicas and proper readiness probes, this disruption is usually invisible. For stateful services or single-replica deployments, it means a hard restart. Always set PodDisruptionBudgets before enabling Auto mode, and never enable Auto mode on StatefulSets without thoroughly testing the restart behaviour.
 
-3. **VPA needs history** — Recommendations improve with more data. Give VPA at least 24-48 hours (ideally 7 days) of data before trusting its recommendations.
+3. **VPA needs history** — Recommendations are only as good as the data they are based on. Give VPA at least 24-48 hours of data for a rough recommendation, and at least 7 days for a recommendation you can trust. Workloads with weekly cycles (higher load on weekdays, lower on weekends) need the full week to produce an accurate picture.
 
-4. **VPA doesn't set limits** — It only manages requests. You need separate policies for limits.
+4. **VPA doesn't set limits** — VPA manages resource requests only. It does not set, recommend, or adjust resource limits. You need a separate policy for limits, and the relationship between requests and limits determines the pod's QoS class, which in turn determines eviction priority under node pressure.
 
-5. **VPA ignores burst patterns** — If your app spikes to 2000m CPU for 5 seconds every hour, VPA might not capture that in its recommendation.
+5. **VPA ignores burst patterns** — If your application spikes to 2000m CPU for 5 seconds once per hour but otherwise idles at 50m, VPA's statistical model may smooth the spike away entirely. The resulting recommendation will be far too low to handle the burst, and your application will experience severe throttling during each spike. Workloads with bursty usage patterns need profiling-based sizing (see below), not pure VPA recommendations.
+
+### The VPA Restart Caveat
+
+A subtle but important consequence of VPA's Auto mode is that changing resource requests usually requires a pod restart. Kubernetes does not support live resource request updates for running containers — the only way to change a pod's resource specification is to terminate the old pod and create a new one with the updated values. VPA's Updater component handles this by evicting pods according to the configured update policy, but the eviction itself is a pod deletion. If your application takes 30 seconds to start, or maintains in-memory state that is not backed by persistent storage, those 30 seconds of unavailability during the restart are the direct cost of automated rightsizing. This is not a VPA bug — it is a fundamental constraint of how Kubernetes manages container resources — but it is a constraint that every VPA deployment plan must account for.
 
 ---
 
 ## HPA Tuning for Cost
 
-The Horizontal Pod Autoscaler (HPA) scales replicas. Most teams configure it for availability — but it's also a powerful cost optimization tool.
+The Horizontal Pod Autoscaler (HPA) scales replicas. Most teams configure it for availability — conservative scale-up, aggressive scale-down — but the same HPA policy is also a cost control surface. Every replica you avoid running is compute you avoid paying for.
 
 ### Aggressive vs Conservative Scaling
 
@@ -233,6 +275,8 @@ spec:
         value: 25                        # Remove max 25% of pods at a time
         periodSeconds: 120
 ```
+
+Each HPA parameter represents a tradeoff between cost and responsiveness. A higher target utilisation (65-80% instead of the default 50%) means fewer replicas are running at steady state, which directly reduces cost — but it also means less headroom to absorb a traffic spike before the next scale-up event completes. Lower minReplicas reduce the baseline cost but increase cold-start latency when traffic arrives after a period of zero load. Faster scale-down policies reclaim idle capacity sooner but risk thrashing if load fluctuates around the threshold. These are not defaults to accept uncritically — they are engineering decisions that should be tuned to the specific workload's traffic pattern and the business's tolerance for latency under load.
 
 ### Cost Impact of HPA Settings
 
@@ -293,7 +337,7 @@ spec:
         averageUtilization: 70
 ```
 
-**Rule**: VPA on memory, HPA on CPU. They don't conflict because they manage different dimensions.
+**Rule**: VPA on memory, HPA on CPU. They don't conflict because they manage different dimensions. VPA ensures each pod has enough memory to avoid OOM-kill; HPA ensures enough pods exist to handle the aggregate CPU demand. The two autoscalers are not fighting over the same signal, so each can do its job without interfering with the other, and the operator can independently tune the cost-vs-reliability tradeoff in each dimension.
 
 ---
 
@@ -301,7 +345,7 @@ spec:
 
 ## Quality of Service (QoS) for Cost
 
-Kubernetes assigns QoS classes to pods based on how requests and limits are configured. QoS affects eviction priority, which has cost implications.
+Kubernetes assigns one of three QoS classes to every pod based on how requests and limits are configured. QoS determines eviction priority when a node runs out of resources — and because eviction means the pod is killed and rescheduled (potentially on a different node), QoS has direct implications for both reliability and cost.
 
 ### The Three QoS Classes
 
@@ -331,6 +375,12 @@ resources:
 resources: {}         # Empty — no guarantees
 ```
 
+### How Eviction Priority Works
+
+When a node exhausts a compressible resource (CPU), the kernel throttles containers proportionally — everyone slows down, but no one is killed. When a node exhausts an incompressible resource (memory or disk), the kubelet must choose a pod to terminate. The eviction order is deterministic: BestEffort pods are killed first, then Burstable pods using more memory than they requested (the "overage" beyond their request), then Burstable pods within their request, and finally Guaranteed pods — which are only evicted when the kubelet itself is at risk of failing.
+
+This priority order creates a direct cost-reliability tradeoff. Guaranteed pods pay for reserved resources at all times — every millicore and every mebibyte is accounted for in the scheduler's bin-packing — but they receive the strongest protection against eviction. Burstable pods pay for their request but can exceed it when slack capacity exists on the node, gaining flexibility at the cost of higher eviction risk. BestEffort pods pay nothing in reservation cost but are the first to die under memory pressure.
+
 ### QoS and Cost Strategy
 
 | QoS Class | When to Use | Cost Implication |
@@ -339,7 +389,7 @@ resources: {}         # Empty — no guarantees
 | **Burstable** | Most production services | Medium — pay for requests, can burst higher when available |
 | **BestEffort** | Batch jobs, dev/test, non-critical tasks | Lowest — no cost guarantee, but evicted under pressure |
 
-**Cost-optimized strategy**: Use Guaranteed only for truly critical workloads (< 20% of pods). Make most workloads Burstable. Use BestEffort for development and batch processing.
+**Cost-optimized strategy**: Reserve Guaranteed QoS for the 10-15% of workloads that are genuinely critical — services where an eviction-caused restart would cause user-visible downtime, data loss, or a breach of SLO. Run the majority of production services as Burstable, which gives them a cost-efficient baseline with the ability to use slack capacity during bursts. Use BestEffort for development namespaces, batch processing jobs that can tolerate restart, and any workload where the cost of idle reservation exceeds the cost of occasional eviction.
 
 ```mermaid
 pie title Cost-Optimized QoS Distribution (Target utilization: 55-70%)
@@ -348,15 +398,19 @@ pie title Cost-Optimized QoS Distribution (Target utilization: 55-70%)
     "Guaranteed (critical)" : 15
 ```
 
+The QoS distribution shown here is a starting point, not a rule. The right distribution for your cluster depends on the mix of workloads, the cost of eviction for each, and the slack capacity available on your nodes. The principle is: use Guaranteed sparingly, because every Guaranteed pod locks resources that could otherwise be shared.
+
 ---
 
 > **Pause and predict**: If a node runs out of memory, which Pod gets evicted first: a Burstable pod using 90% of its requested memory, or a BestEffort pod using 10% of its node's memory?
 
 ## Profiling vs Utilization-Based Rightsizing
 
+How you determine the right resource request depends on what data you have available and how predictable the workload's behaviour is. Two complementary approaches exist: utilization-based (looking backward at historical data) and profiling-based (measuring actual resource needs under controlled load).
+
 ### Utilization-Based (Reactive)
 
-Look at historical usage, set requests to match:
+Look at historical usage data, apply a statistical model to the observed time series, and set requests to match the high percentiles with an explicitly documented safety margin:
 
 ```
 Approach: Watch metrics → set requests = p95 usage + margin
@@ -372,12 +426,18 @@ Previous:        requests.cpu = 1000m
 Savings:         750m CPU per replica (75% reduction)
 ```
 
-**Pros**: Simple, data-driven, works for all workloads
-**Cons**: Backward-looking, doesn't account for future growth or rare events
+**Pros**: Simple, data-driven, works for all workloads with sufficient history.
+**Cons**: Backward-looking, doesn't account for future growth or rare events.
+
+### Choosing p95 vs p99
+
+The choice between p95 and p99 as your sizing target is a business decision dressed in statistical clothing. Using p95 means you accept that the workload will exceed its request roughly 5% of the time — about 72 minutes per day. During those 72 minutes, CPU will be throttled (graceful slowdown) and memory may trigger OOM-kill if limits are tight (catastrophic failure). Using p99 means you cover all but the most extreme 1% of operating conditions — about 14 minutes per day of exposure. The cost difference between p95 and p99 can be substantial for bursty workloads where the tail is long and thin: a workload with p95 of 200m and p99 of 600m costs three times as much to size at p99.
+
+The decision framework is straightforward: for CPU on stateless services, p95 is usually sufficient because throttling is graceful and additional replicas can absorb the spikes. For memory, always use p99 or higher because the consequence of underestimation is OOM-kill, not slowdown. For stateful workloads (databases, caches, message queues), use p99 for both CPU and memory because the cost of eviction — data loss, rebuild time, increased latency during leader election — far exceeds the cost of the additional headroom.
 
 ### Profiling-Based (Proactive)
 
-Measure actual resource needs through controlled tests:
+Measure actual resource needs by running the workload under controlled, representative load and observing its peak consumption during the test:
 
 ```bash
 # Load test to find true resource ceiling
@@ -397,8 +457,8 @@ kubectl top pods -n payments
 # Step 4: Set requests = observed peak + 20% margin
 ```
 
-**Pros**: Accounts for peak load, forward-looking, gives confidence
-**Cons**: Requires load testing infrastructure, time-intensive
+**Pros**: Accounts for peak load, forward-looking, gives confidence.
+**Cons**: Requires load testing infrastructure, time-intensive.
 
 ### Which Approach to Use?
 
@@ -414,7 +474,7 @@ kubectl top pods -n payments
 
 ## Rightsizing Workflow
 
-A structured approach to rightsizing across your cluster:
+Following is a structured, phased approach to rightsizing across your cluster, moving systematically from discovery through validation:
 
 ### Phase 1: Discovery (Week 1)
 
@@ -455,7 +515,7 @@ bash /tmp/rightsizing_discovery.sh
 
 ### Phase 2: Recommend (Week 2)
 
-Deploy VPA in recommendation mode:
+Deploy VPA in Off mode so it begins observing workload usage patterns and generating recommendations without applying any changes to running pods:
 
 ```yaml
 # Deploy VPA for all workloads in target namespace
@@ -482,7 +542,7 @@ spec:
         memory: "4Gi"
 ```
 
-After 24-48 hours, check recommendations:
+After VPA has collected at least 24-48 hours of usage data, query its recommendations to understand the gap between current requests and actual consumption:
 
 ```bash
 kubectl get vpa payment-api-vpa -n payments -o json | \
@@ -501,7 +561,7 @@ for r in recs:
 
 ### Phase 3: Apply (Week 3-4)
 
-Apply changes progressively:
+Apply the rightsized resource values progressively, starting with non-critical workloads and validating each change in staging before promoting to production:
 
 ```bash
 # Start with non-critical workloads
@@ -533,7 +593,109 @@ kubectl get events -n payments --field-selector reason=OOMKilling
 
 ---
 
-> **Stop and think**: Why is it dangerous to set memory requests equal to average usage instead of p95 or p99?
+## Patterns &amp; Anti-Patterns
+
+### Patterns
+
+**Pattern 1: Progressive Rightsizing** — Start with visibility only. Deploy VPA in Off mode and let it collect at least one full business cycle (7-30 days) of data. Review the recommendations with the teams that own each workload. Only after building confidence in the recommendations — and only for workloads where the team agrees the numbers make sense — begin applying changes manually. Graduate to Initial mode for new deployments, and to Auto mode only for workloads where you have PodDisruptionBudgets, minAllowed/maxAllowed bounds, and monitoring dashboards in place. The progression from Off to Auto should be measured in weeks or months, not hours.
+
+**Pattern 2: Memory-First Margins** — Because the consequence of under-provisioning memory is catastrophic (OOM-kill, process death, potential data loss) while the consequence of under-provisioning CPU is graceful (throttling, slower response), apply asymmetric safety margins. CPU gets 10-20% above the chosen percentile target; memory gets 20-30% above p99. For JVM, Go, and other garbage-collected runtimes, add an additional 10-15% to account for GC overhead that does not appear in working-set measurements. Document the margin explicitly in the workload's resource specification or runbook so that future operators understand why the numbers are what they are.
+
+**Pattern 3: Stateless-First Prioritization** — Begin rightsizing with stateless services — web APIs, frontends, workers that can restart cleanly. If a stateless pod is rightsized too aggressively and gets OOM-killed, Kubernetes restarts it automatically and the new pod begins serving traffic within seconds. The blast radius is contained. Only after your rightsizing process has proven itself on stateless workloads should you apply it to stateful services (databases, caches, queues), where eviction carries the risk of data loss, increased latency during leader election, or extended recovery time.
+
+**Pattern 4: Staged Validation** — Never apply rightsizing changes directly to production. Validate in development first: apply the new resource values and run the workload's test suite. Then staging: deploy with the new values and run integration tests and soak tests under representative load. Only after both environments show stable behaviour for at least 24 hours should you promote the change to production. A rightsizing change that passes in dev but fails in staging is a cheap lesson; one that fails in production is an incident.
+
+**Pattern 5: Bounded Automation** — Always set minAllowed and maxAllowed on every VPA object. The lower bound prevents VPA from recommending absurdly small values (such as 1m CPU for a workload that occasionally spikes to 500m) that would cause starvation. The upper bound prevents VPA from recommending values that exceed the node's capacity or your cost tolerance. Bounds are the guardrails that make automated rightsizing safe; operating without them is like running a car without brakes because the road looks straight.
+
+### Anti-Patterns
+
+**Anti-Pattern 1: Set-and-Forget Rightsizing** — Applying new resource requests once and never revisiting them. Usage patterns drift over time as code changes, traffic grows, dependencies evolve, and seasonal patterns shift. A request that was perfectly right-sized in January may be dangerously tight in June or wastefully loose in December. Schedule a monthly review of VPA recommendations (or your own Prometheus-based analysis) for every production workload, and make rightsizing a recurring operational practice rather than a one-time cleanup project.
+
+**Anti-Pattern 2: Average-Based Sizing** — Using mean (p50) usage to set resource requests. The mean is pulled down by idle periods, overnight lulls, and weekend troughs — it systematically under-represents what the workload needs during actual operation. A workload that idles at 50m for 12 hours and runs at 500m for 12 hours has a mean of 275m, which is too low for the active period. Use a high percentile — p95 or p99 — that captures the workload's behaviour when it is actually doing work.
+
+**Anti-Pattern 3: VPA Auto Without Safeguards** — Enabling VPA in Auto mode without PodDisruptionBudgets, without minAllowed/maxAllowed bounds, and without monitoring dashboards that show OOM-kills and throttling in real time. A VPA misconfiguration in Auto mode can evict every pod in a Deployment in rapid succession — especially if the new requests are too low and the pods immediately crash-loop from OOM-kills, triggering further evictions. PDBs, bounds, and monitoring are not optional when VPA is allowed to act on its own.
+
+**Anti-Pattern 4: Symmetric CPU/Memory Margins** — Applying the same 15-20% safety margin to both CPU and memory. The failure modes are fundamentally different: CPU throttling is a performance degradation that resolves when load drops; memory OOM-kill is an instantaneous process death that may lose in-flight transactions, corrupt caches, and trigger cascading failures in upstream services. Memory margins must be larger than CPU margins, and the difference should be explicit and documented.
+
+**Anti-Pattern 5: Rightsizing Without Application Context** — Treating VPA recommendations as authoritative without consulting the engineers who own the workload. The statistical model does not know that the application caches large objects in memory and will perform worse if the cache shrinks, or that a deployment event temporarily doubles CPU usage, or that the workload has a known memory leak that causes gradual growth between restarts. Rightsizing is a collaboration between the platform team (providing data and tooling) and the application team (providing context and domain knowledge). Either side operating alone produces worse outcomes than both working together.
+
+---
+
+## Decision Framework
+
+When facing a rightsizing decision, work through the questions in the flowchart below in the order shown, documenting your path at each decision point:
+
+```mermaid
+flowchart TD
+    A["Do you have >=30 days<br>of usage data?"] -->|Yes| B["Use utilization-based<br>rightsizing (p95/p99 + margin)"]
+    A -->|No| C["Use profiling / load testing<br>to establish baseline"]
+    B --> D{"Is the workload<br>stateless?"}
+    C --> D
+    D -->|Yes| E["Aggressive CPU margin (10-15%)<br>Moderate memory margin (20-25%)"]
+    D -->|No| F["Conservative CPU margin (15-25%)<br>Large memory margin (25-40%)"]
+    E --> G{"Is the workload<br>critical-path?"}
+    F --> G
+    G -->|Yes| H["Both profiling + utilization<br>Monthly review cadence<br>PDBs required before Auto VPA"]
+    G -->|No| I["Utilization-based OK<br>Monthly review cadence<br>Consider Auto VPA"]
+```
+
+This decision tree encodes the key tradeoffs covered throughout the module. Work through it for each workload before making any changes; document which path you took and why. The documentation matters because the next person to touch the workload — possibly you, six months from now — will need to understand why the numbers are what they are.
+
+### The Headroom Decision Matrix
+
+The most consequential single decision in rightsizing is how much headroom to leave above the observed usage. This matrix provides a starting point based on workload characteristics:
+
+| Workload characteristic | CPU headroom | Memory headroom | Rationale |
+|---|---|---|---|
+| Stateless, stable traffic | 10-15% above p95 | 20-25% above p99 | Throttling is graceful; OOM-kill is not |
+| Stateless, bursty traffic | 15-20% above p99 | 25-30% above p99 | Bursts need CPU headroom; memory spikes are rare |
+| Stateful, stable traffic | 15-20% above p99 | 25-35% above p99 | Eviction cost is high for stateful workloads |
+| Stateful, bursty traffic | 20-25% above p99 | 30-40% above p99 | Maximum conservatism for maximum protection |
+| JVM / GC-heavy runtime | +5-10% on CPU | +10-15% on memory | GC overhead not captured in working set |
+| Batch / cron job | p95 of last N runs + 20% | p99 of last N runs + 30% | No continuous data; size from run history |
+
+These numbers are guidelines, not absolutes. The right headroom for your workload depends on the cost of being wrong (what happens if it gets OOM-killed at 3 AM?), the predictability of its traffic pattern (does it have a weekly cycle? a quarterly spike?), and the organisational tolerance for risk. The principle is: make the headroom decision explicit and document the reasoning, so it can be revisited when conditions change.
+
+---
+
+## Cost-Tooling Rosetta
+
+The Kubernetes cost tooling ecosystem maps capabilities to tools. Use this table to understand which tool provides which part of the rightsizing loop, rather than locking into one vendor's ecosystem:
+
+| Durable capability | K8s VPA | OpenCost | Kubecost | Karpenter | Cloud cost explorer | Infracost |
+|---|---|---|---|---|---|---|
+| Rightsizing recommendations | ✓ | via export | ✓ | — | ✓ | — |
+| Request-vs-usage gap analysis | ✓ | ✓ | ✓ | — | — | — |
+| Cost allocation (ns/label) | — | ✓ | ✓ | — | ✓ | — |
+| Idle cost identification | — | ✓ | ✓ | — | — | — |
+| Showback / chargeback | — | ✓ | ✓ | — | ✓ | — |
+| Node bin-packing optimization | — | — | — | ✓ | — | — |
+| Spot instance management | — | — | — | ✓ | ✓ | — |
+| Anomaly detection | — | — | ✓ | — | ✓ | — |
+| CI cost estimation (pre-deploy) | — | — | — | — | — | ✓ |
+| Commitment discount analysis | — | — | ✓ | — | ✓ | — |
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> The ecosystem centres on several key projects. The CNCF hosts **OpenCost**, a vendor-neutral cost allocation specification with a reference implementation that exports data for further analysis. **Kubecost** (built on OpenCost) provides a community and commercial distribution with additional features including anomaly detection, commitment analysis, and rightsizing recommendations. Fairwinds **Goldilocks** offers a simplified dashboard that surfaces VPA recommendations across namespaces. **Karpenter** handles node-level optimization through just-in-time provisioning, consolidation, and drift detection. **Infracost** estimates cloud costs from infrastructure-as-code before deployment. Each major cloud provider ships a native cost explorer (AWS Cost Explorer, GCP Cost Management, Azure Cost Management) that integrates with their respective commitment discount programs and reserved-instance marketplaces.
+>
+> These tools implement different parts of the rightsizing loop described in this module. VPA covers the observe-recommend-apply cycle at the workload level. Karpenter covers the observe-apply cycle at the node level but does not make workload-level resource recommendations. OpenCost and Kubecost cover the observe and recommend phases with richer cost allocation context (namespace, label, team). Cloud cost explorers cover the observe phase with billing-level granularity but typically lack workload-level resource recommendations. Infracost covers the recommend phase for infrastructure that has not yet been deployed, providing cost estimates from Terraform or Pulumi plans. A complete FinOps practice uses the right tool for each phase of the loop rather than expecting any single tool to cover everything.
+
+---
+
+> **Pause and predict**: Why does the Cost-Tooling Rosetta separate Karpenter (node-level) from VPA (workload-level) into different rows? What happens if you try to optimize nodes without first rightsizing the workloads running on them?
+
+## Did You Know?
+
+- **Google's internal research showed that container resource requests are typically set significantly higher than actual usage** across most workloads. This isn't laziness — it's rational risk aversion. Nobody gets blamed for over-provisioning; under-provisioning causes visible outages that wake people up.
+
+- **The Vertical Pod Autoscaler (VPA) was created specifically to solve rightsizing**. Originally developed by Google based on their internal cluster management experience, it is now a Kubernetes autoscaler project that observes actual resource consumption over time and produces statistically grounded recommendations. Its three-component architecture (Recommender, Updater, Admission Controller) separates the phases of the rightsizing loop so that operators can adopt each phase independently.
+
+- **Memory rightsizing is fundamentally different from CPU rightsizing** because of how the Linux kernel handles resource exhaustion. CPU is compressible: when a container exceeds its limit, the kernel throttles it by limiting CPU time, and the application slows down but stays alive. Memory is incompressible: when a container tries to allocate beyond its limit, the kernel invokes the OOM killer, which terminates the process. This asymmetry means memory requests must always include a larger safety margin — typically 20-35% above peak observed usage — and the consequences of getting memory wrong are categorically more severe than getting CPU wrong.
+
+- **Kubernetes QoS classes create a built-in cost-reliability hierarchy** that most teams don't leverage explicitly. By setting requests equal to limits for critical workloads (Guaranteed QoS) and leaving headroom between requests and limits for standard services (Burstable QoS), you create a tiered system where the most important workloads get the strongest eviction protection while less critical workloads can use idle capacity opportunistically. This hierarchy costs nothing to implement — it's a property of how you configure resources, not a feature you install — but it directly determines which pods survive when a node runs out of memory.
+
+---
 
 ## Common Mistakes
 
@@ -556,7 +718,7 @@ kubectl get events -n payments --field-selector reason=OOMKilling
 Scenario: You are auditing a legacy batch processing application. The main Pod requests 2 CPU and 8Gi memory. Over the last 14 days, Prometheus metrics show its CPU p95 usage is 340m and memory p95 is 2.1Gi. The tech lead asks you to provide new resource request recommendations to cut costs without risking stability. What would you recommend, and how did you arrive at those numbers?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
 **CPU**: Recommend 400m. **Memory**: Recommend 2.5Gi to 3Gi.
 
@@ -567,7 +729,7 @@ Here is why: For CPU, we take the p95 usage of 340m and add a ~15% safety margin
 Scenario: A junior engineer on your team proposes a new rightsizing policy: "Set all resource requests (both CPU and memory) to exactly the p95 usage observed over the last 30 days." You need to explain why this policy is dangerous for the application's reliability. How do you explain the difference between CPU and memory under-provisioning?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
 If a container exceeds its allocated CPU, the Linux kernel simply throttles it by limiting its CPU time. The application will run slower and latency will increase, but the process remains alive and can eventually recover once the load decreases. However, memory is an incompressible resource; if a container attempts to allocate more memory than its limit, the kernel immediately terminates it via an OOM-kill. This catastrophic termination can corrupt in-flight transactions, cause data loss, and lead to service outages. Therefore, memory requests and limits must always include a significantly larger safety margin than CPU to absorb sudden spikes without killing the application.
 </details>
@@ -576,34 +738,52 @@ If a container exceeds its allocated CPU, the Linux kernel simply throttles it b
 Scenario: Your team has deployed a critical payment API using the Horizontal Pod Autoscaler (HPA) to scale replicas based on CPU utilization. A colleague now wants to enable the Vertical Pod Autoscaler (VPA) to automatically optimize resource requests for the same Deployment. They ask you if this is a safe configuration. How do you advise them to configure VPA and HPA to work together?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-You should advise them that VPA and HPA can only safely coexist if they are configured to manage entirely different resource dimensions. If both autoscalers attempt to respond to CPU metrics simultaneously, they will conflict—VPA will try to increase the per-pod CPU requests while HPA tries to add more replicas, leading to unpredictable scaling behavior and thrashing. The safe pattern is to configure VPA to manage only memory by setting its `controlledResources` to `["memory"]`, while allowing HPA to continue scaling the replica count based purely on CPU utilization. This ensures each autoscaler operates independently without interfering with the other's scaling logic.
+You should advise them that VPA and HPA can only safely coexist if they are configured to manage entirely different resource dimensions. If both autoscalers attempt to respond to CPU metrics simultaneously, they will conflict — VPA will try to increase the per-pod CPU requests while HPA tries to add more replicas, leading to unpredictable scaling behaviour and thrashing. The safe pattern is to configure VPA to manage only memory by setting its `controlledResources` to `["memory"]`, while allowing HPA to continue scaling the replica count based purely on CPU utilization. This ensures each autoscaler operates independently without interfering with the other's scaling logic.
 </details>
 
 ### Question 4
 Scenario: You are tasked with rolling out VPA across a production cluster that hosts dozens of microservices. You want to gain visibility into resource waste, but the engineering teams are terrified that automated changes will cause pod evictions and unexpected downtime. Which VPA update mode should you use to start this initiative, and how does the adoption path look over time?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-You should start by deploying VPA in `Off` mode for all workloads. In this mode, VPA acts purely as an observability tool—it analyzes historical usage and generates recommendations without applying any changes or evicting running pods. This allows engineering teams to review the suggested requests, compare them against their own understanding of the workload, and build trust in the tool's accuracy. Once the teams are confident in the recommendations, you can transition to `Initial` mode for new deployments, and eventually to `Auto` mode for full automation, provided that proper PodDisruptionBudgets are in place to ensure safe evictions.
+You should start by deploying VPA in `Off` mode for all workloads. In this mode, VPA acts purely as an observability tool — it analyses historical usage and generates recommendations without applying any changes or evicting running pods. This allows engineering teams to review the suggested requests, compare them against their own understanding of the workload, and build trust in the tool's accuracy. Once the teams are confident in the recommendations, you can transition to `Initial` mode for new deployments, and eventually to `Auto` mode for full automation, provided that proper PodDisruptionBudgets are in place to ensure safe evictions.
 </details>
 
 ### Question 5
 Scenario: You've run a cluster-wide analysis and identified that 50 different Deployments are significantly over-provisioned. Your FinOps manager wants to see a quick reduction in the monthly cloud bill, but the SRE team insists on minimizing risk to critical user journeys. How do you prioritize which Deployments to rightsize first?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
 You should prioritize workloads by calculating their 'waste potential', which is the difference between requested and used resources multiplied by the number of replicas and the unit cost. To balance cost savings with risk, you start by targeting non-critical workloads (such as staging environments, batch jobs, or internal tools) that exhibit the largest request-usage gaps and run with high replica counts. Additionally, you should prioritize stateless services over stateful ones, as stateless applications can recover seamlessly from unexpected OOM-kills via simple restarts. By following this strategy, you secure the largest and safest financial wins early on while gradually building the organizational confidence needed to rightsize the more sensitive, mission-critical applications later.
+</details>
+
+### Question 6
+Scenario: You are reviewing a VPA recommendation for a production API that handles payment processing. VPA in Off mode recommends reducing the memory request from 2Gi to 400Mi based on 14 days of data. The engineering team tells you the application is a JVM service with a 1.5Gi heap configured via `-Xmx`. Should you apply VPA's recommendation? Explain your reasoning.
+
+<details>
+<summary>Answer</summary>
+
+No, you should not apply this recommendation directly. VPA's statistical model sees only the working set — the pages the JVM actively references — which may be well below the configured heap size. However, the JVM reserves the full 1.5Gi heap at startup and will use it during garbage collection cycles, object promotion, and peak allocation periods. Reducing the memory request to 400Mi would cause the container to be OOM-killed the moment the JVM attempts to grow its heap beyond that limit. A better approach is to rightsize based on the actual heap requirement plus JVM overhead (metaspace, code cache, thread stacks, native memory), setting the memory request to at least 2Gi (1.5Gi heap + 512Mi overhead) while using VPA only as a monitoring signal to detect if the heap itself could be reduced. This is a textbook case where application context overrides the statistical recommendation.
+</details>
+
+### Question 7
+Scenario: Your team runs a stateless web frontend with HPA configured on CPU (target 70%, min 3 replicas, max 20). You've just completed a rightsizing pass that reduced the CPU request from 500m to 200m per replica. What second-order effect should you watch for in the HPA's behaviour, and why does it happen?
+
+<details>
+<summary>Answer</summary>
+
+Reducing the CPU request from 500m to 200m will cause the HPA's utilization percentage to increase, because utilization is calculated as actual CPU usage divided by the CPU request. If the frontend was using 150m of CPU before rightsizing, its utilization was 150m/500m = 30% — well below the 70% scale-up threshold. After rightsizing to 200m request, the same 150m of usage now reports as 150m/200m = 75% utilization — above the 70% threshold. The HPA will immediately begin scaling up replicas, potentially adding more pods than the workload needs and increasing the total cost rather than reducing it. This is why rightsizing and HPA tuning must be done together: when you lower requests, you may need to raise the HPA target utilization threshold (e.g. from 70% to 80%) to prevent unnecessary scaling events. Always monitor HPA behaviour for at least one full traffic cycle after a rightsizing change.
 </details>
 
 ---
 
 ## Hands-On Exercise: VPA Recommendation Mode
 
-Deploy VPA in recommendation mode on an over-provisioned Deployment and analyze the recommendations.
+In this hands-on lab, you will deploy VPA in Off recommendation mode on a deliberately over-provisioned Deployment and analyze the resulting recommendations to understand how the rightsizing loop works in practice:
 
 ### Prerequisites
 
@@ -625,7 +805,7 @@ cd /tmp/autoscaler/vertical-pod-autoscaler
 kubectl get pods -n kube-system | grep vpa
 ```
 
-Expected output:
+After running the VPA installation script, verify that all three VPA components are up and running in the kube-system namespace. You should see output similar to:
 ```
 vpa-admission-controller-xxx   1/1   Running   0   30s
 vpa-recommender-xxx            1/1   Running   0   30s
@@ -755,7 +935,7 @@ kubectl get vpa overprovisioned-app-vpa -n rightsizing-lab -o yaml | \
   grep -A 30 "recommendation:"
 ```
 
-Expected output (values will vary):
+After VPA has had time to collect data and generate recommendations, query the VPA object. Your values will vary based on your cluster's actual usage, but the structure and relative magnitudes should resemble:
 ```yaml
 recommendation:
   containerRecommendations:
@@ -885,7 +1065,7 @@ kubectl delete pod load-generator -n rightsizing-lab --ignore-not-found
 
 ### Success Criteria
 
-You've completed this exercise when you:
+You have completed this hands-on exercise when you have achieved all of the following verifiable outcomes:
 - [ ] Deployed VPA and verified all three components are running
 - [ ] Created an over-provisioned Deployment (1000m CPU, 1Gi memory for nginx)
 - [ ] Deployed VPA in Off mode and generated recommendations
@@ -897,41 +1077,44 @@ You've completed this exercise when you:
 
 ## Key Takeaways
 
-1. **The request-usage gap is the largest source of Kubernetes waste** — most workloads use 10-20% of what they request
-2. **VPA automates rightsizing recommendations** — start with Off mode, graduate to Auto
-3. **Memory needs more margin than CPU** — CPU throttling is graceful, OOM-killing is catastrophic
-4. **HPA and VPA can coexist** — VPA on memory, HPA on CPU
-5. **Rightsizing is continuous** — usage patterns change, review recommendations monthly
+1. **The request-usage gap is the largest source of Kubernetes waste** — most workloads use a small fraction of what they request, and closing that gap through systematic rightsizing is the highest-ROI FinOps activity available.
+2. **Rightsizing is a continuous loop, not a one-time project** — observe, recommend, apply with explicit headroom, and re-observe on a monthly cadence as usage patterns evolve.
+3. **VPA automates the observe-and-recommend phases** — start with Off mode to build confidence in the recommendations, then graduate to Initial and Auto modes only with PDBs and bounds in place.
+4. **Memory needs more margin than CPU** — CPU throttling is a graceful slowdown; memory OOM-kill is an instantaneous process death. Document your margin decisions explicitly.
+5. **HPA and VPA can coexist safely** — separate the metrics they manage: VPA on memory, HPA on CPU. Never let both autoscalers respond to the same resource dimension.
+6. **Rightsizing improves bin-packing** — tighter resource requests enable the scheduler to place more workloads on each node, amplifying the savings beyond the per-workload reduction.
 
 ---
 
-## Further Reading
+## Sources
 
-**Projects**:
-- **Kubernetes VPA** — github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler
-- **Goldilocks** — github.com/FairwindsOps/goldilocks (VPA dashboard for all workloads)
-
-**Articles**:
-- **"Right-Sizing Your Kubernetes Workloads"** — learnk8s.io
-- **"VPA Best Practices"** — povilasv.me/vertical-pod-autoscaler-best-practices
-- **"CPU Limits in Kubernetes Are Harmful"** — robusta.dev (why some teams remove CPU limits)
-
-**Talks**:
-- **"To Limit or Not to Limit: Kubernetes Resource Management"** — KubeCon (YouTube)
-- **"Goldilocks: Getting Kubernetes Resource Requests Just Right"** — Fairwinds (YouTube)
+- [Kubernetes: Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/) — Official documentation on requests, limits, and how the scheduler uses them
+- [Kubernetes: Vertical Pod Autoscaler](https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler) — VPA project repository with architecture documentation and deployment guides
+- [Kubernetes: Horizontal Pod Autoscaler](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) — HPA configuration, metrics, and behaviour documentation
+- [Kubernetes: Configure Quality of Service for Pods](https://kubernetes.io/docs/tasks/configure-pod-container/quality-service-pod/) — QoS class assignment and eviction priority rules
+- [Kubernetes: Node-pressure Eviction](https://kubernetes.io/docs/concepts/scheduling-eviction/node-pressure-eviction/) — How the kubelet decides which pods to evict under resource pressure
+- [Kubernetes: Pod Disruption Budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/) — PDB configuration for safe voluntary evictions
+- [Kubernetes: Production-Grade Container Orchestration — Autoscaling Overview](https://kubernetes.io/docs/concepts/workloads/autoscaling/) — Overview of all Kubernetes autoscaling mechanisms and their interactions
+- [OpenCost: Open Source Kubernetes Cost Monitoring](https://www.opencost.io/docs/) — Vendor-neutral cost allocation specification and reference implementation
+- [Karpenter: Just-in-Time Node Autoscaler](https://karpenter.sh/docs/) — Node-level optimization through consolidation, drift detection, and instance selection
+- [FinOps Foundation: Optimize Capability](https://www.finops.org/framework/capabilities/optimize-cloud-usage/) — The FinOps Foundation's definition of the optimize capability within the FinOps lifecycle
+- [CNCF TAG Environmental Sustainability: Cloud Native Sustainability](https://tag-env-sustainability.cncf.io/) — CNCF Technical Advisory Group on the intersection of cloud efficiency and environmental sustainability
+- [Infracost: Cloud Cost Estimates for Terraform](https://www.infracost.io/docs/) — Pre-deployment cost estimation for infrastructure-as-code
 
 ---
 
 ## Summary
 
-Rightsizing is the highest-ROI FinOps activity in Kubernetes. By using VPA recommendations, Prometheus metrics, and structured workflows, teams can typically reduce compute costs by 40-70% without impacting application performance. The key is to start with visibility (Off mode VPA), apply changes gradually (non-critical workloads first), and monitor aggressively after changes (OOMKills, throttling, latency). Rightsizing is not a one-time project — it's a continuous practice that should be reviewed monthly as usage patterns evolve.
+Rightsizing is the highest-ROI FinOps activity in Kubernetes because it requires no architectural changes or new infrastructure — only the discipline to measure actual usage, apply statistically grounded recommendations with explicit headroom, and re-observe continuously. The rightsizing loop (observe → recommend → apply → re-observe) works regardless of which tools implement it, and the principles taught in this module — asymmetric CPU/memory margins, progressive VPA adoption, HPA+VPA metric separation, and QoS-aware resource configuration — apply to any Kubernetes cluster on any infrastructure.
+
+The key is to start with visibility (Off mode VPA or Prometheus-based analysis), apply changes gradually (non-critical workloads first, staging before production), and monitor aggressively after changes (OOM-kills, throttling, latency). Rightsizing is not a one-time project — it is a continuous operational practice. Usage patterns evolve with every code change, traffic shift, and seasonal cycle. The teams that treat rightsizing as an ongoing discipline rather than a cleanup sprint are the ones that sustain cost efficiency at scale.
 
 ---
 
 ## Next Module
 
-Continue to [Module 1.4: Cluster Scaling & Compute Optimization](../module-1.4-compute-optimization/) to learn how Karpenter, Spot instances, and node consolidation reduce infrastructure costs at the cluster level.
+Continue to [Module 1.4: Cluster Scaling &amp; Compute Optimization](../module-1.4-compute-optimization/) to learn how Karpenter, Spot instances, and node consolidation reduce infrastructure costs at the cluster level.
 
 ---
 
-*"The most expensive resource is the one nobody's using."* — FinOps proverb
+*"The most expensive resource is the one nobody's using. The second most expensive is the one that was right-sized last year and never checked again."* — FinOps proverb


### PR DESCRIPTION
## What

Wave 1 of the **Platform Disciplines** epic #1953 (successor to the closed Platform Foundations epic #1897). Three genuine T3→T0 expands in **Platform Engineering → Disciplines → Business Value → FinOps**, same proven expand-to-floor loop.

| Module | Was→Now | Author | Cross-family review → fix |
|---|---|---|---|
| 1.1 finops-fundamentals | 1104→5028w | cursor | opus R1 **APPROVE** (clean) |
| 1.2 k8s-cost-allocation | 1203→5401w | codex | cursor R1 NEEDS_CHANGES → fixed |
| 1.3 rightsizing | 897→5004w | deepseek | opus R1 **APPROVE** (ground-checked) |

All three: **T0**, density gates pass, ≥12 sources (14/20/12) all reachable, quiz 7–8, DYK 4, 0 anti-leak (`47`/emoji removed), `revision_pending:false`.

## Real review findings (ground-checked + web-verified)

- **1.2 P1 (verifier-blind lab-breaker):** the OpenCost lab installed `prometheus-community/prometheus` without OpenCost's required `extraScrapeConfigs.yaml` → Prometheus never scrapes OpenCost's `/metrics` (port 9003) → `/allocation` queries return empty. Added the `-f …/extraScrapeConfigs.yaml` flag + a prose note. **Verified against OpenCost's official Prometheus install doc.** Rejected cursor's DNS-target sub-claim as a false positive (the lab port-forwards to `127.0.0.1:9003`; namespace is already `opencost-system`).
- **1.2 P2s:** VPA+HPA same-metric conflict warning + Module 1.3 cross-ref; Kubecost/IBM (acquired 2024) durable-content note in the dated snapshot; KEDA gloss in the decision flowchart.
- **1.3:** deepseek's VPA modes (`updateMode: Off` recommendations-only), HPA `behavior` block, PromQL (`container_cpu_usage_seconds_total` / `kube_pod_container_resource_requests`), and p95/p99 exposure math all ground-checked **correct** (pleasant result for a fab-prone author on a methodology-heavy topic).

## Durable-content compliance (`.claude/rules/durable-vendor-content.md`)

FinOps is heavy volatile-skin territory; all three quarantine prices/tool-maturity into **dated Landscape snapshots + a capability-based Cost-Tooling Rosetta** (OpenCost/Kubecost/cloud-native explorer/Infracost as peers, explicit "no universal winner"), with **no leadership/"best-tool" claims** and `Hypothetical scenario:` labels on every narrative.

## Verification

- `verify_module.py` → all 3 **T0 PASS** (5028 / 5401 / 5004 body words).
- `npm run build` green in PRIMARY (2169 pages, 0 schema errors); `check_site_health.py` 0 errors.

## Learner check

> The choice between p95 and p99 as your sizing target is a business decision dressed in statistical clothing.

Refs #1953