### PR TITLE
feat(content): Platform Disciplines wave 1 — FinOps 1.4/1.5/1.6 → T0 (FinOps 6/6) (#1953)

### DIFF
--- a/src/content/docs/platform/disciplines/business-value/finops/module-1.4-compute-optimization.md
+++ b/src/content/docs/platform/disciplines/business-value/finops/module-1.4-compute-optimization.md
@@ -1,5 +1,4 @@
 ---
-revision_pending: true
 title: "Module 1.4: Cluster Scaling & Compute Optimization"
 slug: platform/disciplines/business-value/finops/module-1.4-compute-optimization
 sidebar:
@@ -22,72 +21,95 @@ Before starting this module:
 
 After completing this module, you will be able to:
 
-- **Implement spot instance strategies for Kubernetes workloads with proper fault tolerance and interruption handling**
-- **Design node pool architectures that mix instance types for optimal price-performance**
-- **Configure cluster autoscaler policies that balance cost efficiency with workload availability requirements**
-- **Evaluate compute pricing models — on-demand, reserved, spot, savings plans — for your workload patterns**
+- **Implement** spot instance strategies for Kubernetes workloads with proper fault tolerance and interruption handling
+- **Design** node pool architectures that mix instance types for optimal price-performance
+- **Configure** cluster autoscaler policies that balance cost efficiency with workload availability requirements
+- **Evaluate** compute pricing models — on-demand, reserved, spot, savings plans — for your workload patterns
+- **Apply** node consolidation strategies that reclaim idle compute capacity without violating disruption budgets
 
 ## Why This Module Matters
 
-Module 1.3 taught you to rightsize individual workloads — giving each Pod exactly the resources it needs. But even with perfectly rightsized Pods, your cluster can still waste enormous amounts of money if the *nodes* underneath those Pods are inefficient.
+Module 1.3 taught you to rightsize individual workloads — giving each Pod exactly the resources it needs. But even with perfectly rightsized Pods, your cluster can still waste enormous amounts of money if the *nodes* underneath those Pods are inefficient. Node-level waste is the second-largest compute cost leak in Kubernetes after over-provisioned Pod requests, and it is harder to see because the bill arrives as a lump sum of EC2 or VM charges rather than a per-namespace allocation report.
 
-Consider this scenario:
-
-**Before Node Optimization:**
+**Hypothetical scenario:** Imagine a development cluster running three large general-purpose nodes. Each node costs roughly three hundred dollars per month in on-demand pricing. Rightsizing has shrunk your Pods so each node now carries only a fraction of its allocatable CPU and memory. The scheduler cannot place additional Pods because of affinity rules or namespace quotas, yet the autoscaler does not remove the nodes because utilization still clears the scale-down threshold. You are paying for three full machines to host workloads that could fit on one right-sized instance after consolidation.
 
 ```mermaid
 graph TD
-    subgraph Node 1 [Node 1: m6i.2xlarge - 8 vCPU, 32GB - $285/mo]
+    subgraph Node1 [Node 1: large general-purpose - 8 vCPU, 32GB]
         P1A[Pod A: 500m/2Gi]
         P1B[Pod B: 300m/1Gi]
-        I1[Idle: 7.2 CPU, 29GB<br>Wasted: $253/mo]
+        I1[Idle: most CPU and memory unused]
     end
 
-    subgraph Node 2 [Node 2: m6i.2xlarge - 8 vCPU, 32GB - $285/mo]
+    subgraph Node2 [Node 2: large general-purpose - 8 vCPU, 32GB]
         P2C[Pod C: 200m/512Mi]
-        I2[Idle: 7.8 CPU, 31.5GB<br>Wasted: $277/mo]
+        I2[Idle: most CPU and memory unused]
     end
 
-    subgraph Node 3 [Node 3: m6i.2xlarge - 8 vCPU, 32GB - $285/mo]
+    subgraph Node3 [Node 3: large general-purpose - 8 vCPU, 32GB]
         P3D[Pod D: 1CPU/4Gi]
         P3E[Pod E: 1CPU/4Gi]
         P3F[Pod F: 500m/2Gi]
-        I3[Idle: 5.5 CPU, 22GB]
+        I3[Idle: moderate slack remains]
     end
 ```
-Total: 3 nodes × $285 = $855/mo
-Utilization: ~15% CPU, ~14% memory
 
-After optimization (consolidation + right-sized nodes):
+After consolidation and right-sized node selection, the same Pod footprint might fit on a single medium general-purpose node. The durable lesson is not a specific dollar figure — it is that **rightsizing Pods without optimizing nodes leaves the largest structural inefficiency untouched**. Cluster autoscaling, consolidation, instance-type selection, and pricing-model choice are the levers that attack node-level waste.
 
-**After Node Optimization:**
+This module teaches the durable methodology behind those levers: how reactive Cluster Autoscaler and just-in-time provisioners like Karpenter differ as *architectural patterns*, how bin-packing and consolidation reclaim idle capacity, how Spot and commitment discounts trade flexibility for price, and how to decide which combination fits your availability requirements. Tools illustrate the concepts — they are not the subject.
 
-```mermaid
-graph TD
-    subgraph Node 1 [Node 1: m6i.xlarge - 4 vCPU, 16GB - $140/mo]
-        PA[Pod A: 500m]
-        PB[Pod B: 300m]
-        PC[Pod C: 200m]
-        PD[Pod D: 1CPU]
-        PE[Pod E: 1CPU]
-        PF[Pod F: 500m]
-        U[Utilization: 87.5% CPU, 84% Memory]
-    end
-```
-Total: 1 node × $140 = $140/mo
-Savings: $715/mo (84% reduction)
-
-This module covers the tools and strategies that make this consolidation happen automatically: **Karpenter, Cluster Autoscaler, Spot instances, bin-packing, and ARM migration**.
+> **The Tetris Analogy**
+>
+> Rightsizing is choosing the right block size for each piece. Cluster compute optimization is playing Tetris on the board itself — picking the right-sized machine, rotating instance families to fit the pending Pod shapes, and clearing empty rows (nodes) before they keep costing money.
 
 ---
 
 ## Did You Know?
 
-- **Karpenter can provision a new node in under 60 seconds** — compared to Cluster Autoscaler's typical 3-5 minutes. Karpenter talks directly to the EC2 API instead of going through Auto Scaling Groups, eliminating an entire layer of indirection.
+- **The Kubernetes scheduler and the cluster autoscaler solve different problems.** The scheduler places Pods onto existing nodes; the cluster autoscaler adds or removes nodes when the scheduler cannot find a fit. Many teams debug "scheduling problems" by tweaking Pod specs when the real bottleneck is that no appropriately sized node exists — or that too many oversized nodes remain after load drops.
 
-- **AWS reports that customers using Graviton (ARM) instances save an average of 20% on compute costs** while getting up to 40% better price-performance. Since most containerized workloads are already compiled for multiple architectures (via multi-arch images), migrating to ARM is often as simple as changing a node selector.
+- **Spot and preemptible instances are not "cheap on-demand" — they are a different contract.** Cloud providers sell unused capacity at a discount in exchange for the right to reclaim it with short notice. Workloads that treat Spot like discounted on-demand without interruption handling will eventually lose data or break SLOs during a reclamation wave.
 
-- **Spot instance interruption rates vary dramatically by instance type.** While the average across all types is roughly 5-7% per month, some instance families (like older m5 types) see rates below 2%, while GPU instances can exceed 15%. Diversifying across multiple instance types and availability zones is the key to reliable Spot usage.
+- **Commitment discounts (Reserved Instances, Savings Plans, Committed Use Discounts) reward predictability, not efficiency.** Buying a three-year reservation for a machine size you rightsized away six months later converts waste into a contractual obligation. FinOps teams cover baseline steady-state usage with commitments and keep burst capacity on flexible pricing models.
+
+- **ARM-based instances (such as AWS Graviton) can change the price-performance curve for container workloads**, but migration has a compatibility cost: multi-arch image builds, native library support, and performance validation in staging. The FinOps win appears only when the portability work is cheaper than the recurring compute savings — a calculation that depends on your software stack, not marketing claims.
+
+---
+
+## The Node-Level Cost Model
+
+Before touching autoscaling configuration, you need a clear picture of where node money goes. Cloud bills for Kubernetes compute typically aggregate to **node hours × instance price × pricing model modifier**. Inside the cluster, cost efficiency is driven by how fully schedulable capacity is *requested* by Pods, how fully requested capacity is *used*, and how many nodes exist to satisfy those requests.
+
+The gap between Pod **requests** and actual **usage** is the rightsizing problem from Module 1.3. The gap between **node allocatable resources** and **sum of Pod requests** on that node is **scheduling slack** — capacity you pay for that no workload has claimed. The gap between **node capacity** and **running Pods** after scale-down delays is **consolidation debt** — nodes that remain because the autoscaler is conservative or because Pod disruption budgets block eviction.
+
+```text
+Node cost efficiency stack (conceptual):
+
+  Cloud bill          →  instance hours × $/hour × commitment discount
+  Node allocatable    →  kube-reserved and system overhead subtracted
+  Scheduled requests  →  sum of Pod CPU/memory requests on the node
+  Actual usage        →  metrics-server / Prometheus observed consumption
+
+  Waste layer 1:  allocatable − scheduled requests   (bin-packing failure)
+  Waste layer 2:  scheduled requests − actual usage  (rightsizing failure)
+  Waste layer 3:  nodes with no schedulable capacity (consolidation failure)
+```
+
+FinOps for compute optimization attacks all three layers, but **order matters**. Rightsizing without consolidation leaves Pods small and nodes large. Consolidation without rightsizing packs inefficient Pods tightly onto expensive machines. Autoscaling without either merely reproduces the same waste pattern at varying cluster sizes. Mature teams run these activities as a pipeline: measure allocation gaps, rightsize requests, then tune autoscaling and consolidation to match real demand shapes.
+
+Unit economics still apply at the node layer. If your platform charges internal teams by namespace, the **cost per schedulable CPU-hour** on a node pool is the bridge between cloud invoices and product decisions. A Spot-backed batch pool and an on-demand control-plane-adjacent pool may both run Kubernetes, but their unit costs and risk profiles differ by an order of magnitude. Making that visible is an Inform-phase activity; choosing the right pool per workload is Optimize-phase engineering.
+
+---
+
+## Cluster Autoscaling: Reactive vs Just-in-Time
+
+Cluster autoscaling answers one question: **when the scheduler marks Pods as unschedulable because no node satisfies their constraints, how does the cluster obtain new capacity — and when load drops, how does it release capacity safely?** Two architectural patterns dominate managed Kubernetes in 2026: **reactive node-group scaling** (Cluster Autoscaler and cloud-managed equivalents) and **just-in-time node provisioning** (Karpenter and similar direct-to-API provisioners).
+
+Reactive scaling assumes you have **pre-declared node groups** — Auto Scaling Groups on AWS, Managed Instance Groups on GCP, Virtual Machine Scale Sets on Azure. Each group has a template: instance type, disk, labels, taints. The autoscaler watches for pending Pods, picks a group whose template could fit them, and increments the group's desired size. Scale-down reverses the flow after a cooldown: if a node is underutilized and its Pods can move elsewhere, the autoscaler cordons, drains, and terminates it.
+
+Just-in-time provisioning removes the fixed group template as the primary abstraction. A provisioner evaluates **all pending Pods collectively**, searches a **catalog of instance types** allowed by policy, and launches the combination that minimizes cost and scheduling latency subject to constraints. When demand falls, it **consolidates** — replacing many underused nodes with fewer right-sized ones, or simply terminating empty nodes. The durable difference is not "faster YAML" but **who owns instance-type selection**: the platform engineer at node-group design time, or the provisioner at scheduling time.
+
+Neither pattern replaces the Kubernetes scheduler. Both depend on accurate Pod resource requests, tolerations, node selectors, topology spread constraints, and Pod disruption budgets. Autoscaling amplifies whatever scheduling policy you already have; it does not fix contradictory affinity rules or missing requests.
 
 ---
 
@@ -95,7 +117,7 @@ This module covers the tools and strategies that make this consolidation happen 
 
 ### Cluster Autoscaler (CAS)
 
-The original Kubernetes node autoscaler. Works with cloud provider Auto Scaling Groups (ASGs).
+The Cluster Autoscaler is the original Kubernetes node autoscaler. It integrates with cloud provider scaling groups and has been in production use since 2016 across AWS, GCP, Azure, and several on-premises integrations. Its mental model matches how many platform teams already think about infrastructure: **you define pools; the autoscaler scales pool size.**
 
 **Cluster Autoscaler Workflow:**
 
@@ -103,84 +125,65 @@ The original Kubernetes node autoscaler. Works with cloud provider Auto Scaling 
 flowchart LR
     A[Pod is Pending<br>no node] --> B[CAS sees<br>unschedulable pod]
     B --> C[CAS asks ASG<br>to scale up]
-    C --> D[ASG adds<br>a node<br>3-5 min]
+    C --> D[ASG adds<br>a node<br>several minutes]
 ```
 
-**How it works**:
-1. Pods become `Pending` because no node has enough capacity
-2. CAS detects pending pods and calculates which node group could fit them
-3. CAS increases the desired count of the matching ASG
-4. ASG launches a new EC2 instance
-5. The instance joins the cluster and the pod is scheduled
+When Pods become `Pending` because no node has enough allocatable CPU, memory, or specialized resources (GPU, local SSD), the Cluster Autoscaler scans configured node groups in priority order. For each candidate group, it simulates whether adding a node from that group's template would schedule the pending Pods. When it finds a fit, it increases the group's desired capacity. The cloud provider launches an instance, the kubelet registers, and the scheduler places the Pods. Scale-up latency is dominated by **image pull, bootstrap, and cloud API speed** — commonly several minutes on AWS when traversing Auto Scaling Groups.
 
-**Limitations**:
-- Must pre-define node groups (ASGs) with fixed instance types
-- Can't mix instance types within a node group (without managed node groups)
-- Slow: ASG → EC2 → kubelet bootstrap → ready = 3-5 minutes
-- Scale-down is conservative (10+ minutes by default)
-- No built-in Spot diversification
+Scale-down is intentionally conservative. The autoscaler waits until nodes are underutilized relative to configured thresholds, respects PodDisruptionBudgets and mirror Pods on system nodes, and avoids flapping with cooldown timers. That conservatism protects availability but leaves **consolidation debt** on the table: three half-empty nodes may persist because no single node in the pre-defined groups can absorb all workloads simultaneously.
+
+**Strengths of the reactive model** include multi-cloud consistency, extensive operational runbooks, and predictable behavior when node groups are well-designed. **Limitations** include fixed instance-type choices per group, slower scale-out when templates are a poor match for pending Pod shapes, and manual work to diversify Spot instance types across multiple groups.
 
 ### Karpenter
 
-The next-generation Kubernetes node provisioner. Replaces ASGs entirely.
+Karpenter is a node provisioning controller originally developed for AWS EKS and now maintained under the Kubernetes SIG Autoscaling umbrella with a vendor-neutral core (`kubernetes-sigs/karpenter`) and cloud-specific providers. It provisions nodes by calling cloud APIs directly rather than resizing pre-defined groups. On AWS, it uses the EC2 Fleet API to launch instances selected from constraints you declare in `NodePool` and `NodeClass` objects.
 
 **Karpenter Workflow:**
 
 ```mermaid
 flowchart LR
     A[Pod is Pending<br>no node] --> B[Karpenter calculates<br>optimal instance]
-    B --> C[EC2 Fleet API<br>spins up node<br>~1 min]
+    B --> C[Cloud Fleet API<br>spins up node<br>~1-2 min typical]
 ```
 
-> **Stop and think**: How does the provisioning speed of Karpenter compared to Cluster Autoscaler change your approach to capacity planning and over-provisioning?
+When Pods are unschedulable, Karpenter evaluates their combined requirements — resource requests, node selectors, affinities, tolerations, topology spread, and daemonset overhead — and selects instance types from an allowed set. It can launch **multiple nodes in parallel** when a single machine cannot satisfy topology spread. When utilization drops, Karpenter's disruption controllers can **consolidate** workloads onto fewer nodes and terminate empties, subject to disruption budgets and consolidation policies you configure.
 
-**How it works**:
-1. Pods become `Pending`
-2. Karpenter evaluates all pending pods' requirements (CPU, memory, GPU, architecture, topology)
-3. Karpenter selects the optimal instance type from a pool of candidates
-4. Karpenter calls the EC2 Fleet API directly (bypassing ASGs)
-5. Node joins the cluster in ~60 seconds
+> **Stop and think**: How does provisioning latency change your tolerance for running nodes at higher utilization? Faster scale-out reduces the need for idle headroom — but only if your workloads tolerate the brief scheduling gap during bursts.
 
-**Advantages over CAS**:
-- No pre-defined node groups needed
-- Selects from hundreds of instance types automatically
-- Bin-packs pods onto right-sized nodes
-- Built-in Spot diversification and fallback
-- Faster provisioning (EC2 Fleet API vs ASG)
-- Native consolidation (replaces under-utilized nodes)
+**Strengths of the just-in-time model** include dynamic instance-type selection, native Spot diversification with on-demand fallback, and built-in consolidation. **Tradeoffs** include additional controller complexity, cloud-provider-specific maturity differences (AWS provider is the most documented; other providers continue to evolve), and a learning curve for disruption budgets and consolidation tuning.
 
 ### Comparison
 
 | Feature | Cluster Autoscaler | Karpenter |
 |---------|-------------------|-----------|
-| Node provisioning | Via ASGs (pre-defined) | Direct EC2 API (dynamic) |
-| Instance selection | Fixed per node group | Dynamic, any compatible type |
-| Provisioning speed | 3-5 minutes | ~60 seconds |
-| Spot support | Manual ASG config | Built-in with fallback |
-| Bin-packing | Basic (fits into existing groups) | Advanced (picks optimal size) |
-| Consolidation | Scale-down only | Replace + consolidate |
-| Multi-arch (ARM) | Separate node groups | Automatic with constraints |
-| Cloud support | AWS, GCP, Azure | AWS (native), Azure (beta) |
-| Maturity | Mature, battle-tested | Rapidly maturing (CNCF Sandbox) |
+| Node provisioning | Via scaling groups (pre-defined) | Direct cloud API (dynamic) |
+| Instance selection | Fixed per node group | Dynamic within policy constraints |
+| Typical provisioning speed | Several minutes | Often one to two minutes on AWS |
+| Spot support | Manual per-group configuration | First-class capacity-type constraints |
+| Bin-packing | Fits into existing group templates | Selects instance size per pending batch |
+| Consolidation | Scale-down of underused nodes | Consolidation + replacement options |
+| Multi-arch (ARM) | Separate node groups | Constraint-based in NodePool |
+| Cloud support | Broad multi-cloud + on-prem options | AWS mature; other providers evolving |
 
-### When to Use Each
+### Choosing Between Patterns
 
-| Scenario | Recommendation |
-|----------|---------------|
-| AWS EKS cluster | Karpenter (first choice) |
-| GKE cluster | Cluster Autoscaler (GKE Autopilot handles it) |
-| AKS cluster | Cluster Autoscaler or Karpenter (Azure preview) |
-| On-premises | Cluster Autoscaler (if supported by your platform) |
-| Need maximum cost optimization | Karpenter (better bin-packing and Spot) |
-| Want simplicity and stability | Cluster Autoscaler (simpler to understand) |
+The durable question is not "which controller wins" but **which constraints dominate your environment**. If you operate multi-cloud Kubernetes with identical node-group patterns across providers, Cluster Autoscaler’s model may reduce cognitive load. If you run large AWS EKS footprints with diverse workload shapes and aggressive cost targets, just-in-time provisioning may extract more bin-packing efficiency — at the cost of learning Karpenter-specific APIs. If your cloud provider offers a managed Kubernetes autopilot tier that provisions nodes transparently, you may already be using just-in-time provisioning without installing either controller.
+
+| Scenario | Cluster Autoscaler emphasis | Karpenter emphasis |
+|----------|----------------------------|-------------------|
+| Multi-cloud standardization | Pre-defined groups per cloud | Per-cloud NodePools with shared patterns |
+| Diverse instance-type needs | Multiple groups per type | Single NodePool with instance constraints |
+| Spot with fallback | Separate Spot and on-demand groups | Mixed capacity-type requirements |
+| Strict change-control | Familiar ASG operations | CRD-driven provisioning policies |
+| Aggressive consolidation | Tune scale-down delays carefully | Tune `consolidationPolicy` and budgets |
+
+Present both as **peers with different architectural assumptions**, not as a ranked leaderboard. Your choice should follow from scheduling latency requirements, cloud scope, and operational familiarity — then be validated with cost and availability metrics in your own clusters.
 
 ---
 
-## Karpenter Deep Dive
+## Configuring Just-in-Time Provisioning
 
-### NodePool Configuration
-
-Karpenter uses `NodePool` resources (formerly Provisioners) to define what kinds of nodes it can create:
+Karpenter expresses policy through `NodePool` resources (scheduling constraints and disruption behavior) and provider-specific classes (for AWS, `EC2NodeClass` defines subnets, AMIs, and security groups). The following manifest illustrates **capacity-type mixing** and **instance family constraints** without locking you to a single machine size:
 
 ```yaml
 apiVersion: karpenter.sh/v1
@@ -194,15 +197,535 @@ spec:
         team: shared
     spec:
       requirements:
-        # Instance categories
         - key: karpenter.k8s.aws/instance-category
           operator: In
-          values: ["c", "m", "r"]     # Compute, General, Memory optimized
-
-        # Instance sizes (avoid tiny and huge)
+          values: ["c", "m", "r"]
         - key: karpenter.k8s.aws/instance-size
           operator: In
           values: ["medium", "large", "xlarge", "2xlarge"]
-
-        # Capacity type — prefer Spot, fall back to On-Demand
         - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot", "on-demand"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64", "arm64"]
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 5m
+```
+
+**Configure** cluster autoscaling policies by translating business rules into these knobs. `consolidateAfter` balances cost against stability: aggressive consolidation saves money but increases Pod churn. `WhenEmptyOrUnderutilized` allows Karpenter to replace an expensive node with a cheaper one if all Pods can reschedule — the heart of **compute optimization without manual node surgery**. PodDisruptionBudgets on stateful workloads tell the provisioner where consolidation must stop.
+
+For Cluster Autoscaler, the parallel levers are **node group boundaries**, **scale-down-enabled flags**, **expander strategies** (`least-waste` vs `random`), and **priority expanders** that prefer cheaper groups when multiple could satisfy pending Pods. Document your chosen policy in runbooks so on-call engineers know whether a pending Pod should trigger a scale-up incident or a rightsizing review.
+
+---
+
+## Node Consolidation and Bin-Packing
+
+**Bin-packing** is the combinatorial problem of fitting Pod resource requests onto machines with finite allocatable CPU and memory. Kubernetes does this online via the scheduler every time a Pod is created. **Consolidation** is offline bin-packing at the node layer: given the current Pod set, is there a cheaper multiset of nodes that could host the same workloads?
+
+Poor bin-packing shows up as many nodes each running at low request utilization. The autoscaler may have scaled up during a traffic spike using large instances because they were the only template that fit GPU or memory-heavy Pods; after scale-in, small Pods remain spread across those large nodes because the scheduler already placed them and nothing forces re-packing until consolidation runs.
+
+**Apply** consolidation strategies incrementally. Start with workloads that are stateless, horizontally scaled, and backed by PodDisruptionBudgets that allow at least one disruption. Batch and CI workloads are typical first candidates. Stateful systems with local data or long startup times need higher `consolidateAfter` delays and tighter budgets. Measure **scheduling latency during consolidation events** alongside **node-hour reduction** — FinOps wins that breach latency SLOs are losses elsewhere.
+
+DaemonSets complicate bin-packing because every node pays their resource tax. A logging or monitoring agent consuming two hundred millicores on a thirty-node cluster is six cores of unavoidable overhead. Centralizing optional agents or using tolerations to limit daemon proliferation is a platform design choice with direct compute cost impact.
+
+```text
+Consolidation decision checklist (platform engineer view):
+
+  1. Can every Pod on the node reschedule elsewhere without violating PDBs?
+  2. Will replacement nodes satisfy topology spread and affinity rules?
+  3. Is there a cheaper instance type or capacity type that fits the bundle?
+  4. Does the workload tolerate eviction notice within the cloud's interruption window?
+  5. Are metrics dashboards watching scheduling latency during the event?
+```
+
+---
+
+## Spot and Preemptible Economics
+
+Spot Instances (AWS), Spot VMs (GCP), and Spot Virtual Machines (Azure) sell spare capacity at variable discounts. The **durable economic idea** is trading **price** for **availability guarantees**: the cloud provider may reclaim capacity when demand returns, giving you a two-minute (AWS) style warning on interruption. Preemptible VMs on GCP follow a similar contract with a maximum lifetime. This is not a loyalty discount — it is a **risk-sharing arrangement**.
+
+**Implement** spot strategies by classifying workloads into interruption tolerance tiers. **Tier 1 — spot-safe**: stateless web tiers with replicas greater than one, batch jobs with checkpointing, queue consumers with at-least-once delivery. **Tier 2 — spot-cautious**: data pipelines with moderate restart cost; use Spot with on-demand fallback and diversified instance types. **Tier 3 — spot-unsafe**: single-replica stateful systems, jobs without idempotency, workloads that cannot tolerate eviction within notice periods.
+
+Kubernetes integrates Spot at the **node pool** layer. Nodes carry labels such as `karpenter.sh/capacity-type=spot` or cloud-specific labels; workloads land on Spot only if they tolerate the corresponding taints or use tolerations explicitly. Mixing Spot and on-demand in one NodePool lets Karpenter attempt Spot first and fall back when capacity is unavailable — diversification across instance types and availability zones reduces the probability that a single reclamation wave blocks scheduling.
+
+Interruption handling belongs in application design, not only infrastructure labels. The AWS Node Termination Handler (and cloud-specific equivalents) listens for reclamation events, cordons nodes, and drains Pods gracefully. Without graceful termination, Spot saves money on paper while increasing incident volume. Pair Spot nodes with **PodDisruptionBudgets** and **terminationGracePeriodSeconds** that fit your drain time budget.
+
+> **Hypothetical scenario:** A batch team runs nightly ETL on Spot-only nodes. One evening, three instance types in an availability zone are reclaimed simultaneously. Without diversified types and without a fallback on-demand NodePool, Jobs remain pending until morning. The FinOps lesson: Spot savings must be modeled with **interruption correlation risk**, not average discount percentage alone.
+
+---
+
+## Instance Type Selection
+
+Cloud providers expose dozens of instance families optimized for different resource shapes: **compute-optimized** (high CPU per dollar), **general-purpose** (balanced), **memory-optimized** (high RAM per dollar), **storage-optimized**, and **accelerator** families for GPUs. Picking the wrong family is a silent tax — you pay for RAM you do not need because you chose a general-purpose size when a compute-optimized size would have scheduled the same Pods at lower hourly cost.
+
+**Design** node architectures that expose **multiple shapes** rather than one "standard worker." A microservices fleet might default to general-purpose medium instances while isolating memory-heavy search replicas on memory-optimized nodes via node selectors. GPU inference belongs on accelerator families with taints so generic workloads never accidentally land on expensive silicon.
+
+The Kubernetes scheduler respects **Pod resource requests**, not machine family names. If your Pods request four CPUs and eight gibibytes of memory, any instance with sufficient allocatable resources is a candidate — unless node selectors, affinities, or taints narrow the set. Autoscaling controllers search within the allowed set. Widening allowed families increases optimization opportunity and **Spot diversification**; narrowing simplifies compliance and debugging.
+
+Local instance store versus network-attached storage also affects cost and performance. Storage-optimized instances with NVMe can be cheaper per IOPS for ephemeral shuffle workloads but wrong for Pods expecting persistent volumes on slow disks. FinOps here merges with architecture: the cheapest node is not cheapest if it forces expensive cross-AZ traffic or oversized persistent disks.
+
+---
+
+## ARM and Graviton Migration
+
+ARM-based cloud instances (AWS Graviton, Azure Ampere Altra, GCP Tau T2A) often change the **price-performance ratio** for containerized Linux workloads because cloud providers pass architectural efficiency to customers as lower hourly rates. The durable FinOps question is whether **migration cost** (building multi-arch images, validating dependencies, regression testing) is less than **recurring savings** over your planning horizon.
+
+Containers simplify architecture portability relative to bare-metal migrations: if your image ships `linux/amd64` and `linux/arm64` manifests, Kubernetes can schedule either via `kubernetes.io/arch` node affinity. Many open-source stacks already publish multi-arch images. Proprietary binaries, JNI libraries, and certain encryption tooling remain common blockers — discover them in staging, not during a finance-mandated cutover.
+
+**Design** heterogeneous clusters that run ARM for compatible workload pools and retain x86 pools for exceptions. Karpenter and multi-group Cluster Autoscaler setups both support arch constraints. Gradual migration beats big-bang replacement: move stateless leaf services first, measure latency and error budgets, then expand scope. FinOps partners with engineering here — savings appear only when reliability is preserved.
+
+---
+
+## Commitment-Based Discounts
+
+On-demand pricing is the **baseline flexible rate**: no upfront commitment, scale any time, pay the highest hourly price. **Reserved Instances (RIs)**, **Savings Plans (SPs)** on AWS, **Committed Use Discounts (CUDs)** on GCP, and **Reserved VM Instances** on Azure trade **term length and spend predictability** for **lower effective rates**. The durable idea: **you are purchasing insurance against your own forecast error** — if actual usage diverges from commitment, savings evaporate while obligations remain.
+
+**Evaluate** pricing models against a **baseline utilization forecast**, not peak burst capacity. A common pattern covers sixty to seventy percent of steady CPU hours with commitments and keeps burst on-demand or Spot. Savings Plans offer flexibility across instance families and regions within a cloud; traditional RIs bind more tightly but may offer deeper discounts for stable shapes.
+
+Kubernetes complicates commitments because cluster rightsizing and consolidation change the instance types and sizes you need over time. Buying three-year reservations for `m6i.4xlarge` nodes before rightsizing shrinks workloads to `m6i.xlarge` leaves you paying for capacity you no longer schedule. FinOps maturity means **syncing commitment purchases with quarterly capacity reviews**, not treating discounts as a one-time procurement event.
+
+| Pricing model | Flexibility | Typical use in Kubernetes |
+|---------------|-------------|----------------------------|
+| On-demand | Highest | Burst, experiments, unknown lifetimes |
+| Spot / preemptible | High with interruption risk | Batch, fault-tolerant replicas |
+| Savings Plans / flexible commitments | Medium | Steady cluster baseline after rightsizing |
+| Reserved / CUD (strict) | Lower | Stable node pools with slow-changing shapes |
+
+---
+
+## Landscape Snapshot — as of 2026-06
+
+> **This changes fast; verify against vendor docs before relying on specifics.**
+
+| Topic | Snapshot (verify at source) |
+|-------|----------------------------|
+| Karpenter project status | Vendor-neutral core under Kubernetes SIG Autoscaling; AWS provider widely documented; check provider maturity per cloud before production rollout |
+| Karpenter stable API | `karpenter.sh/v1` NodePool API; see upstream release notes for consolidation and disruption fields |
+| AWS Spot interruption notice | Two-minute warning for EC2 Spot Instances in most cases; behavior documented in AWS Spot documentation |
+| AWS Graviton positioning | AWS markets Graviton instances as lower cost and better performance per watt for many workloads; validate with your binaries |
+| Cluster Autoscaler | Ships with major cloud Kubernetes offerings; version skew with control plane minor version matters |
+| Commitment products | AWS Savings Plans and Reserved Instances, GCP Committed Use Discounts, Azure Reserved VM Instances — discount depth varies by term, payment option, and region |
+
+---
+
+## Cost-Tooling Rosetta
+
+Capabilities compared as peers — not ranked. Tool features change; verify in docs.
+
+| Capability | OpenCost | Kubecost | Cloud cost explorer | Cluster Autoscaler | Karpenter |
+|------------|----------|----------|---------------------|-------------------|-----------|
+| Cost allocation by namespace/label | Core focus | Core focus | Via tags on nodes/resources | Indirect (tags on groups) | Indirect (labels on nodes) |
+| Idle / slack cost visibility | Yes | Yes | Limited at Pod level | No | No |
+| Showback / chargeback reporting | Integrations | Built-in views | Billing console reports | No | No |
+| Rightsizing recommendations | Limited / partner | Yes | Native advisor tools | No | Indirect via consolidation |
+| Anomaly detection | Varies by install | Yes | Native billing alerts | No | No |
+| Node provisioning | No | No | No | Scale groups | Direct API |
+| Spot / mixed capacity orchestration | No | Guidance | No | Per-group config | Capacity-type constraints |
+| CI cost estimation | No | No | Third-party | No | No |
+
+---
+
+## Patterns
+
+**Rightsize before autoscale aggressively.** Shrinking Pod requests changes the node shapes autoscaling controllers select. Running consolidation on oversized requests packs waste more densely.
+
+**Mixed capacity-type NodePools with on-demand fallback.** Prefer interruptible capacity for eligible workloads while preserving schedulability when Spot pools dry up — implement via provisioner constraints, not wishful scheduling.
+
+**Diversified Spot instance-type allowlists.** Spread reclamation risk across families and zones instead of betting on a single cheap instance type that correlates during capacity crunches.
+
+**Topology-aware consolidation windows.** Run disruptive consolidation during maintenance periods or low-traffic hours when PDBs allow — measure cost saved versus scheduling latency impact.
+
+**Commitment coverage on stabilized baselines.** Purchase flexible commitments only after several quarters of rightsized, consolidated usage data — align finance and engineering calendars.
+
+**Heterogeneous architecture pools.** Operate ARM and x86 pools side by side with explicit arch selectors so migration proceeds workload-by-workload without blocking the scheduler.
+
+---
+
+## Anti-Patterns
+
+| Anti-Pattern | Why It Fails | Better Approach |
+|--------------|--------------|-----------------|
+| Autoscale before rightsizing | Scales nodes to fit bloated requests | Rightsize Pods, then tune autoscaling |
+| Single instance-type node group | Poor bin-packing; Spot correlation | Multiple shapes or dynamic provisioner constraints |
+| Spot for single-replica stateful apps | Interruptions become outages | On-demand or replicated designs with PDBs |
+| Aggressive consolidation without PDBs | Violates availability during evictions | Define budgets per service tier first |
+| Long-term RI before usage stabilizes | Locks spend on wrong shapes | Quarterly baseline review before commitments |
+| Treating Spot discount as guaranteed savings | Ignores interruption handling cost | Model risk-adjusted unit economics |
+| One global autoscaler policy | Batch and latency-sensitive tiers differ | Separate NodePools / groups per tier |
+| Ignoring daemonset overhead | Hidden per-node tax erodes savings | Audit cluster add-ons regularly |
+
+---
+
+## Decision Framework
+
+Use this flowchart when choosing compute pricing and provisioning strategy for a workload tier:
+
+```mermaid
+flowchart TD
+    A[New workload tier] --> B{Interruptible without<br>data loss?}
+    B -->|Yes| C{Latency-sensitive<br>under 2 min scale-up?}
+    B -->|No| D[On-demand or committed baseline nodes]
+    C -->|No| E[Spot / preemptible with diversified types + fallback]
+    C -->|Yes| F{Need dynamic instance<br>shape selection?}
+    F -->|Yes| G[Just-in-time provisioner constraints]
+    F -->|No| H[Reactive autoscaler + multiple node groups]
+    D --> I{Usage stable 6+ months?}
+    I -->|Yes| J[Consider flexible commitments on baseline]
+    I -->|No| K[Stay on-demand; revisit quarterly]
+    E --> L[Require PDB + graceful termination]
+    G --> M[Define consolidationPolicy + budgets]
+    H --> N[Pick expander: least-waste preferred]
+```
+
+Walk the graph with **service tier owners**, not alone. Finance owns commitment questions; SRE owns interruption tolerance; platform engineering owns provisioner configuration.
+
+---
+
+## Integrating Workload and Node Optimization
+
+Rightsizing and cluster compute optimization are sequential stages of the same FinOps pipeline, not competing projects owned by different teams. When Module 1.3 shrinks Pod CPU requests from one full core to two hundred millicores, the scheduler suddenly has more placement options on existing nodes — which can delay scale-up events and reduce node-hour consumption without any autoscaling change at all. Conversely, when consolidation packs Pods tightly but those Pods still request three times their measured usage, you have simply concentrated waste into fewer, still-oversized machines.
+
+The integration pattern that works in production is a **monthly joint review**: platform engineering brings node utilization and consolidation metrics; application teams bring VPA recommendations and latency dashboards; FinOps brings allocated spend per namespace and commitment utilization. Decisions flow in order — first accept or reject rightsizing changes in staging, then adjust NodePool constraints or node group instance types, then revisit commitment coverage if baseline node hours shifted materially. Skipping the first step and leaping to Spot-heavy NodePools amplifies risk without maximizing savings, because large requests force large instances even when Spot is cheap.
+
+Horizontal Pod Autoscaler activity also changes node economics. If HPA adds replicas during business hours, pending Pods may trigger scale-up events that persist after replicas scale down because scale-down cooldowns lag traffic patterns. Tune cluster autoscaling only after HPA behavior is understood — otherwise you optimize nodes for a replica count that no longer exists. The durable mental model is **Pods drive scheduler decisions; schedulers drive autoscaling decisions; finance validates whether the resulting node hours match business value**.
+
+---
+
+## Cluster Autoscaler Configuration in Practice
+
+Cluster Autoscaler behavior is controlled through a combination of deployment flags, cloud-specific settings on node groups, and RBAC permissions to modify scaling groups. The **`--expander`** flag determines which eligible node group receives a scale-up when several could fit pending Pods. The `least-waste` expander prefers the group that leaves the smallest fraction of unused CPU and memory on the new node — a direct bin-packing heuristic at group selection time. The `priority` expander consults a ConfigMap ranking groups so platform teams can prefer cheaper Spot-backed groups for batch namespaces while reserving on-demand groups for system components.
+
+Scale-down behavior hinges on **`--scale-down-utilization-threshold`** and **`--scale-down-unneeded-time`**. A high utilization threshold keeps nodes longer, reducing eviction churn at the cost of idle capacity. A long unneeded time prevents flapping when replica counts oscillate. There is no universal optimum — latency-sensitive platforms accept more headroom; cost-sensitive batch platforms accept more churn. Document chosen values in your platform runbook and revisit them after major application releases.
+
+Cluster Autoscaler also respects **PodDisruptionBudgets**, mirror Pods, and kube-system scheduling rules. If scale-down never removes nodes despite low utilization, common causes include PDBs with `minAvailable` equal to replica count, Pods with local storage, or missing tolerations preventing rescheduling onto remaining nodes. Debugging "why won't nodes scale down" is as important as debugging pending Pods — both sides of autoscaling affect the invoice.
+
+On AWS, ensure IAM permissions allow `autoscaling:SetDesiredCapacity` and that node group tags include the cluster ownership keys Cluster Autoscaler expects. On GKE, node auto-provisioning overlaps conceptually with just-in-time provisioning but uses Google-managed policies. The implementation differs; the FinOps goal is identical: **match billed node hours to schedulable demand**.
+
+---
+
+## Observability for Compute FinOps
+
+You cannot optimize what you measure only as a monthly cloud total. Compute FinOps observability connects **cloud billing exports** with **Kubernetes metrics** so teams see node-hour drivers in the same language they use for reliability work. At minimum, track allocatable versus requested CPU and memory per node, pending Pod duration, scale-up and scale-down event counts, Spot interruption rates, and cost per namespace after allocation.
+
+Prometheus queries against `kube_pod_container_resource_requests` and `kube_node_status_allocatable` expose scheduling slack. Recording rules that compute `sum(requests) / sum(allocatable)` per node pool highlight pools where bin-packing fails. Pending Pod metrics — time from unschedulable to scheduled — validate whether provisioning latency forces over-provisioning. If P95 pending time approaches your SLO breach window, finance may need to accept higher baseline node counts even if average utilization looks low.
+
+Cost tooling such as OpenCost or Kubecost (see the Rosetta table) attributes node costs to namespaces using labels and shared cost splitting rules. Cloud-native billing consoles attribute by tags on instances. The FinOps bridge activity is ensuring **node labels and cloud tags align** with the chargeback model from Module 1.2 — otherwise compute optimization saves money globally while political friction grows locally because teams cannot see their share.
+
+Alerting should treat sustained pending Pods and failed scale-ups as incident-worthy for platforms that promise elastic capacity. A Spot pool that cannot launch for twelve hours is both a scheduling outage and a cost event if workloads fall back to expensive on-demand emergency capacity without governance. Pair infrastructure alerts with weekly cost anomaly review so technical and financial signals reinforce each other.
+
+---
+
+## Operating Just-in-Time Provisioners Day to Day
+
+Karpenter and similar provisioners shift operational work from **managing Auto Scaling Group desired counts** to **managing constraint CRDs and disruption policies**. Day-two tasks include reviewing NodePool allowlists when new instance generations launch, adjusting consolidation aggression after major traffic pattern changes, and auditing orphaned `NodeClaim` objects when cloud instances fail to terminate cleanly.
+
+Disruption budgets in Karpenter limit how aggressively consolidation may proceed within a time window — analogous in purpose to Kubernetes PodDisruptionBudgets but at the provisioner layer. When security patching requires node replacement, provisioners may use **drift** or **expiration** policies to cycle nodes even when utilization is high. FinOps participates in those windows: replacing nodes during business hours may save less than patching during maintenance if fallback capacity requires on-demand burst.
+
+Version upgrades for provisioner controllers should run through staging clusters that mirror production instance constraints. API migrations — such as moves between alpha and stable CRD versions — can silently halt provisioning if validation fails. Treat provisioner upgrades like control plane upgrades: test pending Pod scenarios, Spot fallback, and consolidation in a sandbox before production promotion.
+
+Runbooks should document **when to pause consolidation** — for example during peak retail hours or end-of-quarter batch jobs — and how to pin workloads to on-demand NodePools temporarily. Emergency levers belong in runbooks finance approves in advance so incident response does not accidentally double spend.
+
+---
+
+## Accelerator and GPU Compute Economics
+
+General-purpose CPU optimization dominates FinOps conversations because most Kubernetes workloads are web services and workers. Accelerator families break the usual bin-packing math: GPUs are expensive, partially shareable only with specific software stacks, and often idle between inference bursts. The FinOps posture is **isolation and time-sharing**, not "run everything on the cheapest CPU node."
+
+GPU pools should carry taints and clear labels so only workloads requesting `nvidia.com/gpu` (or vendor-specific resources) schedule there. Autoscaling GPU nodes without autoscaling GPU-consuming Pods wastes silicon — Karpenter and Cluster Autoscaler will happily launch expensive nodes for Pods that requested GPUs unnecessarily. Rightsizing GPU requests and using horizontal scaling for stateless inference replicas often beats vertical giant instances.
+
+Spot can apply to some GPU instance types in certain regions, but interruption correlation and capacity scarcity make fallback planning essential. Many teams run GPU baselines on committed on-demand or reserved capacity and treat Spot GPU as optional acceleration for fault-tolerant training jobs with checkpointing. The evaluation framework matches CPU: classify tolerance, model interruption cost, measure unit economics per inference or training hour — not per node.
+
+---
+
+## FinOps Lifecycle Alignment
+
+Cluster compute optimization spans all three FinOps Foundation phases. **Inform** builds the dashboards and allocation rules that show which node pools drive spend and which namespaces consume them. **Optimize** applies rightsizing, autoscaling policy tuning, Spot adoption, consolidation, and commitment purchases. **Operate** institutionalizes monthly reviews, budgets, anomaly alerts, and approval workflows for expensive instance types or long-term commitments.
+
+Personas collaborate differently in each phase. **FinOps practitioners** translate billing data into node-hour trends. **Engineering directors** approve risk tradeoffs between Spot and on-demand. **Platform engineers** implement NodePools and Cluster Autoscaler flags. **Product owners** decide whether latency SLOs justify higher baseline capacity. When any persona is missing, organizations oscillate between panic cost cuts and unconstrained spend.
+
+> **Hypothetical scenario:** A platform team enables aggressive consolidation every night without informing application owners. Stateless APIs recover fine, but a nightly billing batch job with a thirty-minute startup time misses its finance deadline twice in one week. The fix is Operate-phase governance: consolidation windows published in advance, PDBs negotiated per tier, and FinOps metrics showing savings alongside job completion rates. Compute optimization succeeded technically while failing organizationally — a reminder that node dollars always sit inside business processes.
+
+---
+
+## Capacity Planning Versus Continuous Optimization
+
+Traditional capacity planning asks, "How many nodes will we need next quarter?" and provisions headroom upfront. Kubernetes autoscaling inverts part of that logic: capacity becomes **elastic**, and planning focuses on **constraints and ceilings** rather than fixed counts. FinOps still needs forecasts — commitments and budgets require them — but the unit of planning shifts from "number of m6i.xlarge nodes" to "baseline vCPU-hours per environment" plus "burst multiplier for peak events."
+
+A practical hybrid approach keeps **two numbers** on the dashboard. First, **steady-state vCPU-hours** after rightsizing and consolidation, smoothed over four to six weeks — this feeds commitment purchases and departmental budgets. Second, **peak schedulable demand** observed during the busiest day in the same window — this feeds autoscaling maximums, Spot fallback capacity, and latency SLO reviews. When steady-state is far below peak, your cluster is burst-heavy; Spot and just-in-time provisioning extract more value. When steady-state approximates peak, you run hot — consolidation opportunities are smaller and commitments safer.
+
+Seasonal events (retail peaks, tax filing, semester starts) should trigger **pre-warming policies** agreed with finance in advance. Temporarily raising minimum node counts or relaxing consolidation is not failure — it is priced risk management. Document the expected incremental node-hour cost and retire the policy after the event so temporary capacity does not become permanent sediment. FinOps maturity shows up in how cleanly you return to optimized baselines after known peaks.
+
+Finally, distinguish **engineering-driven optimization** from **vendor-driven price changes**. A new instance generation or regional price cut can lower bills without any cluster change — finance may celebrate while platform work is unchanged. Conversely, excellent autoscaling work can be invisible on the invoice if usage grew simultaneously. Always report optimization as **unit cost per workload transaction** or **cost per namespace per week**, not only absolute spend, so improvements remain visible inside growth.
+
+Platform engineers should also maintain a **change log for autoscaling policy** tied to cost dashboards. When you tighten consolidation, widen Spot allowlists, or add a new instance family to a NodePool, record the date and the hypothesis ("we expect batch namespaces to shed twenty node-hours per week"). Review outcomes two weeks later against Prometheus and billing exports. This closes the FinOps feedback loop and prevents policy churn driven by anecdote rather than evidence — the same scientific habit Module 1.3 applied to Pod requests, extended to the node layer where invoices actually materialize.
+
+Treat every autoscaling change as a **two-week experiment** with a written success criterion. If node-hours fall but pending Pod duration breaches SLO, roll back and capture the lesson. If node-hours stay flat but latency improves, you may have traded cost for reliability intentionally — finance should see that trade documented, not hidden inside a cluster upgrade ticket. Shared experiment notes help the next engineer avoid repeating a failed consolidation policy on the same workload tier.
+
+---
+
+## Common Mistakes
+
+| Mistake | Problem | Solution |
+|---------|---------|----------|
+| Scaling clusters without rightsizing Pods first | Pays for larger nodes than workloads need | Complete Module 1.3 rightsizing pipeline before autoscale tuning |
+| Using one instance type for all workloads | Memory-heavy and CPU-heavy Pods share wrong economics | Split pools or use dynamic instance constraints |
+| Running Spot without interruption handling | Reclamations cause failed jobs and pager storms | Add termination handlers, PDBs, and fallback capacity |
+| Setting consolidation aggression too high | Latency spikes during node replacements | Increase `consolidateAfter`; consolidate tier by tier |
+| Buying maximum-term reservations early | Locks wrong instance shapes after optimization | Commit only after baseline utilization stabilizes |
+| Ignoring Pod disruption budgets | Consolidation blocked unpredictably or unsafe evictions | Define PDBs before enabling consolidation |
+| Treating autoscaling as set-and-forget | Drift in workload shapes erodes original policy fit | Review autoscaling metrics monthly with cost dashboards |
+| Measuring success only by node count | Fewer nodes can still be wrong instance families | Track cost per schedulable CPU-hour and request utilization |
+
+---
+
+## Quiz
+
+1. **Scenario:** Your cluster has three half-empty on-demand nodes after a traffic drop. Rightsizing is complete. Pending Pods are zero. What FinOps mechanism reclaims this waste, and what guardrail prevents an outage during it?
+
+   <details>
+   <summary>Answer</summary>
+   Node consolidation (via Karpenter consolidation or Cluster Autoscaler scale-down) reclaims idle capacity by evicting Pods and terminating underused nodes. PodDisruptionBudgets limit simultaneous evictions so highly available services keep minimum replicas online. Configure cluster autoscaler policies with appropriate consolidation delays and test with stateless tiers first before touching latency-sensitive workloads.
+   </details>
+
+2. **Scenario:** A finance leader asks you to move every workload to Spot immediately for maximum savings. How do you respond with a durable FinOps framing?
+
+   <details>
+   <summary>Answer</summary>
+   Spot trades availability guarantees for lower price — it is not discounted on-demand. Implement spot strategies only for interruption-tolerant tiers with diversified instance types, graceful termination, and on-demand fallback. Evaluate compute pricing models per workload class: batch and redundant replicas may qualify; single-replica stateful systems do not. Present unit economics with interruption risk, not headline discount percentages.
+   </details>
+
+3. **Why does rightsizing Pod requests change cluster autoscaling economics even when node counts stay the same?**
+
+   <details>
+   <summary>Answer</summary>
+   Autoscalers and provisioners select node sizes based on pending Pod resource requests and constraints. Smaller requests allow scheduling onto smaller instance types and improve bin-packing efficiency. Without rightsizing, autoscaling launches larger nodes than necessary, paying for allocatable CPU and memory no Pod will ever request. Rightsizing shrinks the Tetris pieces so consolidation and instance selection can find cheaper boards.
+   </details>
+
+4. **Compare reactive Cluster Autoscaler scaling groups with Karpenter-style just-in-time provisioning along two axes: who chooses instance type, and how consolidation typically works.**
+
+   <details>
+   <summary>Answer</summary>
+   Cluster Autoscaler chooses among pre-defined node group templates fixed at design time; scale-down removes underutilized nodes after cooldowns. Karpenter chooses instance types dynamically from policy constraints when Pods are pending and can consolidate by replacing nodes with cheaper alternatives that still fit the Pod bundle. Neither replaces the scheduler; both amplify scheduling and rightsizing quality.
+   </details>
+
+5. **Design question:** You need GPU inference nodes for bursty traffic and separate general-purpose nodes for APIs. How should node pool architectures reflect this?
+
+   <details>
+   <summary>Answer</summary>
+   Design node pool architectures with separate pools or NodePools: accelerator families with taints for GPU inference, general-purpose families for APIs. Apply spot strategies only if inference jobs tolerate interruption or maintain on-demand fallback GPUs. Mix instance types within each tier for Spot diversification where applicable. Measure price-performance per tier instead of forcing one instance type for optimal price-performance globally.
+   </details>
+
+6. **When are commitment-based discounts (Savings Plans, Reserved Instances, CUDs) appropriate in a Kubernetes cluster, and when are they dangerous?**
+
+   <details>
+   <summary>Answer</summary>
+   Commitments fit stable baseline node hours after rightsizing and consolidation have stabilized — typically steady production footprints, not bursty dev clusters. They are dangerous when purchased before instance shapes are validated: Kubernetes optimization continuously changes the ideal node size and family. Evaluate compute pricing models quarterly; cover baseline with flexible commitments and keep burst on Spot or on-demand.
+   </details>
+
+7. **Scenario:** Pods stay Pending during Spot capacity shortages. Your NodePool allows only Spot. What configuration change fixes scheduling without abandoning Spot economics entirely?
+
+   <details>
+   <summary>Answer</summary>
+   Configure cluster autoscaler policies to allow both Spot and on-demand capacity types in the NodePool requirements so the provisioner can fall back when Spot is unavailable. Diversify allowed instance types and zones to reduce correlation. Implement spot instance strategies with interruption handlers so reclaimed nodes drain safely. Long term, separate burst tiers that accept on-demand from batch tiers that can wait for Spot capacity.
+   </details>
+
+8. **How do Pod disruption budgets interact with node consolidation decisions?**
+
+   <details>
+   <summary>Answer</summary>
+   PodDisruptionBudgets cap voluntary evictions during consolidation — if a PDB allows only one disruption and multiple Pods need moving, consolidation pauses or skips that node. Apply node consolidation strategies by setting budgets per service tier: strict budgets for stateful systems, looser budgets for stateless replicas. Without PDBs, aggressive consolidation can violate availability; with overly strict PDBs, savings stall.
+   </details>
+
+---
+
+## Hands-On Exercise: Node Utilization and Spot-Safe Scheduling
+
+This exercise uses a local cluster (kind or minikube) to practice measuring node-level slack and declaring Spot-safe scheduling patterns. Cloud provisioning controllers are not required — you will apply the same FinOps concepts via labels, taints, tolerations, and PodDisruptionBudgets.
+
+### Step 1: Create a lab namespace
+
+```bash
+kubectl create namespace compute-finops-lab
+```
+
+### Step 2: Deploy a sample workload with explicit requests
+
+```bash
+kubectl apply -n compute-finops-lab -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: api-sim
+spec:
+  replicas: 3
+  selector:
+    matchLabels:
+      app: api-sim
+  template:
+    metadata:
+      labels:
+        app: api-sim
+        tier: stateless
+    spec:
+      containers:
+        - name: app
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
+          command: ["agnhost", "pause"]
+          resources:
+            requests:
+              cpu: 100m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+EOF
+```
+
+### Step 3: Measure node-level request utilization
+
+```bash
+kubectl top nodes
+kubectl describe nodes | grep -A5 "Allocated resources"
+```
+
+Compare **allocatable** CPU and memory on each node with **requested** totals from the describe output. Large gaps indicate scheduling slack — the node-level waste this module addresses.
+
+### Step 4: Simulate a Spot-style taint and toleration
+
+```bash
+# Label and taint one node as if it were spot (pick an actual node name from kubectl get nodes)
+NODE=$(kubectl get nodes -o jsonpath='{.items[0].metadata.name}')
+kubectl label node "$NODE" capacity-type=spot --overwrite
+kubectl taint node "$NODE" spot=true:NoSchedule --overwrite
+
+kubectl apply -n compute-finops-lab -f - <<'EOF'
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: spot-tolerant-worker
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: spot-worker
+  template:
+    metadata:
+      labels:
+        app: spot-worker
+    spec:
+      tolerations:
+        - key: spot
+          operator: Equal
+          value: "true"
+          effect: NoSchedule
+      nodeSelector:
+        capacity-type: spot
+      containers:
+        - name: worker
+          image: registry.k8s.io/e2e-test-images/agnhost:2.45
+          command: ["agnhost", "pause"]
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+EOF
+```
+
+After applying the Spot-tolerant Deployment, confirm scheduling succeeded by listing Pod placement across nodes — you should see the spot-worker replicas on the node that carries the `capacity-type=spot` label and `spot=true` taint, demonstrating that tolerations override the taint while other workloads without tolerations remain excluded from interruptible capacity.
+
+```bash
+kubectl get pods -n compute-finops-lab -o wide
+```
+
+### Step 5: Add a PodDisruptionBudget for spot-tolerant workers
+
+```bash
+kubectl apply -n compute-finops-lab -f - <<'EOF'
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: spot-worker-pdb
+spec:
+  minAvailable: 1
+  selector:
+    matchLabels:
+      app: spot-worker
+EOF
+```
+
+The PodDisruptionBudget you apply next encodes how many spot-worker replicas must remain available during voluntary disruptions — the same constraint a provisioner respects when consolidating nodes. After creating the PDB, read its status to see `allowedDisruptions` and verify your minimum availability matches the fault tolerance you intend for interruptible capacity.
+
+```bash
+kubectl get pdb -n compute-finops-lab
+```
+
+### Step 6: Validate a Karpenter-style NodePool manifest (dry-run)
+
+Even when Karpenter is not installed locally, writing and client-validating a NodePool manifest builds fluency with the policy objects that govern just-in-time provisioning in production clusters. The dry-run below checks API shape and field names without contacting a cloud provider, which is the same validation loop platform engineers use in CI pipelines before promoting autoscaling policy changes.
+
+```bash
+kubectl apply --dry-run=client -f - <<'EOF'
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: lab-example
+spec:
+  template:
+    spec:
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot", "on-demand"]
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 10m
+EOF
+```
+
+### Step 7: Cleanup
+
+```bash
+kubectl delete namespace compute-finops-lab
+kubectl taint node "$NODE" spot=true:NoSchedule- 2>/dev/null || true
+kubectl label node "$NODE" capacity-type- 2>/dev/null || true
+```
+
+### Success Criteria
+
+- [ ] Measured allocatable versus requested resources on at least one node and identified scheduling slack
+- [ ] Deployed a Spot-tolerant workload using taints, tolerations, and node labels
+- [ ] Created a PodDisruptionBudget that allows safe consolidation of spot-tolerant replicas
+- [ ] Validated a NodePool manifest with `kubectl apply --dry-run=client`
+
+---
+
+## Sources
+
+- [FinOps Foundation Framework](https://www.finops.org/framework/) — domains, capabilities, and personas for cloud financial management
+- [Kubernetes Cluster Autoscaling](https://kubernetes.io/docs/concepts/cluster-administration/cluster-autoscaling/) — how the Cluster Autoscaler integrates with schedulers and node groups
+- [Kubernetes Autoscaling Overview](https://kubernetes.io/docs/concepts/workloads/autoscaling/) — HPA, VPA, and cluster-level scaling relationships
+- [Karpenter Documentation](https://karpenter.sh/docs/) — just-in-time node provisioning concepts and operations
+- [Karpenter NodePools](https://karpenter.sh/docs/concepts/nodepools/) — constraints, disruption, and consolidation policies
+- [AWS Well-Architected Cost Optimization Pillar](https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/welcome.html) — durable cost practices including pricing model selection
+- [AWS Spot Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/using-spot-instances.html) — interruption behavior and Spot request mechanics
+- [AWS Reserved Instances](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-reserved-instances.html) — commitment-based EC2 discounts and flexibility tradeoffs
+- [Google Cloud Spot VMs](https://cloud.google.com/compute/docs/instances/spot) — preemptible capacity model on GCP
+- [Azure Well-Architected Cost Optimization](https://learn.microsoft.com/en-us/azure/well-architected/cost-optimization) — commitment and usage optimization patterns
+- [Kubernetes Pod Disruption Budgets](https://kubernetes.io/docs/concepts/workloads/pods/disruptions/) — voluntary disruption controls during consolidation and drains
+- [OpenCost Documentation](https://opencost.io/docs/) — Kubernetes cost allocation primitives for showback
+
+---
+
+## Next Module
+
+Continue to [Module 1.5: Storage & Network Cost Management](../module-1.5-storage-network-costs/) to tackle the storage and networking cost categories that often hide beneath compute on your cloud bill.

--- a/src/content/docs/platform/disciplines/business-value/finops/module-1.5-storage-network-costs.md
+++ b/src/content/docs/platform/disciplines/business-value/finops/module-1.5-storage-network-costs.md
@@ -3,159 +3,179 @@ title: "Module 1.5: Storage & Network Cost Management"
 slug: platform/disciplines/business-value/finops/module-1.5-storage-network-costs
 sidebar:
   order: 6
+revision_pending: false
 ---
 > **Discipline Module** | Complexity: `[MEDIUM]` | Time: 2h
-
-## Prerequisites
-
-Before starting this module:
-- **Required**: [Module 1.1: FinOps Fundamentals](../module-1.1-finops-fundamentals/) — FinOps lifecycle, billing concepts
-- **Required**: Understanding of Kubernetes Persistent Volumes and StorageClasses
-- **Required**: Basic networking concepts (VPC, subnets, NAT, load balancers)
-- **Recommended**: AWS or GCP experience (examples use AWS terminology)
-- **Recommended**: Familiarity with cloud storage tiers (S3, EBS, EFS)
-
----
+>
+> **Prerequisites**: [Module 1.1: FinOps Fundamentals](../module-1.1-finops-fundamentals/), Kubernetes Persistent Volumes and StorageClasses, basic VPC networking, and the idea that cloud bills are usage records rather than a single invoice line.
 
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
-- **Implement storage cost optimization through lifecycle policies, tiering, and right-sized volume claims**
-- **Design network cost reduction strategies that minimize cross-AZ traffic and egress charges**
-- **Analyze storage and network spending to identify the largest cost drivers in your Kubernetes environment**
-- **Build monitoring dashboards that track storage utilization and network transfer costs by namespace and service**
+- **Audit** storage and network cost drivers across PersistentVolumes, object storage, snapshots, load balancers, NAT, and data transfer paths.
+- **Design** allocation models that attribute shared storage and network costs to namespaces, services, teams, products, or business units without pretending the model is perfect.
+- **Apply** lifecycle, tiering, topology, and right-sizing methods that reduce waste while preserving recovery, durability, latency, and availability requirements.
+- **Evaluate** the tradeoffs between volume size, provisioned performance, retention, retrieval cost, cross-zone traffic, private endpoints, and internet egress before changing architecture.
+- **Build** a repeatable FinOps operating loop that turns storage and network findings into backlog items, review rituals, and measurable unit economics.
 
 ## Why This Module Matters
 
-Everyone optimizes compute. It's the obvious line item — the big EC2 or GCE charges that dominate the bill. But lurking beneath are two cost categories that grow silently and are far harder to control: **storage** and **networking**.
+Compute cost is visible because nodes have names, pods have requests, and autoscalers produce events that engineers already watch. Storage and network cost are quieter. A PersistentVolume can outlive the StatefulSet that once needed it, a snapshot can outlive the incident that justified it, and a service-to-service call can cross an availability-zone boundary thousands of times before anyone notices the billing dimension. These costs are not mysterious, but they are under-attributed because they are attached to flows and retained assets rather than to the deployment object that started the work.
 
-Here's what makes them dangerous:
+The practical danger is that storage and network decisions often sit outside the normal platform feedback loop. A team might tune CPU requests every sprint while leaving volume claims sized for a worst-case future that never arrived. Another team might deploy services across three zones for resilience, then accidentally send chatty internal traffic across those zones because the service routing model is unaware of cost. A third team might archive every log file into a cheap-looking object-storage tier, only to discover during an investigation that retrieval, restore time, and request charges matter as much as the storage rate.
 
-**Storage**: Resources that persist after workloads die. Delete a Deployment, and the PersistentVolume stays. Terminate a node, and the EBS volume remains. Take a snapshot "just in case," and it lives forever. Storage costs accumulate like sediment — slowly, quietly, and expensively.
+FinOps treats these problems as engineering design questions, not as finance complaints. The goal is not to minimize every byte, shrink every disk, or route all traffic through the cheapest path. The goal is to make the cost model visible enough that product, engineering, finance, and operations can choose the right tradeoff. Sometimes the right answer is to pay for cross-zone traffic because the workload needs resilience. Sometimes it is to keep a manual-retain volume because recovery is more important than automation. FinOps asks you to make those decisions intentionally, document the reason, and revisit the decision when usage changes.
 
-**Networking**: The invisible tax on everything. Every cross-AZ call costs money. Every response to a user costs money. Every NAT Gateway byte costs money. And nobody budgets for it because nobody can predict it.
+> **The Warehouse and Highway Analogy**
+>
+> Storage is a warehouse lease, and network is the toll road between warehouses, factories, and customers. A platform team can make the warehouse look cheap by moving boxes into distant cold storage, but that only works if nobody needs those boxes quickly. The team can also make the highway look invisible by focusing on the trucks rather than the tolls, but every unnecessary detour still becomes part of the delivered cost of the product.
 
-```mermaid
-pie title Typical cloud bill breakdown
-    "Compute (everyone optimizes this)" : 58
-    "Storage (few people optimize this)" : 22
-    "Network (nobody optimizes this)" : 12
-    "Other" : 8
-```
+The Kubernetes twist is that the platform deliberately abstracts the underlying warehouse and highway. A PVC asks for capacity, not a finance category. A Service asks for stable discovery, not a cross-zone cost boundary. A load balancer exposes an endpoint, not a chargeback plan. Those abstractions are useful, but they create a translation job. Platform FinOps is the discipline of mapping Kubernetes intent back to cloud billing primitives without making engineers read raw billing exports for every decision.
 
-The 34% that's storage and network? That's where the hidden waste lives. This module shows you how to find it and fix it.
+## Part 1: Storage And Network In The FinOps Lifecycle
 
----
+Storage and network optimization should follow the same durable lifecycle you learned in the earlier FinOps modules: Inform, Optimize, and Operate. In the Inform phase, the platform creates trustworthy visibility into which workloads hold storage, which flows move data, which shared services create overhead, and which labels or namespaces can carry allocation. In the Optimize phase, teams choose actions such as deleting orphaned volumes, adjusting claims, changing lifecycle rules, colocating chatty services, or replacing public paths with private endpoints. In the Operate phase, those choices become defaults, guardrails, backlog rituals, review dashboards, and exception processes.
 
-## Did You Know?
+The important lesson is that storage and network cost management is not a one-time cleanup campaign. A cleanup can remove waste, but the waste returns unless the operating model changes. If every new StatefulSet still starts with an oversized volume claim, every temporary snapshot still lacks an expiration owner, and every service still communicates through a topology-blind route, the same bill shape will reappear. A mature FinOps practice turns the cleanup findings into platform defaults, CI checks, review prompts, and team-level scorecards.
 
-- **AWS data transfer costs can be the third-largest line item** on a cloud bill, after compute and storage. Cross-AZ data transfer alone costs $0.01/GB in each direction — which sounds cheap until you realize a busy microservice architecture can generate terabytes of cross-AZ traffic monthly. One company discovered their service mesh was costing $23,000/month just in cross-AZ data transfer.
+The FinOps Foundation framework is useful here because it separates activities from personas. Finance needs forecastable categories and allocation rules. Engineering needs controls that are safe to apply and easy to understand. Product needs unit economics that connect infrastructure spend to customer value. Platform teams bridge those needs by translating cloud line items into workload-level evidence. Storage and network are especially good tests of this bridge because raw bills describe services and transfer types, while engineers reason about databases, caches, APIs, logs, backups, and user-facing paths.
 
-- **Orphaned EBS volumes are one of the most common sources of cloud waste.** When a Kubernetes node is terminated or a PV is released with a `Retain` reclaim policy, the underlying EBS volume persists — and you keep paying for it. AWS estimates that 20-30% of EBS volumes in a typical account are unattached.
+The first allocation decision is the grain of accountability. Namespace-level showback is easy to explain and often good enough for early visibility, but it hides shared storage, shared ingress, centralized telemetry, and cross-namespace dependencies. Label-based allocation gives more business meaning when labels such as `team`, `product`, `environment`, and `cost-center` are reliable. Chargeback requires even more care because teams will optimize toward the rule they are charged against. A weak rule can create perverse behavior, such as deleting useful telemetry, avoiding shared services that reduce total cost, or moving traffic patterns out of sight.
 
-- **NAT Gateway pricing is often the biggest networking surprise.** At $0.045/GB for data processing plus $0.045/hour for the gateway itself, a NAT Gateway processing 5 TB/month costs over $250 — just for routing traffic. VPC Endpoints for AWS services (S3, DynamoDB, ECR) can eliminate most of this cost for free.
+Showback and chargeback are not moral categories. Showback teaches teams what they consume and creates conversation without direct financial transfer. Chargeback moves cost into budgets and creates stronger incentives, but it also raises the fairness bar. For storage and network, most organizations should begin with showback, validate that allocation rules are stable, explicitly split shared and idle cost, then move selected categories into chargeback only when teams can influence the cost driver. Charging a product team for a central NAT gateway they cannot change is not accountability; it is accounting theater.
 
----
-
-## Storage Cost Management
-
-### EBS Volume Types and Costs
-
-Understanding which storage type to use is the first optimization lever:
-
-| Volume Type | IOPS | Throughput | Cost ($/GB/mo) | Best For |
-|-------------|------|------------|-----------------|----------|
-| gp3 (General Purpose SSD) | 3,000 baseline (free) | 125 MB/s baseline | $0.08 | Most workloads (default) |
-| gp2 (Older GP SSD) | 3 IOPS/GB (min 100) | Tied to IOPS | $0.10 | Legacy — migrate to gp3 |
-| io2 (Provisioned IOPS) | Up to 64,000 | Up to 1,000 MB/s | $0.125 + $0.065/IOPS | Databases needing guaranteed IOPS |
-| st1 (Throughput HDD) | 500 | 500 MB/s | $0.045 | Big data, sequential reads |
-| sc1 (Cold HDD) | 250 | 250 MB/s | $0.015 | Infrequent access, archives |
-
-### Quick Win: gp2 to gp3 Migration
-
-gp3 is almost always cheaper than gp2 — with better baseline performance:
+Unit economics bring the discussion closer to business value. A platform might track cost per customer, cost per request, cost per GiB retained, cost per report generated, or cost per training run. Storage and network matter because they often scale with customer behavior even when compute stays steady. A product that serves more media, stores more audit history, or moves more data between regions can become more expensive per customer without adding many pods. Good unit economics expose that pattern early enough for product and architecture teams to make deliberate decisions.
 
 ```mermaid
-graph TD
-    A[500 GB Volume] --> B(gp2)
-    A --> C(gp3)
-    
-    B --> B1["Cost: $50/mo ($0.10/GB)"]
-    B --> B2["IOPS: 1,500 (3 per GB)"]
-    B --> B3["Throughput: 250 MB/s"]
-    
-    C --> C1["Cost: $40/mo ($0.08/GB)"]
-    C --> C2["IOPS: 3,000 baseline (free)"]
-    C --> C3["Throughput: 125 MB/s"]
-    
-    C1 -.-> D["Savings: $10/mo per volume (20%)"]
-    C2 -.-> E["2x the IOPS at no extra cost!"]
-    D -.-> F["× 40 volumes = $400/mo saved"]
+flowchart LR
+    A["Inform<br/>Inventory assets and flows"] --> B["Optimize<br/>Choose safe changes"]
+    B --> C["Operate<br/>Bake choices into defaults"]
+    C --> A
+
+    A --> A1["PVCs, PVs, snapshots,<br/>object buckets, load balancers,<br/>NAT, transfer paths"]
+    B --> B1["Rightsize, tier, expire,<br/>route locally, use private paths,<br/>split shared cost"]
+    C --> C1["StorageClass defaults,<br/>lifecycle policies, topology rules,<br/>dashboards, reviews"]
 ```
 
-### Kubernetes StorageClass for Cost Optimization
+## Part 2: Allocation For The Under-Attributed Half Of The Bill
+
+Storage and network become under-attributed because the cost owner is rarely the same object that created the technical dependency. A PersistentVolume may be linked to a PVC, but the cloud disk may be visible in a cloud billing export under a volume identifier rather than a Kubernetes namespace. A snapshot may be created by a backup controller, yet its value belongs to the application whose recovery point it protects. A NAT gateway may sit in a networking account and serve every private subnet, while the actual bytes come from image pulls, package downloads, telemetry export, backups, and application calls.
+
+The durable allocation method is to separate direct, shared, idle, and overhead cost before assigning numbers to teams. Direct cost has a clear owner, such as a namespace-specific volume or a bucket prefix dedicated to one product. Shared cost supports multiple tenants, such as a central ingress controller, telemetry pipeline, backup bucket, or NAT gateway. Idle cost is paid capacity that does not currently serve work, such as released PVs, unattached disks, empty but retained volumes, or provisioned performance that usage never approaches. Overhead cost is the platform cost required to provide the service at all, such as control-plane fees, base networking components, or shared operational storage.
+
+A common mistake is to force every shared byte into a single owner because the spreadsheet needs a row. That creates false precision and weak trust. It is better to publish a simple rule and its limitations. For example, a shared log bucket might be allocated by bytes ingested per namespace, while the bucket's fixed overhead is split by active namespace count. A NAT gateway might be allocated by flow-log bytes when the data exists, then moved to a platform overhead pool when the flow evidence is incomplete. The allocation model should be honest about what it knows, what it estimates, and what remains intentionally unallocated.
+
+Labels are the contract between Kubernetes intent and FinOps reporting. Namespace labels can identify team and environment, deployment labels can identify service and product, and cloud tags can carry the same values to provider billing systems. The hard part is not adding labels once. The hard part is keeping labels valid when teams rename services, split products, move namespaces, run temporary jobs, or create resources through multiple tools. A useful FinOps platform treats missing or invalid labels as an operational signal, not as a finance cleanup ticket.
+
+Showback dashboards should explain the driver before showing the number. A team seeing "network cost increased" needs to know whether the increase came from internet egress, cross-zone traffic, NAT processing, load balancer processing, cross-region replication, or object-store retrieval. A team seeing "storage cost increased" needs to know whether the increase came from larger claims, more retained snapshots, colder-tier retrieval, higher provisioned IOPS, or orphaned assets. Cost without driver context produces arguments. Cost with driver context produces engineering choices.
+
+Chargeback should be reserved for categories where teams can act safely. Direct namespace volumes are usually chargeback candidates once labels are reliable. Orphaned resources can be charged to the owning team after a grace period if ownership is clear. Shared network egress is usually better handled through showback first because architecture, platform defaults, and provider-specific networking constraints strongly influence the bill. The decision is not "finance versus engineering"; it is whether the cost signal points to the person who can change the system without breaking it.
+
+```mermaid
+flowchart TD
+    A["Cloud bill line item"] --> B{"Can we map it to<br/>a workload owner?"}
+    B -- "Yes, strong evidence" --> C["Direct allocation<br/>namespace, label, product"]
+    B -- "Multiple consumers" --> D["Shared allocation<br/>usage-weighted or policy split"]
+    B -- "No active consumer" --> E["Idle or orphaned<br/>cleanup queue"]
+    B -- "Platform baseline" --> F["Overhead pool<br/>show transparently"]
+    D --> G["Publish method and limitation"]
+    E --> H["Owner review, retention check,<br/>then delete or document exception"]
+    F --> I["Use in unit economics,<br/>not as blame"]
+```
+
+## Part 3: Kubernetes Storage Cost Model
+
+Kubernetes storage cost begins with a request, but the bill is paid on the provider asset. A PVC asks for capacity and access mode, a StorageClass translates the request into a storage backend, and a CSI driver provisions or attaches the underlying disk, file share, or volume. The platform bill is shaped by the provisioned size, selected storage class, retained lifecycle, provisioned performance, replication model, snapshots, and the operational pattern of the workload. A small YAML field can therefore become a long-lived financial commitment.
+
+The request-versus-usage gap is the storage version of idle compute. If a team asks for a large volume because it might need room later, the provider usually bills the provisioned capacity immediately. Kubernetes volume expansion can make "start smaller and grow" practical for many workloads, but volume shrinking is not generally the same simple operation. That asymmetry changes behavior. Teams often over-request because expansion planning feels risky, while platform teams need to make expansion safe enough that oversized initial claims stop looking like the only responsible choice.
+
+Provisioned performance adds another dimension. Some storage types bind performance to size, which encourages teams to over-provision capacity just to get throughput or IOPS. Newer generations or different classes may decouple capacity from performance, allowing the platform to buy the performance it needs without carrying unnecessary GiB. The durable principle is not that one provider's volume family is always the answer. The durable principle is that storage class economics change over time, and platform defaults must be revisited when a newer generation changes the capacity-performance-price triangle.
+
+Reclaim policy is a safety and cost decision, not just a Kubernetes cleanup flag. A `Delete` policy removes the Kubernetes PV and, for supported dynamic provisioners, the backing storage asset when the claim is removed. A `Retain` policy keeps the underlying asset for manual recovery. Retain is valuable for important data and dangerous for temporary environments because it creates assets that stop appearing in ordinary workload views while continuing to exist in cloud inventory. The right policy depends on the data's recovery requirement, not on a universal preference for either deletion or retention.
+
+`WaitForFirstConsumer` is another cost-relevant storage setting because topology-constrained volumes must land where pods can actually run. Immediate provisioning can create a volume before the scheduler has selected a node, which is risky when zones matter. Delayed binding lets Kubernetes consider scheduling constraints before provisioning or binding the volume. The cost impact is indirect but real: fewer unschedulable pods, fewer abandoned attempts, and fewer volumes stranded in the wrong place because the storage asset was created before workload placement was known.
+
+StorageClass defaults deserve a regular FinOps review. A platform should ask whether the default class matches the common workload, whether encryption and expansion settings match policy, whether the reclaim policy is safe for the environment, whether the class is zone-aware, and whether older classes remain only for compatibility. A default created during the first cluster build can silently shape every team's cost for years. Treat it like an API contract that needs release notes, migration guidance, and an exception path.
 
 ```yaml
-# Cost-optimized gp3 StorageClass
+# Example StorageClass for general stateful workloads.
+# Validate parameters against your CSI driver and cloud provider before use.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: gp3-cost-optimized
+  name: general-purpose-expandable
 provisioner: ebs.csi.aws.com
 parameters:
   type: gp3
   fsType: ext4
   encrypted: "true"
-reclaimPolicy: Delete      # Auto-cleanup when PVC deleted
-allowVolumeExpansion: true  # Grow without recreating
-volumeBindingMode: WaitForFirstConsumer  # Bind to same AZ as pod
+reclaimPolicy: Delete
+allowVolumeExpansion: true
+volumeBindingMode: WaitForFirstConsumer
 ---
-# Cold storage for infrequent access (logs, archives)
+# Example StorageClass for retained data where manual recovery is required.
+# Retain should come with an owner review and cleanup process.
 apiVersion: storage.k8s.io/v1
 kind: StorageClass
 metadata:
-  name: cold-storage
+  name: retained-recovery-data
 provisioner: ebs.csi.aws.com
 parameters:
-  type: sc1
+  type: gp3
   fsType: ext4
-reclaimPolicy: Delete
+  encrypted: "true"
+reclaimPolicy: Retain
+allowVolumeExpansion: true
 volumeBindingMode: WaitForFirstConsumer
 ```
 
-### Orphaned Volumes: The Silent Cost Drain
+The StorageClass example preserves the useful shape from the original module while changing the lesson. The point is not that every cluster should use these exact names or an AWS CSI driver. The point is that a platform default should encode the financial and operational posture: choose a current general-purpose class, allow controlled growth, bind with scheduling context, encrypt by default, and reserve manual retention for data that has a documented recovery reason. A different cloud or CSI driver will use different parameters, but the review questions stay the same.
 
-Orphaned volumes happen when:
-1. A PVC is deleted but the PV has `reclaimPolicy: Retain`
-2. A node is terminated but the EBS volume isn't cleaned up
-3. A StatefulSet is deleted but its PVCs persist (by design)
-4. Terraform creates volumes that aren't managed by Kubernetes
+## Part 4: Orphaned Volumes, Unattached Disks, And Stale Snapshots
 
-> **Stop and think**: If a developer deletes a namespace containing a StatefulSet, what happens to the underlying cloud volumes? By default, the PVCs might be deleted depending on garbage collection policies, but if the PV `reclaimPolicy` is `Retain`, the underlying EBS volumes will persist forever.
+Orphaned storage is waste with a memory. It usually began as a legitimate safety measure: keep the database volume when deleting a test StatefulSet, preserve a disk during a node migration, retain snapshots before a risky release, or hold a backup until the new restore process is proven. The cost problem appears when the safety decision has no expiration, owner, or review path. The data may still be valuable, but nobody can explain why it is retained, what recovery point it protects, or when it can be deleted.
+
+Kubernetes exposes several early signals. PVs in `Released` state deserve review because their claims are gone while the PV object remains. PVs in `Available` state deserve review because they are not bound to a claim. PVCs that are bound but not mounted by any running pod may be valid, especially for paused workloads, but they should not be invisible. Cloud inventory adds another layer by showing unattached disks, snapshots without recent restore tests, disks not tagged with a Kubernetes owner, and volumes whose size or performance class no longer matches observed usage.
+
+Snapshot cost is subtle because snapshots feel smaller and safer than full copies. Incremental storage helps, but retention count, change rate, and restore requirements still matter. A busy database with frequent writes can accumulate much more snapshot data than a mostly static volume, and a long retention window can outlive the business need. FinOps does not say "take fewer backups" as a blanket rule. It asks teams to connect snapshot frequency and retention to recovery point objective, recovery time objective, legal retention, and tested restore practice.
+
+The most reliable snapshot policy is tiered by recovery value. Recent restore points are usually more valuable because most operational mistakes are discovered quickly. Weekly or monthly restore points may be useful for longer investigations or compliance, but they should have a documented reason. If a team cannot state why a snapshot is retained, what system it restores, and who approves deletion, the snapshot belongs in a review queue. That queue should include engineering and data owners because deletion is a data-loss decision, not a finance-only action.
+
+Hypothetical scenario: A team creates a temporary analytics namespace for a migration rehearsal and requests three retained volumes: 100 Gi, 250 Gi, and 500 Gi. The rehearsal ends, the namespace is deleted, and the PVs move to a released state because the reclaim policy was intentionally conservative. In a healthy FinOps loop, the next storage audit flags those released PVs, the owner confirms the rehearsal data is no longer needed, and the volumes are deleted after a short review window. In an unhealthy loop, the volumes remain because everyone assumes someone else owns the cleanup.
 
 ```mermaid
 graph LR
-    A["Created<br/>(PVC created)<br/>$0.08/GB/month"] --> B["In Use<br/>(Pod running)<br/>$0.08/GB/month"]
-    B --> C["Released<br/>(Pod gone, PV stays)<br/>$0.08/GB/month"]
-    C --> D["Orphaned<br/>(Nobody knows it exists)<br/>$0.08/GB FOREVER"]
+    A["PVC created<br/>owner and purpose known"] --> B["PV bound<br/>workload uses data"]
+    B --> C["Claim removed<br/>reclaim policy decides next state"]
+    C --> D{"Retain or Delete?"}
+    D -- "Delete" --> E["PV and backing asset removed<br/>when provisioner supports it"]
+    D -- "Retain" --> F["Released PV<br/>manual review required"]
+    F --> G["Keep with documented owner<br/>or delete backing asset"]
 ```
 
-### Finding Orphaned PVs in Kubernetes
+The audit loop should produce a decision, not merely a list. For every suspicious asset, record the owner, data class, age, last mounted workload, reclaim policy, restore requirement, and proposed action. The action may be delete, retain with expiration, resize, migrate to a different class, or add a missing tag. A list that nobody reviews is another dashboard. A list that feeds a weekly cleanup queue is an operating mechanism.
 
 ```bash
-# Find PVs that are Released (no longer bound to a PVC)
-# Note: PVs only support metadata.name and metadata.namespace field selectors,
-# so we filter by phase using grep or jq instead
-kubectl get pv | grep Released
+# Find PVs that are Released or Available.
+kubectl get pv
 
-# Find PVs that are Available (never claimed)
-kubectl get pv | grep Available
+# Structured view for review. PVs only support a limited set of field selectors,
+# so filter phase with jq when you need precise output.
+kubectl get pv -o json | jq -r '
+  .items[]
+  | select(.status.phase == "Released" or .status.phase == "Available")
+  | [
+      .metadata.name,
+      .status.phase,
+      .spec.capacity.storage,
+      .spec.persistentVolumeReclaimPolicy,
+      (.spec.storageClassName // "-"),
+      .metadata.creationTimestamp
+    ]
+  | @tsv'
 
-# For structured output, use jq:
-# kubectl get pv -o json | jq '.items[] | select(.status.phase=="Released") | .metadata.name'
-
-# Detailed view with age
+# Detailed inventory for owner review.
 kubectl get pv -o custom-columns=\
 NAME:.metadata.name,\
 STATUS:.status.phase,\
@@ -165,75 +185,23 @@ STORAGECLASS:.spec.storageClassName,\
 AGE:.metadata.creationTimestamp
 ```
 
-### Snapshot Management
+## Part 5: Object Storage Tiering Without The Retrieval Trap
 
-Snapshots are another silent cost accumulator:
+Object storage is usually where teams learn that "cheap at rest" is not the same as "cheap to use." Hot, warm, cold, and archive tiers are durable concepts across providers, even though each provider names and prices them differently. Hot tiers optimize for frequent access and low operational friction. Warm or infrequent tiers reduce storage cost when access is rare enough. Cold and archive tiers can be excellent for long retention, but retrieval time, retrieval fees, minimum storage duration, metadata overhead, and request costs can change the economics completely.
 
-```mermaid
-flowchart TD
-    A["EBS Snapshot pricing: $0.05/GB/month"] --> B["Policy: Keep 30 daily snapshots"]
-    B --> C["500 GB volume × 30 days<br/>(Incremental, ~60% of full size)"]
-    C --> D["~300 GB effective snapshot storage"]
-    D --> E["= $15/month per volume"]
-    E --> F["× 40 volumes = $600/month"]
-    F --> G["Annual Cost: $7,200/year 'just in case'"]
-```
+Lifecycle policies are useful because they move the decision from human memory into declared behavior. Logs might remain hot for immediate troubleshooting, transition to a lower-access tier after the common incident window, and expire after the retention requirement ends. Backups might follow a different path because restore speed matters more than casual query access. Compliance archives might prioritize retention and immutability over speed. The policy should reflect access patterns and obligations, not a generic desire to make everything colder.
 
-### Snapshot Lifecycle Policy
+The retrieval trap happens when a team optimizes only the storage line item. A cold tier can be cheaper while data sits untouched, but an investigation, reprocessing job, migration, or customer export may require reading a large amount of that data. Retrieval can add direct cost, operational delay, and engineering coordination. The right question is not "which tier has the lowest storage rate?" The right question is "what will this data cost over its whole lifecycle, including transition, minimum duration, retrieval, restore delay, and deletion?"
 
-```json
-{
-  "Description": "Cost-optimized snapshot lifecycle",
-  "Rules": [
-    {
-      "Name": "daily-snapshots-7-day-retention",
-      "Schedule": "cron(0 2 * * *)",
-      "Retain": 7,
-      "CopyTags": true,
-      "Tags": {
-        "lifecycle": "managed",
-        "retention": "7-days"
-      }
-    },
-    {
-      "Name": "weekly-snapshots-30-day-retention",
-      "Schedule": "cron(0 3 * * 0)",
-      "Retain": 4,
-      "CopyTags": true,
-      "Tags": {
-        "lifecycle": "managed",
-        "retention": "30-days"
-      }
-    }
-  ]
-}
-```
+Small objects deserve special attention. Some providers apply minimum billable object sizes, per-object transition charges, or metadata overhead in colder classes. A bucket full of tiny log fragments can behave very differently from a bucket of large backup archives. Before moving a large population of objects, sample the object count, average size, access history, and expected retrieval pattern. A policy that is economical for large monthly archives may be wasteful for millions of tiny files.
 
----
-
-## S3 Storage Tiering
-
-> **Stop and think**: If you have 50 TB of application logs generated monthly, should you store them in S3 Standard? Logs are rarely read after the first week unless there is an incident, making them perfect candidates for S3 Glacier Instant Retrieval or Deep Archive via lifecycle policies.
-
-For object storage, choosing the right tier can save 50-90%:
-
-| Tier | Cost ($/GB/mo) | Retrieval Cost | Access Pattern |
-|------|----------------|----------------|----------------|
-| S3 Standard | $0.023 | Free | Frequent access |
-| S3 Intelligent-Tiering | $0.023-$0.004 | Free | Unknown/changing patterns |
-| S3 Standard-IA | $0.0125 | $0.01/GB | Monthly access |
-| S3 One Zone-IA | $0.01 | $0.01/GB | Reproducible data, monthly |
-| S3 Glacier Instant | $0.004 | $0.03/GB | Quarterly, instant retrieval |
-| S3 Glacier Flexible | $0.0036 | Minutes to hours | Annual compliance |
-| S3 Glacier Deep Archive | $0.00099 | 12-48 hours | Regulatory retention |
-
-### Lifecycle Policy Example
+Lifecycle design also needs product context. Audit logs, customer exports, security evidence, training data, and application attachments have different value curves. Security logs may be rarely accessed but extremely valuable during an incident. Customer content may have strict deletion requirements. Derived analytics data may be reproducible and safe to expire sooner. The FinOps contribution is to help the platform expose the tradeoff so the data owner can choose deliberately.
 
 ```json
 {
   "Rules": [
     {
-      "ID": "logs-lifecycle",
+      "ID": "logs-lifecycle-example",
       "Filter": { "Prefix": "logs/" },
       "Status": "Enabled",
       "Transitions": [
@@ -258,84 +226,21 @@ For object storage, choosing the right tier can save 50-90%:
 }
 ```
 
-```mermaid
-flowchart TD
-    subgraph Without Lifecycle
-        A["7 years × 12 months × $23/TB"] --> B["Total: $1,932"]
-    end
-    
-    subgraph With Lifecycle
-        C["First 30 days: Standard ($23)"] --> D["Days 31-90: Standard-IA ($25)"]
-        D --> E["Days 91-365: Glacier IR ($36)"]
-        E --> F["Years 2-7: Deep Archive ($71)"]
-        F --> G["Total: $155"]
-    end
-    
-    B -.-> H["Savings: $1,777 per TB (92% reduction!)"]
-    G -.-> H
-```
+The JSON example is intentionally an example, not a universal policy. The durable method is to start with the access pattern, map the legal and operational retention requirement, model the full lifecycle cost, and then test retrieval before relying on the tier. A backup that cannot be restored within the required window is not a backup, even if the storage line looks efficient. An archive that costs more to retrieve than the team expected is still a product decision, but it should be a known decision.
 
----
+## Part 6: The Invisible Network Bill
 
-## Network Cost Management
+Network cost is difficult because engineers experience network as latency, reliability, and reachability, while bills experience network as direction, boundary, service, and processing path. Moving data inside one zone can have a different cost profile from moving data between zones. Moving data between regions differs from moving data to the public internet. Passing data through a managed NAT service, load balancer, firewall, service mesh, private endpoint, or transit component can add processing dimensions. The topology is the cost model.
 
-### The Data Transfer Cost Map
+Kubernetes adds another layer because Services intentionally hide individual pod locations. A client calls a stable service name, and Kubernetes chooses a backend endpoint according to service semantics, readiness, topology hints or preferences, and implementation details. That abstraction is usually the right engineering tradeoff. The FinOps risk appears when a chatty service pair is spread across zones and the default traffic path ignores locality. The application still works, but internal traffic can become a recurring transfer charge.
 
-Understanding where data transfer charges apply:
+Cross-zone traffic should be treated as a reliability tradeoff, not automatically as waste. Multi-zone distribution protects workloads from zone failure and is often required for production. The waste appears when routine traffic crosses zones even though equivalent local endpoints exist, or when a chatty dependency is spread in a way that adds cost without adding meaningful resilience. A cost-aware platform keeps high-availability design intact while preferring local paths where safe.
 
-```mermaid
-graph TD
-    Internet -- "$0.09/GB (Ingress is Free)" --> AWS
-    AWS -- "$0.09/GB (Egress)" --> Internet
-
-    subgraph "Region A"
-        AZ1[AZ-1] <-->|"$0.01/GB each way"| AZ2[AZ-2]
-        EC2_1[EC2] <-->|"FREE (same AZ)"| EC2_2[EC2]
-        AZ1 -.-> EC2_1
-    end
-
-    subgraph "Region B"
-        AZ3[AZ]
-    end
-
-    Region_A_Gateway["Region A"] <-->|"$0.02/GB"| Region_B_Gateway["Region B"]
-
-    subgraph "Networking Costs"
-        N1["VPC Endpoint to S3/DynamoDB: FREE (Gateway endpoint)"]
-        N2["NAT Gateway processing: $0.045/GB"]
-        N3["Load Balancer: $0.008/GB processed"]
-    end
-```
-
-### Cross-AZ Traffic: The Kubernetes Hidden Tax
-
-In Kubernetes, services communicate across AZs constantly. Every cross-AZ call costs $0.01/GB in each direction ($0.02/GB round-trip).
-
-```mermaid
-graph LR
-    subgraph "AZ-a"
-        API["API (Pod)"]
-    end
-    subgraph "AZ-b"
-        Search["Search (Pod)"]
-    end
-    subgraph "AZ-c"
-        Cache["Cache (Pod)"]
-    end
-
-    API -- "$0.01/GB" --> Search
-    Search -- "$0.01/GB" --> Cache
-    API -- "$0.01/GB" --> Cache
-
-    Cost["100 GB/day = $60/month<br/>500 GB/day = $300/month ($3,600/year)"]
-```
-
-### Reducing Cross-AZ Traffic
-
-**Strategy 1: Topology-Aware Service Routing**
+Kubernetes service traffic distribution is one tool for expressing that preference. In the Kubernetes 1.35 target for this curriculum, `PreferSameZone` and `PreferSameNode` are generally available values for the Service `trafficDistribution` field, while the older `PreferClose` name is deprecated in favor of the more explicit zone-oriented value. This is still a preference rather than a hard isolation rule. The service must have healthy local endpoints, and the implementation can fall back when local endpoints are unavailable.
 
 ```yaml
-# Route traffic to same-AZ endpoints first
+# Prefer endpoints in the same zone when healthy endpoints exist.
+# Kubernetes 1.35 uses PreferSameZone as the explicit value.
 apiVersion: v1
 kind: Service
 metadata:
@@ -345,14 +250,12 @@ spec:
   selector:
     app: search-api
   ports:
-  - port: 80
-    targetPort: 8080
-  trafficDistribution: PreferClose
+    - port: 80
+      targetPort: 8080
+  trafficDistribution: PreferSameZone
 ```
 
-With `trafficDistribution: PreferClose` (the standard in Kubernetes v1.31+), Kubernetes routes traffic to same-zone endpoints when possible, falling back to cross-zone only when needed.
-
-**Strategy 2: Pod Topology Spread with Zone Awareness**
+Topology spread constraints complete the picture by making local endpoints possible. If every replica of a backend happens to land in one zone, same-zone routing cannot help clients in other zones. Spread constraints let the scheduler distribute pods across zones so each zone has a reasonable chance of local service endpoints. The goal is not to pin everything to one zone, which would weaken resilience. The goal is to make the resilient topology cost-aware.
 
 ```yaml
 apiVersion: apps/v1
@@ -361,99 +264,68 @@ metadata:
   name: search-api
 spec:
   replicas: 6
+  selector:
+    matchLabels:
+      app: search-api
   template:
+    metadata:
+      labels:
+        app: search-api
     spec:
       topologySpreadConstraints:
-      - maxSkew: 1
-        topologyKey: topology.kubernetes.io/zone
-        whenUnsatisfiable: DoNotSchedule
-        labelSelector:
-          matchLabels:
-            app: search-api
+        - maxSkew: 1
+          topologyKey: topology.kubernetes.io/zone
+          whenUnsatisfiable: DoNotSchedule
+          labelSelector:
+            matchLabels:
+              app: search-api
+      containers:
+        - name: search-api
+          image: registry.k8s.io/pause:3.10
 ```
 
-This ensures pods are evenly distributed across AZs, so each AZ has local endpoints to talk to.
-
-**Strategy 3: Zone-Affine Deployments**
-
-For services that communicate heavily, co-locate them in the same AZ:
+Zone affinity can help with tightly coupled dependencies, but it must be used carefully. Co-locating an API and cache can reduce cross-zone traffic and latency, but over-constraining placement can reduce availability or create scheduling pressure. A preferred affinity is often safer than a required rule because it expresses the cost preference without blocking scheduling when the cluster is under stress. Strong rules belong only where the resilience and capacity implications are understood.
 
 ```yaml
-# Co-locate API and its cache in the same AZ
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: api-server
 spec:
+  selector:
+    matchLabels:
+      app: api-server
   template:
+    metadata:
+      labels:
+        app: api-server
     spec:
       affinity:
         podAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app: redis-cache
-              topologyKey: topology.kubernetes.io/zone
+            - weight: 100
+              podAffinityTerm:
+                labelSelector:
+                  matchLabels:
+                    app: redis-cache
+                topologyKey: topology.kubernetes.io/zone
+      containers:
+        - name: api-server
+          image: registry.k8s.io/pause:3.10
 ```
 
-### NAT Gateway vs VPC Endpoints
+The same logic applies outside the cluster. NAT gateways, cloud NAT services, private endpoints, interface endpoints, gateway endpoints, load balancers, and egress gateways all represent design choices about where traffic exits a private network and which managed service processes it. A NAT gateway is convenient because private workloads can reach external endpoints without public addresses. It can also become a concentrated data-processing line item if image pulls, package downloads, backups, telemetry export, and cloud API calls all pass through it.
 
-> **Pause and predict**: Which AWS service generates the most outbound traffic from an average Kubernetes cluster? (Hint: Think about how your pods start up). ECR image pulls and S3 backups are consistently the heaviest consumers of NAT Gateway bandwidth.
-
-NAT Gateway is one of the most expensive networking components — and often unnecessary.
-
-```mermaid
-flowchart TD
-    A["NAT Gateway Costs"] --> B["Hourly charge: $0.045/hr<br/>Fixed: $32.85/month/gateway"]
-    A --> C["Data processing: $0.045/GB"]
-
-    C --> D["ECR image pulls: 50 GB/mo = $2.25"]
-    C --> E["S3 access (logs): 200 GB/mo = $9.00"]
-    C --> F["External API calls: 30 GB/mo = $1.35"]
-    C --> G["DynamoDB: 100 GB/mo = $4.50"]
-    C --> H["Monitoring/telemetry: 80 GB/mo = $3.60"]
-
-    D & E & F & G & H --> I["Total processing: $20.70"]
-    B --> J["Total Fixed: $32.85"]
-    I & J --> K["Per-AZ Total: $53.55"]
-    K --> L["× 3 AZs = $160.65/mo"]
-```
-
-### VPC Endpoints Eliminate Most NAT Costs
-
-```mermaid
-flowchart TD
-    subgraph Gateway Endpoints
-        A["FREE"] --> B["S3 (saves $9.00/mo)"]
-        A --> C["DynamoDB (saves $4.50/mo)"]
-    end
-
-    subgraph Interface Endpoints
-        D["$0.01/hr + $0.01/GB"] --> E["ECR/ECR API ($7.80/mo)"]
-        D --> F["CloudWatch ($7.60/mo)"]
-        D --> G["STS ($7.31/mo)"]
-    end
-
-    subgraph Still using NAT
-        H["External APIs ($1.35/mo)"]
-    end
-
-    I["Before VPC Endpoints: $160.65/mo"] --> J["After VPC Endpoints: $55.41/mo"]
-    J --> K["Savings: $105.24/mo (65%)"]
-```
-
-### Essential VPC Endpoints for EKS
+Private endpoints are not automatically cheaper; they are a design option. Gateway-style endpoints for object storage or key-value services can remove unnecessary NAT paths in some clouds. Interface-style endpoints may add hourly and per-data charges while reducing NAT processing, improving private routing, or meeting security requirements. The decision should compare the whole path: endpoint fixed cost, endpoint processing, NAT processing, data transfer, operational complexity, security posture, and failure modes. FinOps makes that comparison explicit before architecture hardens around a default.
 
 ```hcl
-# Terraform: Create VPC Endpoints for EKS cost optimization
+# Terraform sketch: private AWS service endpoints for a private EKS network.
+# Confirm current pricing, service support, and route-table behavior in your region.
 resource "aws_vpc_endpoint" "s3" {
-  vpc_id       = aws_vpc.main.id
-  service_name = "com.amazonaws.${var.region}.s3"
+  vpc_id            = aws_vpc.main.id
+  service_name      = "com.amazonaws.${var.region}.s3"
   vpc_endpoint_type = "Gateway"
   route_table_ids   = aws_route_table.private[*].id
-  # Gateway endpoints are FREE
 }
 
 resource "aws_vpc_endpoint" "ecr_api" {
@@ -484,98 +356,211 @@ resource "aws_vpc_endpoint" "logs" {
 }
 ```
 
----
+## Part 7: Measuring Traffic Topology
+
+A network cost dashboard should start with flows, not with blame. Useful questions include which services talk most, which namespace pairs cross zones, which workloads create internet egress, which private subnets depend on NAT, which load balancers process the most data, which object buckets receive or return the most data, and which flows have no clear owner label. This is where platform engineering and finance meet: finance can show that a transfer category increased, but engineering telemetry explains why.
+
+Provider flow logs are often the bridge between billing and topology. VPC Flow Logs, cloud network telemetry, load balancer metrics, NAT metrics, service mesh telemetry, and eBPF-based network observability can each reveal a different part of the path. None of them is perfect. Flow logs may show IP addresses rather than Kubernetes owners. Service mesh telemetry may miss traffic that bypasses the mesh. Billing exports may show usage type without application context. The platform job is to join enough signals to support decisions while making uncertainty visible.
+
+The first dashboard view should separate traffic by boundary. Same-zone, cross-zone, cross-region, internet egress, provider-service traffic, and NAT-processed traffic answer different questions. Lumping them into "network" hides the action. A cross-zone increase might call for topology-aware routing or workload placement changes. Internet egress might call for CDN, caching, compression, product-level rate limiting, or customer data-export review. NAT growth might call for private endpoints, dependency inventory, image-pull optimization, or a review of outbound architecture.
+
+The second dashboard view should connect traffic to unit economics. Cost per request can reveal chatty internals, but it can also mislead if request size varies widely. Cost per GiB served is useful for media and data products, but it ignores business value if some exports are premium features. Cost per customer can reveal growth pressure, but only if customer usage is reasonably attributed. Good unit metrics are chosen with product context, then trended over time so teams can see whether architecture is improving or merely moving costs between categories.
+
+The third dashboard view should show exceptions. Some flows should be expensive because they are valuable, such as regulated exports, critical replication, or active incident investigation. Other flows should be flagged because they are surprising, such as a test namespace generating steady internet egress, a telemetry exporter sending uncompressed payloads, or a service calling a regional dependency through a public path. FinOps is not about shaming expensive flows. It is about distinguishing expensive value from expensive accidents.
+
+Hypothetical scenario: A platform team notices that a search API and cache exchange a large amount of data every day. Both services are healthy and the application latency is acceptable, so ordinary reliability dashboards show no problem. Flow evidence shows that most calls cross zone boundaries because replicas are unevenly distributed and the Service has no locality preference. The fix is not to collapse the workload into one zone; it is to add spread constraints, use same-zone traffic preference where supported, and monitor whether the cross-zone share falls without hurting availability.
+
+```mermaid
+flowchart TD
+    A["Billing export<br/>usage types and charges"] --> D["Network cost model"]
+    B["Flow logs<br/>source, destination, bytes"] --> D
+    C["Kubernetes metadata<br/>namespace, labels, owner refs"] --> D
+    E["Service mesh or eBPF telemetry<br/>service-level paths"] --> D
+    D --> F["Showback by product and driver"]
+    D --> G["Optimization backlog"]
+    D --> H["Unit economics trend"]
+```
+
+## Part 8: Decision Framework
+
+Cost decisions fail when they are framed as one-dimensional choices. Showback versus chargeback is not a finance preference; it depends on evidence quality and control. Rightsize versus autoscale is not a tool preference; it depends on workload shape and safety. Commit, on-demand, and spot-style capacity are not ranks; they trade flexibility, interruption tolerance, and price. Storage and network decisions need the same multi-axis thinking because the cheapest line item can be the wrong system outcome.
+
+Use a decision framework when the same debate keeps returning. The framework should name the driver, the evidence needed, the safe default, the exception path, and the review cadence. If a workload needs a retained PV, the exception is valid when it has a data owner, recovery reason, and expiry review. If a service needs cross-zone calls, the exception is valid when it supports resilience, latency, or data-locality requirements. If an archive needs a cold tier, the exception is valid when retrieval delay and cost are acceptable.
+
+| Decision | Choose This When | Avoid This When | Review Signal |
+|----------|------------------|-----------------|---------------|
+| Showback before chargeback | Allocation evidence is incomplete, teams need learning time, or shared platform costs dominate | Teams already control the driver and budgets require direct recovery | Teams ask the same "why is this mine?" question repeatedly |
+| Chargeback for direct storage | PVCs, buckets, or prefixes have strong owner labels and teams can resize, delete, or justify retention | Shared services or missing labels would make the charge feel arbitrary | Cost owners can explain their top drivers without finance translation |
+| Right-size volume claims | Usage is stable, expansion is supported, and restore testing covers the change | The workload has unknown growth, shrink operations are risky, or the data owner cannot validate recovery | Provisioned capacity remains far above observed high-water mark |
+| Lifecycle object data | Access pattern and retention obligation are known | Data has unpredictable urgent retrieval needs or many tiny objects with unfavorable transition economics | Retrieval cost, restore delay, or transition requests surprise the team |
+| Prefer local network paths | Equivalent healthy endpoints exist in the same zone or private path | Locality preference would weaken failover, overload one zone, or hide a required replication path | Cross-zone or NAT-processed traffic grows faster than product usage |
+| Commit to capacity or rates | Usage is predictable and the service can tolerate reduced flexibility | Demand is spiky, experimental, or tied to short-lived projects | On-demand baseline remains steady across several planning periods |
+| Use spot-style capacity | Work is interruptible, checkpointed, or horizontally redundant | State, latency, or recovery requirements make interruption unsafe | Evictions are handled without violating user-facing objectives |
+
+```mermaid
+flowchart TD
+    A["Cost finding"] --> B{"Is the owner clear<br/>and can they act?"}
+    B -- "No" --> C["Showback, improve labels,<br/>split shared/idle/overhead"]
+    B -- "Yes" --> D{"Is the cost tied to<br/>retained data?"}
+    D -- "Yes" --> E["Validate retention, restore,<br/>lifecycle, and deletion policy"]
+    D -- "No" --> F{"Is the cost tied to<br/>traffic topology?"}
+    F -- "Yes" --> G["Map boundary, locality,<br/>private path, and resilience tradeoff"]
+    F -- "No" --> H["Evaluate rightsize,<br/>autoscale, or rate commitment"]
+    E --> I["Backlog item with owner,<br/>risk, metric, and review date"]
+    G --> I
+    H --> I
+```
+
+This framework also protects teams from recommendation autopilot. A cost tool can flag a volume as underused, a bucket as a tiering candidate, or a service path as expensive. That recommendation is input, not permission to mutate production. Platform teams should validate workload behavior, recovery objectives, compliance constraints, and owner intent before applying a change. The strongest FinOps practices combine automated detection with human review at the point where cost, reliability, and data safety intersect.
+
+## Part 9: Patterns & Anti-Patterns
+
+The strongest storage and network FinOps patterns are boring in the best way. They make cost visible at the same place engineers already make design decisions. They favor defaults that prevent accidental waste, while leaving room for documented exceptions. They turn billing surprises into architecture learning, not into a monthly blame cycle. They also avoid pretending that cloud financial management is separate from reliability, security, and product design.
+
+**Pattern: Owner-first storage inventory.** Every PV, bucket prefix, snapshot policy, and retained disk should carry enough ownership context to answer who uses it, why it exists, what data class it holds, and when it should be reviewed. The implementation may use Kubernetes labels, cloud tags, backup metadata, or a CMDB, but the operating goal is the same. If ownership cannot be established, the item enters an investigation queue before it enters a deletion queue.
+
+**Pattern: Cost-aware defaults with explicit exceptions.** A default StorageClass, lifecycle policy, or topology preference should match the common case and encode the platform's current best understanding. Exceptions should be easy enough that teams do not bypass the platform, but explicit enough that the exception has an owner and review date. This pattern is more durable than trying to approve every resource manually.
+
+**Pattern: Flow-based network review.** Network cost reviews should start from traffic boundaries and service paths rather than from aggregate spend. Teams should be able to see cross-zone, cross-region, internet, private-provider, NAT-processed, and load-balanced traffic separately. Once the path is visible, the platform can decide whether the flow is valuable, accidental, or better served by a different topology.
+
+**Pattern: Unit economics connected to product behavior.** Storage and network unit metrics should be tied to the way customers use the product. A data platform might track cost per GiB processed, while an API product might track network cost per thousand requests or per active customer. The metric does not need to be perfect. It needs to be stable enough that teams can see whether architecture changes improve the cost of delivering value.
+
+**Anti-pattern: Treating deleted Kubernetes objects as deleted cloud cost.** Kubernetes object deletion and cloud asset deletion are related but not identical. Retain policies, finalizers, backup controllers, external provisioners, and failed cleanup operations can leave billable assets behind. Assuming deletion is complete without checking the provider inventory is how orphaned disks and stale snapshots become permanent.
+
+**Anti-pattern: Freezing storage in the coldest tier by default.** Cold and archive tiers are useful when access is rare and retrieval delay is acceptable. They are harmful when teams need urgent restoration, frequent investigation, or large reprocessing. The cheapest storage tier can create the most expensive incident if it blocks recovery or surprises the team with retrieval economics.
+
+**Anti-pattern: Optimizing network paths without resilience review.** Local routing, private endpoints, and zone affinity can reduce unnecessary transfer, but they can also change failure behavior. A platform that removes cross-zone traffic by weakening failover has not optimized cost; it has traded an obvious bill for a hidden reliability risk. Every network optimization should state the resilience assumption it preserves.
+
+**Anti-pattern: Blindly applying cost-tool recommendations.** Tools can detect patterns faster than humans, but they cannot know every recovery objective, legal hold, incident context, or product promise. Recommendations should feed a review queue with evidence and suggested action. The team should decide whether to apply, defer, reject, or turn the recommendation into a safer platform default.
+
+## Landscape Snapshot And Cost-Tooling Rosetta
+
+> **Landscape snapshot - as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> Kubernetes 1.35 promotes the explicit `PreferSameZone` and `PreferSameNode` Service `trafficDistribution` values to general availability, with `PreferClose` deprecated in favor of `PreferSameZone`. AWS documentation describes gp3 as a newer general-purpose EBS generation with independently configurable performance and a lower per-GB price than gp2 in common regions, but storage prices remain region-specific and should be checked on the live pricing page. AWS, Google Cloud, and Azure all publish separate pricing dimensions for storage class, retrieval, data transfer, and NAT-style processing; do not collapse provider, region, transfer boundary, and product into a ranked list. OpenCost is a CNCF-owned, vendor-neutral Kubernetes cost allocation project, Kubecost builds a commercial product around Kubernetes cost visibility, cloud-native cost explorers expose provider billing and recommendations, Vantage provides multi-cloud cost management views, and Infracost estimates infrastructure-as-code cost impact before changes merge.
+
+| Durable Capability | OpenCost | Kubecost | Cloud-Native Cost Explorer | Infracost |
+|--------------------|----------|----------|----------------------------|-----------|
+| Kubernetes allocation | Vendor-neutral allocation model for cluster assets and workloads | Kubernetes-focused allocation and reporting built around similar workload concepts | Provider billing views can show managed Kubernetes services and tags, but pod-level context varies | Not a runtime allocator; estimates resources declared in supported IaC |
+| Persistent volume cost visibility | Models persistent volumes and attached storage when metrics and pricing inputs are available | Shows persistent volume cost and workload association when integrated with cluster data | Shows disks, snapshots, and storage services from provider billing inventory | Estimates declared disks, buckets, and related resources before deployment |
+| Idle or shared cost handling | Supports allocation concepts that can expose idle and shared cluster cost | Provides views for idle, shared, and namespace/team allocation depending on configuration | Depends on tag hygiene, account structure, and provider recommendation features | Can flag cost impact in pull requests but not runtime idle state |
+| Network and load balancer cost | Can include load balancer and network ingress or egress cost in cluster allocation models | Provides Kubernetes network and load balancer cost views where data sources support them | Usually strongest for provider-native transfer, NAT, and load balancer billing dimensions | Estimates declared network resources, not actual traffic volume unless usage assumptions are supplied |
+| Showback and chargeback | Useful as an allocation data source for showback exports | Provides dashboards and reports for team-oriented showback workflows | Useful for finance-owned reporting by account, project, subscription, tag, or cost category | Useful for pre-merge cost review and policy discussion |
+| Anomaly and budget workflow | Can feed metrics and external alerting systems | Provides product-level workflows depending on edition and configuration | Native anomaly, budget, and recommendation features vary by provider | Focuses on change-time estimation and policy guardrails |
+| CI cost estimation | Not its primary role | Not its primary role | Not its primary role | Primary use case: show cost impact in engineering workflows before merge |
+
+This table is a Rosetta stone, not a ranking. Each column answers a different question at a different point in the lifecycle. Runtime Kubernetes allocation tools help explain what happened inside clusters. Cloud-native explorers reconcile provider bills, commitments, and account-level services. IaC estimators help catch cost changes before they deploy. A mature platform may use more than one category because Inform, Optimize, and Operate need different evidence.
+
+## Did You Know?
+
+- **PersistentVolume reclaim policy changes the cleanup path**: Kubernetes documents that `Retain` keeps the PV and backing asset for manual reclamation, while `Delete` removes supported dynamically provisioned backing storage with the PV.
+- **Volume expansion is one-way in many workflows**: Kubernetes StorageClass documentation notes that expansion is for growing a volume, not shrinking it, which is why oversized initial claims become sticky.
+- **Traffic distribution is now more explicit**: Kubernetes 1.35 makes `PreferSameZone` and `PreferSameNode` generally available for Service traffic distribution, while the older `PreferClose` value is deprecated.
+- **Object tiering has more than one price dimension**: Provider storage docs separate storage, retrieval, request, transition, minimum-duration, and data-transfer behavior, so a lifecycle policy needs full-lifecycle modeling.
 
 ## Common Mistakes
 
 | Mistake | Why It Happens | How to Fix It |
-|---------|---------------|---------------|
-| Using gp2 instead of gp3 | Default in many tools/templates | Change default StorageClass to gp3 |
-| PVs with Retain policy and no cleanup | Safety-first mentality | Use Delete policy for non-critical data, automate cleanup for Retain |
-| No snapshot lifecycle policy | "Snapshots are cheap" | Implement DLM policies: 7 daily, 4 weekly |
-| All traffic through NAT Gateway | Simple architecture | Add Gateway endpoints (S3, DynamoDB) and Interface endpoints (ECR, CloudWatch) |
-| Ignoring cross-AZ data transfer | Invisible on most dashboards | Enable topology-aware routing, monitor with VPC Flow Logs |
-| Over-sized EBS volumes "just in case" | Can't shrink EBS | Start small with volume expansion enabled |
-| S3 Standard for everything | Default tier | Implement lifecycle policies for logs and backups |
-| No volume encryption | "We'll do it later" | Encrypt by default — gp3 encrypted costs the same |
-
----
+|---------|----------------|---------------|
+| Treating PVC deletion as proof that cloud storage disappeared | The Kubernetes object lifecycle and provider asset lifecycle can diverge through retain policies, CSI behavior, or failed cleanup | Audit PV phase, cloud disks, snapshots, tags, and owner metadata together before closing cleanup work |
+| Choosing a storage class once and never revisiting it | Platform defaults feel stable even when provider generations and workload needs change | Add StorageClass economics to quarterly platform review and publish migration guidance for safer defaults |
+| Oversizing volumes because growth planning is uncomfortable | Teams know expansion might be easier than emergency recovery, but they lack a safe growth process | Enable expansion where appropriate, document growth runbooks, and review high provisioned-to-used gaps |
+| Keeping snapshots without a restore story | Backup creation is automated, but restore ownership and retention review are not | Tie snapshot policies to RPO, RTO, data owner, restore test, and expiration review |
+| Moving objects to cold tiers based only on storage rate | Retrieval, requests, minimum duration, and restore delay are easy to ignore | Model the full lifecycle and test retrieval before changing large buckets |
+| Aggregating all network spend into one dashboard line | Billing categories are easier to sum than to explain | Split same-zone, cross-zone, cross-region, internet egress, NAT, endpoint, and load-balancer drivers |
+| Charging teams for shared network costs they cannot influence | Finance wants allocation before engineering evidence is mature | Start with showback, improve labels and flow attribution, then charge back only controllable drivers |
+| Applying cost recommendations automatically | Tools can detect waste but cannot know every data-safety or reliability requirement | Route recommendations through owner review with risk, rollback, and success metrics |
 
 ## Quiz
 
 ### Question 1
-Your platform team has been running 35 gp2 EBS volumes for various StatefulSets. Each volume averages 200 GB in size and requires around 1,500 IOPS during peak hours. Your finance department has mandated a 10% reduction in cloud storage spend. How much can you save annually by migrating these volumes to gp3, and will performance be impacted?
+
+A team deletes a namespace after a migration rehearsal. The StatefulSet is gone, but the platform storage dashboard still shows several released PVs with a `Retain` reclaim policy. The team says Kubernetes cleanup already ran, and finance asks whether the volumes can be removed immediately. What should the platform FinOps response be?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-Migrating to gp3 will save your team $1,680 per year. Here is why: gp2 charges $0.10/GB/month, meaning 35 volumes at 200 GB costs $700/month. gp3 charges $0.08/GB/month, which reduces the cost to $560/month, yielding a $140 monthly savings. Furthermore, your performance will actually improve. gp2 provides 3 IOPS per GB, so a 200 GB volume only guarantees 600 IOPS (though it bursts). gp3 provides a guaranteed 3,000 IOPS baseline for free, comfortably exceeding your 1,500 IOPS peak requirement without any extra provisioning costs. This represents a rare "win-win" in FinOps where you simultaneously cut costs and increase performance reliability.
+The right response is to **audit** the storage driver before deleting anything. A `Retain` policy means the PV and backing asset may intentionally remain for manual recovery, so the platform should identify owner, data class, last workload, and recovery reason before action. If the rehearsal data is no longer needed, deletion is a good cleanup item; if it protects a recovery point, it should be retained with an expiration review. This answer aligns storage cost reduction with data safety instead of treating cost visibility as automatic deletion permission.
 </details>
 
 ### Question 2
-An EKS cluster you manage has seen a massive spike in NAT Gateway data processing costs, reaching 8 TB this past month. Upon investigating VPC Flow Logs, you discover that 5 TB of this traffic is backups heading to S3, and 2 TB consists of container image pulls from ECR. Your manager wants to know how much money you can save by implementing VPC Endpoints without changing the application code.
+
+Your cost dashboard shows that network spend increased, but the only label in the finance report is "data transfer." The cluster runs user-facing APIs, internal caches, image pulls, backups, and telemetry exporters. What additional views do you need before assigning the increase to a team?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-You can save approximately $3,360 per year ($280/month) by implementing VPC Endpoints. Here is why: Traffic routed through a NAT Gateway incurs a $0.045/GB processing fee. By adding an S3 Gateway Endpoint, you route the 5 TB of S3 backup traffic entirely within the AWS network for free, immediately saving $225/month. For the 2 TB of ECR traffic, you can deploy Interface Endpoints (AWS PrivateLink), which cost $0.01/hour per AZ plus $0.01/GB processed. This reduces the ECR data processing cost from $90/month (via NAT) to roughly $34.60/month, yielding an additional $55.40 in savings. The application code requires no changes because Gateway Endpoints automatically update route tables, and Interface Endpoints provide private DNS resolution that seamlessly intercepts the traffic.
+You need to **design** an allocation view that separates the traffic boundary and the owner evidence. At minimum, split cross-zone, cross-region, internet egress, NAT-processed, load-balancer, provider-service, and private-endpoint traffic, then join those flows to namespace, service, product, or team labels where the evidence is strong. Shared and unclear flows should remain in showback or overhead until the model is trustworthy. This prevents a chargeback rule from punishing a team for traffic it cannot see or influence.
 </details>
 
 ### Question 3
-Your distributed microservices architecture spans three Availability Zones (AZs) for high availability. However, your monthly AWS bill shows a significant and growing line item for "Data Transfer - Inter-AZ". The development team claims they only communicate internally. Why is this happening, and what specific Kubernetes configurations can you implement to mitigate this cost?
+
+A product team wants to move all logs older than one week into the coldest available object-storage tier because the storage rate is lower. The security team sometimes needs to retrieve several months of logs during investigations. How should you evaluate the policy?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-This happens because kube-proxy's default behavior is to load-balance service requests randomly across all available backend pods, regardless of their Availability Zone. Since AWS charges $0.01/GB for cross-AZ data transfer in each direction ($0.02/GB round-trip), an API pod in AZ-a calling a service will statistically send about 66% of its traffic across AZ boundaries. To mitigate this, you should implement topology-aware routing by setting the `trafficDistribution: PreferClose` field in your Services (the standard approach in Kubernetes v1.31+), which instructs kube-proxy to prefer endpoints in the same AZ. Additionally, you should configure Pod Topology Spread Constraints to ensure your deployments are evenly distributed across AZs, guaranteeing that local endpoints are always available to handle the routing requests.
+You should **evaluate** the full lifecycle, not only the at-rest storage rate. The policy needs to account for retrieval cost, restore delay, request or transition charges, minimum storage duration, object size distribution, and the operational value of fast investigation. A colder tier may still be correct for older logs, but the cutoff should reflect access history and incident requirements. A small retrieval test should happen before the policy becomes a broad platform default.
 </details>
 
 ### Question 4
-A development team running a 500 GB PostgreSQL database on Kubernetes has configured an automated cron job to take a daily EBS snapshot for disaster recovery. They have been running this for 50 days without an expiration policy, resulting in 50 snapshots. They are surprised to see a massive spike in snapshot costs. What is their current monthly cost, and how can they adjust their retention policy to balance safety with budget?
+
+Two services exchange heavy internal traffic and are deployed across three zones. Reliability is good, but flow logs show that many calls cross zone boundaries even when same-zone pods exist. What Kubernetes changes could reduce cost without collapsing resilience?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-Their current monthly snapshot cost is approximately $760/month, but this can be drastically reduced by implementing a tiered retention policy. Here is why the cost is so high: AWS charges $0.05/GB/month for EBS snapshots. While the first snapshot is a full 500 GB, subsequent daily snapshots are incremental and typically average around 60% of the volume size (300 GB) for active databases. This means they are storing over 15,200 GB of snapshot data. To optimize this, they should implement a Data Lifecycle Manager (DLM) policy that keeps only 7 daily snapshots, 4 weekly snapshots, and perhaps 3 monthly snapshots. This provides robust point-in-time recovery for the critical recent window while reducing their total retained snapshots from 50 to 14, effectively lowering their monthly cost to around $210/month.
+The platform can **apply** topology-aware methods rather than forcing everything into one zone. In Kubernetes 1.35, a Service can express `trafficDistribution: PreferSameZone`, and the backend Deployment can use topology spread constraints so each zone has local endpoints. Preferred pod affinity can help colocate tightly coupled services when it does not block scheduling or weaken failover. The success metric is a lower cross-zone share while availability and latency objectives remain intact.
 </details>
 
 ### Question 5
-You are tasked with redesigning the network architecture for a high-traffic Kubernetes cluster to minimize NAT Gateway expenses. You have the option to use VPC Gateway Endpoints and VPC Interface Endpoints to route traffic to various AWS services. How should you decide which type of endpoint to use for services like S3, DynamoDB, and ECR?
+
+An infrastructure pull request adds several new buckets, volumes, and private endpoints for a feature launch. Runtime allocation tools will not show real usage until after deployment. What FinOps signal can you provide before the change merges?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-You should always use Gateway Endpoints for S3 and DynamoDB, while reserving Interface Endpoints for high-traffic services like ECR when the data transfer savings outweigh the hourly endpoint cost. Here is why: Gateway Endpoints are entirely free and operate at the network layer by adding a target route to your VPC route tables, making them the most cost-effective solution for S3 and DynamoDB traffic. Interface Endpoints, powered by AWS PrivateLink, create an Elastic Network Interface (ENI) within your subnets and support over 100 AWS services (including ECR and CloudWatch). However, Interface Endpoints charge an hourly fee per AZ (around $0.01/hr) plus a $0.01/GB processing fee. Therefore, Interface Endpoints only make financial sense when the service generates enough traffic that paying the $0.01/GB rate is significantly cheaper than the $0.045/GB NAT Gateway fee.
+You can **build** a pre-merge cost review using infrastructure-as-code estimation and policy checks. The estimate will not know exact future traffic, but it can expose declared storage size, storage class, endpoint count, lifecycle settings, and assumptions that deserve review. That review should be paired with post-deploy runtime allocation because change-time estimates and actual usage answer different questions. This keeps FinOps in the engineering workflow instead of waiting for the next invoice.
 </details>
 
----
+### Question 6
 
-## Hands-On Exercise: Find Unattached PVs and Old Snapshots
+A finance partner proposes charging every namespace an equal share of the central NAT gateway because the bill cannot yet map bytes to workloads. Engineering objects that some namespaces never use external services. What is the best next step?
 
-Write scripts to identify storage waste in your Kubernetes cluster.
+<details>
+<summary>Answer</summary>
 
-### Step 1: Setup
+The best next step is showback with better evidence, not immediate equal chargeback. The platform should inspect NAT metrics, flow logs, egress gateways, image pulls, backups, telemetry export, and dependency paths to learn which namespaces or services drive traffic. Until the evidence is reliable, the NAT cost can be shown as shared platform overhead with an explicit allocation limitation. Chargeback becomes reasonable only when the cost owner can understand and influence the driver.
+</details>
+
+### Question 7
+
+A tool recommends shrinking or deleting a volume because observed usage is low. The volume belongs to a database that supports a regulated workflow, and the data owner is not sure how restore testing works. Should the platform apply the recommendation automatically?
+
+<details>
+<summary>Answer</summary>
+
+No. A recommendation is input to review, not autopilot. The platform should validate data classification, recovery objectives, restore evidence, growth pattern, and whether the storage backend supports the proposed change safely. If the volume is genuinely oversized, the outcome may be a planned migration, a new expansion policy, or a future resize after testing. This is how you optimize cost while preserving reliability, compliance, and trust.
+</details>
+
+## Hands-On Exercise: Storage And Network Cost Audit
+
+This lab uses a local kind cluster to practice the inventory side of the FinOps loop. The cluster cannot create real cloud disks or real cloud data-transfer charges, so the exercise simulates storage states and teaches the review workflow. In a real environment, you would join this Kubernetes evidence with cloud inventory, billing export, flow logs, and owner labels before deleting or reallocating anything.
+
+### Step 1: Create A Local Cluster And Simulated Storage
 
 ```bash
-# Create a kind cluster
-kind create cluster --name storage-lab
-
-# Create namespace
+kind create cluster --name storage-network-lab
 kubectl create namespace storage-lab
-```
 
-### Step 2: Create Storage Resources (Simulated Waste)
-
-```bash
-# Create PVs and PVCs to simulate various states
 kubectl apply -f - << 'EOF'
-# PV with Retain policy (will become orphaned)
 apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: orphaned-pv-001
   labels:
-    type: database-backup
+    owner: payments
+    data-class: rehearsal
 spec:
   capacity:
     storage: 100Gi
@@ -591,7 +576,8 @@ kind: PersistentVolume
 metadata:
   name: orphaned-pv-002
   labels:
-    type: log-archive
+    owner: search
+    data-class: log-archive
 spec:
   capacity:
     storage: 250Gi
@@ -607,7 +593,8 @@ kind: PersistentVolume
 metadata:
   name: orphaned-pv-003
   labels:
-    type: ml-model-store
+    owner: ml-platform
+    data-class: model-cache
 spec:
   capacity:
     storage: 500Gi
@@ -618,11 +605,13 @@ spec:
   hostPath:
     path: /tmp/pv-003
 ---
-# Active PV with PVC (this one is in use)
 apiVersion: v1
 kind: PersistentVolume
 metadata:
   name: active-pv-001
+  labels:
+    owner: checkout
+    data-class: active
 spec:
   capacity:
     storage: 50Gi
@@ -642,245 +631,220 @@ spec:
   accessModes:
     - ReadWriteOnce
   storageClassName: manual
+  selector:
+    matchLabels:
+      owner: checkout
+      data-class: active
   resources:
     requests:
       storage: 50Gi
 EOF
-
-echo "Storage resources created."
 ```
 
-### Step 3: Write the Waste Detection Script
+### Step 2: Run A Kubernetes Storage Audit
 
 ```bash
 cat > /tmp/storage_audit.sh << 'SCRIPT'
-#!/bin/bash
-echo "============================================"
-echo "  Storage Waste Audit Report"
-echo "  Date: $(date +%Y-%m-%d)"
-echo "============================================"
-echo ""
+#!/usr/bin/env bash
+set -euo pipefail
+PYTHON_BIN="${PYTHON_BIN:-.venv/bin/python}"
 
-# Section 1: Unbound PVs (Available or Released)
-echo "--- Unbound Persistent Volumes ---"
-echo ""
-UNBOUND=$(kubectl get pv -o json 2>/dev/null | python3 -c "
-import json, sys
+echo "Storage Waste Audit Report"
+echo "Generated: $(date +%Y-%m-%d)"
+echo
+
+echo "Unbound retained PersistentVolumes"
+kubectl get pv -o json | "$PYTHON_BIN" -c '
+import json
+import sys
+
 data = json.load(sys.stdin)
-items = [pv for pv in data.get('items', []) if pv['status']['phase'] != 'Bound']
-json.dump({'items': items}, sys.stdout)
-" 2>/dev/null)
-UNBOUND_COUNT=$(echo "$UNBOUND" | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-pvs = data.get('items', [])
-print(len(pvs))
-" 2>/dev/null)
+items = [
+    pv for pv in data.get("items", [])
+    if pv.get("status", {}).get("phase") != "Bound"
+    and pv.get("spec", {}).get("persistentVolumeReclaimPolicy") == "Retain"
+]
 
-if [ "$UNBOUND_COUNT" -gt 0 ]; then
-  echo "Found $UNBOUND_COUNT unbound PV(s):"
-  echo ""
-  echo "$UNBOUND" | python3 -c "
-import json, sys
-data = json.load(sys.stdin)
-total_gb = 0
-for pv in data.get('items', []):
-    name = pv['metadata']['name']
-    phase = pv['status']['phase']
-    cap = pv['spec']['capacity']['storage']
-    reclaim = pv['spec']['persistentVolumeReclaimPolicy']
-    created = pv['metadata']['creationTimestamp']
-    pv_type = pv['metadata'].get('labels', {}).get('type', 'unknown')
+if not items:
+    print("  none")
+    raise SystemExit(0)
 
-    # Parse capacity
-    gb = 0
-    if 'Gi' in cap:
-        gb = int(cap.replace('Gi', ''))
-    elif 'Ti' in cap:
-        gb = int(cap.replace('Ti', '')) * 1024
+total_gib = 0
+for pv in items:
+    meta = pv["metadata"]
+    spec = pv["spec"]
+    name = meta["name"]
+    phase = pv["status"]["phase"]
+    capacity = spec["capacity"]["storage"]
+    labels = meta.get("labels", {})
+    owner = labels.get("owner", "unknown")
+    data_class = labels.get("data-class", "unknown")
+    reclaim = spec.get("persistentVolumeReclaimPolicy", "unknown")
 
-    total_gb += gb
-    cost_mo = gb * 0.08  # gp3 pricing
+    gib = 0
+    if capacity.endswith("Gi"):
+        gib = int(capacity[:-2])
+    elif capacity.endswith("Ti"):
+        gib = int(capacity[:-2]) * 1024
+    total_gib += gib
 
-    print(f'  {name}')
-    print(f'    Status: {phase} | Size: {cap} | Reclaim: {reclaim}')
-    print(f'    Type: {pv_type} | Created: {created}')
-    print(f'    Estimated cost: \${cost_mo:.2f}/month')
-    print()
+    print(f"  {name}")
+    print(f"    phase={phase} capacity={capacity} reclaim={reclaim}")
+    print(f"    owner={owner} data_class={data_class}")
+    print("    action=owner review before delete")
 
-total_cost = total_gb * 0.08
-print(f'  TOTAL UNBOUND: {total_gb} Gi = \${total_cost:.2f}/month (\${total_cost * 12:.2f}/year)')
-"
-else
-  echo "  No unbound PVs found."
-fi
+print(f"  total_unbound_capacity_gib={total_gib}")
+'
 
-echo ""
+echo
+echo "PVCs not mounted by any pod"
+mounted="$(
+  kubectl get pods -A -o json | "$PYTHON_BIN" -c '
+import json
+import sys
 
-# Section 2: PVCs without active Pods
-echo "--- PVCs Not Mounted by Any Pod ---"
-echo ""
-
-# Get all PVC names that are currently mounted
-MOUNTED_PVCS=$(kubectl get pods -A -o json 2>/dev/null | python3 -c "
-import json, sys
 data = json.load(sys.stdin)
 mounted = set()
-for pod in data.get('items', []):
-    ns = pod['metadata']['namespace']
-    for vol in pod['spec'].get('volumes', []):
-        pvc = vol.get('persistentVolumeClaim', {}).get('claimName')
-        if pvc:
-            mounted.add(f'{ns}/{pvc}')
-for m in sorted(mounted):
-    print(m)
-" 2>/dev/null)
+for pod in data.get("items", []):
+    ns = pod["metadata"]["namespace"]
+    for volume in pod["spec"].get("volumes", []):
+        claim = volume.get("persistentVolumeClaim", {}).get("claimName")
+        if claim:
+            mounted.add(f"{ns}/{claim}")
+for item in sorted(mounted):
+    print(item)
+'
+)"
 
-# Get all PVCs and check if they're mounted
-kubectl get pvc -A -o json 2>/dev/null | python3 -c "
-import json, sys
+kubectl get pvc -A -o json | MOUNTED_PVCS="$mounted" "$PYTHON_BIN" -c '
+import json
+import os
+import sys
 
-mounted = set(line.strip() for line in '''$MOUNTED_PVCS'''.strip().split('\n') if line.strip())
-
+mounted = {
+    line.strip()
+    for line in os.environ.get("MOUNTED_PVCS", "").splitlines()
+    if line.strip()
+}
 data = json.load(sys.stdin)
 unmounted = []
-for pvc in data.get('items', []):
-    ns = pvc['metadata']['namespace']
-    name = pvc['metadata']['name']
-    key = f'{ns}/{name}'
+for pvc in data.get("items", []):
+    ns = pvc["metadata"]["namespace"]
+    name = pvc["metadata"]["name"]
+    key = f"{ns}/{name}"
     if key not in mounted:
-        cap = pvc['status'].get('capacity', {}).get('storage', 'unknown')
-        unmounted.append((ns, name, cap))
+        capacity = pvc.get("status", {}).get("capacity", {}).get("storage", "unknown")
+        unmounted.append((key, capacity))
 
-if unmounted:
-    for ns, name, cap in unmounted:
-        print(f'  {ns}/{name} ({cap}) — not mounted by any pod')
-    print(f'\n  Total unmounted PVCs: {len(unmounted)}')
+if not unmounted:
+    print("  none")
 else:
-    print('  All PVCs are actively mounted.')
-"
+    for key, capacity in unmounted:
+        print(f"  {key} capacity={capacity} action=confirm owner and workload state")
+'
 
-echo ""
-
-# Section 3: Storage class analysis
-echo "--- StorageClass Summary ---"
-echo ""
+echo
+echo "StorageClass Summary"
 kubectl get sc -o custom-columns=\
 NAME:.metadata.name,\
 PROVISIONER:.provisioner,\
 RECLAIM:.reclaimPolicy,\
-BINDING:.volumeBindingMode 2>/dev/null
+BINDING:.volumeBindingMode 2>/dev/null || true
 
-echo ""
-
-# Section 4: Recommendations
-echo "--- Recommendations ---"
-echo ""
-echo "  1. Review all Released/Available PVs — delete if data is no longer needed"
-echo "  2. Change default StorageClass to gp3 if currently using gp2"
-echo "  3. Set reclaim policy to Delete for non-critical PVs"
-echo "  4. Implement snapshot lifecycle policies (7 daily, 4 weekly)"
-echo "  5. Use volume expansion instead of creating oversized volumes"
-echo ""
-echo "============================================"
+echo
+echo "Recommendations"
+echo "  1. Review released or available PVs with owner and data-class labels."
+echo "  2. Compare provisioned capacity with observed high-water marks before resizing."
+echo "  3. Confirm snapshot retention has an owner, restore objective, and expiration."
+echo "  4. Check whether default StorageClasses still match current provider economics."
+echo "  5. Split direct, shared, idle, and overhead storage cost in showback reports."
 SCRIPT
 
 chmod +x /tmp/storage_audit.sh
 bash /tmp/storage_audit.sh
 ```
 
-### Step 4: AWS-Specific Audit (Reference)
-
-For real AWS environments, extend the audit to EBS and snapshots:
+### Step 3: Sketch The Cloud Inventory Join
 
 ```bash
-# Find unattached EBS volumes (AWS CLI)
-cat > /tmp/aws_storage_audit.sh << 'AWSSCRIPT'
-#!/bin/bash
-# NOTE: This requires AWS CLI configured with appropriate permissions
+cat > /tmp/cloud_storage_review.md << 'EOF'
+# Cloud Storage Review Template
 
-echo "--- Unattached EBS Volumes ---"
-aws ec2 describe-volumes \
-  --filters Name=status,Values=available \
-  --query 'Volumes[].{ID:VolumeId,Size:Size,Type:VolumeType,Created:CreateTime,AZ:AvailabilityZone}' \
-  --output table 2>/dev/null || echo "  (AWS CLI not configured — skipping)"
+For each unattached disk, retained volume, stale snapshot, or object lifecycle finding:
 
-echo ""
-echo "--- Old EBS Snapshots (>90 days) ---"
-NINETY_DAYS_AGO=$(date -v-90d +%Y-%m-%dT00:00:00 2>/dev/null || date -d "90 days ago" +%Y-%m-%dT00:00:00 2>/dev/null)
-aws ec2 describe-snapshots \
-  --owner-ids self \
-  --query "Snapshots[?StartTime<='${NINETY_DAYS_AGO}'].{ID:SnapshotId,Size:VolumeSize,Started:StartTime,Description:Description}" \
-  --output table 2>/dev/null || echo "  (AWS CLI not configured — skipping)"
+- Kubernetes owner evidence:
+- Cloud tag evidence:
+- Data class:
+- Last attached workload:
+- Restore requirement:
+- Retention rule:
+- Proposed action:
+- Risk if deleted:
+- Risk if retained:
+- Review owner:
+- Review date:
+EOF
 
-echo ""
-echo "--- EBS Volume Type Distribution ---"
-aws ec2 describe-volumes \
-  --query 'Volumes[].VolumeType' \
-  --output text 2>/dev/null | tr '\t' '\n' | sort | uniq -c | sort -rn || \
-  echo "  (AWS CLI not configured — skipping)"
-AWSSCRIPT
+cat /tmp/cloud_storage_review.md
+```
 
-chmod +x /tmp/aws_storage_audit.sh
-echo "AWS audit script created at /tmp/aws_storage_audit.sh"
-echo "(Run manually if you have AWS CLI configured)"
+### Step 4: Map Network Drivers
+
+```bash
+cat > /tmp/network_cost_questions.md << 'EOF'
+# Network Cost Driver Questions
+
+1. Which namespace pairs produce the largest internal byte volume?
+2. Which flows cross zones when same-zone endpoints exist?
+3. Which workloads use NAT or public egress for provider services?
+4. Which object buckets produce retrieval or internet egress?
+5. Which load balancers or ingress paths process the most data?
+6. Which traffic categories lack team, product, or environment labels?
+7. Which flows are valuable exceptions that should be documented?
+EOF
+
+cat /tmp/network_cost_questions.md
 ```
 
 ### Step 5: Cleanup
 
 ```bash
-kind delete cluster --name storage-lab
+kind delete cluster --name storage-network-lab
+rm -f /tmp/storage_audit.sh /tmp/cloud_storage_review.md /tmp/network_cost_questions.md
 ```
 
 ### Success Criteria
 
-You've completed this exercise when you:
-- [ ] Created PVs simulating both active and orphaned states
-- [ ] Ran the storage audit script and identified 3 orphaned PVs
-- [ ] Calculated the monthly cost of orphaned storage ($68/month for 850Gi at gp3 rates)
-- [ ] Reviewed the AWS audit script for finding unattached EBS volumes and old snapshots
-- [ ] Listed at least 3 storage optimization recommendations for your environment
+- [ ] Created the simulated PV and PVC inventory in a local kind cluster.
+- [ ] Ran the audit script and identified three unbound retained PVs.
+- [ ] Wrote an owner-review action for each retained storage item before deletion.
+- [ ] Listed the evidence needed to join Kubernetes storage objects with cloud inventory.
+- [ ] Separated at least five network cost drivers by traffic boundary or managed processing path.
+- [ ] Proposed one showback metric and one unit-economic metric for storage or network cost.
 
----
+## Sources
 
-## Key Takeaways
-
-1. **Storage costs accumulate silently** — orphaned PVs, unmanaged snapshots, and wrong volume types add up fast
-2. **gp2 to gp3 is a no-brainer** — 20% cheaper with 2x baseline IOPS, zero downside
-3. **Cross-AZ data transfer is the hidden Kubernetes tax** — use topology-aware routing to keep traffic local
-4. **NAT Gateways are expensive** — VPC Gateway Endpoints for S3/DynamoDB are free and save hundreds monthly
-5. **S3 lifecycle policies save 80-90%** — move logs and backups through storage tiers automatically
-
----
-
-## Further Reading
-
-**Articles**:
-- **"Understanding AWS Data Transfer Costs"** — aws.amazon.com/blogs/architecture
-- **"EBS Volume Types Explained"** — docs.aws.amazon.com/ebs/latest/userguide
-- **"Kubernetes Storage Best Practices"** — cloud.google.com/architecture
-
-**Tools**:
-- **AWS Cost Explorer** — Filter by service/usage type to find storage and network waste
-- **S3 Storage Lens** — Dashboard for S3 usage patterns and optimization recommendations
-- **VPC Flow Logs** — Analyze network traffic patterns for cross-AZ cost optimization
-
-**Talks**:
-- **"Taming Data Transfer Costs"** — AWS re:Invent (YouTube)
-- **"Storage Cost Optimization in Kubernetes"** — KubeCon (YouTube)
-
----
-
-## Summary
-
-Storage and network costs are the silent budget killers in cloud. While compute gets all the optimization attention, storage grows through orphaned volumes, unmanaged snapshots, and wrong tier choices. Network costs compound through cross-AZ traffic, NAT Gateways, and data egress. The fixes are often straightforward — migrate to gp3, add VPC endpoints, enable topology-aware routing, implement lifecycle policies — but they require awareness first. Regular storage audits and network flow analysis should be part of every FinOps practice.
-
----
+- [FinOps Framework](https://www.finops.org/framework/)
+- [FinOps Personas](https://www.finops.org/framework/personas/)
+- [OpenCost Specification](https://opencost.io/docs/specification/)
+- [CNCF FinOps for Kubernetes Report](https://www.cncf.io/wp-content/uploads/2021/06/FINOPS_Kubernetes_Report.pdf)
+- [Kubernetes Persistent Volumes](https://kubernetes.io/docs/concepts/storage/persistent-volumes/)
+- [Kubernetes Storage Classes](https://kubernetes.io/docs/concepts/storage/storage-classes/)
+- [Kubernetes Services](https://kubernetes.io/docs/concepts/services-networking/service/)
+- [Kubernetes Pod Topology Spread Constraints](https://kubernetes.io/docs/concepts/scheduling-eviction/topology-spread-constraints/)
+- [Amazon EBS Volume Types](https://docs.aws.amazon.com/ebs/latest/userguide/ebs-volume-types.html)
+- [Amazon EBS Pricing](https://aws.amazon.com/ebs/pricing/)
+- [AWS Data Transfer Costs for Common Architectures](https://aws.amazon.com/blogs/architecture/overview-of-data-transfer-costs-for-common-architectures/)
+- [AWS NAT Gateway Pricing](https://docs.aws.amazon.com/vpc/latest/userguide/nat-gateway-pricing.html)
+- [Amazon S3 Object Lifecycle Management](https://docs.aws.amazon.com/AmazonS3/latest/userguide/object-lifecycle-mgmt.html)
+- [Amazon S3 Storage Classes](https://docs.aws.amazon.com/AmazonS3/latest/userguide/storage-class-intro.html)
+- [Google Cloud Storage Classes](https://cloud.google.com/storage/docs/storage-classes)
+- [Google Cloud Storage Pricing](https://cloud.google.com/storage/pricing)
+- [Google Cloud Network Pricing](https://cloud.google.com/vpc/network-pricing)
+- [Azure Blob Storage Access Tiers](https://learn.microsoft.com/en-us/azure/storage/blobs/access-tiers-overview)
+- [Azure Bandwidth Pricing](https://azure.microsoft.com/en-us/pricing/details/bandwidth/)
+- [AWS Well-Architected Cost Optimization Pillar](https://docs.aws.amazon.com/wellarchitected/latest/cost-optimization-pillar/welcome.html)
 
 ## Next Module
 
-Continue to [Module 1.6: FinOps Culture & Automation](../module-1.6-finops-culture/) to learn how to build organizational habits, automate cost governance, and embed FinOps into your CI/CD pipeline.
-
----
-
-*"Data has mass. And mass has cost."* — Cloud networking truth
+Continue to [Module 1.6: FinOps Culture & Automation](../module-1.6-finops-culture/) to learn how to turn cost visibility into durable engineering habits, policy automation, and team operating rhythms.

--- a/src/content/docs/platform/disciplines/business-value/finops/module-1.6-finops-culture.md
+++ b/src/content/docs/platform/disciplines/business-value/finops/module-1.6-finops-culture.md
@@ -4,11 +4,13 @@ slug: platform/disciplines/business-value/finops/module-1.6-finops-culture
 sidebar:
   order: 7
 ---
+
 > **Discipline Module** | Complexity: `[MEDIUM]` | Time: 2h
 
 ## Prerequisites
 
 Before starting this module:
+
 - **Required**: [Module 1.5: Storage & Network Cost Management](../module-1.5-storage-network-costs/) — Completing the technical FinOps modules
 - **Required**: Understanding of CI/CD pipelines (GitHub Actions, GitLab CI, or similar)
 - **Required**: Basic Terraform familiarity (for Infracost exercise)
@@ -22,52 +24,47 @@ Before starting this module:
 After completing this module, you will be able to:
 
 - **Lead organizational change that embeds cost awareness into engineering culture and daily practices**
-- **Design gamification and incentive programs that motivate teams to optimize cloud spending**
-- **Build cost review processes that integrate with sprint planning and architecture decision records**
-- **Implement cost anomaly detection that alerts teams to unexpected spending changes before they compound**
+- **Design accountability models and incentive programs that motivate teams to optimize cloud spending without blaming individuals**
+- **Build cost review processes that integrate with sprint planning, pull requests, and architecture decision records**
+- **Implement cost anomaly detection and budget forecasting that alerts teams to unexpected spending changes before they compound**
+- **Deploy automation patterns that enforce tagging, reclaim idle resources, and schedule non-production shutdowns without manual intervention**
+
+---
 
 ## Why This Module Matters
 
-You've learned the technical side of FinOps: cost allocation, rightsizing, compute optimization, storage and network management. Impressive. But here's the uncomfortable truth:
+You have learned the technical side of FinOps: cost allocation, rightsizing, compute optimization, storage and network management. Those skills let you identify waste and execute optimizations. But here is the uncomfortable truth that every FinOps practitioner discovers: **technical optimization without cultural change is temporary.**
 
-**Technical optimization without cultural change is temporary.**
+You can rightsize every workload, migrate every volume to gp3, and add VPC endpoints everywhere — and six months later, costs will be right back where they started. The reason is not that the optimizations failed. It is that the *behaviors* that created the waste never changed. Developers will still over-provision out of caution. Teams will still spin up resources without tags because nobody asks for them. Nobody will look at the dashboards you built because the dashboards live in a separate tab that nobody opens.
 
-You can rightsize every workload, migrate every volume to gp3, and add VPC endpoints everywhere — and six months later, costs will be right back where they started. Why? Because the *behaviors* that created the waste haven't changed. Developers will still over-provision. Teams will still spin up resources without tags. Nobody will look at the dashboards you built.
+This module addresses the durable principle behind every successful FinOps practice: **FinOps is far more about culture than technology.** The tools — OpenCost, Kubecost, Infracost, cloud-native cost explorers, Vantage — are necessary but insufficient. They provide visibility. Visibility without accountability produces awareness. Awareness without incentives produces indifference. Indifference produces the cost drift you set out to eliminate.
 
-FinOps is 30% technology and 70% culture. This module covers the 70%.
+The cultural work happens at multiple layers simultaneously. At the individual level, engineers need cost data surfaced where they already work — in pull requests, in their developer portal, in sprint planning. At the team level, cost must become a shared metric alongside latency, error rate, and throughput — not a separate spreadsheet owned by a different department. At the organizational level, the engineering and finance functions must develop a shared vocabulary so that infrastructure decisions are evaluated in business terms (dollars, margins, unit economics) rather than purely technical ones (CPU cores, gigabytes, instance types). At the automation level, policy must be encoded so that good behavior is the path of least resistance and anomalous spending triggers alerts before the monthly bill arrives.
 
 ```mermaid
 graph TD
-    Start[Month 1: Big optimization push<br/>↓ -35% cost]
+    Start[Month 1: Big optimization push<br/>cost reduction achieved]
 
     subgraph Without Culture Change
-        W_M3[Month 3: Teams drift back<br/>↑ +12%]
-        W_M6[Month 6: Nobody watching<br/>↑ +22%]
-        W_M12[Month 12: Back to original<br/>↑ +35%]
-        
+        W_M3[Month 3: Teams drift back<br/>costs begin rising]
+        W_M6[Month 6: Nobody watching<br/>costs continue upward]
+        W_M12[Month 12: Back to original<br/>all gains erased]
+
         Start --> W_M3 --> W_M6 --> W_M12
     end
 
     subgraph With Culture Change
-        C_M3[Month 3: Automated guardrails<br/>→ -2% more]
-        C_M6[Month 6: Teams self-optimize<br/>→ -5% more]
-        C_M12[Month 12: Continuous improvement<br/>→ -8% more]
-        
+        C_M3[Month 3: Automated guardrails<br/>further small reductions]
+        C_M6[Month 6: Teams self-optimize<br/>organic efficiency gains]
+        C_M12[Month 12: Continuous improvement<br/>compounding savings]
+
         Start --> C_M3 --> C_M6 --> C_M12
     end
 ```
 
-> **Pause and predict**: If you ask an engineer to choose between shipping a feature a week early or saving $500 a month in cloud costs, which will they choose? How does a FinOps guild change this calculation?
+The mermaid diagram above illustrates a pattern observed across organizations that treat FinOps as a one-time project versus those that embed it as an ongoing practice. The "without culture change" path is not hypothetical — it mirrors the experience of teams that complete a cost-optimization sprint, declare victory, and move on. The "with culture change" path requires sustained investment in the practices this module teaches: guild formation, shift-left estimation, anomaly detection, automation, gamification, and the engineering-finance bridge. The payoff is not a single cost reduction but a permanently lower cost-growth trajectory.
 
----
-
-## Did You Know?
-
-- **The FinOps Foundation's 2024 survey found that the #1 challenge for FinOps practitioners is "getting engineers to take action"** — not tooling, not data quality, not executive support. 73% of respondents cited cultural adoption as harder than technical implementation.
-
-- **Spotify runs a "Cost Insights" plugin in their internal developer portal (Backstage)** that shows every team their cloud costs alongside their service catalog. Engineers see cost data every time they open their service page — no separate dashboard required. This passive visibility has been credited with a 19% reduction in organic cost growth.
-
-- **Etsy gamified cloud cost optimization by creating a "Cloud Leaderboard"** showing which teams had the best cost-per-request metrics. Teams competed to optimize, and the program saved over $2 million in its first year. The leaderboard cost nothing to build — it was just a Grafana dashboard.
+> **Pause and predict**: If you ask an engineer to choose between shipping a feature a week early or saving a few hundred dollars a month in cloud costs, which will they choose? How does a FinOps guild change this calculation? If you answer "the feature, every time," you have correctly identified the problem. The guild's job is not to flip that choice — it is to make the cost data so visible and the optimized path so easy that the tradeoff never arises.
 
 ---
 
@@ -75,17 +72,21 @@ graph TD
 
 ### What Is a FinOps Guild?
 
-A FinOps guild (or community of practice) is a cross-functional group that drives cost awareness across the organization. Unlike a centralized FinOps team that *does* the work, a guild *enables* others to do the work.
+A FinOps guild — also called a community of practice — is a cross-functional group that drives cost awareness across the organization. The distinction between a guild and a centralized FinOps *team* is fundamental to understanding why some organizations sustain cost efficiency while others cycle through optimization-and-drift loops. A centralized team *does* the optimization work. A guild *enables* every team to do its own optimization work.
+
+The centralized model appears efficient at first. Three dedicated FinOps engineers can rightsize pods, migrate storage classes, and clean up unattached volumes faster than any distributed group of part-time ambassadors. But the centralized model creates a structural dependency: engineers learn that cost is someone else's problem. When the next sprint introduces a new microservice with generous resource requests, nobody flags it because the FinOps team will catch it later. The FinOps team *does* catch it — three months later, after the cloud bill arrives — and the cycle repeats.
+
+The guild model breaks this dependency by distributing ownership. Every engineering team has an ambassador — typically a senior engineer who spends two to four hours a month on FinOps activities. The ambassador reviews their team's cost reports, flags anomalies in sprint planning, and represents the team in guild meetings. A single dedicated FinOps lead provides centralized tooling, dashboards, reporting infrastructure, and facilitation. The lead does not optimize individual workloads; they build the systems that make optimization visible and measurable for everyone else. This division of labor — ambassadors own the decisions, the lead owns the decision-support infrastructure — is what makes the guild model scale beyond what any centralized team could achieve on its own.
 
 ```mermaid
 graph TD
     FL[FinOps Lead<br/>1 person, dedicated]
-    
+
     FL --> FP[Finance Partner<br/>CFO/FP&A representative]
     FL --> EA[Engineering Ambassadors<br/>1 per team]
     FL --> IR[Infrastructure/SRE representative]
     FL --> PR[Product/Business representative]
-    
+
     EA --> T1[Payments team ambassador]
     EA --> T2[Search team ambassador]
     EA --> T3[ML team ambassador]
@@ -93,7 +94,11 @@ graph TD
     EA --> T5[Data team ambassador]
 ```
 
+This structure mirrors the organizational pattern that the FinOps Foundation describes in its framework: cross-functional stakeholders with clearly defined responsibilities, operating on a regular cadence. The Finance Partner translates cloud costs into business metrics and owns budgeting. The Infrastructure representative handles the technical tooling — deploying cost collectors, configuring anomaly alerts, and maintaining the automation pipelines. The Product representative connects cost to product value, ensuring that optimization efforts are prioritized against feature work with a shared understanding of the tradeoffs.
+
 ### Roles and Responsibilities
+
+The table below captures the standard roles in a FinOps guild. The time commitments are guidelines drawn from organizations that have mature practices; they will vary with organizational size and cloud spend.
 
 | Role | Responsibility | Time Commitment |
 |------|---------------|-----------------|
@@ -105,74 +110,150 @@ graph TD
 
 ### Starting a Guild from Scratch
 
-**Month 1: Foundation**
-- Identify FinOps lead (can be part-time initially)
-- Recruit one ambassador per engineering team
-- Deploy basic cost visibility (OpenCost or Kubecost free tier)
-- Send first monthly cost report (showback)
+Building a guild is itself a cultural change initiative. The sequence matters. Starting with chargeback before teams have visibility breeds resentment. Starting with complex automation before teams understand their cost baseline produces confusion. The three-phase progression below represents a path that multiple organizations have followed successfully.
 
-**Month 2-3: Awareness**
-- Run first cost optimization sprint (pick top 5 waste items)
-- Create team-level dashboards
-- Start weekly Slack cost updates
-- Celebrate wins publicly (people love seeing "Team X saved $800/month")
+**Phase 1 — Foundation (Month 1).** Identify a FinOps lead — this can be a part-time role initially allocated from an existing platform or infrastructure engineer. Recruit one ambassador per engineering team by framing the role as a leadership development opportunity, not an administrative burden. Deploy basic cost visibility using an open-source cost monitoring tool such as OpenCost or the Kubecost free tier, integrated with your existing observability stack. Send the first monthly cost report as showback — a "for your information" communication with no financial consequences attached. The goal of Phase 1 is not optimization. It is establishing that cost data exists and is accessible.
 
-**Month 4-6: Habits**
-- Integrate cost into sprint planning ("this feature will cost ~$X/month")
-- Launch cost anomaly alerts
-- Begin chargeback conversations
-- Train ambassadors on cost optimization techniques
+**Phase 2 — Awareness (Months 2-3).** Run the first cost optimization sprint by selecting the top sources of waste visible in the Phase 1 data — unattached volumes, oversized pods, non-production clusters running over weekends. Create team-level dashboards so each ambassador can see their own team's data without wading through the entire organizational view. Start a weekly communication cadence — a Slack message with the top three cost movements, a brief note on the largest anomaly, and a callout celebrating whichever team made the biggest improvement. Celebrate wins publicly. The behavioral mechanism here is social proof: when the Search team sees the Payments team getting recognized for a cost improvement, they become curious about their own numbers.
+
+**Phase 3 — Habits (Months 4-6).** Integrate cost estimation into sprint planning so that every new feature proposal includes an approximate monthly infrastructure cost alongside the effort estimate. Deploy cost anomaly alerts so that unexpected spending changes reach the responsible team within hours, not at the end of the billing cycle. Begin chargeback conversations — transitioning from "here is what your infrastructure costs" to "this amount is allocated to your budget." Train ambassadors on deeper cost optimization techniques: spot instance adoption, commitment-based discount planning, and storage tiering. By the end of Phase 3, cost awareness should feel like a normal part of engineering work, not a special initiative.
+
+---
+
+## The Engineering-Finance Bridge
+
+### Why Engineers and Finance Speak Different Languages
+
+The single largest communication gap in cloud financial management sits between the engineering organization and the finance function. Engineers describe infrastructure in terms of CPU cores, gigabytes of memory, IOPS, and instance families. Finance describes the business in terms of dollars, gross margins, operating expenses, and return on invested capital. Neither vocabulary is wrong, but neither is directly translatable into the other without deliberate effort.
+
+When an infrastructure team says "we need twenty more CPU cores to handle projected growth," finance hears an unbounded cost request with no business justification. When finance asks "what is the ROI of that Kubernetes cluster," engineering hears a request to justify the existence of the platform itself. Both sides become frustrated, and the conversation stalls.
+
+The FinOps practitioner's role at this bridge is translation — in both directions. To engineering, you translate financial concepts into operational terms: "Our infrastructure cost as a percentage of revenue is climbing. That means if we maintain our current trajectory, infrastructure will consume our entire margin on the mid-tier customer segment within three quarters. We need to find efficiencies that do not degrade the customer experience." To finance, you translate engineering work into financial impact: "The platform team migrated forty stateless workloads to spot instances this quarter. That reduces our annual compute run rate by a significant amount while maintaining availability above our SLA. It is a permanent cost reduction with no recurring engineering overhead."
+
+### The Translation Table
+
+The following table maps common engineering statements to their financial equivalents. Learning to produce both columns — and to choose the right column for the right audience — is a core FinOps competency.
+
+| Engineering Metric | Finance Translation |
+|-------------------|-------------------|
+| "We need 20 more CPU cores" | "We need additional compute capacity to handle projected growth; the monthly cost impact is the relevant figure" |
+| "Our p99 latency improved 40ms" | "Response time improvement correlates with user retention; each millisecond of latency reduction has measurable revenue impact" |
+| "We rightsized 30 pods" | "We reduced recurring infrastructure cost without service degradation — it is a permanent efficiency gain" |
+| "We migrated to Spot" | "We reduced compute costs by trading a small availability risk for a substantial price discount, with automated fallback" |
+| "Our cluster utilization is 18%" | "We are paying for significantly more capacity than we consume on average; this is idle cost that could fund other initiatives" |
+
+### Showback, Chargeback, and the Accountability Maturity Model
+
+Accountability for cloud costs matures along a predictable spectrum. Understanding where your organization sits on this spectrum determines which interventions will be effective and which will generate resistance.
+
+**Level 1 — No Visibility.** Costs are aggregated into a single cloud bill with no breakdown by team, service, or environment. Nobody knows what anything costs. FinOps is not practiced because there is no data to practice it on.
+
+**Level 2 — Showback.** Costs are allocated to teams or business units and reported regularly, but there are no financial consequences. The communication is informational: "Your team's infrastructure cost this month was approximately this amount. Here is the breakdown." Showback builds cost awareness without triggering defensive reactions. It is the correct starting point for any organization beginning FinOps.
+
+**Level 3 — Chargeback (Soft).** Costs are allocated to team budgets, but overruns trigger a conversation rather than a penalty. Teams are expected to understand their spending and explain deviations. The accountability is social and reputational — nobody wants to be the team that blew its budget with nothing to show for it.
+
+**Level 4 — Chargeback (Hard).** Cloud costs are deducted from team budgets with real financial consequences. An overrun in infrastructure means less budget for headcount, tools, or conferences. Hard chargeback creates strong incentives but can also create perverse behaviors: teams under-provision to stay under budget, degrading reliability. Hard chargeback should only be deployed after teams have had at least six months of showback and soft chargeback to develop cost literacy.
+
+**Level 5 — Unit Economics.** Accountability moves beyond absolute spending to efficiency ratios: cost per customer, cost per request, cost per feature. Teams are evaluated on whether their unit costs are improving over time, not whether their absolute spend went up or down. This is the most mature level because it aligns cost accountability with business growth — a team that doubled its customer base while keeping unit costs flat has performed excellently, even though its absolute spend doubled.
+
+The progression through these levels is cultural work. Moving from Level 1 to Level 2 requires deploying cost allocation tooling. Moving from Level 2 to Level 3 requires building trust between engineering and finance. Moving from Level 3 to Level 4 requires a mature budgeting process. Moving to Level 5 requires stable unit-economic metrics that both engineering and finance agree are the right measures of efficiency.
+
+### The Monthly FinOps Business Review
+
+> **Hypothetical scenario: Monthly FinOps Review**
+>
+> **Executive Summary:**
+> - Total cloud spend: $170,000 (budget: $180,000) — under budget
+> - Month-over-month change: +3%
+> - Cost per customer: $0.70 (target: under $0.75) — target met
+> - Savings realized this month: $8,000
+>
+> **Key Wins:**
+> - Payments team rightsizing: reduced monthly spend by approximately $3,000 (ongoing)
+> - Storage class migration: reduced monthly spend by approximately $1,500 (one-time, permanent)
+> - Spot adoption for CI/CD: reduced monthly spend by approximately $4,000 (ongoing)
+>
+> **Risks:**
+> - ML training costs growing month-over-month (investigating)
+> - Untagged resources: approximately $7,000/month (down from $10,000 — improving)
+>
+> **Next Month Focus:**
+> - Complete cross-AZ traffic optimization
+> - Begin Reserved Instance planning for upcoming quarter
+> - Launch team cost dashboards in developer portal
+
+The review format above illustrates a durable pattern: executive summary, wins with approximate dollar figures, risks with trend direction, and forward-looking focus items. The specific dollar amounts are illustrative and round. In a real organization, these would be replaced with actual figures from the cloud billing data. The structure — summary, wins, risks, forward plan — is what persists across organizations regardless of their absolute spend level.
+
+### Finance Report Template
+
+| KPI | This Month | Last Month | Trend |
+|-----|------------|------------|-------|
+| Total cloud spend | $170,000 | $165,000 | up |
+| Budget variance | ($10,000) | ($15,000) | rising |
+| Cost per customer | $0.70 | $0.72 | down |
+| Revenue per customer | $4.20 | $4.15 | up |
+| Infra as % of revenue | 16% | 17% | down |
+| Savings this month | $8,000 | $5,000 | up |
+| Commitment utilization | 87% | 82% | up |
+| Tagging compliance | 91% | 88% | up |
+| Waste (estimated) | $22,000 | $29,000 | down |
 
 ---
 
 ## Cost in CI/CD: Shift-Left FinOps
 
-> **Stop and think**: Why is catching a $500/month architectural mistake in a pull request exponentially more valuable than catching it on a cloud bill 30 days later?
+The cheapest moment to catch a cost problem is before the infrastructure that creates it exists. A pod sized at eight CPU cores when two would suffice costs the same whether you discover the waste on day one or day ninety — but discovering it on day one saves eighty-nine days of unnecessary spend. This is the principle of shift-left FinOps: moving cost evaluation as early in the development lifecycle as possible.
 
-The cheapest time to catch a cost problem is before it's deployed. Infracost integrates into your Terraform/OpenTofu CI pipeline to estimate the cost of infrastructure changes *before they're applied*.
+Shift-left cost estimation has three natural integration points. The earliest is the architecture decision record or design review, where a proposed system topology can be cost-modeled before a single line of Terraform is written. This is the cheapest and most flexible intervention point — changing an architecture diagram costs nothing. The next is the pull request, where infrastructure-as-code changes can be automatically cost-estimated and the estimate posted as a PR comment. At this stage the design is committed to code but not yet deployed, so corrections still require engineering time but incur no cloud spend. The latest — and still valuable — is the deployment pipeline, where cost guards can block or flag changes that exceed predefined thresholds. At this stage the change is minutes from being live, and a block here is the most expensive in terms of engineer context-switching cost, but still far cheaper than discovering the waste on the monthly bill.
 
-### How Infracost Works
+The pull-request integration point offers the best balance of accuracy and timeliness. At this stage, the infrastructure change is fully specified (instance types, counts, storage sizes, data transfer patterns) so the cost estimate is concrete, but the change has not yet been applied so there is no incurred waste. Infracost is a widely used tool for this integration point, but the principle — cost estimation from infrastructure-as-code diffs — is durable and can be implemented with other tools or custom scripts that query cloud pricing APIs.
+
+### How Shift-Left Cost Estimation Works
 
 ```mermaid
 sequenceDiagram
     participant D as Developer
     participant PR as Pull Request
     participant CI as CI Pipeline
-    participant IC as Infracost
+    participant CE as Cost Estimator
 
     D->>PR: Creates PR with Terraform
     PR->>CI: Triggers pipeline
-    CI->>IC: Runs Infracost diff
-    IC-->>CI: Returns cost estimate
+    CI->>CE: Runs cost diff
+    CE-->>CI: Returns cost estimate
     CI->>PR: Posts cost estimate as PR comment
-    
-    Note over PR: "This PR increases monthly cost by $342 (+18%)"<br/>Check: Under threshold OR Blocks if >10%
+
+    Note over PR: "This PR changes monthly cost by approximately +$350 (+15%)"<br/>Check: Under threshold OR Blocks if exceeds policy limit
 ```
+
+The flow is straightforward: a developer opens a pull request containing infrastructure-as-code changes. The CI pipeline runs a cost estimation tool against the proposed changes, comparing them to the current baseline. The tool produces a cost diff — how much the monthly bill would change if this PR were merged. That diff is posted as a comment on the PR, visible to the author, the reviewers, and anyone else watching the repository.
 
 ### Infracost PR Comment Example
 
 ```markdown
-## 💰 Infracost Cost Estimate
+## Infracost Cost Estimate
 
 | Project | Previous | New | Diff |
 |---------|----------|-----|------|
-| production/eks | $1,847/mo | $2,189/mo | +$342 (+18.5%) |
+| production/eks | $1,850/mo | $2,200/mo | +$350 (+19%) |
 
 ### Cost Breakdown
 
 | Resource | Monthly Cost | Change |
 |----------|-------------|--------|
-| aws_eks_node_group.workers | $1,420 → $1,762 | +$342 |
-| (added 2× m6i.xlarge nodes) | | |
+| aws_eks_node_group.workers | $1,400 to $1,750 | +$350 |
+| (added 2 compute-optimized nodes) | | |
 
 ### Details
 - Node group scaled from 5 to 7 instances
-- Instance type: m6i.xlarge ($140.16/mo each)
-- Consider: Could Karpenter autoscaling handle this instead?
+- Instance type: compute-optimized (~$175/mo each)
+- Consider: Could Karpenter autoscaling handle this workload elasticity instead of static scaling?
 
-⚠️ **This PR exceeds the 10% cost increase threshold.**
+**This PR exceeds the 10% cost increase threshold.**
 Approval from @finops-team required.
 ```
+
+The example above uses approximate round numbers to illustrate the pattern. In a real pipeline, Infracost queries live cloud pricing APIs and produces exact figures. The key design elements are: a summary table showing the total cost change, a breakdown showing which resources changed, a human-readable explanation of what changed, and a clear gate — the threshold check that determines whether the PR requires additional approval.
 
 ### GitHub Actions: Infracost with Cost Threshold
 
@@ -285,19 +366,31 @@ infracost:
 
 ---
 
-## Cost Anomaly Detection
+## Cost Anomaly Detection and Forecasting
 
-Anomaly detection catches unexpected cost spikes before they become budget-busting surprises.
+Anomaly detection is the Operate-phase capability that catches unexpected cost movements before they compound into budget-busting surprises. Its value is not in the detection itself — a spike visible on a dashboard is still a spike you have to pay for — but in the *lead time* it creates. Detecting an anomaly within hours means the team can investigate while the affected resources are still running and the root cause is fresh. Detecting it at the end of the billing cycle means the money is already spent and the investigation must reconstruct events from logs.
 
-### Types of Anomalies
+The distinction between anomaly detection and threshold alerting is worth understanding clearly because they are often conflated. A threshold alert fires when a metric crosses a fixed boundary — "alert when daily spend exceeds $5,000." A cost anomaly detection system learns the normal spending pattern for each service, account, or tag combination and fires when the actual spending diverges from that pattern in a statistically significant way. A threshold alert on a service that normally spends $4,000/day will miss a spike to $4,900 because the threshold was never crossed, even though the spike represents a 22% increase. An anomaly detection system tuned to that service's baseline would catch the same spike because it recognizes the deviation from the expected pattern. For this reason, anomaly detection is the preferred approach for variable-cost services — those whose spending naturally fluctuates with traffic — while threshold alerting remains appropriate for fixed-cost resources like Reserved Instances and committed-use discounts where the expected spend is known precisely.
+
+### Types of Cost Anomalies
+
+Not all cost anomalies look the same, and each type requires a different detection strategy. A threshold-based alert that catches a 40% day-over-day spike will miss a gradual 5% weekly increase that compounds into a substantial overrun over two months. A trend-analysis system that catches the gradual increase may produce too many false positives if applied to naturally volatile workloads.
 
 | Anomaly Type | Example | Detection Method |
 |-------------|---------|-----------------|
-| **Spike** | Cost jumps 40% day-over-day | Threshold alerting |
-| **Trend** | Gradual 5% weekly increase for 6 weeks | Trend analysis |
-| **New resource** | Unfamiliar service appears on bill | Service allowlist |
-| **Rate change** | RI expires, On-Demand kicks in | Commitment monitoring |
+| **Spike** | Cost jumps sharply day-over-day | Threshold alerting |
+| **Trend** | Gradual weekly increase sustained over multiple weeks | Trend analysis |
+| **New resource** | Unfamiliar service appears on bill | Service catalog allowlist |
+| **Rate change** | Commitment expires, on-demand pricing kicks in | Commitment monitoring |
 | **Data transfer** | Cross-region traffic surge | Network flow analysis |
+
+Each detection method has a characteristic false-positive profile. Threshold alerting is simple to implement but produces noise for workloads with legitimate burst patterns. Trend analysis catches slow leaks but requires enough historical data to establish a baseline — typically at least four to six weeks. Service allowlisting flags brand-new cost sources immediately but requires maintaining the allowlist as the service catalog evolves. The durable principle is defense in depth: deploy multiple detection methods and route each to the appropriate responder — the team that owns the affected resources, not a centralized FinOps operations desk.
+
+### Integrating Anomaly Detection with Forecasting
+
+Anomaly detection answers the question "what happened unexpectedly?" Forecasting answers the question "where are we headed?" The two capabilities reinforce each other. A forecast that does not account for anomalies will be systematically optimistic — it will project a smooth trend line through a noisy reality and consistently under-predict actual spend. Conversely, anomaly detection without forecasting context will generate alerts for spending changes that are actually expected (a planned marketing campaign that doubles traffic, a seasonal peak, a known infrastructure expansion).
+
+The forecasting techniques available range from simple linear extrapolation — suitable for stable, predictable workloads — to machine-learning-based models that decompose spend into trend, seasonal, and residual components. The technique matters less than the process: forecasts must be reviewed regularly against actuals, and the forecast error must be tracked as a metric in its own right. An organization that cannot forecast its cloud spend within a predictable error band cannot set meaningful budgets, and an organization without meaningful budgets cannot practice chargeback.
 
 ### AWS Cost Anomaly Detection
 
@@ -401,46 +494,56 @@ spec:
 
 ---
 
-## Gamification and Incentives
+## Automation Patterns for FinOps
 
-Making cost optimization fun and competitive is surprisingly effective.
+Automation is the mechanism that converts cultural intent into reliable behavior. A team that *intends* to tag every resource will still miss tags during an incident at 3 AM. A policy that *requires* non-production clusters to shut down over weekends will be forgotten during the sprint-end crunch. Automation encodes the policy so that compliance is the default and non-compliance requires an explicit override.
 
-### The Cloud Cost Leaderboard
+### Scheduled Scale-Down for Non-Production Environments
 
-> **Monthly Cloud Efficiency Leaderboard**
-> 
-> **Team Rankings (Cost per 1K Requests)**
-> 1. **Search Team**: $0.031/1K req (↓ 22% vs last mo)
-> 2. **Payments Team**: $0.044/1K req (↓ 15% vs last mo)
-> 3. **Platform Team**: $0.052/1K req (↓ 8% vs last mo)
-> 4. **ML Pipeline**: $0.189/1K req (↓ 3% vs last mo)
-> 5. **Data Team**: $0.210/1K req (↑ 5% vs last mo)
-> 
-> **Biggest Improver**: Search Team (-22%!)
-> **Most Improved Resource**: `search-indexer` rightsizing
-> 
-> **Total org savings this month**: $4,280
+Non-production environments — development, staging, sandbox — typically do not need to run continuously. A cluster that serves developers during business hours can be scaled to zero overnight and on weekends. The automation pattern is straightforward: a cron schedule that scales deployments to zero replicas at a defined time and restores them before the next working day begins.
 
-### Gamification Ideas That Work
+The implementation can be as simple as a Kubernetes CronJob that adjusts replica counts, or as sophisticated as a cluster autoscaler integration that suspends entire node groups. The durable principle is not the specific implementation but the recognition that non-production infrastructure should not run at production availability levels. The savings from this single pattern are typically substantial because non-production environments often represent a significant fraction of total cloud spend.
 
-| Idea | How It Works | Cost to Implement |
-|------|-------------|-------------------|
-| **Efficiency Leaderboard** | Rank teams by cost-per-unit metric monthly | Grafana dashboard (free) |
-| **Savings Spotlight** | Feature one team's optimization in company Slack | 5 minutes/week |
-| **Cost Champion Badge** | Badge on internal profile for completing FinOps training | Internal tool update |
-| **Optimization Bounty** | $50 gift card for each $500+/month savings identified | Minimal vs savings |
-| **Waste Hunter Week** | Dedicated week where teams compete to find/fix waste | Team time only |
-| **CFO Shoutout** | CFO mentions top saver in all-hands | Free, high impact |
+Implementing scheduled scale-down well requires attention to two edge cases. The first is stateful workloads. Stateless deployments can be scaled to zero and restored trivially because they carry no persistent data. Stateful workloads — databases, message queues, search indexes — require a graceful shutdown sequence that flushes data and a startup sequence that verifies data integrity before accepting traffic. Automating scale-down for stateful workloads is possible but demands testing that validates the full stop-start cycle, not just the individual stop and start operations in isolation. The second edge case is scheduling across time zones. A scale-down schedule set to "8 PM Eastern" will cut off developers on the West Coast at 5 PM their time, potentially disrupting late-afternoon work. The solution is either to align the schedule with the latest-working time zone in the organization or to allow per-team overrides so that each team controls its own non-production availability window.
 
-### What NOT to Do
+### Idle Resource Reaping
 
-| Anti-pattern | Why It Fails |
-|-------------|-------------|
-| Publicly shame high-spending teams | Creates resentment, hides real costs |
-| Reward absolute spend reduction | Penalizes growing teams, incentivizes under-investing |
-| Individual bonuses for savings | Creates perverse incentives (cut needed resources) |
-| Mandatory cost reports without context | Information without action = noise |
-| Punishing cost overruns | Teams stop experimenting, innovation dies |
+Resources that are provisioned but unused accumulate silently. Unattached persistent volumes, load balancers pointing to terminated backends, elastic IPs not associated with any instance, and stopped instances that still accrue storage charges all contribute to a slow cost leakage that is invisible unless someone actively searches for it. Idle resource reaping is the automated process of identifying and removing these resources.
+
+The pattern has three stages: detection, notification, and removal. Detection queries the cloud API for resources matching "unused" criteria (volume status "available," load balancer with zero healthy targets, IP address with no association). Notification informs the resource owner — deduced from tags — and provides a grace period, typically seven days. Removal executes after the grace period expires with no response. The grace period is essential: an unattached volume might be a snapshot target awaiting a maintenance window, and automated deletion without warning causes incidents.
+
+Designing an effective reaping system requires balancing thoroughness against safety. A reaper that aggressively removes every unattached resource the moment it is detected will cause production incidents when it deletes a volume that was temporarily detached for a maintenance operation. A reaper that requires manual approval for every removal will never achieve coverage because the approval queue will grow faster than anyone can triage it. The middle ground is a tiered approach: resources that have been unattached for a short window (under 48 hours) generate a notification only; resources unattached for a medium window (48 hours to 14 days) generate a notification with an auto-resolution deadline; resources unattached beyond 14 days are removed automatically with a final notification sent at the time of deletion. The tiers and thresholds should be configurable per environment — production might use longer windows and require manual approval at every stage, while sandbox environments can use aggressive auto-removal.
+
+### Tagging Enforcement
+
+Resource tagging is the foundation of cost allocation, but manual tagging compliance decays over time. New services are created during incidents without tags. Infrastructure provisioned through a new CI pipeline lacks the tagging step that the old pipeline included. Tagging enforcement uses policy-as-code to reject or flag resources that lack required tags at provisioning time.
+
+Cloud-native policy engines — AWS Organizations SCPs, Azure Policy, GCP Organization Policy — can block resource creation when mandatory tags are absent. Kubernetes-native approaches include admission controllers that mutate or reject resources based on label requirements. The enforcement should be progressive: start with audit-only mode that reports violations without blocking, transition to soft enforcement that blocks in non-production but warns in production, and eventually reach hard enforcement everywhere. As with showback-to-chargeback, the progression builds trust and gives teams time to adapt their workflows.
+
+Effective tagging enforcement must also address the tag quality problem, not just tag presence. A resource tagged with `team=misc` or `environment=unknown` satisfies a presence check but contributes nothing to cost allocation. Tagging policies should validate against a controlled vocabulary — an approved list of team names, environment designations, and cost-center codes — and reject values that fall outside that vocabulary. Maintaining the controlled vocabulary is itself a cross-functional task: finance owns the cost-center list, engineering leadership owns the team list, and platform engineering owns the environment taxonomy. When these stakeholders do not coordinate, the vocabulary drifts and the enforcement becomes a source of friction rather than a quality guarantee.
+
+### Cost Policy as Code
+
+The shift-left principle applied to policy means that cost rules should be version-controlled, tested, and deployed through the same pipelines as application code. A cost policy that lives in a wiki page has no enforcement mechanism. A cost policy encoded as Open Policy Agent (OPA) rules, Kyverno policies, or cloud-native policy definitions can be automatically enforced at resource creation time.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+
+The tools available for cost policy enforcement span multiple layers of the stack. At the infrastructure-as-code layer, tools like Infracost and Open Policy Agent can evaluate Terraform plans against cost policies before resources are created. At the Kubernetes admission layer, Kyverno and OPA Gatekeeper can enforce resource request limits, require cost allocation labels, and reject configurations that exceed defined budgets. At the cloud-provider layer, each of the major providers offers policy engines — AWS Organizations SCPs, Azure Policy, GCP Organization Policy — that can enforce tagging, restrict expensive instance types, and limit region usage.
+
+The **Cost-Tooling Rosetta** below maps durable FinOps capabilities to the tools that implement them. Treat the "tool" column as illustrative, not prescriptive. The capability column describes the permanent function; any given tool may gain, lose, or change its implementation of that function over time.
+
+| Capability | Illustrative Tools | Durable Principle |
+|---|---|---|
+| Cost allocation by namespace/label | OpenCost, Kubecost, cloud-native cost explorers | Allocate spend to the team or service responsible |
+| Idle-cost attribution | Kubecost, cloud-native cost explorers | Expose the request-versus-usage gap |
+| Showback reporting | OpenCost, Kubecost, Vantage | Provide visibility without financial consequences |
+| Chargeback/showback automation | Kubecost, cloud-native cost explorers | Automate the allocation-to-team pipeline |
+| Rightsizing recommendations | Kubecost, cloud-native cost advisors, VPA | Produce recommendations as input to human decision |
+| Anomaly detection | Cloud-native anomaly detection, Kubecost alerts | Detect unexpected spending movements early |
+| CI cost estimation | Infracost, cloud-native cost estimators | Estimate cost from infrastructure-as-code diffs |
+| Commitment planning | Cloud-native cost explorers, Vantage | Model Reserved Instance / Savings Plan scenarios |
+| Spot instance automation | Karpenter, Cluster Autoscaler | Trade flexibility for cost on interruptible workloads |
+| Scheduled scaling | KEDA, CronJobs, cloud-native instance schedulers | Scale non-production environments to zero off-hours |
 
 ---
 
@@ -448,36 +551,40 @@ Making cost optimization fun and competitive is surprisingly effective.
 
 ### Setting Cloud Budgets
 
+A cloud budget is more than a spending limit — it is a planning tool that forces the organization to allocate finite resources across competing priorities. Budgets that are set once annually and never revisited fail in both directions: they constrain teams whose growth exceeds projections, and they mask waste in teams whose spending is well below the budget ceiling. Effective cloud budgeting operates on a monthly cadence with quarterly re-forecasting.
+
 ```mermaid
 graph LR
     Org[Organization Budget<br/>$180,000/month]
-    
-    Prod[Production: 72%<br/>$130,000]
-    NonProd[Non-Production: 19%<br/>$35,000]
-    Shared[Shared/Platform: 9%<br/>$15,000]
-    Buffer[Buffer: 10%<br/>$18,000]
-    
+
+    Prod[Production: 70%]
+    NonProd[Non-Production: 20%]
+    Shared[Shared/Platform: 10%]
+    Buffer[Buffer: 10%]
+
     Org --> Prod
     Org --> NonProd
     Org --> Shared
     Org -.-> Buffer
-    
-    Prod --> P1[Payments: $32,000]
-    Prod --> P2[Search: $41,000]
-    Prod --> P3[Data: $28,000]
-    Prod --> P4[ML: $18,000]
-    Prod --> P5[Platform: $11,000]
-    
-    NonProd --> NP1[Staging: $15,000]
-    NonProd --> NP2[Dev: $12,000]
-    NonProd --> NP3[Sandbox: $8,000]
-    
-    Shared --> S1[Networking: $6,000]
-    Shared --> S2[Monitoring: $5,000]
-    Shared --> S3[Security: $4,000]
+
+    Prod --> P1[Payments]
+    Prod --> P2[Search]
+    Prod --> P3[Data]
+    Prod --> P4[ML]
+    Prod --> P5[Platform]
+
+    NonProd --> NP1[Staging]
+    NonProd --> NP2[Dev]
+    NonProd --> NP3[Sandbox]
+
+    Shared --> S1[Networking]
+    Shared --> S2[Monitoring]
+    Shared --> S3[Security]
 ```
 
-### Budget Alerts
+The budget tree above illustrates a common allocation pattern: production workloads receive the largest share, non-production environments are explicitly budgeted rather than ignored, shared platform services are accounted for separately, and a buffer — typically 10% — absorbs unexpected spikes without triggering overrun alerts. The buffer is not "free money." It is a recognition that cloud spending is inherently variable and that setting budgets at exactly 100% of expected spend guarantees that every minor deviation triggers an alert, which causes alert fatigue.
+
+### AWS Budget Configuration with Tiered Alerts
 
 ```hcl
 # Terraform: AWS Budget with alerts at multiple thresholds
@@ -526,69 +633,77 @@ resource "aws_budgets_budget" "team_payments" {
 }
 ```
 
-### Forecasting Techniques
-
-| Technique | Accuracy | Complexity | Best For |
-|-----------|----------|-----------|----------|
-| **Linear extrapolation** | Low-medium | Simple | Stable, predictable workloads |
-| **Moving average** | Medium | Simple | Gradually changing workloads |
-| **Seasonal decomposition** | High | Medium | Workloads with weekly/monthly patterns |
-| **ML-based (Prophet, etc.)** | High | Complex | Large datasets with multiple signals |
-| **Commitment-adjusted** | High | Medium | Incorporating RI/SP changes |
+The tiered alert design is deliberate. At 75% of the forecasted budget, only the team lead receives a notification — this is a heads-up, not an alarm. At 90% of actual spend, the FinOps team is added to provide support and investigate whether the trajectory is justified. At 100%, the VP of Engineering is included, which elevates the conversation to a business decision: is this overrun justified by business need, and should the budget be adjusted? This escalation path prevents both alert fatigue (by not alarming everyone at every threshold) and unnoticed overruns (by widening the audience as the situation approaches the limit).
 
 ---
 
-## Communicating with Finance
+## Patterns and Anti-Patterns
 
-### Speak Their Language
+The difference between a FinOps practice that sustains and one that fades is often not the sophistication of the tooling or the size of the budget. It is whether the organization has internalized the patterns that make cost efficiency self-reinforcing or fallen into the anti-patterns that make it adversarial. The patterns below describe recurring solutions to the cultural, organizational, and automation challenges that every FinOps practitioner encounters. The anti-patterns describe the failure modes that are predictable enough to identify and avoid before they take root.
 
-Engineers think in CPU cores and gigabytes. Finance thinks in dollars, margins, and ROI. You need to translate.
+### Patterns — What Good Looks Like
 
-| Engineering Metric | Finance Translation |
-|-------------------|-------------------|
-| "We need 20 more CPU cores" | "We need $1,400/month more compute to handle 30% growth" |
-| "Our p99 latency improved 40ms" | "Response time improvement retains ~2% more users ($50K ARR)" |
-| "We rightsized 30 pods" | "We reduced infrastructure cost by $2,100/month without service impact" |
-| "We migrated to Spot" | "We reduced compute costs 65% with <0.1% availability impact" |
-| "Our cluster utilization is 18%" | "We're paying for 5.5x more capacity than we use — $110K annual waste" |
+1. **Cost as a shared metric, not a finance spreadsheet.** Embed cost data where engineers already work: PR comments, developer portals, sprint planning tools. When cost data requires opening a separate dashboard in a separate tab, it will not be checked. When it appears alongside the metrics engineers already care about — latency, error rate, deployment frequency — it becomes part of the operational rhythm.
 
-### The Monthly FinOps Business Review
+2. **Progressive accountability.** Start with showback until teams understand their cost data. Move to soft chargeback when teams can explain their spending. Graduate to hard chargeback only after teams have the tooling and knowledge to control their costs. Skipping stages generates resistance because teams are being held accountable for something they cannot yet influence.
 
-> **Monthly FinOps Review — March 2026**
-> 
-> **Executive Summary:**
-> - Total cloud spend: $172,400 (budget: $180,000) ✅ Under budget
-> - Month-over-month change: +3.2% ($5,400)
-> - Cost per customer: $0.68 (target: <$0.75) ✅ Target met
-> - Savings realized this month: $8,300
-> 
-> **Key Wins:**
-> - Payments team rightsizing: -$2,800/month (ongoing)
-> - gp2 → gp3 migration: -$1,400/month (one-time, permanent)
-> - Spot adoption for CI/CD: -$4,100/month (ongoing)
-> 
-> **Risks:**
-> - ML training costs growing 12% month-over-month (investigating)
-> - Untagged resources: $7,200/month (down from $9,800 — improving)
-> 
-> **Next Month Focus:**
-> - Complete cross-AZ traffic optimization (est. -$3,000/month)
-> - Begin Reserved Instance planning for Q3 commitments
-> - Launch team cost dashboards in Backstage
+3. **Ambassadors over enforcers.** A FinOps guild with engineering ambassadors from each team scales cost awareness horizontally. A centralized FinOps team that enforces policies from above creates an adversarial relationship where engineers optimize to satisfy the policy rather than to improve efficiency. Ambassadors translate FinOps goals into engineering language and surface engineering concerns back to the FinOps lead.
 
-### Finance Report Template
+4. **Automation as cultural reinforcement.** Automate tagging enforcement, idle resource reaping, and non-production scale-down so that the path of least resistance is the cost-efficient path. Automation is not a substitute for culture — it is the mechanism that makes the desired culture the default.
 
-| KPI | This Month | Last Month | Trend |
-|-----|------------|------------|-------|
-| Total cloud spend | $172,400 | $167,000 | ↑ |
-| Budget variance | -$7,600 | -$11,200 | ↑ |
-| Cost per customer | $0.68 | $0.71 | ↓ |
-| Revenue per customer | $4.20 | $4.15 | ↑ |
-| Infra as % of revenue | 16.2% | 17.1% | ↓ |
-| Savings this month | $8,300 | $5,100 | ↑ |
-| RI/SP utilization | 87% | 82% | ↑ |
-| Tagging compliance | 91% | 88% | ↑ |
-| Waste (est.) | $22,100 | $29,400 | ↓ |
+5. **Wins celebrated publicly, overruns discussed privately.** Public recognition for cost optimization creates positive social pressure. Public shaming for cost overruns creates defensive behavior and hidden costs. The team that overspent should have a private conversation with the FinOps lead to understand what happened and whether the spending was justified; the team that achieved a significant saving should be recognized in the company-wide communication channel.
+
+### Anti-Patterns — What to Avoid
+
+| Anti-Pattern | Why It Fails | Better Approach |
+|---|---|---|
+| **Making FinOps synonymous with cost cutting** | Creates a mindset where optimization is framed as austerity, which engineers resist | Frame FinOps as cost *efficiency* — getting maximum business value per dollar spent |
+| **Imposing FinOps top-down without engineering buy-in** | Engineers treat it as a compliance checkbox rather than a practice they own | Start with showback, give teams visibility into their own data, let curiosity drive the first optimizations |
+| **Overcomplicating cost allocation before basic visibility exists** | Teams spend months perfecting allocation models while real waste goes unaddressed | 80% accuracy in allocation is sufficient to start finding and fixing waste; refine the model iteratively |
+| **Ignoring non-production costs** | Dev, staging, and sandbox environments can collectively rival production spend | Budget non-production explicitly, automate scale-down off-hours, treat non-production cost as a first-class concern |
+| **No automation in CI/CD** | Manual cost reviews do not scale beyond a handful of teams and are inconsistently applied | Integrate cost estimation into the PR pipeline so every infrastructure change is evaluated automatically |
+| **Annual budgeting for cloud spend** | Cloud spending is variable by nature; annual budgets create artificial cliffs and gaming behavior | Monthly budgets with quarterly re-forecasting accommodate the natural variability of cloud consumption |
+| **Central FinOps team owns all optimization** | Creates a bottleneck and signals to engineers that cost is someone else's responsibility | Decentralize ownership through ambassadors; centralize tooling, dashboards, and automation infrastructure |
+| **No celebration of wins** | Optimization feels like unrewarded overhead, and teams stop engaging | Public recognition, ambassador spotlights, and leadership acknowledgment make cost work visible and valued |
+
+---
+
+## Decision Framework: When to Use Which Cost Intervention
+
+```mermaid
+graph TD
+    Q1{Is cost data visible<br/>to engineering teams?}
+
+    Q1 -->|No| A1[Deploy cost visibility<br/>Showback first]
+    Q1 -->|Yes| Q2{Do teams understand<br/>their cost data?}
+
+    Q2 -->|No| A2[Run cost literacy workshops<br/>Build team dashboards]
+    Q2 -->|Yes| Q3{Is cost trending in<br/>the right direction?}
+
+    Q3 -->|No, rising| Q4{Is the rise from<br/>known growth?}
+
+    Q4 -->|Yes| A3[Update budgets to reflect growth<br/>Monitor unit economics]
+    Q4 -->|No| A4[Investigate root cause<br/>Deploy anomaly detection<br/>Run targeted optimization sprint]
+
+    Q3 -->|Yes, stable or falling| Q5{Are unit economics<br/>improving?}
+
+    Q5 -->|Yes| A5[Mature the practice:<br/>Shift-left, chargeback,<br/>automation, commitment planning]
+    Q5 -->|No| A6[Refocus on efficiency metrics<br/>Rightsizing, Spot adoption,<br/>storage tiering]
+```
+
+The decision framework above is organized around a single question sequence that any FinOps practitioner can ask when evaluating their organization's state. It starts with visibility because without visibility, no other intervention is possible. It moves through understanding, trend assessment, root-cause analysis, and finally maturity. The framework is deliberately tool-agnostic — it describes *what to do* at each stage without prescribing *which tool* to do it with.
+
+---
+
+## Did You Know?
+
+- **The FinOps Foundation's practitioner survey has consistently identified "getting engineers to take action" as the top challenge for FinOps practitioners** — ranking above tooling, data quality, and executive support. A large majority of respondents cite cultural adoption as harder than technical implementation. This finding has been stable across multiple survey years, which is why the FinOps Foundation lists "Engineering Alignment" as a core domain alongside cost allocation and optimization.
+
+- **Embedding cost data where engineers already work is more effective than building dedicated dashboards.** The behavioral insight is straightforward: engineers spend their time in terminals, IDEs, pull requests, and developer portals. A cost dashboard that requires navigating to a separate URL competes with every other demand on attention and loses. Cost data surfaced in a PR comment (through a CI integration) or in a developer portal plugin (such as the Backstage Cost Insights plugin) reaches engineers in their existing workflow, where the cognitive cost of engaging with it is near zero.
+
+- **Gamification works because engineering culture is already competitive.** Teams compete on latency percentiles, deployment frequency, and incident response time. Adding cost efficiency to the set of competitive metrics — through a leaderboard that ranks teams by cost-per-request or cost-per-customer rather than absolute spend — taps into existing cultural dynamics rather than trying to create new ones. The leaderboard itself requires no expensive tooling: a dashboard that queries the existing cost allocation data and ranks the results is sufficient.
+
+- **The shift-left principle in FinOps is economically asymmetric.** Catching a cost-increasing change in a pull request costs the time to run the estimation tool and review the comment — roughly five minutes of an engineer's and a reviewer's time. Catching the same change on a cloud bill thirty days later costs thirty days of the unnecessary spend *plus* the engineering time to investigate, root-cause, and remediate — which is nearly always longer than the five-minute PR review would have been. This asymmetry is why the return on investment for CI-integrated cost estimation is among the highest of any FinOps practice.
 
 ---
 
@@ -599,32 +714,32 @@ Engineers think in CPU cores and gigabytes. Finance thinks in dollars, margins, 
 | Making FinOps = cost cutting | Pressure from leadership | Frame as "cost efficiency" and unit economics, not austerity |
 | No engineering buy-in | FinOps imposed top-down | Start with showback, empower teams with data |
 | Overcomplicating cost models | Perfectionism in allocation | 80% accuracy is fine to start; iterate |
-| Ignoring non-production costs | "It's just dev" | Dev/staging can be 20-30% of total spend |
-| No automation in CI/CD | Manual reviews don't scale | Deploy Infracost and automate cost checks |
+| Ignoring non-production costs | "It's just dev" | Dev/staging can be a substantial fraction of total spend |
+| No automation in CI/CD | Manual reviews don't scale | Deploy cost estimation in CI and automate cost checks |
 | Annual budgets for cloud | CapEx thinking applied to OpEx | Monthly budgets with quarterly re-forecasting |
 | FinOps team owns all optimization | Bottleneck, single point of failure | Decentralize with ambassadors, centralize tooling |
-| No celebration of wins | Optimization feels like a chore | Public recognition, leaderboards, CFO shoutouts |
+| No celebration of wins | Optimization feels like a chore | Public recognition, leaderboards, leadership acknowledgment |
 
 ---
 
 ## Quiz
 
 ### Question 1
-You are the newly appointed FinOps Lead at a mid-sized SaaS company. The company ran a huge optimization push six months ago, but since then, costs have crept back up. You notice engineers never look at the cost dashboards you built in Grafana. How should you change your approach to ensure long-term cost awareness?
+You are the newly appointed FinOps Lead at a mid-sized SaaS company. The company ran a substantial optimization push six months ago, but since then, costs have crept back up. You notice engineers never look at the cost dashboards you built in Grafana. How should you change your approach to ensure long-term cost awareness?
 
 <details>
 <summary>Show Answer</summary>
 
-Passive dashboards require engineers to actively interrupt their workflow to seek out cost data, which rarely happens in practice. To change this behavior, you must bring the cost data directly to where engineers already work, such as embedding it in CI/CD pipeline PR comments or a developer portal (like Backstage). Additionally, introducing gamification like a team leaderboard taps into engineering competitiveness, making cost optimization a visible and social effort. Finally, shifting from a centralized team model to a guild model ensures that every engineering team has a local ambassador who champions these metrics. By making cost data unavoidable and actionable, you integrate it into the daily engineering culture rather than treating it as a separate chore.
+Passive dashboards require engineers to actively interrupt their workflow to seek out cost data, which rarely happens in practice. To change this behavior, you must bring the cost data directly to where engineers already work, such as embedding it in CI/CD pipeline PR comments or a developer portal. Additionally, introducing gamification like a team leaderboard taps into engineering competitiveness, making cost optimization a visible and social effort. Finally, shifting from a centralized team model to a guild model ensures that every engineering team has a local ambassador who champions these metrics. By making cost data unavoidable and actionable, you integrate it into the daily engineering culture rather than treating it as a separate chore.
 </details>
 
 ### Question 2
-A developer on the payments team opens a PR that adds 3 new `c6i.2xlarge` EC2 instances to a Terraform module. Infracost, running in your CI pipeline, estimates a $420/month increase (+18% for that module). Your organization's policy blocks PRs with a >10% cost increase. The developer complains that this is blocking an urgent feature launch. How should you handle this situation?
+A developer on the payments team opens a PR that adds 3 new compute-optimized EC2 instances to a Terraform module. Infracost, running in your CI pipeline, estimates a substantial monthly increase for that module (approximately 18%). Your organization's policy blocks PRs with a cost increase exceeding 10%. The developer complains that this is blocking an urgent feature launch. How should you handle this situation?
 
 <details>
 <summary>Show Answer</summary>
 
-The automated block is functioning exactly as intended: it is designed to create a mandatory conversation, not to act as a permanent hard stop. Growth naturally requires spending, but the FinOps review ensures that this spending is intentional and optimized before resources are provisioned. You should engage with the developer to understand the architectural requirements and explore if cheaper alternatives like ARM-based Graviton instances or spot instances could meet their needs. If the instances are justified and optimized, you should approve the exception and document the rationale for the monthly business review. This process reinforces cost-conscious engineering without stalling necessary product delivery.
+The automated block is functioning exactly as intended: it is designed to create a mandatory conversation, not to act as a permanent hard stop. Growth naturally requires spending, but the FinOps review ensures that this spending is intentional and optimized before resources are provisioned. You should engage with the developer to understand the architectural requirements and explore whether cheaper alternatives — ARM-based Graviton instances, spot instances, or smaller instance types with horizontal scaling — could meet their needs. If the instances are justified and optimized, you should approve the exception and document the rationale for the monthly business review. This process reinforces cost-conscious engineering without stalling necessary product delivery.
 </details>
 
 ### Question 3
@@ -633,11 +748,11 @@ Your infrastructure team just completed a major initiative, migrating 40 statele
 <details>
 <summary>Show Answer</summary>
 
-You must translate the technical achievement into financial and business impact because a CFO thinks in terms of risk, annualized savings, and margins, not pods or spot markets. Instead of discussing the underlying Kubernetes mechanics, you should state: 'We reduced our annual compute run rate by $74,400 by safely utilizing discounted spare capacity, all while maintaining our 99.97% service availability SLA.' This framing highlights the dollar amount over a long-term horizon, reassures them that customer experience (risk) was not compromised, and emphasizes that the optimization requires no ongoing engineering effort. By speaking the language of finance, you clearly demonstrate how the engineering team is directly improving the company's unit economics.
+You must translate the technical achievement into financial and business impact because a CFO thinks in terms of risk, annualized savings, and margins, not pods or spot markets. Instead of discussing the underlying Kubernetes mechanics, you should state: "We reduced our annual compute run rate by a substantial amount by safely utilizing discounted spare capacity, all while maintaining our service availability SLA." This framing highlights the dollar amount over a long-term horizon, reassures them that customer experience was not compromised, and emphasizes that the optimization requires no ongoing engineering effort. By speaking the language of finance, you clearly demonstrate how the engineering team is directly improving the company's unit economics.
 </details>
 
 ### Question 4
-Your CTO wants to improve cloud cost efficiency and proposes hiring three dedicated FinOps engineers to form a central team that will handle all optimization tasks. You advocate for building a 'FinOps Guild' instead, with only one dedicated lead and ambassadors from each engineering team. Why is the guild model more effective for long-term cultural change?
+Your CTO wants to improve cloud cost efficiency and proposes hiring three dedicated FinOps engineers to form a central team that will handle all optimization tasks. You advocate for building a FinOps Guild instead, with only one dedicated lead and ambassadors from each engineering team. Why is the guild model more effective for long-term cultural change?
 
 <details>
 <summary>Show Answer</summary>
@@ -646,12 +761,30 @@ A centralized FinOps team that executes all optimizations often becomes a bottle
 </details>
 
 ### Question 5
-You want to introduce a 'Cloud Efficiency Leaderboard' to gamify cost optimization among your five engineering teams. The finance department suggests ranking the teams by 'Total Dollars Saved' this month. Why is this a dangerous metric, and what should you use instead?
+You want to introduce a Cloud Efficiency Leaderboard to gamify cost optimization among your five engineering teams. The finance department suggests ranking the teams by "Total Dollars Saved" this month. Why is this a dangerous metric, and what should you use instead?
 
 <details>
 <summary>Show Answer</summary>
 
-Ranking teams by absolute 'Total Dollars Saved' or 'Lowest Total Spend' creates perverse incentives because it inherently penalizes rapidly growing teams while rewarding stagnant ones. A team supporting a highly successful, fast-growing product line will naturally spend more and might struggle to find massive absolute savings, whereas an over-provisioned legacy team could easily slash thousands of dollars. Instead, you should gamify efficiency metrics like 'Cost per 1,000 requests' or 'Cost per customer served' to ensure you are measuring the true business value of the infrastructure. Using unit economics ensures that teams are encouraged to architect their systems efficiently and scale responsibly, rather than simply starving their applications of necessary resources to win a contest.
+Ranking teams by absolute "Total Dollars Saved" or "Lowest Total Spend" creates perverse incentives because it inherently penalizes rapidly growing teams while rewarding stagnant ones. A team supporting a highly successful, fast-growing product line will naturally spend more and might struggle to find massive absolute savings, whereas an over-provisioned legacy team could easily slash thousands of dollars. Instead, you should gamify efficiency metrics like "Cost per 1,000 requests" or "Cost per customer served" to ensure you are measuring the true business value of the infrastructure. Using unit economics ensures that teams are encouraged to architect their systems efficiently and scale responsibly, rather than simply starving their applications of necessary resources to win a contest.
+</details>
+
+### Question 6
+Your organization currently practices showback — teams receive monthly cost reports with no financial consequences. The CFO wants to move directly to hard chargeback, where cloud costs are deducted from team budgets. You advise against skipping the intermediate step of soft chargeback. Explain why the progression matters.
+
+<details>
+<summary>Show Answer</summary>
+
+Moving directly from showback to hard chargeback creates a situation where teams are held financially accountable for costs they have never had to manage before, and they lack the tooling, knowledge, and cultural practice to control those costs. The result is typically a combination of panic-driven under-provisioning (which degrades reliability), blame-shifting (teams disputing allocation accuracy rather than optimizing), and gaming behavior (deferring legitimate infrastructure investments to stay under budget). Soft chargeback serves as a transitional phase: costs are allocated to team budgets and overruns trigger a conversation, but there are no immediate financial penalties. This gives teams time to develop cost literacy, build optimization workflows, and trust the accuracy of the allocation data before real money is at stake. The progression should typically span at least two quarters.
+</details>
+
+### Question 7
+You have been asked to design a cost anomaly detection system. Your first draft uses a single detection method: a threshold alert that fires when any service's daily cost exceeds its seven-day average by more than 30%. What gaps does this single-method approach leave, and how would you address them?
+
+<details>
+<summary>Show Answer</summary>
+
+A single threshold-based detection method leaves at least three significant gaps. First, it will miss gradual cost creep — a service that increases spending by 5% each week will never trigger a 30% day-over-day alert but will double its cost over three months. Second, it will produce false positives for legitimate burst patterns — a batch processing job that runs weekly and spikes costs on that day will trigger an alert every week, rapidly causing alert fatigue. Third, it cannot detect new cost sources — if a team spins up a brand-new service with no historical baseline, there is no seven-day average to compare against. A defense-in-depth approach would add trend analysis to catch gradual increases, seasonal decomposition or schedule awareness to suppress alerts during known burst windows, and a service catalog allowlist to flag entirely new cost sources for review.
 </details>
 
 ---
@@ -875,7 +1008,7 @@ if [ "$(echo "$PAST_COST > 0" | bc)" -eq 1 ]; then
   echo ""
 
   if [ "$(echo "$PCT > $THRESHOLD_PCT" | bc)" -eq 1 ]; then
-    echo "❌ FAILED: Cost increase of ${PCT}% exceeds ${THRESHOLD_PCT}% threshold."
+    echo "FAILED: Cost increase of ${PCT}% exceeds ${THRESHOLD_PCT}% threshold."
     echo ""
     echo "Actions required:"
     echo "  1. Review if all new resources are necessary"
@@ -883,11 +1016,11 @@ if [ "$(echo "$PAST_COST > 0" | bc)" -eq 1 ]; then
     echo "  3. Get FinOps team approval before merging"
     exit 1
   else
-    echo "✅ PASSED: Cost change within acceptable threshold."
+    echo "PASSED: Cost change within acceptable threshold."
   fi
 else
   echo "No base cost for comparison (new infrastructure)."
-  echo "✅ PASSED: New infrastructure, no threshold to compare."
+  echo "PASSED: New infrastructure, no threshold to compare."
 fi
 SCRIPT
 
@@ -904,56 +1037,45 @@ rm -rf ~/finops-infracost-lab
 ### Success Criteria
 
 You've completed this exercise when you:
+
 - [ ] Installed Infracost and obtained an API key
 - [ ] Created a base Terraform configuration with cost estimate
 - [ ] Added new resources simulating a cost-increasing PR
 - [ ] Generated a cost diff showing the increase
-- [ ] Ran the threshold check script and saw it fail (>10% increase)
+- [ ] Ran the threshold check script and saw it fail (exceeding the threshold)
 - [ ] Understood how this integrates into GitHub Actions or GitLab CI
 
 ---
 
-## Key Takeaways
+## Sources
 
-1. **FinOps is 70% culture, 30% technology** — tools without behavior change produce temporary savings
-2. **Build a guild, not a team** — decentralize ownership, centralize tooling
-3. **Shift cost left into CI/CD** — Infracost catches expensive changes before deployment
-4. **Gamification works** — leaderboards and recognition drive optimization naturally
-5. **Speak finance's language** — dollars, margins, and ROI, not CPU cores and gigabytes
-6. **Automate everything** — anomaly detection, budget alerts, and cost thresholds prevent surprises
-
----
-
-## Further Reading
-
-**Books**:
-- **"Cloud FinOps"** — J.R. Storment & Mike Fuller (O'Reilly, 2nd edition)
-- **"Team Topologies"** — Matthew Skelton & Manuel Pais (for org design that supports FinOps)
-
-**Tools**:
-- **Infracost** — infracost.io (cost estimation for Terraform in CI/CD)
-- **Backstage Cost Insights** — backstage.io/docs/features/cost-insights (developer portal cost plugin)
-- **AWS Cost Anomaly Detection** — docs.aws.amazon.com/cost-management
-
-**Talks**:
-- **"Building a FinOps Culture"** — FinOps X Conference (YouTube)
-- **"How We Saved $5M with Cloud Cost Engineering"** — Spotify, QCon (YouTube)
-- **"Infracost: Cloud Cost Estimates for Terraform"** — HashiConf (YouTube)
+- **FinOps Foundation Framework** — https://www.finops.org/framework/ — The canonical reference for FinOps domains, capabilities, and personas. Defines the Inform, Optimize, and Operate lifecycle phases that structure FinOps practice.
+- **FinOps Foundation — Capabilities** — https://www.finops.org/framework/capabilities/ — Detailed descriptions of each FinOps capability, including cost allocation, anomaly detection, and unit economics.
+- **Infracost Documentation** — https://www.infracost.io/docs/ — Documentation for the open-source tool that estimates cloud costs from Terraform plans in CI/CD pipelines.
+- **OpenCost Documentation** — https://www.opencost.io/docs/ — Documentation for the CNCF sandbox project that provides real-time cost monitoring and allocation for Kubernetes.
+- **Kubernetes — Managing Resources for Containers** — https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/ — The authoritative reference for Kubernetes resource requests and limits, the foundation of the Kubernetes cost model.
+- **Kubernetes — Horizontal Pod Autoscaling** — https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscaling/ — Documentation for the HPA controller, a core technique for matching provisioned capacity to actual demand.
+- **Kubernetes — Vertical Pod Autoscaler** — https://github.com/kubernetes/autoscaler/tree/master/vertical-pod-autoscaler — The VPA project, which produces resource recommendations (rightsizing) and can optionally apply them automatically.
+- **Karpenter Documentation** — https://karpenter.sh/docs/ — Documentation for the open-source Kubernetes node autoscaler that provisions right-sized instances and supports spot instance automation.
+- **AWS Cost Anomaly Detection** — https://docs.aws.amazon.com/cost-management/latest/userguide/manage-ad.html — AWS documentation for the native cost anomaly detection service, including monitor types and subscription configuration.
+- **AWS Budgets** — https://docs.aws.amazon.com/cost-management/latest/userguide/budgets-managing-costs.html — AWS documentation for budget creation, threshold alerts, and forecasting integration.
+- **CNCF TAG Environmental Sustainability — Cloud Native Cost** — https://tag-env-sustainability.cncf.io/ — The CNCF Technical Advisory Group addressing the intersection of cloud cost optimization and environmental sustainability, with guidance on measuring and reducing the carbon impact of cloud infrastructure.
+- **Backstage Cost Insights Plugin** — https://backstage.io/docs/features/software-catalog/descriptor-format — The Backstage developer portal plugin that surfaces cloud costs alongside service metadata, implementing the "embed cost where engineers already work" pattern.
 
 ---
 
 ## Summary
 
-Technical FinOps without cultural FinOps is a project. Technical FinOps *with* cultural FinOps is a practice. By building a FinOps guild with engineering ambassadors, embedding cost into CI/CD pipelines via Infracost, automating anomaly detection and budget alerts, gamifying optimization through leaderboards, and communicating in finance's language, organizations transform cloud cost management from a periodic cleanup into a continuous, self-sustaining discipline. The result: costs stay optimized not because someone is watching, but because everyone is.
+Technical FinOps without cultural FinOps is a project. Technical FinOps *with* cultural FinOps is a practice. By building a FinOps guild with engineering ambassadors, embedding cost into CI/CD pipelines, automating anomaly detection and budget alerts, gamifying optimization through leaderboards, and communicating in the language of finance, organizations transform cloud cost management from a periodic cleanup into a continuous, self-sustaining discipline. The result: costs stay optimized not because someone is watching, but because everyone is.
 
 ---
 
-## Next Steps
+## Next Module
 
-You've completed the FinOps discipline track. To continue your learning:
+You have completed the FinOps discipline track. To continue your learning:
 
 - **Review the FinOps modules** for a summary of all topics and additional resources
-- **Apply what you've learned** — start with Module 1.1's exercise on your own cloud bill
+- **Apply what you have learned** — start with Module 1.1's exercise on your own cloud bill
 - **Join the FinOps Foundation** at finops.org for community, certifications, and frameworks
 - **Explore related disciplines**: [SRE](/platform/disciplines/core-platform/sre/), [Platform Engineering](/platform/disciplines/core-platform/platform-engineering/), [GitOps](/platform/disciplines/delivery-automation/gitops/)
 


### PR DESCRIPTION
## What

Completes **FinOps** (Platform Disciplines wave 1, epic #1953) — the section is now **6/6 done** (batch 1 = 1.1/1.2/1.3 in #1954).

| Module | Was→Now | Author | Cross-family review |
|---|---|---|---|
| 1.4 compute-optimization | **180w stub**→5002w | cursor | opus R1 **APPROVE** |
| 1.5 storage-network-costs | 874→5658w | codex | opus R1 **APPROVE** |
| 1.6 finops-culture | 809→5013w | deepseek | opus R1 NEEDS_CHANGES → fixed |

## Ground-checked / web-verified

- **1.4:** Karpenter facts correct (`kubernetes-sigs/karpenter` vendor-neutral core under SIG Autoscaling, EC2 Fleet API); durable-content exemplary (explicitly disclaims dollar figures, "not which controller wins").
- **1.5:** the one hard currency claim — **K8s 1.35 `trafficDistribution` `PreferSameZone`/`PreferSameNode` GA, `PreferClose` deprecated** — web-verified accurate (KEP-3015). gp3/gp2 quarantined qualitatively in the dated snapshot.
- **1.6 (deepseek, fixed):** removed a **banned market-share claim** ("Infracost is the most widely adopted tool" → peer framing) and an **invented precise ratio** ("FinOps is roughly 30% technology and 70% culture" → qualitative). Infracost GitHub Actions YAML ground-checked correct.

## Durable-content compliance

All three quarantine volatile facts into dated Landscape snapshots + a capability **Cost-Tooling Rosetta** (peers, "not a ranking"); no best-tool/market-share claims; `Hypothetical scenario:` labels throughout.

## Verification

- `verify_module.py` → all 3 **T0** (5002 / 5658 / 5013 body words); 0 anti-leak (`47`/emoji removed).
- `npm run build` green PRIMARY (2169 pages, 0 schema errors); `check_site_health.py` 0 errors.

## Learner check

> This table is a Rosetta stone, not a ranking.

Refs #1953