### PR TITLE
chore(telemetry): wire record-build into finalize via scripts/finalize_module.sh (#1978)

### DIFF
--- a/.claude/skills/curriculum-orchestrator/SKILL.md
+++ b/.claude/skills/curriculum-orchestrator/SKILL.md
@@ -118,6 +118,7 @@ Per user policy refinement: every shipped module must carry a composer-2.5 cross
 ## Operational rules
 
 - Quality-gate numbers live in `scripts/quality/verify_module.py` and `scripts/config.py`. Change the test fixture in the same commit as the gate ([[feedback_three_way_rule_agreement]]).
+- **Finalize a module with `scripts/finalize_module.sh`** (the standard finalize unit, #1978) — after writing the bespoke `.pipeline/reviews/<__path>.md` APPROVE record, run `scripts/finalize_module.sh <dash-slug> <review-record-path> -- <record-build args…>`. It GUARDS that the latest review verdict is APPROVE, then `reset-stage COMMITTED` **and** `record-build` (telemetry) together — so `/telemetry` is auto-populated every wave instead of `record-build` being a forgotten manual step. `--dry-run` to preview; `--help` for the worked example. Per-wave `_finalize.sh` scripts call this once per module.
 - `STATUS.md` is an INDEX, not a log. Full handoffs go in `docs/session-state/YYYY-MM-DD-<topic>.html` per HTML-first artifact policy ([[feedback_html_over_markdown_for_artifacts]]).
 - HTML artifacts MUST be served via `http://127.0.0.1:8768/`, never `open <file>` or `file://` ([[feedback_html_artifacts_via_local_api]]).
 - Briefing API parses `## TODO` (unchecked `- [ ]`) and `## Blockers` (`- `) from STATUS.md. Keep those headings populated.

--- a/scripts/finalize_module.sh
+++ b/scripts/finalize_module.sh
@@ -1,0 +1,115 @@
+#!/usr/bin/env bash
+# scripts/finalize_module.sh — canonical per-module finalize for curriculum waves.
+#
+# Bundles the deterministic finalize steps for ONE module so /telemetry is
+# auto-populated on EVERY wave. Before #1978, record-build was a manual CLI call
+# separate from the finalize flow and got forgotten → the dashboard went stale.
+#
+# This helper runs, in order:
+#   1. GUARD  — assert the .pipeline/reviews APPROVE record exists (latest verdict
+#               is APPROVE). Prevents flipping a module to COMMITTED with no review
+#               — a real past gotcha.
+#   2. git add -f <review-record>           (track the review record)
+#   3. reset-stage <stage-slug> COMMITTED   (board flip — scripts.quality.pipeline)
+#   4. record-build <passthrough args>      (telemetry — scripts.agent_telemetry)
+#
+# The bespoke APPROVE prose is written by the CALLER before invoking this (it
+# varies per module); the helper only verifies + tracks it, then flips + records.
+#
+# Usage:
+#   scripts/finalize_module.sh [--dry-run] <stage-slug> <review-record-path> \
+#       -- <record-build args…>
+#
+# Example:
+#   scripts/finalize_module.sh \
+#     platform-disciplines-core-platform-platform-engineering-module-2.3-internal-developer-platforms \
+#     .pipeline/reviews/platform__disciplines__core-platform__platform-engineering__module-2.3-internal-developer-platforms.md \
+#     -- --track platform/disciplines/core-platform/platform-engineering \
+#        --slug module-2.3-internal-developer-platforms \
+#        --module-title "Internal Developer Platforms (IDPs)" \
+#        --source orchestrator --no-swarm --swarm-note "solo expand" --pr 1980 \
+#        --participant "role=author,agent=cursor,model=auto,total_tokens=240000,token_source=est" \
+#        --participant "role=reviewer,agent=codex,model=gpt-5.5,total_tokens=60000,token_source=est"
+#
+# Run from anywhere inside the repo (resolves the repo root via git). Review-record
+# paths are interpreted relative to the repo root.
+set -euo pipefail
+
+usage() { sed -n '2,40p' "$0"; }
+
+DRY_RUN=0
+while [ $# -gt 0 ]; do
+  case "$1" in
+    -h|--help) usage; exit 0 ;;
+    -n|--dry-run) DRY_RUN=1; shift ;;
+    --) break ;;            # no positionals supplied before --
+    -*) echo "finalize_module: unknown flag '$1'" >&2; usage >&2; exit 2 ;;
+    *) break ;;             # first positional (stage-slug)
+  esac
+done
+
+STAGE_SLUG="${1:-}"
+REVIEW_PATH="${2:-}"
+if [ -z "$STAGE_SLUG" ] || [ -z "$REVIEW_PATH" ]; then
+  echo "finalize_module: missing <stage-slug> and/or <review-record-path>" >&2
+  usage >&2; exit 2
+fi
+shift 2 || true
+
+if [ "${1:-}" != "--" ]; then
+  echo "finalize_module: expected '--' before the record-build args" >&2
+  usage >&2; exit 2
+fi
+shift  # drop the --
+if [ $# -eq 0 ]; then
+  echo "finalize_module: no record-build args after '--'" >&2
+  usage >&2; exit 2
+fi
+
+REPO_ROOT="$(git rev-parse --show-toplevel)"
+cd "$REPO_ROOT"
+
+# Resolve the review record relative to the repo root.
+case "$REVIEW_PATH" in
+  /*) REVIEW_ABS="$REVIEW_PATH" ;;
+  *)  REVIEW_ABS="$REPO_ROOT/$REVIEW_PATH" ;;
+esac
+
+# --- Step 1: GUARD — the APPROVE review record must exist and be APPROVE'd ---
+if [ ! -s "$REVIEW_ABS" ]; then
+  echo "finalize_module: review record missing or empty: $REVIEW_PATH" >&2
+  echo "  Write the .pipeline/reviews APPROVE record BEFORE finalizing." >&2
+  exit 3
+fi
+LAST_HEADER="$(grep -E '^##[[:space:]].*REVIEW' "$REVIEW_ABS" | tail -1 || true)"
+if [ -z "$LAST_HEADER" ]; then
+  echo "finalize_module: no '## … REVIEW …' verdict header in $REVIEW_PATH" >&2
+  exit 3
+fi
+if ! printf '%s' "$LAST_HEADER" | grep -q 'APPROVE'; then
+  echo "finalize_module: latest review verdict is not APPROVE — refusing to flip." >&2
+  echo "  latest header: $LAST_HEADER" >&2
+  exit 3
+fi
+
+# Pick the project interpreter (.venv preferred).
+PY="$REPO_ROOT/.venv/bin/python"
+[ -x "$PY" ] || PY="python3"
+
+run() {
+  if [ "$DRY_RUN" -eq 1 ]; then
+    printf '[dry-run] '; printf '%q ' "$@"; printf '\n'
+  else
+    "$@"
+  fi
+}
+
+echo "finalize_module: $STAGE_SLUG (guard OK — latest verdict APPROVE)"
+# --- Step 2: track the review record ---
+run git add -f "$REVIEW_ABS"
+# --- Step 3: board flip ---
+run "$PY" -m scripts.quality.pipeline reset-stage "$STAGE_SLUG" COMMITTED
+# --- Step 4: telemetry (record-build) ---
+run "$PY" -m scripts.agent_telemetry record-build "$@"
+
+echo "finalize_module: done ($([ "$DRY_RUN" -eq 1 ] && echo dry-run || echo committed)) — $STAGE_SLUG"


### PR DESCRIPTION
## What
`record-build` (#1973) was a **manual** CLI call, separate from the per-module finalize flow (`reset-stage COMMITTED` + `.pipeline/reviews` APPROVE record). It got forgotten → `/telemetry` went stale. User approved wiring it in (s149).

Adds `scripts/finalize_module.sh` — the reusable, canonical per-module finalize unit. It bundles the deterministic steps:

1. **GUARD** — the latest `.pipeline/reviews/<__path>.md` verdict must be `APPROVE`, else refuse to flip (prevents `COMMITTED`-without-review, a real past gotcha). The check looks only at `## … REVIEW …` **header** lines, so prose like "NEEDS_CHANGES → fixed" inside an APPROVE record doesn't false-fail.
2. `git add -f` the review record.
3. `reset-stage <dash-slug> COMMITTED` (board flip).
4. `record-build <passthrough>` (telemetry — role/agent/model/tokens(est)/swarm/PR).

Per-wave `_finalize.sh` scripts call this once per module instead of copy-pasting `reset-stage` and (forgetting) `record-build`. The `curriculum-orchestrator` skill Operational-rules section now mandates it.

## Interface
```
scripts/finalize_module.sh [--dry-run] <stage-slug> <review-record-path> -- <record-build args…>
```
`set -euo pipefail`, `--help` with a worked example, `.venv`-or-`python3` interpreter resolution, repo-root-relative review paths.

## Verification
- `bash -n` clean.
- Guard tests: missing/empty record → exit 3; latest header `NEEDS_CHANGES` → exit 3; APPROVE record with `NEEDS_CHANGES` in prose → passes; `--help` → exit 0.
- `--dry-run` prints the exact `git add` / `reset-stage` / `record-build` commands.
- Live flip/record intentionally **not** run (would mutate real board + telemetry); the helper is a thin wrapper over the already-proven `reset-stage` + `record-build` (11 real builds dogfooded in s149).

Closes #1978