### PR TITLE
ci/dod: astro-build PR gate + verify_shippable + cold-start freshness (#1961)

### DIFF
--- a/.github/workflows/build-check.yml
+++ b/.github/workflows/build-check.yml
@@ -1,0 +1,52 @@
+name: Astro build (render + schema)
+
+# THE RENDER GATE (#1961). Before this workflow, `astro build` ran only in
+# deploy.yml on push:main — i.e. AFTER merge — so a frontmatter/schema break
+# (e.g. an out-of-enum `lab.difficulty`, a missing required field, a bad slug)
+# or any render-breaking content merged clean and only broke `main`'s deploy
+# silently. The required PR checks (incident-dedup, site-health) do NOT build or
+# validate the content-collection Zod schema, and verify_module.py only checks
+# density/tier. This job makes the full build a PR gate so Definition-of-Done
+# includes render, not just the build-time gates.
+#
+# No `paths:` filter — a path-filtered required check never reports on PRs that
+# miss those paths, leaving them permanently BLOCKED (the CodeQL/PR #1742
+# deadlock; see link-check.yml). A build is the universal content gate, so
+# always-on is correct. It needs NO secrets and NO write scope, so it runs
+# safely on fork PRs too.
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  astro-build:
+    name: Astro build (render + schema)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # .npmrc sets ignore-scripts=true (supply-chain hardening, #1812). `npm rebuild`
+      # also honours ignore-scripts, so it must be re-enabled for JUST these two
+      # audited native deps — otherwise esbuild/sharp are no-op stubs and the build
+      # fails. Mirrors deploy.yml (review: codex #1813).
+      - name: Rebuild allow-listed native deps
+        run: npm rebuild esbuild sharp --ignore-scripts=false
+
+      - name: Build site (fails on schema or render errors)
+        run: npm run build

--- a/scripts/cold-start.sh
+++ b/scripts/cold-start.sh
@@ -71,7 +71,17 @@ git status --short || true
 # warn (destructive/auto git on the user's tree is banned, see
 # feedback_never_destructive_git_on_user_files). `|| true` keeps cold-start
 # working offline.
-git fetch --quiet origin main 2>/dev/null || true
+# Bound the fetch so a stalled network can't hang cold-start (review: cursor R1).
+# `timeout` is GNU coreutils (Linux); on macOS it's `gtimeout` if present, else
+# run unbounded — `|| true` still keeps cold-start alive.
+FETCH_TIMEOUT="${KUBEDOJO_FETCH_TIMEOUT:-10}"
+if command -v timeout >/dev/null 2>&1; then
+  timeout "$FETCH_TIMEOUT" git fetch --quiet origin main 2>/dev/null || true
+elif command -v gtimeout >/dev/null 2>&1; then
+  gtimeout "$FETCH_TIMEOUT" git fetch --quiet origin main 2>/dev/null || true
+else
+  git fetch --quiet origin main 2>/dev/null || true
+fi
 behind=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
 if [[ "${behind:-0}" -gt 0 ]]; then
   echo "⚠ primary is ${behind} commit(s) BEHIND origin/main — STATUS/handoff below may be stale."

--- a/scripts/cold-start.sh
+++ b/scripts/cold-start.sh
@@ -65,6 +65,18 @@ scripts/services-up >&2 || true
 
 echo "--- kubedojo:workspace ---"
 git status --short || true
+# Read-only freshness check (#1961): a session that cold-starts from a primary
+# behind origin/main can re-fire already-merged work (the learn-ukrainian
+# Session-28/29 re-collision). Fetch is read-only and NEVER auto-pulls — we only
+# warn (destructive/auto git on the user's tree is banned, see
+# feedback_never_destructive_git_on_user_files). `|| true` keeps cold-start
+# working offline.
+git fetch --quiet origin main 2>/dev/null || true
+behind=$(git rev-list --count HEAD..origin/main 2>/dev/null || echo 0)
+if [[ "${behind:-0}" -gt 0 ]]; then
+  echo "⚠ primary is ${behind} commit(s) BEHIND origin/main — STATUS/handoff below may be stale."
+  echo "  sync first (non-destructive): git pull --ff-only origin main"
+fi
 echo ""
 
 echo "--- kubedojo:pending-decisions ---"

--- a/scripts/quality/verify_shippable.sh
+++ b/scripts/quality/verify_shippable.sh
@@ -24,6 +24,16 @@ set -euo pipefail
 REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
 cd "$REPO_ROOT"
 
+# Prefer the repo venv interpreter (worktrees may lack a venv → fall back to the
+# primary repo's, then to PATH `python`). Mirrors scripts/ops/* (review: cursor R1).
+if [[ -x "${REPO_ROOT}/.venv/bin/python" ]]; then
+  PYTHON="${REPO_ROOT}/.venv/bin/python"
+elif [[ -x "$(git -C "$REPO_ROOT" rev-parse --git-common-dir 2>/dev/null)/../.venv/bin/python" ]]; then
+  PYTHON="$(cd "$(git -C "$REPO_ROOT" rev-parse --git-common-dir)/.." && pwd)/.venv/bin/python"
+else
+  PYTHON="python"
+fi
+
 RUN_DENSITY=1
 FILES=()
 for arg in "$@"; do
@@ -43,7 +53,7 @@ if [[ "$RUN_DENSITY" -eq 1 && "${#FILES[@]}" -gt 0 ]]; then
   echo "==> [1/2] density / tier gates (verify_module.py)"
   for f in "${FILES[@]}"; do
     echo "    --- $f"
-    if ! python scripts/quality/verify_module.py "$f"; then
+    if ! "$PYTHON" scripts/quality/verify_module.py "$f"; then
       echo "    DENSITY/TIER FAIL: $f" >&2
       fail=1
     fi

--- a/scripts/quality/verify_shippable.sh
+++ b/scripts/quality/verify_shippable.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+# verify_shippable — the codified local Definition-of-Done for content (#1961).
+#
+# A module is NOT shippable on density/tier alone. The learn-ukrainian autopsy
+# (2026-06-14) and KubeDojo's own CKS-5.2 break (an out-of-enum `lab.difficulty`
+# that passed every build-time gate and broke `main`'s deploy) show the same
+# lesson: Definition-of-Done must include RENDER. This wraps both axes into one
+# green/red:
+#
+#   1. verify_module.py  — density / tier gates (per file given)
+#   2. npm run build     — full astro render + content-collection Zod schema
+#                          validation (the gate CI defers to deploy and that
+#                          verify_module.py does NOT do)
+#
+# Run it before declaring any content wave done. Mirrors the PR gate in
+# .github/workflows/build-check.yml so "green locally" == "green in CI".
+#
+# Usage:
+#   scripts/quality/verify_shippable.sh [FILE ...]   # density-gate each FILE, then build
+#   scripts/quality/verify_shippable.sh --no-density  # build only (schema/render)
+#   scripts/quality/verify_shippable.sh               # build only (no files given)
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+cd "$REPO_ROOT"
+
+RUN_DENSITY=1
+FILES=()
+for arg in "$@"; do
+  case "$arg" in
+    --no-density) RUN_DENSITY=0 ;;
+    -h|--help)
+      grep '^#' "$0" | sed 's/^# \{0,1\}//'
+      exit 0
+      ;;
+    *) FILES+=("$arg") ;;
+  esac
+done
+
+fail=0
+
+if [[ "$RUN_DENSITY" -eq 1 && "${#FILES[@]}" -gt 0 ]]; then
+  echo "==> [1/2] density / tier gates (verify_module.py)"
+  for f in "${FILES[@]}"; do
+    echo "    --- $f"
+    if ! python scripts/quality/verify_module.py "$f"; then
+      echo "    DENSITY/TIER FAIL: $f" >&2
+      fail=1
+    fi
+  done
+else
+  echo "==> [1/2] density / tier gates SKIPPED (no files / --no-density)"
+fi
+
+echo "==> [2/2] astro build (render + Zod schema) — the render gate"
+# Surface the first schema/render error without dumping the ~5,600-line route
+# manifest (per feedback_never_read_build_logs).
+BUILD_LOG="$(mktemp)"
+trap 'rm -f "$BUILD_LOG"' EXIT
+if npm run build >"$BUILD_LOG" 2>&1; then
+  grep -E "built in|[0-9]+ page" "$BUILD_LOG" | tail -1 || true
+else
+  echo "    BUILD FAILED — first schema/render error:" >&2
+  grep -nE "InvalidContentEntryDataError|does not match|Error|error:" "$BUILD_LOG" | head -10 >&2 || tail -20 "$BUILD_LOG" >&2
+  fail=1
+fi
+
+if [[ "$fail" -ne 0 ]]; then
+  echo "RESULT: NOT SHIPPABLE ❌" >&2
+  exit 1
+fi
+echo "RESULT: SHIPPABLE ✅"


### PR DESCRIPTION
Closes #1961.

## What

Adds the **render gate** to Definition-of-Done. Before this PR, `astro build` (full render + content-collection Zod schema validation) ran **only in `deploy.yml` on `push: main`** — i.e. *after* merge — so a frontmatter/schema break or any render-breaking content **merged clean and broke `main`'s deploy silently**. The required PR checks (`Incident dedup gate`, `Site health link check`) don't build, and `verify_module.py` only checks density/tier.

Same class of bug as the learn-ukrainian "declared ready while CI was red" autopsy (fixes A/B/C/E). It already bit KubeDojo once — the CKS 5.2 out-of-enum `lab.difficulty: medium` that passed every gate and broke the build (`feedback_pr_ci_has_no_full_astro_build`).

## Changes

- **`.github/workflows/build-check.yml`** — full `npm ci` + `npm run build` on every PR. **Fork-safe** (no secrets, `contents: read`), `persist-credentials: false`, all `uses:` SHA-pinned with version comments, **de-path-filtered** so it's a stable always-run required check (a path-filtered required check permanently BLOCKS fork PRs — the PR #1742 deadlock). Mirrors `deploy.yml`'s known-good build, including the `npm rebuild esbuild sharp` step required because `.npmrc` sets `ignore-scripts=true`.
- **`scripts/quality/verify_shippable.sh`** — one-command local DoD: `verify_module.py` density gate → `astro build` (render + schema) → single green/red. Mirrors the PR gate so "green locally" == "green in CI".
- **`scripts/cold-start.sh`** — read-only `git fetch origin main` + behind-warning so a session can't cold-start from a stale primary and re-fire merged work. **Never auto-pulls** (non-destructive per `feedback_never_destructive_git_on_user_files`); `|| true` keeps it working offline.

## Self-test

This PR's own `build-check` job is the proof the gate works (no path filter → it runs here). `uvx zizmor --offline --strict-collection .github/` is clean.

## Follow-up (user/admin)

Add **`Astro build (render + schema)`** to the branch-protection required checks on `main` (currently `Incident dedup gate` + `Site health link check`) so the gate is blocking.

🤖 Generated with [Claude Code](https://claude.com/claude-code)