### PR TITLE
fix(ci): vitest PR gate + relax homepage-i18n UK EN-fallback (#1965)

### DIFF
--- a/.github/workflows/vitest-check.yml
+++ b/.github/workflows/vitest-check.yml
@@ -1,0 +1,48 @@
+name: Unit tests (vitest)
+
+# THE TEST GATE (#1965). `npm test` (vitest) ran nowhere in CI, so a red test
+# sat on `main` undetected (the homepage-i18n /ai/ EN-fallback assertion). Same
+# class as the render gate (#1961, build-check.yml): a gate that does not run
+# lets breaks land silently. This job runs the vitest suite as a PR check.
+#
+# No `paths:` filter — a path-filtered required check never reports on PRs that
+# miss those paths, leaving them permanently BLOCKED (the CodeQL/PR #1742
+# deadlock; see build-check.yml / link-check.yml). Tests guard cross-cutting
+# invariants (i18n parity, Russicisms), so always-on is correct. It needs NO
+# secrets and NO write scope, so it runs safely on fork PRs too.
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  vitest:
+    name: Unit tests (vitest)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          persist-credentials: false
+
+      - name: Set up Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e  # v6.4.0
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      # .npmrc sets ignore-scripts=true (supply-chain hardening, #1812). vitest
+      # transforms the TypeScript test imports via esbuild, whose native binary
+      # is a no-op stub under ignore-scripts — re-enable scripts for JUST this
+      # audited native dep so the suite can run. Mirrors build-check.yml.
+      - name: Rebuild allow-listed native deps
+        run: npm rebuild esbuild --ignore-scripts=false
+
+      - name: Run tests (vitest)
+        run: npm test

--- a/tests/homepage-i18n.test.ts
+++ b/tests/homepage-i18n.test.ts
@@ -56,8 +56,16 @@ describe('Homepage translations', () => {
     expect(translations.en.langSwitchHref).toBe('/uk/');
   });
 
-  it('uk whereRows hrefs include /uk/ prefix', () => {
+  // EN-fallback allowlist: tracks with no uk/ translation yet. Linking these to
+  // /uk/<track>/ would 404 (no content exists), so the UK homepage intentionally
+  // points them at the EN page until a translation lands. Starlight serves the EN
+  // page under the same URL. Remove an entry here once uk/<track> content exists.
+  // See #1965 (owner decision: accept EN fallback for untranslated tracks).
+  const UK_EN_FALLBACK_HREFS = ['/ai/', '/ai-ml-engineering/'];
+
+  it('uk whereRows hrefs include /uk/ prefix (except documented EN-fallback tracks)', () => {
     for (const row of translations.uk.whereRows) {
+      if (UK_EN_FALLBACK_HREFS.includes(row[2])) continue; // documented untranslated track — EN fallback
       expect(row[2], `UK href "${row[2]}" should start with /uk/`).toMatch(/^\/uk\//);
     }
   });


### PR DESCRIPTION
## What

Closes the two findings in #1965.

### 1. `npm test` was RED on `main` → fixed
`tests/homepage-i18n.test.ts` asserted every UK `whereRows` href starts with `/uk/`. Two rows intentionally fall back to the EN page — **AI literacy (`/ai/`)** and **AI/ML Engineering (`/ai-ml-engineering/`)** — because neither `uk/ai` nor `uk/ai-ml-engineering` content exists, so `/uk/ai*` would 404.

**Owner decision (issue #1965): option (a)** — accept EN fallback for untranslated tracks. Relaxed the assertion with a documented `UK_EN_FALLBACK_HREFS` allowlist. Both EN fallback targets verified to exist; both UK dirs verified absent. The issue listed only `/ai/`; the test surfaced the `/ai-ml-engineering/` sibling, so I allowlisted **both** (sibling-grep).

### 2. vitest ran nowhere in CI → new gate
That's *why* a red test sat on `main` (same class as the render gate #1961). New `.github/workflows/vitest-check.yml` mirrors `build-check.yml` exactly:
- SHA-pinned actions (`checkout` v6.0.3, `setup-node` v6.4.0), `persist-credentials: false`, `permissions: contents: read`
- No `paths:` filter → stable required check (avoids the CodeQL/#1742 permanently-BLOCKED trap)
- Fork-safe (no secrets, no write scope)
- Rebuilds `esbuild` (vitest's TS transform; `.npmrc` sets `ignore-scripts=true`)

> Named `vitest-check.yml` not `test-check.yml`: `.gitignore`'s broad `test-*` pattern silently ignores any `test-*` basename — a latent footgun noted in #1965.

## Verification
- `npm test`: **51 passed** ✅
- `eslint tests/homepage-i18n.test.ts`: clean
- `uvx zizmor --offline --strict-collection .github/`: **No findings**
- This PR **self-verifies**: the new `Unit tests (vitest)` check runs on its own PR.

## Acceptance Criteria (#1965)
- [x] Decide (a)/(b)/(c) for the `/ai/` UK fallback; fix so `npm test` is green
- [x] Add a `vitest` PR gate (mirror `build-check.yml`)
- [x] `npm run check` components green (build/test/lint/site-health)

After merge: make **Unit tests (vitest)** a required check (admin setting).

Refs #1965

🤖 Generated with [Claude Code](https://claude.com/claude-code)