### PR TITLE
fix(telemetry): finalize_module.sh record-build invocation (script-mode) (#1978)

### DIFF
--- a/scripts/finalize_module.sh
+++ b/scripts/finalize_module.sh
@@ -110,6 +110,9 @@ run git add -f "$REVIEW_ABS"
 # --- Step 3: board flip ---
 run "$PY" -m scripts.quality.pipeline reset-stage "$STAGE_SLUG" COMMITTED
 # --- Step 4: telemetry (record-build) ---
-run "$PY" -m scripts.agent_telemetry record-build "$@"
+# Run as a SCRIPT, not `-m scripts.agent_telemetry`: agent_telemetry.py uses flat
+# sibling imports (`from telemetry_store import …`), which need scripts/ on sys.path.
+# The `-m` form puts repo-root on the path instead → ModuleNotFoundError (#1978 dogfood).
+run "$PY" "$REPO_ROOT/scripts/agent_telemetry.py" record-build "$@"
 
 echo "finalize_module: done ($([ "$DRY_RUN" -eq 1 ] && echo dry-run || echo committed)) — $STAGE_SLUG"

--- a/scripts/module_build_telemetry_page.py
+++ b/scripts/module_build_telemetry_page.py
@@ -266,7 +266,8 @@ def render_module_builds_page_html(*, top_nav: str = "", nav_css: str = "", ds_l
 
     <div class="mb-legend">
       Module builds: record finalize-time token rollups with
-      <code>python -m scripts.agent_telemetry record-build</code> or
+      <code>scripts/finalize_module.sh</code> (which calls
+      <code>python scripts/agent_telemetry.py record-build</code>) or
       <code>POST /api/telemetry/module-builds</code>.
       Tool timings: ingest via <code>POST /api/telemetry/tool-timings</code>.
     </div>


### PR DESCRIPTION
## What
Dogfooding `finalize_module.sh` (#1978) on the #1953 platform-engineering wave caught a real bug: `record-build` failed with `ModuleNotFoundError: No module named 'telemetry_store'`.

**Root cause:** `agent_telemetry.py` uses flat sibling imports (`from telemetry_store import …`), which require `scripts/` on `sys.path`. Invoking it as `python -m scripts.agent_telemetry` puts repo-root on the path instead → import fails. (The guard + `reset-stage` steps worked fine; only the telemetry step broke.)

**Fix:** run it as a script — `python scripts/agent_telemetry.py record-build`. Also corrected the same wrong `-m` form in the `/telemetry` page legend (`module_build_telemetry_page.py`) and pointed it at `finalize_module.sh`.

The wave's two modules (2.3 IDPs, 2.4 Golden Paths) were finalized + telemetry-recorded directly with the correct command (board shows both `done`/COMMITTED/5.0; `/telemetry` now has 13 records). This PR fixes the reusable helper so every future wave works via `finalize_module.sh`.

## Verification
- `bash -n` clean; `py_compile` clean.
- `--dry-run` now emits `python …/scripts/agent_telemetry.py record-build …` (script-mode).
- Real script-mode invocation confirmed working (recorded both wave modules).

Refs #1978