### PR TITLE
feat(telemetry): tool-timings + runtime usage telemetry (#1973 P2+P3)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -117,6 +117,7 @@ test_script.sh
 .pipeline/teaching-audit/
 .pipeline/quality-pipeline/
 .pipeline/runs/
+.pipeline/telemetry/*.db
 .cache/
 
 # Quality progress ledger lock (the .tsv itself IS committed as the audit trail)

--- a/scripts/local_api.py
+++ b/scripts/local_api.py
@@ -9170,6 +9170,44 @@ def route_request(repo_root: Path, raw_path: str) -> tuple[int, Any, str]:
             slug=slug_part,
             limit=limit_val,
         ), "application/json; charset=utf-8"
+    if path == "/api/telemetry/tool-timings":
+        from telemetry_store import build_tool_timing_payload
+
+        window_raw = query.get("window", ["1h"])[0] or "1h"
+        tool_raw = query.get("tool", [None])[0]
+        return 200, build_tool_timing_payload(
+            repo_root,
+            window=str(window_raw),
+            tool=tool_raw,
+        ), "application/json; charset=utf-8"
+    if path == "/api/telemetry/runtime/usage":
+        from runtime_usage import build_runtime_usage_payload
+
+        days_raw = query.get("days", ["7"])[0]
+        agent_raw = query.get("agent", [None])[0]
+        task_class_raw = query.get("task_class", [None])[0]
+        try:
+            days_val = int(days_raw)
+        except (TypeError, ValueError):
+            days_val = 7
+        return 200, build_runtime_usage_payload(
+            repo_root,
+            days=days_val,
+            agent=agent_raw or None,
+            task_class=task_class_raw or None,
+        ), "application/json; charset=utf-8"
+    if path == "/api/telemetry/runtime/recent":
+        from runtime_usage import build_runtime_recent_payload
+
+        limit_raw = query.get("limit", ["50"])[0]
+        try:
+            limit_val = int(limit_raw)
+        except (TypeError, ValueError):
+            limit_val = 50
+        return 200, build_runtime_recent_payload(
+            repo_root,
+            limit=limit_val,
+        ), "application/json; charset=utf-8"
     decision_page = _DECISION_ROUTES.route_decision_page_request(
         repo_root,
         path,
@@ -9596,6 +9634,20 @@ def route_post_request(
         except ValueError as exc:
             return 400, {"error": str(exc)}, "application/json; charset=utf-8"
         return 200, {"ok": True, "run_id": run_id}, "application/json; charset=utf-8"
+    if path == "/api/telemetry/tool-timings":
+        from telemetry_store import ingest_tool_timing
+
+        if not body_bytes:
+            return 400, {"error": "empty body"}, "application/json; charset=utf-8"
+        try:
+            payload = json.loads(body_bytes.decode("utf-8"))
+        except (UnicodeDecodeError, json.JSONDecodeError):
+            return 400, {"error": "invalid JSON"}, "application/json; charset=utf-8"
+        try:
+            ingest_tool_timing(repo_root, payload)
+        except ValueError as exc:
+            return 400, {"error": str(exc)}, "application/json; charset=utf-8"
+        return 200, {"ok": True}, "application/json; charset=utf-8"
     return 404, {"error": "not_found", "path": path}, "application/json; charset=utf-8"
 
 

--- a/scripts/module_build_telemetry_page.py
+++ b/scripts/module_build_telemetry_page.py
@@ -1,7 +1,8 @@
-"""HTML page for module-build telemetry (#1973 P1).
+"""HTML page for KubeDojo telemetry dashboard (#1973 P1–P3).
 
-Renders token/cost rollups from ``/api/telemetry/module-builds``. Kept out of
-``local_api.py`` to match the agents telemetry page pattern.
+Renders module-build, tool-timing, and runtime dispatch rollups from the
+``/api/telemetry/*`` JSON endpoints. Kept out of ``local_api.py`` to match
+the agents telemetry page pattern.
 """
 from __future__ import annotations
 
@@ -15,6 +16,13 @@ _PAGE_CSS = """
 .mb-card .value{font-size:1.15rem;font-weight:700;color:#1e3a8a;margin-top:.15rem}
 .mb-section{margin:1.6rem 0}
 .mb-section h2{font-size:1.05rem;color:#1e3a8a;margin:0 0 .5rem}
+.mb-section-head{display:flex;flex-wrap:wrap;align-items:center;gap:.5rem;margin-bottom:.5rem}
+.mb-section-head h2{margin:0}
+.mb-win-btns{display:flex;gap:.35rem}
+.mb-win-btns button{font-size:.75rem;padding:.2rem .45rem;border:1px solid #cbd5e1;background:#fff;border-radius:.25rem;cursor:pointer;color:#334155}
+.mb-win-btns button.active{background:#eff6ff;border-color:#93c5fd;color:#1e3a8a;font-weight:600}
+.mb-note{color:#64748b;font-size:.82rem;margin:.35rem 0 .6rem}
+.mb-note a{color:#2563eb}
 table.mb{border-collapse:collapse;width:100%;font-size:.84rem;background:#fff}
 table.mb th,table.mb td{border:1px solid #e2e8f0;padding:.35rem .5rem;text-align:right;vertical-align:top}
 table.mb th:first-child,table.mb td:first-child,
@@ -30,8 +38,10 @@ table.mb td.no{color:#64748b}
 """
 
 _PAGE_JS = """
+var ttWindow='1h';
 function fmt(v){return v==null?'\\u2014':String(v);}
 function money(v){return v==null?'\\u2014':'$'+Number(v).toFixed(4);}
+function pct(v){return v==null?'\\u2014':(Number(v)*100).toFixed(1)+'%';}
 function el(tag,text,cls){var e=document.createElement(tag);if(text!=null)e.textContent=text;if(cls)e.className=cls;return e;}
 function renderTotals(t){
   var host=document.getElementById('mb-totals');
@@ -71,17 +81,125 @@ function renderRuns(rows){
   });
   table.appendChild(tb);host.appendChild(table);
 }
+function renderToolTimings(rows){
+  var host=document.getElementById('tt-tools');
+  host.textContent='';
+  if(!rows||!rows.length){host.appendChild(el('div','no tool timings in window','empty'));return;}
+  var table=el('table',null,'mb');
+  var thead=el('thead'),htr=el('tr');
+  ['tool','count','p50 ms','p95 ms','p99 ms','mean ms','failures'].forEach(function(c){htr.appendChild(el('th',c));});
+  thead.appendChild(htr);table.appendChild(thead);
+  var tb=el('tbody');
+  rows.forEach(function(r){
+    var tr=el('tr');
+    tr.appendChild(el('td',r.tool_name,'k'));
+    tr.appendChild(el('td',fmt(r.count)));
+    tr.appendChild(el('td',fmt(r.p50_ms)));
+    tr.appendChild(el('td',fmt(r.p95_ms)));
+    tr.appendChild(el('td',fmt(r.p99_ms)));
+    tr.appendChild(el('td',fmt(r.mean_ms)));
+    tr.appendChild(el('td',fmt(r.failure_count)));
+    tb.appendChild(tr);
+  });
+  table.appendChild(tb);host.appendChild(table);
+}
+function renderRuntimeUsage(agents, totals){
+  var host=document.getElementById('ru-usage');
+  host.textContent='';
+  var cardsHost=document.getElementById('ru-totals');
+  cardsHost.textContent='';
+  var cards=[
+    ['calls',totals.calls],['ok',totals.ok],['failed',totals.failed],
+    ['fail rate',pct(totals.rate_failed)],['mean elapsed s',fmt(totals.mean_elapsed_s)]
+  ];
+  cards.forEach(function(pair){
+    var card=el('div',null,'mb-card');
+    card.appendChild(el('div',pair[0],'label'));
+    card.appendChild(el('div',fmt(pair[1]),'value'));
+    cardsHost.appendChild(card);
+  });
+  if(!agents||!agents.length){host.appendChild(el('div','no dispatch records in window','empty'));return;}
+  var table=el('table',null,'mb');
+  var thead=el('thead'),htr=el('tr');
+  ['agent','calls','ok','failed','fail rate','mean s','p95 s','models'].forEach(function(c){htr.appendChild(el('th',c));});
+  thead.appendChild(htr);table.appendChild(thead);
+  var tb=el('tbody');
+  agents.forEach(function(r){
+    var tr=el('tr');
+    tr.appendChild(el('td',r.agent,'k'));
+    tr.appendChild(el('td',fmt(r.calls)));
+    tr.appendChild(el('td',fmt(r.ok)));
+    tr.appendChild(el('td',fmt(r.failed)));
+    tr.appendChild(el('td',pct(r.rate_failed)));
+    tr.appendChild(el('td',fmt(r.mean_elapsed_s)));
+    tr.appendChild(el('td',fmt(r.p95_elapsed_s)));
+    tr.appendChild(el('td',(r.models||[]).join(', '),'meta'));
+    tb.appendChild(tr);
+  });
+  table.appendChild(tb);host.appendChild(table);
+}
+function renderRuntimeRecent(rows){
+  var host=document.getElementById('ru-recent');
+  host.textContent='';
+  if(!rows||!rows.length){host.appendChild(el('div','no recent dispatches','empty'));return;}
+  var table=el('table',null,'mb');
+  var thead=el('thead'),htr=el('tr');
+  ['ts','agent','model','class','ok','elapsed s','task id'].forEach(function(c){htr.appendChild(el('th',c));});
+  thead.appendChild(htr);table.appendChild(thead);
+  var tb=el('tbody');
+  rows.forEach(function(r){
+    var tr=el('tr');
+    tr.appendChild(el('td',fmt(r.ts),'meta'));
+    tr.appendChild(el('td',r.agent,'k'));
+    tr.appendChild(el('td',r.model,'meta'));
+    tr.appendChild(el('td',r.task_class,'meta'));
+    tr.appendChild(el('td',r.ok===false?'no':'yes',r.ok===false?'no':'yes'));
+    tr.appendChild(el('td',fmt(r.elapsed_s)));
+    tr.appendChild(el('td',r.task_id,'meta'));
+    tb.appendChild(tr);
+  });
+  table.appendChild(tb);host.appendChild(table);
+}
+function setToolWindow(w, btn){
+  ttWindow=w;
+  document.querySelectorAll('.mb-win-btns button').forEach(function(b){b.classList.remove('active');});
+  if(btn) btn.classList.add('active');
+  loadToolTimings();
+}
 async function loadModuleBuilds(){
   try{
     var r=await fetch('/api/telemetry/module-builds?limit=100');
     var d=await r.json();
     document.getElementById('mb-summary').textContent=
-      d.records_total+' records \\u00b7 generated '+d.generated_at;
+      d.records_total+' module-build records \\u00b7 generated '+d.generated_at;
     renderTotals(d.totals||{});
     renderRuns(d.runs||[]);
-  }catch(e){document.getElementById('mb-summary').textContent='failed to load: '+e;}
+  }catch(e){document.getElementById('mb-summary').textContent='failed to load module builds: '+e;}
+}
+async function loadToolTimings(){
+  try{
+    var r=await fetch('/api/telemetry/tool-timings?window='+encodeURIComponent(ttWindow));
+    var d=await r.json();
+    document.getElementById('tt-summary').textContent=
+      (d.tools||[]).length+' tools \\u00b7 window '+d.window+' \\u00b7 generated '+d.generated_at;
+    renderToolTimings(d.tools||[]);
+  }catch(e){document.getElementById('tt-summary').textContent='failed to load tool timings: '+e;}
+}
+async function loadRuntime(){
+  try{
+    var ur=await fetch('/api/telemetry/runtime/usage?days=7');
+    var u=await ur.json();
+    document.getElementById('ru-summary').textContent=
+      'last '+u.days+' days \\u00b7 generated '+u.generated_at;
+    renderRuntimeUsage(u.agents||[], u.totals||{});
+    var rr=await fetch('/api/telemetry/runtime/recent?limit=50');
+    var rec=await rr.json();
+    renderRuntimeRecent(rec.records||[]);
+  }catch(e){document.getElementById('ru-summary').textContent='failed to load runtime usage: '+e;}
 }
 loadModuleBuilds();
+loadToolTimings();
+loadRuntime();
 """
 
 
@@ -102,22 +220,51 @@ def render_module_builds_page_html(*, top_nav: str = "", nav_css: str = "", ds_l
   {top_nav}
   <main class="mb-main">
     <div class="mb-head">
-      <h1>Module Build Telemetry</h1>
-      <div class="mb-sub" id="mb-summary">loading&hellip;</div>
+      <h1>Telemetry</h1>
+      <div class="mb-sub" id="mb-summary">loading module builds&hellip;</div>
     </div>
 
     <div id="mb-totals" class="mb-cards"></div>
 
     <div class="mb-section">
-      <h2>Recent runs</h2>
+      <h2>Module build runs</h2>
       <div id="mb-runs"><div class="empty">loading&hellip;</div></div>
     </div>
 
+    <div class="mb-section">
+      <div class="mb-section-head">
+        <h2>Tool timings</h2>
+        <div class="mb-win-btns">
+          <button type="button" onclick="setToolWindow('5m', this)">5m</button>
+          <button type="button" class="active" onclick="setToolWindow('1h', this)">1h</button>
+          <button type="button" onclick="setToolWindow('24h', this)">24h</button>
+        </div>
+      </div>
+      <div class="mb-sub" id="tt-summary">loading tool timings&hellip;</div>
+      <div id="tt-tools"><div class="empty">loading&hellip;</div></div>
+    </div>
+
+    <div class="mb-section">
+      <h2>Runtime usage</h2>
+      <div class="mb-note">
+        <a href="/agents">/agents</a> tracks review-outcome quality (annotated ground checks);
+        this section shows dispatch usage and latency from <code>logs/smart_dispatch.jsonl</code>.
+      </div>
+      <div class="mb-sub" id="ru-summary">loading runtime usage&hellip;</div>
+      <div id="ru-totals" class="mb-cards"></div>
+      <div id="ru-usage"><div class="empty">loading&hellip;</div></div>
+    </div>
+
+    <div class="mb-section">
+      <h2>Recent dispatches</h2>
+      <div id="ru-recent"><div class="empty">loading&hellip;</div></div>
+    </div>
+
     <div class="mb-legend">
-      Token totals roll up participant prompt/response/total fields.
-      Record finalize-time builds with
+      Module builds: record finalize-time token rollups with
       <code>python -m scripts.agent_telemetry record-build</code> or
       <code>POST /api/telemetry/module-builds</code>.
+      Tool timings: ingest via <code>POST /api/telemetry/tool-timings</code>.
     </div>
   </main>
   <script>

--- a/scripts/runtime_usage.py
+++ b/scripts/runtime_usage.py
@@ -1,0 +1,192 @@
+"""Runtime dispatch usage telemetry from ``logs/smart_dispatch.jsonl`` (#1973 P3).
+
+Read-only rollups over smart_dispatch records: calls, ok/failed counts, elapsed
+latency — no token/cost fields (those are not captured in the dispatch log).
+"""
+from __future__ import annotations
+
+import json
+import time
+from collections import defaultdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+from telemetry_store import _percentile_ms
+
+_dispatch_log_override: Path | None = None
+
+
+def dispatch_log_path(repo_root: Path) -> Path:
+    if _dispatch_log_override is not None:
+        return _dispatch_log_override
+    return repo_root / "logs" / "smart_dispatch.jsonl"
+
+
+def _load_jsonl(path: Path) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    if not path.exists():
+        return rows
+    for line in path.read_text(encoding="utf-8").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            row = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if isinstance(row, dict):
+            rows.append(row)
+    return rows
+
+
+def _dispatch_ts(record: dict[str, Any]) -> int | None:
+    ts = record.get("ts")
+    if isinstance(ts, (int, float)):
+        return int(ts)
+    if isinstance(ts, str) and ts.strip():
+        text = ts.strip()
+        if text.endswith("Z"):
+            text = text[:-1] + "+00:00"
+        try:
+            parsed = datetime.fromisoformat(text)
+            if parsed.tzinfo is None:
+                parsed = parsed.replace(tzinfo=UTC)
+            return int(parsed.timestamp())
+        except ValueError:
+            return None
+    return None
+
+
+def _is_failed(record: dict[str, Any]) -> bool:
+    return record.get("ok") is False or (record.get("response_chars") or 0) == 0
+
+
+def _elapsed_values(records: list[dict[str, Any]]) -> list[float]:
+    values: list[float] = []
+    for record in records:
+        elapsed = record.get("elapsed_s")
+        if isinstance(elapsed, (int, float)):
+            values.append(float(elapsed))
+    return values
+
+
+def _agent_bucket(records: list[dict[str, Any]]) -> dict[str, Any]:
+    failed = sum(1 for record in records if _is_failed(record))
+    calls = len(records)
+    ok = calls - failed
+    elapsed = _elapsed_values(records)
+    models = sorted({str(record["model"]) for record in records if record.get("model")})
+    by_class: dict[str, int] = defaultdict(int)
+    for record in records:
+        by_class[str(record.get("task_class") or "?")] += 1
+    mean_elapsed = round(sum(elapsed) / len(elapsed), 3) if elapsed else None
+    p95_elapsed = round(_percentile_ms([int(round(v * 1000)) for v in elapsed], 0.95) / 1000, 3) if elapsed else None
+    return {
+        "calls": calls,
+        "ok": ok,
+        "failed": failed,
+        "rate_failed": round(failed / calls, 4) if calls else 0.0,
+        "mean_elapsed_s": mean_elapsed,
+        "p95_elapsed_s": p95_elapsed,
+        "models": models,
+        "by_class": dict(sorted(by_class.items())),
+    }
+
+
+def _totals_from_records(records: list[dict[str, Any]]) -> dict[str, Any]:
+    bucket = _agent_bucket(records)
+    return {
+        "calls": bucket["calls"],
+        "ok": bucket["ok"],
+        "failed": bucket["failed"],
+        "rate_failed": bucket["rate_failed"],
+        "mean_elapsed_s": bucket["mean_elapsed_s"],
+    }
+
+
+def load_dispatch_records(
+    repo_root: Path,
+    *,
+    days: int | None = None,
+    agent: str | None = None,
+    task_class: str | None = None,
+) -> list[dict[str, Any]]:
+    records = _load_jsonl(dispatch_log_path(repo_root))
+    window_days = min(max(1, int(days)), 30) if days is not None else None
+    cutoff = int(time.time()) - window_days * 86400 if window_days is not None else None
+
+    filtered: list[dict[str, Any]] = []
+    for record in records:
+        ts = _dispatch_ts(record)
+        if cutoff is not None and (ts is None or ts < cutoff):
+            continue
+        if agent and record.get("agent") != agent:
+            continue
+        if task_class and record.get("task_class") != task_class:
+            continue
+        filtered.append(record)
+    return filtered
+
+
+def build_runtime_usage_payload(
+    repo_root: Path,
+    *,
+    days: int = 7,
+    agent: str | None = None,
+    task_class: str | None = None,
+) -> dict[str, Any]:
+    window_days = min(max(1, int(days)), 30)
+    records = load_dispatch_records(
+        repo_root,
+        days=window_days,
+        agent=agent,
+        task_class=task_class,
+    )
+
+    by_agent: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for record in records:
+        agent_name = str(record.get("agent") or "?")
+        by_agent[agent_name].append(record)
+
+    agents: list[dict[str, Any]] = []
+    for agent_name in sorted(by_agent, key=lambda name: -len(by_agent[name])):
+        bucket = _agent_bucket(by_agent[agent_name])
+        agents.append({"agent": agent_name, **bucket})
+
+    return {
+        "generated_at": int(time.time()),
+        "days": window_days,
+        "agent_filter": agent,
+        "task_class_filter": task_class,
+        "totals": _totals_from_records(records),
+        "agents": agents,
+    }
+
+
+def build_runtime_recent_payload(
+    repo_root: Path,
+    *,
+    limit: int = 50,
+) -> dict[str, Any]:
+    record_limit = min(max(1, int(limit)), 500)
+    records = _load_jsonl(dispatch_log_path(repo_root))
+    summaries: list[dict[str, Any]] = []
+    for record in records:
+        ts = _dispatch_ts(record)
+        summaries.append(
+            {
+                "ts": ts if ts is not None else record.get("ts"),
+                "agent": record.get("agent"),
+                "model": record.get("model"),
+                "task_class": record.get("task_class"),
+                "ok": record.get("ok"),
+                "elapsed_s": record.get("elapsed_s"),
+                "task_id": record.get("task_id"),
+            }
+        )
+    summaries.sort(key=lambda item: item.get("ts") or 0, reverse=True)
+    return {
+        "generated_at": int(time.time()),
+        "records": summaries[:record_limit],
+    }

--- a/scripts/telemetry_store.py
+++ b/scripts/telemetry_store.py
@@ -1,26 +1,41 @@
-"""SQLite persistence for module-build token telemetry (#1973 P1).
+"""SQLite persistence for KubeDojo telemetry (#1973).
 
-Stores orchestrator finalize-time records: track + slug, swarm/solo metadata,
-PR/commit context, and per-participant token/cost rollups under
-``.pipeline/telemetry/module_builds.db`` (runtime state, gitignored).
+- Module-build token telemetry in ``.pipeline/telemetry/module_builds.db``
+- Tool-timing telemetry in ``.pipeline/telemetry/tool_timings.db``
 """
 from __future__ import annotations
 
 import sqlite3
 from collections import defaultdict
 from contextlib import closing
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 from typing import Any
 from uuid import uuid4
 
 _db_path_override: Path | None = None
+_tool_timings_db_path_override: Path | None = None
+
+_TOOL_TIMING_WINDOWS = {
+    "5m": timedelta(minutes=5),
+    "15m": timedelta(minutes=15),
+    "1h": timedelta(hours=1),
+    "6h": timedelta(hours=6),
+    "24h": timedelta(hours=24),
+    "7d": timedelta(days=7),
+}
 
 
 def db_path(repo_root: Path) -> Path:
     if _db_path_override is not None:
         return _db_path_override
     return repo_root / ".pipeline" / "telemetry" / "module_builds.db"
+
+
+def tool_timings_db_path(repo_root: Path) -> Path:
+    if _tool_timings_db_path_override is not None:
+        return _tool_timings_db_path_override
+    return repo_root / ".pipeline" / "telemetry" / "tool_timings.db"
 
 
 def _isoformat_z(value: datetime) -> str:
@@ -464,4 +479,163 @@ def build_module_build_detail_payload(
         "totals": payload["totals"],
         "latest": payload["runs"][0] if payload["runs"] else None,
         "runs": payload["runs"],
+    }
+
+
+# ---------------------------------------------------------------------------
+# Tool-timing telemetry (#1973 P2)
+# ---------------------------------------------------------------------------
+
+
+def _ensure_tool_timings_schema(conn: sqlite3.Connection) -> None:
+    conn.executescript(
+        """
+        CREATE TABLE IF NOT EXISTS tool_timings (
+            id          INTEGER PRIMARY KEY AUTOINCREMENT,
+            ts          TEXT NOT NULL,
+            tool_name   TEXT NOT NULL,
+            duration_ms INTEGER NOT NULL,
+            tool_use_id TEXT,
+            session_id  TEXT,
+            failed      INTEGER NOT NULL DEFAULT 0
+        );
+        CREATE INDEX IF NOT EXISTS idx_tt_ts ON tool_timings(ts);
+        CREATE INDEX IF NOT EXISTS idx_tt_name_ts ON tool_timings(tool_name, ts);
+        """
+    )
+
+
+def _percentile_ms(values: list[int], percentile: float) -> int:
+    if not values:
+        return 0
+    sorted_values = sorted(values)
+    if len(sorted_values) == 1:
+        return sorted_values[0]
+
+    rank = (len(sorted_values) - 1) * percentile
+    lower = int(rank)
+    upper = min(lower + 1, len(sorted_values) - 1)
+    fraction = rank - lower
+    return round(sorted_values[lower] + (sorted_values[upper] - sorted_values[lower]) * fraction)
+
+
+def _tool_timing_window_start(window: str) -> tuple[str, str]:
+    delta = _TOOL_TIMING_WINDOWS.get(window)
+    if delta is None:
+        window = "1h"
+        delta = _TOOL_TIMING_WINDOWS[window]
+    return window, _isoformat_z(datetime.now(UTC) - delta)
+
+
+def validate_tool_timing_ingest(payload: dict[str, Any]) -> dict[str, Any]:
+    if not isinstance(payload, dict):
+        raise ValueError("payload must be a JSON object")
+
+    tool_name = _required_text(payload.get("tool_name"), "tool_name")
+    duration_ms = payload.get("duration_ms")
+    if duration_ms is None:
+        raise ValueError("duration_ms is required")
+    try:
+        duration_val = int(duration_ms)
+    except (TypeError, ValueError) as exc:
+        raise ValueError("duration_ms must be a non-negative integer") from exc
+    if duration_val < 0:
+        raise ValueError("duration_ms must be a non-negative integer")
+
+    return {
+        "ts": _parse_recorded_at(payload.get("ts")),
+        "tool_name": tool_name,
+        "duration_ms": duration_val,
+        "tool_use_id": _clean_text(payload.get("tool_use_id")),
+        "session_id": _clean_text(payload.get("session_id")),
+        "failed": 1 if payload.get("failed") else 0,
+    }
+
+
+def ingest_tool_timing(repo_root: Path, record: dict[str, Any]) -> None:
+    validated = validate_tool_timing_ingest(record)
+    db_file = tool_timings_db_path(repo_root)
+    with closing(_connect(db_file)) as conn:
+        _ensure_tool_timings_schema(conn)
+        conn.execute(
+            """
+            INSERT INTO tool_timings (ts, tool_name, duration_ms, tool_use_id, session_id, failed)
+            VALUES (?, ?, ?, ?, ?, ?)
+            """,
+            (
+                validated["ts"],
+                validated["tool_name"],
+                validated["duration_ms"],
+                validated["tool_use_id"],
+                validated["session_id"],
+                validated["failed"],
+            ),
+        )
+        conn.commit()
+
+
+def tool_timing_summary(
+    repo_root: Path,
+    *,
+    window: str = "1h",
+    tool: str | None = None,
+) -> list[dict[str, Any]]:
+    window, window_start = _tool_timing_window_start(window)
+    conditions = ["ts >= ?"]
+    params: list[Any] = [window_start]
+    if tool:
+        conditions.append("tool_name = ?")
+        params.append(tool.strip())
+
+    where = " AND ".join(conditions)
+    db_file = tool_timings_db_path(repo_root)
+    with closing(_connect(db_file)) as conn:
+        _ensure_tool_timings_schema(conn)
+        rows = conn.execute(
+            f"""
+            SELECT tool_name, duration_ms, failed
+            FROM tool_timings
+            WHERE {where}
+            ORDER BY tool_name, duration_ms
+            """,
+            params,
+        ).fetchall()
+
+    durations: dict[str, list[int]] = defaultdict(list)
+    failures: dict[str, int] = defaultdict(int)
+    for row in rows:
+        tool_name = str(row["tool_name"])
+        durations[tool_name].append(int(row["duration_ms"]))
+        failures[tool_name] += int(row["failed"])
+
+    results: list[dict[str, Any]] = []
+    for tool_name, values in durations.items():
+        count = len(values)
+        results.append(
+            {
+                "tool_name": tool_name,
+                "count": count,
+                "p50_ms": _percentile_ms(values, 0.50),
+                "p95_ms": _percentile_ms(values, 0.95),
+                "p99_ms": _percentile_ms(values, 0.99),
+                "mean_ms": round(sum(values) / count),
+                "failure_count": failures[tool_name],
+            }
+        )
+
+    return sorted(results, key=lambda item: (-item["count"], item["tool_name"]))
+
+
+def build_tool_timing_payload(
+    repo_root: Path,
+    *,
+    window: str = "1h",
+    tool: str | None = None,
+) -> dict[str, Any]:
+    window, _ = _tool_timing_window_start(window)
+    tools = tool_timing_summary(repo_root, window=window, tool=tool)
+    return {
+        "generated_at": _now_z(),
+        "window": window,
+        "tools": tools,
     }

--- a/tests/test_telemetry_store.py
+++ b/tests/test_telemetry_store.py
@@ -5,6 +5,7 @@ import importlib.util
 import json
 import sqlite3
 import sys
+import time
 from contextlib import closing
 from pathlib import Path
 
@@ -293,3 +294,208 @@ def test_post_ingest_validator(repo_root: Path) -> None:
     )
     assert status == 400
     assert payload["error"] == "swarm_note must not be blank"
+
+
+def _load_runtime_usage():
+    module_path = SCRIPTS_DIR / "runtime_usage.py"
+    spec = importlib.util.spec_from_file_location("runtime_usage", module_path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runtime_usage = _load_runtime_usage()
+
+
+@pytest.fixture
+def tool_timings_db(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    db_path = tmp_path / "tool_timings.db"
+    monkeypatch.setattr(telemetry_store, "_tool_timings_db_path_override", db_path)
+    return db_path
+
+
+def test_tool_timing_percentiles(repo_root: Path, tool_timings_db: Path) -> None:
+    for duration_ms in (10, 20, 30, 40, 50):
+        telemetry_store.ingest_tool_timing(
+            repo_root,
+            {"tool_name": "Bash", "duration_ms": duration_ms},
+        )
+
+    summary = telemetry_store.tool_timing_summary(repo_root, window="1h")
+    bash = next(item for item in summary if item["tool_name"] == "Bash")
+    assert bash["count"] == 5
+    assert bash["p50_ms"] == 30
+    assert bash["p95_ms"] == 48
+    assert bash["p99_ms"] == 50
+    assert bash["mean_ms"] == 30
+    assert bash["failure_count"] == 0
+
+    telemetry_store.ingest_tool_timing(
+        repo_root,
+        {"tool_name": "Bash", "duration_ms": 100, "failed": True},
+    )
+    summary = telemetry_store.tool_timing_summary(repo_root, window="1h")
+    bash = next(item for item in summary if item["tool_name"] == "Bash")
+    assert bash["failure_count"] == 1
+
+
+def test_tool_timing_window_excludes_old_rows(
+    repo_root: Path, tool_timings_db: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setattr(
+        telemetry_store,
+        "_tool_timing_window_start",
+        lambda window: ("1h", "2026-06-14T11:00:00Z"),
+    )
+
+    telemetry_store.ingest_tool_timing(
+        repo_root,
+        {"ts": "2026-06-14T11:30:00Z", "tool_name": "Read", "duration_ms": 50},
+    )
+    telemetry_store.ingest_tool_timing(
+        repo_root,
+        {"ts": "2026-06-14T10:00:00Z", "tool_name": "Read", "duration_ms": 999},
+    )
+
+    summary = telemetry_store.tool_timing_summary(repo_root, window="1h")
+    read = next(item for item in summary if item["tool_name"] == "Read")
+    assert read["count"] == 1
+    assert read["mean_ms"] == 50
+
+
+def test_tool_timing_empty_window_is_safe(repo_root: Path, tool_timings_db: Path) -> None:
+    assert telemetry_store.tool_timing_summary(repo_root, window="5m") == []
+    payload = telemetry_store.build_tool_timing_payload(repo_root, window="5m")
+    assert payload["window"] == "5m"
+    assert payload["tools"] == []
+
+
+def test_tool_timing_unknown_window_defaults_to_1h(repo_root: Path, tool_timings_db: Path) -> None:
+    telemetry_store.ingest_tool_timing(
+        repo_root,
+        {"tool_name": "Grep", "duration_ms": 12},
+    )
+    payload = telemetry_store.build_tool_timing_payload(repo_root, window="bad")
+    assert payload["window"] == "1h"
+    assert len(payload["tools"]) == 1
+
+
+def test_post_tool_timing_ingest(repo_root: Path, tool_timings_db: Path) -> None:
+    local_api = _load_local_api()
+
+    status, payload, _ = local_api.route_post_request(
+        repo_root,
+        "/api/telemetry/tool-timings",
+        body_bytes=json.dumps(
+            {"tool_name": "Shell", "duration_ms": 250, "failed": False}
+        ).encode("utf-8"),
+        content_type="application/json",
+    )
+    assert status == 200
+    assert payload == {"ok": True}
+
+    status, payload, _ = local_api.route_post_request(
+        repo_root,
+        "/api/telemetry/tool-timings",
+        body_bytes=json.dumps({"tool_name": "Shell", "duration_ms": -1}).encode("utf-8"),
+        content_type="application/json",
+    )
+    assert status == 400
+    assert "duration_ms" in payload["error"]
+
+
+@pytest.fixture
+def dispatch_log(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> Path:
+    logs = tmp_path / "logs"
+    logs.mkdir()
+    log_path = logs / "smart_dispatch.jsonl"
+    monkeypatch.setattr(runtime_usage, "_dispatch_log_override", log_path)
+    return log_path
+
+
+def _write_dispatch_fixture(path: Path, rows: list[dict]) -> None:
+    path.write_text("\n".join(json.dumps(row) for row in rows), encoding="utf-8")
+
+
+def test_runtime_usage_aggregation(repo_root: Path, dispatch_log: Path) -> None:
+    now = int(time.time())
+    _write_dispatch_fixture(
+        dispatch_log,
+        [
+            {
+                "ts": now - 3600,
+                "agent": "codex",
+                "model": "gpt-5.5",
+                "task_class": "review",
+                "ok": True,
+                "response_chars": 100,
+                "elapsed_s": 10.0,
+                "task_id": "t1",
+            },
+            {
+                "ts": now - 7200,
+                "agent": "codex",
+                "model": "gpt-5.5",
+                "task_class": "draft",
+                "ok": False,
+                "response_chars": 0,
+                "elapsed_s": 20.0,
+                "task_id": "t2",
+            },
+            {
+                "ts": now - (9 * 86400),
+                "agent": "cursor",
+                "model": "auto",
+                "task_class": "edit",
+                "ok": True,
+                "response_chars": 50,
+                "elapsed_s": 5.0,
+                "task_id": "old",
+            },
+        ],
+    )
+
+    payload = runtime_usage.build_runtime_usage_payload(repo_root, days=7)
+    assert payload["totals"]["calls"] == 2
+    assert payload["totals"]["failed"] == 1
+    assert payload["totals"]["ok"] == 1
+    assert payload["totals"]["mean_elapsed_s"] == 15.0
+
+    codex = next(item for item in payload["agents"] if item["agent"] == "codex")
+    assert codex["calls"] == 2
+    assert codex["failed"] == 1
+    assert codex["rate_failed"] == 0.5
+    assert codex["by_class"]["review"] == 1
+    assert codex["by_class"]["draft"] == 1
+    assert codex["models"] == ["gpt-5.5"]
+
+
+def test_runtime_recent_ordering(repo_root: Path, dispatch_log: Path) -> None:
+    _write_dispatch_fixture(
+        dispatch_log,
+        [
+            {"ts": 100, "agent": "a", "model": "m1", "task_class": "edit", "ok": True, "elapsed_s": 1, "task_id": "old"},
+            {"ts": 300, "agent": "b", "model": "m2", "task_class": "review", "ok": True, "elapsed_s": 2, "task_id": "new"},
+        ],
+    )
+
+    payload = runtime_usage.build_runtime_recent_payload(repo_root, limit=10)
+    assert [row["task_id"] for row in payload["records"]] == ["new", "old"]
+
+
+def test_runtime_usage_days_filter(repo_root: Path, dispatch_log: Path) -> None:
+    now = int(time.time())
+    _write_dispatch_fixture(
+        dispatch_log,
+        [
+            {"ts": now - 86400, "agent": "codex", "ok": True, "response_chars": 1, "elapsed_s": 1, "task_id": "d1"},
+            {"ts": now - (3 * 86400), "agent": "codex", "ok": True, "response_chars": 1, "elapsed_s": 1, "task_id": "d2"},
+        ],
+    )
+
+    one_day = runtime_usage.build_runtime_usage_payload(repo_root, days=1)
+    seven_day = runtime_usage.build_runtime_usage_payload(repo_root, days=7)
+    assert one_day["totals"]["calls"] == 1
+    assert seven_day["totals"]["calls"] == 2


### PR DESCRIPTION
## #1973 Phases 2+3 — tool-timings + runtime usage (completes the LU telemetry port)

Builds on the merged Phase 1 (module-builds), extending the same `telemetry_store.py` / `/telemetry` page / `local_api.py`.

### Phase 2 — Tool-timing telemetry
- `tool_timings` table (`.pipeline/telemetry/tool_timings.db`, gitignored). `POST /api/telemetry/tool-timings` (validated → 400 on bad input). `GET /api/telemetry/tool-timings?window=1h&tool=` → per-tool `{count, p50_ms, p95_ms, p99_ms, mean_ms, failure_count}` (linear-interp percentiles; windows 5m/15m/1h/6h/24h/7d). New **Tool timings** section on `/telemetry`.

### Phase 3 — Runtime usage / recent
- `scripts/runtime_usage.py` aggregates `logs/smart_dispatch.jsonl` (no fabricated tokens/cost — that source has none). `GET /api/telemetry/runtime/usage?days=7&agent=&task_class=` → per-agent calls/ok/failed/mean+p95 elapsed/models/by-class + totals. `GET /api/telemetry/runtime/recent?limit=` → newest-first dispatches. New **Runtime usage** section on `/telemetry`, with a note reconciling vs `/agents` (review-quality) — not duplicated.

### Verification (orchestrator ground-check, live API)
- Tool-timing percentiles math-checked ([50,100,150,900] → p50=125, mean=300, p95≈787, failure=1); validation 400s. Runtime usage aggregated **real** data (332 calls/7d, top agent cursor 136/133-ok); recent returns newest-first. `/telemetry` + P1 module-builds + `/agents` all still 200. ruff clean; **17 tests pass**; no `.db` committed.

Closes #1973 (all 3 phases shipped).

🤖 Generated with [Claude Code](https://claude.com/claude-code)