### PR TITLE
content(platform): expand advanced-networking 1.6-zero-trust → T0 (closes Platform Foundations) (#1952)

### DIFF
--- a/src/content/docs/platform/foundations/advanced-networking/module-1.6-zero-trust.md
+++ b/src/content/docs/platform/foundations/advanced-networking/module-1.6-zero-trust.md
@@ -27,7 +27,7 @@ After completing this module, you will be able to design, evaluate, implement, a
 
 In 2020, the SolarWinds supply-chain compromise reached nearly 18,000 organizations that received the compromised Orion updates; the attackers then selected a much smaller, high-value subset (around 100) for active follow-on intrusion — not by breaking firewalls at scale, but by exploiting implicit trust once inside selected targets. <!-- incident-xref: solarwinds-2020 --> For the full case study, see [CI/CD Pipelines](../../../prerequisites/modern-devops/module-1.3-cicd-pipelines/).
 
-The SolarWinds breach was not the first time the perimeter model failed catastrophically, but it became the definitive case study for why "trust the network" is a fundamentally broken security model. It accelerated a shift that had been building for years: the move to **Zero Trust**, where no user, device, or network location is inherently trusted, and every access request must be explicitly verified.
+That breach was not the first time the perimeter model failed catastrophically, but it became the definitive case study for why "trust the network" is a fundamentally broken security model. It accelerated a shift that had been building for years: the move to **Zero Trust**, where no user, device, or network location is inherently trusted, and every access request must be explicitly verified.
 
 This module covers the principles, architectures, and practical implementations of Zero Trust networking — the model that replaces VPNs, firewalls-as-security, and the assumption that "inside the network" means "safe." You will learn durable patterns that survive vendor churn: identity-aware proxies, mutual TLS for workloads, device posture gates, and the policy layering that makes deny-by-default operational rather than theoretical.
 
@@ -88,7 +88,7 @@ flowchart TD
     end
 ```
 
-The perimeter failures repeat across retail breaches, credit bureau exposures, supply-chain compromises, and ransomware incidents where attackers never needed to defeat TLS at the edge because the interior never challenged them. A major retailer was breached via a third-party HVAC vendor's network access; a credit bureau was compromised through an unpatched internet-facing web framework; a fuel pipeline operator was hit by credential-based ransomware after remote-access VPN trust extended too far inside the network. Those patterns share a structural lesson with SolarWinds: attackers did not need novel zero-day exploits at the perimeter if interior systems accepted connections without re-authenticating the client. Retail POS networks, credit bureau web tiers, build pipelines, and fuel-distribution SCADA interfaces each trusted network placement more than cryptographic identity.
+The perimeter failures repeat across retail breaches, credit bureau exposures, supply-chain compromises, and ransomware incidents where attackers never needed to defeat TLS at the edge because the interior never challenged them. A major retailer was breached via a third-party HVAC vendor's network access; a credit bureau was compromised through an unpatched internet-facing web framework; a fuel pipeline operator was hit by credential-based ransomware after remote-access VPN trust extended too far inside the network. Those patterns share a structural lesson with that campaign: attackers did not need novel zero-day exploits at the perimeter if interior systems accepted connections without re-authenticating the client. Retail POS networks, credit bureau web tiers, build pipelines, and fuel-distribution SCADA interfaces each trusted network placement more than cryptographic identity.
 
 Documenting your own interior trust assumptions is the first deliverable in any Zero Trust program. Walk a single user journey—from laptop browser to Kubernetes API to etcd backup bucket—and note every hop that checks only source IP or VPC ID. Those hops are where IAP, mTLS, or signed service tokens pay off first because they remove implicit trust without waiting for a full VPN decommission project to finish.
 
@@ -99,7 +99,7 @@ WHY THIS FAILS
     1. LATERAL MOVEMENT
     ─────────────────────────────────────────────
     Once inside, attacker moves freely between systems.
-    SolarWinds: months of undetected lateral movement in
+    Supply-chain compromise: months of undetected lateral movement in
     actively compromised targets.
     Credential-based ransomware: one stolen VPN credential
     → operational shutdown of critical infrastructure.
@@ -1562,8 +1562,8 @@ Continue the Advanced Networking track with [Module 1.7: IPv6 Fundamentals](../m
 
 ## Sources
 
-- [CISA Advisory AA20-352A: Advanced Persistent Threat Compromise of Government Agencies, Critical Infrastructure, and Private Sector Organizations](https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-352a) — Documents the SolarWinds campaign, including the compromise timeline and U.S. attribution to Russia's SVR.
-- [FBI/CISA Joint Statement on SolarWinds](https://www.cisa.gov/news-events/news/joint-statement-federal-bureau-investigation-fbi-cybersecurity-and-infrastructure-security-agency-0) — Summarizes the scope of affected SolarWinds customers and the narrower set of follow-on compromise victims.
+- [CISA Advisory AA20-352A: Advanced Persistent Threat Compromise of Government Agencies, Critical Infrastructure, and Private Sector Organizations](https://www.cisa.gov/news-events/cybersecurity-advisories/aa20-352a) — Documents the 2020 Orion supply-chain campaign, including the compromise timeline and U.S. attribution to Russia's SVR.
+- [FBI/CISA Joint Statement on the 2020 supply-chain compromise](https://www.cisa.gov/news-events/news/joint-statement-federal-bureau-investigation-fbi-cybersecurity-and-infrastructure-security-agency-0) — Summarizes the scope of affected organizations and the narrower set of follow-on compromise victims.
 - [NIST SP 800-207: Zero Trust Architecture](https://csrc.nist.gov/pubs/sp/800/207/final) — Defines zero-trust terminology, principles, and reference deployment models in the primary standards document.
 - [Google Cloud Identity-Aware Proxy Documentation](https://cloud.google.com/iap/docs) — Describes Google Cloud IAP as a context-aware access layer for services such as Cloud Run, App Engine, Compute Engine, and GKE.
 - [RFC 8446: TLS 1.3](https://www.rfc-editor.org/rfc/rfc8446.html) — Specifies TLS 1.3 handshake behavior, including server authentication and optional client-certificate authentication.

--- a/src/content/docs/platform/foundations/advanced-networking/module-1.6-zero-trust.md
+++ b/src/content/docs/platform/foundations/advanced-networking/module-1.6-zero-trust.md
@@ -25,7 +25,7 @@ After completing this module, you will be able to design, evaluate, implement, a
 
 ---
 
-In 2020, the SolarWinds supply-chain compromise reached nearly 18,000 organizations that received the compromised Orion updates; the attackers then selected a much smaller, high-value subset (around 100) for active follow-on intrusion — not by breaking firewalls at scale, but by exploiting implicit trust once inside selected targets. <!-- incident-xref: solarwinds-2020 --> For the full case study, see [CI/CD Pipelines](../../../prerequisites/modern-devops/module-1.3-cicd-pipelines/).
+In 2020, the SolarWinds supply-chain compromise <!-- incident-xref: solarwinds-2020 --> spread a backdoored software update to nearly 18,000 organizations; the attackers then moved freely inside the much smaller set they chose to exploit, because interior systems trusted network location over verified identity. For the full case study, see [CI/CD Pipelines](../../../prerequisites/modern-devops/module-1.3-cicd-pipelines/).
 
 That breach was not the first time the perimeter model failed catastrophically, but it became the definitive case study for why "trust the network" is a fundamentally broken security model. It accelerated a shift that had been building for years: the move to **Zero Trust**, where no user, device, or network location is inherently trusted, and every access request must be explicitly verified.
 

--- a/src/content/docs/platform/foundations/advanced-networking/module-1.6-zero-trust.md
+++ b/src/content/docs/platform/foundations/advanced-networking/module-1.6-zero-trust.md
@@ -25,7 +25,7 @@ After completing this module, you will be able to design, evaluate, implement, a
 
 ---
 
-In 2020, the SolarWinds supply-chain compromise allowed attackers to move laterally across 18,000 customer networks for months — not by breaking firewalls, but by exploiting implicit trust once inside. <!-- incident-xref: solarwinds-2020 --> For the full case study, see [CI/CD Pipelines](../../../prerequisites/modern-devops/module-1.3-cicd-pipelines/).
+In 2020, the SolarWinds supply-chain compromise reached nearly 18,000 organizations that received the compromised Orion updates; the attackers then selected a much smaller, high-value subset (around 100) for active follow-on intrusion — not by breaking firewalls at scale, but by exploiting implicit trust once inside selected targets. <!-- incident-xref: solarwinds-2020 --> For the full case study, see [CI/CD Pipelines](../../../prerequisites/modern-devops/module-1.3-cicd-pipelines/).
 
 The SolarWinds breach was not the first time the perimeter model failed catastrophically, but it became the definitive case study for why "trust the network" is a fundamentally broken security model. It accelerated a shift that had been building for years: the move to **Zero Trust**, where no user, device, or network location is inherently trusted, and every access request must be explicitly verified.
 
@@ -45,7 +45,7 @@ That world is gone. Your developers work from home, coffee shops, and co-working
 
 Zero Trust is not a product you buy. It's an architectural principle: **never trust, always verify**. [Every request is authenticated and authorized regardless of network location](https://csrc.nist.gov/pubs/sp/800/207/final). Every connection is encrypted. Every access decision considers user identity, device health, application context, and risk signals — not just "are you on the corporate network?"
 
-For platform engineers, Zero Trust changes how you architect access to Kubernetes dashboards, internal tools, databases, and cloud consoles. It replaces VPNs with identity-aware proxies. It replaces network segmentation with application-level authorization. And it provides better security with a better user experience when implemented as a coherent program rather than a single product purchase.
+For platform engineers, Zero Trust changes how you architect access to Kubernetes dashboards, internal tools, databases, and cloud consoles. It replaces VPNs with identity-aware proxies. It augments network segmentation with application-level authorization. And it provides better security with a better user experience when implemented as a coherent program rather than a single product purchase.
 
 The same engineering discipline that makes load balancers and DNS policies auditable applies here: every allow decision should cite a policy version, every deny should log enough context to replay in an incident review, and every exception should expire automatically. Zero Trust is not less convenient than VPN by necessity—it is less convenient only when teams skip the SSO integration work and bolt a proxy onto legacy basic-auth applications without cleaning up the trust assumptions underneath.
 
@@ -88,7 +88,7 @@ flowchart TD
     end
 ```
 
-The perimeter failures include two canonical case studies: the [2013 Target breach](../security-principles/module-4.2-defense-in-depth/)<!-- incident-xref: target-2013 --> and the [2017 Equifax breach](../../../prerequisites/cloud-native-101/module-1.2-docker-fundamentals/)<!-- incident-xref: equifax-2017 --> — both covered in depth in their canonical modules. Those incidents share a structural lesson with SolarWinds and Colonial Pipeline: attackers did not need novel zero-day exploits at the perimeter if interior systems accepted connections without re-authenticating the client. Retail POS networks, credit bureau web tiers, build pipelines, and fuel-distribution SCADA interfaces each trusted network placement more than cryptographic identity.
+The perimeter failures repeat across retail breaches, credit bureau exposures, supply-chain compromises, and ransomware incidents where attackers never needed to defeat TLS at the edge because the interior never challenged them. A major retailer was breached via a third-party HVAC vendor's network access; a credit bureau was compromised through an unpatched internet-facing web framework; a fuel pipeline operator was hit by credential-based ransomware after remote-access VPN trust extended too far inside the network. Those patterns share a structural lesson with SolarWinds: attackers did not need novel zero-day exploits at the perimeter if interior systems accepted connections without re-authenticating the client. Retail POS networks, credit bureau web tiers, build pipelines, and fuel-distribution SCADA interfaces each trusted network placement more than cryptographic identity.
 
 Documenting your own interior trust assumptions is the first deliverable in any Zero Trust program. Walk a single user journey—from laptop browser to Kubernetes API to etcd backup bucket—and note every hop that checks only source IP or VPC ID. Those hops are where IAP, mTLS, or signed service tokens pay off first because they remove implicit trust without waiting for a full VPN decommission project to finish.
 
@@ -99,9 +99,10 @@ WHY THIS FAILS
     1. LATERAL MOVEMENT
     ─────────────────────────────────────────────
     Once inside, attacker moves freely between systems.
-    SolarWinds: 9 months of undetected lateral movement.
-    Colonial Pipeline: One compromised VPN credential
-    → ransomware shut down US fuel supply.
+    SolarWinds: months of undetected lateral movement in
+    actively compromised targets.
+    Credential-based ransomware: one stolen VPN credential
+    → operational shutdown of critical infrastructure.
 
     2. VPN = FULL NETWORK ACCESS
     ─────────────────────────────────────────────
@@ -122,14 +123,20 @@ WHY THIS FAILS
     10 employees in one office: trust works.
     10,000 employees in 50 countries with BYOD: trust breaks.
 
-BREACHES CAUSED BY PERIMETER TRUST
+BREACHES CAUSED BY PERIMETER TRUST (PATTERNS)
 ─────────────────────────────────────────────────────────────
-    2013: Target — third-party vendor access contributed to a major retail breach affecting tens of millions of customers
-    2017: Equifax — an internet-facing web application flaw exposed personal data for well over 100 million people
-    2020: SolarWinds — a supply-chain compromise reached multiple government and private-sector networks
-    2021: Colonial Pipeline — a remote-access compromise and ransomware incident disrupted fuel distribution
-    2023: MGM Resorts — social engineering triggered a disruptive cyber incident with major operational and financial consequences
-    2023: Okta — Employee laptop → customer support systems
+    Third-party vendor access → major retail breach affecting
+    tens of millions of customers
+    Unpatched internet-facing web application → credit bureau
+    exposure of well over 100 million personal records
+    Supply-chain compromise → trojanized updates reaching
+    thousands of downstream organizations
+    Stolen remote-access credentials → ransomware disrupting
+    fuel distribution operations
+    Social engineering against IT help desk → disruptive
+    cyber incident with major operational and financial impact
+    Compromised employee laptop → lateral movement into
+    customer-facing support systems
 ```
 
 The perimeter model treats the corporate network as a single trust zone. Once a packet crosses the firewall, routing and application layers often assume the sender is legitimate. That assumption made sense when every employee sat at a desk on a managed LAN and every server lived in the same datacenter rack. It collapses the moment your attack surface spans SaaS logins, contractor laptops, CI runners in ephemeral cloud VMs, and Kubernetes API servers reachable from half a dozen ingress paths.
@@ -395,7 +402,7 @@ Inside the cluster, complement north-south IAP controls with east-west defaults 
 | Primary layer | HTTP/TCP application proxy | Edge-terminated HTTP/SSH/TCP | L3/L4 mesh VPN with ACLs | Load-balancer-integrated HTTP |
 | Typical deployment | Kubernetes or VM in your VPC | Agent (`cloudflared`) + edge PoPs | Agent on each device/server | GCP LB policy attachment |
 | Identity integration | OIDC/SAML from any IdP | OIDC/SAML from any IdP | SSO + ACL tags | Google/Cloud Identity |
-| Best fit when | You need data sovereignty and per-route YAML policies | You want zero ingress ports and global edge auth | You need arbitrary TCP/UDP between many hosts | You already run services on GCP |
+| Best fit when | You need data sovereignty and per-route YAML policies | You want zero ingress ports and global edge auth | You need arbitrary TCP between many hosts | You already run services on GCP |
 
 The comparison table captures **capabilities**, not rankings. Teams frequently run more than one column simultaneously: mesh overlay for engineer SSH, managed SSE for SaaS-like internal tools, and mesh mTLS inside the cluster.
 
@@ -425,7 +432,7 @@ CLOUDFLARE ACCESS (Managed)
     Auth:           OIDC, SAML, GitHub, Google, Okta, Azure AD
     Deployment:     Cloudflare edge (managed) + Tunnel agent
     Device Trust:   Cloudflare WARP client
-    Protocol:       HTTP, SSH, RDP, arbitrary TCP/UDP
+    Protocol:       HTTP, SSH, RDP, arbitrary TCP
     Pricing:        Free (up to 50 users), then per-seat
 
     Strengths:
@@ -463,14 +470,16 @@ TAILSCALE (WireGuard-Based)
     Auth:           SSO integration (Google, Microsoft, Okta)
     Deployment:     Agent on each device/server
     Protocol:       Any IP traffic (full network layer)
-    Device Trust:   Tailscale manages device identity
+    Device Trust:   Tailscale coordinates device identity
     Pricing:        Free personal tier, then per-seat plans
 
     Architecture:
     ─────────────────────────────────────────────
     Every device runs Tailscale agent.
-    Devices connect peer-to-peer via WireGuard.
-    Coordination server (hosted or self-hosted) manages keys.
+    Devices connect peer-to-peer via WireGuard when possible.
+    Coordination server distributes public keys and helps
+    endpoints discover each other (private keys never leave
+    the device).
 ```
 
 ```mermaid
@@ -497,7 +506,9 @@ flowchart LR
       ]
     }
 
-    [+] True peer-to-peer (no traffic through central server)
+    [+] Peer-to-peer WireGuard when direct paths exist (DERP
+        relay servers carry encrypted traffic when NAT or
+        firewall rules block a direct connection)
     [+] Works for ANY protocol (not just HTTP)
     [+] NAT traversal built-in (works from any network)
     [+] MagicDNS (hostname resolution for all devices)
@@ -566,11 +577,10 @@ sequenceDiagram
     participant Client
     participant Server
     
-    Client->>Server: "Hello"
-    Server-->>Client: Certificate (server.crt)
+    Client->>Server: ClientHello (key shares)
+    Server-->>Client: ServerHello + certificate
     Note over Client: Verify server cert<br/>(Is it signed by trusted CA?)
-    Client->>Server: Generate session key
-    Note over Server: Decrypt with private key
+    Note over Client,Server: (EC)DHE key agreement<br/>derives shared traffic secrets
     Note over Client,Server: ─── Encrypted communication begins ───
 ```
 
@@ -629,10 +639,13 @@ WHERE mTLS IS USED
     Cloudflare → [client cert] → Your Origin
     (Prevents direct-to-origin attacks bypassing CDN/WAF)
 
-    4. DIRECT CONNECT / PRIVATE INTERCONNECTION
+    4. SERVICE-TO-SERVICE mTLS (INTERNAL APIs)
     ─────────────────────────────────────────────
-    Cloud provider and customer authenticate each other
-    on dedicated interconnect links.
+    Internal microservices present client certificates to
+    each other or to an API gateway that enforces mTLS.
+
+    payments-svc → [client cert] → ledger-api
+    Gateway verifies cert is signed by your private CA.
 
     5. ZERO TRUST SERVICE-TO-SERVICE
     ─────────────────────────────────────────────
@@ -679,7 +692,7 @@ Meshless mTLS is viable when you cannot justify a full Istio control plane. Side
 
 For machine identity, treat certificates like API keys that expire quickly. A one-year TLS cert on an internal service is a latent breach window; a twenty-four-hour cert limits attacker utility and forces you to build the automation you needed anyway for GitOps-driven clusters. Auditors and incident responders also benefit: every issuance event in Vault or SPIRE logs maps to a service account or namespace, making blast-radius analysis faster than grep-ing nginx access logs for mystery IPs.
 
-Service meshes remain the most common on-ramp to mTLS inside Kubernetes, but they are not mandatory. Teams allergic to sidecars can terminate mTLS at ingress gateways and enforce client certificates on admin APIs while keeping stateless microservices on plain HTTP behind NetworkPolicy. The wrong choice is skipping machine identity entirely because Istio feels heavyweight—pick SPIRE, cert-manager with Let's Encrypt private CAs, or cloud KMS-backed issuers that match your operational maturity, then grow into full mesh when east-west traffic justifies the control-plane cost.
+Service meshes remain the most common on-ramp to mTLS inside Kubernetes, but they are not mandatory. Teams allergic to sidecars can terminate mTLS at ingress gateways and enforce client certificates on admin APIs while keeping stateless microservices on plain HTTP behind NetworkPolicy. The wrong choice is skipping machine identity entirely because Istio feels heavyweight—pick SPIRE, cert-manager with a private CA issuer (Vault PKI or an internal CA), or cloud KMS-backed issuers that match your operational maturity, then grow into full mesh when east-west traffic justifies the control-plane cost.
 
 ---
 
@@ -821,7 +834,7 @@ VPN REPLACEMENT PATTERNS
 PATTERN 1: IDENTITY-AWARE PROXY FOR WEB APPS
 ─────────────────────────────────────────────────────────────
 Replace: VPN → Internal web applications
-With:    IAP (Pomerium/Cloudflare Access) in front of apps
+With:    Identity-aware proxy (IAP) in front of apps
 
     Before:
     User → VPN → Corporate network → App (http://internal-app:8080)
@@ -839,46 +852,47 @@ With:    IAP (Pomerium/Cloudflare Access) in front of apps
 PATTERN 2: TUNNEL FOR NON-HTTP SERVICES
 ─────────────────────────────────────────────────────────────
 Replace: VPN → SSH to servers, database access
-With:    Tailscale/Cloudflare Tunnel + ACLs
+With:    Mesh overlay or managed tunnel + ACLs
 
     Before:
     User → VPN → ssh jump-host → ssh prod-server
     User → VPN → psql -h db.internal:5432
 
-    After (Tailscale):
-    User → ssh prod-server.tailnet.ts.net
-    User → psql -h db.tailnet.ts.net:5432
-
+    After (mesh overlay):
+    User → encrypted overlay hostname for prod-server
+    User → encrypted overlay hostname for database
     ACLs control who can reach which services.
     No jump hosts. No VPN. Direct encrypted access.
 
-    After (Cloudflare Tunnel):
-    User → cloudflared access ssh --hostname ssh.company.com
-    User → cloudflared access tcp --hostname db.company.com:5432
+    After (managed SSE tunnel):
+    User → identity-verified SSH or TCP tunnel to hostname
+    Gateway verifies identity before establishing the tunnel.
 
-    Cloudflare Access verifies identity before
-    establishing the tunnel to the service.
+    (See the landscape snapshot in Part 3.2 for current
+    vendor-specific tunnel and mesh commands.)
 
 PATTERN 3: KUBERNETES ACCESS WITHOUT VPN
 ─────────────────────────────────────────────────────────────
 Replace: VPN → kubectl to private API server
 With:    Multiple options:
 
-    Option A: Teleport (with Kubernetes support)
+    Option A: Certificate-based access broker
     ─────────────────────────────────────────────
-    tsh kube login --cluster=prod
-    kubectl get pods  # Authenticated via SSO
+    SSO-authenticated kubectl via a broker that issues
+    short-lived credentials mapped to RBAC.
 
-    Option B: Tailscale Operator for Kubernetes
+    Option B: Mesh operator for Kubernetes
     ─────────────────────────────────────────────
-    Install Tailscale operator in cluster.
-    API server exposed on Tailscale network.
-    kubectl access with Tailscale ACLs.
+    Expose API server on an encrypted overlay network.
+    kubectl access governed by overlay ACLs.
 
-    Option C: IAP + kubectl proxy
+    Option C: IAP + OIDC kubeconfig
     ─────────────────────────────────────────────
-    Pomerium/Cloudflare Access in front of K8s API.
+    Identity-aware proxy in front of K8s API.
     Requires kubeconfig with OIDC auth.
+
+    (See the landscape snapshot in Part 3.2 for current
+    Teleport, Tailscale, and IAP integration patterns.)
 
 PATTERN 4: THIRD-PARTY/CONTRACTOR ACCESS
 ─────────────────────────────────────────────────────────────
@@ -1058,7 +1072,7 @@ Executive sponsorship matters because Zero Trust crosses organizational silos. N
    Zero Trust treats location as one context signal among many; passing device posture does not override an explicit geofence when production API access is high risk. The durable rationale is deny-by-default with auditable exceptions rather than implicit trust based on historical VPN convenience. A minimum break-glass process issues a time-boxed policy exception recorded in your change system, requires secondary approval from on-call security, forces hardware MFA for the session, and expires automatically—never a standing "travel VPN profile" that bypasses IAP policy permanently.
    </details>
 
-8. **Scenario: After deploying OAuth2 Proxy in front of an internal dashboard in kind, you verify that unauthenticated requests receive HTTP 403 while authenticated engineers reach the app. NetworkPolicy allows ingress only from the proxy pod. A teammate asks why you still need RBAC on the Kubernetes API server if NetworkPolicy already blocks lateral movement. What layered defense argument do you give?**
+8. **Scenario: After deploying OAuth2 Proxy with Dex in front of an internal dashboard in kind, you verify that unauthenticated requests receive HTTP 403 (or a redirect to SSO) while authenticated engineers reach the app with a valid session cookie. NetworkPolicy allows ingress only from the proxy pod. A teammate asks why you still need RBAC on the Kubernetes API server if NetworkPolicy already blocks lateral movement. What layered defense argument do you give?**
    <details>
    <summary>Answer</summary>
 
@@ -1069,9 +1083,11 @@ Executive sponsorship matters because Zero Trust crosses organizational silos. N
 
 ## Hands-On Exercise
 
-**Objective**: Deploy Pomerium as an Identity-Aware Proxy to protect a Kubernetes Dashboard with SSO authentication, demonstrating Zero Trust access without VPN.
+**Objective**: Deploy OAuth2 Proxy with an in-cluster Dex OIDC provider to protect an internal dashboard, demonstrating Zero Trust access without VPN.
 
-**Environment**: kind cluster with OAuth2 Proxy simulating IAP behavior and a mock OIDC provider workflow—sufficient to validate policy layering without provisioning a production IdP tenant for this exercise.
+**Environment**: kind cluster with Dex (minimal OIDC IdP), OAuth2 Proxy as the identity-aware proxy, and a programmatic test that completes the OIDC login flow to obtain a session cookie.
+
+**Lab credentials**: `engineer@company.com` / `demo` (static Dex user for this exercise only).
 
 ### Part 1: Create the Cluster (5 minutes)
 
@@ -1152,12 +1168,84 @@ spec:
 EOF
 ```
 
-### Part 3: Deploy OAuth2 Proxy as IAP Simulation (20 minutes)
+### Part 3: Deploy Dex as In-Cluster OIDC Provider (15 minutes)
+
+OAuth2 Proxy's OIDC provider requires a real `client-id`, `client-secret`, and issuer URL — `htpasswd_file` does not replace OIDC. For this lab, deploy Dex with a static password user and a static OAuth client so the full login flow runs without an external IdP.
 
 ```bash
-# Since we can't use a real IdP in a local lab, we'll deploy
-# OAuth2 Proxy with a built-in test provider to simulate IAP behavior.
+cat <<'EOF' | kubectl apply -f -
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: dex-config
+data:
+  config.yaml: |
+    issuer: http://dex:5556/dex
+    storage:
+      type: memory
+    web:
+      http: 0.0.0.0:5556
+    staticClients:
+      - id: oauth2-proxy
+        redirectURIs:
+          - 'http://iap-proxy/oauth2/callback'
+        name: oauth2-proxy
+        secret: lab-client-secret-32chars!
+    enablePasswordDB: true
+    staticPasswords:
+      - email: engineer@company.com
+        hash: "$2y$10$plHR9N7dMGAm11oy3oAYqO8wpUN.rloPqfBIfjmbETxkfosG5wlq."
+        username: engineer
+        userID: "08a8684b-db88-4b73-90a9-dda7459c5ba7"
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: dex
+  labels:
+    app: dex
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: dex
+  template:
+    metadata:
+      labels:
+        app: dex
+    spec:
+      containers:
+        - name: dex
+          image: ghcr.io/dexidp/dex:v2.41.1
+          args: ["dex", "serve", "/etc/dex/config.yaml"]
+          ports:
+            - containerPort: 5556
+          volumeMounts:
+            - name: dex-config
+              mountPath: /etc/dex
+      volumes:
+        - name: dex-config
+          configMap:
+            name: dex-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: dex
+spec:
+  selector:
+    app: dex
+  ports:
+    - port: 5556
+      targetPort: 5556
+EOF
 
+kubectl wait --for=condition=available deployment/dex --timeout=120s
+```
+
+### Part 4: Deploy OAuth2 Proxy as IAP (20 minutes)
+
+```bash
 cat <<'EOF' | kubectl apply -f -
 apiVersion: v1
 kind: ConfigMap
@@ -1165,47 +1253,22 @@ metadata:
   name: oauth2-proxy-config
 data:
   oauth2-proxy.cfg: |
-    # OAuth2 Proxy configuration
-    # In production, replace with real OIDC provider
-
-    # Listen address
     http_address = "0.0.0.0:4180"
-
-    # Upstream (the protected application)
     upstreams = ["http://internal-dashboard:80"]
-
-    # Use a built-in test provider for local demo
     provider = "oidc"
-    provider_display_name = "Company SSO (Simulated)"
-
-    # Cookie settings
+    provider_display_name = "Lab SSO (Dex)"
+    oidc_issuer_url = "http://dex:5556/dex"
+    client_id = "oauth2-proxy"
+    client_secret = "lab-client-secret-32chars!"
+    redirect_url = "http://iap-proxy/oauth2/callback"
     cookie_name = "_zero_trust_session"
     cookie_secret = "dGhpc2lzYXZlcnlzZWN1cmVzZWNyZXQ="
-    cookie_secure = false  # Only for lab! Use true in production
-
-    # In a real deployment, these would point to your IdP:
-    # client_id = "your-client-id"
-    # client_secret = "your-client-secret"
-    # oidc_issuer_url = "https://accounts.google.com"
-
-    # For this lab, we'll use htpasswd for local auth
-    # to demonstrate the proxy pattern
-    htpasswd_file = "/etc/oauth2-proxy/htpasswd"
-
-    # Headers passed to upstream (simulating IAP headers)
+    cookie_secure = false
+    email_domains = ["*"]
     set_xauthrequest = true
     pass_access_token = false
-
-    # Email domain restriction (simulating group-based access)
-    email_domains = ["*"]
-
-    # Skip the OIDC provider for local testing
-    skip_provider_button = true
-  htpasswd: |
-    # user: engineer@company.com, password: demo
-    engineer@company.com:$2y$10$xGj.FYiT0o8fPKSy.tXnZeN0Jl0VxQhHhGxxU7e/8.0.hGUq.iuy
-    # user: auditor@company.com, password: readonly
-    auditor@company.com:$2y$10$xGj.FYiT0o8fPKSy.tXnZeN0Jl0VxQhHhGxxU7e/8.0.hGUq.iuy
+    skip_provider_button = false
+    insecure_oidc_skip_issuer_verification = true
 ---
 apiVersion: apps/v1
 kind: Deployment
@@ -1228,12 +1291,6 @@ spec:
           image: quay.io/oauth2-proxy/oauth2-proxy:v7.7.1
           args:
             - --config=/etc/oauth2-proxy/oauth2-proxy.cfg
-            - --skip-oidc-discovery
-            - --login-url=http://localhost:4180/sign_in
-            - --redeem-url=http://localhost:4180/sign_in
-            - --oidc-jwks-url=http://localhost:4180
-            - --htpasswd-user-group=engineer@company.com:engineering
-            - --htpasswd-user-group=auditor@company.com:audit
           ports:
             - containerPort: 4180
           volumeMounts:
@@ -1255,12 +1312,15 @@ spec:
     - port: 80
       targetPort: 4180
 EOF
+
+kubectl wait --for=condition=available deployment/iap-proxy --timeout=120s
 ```
 
-### Part 4: Demonstrate the Zero Trust Access Pattern (15 minutes)
+### Part 5: Demonstrate the Zero Trust Access Pattern (15 minutes)
+
+The test pod uses `curl` to show the difference between unauthenticated and authenticated access. Unauthenticated requests hit the IAP sign-in challenge; authenticated requests complete the Dex OIDC flow (login + consent approval) and reuse the resulting session cookie.
 
 ```bash
-# Deploy a test client to demonstrate the access pattern
 cat <<'EOF' | kubectl apply -f -
 apiVersion: v1
 kind: ConfigMap
@@ -1269,6 +1329,9 @@ metadata:
 data:
   test.sh: |
     #!/bin/sh
+    set -e
+    COOKIE_JAR=/tmp/cookies.txt
+
     echo "============================================"
     echo "  Zero Trust Access Pattern Demonstration"
     echo "============================================"
@@ -1277,37 +1340,44 @@ data:
     echo "=== Test 1: Direct access to internal dashboard ==="
     echo "    (Simulates: attacker on the network)"
     echo ""
-    STATUS=$(wget -q -O /dev/null -S http://internal-dashboard 2>&1 | grep "HTTP/" | awk '{print $2}')
+    STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://internal-dashboard/ || echo "000")
     echo "    Direct access: HTTP $STATUS"
-    echo "    WARNING: In production, internal-dashboard would NOT be"
-    echo "    accessible without going through the IAP."
-    echo "    NetworkPolicy would block direct access."
+    echo "    In production, NetworkPolicy blocks direct access."
     echo ""
 
-    echo "=== Test 2: Access through IAP without credentials ==="
+    echo "=== Test 2: IAP access without credentials ==="
     echo "    (Simulates: unauthenticated user)"
     echo ""
-    STATUS=$(wget -q -O /dev/null -S http://iap-proxy 2>&1 | grep "HTTP/" | awk '{print $2}')
-    echo "    IAP without auth: HTTP $STATUS"
-    echo "    Expected: 403 or redirect to login"
+    UNAUTH=$(curl -s -o /dev/null -w "%{http_code}" http://iap-proxy/)
+    echo "    IAP without session cookie: HTTP $UNAUTH"
+    echo "    Expected: 403 sign-in challenge or 302 redirect to SSO"
+    case "$UNAUTH" in 403|302|401) echo "    Result: blocked as expected" ;; *) echo "    WARNING: unexpected status"; exit 1 ;; esac
     echo ""
 
-    echo "=== Test 3: IAP with valid credentials ==="
+    echo "=== Test 3: IAP with valid OIDC session ==="
     echo "    (Simulates: authenticated engineer)"
     echo ""
-    RESPONSE=$(wget -q -O - http://iap-proxy/ 2>/dev/null || echo "Authentication required")
-    echo "    Response: $(echo $RESPONSE | head -c 100)..."
+    rm -f "$COOKIE_JAR"
+    curl -s -c "$COOKIE_JAR" -b "$COOKIE_JAR" -D /tmp/oauth-start.hdr -o /dev/null \
+      "http://iap-proxy/oauth2/start?rd=%2F"
+    DEX_AUTH=$(grep -i "^location:" /tmp/oauth-start.hdr | tr -d '\r' | awk '{print $2}')
+    curl -s -c "$COOKIE_JAR" -b "$COOKIE_JAR" -o /tmp/dex-login.html -L --max-redirs 2 "$DEX_AUTH"
+    LOGIN_ACTION=$(grep -o 'action="[^"]*"' /tmp/dex-login.html | head -1 | sed 's/action="//;s/"$//;s/&amp;/\&/g')
+    case "$LOGIN_ACTION" in /*) LOGIN_ACTION="http://dex:5556$LOGIN_ACTION";; esac
+    curl -s -c "$COOKIE_JAR" -b "$COOKIE_JAR" -D /tmp/dex-post.hdr -o /dev/null --max-redirs 0 \
+      -X POST "$LOGIN_ACTION" -d "login=engineer@company.com&password=demo"
+    APPROVAL_URL=$(grep -i "^location:" /tmp/dex-post.hdr | tr -d '\r' | awk '{print $2}')
+    case "$APPROVAL_URL" in /*) APPROVAL_URL="http://dex:5556$APPROVAL_URL";; esac
+    curl -s -c "$COOKIE_JAR" -b "$COOKIE_JAR" -D /tmp/dex-approve.hdr -o /dev/null --max-redirs 0 \
+      -X POST "$APPROVAL_URL" -d "approval=approve"
+    CALLBACK_URL=$(grep -i "^location:" /tmp/dex-approve.hdr | tr -d '\r' | awk '{print $2}')
+    curl -s -c "$COOKIE_JAR" -b "$COOKIE_JAR" -L --max-redirs 3 -o /dev/null "$CALLBACK_URL"
+    AUTH_BODY=$(curl -s -b "$COOKIE_JAR" http://iap-proxy/)
+    echo "$AUTH_BODY" | grep -q "Internal Kubernetes Dashboard" && echo "    Authenticated access: OK" || { echo "    Authenticated access: FAILED"; exit 1; }
     echo ""
 
     echo "=== Architecture Summary ==="
-    echo ""
-    echo "    Traditional (VPN):"
-    echo "    User → VPN → Network → Dashboard (anyone on network can access)"
-    echo ""
-    echo "    Zero Trust (IAP):"
-    echo "    User → IAP → (auth + device + policy) → Dashboard"
-    echo "    (only authenticated, authorized users with trusted devices)"
-    echo ""
+    echo "    Zero Trust (IAP): User → IAP → (OIDC auth) → Dashboard"
     echo "============================================"
 ---
 apiVersion: v1
@@ -1317,7 +1387,7 @@ metadata:
 spec:
   containers:
     - name: demo
-      image: busybox:1.37
+      image: curlimages/curl:8.11.1
       command: ["/bin/sh", "/scripts/test.sh"]
       volumeMounts:
         - name: scripts
@@ -1330,12 +1400,12 @@ spec:
         defaultMode: 0755
 EOF
 
-# View the demonstration output
-kubectl wait --for=condition=complete pod/zt-demo --timeout=60s 2>/dev/null
+kubectl wait --for=condition=Ready pod/zt-demo --timeout=120s
+kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/zt-demo --timeout=120s
 kubectl logs zt-demo
 ```
 
-### Part 5: Deploy NetworkPolicy (True Zero Trust) (15 minutes)
+### Part 6: Deploy NetworkPolicy (True Zero Trust) (15 minutes)
 
 ```bash
 # In true Zero Trust, the dashboard is ONLY accessible through the IAP.
@@ -1400,7 +1470,7 @@ echo "Note: NetworkPolicy enforcement requires a CNI that supports it"
 echo "(Calico, Cilium, etc.). kind's default CNI (kindnet) has limited support."
 ```
 
-### Part 6: Examine the Zero Trust Architecture (10 minutes)
+### Part 7: Examine the Zero Trust Architecture (10 minutes)
 
 ```bash
 # Review the full architecture
@@ -1457,8 +1527,10 @@ kind delete cluster --name zero-trust-lab
 **Success Criteria**: Complete each checkpoint below to confirm the lab demonstrated identity-aware access rather than merely deploying containers—the distinction matters when you translate the pattern to production IAP policy.
 
 - [ ] Internal dashboard deployed and serving content
-- [ ] IAP proxy deployed as the authentication gateway
-- [ ] Understood that unauthenticated requests are rejected by the IAP
+- [ ] Dex OIDC provider deployed with static lab user
+- [ ] OAuth2 Proxy deployed and connected to Dex
+- [ ] Unauthenticated requests blocked by IAP (403 or SSO redirect)
+- [ ] Authenticated session reaches dashboard after OIDC login
 - [ ] NetworkPolicy deployed to restrict direct dashboard access
 - [ ] Understood the architectural difference between VPN and IAP patterns
 - [ ] Recognized that the IAP sets identity headers (X-Auth-User, JWT) for the backend
@@ -1475,7 +1547,7 @@ Before moving on, ensure you understand:
 - [ ] **The perimeter model fails because there is no perimeter**: Cloud, remote work, SaaS, and mobile devices make "inside the network" meaningless as a trust signal
 - [ ] **Zero Trust verifies every request**: Identity, device, application, context, and risk are evaluated for every access decision, not just at the gate
 - [ ] **Identity-Aware Proxies replace VPNs for web apps**: Users get SSO access to specific applications without network-level access. Better security AND better UX
-- [ ] **Tailscale/WireGuard replaces VPN for non-HTTP**: When you need TCP/UDP access (databases, SSH), mesh VPN with ACLs provides per-service access control
+- [ ] **Mesh VPN overlays replace VPN for non-HTTP**: When you need TCP access (databases, SSH), encrypted mesh overlays with ACLs provide per-service access control
 - [ ] **mTLS authenticates machines, not just humans**: Service-to-service communication must be authenticated and encrypted even on "internal" networks
 - [ ] **Device posture is part of access decisions**: An authenticated user on a compromised device is still a risk. OS version, encryption, and EDR status matter
 - [ ] **Conditional access creates tiered trust**: High-risk operations require managed devices + MFA + hardware keys; documentation access can be lighter

--- a/src/content/docs/platform/foundations/advanced-networking/module-1.6-zero-trust.md
+++ b/src/content/docs/platform/foundations/advanced-networking/module-1.6-zero-trust.md
@@ -3,6 +3,7 @@ title: "Module 1.6: Zero Trust Networking & VPN Alternatives"
 slug: platform/foundations/advanced-networking/module-1.6-zero-trust
 sidebar:
   order: 7
+revision_pending: false
 ---
 > **Complexity**: `[MEDIUM]`
 >
@@ -12,14 +13,15 @@ sidebar:
 >
 > **Track**: Foundations — Advanced Networking
 
-### What You'll Be Able to Do
+## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+After completing this module, you will be able to design, evaluate, implement, analyze, and deploy Zero Trust controls using the same vocabulary your security and platform peers use in architecture reviews:
 
 1. **Design** a zero trust architecture that replaces perimeter-based security with identity-aware, context-driven access controls
 2. **Evaluate** VPN alternatives (BeyondCorp-style proxies, ZTNA, service mesh mTLS) and justify which approach fits a given organizational context
 3. **Implement** micro-segmentation and continuous verification policies that limit lateral movement even after credential compromise
 4. **Analyze** existing network architectures to identify implicit trust assumptions and create a migration plan toward zero trust
+5. **Deploy** an identity-aware proxy in front of an internal application, wiring SSO authentication, device posture checks, and network-level enforcement without relying on a corporate VPN
 
 ---
 
@@ -27,7 +29,11 @@ In 2020, the SolarWinds supply-chain compromise allowed attackers to move latera
 
 The SolarWinds breach was not the first time the perimeter model failed catastrophically, but it became the definitive case study for why "trust the network" is a fundamentally broken security model. It accelerated a shift that had been building for years: the move to **Zero Trust**, where no user, device, or network location is inherently trusted, and every access request must be explicitly verified.
 
-This module covers the principles, architectures, and practical implementations of Zero Trust networking — the model that replaces VPNs, firewalls-as-security, and the assumption that "inside the network" means "safe."
+This module covers the principles, architectures, and practical implementations of Zero Trust networking — the model that replaces VPNs, firewalls-as-security, and the assumption that "inside the network" means "safe." You will learn durable patterns that survive vendor churn: identity-aware proxies, mutual TLS for workloads, device posture gates, and the policy layering that makes deny-by-default operational rather than theoretical.
+
+Each part builds on the previous one. Part 1 explains why perimeter trust fails in cloud-native environments. Part 2 introduces BeyondCorp as a reference shape. Parts 3 through 5 cover the three enforcement layers most platform teams deploy first—human access via IAP, machine access via mTLS, and device context via conditional access. Part 6 ties the patterns into a migration playbook you can adapt to your organization, followed by a hands-on lab that implements the IAP plus NetworkPolicy stack on kind.
+
+Platform engineers often inherit a patchwork of access paths: legacy VPN for databases, SSO for SaaS, shared SSH keys for break-glass, and cluster-admin kubeconfigs distributed through runbooks. Zero Trust consolidation does not mean eliminating diversity overnight—it means making every path explicit, logged, and revocable. When you present leadership with a single diagram showing enforcement points instead of a slide deck of vendor logos, you earn budget for the unglamorous work: certificate rotation, IdP group hygiene, and SIEM field normalization that determines whether the program survives its first audit.
 
 ---
 
@@ -39,7 +45,9 @@ That world is gone. Your developers work from home, coffee shops, and co-working
 
 Zero Trust is not a product you buy. It's an architectural principle: **never trust, always verify**. [Every request is authenticated and authorized regardless of network location](https://csrc.nist.gov/pubs/sp/800/207/final). Every connection is encrypted. Every access decision considers user identity, device health, application context, and risk signals — not just "are you on the corporate network?"
 
-For platform engineers, Zero Trust changes how you architect access to Kubernetes dashboards, internal tools, databases, and cloud consoles. It replaces VPNs with identity-aware proxies. It replaces network segmentation with application-level authorization. And it provides better security with a better user experience.
+For platform engineers, Zero Trust changes how you architect access to Kubernetes dashboards, internal tools, databases, and cloud consoles. It replaces VPNs with identity-aware proxies. It replaces network segmentation with application-level authorization. And it provides better security with a better user experience when implemented as a coherent program rather than a single product purchase.
+
+The same engineering discipline that makes load balancers and DNS policies auditable applies here: every allow decision should cite a policy version, every deny should log enough context to replay in an incident review, and every exception should expire automatically. Zero Trust is not less convenient than VPN by necessity—it is less convenient only when teams skip the SSO integration work and bolt a proxy onto legacy basic-auth applications without cleaning up the trust assumptions underneath.
 
 > **The Hotel Keycard Analogy**
 >
@@ -47,19 +55,11 @@ For platform engineers, Zero Trust changes how you architect access to Kubernete
 
 ---
 
-## What You'll Learn
-
-- The perimeter model's failure and the principles behind Zero Trust (BeyondCorp)
-- Identity-Aware Proxies: architecture and access decisions
-- mTLS beyond the service mesh: machine-to-machine authentication
-- Security Service Edge (SSE): Tailscale, Cloudflare Access, Zscaler
-- Device posture assessment and conditional access policies
-- Practical deployment patterns for protecting internal services
-- Hands-on: Protecting a Kubernetes dashboard with SSO using Pomerium
-
----
-
 ## Part 1: The Perimeter Model and Why It Failed
+
+Perimeter security dominated enterprise design for two decades because it matched how datacenters were physically wired: a DMZ for public services, a trusted interior for databases, and a firewall between them. That mental model still appears in runbooks written as "if the request originates inside the VPC, skip authentication." Cloud-native platforms inherit the same bug when security groups default to allow-all east-west traffic and engineers assume Kubernetes NetworkPolicy is optional until an audit fails.
+
+Understanding why the model failed is prerequisite to selling Zero Trust to stakeholders who remember when VPN plus firewall was "good enough." The failures are not anecdotal—they repeat across retail breaches, credit bureau exposures, supply-chain compromises, and ransomware incidents where attackers never needed to defeat TLS at the edge because the interior never challenged them.
 
 ### 1.1 The Castle-and-Moat Problem
 
@@ -88,7 +88,9 @@ flowchart TD
     end
 ```
 
-The perimeter failures include two canonical case studies: the [2013 Target breach](../security-principles/module-4.2-defense-in-depth/)<!-- incident-xref: target-2013 --> and the [2017 Equifax breach](../../../prerequisites/cloud-native-101/module-1.2-docker-fundamentals/)<!-- incident-xref: equifax-2017 --> — both covered in depth in their canonical modules.
+The perimeter failures include two canonical case studies: the [2013 Target breach](../security-principles/module-4.2-defense-in-depth/)<!-- incident-xref: target-2013 --> and the [2017 Equifax breach](../../../prerequisites/cloud-native-101/module-1.2-docker-fundamentals/)<!-- incident-xref: equifax-2017 --> — both covered in depth in their canonical modules. Those incidents share a structural lesson with SolarWinds and Colonial Pipeline: attackers did not need novel zero-day exploits at the perimeter if interior systems accepted connections without re-authenticating the client. Retail POS networks, credit bureau web tiers, build pipelines, and fuel-distribution SCADA interfaces each trusted network placement more than cryptographic identity.
+
+Documenting your own interior trust assumptions is the first deliverable in any Zero Trust program. Walk a single user journey—from laptop browser to Kubernetes API to etcd backup bucket—and note every hop that checks only source IP or VPC ID. Those hops are where IAP, mTLS, or signed service tokens pay off first because they remove implicit trust without waiting for a full VPN decommission project to finish.
 
 ```text
 WHY THIS FAILS
@@ -129,6 +131,16 @@ BREACHES CAUSED BY PERIMETER TRUST
     2023: MGM Resorts — social engineering triggered a disruptive cyber incident with major operational and financial consequences
     2023: Okta — Employee laptop → customer support systems
 ```
+
+The perimeter model treats the corporate network as a single trust zone. Once a packet crosses the firewall, routing and application layers often assume the sender is legitimate. That assumption made sense when every employee sat at a desk on a managed LAN and every server lived in the same datacenter rack. It collapses the moment your attack surface spans SaaS logins, contractor laptops, CI runners in ephemeral cloud VMs, and Kubernetes API servers reachable from half a dozen ingress paths.
+
+Lateral movement is the mechanism attackers exploit once that implicit trust exists. A stolen VPN credential or a compromised developer laptop does not need to break additional firewalls if east-west traffic inside the VPC is unauthenticated HTTP. The attacker pivots from a low-value staging pod to a production database because nothing at the network or application layer re-verifies identity on each hop. Micro-segmentation and per-request authorization exist precisely to break that pivot chain.
+
+Remote work, bring-your-own-device policies, and multi-cloud deployments removed the physical boundary the perimeter model depended on. Your "internal network" is now a graph of identities, certificates, and policy engines—not a VLAN you can draw on a whiteboard. Platform engineers feel this acutely when a security team asks for "VPN access to the cluster" while developers already reach the same API through three different ingress controllers, each with different authentication behavior.
+
+Zero Trust reframes the question from "which network are you on?" to "who are you, on what device, requesting access to which resource, under what risk signals right now?" The durable primitives—identity providers, device posture agents, identity-aware proxies, mutual TLS, and continuous policy evaluation—outlast any single vendor product. The sections that follow teach those primitives first and only then map them to current tools in a dated landscape snapshot.
+
+Incident response playbooks should assume attackers target your IAP and IdP integrations directly once VPN routes disappear. Phishing pages that mimic your SSO login, stolen refresh tokens, and compromised CI pipelines that mint valid OIDC tokens are the next wave after perimeter hardening. Pair technical controls with user education on recognizing IdP prompts and with detection rules on impossible OAuth grant patterns—Zero Trust shifts the adversary's focus from firewall rules to identity artifacts you must guard with equal rigor.
 
 ### 1.2 Zero Trust Principles
 
@@ -191,13 +203,21 @@ ZERO TRUST vs PERIMETER
     Monitoring          Perimeter logs     All access logged
 ```
 
-> **Stop and think**: Think about your own organization's current access model. Are there any internal systems that assume trust simply because you are connected to the corporate network or VPN? How would an attacker exploit that implicit trust?
+The comparison table above is the checklist for architecture reviews. When you read a design document, highlight every row where the proposed system still behaves like the perimeter column—full-network VPN profiles, shared admin passwords on internal UIs, or services that trust client IP without verifying identity. Each highlighted row is a migration ticket.
+
+Principle 1 (**verify explicitly**) means authentication and authorization happen at the enforcement point closest to the resource, not once at the VPN concentrator. Principle 2 (**least privilege**) means contractors receive documentation access without inheriting SSH keys to production nodes. Principle 3 (**assume breach**) means your monitoring budget assumes compromise has already occurred and optimizes for detection speed and blast-radius containment rather than perfect prevention alone.
+
+> **Stop and think**: Map every internal hostname your team reaches through VPN today—Grafana, Argo CD, Jenkins, the Kubernetes API, artifact registries, and runbook wikis. For each one, ask whether network location alone ever justified access, and what an identity-aware proxy would need to know (groups, device posture, MFA method) to make the same allow decision explicitly.
 
 ---
 
 ## Part 2: BeyondCorp — Google's Zero Trust Implementation
 
 ### 2.1 The BeyondCorp Model
+
+Google's public BeyondCorp writing describes a deliberate inversion: internal applications receive the same threat model as SaaS products on the public internet. There is no trusted interior VLAN—only authenticated sessions, device certificates, and policy decisions evaluated at the proxy. Google's scale is unusual, but the decomposition is portable. Small teams run the same shape with a single Pomerium deployment and an Okta tenant; enterprises add dedicated policy engines and SIEM pipelines without changing the core ask of every request.
+
+The access control engine aggregates signals that used to live in separate silos. HR identity from the IdP, device compliance from MDM, geolocation from IP reputation feeds, and application metadata from service catalogs feed one decision. When the engine denies access, the user sees a actionable error ("device encryption disabled") rather than a generic 403, which reduces help-desk load during rollout. When it allows access, downstream apps receive signed assertions they can verify independently—critical when multiple teams own different microservices behind the same ingress.
 
 ```text
 BEYONDCORP — ZERO TRUST AT GOOGLE SCALE
@@ -260,9 +280,25 @@ IMPACT
     Published in 2014 research papers, now industry standard.
 ```
 
+BeyondCorp is the reference architecture most teams cite when they say "Zero Trust networking," not because Google invented the idea, but because Google published enough detail for others to copy the shape. Four components recur in every serious deployment: an **access proxy** that terminates TLS and enforces policy inline, an **access control engine** that evaluates identity and context signals, a **device inventory** that knows which endpoints are managed and compliant, and a **trust inference** layer that scores risk from telemetry rather than from IP geolocation alone.
+
+The shift from network-location trust to identity-plus-device trust is the durable lesson. A developer on a managed laptop authenticating through SSO to reach an internal wiki is the same trust path whether they sit in headquarters or a hotel in another country. The proxy never asks "are you on the corporate VLAN?" It asks "does this OIDC token belong to an active employee, is the device certificate valid, and does policy allow this URL path?" That inversion is what makes Zero Trust portable across cloud regions and Kubernetes namespaces.
+
+When you design platform access, treat BeyondCorp as a pattern library rather than a product checklist. You might deploy Pomerium in front of Grafana, Cloudflare Access in front of a legacy PHP admin panel, and mesh mTLS between microservices—all in the same organization. The unifying idea is that each enforcement point makes an explicit allow/deny decision with enough logging to reconstruct an incident timeline months later.
+
+Operationalizing BeyondCorp also means investing in device inventory hygiene. A proxy that trusts device certificates without a revocation story recreates VPN weaknesses in X.509 form. Runbooks should cover certificate renewal on reinstalled laptops, offboarding contractors whose devices still appear in MDM, and emergency revocation when a fleet of managed machines shares a compromised root of trust. These processes are boring infrastructure work—and they determine whether Zero Trust survives your first real incident.
+
+Brownfield migrations should inventory authentication headers your applications already consume. Many internal Rails or Spring services read `REMOTE_USER` or custom headers set by an older reverse proxy. Mapping those headers to IAP-issued JWT claims reduces rewrite scope: the proxy changes, the application binary does not. Where applications parse headers unsafely, fix that before exposing them through a new IAP hostname—header injection bugs become critical when the proxy is the sole gate.
+
 ---
 
 ## Part 3: Identity-Aware Proxies
+
+Identity-aware proxies are the user-facing enforcement point in most Zero Trust rollouts. They terminate TLS from browsers, integrate with your IdP's OIDC or SAML flows, evaluate policy, and only then forward requests to upstream applications that may still speak plain HTTP inside the cluster. That last detail matters for brownfield migrations: you can protect legacy apps without rewriting them for OAuth if the proxy handles authentication and injects trusted headers the app already understands.
+
+Policy documents for IAPs should be version-controlled like application code. A policy change that accidentally grants contractors write access to production Grafana is a production incident waiting for the next business day. GitOps workflows—pull request review, automated diff in CI, staged rollout to staging hostnames—apply directly to Pomerium routes, Cloudflare Access applications, and Google IAP bindings even when the vendor UI also offers click-to-edit consoles.
+
+Testing IAP policies requires negative cases, not only happy-path SSO logins. Automated suites should assert that unauthenticated requests receive 401 or 403, that users outside required IdP groups cannot reach upstream paths, and that expired sessions cannot reuse stale cookies. Include a case where device posture fails—simulated by marking a test device non-compliant in MDM—to confirm deny messages are actionable for help-desk staff rather than opaque "access denied" strings with no remediation hint.
 
 ### 3.1 How Identity-Aware Proxies Work
 
@@ -340,7 +376,28 @@ HEADERS PASSED TO BACKEND
     implicitly. The backend validates the JWT signature.
 ```
 
+An identity-aware proxy differs from a VPN in scope and granularity. A VPN extends your internal routing table to a remote laptop; once connected, the user can often reach any RFC1918 address the firewall permits. An IAP exposes only the applications you front with it—typically over HTTPS—and evaluates policy per request. VPN access is network-level; IAP access is application-level. Both can use the same identity provider, but the blast radius of a stolen VPN session is usually much larger than a stolen IAP session scoped to one hostname.
+
+OIDC authorization-code flow with PKCE is the default integration pattern for browser-based IAP deployments in 2026. The proxy redirects unauthenticated users to the IdP, receives an authorization code on the registered callback URL, exchanges it for ID and access tokens server-side, and stores a session cookie scoped to the proxy hostname. SAML remains common in regulated industries where legacy assertions must map to mainframe or ERP systems; many teams run both protocols in parallel during multi-year migrations. Regardless of protocol, never forward raw tokens to upstream applications unless those applications validate audience, issuer, and expiry—prefer signed JWT assertions with narrow claims.
+
+The request flow always follows the same choreography even when vendors differ. The user hits the proxy URL, the proxy redirects unauthenticated sessions to the IdP, the IdP returns an OIDC authorization code or SAML assertion, and the proxy mints a session cookie or bearer token for subsequent requests. On each request the policy engine re-evaluates group membership, device posture, and optional risk scores before forwarding to the upstream. Backends that trust `X-Forwarded-*` headers without verifying a signed JWT assertion recreate the perimeter mistake at the application layer—always validate cryptographically.
+
+For Kubernetes platform teams, IAPs solve a recurring problem: the dashboard and metrics stack were never meant to face the public internet, yet engineers need them from home. Placing an IAP in front of the ingress—rather than opening a VPN route to the entire cluster API—limits exposure to one hostname and one policy document. Pair that with NetworkPolicy so only the proxy pod can reach the dashboard Service, and you have defense in depth without managing split-tunnel VPN profiles for every OS.
+
+Inside the cluster, complement north-south IAP controls with east-west defaults that deny all traffic except explicitly allowed paths. Kubernetes RBAC scopes who may impersonate service accounts or read Secrets cluster-wide; NetworkPolicy scopes which pods may dial which Services; Istio or Linkerd peer authentication scopes which workloads present valid client certificates. None of these layers replaces the others—auditors expect defense in depth, and attackers expect at least one layer to be misconfigured. Your architecture wins when misconfiguring a single layer still leaves two independent gates intact.
+
 ### 3.2 Major IAP Solutions
+
+> **Landscape snapshot — as of 2026-06. Vendor features, pricing tiers, and product names change quickly; verify against current documentation before relying on specifics.**
+
+| Capability | Self-hosted IAP (e.g. Pomerium) | Managed SSE gateway (e.g. Cloudflare Access) | Mesh overlay (e.g. Tailscale) | Cloud-native IAP (e.g. Google Cloud IAP) |
+|------------|--------------------------------|-----------------------------------------------|------------------------------|------------------------------------------|
+| Primary layer | HTTP/TCP application proxy | Edge-terminated HTTP/SSH/TCP | L3/L4 mesh VPN with ACLs | Load-balancer-integrated HTTP |
+| Typical deployment | Kubernetes or VM in your VPC | Agent (`cloudflared`) + edge PoPs | Agent on each device/server | GCP LB policy attachment |
+| Identity integration | OIDC/SAML from any IdP | OIDC/SAML from any IdP | SSO + ACL tags | Google/Cloud Identity |
+| Best fit when | You need data sovereignty and per-route YAML policies | You want zero ingress ports and global edge auth | You need arbitrary TCP/UDP between many hosts | You already run services on GCP |
+
+The comparison table captures **capabilities**, not rankings. Teams frequently run more than one column simultaneously: mesh overlay for engineer SSH, managed SSE for SaaS-like internal tools, and mesh mTLS inside the cluster.
 
 ```text
 IAP SOLUTIONS COMPARISON
@@ -474,11 +531,19 @@ ZSCALER PRIVATE ACCESS (ZPA) — Enterprise
     [-] Complex to deploy
 ```
 
+Security Service Edge (SSE) products bundle identity-aware access with other edge security functions, but the primitive you are buying is the same: an enforcement point that knows who the user is before packets reach your origin. Whether that enforcement runs on a global CDN edge, inside your cluster as a sidecar, or on a WireGuard interface is an operational tradeoff, not a different security model. Choose based on protocol needs (HTTP only versus arbitrary TCP), data residency requirements, and how much control you need over policy YAML versus a vendor console.
+
+Integrations with enterprise IdPs should be planned before vendor selection. If your organization standardizes on SAML for legacy apps and OIDC for cloud-native tooling, confirm the proxy supports both flows on the same hostname routes without forcing duplicate user records. Group membership propagation—engineering, sre-team, contractors—must map cleanly to policy rules; otherwise you will recreate role sprawl inside YAML files that are harder to audit than IdP group memberships alone.
+
+Session lifetime and step-up authentication belong in the same policy document as hostname routes. A common failure mode is configuring brilliant per-app rules while leaving refresh tokens valid for thirty days on shared kiosks. Pair short IAP session cookies with IdP conditional access so sensitive routes require fresh MFA even when the user already has a valid SSO session for email or chat applications.
+
 ---
 
-> **Pause and predict**: If Identity-Aware Proxies handle user-to-service authentication, how do headless microservices authenticate with each other? Without user intervention, how can a backend API guarantee the request came from the legitimate frontend service and not a rogue container?
+> **Pause and predict**: Before reading Part 4, sketch the trust boundaries in your cluster: which Services accept traffic from the internet via Ingress, which accept only in-cluster clients, and which Secrets or ConfigMaps those clients could read if mTLS were absent. That sketch becomes your micro-segmentation backlog.
 
 ## Part 4: mTLS Beyond the Service Mesh
+
+Human-facing Zero Trust gets the executive slides, but machine-to-machine authentication determines whether a compromised pod can harvest Secrets or pivot to the control plane. Every IAP deployment should have a paired story for service identity: how workloads prove themselves when no browser session exists, how certificates rotate without weekend maintenance windows, and how audit logs attribute API calls to SPIFFE IDs rather than ephemeral pod IPs.
 
 ### 4.1 Machine-to-Machine Authentication
 
@@ -608,9 +673,19 @@ CERTIFICATE MANAGEMENT AT SCALE
     Rotation: Less painful when automated and frequent.
 ```
 
+SPIFFE (Secure Production Identity Framework for Everyone) standardizes **workload identity** as a URI-shaped SPIFFE ID such as `spiffe://example.com/ns/prod/sa/payments`. SPIRE, the reference implementation, runs as an agent on each node, attests the workload (often via Kubernetes service account tokens), and issues short-lived X.509 SVID certificates bound to that identity. cert-manager and Vault PKI solve overlapping problems when you already standardized on those tools—the important design choice is automated rotation on a schedule measured in hours, not years.
+
+Meshless mTLS is viable when you cannot justify a full Istio control plane. Sidecar-less approaches attach certificates directly to applications or terminate mTLS at ingress gateways while still requiring client certificates for admin APIs. The operational cost shifts from "manage a mesh" to "manage a CA and issuance pipeline," which is why many platform teams centralize on Vault or cloud KMS-backed private CAs regardless of mesh adoption.
+
+For machine identity, treat certificates like API keys that expire quickly. A one-year TLS cert on an internal service is a latent breach window; a twenty-four-hour cert limits attacker utility and forces you to build the automation you needed anyway for GitOps-driven clusters. Auditors and incident responders also benefit: every issuance event in Vault or SPIRE logs maps to a service account or namespace, making blast-radius analysis faster than grep-ing nginx access logs for mystery IPs.
+
+Service meshes remain the most common on-ramp to mTLS inside Kubernetes, but they are not mandatory. Teams allergic to sidecars can terminate mTLS at ingress gateways and enforce client certificates on admin APIs while keeping stateless microservices on plain HTTP behind NetworkPolicy. The wrong choice is skipping machine identity entirely because Istio feels heavyweight—pick SPIRE, cert-manager with Let's Encrypt private CAs, or cloud KMS-backed issuers that match your operational maturity, then grow into full mesh when east-west traffic justifies the control-plane cost.
+
 ---
 
 ## Part 5: Device Posture and Conditional Access
+
+Device posture closes the gap between "correct password" and "safe endpoint." Phishing-resistant MFA stops credential theft at the IdP, but it cannot stop an engineer from authenticating on a family PC infected with credential-stuffing malware. Conditional access policies combine user identity with device signals so high-risk applications refuse sessions that would have sailed through a VPN concentrator because the tunnel itself was considered proof of trust.
 
 ### 5.1 Device Trust Assessment
 
@@ -713,11 +788,29 @@ IMPLEMENTATION
     Reports to Tailscale/Pomerium for policy decisions.
 ```
 
-> **Stop and think**: How would a conditional access policy handle a scenario where an authorized user logs in from a known, managed device, but their IP address originates from a country where your company does no business?
+Conditional access is where human identity meets device telemetry. Microsoft Entra ID, Google BeyondCorp Enterprise, and open-source proxies like Pomerium all consume the same signal categories even when the UI differs: Is disk encryption enabled? Is the OS within your patch window? Is an EDR agent reporting clean status? A policy that ignores device posture effectively says "any browser on any machine counts as corporate," which defeats the purpose of moving beyond VPN trust.
+
+Tiered trust lets you tune friction to risk. Read-only documentation might require only SSO from a managed device, while production `kubectl` access demands hardware MFA plus a device certificate issued by your MDM. Step-up authentication triggers when signals change mid-session—impossible travel, a new device fingerprint, or a spike in denied authorization attempts. Platform engineers should document which tier each internal tool requires so security reviews do not rediscover the matrix from scratch every quarter.
+
+When a user connects from a known managed device but the IP geolocates to a country where you have no employees, the durable response is deny-by-default with an explicit break-glass path—not silent allow because the device certificate looked fine. Log the decision with enough context (user, device ID, policy version, matched rule) to explain to auditors why access was blocked without asking them to trust a black-box score.
+
+Device posture agents differ from MDM enrollment checks. MDM confirms the device is registered in your fleet; posture agents report runtime state such as encryption status, firewall configuration, and EDR health. Both signals matter because a registered laptop with disabled disk encryption remains a high-risk endpoint for production access. Start with boolean gates in IAP policy, then evolve toward numeric risk scores once your telemetry pipeline matures enough to avoid false positives during patch cycles.
+
+Geolocation and impossible-travel rules should ship with documented break-glass workflows tied to change tickets. Permanent country allow-lists that bypass IAP recreate VPN-era trust assumptions under a different label. Time-boxed exceptions with executive approval on file satisfy auditors while keeping daily operations predictable for engineers who legitimately travel.
+
+Risk-based step-up authentication also applies inside long-lived platform sessions. An engineer who authenticated to a staging cluster eight hours ago should not inherit the same trust score when opening a production incident channel during a declared Sev-1. Proxies and IdPs that support incremental authentication—demanding hardware MFA only when crossing sensitivity tiers—reduce daily friction while preserving strict gates where database dumps or kube-admin credentials are in scope.
+
+> **Stop and think**: Draft a three-tier policy matrix for your organization—low sensitivity (internal docs), medium sensitivity (CI/CD and staging clusters), high sensitivity (production control plane and customer data stores). For each tier, specify minimum device posture, MFA type, session lifetime, and logging destination before selecting a vendor console to implement it.
 
 ---
 
 ## Part 6: Practical Zero Trust Patterns
+
+**Hypothetical scenario:** A platform team decommissions corporate VPN over a single weekend after buying an SSE license. Monday morning, database administrators cannot reach PostgreSQL because their GUI tools relied on split-tunnel RFC1918 routes, contractors lose access to legal-review portals that were never added to the IAP catalog, and on-call engineers discover that break-glass SSH still pointed at jump hosts removed from DNS. The technology worked; the migration sequencing did not.
+
+Avoid that failure mode by publishing a phased roadmap tied to application tiers. Phase one centralizes identity and enables MFA on every IdP-integrated app. Phase two fronts tier-one internal web properties with IAP and enables device posture on those same routes. Phase three enforces east-west mTLS or default-deny NetworkPolicy inside Kubernetes. Phase four retires VPN routes as each legacy dependency documents an alternative path. Each phase has measurable exit criteria—percentage of apps behind IAP, count of VPN sessions, percentage of namespaces with deny-all default—so leadership sees progress without mistaking license purchase for architecture change.
+
+Compliance frameworks increasingly ask for evidence of least privilege rather than checkbox firewall diagrams. SOC 2 and ISO 27001 auditors want to see who accessed production during a change window, whether contractors were time-boxed, and whether deny decisions were logged with enough context to replay. Zero Trust architectures produce that evidence as a byproduct when IAP and IdP logs feed a centralized SIEM with retention policies matching your regulatory obligations. Treat log schema design as part of the architecture—fields like `policy_id`, `device_posture_status`, and `auth_method` should be consistent across every enforcement point so correlation queries remain simple during quarterly access reviews.
 
 ### 6.1 Replacing VPN with Zero Trust
 
@@ -808,6 +901,20 @@ With:    Time-limited, app-specific access
     No network-level access. Only the specific application.
 ```
 
+Adoption rarely succeeds as a big-bang VPN replacement. Mature teams sequence the journey deliberately: consolidate identity with SSO and MFA everywhere, front the highest-risk internal apps with an IAP, introduce device posture checks for those same apps, roll out east-west mTLS or network policies inside Kubernetes, and only then declare the legacy VPN read-only before decommissioning it. Skipping straight to mesh mTLS while employees still share one VPN password for twelve legacy systems produces expensive certificates that nobody trusts in incident response.
+
+Start with applications that already hurt when accessed remotely—Kubernetes dashboards, internal Git hosting, on-call runbooks behind basic auth. Each IAP deployment teaches your IdP integration, header trust model, and logging pipeline before you tackle harder targets like mainframe terminal sessions or air-gapped build agents. Document every implicit trust assumption you remove; that list becomes the migration backlog your security champions can prioritize with product owners.
+
+The hands-on exercise later in this module walks through the IAP plus NetworkPolicy pattern on a kind cluster. The goal is not to memorize Pomerium YAML syntax—it is to internalize the layering: identity at the proxy, segmentation at the network policy, authorization at RBAC inside the API server. That three-layer pattern repeats whether your proxy is Pomerium, Cloudflare Access, or a cloud provider's native IAP integration.
+
+Contractor and third-party access deserves explicit mention because it is where VPN sprawl historically began. Instead of issuing shared contractor VPN profiles, issue IdP guest accounts with IAP routes scoped to single hostnames, automatic expiry aligned to contract end dates, and device posture requirements that match the sensitivity of the data being accessed. Legal and procurement teams often welcome this model because access revocation becomes an automated IdP lifecycle event rather than a ticket to network operations asking someone to delete a firewall rule at midnight.
+
+Logging and detection complete the pattern. Every deny decision should reach your SIEM with structured fields; every allow to production systems should correlate with change-management records when possible. Zero Trust without telemetry is merely expensive authentication—you cannot prove least privilege during audits or reconstruct lateral movement during incidents if proxy logs live only on a single VM's disk with thirty-day rotation.
+
+Runbooks for on-call engineers should document how to rotate IAP signing keys, how to disable a compromised IdP application registration, and which stakeholders approve emergency access when the primary proxy fails open versus fails closed. Those procedures rarely appear in vendor quick-start guides, yet they determine whether a Sev-1 lasts hours or days when authentication infrastructure itself is the incident.
+
+Treat break-glass accounts like production secrets: few in number, hardware-MFA protected, monitored with higher alert sensitivity, and reviewed weekly for stale permissions. Zero Trust programs fail reputational audits when emergency bypass accounts become the everyday login path for teams that never finished IAP rollout. Document every break-glass use in the same ticket system you use for production changes so auditors can correlate access spikes with approved incidents.
+
 ### 6.2 Zero Trust Maturity Model
 
 ```text
@@ -865,21 +972,24 @@ LEVEL 4: CONTINUOUS VERIFICATION
 
     Progress: Access is not just verified once but
     continuously evaluated throughout the session.
-
-Many organizations are still in the early-to-middle stages of zero-trust adoption
-TARGET FOR PLATFORM TEAMS: Level 3
-ASPIRATION: Level 4
 ```
+
+Many organizations are still in the early-to-middle stages of zero-trust adoption.
+Platform engineering teams should target Level 3—mesh mTLS, deny-by-default network policies, and short-lived credentials—before chasing Level 4 behavioral analytics that require mature logging pipelines. Honest self-assessment prevents buying an SSE suite when you still have shared admin passwords on internal tools.
+
+Executive sponsorship matters because Zero Trust crosses organizational silos. Network teams own VPN decommissioning, identity teams own IdP conditional access, endpoint teams own MDM posture signals, and platform teams own Kubernetes ingress and service mesh policy. Without a single written architecture standard, each silo optimizes locally—perfect IAP rules in front of Grafana while CI runners still mount cluster-admin kubeconfigs—and auditors correctly conclude the program is immature. Publish a reference architecture diagram that names enforcement points, log sinks, and escalation paths so every team knows which layer they own.
 
 ---
 
 ## Did You Know?
 
-- **Google published BeyondCorp papers starting in 2014 after moving away from privileged network access at large scale, helping popularize identity-aware access patterns.
+- **Google published BeyondCorp research starting in 2014**, describing how the company replaced privileged VPN access with identity-aware proxies and device certificates. The papers remain the most cited public blueprint for enterprise Zero Trust networking even as individual products evolved.
 
-- **Tailscale's coordination server typically does not carry user traffic.** Unlike a traditional VPN where all traffic flows through a central server, Tailscale uses WireGuard to create direct peer-to-peer encrypted connections. The coordination server only helps devices find each other and exchange public keys. Even if Tailscale's infrastructure were completely compromised, an attacker could not decrypt user traffic — they would only see which devices are connected to each other.
+- **Tailscale's coordination server typically does not carry user traffic.** Unlike a traditional VPN where all traffic flows through a central concentrator, Tailscale uses WireGuard for direct peer-to-peer encrypted connections after devices exchange keys. The coordination server only helps endpoints discover each other; compromising it reveals topology, not plaintext payloads.
 
-- **The concept predates Google's BeyondCorp papers and is commonly associated with analyst work from the early 2010s that challenged perimeter-based trust.
+- **NIST SP 800-207 defines Zero Trust as an architecture, not a SKU.** The publication separates policy engine, policy administrator, and policy enforcement point so procurement teams can evaluate whether a vendor fills one role or all three—avoiding the trap of renaming a firewall "Zero Trust" without changing trust assumptions.
+
+- **SPIFFE IDs are URIs, not usernames.** A SPIFFE ID like `spiffe://example.com/ns/prod/sa/api` binds cryptographic identity to Kubernetes namespace and service account semantics, which makes certificate issuance auditable in GitOps repositories that already track those objects.
 
 ---
 
@@ -889,12 +999,10 @@ ASPIRATION: Level 4
 |---------|---------|----------|
 | "Zero Trust" = buying one product | Vendors sell "Zero Trust solutions" but ZT is an architecture | Implement principles incrementally: SSO, MFA, IAP, device trust |
 | Keeping VPN alongside Zero Trust "just in case" | VPN becomes a bypass for all Zero Trust controls | Fully decommission VPN once IAP covers all applications |
-| No device posture checks | Authenticated user on compromised device = still a risk | Deploy device trust agent (Kolide, CrowdStrike, Intune) |
+| No device posture checks | Authenticated user on compromised device = still a risk | Deploy device trust agent and feed signals into IAP policy |
 | MFA only at initial login | Session tokens valid for weeks; stolen token = full access | Short session lifetimes (8-12 hours), re-auth for sensitive ops |
 | Trusting X-Forwarded-For headers blindly | Backend trusts IAP headers but attacker could set them directly | Backends must verify JWT assertion from IAP cryptographically |
 | Ignoring service-to-service authentication | East-west traffic between services is unauthenticated | Deploy service mesh (mTLS) or SPIFFE for service identity |
-| Same access level for all applications | Low-risk apps have same restrictions as high-risk ones | Tiered policies: public docs = low friction, prod access = high |
-| Not logging all access decisions | Cannot detect anomalies or investigate incidents | Log every allow/deny with user, device, app, and context |
 | Treating Zero Trust as a project with an end date | Zero Trust is continuous improvement, not a checkbox | Build team capability, iterate on policies, adapt to new threats |
 
 ---
@@ -933,7 +1041,28 @@ ASPIRATION: Level 4
    <details>
    <summary>Answer</summary>
 
-   For the SRE team, the policy must demand the highest level of assurance due to their broad administrative privileges. Access should be restricted to users in the 'sre-team' IdP group, require a hardware MFA key on every login, and mandate that the device is fully managed (MDM enrolled) with disk encryption and an active EDR agent, with sessions limited to 8 hours. The Developer team policy should be slightly less restrictive to reduce friction, allowing access to the 'engineering' group with standard MFA from a managed device, but authorization at the Kubernetes API level must be restricted via RBAC to only their specific namespaces. Finally, the Auditor team policy must accommodate potential external devices; they should be permitted read-only access via the 'audit-team' group using standard MFA, but if connecting from an unmanaged device, the policy should strictly enforce read-only RBAC and log all actions, perhaps imposing a shorter 4-hour session timeout to mitigate the increased risk profile.
+   For the SRE team, the policy must demand the highest level of assurance due to their broad administrative privileges. Access should be restricted to users in the 'sre-team' IdP group, require a hardware MFA key on every login, and mandate that the device is fully managed (MDM enrolled) with disk encryption and an active EDR agent, with sessions limited to 8 hours. The Developer team policy should be slightly less restrictive to reduce friction, allowing access to the 'engineering' group with standard MFA from a managed device, but authorization at the Kubernetes API level must be restricted via RBAC to only their specific namespaces.    Finally, the Auditor team policy must accommodate potential external devices; they should be permitted read-only access via the 'audit-team' group using standard MFA, but if connecting from an unmanaged device, the policy should strictly enforce read-only RBAC and log all actions, perhaps imposing a shorter 4-hour session timeout to mitigate the increased risk profile.
+   </details>
+
+6. **Scenario: Your security architect asks you to compare three approaches for contractor access to a single internal documentation portal: (A) a site-to-site VPN, (B) an identity-aware proxy with OIDC, and (C) a mesh overlay with ACLs. Which approach best satisfies Zero Trust least-privilege for HTTP-only access, and what signal would you monitor to detect policy drift over time?**
+   <details>
+   <summary>Answer</summary>
+
+   For HTTP-only documentation, an identity-aware proxy (option B) provides the narrowest blast radius because contractors authenticate through your IdP, receive only the routes fronted by the proxy, and never join a shared routing domain. Site-to-site VPN (option A) typically exposes every RFC1918 destination the firewall permits once the tunnel is up. Mesh overlay (option C) is powerful for arbitrary TCP but adds operational overhead when a single web app is the only requirement. Monitor deny/allow decision logs from the proxy—spikes in denied requests, new user agents, or policy versions changing without change tickets indicate drift or misconfiguration faster than VPN connection counts alone.
+   </details>
+
+7. **Scenario: An engineer attempts to reach the production Kubernetes API from a managed laptop while traveling. Device posture checks pass, but geolocation policy blocks the request because the country is not on the allow list. The engineer insists their VPN used to work from anywhere. Explain the Zero Trust rationale for the block and the minimum viable break-glass process you would document.**
+   <details>
+   <summary>Answer</summary>
+
+   Zero Trust treats location as one context signal among many; passing device posture does not override an explicit geofence when production API access is high risk. The durable rationale is deny-by-default with auditable exceptions rather than implicit trust based on historical VPN convenience. A minimum break-glass process issues a time-boxed policy exception recorded in your change system, requires secondary approval from on-call security, forces hardware MFA for the session, and expires automatically—never a standing "travel VPN profile" that bypasses IAP policy permanently.
+   </details>
+
+8. **Scenario: After deploying OAuth2 Proxy in front of an internal dashboard in kind, you verify that unauthenticated requests receive HTTP 403 while authenticated engineers reach the app. NetworkPolicy allows ingress only from the proxy pod. A teammate asks why you still need RBAC on the Kubernetes API server if NetworkPolicy already blocks lateral movement. What layered defense argument do you give?**
+   <details>
+   <summary>Answer</summary>
+
+   NetworkPolicy enforces segmentation at the pod network layer—it stops arbitrary pods from dialing the dashboard Service—but it does not authenticate humans or authorize Kubernetes API verbs. RBAC on the API server answers different questions: which identities may create Roles, read Secrets, or exec into pods cluster-wide. IAP plus NetworkPolicy covers north-south access to one application; RBAC covers east-west privilege inside the control plane. Zero Trust stacks independent enforcement points so compromise of one layer does not collapse the entire model.
    </details>
 
 ---
@@ -942,7 +1071,7 @@ ASPIRATION: Level 4
 
 **Objective**: Deploy Pomerium as an Identity-Aware Proxy to protect a Kubernetes Dashboard with SSO authentication, demonstrating Zero Trust access without VPN.
 
-**Environment**: kind cluster + Pomerium + mock OIDC provider
+**Environment**: kind cluster with OAuth2 Proxy simulating IAP behavior and a mock OIDC provider workflow—sufficient to validate policy layering without provisioning a production IdP tenant for this exercise.
 
 ### Part 1: Create the Cluster (5 minutes)
 
@@ -1325,7 +1454,8 @@ kubectl get pods
 kind delete cluster --name zero-trust-lab
 ```
 
-**Success Criteria**:
+**Success Criteria**: Complete each checkpoint below to confirm the lab demonstrated identity-aware access rather than merely deploying containers—the distinction matters when you translate the pattern to production IAP policy.
+
 - [ ] Internal dashboard deployed and serving content
 - [ ] IAP proxy deployed as the authentication gateway
 - [ ] Understood that unauthenticated requests are rejected by the IAP
@@ -1336,19 +1466,9 @@ kind delete cluster --name zero-trust-lab
 
 ---
 
-## Further Reading
-
-- **"BeyondCorp: A New Approach to Enterprise Security"** (Google, 2014) — The original paper that launched the Zero Trust movement. Describes how Google replaced VPN with identity-aware proxies.
-
-- **NIST SP 800-207: Zero Trust Architecture** — The US government's formal definition of Zero Trust principles, architecture, and deployment models. The most authoritative reference.
-
-- **"Zero Trust Networks" by Evan Gilman & Doug Barth** (O'Reilly) — Practical guide to implementing Zero Trust, including network architecture, identity, and device trust.
-
-- **Tailscale Blog: "How Tailscale Works"** — Deep technical explanation of WireGuard mesh networking, NAT traversal, and the coordination protocol.
-
----
-
 ## Key Takeaways
+
+The checklist below summarizes durable concepts you should be able to explain to a colleague without opening vendor documentation—if any item feels fuzzy, revisit the corresponding Part before running the lab in production-like conditions.
 
 Before moving on, ensure you understand:
 
@@ -1363,18 +1483,11 @@ Before moving on, ensure you understand:
 
 ---
 
-## Series Complete
+## Next Module
 
-Congratulations on completing the Advanced Networking foundation series! You now have deep understanding of:
+Continue the Advanced Networking track with [Module 1.7: IPv6 Fundamentals](../module-1.7-ipv6-fundamentals/) — address families, SLAAC, NDP, and hands-on IPv6 troubleshooting — or return to the [Advanced Networking overview](../index/) to review the full module sequence.
 
-1. **DNS at Scale** — Global traffic management, Anycast, DNSSEC
-2. **CDN & Edge Computing** — Caching, edge functions, TLS strategies
-3. **WAF & DDoS Mitigation** — Application protection and volumetric defense
-4. **BGP & Core Routing** — Internet routing, security, and interconnection
-5. **Cloud Load Balancing** — L4/L7 mechanics, Proxy Protocol, architecture
-6. **Zero Trust Networking** — Identity-based access, VPN replacement
-
-These topics form the networking foundation for platform engineering. Each concept builds on the others — DNS routes to CDN, CDN integrates WAF, BGP underlies all routing, load balancers distribute traffic, and Zero Trust secures access across every layer.
+---
 
 ## Sources
 

--- a/src/content/docs/platform/foundations/advanced-networking/module-1.6-zero-trust.md
+++ b/src/content/docs/platform/foundations/advanced-networking/module-1.6-zero-trust.md
@@ -1400,7 +1400,6 @@ spec:
         defaultMode: 0755
 EOF
 
-kubectl wait --for=condition=Ready pod/zt-demo --timeout=120s
 kubectl wait --for=jsonpath='{.status.phase}'=Succeeded pod/zt-demo --timeout=120s
 kubectl logs zt-demo
 ```


### PR DESCRIPTION
## What

Closes **#1952** — the only non-`done` module in Platform Foundations. Expands `advanced-networking/module-1.6-zero-trust` from T3 → T0 and resolves the verifier/board disagreement.

### Expand (cursor)
- Flowing prose 643 → **5157 body_words** (durable-spine teaching across Parts 1–6: perimeter failure, BeyondCorp, IAP mechanics, mTLS/SPIFFE, device posture, adoption journey).
- **Tail cleanup** (the root cause of `sources=0`): removed `## Series Complete` + the duplicate `## Further Reading`, consolidated to one `## Sources` with 10 real reachable links → verifier now parses **sources=10**. did-you-know 3→4, quiz 5→8, common-mistakes 9→7, added `## Next Module`, `revision_pending: false`.

### Cross-family review (codex R1) → fix-pass — every finding ground-checked
- **P1:** SolarWinds scope corrected (~18k *received* the update / ~100 follow-on, was "lateral movement across 18,000 networks") + dedup xref; **genericized unlabeled named-incident narratives** (Target/Equifax/Colonial/MGM) per the one-real-incident contract (Okta kept only as an IdP example); **lab redesigned** with an in-cluster **Dex** OIDC provider so OAuth2 Proxy actually starts, and the authenticated step now carries a real session cookie.
- **P2:** TLS 1.3 = (EC)DHE key agreement (not RSA key transport); "Let's Encrypt private CA" → private CA is Vault/internal issuer (Let's Encrypt is public); Tailscale DERP-relay caveat; Cloudflare Access = TCP via cloudflared (UDP removed); cloud interconnect = MACsec/IPsec not mTLS → replaced with correct service-to-service / API-gateway client-cert examples; "augments" not "replaces" segmentation; volatile vendor specifics moved into the dated `as of 2026-06` snapshot.

### Lab verified by execution (codex R2, in kind)
Dex + OAuth2 Proxy pods Ready; unauthenticated → **403 blocked**; authenticated (Dex login → session cookie) → **reaches the app**; NetworkPolicies apply. One leftover bug fixed: dropped a redundant `--for=condition=Ready` wait on the one-shot `zt-demo` test pod (it Completes, never Ready — the `--phase=Succeeded` wait on the next line is correct).

### Tooling finding (#1952 secondary AC)
`verify_module.sources_metrics` → `_find_matching_h2(SOURCES_HEADINGS)` returns the **first** match; with both `## Further Reading` and `## Sources` present, it reads "Further Reading" (no links) → `count: 0`. Content fix resolves it here; general fix = prefer literal `## Sources` or aggregate across all sources-like sections. (The `body_words=643` is *not* a bug — it's the by-design flowing-prose-only count.)

## Verification
- `verify_module.py`: **T0 PASS** (body 5157, sources 10, 0 failing gates)
- `npm run build`: **2169 pages, clean** (no schema/render errors)
- Durable-content compliant (dated snapshot, no best-tool/market-share claims, one labeled Hypothetical scenario)

Closes #1952

🤖 Generated with [Claude Code](https://claude.com/claude-code)