### PR TITLE
feat(telemetry): module-build telemetry — store + ingest + API + /telemetry page (#1973 P1)

### DIFF
--- a/scripts/agent_telemetry.py
+++ b/scripts/agent_telemetry.py
@@ -29,6 +29,7 @@ import json
 import time
 from collections import defaultdict
 from pathlib import Path
+from uuid import uuid4
 
 PRIMARY_REPO = Path(__file__).resolve().parent.parent
 DISPATCH_LOG = PRIMARY_REPO / "logs" / "smart_dispatch.jsonl"
@@ -221,6 +222,62 @@ def _print_table(title: str, key_name: str, rows: list[dict]) -> None:
         )
 
 
+def _parse_participant(raw: str) -> dict:
+    parts: dict[str, str] = {}
+    for chunk in raw.split(","):
+        chunk = chunk.strip()
+        if not chunk or "=" not in chunk:
+            continue
+        key, value = chunk.split("=", 1)
+        parts[key.strip()] = value.strip()
+    if "role" not in parts or "agent" not in parts:
+        raise ValueError("each --participant must include role= and agent=")
+    participant: dict = {
+        "role": parts["role"],
+        "agent": parts["agent"],
+        "token_source": parts.get("token_source", "unavailable"),
+    }
+    for key in ("model", "effort", "label", "notes"):
+        if key in parts:
+            participant[key] = parts[key]
+    for key in ("calls", "prompt_tokens", "response_tokens", "total_tokens"):
+        if key in parts:
+            participant[key] = int(parts[key])
+    if "cost_usd_est" in parts:
+        participant["cost_usd_est"] = float(parts["cost_usd_est"])
+    return participant
+
+
+def record_build(args: argparse.Namespace) -> int:
+    from telemetry_store import upsert_run
+
+    payload = {
+        "run_id": args.run_id or f"mbt-{uuid4().hex}",
+        "track": args.track,
+        "slug": args.slug,
+        "module_title": args.module_title,
+        "branch": args.branch,
+        "commit_sha": args.commit,
+        "pr_number": args.pr,
+        "pr_url": args.pr_url,
+        "status": args.status,
+        "swarm_used": args.swarm,
+        "swarm_label": args.swarm_label,
+        "swarm_note": args.swarm_note,
+        "wall_clock_minutes": args.wall_clock_min,
+        "source": args.source,
+        "notes": args.notes,
+        "participants": [_parse_participant(item) for item in args.participant],
+    }
+    try:
+        run_id = upsert_run(PRIMARY_REPO, payload)
+    except ValueError as exc:
+        print(f"error: {exc}")
+        return 2
+    print(f"recorded module build: {run_id} [{args.track}/{args.slug}]")
+    return 0
+
+
 def report(args: argparse.Namespace) -> int:
     data = build_agent_telemetry(since=args.since)
     print(f"Agent performance — {data['dispatch_total']} dispatches, "
@@ -258,6 +315,33 @@ def main(argv: list[str] | None = None) -> int:
     r.add_argument("--by", choices=("lane", "harness", "model", "all"), default="lane")
     r.add_argument("--since", type=int, help="unix ts lower bound")
     r.set_defaults(func=report)
+
+    b = sub.add_parser("record-build", help="record module-build token telemetry (#1973)")
+    b.add_argument("--run-id", help="stable run id (default: generated mbt-…)")
+    b.add_argument("--track", required=True)
+    b.add_argument("--slug", required=True)
+    b.add_argument("--module-title")
+    b.add_argument("--branch")
+    b.add_argument("--commit")
+    b.add_argument("--pr", type=int)
+    b.add_argument("--pr-url")
+    b.add_argument("--status", default="recorded")
+    swarm = b.add_mutually_exclusive_group()
+    swarm.add_argument("--swarm", dest="swarm", action="store_true")
+    swarm.add_argument("--no-swarm", dest="swarm", action="store_false")
+    b.set_defaults(swarm=False)
+    b.add_argument("--swarm-label", default="none")
+    b.add_argument("--swarm-note", required=True)
+    b.add_argument("--wall-clock-min", type=float)
+    b.add_argument("--source", required=True)
+    b.add_argument("--notes")
+    b.add_argument(
+        "--participant",
+        action="append",
+        default=[],
+        help="role=...,agent=...,model=...,total_tokens=...,cost_usd_est=...,label=...,token_source=...",
+    )
+    b.set_defaults(func=record_build)
 
     args = p.parse_args(argv)
     return args.func(args)

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -4337,6 +4337,7 @@ def _render_top_nav(active: str) -> str:
         ("activity", "/activity", "Activity"),
         ("benchmarks", "/benchmarks", "Benchmarks"),
         ("agents", "/agents", "Agents"),
+        ("telemetry", "/telemetry", "Telemetry"),
         ("channels", "/channels", "Channels"),
         ("decisions", "/decisions", "Decisions"),
         ("health", "/health", "Health"),
@@ -9122,6 +9123,53 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
             except (TypeError, ValueError):
                 since_val = None
         return 200, build_agent_telemetry(repo_root, since=since_val), "application/json; charset=utf-8"
+    if path == "/telemetry":
+        from module_build_telemetry_page import render_module_builds_page_html
+
+        return 200, render_module_builds_page_html(
+            top_nav=_render_top_nav("telemetry"),
+            nav_css=_TOP_NAV_CSS,
+            ds_link=_design_system_link(),
+        ), "text/html; charset=utf-8"
+    if path == "/api/telemetry/module-builds":
+        from telemetry_store import build_module_build_payload
+
+        track_raw = query.get("track", [None])[0]
+        slug_raw = query.get("slug", [None])[0]
+        swarm_raw = query.get("swarm_used", [None])[0]
+        limit_raw = query.get("limit", ["100"])[0]
+        swarm_used = None
+        if swarm_raw is not None:
+            swarm_used = str(swarm_raw).strip().lower() in {"1", "true", "yes"}
+        try:
+            limit_val = int(limit_raw)
+        except (TypeError, ValueError):
+            limit_val = 100
+        return 200, build_module_build_payload(
+            repo_root,
+            track=track_raw,
+            slug=slug_raw,
+            swarm_used=swarm_used,
+            limit=limit_val,
+        ), "application/json; charset=utf-8"
+    if path.startswith("/api/telemetry/module-builds/"):
+        from telemetry_store import build_module_build_detail_payload
+
+        remainder = path[len("/api/telemetry/module-builds/") :].strip("/")
+        if not remainder or "/" not in remainder:
+            return 404, {"error": "not_found", "path": path}, "application/json; charset=utf-8"
+        track_part, slug_part = remainder.rsplit("/", 1)
+        limit_raw = query.get("limit", ["20"])[0]
+        try:
+            limit_val = int(limit_raw)
+        except (TypeError, ValueError):
+            limit_val = 20
+        return 200, build_module_build_detail_payload(
+            repo_root,
+            track=track_part,
+            slug=slug_part,
+            limit=limit_val,
+        ), "application/json; charset=utf-8"
     decision_page = _DECISION_ROUTES.route_decision_page_request(
         repo_root,
         path,
@@ -9534,6 +9582,20 @@ def route_post_request(
     )
     if channel_post is not None:
         return channel_post
+    if path == "/api/telemetry/module-builds":
+        from telemetry_store import upsert_run
+
+        if not body_bytes:
+            return 400, {"error": "empty body"}, "application/json; charset=utf-8"
+        try:
+            payload = json.loads(body_bytes.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return 400, {"error": "invalid JSON"}, "application/json; charset=utf-8"
+        try:
+            run_id = upsert_run(repo_root, payload)
+        except ValueError as exc:
+            return 400, {"error": str(exc)}, "application/json; charset=utf-8"
+        return 200, {"ok": True, "run_id": run_id}, "application/json; charset=utf-8"
     return 404, {"error": "not_found", "path": path}, "application/json; charset=utf-8"
 
 

--- a/scripts/module_build_telemetry_page.py
+++ b/scripts/module_build_telemetry_page.py
@@ -1,0 +1,127 @@
+"""HTML page for module-build telemetry (#1973 P1).
+
+Renders token/cost rollups from ``/api/telemetry/module-builds``. Kept out of
+``local_api.py`` to match the agents telemetry page pattern.
+"""
+from __future__ import annotations
+
+_PAGE_CSS = """
+.mb-main{max-width:1180px;margin:0 auto;padding:1.2rem}
+.mb-head h1{font-size:1.4rem;margin:0 0 .2rem}
+.mb-sub{color:#64748b;font-size:.9rem;margin-bottom:1rem}
+.mb-cards{display:grid;grid-template-columns:repeat(auto-fit,minmax(140px,1fr));gap:.75rem;margin:1rem 0 1.4rem}
+.mb-card{background:#fff;border:1px solid #e2e8f0;border-radius:.5rem;padding:.65rem .75rem}
+.mb-card .label{color:#64748b;font-size:.75rem;text-transform:uppercase;letter-spacing:.03em}
+.mb-card .value{font-size:1.15rem;font-weight:700;color:#1e3a8a;margin-top:.15rem}
+.mb-section{margin:1.6rem 0}
+.mb-section h2{font-size:1.05rem;color:#1e3a8a;margin:0 0 .5rem}
+table.mb{border-collapse:collapse;width:100%;font-size:.84rem;background:#fff}
+table.mb th,table.mb td{border:1px solid #e2e8f0;padding:.35rem .5rem;text-align:right;vertical-align:top}
+table.mb th:first-child,table.mb td:first-child,
+table.mb th:nth-child(2),table.mb td:nth-child(3),
+table.mb td.meta{text-align:left}
+table.mb th{background:#eff6ff;color:#1e293b;font-weight:600}
+table.mb td.k{font-weight:600;text-align:left}
+table.mb td.meta{color:#64748b;font-size:.8rem}
+table.mb td.yes{color:#047857;font-weight:600}
+table.mb td.no{color:#64748b}
+.mb-legend{color:#64748b;font-size:.8rem;margin-top:1.2rem;border-top:1px solid #e2e8f0;padding-top:.6rem}
+.empty{color:#94a3b8;font-style:italic;padding:.5rem}
+"""
+
+_PAGE_JS = """
+function fmt(v){return v==null?'\\u2014':String(v);}
+function money(v){return v==null?'\\u2014':'$'+Number(v).toFixed(4);}
+function el(tag,text,cls){var e=document.createElement(tag);if(text!=null)e.textContent=text;if(cls)e.className=cls;return e;}
+function renderTotals(t){
+  var host=document.getElementById('mb-totals');
+  host.textContent='';
+  var cards=[
+    ['runs',t.runs],['swarm',t.swarm_runs],['solo',t.solo_runs],['participants',t.participants],
+    ['prompt tok',t.prompt_tokens],['response tok',t.response_tokens],['total tok',t.total_tokens],['cost est',money(t.cost_usd_est)]
+  ];
+  cards.forEach(function(pair){
+    var card=el('div',null,'mb-card');
+    card.appendChild(el('div',pair[0],'label'));
+    card.appendChild(el('div',fmt(pair[1]),'value'));
+    host.appendChild(card);
+  });
+}
+function renderRuns(rows){
+  var host=document.getElementById('mb-runs');
+  host.textContent='';
+  if(!rows||!rows.length){host.appendChild(el('div','no module-build records yet','empty'));return;}
+  var table=el('table',null,'mb');
+  var thead=el('thead'),htr=el('tr');
+  ['track','slug','run','swarm','tokens','cost','participants','source'].forEach(function(c){htr.appendChild(el('th',c));});
+  thead.appendChild(htr);table.appendChild(thead);
+  var tb=el('tbody');
+  rows.forEach(function(r){
+    var tr=el('tr');
+    tr.appendChild(el('td',r.track,'meta'));
+    tr.appendChild(el('td',r.slug,'meta'));
+    tr.appendChild(el('td',r.run_id,'k'));
+    var sw=el('td',r.swarm_used?'yes ('+r.swarm_label+')':'no',r.swarm_used?'yes':'no');
+    tr.appendChild(sw);
+    tr.appendChild(el('td',fmt((r.totals||{}).total_tokens)));
+    tr.appendChild(el('td',money((r.totals||{}).cost_usd_est)));
+    tr.appendChild(el('td',fmt((r.totals||{}).participants)));
+    tr.appendChild(el('td',r.source,'meta'));
+    tb.appendChild(tr);
+  });
+  table.appendChild(tb);host.appendChild(table);
+}
+async function loadModuleBuilds(){
+  try{
+    var r=await fetch('/api/telemetry/module-builds?limit=100');
+    var d=await r.json();
+    document.getElementById('mb-summary').textContent=
+      d.records_total+' records \\u00b7 generated '+d.generated_at;
+    renderTotals(d.totals||{});
+    renderRuns(d.runs||[]);
+  }catch(e){document.getElementById('mb-summary').textContent='failed to load: '+e;}
+}
+loadModuleBuilds();
+"""
+
+
+def render_module_builds_page_html(*, top_nav: str = "", nav_css: str = "", ds_link: str = "") -> str:
+    return f"""<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Telemetry - KubeDojo Local Monitor</title>
+  {ds_link}
+  <style>
+{nav_css}
+{_PAGE_CSS}
+  </style>
+</head>
+<body>
+  {top_nav}
+  <main class="mb-main">
+    <div class="mb-head">
+      <h1>Module Build Telemetry</h1>
+      <div class="mb-sub" id="mb-summary">loading&hellip;</div>
+    </div>
+
+    <div id="mb-totals" class="mb-cards"></div>
+
+    <div class="mb-section">
+      <h2>Recent runs</h2>
+      <div id="mb-runs"><div class="empty">loading&hellip;</div></div>
+    </div>
+
+    <div class="mb-legend">
+      Token totals roll up participant prompt/response/total fields.
+      Record finalize-time builds with
+      <code>python -m scripts.agent_telemetry record-build</code> or
+      <code>POST /api/telemetry/module-builds</code>.
+    </div>
+  </main>
+  <script>
+{_PAGE_JS}
+  </script>
+</body>
+</html>"""

--- a/scripts/telemetry_store.py
+++ b/scripts/telemetry_store.py
@@ -1,0 +1,467 @@
+"""SQLite persistence for module-build token telemetry (#1973 P1).
+
+Stores orchestrator finalize-time records: track + slug, swarm/solo metadata,
+PR/commit context, and per-participant token/cost rollups under
+``.pipeline/telemetry/module_builds.db`` (runtime state, gitignored).
+"""
+from __future__ import annotations
+
+import sqlite3
+from collections import defaultdict
+from contextlib import closing
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+from uuid import uuid4
+
+_db_path_override: Path | None = None
+
+
+def db_path(repo_root: Path) -> Path:
+    if _db_path_override is not None:
+        return _db_path_override
+    return repo_root / ".pipeline" / "telemetry" / "module_builds.db"
+
+
+def _isoformat_z(value: datetime) -> str:
+    if value.tzinfo is None:
+        value = value.replace(tzinfo=UTC)
+    return value.astimezone(UTC).isoformat().replace("+00:00", "Z")
+
+
+def _now_z() -> str:
+    return _isoformat_z(datetime.now(UTC))
+
+
+def _clean_text(value: str | None) -> str | None:
+    if value is None:
+        return None
+    cleaned = str(value).strip()
+    return cleaned or None
+
+
+def _required_text(value: str | None, field: str) -> str:
+    cleaned = _clean_text(value)
+    if cleaned is None:
+        raise ValueError(f"{field} must not be blank")
+    return cleaned
+
+
+def _parse_recorded_at(value: str | None) -> str:
+    if value is None:
+        return _now_z()
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return _now_z()
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            return _isoformat_z(datetime.fromisoformat(text))
+        except ValueError as exc:
+            raise ValueError("recorded_at must be a valid ISO-8601 timestamp") from exc
+    raise ValueError("recorded_at must be a valid ISO-8601 timestamp")
+
+
+def _computed_total_tokens(participant: dict[str, Any]) -> int | None:
+    total = participant.get("total_tokens")
+    if total is not None:
+        return int(total)
+    prompt = participant.get("prompt_tokens")
+    response = participant.get("response_tokens")
+    if prompt is None and response is None:
+        return None
+    return int(prompt or 0) + int(response or 0)
+
+
+def _connect(db_file: Path) -> sqlite3.Connection:
+    db_file.parent.mkdir(parents=True, exist_ok=True)
+    conn = sqlite3.connect(str(db_file))
+    conn.row_factory = sqlite3.Row
+    conn.execute("PRAGMA journal_mode = WAL")
+    conn.execute("PRAGMA foreign_keys = ON")
+    return conn
+
+
+def _ensure_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS module_build_runs (
+            run_id             TEXT PRIMARY KEY,
+            created_at         TEXT NOT NULL,
+            updated_at         TEXT NOT NULL,
+            track              TEXT NOT NULL,
+            slug               TEXT NOT NULL,
+            module_title       TEXT,
+            branch             TEXT,
+            commit_sha         TEXT,
+            pr_number          INTEGER,
+            pr_url             TEXT,
+            status             TEXT NOT NULL DEFAULT 'recorded',
+            swarm_used         INTEGER NOT NULL,
+            swarm_label        TEXT NOT NULL DEFAULT 'none',
+            swarm_note         TEXT NOT NULL,
+            wall_clock_minutes REAL,
+            source             TEXT NOT NULL,
+            notes              TEXT
+        );
+        CREATE INDEX IF NOT EXISTS idx_mbr_track_slug
+            ON module_build_runs(track, slug, updated_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_mbr_updated
+            ON module_build_runs(updated_at DESC);
+        CREATE INDEX IF NOT EXISTS idx_mbr_swarm
+            ON module_build_runs(swarm_used, updated_at DESC);
+
+        CREATE TABLE IF NOT EXISTS module_build_participants (
+            id              INTEGER PRIMARY KEY AUTOINCREMENT,
+            run_id          TEXT NOT NULL,
+            role            TEXT NOT NULL,
+            agent           TEXT NOT NULL,
+            model           TEXT,
+            effort          TEXT,
+            label           TEXT,
+            calls           INTEGER,
+            prompt_tokens   INTEGER,
+            response_tokens INTEGER,
+            total_tokens    INTEGER,
+            token_source    TEXT NOT NULL DEFAULT 'unavailable',
+            cost_usd_est    REAL,
+            notes           TEXT,
+            FOREIGN KEY(run_id) REFERENCES module_build_runs(run_id)
+                ON DELETE CASCADE
+        );
+        CREATE INDEX IF NOT EXISTS idx_mbp_run
+            ON module_build_participants(run_id, id);
+        """
+    )
+
+
+def _participant_row_to_dict(row: sqlite3.Row) -> dict[str, Any]:
+    return {
+        "role": row["role"],
+        "agent": row["agent"],
+        "model": row["model"],
+        "effort": row["effort"],
+        "label": row["label"],
+        "calls": row["calls"],
+        "prompt_tokens": row["prompt_tokens"],
+        "response_tokens": row["response_tokens"],
+        "total_tokens": row["total_tokens"],
+        "token_source": row["token_source"],
+        "cost_usd_est": row["cost_usd_est"],
+        "notes": row["notes"],
+    }
+
+
+def participant_totals(participants: list[dict[str, Any]]) -> dict[str, Any]:
+    prompt = sum(int(item["prompt_tokens"] or 0) for item in participants)
+    response = sum(int(item["response_tokens"] or 0) for item in participants)
+    total = sum(int(item["total_tokens"] or 0) for item in participants)
+    cost = sum(float(item["cost_usd_est"] or 0.0) for item in participants)
+    return {
+        "participants": len(participants),
+        "prompt_tokens": prompt,
+        "response_tokens": response,
+        "total_tokens": total,
+        "cost_usd_est": round(cost, 6),
+    }
+
+
+def rollup(runs: list[dict[str, Any]]) -> dict[str, Any]:
+    prompt = sum(int(run["totals"]["prompt_tokens"]) for run in runs)
+    response = sum(int(run["totals"]["response_tokens"]) for run in runs)
+    total = sum(int(run["totals"]["total_tokens"]) for run in runs)
+    participants = sum(int(run["totals"]["participants"]) for run in runs)
+    cost = sum(float(run["totals"]["cost_usd_est"]) for run in runs)
+    swarm_runs = sum(1 for run in runs if run["swarm_used"])
+    return {
+        "runs": len(runs),
+        "swarm_runs": swarm_runs,
+        "solo_runs": len(runs) - swarm_runs,
+        "participants": participants,
+        "prompt_tokens": prompt,
+        "response_tokens": response,
+        "total_tokens": total,
+        "cost_usd_est": round(cost, 6),
+    }
+
+
+def _run_row_to_dict(row: sqlite3.Row, participants: list[dict[str, Any]]) -> dict[str, Any]:
+    return {
+        "run_id": row["run_id"],
+        "created_at": row["created_at"],
+        "updated_at": row["updated_at"],
+        "track": row["track"],
+        "slug": row["slug"],
+        "module_title": row["module_title"],
+        "branch": row["branch"],
+        "commit_sha": row["commit_sha"],
+        "pr_number": row["pr_number"],
+        "pr_url": row["pr_url"],
+        "status": row["status"],
+        "swarm_used": bool(row["swarm_used"]),
+        "swarm_label": row["swarm_label"],
+        "swarm_note": row["swarm_note"],
+        "wall_clock_minutes": row["wall_clock_minutes"],
+        "source": row["source"],
+        "notes": row["notes"],
+        "participants": participants,
+        "totals": participant_totals(participants),
+    }
+
+
+def _load_participants(conn: sqlite3.Connection, run_ids: list[str]) -> dict[str, list[dict[str, Any]]]:
+    if not run_ids:
+        return {}
+    placeholders = ",".join("?" for _ in run_ids)
+    rows = conn.execute(
+        f"""
+        SELECT run_id, role, agent, model, effort, label, calls, prompt_tokens,
+               response_tokens, total_tokens, token_source, cost_usd_est, notes
+        FROM module_build_participants
+        WHERE run_id IN ({placeholders})
+        ORDER BY run_id, id
+        """,
+        run_ids,
+    ).fetchall()
+    participants: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for row in rows:
+        participants[str(row["run_id"])].append(_participant_row_to_dict(row))
+    return participants
+
+
+def _normalize_participant(raw: dict[str, Any]) -> dict[str, Any]:
+    return {
+        "role": _required_text(raw.get("role"), "participant.role"),
+        "agent": _required_text(raw.get("agent"), "participant.agent"),
+        "model": _clean_text(raw.get("model")),
+        "effort": _clean_text(raw.get("effort")),
+        "label": _clean_text(raw.get("label")),
+        "calls": raw.get("calls"),
+        "prompt_tokens": raw.get("prompt_tokens"),
+        "response_tokens": raw.get("response_tokens"),
+        "total_tokens": _computed_total_tokens(raw),
+        "token_source": _required_text(raw.get("token_source") or "unavailable", "participant.token_source"),
+        "cost_usd_est": raw.get("cost_usd_est"),
+        "notes": _clean_text(raw.get("notes")),
+    }
+
+
+def validate_module_build_ingest(payload: dict[str, Any]) -> dict[str, Any]:
+    """Validate ingest JSON; raises ValueError with a field-specific message."""
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be a JSON object")
+
+    run_id = _required_text(payload.get("run_id") or f"mbt-{uuid4().hex}", "run_id")
+    track = _required_text(payload.get("track"), "track")
+    slug = _required_text(payload.get("slug"), "slug")
+    status = _required_text(payload.get("status") or "recorded", "status")
+    swarm_label = _clean_text(payload.get("swarm_label")) or "none"
+    swarm_note = _required_text(payload.get("swarm_note"), "swarm_note")
+    source = _required_text(payload.get("source"), "source")
+
+    if "swarm_used" not in payload:
+        raise ValueError("swarm_used is required")
+
+    participants_raw = payload.get("participants") or []
+    if not isinstance(participants_raw, list):
+        raise ValueError("participants must be a list")
+
+    return {
+        "run_id": run_id,
+        "created_at": _parse_recorded_at(payload.get("recorded_at")),
+        "updated_at": _now_z(),
+        "track": track,
+        "slug": slug,
+        "module_title": _clean_text(payload.get("module_title")),
+        "branch": _clean_text(payload.get("branch")),
+        "commit_sha": _clean_text(payload.get("commit_sha")),
+        "pr_number": payload.get("pr_number"),
+        "pr_url": _clean_text(payload.get("pr_url")),
+        "status": status,
+        "swarm_used": bool(payload["swarm_used"]),
+        "swarm_label": swarm_label,
+        "swarm_note": swarm_note,
+        "wall_clock_minutes": payload.get("wall_clock_minutes"),
+        "source": source,
+        "notes": _clean_text(payload.get("notes")),
+        "participants": [_normalize_participant(item) for item in participants_raw],
+    }
+
+
+def upsert_run(repo_root: Path, payload: dict[str, Any]) -> str:
+    """Validate and upsert a module-build run; returns run_id."""
+    validated = validate_module_build_ingest(payload)
+    run_id = validated["run_id"]
+    participant_rows = [
+        (
+            run_id,
+            participant["role"],
+            participant["agent"],
+            participant["model"],
+            participant["effort"],
+            participant["label"],
+            participant["calls"],
+            participant["prompt_tokens"],
+            participant["response_tokens"],
+            participant["total_tokens"],
+            participant["token_source"],
+            participant["cost_usd_est"],
+            participant["notes"],
+        )
+        for participant in validated["participants"]
+    ]
+
+    db_file = db_path(repo_root)
+    with closing(_connect(db_file)) as conn:
+        _ensure_schema(conn)
+        conn.execute(
+            """
+            INSERT INTO module_build_runs (
+                run_id, created_at, updated_at, track, slug, module_title,
+                branch, commit_sha, pr_number, pr_url, status, swarm_used,
+                swarm_label, swarm_note, wall_clock_minutes, source, notes
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            ON CONFLICT(run_id) DO UPDATE SET
+                created_at = module_build_runs.created_at,
+                updated_at = excluded.updated_at,
+                track = excluded.track,
+                slug = excluded.slug,
+                module_title = excluded.module_title,
+                branch = excluded.branch,
+                commit_sha = excluded.commit_sha,
+                pr_number = excluded.pr_number,
+                pr_url = excluded.pr_url,
+                status = excluded.status,
+                swarm_used = excluded.swarm_used,
+                swarm_label = excluded.swarm_label,
+                swarm_note = excluded.swarm_note,
+                wall_clock_minutes = excluded.wall_clock_minutes,
+                source = excluded.source,
+                notes = excluded.notes
+            """,
+            (
+                run_id,
+                validated["created_at"],
+                validated["updated_at"],
+                validated["track"],
+                validated["slug"],
+                validated["module_title"],
+                validated["branch"],
+                validated["commit_sha"],
+                validated["pr_number"],
+                validated["pr_url"],
+                validated["status"],
+                1 if validated["swarm_used"] else 0,
+                validated["swarm_label"],
+                validated["swarm_note"],
+                validated["wall_clock_minutes"],
+                validated["source"],
+                validated["notes"],
+            ),
+        )
+        conn.execute("DELETE FROM module_build_participants WHERE run_id = ?", (run_id,))
+        if participant_rows:
+            conn.executemany(
+                """
+                INSERT INTO module_build_participants (
+                    run_id, role, agent, model, effort, label, calls, prompt_tokens,
+                    response_tokens, total_tokens, token_source, cost_usd_est, notes
+                )
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                participant_rows,
+            )
+        conn.commit()
+    return run_id
+
+
+def query_runs(
+    repo_root: Path,
+    *,
+    track: str | None = None,
+    slug: str | None = None,
+    swarm_used: bool | None = None,
+    limit: int = 100,
+) -> list[dict[str, Any]]:
+    conditions: list[str] = []
+    params: list[Any] = []
+    if track:
+        conditions.append("track = ?")
+        params.append(track.strip())
+    if slug:
+        conditions.append("slug = ?")
+        params.append(slug.strip())
+    if swarm_used is not None:
+        conditions.append("swarm_used = ?")
+        params.append(1 if swarm_used else 0)
+
+    where = f"WHERE {' AND '.join(conditions)}" if conditions else ""
+    params.append(max(1, min(int(limit), 500)))
+
+    db_file = db_path(repo_root)
+    with closing(_connect(db_file)) as conn:
+        _ensure_schema(conn)
+        rows = conn.execute(
+            f"""
+            SELECT *
+            FROM module_build_runs
+            {where}
+            ORDER BY updated_at DESC
+            LIMIT ?
+            """,
+            params,
+        ).fetchall()
+        run_ids = [str(row["run_id"]) for row in rows]
+        participants = _load_participants(conn, run_ids)
+
+    return [_run_row_to_dict(row, participants.get(str(row["run_id"]), [])) for row in rows]
+
+
+def build_module_build_payload(
+    repo_root: Path,
+    *,
+    track: str | None = None,
+    slug: str | None = None,
+    swarm_used: bool | None = None,
+    limit: int = 100,
+) -> dict[str, Any]:
+    runs = query_runs(
+        repo_root,
+        track=track,
+        slug=slug,
+        swarm_used=swarm_used,
+        limit=limit,
+    )
+    return {
+        "generated_at": _now_z(),
+        "records_total": len(runs),
+        "totals": rollup(runs),
+        "runs": runs,
+    }
+
+
+def build_module_build_detail_payload(
+    repo_root: Path,
+    *,
+    track: str,
+    slug: str,
+    limit: int = 20,
+) -> dict[str, Any]:
+    payload = build_module_build_payload(
+        repo_root,
+        track=track.strip(),
+        slug=slug.strip(),
+        swarm_used=None,
+        limit=limit,
+    )
+    return {
+        "generated_at": payload["generated_at"],
+        "track": track.strip(),
+        "slug": slug.strip(),
+        "records_total": payload["records_total"],
+        "totals": payload["totals"],
+        "latest": payload["runs"][0] if payload["runs"] else None,
+        "runs": payload["runs"],
+    }

--- a/tests/test_telemetry_store.py
+++ b/tests/test_telemetry_store.py
@@ -1,0 +1,295 @@
+"""Tests for module-build telemetry store + ingest validation (#1973 P1)."""
+from __future__ import annotations
+
+import importlib.util
+import json
+import sqlite3
+import sys
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+
+SCRIPTS_DIR = Path(__file__).resolve().parent.parent / "scripts"
+if str(SCRIPTS_DIR) not in sys.path:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+
+
+def _load_telemetry_store():
+    module_path = SCRIPTS_DIR / "telemetry_store.py"
+    spec = importlib.util.spec_from_file_location("telemetry_store", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+telemetry_store = _load_telemetry_store()
+
+
+def _load_local_api():
+    module_path = SCRIPTS_DIR / "local_api.py"
+    spec = importlib.util.spec_from_file_location("local_api_telemetry", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(autouse=True)
+def temp_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "module_builds.db"
+    monkeypatch.setattr(telemetry_store, "_db_path_override", db_path)
+    return db_path
+
+
+@pytest.fixture
+def repo_root(tmp_path: Path) -> Path:
+    return tmp_path
+
+
+def test_schema_init_idempotent(temp_db: Path, repo_root: Path) -> None:
+    with closing(telemetry_store._connect(temp_db)) as conn:
+        telemetry_store._ensure_schema(conn)
+        telemetry_store._ensure_schema(conn)
+        tables = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='table'"
+            ).fetchall()
+        }
+    assert "module_build_runs" in tables
+    assert "module_build_participants" in tables
+
+
+def _sample_payload(*, run_id: str = "run-1", swarm_used: bool = True) -> dict:
+    return {
+        "run_id": run_id,
+        "recorded_at": "2026-06-14T12:00:00Z",
+        "track": "platform/disciplines/core-platform/leadership",
+        "slug": "module-1.1-platform-team-building",
+        "module_title": "Platform Team Building",
+        "branch": "feat/platform-team",
+        "commit_sha": "abc123",
+        "pr_number": 1973,
+        "pr_url": "https://github.com/kube-dojo/kube-dojo.github.io/pull/1973",
+        "status": "merged",
+        "swarm_used": swarm_used,
+        "swarm_label": "thin",
+        "swarm_note": "Used bounded reviewers and validation runner.",
+        "wall_clock_minutes": 30.5,
+        "source": "codex-final",
+        "participants": [
+            {
+                "role": "main",
+                "agent": "codex",
+                "model": "gpt-5.5",
+                "prompt_tokens": 120000,
+                "response_tokens": 18000,
+                "token_source": "estimated",
+            },
+            {
+                "role": "helper",
+                "agent": "gemini",
+                "model": "gemini-3.1-pro-preview",
+                "total_tokens": 42000,
+                "token_source": "estimated",
+                "cost_usd_est": 0.12,
+            },
+        ],
+    }
+
+
+def test_upsert_and_readback(repo_root: Path) -> None:
+    telemetry_store.upsert_run(repo_root, _sample_payload())
+
+    runs = telemetry_store.query_runs(
+        repo_root,
+        track="platform/disciplines/core-platform/leadership",
+        slug="module-1.1-platform-team-building",
+    )
+    assert len(runs) == 1
+    run = runs[0]
+    assert run["track"] == "platform/disciplines/core-platform/leadership"
+    assert run["swarm_used"] is True
+    assert run["totals"]["participants"] == 2
+    assert run["totals"]["prompt_tokens"] == 120000
+    assert run["totals"]["response_tokens"] == 18000
+    assert run["totals"]["total_tokens"] == 180000
+    assert run["totals"]["cost_usd_est"] == 0.12
+
+
+def test_upsert_replaces_participants(repo_root: Path) -> None:
+    base = _sample_payload(run_id="replace-me", swarm_used=False)
+    telemetry_store.upsert_run(
+        repo_root,
+        {
+            **base,
+            "participants": [
+                {"role": "main", "agent": "codex", "total_tokens": 100, "token_source": "estimated"}
+            ],
+        },
+    )
+    telemetry_store.upsert_run(
+        repo_root,
+        {
+            **base,
+            "participants": [
+                {"role": "main", "agent": "codex", "total_tokens": 250, "token_source": "actual"}
+            ],
+        },
+    )
+
+    runs = telemetry_store.query_runs(repo_root, slug="module-1.1-platform-team-building")
+    assert len(runs) == 1
+    assert runs[0]["participants"] == [
+        {
+            "role": "main",
+            "agent": "codex",
+            "model": None,
+            "effort": None,
+            "label": None,
+            "calls": None,
+            "prompt_tokens": None,
+            "response_tokens": None,
+            "total_tokens": 250,
+            "token_source": "actual",
+            "cost_usd_est": None,
+            "notes": None,
+        }
+    ]
+    with closing(sqlite3.connect(str(telemetry_store.db_path(repo_root)))) as conn:
+        count = conn.execute(
+            "SELECT COUNT(*) FROM module_build_participants WHERE run_id = ?",
+            ("replace-me",),
+        ).fetchone()[0]
+    assert count == 1
+
+
+def test_query_runs_filters(repo_root: Path) -> None:
+    for run_id, swarm_used in (("solo", False), ("swarm", True)):
+        telemetry_store.upsert_run(
+            repo_root,
+            {
+                "run_id": run_id,
+                "track": "platform/disciplines/sre",
+                "slug": "filter-demo",
+                "swarm_used": swarm_used,
+                "swarm_label": "thin" if swarm_used else "none",
+                "swarm_note": "swarm used" if swarm_used else "solo run; no swarm used",
+                "source": "manual",
+            },
+        )
+
+    solo_runs = telemetry_store.query_runs(repo_root, slug="filter-demo", swarm_used=False)
+    assert len(solo_runs) == 1
+    assert solo_runs[0]["run_id"] == "solo"
+
+    track_runs = telemetry_store.query_runs(repo_root, track="platform/disciplines/sre")
+    assert len(track_runs) == 2
+
+
+def test_rollup_math(repo_root: Path) -> None:
+    telemetry_store.upsert_run(repo_root, _sample_payload(run_id="swarm", swarm_used=True))
+    telemetry_store.upsert_run(
+        repo_root,
+        {
+            "run_id": "solo",
+            "track": "k8s/cka",
+            "slug": "solo-demo",
+            "swarm_used": False,
+            "swarm_note": "solo run; no swarm used",
+            "source": "manual",
+            "participants": [
+                {"role": "main", "agent": "cursor", "total_tokens": 1000, "token_source": "estimated"}
+            ],
+        },
+    )
+
+    runs = telemetry_store.query_runs(repo_root, limit=10)
+    totals = telemetry_store.rollup(runs)
+    assert totals["runs"] == 2
+    assert totals["swarm_runs"] == 1
+    assert totals["solo_runs"] == 1
+    assert totals["participants"] == 3
+    assert totals["total_tokens"] == 181000
+    assert totals["cost_usd_est"] == 0.12
+
+
+def test_validate_requires_swarm_note() -> None:
+    with pytest.raises(ValueError, match="swarm_note must not be blank"):
+        telemetry_store.validate_module_build_ingest(
+            {
+                "track": "k8s/cka",
+                "slug": "solo-demo",
+                "swarm_used": False,
+                "source": "manual",
+            }
+        )
+
+
+def test_validate_rejects_blank_swarm_note() -> None:
+    with pytest.raises(ValueError, match="swarm_note must not be blank"):
+        telemetry_store.validate_module_build_ingest(
+            {
+                "track": "k8s/cka",
+                "slug": "solo-demo",
+                "swarm_used": False,
+                "swarm_note": "   ",
+                "source": "manual",
+            }
+        )
+
+
+def test_validate_requires_source_and_slug() -> None:
+    with pytest.raises(ValueError, match="source must not be blank"):
+        telemetry_store.validate_module_build_ingest(
+            {
+                "track": "k8s/cka",
+                "slug": "solo-demo",
+                "swarm_used": False,
+                "swarm_note": "solo run",
+                "source": " ",
+            }
+        )
+    with pytest.raises(ValueError, match="slug must not be blank"):
+        telemetry_store.validate_module_build_ingest(
+            {
+                "track": "k8s/cka",
+                "slug": " ",
+                "swarm_used": False,
+                "swarm_note": "solo run",
+                "source": "manual",
+            }
+        )
+
+
+def test_post_ingest_validator(repo_root: Path) -> None:
+    local_api = _load_local_api()
+
+    status, payload, _ = local_api.route_post_request(
+        repo_root,
+        "/api/telemetry/module-builds",
+        body_bytes=json.dumps(_sample_payload()).encode("utf-8"),
+        content_type="application/json",
+    )
+    assert status == 200
+    assert payload == {"ok": True, "run_id": "run-1"}
+
+    status, payload, _ = local_api.route_post_request(
+        repo_root,
+        "/api/telemetry/module-builds",
+        body_bytes=json.dumps(
+            {
+                "track": "k8s/cka",
+                "slug": "solo-demo",
+                "swarm_used": False,
+                "source": "manual",
+            }
+        ).encode("utf-8"),
+        content_type="application/json",
+    )
+    assert status == 400
+    assert payload["error"] == "swarm_note must not be blank"


### PR DESCRIPTION
## #1973 Phase 1 — module-build telemetry (lifted from learn-ukrainian)

First vertical slice of the LU telemetry port: track which agents built each module, with tokens/cost, swarm-vs-solo, wall-clock, and PR linkage.

### What's added (additive — existing `/agents` + `agent_telemetry annotate/report` untouched)
- **`scripts/telemetry_store.py`** — SQLite store at `.pipeline/telemetry/module_builds.db` (gitignored): `module_build_runs` + `module_build_participants`, idempotent schema, upsert-by-`run_id`, query + rollup. LU's `level` → KubeDojo **`track`** (path-addressed modules).
- **Ingest:** CLI `agent_telemetry.py record-build …` (orchestrator finalize-time path) **and** `POST /api/telemetry/module-builds` (validated — `swarm_note`/`source`/`slug` required → 400 on blanks).
- **API:** `GET /api/telemetry/module-builds?track=&slug=&swarm_used=&limit=` (paginated + `totals` rollup) and `GET /api/telemetry/module-builds/{track}/{slug}`.
- **UI:** `Telemetry` nav tab → `/telemetry` page (JS-driven, polls the API; mirrors `/agents` style).
- **Tests:** `tests/test_telemetry_store.py` (9 — schema idempotency, upsert-replace, filters, rollup math, validation).

### Verification (orchestrator ground-check, live API on a spare port)
- POST→`{ok,run_id}`; missing `swarm_note`→**400**; GET rollup totals correct (participants/tokens/cost, swarm vs solo); per-module detail returns the run; `/telemetry`→200; **`/agents` + `/api/telemetry/agents` still 200**. `ruff check` clean; 9 tests pass.

Phases 2 (tool-timings) and 3 (runtime usage from `smart_dispatch.jsonl`) follow per #1973.

🤖 Generated with [Claude Code](https://claude.com/claude-code)