### PR TITLE
fix(content): ai-infrastructure FIX wave — 6 modules' verifier-blind defects (#1957)

### DIFF
--- a/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.1-gpu-provisioning.md
+++ b/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.1-gpu-provisioning.md
@@ -212,18 +212,32 @@ flowchart TD
     Controller --> GFD["GPU Feature Discovery DaemonSet"]
 ```
 
-For a first installation, keep the configuration explicit even when defaults would work. The values below enable the major stack components, turn on DCGM-Exporter, select a MIG strategy, and install NFD. In a managed Kubernetes environment, you may disable driver management if the node image already includes the correct driver, but do that intentionally and document the owner of driver upgrades.
+For a first installation, keep the configuration explicit even when defaults would work. The values below enable the major stack components, turn on DCGM-Exporter, select a MIG strategy, and install NFD. In a managed Kubernetes environment, you may disable driver management if the node image already includes the correct driver, but do that intentionally and document the owner of driver upgrades. Version pins belong in a short-lived release plan, not scattered through teaching prose, because the Operator, driver branch, container toolkit, device plugin, and exporter move on their own release schedules.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> | Volatile item | Verified value | Why it is quarantined |
+> |---------------|----------------|-----------------------|
+> | GPU Operator Helm chart | `v26.3.2` is the current patch release in the NVIDIA install docs | Chart releases change quickly, and old pins can silently pull unsupported operands |
+> | GPU Operator support window | `26.3.x` is supported; `25.10.x` is deprecated; `25.3.x` and older are end of support | Support status changes with the Operator lifecycle rather than with Kubernetes itself |
+> | v26.3.2 default or recommended operands | Driver `580.126.20` default, driver `580.159.04` recommended, Container Toolkit `1.19.1`, device plugin and GPU Feature Discovery `0.19.2`, DCGM Exporter `v4.5.3-4.8.2`, Node Feature Discovery `v0.18.3`, MIG Manager `0.14.2` | These are release-matrix facts; let the chart defaults carry them unless your upgrade test plan pins specific operands |
+> | H100 power envelope | H100 SXM lists maximum TDP up to `700W`; H100 NVL in PCIe form factor lists `350-400W`, configurable by SKU | Power and cooling plans must use the exact SKU and server BOM, not a generic H100 statement |
+> | CUDA sample images used below | `nvcr.io/nvidia/k8s/cuda-sample:vectoradd-cuda12.5.0` and `nvcr.io/nvidia/k8s/cuda-sample:nbody` resolved with registry manifest inspection | Public sample tags can appear or disappear; production validation should pin a verified digest in your own runbook |
 
 ```bash
 # Add the NVIDIA Helm repository
 helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
 helm repo update
 
+# Pin the chart release you have tested; refresh this against NVIDIA docs before reuse.
+RELEASE_TAG=v26.3.2
+
 # Install the GPU Operator
 helm install gpu-operator nvidia/gpu-operator \
+  --wait \
   --namespace gpu-operator \
   --create-namespace \
-  --version v24.9.0 \
+  --version "${RELEASE_TAG}" \
   --set driver.enabled=true \
   --set toolkit.enabled=true \
   --set dcgmExporter.enabled=true \
@@ -231,7 +245,7 @@ helm install gpu-operator nvidia/gpu-operator \
   --set nfd.enabled=true
 ```
 
-The `ClusterPolicy` is the declarative contract for the Operator. Read it the same way you would read a CNI or storage operator configuration: each field names an operational responsibility that must be owned somewhere. Driver version controls compatibility with CUDA user-space expectations, toolkit version controls runtime injection behavior, device plugin version controls resource advertisement, DCGM version controls metric availability, and MIG strategy controls whether partitioned GPU instances are exposed in a consistent way across the node.
+The `ClusterPolicy` is the declarative contract for the Operator. Read it the same way you would read a CNI or storage operator configuration: each field names an operational responsibility that must be owned somewhere. Driver policy controls compatibility with CUDA user-space expectations, toolkit policy controls runtime injection behavior, device plugin policy controls resource advertisement, DCGM policy controls metric availability, and MIG strategy controls whether partitioned GPU instances are exposed in a consistent way across the node. Leave operand versions on the chart's supported defaults unless you have a documented compatibility reason to pin them, and keep any pins in a dated release note that can be refreshed as a unit.
 
 ```yaml
 apiVersion: nvidia.com/v1
@@ -243,23 +257,19 @@ spec:
     defaultRuntime: containerd
   driver:
     enabled: true
-    version: "550.127.08"
     repository: nvcr.io/nvidia
     image: driver
     licensingConfig:
       configMapName: ""
   toolkit:
     enabled: true
-    version: v1.16.2-ubuntu22.04
   devicePlugin:
     enabled: true
-    version: v0.16.2
     config:
       name: device-plugin-config
       default: default
   dcgmExporter:
     enabled: true
-    version: 3.3.8-3.6.0-ubuntu22.04
     serviceMonitor:
       enabled: true         # Create ServiceMonitor for Prometheus
   mig:
@@ -283,7 +293,7 @@ kubectl get pods -n gpu-operator
 # nvidia-cuda-validator-gpu-worker-01                   0/1     Completed
 # nvidia-dcgm-exporter-5k2j8                           1/1     Running
 # nvidia-device-plugin-daemonset-lr4nt                 1/1     Running
-# nvidia-driver-daemonset-550.127.08-gpu-worker-01     1/1     Running
+# nvidia-driver-daemonset-<driver-version>-gpu-worker-01  1/1     Running
 # nvidia-node-feature-discovery-master-6c4b8f7-m9xj2  1/1     Running
 # nvidia-node-feature-discovery-worker-7g8x4           1/1     Running
 # nvidia-operator-validator-gpu-worker-01               1/1     Running
@@ -323,11 +333,11 @@ GPU utilization needs careful interpretation. A training job may show bursty uti
 | `DCGM_FI_DEV_GPU_TEMP` | GPU temperature (C) | Thermal throttling? |
 | `DCGM_FI_DEV_POWER_USAGE` | Power draw (W) | Energy cost tracking |
 | `DCGM_FI_DEV_SM_CLOCK` | Streaming multiprocessor clock (MHz) | Is the GPU at full speed? |
-| `DCGM_FI_DEV_XID_ERRORS` | Xid error count | Hardware problems? |
+| `DCGM_FI_DEV_XID_ERRORS` | Last Xid error code/value | Hardware or driver fault event? |
 | `DCGM_FI_DEV_PCIE_TX_THROUGHPUT` | PCIe TX throughput (KB/s) | Data transfer bottleneck? |
 | `DCGM_FI_PROF_GR_ENGINE_ACTIVE` | Ratio of time the GPU was active | More precise than utilization |
 
-DCGM-Exporter can be configured to expose the counters your team actually uses. More metrics are not always better because cardinality, scrape volume, and dashboard noise can hide the signals that matter. Start with utilization, memory, temperature, power, PCIe throughput, Xid errors, and profiling engine activity; add specialized counters when you have a concrete question about tensor cores, NVLink, ECC behavior, or application-level performance.
+DCGM-Exporter can be configured to expose the counters your team actually uses. More metrics are not always better because cardinality, scrape volume, and dashboard noise can hide the signals that matter. Start with utilization, memory, temperature, power, PCIe throughput, the last Xid error code, and profiling engine activity; add specialized counters when you have a concrete question about tensor cores, NVLink, ECC behavior, or application-level performance.
 
 ```yaml
 apiVersion: v1
@@ -345,12 +355,12 @@ data:
     DCGM_FI_DEV_POWER_USAGE,      gauge, Power draw (W).
     DCGM_FI_DEV_PCIE_TX_THROUGHPUT, gauge, PCIe TX throughput (KB/s).
     DCGM_FI_DEV_PCIE_RX_THROUGHPUT, gauge, PCIe RX throughput (KB/s).
-    DCGM_FI_DEV_XID_ERRORS,       gauge, Value of the last XID error.
+    DCGM_FI_DEV_XID_ERRORS,       gauge, Value of the last Xid error.
     DCGM_FI_PROF_GR_ENGINE_ACTIVE, gauge, Ratio of time the graphics engine is active.
     DCGM_FI_PROF_PIPE_TENSOR_ACTIVE, gauge, Ratio of time the tensor cores are active.
 ```
 
-The original NVIDIA DCGM Grafana dashboard is useful for a first view, but production teams should add panels that map metrics to decisions. Show per-node and per-Pod utilization together, because a node-level graph without workload labels does not tell you who owns the waste. Show VRAM used and free together, because compute utilization alone misses memory-bound failures. Show Xid errors as events rather than only averages, because one severe hardware fault deserves immediate investigation even when the aggregate rate looks tiny.
+The original NVIDIA DCGM Grafana dashboard is useful for a first view, but production teams should add panels that map metrics to decisions. Show per-node and per-Pod utilization together, because a node-level graph without workload labels does not tell you who owns the waste. Show VRAM used and free together, because compute utilization alone misses memory-bound failures. Show Xid codes as latest-event signals rather than counters or rates, because one severe hardware fault deserves immediate investigation even when an aggregate dashboard looks quiet.
 
 ```mermaid
 xychart-beta
@@ -394,7 +404,7 @@ spec:
           labels:
             severity: critical
           annotations:
-            summary: "GPU {{ $labels.gpu }} Xid error {{ $value }} — check dmesg"
+            summary: "GPU {{ $labels.gpu }} reported last Xid code {{ $value }} — check dmesg"
 
         - alert: GPUUnderutilized
           expr: DCGM_FI_DEV_GPU_UTIL < 10
@@ -497,7 +507,7 @@ For mature platforms, the decision framework should feed a service catalog. User
 
 ## Did You Know?
 
-1. **A single NVIDIA H100 SXM5 accelerator can draw up to 700 watts (PCIe variants top out at ~350 watts).** An eight-GPU server can therefore demand several kilowatts before you count CPUs, memory, networking, and cooling overhead, which is why power and thermal metrics belong in the same conversation as scheduling.
+1. **H100 power and cooling plans are SKU-specific, not generic.** A high-density SXM accelerator and a PCIe-form-factor H100 NVL do not have the same thermal design target, so use the dated hardware snapshot and your vendor BOM before sizing rack power, cooling, or autoscaling boundaries.
 
 2. **The Kubernetes Device Plugin API became stable in Kubernetes 1.26, but the operational pattern remains important in Kubernetes 1.35 and newer.** Stability means the API contract is mature; it does not mean every vendor plugin, driver version, and runtime integration is interchangeable without testing.
 
@@ -574,8 +584,14 @@ You need a Kubernetes cluster with at least one GPU node. Cloud options include 
 ```bash
 # Verify you have a GPU node (look for NVIDIA PCI device)
 kubectl get nodes -o wide
-kubectl debug node/<gpu-node-name> -it --image=ubuntu -- lspci | grep -i nvidia
+kubectl debug node/<gpu-node-name> -it --profile=sysadmin --image=ubuntu:24.04 -- bash -lc '
+  apt-get update >/dev/null
+  apt-get install -y pciutils >/dev/null
+  lspci | grep -i nvidia
+'
 ```
+
+The debug command uses the `sysadmin` profile because Kubernetes mounts the node root filesystem at `/host` for node debugging, but the default debug Pod is not privileged enough for every host inspection pattern. Installing `pciutils` inside the temporary Ubuntu debug container makes `lspci` available without assuming the node image already carries that troubleshooting package.
 
 ### Task 1: Install Prometheus Stack
 
@@ -608,11 +624,15 @@ Install the GPU Operator with DCGM ServiceMonitor creation enabled. The wait com
 helm repo add nvidia https://helm.ngc.nvidia.com/nvidia
 helm repo update
 
+# Pin the chart release you have tested; refresh this against NVIDIA docs before reuse.
+RELEASE_TAG=v26.3.2
+
 # Install GPU Operator with DCGM-Exporter ServiceMonitor enabled
 helm install gpu-operator nvidia/gpu-operator \
+  --wait \
   --namespace gpu-operator \
   --create-namespace \
-  --version v24.9.0 \
+  --version "${RELEASE_TAG}" \
   --set dcgmExporter.serviceMonitor.enabled=true \
   --set dcgmExporter.serviceMonitor.additionalLabels.release=kube-prometheus
 
@@ -665,8 +685,9 @@ spec:
       restartPolicy: Never
       containers:
         - name: gpu-burn
-          image: nvcr.io/nvidia/k8s/cuda-sample:nbody-cuda12.5.0
-          args: ["-benchmark", "-numbodies=1024000", "-iterations=50"]
+          image: nvcr.io/nvidia/k8s/cuda-sample:nbody
+          command: ["nbody"]
+          args: ["-gpu", "-benchmark", "-numbodies=1024000", "-iterations=50"]
           resources:
             limits:
               nvidia.com/gpu: 1
@@ -714,19 +735,9 @@ Import the NVIDIA DCGM dashboard or build an equivalent internal dashboard. The 
 ```bash
 # Port-forward to Grafana
 kubectl port-forward -n monitoring svc/kube-prometheus-grafana 3000:80 &
-
-# Login: admin / kubedojo
-# Import dashboard ID 12239 (NVIDIA DCGM Exporter Dashboard)
-# Or use the API:
-curl -X POST http://admin:kubedojo@127.0.0.1:3000/api/dashboards/import \
-  -H 'Content-Type: application/json' \
-  -d '{
-    "dashboard": {"id": 12239},
-    "overwrite": true,
-    "inputs": [{"name": "DS_PROMETHEUS", "type": "datasource", "pluginId": "prometheus", "value": "Prometheus"}],
-    "folderId": 0
-  }'
 ```
+
+Log in with `admin` and the password from your Helm values, then use Grafana's dashboard import UI with ID `12239` and select your Prometheus data source. If you automate this later, download or export the full dashboard JSON first and post a complete dashboard body; a stub payload that contains only the dashboard ID is not a valid import request and will fail because Grafana has no title, panels, or datasource mapping to import.
 
 <details>
 <summary>Solution notes</summary>
@@ -757,18 +768,24 @@ kubectl delete namespace ai-lab
 
 ## Sources
 
-- https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/
-- https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/
-- https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/
-- https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/
-- https://docs.nvidia.com/datacenter/cloud-native/gpu-telemetry/latest/dcgm-exporter.html
-- https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/
-- https://docs.nvidia.com/deploy/cuda-compatibility/
-- https://github.com/NVIDIA/k8s-device-plugin
-- https://github.com/kubernetes-sigs/node-feature-discovery
-- https://github.com/cncf-tags/container-device-interface
-- https://prometheus-operator.dev/docs/developer/getting-started/
-- https://grafana.com/grafana/dashboards/12239-nvidia-dcgm-exporter-dashboard/
+- [Kubernetes Device Plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
+- [Kubernetes Resource Management for Pods and Containers](https://kubernetes.io/docs/concepts/configuration/manage-resources-containers/)
+- [Kubernetes Node Debugging with kubectl](https://kubernetes.io/docs/tasks/debug/debug-cluster/kubectl-node-debug/)
+- [NVIDIA GPU Operator Installation Guide](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/getting-started.html)
+- [NVIDIA GPU Operator Platform Support and Component Matrix](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/platform-support.html)
+- [NVIDIA Container Toolkit Documentation](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/)
+- [NVIDIA DCGM Exporter Documentation](https://docs.nvidia.com/datacenter/cloud-native/gpu-telemetry/latest/dcgm-exporter.html)
+- [NVIDIA DCGM Field Identifiers](https://docs.nvidia.com/datacenter/dcgm/latest/dcgm-api/dcgm-api-field-ids.html)
+- [NVIDIA DCGM User Guide](https://docs.nvidia.com/datacenter/dcgm/latest/user-guide/)
+- [NVIDIA CUDA Compatibility Documentation](https://docs.nvidia.com/deploy/cuda-compatibility/)
+- [NVIDIA H100 Tensor Core GPU](https://www.nvidia.com/en-us/data-center/h100/)
+- [NVIDIA CUDA Samples on NGC](https://catalog.ngc.nvidia.com/orgs/nvidia/teams/k8s/containers/cuda-sample)
+- [NVIDIA Kubernetes Device Plugin](https://github.com/NVIDIA/k8s-device-plugin)
+- [Kubernetes SIG Node Feature Discovery](https://github.com/kubernetes-sigs/node-feature-discovery)
+- [Container Device Interface Specification](https://github.com/cncf-tags/container-device-interface)
+- [Prometheus Operator Getting Started](https://prometheus-operator.dev/docs/developer/getting-started/)
+- [Grafana NVIDIA DCGM Exporter Dashboard](https://grafana.com/grafana/dashboards/12239-nvidia-dcgm-exporter-dashboard/)
+- [Grafana Dashboard APIs](https://grafana.com/docs/grafana/latest/developer-resources/api-reference/http-api/dashboard/)
 
 ## Next Module
 

--- a/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.2-gpu-scheduling.md
+++ b/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.2-gpu-scheduling.md
@@ -37,9 +37,11 @@ Whole-GPU allocation is the safest starting point because it gives each workload
 
 The basic waste pattern is easiest to see when you separate allocation from utilization. Allocation answers "who owns the resource right now," while utilization answers "how much useful work is the device performing." A cluster can be over-allocated and underutilized at the same time because reservations are coarse and demand is bursty. That is the reason GPU sharing is a platform discipline rather than a simple cost optimization: the scheduler needs better resource shapes, and the platform needs guardrails so density does not turn into instability.
 
+Hypothetical scenario:
+
 ```
 Cluster: 8 nodes x 4 A100-80GB GPUs = 32 GPUs total
-Cost: $3.06/GPU/hr x 32 GPUs x 730 hr/month = $71,482/month
+Cost: ~$3/GPU/hr x 32 GPUs x 730 hr/month = ~$70,000/month
 
 Workloads:
   - 4 training jobs using 4 GPUs each (fully utilizing GPUs)     -> 16 GPUs
@@ -47,8 +49,8 @@ Workloads:
   - 8 Jupyter notebooks using 1 GPU each (avg 5% utilization)    ->  8 GPUs
 
 Total allocated: 36 GPUs (exceeds capacity, so 4 workloads queue)
-Effective utilization: (16x95% + 12x15% + 8x5%) / 36 = 48%
-Money wasted: ~$37,000/month
+Effective utilization: (16x95% + 12x15% + 8x5%) / 36 = ~50%
+Money wasted: ~$35,000/month
 ```
 
 The important lesson in that model is not the exact cost number, because every cloud contract and hardware purchase looks different. The lesson is that "allocated" is not the same as "busy." When teams use a full accelerator as the scheduling unit for every workload class, the queue grows even while the devices have idle compute, free memory, and unserved demand. GPU sharing exists to create smaller or more flexible scheduling units, but every sharing method gives up some isolation in exchange.
@@ -166,7 +168,7 @@ data:
             "1g.10gb": 1
 ```
 
-Changing a node's MIG layout is disruptive because workloads using the device must leave before the hardware profile changes. The label command is simple, but the procedure around it matters more than the command. A safe runbook cordons the node, drains GPU workloads that can move, verifies there are no important local artifacts, applies the label, watches the MIG Manager, and then confirms the device plugin advertises the expected resources. If your platform reconfigures MIG profiles casually during business hours, users will experience surprise evictions and Pending Pods.
+Changing a node's MIG layout is disruptive because workloads using the device must leave before the hardware profile changes. The label command is simple, but the procedure around it matters more than the command. A safe runbook cordons the node, drains user GPU workloads that can move, verifies there are no important local artifacts, applies the label, watches the MIG Manager, and then confirms the device plugin advertises the expected resources. MIG Manager is not a substitute for `kubectl drain`: NVIDIA's runbook expects the administrator to cordon and drain user GPU Pods first. After the label change, MIG Manager stops and restarts GPU Operator-managed Pods on the node and fails the reconfiguration if user GPU workloads are still active. If your platform reconfigures MIG profiles casually during business hours, users will experience surprise evictions and Pending Pods.
 
 MIG reconfiguration should also be treated as a capacity event. When one node leaves service for repartitioning, the remaining pool must absorb both new scheduling demand and any workloads evicted from the changing node. If the platform has only one node with a particular profile, the maintenance window is effectively a service outage for that resource class. Mature teams model this before applying labels, then use PodDisruptionBudgets, queue controls, and tenant communication to keep the change predictable.
 
@@ -174,8 +176,8 @@ MIG reconfiguration should also be treated as a capacity event. When one node le
 # Apply the "all-balanced" configuration
 kubectl label node gpu-worker-01 nvidia.com/mig.config=all-balanced --overwrite
 
-# The GPU Operator will:
-# 1. Drain GPU workloads from the node
+# After you cordon and drain user GPU workloads, the GPU Operator will:
+# 1. Stop and restart GPU Operator-managed Pods on the node (MIG Manager)
 # 2. Disable MIG mode
 # 3. Enable MIG mode with new profiles
 # 4. Restart the device plugin
@@ -241,7 +243,7 @@ The memory point deserves extra attention because Kubernetes resource limits do 
 | Compute isolation | **None**: all containers share all SMs |
 | Memory isolation | **None**: all containers share all VRAM |
 | Overcommit factor | Configurable (for example, 4x means 4 virtual GPUs per physical GPU) |
-| Context switching | About 1ms overhead per switch |
+| Context switching | Context-switch overhead depends on driver quantum settings (often 100ms-class by default) |
 | Failure blast radius | One container's OOM can affect all containers on that GPU |
 | GPU support | Any NVIDIA GPU supported by the device plugin |
 
@@ -370,9 +372,9 @@ gantt
 | Property | Time-Slicing | MPS |
 |----------|-------------|-----|
 | Compute sharing | Temporal (round-robin) | Spatial (simultaneous) |
-| Context overhead | About 1ms per switch | Near zero |
+| Context overhead | Driver quantum settings (often 100ms-class by default) | Near zero |
 | Memory isolation | None | Configurable per-client limits |
-| Max clients | Limited by driver | 48 clients per GPU |
+| Max clients | Limited by driver | Up to 48–60 depending on driver/CUDA version |
 | Failure isolation | None | Partial (client failures can be contained) |
 | Best for | Interactive, bursty workloads | Steady-state inference |
 
@@ -396,14 +398,13 @@ data:
         resources:
           - name: nvidia.com/gpu
             replicas: 8
-            devices: all
 ```
 
 Which approach would you choose here and why: four production inference services with fixed 8 GiB memory footprints on an H100, or twenty exploratory notebooks on older T4 nodes? The first case points toward MIG if the device supports it, because production memory isolation and predictable latency are more valuable than maximum density. The second case points toward time-slicing, because the workloads are interactive, bursty, and less likely to justify hardware partitioning.
 
 ## Dynamic Resource Allocation and Topology
 
-Dynamic Resource Allocation is the Kubernetes 1.35 stable direction for expressing device needs as claims rather than as simple integer counts. The older device-plugin model is easy to schedule but weak at describing attributes: a Pod asks for `nvidia.com/gpu: 1`, then node labels, affinity, and human convention do the rest. DRA introduces DeviceClasses, ResourceClaims, ResourceClaimTemplates, ResourceSlices, and scheduler integration so workloads can request devices through structured objects. It is conceptually similar to how storage moved from "mount something on this node" to PersistentVolumeClaims with classes and binding rules.
+Dynamic Resource Allocation is the Kubernetes direction for expressing device needs as claims rather than as simple integer counts. Core DRA GA'd in Kubernetes 1.34 and is always enabled in 1.35. The older device-plugin model is easy to schedule but weak at describing attributes: a Pod asks for `nvidia.com/gpu: 1`, then node labels, affinity, and human convention do the rest. DRA introduces DeviceClasses, ResourceClaims, ResourceClaimTemplates, ResourceSlices, and scheduler integration so workloads can request devices through structured objects. It is conceptually similar to how storage moved from "mount something on this node" to PersistentVolumeClaims with classes and binding rules.
 
 ```mermaid
 flowchart TD
@@ -423,6 +424,7 @@ DRA does not remove the need for platform policy; it gives you a better place to
 The adoption path should be incremental because DRA changes both user workflow and operator mental models. A team that understands `resources.limits.nvidia.com/gpu: 1` will need to learn claims, classes, and how those claims bind to Pods. Operators will need dashboards and runbooks that explain why a ResourceClaim is pending or allocated. Start where the old model is visibly painful, such as a heterogeneous training pool where label combinations have become fragile, and keep the first DeviceClasses narrow.
 
 ```yaml
+# Illustrative example — requires the NVIDIA DRA driver and a matching DeviceClass on the cluster.
 # Define a GPU class
 apiVersion: resource.k8s.io/v1
 kind: DeviceClass
@@ -431,7 +433,7 @@ metadata:
 spec:
   selectors:
     - cel:
-        expression: "device.driver == 'gpu.nvidia.com' && device.attributes['memory'] >= 40000"
+        expression: "device.driver == 'gpu.nvidia.com' && device.capacity['gpu.nvidia.com'].memory.isGreaterThan(quantity('40Gi'))"
 ---
 # Claim a GPU
 apiVersion: resource.k8s.io/v1
@@ -443,8 +445,9 @@ spec:
   devices:
     requests:
       - name: gpu
-        deviceClassName: gpu-large
-        count: 1
+        exactly:
+          deviceClassName: gpu-large
+          count: 1
 ---
 # Use the claim in a Pod
 apiVersion: v1
@@ -470,7 +473,7 @@ spec:
 | Fractional allocation | Indirect through MIG, time-slicing, or MPS | Expressed through driver-supported DRA models |
 | Topology awareness | Mostly external labels and kubelet hints | Integrated with ResourceSlices and scheduler decisions |
 | Admin policies | Convention, admission, quotas, and node pools | DeviceClasses define allowed device sets |
-| API maturity | Stable device plugin pattern | Stable DRA feature in Kubernetes 1.35 |
+| API maturity | Stable device plugin pattern | DRA GA in Kubernetes 1.34; always enabled in 1.35 |
 | NVIDIA support | Mature GPU Operator and device plugin | NVIDIA DRA driver available for modern clusters |
 
 Topology is the other half of advanced GPU scheduling. Multi-GPU training does not only need the correct count of devices; it needs devices that communicate efficiently with each other and with local CPU and memory. On one server, two GPUs might share an NVSwitch fabric, while another pair might communicate across PCIe switches or even across CPU sockets. For collective operations such as gradient all-reduce, those differences can dominate runtime.
@@ -502,10 +505,10 @@ flowchart TD
     NVS --- G6
     NVS --- G7
 
-    SW0["PCIe Switch 0 (16 GB/s)"]
-    SW1["PCIe Switch 1 (16 GB/s)"]
-    SW2["PCIe Switch 2 (16 GB/s)"]
-    SW3["PCIe Switch 3 (16 GB/s)"]
+    SW0["PCIe Switch 0 (~32 GB/s unidirectional)"]
+    SW1["PCIe Switch 1 (~32 GB/s unidirectional)"]
+    SW2["PCIe Switch 2 (~32 GB/s unidirectional)"]
+    SW3["PCIe Switch 3 (~32 GB/s unidirectional)"]
 
     G0 --- SW0
     G1 --- SW0
@@ -517,7 +520,7 @@ flowchart TD
     G7 --- SW3
 ```
 
-The `nvidia-smi topo -m` command gives you the fast first look. It will not make a scheduling decision for Kubernetes by itself, but it tells you whether the hardware layout matches the assumptions in your node pool design. A topology-aware platform records this output during node qualification, labels nodes by hardware family, uses kubelet Topology Manager where appropriate, and avoids mixing very different interconnect layouts behind one generic GPU resource name.
+The `nvidia-smi topo -m` command gives you the fast first look. It will not make a scheduling decision for Kubernetes by itself, but it tells you whether the hardware layout matches the assumptions in your node pool design. On PCIe Gen4 x16 links, each switch hop is roughly 32 GB/s unidirectional (about 64 GB/s bidirectional), which is much slower than NVSwitch paths between GPUs on the same fabric. A topology-aware platform records this output during node qualification, labels nodes by hardware family, uses kubelet Topology Manager where appropriate, and avoids mixing very different interconnect layouts behind one generic GPU resource name.
 
 When you debug a slow training job, topology checks should happen before deep framework tuning. It is tempting to start with batch size, dataloader workers, NCCL environment variables, or image versions because those are familiar to ML engineers. Those knobs matter, but they cannot overcome a placement decision that sends gradient traffic over a weak path. First prove that the job received the intended hardware arrangement, then tune the training stack inside that known-good envelope.
 
@@ -575,7 +578,8 @@ For multi-node jobs, think in two rings of topology. The inner ring is inside on
 
 ```bash
 gcloud compute resource-policies create group-placement training-compact \
-  --collocation=COLLOCATED \
+  --region=us-central1 \
+  --collocation=collocated \
   --vm-count=8
 
 gcloud container node-pools create gpu-training \
@@ -585,7 +589,26 @@ gcloud container node-pools create gpu-training \
   --placement-policy=training-compact
 ```
 
+In Karpenter v1, kubelet configuration moved out of `NodePool` and into provider-specific node classes. On AWS, set Topology Manager policy in an `EC2NodeClass` — for Bottlerocket, use `userData` under `[settings.kubernetes]`:
+
 ```yaml
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: gpu-training
+spec:
+  amiFamily: Bottlerocket
+  role: "KarpenterNodeRole-${CLUSTER_NAME}"
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "${CLUSTER_NAME}"
+  userData: |
+    [settings.kubernetes]
+    topology-manager-policy = "restricted"
+---
 apiVersion: karpenter.sh/v1
 kind: NodePool
 metadata:
@@ -593,12 +616,14 @@ metadata:
 spec:
   template:
     spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: gpu-training
       requirements:
         - key: node.kubernetes.io/instance-type
           operator: In
           values: ["p5.48xlarge"]
-      kubelet:
-        topologyManagerPolicy: restricted
 ```
 
 Exercise scenario: a four-GPU PyTorch job usually finishes in one evening on a validated NVSwitch node, but it takes much longer after moving into a general GPU node pool. The first checks are not the Python training loop or the container image. Inspect the Pod events, confirm which node was chosen, run `nvidia-smi topo -m` on that node, and compare the assigned GPU locality with the node pool's intended topology policy. Only after placement is verified should you tune NCCL, batch size, or framework settings.
@@ -610,6 +635,31 @@ Advanced GPU scheduling fails when it is treated as a bag of independent feature
 Fairness starts with names and quotas. A namespace that can request unlimited `nvidia.com/gpu.shared` will eventually consume every shared slot, even if each slot maps to a tiny fraction of real capacity. A team that can request `nvidia.com/mig-1g.10gb` but not `nvidia.com/gpu` cannot accidentally starve training jobs. PriorityClasses and preemption can protect urgent workloads, but they should be reserved for clear service tiers because preemption is disruptive. The goal is to make the scheduler enforce policy before humans have to negotiate every incident.
 
 Quota design should follow the resource catalog. For example, a research namespace might receive generous `nvidia.com/gpu.shared` quota, a small number of `nvidia.com/mig-1g.10gb` instances, and no full-GPU quota. A training namespace might receive full GPUs and access to topology-aligned nodes, but no shared development replicas. Those boundaries reduce accidental misuse and make capacity conversations concrete. When a team asks for more, they are asking for a named service tier with known tradeoffs.
+
+The following example ties quota limits to a training PriorityClass so urgent jobs can preempt lower-priority work when the scheduler allows it:
+
+```yaml
+apiVersion: v1
+kind: ResourceQuota
+metadata:
+  name: ml-training-gpu-quota
+  namespace: ml-training
+spec:
+  hard:
+    nvidia.com/gpu: "16"
+    nvidia.com/mig-1g.10gb: "0"
+    nvidia.com/gpu.shared: "0"
+---
+apiVersion: scheduling.k8s.io/v1
+kind: PriorityClass
+metadata:
+  name: gpu-training-high
+value: 100000
+globalDefault: false
+description: "High-priority distributed training jobs that may preempt lower tiers"
+```
+
+Pair the PriorityClass with Pod specs in the training namespace and keep preemption scoped to namespaces or tiers where disruption is acceptable.
 
 Observability must also reflect the sharing model. DCGM metrics show device utilization, memory use, temperature, health, and error conditions, but they do not automatically explain tenant fairness. Combine DCGM with Kubernetes data: which Pod requested which resource name, which namespace owns it, which node profile is active, and whether a Pending Pod is blocked by capacity, affinity, taints, topology admission, or quota. A useful GPU dashboard separates exclusive, MIG, time-sliced, and MPS capacity instead of presenting one blended utilization line.
 
@@ -678,7 +728,7 @@ Revisit the decision whenever demand changes. A notebook tier that begins as a s
 
 ## Did You Know?
 
-1. **Kubernetes Dynamic Resource Allocation reached stable status in Kubernetes 1.35.** That matters because DRA moves device selection toward claims, classes, and scheduler-visible attributes instead of relying only on extended resource counts and node labels.
+1. **Kubernetes Dynamic Resource Allocation reached GA in Kubernetes 1.34 and is always enabled in 1.35.** That matters because DRA moves device selection toward claims, classes, and scheduler-visible attributes instead of relying only on extended resource counts and node labels.
 2. **An A100-80GB can expose seven `1g.10gb` MIG instances from one physical GPU.** That turns one expensive accelerator into several hardware-isolated scheduling units when the workload profile fits the memory and compute shape.
 3. **NVIDIA GPU time-slicing intentionally provides no memory or fault isolation between replicas.** It improves access for bursty workloads, but a process that consumes too much VRAM can still affect its neighbors on the same physical device.
 4. **Topology Manager has been stable since Kubernetes 1.27, but it is a kubelet admission feature rather than a global optimizer.** It can reject poorly aligned Pods on a node, yet you still need correct node pools, labels, and scheduling policy.
@@ -770,7 +820,7 @@ GPU_NODE=$(kubectl get nodes -l nvidia.com/gpu.present=true -o jsonpath='{.items
 kubectl label node $GPU_NODE nvidia.com/device-plugin.config=timeslice-4 --overwrite
 
 # Update the ClusterPolicy to reference the ConfigMap
-kubectl patch clusterpolicy cluster-policy --type=merge -p '{
+kubectl patch clusterpolicies.nvidia.com cluster-policy --type=merge -p '{
   "spec": {
     "devicePlugin": {
       "config": {

--- a/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.3-distributed-training.md
+++ b/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.3-distributed-training.md
@@ -241,8 +241,12 @@ NCCL_MAX_NCHANNELS=12          # Maximum parallel channels
 NCCL_BUFFSIZE=8388608          # Buffer size per channel (8MB)
 
 # GPUDirect
-NCCL_NET_GDR_LEVEL=5           # GPUDirect RDMA level (5 = across PCIe switches)
-NCCL_P2P_LEVEL=5               # Peer-to-peer level (intra-node)
+NCCL_NET_GDR_LEVEL=SYS         # GPUDirect RDMA across SMP interconnect (always enabled)
+NCCL_P2P_LEVEL=SYS             # P2P across NUMA nodes via SMP interconnect (always enabled)
+
+# Note: Use STRING identifiers (LOC, PIX, PXB, PHB, SYS) rather than legacy integer
+# values. Integer values are discouraged by the NCCL docs — path-type IDs can change
+# across NCCL releases. Values above 4 (e.g., 5) are treated as SYS regardless.
 
 # Debugging
 NCCL_DEBUG=INFO                # Logging: WARN, INFO, TRACE
@@ -337,17 +341,19 @@ spec:
   config: |
     {
       "cniVersion": "0.3.1",
-      "type": "ib-sriov",
-      "pkey": "0x00FF",
+      "type": "sriov",
       "link_state": "enable",
-      "rdmaIsolation": true,
-      "ibKubernetesEnabled": true,
       "ipam": {
         "type": "whereabouts",
         "range": "192.168.20.0/24"
       }
     }
 ```
+
+For InfiniBand fabrics, plugins such as `ib-sriov-cni` (Mellanox/NVIDIA) add InfiniBand-specific
+fields — partition keys, RDMA isolation, and IB-address management — on top of the standard SR-IOV
+CNI. Consult your fabric vendor's CNI plugin documentation when deploying on InfiniBand; the standard
+`sriov` CNI shown here is a valid starting point for RoCE-over-Ethernet environments.
 
 The host-device style is the most direct of the examples because a specific host device is attached into the pod. It can be useful for controlled environments and diagnostics, but it reduces scheduling flexibility because the pod now depends on a particular local device name. If you use this model, node labels and admission controls should prevent jobs from landing on nodes that cannot satisfy the device assumption.
 
@@ -411,6 +417,14 @@ You should also decide how secondary networks are requested by tenants. Letting 
 ## Training Operators, Placement, and Failure Recovery
 
 Kubeflow Training Operator turns distributed training from a hand-managed set of pods into declarative job resources. It does not remove the need to understand PyTorch, MPI, NCCL, or networking, but it gives Kubernetes a controller that can create the right launcher, master, and worker pods for each framework style. That controller becomes the place where restart policy, replica counts, clean-up behavior, and framework-specific launch conventions are expressed consistently.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> The examples in this section use **Kubeflow Training Operator v1.8.1**, which is the legacy API.
+> The project has been renamed `kubeflow/trainer`; v2.x (latest: v2.2.0, March 2026) introduces
+> breaking changes: `nprocPerNode` is removed from the Torch API, and `ElasticPolicy` is removed
+> entirely. The v1 PyTorchJob and MPIJob examples still work on v1.8.1, but new deployments should
+> use the v2 Trainer API. See the [v2 migration guide](https://github.com/kubeflow/trainer#kubeflow-training-operator-v1).
 
 | CRD | Framework | Communication |
 |-----|-----------|---------------|
@@ -663,7 +677,11 @@ Failure recovery is not optional for multi-day training because the probability 
 
 > **Pause and predict**: If one node fails in a 128-node training group, can the remaining workers keep training immediately, or do they need a new rendezvous and checkpoint decision?
 
-| Failure | Frequency (per 1000 GPU-hours) | Impact |
+> Representative ranges observed across large GPU operators; your cluster hardware,
+> workload profile, and maintenance practices will produce different values.
+> Use these as order-of-magnitude reference, not as a prediction for any specific cluster.
+
+| Failure | Typical Observed Range (per 1000 GPU-hours) | Impact |
 |---------|-------------------------------|--------|
 | GPU Xid errors (recoverable) | 2-5 | Training step fails, retry |
 | GPU fallen off bus (Xid 79) | 0.5-1 | Node reboot required |
@@ -709,10 +727,10 @@ kind: PyTorchJob
 metadata:
   name: elastic-training
 spec:
+  maxRestarts: 10           # Total restart budget (spec-level field)
   elasticPolicy:
     minReplicas: 2        # Minimum workers to continue training
     maxReplicas: 8        # Maximum workers if available
-    maxRestarts: 10       # Total restart budget
     rdzvBackend: c10d
   pytorchReplicaSpecs:
     Worker:
@@ -1221,6 +1239,7 @@ You have completed this exercise when:
 - [SR-IOV Network Device Plugin](https://github.com/k8snetworkplumbingwg/sriov-network-device-plugin)
 - [Kubeflow Training Operator](https://www.kubeflow.org/docs/components/training/)
 - [Kubeflow PyTorchJob guide](https://www.kubeflow.org/docs/components/training/user-guides/pytorch/)
+- [Kubeflow Trainer v2 migration guide](https://github.com/kubeflow/trainer#kubeflow-training-operator-v1)
 - [PyTorch torchrun elastic launch](https://pytorch.org/docs/stable/elastic/run.html)
 - [PyTorch distributed package](https://pytorch.org/docs/stable/distributed.html)
 - [AWS EC2 placement groups](https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/placement-groups.html)

--- a/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.4-ai-storage.md
+++ b/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.4-ai-storage.md
@@ -27,23 +27,38 @@ After completing this module, you will be able to:
 
 Hypothetical scenario: your platform team has just delivered a clean GPU pool for the machine learning group. The nodes have modern accelerators, the scheduler can place GPU jobs, and the team has confidence in quota enforcement because earlier modules covered provisioning and sharing. Then the first serious image-training job lands, eight GPUs light up for a few seconds, and the utilization graph flattens around forty percent because the workers spend most of each step waiting for the next batch to arrive from storage.
 
-Meta's Llama 3 training run is the same lesson at industrial scale. Meta reported that its storage system served **240 PB over 54 days**, which works out to about **4.4 PB per day** or **51 GB/s sustained**. That number is memorable because it is not a burst benchmark; it is the rate a training platform had to keep feeding the job for weeks so the accelerators did not starve.
+Meta's Llama 3 training run is the same lesson at industrial scale. In the Llama 3 paper, Meta describes a Tectonic-based storage fabric with **240 PB of capacity** across **7,500 SSD-equipped servers**, supporting **2 TB/s sustainable** and **7 TB/s peak** throughput for pre-training I/O and highly bursty checkpoint writes. The **54-day** figure in that paper is a fault-analysis snapshot window for training interruptions, not a total data-served duration, and Meta does not report a single derived average read rate across the full run. The takeaway is structural: industrial LLM training needs storage that can sustain terabyte-scale throughput and absorb checkpoint bursts without starving accelerators for weeks.
 
 That situation is frustrating because it looks like a GPU problem from a distance, but it is usually a data path problem. A training loop cannot compute on examples it has not loaded, decoded, shuffled, transferred, and staged, so storage design directly determines how much expensive accelerator time turns into useful gradient updates. If the platform exposes only a generic network filesystem or a direct object-store mount, the job may be correct yet still waste more money than a scheduling bug would.
 
 This module teaches storage as an operational design problem rather than a shopping list of tools. You will start by recognizing the I/O shape of different AI workloads, then build up the storage tiers that Kubernetes can expose: local NVMe for hot data, distributed filesystems for shared warm data, object storage for durable cold data, and caching systems that move bytes closer to the GPUs. The goal is not to memorize one preferred product; the goal is to choose a path that matches the dataset, checkpoint cadence, fault-tolerance needs, and Kubernetes scheduling constraints in front of you.
 
-The performance gap explains why the storage layer deserves its own module. GPU memory and GPU compute move at speeds that storage systems cannot approach, so the platform has to hide latency through locality, batching, prefetching, and parallelism. The exact numbers vary by hardware and cloud provider, but the relative order is stable enough to use as a design compass.
+The performance gap explains why the storage layer deserves its own module. GPU memory and GPU compute move at speeds that storage systems cannot approach, so the platform has to hide latency through locality, batching, prefetching, and parallelism. The relative order is stable enough to use as a design compass: GPU memory and compute sit closest to the accelerator, local NVMe is the fastest node-local tier, shared filesystems trade latency for sharing semantics, and object storage trades per-request latency for durability and cost at scale.
 
-| Component | Throughput | Latency |
-|-----------|-----------|---------|
-| GPU compute (A100 BF16) | 312 TFLOPS | nanoseconds |
-| GPU memory (HBM3) | 2 TB/s | nanoseconds |
-| NVMe SSD (local) | 7 GB/s | 10-100 us |
-| Network storage (CephFS) | 1-5 GB/s | 0.5-5 ms |
-| Object storage (S3) | 100-500 MB/s | 10-100 ms |
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> | Layer | Indicative throughput / latency |
+> |-------|----------------------------------|
+> | GPU compute (A100 BF16) | ~312 TFLOPS |
+> | GPU memory (HBM3) | ~2 TB/s |
+> | Local NVMe SSD | ~7 GB/s read; 10–100 µs latency |
+> | Network filesystem (e.g., CephFS) | ~1–5 GB/s; 0.5–5 ms latency |
+> | Object storage (e.g., S3) | ~100–500 MB/s per prefix; 10–100 ms per request |
+>
+> **Workload I/O profiles (indicative):**
+>
+> | Workload | Data size | Access pattern | Typical read size | Throughput need |
+> |----------|-----------|----------------|-------------------|-----------------|
+> | Image classification (ImageNet) | ~150 GB | Random small files | 100–500 KB | ~2–5 GB/s |
+> | Object detection (COCO) | ~20 GB | Random medium files | 200 KB–5 MB | ~1–3 GB/s |
+> | NLP pre-training (C4) | ~800 GB | Sequential shards | 1–100 MB | ~5–20 GB/s |
+> | Video training | 5–50 TB | Sequential large files | 50–500 MB | ~10–50 GB/s |
+> | LLM fine-tuning (tokenized) | 10–100 GB | Sequential | 1–10 MB | ~1–5 GB/s |
+> | Checkpoint save | 1–50 GB per save | Sequential write burst | Full model state | ~5–20 GB/s burst |
+>
+> **Dataset-cache tooling (peer capabilities):** Fluid (CNCF Incubating since 2026-01-08) coordinates cache engines such as Alluxio, JuiceFS, and JindoFS with dataset-aware scheduling; JuiceFS exposes POSIX over object storage with local cache; Alluxio tiers memory and disk cache in front of under-storage.
 
-The table is not a promise that every NVMe disk, CephFS cluster, or S3 bucket will hit those values. It is a reminder that storage sits far away from the compute unit in both latency and throughput, especially when the training workload issues millions of small reads. A platform that ignores this gap can buy more GPUs and still deliver slower training, while a platform that respects the gap can improve utilization with a cache, a packaging change, or a different checkpoint strategy.
+These figures are not promises that every disk, cluster, or bucket will match them on your hardware. They are a reminder that storage sits far away from the compute unit in both latency and throughput, especially when the training workload issues millions of small reads. A platform that ignores this gap can buy more GPUs and still deliver slower training, while a platform that respects the gap can improve utilization with a cache, a packaging change, or a different checkpoint strategy.
 
 ## The I/O Bottleneck in ML Workloads
 
@@ -60,16 +75,7 @@ flowchart LR
 
 The diagram deliberately separates storage reads from GPU transfer because they fail in different ways. A PCIe transfer bottleneck often shows up after the batch is already resident in host memory, while a storage bottleneck shows up before the CPU workers can produce the batch. That distinction matters when you decide whether to tune `DataLoader` workers, pre-stage data onto local disks, package small files into larger records, or change the filesystem entirely.
 
-Different ML workloads have radically different I/O profiles, and platform teams get into trouble when they treat all training jobs as if they were the same. Image training often reads a huge count of tiny objects in random order, which punishes object storage and metadata-heavy network filesystems. Tokenized language-model training is usually friendlier because it can read larger sequential shards, but the required throughput may be much higher because the GPUs consume tokens quickly.
-
-| Workload | Data Size | Access Pattern | Read Size | Throughput Need |
-|----------|-----------|---------------|-----------|-----------------|
-| Image classification (ImageNet) | 150 GB | Random, small files | 100-500 KB | 2-5 GB/s |
-| Object detection (COCO) | 20 GB | Random, medium files | 200 KB - 5 MB | 1-3 GB/s |
-| NLP pre-training (C4) | 800 GB | Sequential, large files | 1-100 MB | 5-20 GB/s |
-| Video training | 5-50 TB | Sequential, very large | 50-500 MB | 10-50 GB/s |
-| LLM fine-tuning (tokenized) | 10-100 GB | Sequential | 1-10 MB | 1-5 GB/s |
-| Checkpoint save | 1-50 GB per save | Sequential write | Full model | 5-20 GB/s burst |
+Different ML workloads have radically different I/O profiles, and platform teams get into trouble when they treat all training jobs as if they were the same. Image training often reads a huge count of tiny objects in random order, which punishes object storage and metadata-heavy network filesystems. Tokenized language-model training is usually friendlier because it can read larger sequential shards, but the required aggregate throughput may be much higher because the GPUs consume tokens quickly. Video workloads favor large sequential reads; checkpointing flips the problem from reads to write bursts. See the **Landscape snapshot** above for indicative size and throughput ranges by workload type.
 
 The key design move is to translate the workload into read size, randomness, concurrency, and write burst requirements before choosing storage. Image classification against millions of JPEG files may need local caching or dataset repackaging even when the total dataset is modest. Video training may tolerate higher latency per file because each read is large, but it can saturate network links if several jobs stream at once. Checkpointing flips the problem from reads to writes, and a fast read cache does not automatically make checkpoint saves safe or durable.
 
@@ -83,8 +89,8 @@ Before optimizing, measure the job that is actually slow. GPU utilization tells 
 # Monitor GPU utilization during training
 # If GPU util is < 80% and you're not memory-bound, you're IO-bound
 
-# Quick check: watch nvidia-smi during training
-kubectl exec -it training-pod -- watch -n 1 'nvidia-smi --query-gpu=utilization.gpu,utilization.memory --format=csv,noheader'
+# Quick check: poll nvidia-smi during training (minimal GPU images often lack watch)
+kubectl exec -it training-pod -- bash -c 'while true; do nvidia-smi --query-gpu=utilization.gpu,utilization.memory --format=csv,noheader; sleep 1; done'
 
 # Better: check PyTorch DataLoader timing
 # Add this to your training script:
@@ -108,10 +114,10 @@ AI platforms usually need multiple storage tiers because no single tier gives pe
 
 ```mermaid
 flowchart TD
-    A["GPU VRAM (training)\n2 TB/s, us latency\nManaged by framework"]
-    B["Local NVMe (hot cache)\n3-14 GB/s, 10-100 us\nTopoLVM, OpenEBS LVM"]
-    C["Distributed FS (warm)\n1-10 GB/s, 0.5-5 ms\nCephFS, GlusterFS, JuiceFS"]
-    D["Object Storage (cold)\n100 MB-5 GB/s, 10-100 ms\nS3, GCS, MinIO"]
+    A["GPU VRAM (training)\nClosest to compute\nManaged by framework"]
+    B["Local NVMe (hot cache)\nNode-local; lowest remote latency\nTopoLVM, OpenEBS LVM"]
+    C["Distributed FS (warm)\nShared POSIX; network path\nCephFS, GlusterFS, JuiceFS"]
+    D["Object Storage (cold)\nDurable; request-oriented API\nS3, GCS, MinIO"]
     E["Tape/Archive\nArchival\nGlacier, Coldline"]
 
     A -->|"Cost $, Speed $$$$"| B
@@ -200,14 +206,13 @@ spec:
 OpenEBS LVM LocalPV offers a similar local-volume pattern with a different operational footprint. It is attractive when you want a simpler local-provisioning story and already manage node volume groups outside the storage driver. As with TopoLVM, the key is not the product name but the combination of local disk performance, CSI lifecycle management, and delayed binding so the scheduler does not make impossible placement decisions.
 
 ```bash
-# Install OpenEBS LVM LocalPV
+# Install OpenEBS (default chart enables Local PV LVM; disable Mayastor if not needed)
 helm repo add openebs https://openebs.github.io/openebs
 helm repo update
 
 helm install openebs openebs/openebs \
   --namespace openebs \
   --create-namespace \
-  --set lvm-localpv.enabled=true \
   --set engines.replicated.mayastor.enabled=false
 ```
 
@@ -219,7 +224,7 @@ metadata:
 provisioner: local.csi.openebs.io
 parameters:
   storage: "lvm"
-  vgPattern: "nvme-vg"          # LVM volume group pattern
+  vgpattern: "nvme-vg"          # LVM volume group pattern (regex)
   fsType: "xfs"                  # XFS recommended for large files
 volumeBindingMode: WaitForFirstConsumer
 ```
@@ -378,6 +383,8 @@ The mount options show where performance choices become explicit. A larger cache
 Caching becomes most valuable when the same data is read repeatedly by many jobs. Without a cache, each run pays the object-store request latency and network transfer cost again, even if another pod on the same node just read the same files. With a cache, the first read is still cold, but later reads can be served from local disk or memory, and the platform can stop treating every training run as a brand-new download.
 
 ```text
+Hypothetical scenario: fifty engineers each run a training job that downloads 500 GB from S3.
+
 Engineer 1 training job: Downloads 500GB from S3 -> 30 min
 Engineer 2 training job: Downloads 500GB from S3 -> 30 min
 ...
@@ -387,6 +394,8 @@ Total: 25 TB downloaded, 25 hours of wait time, $50+ in S3 egress
 ```
 
 ```text
+Hypothetical scenario: the same fifty engineers reuse a warm node-local cache.
+
 Engineer 1 training job: Downloads 500GB from S3 -> 30 min (cold)
 Engineer 2 training job: Reads from cache -> 2 min (warm)
 ...
@@ -401,7 +410,7 @@ Those numbers are illustrative, but the direction is real: repeated reads turn n
 >
 > **Answer:** Include GPU idle time, experiment turnaround, network contention, cache disk cost, operational overhead, and the risk of stale data.
 
-Fluid is a CNCF sandbox project that brings dataset-aware scheduling to Kubernetes. Instead of treating a dataset as just another PVC, Fluid models the dataset as a resource and coordinates cache engines such as Alluxio, JuiceFS, or JindoFS under the hood. That resource model lets the platform track cache placement and influence pod scheduling so jobs prefer nodes where the needed data is already warm.
+Fluid brings dataset-aware scheduling to Kubernetes as a CNCF Incubating project (see the **Landscape snapshot** for current maturity). Instead of treating a dataset as just another PVC, Fluid models the dataset as a resource and coordinates cache engines such as Alluxio, JuiceFS, or JindoFS under the hood. That resource model lets the platform track cache placement and influence pod scheduling so jobs prefer nodes where the needed data is already warm.
 
 ```bash
 # Install Fluid
@@ -444,9 +453,14 @@ spec:
   replicas: 3                    # 3 cache workers
   tieredstore:
     levels:
+      - mediumtype: MEM
+        path: /dev/shm
+        quota: 100Gi              # RAM cache per worker
+        high: "0.95"
+        low: "0.7"
       - mediumtype: SSD
-        path: /dev/shm,/var/cache/alluxio
-        quota: 100Gi,400Gi       # 100GB RAM + 400GB SSD cache per worker
+        path: /var/cache/alluxio
+        quota: 400Gi              # SSD cache per worker
         high: "0.95"
         low: "0.7"
   fuse:
@@ -516,10 +530,10 @@ spec:
 Alluxio can also be deployed independently when a team wants more control over the cache layer. That may be appropriate in an environment with multiple compute platforms or a mature storage team that already operates Alluxio outside Kubernetes. The cost is that you now own more of the integration and scheduling behavior yourself, so the operational model should be chosen deliberately rather than by habit.
 
 ```bash
-helm repo add alluxio https://alluxio-charts.storage.googleapis.com/openSource
+helm repo add alluxio-charts https://alluxio-charts.storage.googleapis.com/openSource/2.9.5
 helm repo update
 
-helm install alluxio alluxio/alluxio \
+helm install alluxio alluxio-charts/alluxio \
   --namespace alluxio \
   --create-namespace \
   --set master.count=1 \
@@ -573,25 +587,26 @@ thread.start()
 # Training continues immediately
 ```
 
-Sharded checkpoints match the distributed shape of modern training. Instead of one worker writing the entire model state, each rank writes its own shard in parallel, which reduces wall-clock save time and avoids funneling every byte through one process. The storage target must still handle the aggregate write burst, so sharding helps most when the filesystem or object-backed layer can accept parallel writes without turning metadata into the next bottleneck.
+Sharded checkpoints match the distributed shape of modern training. Instead of one worker writing the entire model state, each rank writes its own shard in parallel, which reduces wall-clock save time and avoids funneling every byte through one process. The storage target must still handle the aggregate write burst, so sharding helps most when the filesystem or object-backed layer can accept parallel writes without turning metadata into the next bottleneck. Hypothetical scenario: eight GPUs each writing an 87.5 GB shard at 2 GB/s completes in about 44 seconds wall-clock versus roughly 350 seconds for one serial 700 GB write.
 
 ```python
-# Each GPU saves its own shard in parallel
-# 8 GPUs writing 87.5 GB each at 2 GB/s = 44 seconds (vs 350 seconds serial)
+# Requires torch.distributed init and FSDP or model-parallel setup.
 from torch.distributed.checkpoint import save
-save(model.state_dict(), checkpoint_id=f"/checkpoints/step_{step}")
+
+state_dict = {"model": model.state_dict()}
+save(state_dict, checkpoint_id=f"/checkpoints/step_{step}")
 ```
 
 > **Pause and predict:** What is the risk of using asynchronous checkpointing if the node crashes exactly while the background thread is writing the checkpoint?
 >
 > **Answer:** The write may leave a partial or corrupt checkpoint that looks usable unless the design uses temporary paths, completion markers, atomic promotion, validation, and a durable source of truth.
 
-| Storage Type | Write Speed | Best For |
-|-------------|-------------|----------|
-| Local NVMe (TopoLVM) | 5-7 GB/s | Fastest saves; risk of data loss on node failure |
-| CephFS / GlusterFS (RWX) | 1-5 GB/s | Shared access, multi-node distributed saves |
-| JuiceFS (NVMe cache + S3) | 3-7 GB/s local, async to S3 | Best of both: fast writes, durable storage |
-| NFS | 0.5-2 GB/s | Simple, widely available; potential bottleneck |
+| Storage Type | Write profile | Best For |
+|-------------|---------------|----------|
+| Local NVMe (TopoLVM) | Highest node-local sequential bandwidth | Fastest saves; risk of data loss on node failure |
+| CephFS / GlusterFS (RWX) | Shared parallel writes across nodes | Shared access, multi-node distributed saves |
+| JuiceFS (NVMe cache + S3) | Fast local landing with async object flush | Fast writes with durable object-store backend |
+| NFS | Moderate shared throughput; metadata-sensitive | Simple, widely available; benchmark before large checkpoints |
 
 The table is a decision aid, not a universal ranking. Local NVMe may be the right first landing zone for very frequent checkpoints if a separate process quickly copies completed checkpoints to durable storage. A shared filesystem may be better when many ranks need a common path and the platform can provision enough throughput. NFS remains useful for small teams and modest jobs, but it should be benchmarked under checkpoint-like writes before it becomes the default for large models.
 
@@ -1081,8 +1096,10 @@ You have completed this exercise when:
 - [JuiceFS CSI Driver introduction](https://juicefs.com/docs/csi/introduction/)
 - [JuiceFS Helm charts](https://juicedata.github.io/charts/)
 - [Fluid — CNCF dataset orchestration & caching for AI](https://fluid-cloudnative.github.io/)
+- [Fluid CNCF project page](https://www.cncf.io/projects/fluid/)
 - [Fluid GitHub repository](https://github.com/fluid-cloudnative/fluid)
-- [Alluxio on Kubernetes](https://docs.alluxio.io/os/user/stable/en/kubernetes/Running-Alluxio-On-Kubernetes.html)
+- [The Llama 3 Herd of Models (arXiv:2407.21783)](https://arxiv.org/abs/2407.21783)
+- [Alluxio on Kubernetes (Helm deployment)](https://documentation.alluxio.io/os-en/kubernetes/running-alluxio-on-kubernetes)
 - [Alluxio Kubernetes integration (Helm chart in repo)](https://github.com/Alluxio/alluxio)
 - [PyTorch distributed checkpoint API](https://pytorch.org/docs/stable/distributed.checkpoint.html)
 - [MinIO Kubernetes documentation](https://min.io/docs/minio/kubernetes/upstream/index.html)

--- a/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.5-llm-serving.md
+++ b/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.5-llm-serving.md
@@ -27,19 +27,29 @@ After completing this module, you will be able to:
 
 Hypothetical scenario: your team has just moved a useful internal assistant from a notebook into a shared Kubernetes service. The demo looked fast with one user, but the first real traffic spike creates a confusing failure pattern: GPUs are full, CPU dashboards look calm, scale-up takes several minutes, and users see either a blank spinner or a response that stops halfway through. Nothing about that incident looks like a normal REST outage, because the bottleneck is not a saturated web thread pool. It is the interaction between model weights, KV cache memory, decode bandwidth, request queues, cold starts, and Kubernetes lifecycle behavior.
 
-Training a model is an investment, but serving it is where the operational bill arrives every hour. A typical CRUD endpoint might complete in a few milliseconds and release its connection quickly. An LLM request can hold a GPU reservation for many seconds while it streams tokens, and the cost of each token depends on how efficiently the serving engine keeps the GPU occupied. If a single A100 is rented for several dollars per hour, then a deployment that handles five requests per second and a deployment that handles dozens of requests per second can have the same hardware cost but radically different unit economics.
+Training a model is an investment, but serving it is where the operational bill arrives every hour. A typical CRUD endpoint might complete in a few milliseconds and release its connection quickly. An LLM request can hold a GPU reservation for many seconds while it streams tokens, and the cost of each token depends on how efficiently the serving engine keeps the GPU occupied. When the same rented accelerator produces more useful tokens per minute for the same workload class, the platform has improved unit economics without changing the model.
 
 This module teaches the production mechanics that make LLM serving practical on Kubernetes 1.35 and newer clusters. You will start by separating inference from training, then examine why engines such as vLLM and Hugging Face Text Generation Inference use PagedAttention and continuous batching. From there, you will connect those engine-level ideas to Kubernetes decisions: how to request GPUs, how to choose model length and tensor parallelism, how to scale on queue depth instead of CPU, and how to drain long-running requests during rollouts. The goal is not to memorize flags. The goal is to reason from workload physics to deployment design.
 
 ```
-1 A100 at $3/hr serving Llama-3-8B:
-  - Without optimization: 5 requests/second -> $0.17 per 1K requests
-  - With vLLM + continuous batching: 40 requests/second -> $0.02 per 1K requests
-
-That's an 8x cost difference from software optimization alone.
+Hypothetical scenario:
+  - Same GPU, same model, same prompt mix, same user-facing SLO.
+  - A naive script processes a small trickle because it admits work one request at a time.
+  - A production serving engine keeps the GPU busier with continuous batching and cache-aware scheduling.
+  - The unit cost falls because the fixed GPU-hour is amortized across more useful tokens.
 ```
 
-The simple cost sketch above is intentionally rough, but it captures the important lesson: serving efficiency is a first-class platform concern. If you treat an LLM server like a normal stateless HTTP app, you will probably scale late, terminate useful work during rollouts, and waste GPU memory on empty KV cache reservations. If you understand why those failures happen, the fixes become concrete: better serving engines, realistic sequence limits, request-aware batching, cached model weights, careful probes, and autoscaling signals that reflect what users are waiting on.
+The simple cost sketch above is intentionally illustrative, but it captures the important lesson: serving efficiency is a first-class platform concern. If you treat an LLM server like a normal stateless HTTP app, you will probably scale late, terminate useful work during rollouts, and waste GPU memory on empty KV cache reservations. If you understand why those failures happen, the fixes become concrete: better serving engines, realistic sequence limits, request-aware batching, cached model weights, careful probes, and autoscaling signals that reflect what users are waiting on.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> | Surface | Snapshot value | Operational note |
+> |---------|----------------|------------------|
+> | vLLM examples | `vllm/vllm-openai:v0.23.0` | The upstream release and Docker tag were live-checked for this module; older 2024-era tags are stale. |
+> | TGI example | `ghcr.io/huggingface/text-generation-inference:3.3.7` | Hugging Face documents TGI as maintenance-mode, so treat it as a peer runtime for suitable workflows rather than a default future bet. |
+> | KEDA lab | Helm chart `2.20.1` | The chart release is current for the 2.20 line; cluster operators may still pin CRDs separately. |
+> | vLLM metric names | `vllm:num_requests_waiting`, `vllm:request_time_per_output_token_seconds`, `vllm:request_success`, `vllm:kv_cache_usage_perc` | Metrics are versioned API surface; verify names after every engine upgrade. |
+> | Llama 3.1 8B cache math | 32 layers, 32 attention heads, 8 KV heads, head dimension 128 | Grouped-query attention means KV-cache estimates use KV heads, not the full hidden dimension. |
 
 ## Inference and Training Have Different Operating Shapes
 
@@ -47,7 +57,7 @@ Training and inference both use GPUs, but they stress the platform in different 
 
 | Property | Training | Inference |
 |----------|----------|-----------|
-| GPU utilization | 95%+ (constant compute) | 10-80% (bursty, depends on traffic) |
+| GPU utilization | High and steady when the job is well tuned | Bursty and traffic-shaped; high utilization can still hide queueing |
 | Batch size | Large (64-4096) | Small (1-64, depends on concurrency) |
 | Memory pattern | Predictable, static | Dynamic (KV cache grows with sequence) |
 | Latency requirement | None (throughput matters) | Strict (users wait for responses) |
@@ -61,8 +71,8 @@ LLM inference also has two phases with different performance characteristics. In
 
 ```mermaid
 flowchart LR
-    Prefill["<b>Prefill Phase</b><br><br>Process entire prompt in parallel<br>Compute-bound (matrix multiplications)<br>Duration: 100-500ms<br><br><i>TTFT (Time to First Token)</i>"]
-    Decode["<b>Decode Phase</b><br><br>Generate tokens one at a time<br>Memory-bandwidth-bound (KV cache)<br>Duration: 2-30s<br><br><i>TPOT (Time Per Output Token)</i>"]
+    Prefill["<b>Prefill Phase</b><br><br>Process entire prompt in parallel<br>Compute-bound (matrix multiplications)<br>Usually shorter for short prompts<br><br><i>TTFT (Time to First Token)</i>"]
+    Decode["<b>Decode Phase</b><br><br>Generate tokens one at a time<br>Memory-bandwidth-bound (KV cache)<br>Often dominates long streamed answers<br><br><i>TPOT (Time Per Output Token)</i>"]
     
     Prefill --> Decode
 ```
@@ -75,20 +85,20 @@ Pause and predict: if a normal web request holds a connection for 30 millisecond
 
 The inference engine is the part of the stack that decides how prompts become GPU work. A basic Python script can load a model and generate text, but it will usually waste memory and leave throughput on the table because it lacks a production scheduler. Production engines add request admission, batching, KV cache management, metrics, OpenAI-compatible APIs, model parallelism, and health endpoints. Kubernetes decides where the Pod runs; the engine decides how well that Pod uses the GPU once requests arrive.
 
-vLLM is widely deployed because it combines a familiar OpenAI-compatible API with a scheduler built around PagedAttention. Hugging Face Text Generation Inference, often shortened to TGI, provides similar production features and fits naturally into the Hugging Face model ecosystem. NVIDIA Triton Inference Server and TensorRT-LLM are important when teams need a broader inference platform or highly optimized NVIDIA-specific execution. You do not have to choose one engine forever, but you do need to choose one deliberately because its metrics, flags, batching model, and failure modes become part of your platform contract.
+vLLM combines a familiar OpenAI-compatible API with a scheduler built around PagedAttention. Hugging Face Text Generation Inference, often shortened to TGI, provides similar production features and fits naturally into the Hugging Face model ecosystem. NVIDIA Triton Inference Server and TensorRT-LLM are important when teams need a broader inference platform or highly optimized NVIDIA-specific execution. You do not have to choose one engine forever, but you do need to choose one deliberately because its metrics, flags, batching model, and failure modes become part of your platform contract.
 
 The KV cache problem explains why purpose-built engines matter. During generation, each new token attends to previous tokens, so the server stores key and value tensors for each layer and each generated position. That cache grows with sequence length and concurrency. If the engine reserves the maximum sequence length for every request up front, short prompts waste enormous amounts of VRAM, and the deployment reaches its concurrency limit even though most reserved cache slots are empty.
 
 ```
 Llama-3-8B, sequence length 4096:
-  KV cache per request = 2 x num_layers x hidden_dim x seq_len x 2 bytes
-                       = 2 x 32 x 4096 x 4096 x 2
-                       = ~2 GB per request
+  KV cache per request = 2 x layers x num_key_value_heads x head_dim x seq_len x bytes
+                       = 2 x 32 x 8 x 128 x 4096 x 2
+                       = 536,870,912 bytes, or 512 MiB per request
 
-With 40GB GPU: max ~20 concurrent requests
+With a 40 GB GPU: this cache estimate is one capacity input, not the full concurrency limit
 ```
 
-Pause and predict: if every request reserves cache for the maximum possible context window, what happens when most users send short prompts and ask for short answers? The GPU appears full, but much of the fullness is reserved capacity that cannot be used by other requests. That is why a serving configuration copied from a model card's theoretical context length can be much worse than a configuration based on observed product traffic.
+The important correction is the `num_key_value_heads` term. Llama 3.1 8B uses grouped-query attention, so the cache stores keys and values for the smaller KV-head set rather than for every query head. Using `hidden_dim` directly in this example treats all attention heads as KV heads and overstates the cache requirement by the query-to-KV-head ratio. Pause and predict: if every request reserves cache for the maximum possible context window, what happens when most users send short prompts and ask for short answers? The GPU appears full, but much of the fullness is reserved capacity that cannot be used by other requests. That is why a serving configuration copied from a model card's theoretical context length can be much worse than a configuration based on observed product traffic.
 
 PagedAttention, introduced by the vLLM project, treats KV cache more like virtual memory than like one large contiguous allocation per request. The engine breaks cache into blocks and maps logical token positions to physical blocks. A request receives more blocks as it grows, and only the final partially filled block is likely to waste space. This does not make memory free, but it changes the dominant failure mode from huge static reservations to much smaller fragmentation.
 
@@ -99,7 +109,7 @@ flowchart TD
         TR1["Request 1: 400 slots used, 3696 wasted"]
         TR2["Request 2: 800 slots used, 3296 wasted"]
         TR3["Request 3: 200 slots used, 3896 wasted"]
-        TR4["WASTED: 88% of allocated memory"]
+        TR4["WASTED: most allocated slots"]
         TR1 ~~~ TR2 ~~~ TR3 ~~~ TR4
     end
 
@@ -107,7 +117,7 @@ flowchart TD
         direction TB
         PA1["Physical Pages: R1, R1, R2, R2, R2, R3, Free"]
         PA2["                R2, R2, R1, Free, Free, Free"]
-        PA3["WASTED: 4% (Fragmentation only in last page)"]
+        PA3["WASTED: mostly final-page fragmentation"]
         PA1 ~~~ PA2 ~~~ PA3
     end
 ```
@@ -132,7 +142,7 @@ spec:
     spec:
       containers:
         - name: vllm
-          image: vllm/vllm-openai:v0.6.5
+          image: vllm/vllm-openai:v0.23.0
           args:
             - --model=meta-llama/Llama-3.1-8B-Instruct
             - --tensor-parallel-size=1
@@ -140,7 +150,7 @@ spec:
             - --max-model-len=8192
             - --max-num-seqs=64
             - --enable-chunked-prefill
-            - --disable-log-stats=false
+            - --shutdown-timeout=180
             - --port=8000
           ports:
             - containerPort: 8000
@@ -181,7 +191,7 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 8Gi
-      terminationGracePeriodSeconds: 120   # Allow in-flight requests to finish
+      terminationGracePeriodSeconds: 210   # Must exceed vLLM shutdown timeout
 ---
 apiVersion: v1
 kind: Service
@@ -206,7 +216,7 @@ The most dangerous vLLM flags are the ones that look harmless because they are j
 | `--max-num-seqs` | Maximum concurrent requests | Start with 64, tune based on TPOT requirements |
 | `--tensor-parallel-size` | Number of GPUs for tensor parallelism | 1 for 8B models; 2 for 70B; 4-8 for 405B |
 | `--enable-chunked-prefill` | Process long prompts in chunks, interleaved with decode | Enable for mixed-length traffic |
-| `--quantization` | Weight quantization (awq, gptq, fp8) | Use AWQ/GPTQ for 2x memory savings, ~5% quality loss |
+| `--quantization` | Weight quantization (awq, gptq, fp8) | Memory and quality impact are model- and workload-specific; benchmark before rollout |
 | `--enforce-eager` | Disable CUDA graph caching | Use for debugging; disable in production |
 | `--swap-space` | CPU RAM for swapping KV cache (GB) | 4-16 for handling burst traffic |
 
@@ -230,7 +240,7 @@ spec:
     spec:
       containers:
         - name: tgi
-          image: ghcr.io/huggingface/text-generation-inference:2.4
+          image: ghcr.io/huggingface/text-generation-inference:3.3.7
           args:
             - --model-id=meta-llama/Llama-3.1-8B-Instruct
             - --max-input-tokens=4096
@@ -262,7 +272,7 @@ spec:
             sizeLimit: 8Gi
 ```
 
-The practical comparison is less about which engine is universally better and more about the workload you have to operate. vLLM is a strong default for OpenAI-compatible serving, high-throughput scheduling, prefix caching, and multi-LoRA patterns. TGI is attractive for teams already invested in Hugging Face deployment workflows. Triton and TensorRT-LLM become compelling when an organization wants standardized NVIDIA inference operations, model repositories, or deeper graph optimization. Whichever path you choose, keep the SLO written in user terms: TTFT, TPOT, error rate, and cost per useful token.
+The practical comparison is less about which engine is universally better and more about the workload you have to operate. vLLM is a useful fit for OpenAI-compatible serving, high-throughput scheduling, prefix caching, and multi-LoRA patterns. TGI remains relevant for teams already invested in Hugging Face deployment workflows, but the snapshot above matters because maintenance-mode projects should be adopted with a clearer upgrade and migration plan. Triton and TensorRT-LLM become compelling when an organization wants standardized NVIDIA inference operations, model repositories, or deeper graph optimization. Whichever path you choose, keep the SLO written in user terms: TTFT, TPOT, error rate, and cost per useful token.
 
 | Feature | vLLM | TGI |
 |---------|------|-----|
@@ -272,9 +282,9 @@ The practical comparison is less about which engine is universally better and mo
 | Quantization | AWQ, GPTQ, FP8, GGUF | AWQ, GPTQ, BitsAndBytes |
 | OpenAI-compatible API | Yes (native) | Yes (via flag) |
 | Speculative decoding | Yes | Yes |
-| Prefix caching | Yes | No |
+| Prefix caching | Yes | Yes, with v3 optimized caching |
 | LoRA serving | Yes (multi-LoRA) | Yes |
-| Community | Larger, faster-moving | Hugging Face ecosystem |
+| Operational fit | General OpenAI-compatible serving, multi-LoRA, and high-throughput scheduling | Existing Hugging Face serving workflows where maintenance-mode status is acceptable |
 
 ## Batching, Memory, and Multi-GPU Serving
 
@@ -350,15 +360,17 @@ spec:
       labels:
         app: vllm-llama3-70b
     spec:
+      terminationGracePeriodSeconds: 210
       containers:
         - name: vllm
-          image: vllm/vllm-openai:v0.6.5
+          image: vllm/vllm-openai:v0.23.0
           args:
             - --model=meta-llama/Llama-3.1-70B-Instruct
             - --tensor-parallel-size=2    # Split across 2 GPUs
             - --gpu-memory-utilization=0.92
             - --max-model-len=8192
             - --max-num-seqs=32
+            - --shutdown-timeout=180
             - --port=8000
           resources:
             limits:
@@ -373,7 +385,8 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: 16Gi
-      # Ensure both GPUs are on the same node with NVLink
+      # Coarse capacity filter plus an explicit operator-managed topology label.
+      # The GPU count alone does not prove NVLink or any other interconnect.
       affinity:
         nodeAffinity:
           requiredDuringSchedulingIgnoredDuringExecution:
@@ -382,6 +395,9 @@ spec:
                   - key: nvidia.com/gpu.count
                     operator: In
                     values: ["2", "4", "8"]
+                  - key: topology.kubedojo.io/gpu-interconnect
+                    operator: In
+                    values: ["nvlink"]
 ```
 
 Pipeline parallelism splits layers across GPUs sequentially. It may help when model weights cannot fit otherwise or when interconnect bandwidth is weaker, but it often increases token latency because activations must move through stages. For serving, tensor parallelism is usually preferred inside one machine with fast GPU links, while pipeline parallelism is a fallback for larger models, constrained topologies, or specialized serving stacks. The right decision comes from measuring TTFT, TPOT, and cost per generated token rather than from choosing the largest model that can be made to start.
@@ -429,7 +445,7 @@ helm repo update
 helm install keda kedacore/keda \
   --namespace keda \
   --create-namespace \
-  --version 2.16.0
+  --version 2.20.1
 ```
 
 The ScaledObject below scales a vLLM Deployment based on average waiting requests. The polling interval and cooldown are intentionally conservative because LLM Pods are expensive and slow to start. Scaling up one Pod at a time prevents a sudden burst from consuming all available GPU nodes, while the longer scale-down window avoids removing capacity during short pauses in traffic. These values should be tuned against cold-start time, budget, and SLO, not copied blindly.
@@ -494,35 +510,34 @@ spec:
         serverAddress: http://kube-prometheus-prometheus.monitoring:9090
         query: |
           histogram_quantile(0.95,
-            sum(rate(vllm:time_per_output_token_seconds_bucket{namespace="inference"}[2m]))
+            sum(rate(vllm:request_time_per_output_token_seconds_bucket{namespace="inference"}[2m]))
             by (le)
           )
         threshold: "0.060"        # Scale up when P95 TPOT exceeds 60ms
         activationThreshold: "0.040"
 ```
 
-Scale-to-zero is tempting for development models and rarely used internal tools, but it has a painful first-request cost. An LLM Pod may need to schedule onto a GPU node, mount or download weights, load them into VRAM, warm kernels, and pass readiness before it can answer. That can take minutes for large models. Scale-to-zero works best when callers can tolerate cold starts, when a queue protects the user experience, or when a warm pool handles interactive requests while dormant replicas serve batch or experimental traffic.
+Scale-to-zero is tempting for development models and rarely used internal tools, but it has a painful first-request cost. An LLM Pod may need to schedule onto a GPU node, mount or download weights, load them into VRAM, warm kernels, and pass readiness before it can answer. That can take minutes for large models. If your scaling signal is emitted by the target Pod itself, keep at least one warm replica because a zero-replica Deployment emits no vLLM metrics. True scale-to-zero needs an external signal such as the KEDA HTTP add-on, a gateway queue, Redis, Kafka, or another source that exists while the model Pods are absent.
 
 ```yaml
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: vllm-dev-scaler
+  name: vllm-dev-warm-floor-scaler
   namespace: inference
 spec:
   scaleTargetRef:
     name: vllm-dev-model
-  minReplicaCount: 0               # Scale to zero!
+  minReplicaCount: 1               # Keep one warm emitter for target-side metrics
   maxReplicaCount: 2
-  idleReplicaCount: 0              # Idle = 0 replicas
-  cooldownPeriod: 900              # Wait 15 min before scaling to zero
+  cooldownPeriod: 900              # Wait 15 min before scaling down
   triggers:
     - type: prometheus
       metadata:
         serverAddress: http://kube-prometheus-prometheus.monitoring:9090
         query: |
-          sum(rate(vllm:request_success_total{namespace="inference",pod=~"vllm-dev.*"}[5m]))
-        threshold: "0.1"           # Scale up on any traffic
+          avg(vllm:num_requests_waiting{namespace="inference",pod=~"vllm-dev.*"})
+        threshold: "1"             # Add the second warm Pod when work waits
 ```
 
 Lifecycle behavior is just as important as scale-up behavior. During a rollout or scale-down, Kubernetes removes a Pod from Service endpoints and sends SIGTERM, but existing connections and upstream retries can still create visible user impact. For a normal web server, a default termination grace period may be enough. For an LLM server producing a long answer, the default can kill the response before completion. That turns a routine image update into a user-facing reliability event.
@@ -531,24 +546,26 @@ Lifecycle behavior is just as important as scale-up behavior. During a rollout o
 1. KEDA decides to scale down (or rolling update begins)
 2. Kubernetes removes Pod from Service endpoints (no new traffic)
 3. Kubernetes sends SIGTERM to Pod
-4. vLLM catches SIGTERM:
-   a. Stops accepting new requests
-   b. Continues processing in-flight requests
-   c. Waits until all in-flight requests complete
+4. vLLM receives SIGTERM:
+   a. With the default shutdown timeout, the process aborts quickly
+   b. With a positive --shutdown-timeout, it can wait for in-flight work
+   c. Readiness and upstream routing still need to stop new requests
 5. vLLM exits cleanly
 6. If terminationGracePeriodSeconds expires: SIGKILL (forced)
 ```
 
-The shutdown flow above only works if the serving process handles SIGTERM, the readiness path stops admitting new traffic, and the grace period matches realistic generation time. A Pod that advertises Ready while it is draining will receive new work during shutdown. A grace period shorter than long generations will still cut off users. A load balancer timeout shorter than the model's normal answer time can create retries that double the work. Draining is therefore an end-to-end design, not a single Kubernetes field.
+The shutdown flow above only works if the serving process is configured to wait, the readiness path stops admitting new traffic, and the grace period matches realistic generation time. Current vLLM documents `--shutdown-timeout` with a default of zero, so graceful waiting is not something to assume from the image alone. A Pod that advertises Ready while it is draining will receive new work during shutdown. A grace period shorter than long generations will still cut off users. A load balancer timeout shorter than the model's normal answer time can create retries that double the work. Draining is therefore an end-to-end design, not a single Kubernetes field.
 
 ```yaml
 spec:
   template:
     spec:
-      terminationGracePeriodSeconds: 180   # 3 minutes for in-flight requests
+      terminationGracePeriodSeconds: 210   # Must exceed vLLM shutdown timeout
       containers:
         - name: vllm
-          # vLLM handles SIGTERM gracefully by default
+          args:
+            - --shutdown-timeout=180
+          # A positive shutdown timeout asks vLLM to wait during termination.
           lifecycle:
             preStop:
               exec:
@@ -556,9 +573,8 @@ spec:
                   - sh
                   - -c
                   - |
-                    # Stop accepting new requests via readiness probe
-                    # vLLM's /health endpoint will return 503 after SIGTERM
-                    # Wait for in-flight requests to drain
+                    # Give endpoint removal and gateway routing a short head start.
+                    # Verify readiness behavior against your pinned vLLM version.
                     sleep 5
 ```
 
@@ -593,7 +609,7 @@ Anti-pattern four is hiding multiple model variants behind one service without c
 
 ## Decision Framework
 
-Start by asking what the user is waiting for, because that decides the first SLO. If the product is interactive chat, TTFT and streaming cadence matter more than absolute batch throughput. If the workload is offline summarization, throughput per dollar may matter more than low first-token latency. If the model is a developer tool, long prompts and long outputs may dominate cache usage. The best engine and scaling policy are downstream of that workload shape, so the decision process should begin with traffic, not with a preferred serving project.
+Start by asking what the user is waiting for, because that decides the first SLO. If the product is interactive chat, TTFT and streaming cadence matter more than absolute batch throughput. If the workload is offline summarization, throughput per dollar may matter more than low first-token latency. If the model is a developer tool, long prompts and long outputs may dominate cache usage. The engine and scaling policy are downstream of that workload shape, so the decision process should begin with traffic, not with a preferred serving project.
 
 Next, choose the smallest model and context policy that satisfies the product requirement. Smaller models often have better operational characteristics because they fit on one GPU, recover faster, and leave more room for KV cache. If a larger model is required, decide whether tensor parallelism on one node is available; if not, evaluate whether the added latency and operational complexity are acceptable. Quantization should be tested whenever memory is the limiting factor, but it should be promoted only after quality checks match the product domain.
 
@@ -633,7 +649,7 @@ done
 wait
 
 # Check vLLM metrics
-curl -s http://localhost:8000/metrics | grep -E "vllm:(num_requests|avg_generation|gpu_cache)"
+curl -s http://localhost:8000/metrics | grep -E "vllm:(num_requests|request_time_per_output_token|kv_cache_usage_perc)"
 ```
 
 When you read the benchmark results, resist the urge to optimize one number in isolation. A very high throughput result may be unacceptable if TTFT is poor for interactive users. A low latency result may be too expensive if it comes from underfilled GPUs. A long context limit may look safe in a functional test and then collapse concurrency in production. The skill is to connect the numbers back to the product's tolerance for waiting, the platform's budget, and the model's memory behavior.
@@ -727,6 +743,12 @@ A smoke test only proves that the endpoint responds; it does not prove that quan
 First, measure the startup path so you know how much time is spent scheduling, loading weights, moving them into VRAM, and warming the engine. Pre-cache model weights on predictable storage and avoid downloading them from external services during scale-up. Trigger scale-up earlier by using queue depth thresholds that account for cold-start time, and keep a warm minimum replica count for interactive models. Also verify readiness probes so traffic is not routed until the model can actually answer.
 </details>
 
+<details>
+<summary>Question 8: You need to serve three variants: an 8B assistant that fits on one GPU, a 70B assistant that fits only when split across two GPUs on one node, and a larger model that cannot fit within one node's GPU memory. Which serving shape should you evaluate first for each case?</summary>
+
+Use a single-GPU serving Pod for the 8B model because the simpler shape has fewer topology, communication, and rollout failure modes. Evaluate tensor parallelism first for the 70B model when the node has a fast local GPU interconnect, because every token step can use both GPUs together without crossing nodes. For the model that cannot fit on one node, evaluate pipeline parallelism or a serving stack designed for larger multi-stage layouts, then measure whether the added latency and operational complexity are acceptable for the product. The decision is not based only on parameter count; it depends on weight memory, KV-cache headroom, interconnect topology, TTFT, TPOT, and the route's SLO.
+</details>
+
 ## Hands-On Exercise: vLLM Serving with KEDA Autoscaling
 
 In this exercise you will deploy vLLM, expose the OpenAI-compatible completions endpoint, configure KEDA to scale on request queue depth, and observe how the deployment behaves under concurrent load. The manifest uses TinyLlama so the workflow is practical on smaller GPUs, but the same structure applies to larger models after you adjust memory, model cache, and parallelism settings. Treat this as a controlled lab rather than a production template, because real clusters differ in storage class, GPU topology, Prometheus labels, and model access rules.
@@ -740,7 +762,7 @@ helm repo update
 helm install keda kedacore/keda \
   --namespace keda \
   --create-namespace \
-  --version 2.16.0
+  --version 2.20.1
 
 kubectl -n keda wait --for=condition=Ready pods --all --timeout=120s
 ```
@@ -811,15 +833,16 @@ spec:
         prometheus.io/port: "8000"
         prometheus.io/path: "/metrics"
     spec:
-      terminationGracePeriodSeconds: 120
+      terminationGracePeriodSeconds: 150
       containers:
         - name: vllm
-          image: vllm/vllm-openai:v0.6.5
+          image: vllm/vllm-openai:v0.23.0
           args:
             - --model=TinyLlama/TinyLlama-1.1B-Chat-v1.0
             - --gpu-memory-utilization=0.85
             - --max-model-len=2048
             - --max-num-seqs=32
+            - --shutdown-timeout=120
             - --port=8000
           ports:
             - containerPort: 8000
@@ -854,10 +877,13 @@ kind: Service
 metadata:
   name: vllm-serve
   namespace: inference
+  labels:
+    app: vllm-serve
 spec:
   ports:
     - port: 8000
       targetPort: 8000
+      name: http
   selector:
     app: vllm-serve
 EOF
@@ -1039,14 +1065,23 @@ You have completed this exercise when:
 - [Kubernetes Horizontal Pod Autoscaling](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/)
 - [Kubernetes GPU scheduling](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/)
 - [vLLM documentation](https://docs.vllm.ai/)
+- [vLLM v0.23.0 release](https://github.com/vllm-project/vllm/releases/tag/v0.23.0)
 - [vLLM serving OpenAI-compatible server](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html)
-- [vLLM metrics documentation](https://docs.vllm.ai/en/latest/usage/metrics.html)
+- [vLLM engine arguments](https://docs.vllm.ai/en/stable/configuration/engine_args/)
+- [vLLM production metrics](https://docs.vllm.ai/en/v0.14.0/usage/metrics/)
 - [Hugging Face Text Generation Inference documentation](https://huggingface.co/docs/text-generation-inference/index)
+- [Hugging Face TGI maintenance notice](https://huggingface.co/docs/text-generation-inference/en/index)
+- [Hugging Face TGI v3 caching and chunking](https://huggingface.co/docs/text-generation-inference/en/conceptual/chunking)
+- [Hugging Face TGI v3.3.7 release](https://github.com/huggingface/text-generation-inference/releases/tag/v3.3.7)
 - [NVIDIA Triton Inference Server documentation](https://docs.nvidia.com/deeplearning/triton-inference-server/user-guide/docs/)
 - [NVIDIA TensorRT-LLM documentation](https://nvidia.github.io/TensorRT-LLM/)
 - [KEDA documentation](https://keda.sh/docs/)
+- [KEDA chart releases](https://github.com/kedacore/charts/releases)
+- [KEDA 2.20 deployment documentation](https://keda.sh/docs/2.20/deploy/)
 - [KEDA Prometheus scaler](https://keda.sh/docs/latest/scalers/prometheus/)
 - [Prometheus querying basics](https://prometheus.io/docs/prometheus/latest/querying/basics/)
+- [Meta Llama 3.1 model card](https://github.com/meta-llama/llama-models/blob/main/models/llama3_1/MODEL_CARD.md)
+- [Llama 3.1 8B configuration mirror](https://huggingface.co/NousResearch/Meta-Llama-3.1-8B-Instruct/blob/main/config.json)
 - [Efficient Memory Management for Large Language Model Serving with PagedAttention](https://arxiv.org/abs/2309.06180)
 
 ## Next Module

--- a/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.6-ai-cost.md
+++ b/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.6-ai-cost.md
@@ -10,6 +10,8 @@ revision_pending: false
 > **Time to Complete**: 3 hours
 >
 > **Prerequisites**: [Module 1.1: GPU Provisioning & Device Plugins](../module-1.1-gpu-provisioning/), [Module 1.5: Serving LLMs at Scale](../module-1.5-llm-serving/), Kubernetes autoscaling concepts, and basic cloud billing familiarity
+>
+> **Content current as of 2026-06.** Volatile pricing, spot availability, and queue-controller versions are quarantined in dated Landscape snapshots below; verify against your provider's current docs before relying on specifics.
 
 ---
 
@@ -32,6 +34,8 @@ The goal is not to make every workload cheap. Production inference may justify o
 
 AI infrastructure is the most expensive line item in many organizations' cloud bills. The numbers are staggering:
 
+> **Landscape snapshot — as of 2026-06. GPU pricing changes frequently; verify against your cloud provider's current pricing page before relying on specifics.**
+
 | GPU Instance | Cloud Cost (on-demand) | Yearly Cost (1 node) |
 |-------------|----------------------|---------------------|
 | AWS p5.48xlarge (8x H100) | $98.32/hr | $861,283 |
@@ -50,6 +54,8 @@ Cost anatomy also exposes why utilization alone is not enough. A production infe
 Pause and predict: if your dashboard shows low GPU utilization across the fleet, what extra label would you need before deciding whether to terminate nodes, reduce replicas, or move jobs to spot capacity? The useful answer is usually a workload label such as `training`, `inference`, or `development`, because the same metric means different things under different service expectations. A cost dashboard without workload identity is like a power meter without room labels: it tells you electricity is being used, but not whether the refrigerator, the heater, or a forgotten lamp is responsible.
 
 Break down a typical AI team's GPU spending:
+
+> **Landscape snapshot — as of 2026-06. GPU pricing changes frequently; verify against your cloud provider's current pricing page before relying on specifics.**
 
 ```mermaid
 graph TD
@@ -95,6 +101,8 @@ The basic economic question is whether the cost of lost work is smaller than the
 Pause and predict: if spot instances can be terminated with only a short warning, what specific training behavior makes a multi-day run economically safe on spot capacity? The answer is frequent, validated checkpointing to durable storage, combined with job logic that resumes from the newest complete checkpoint after eviction. Without that behavior, spot pricing turns into a gamble. With it, spot pricing becomes a controlled interruption model where lost work is bounded and measurable.
 
 Cloud providers sell excess GPU capacity at large discounts as spot instances, preemptible VMs, or equivalent discounted capacity. The catch is that they can reclaim the instance with limited notice, and availability varies by region, zone, instance type, and time. For cost planning, this means you should diversify instance types where the workload allows it, keep capacity requirements flexible, and reserve on-demand fallback for workloads that cannot safely wait.
+
+> **Landscape snapshot — as of 2026-06. GPU pricing changes frequently; verify against your cloud provider's current pricing page before relying on specifics.**
 
 | Provider | GPU Instance | On-Demand | Spot Price | Savings |
 |----------|-------------|-----------|------------|---------|
@@ -421,8 +429,15 @@ The architecture introduces three operational handles. A `ResourceFlavor` descri
 
 Install Kueue:
 
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> | Item | Value tested in this module |
+> |------|----------------------------|
+> | Kueue release | v0.18.1 |
+> | Kueue API | `kueue.x-k8s.io/v1beta2` |
+
 ```bash
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.1/manifests.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.18.1/manifests.yaml
 
 # Verify
 kubectl -n kueue-system get pods
@@ -431,7 +446,7 @@ kubectl -n kueue-system get pods
 The first configuration step is to define resource flavors. These labels must line up with node labels produced by your GPU device plugin, cloud provider integration, or autoscaler. If labels are wrong, Kueue can admit a workload to capacity that Kubernetes cannot actually provide. Treat label design as part of your cost model because it determines whether a job uses spot, on-demand, A100, T4, or another accelerator class.
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: gpu-a100-spot
@@ -440,7 +455,7 @@ spec:
     nvidia.com/gpu.product: NVIDIA-A100-SXM4-80GB
     karpenter.sh/capacity-type: spot
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: gpu-a100-ondemand
@@ -449,7 +464,7 @@ spec:
     nvidia.com/gpu.product: NVIDIA-A100-SXM4-80GB
     karpenter.sh/capacity-type: on-demand
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: gpu-t4-spot
@@ -462,12 +477,12 @@ spec:
 The ClusterQueue is where budget policy becomes scheduling behavior. In this example, spot A100 capacity has a large nominal quota and a borrowing limit, on-demand A100 capacity is smaller and protected, and T4 spot capacity is available for workloads that can use it. Borrowing lets one team use another team's idle share, but preemption policies make sure borrowed resources can be reclaimed when the owner needs them back. This is how a shared GPU platform can be both efficient and fair.
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: gpu-cluster-queue
 spec:
-  cohort: ai-platform              # Cohort for borrowing
+  cohortName: ai-platform              # Cohort for borrowing
   preemption:
     reclaimWithinCohort: Any
     borrowWithinCohort:
@@ -510,7 +525,7 @@ spec:
 LocalQueues keep team submission paths clean. A research namespace submits to its local queue, a platform namespace submits to its queue, and production has its own queue. The platform team can change the backing ClusterQueue policy without forcing every training script to learn the entire cluster budget. That is important for adoption because cost controls fail when they require every user to become a scheduler expert.
 
 ```yaml
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: ml-research-queue
@@ -518,7 +533,7 @@ metadata:
 spec:
   clusterQueue: gpu-cluster-queue
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: ml-platform-queue
@@ -526,7 +541,7 @@ metadata:
 spec:
   clusterQueue: gpu-cluster-queue
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: ml-production-queue
@@ -962,10 +977,10 @@ After applying the manifests, inspect the NodePool and NodeClass with `kubectl g
 
 ### Step 2: Install Kueue
 
-Kueue provides the admission controller and queue APIs used by the rest of the lab. The exercise uses the preserved upstream manifest URL from the original module, so review compatibility with your cluster policy before applying it in a managed environment. In production, you would pin versions through your normal deployment system rather than applying directly from a release URL.
+Kueue provides the admission controller and queue APIs used by the rest of the lab. The exercise installs Kueue v0.18.1 with the `kueue.x-k8s.io/v1beta2` API, matching the manifests in the Priority, Queues, and Fair GPU Sharing section above. Review compatibility with your cluster policy before applying a release URL in a managed environment. In production, pin versions through your normal deployment system rather than applying directly from GitHub.
 
 ```bash
-kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.1/manifests.yaml
+kubectl apply --server-side -f https://github.com/kubernetes-sigs/kueue/releases/download/v0.18.1/manifests.yaml
 kubectl -n kueue-system wait --for=condition=Ready pods --all --timeout=120s
 ```
 
@@ -1003,7 +1018,7 @@ EOF
 
 # ResourceFlavor
 cat <<'EOF' | kubectl apply -f -
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ResourceFlavor
 metadata:
   name: gpu-spot
@@ -1014,12 +1029,12 @@ EOF
 
 # ClusterQueue
 cat <<'EOF' | kubectl apply -f -
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: ClusterQueue
 metadata:
   name: gpu-exercise-queue
 spec:
-  cohort: exercise
+  cohortName: exercise
   preemption:
     withinClusterQueue: LowerPriority
     reclaimWithinCohort: Any
@@ -1038,7 +1053,7 @@ EOF
 
 # LocalQueues
 cat <<'EOF' | kubectl apply -f -
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: team-alpha-queue
@@ -1046,7 +1061,7 @@ metadata:
 spec:
   clusterQueue: gpu-exercise-queue
 ---
-apiVersion: kueue.x-k8s.io/v1beta1
+apiVersion: kueue.x-k8s.io/v1beta2
 kind: LocalQueue
 metadata:
   name: team-beta-queue
@@ -1170,7 +1185,7 @@ echo "=== Team Beta workloads ==="
 kubectl -n team-beta get workloads
 echo ""
 echo "=== All pods ==="
-kubectl get pods -n team-alpha -n team-beta
+kubectl get pods -A | grep -E 'team-alpha|team-beta'
 ```
 
 <details>
@@ -1235,7 +1250,7 @@ You have completed this exercise when:
 ## Sources
 
 - [AWS EKS charts for AWS Node Termination Handler](https://aws.github.io/eks-charts)
-- [Kueue release manifest used in the exercise](https://github.com/kubernetes-sigs/kueue/releases/download/v0.9.1/manifests.yaml)
+- [Kueue v0.18.1 release manifest used in the exercise](https://github.com/kubernetes-sigs/kueue/releases/download/v0.18.1/manifests.yaml)
 - [Karpenter documentation](https://karpenter.sh/docs/)
 - [Karpenter NodePools](https://karpenter.sh/docs/concepts/nodepools/)
 - [Karpenter NodeClasses](https://karpenter.sh/docs/concepts/nodeclasses/)


### PR DESCRIPTION
## ai-infrastructure FIX wave — 6 modules, verifier-blind defects corrected (#1957)

Part of Platform Disciplines epic #1953. The `data-ai/ai-infrastructure` section (6 modules, all
authored by gemini-3.1-pro, never cross-family reviewed) showed on the board as `shipped_unreviewed`
at score **5.0** / verifier **T0** — but adversarial cross-family review found every module hides
real, verifier-blind defects: stale versions/APIs, non-runnable code, wrong technical facts, and
durable-content violations. This PR fixes all of them. Each module stays **T0** (fixes are
net-additive; no density regression) and is cross-family ground-checked.

### Per-module summary

**1.1 gpu-provisioning** (fixer: codex · R1: codex → R2: opus-inline)
- GPU Operator versions (`v24.9.0`) → dated Landscape snapshot + `RELEASE_TAG=v26.3.2` pattern with full operand matrix.
- Non-runnable image `…cuda-sample:nbody-cuda12.5.0` (NGC 404) → `:nbody` (verified 200); `:vectoradd-cuda12.5.0` (verified 200).
- `kubectl debug --image=ubuntu -- lspci` → installs `pciutils` in the debug container.
- Grafana stub import payload → UI import by ID + explanation of why the stub fails.
- `DCGM_FI_DEV_XID_ERRORS` "count" → "last Xid error code/value".
- H100 power → SKU-specific (SXM 700W / NVL PCIe 350–400W) in the dated snapshot.
- Sources → titled `[Title](url)` citations.

**1.2 gpu-scheduling** (fixer: cursor · R2: opus-inline)
- Dollar pricing block → `Hypothetical scenario:`/dated snapshot.
- PCIe Gen4 x16 bandwidth `16 GB/s` → ~32 GB/s unidirectional / ~64 GB/s bidirectional (all switch labels).
- MIG drain semantics → admin cordons/drains first; MIG Manager is not a `kubectl drain` substitute.
- `gcloud --collocation=COLLOCATED` → `collocated` (+ `--region`).
- Karpenter v1 kubelet config → `EC2NodeClass` + Bottlerocket `userData`.
- MPS ConfigMap `devices: all` removed; DRA YAML → `resource.k8s.io/v1` (`exactly:` + driver-qualified `isGreaterThan(quantity('40Gi'))`).
- Time-slicing "1ms" → quantum-dependent (~100ms-class default); MPS clients 48→"48–60"; "DRA stable 1.35" → "GA 1.34; always enabled 1.35"; ResourceQuota/PriorityClass example added; lab uses fully-qualified `clusterpolicies.nvidia.com`.

**1.3 distributed-training** (fixer: deepseek · R2: opus-inline)
- `maxRestarts` hoisted from `elasticPolicy` to `PyTorchJobSpec` (`spec:`) level (was silently dropped).
- `NCCL_NET_GDR_LEVEL`/`NCCL_P2P_LEVEL` → `SYS` string IDs with correct comments + note that integer values are discouraged.
- Training Operator v1.8.1 legacy callout (kubeflow/trainer v2 removes `numProcPerNode` + `ElasticPolicy`) + v2 migration source.
- `ib-sriov` CNI type → standard `sriov` + InfiniBand/RoCE note; failure-frequency table hedged as illustrative.

**1.4 ai-storage** (fixer: cursor · R2: opus-inline)
- Meta Llama-3 figures corrected (240 PB capacity + 2 TB/s sustainable / 7 TB/s peak; 54-day = fault-analysis window; no fabricated 51 GB/s average).
- Fluid CNCF **sandbox → Incubating** (2026-01-08) in a dated snapshot.
- AlluxioRuntime `tieredstore` → two levels (`MEM` for `/dev/shm`, `SSD` for cache) with per-level `quota`.
- Dated Landscape snapshot for hardware-throughput/maturity; OpenEBS `vgpattern` casing; Alluxio Helm repo versioned `/openSource/2.9.5`; PyTorch DCP `{"model": …}` dict wrapper; egress `$` → `Hypothetical scenario:`; `watch` → `while` loop.

**1.5 llm-serving** (fixer: codex · R2: opus-inline) — *see commit*

**1.6 ai-cost** (fixer: cursor + orchestrator · R2: opus-inline)
- Kueue `v0.9.1`/`v1beta1` → **v0.18.1** install + **`v1beta2`** API across all manifests (live-verified: latest release v0.18.1, manifests serve v1beta2).
- **`ClusterQueue.spec.cohort` → `cohortName`** (renamed in v1beta2 — the naive apiVersion bump would have left invalid manifests; caught at R2 ground-check against the live CRD).
- GPU pricing tables → dated Landscape snapshots + module-level currency note.
- `kubectl get pods -n a -n b` → `get pods -A | grep -E`.

### Review method
All findings ground-checked by the orchestrator (opus-inline, cross-family to each fixer) against live
vendor/upstream docs and the actual registry/CRD/release APIs — not just the verifier tier. Closes
#1957; advances #1953.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
