### PR TITLE
content(platform): expand SRE 1.1/1.3/1.4 to T0 (#1953)

### DIFF
--- a/src/content/docs/platform/disciplines/core-platform/sre/module-1.1-what-is-sre.md
+++ b/src/content/docs/platform/disciplines/core-platform/sre/module-1.1-what-is-sre.md
@@ -1,19 +1,19 @@
 ---
-revision_pending: true
 title: "Module 1.1: What is SRE?"
 slug: platform/disciplines/core-platform/sre/module-1.1-what-is-sre
 sidebar:
   order: 2
 ---
-> **Discipline Module** | Complexity: `[MEDIUM]` | Time: 30-35 min
+> **Discipline Module** | Complexity: `[MEDIUM]` | Time: 55-65 min
 
 ## Prerequisites
 
-Before starting this module:
-- **Required**: [Reliability Engineering Track](/platform/foundations/reliability-engineering/) — Understanding failure and resilience
-- **Required**: [Systems Thinking Track](/platform/foundations/systems-thinking/) — See systems as wholes
-- **Recommended**: Some experience operating production systems
-- **Recommended**: Understanding of software development lifecycle
+Before starting this module, you should have completed the reliability and systems-thinking foundations so you can reason about failure, feedback loops, and user-visible impact rather than treating uptime as a vague aspiration.
+
+- **Required**: [Reliability Engineering Track](/platform/foundations/reliability-engineering/) — understanding failure, redundancy, and resilience
+- **Required**: [Systems Thinking Track](/platform/foundations/systems-thinking/) — seeing services as wholes within larger systems
+- **Recommended**: Some experience operating production systems or participating in on-call rotations
+- **Recommended**: Familiarity with the software development lifecycle and basic observability concepts
 
 ---
 
@@ -28,107 +28,170 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-You've learned reliability principles. Now you need a **framework** to apply them.
+You already know that systems fail, that redundancy helps, and that observability beats guessing. What you may not yet have is an operating model that turns those ideas into daily decisions about staffing, releases, alerting, and trade-offs. Site Reliability Engineering is that model. [Google introduced SRE around 2003](https://sre.google/sre-book/introduction/) when rapid growth made manual operations and developer–operations silos unsustainable, and the discipline has since spread because it answers a question every growing organization eventually faces: how do you ship quickly without treating production pain as someone else's problem?
 
-Site Reliability Engineering (SRE) is that framework. [Invented at Google, adopted worldwide](https://cloud.google.com/blog/products/devops-sre/sre-in-the-2022-state-of-devops-report), SRE transforms reliability from "someone else's problem" to "everyone's measurable responsibility."
+Without a shared reliability framework, organizations drift into predictable dysfunction. Reliability becomes a slogan rather than a metric, operations becomes a dumping ground for manual work, and product teams treat production risk as an externality they can ignore until an outage forces attention. Meetings about "how reliable is enough?" turn into opinion battles because nobody has agreed on indicators, targets, or what should happen when those targets slip. SRE replaces that ambiguity with explicit service level objectives, error budgets that connect reliability to release policy, and engineering habits that shrink repetitive operational work over time.
 
-> **Stop and think**: How is reliability currently handled in your organization? Is it a shared goal, or does it fall squarely on the shoulders of a single team when things break?
-
-**Here's the thing**: Without SRE, reliability is:
-- A vague goal ("make it more reliable")
-- Someone else's job ("ops will handle it")
-- In conflict with features ("we don't have time for reliability")
-
-With SRE, reliability is:
-- A measurable objective (99.9% availability)
-- A shared responsibility (developers on-call)
-- Balanced with velocity (error budgets)
-
-This module shows you how SRE makes this transformation happen.
+SRE is not a rebranding exercise for an existing operations team, nor is it a license to slow development to a crawl in the name of stability. It is a way to make reliability negotiable in the same language product and engineering already use for features: measurable commitments, explicit trade-offs, and shared ownership of production outcomes. When SRE works, developers still own their services, operators still understand the platform, and leadership can see whether the organization is buying reliability improvements or merely hoping for them. This module establishes the vocabulary and principles you will use throughout the rest of the SRE track, including SLO design in [Module 1.2](../module-1.2-slos/), error budget policy in [Module 1.3](../module-1.3-error-budgets/), and incident learning in [Module 1.6](../module-1.6-postmortems/).
 
 ---
 
-## The Origin Story
+## What SRE Is: Treating Operations as a Software Problem
 
-### 2003: Google's Problem
+Site Reliability Engineering is [what happens when you ask a software engineer to design an operations function](https://sre.google/sre-book/introduction/). That definition is deliberately provocative. It does not mean every SRE must write application features all day, and it does not mean traditional operational skills disappear. It means the default response to repetitive production work should be the same default response engineers apply elsewhere: understand the system, automate the safe parts, measure outcomes, and simplify the architecture so fewer heroic interventions are required.
 
-Google was growing fast. Very fast.
+The shift is philosophical before it is organizational. Traditional operations often optimizes for immediate restoration: patch the server, restart the process, clear the queue, and move on. SRE still cares about restoration, but it treats recurring restoration as a design defect. If the same manual remediation happens every week, the SRE question is not only "how do we fix it faster?" but also "what change eliminates this class of work permanently?" That mindset is why SRE teams invest in release automation, self-healing controllers, better defaults, and observability that explains user impact rather than merely listing infrastructure symptoms.
 
-Traditional operations couldn't keep up:
-- **Manual processes**: Too slow for Google's scale
-- **Siloed teams**: Developers threw code over the wall
-- **Perverse incentives**: Ops wanted stability, Dev wanted features
+Google's framing also explains why SRE sits between development and operations rather than replacing either group entirely. Developers understand feature logic and change velocity; operators understand production constraints and failure modes; SRE provides the engineering discipline that connects those perspectives with explicit reliability targets. [The production environment chapter of the SRE book](https://sre.google/sre-book/production-environment/) describes how Google pairs software expertise with operational responsibility so large distributed systems remain governable. You do not need Google's scale for the idea to matter. Any team that deploys frequently, depends on shared platforms, or answers to users about availability is already living inside the problem SRE was built to solve.
 
-Ben Treynor (now Treynor Sloss) was tasked with fixing this. His solution: treat operations as a **software engineering problem**.
-
-> "SRE is what happens when you ask a software engineer to design an operations team."
-> — Ben Treynor Sloss
-
-### The Key Insight
-
-Instead of hiring traditional sysadmins, Google hired software engineers and gave them operations responsibilities.
-
-These engineers did what engineers do:
-- Automated repetitive tasks
-- Built tools to manage systems at scale
-- Applied engineering rigor to reliability
-- Measured everything
-
-The result was **Site Reliability Engineering** — a discipline that bridges development and operations through software engineering.
+> **The SRE Analogy**
+>
+> Imagine a hospital that treats the same preventable injury every weekend. Traditional ops is the emergency room: skilled, fast, and essential. SRE is the public-health program that asks why the injury keeps happening, installs guardrails, trains staff, and measures whether admissions fall. Both roles save lives, but only one reduces how often the emergency room must scramble.
 
 ---
 
-## The SRE Mindset
+## The Origin at Google
 
-### Engineering, Not Administration
+Ben Treynor Sloss built Google's SRE function when the company's infrastructure outgrew classic sysadmin workflows. Hiring more people to perform the same manual steps could not keep pace with service growth, and the handoff model—developers write code, operations run it—created incentives that rewarded local speed over systemic stability. Treynor's bet was that software engineers, given operational responsibility, would apply the same design rigor to production that they applied to product code. The resulting discipline became Site Reliability Engineering, and [the introduction to the Google SRE book](https://sre.google/sre-book/introduction/) remains the canonical statement of that origin story.
 
-Traditional ops focuses on **doing work**: patching servers, deploying code, responding to alerts.
+The early SRE teams did not invent reliability from scratch. They inherited decades of systems-engineering practice—capacity planning, change control, incident command, post-incident review—and replaced ad hoc execution with software-backed enforcement where possible. Configuration management, automated rollouts, monitoring pipelines, and SLO-driven alerting turned fragile manual rituals into repeatable systems. That historical detail matters for adopters today because it explains why SRE emphasizes measurement and automation together. Without measurement, you have no way to tell whether a change improved reliability; without automation, you will struggle to afford the reliability level you claim to target.
 
-SRE focuses on **eliminating work**: automating deployments, reducing toil, preventing incidents.
-
-| Traditional Ops | SRE Approach |
-|-----------------|--------------|
-| Manual deployments | Automated CI/CD |
-| Reactive firefighting | Proactive prevention |
-| Tribal knowledge | Documented runbooks |
-| "Keep it running" | "Make it self-healing" |
-| Blame individuals | Blame systems |
-
-### The 50% Rule
-
-SRE teams have a hard rule: **[no more than 50% of time on operational work](https://cloud.google.com/blog/products/management-tools/identifying-and-tracking-toil-using-sre-principles)**.
-
-The rest goes to engineering projects that:
-- Reduce future operational burden
-- Improve system reliability
-- Automate repetitive tasks
-- Build better tools
-
-> **Pause and predict**: What happens if an SRE team ignores the 50% rule and spends 90% of their time fighting fires? 
-
-If operational work exceeds 50%, something is wrong. Either:
-- The system is too unreliable (needs reliability work)
-- Too much toil exists (needs automation)
-- The team is understaffed (needs hiring)
-
-This rule ensures SRE remains an engineering discipline, not just operations with a fancy name.
-
-### Embrace Risk (Carefully)
-
-Here's a counterintuitive SRE principle: **[chasing 100% reliability is usually the wrong goal](https://cloud.google.com/architecture/framework/reliability/choose-slos)**.
-
-Why? Because:
-1. **Users may not notice**: If other parts of the end-to-end path are less reliable than your service, pushing for additional 9s may yield little visible improvement
-2. **It's expensive**: Each additional 9 costs exponentially more
-3. **It's slow**: Extreme reliability requires extreme caution, which means slow releases
-
-SRE embraces calculated risk through **error budgets** (more in Module 1.3).
+Adoption outside Google does not require copying Google's headcount or tooling stack. Organizations adapt SRE principles to regulated industries, smaller teams, and vendor-managed platforms every day. The durable lesson is structural: reliability improves when the people who can change the system are accountable for operating it, when operational pain is quantified, and when engineering time is protected to pay down the causes of that pain. Everything else—team names, ticket queues, vendor choices—is implementation detail that should follow your context rather than a slide deck from someone else's organization.
 
 ---
 
-## Try This: Calculate Your Users' Reliability Experience
+## The SRE Tenets and Why Each One Exists
 
-Think about your service's path to users:
+Google's SRE material organizes reliability practice around a small set of tenets. They are not slogans for posters; each tenet resolves a failure mode that appears when organizations treat reliability as vague goodwill rather than engineered behavior.
+
+### Embracing risk
+
+[The embracing risk chapter](https://sre.google/sre-book/embracing-risk/) argues that **100% reliability is the wrong target** for most services. Perfection is not free—it demands slower change, heavier redundancy, stricter change windows, and often higher cost—while users may be unable to perceive the difference because other parts of the path are less reliable. SRE therefore chooses an appropriate level of risk, documents it as a service level objective, and spends the remaining unreliability deliberately through error budgets rather than pretending failures should never happen.
+
+### Service level objectives
+
+Reliability without measurement becomes argument. [Service level objectives](https://sre.google/sre-book/service-level-objectives/) translate user expectations into indicators and targets over explicit windows, such as "99.9% of checkout requests return a non-5xx response over 30 days." SLOs are internal operating targets, stricter than most external SLAs, and they give teams a shared answer to whether the service is healthy enough to accept additional release risk. Module 1.2 goes deep on SLI selection and target setting; here the key idea is that SRE speaks in SLOs instead of adjectives like "stable" or " flaky."
+
+### Error budgets
+
+An error budget is the complement of the SLO: if the target is 99.9% availability, the budget is 0.1% allowed bad events over the measurement window. Budgets turn reliability and velocity into a zero-sum negotiation with data. When budget remains, teams can ship aggressively; when budget burns quickly, reliability work and release freezes take precedence. [Implementing SLOs in the SRE Workbook](https://sre.google/workbook/implementing-slos/) shows how this math connects to alerting and policy documents you can adopt verbatim or adapt.
+
+### Eliminating toil
+
+[Toil is manual, repetitive, automatable work tied to running a production service](https://sre.google/sre-book/eliminating-toil/), and it scales linearly with traffic unless you remove it. Resetting stuck jobs by hand, copying credentials between systems, and manually scaling replicas during predictable peaks are classic toil. SRE teams measure toil, cap it, and fund engineering projects that eliminate the worst sources. Google's internal guidance targets keeping toil below half of an SRE's time; the exact percentage matters less than the discipline of measuring and pushing back when operational work crowds out improvement work.
+
+### Monitoring and the four golden signals
+
+[Monitoring distributed systems](https://sre.google/sre-book/monitoring-distributed-systems/) teaches SREs to focus on **latency, traffic, errors, and saturation**—the four golden signals—because those dimensions explain most user-visible failure modes. Latency tells you whether work completes in time; traffic tells you how much demand exists; errors tell you how often work fails; saturation tells you how full the system is. Infrastructure metrics such as CPU percentage can help diagnose problems, but they are not substitutes for user-centered signals when deciding whether a service meets its SLO.
+
+### Automation
+
+[Automation at Google](https://sre.google/sre-book/automation-at-google/) describes a maturity path from manual operation to autonomous systems that handle routine events without human intervention. SRE does not automate for novelty's sake; it automates to reduce variance, shorten recovery time, and free humans for work that requires judgment. The guiding question is whether a machine can perform the action more consistently than a tired engineer at 03:00. If yes, the action belongs in code, a controller, or a pipeline—not in a runbook step that will be skipped under pressure.
+
+### Release engineering
+
+Reliability and change are inseparable. Most outages trace to deployments, configuration edits, or dependency upgrades rather than spontaneous hardware failure. SRE therefore partners with release engineering to make rollouts reversible, observable, and incremental. Canary releases, automated verification, and clear rollback paths reduce the blast radius of change. You will practice these ideas concretely in later modules; at this stage, remember that SRE treats every production change as a reliability experiment with measurable outcomes.
+
+### Simplicity
+
+Complex systems fail in complex ways. [The simplicity chapter](https://sre.google/sre-book/simplicity/) argues that unnecessary components, opaque dependencies, and special-case tooling increase operational load and incident duration. SRE teams push back on architecture that trades short-term delivery speed for long-term fragility, because fragility becomes toil and toil consumes the error budget you needed for feature work. Simplicity is not minimalism for aesthetics; it is a reliability strategy that keeps systems understandable under stress.
+
+---
+
+## Error Budgets as the Bridge Between Dev and SRE
+
+The central mechanism that makes SRE workable in product-driven organizations is the error budget. Developers want to ship features; SRE wants sustainable reliability; executives want both without endless debate. Error budgets give all three parties the same spreadsheet. When the budget is healthy, product-led risk is explicitly allowed. When the budget is exhausted, the organization agreed in advance that reliability work takes precedence over new feature launches until service quality recovers.
+
+Consider a service with a 99.9% availability SLO measured over 30 days. The allowed bad ratio is 0.1%, which equals roughly 43.2 minutes of downtime in a 30-day month if you express the budget in time, or 1,000 failed requests per million requests if you express it in events. Those numbers come directly from the target; they are not moral judgments about whether failures are acceptable. They are accounting rules that make trade-offs visible. A team burning budget on repeated deploy regressions sees a signal to invest in tests and canaries; a team that never touches its budget may be holding an SLO so loose that users suffer before internal charts turn red.
+
+Budgets also prevent the two classic failure modes of reliability programs. Without budgets, teams either argue forever about whether a release is "safe enough," or operations unilaterally blocks change without transparent criteria. With budgets, the policy can be written down: while budget remains above a threshold, releases proceed under normal review; when burn rate spikes, trigger incident review; when budget hits zero, freeze non-emergency changes and fund remediation. [Alerting on SLOs in the SRE Workbook](https://sre.google/workbook/alerting-on-slos/) connects those policies to multi-window burn-rate alerts so teams detect budget consumption early instead of discovering exhaustion at month end.
+
+This module previews error budgets because SRE's relationship to development velocity is unintelligible without them. Module 1.3 dedicates an entire lesson to budget math, policies, and organizational escalation. For now, internalize the cultural shift: reliability is not maximized; it is **negotiated to a defined level**, and the unused portion of that level is a resource you spend on innovation.
+
+---
+
+## Monitoring Philosophy: Symptoms, Not Just Causes
+
+SRE monitoring begins with user-visible symptoms and works backward toward causes. A database can show healthy replication lag while returning corrupt rows; a pod can restart cleanly while failing every request; a load balancer can report green backends while routing to an empty cache. Symptom-based alerting aligns with SLOs because both ask whether users are receiving acceptable service. Cause-based metrics remain valuable for diagnosis after you know users hurt, but paging humans on every CPU spike trains teams to ignore alerts and hides real outages behind noise.
+
+Rob Ewaschuk's essay on alerting philosophy, cited throughout Google's SRE practice materials, emphasizes that alerts should be actionable, attributable, and tied to urgency that matches user impact. [Practical alerting in the SRE book](https://sre.google/sre-book/practical-alerting/) extends that idea with concrete guidance about paging sparingly and using ticket severity for lower-urgency work. The four golden signals give you a minimum viable dashboard for any service: if latency, traffic, errors, or saturation move abnormally relative to baseline, you likely have a story worth investigating even before you know which subsystem failed.
+
+For Kubernetes environments running on modern observability stacks, that philosophy usually means exporting HTTP metrics from ingress or service meshes, tracking queue depth for workers, and defining SLO recording rules in Prometheus rather than maintaining dozens of unrelated infrastructure charts. Tools change; the durable rule does not: **measure what users experience first**, then instrument components deeply enough to explain deviations quickly when they occur.
+
+---
+
+## SRE vs DevOps vs Traditional Operations
+
+These terms overlap in conversation, but they answer different questions. Confusing them leads to organizational theater—renaming teams without changing incentives—or to tool purchases mistaken for culture change.
+
+Traditional operations, often rooted in the sysadmin era, emphasizes stable production through controlled procedures, specialized operators, and separation from development. Developers hand off artifacts; operators deploy and tend them. That model can work for slow release cadences and small systems, but it breaks when deployment frequency rises and services become distributed platforms rather than single servers. Operators become bottlenecks, developers lack production feedback, and incidents devolve into blame because the people who can fix code are not the people awake at night.
+
+DevOps is the cultural movement that challenged those silos. It emphasizes collaboration, automation, measurement, and shared responsibility for the full lifecycle. DevOps is intentionally underspecified about implementation because it aims to change beliefs and incentives across roles. You can agree with DevOps values while still lacking concrete reliability targets, on-call models, or policies that decide when to stop releasing. DevOps tells you **what to believe** about collaboration; it does not by itself tell you **what to do** at 02:00 when checkout error rates double.
+
+SRE is a concrete implementation of DevOps principles for reliability-focused work. [The SRE Workbook's opening chapter on how SRE relates to DevOps](https://sre.google/workbook/how-sre-relates/) uses the metaphor "class SRE implements interface DevOps": SLOs, error budgets, toil caps, blameless postmortems, and production readiness reviews are the methods that instantiate DevOps ideals in running systems. Seth Vargo and Liz Fong-Jones popularized that phrasing because it clarifies that SRE is not competing with DevOps—it is one rigorous way to practice it.
+
+Traditional operations versus SRE is therefore not a question of hats versus hoodies. It is a question of whether operational work is treated as a manufacturing line that must be staffed forever or as a software problem whose manual portions should shrink over time. SRE teams still operate production, but they are measured partly by how much operational work they eliminate, not by how many tickets they close per shift.
+
+| Dimension | Traditional ops | DevOps culture | SRE practice |
+|-----------|-----------------|----------------|--------------|
+| Primary goal | Keep production stable | Break silos; accelerate delivery | Make reliability measurable and sustainable |
+| Success metric | Uptime heroics, ticket closure | Collaboration and flow | SLO attainment, budget policy, toil reduction |
+| Change relationship | Controlled handoffs | Shared ownership | Budget-gated releases with explicit risk |
+| Tooling stance | Procedures and runbooks | Automation everywhere | Automation prioritized by measured toil |
+| Incident learning | Often blame-oriented | Improving feedback loops | Blameless postmortems with action items |
+
+---
+
+## Platform Engineering and Where SRE Fits
+
+Platform Engineering builds internal platforms—developer portals, golden paths, self-service clusters, standardized pipelines—that make the right way the easy way. SRE and platform engineering are complementary because platforms fail in production too, and because reliability guardrails embedded in platforms scale farther than policy documents alone. An internal platform team might provide a paved-road deployment pipeline with canary hooks and default Prometheus rules; an SRE team might define the SLOs those defaults enforce and the error budget policy that gates promotion to production.
+
+You can practice SRE without a formal platform organization, and you can build platforms without hiring people titled SRE. Many organizations do both. The distinction worth preserving is responsibility: platform teams optimize developer experience and standardization; SRE teams optimize measurable reliability and operational sustainability. When those groups collaborate, developers encounter SLO templates when they scaffold a service, on-call rotations include clear escalation paths, and incident tooling captures timelines automatically for postmortems.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> On-call and incident tooling is a capability map, not a popularity contest. **Alert routing** turns monitoring signals into notified humans; **scheduling** maintains fair rotations; **incident coordination** tracks roles, timelines, and communications; **status pages** publish user-facing updates. Peers in this space include PagerDuty, Grafana OnCall, Incident.io, and Opsgenie—the last reached end-of-life with Atlassian directing customers toward Jira Service Management integrations. Choose based on integration with your metrics stack, audit requirements, and workflow—not slogans about market leadership.
+
+---
+
+## The SRE Engagement Model and the 50% Rule
+
+How SRE teams attach to product organizations determines whether they improve systems or become human shields for unreliable code. [Google's evolving SRE engagement model](https://sre.google/sre-book/evolving-sre-engagement-model/) and [the workbook's engagement chapter](https://sre.google/workbook/engagement-model/) describe a lifecycle: consulting early, sharing tools, taking co-ownership of critical services, and stepping back when teams mature. The goal is not permanent dependency; the goal is raising the reliability floor until product teams can operate safely with lighter SRE involvement.
+
+Production readiness reviews are a practical handshake in that lifecycle. Before a service accepts production traffic at scale, SRE partners review observability, runbooks, capacity assumptions, failure modes, and on-call readiness. The review is not a gatekeeping ritual for its own sake; it ensures that the people who will be paged understand how the service fails and how users experience those failures. Shared ownership means developers participate in on-call rotations for the services they build, which aligns incentives faster than any policy memo about "quality culture."
+
+The **50% rule** caps operational work at half of SRE time so the function remains engineering. [Google's guidance on identifying and tracking toil](https://cloud.google.com/blog/products/management-tools/identifying-and-tracking-toil-using-sre-principles/) states that SREs should spend no more than 50% of their time on toil; the remainder funds automation and reliability projects. When operational load chronically exceeds that cap, the response is not heroic overtime—it is staffing adjustment, reliability remediation, or pushing operational responsibility back to the owning team until the system is governable again.
+
+That rule protects SRE credibility. An team that spends every week manually scaling, patching, and restarting without fixing root causes becomes indistinguishable from traditional ops with a new title. Leadership may wonder why expensive engineers are performing tasks that a runbook could describe. Conversely, an SRE team that never touches production loses situational awareness and becomes advisory wallpaper. The balance is intentional: enough operational exposure to feel pain, enough protected project time to remove pain permanently.
+
+---
+
+## SRE Team Structures
+
+No single org chart fits every company, but the trade-offs recur. Centralized SRE teams spread expertise efficiently but risk becoming bottlenecks if product teams treat them as a remote ops department. Embedded SREs deepen product context but may diverge in practice or get captured by feature work. Hybrid models—central platform standards with embedded liaisons—scale well in large enterprises but require explicit governance so standards do not ossify and embeds do not fork tooling silently.
+
+```mermaid
+flowchart TD
+    subgraph DevOps["DevOps Culture"]
+        direction LR
+        SRE["SRE (Practice)<br/><br/>• SLOs<br/>• Error budgets<br/>• On-call<br/>• Postmortems"]
+        PE["Platform Engineering (Approach)<br/><br/>• IDPs<br/>• Golden paths<br/>• Self-service<br/>• Backstage"]
+    end
+```
+
+The centralized model places one SRE organization responsible for reliability across many product teams. Consistency is the win: the same SLO templates, incident tools, and postmortem formats apply everywhere. The loss is context switching and queue latency if demand exceeds capacity. [Google Cloud's overview of how SRE teams are organized](https://cloud.google.com/blog/products/devops-sre/how-sre-teams-are-organized-and-how-to-get-started) recommends this pattern for early adoption because it concentrates learning before practices fragment.
+
+Embedded SREs sit inside product teams, often one or two per group. They attend the same planning meetings, know the roadmap, and can challenge reliability implications before code merges. The risk is inconsistent standards and career isolation if embeds lack a strong central community. Hybrid structures address that by maintaining a central SRE platform team for tooling, training, and standards while assigning embeds or liaisons to critical product areas.
+
+The "you build it, you run it" model pushes operational responsibility directly to development teams without dedicated SRE headcount. That can work when services are small, platforms are mature, and engineers accept on-call duty—but it fails silently when teams lack reliability skills or when leadership assigns operations work without freeing capacity. Enabling teams that provide observability baselines, deployment pipelines, and documentation often support this model even without the SRE name.
+
+When evaluating structures for your organization, ask who owns SLOs, who is paged, who funds reliability projects, and what happens when budget burns. If answers differ by team without explicit reason, you have an adoption roadmap problem rather than a naming problem.
+
+---
+
+## End-to-End Reliability: Why Local Perfection Misleading
+
+Reliability is path-dependent. Your service can exceed its SLO while users still fail because DNS, TLS, client devices, or upstream APIs dominate the experience. SRE teaches you to match investment to the weakest meaningful link rather than buying extra nines where users will not perceive them.
 
 ```mermaid
 flowchart TD
@@ -144,238 +207,103 @@ Combined: 0.999 × 0.9995 × 0.999 × 0.99 × 0.995 × 0.999
         = ~97.3%
 ```
 
-> **Pause and predict**: If you spend engineering effort to increase your service reliability from 99.9% to 99.999%, how much will your users' perceived reliability improve?
+If your service improves from 99.9% to 99.99% while the rest of the path remains unchanged, user-perceived availability moves only marginally because the chain multiplies. [Google's guidance on choosing SLOs](https://cloud.google.com/architecture/framework/reliability/choose-slos) uses this reasoning to argue against pursuing 100% reliability targets that consume engineering time without improving customer outcomes. The lesson for architects is to instrument end-to-end journeys where possible and to set internal targets that reflect realistic dependencies rather than aspirational isolation.
 
-Your 99.9% doesn't matter much when users only see ~97.3%.
-
-**Lesson**: Match your reliability to what users can actually perceive.
+The [availability table in the SRE book appendix](https://sre.google/sre-book/availability-table/) quantifies nines in downtime per year and month. At 99.9%, you allow about 8.76 hours of downtime per year or roughly 43.8 minutes per month; at 99.99%, about 52.6 minutes per year. Those figures are useful when executives ask for "five nines" without calculating cost. SRE makes the cost explicit so organizations choose reliability levels deliberately.
 
 ---
 
-## SRE vs DevOps vs Platform Engineering
+## Patterns and Anti-Patterns
 
-These terms get confused. Let's clarify:
+| Pattern | Why it works | When to use it |
+|---------|--------------|----------------|
+| SLO-first design | Forces explicit user-centered targets before tooling debates | Any service with external users or contractual commitments |
+| Error budget policy | Converts reliability/velocity conflict into written rules | Teams that argue about release freezes every quarter |
+| Toil measurement | Shows where SRE time disappears and justifies automation | SRE teams above 50% operational load |
+| Blameless postmortems | Surfaces systemic fixes instead of hiding fear | After every significant incident or near miss |
+| Production readiness reviews | Catches missing observability before launch | New services or major architecture changes |
 
-### DevOps: A Culture
-
-DevOps is a **cultural movement** that breaks down silos between development and operations.
-
-Core values:
-- **Collaboration**: Dev and Ops work together
-- **Automation**: Reduce manual work
-- **Measurement**: Track what matters
-- **Sharing**: Knowledge flows freely
-- **Feedback**: Fast loops everywhere
-
-DevOps is **what you believe**.
-
-### SRE: A Practice
-
-SRE is a **specific implementation** of DevOps principles.
-
-It provides:
-- **Concrete practices**: SLOs, error budgets, toil reduction
-- **Defined roles**: SRE teams with specific responsibilities
-- **Measurable goals**: Reliability targets, not vague aspirations
-- **Engineering focus**: Treat operations as software problem
-
-SRE is **how you work**.
-
-> "Class SRE implements interface DevOps."
-> — Seth Vargo and Liz Fong-Jones
-
-### Platform Engineering: An Approach
-
-Platform Engineering focuses on building **internal developer platforms** that make reliability, deployment, and operations self-service.
-
-It provides:
-- **Golden paths**: Paved roads for common tasks
-- **Self-service**: Developers help themselves
-- **Abstraction**: Hide infrastructure complexity
-- **Standardization**: Consistent patterns across teams
-
-Platform Engineering is **what you build**.
-
-> **Stop and think**: Is your organization trying to "buy DevOps" by simply renaming your traditional operations team, or are you actually changing your practices to align with SRE?
-
-### The Overlap
-
-```mermaid
-flowchart TD
-    subgraph DevOps["DevOps Culture"]
-        direction LR
-        SRE["SRE (Practice)<br/><br/>• SLOs<br/>• Error budgets<br/>• On-call<br/>• Postmortems"]
-        PE["Platform Engineering (Approach)<br/><br/>• IDPs<br/>• Golden paths<br/>• Self-service<br/>• Backstage"]
-    end
-```
-
-You can do SRE without Platform Engineering. You can do Platform Engineering without dedicated SREs. But many organizations do both, and they complement each other well.
+| Anti-pattern | Why it fails | Better approach |
+|--------------|--------------|-----------------|
+| "We hired an SRE" | Titles without practices recreate old ops | Adopt SLOs, budgets, and ownership rules org-wide |
+| 100% reliability targets | Impossible and starves innovation | Set evidence-based SLOs with executive sign-off |
+| SRE as sole operator | Creates bottleneck and weak dev incentives | Shared on-call with developers who can change code |
+| Alerting on every metric | Pages become noise; real outages hide | Page on SLO burn or user-visible symptoms |
+| Copy-paste Google staffing | Context differs; practices must adapt | Start with one critical service and expand deliberately |
+| Ignoring toil | Team becomes permanent manual ops | Track toil weekly; fund elimination projects |
 
 ---
 
-## SRE Team Structures
+## Decision Framework: Should You Adopt SRE?
 
-There's no single way to structure SRE. Here are common models:
-
-### Model 1: Centralized SRE Team
+Use this framework when leadership asks whether SRE fits your organization. It is not a scorecard for vendors; it evaluates whether the **practices** will change outcomes.
 
 ```mermaid
 flowchart TD
-    Central["Central SRE Team<br/>(Owns reliability for all services)"]
-    TeamA["Team A (Dev)"]
-    TeamB["Team B (Dev)"]
-    TeamC["Team C (Dev)"]
-    Central --> TeamA
-    Central --> TeamB
-    Central --> TeamC
+    A["Do users depend on your service availability?"] -->|No| B["Start with basic monitoring; revisit when impact grows"]
+    A -->|Yes| C["Can you measure user-visible success rates?"]
+    C -->|Not yet| D["Invest in SLIs and dashboards first"]
+    C -->|Yes| E["Do releases cause most outages?"]
+    E -->|Yes| F["Adopt SLOs + error budgets + release automation"]
+    E -->|No| G["Focus on dependency SLOs and capacity"]
+    F --> H["Can developers join on-call?"]
+    G --> H
+    H -->|No| I["Fix ownership and staffing before scaling SRE rituals"]
+    H -->|Yes| J["Choose team structure; run production readiness reviews"]
 ```
 
-**Pros**:
-- Consistent practices across organization
-- Efficient use of specialized skills
-- Clear ownership of reliability
+Ask the questions in order. If you lack user-visible success metrics, SLO workshops will frustrate everyone because debates lack data. If developers do not participate in on-call, SRE becomes a buffer that hides misaligned incentives rather than fixing them. When prerequisites exist, start with one critical user journey, define an SLO and budget policy for it, and expand practices only after that service demonstrates improved decision making during incidents and releases.
 
-**Cons**:
-- Bottleneck for all teams
-- SREs disconnected from product context
-- "Throw it to SRE" mentality
+---
 
-**Best for**: Smaller organizations, early SRE adoption
+## On-Call, Incidents, and Blameless Learning
 
-### Model 2: Embedded SREs
+SRE is not only metrics on dashboards; it is also how humans behave when metrics turn red. [Being on-call in the SRE book](https://sre.google/sre-book/being-on-call/) treats sustainable rotations as a design problem: clear escalation paths, runbooks that reflect real failure modes, and post-incident reviews that improve systems instead of punishing individuals. An organization can adopt every SLO template in the industry and still fail if the first response to an outage is to hunt for someone to blame, because people will hide uncertainty, skip documenting actions, and repeat the same manual fixes without recording why they worked.
 
-```mermaid
-flowchart TD
-    subgraph TA["Team A"]
-        DevA["Developers<br/>+ 1-2 SREs"]
-    end
-    subgraph TB["Team B"]
-        DevB["Developers<br/>+ 1-2 SREs"]
-    end
-    subgraph TC["Team C"]
-        DevC["Developers<br/>+ 1-2 SREs"]
-    end
-```
+Blameless postmortems are the cultural complement to error budgets. Budgets govern change before failure; postmortems govern learning after failure. [Google's postmortem culture chapter](https://sre.google/sre-book/postmortem-culture/) emphasizes identifying contributing factors across tooling, process, and architecture rather than stopping at a single human error. That approach aligns with resilience engineering practice and with John Allspaw's early advocacy at Etsy for debriefs that make it safe to describe mistakes honestly. The output of a good postmortem is not a lengthy narrative for archives—it is a short list of action items with owners, prioritized by how much they reduce future user impact or toil.
 
-**Pros**:
-- SREs understand product context
-- Faster response to team-specific issues
-- Strong collaboration with developers
+On-call sustainability also connects to the 50% rule. If every incident requires hours of manual recovery, on-call engineers will burn out even when pages are "successful." SRE teams therefore track repeat incidents and fund fixes that turn pages into tickets or into silent self-healing. [Practical alerting guidance](https://sre.google/sre-book/practical-alerting/) reinforces paging only when human action is urgent and time-sensitive; everything else should become tracked work that survives daylight hours. That discipline protects the engineers who implement the automation that keeps SRE scalable.
 
-**Cons**:
-- Inconsistent practices across teams
-- SREs can get "captured" by product work
-- Less efficient (specialized skills spread thin)
+For Kubernetes operators, the lesson translates directly: cluster health probes and node NotReady conditions matter, but they should not page unless user-facing SLOs are at risk or cluster failure is imminent. Tie paging policies to customer journeys—checkout, authentication, data ingestion—and use infrastructure alerts to support diagnosis after those journeys show distress. This ordering prevents the common anti-pattern of waking someone because a non-critical DaemonSet restarted while users continue unaffected.
 
-**Best for**: Larger organizations, mature teams
+---
 
-### Model 3: Hybrid
+## DORA Metrics and the Delivery–Reliability Link
 
-```mermaid
-flowchart TD
-    Central["Central SRE Platform<br/>(Tooling, standards, knowledge)"]
-    TeamA["Team A<br/>+ SRE"]
-    TeamB["Team B<br/>+ SRE"]
-    TeamC["Team C<br/>+ SRE"]
-    Central --> TeamA
-    Central --> TeamB
-    Central --> TeamC
-```
+SRE does not ask teams to choose between shipping and staying up; it asks them to measure both and to improve both deliberately. The [DORA research program](https://dora.dev/guides/) identifies capabilities such as deployment frequency, lead time for changes, change fail rate, and time to restore service after failure. Those metrics mirror SRE concerns: fast recovery depends on observability and rehearsed incident response; low change fail rate depends on error budgets, canaries, and postmortem follow-through; sensible deployment frequency depends on automation rather than manual gatekeeping.
 
-**Pros**:
-- Consistent tooling and standards
-- SREs have product context
-- Best practices shared centrally
+High-performing organizations in DORA studies do not treat operations as a separate universe from development. They invest in continuous integration, trunk-based development where appropriate, and monitoring that developers trust during rollouts. SRE gives those investments a reliability vocabulary. When change fail rate rises, SRE teams examine whether budget burn spiked, whether alerts fired early enough, and whether rollbacks are practiced rather than theoretical. When recovery time improves, they capture what tooling or runbook change made the difference so other services inherit the gain.
 
-**Cons**:
-- More complex to manage
-- Potential for duplication
-- Requires mature organization
+This connection helps when executives ask why reliability headcount should grow alongside feature teams. The answer is not mystical dedication to uptime—it is that unreliability taxes every DORA metric simultaneously. Slow recovery lengthens incidents that already anger customers; high change fail rate wastes engineering time on hotfixes; fearful release processes lengthen lead time and push teams toward risky manual pushes. SRE practices attack those taxes at the root by making risk explicit, automating toil, and learning from failures without scapegoating.
 
-**Best for**: Large organizations, scaled SRE
+---
 
-### Model 4: You Build It, You Run It (No Dedicated SREs)
+## Production Readiness as the Handshake Between Dev and SRE
 
-```mermaid
-flowchart TD
-    TeamA["Team A<br/>Develops AND Operates their services"]
-    TeamB["Team B<br/>Develops AND Operates their services"]
-    TeamC["Team C<br/>Develops AND Operates their services"]
-    Enabling["Enabling Team<br/>(Tooling, docs)"]
-    TeamA --> Enabling
-    TeamB --> Enabling
-    TeamC --> Enabling
-```
+Before a service graduates from "works in staging" to "trusted in production," SRE teams often run a production readiness review. The review is a structured conversation, not a bureaucratic veto, and [the engagement model material](https://sre.google/workbook/engagement-model/) describes it as a way to share accountability early. Typical checklist topics include defining SLIs and SLOs, ensuring dashboards and alerts exist, documenting dependencies and failure modes, verifying capacity plans, confirming on-call runbooks, and practicing rollback. Missing any one item does not always block launch, but it should trigger explicit acceptance of risk—ideally recorded alongside the error budget policy so leaders understand the trade-off.
 
-**Pros**:
-- Developers fully own their services
-- No "throw it over the wall"
-- Deep product understanding
+Production readiness also surfaces hidden toil. If launching requires a manual database migration script, a special flag toggled by one engineer, or a traffic switch that only veterans understand, the review captures that debt before it becomes midnight folklore. SRE partners can then prioritize automation or require feature teams to embed operations into their definition of done. Over time, the checklist shrinks because platforms encode the defaults: new services inherit monitoring templates, standard ingress patterns, and deployment pipelines with canary hooks in Kubernetes environments aligned with current best practices for version 1.35 clusters.
 
-**Cons**:
-- Not everyone wants operations work
-- Inconsistent reliability practices
-- Specialized skills may be lacking
+The handshake works best when developers co-own the checklist items rather than receiving a failing grade from a distant team. Embed SREs or trained champions inside product groups so readiness conversations happen during design, not forty-eight hours before marketing announces a launch date. That timing shift is one of the highest-leverage differences between traditional ops gatekeeping and SRE partnership.
 
-**Best for**: Small organizations, high-autonomy cultures
+---
+
+## Hypothetical scenario: Scaling operations without scaling reliability
+
+**Hypothetical scenario:** A software company grows its engineering headcount from 40 to 200 in eighteen months while keeping a six-person operations team. On-call pages triple, deploy queues stretch across days, and engineers bypass process because waiting feels slower than risky manual pushes. Leadership hires four additional operators, which smooths the queue briefly until traffic and microservice count grow again. Burnout rises because the organization treats reliability as headcount math rather than systems design.
+
+The turning point comes when the company adopts SRE practices rather than another hiring round. Product and SRE define SLOs for three revenue-critical paths, publish an error budget policy that pauses discretionary releases when burn exceeds agreed thresholds, and measure toil from ticket tags. Developers join a lightweight on-call rotation with runbooks generated from actual incident timelines. Within two quarters—using round illustrative numbers, not measured claims—the deploy queue shrinks because automated pipelines replace manual steps, pages become correlated with SLO burn rather than noisy CPU alerts, and the same operations headcount supports a larger engineering organization because repetitive work is automated away.
+
+The lesson is structural: hiring alone will not dig you out of operational debt indefinitely. Eventually you must engineer reliability into platforms, ownership models, and measurement—or growth will outrun any ops team you staff.
 
 ---
 
 ## Did You Know?
 
-1. **Google's SRE teams are about 50% software engineering work**. They spend half their time on automation projects that reduce future operational burden, not just keeping things running.
-
-2. **Error budgets became a core Google SRE concept** for balancing reliability work against feature delivery.
-
-3. **Some organizations avoid a separate SRE function** and instead use a "you build it, you run it" or full-cycle developer model, supported by strong internal tooling.
-
-4. **When Google published the first SRE book in 2016, it helped push SRE ideas into the broader DevOps conversation.** Operations became much more widely discussed in explicit engineering terms.
-
----
-
-## War Story: The Team That Couldn't Scale
-
-A fast-growing company can end up in a situation like this:
-
-- A small operations group handling production for a much larger engineering organization
-- On-call interruptions were frequent and exhausting
-- Deployments were backed up long enough to slow delivery noticeably
-- Burnout was rampant
-
-They hired more ops people. It helped briefly, then got worse again.
-
-**The problem**: They were scaling linearly while the system grew exponentially.
-
-**The fix**: They adopted SRE practices:
-
-1. **Established SLOs**: Defined what "good enough" meant
-2. **Created error budgets**: Developers owned reliability
-3. **Mandated toil measurement**: Found where time went
-4. **Set the 50% rule**: Forced automation investment
-
-Within 6 months:
-- Deployment queue: Same day
-- On-call incidents: Meaningfully reduced
-- Team size: Held steady
-- Coverage: Able to support a larger engineering organization
-
-The shift wasn't hiring more people. It was **working differently**.
-
-**Lesson**: You can't hire your way out of operational problems. You have to engineer your way out.
-
----
-
-## SRE Principles Summary
-
-| Principle | Meaning |
-|-----------|---------|
-| **Reliability is a feature** | It's not separate from product development |
-| **Embrace risk** | Chasing 100% is usually the wrong goal; match reliability to user needs |
-| **Service level objectives** | Measure reliability concretely |
-| **Error budgets** | Balance reliability with velocity |
-| **Toil reduction** | Automate repetitive work away |
-| **Blameless postmortems** | Learn from failure without blame |
-| **Engineering mindset** | Treat operations as software problem |
+- **Google's SRE teams target spending at least half their time on engineering projects**, not reactive operations, because the discipline only scales when manual work shrinks over time.
+- **The first Google SRE book was published in 2016 and released free online**, which accelerated industry-wide adoption of SLOs, error budgets, and blameless postmortems as shared vocabulary.
+- **DORA research ties organizational performance to metrics such as deployment frequency, lead time, change fail rate, and time to restore service**, aligning closely with SRE's emphasis on sustainable change and fast recovery ([DORA guides](https://dora.dev/guides/)).
+- **Blameless postmortem culture draws from both Google's SRE book and earlier resilience engineering practice**, including John Allspaw's work at Etsy on learning from failure without punishing people for speaking candidly.
 
 ---
 
@@ -383,178 +311,154 @@ The shift wasn't hiring more people. It was **working differently**.
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| "We hired an SRE" | SRE is a practice, not a person | Adopt SRE practices org-wide |
-| 100% reliability target | Expensive and slow | Set realistic SLOs based on user needs |
-| SRE team does all ops | Creates bottleneck and resentment | Shared responsibility model |
-| Ignoring the 50% rule | SREs become glorified ops | Protect engineering time ruthlessly |
-| SRE without SLOs | No way to measure success | Define SLOs before anything else |
-| Copy Google exactly | Their context isn't yours | Adapt principles to your situation |
+| Renaming ops to SRE without SLOs | No shared definition of "reliable enough" | Define SLIs and SLOs for critical journeys first |
+| Treating SRE as a gatekeeper team | Developers offload responsibility; resentment grows | Use production readiness reviews with shared ownership |
+| Pursuing maximum nines everywhere | Cost explodes; velocity collapses | Match targets to user-visible need and dependency limits |
+| Skipping error budget policy | Release debates revert to opinions | Write budget thresholds and actions before the next outage |
+| Ignoring the 50% toil cap | SREs become permanent manual operators | Measure toil; fund automation or return work to owners |
+| Copying Google's org chart blindly | Context differs; practices fragment | Adapt engagement model to one service, then expand |
+| Alerting on infrastructure only | Miss user-visible failures; page fatigue | Start from four golden signals and SLO burn alerts |
+| Skipping developer on-call | Fixes slow; incentives stay misaligned | Pair SRE embeds with dev rotation and clear runbooks |
 
 ---
 
-## Quiz: Check Your Understanding
+## Quiz
 
 ### Question 1
-Your company is migrating from a traditional operations model to an SRE model. The VP of Engineering suggests that the new SRE team should handle all deployments and manual server patching to free up developers. Based on SRE principles, why is this approach problematic?
+Your VP asks the new SRE team to handle all manual deployments and server patching so developers can focus on features. Why does this conflict with core SRE principles?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-This approach is problematic because it treats the SRE team as a traditional operations group focused on manual work rather than engineering solutions. In SRE, the primary goal is to treat operations as a software engineering problem. SREs should focus on automating deployments and reducing toil, governed by the 50% rule where no more than half their time is spent on operational tasks. By taking on all manual patching and deployments, the team would quickly exceed this limit and fail to build the scalable, automated systems that SRE is designed to create.
+This plan recreates a traditional operations silo where SREs perform repetitive manual work instead of engineering it away. SRE treats operations as a software problem: deployments and patching should be automated through pipelines and configuration management, not executed by hand indefinitely. The 50% rule exists precisely to prevent SRE teams from spending all their time on toil, because that leaves no capacity to build the systems that eliminate future manual work. A credible adoption roadmap assigns automation projects and shared ownership rather than expanding a human-powered deployment queue.
 
 </details>
 
 ### Question 2
-Your product manager insists that the new critical payment service must be built to achieve 100% reliability, arguing that "any downtime is unacceptable for payments." As an SRE, how would you address this requirement?
+A product manager demands 100% reliability for a payment API, arguing that any failure is unacceptable. How should an SRE respond using principles from this module?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-Targeting 100% reliability is considered an anti-pattern in SRE because it is both practically impossible and misaligned with actual user experience. Even if your service does not fail, users can still experience errors due to unstable internet connections, ISP outages, or device issues, making some of the extra effort invisible to them. Furthermore, achieving each additional "nine" of reliability costs exponentially more in engineering effort and severely throttles feature velocity. Instead, the SRE approach is to set a realistic Service Level Objective (SLO), such as 99.99%, and use the remaining error budget to safely deploy updates and balance reliability with innovation.
+SRE teaches that 100% reliability is usually the wrong target because it is practically unattainable and often invisible to users who experience failures elsewhere in the path. Even a perfect API does not control client networks, DNS, or third-party dependencies, so extra nines may not improve perceived experience. Extreme targets also slow innovation because every change requires disproportionate verification. The SRE response is to propose a realistic SLO such as 99.95% or 99.99%, define it with measurable SLIs, and use the resulting error budget to govern how aggressively the team ships changes.
 
 </details>
 
 ### Question 3
-An executive at your company states, "We don't need to adopt DevOps because we're already building a Platform Engineering team, and we'll hire SREs to run it." How would you clarify the relationship between these three concepts to correct this misunderstanding?
+An executive says, "We do not need DevOps because we hired SREs and built an internal platform." How do SRE, DevOps, and platform engineering relate?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-It is crucial to clarify that DevOps, SRE, and Platform Engineering are complementary concepts, not mutually exclusive alternatives. DevOps is the foundational cultural movement that emphasizes collaboration, shared responsibility, and breaking down silos between development and operations. SRE is a specific, prescriptive implementation of those DevOps principles, providing concrete practices like Service Level Objectives (SLOs) and error budgets. Meanwhile, Platform Engineering focuses on building internal developer platforms to enable self-service and standardize workflows. You still need the DevOps culture and SRE practices to ensure the platform is reliable and aligns with your business goals.
+DevOps is the cultural foundation emphasizing collaboration, measurement, and shared lifecycle ownership. SRE is a concrete implementation of those ideals for reliability, providing practices like SLOs, error budgets, and blameless postmortems rather than replacing DevOps. Platform engineering builds self-service tooling and golden paths that make good practices easy to adopt. Organizations still need the cultural alignment DevOps describes, the reliability mechanisms SRE specifies, and often platforms that embed both; the three are complementary layers, not substitutes.
 
 </details>
 
 ### Question 4
-Six months into your SRE team's existence, you audit their time and find they are spending 75% of their week resolving tickets, responding to alerts, and manually scaling infrastructure. What SRE principle is being violated, and what should be the immediate course of action?
+After six months, audits show SREs spending 75% of their time on tickets, manual scaling, and alert response. Which principle is violated and what should happen next?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-This situation directly violates the 50% rule, which mandates that SREs must spend at least half of their time on project-based engineering work rather than reactive operations. When operational work (toil) exceeds 50%, it indicates that the system is either too unreliable, under-automated, or the team is understaffed. The immediate course of action should be to push back on operational duties, potentially routing excess tickets back to the development teams. The SRE team must then redirect their focus toward automating the manual scaling and addressing the root causes of the alerts to permanently reduce the operational burden.
+This violates the 50% rule capping toil and operational work. Chronic overload signals that the system is under-automated, understaffed, or inappropriately owning work that product teams should fix in code. The immediate response is to stop accepting new manual responsibilities, route recurring work back to owning teams with data, and prioritize engineering projects that remove top toil sources. Leadership should treat sustained overload as a reliability incident requiring remediation funding, not as proof that the SRE team needs to work harder manually.
+
+</details>
+
+### Question 5
+You are evaluating whether SRE fits a small startup with eight engineers and one critical SaaS API. They deploy daily but have no SLOs and no on-call rotation. What is the smallest credible first step?
+
+<details>
+<summary>Answer</summary>
+
+Start with one user-critical SLI and SLO for the API, such as successful request rate over 30 days, because measurement must precede elaborate team structures. Add a minimal on-call rotation that includes the developers who can fix code, plus a blameless postmortem template for any outage. Defer centralized SRE hiring until the team feels pain that tooling and ownership fail to solve. This evaluates fit cheaply: if SLOs improve release conversations within a quarter, expand budgets and automation; if not, examine whether reliability pain is real or whether another bottleneck dominates.
+
+</details>
+
+### Question 6
+Your organization debates centralized versus embedded SRE. The platform VP wants consistency; product directors want dedicated partners. Which trade-offs should decide the structure?
+
+<details>
+<summary>Answer</summary>
+
+Centralized teams maximize consistent SLO templates, tooling, and incident practices but risk bottlenecks if product teams treat SRE as remote ops. Embedded SREs maximize product context and faster feedback but may diverge in standards without a strong guild. Hybrid models work when a central team owns platforms and standards while embeds partner on critical services. Choose based on scale, service criticality, and whether developers already operate their code; the engagement model should make ownership and budget policy explicit regardless of chart shape.
+
+</details>
+
+### Question 7
+Monitoring shows green CPU and memory while support tickets report slow checkout. Which SRE monitoring principle explains the gap?
+
+<details>
+<summary>Answer</summary>
+
+Infrastructure metrics measure causes; users experience symptoms such as latency, errors, traffic drops, or saturation. Green CPU does not guarantee acceptable latency or correct responses, so symptom-based monitoring aligned with SLOs should drive paging decisions. The four golden signals exist to keep dashboards anchored to user-visible behavior before drilling into component metrics. Fixing this gap means defining SLIs on checkout success and latency, then alerting on SLO burn rather than resource thresholds alone.
+
+</details>
+
+### Question 8
+Leadership asks for an adoption roadmap from traditional ops to SRE. What gaps should the roadmap explicitly analyze?
+
+<details>
+<summary>Answer</summary>
+
+Compare current state to SRE on measurement, ownership, toil, and learning loops. Traditional ops often lacks SLOs, keeps developers off-call, measures ticket closure instead of budget burn, and resolves incidents without blameless postmortems. The roadmap should sequence SLI/SLO definition for one service, error budget policy, toil tracking, developer on-call participation, and production readiness reviews before scaling headcount. Each milestone should include success criteria such as reduced manual deploy steps or postmortem action items completed, not merely renamed teams.
 
 </details>
 
 ---
 
-## Hands-On Exercise: SRE Self-Assessment
+## Hands-On
 
-Assess your organization's SRE maturity:
+Complete these exercises to connect SRE principles to your environment. Use hypothetical numbers where you lack production data, but be explicit about assumptions.
 
-### Instructions
+### Exercise 1: SRE readiness assessment
 
-Rate each area from 1 (not at all) to 5 (fully implemented):
+Rate your organization from 1 (not present) to 5 (embedded practice) on reliability measurement, operational practices, engineering investment, and culture. Identify the lowest category and write three concrete improvements tied to SLOs, budgets, or toil reduction.
 
-**Reliability Measurement**
-```text
-[ ] We have SLOs for our critical services
-[ ] We measure availability and latency
-[ ] We have dashboards showing reliability metrics
-[ ] We review reliability metrics regularly
+### Exercise 2: Draft a one-page error budget policy
 
-Score: ___/20
-```
+Pick a fictional 99.9% monthly availability target for a checkout API. Calculate the allowed bad ratio and approximate minutes of downtime per 30-day window using the availability table. Write policy sentences describing what happens at 50% budget remaining, rapid burn, and exhausted budget.
 
-**Operational Practices**
-```text
-[ ] We have documented runbooks for common issues
-[ ] We do blameless postmortems after incidents
-[ ] We track and measure toil
-[ ] We have a formal on-call rotation
+### Exercise 3: Map your team structure
 
-Score: ___/20
-```
-
-**Engineering Investment**
-```text
-[ ] Developers participate in on-call
-[ ] We regularly invest in automation
-[ ] We have error budgets that gate releases
-[ ] We protect time for reliability engineering
-
-Score: ___/20
-```
-
-**Culture**
-```text
-[ ] Reliability is a product feature, not ops problem
-[ ] We learn from failures, not blame individuals
-[ ] Developers and operations collaborate closely
-[ ] Leadership supports reliability investment
-
-Score: ___/20
-```
-
-### Interpreting Your Score
-
-| Score | Maturity Level | Focus Area |
-|-------|----------------|------------|
-| 60-80 | Advanced SRE | Continuous improvement |
-| 40-60 | Developing | Fill in gaps systematically |
-| 20-40 | Beginning | Start with SLOs and postmortems |
-| 0-20 | Pre-SRE | Build awareness and buy-in |
+Draw whether your organization is centralized, embedded, hybrid, or full-cycle developer ownership. List who owns SLOs, who is paged, and where operational work piles up today.
 
 ### Success Criteria
 
-You've completed this exercise when you:
-- [ ] Honestly assessed all 16 areas
-- [ ] Identified your lowest-scoring category
-- [ ] Listed 3 specific improvements for that category
-
----
-
-## Key Takeaways
-
-1. **SRE is software engineering applied to operations** — not just ops with a new name
-2. **The 50% rule** protects engineering time and forces automation
-3. **Chasing 100% reliability is usually the wrong goal** — match reliability to user needs
-4. **SRE implements DevOps** — concrete practices for cultural values
-5. **Team structure matters** — choose based on your organization's maturity
-
----
-
-## Further Reading
-
-**Books**:
-- **"Site Reliability Engineering"** — Google (the original SRE book, free online)
-- **"The Site Reliability Workbook"** — Google (practical companion)
-- **"Seeking SRE"** — David Blank-Edelman (SRE across different contexts)
-
-**Articles**:
-- **"What is SRE?"** — Google Cloud (cloud.google.com/blog/products/devops-sre)
-- **"SRE vs DevOps"** — Atlassian (atlassian.com/incident-management)
-
-**Talks**:
-- **"Keys to SRE"** — Ben Treynor Sloss (YouTube)
-- **"SRE: An Incomplete Guide to Cultural Nuance"** — Liz Fong-Jones (YouTube)
-
----
-
-## Summary
-
-Site Reliability Engineering is a discipline that brings software engineering practices to operations. Born at Google, it provides:
-
-- **Measurable reliability** through SLOs
-- **Balanced velocity** through error budgets
-- **Reduced toil** through automation
-- **Learning culture** through blameless postmortems
-
-SRE isn't about perfection — it's about being **reliably good enough** while still shipping features.
+- [ ] Documented four maturity scores with evidence, not gut feel alone
+- [ ] Calculated error budget math correctly for a 99.9% target over 30 days
+- [ ] Identified at least three gaps between traditional ops behaviors and SRE principles in your roadmap
+- [ ] Proposed one team structure with explicit ownership for on-call and SLO reviews
 
 ---
 
 ## Next Module
 
-Continue to [Module 1.2: Service Level Objectives (SLOs)](../module-1.2-slos/) to learn how to define and measure reliability targets.
+Continue to [Module 1.2: Service Level Objectives (SLOs)](../module-1.2-slos/) to learn how to define and measure reliability targets that make everything in this module actionable.
 
 ---
 
-*"Hope is not a strategy."* — Traditional SRE saying
-
 ## Sources
 
-- [cloud.google.com: sre in the 2022 state of devops report](https://cloud.google.com/blog/products/devops-sre/sre-in-the-2022-state-of-devops-report) — This Google Cloud post directly says Google's SRE practice has been embraced and extended by a global community.
-- [cloud.google.com: identifying and tracking toil using sre principles](https://cloud.google.com/blog/products/management-tools/identifying-and-tracking-toil-using-sre-principles) — The Google Cloud post explicitly states that within Google SRE the target is to keep toil below 50% of each SRE's time.
-- [cloud.google.com: choose slos](https://cloud.google.com/architecture/framework/reliability/choose-slos) — The Google Cloud Architecture Center page directly states that a goal of 100% reliability is often not the most effective strategy.
-- [Google Cloud: Site Reliability Engineering](https://cloud.google.com/sre) — A current Google overview of SRE concepts, tools, and entry points for deeper study.
-- [How SRE Teams Are Organized, and How to Get Started](https://cloud.google.com/blog/products/devops-sre/how-sre-teams-are-organized-and-how-to-get-started) — Useful follow-up for the team-structure section because it walks through common SRE organizational models and their tradeoffs.
-- [The Systems Engineering Side of Site Reliability Engineering](https://www.usenix.org/publications/login/june15/hixson) — A foundational article on the systems-engineering mindset behind SRE and how it differs from purely software-focused roles.
+- [Google SRE Book — Introduction](https://sre.google/sre-book/introduction/) — Canonical definition of SRE and Ben Treynor Sloss's framing of operations as a software engineering problem.
+- [Google SRE Book — Production Environment](https://sre.google/sre-book/production-environment/) — How Google structures production responsibility from an SRE viewpoint.
+- [Google SRE Book — Embracing Risk](https://sre.google/sre-book/embracing-risk/) — Why pursuing 100% reliability is usually the wrong goal and how risk becomes explicit.
+- [Google SRE Book — Service Level Objectives](https://sre.google/sre-book/service-level-objectives/) — Foundational SLI/SLO vocabulary and the role of targets in reliability decisions.
+- [Google SRE Book — Eliminating Toil](https://sre.google/sre-book/eliminating-toil/) — Definition of toil and why SRE teams must cap manual operational work.
+- [Google SRE Book — Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/) — The four golden signals and symptom-oriented monitoring philosophy.
+- [Google SRE Book — Automation at Google](https://sre.google/sre-book/automation-at-google/) — Maturity model for automating operational tasks safely.
+- [Google SRE Book — Simplicity](https://sre.google/sre-book/simplicity/) — Reliability arguments for resisting unnecessary complexity.
+- [Google SRE Book — Practical Alerting](https://sre.google/sre-book/practical-alerting/) — Guidance on actionable alerts and sustainable on-call load.
+- [Google SRE Book — Being On-Call](https://sre.google/sre-book/being-on-call/) — Practices for sustainable rotations and escalation.
+- [Google SRE Book — Postmortem Culture](https://sre.google/sre-book/postmortem-culture/) — Blameless learning from incidents with systemic follow-up.
+- [Google SRE Book — Evolving SRE Engagement Model](https://sre.google/sre-book/evolving-sre-engagement-model/) — How SRE partners with product teams over a service lifecycle.
+- [Google SRE Book — Availability Table](https://sre.google/sre-book/availability-table/) — Nines-of-availability translated into downtime budgets.
+- [SRE Workbook — How SRE Relates to DevOps](https://sre.google/workbook/how-sre-relates/) — "Class SRE implements interface DevOps" and concrete practice mapping.
+- [SRE Workbook — SRE Engagement Model](https://sre.google/workbook/engagement-model/) — Workbook treatment of consulting, co-ownership, and stepping back.
+- [SRE Workbook — Implementing SLOs](https://sre.google/workbook/implementing-slos/) — Practical steps connecting SLIs, SLOs, and error budgets.
+- [SRE Workbook — Alerting on SLOs](https://sre.google/workbook/alerting-on-slos/) — Multi-window burn-rate alerting aligned with budget policy.
+- [Google Cloud — Identifying and Tracking Toil](https://cloud.google.com/blog/products/management-tools/identifying-and-tracking-toil-using-sre-principles/) — Google's 50% toil guidance for SRE time allocation.
+- [Google Cloud — Choosing SLOs](https://cloud.google.com/architecture/framework/reliability/choose-slos/) — Architecture guidance on realistic targets versus 100% reliability.
+- [Google Cloud — How SRE Teams Are Organized](https://cloud.google.com/blog/products/devops-sre/how-sre-teams-are-organized-and-how-to-get-started/) — Trade-offs among centralized, embedded, and hybrid models.
+- [DORA Guides](https://dora.dev/guides/) — Research-backed metrics linking delivery performance to reliability outcomes.
+- [Prometheus — Alerting Best Practices](https://prometheus.io/docs/practices/alerting/) — Upstream guidance on symptom-oriented alerting complementary to SLO practice.
+- [USENIX Login — Systems Engineering Side of SRE](https://www.usenix.org/publications/login/june15/hixson) — Historical perspective on the systems-engineering roots of SRE thinking.

--- a/src/content/docs/platform/disciplines/core-platform/sre/module-1.3-error-budgets.md
+++ b/src/content/docs/platform/disciplines/core-platform/sre/module-1.3-error-budgets.md
@@ -1,676 +1,552 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 1.3: Error Budgets"
 slug: platform/disciplines/core-platform/sre/module-1.3-error-budgets
 sidebar:
   order: 4
 ---
-> **Discipline Module** | Complexity: `[MEDIUM]` | Time: 30-35 min
-
-## Prerequisites
-
-Before starting this module:
-- **Required**: [Module 1.2: Service Level Objectives](../module-1.2-slos/) — Understanding SLOs
-- **Required**: [Reliability Engineering Track](/platform/foundations/reliability-engineering/) — Reliability concepts
-- **Recommended**: Experience with software releases and deployment
-
----
+> **Discipline Module** | Complexity: `[MEDIUM]` | Time: 45-60 min
+>
+> **Prerequisites**: [Module 1.2: Service Level Objectives](../module-1.2-slos/) and the [Reliability Engineering Track](/platform/foundations/reliability-engineering/). You should already understand SLIs, SLOs, and why user-visible reliability matters more than internal comfort metrics.
 
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
-- **Implement error budget policies that balance feature velocity with reliability goals**
-- **Design escalation procedures triggered by error budget burn rate thresholds**
-- **Analyze error budget consumption patterns to identify systemic reliability issues**
-- **Build automated error budget tracking that informs release and deployment decisions**
+- **Implement error budget policies that balance feature velocity with reliability goals** by turning an SLO into a written operating agreement, not just a dashboard tile that people admire during incidents.
+- **Design escalation procedures triggered by error budget burn rate thresholds** so fast-moving failures page humans quickly, while slower budget leaks become planned reliability work.
+- **Analyze error budget consumption patterns to identify systemic reliability issues** by separating isolated incidents, repeated failure classes, seasonal load effects, and measurement defects.
+- **Build automated error budget tracking that informs release and deployment decisions** using SLI ratios, recording rules, alerting rules, dashboards, and review rituals that tie engineering choices to user impact.
 
 ## Why This Module Matters
 
-Here's the fundamental tension in every software organization:
+Hypothetical scenario: A checkout service has a 99.9% availability SLO over a rolling 30-day window. The team wants to ship a medium-risk change before a seasonal launch week, but the service has already spent half of its monthly allowance on two incidents. Without an error budget, the conversation becomes political: product argues that the launch matters, operations argues that production is fragile, leadership asks for confidence, and nobody can say how much reliability risk is actually left.
 
-- **Development wants**: Ship features fast, experiment, innovate
-- **Operations wants**: Stability, predictability, no surprises
+With an error budget, that same conversation becomes concrete. The SLO says how reliable the service must be, the error budget says how much unreliability can still be spent, and the policy says what happens when the remaining budget drops below agreed thresholds. The team can still make a hard business decision, but it makes that decision with the cost visible instead of hidden inside mood, seniority, or optimism.
 
-These goals seem opposed. The faster you ship, the more risk. The more stable you are, the slower you ship.
+This is why the Google SRE literature treats error budgets as more than arithmetic. In the SRE Book's chapter on embracing risk, Google frames reliability as a risk-management problem rather than a pursuit of perfect uptime. Past a useful point, extra reliability has opportunity cost because the same engineers could be improving features, simplifying systems, or removing toil. Error budgets make that trade visible in a single shared measure.
 
-**Error budgets resolve this tension.** They turn the reliability vs. velocity debate into a data-driven conversation.
+The important word is shared. Development teams often feel pressure to increase velocity, while operations or SRE teams feel pressure to reduce change and preserve stability. If each side is judged by a different number, the organization creates a tug-of-war and then acts surprised when release decisions become emotional. An error budget gives both sides one number that connects user happiness, release risk, and reliability investment.
 
-Instead of arguing "should we release?" you calculate "do we have budget to release?"
+Think of an error budget like a monthly household budget for risk rather than money. You do not win by spending nothing, because that may mean you skipped useful opportunities. You also do not win by spending carelessly, because then you lose the ability to handle surprises. The discipline is to spend intentionally, notice the spending rate, and change behavior before the account runs empty.
 
-This module shows you how error budgets work and how to use them to make better decisions.
+The rest of this module teaches the durable practice. Tools such as Prometheus, Grafana, PagerDuty, Incident.io, and cloud monitoring products can help you calculate, visualize, and route alerts, but they do not create the operating agreement. The agreement comes from clear SLIs, defensible math, leadership-backed policy, and a culture that treats budget consumption as information rather than blame.
 
----
+Error budgets also teach restraint in both directions. A team that treats every incident as proof that releases must slow forever will eventually create a brittle organization that fears change. A team that treats every successful release as proof that reliability concerns are excessive will eventually spend the budget by accident. The SRE discipline sits between those extremes by asking whether current behavior is still inside the risk envelope users and leaders agreed to accept.
 
-## What Is an Error Budget?
+The hard part is that the envelope is not purely technical. User expectations, product maturity, contractual promises, dependency quality, traffic shape, and team capacity all influence the right SLO. Error budgets force those factors into a concrete conversation. Instead of saying "this feels risky," you can say "this release would happen while the service has 18% budget remaining and a slow-burn ticket already open." That sentence changes the decision room because it names both the remaining margin and the current trend.
 
-> **Stop and think**: If your product manager asks for 100% uptime, what are the actual engineering and business costs of trying to achieve that goal?
+## Error Budgets in One Number
 
-[An error budget is the inverse of your SLO](https://cloud.google.com/stackdriver/docs/solutions/slo-monitoring) — the amount of unreliability you're allowed.
+An error budget is the inverse of an SLO: `error budget = 1 - SLO`. If a service promises 99.9% good events during a window, the service is allowed 0.1% bad events during that same window. The budget is not a loophole or a consolation prize; it is the explicit quantity of unreliability the business is willing to tolerate while still calling the service reliable enough.
 
-```
-Error Budget = 100% - SLO Target
+That definition depends completely on the SLI from the previous module. For a request-based availability SLI, the budget is a number of bad requests. For a latency SLI, the budget is a number of requests slower than the threshold. For a freshness SLI, the budget might be the number of reads that return stale data beyond an agreed age. The budget only makes sense after the team has agreed what counts as good service.
 
-For 99.9% availability SLO:
-  Error Budget = 100% - 99.9% = 0.1%
-```
+The budget is therefore not a second SLO bolted onto the first one. It is the operational form of the SLO. If the SLO is written for humans, the budget is written for decisions: whether to release, whether to page, whether to defer a migration, whether to spend a sprint on reliability, and whether a dependency contract is good enough. That is why a vague SLO produces a vague budget, and a vague budget produces inconsistent behavior.
 
-That 0.1% is **yours to spend**. You can "spend" it on:
-- Feature releases that might have bugs
-- Experiments that might fail
-- Infrastructure changes that might cause issues
-- Maintenance windows
-- Or just accept that some failures happen
+This is the first place teams make a subtle mistake. They say "we have a 99.9% uptime SLO" when their service is rarely all the way up or all the way down. Modern systems often fail partially: one region degrades, one dependency times out, one API path slows down, or one user cohort sees errors. A request-based SLI usually captures that partial failure better than a binary up/down clock, because it measures the proportion of user interactions that were good.
 
-When you exhaust your budget, you stop releasing until it recovers.
+The SRE Book's availability table is still useful because it builds intuition. At 99.9% availability, the Google table permits 43.2 minutes of unavailability per month and 8.76 hours per year. If you use an average calendar month rather than a fixed 30-day planning window, the monthly figure is about 43m49s. If your SLO window is exactly 30 days, the calculation is exactly 43.2 minutes, or 43 minutes and 12 seconds.
 
-### The Genius of Error Budgets
+The arithmetic is simple enough to write on a whiteboard:
 
-Error budgets reframe the conversation:
+```text
+budget = (1 - SLO) * window
 
-| Without Error Budgets | With Error Budgets |
-|----------------------|-------------------|
-| "Is this release risky?" | "Do we have budget for this risk?" |
-| "Operations says no releases" | "Budget says we can release" |
-| "Zero failures is the goal" | "We're supposed to have some failures" |
-| Endless debates | Data-driven decisions |
-
-**Key insight**: If you almost never exhaust your error budget, your SLO is probably too loose. If you routinely exhaust it, your SLO is probably too tight.
-
----
-
-## Error Budget Math
-
-> **Pause and predict**: Will a time-based budget or a request-based budget be more forgiving during a low-traffic period in the middle of the night?
-
-### Time-Based Calculation
-
-```
-Budget in time = SLO Window × (1 - SLO Target)
-
-For 99.9% SLO over 30 days:
-  Budget = 30 days × (1 - 0.999)
-        = 30 days × 0.001
-        = 0.03 days
-        = 43.2 minutes
-
-You're allowed 43.2 minutes of downtime per month.
+For a 99.9% SLO over a fixed 30-day window:
+  budget = (1 - 0.999) * 30 days
+         = 0.001 * 30 days
+         = 0.03 days
+         = 43.2 minutes
 ```
 
-### Request-Based Calculation
+That time-based calculation is easy to explain, but it is not always the best operational measure. If traffic is very low overnight, a short full outage may hurt fewer users than a smaller daytime degradation. If traffic is bursty, request-based accounting usually maps more directly to user pain. The right question is not which formula looks cleaner; the right question is which formula best represents the promise users and stakeholders actually care about.
 
-```
-Budget in requests = Total Requests × (1 - SLO Target)
+For request-based accounting, multiply the eligible event count by the error budget ratio:
 
-For 99.9% SLO with 10 million requests/month:
-  Budget = 10,000,000 × (1 - 0.999)
-        = 10,000,000 × 0.001
-        = 10,000 failed requests
+```text
+allowed_bad_events = eligible_events * (1 - SLO)
 
-You're allowed 10,000 failed requests per month.
-```
-
-### Budget Consumption
-
-```
-Budget Consumed = (Allowed Errors - Actual Errors) / Allowed Errors
-               = Actual Errors / Allowed Errors
-
-Example:
-  Allowed: 10,000 failed requests
-  Actual so far: 4,000 failed requests
-
-  Budget Remaining = (10,000 - 4,000) / 10,000
-                  = 60% remaining
+For a 99.9% request SLO with 10,000,000 eligible requests:
+  allowed_bad_events = 10,000,000 * 0.001
+                     = 10,000 bad requests
 ```
 
----
+The remaining budget then follows from actual bad events:
 
-## Try This: Calculate Your Error Budget
+```text
+budget_spent = actual_bad_events / allowed_bad_events
+budget_remaining = 1 - budget_spent
 
-For a service you work on:
-
-```
-1. What's your SLO? ____%
-2. What's your SLO window? ____ days
-3. How many requests per window? ____
-
-Time budget = window × (1 - SLO) = ____ minutes
-Request budget = requests × (1 - SLO) = ____ requests
-
-Current errors this window: ____
-Budget remaining: ____%
+If 4,000 requests were bad and 10,000 bad requests were allowed:
+  budget_spent = 4,000 / 10,000 = 40%
+  budget_remaining = 60%
 ```
 
----
+Notice the denominator. Budget spent is not actual errors divided by all requests; that gives you the current error ratio. Budget spent is actual errors divided by allowed errors; that tells you how much of your permission to fail has already been consumed. SREs care about both numbers, but they answer different questions.
 
-## Error Budget Policies
+The current error ratio answers "how bad is the service right now?" The budget-spent ratio answers "how much of the agreed tolerance have we already used?" A service can have a high current error ratio for a few minutes and still preserve most of its budget, especially if the failure is detected and rolled back quickly. A service can also have a low current error ratio for many days and quietly exhaust the budget. Burn-rate alerting exists because humans need both the immediate symptom and the long-window accounting.
 
-An error budget is useless without policies that define what happens when it's consumed.
+Low-traffic services need special care. If a service receives only a few hundred requests per window, one or two bad events can create alarming percentages that do not support useful decisions. In that case, the team may need longer windows, window-based SLIs, synthetic user journeys, or a different contract with internal customers. The principle remains the same: choose a budget that represents user pain well enough to guide behavior.
 
-> **Stop and think**: If an error budget policy has no consequences for exhausting the budget, is it actually a policy or just a dashboard metric?
+## Implement Error Budget Policies
 
-### The Standard Policy
+An error budget number without a policy is a measurement, not a control system. A policy states what the organization will do when the service is healthy, when the budget is being consumed faster than planned, and when the budget is exhausted. The SRE Workbook's example error-budget policy makes this explicit: releases can continue while the service is within SLO, but change can halt when the service exceeds its budget, with carve-outs for urgent fixes and security work.
 
-```
-If error budget remaining:
-  > 50%: Full speed ahead. Ship what you want.
-  25-50%: Caution. Extra testing, staged rollouts.
-  0-25%: Slow down. Only critical releases.
-  < 0%: Stop. Reliability work only.
-```
+The policy matters because reliability tradeoffs create local incentives. Product teams may be rewarded for shipping visible features, platform teams may be rewarded for reducing incidents, and executives may be rewarded for hitting launch dates. If the consequences of budget exhaustion are negotiated during each crisis, the loudest stakeholder often wins. A written policy moves that argument earlier, when people are calmer and can reason from user impact.
 
-### Example Policy Document
+A useful policy has at least five parts. It names the service and SLO. It states the measurement window and SLI query. It defines budget states that map remaining budget or burn rate to operating behavior. It lists exceptions that are allowed even during a freeze. It names the escalation path for disputes, because policies fail quietly when nobody has authority to enforce them.
+
+Here is a compact policy shape that keeps the old module's spirit while making the consequences concrete:
 
 ```yaml
 error_budget_policy:
-  service: payment-api
-  slo_target: 99.9%
-  window: 30d
+  service: checkout-api
+  slo:
+    target: 99.9%
+    window: 30d
+    sli: "good HTTP requests divided by eligible HTTP requests"
 
-  thresholds:
+  states:
     healthy:
-      range: "> 50% budget remaining"
-      actions:
-        - Normal release cadence
-        - Experiments allowed
-        - On-call: standard procedures
+      condition: "more than 50% budget remaining and no page-level burn-rate alert"
+      release_policy: "normal release cadence with standard canary and rollback controls"
+      review: "weekly service review"
 
     caution:
-      range: "25-50% budget remaining"
-      actions:
-        - Staged rollouts required
-        - Increased monitoring during releases
-        - On-call: heightened awareness
+      condition: "25% to 50% budget remaining or slow-burn ticket alert active"
+      release_policy: "staged rollouts, explicit rollback owner, and release note in service review"
+      review: "budget trend reviewed twice weekly"
 
     critical:
-      range: "5-25% budget remaining"
-      actions:
-        - Only critical bug fixes
-        - All releases need SRE approval
-        - Reliability improvements prioritized
+      condition: "5% to 25% budget remaining or repeated page-level burn-rate alerts"
+      release_policy: "only low-risk fixes, reliability work, and explicitly approved launches"
+      review: "daily review until back above the threshold"
 
     frozen:
-      range: "< 5% budget remaining"
-      actions:
-        - Feature freeze
-        - Only reliability work
-        - Incident review for all outages
-        - Daily leadership updates
+      condition: "less than 5% budget remaining or SLO already missed"
+      release_policy: "feature freeze; security fixes and reliability fixes remain allowed"
+      review: "leadership-visible recovery plan with owners and dates"
 
   exceptions:
-    - Security fixes: Always allowed
-    - Critical bugs: Case-by-case
-    - Scheduled maintenance: Pre-approved budget spend
+    always_allowed:
+      - security fixes with rollback plan
+      - reliability fixes expected to reduce current or future budget burn
+    requires_approval:
+      - launches with material business impact
+      - changes requested by a dependency team during a broader incident
+
+  escalation:
+    owner: "service engineering lead"
+    approver: "engineering leader accountable for the service SLO"
+    dispute_path: "product, SRE, and engineering leadership review the SLI data together"
 ```
 
-### Making the Policy Real
+Do not copy that policy blindly. A payments service, a search page, a batch billing export, and a developer portal may need different thresholds because their user impact differs. The durable pattern is that each threshold changes behavior. If a threshold only changes the dashboard color, it is decoration.
 
-The policy must have consequences, or it won't work:
+Executive buy-in is not ceremonial. The first time a budget is exhausted, someone will ask for an exception. That may be the correct business decision, but the policy must make the reliability debt explicit. A healthy exception process records who approved the risk, what mitigation was required, what budget was spent, and what reliability work follows. Without that record, exceptions become a second release process with weaker controls.
 
-**Development Impact:**
-- Budget healthy → Ship features
-- Budget exhausted → Stop features, fix reliability
+The policy should also say what does not count as punishment. Budget exhaustion is a signal that users experienced more bad service than the organization agreed to tolerate. The response is to reduce risk, learn, and repair weak systems. If teams learn that budget burn creates shame, they will hide incidents, redefine errors, or argue over measurement details instead of improving reliability.
 
-**On-Call Impact:**
-- Budget healthy → Standard response
-- Budget low → Heightened awareness, faster escalation
+A strong policy is specific about release classes. "No releases" sounds simple, but it breaks down immediately when a security fix, rollback, dependency patch, or reliability improvement needs to ship. Better policies distinguish feature risk from reliability risk. During a freeze, a new recommendation feature may wait, while a fix that reduces retry amplification may proceed with extra review. This distinction keeps the policy from blocking the very work needed to recover the service.
 
-**Leadership Impact:**
-- Budget healthy → Business as usual
-- Budget exhausted → Daily reports, priority adjustment
+The policy also needs a review loop because SLOs are hypotheses. If the service repeatedly exhausts budget despite competent engineering, the target may be too strict for the architecture or business investment available. If the service never spends budget and releases are slow, the target may be stricter than users need. Reviewing the policy does not mean weakening standards to avoid accountability; it means checking whether the reliability contract still matches user expectations and organizational priorities.
 
----
+## Budget Accounting and Windows
 
-## Balancing Reliability and Velocity
+Budget accounting starts with eligible events. In a request-based SLO, eligible events might be production requests from real users, excluding health checks, synthetic probes, load tests, and requests outside the service contract. In a batch SLO, eligible events might be completed jobs or fresh records delivered before a deadline. In a Kubernetes-hosted service, a readiness probe failure may explain user impact, but it should not automatically count against a user-facing SLO unless the SLI defines it that way.
 
-Error budgets are a negotiation tool between development and operations.
+The words "good" and "bad" should be written down with the same care as the target. A successful HTTP status can still be bad if the response is wrong, empty, too slow, or stale. A failed HTTP status may be excluded if it reflects a caller error outside the service contract. The SRE Book's monitoring chapter warns that errors include explicit failures, implicit failures, and policy failures, which is why teams need user-centered SLI definitions rather than convenient infrastructure counters.
 
-### The Trade-Off Visualization
+The SLI also decides how multiple failures are counted. If one user action fans out to five internal requests, counting all five internal failures may overstate user-visible harm. If one API request hides ten failed retries before returning success, counting only the final success may understate fragility and saturation risk. You can track internal causes on dashboards, but the budget should be anchored to the user-visible contract unless the service has a clearly internal customer.
+
+Window choice changes behavior. Calendar windows line up with planning cycles, monthly reviews, and leadership reporting. They are easy to explain because everyone knows when the month or quarter ends. Their weakness is the cliff at the boundary: a severe incident late in the month can appear to disappear when the calendar turns, even though users and engineers still remember the pain.
+
+Rolling windows keep recent user experience visible. The SRE Workbook recommends a four-week rolling window as a useful general-purpose interval because it contains a consistent number of weekends and smooths calendar artifacts. Rolling windows are better for operational decisions, but they require more careful communication because the budget recovers gradually as old bad events age out.
+
+Short windows create faster feedback, while long windows support strategic decisions. A weekly SLO may tell a team to pause risky changes after a bad deploy, but it cannot justify a large architecture investment by itself. A quarterly view may show that one dependency class repeatedly consumes budget, but it reacts too slowly for paging. Mature teams usually keep several views: an alerting view, an operational review view, and an executive planning view.
+
+Budget accounting should classify spending by source. Incidents, deployments, dependency failures, capacity saturation, data migrations, and measurement errors deserve different follow-up. If every budget event is labeled "outage," the trend is not actionable. If the team can say that repeated slow burns come from database saturation during predictable traffic peaks, the next reliability investment becomes much easier to defend.
+
+Classification should be honest about ownership without turning into blame. A dependency failure can consume your user-facing budget even if another team caused the underlying fault. From the user's perspective, your service failed to deliver the promised outcome. The right response may be a dependency SLO, timeout tuning, fallback behavior, circuit breaking, or a product decision to accept degraded functionality. The budget keeps the user impact visible while the engineering analysis finds the most useful control point.
+
+Planned maintenance deserves explicit treatment as well. Some services count planned downtime against the same budget because users still experience unavailability. Other services negotiate maintenance windows outside the SLO because the user base can tolerate scheduled interruption. Either choice can be valid, but ambiguity is dangerous. If maintenance is excluded, the exclusion must be documented, communicated, and bounded so teams cannot relabel avoidable incidents as planned work after the fact.
+
+## Spend Budget Intentionally
+
+The point is not to avoid all budget spend. If a team never spends budget, the SLO may be too loose, the release process may be too slow, or the service may be over-engineered relative to user needs. Google SRE frames an availability target as both a minimum and, in a practical sense, a maximum: exceeding it by too much can waste opportunities to improve the product or reduce operational cost.
+
+Spending budget intentionally means attaching risk to decisions. A small, reversible UI change may be acceptable when the service is in caution state. A database migration that touches the write path may wait until budget recovers, or it may proceed only with a smaller batch size and a tested rollback. A reliability fix may proceed during a freeze because the policy should distinguish risk that helps reliability from risk that only adds feature surface.
+
+Hypothetical scenario: A team has 40% of its request budget remaining with ten days left in a 30-day window. A new checkout promotion could increase traffic and touches code near payment authorization. The team chooses a staged rollout to 10% of users, watches the SLI and burn-rate alerts for two hours, then either expands the rollout or rolls back. The key decision is not "launch or no launch"; the key decision is how much budget the team is willing to risk for the expected value.
+
+The same reasoning applies to reliability work. A risky refactor that reduces a known failure mode may be worth doing while budget is low, but only if the expected reliability gain is near-term and the rollback path is credible. A cosmetic feature that adds a new dependency probably waits. The budget does not decide for you; it supplies the shared constraint that makes the decision honest.
+
+The healthiest teams review budget spend the way finance teams review forecast variance. They ask what changed, whether the current plan still fits the remaining budget, and which assumptions were wrong. They do not ask who can be blamed for spending the budget. Blameless postmortem culture matters here because accurate accounting depends on people being willing to surface weak signals and uncomfortable facts.
+
+Intentional spending also changes how teams talk about launches. A launch does not become safe because someone important wants it, and it does not become unsafe because an engineer feels nervous. It becomes a risk decision with known controls: rollout size, guardrail metrics, rollback time, dependency readiness, support coverage, and remaining budget. When those controls are visible, stakeholders can choose a smaller launch, a delayed launch, or an exception with open eyes.
+
+## Design Burn-Rate Escalation
+
+Remaining budget tells you the current balance. Burn rate tells you how fast the balance is being consumed compared with the sustainable rate. A burn rate of 1x means the service is consuming budget exactly fast enough to use the full budget by the end of the window. A burn rate above 1x means the service will run out early if the condition continues.
+
+For a 99.9% SLO, the error budget ratio is 0.001. If the observed bad-event ratio over a window is 0.006, the burn rate is `0.006 / 0.001 = 6x`. That does not mean six percent of all requests are failing; it means the service is burning the monthly budget six times faster than the sustainable pace. This distinction matters because burn rate normalizes alert thresholds across SLO targets.
+
+The SRE Workbook's alerting chapter gives canonical starting points for a 99.9% SLO. A 14.4x burn rate over one hour with a five-minute short window is page-worthy because it spends about 2% of the budget quickly. A 6x burn rate over six hours with a 30-minute short window is also page-worthy because it spends about 5% of the budget. A 1x burn rate over three days with a six-hour short window is usually ticket-worthy because it signals a sustained leak rather than an immediate emergency.
+
+The multi-window part is important. If you only alert on a long window, an incident can remain paging long after the user-visible failure stops. If you only alert on a short window, a brief spike can create noise without meaningful budget impact. Requiring both the long and short window to exceed the threshold says two things at once: enough budget has been consumed to matter, and the service is still actively burning.
+
+Here is a complete Prometheus rules file that follows the SRE Workbook pattern for a request-based 99.9% availability SLO. The metric names are illustrative, but the Prometheus structure is real: recording rules precompute error ratios for each window, and alerting rules compare those ratios with burn-rate thresholds multiplied by the budget ratio.
+
+```yaml
+groups:
+  - name: checkout-api-slo
+    interval: 30s
+    rules:
+      - record: job:slo_errors_per_request:ratio_rate5m
+        expr: |
+          sum by (job) (
+            rate(http_requests_total{job="checkout-api",code=~"5.."}[5m])
+          )
+          /
+          sum by (job) (
+            rate(http_requests_total{job="checkout-api"}[5m])
+          )
+
+      - record: job:slo_errors_per_request:ratio_rate30m
+        expr: |
+          sum by (job) (
+            rate(http_requests_total{job="checkout-api",code=~"5.."}[30m])
+          )
+          /
+          sum by (job) (
+            rate(http_requests_total{job="checkout-api"}[30m])
+          )
+
+      - record: job:slo_errors_per_request:ratio_rate1h
+        expr: |
+          sum by (job) (
+            rate(http_requests_total{job="checkout-api",code=~"5.."}[1h])
+          )
+          /
+          sum by (job) (
+            rate(http_requests_total{job="checkout-api"}[1h])
+          )
+
+      - record: job:slo_errors_per_request:ratio_rate6h
+        expr: |
+          sum by (job) (
+            rate(http_requests_total{job="checkout-api",code=~"5.."}[6h])
+          )
+          /
+          sum by (job) (
+            rate(http_requests_total{job="checkout-api"}[6h])
+          )
+
+      - record: job:slo_errors_per_request:ratio_rate3d
+        expr: |
+          sum by (job) (
+            rate(http_requests_total{job="checkout-api",code=~"5.."}[3d])
+          )
+          /
+          sum by (job) (
+            rate(http_requests_total{job="checkout-api"}[3d])
+          )
+
+      - alert: CheckoutApiFastBudgetBurn
+        expr: |
+          (
+            job:slo_errors_per_request:ratio_rate1h{job="checkout-api"} > (14.4 * 0.001)
+            and
+            job:slo_errors_per_request:ratio_rate5m{job="checkout-api"} > (14.4 * 0.001)
+          )
+          or
+          (
+            job:slo_errors_per_request:ratio_rate6h{job="checkout-api"} > (6 * 0.001)
+            and
+            job:slo_errors_per_request:ratio_rate30m{job="checkout-api"} > (6 * 0.001)
+          )
+        labels:
+          severity: page
+          service: checkout-api
+        annotations:
+          summary: "checkout-api is burning the 99.9% availability budget quickly"
+          description: "Fast burn-rate threshold crossed; follow the checkout-api SLO runbook."
+
+      - alert: CheckoutApiSlowBudgetBurn
+        expr: |
+          job:slo_errors_per_request:ratio_rate3d{job="checkout-api"} > (1 * 0.001)
+          and
+          job:slo_errors_per_request:ratio_rate6h{job="checkout-api"} > (1 * 0.001)
+        labels:
+          severity: ticket
+          service: checkout-api
+        annotations:
+          summary: "checkout-api has sustained 99.9% availability budget burn"
+          description: "Slow burn-rate threshold crossed; plan reliability work before the budget is exhausted."
+```
+
+The rule uses `rate()` because `http_requests_total` is a counter. Prometheus's documentation recommends recording rules for expressions that are reused often, and SLO alerting is a good fit because dashboards and alerts ask for the same ratios repeatedly. In production, you would also decide how to handle missing traffic, canary labels, regional aggregation, low-volume services, and whether caller-caused errors are eligible events.
+
+Burn-rate alerts should trigger procedures, not just messages. A page-level fast burn might require an incident commander, rollback evaluation, stakeholder communication, and temporary release hold. A slow-burn ticket might require a reliability owner, trend analysis, and a planning item. The escalation is part of the error-budget policy because alerts without agreed action become noise.
+
+The alert thresholds are starting points, not sacred constants. A user-facing payment path may page on fast burn because every minute of failure directly blocks business activity. An internal analytics export may use ticket-level handling for the same burn rate if the data can be replayed before users notice. The math tells you how quickly the budget is disappearing; service criticality and user impact decide the response attached to that disappearance.
+
+False positives are budget-policy bugs, not merely monitoring annoyances. If a page-level burn alert repeatedly fires when users are not harmed, responders will learn to distrust the SLO signal. If the alert never fires until customers complain, the SLI or threshold is missing real pain. Review every noisy burn alert with the same seriousness as a small incident, because alert trust is part of the reliability system.
+
+## Analyze Budget Consumption
+
+Error budget analysis asks why the budget is being spent, not merely how much remains. A single large incident suggests one kind of response. Many small incidents with the same cause suggest another. A constant low burn may indicate capacity pressure, retry storms, a dependency with a weak contract, or an SLI threshold that no longer matches user expectations. The budget number gets attention; the pattern tells you where to invest.
+
+A useful analysis starts with an event ledger. For each material budget movement, record the time window, affected SLI, estimated bad events, related deploy or incident, dependency involvement, user segment, and whether the event was planned. This ledger should not become bureaucracy. Its purpose is to make the next review factual enough that people can see repeated causes instead of relying on memory.
+
+The most valuable category is usually "same class, different day." If three releases each consumed a small portion of budget because rollback took too long, the systemic issue is not the individual releases. It is rollback design, test coverage, feature flagging, or ownership. If several incidents trace to one dependency, the right discussion may be dependency SLOs, fallback behavior, caching, backpressure, or graceful degradation.
+
+Do not confuse budget recovery with system recovery. In a rolling window, budget returns as old bad events age out, even if the underlying weakness remains. A service can look healthier on the dashboard while carrying the same latent risk that caused the last incident. This is why budget reviews should connect remaining budget, burn pattern, and postmortem action status.
+
+Budget analysis also catches measurement defects. If users report severe impact but the budget barely moves, the SLI may be missing an important path or counting retries incorrectly. If the budget is consumed by traffic that users never see, the eligibility rules may be too broad. Treat these as first-class reliability findings, because a misleading budget can authorize risky decisions with false confidence.
+
+DORA's software delivery metrics provide a useful complement. Deployment frequency, change lead time, change fail rate, failed deployment recovery time, and deployment rework rate describe delivery flow and instability. Error budgets describe user-facing reliability against the SLO. When a team improves delivery metrics while staying within budget, it is learning to move quickly without hiding reliability cost. When velocity improves by burning budget faster, the budget makes that trade visible.
+
+The most useful review question is often "what would have reduced budget spend without slowing every future change?" That framing steers teams away from blanket process additions. A mandatory approval meeting for all deployments may reduce risk, but it also taxes safe changes and encourages batching. A targeted improvement, such as automatic rollback on SLI regression or safer schema migration tooling, can reduce budget spend while preserving velocity. Error-budget analysis should prefer controls that make the safe path easier.
+
+Another useful question is "which budget events were surprises?" Predictable budget spend is easier to manage because the team can choose mitigation before user impact grows. Surprise spend points to observability gaps, dependency assumptions, missing load tests, or rollout controls that did not match real traffic. Over time, the goal is not to eliminate every failure. The goal is to make failures smaller, more observable, and less surprising.
+
+## Build Automated Budget Tracking
+
+Automated tracking should answer four operational questions quickly. How much budget remains? How fast are we burning it? Which events consumed it? What policy state are we in? A dashboard that cannot answer those questions may still be visually polished, but it will not reliably inform release decisions.
+
+The minimum dashboard has a current budget panel, burn-rate panels for alert windows, a trend over the SLO window, and an event annotation lane. The event lane matters because humans reason by connecting changes to outcomes. If a deploy, dependency incident, or traffic event lines up with budget burn, the review starts with better hypotheses. If no event lines up, the team has learned that instrumentation or operational awareness is incomplete.
+
+The dashboard should separate SLI views from cause views. The SLI view tells whether users received good service. Cause views show latency by dependency, saturation by resource, errors by version, or readiness by Kubernetes workload. Cause views help debugging, but the budget should remain anchored to user-facing SLOs. This prevents a common failure mode where teams optimize a convenient internal metric while users still experience bad service.
+
+Automation also helps release systems consume budget state. A deployment pipeline can show the current state before rollout, require extra approval in caution state, require a rollback owner in critical state, and block feature releases in frozen state. The pipeline should not become the only enforcement point, because emergencies and exceptions exist. It should make the policy visible at the moment risk is introduced.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> Error-budget practice depends on durable capabilities, not a single vendor. Prometheus can evaluate recording and alerting rules, Grafana or similar tools can visualize SLI and budget time series, PagerDuty or Incident.io can route on-call notifications and incident workflows, and status-page tooling can communicate externally. Treat these as interchangeable capability examples: alert evaluation, dashboarding, on-call scheduling, incident coordination, and customer communication.
+
+| Durable Capability | Example Tools or Approaches | Decision Question |
+|--------------------|-----------------------------|-------------------|
+| SLI calculation | Prometheus recording rules, managed monitoring, batch jobs | Can we compute good and eligible events consistently? |
+| Burn-rate alerting | Prometheus alerts, cloud monitoring alerts, SLO platforms | Can alerts distinguish fast pages from slow tickets? |
+| Visualization | Grafana, Perses, cloud dashboards, generated reports | Can humans see remaining budget and annotated spend? |
+| Release enforcement | CI/CD gates, change-management workflow, deployment policy | Does budget state change rollout behavior before risk lands? |
+| Incident routing | On-call tools, incident-management tools, team runbooks | Does each alert have an owner and an expected response? |
+
+The tracking system should remain explainable. If only one specialist understands the SLI query, the policy will fail during urgent decisions. Keep formulas close to dashboards, link runbooks from alerts, and review the budget calculation in service reviews. The goal is not to make everyone an observability expert; the goal is to make reliability risk legible enough that the team can act together.
+
+Good automation should also preserve human judgment. A pipeline gate that blocks a risky release during a frozen state is useful, but the organization still needs a deliberate exception path for urgent security or reliability work. The gate should make the cost visible, require the right approver, and leave an audit trail for the next review. It should not pretend that every reliability decision can be reduced to a boolean check.
+
+Finally, automated tracking should connect to planning. If slow burn is repeatedly ticketed but never scheduled, the alerting system is only producing a backlog of ignored risk. Service reviews should convert budget evidence into owned work: fix the noisy dependency, improve rollback, add capacity, change the SLI, or renegotiate the SLO. Automation earns its keep when it changes priorities before the next incident, not when it merely proves that the last incident was measurable.
+
+## Patterns & Anti-Patterns
+
+### Patterns
+
+The first strong pattern is a user-centered SLI with written eligibility rules. The budget only works when everyone understands what counts as a good event and what is excluded. This avoids debates during incidents and gives reviewers a stable basis for comparing budget spend across releases, dependencies, and operating periods.
+
+The second strong pattern is a policy that changes release behavior before the SLO is missed. Waiting until the budget is exhausted turns the budget into a postmortem statistic. A better policy creates intermediate states where the team can reduce rollout size, increase review, pause risky work, and schedule reliability fixes while there is still room to maneuver.
+
+The third strong pattern is multi-window burn-rate alerting tied to escalation. Fast failures deserve pages because the budget can disappear quickly. Slow failures deserve tickets or planning items because they are still real user pain, even if they do not justify waking someone immediately. The alert priority should match the urgency of defending the SLO.
+
+The fourth strong pattern is trend review across incidents. Teams that only inspect budget during outages miss the repeated small burns that shape long-term reliability. A weekly or biweekly review can reveal weak dependencies, fragile deploys, or load-related degradation while the fixes are still cheaper than the next incident.
+
+### Anti-Patterns
+
+The most common anti-pattern is treating the budget as a punishment ledger. If every budget event becomes a search for the person who caused it, teams will learn to minimize disclosure. The budget should make user impact visible and support blameless learning, not provide a scoreboard for shame.
+
+Another anti-pattern is using infrastructure health as a substitute for user experience. CPU saturation, pod restarts, readiness failures, and dependency errors are useful diagnostic signals, but they are not automatically bad user events. If the SLI does not represent the user's view of service quality, the budget can be both precise and wrong.
+
+A third anti-pattern is allowing unlimited exceptions. A policy that always bends for launches is not a policy; it is a dashboard with ceremonies around it. Exceptions should be rare, named, approved, and followed by reliability work when they spend meaningful budget.
+
+A fourth anti-pattern is alerting on budget exhaustion without burn-rate context. By the time the budget is gone, the SLO may already be lost. Burn-rate alerting provides earlier warnings and lets the team choose between immediate incident response and planned reliability work.
+
+### Decision Framework
+
+Use this flow when a release, incident, or reliability investment touches the error budget. The point is to decide from the SLI, remaining budget, burn rate, and policy state, then document exceptions when the business chooses to accept extra risk.
 
 ```mermaid
-quadrantChart
-    title Reliability vs Velocity Trade-Off
-    x-axis "Low Velocity" --> "High Velocity"
-    y-axis "Low Reliability" --> "High Reliability"
-    quadrant-1 "Unicorn Zone (Hard to achieve)"
-    quadrant-2 "Ops Happy, Devs Frustrated"
-    quadrant-3 "Danger Zone (Worst case)"
-    quadrant-4 "Devs Happy, Ops Frustrated"
-    "Error Budget Sweet Spot": [0.7, 0.6]
+flowchart TD
+    A[Change or incident affects a service] --> B{Is the SLI user-centered and current?}
+    B -- No --> C[Fix SLI definition before relying on budget]
+    B -- Yes --> D{Is budget still healthy?}
+    D -- Yes --> E[Proceed with normal safeguards and annotate budget events]
+    D -- No --> F{Is burn rate fast enough to defend immediately?}
+    F -- Yes --> G[Page, start incident response, evaluate rollback or mitigation]
+    F -- No --> H{Does the policy allow this work?}
+    H -- Yes --> I[Proceed with reduced risk and explicit owner]
+    H -- No --> J[Freeze feature risk, prioritize reliability, document exceptions]
 ```
 
-Error budgets find the sweet spot where:
-  - Users are happy enough (meeting SLO)
-  - Development moves fast enough (spending budget)
-
-### Using Budget to Make Decisions
-
-**Scenario**: Team wants to ship a risky new feature
-
-| Budget Status | Decision |
-|--------------|----------|
-| 70% remaining | Ship it! We have budget for risk |
-| 30% remaining | Ship with extra monitoring and quick rollback |
-| 10% remaining | Wait or reduce scope |
-| Exhausted | No, fix reliability first |
-
-**Scenario**: Major refactoring needed
-
-| Budget Status | Decision |
-|--------------|----------|
-| High budget | Good time for risky changes |
-| Low budget | Bad time, defer unless it improves reliability |
-| Exhausted | Only if refactoring improves reliability |
-
-### When to Spend vs. Save Budget
-
-**Good reasons to spend budget:**
-- Shipping valuable features
-- Running experiments
-- Necessary maintenance
-- Learning from controlled failures
-
-**Bad reasons to spend budget:**
-- Sloppy releases
-- Skipping testing
-- Ignoring monitoring
-- Inadequate rollback plans
-
-The question isn't "avoid spending budget" — it's "spend budget wisely."
-
----
+| Decision | Use Budget Data For | Healthy State | Caution or Critical State | Frozen or Missed SLO |
+|----------|---------------------|---------------|---------------------------|----------------------|
+| Feature release | Remaining budget and recent burn | Normal rollout with canary | Smaller rollout, explicit rollback owner | Defer unless approved exception |
+| Reliability fix | Expected effect on future burn | Schedule normally | Prioritize if risk is controlled | Usually allowed with rollback plan |
+| Dependency incident | Bad events attributed to dependency | Track and review | Escalate contract or fallback work | Freeze feature risk until mitigated |
+| SLI revision | Mismatch between user reports and budget | Review in planning | Fix before major decisions | Treat policy decisions as unreliable |
 
 ## Did You Know?
 
-> **Pause and predict**: How might an 'error budget loan' affect the engineering team's workload in the following month?
+1. **Error budgets are intentionally uncomfortable when they work well.** They create a shared constraint that prevents both reckless shipping and excessive caution, which means each side sometimes hears "not yet" from the same number it previously used to justify its own preference.
 
-1. **Some teams use user-centric SLIs** - for example, they may track abandonment, playback failures, or other outcomes that matter more directly to users than raw availability alone.
+2. **A surplus can be a problem signal.** If a service never spends budget, users may not need the current reliability target, or the team may be paying too much in delivery delay, infrastructure cost, or manual process to exceed a target nobody values.
 
-2. **Teams choose budget windows deliberately** - calendar-aligned windows simplify planning, while rolling windows smooth out one-day spikes and keep recent user impact visible.
+3. **Burn rate makes different SLO targets comparable.** A 6x burn on a 99% SLO and a 6x burn on a 99.9% SLO represent the same relationship to each service's own budget, even though the raw error percentages are different.
 
-3. **Some organizations define exception processes** - a critical launch may require explicit approval, tighter monitoring, and follow-up reliability work if it proceeds under elevated risk.
-
-4. **Error budgets fundamentally changed the Dev vs Ops dynamic** at Google. Before error budgets, operations could always say "no" to releases. After, developers could say "we have budget" and release without permission—as long as they owned the consequences when budget ran out.
-
----
-
-## War Story: The Budget That Saved the Launch
-
-A team preparing for a major traffic event can use error-budget analysis to decide whether a risky launch should proceed:
-
-**The Situation:**
-- Major new feature ready for Black Friday
-- Error budget at 40% (healthy, but important month)
-- Feature touched payment flow (high risk)
-- Leadership pressure: "Ship it!"
-
-**Without Error Budgets (Previous Years):**
-- Emotional debates: "It's risky!" "But we need it!"
-- HiPPO decision (Highest Paid Person's Opinion)
-- Features shipped, problems occurred, finger-pointing followed
-
-**With Error Budgets (This Time):**
-
-Analysis:
-```
-Current budget: 40% remaining
-Days until Black Friday: 10
-Historical: major traffic spikes can consume a significant share of the remaining budget
-
-If feature causes 10% budget spend:
-  Pre-Black Friday: 40% - 10% = 30%
-  After Black Friday: 30% - 20% = 10%
-  Buffer: 10% (uncomfortably low)
-
-If feature causes 20% budget spend:
-  Pre-Black Friday: 40% - 20% = 20%
-  After Black Friday: 20% - 20% = 0%
-  Buffer: NONE (SLO violation risk)
-```
-
-**The Decision:**
-1. Ship feature to 10% of users (canary)
-2. Monitor for 48 hours
-3. If budget impact < 5%, proceed with full rollout
-4. If budget impact > 5%, defer to December
-
-**The Result:**
-- The canary showed acceptable budget impact
-- Full rollout proceeded
-- Black Friday successful
-- No SLO violation
-- No blame, no drama — just data
-
-**Lesson**: Error budgets turned a political decision into a technical decision.
-
----
-
-## Error Budget Tracking
-
-### Dashboard Elements
-
-An error budget dashboard should show:
-
-```mermaid
-graph TB
-    subgraph Dashboard["Error Budget Dashboard"]
-        Status["Budget Remaining: 62% (HEALTHY)"]
-        
-        subgraph Metrics["Current Cycle Metrics"]
-            Time["Time Budget<br>Allowed: 43.2min<br>Used: 16.4min<br>Remaining: 26.8min"]
-            Req["Request Budget<br>Allowed: 10,000<br>Used: 3,800<br>Remaining: 6,200"]
-        end
-        
-        subgraph Trend["Budget Consumption Over Time"]
-            D1["Day 1"] --> D10["Day 10"] --> D20["Day 20"] --> D30["Day 30"]
-        end
-        
-        subgraph Events["Recent Budget Impacts"]
-            E1["Jan 5: Deploy v2.3.1 (-2.1%)"]
-            E2["Jan 8: Database migration (-0.8%)"]
-            E3["Jan 12: Deploy v2.4.0 (-3.5%)"]
-            E4["Jan 15: Network issue (-8.2%)"]
-        end
-        
-        Status --> Metrics
-        Metrics --> Trend
-        Trend --> Events
-    end
-```
-
-### Key Metrics to Track
-
-```yaml
-metrics:
-  budget_remaining_percentage:
-    description: Current budget remaining
-    alert_thresholds:
-      - below: 50%
-        action: notify_team
-      - below: 25%
-        action: restrict_releases
-      - below: 5%
-        action: freeze_releases
-
-  burn_rate:
-    description: How fast budget is being consumed
-    calculation: "budget_consumed / time_elapsed"
-    alert_thresholds:
-      - above: 2x
-        duration: 1h
-        action: investigate
-
-  time_to_exhaustion:
-    description: At current burn rate, when will budget run out?
-    calculation: "budget_remaining / burn_rate"
-    alert_thresholds:
-      - below: 7d
-        action: warn
-      - below: 2d
-        action: critical
-```
-
----
-
-## Error Budget in Practice
-
-### Scenario 1: New Feature Release
-
-```
-Before Release:
-  Budget: 65%
-  Feature risk: Medium (new code path)
-
-Decision: Proceed with staged rollout
-
-Rollout Plan:
-  Stage 1: 5% traffic (1 hour)
-    - Monitor error rate
-    - Auto-rollback if budget drops > 5%
-
-  Stage 2: 25% traffic (2 hours)
-    - Continue monitoring
-    - Human review before proceeding
-
-  Stage 3: 100% traffic
-    - Full monitoring
-    - Fast rollback capability
-
-Outcome Tracking:
-  - Budget consumed by release: 2.3%
-  - New budget: 62.7%
-  - Decision: Good investment
-```
-
-### Scenario 2: Production Incident
-
-```
-Incident: Database connection pool exhaustion
-Duration: 23 minutes
-Impact: 15% of requests failed
-
-Budget Impact:
-  Before: 45%
-  Consumption: 7.8%
-  After: 37.2%
-
-Actions Triggered:
-  - Moved from "Healthy" to "Caution" state
-  - Release cadence reduced
-  - Postmortem scheduled
-  - Connection pool fix prioritized
-
-Recovery Plan:
-  - Fix deployed: Expected +2% reliability
-  - Budget recovery: ~5 days to return to Healthy
-```
-
-### Scenario 3: Budget Exhaustion
-
-```
-Situation:
-  Budget: -3% (exhausted)
-  Cause: Multiple small incidents + risky release
-
-Freeze Policy Activated:
-  1. Feature freeze immediate
-  2. All releases require VP approval
-  3. Team focus shifts to reliability:
-     - Fix flaky tests
-     - Add missing monitoring
-     - Address tech debt
-     - Improve rollback speed
-
-Recovery Timeline:
-  Week 1: Stabilization, budget returns to 0%
-  Week 2: Conservative operations, budget at 15%
-  Week 3: Limited releases, budget at 25%
-  Week 4: Resume normal operations
-```
-
----
+4. **Budget recovery is not the same as learning.** Rolling windows eventually forget old bad events, but systems do not automatically improve when old errors age out; postmortems and follow-up work are what convert budget spend into better reliability.
 
 ## Common Mistakes
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| No enforcement | Policy ignored when convenient | Leadership buys in, consequences real |
-| Static thresholds | Same rules for all seasons | Adjust for high-traffic periods |
-| Budget as punishment | Teams hide incidents | Budget is tool, not weapon |
-| Ignore budget surplus | Never ship risky changes | Surplus means room to experiment |
-| Reset too often | No pressure to improve | Use rolling windows |
-| Too many exceptions | Policy becomes meaningless | Exceptions rare and documented |
+| Defining the budget before the SLI | The team argues about math while the user-visible promise remains unclear | Write good-event and eligible-event rules before choosing thresholds |
+| Treating all failures equally | Minor internal noise can crowd out serious user harm, or severe partial failures can be undercounted | Account against the SLI and keep diagnostic metrics separate |
+| Using budget thresholds with no consequences | Dashboards change color while releases continue exactly as before | Tie each state to release policy, review cadence, and escalation |
+| Paging only when the budget is exhausted | The team learns too late to defend the SLO | Use multi-window burn-rate alerts for fast and slow budget consumption |
+| Allowing vague exceptions | Every important launch becomes special, and the policy loses credibility | Require named approvers, mitigation, and follow-up reliability work |
+| Resetting attention at calendar boundaries | Teams forget incidents when the budget resets, even if the weakness remains | Keep a ledger and review trend patterns across windows |
+| Optimizing for zero budget spend | The service may become over-engineered or release velocity may collapse | Revisit the SLO and spend budget intentionally on valuable, controlled risk |
+| Using budget as blame | People hide incidents or fight measurement instead of improving systems | Keep reviews blameless and focus on systemic causes and action items |
 
----
-
-## Quiz: Check Your Understanding
+## Quiz
 
 ### Question 1
-Your team manages the checkout service, which processes 5 million requests per day. The business has agreed to a 99.9% SLO over a rolling 30-day window. During a recent deployment, you noticed a spike in errors. To understand if you are at risk of violating your agreement, calculate how many total failed requests your monthly error budget allows.
+
+Your API has a 99.9% request availability SLO over a rolling 30-day window. It receives 20,000,000 eligible requests in that window, and 8,000 requests have been bad so far. How many bad requests are allowed, how much budget has been spent, and what policy question should the team ask next?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-To determine the allowed failures, you first calculate the total requests in the window, which is 5 million requests multiplied by 30 days, equaling 150 million total requests. Your error budget is the inverse of your SLO (100% - 99.9% = 0.1%). By multiplying the total requests (150 million) by your error budget (0.001), you find that you are permitted 150,000 failed requests per month. This means you can tolerate roughly 5,000 failed requests per day without violating your SLO. Knowing this hard number allows your team to evaluate whether the recent deployment spike is a minor blip or a critical threat to your budget.
+A 99.9% SLO leaves a 0.1% error budget, so the service is allowed 20,000 bad requests in the window. With 8,000 bad requests so far, the team has spent 40% of the budget and has 60% remaining. The next question is not merely whether the service is "up"; it is whether the current policy state still allows normal release risk. This is the foundation for implementing error budget policies that balance feature velocity with reliability goals.
 
 </details>
 
 ### Question 2
-It's the 20th of the month, and your team is preparing to release a highly anticipated, medium-risk feature. However, your error budget dashboard shows you only have 20% of your budget remaining due to a database outage earlier in the month. The product manager is pushing for the release to meet a marketing deadline. Should you proceed with the deployment?
+
+A service has 35% of its budget remaining, and a medium-risk release touches the highest-traffic request path. The product owner wants to ship today because the feature is important, while the SRE on call is worried about recent slow-burn errors. What should the team do with the error-budget policy?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-Under standard error budget policies, having only 20% budget remaining places you in the 'Critical' or 'Caution' zone, meaning you should likely halt or significantly de-risk the release. Proceeding with a medium-risk deployment could easily consume the remaining margin, pushing you into an SLO violation and breaching customer trust. Instead, you should consult your pre-defined policy exceptions to see if the business value outweighs the reliability risk, or explore mitigations like a small canary release. If the feature cannot be safely rolled out without threatening the remaining budget, the data dictates that the release must be delayed until the budget window resets. This removes the emotion from the decision and relies on the agreed-upon mathematical limits.
+The team should use the written policy rather than renegotiating from scratch. At 35% remaining, many policies would place the service in a caution state, allowing a release only with reduced rollout size, extra observation, and a named rollback owner. If slow-burn alerts are active, the release may need to wait or be narrowed until the team understands the budget leak. The point is to make the business tradeoff explicit, not to let either product urgency or operational fear silently override the SLO.
 
 </details>
 
 ### Question 3
-Your engineering team has consistently maintained a 100% error budget surplus for the past six months by over-provisioning infrastructure, enforcing multi-week QA cycles, and restricting deployments to once a month. The operations team is thrilled, but the product team is complaining that feature delivery is moving at a glacial pace. Why is hoarding the error budget in this manner actually a bad practice?
+
+Your team says a pod readiness failure should count against the user-facing availability budget because it is visible in Kubernetes events. Is that always correct?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-Hoarding your error budget indicates that your system is performing significantly higher than the reliability targets your users actually require. The error budget exists specifically to be spent on innovation, feature velocity, and measured risk-taking, all of which are being sacrificed in this scenario. By maintaining a 100% surplus, your team is over-investing in stability at the direct expense of delivering business value and learning from controlled failures. A consistent surplus is a clear signal that you should either increase your deployment frequency, loosen your testing bottlenecks, or renegotiate a tighter SLO that accurately reflects the effort required to maintain it.
+No, not automatically. A readiness failure is a useful diagnostic signal, and in Kubernetes it can stop traffic from being sent to a pod, but the error budget should count bad events defined by the SLI. If users still receive successful responses from other pods, the readiness failure may explain risk without consuming user-facing budget. If the readiness failure causes eligible user requests to fail or violate latency policy, those bad user events should count.
 
 </details>
 
 ### Question 4
-A misconfigured Kubernetes deployment just caused a major incident that consumed 30% of your rolling 30-day error budget in a single afternoon. Your total remaining budget has now dropped from a comfortable 45% down to a precarious 15%. According to standard error budget practices, what actions should your team immediately take?
+
+Your 99.9% service shows a bad-event ratio of 0.0144 over one hour and 0.0144 over five minutes. What burn-rate condition is this, and what escalation should it trigger?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-The sudden drop to 15% remaining budget would typically shift your service from a 'Healthy' state into a 'Critical' or 'Caution' state, triggering predefined policy responses. First, your team should restrict any upcoming feature releases and shift engineering focus toward reliability and technical debt to prevent further burn. Second, you must conduct a blameless postmortem to understand how the misconfiguration bypassed your CI/CD checks and implement automated safeguards against a recurrence. Finally, leadership must be notified of the budget state and the subsequent feature freeze, ensuring that everyone understands the data-driven rationale for pausing feature work until the budget recovers.
+The error budget ratio for a 99.9% SLO is 0.001, so a 0.0144 bad-event ratio is a 14.4x burn rate. Because both the one-hour long window and five-minute short window are above the same threshold, this matches the fast-burn pattern from the SRE Workbook. It should normally trigger a page-level response because enough budget has been consumed to matter and the burn is still active. This is how you design escalation procedures triggered by error budget burn rate thresholds.
 
 </details>
 
----
+### Question 5
 
-## Hands-On Exercise: Create an Error Budget Policy
+During the last two windows, budget consumption came from five small incidents rather than one major outage. Each incident involved a deploy that required manual rollback and took longer than expected. What does that pattern suggest?
 
-Design an error budget policy for your organization.
+<details>
+<summary>Answer</summary>
 
-### Your Task
+The pattern suggests a systemic release and rollback problem rather than five unrelated accidents. The team should analyze error budget consumption patterns to identify systemic reliability issues such as slow rollback, weak canarying, missing automated checks, or unclear release ownership. The next investment may be safer deployment automation rather than a narrow fix for the last incident. Blameless review matters because people must be willing to describe where the process made the wrong action easy.
 
-**1. Define Your Service**
+</details>
 
-```yaml
-service:
-  name: # Your service
-  slo_target: # e.g., 99.9%
-  window: # e.g., 30 days
-  criticality: # high/medium/low
-```
+### Question 6
 
-**2. Define Budget Thresholds**
+You are building a dashboard for an error-budget review. It shows remaining budget as a percentage, but it does not show burn rate, annotations for deploys or incidents, or the policy state. Why is this insufficient?
 
-```yaml
-thresholds:
-  healthy:
-    range: # e.g., "> 50%"
-    release_policy: # What's allowed?
-    on_call_stance: # How to respond?
+<details>
+<summary>Answer</summary>
 
-  caution:
-    range: # e.g., "25-50%"
-    release_policy:
-    on_call_stance:
+Remaining budget alone tells the current balance, but it does not tell whether the service is actively burning, why the budget moved, or what the team is supposed to do next. A useful dashboard should show burn-rate windows, event annotations, and the current policy state so release and incident decisions can happen quickly. It should also link to the SLI query and runbook so the calculation remains explainable. That is what it means to build automated error budget tracking that informs release and deployment decisions.
 
-  critical:
-    range: # e.g., "5-25%"
-    release_policy:
-    on_call_stance:
+</details>
 
-  frozen:
-    range: # e.g., "< 5%"
-    release_policy:
-    on_call_stance:
-```
+### Question 7
 
-**3. Define Exceptions**
+A team has stayed at 100% budget remaining for six months by allowing only one release each month and requiring long manual testing cycles. Leadership celebrates the reliability dashboard, but users complain that important improvements take too long. What should the team revisit?
+
+<details>
+<summary>Answer</summary>
+
+The team should revisit both the SLO and the release process. A long-lived full budget may mean the service is more reliable than users need, or that the team is buying reliability with too much delivery delay. Error budgets are designed to permit thoughtful risk, so never spending the budget can be as informative as overspending it. The team should ask whether smaller, safer, more frequent releases could improve velocity while still preserving the agreed SLO.
+
+</details>
+
+## Hands-On
+
+Create an error-budget policy and tracking plan for a service you know. If you do not have a production service available, use a hypothetical request-response service with 10,000,000 eligible requests in a 30-day rolling window and a 99.9% availability SLO. Keep the numbers round, label the scenario as hypothetical in your notes, and focus on whether each decision follows from the SLI and policy.
+
+### Step 1: Define the SLO and Budget
+
+Write the SLI in one sentence, including what counts as a good event and what counts as an eligible event. Then calculate both the allowed bad-event count and the time-based intuition for the same SLO window. The request-based budget should drive your policy if your service is traffic-based, while the time-based number helps stakeholders build intuition.
 
 ```yaml
-exceptions:
-  always_allowed:
-    - # Security fixes?
-    - # Critical bugs?
-
-  requires_approval:
-    - # Who approves exceptions?
-    - # What's the process?
+service: checkout-api
+slo:
+  target: 99.9%
+  window: 30d
+  sli: "successful eligible HTTP requests divided by all eligible HTTP requests"
+budget:
+  error_budget_ratio: 0.001
+  eligible_events: 10000000
+  allowed_bad_events: 10000
 ```
 
-**4. Define Enforcement**
+### Step 2: Write the Policy
 
-```yaml
-enforcement:
-  who_monitors: # Team/role responsible
-  escalation_path: # Who gets notified at each level
-  review_cadence: # How often to review policy
-```
+Define healthy, caution, critical, and frozen states. For each state, write what releases are allowed, who must approve exceptions, what review cadence applies, and what communication is expected. Make sure at least one state changes behavior before the budget is exhausted.
+
+### Step 3: Add Burn-Rate Alerts
+
+Adapt the Prometheus rule example from this module to your metric names, or write equivalent pseudocode if your monitoring system is not Prometheus. You should include a fast page-level alert and a slow ticket-level alert. For a 99.9% SLO, start with 14.4x over one hour plus five minutes, 6x over six hours plus 30 minutes, and 1x over three days plus six hours.
+
+### Step 4: Review a Hypothetical Incident
+
+Hypothetical scenario: A deployment causes 2,000 bad requests before rollback, and the service budget allows 10,000 bad requests in the window. Record the budget impact, identify the policy state after the incident, and write two blameless follow-up actions. Avoid saying "the deployer caused the outage"; describe the system conditions that let the bad change reach users.
 
 ### Success Criteria
 
-- [ ] All four threshold levels defined with clear actions
-- [ ] Exceptions are specific and limited
-- [ ] Enforcement mechanism is realistic
-- [ ] Policy reviewed with stakeholders (or ready for review)
-
----
-
-## Key Takeaways
-
-1. **Error budget = 1 - SLO** — quantified acceptable unreliability
-2. **Budgets balance velocity and reliability** — data replaces debate
-3. **Policies must have teeth** — consequences at each threshold
-4. **Spend wisely, not zero** — unused budget means loose SLO
-5. **Budget is a tool, not a weapon** — enable, don't punish
-
----
-
-## Further Reading
-
-**Books**:
-- **"Implementing Service Level Objectives"** — Alex Hidalgo, Chapter 8: Error Budgets
-- **"Site Reliability Engineering"** — Google, Chapter 3: Embracing Risk
-
-**Articles**:
-- **"Error Budgets"** — Google SRE Book
-- **"How to Use Error Budgets"** — Honeycomb blog
-
-**Tools**:
-- **Nobl9**: SLO platform with error budget tracking
-- **Sloth**: Prometheus-based SLO management
-- **Google SLO Generator**: For Google Cloud
-
----
-
-## Summary
-
-Error budgets are the mechanism that makes SLOs actionable. They:
-
-- Quantify acceptable risk
-- Enable data-driven release decisions
-- Balance reliability and velocity
-- Create shared ownership of reliability
-- Turn debates into calculations
-
-Without error budgets, SLOs are just numbers. With them, SLOs drive behavior.
-
----
-
-## Next Module
-
-Continue to [Module 1.4: Toil and Automation](../module-1.4-toil-automation/) to learn how to identify and eliminate repetitive operational work.
-
----
-
-*Error budgets create a shared way to reason about reliability risk.*
+- [ ] The policy includes a clear SLI definition, SLO target, window, allowed bad-event budget, and written eligibility rules that another engineer can review.
+- [ ] The policy defines at least four budget states with release behavior, exception rules, escalation ownership, and review cadence for each state.
+- [ ] The alerting plan includes both fast-burn and slow-burn thresholds, with page-level and ticket-level responses tied to expected action.
+- [ ] The dashboard plan shows remaining budget, burn rate, annotated budget events, current policy state, and a link to the SLI query or calculation.
+- [ ] The hypothetical incident review calculates budget spent correctly and produces blameless follow-up actions tied to systemic improvement.
+- [ ] Every exception path names an approver and records what reliability work follows if the exception consumes meaningful budget.
 
 ## Sources
 
-- [cloud.google.com: slo monitoring](https://cloud.google.com/stackdriver/docs/solutions/slo-monitoring) — The Google Cloud service-monitoring concepts page explicitly defines the error budget as starting at 1 minus the SLO and explains how it is consumed.
-- [Prometheus Alerting Rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) — Useful for implementing error-budget and burn-rate policy thresholds as actionable alerts.
-- [Prometheus Recording Rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) — Shows how to precompute the time series commonly used in SLO dashboards and error-budget calculations.
+- [Google SRE Book: Embracing Risk](https://sre.google/sre-book/embracing-risk/) — Risk tradeoffs, motivation for error budgets, and the relationship between reliability and product velocity.
+- [Google SRE Book: Service Level Objectives](https://sre.google/sre-book/service-level-objectives/) — SLO definition guidance and the argument against targeting 100% reliability.
+- [Google SRE Book: Availability Table](https://sre.google/sre-book/availability-table/) — Verified nines-of-availability calculations, including 99.9% monthly and yearly unavailability.
+- [SRE Workbook: Implementing SLOs](https://sre.google/workbook/implementing-slos/) — SLI selection, rolling windows, stakeholder agreement, and error-budget calculations.
+- [SRE Workbook: Alerting on SLOs](https://sre.google/workbook/alerting-on-slos/) — Burn-rate alerting, multi-window thresholds, and recommended 99.9% alert parameters.
+- [SRE Workbook: Example Error Budget Policy](https://sre.google/workbook/error-budget-policy/) — Written policy consequences, release pauses, exception handling, and escalation examples.
+- [Google SRE Book: Monitoring Distributed Systems](https://sre.google/sre-book/monitoring-distributed-systems/) — Four golden signals, symptom-based monitoring, and Rob Ewaschuk's alerting philosophy.
+- [Google SRE Book: Postmortem Culture](https://sre.google/sre-book/postmortem-culture/) — Blameless postmortem practice and why incidents should produce system learning.
+- [Prometheus Alerting Rules](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) — Current Prometheus alert rule syntax, labels, annotations, and alert behavior.
+- [Prometheus Recording Rules](https://prometheus.io/docs/prometheus/latest/configuration/recording_rules/) — Current Prometheus recording rule syntax and guidance for precomputing repeated expressions.
+- [Prometheus Query Functions](https://prometheus.io/docs/prometheus/latest/querying/functions/) — Current PromQL function documentation, including `rate()` for counters.
+- [Prometheus Query Operators](https://prometheus.io/docs/prometheus/latest/querying/operators/) — Current PromQL logical, comparison, and aggregation operator behavior used by alert expressions.
+- [DORA: Software Delivery Performance Metrics](https://dora.dev/guides/dora-metrics/) — Delivery and instability metrics that complement SLO and error-budget analysis.
+- [Google Cloud Observability: Concepts in Service Monitoring](https://docs.cloud.google.com/stackdriver/docs/solutions/slo-monitoring) — Service monitoring terminology, SLI/SLO concepts, and error-budget formula examples.
+- [Kubernetes v1.35: Liveness, Readiness, and Startup Probes](https://v1-35.docs.kubernetes.io/docs/concepts/configuration/liveness-readiness-startup-probes/) — Current target-version reference for how Kubernetes probes affect traffic and container health.
+
+## Next Module
+
+Continue to [Module 1.4: Toil and Automation](../module-1.4-toil-automation/) to learn how error-budget signals connect to repetitive operational work and where automation creates the most leverage.

--- a/src/content/docs/platform/disciplines/core-platform/sre/module-1.4-toil-automation.md
+++ b/src/content/docs/platform/disciplines/core-platform/sre/module-1.4-toil-automation.md
@@ -1,11 +1,11 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 1.4: Toil and Automation"
 slug: platform/disciplines/core-platform/sre/module-1.4-toil-automation
 sidebar:
   order: 5
 ---
-> **Discipline Module** | Complexity: `[MEDIUM]` | Time: 30-35 min
+> **Discipline Module** | Complexity: `[MEDIUM]` | Time: 35-45 min
 
 ## Prerequisites
 
@@ -25,53 +25,53 @@ After completing this module, you will be able to:
 - **Implement self-healing systems that resolve common incidents without human intervention**
 - **Measure toil reduction over time and build a business case for continued automation investment**
 
+---
+
 ## Why This Module Matters
 
-You're drowning in repetitive work. Every day:
-- Reset user passwords (again)
-- Restart that flaky service (again)
-- Run the same diagnostic commands (again)
-- Provision resources manually (again)
+> **Hypothetical scenario:** Imagine a platform engineering team of five people supporting a dozen production services. Every morning, a rotation engineer spends 45 minutes running a series of database health checks — connecting to each instance, executing the same diagnostic queries, pasting the output into a spreadsheet. Twice a week, that same engineer provisions new development namespaces by clicking through a cloud console, filling in the same fields each time. By Friday, roughly 30 hours of collective effort — nearly a full person-week — has disappeared into tasks that required no creative judgment, produced no lasting improvement, and looked identical to the previous week's work. The team has a backlog of meaningful projects: a canary deployment pipeline, an automated failover mechanism, a dashboard that would let developers self-serve answers to their most common questions. None of those projects move forward, because the team is trapped in a cycle of manual, repetitive, low-value work that expands linearly with the number of services they support. Add three more services next quarter and the same tasks simply take proportionally more time.
 
-This work keeps the lights on, but it's eating your time. You rarely get to the projects that would make things better.
-
-**This is toil.** And SRE has a systematic approach to eliminating it.
-
-This module teaches you to identify toil, measure it, and eliminate it through automation — freeing you to work on things that actually matter.
+This is toil, and it is one of the most corrosive forces in operations engineering precisely because it is invisible in the moment. Each individual task feels minor — "it's only 15 minutes" — but in aggregate, toil consumes the capacity that should be directed at making systems more reliable, more scalable, and more maintainable. The site reliability engineering discipline developed a precise vocabulary and a systematic methodology for confronting this problem, and this module teaches you both. You will learn to identify toil with precision, distinguish it from legitimate operational overhead, measure its impact quantitatively, and apply an automation strategy that eliminates the highest-cost toil first while avoiding the trap of over-automation. By the end, you will be equipped to break the cycle and reclaim engineering time for engineering work.
 
 ---
 
 ## What Is Toil?
 
-> **Stop and think**: Think about the most annoying task you performed this week. Did it require you to make a creative decision, or were you just acting as a human script runner? If it's the latter, you were performing toil.
+The term "toil" entered the operations engineering lexicon through the Google SRE Book (Chapter 5, "Eliminating Toil," Beyer et al., 2016), and its definition is more precise than most practitioners realise. Toil is not simply "work I dislike" or "busywork." It is work that satisfies a specific conjunction of attributes: it is manual, repetitive, automatable, tactical, devoid of enduring value, and scales linearly with service growth. Each of these attributes matters, and understanding them individually is essential to diagnosing toil accurately in your own environment.
 
-[Toil is work that:](https://cloud.google.com/blog/products/management-tools/identifying-and-tracking-toil-using-sre-principles)
-- **Manual**: Requires human hands
-- **Repetitive**: Done over and over
-- **Automatable**: Could be done by machines
-- **Tactical**: Reactive, not strategic
-- **Devoid of value**: Doesn't improve the system
-- **Scales with load**: More traffic = more toil
+**Manual** means the work requires direct human action to execute. If a script or system can perform the task without a human typing commands, clicking buttons, or making decisions, the work is not manual. Restarting a service by SSHing into a host and running `systemctl restart` is manual. Kubernetes performing a liveness-probe-triggered restart is not. The distinction matters because manual work consumes a scarce resource — human attention — that could be directed at tasks requiring judgment and creativity.
+
+**Repetitive** means the work is performed frequently enough that its recurrence is predictable. A one-off data migration is not toil, even if it is manual and tedious, because it does not establish a recurring drain on team capacity. Running the same database backup verification script every morning, on the other hand, is repetitive. The frequency threshold is contextual — a quarterly manual financial reconciliation that takes two days may still qualify if it follows the same steps each quarter and could be automated — but the core idea is that toil is the work that keeps coming back.
+
+**Automatable** is the attribute that separates toil from the genuinely human work of operations. If a task can be encoded as a program, script, or declarative configuration that a machine executes correctly without ongoing human involvement, it is automatable. Writing a postmortem is not automatable because it requires analysis, synthesis, and judgment. Restarting a pod when memory exceeds a threshold is automatable, and Kubernetes does exactly that with resource limits and liveness probes already. The automatable attribute is also why toil is fundamentally distinct from "overhead" — meetings, email, code reviews, and planning sessions are not automatable in any meaningful sense, and they are therefore not toil, even though they consume time that could be spent on other activities.
+
+**Tactical** means the work is reactive rather than strategic. It addresses an immediate, surfaced need — a service is unhealthy and needs restarting, a user account needs provisioning, a certificate is about to expire — rather than changing the underlying conditions that cause the need to arise. Tactical work keeps the system running in its current state. Strategic work changes the state so that fewer tactical interventions are needed in the future. Toil is inherently tactical.
+
+**Devoid of enduring value** is perhaps the most counterintuitive attribute, because executing toil often feels productive. Restarting a failing service restores availability — that has real, immediate value to users. But the value evaporates the moment the task is complete: the service is no more reliable after your manual restart than it was before the failure occurred. You have not improved its resilience, added monitoring that would detect the condition earlier, or built a mechanism that prevents recurrence. A postmortem, by contrast, produces enduring value because the analysis and action items it generates improve the system permanently.
+
+**Scales linearly with service growth** is the attribute that makes toil an existential threat to teams. When a team supporting 5 services spends 10 hours per week on manual certificate rotation, supporting 20 services will require roughly 40 hours per week — a linear relationship. This means that if toil is not actively capped and reduced, service growth consumes all available capacity, and the team's ability to do engineering work goes to zero. The scaling property is what distinguishes toil from overhead: code reviews scale roughly with team size and change velocity, not linearly with the number of services the team supports. Toil scales with the operational surface area and, left unchecked, grows until it fills every available hour.
 
 ### The Toil Test
 
-Ask these questions about any task:
+With these attributes in mind, you can evaluate any operational task by asking a short series of questions. The table below provides a diagnostic framework. A task that answers "yes" to most of questions 1 through 4 and "no" to question 5 is likely toil.
 
 | Question | "Yes" Points to Toil |
 |----------|---------------------|
-| Could a script do this? | ✓ |
-| Do I do this frequently? | ✓ |
-| Does it require human judgment? | ✗ (not toil) |
-| Does it permanently improve things? | ✗ (not toil) |
-| Does it scale linearly with growth? | ✓ |
-| Is it the same every time? | ✓ |
+| Could a script do this? | Yes |
+| Do I do this frequently? | Yes |
+| Does it require human judgment? | No (not toil) |
+| Does it permanently improve things? | No (not toil) |
+| Does it scale linearly with growth? | Yes |
+| Is it the same every time? | Yes |
 
 ### Toil vs. Not Toil
+
+Applying the taxonomy to real operational tasks makes the distinction concrete. Consider manual pod restarts: the work is manual (you SSH or run `kubectl delete pod`), repetitive (the same pods fail under the same conditions), automatable (a liveness probe or HorizontalPodAutoscaler can handle it), tactical (it restores service without fixing the underlying cause), and the value is transient. This is unambiguous toil. Responding to a page is more nuanced: the investigation component — determining what is broken and why — requires human judgment and is not automatable in the general case, but the remediation step might be (if you always run the same script after diagnosing a full disk, that script execution should be automated). Writing postmortems is not toil: it requires judgment, produces a permanent artifact that improves the system, and is not repetitive in the same mechanistic sense. Capacity planning requires analysis of growth trends, workload patterns, and business priorities — not toil. Running manual backups, however, is textbook toil: same steps every time, no judgment, could be a cron job.
 
 | Task | Is It Toil? | Why |
 |------|-------------|-----|
 | Restarting pods manually | Yes | Repetitive, automatable |
-| Responding to pages | Depends | Investigation isn't, remediation might be |
+| Responding to pages | Depends | Investigation isn't toil, remediation might be |
 | Writing postmortems | No | Requires judgment, creates permanent value |
 | Provisioning users | Yes | Same steps each time, automatable |
 | Capacity planning | No | Requires analysis and judgment |
@@ -80,98 +80,41 @@ Ask these questions about any task:
 
 ### Overhead vs. Toil
 
-Not all operational work is toil:
-
-**Overhead** (necessary, not toil):
-- Team meetings
-- Code reviews
-- Planning sessions
-- Training and learning
-- Interviews
-
-**Toil** (should be eliminated):
-- Manual deployments
-- Repetitive tickets
-- Manual scaling
-- Routine restarts
-- Manual monitoring checks
+A common mistake is to conflate toil with all operational work or with all work that feels like a distraction from engineering. The category distinction matters because the remediation strategy is different for each category, and applying the wrong strategy makes both problems worse. Overhead — team meetings, code reviews, planning sessions, training, interviewing — is necessary organisational work that keeps the team functioning as a team. It is not automatable in any practical sense, and attempting to "eliminate" it usually damages communication and coordination. The appropriate response to overhead is to optimise it (shorter meetings, better agendas, lighter-weight review processes) rather than to automate it away, because there is nothing to automate — the work is inherently human and relational. Toil, by contrast, is unnecessary operational work that machines could do but humans are currently doing. The appropriate response to toil is to automate it out of existence, because the human effort it consumes produces no lasting improvement and the machine can perform the task more consistently and at lower cost. Confusing these two categories leads to two symmetric failures: teams that try to "automate" meetings and code reviews waste engineering effort on an unsolvable problem, while teams that accept toil as an inevitable cost of operations never build the automation that would free them from it.
 
 ---
 
 ## The 50% Rule
 
-> **Pause and predict**: If a team spends 90% of their time resolving tickets manually, what happens to the reliability of the system over the next year?
+Google's SRE teams operate under an explicit guardrail codified in the original SRE book: no more than 50% of an SRE's time may be spent on operational work, and toil is the operational work that should be driven as close to zero as possible — within that 50% ceiling, but ideally much lower. The other 50% or more is reserved for engineering projects: building automation that reduces future toil, improving system reliability through architectural changes, developing better tools and platforms, and performing the kind of strategic work that produces enduring value.
 
-Google's SRE teams have a hard rule:
+This ratio is not arbitrary. When operational work consumes less than half of a team's capacity, the remaining time is sufficient to run meaningful engineering projects that compound over time — each project reduces the operational load slightly, which frees more time for the next project, creating a virtuous cycle. When operational work exceeds 50%, the engineering time shrinks below the threshold where meaningful projects can be sustained. The team enters a reactive death spiral: they are too busy fighting fires to build fire prevention, which means more fires, which means even less time for prevention. Teams that operate above 80% operational load for more than a quarter or two almost never self-correct without external intervention, because the capacity to design and execute a recovery plan no longer exists within the team.
 
-> **[No more than 50% of SRE time should be spent on toil.](https://cloud.google.com/blog/products/management-tools/identifying-and-tracking-toil-using-sre-principles)**
-
-The other 50%+ goes to engineering projects that:
-- Reduce future toil
-- Improve system reliability
-- Build better tools
-- Automate repetitive tasks
-
-### Why 50%?
-
-- **Less than 50%**: Allows toil to be addressed, not just managed
-- **More than 50%**: The team becomes glorified ops, not engineers
-- **Way more**: Indicates systemic problems — either too much toil or understaffed
+The 50% rule is a forcing function, not a law of nature. It forces an explicit conversation every time the operational load drifts upward: the team must either reduce the toil (by automating it), reduce the operational surface area (by consolidating services or improving their reliability), temporarily increase capacity (by borrowing engineers from elsewhere or slowing feature development), or renegotiate the service ownership arrangement that produces the load. Each of these options is uncomfortable, which is the point — the discomfort of confronting the 50% boundary prevents the quiet drift into a state where the team is too overloaded to recover.
 
 ### When Toil Exceeds 50%
 
-If your team's toil exceeds 50%, something must change:
+If your team's toil exceeds the 50% ceiling, four responses are available, and the SRE workbook recommends pursuing them in roughly this order because each builds capacity for the next.
 
-1. **Automate aggressively**: Invest in eliminating top toil sources
-2. **Push back on service**: Service may need reliability improvements
-3. **Create temporary capacity**: Free time for the team to reduce operational load and automation debt
-4. **Rebalance ownership**: Revisit service ownership if the current arrangement is unsustainably toil-heavy
+**Automate aggressively** means identifying the highest-frequency, lowest-complexity toil sources and eliminating them as quickly as possible. This is the fastest way to reclaim capacity and is usually the first response because it directly attacks the problem at its source. A team spending 15 hours per week on manual user provisioning can typically automate 80% of that work in a single engineering sprint, reclaiming 12 hours of capacity immediately.
 
-The 50% rule is a **forcing function** that ensures SRE remains an engineering discipline.
+**Push back on the service** means confronting the reliability problems in the service itself rather than absorbing them as operational work. If a service requires three manual restarts per week, the service has a reliability defect, and the correct response is to fix the defect, not to hire more people to perform the restarts. This can mean filing bugs, requesting architectural changes from the development team, or — in the SRE model — temporarily handing operational responsibility back to the developers until the service meets a minimum reliability bar.
 
----
+**Create temporary capacity** means finding a way to give the team focused engineering time even when the operational load is high. This could involve an "engineering week" where operational work is handled by a skeleton rotation or by neighbouring teams, or it could involve temporarily pausing feature development to let the entire organisation focus on reliability improvements. The key is that the temporary capacity must be used to build permanent capacity through automation — otherwise the team returns to the same overloaded state when the temporary period ends.
 
-## Try This: Toil Audit
-
-List your top 5 repetitive tasks this week:
-
-```
-Task 1: ________________
-  Time spent: ___ hours
-  Frequency: ___/week
-  Could be automated? Y/N
-
-Task 2: ________________
-  Time spent: ___ hours
-  Frequency: ___/week
-  Could be automated? Y/N
-
-Task 3: ________________
-  Time spent: ___ hours
-  Frequency: ___/week
-  Could be automated? Y/N
-
-Task 4: ________________
-  Time spent: ___ hours
-  Frequency: ___/week
-  Could be automated? Y/N
-
-Task 5: ________________
-  Time spent: ___ hours
-  Frequency: ___/week
-  Could be automated? Y/N
-
-Total toil time: ___ hours/week
-Percentage of work week: ___%
-```
+**Rebalance ownership** means revisiting the fundamental arrangement of who is responsible for what. In the Google SRE model, a service that generates excessive operational toil may be returned to its development team until it meets defined reliability standards — a practice sometimes called the "production readiness review" gate. This rebalancing is not a punishment; it is an acknowledgment that certain operational loads are symptoms of design problems that the development team is best positioned to fix.
 
 ---
 
 ## Measuring Toil
 
-You can't reduce what you don't measure.
+You cannot reduce what you do not measure, and toil is particularly easy to underestimate without systematic tracking. Individual tasks feel small in the moment — "it's only ten minutes" — and the human mind is remarkably poor at aggregating dozens of small time expenditures into an accurate total. A team that guesses its toil at 30% is often shocked to discover the real number is closer to 55% or 60% once time tracking is introduced. This gap between perceived and actual toil is one of the most consistent findings in the SRE literature, and it has an important consequence: the team that is most convinced it does not have a toil problem is often the team that most urgently needs to measure. The very act of tracking toil changes behaviour. When engineers log each manual task and see the weekly total, they begin to notice patterns they previously overlooked. The same alert fires every Tuesday morning after the weekend batch job. The same deployment step fails half the time and requires manual intervention. The same access request could have been handled by a self-service form weeks ago. These patterns were always present, but they were invisible because they were distributed across different days, different people, and different contexts. A toil-tracking practice consolidates them into a single view where their aggregate cost becomes undeniable.
 
-### Toil Measurement Framework
+The first step in any toil-reduction programme is making toil visible. This can start with something as simple as a shared spreadsheet where team members log each recurring operational task, its category, time spent, and an assessment of whether it could be automated. The spreadsheet approach is deliberately low-ceremony: the goal is to establish the habit of tracking before investing in tooling. Once the practice is established, you can graduate to purpose-built time-tracking tools that integrate with your workflow, or to survey-based approaches where team members periodically self-report their toil distribution.
+
+A survey-based approach — asking each team member to estimate what percentage of their past week went to toil, overhead, and engineering work — is surprisingly effective when done consistently over multiple measurement periods. Individual estimates are noisy, but the aggregate trend over four to eight weeks reliably reveals whether toil is increasing, decreasing, or stable. The SRE workbook recommends surveying at least once per month and tracking the trend on a shared dashboard so the entire team can see whether automation investments are producing measurable results.
+
+The YAML structure below illustrates the categories and tracking dimensions that a mature toil measurement framework typically includes. This is a template, not a tool — the implementation can be a spreadsheet, a time-tracking application, or a custom dashboard, but the conceptual structure of categories, tasks, frequency, and trend is universal.
 
 ```yaml
 toil_tracking:
@@ -219,26 +162,17 @@ toil_tracking:
 | **Toil per incident** | How much manual work per incident? |
 | **Time to automate** | ROI of automation efforts |
 
-### Simple Tracking
-
-Start simple — a shared spreadsheet:
-
-| Week | Category | Task | Time (hrs) | Automatable? |
-|------|----------|------|------------|--------------|
-| 1 | Users | Password resets | 2 | Yes |
-| 1 | Deploy | Manual deploy | 4 | Yes |
-| 1 | Incident | Service restart | 1 | Yes |
-| 1 | Meetings | Team sync | 3 | No |
+Each metric answers a different question. The toil percentage tells you whether the 50% guardrail is being respected. The per-member distribution reveals whether the toil burden falls disproportionately on a subset of the team — a common pattern where newer team members or those in certain time zones absorb more operational load, creating an invisible inequity that affects morale and retention. The trend over time is the single most important metric for evaluating whether your automation investments are working: a flat or rising trend after automation projects suggests the automation is not reducing toil as expected, or that new toil is entering the system faster than old toil is being eliminated. Toil per incident is a leading indicator — if it is rising, each incident is becoming more expensive to resolve, which means either the system is growing more complex or the runbooks and tooling are falling behind.
 
 ---
 
 ## Automation Strategies
 
-> **Stop and think**: Is it possible to over-automate? Think about a scenario where automating a task might actually be a bad idea.
+Automation is the primary tool for eliminating toil, but it is not free. Every automated system is itself a piece of software that must be designed, built, tested, deployed, monitored, and maintained. An automation that breaks silently and goes unnoticed for weeks is worse than the manual process it replaced, because it creates a false sense that the work is being handled while problems accumulate unseen. The decision to automate must therefore balance the toil-reduction benefit against the build cost and the ongoing maintenance burden.
 
-### The Automation Hierarchy
+### The Automation Ladder
 
-Not everything should be automated the same way:
+The progression from fully manual to fully automated is not a binary switch but a series of steps, each of which reduces the human involvement required. Understanding these levels helps you target the right level for each task rather than reflexively pursuing full automation for everything.
 
 ```mermaid
 flowchart TD
@@ -248,47 +182,35 @@ flowchart TD
     L3["<b>Level 3: Auto-triggered</b><br/>System detects need, asks permission<br/><i>Example: 'Service unhealthy. Restart? [Y/n]'</i>"]
     L4["<b>Level 4: Fully automated</b><br/>System handles automatically<br/><i>Example: Kubernetes self-healing</i>"]
     L5["<b>Level 5: Self-optimizing</b><br/>System learns and improves<br/><i>Example: Auto-scaling based on patterns</i>"]
-    
+
     L0 --> L1 --> L2 --> L3 --> L4 --> L5
 ```
 
+Each level on this ladder represents a meaningful reduction in the human attention required per incident. Level 1 (documented) is better than Level 0 (pure manual) because the runbook eliminates the cognitive overhead of remembering the procedure, but it does not reduce the time cost of execution. Level 2 (semi-automated) reduces execution time and eliminates human error in running the commands, but still requires a human to decide when to run the script and to trigger it. Level 3 (auto-triggered with confirmation) moves the detection into the system but retains a human approval gate — useful for operations where the blast radius of a mistake is large, such as a database failover. Level 4 (fully automated) removes the human entirely from the detection-trigger-execution loop. Level 5 (self-optimising) is aspirational for most systems: the automation not only handles incidents but learns from patterns to improve its responses over time — think of a HorizontalPodAutoscaler that adjusts scaling thresholds based on historical traffic patterns rather than static configuration.
+
 ### When to Automate
 
-The ROI calculation:
+The return-on-investment calculation for automation is straightforward in principle: compare the labour cost of continuing to perform the task manually against the engineering cost of building and maintaining the automation. For a task that takes 30 minutes, occurs 40 times per month, and would require 20 hours to automate, the formula is:
 
 ```
-Automation ROI = (Time saved per occurrence × Occurrences) - Development time
-
-Example:
-  Task: Manual deployment
-  Time per deployment: 30 minutes
-  Deployments per month: 40
-  Automation development time: 20 hours
-
-  Monthly savings: 40 × 0.5 hours = 20 hours
-  Payback period: 20 hours / 20 hours = 1 month
-
-  Verdict: Definitely automate
+Monthly manual cost: 40 x 0.5 hrs = 20 hrs
+Automation build cost: 20 hrs
+Payback period: 1 month
 ```
 
-XKCD's classic chart helps decide:
+After the first month, the automation has paid for itself, and every subsequent month saves 20 hours of human effort. The payback period should be short enough that the automation is likely to remain relevant — automating a task that will be obsolete in three months because the underlying system is being replaced is rarely worthwhile, even if the ROI calculation looks favourable on paper.
 
-| How often? | Time saved | Automation worth it if takes... |
-|------------|------------|--------------------------------|
-| 50x/day | 5 min | Up to 6 weeks |
+The decision framework for what to automate can be organised along two axes: frequency (how often the task occurs) and complexity (how difficult it is to automate). This produces a simple quadrant that guides prioritisation.
+
+| How often? | Time saved | Automation worth it if development takes... |
+|------------|------------|---------------------------------------------|
+| 50 times/day | 5 min | Up to 6 weeks |
 | Daily | 5 min | Up to 4 days |
 | Weekly | 5 min | Up to 1 day |
 | Monthly | 30 min | Up to 4 hours |
 | Yearly | 1 hour | Up to 30 minutes |
 
-### What to Automate First
-
-Prioritize by combining frequency and complexity:
-
-1. **High frequency, low complexity**: Quick wins (Do these first)
-2. **High frequency, high complexity**: Big impact (Major engineering projects)
-3. **Low frequency, low complexity**: Steady progress (Good for onboarding or slow days)
-4. **Low frequency, high complexity**: Maybe don't automate (Negative ROI)
+This table is derived from the classic XKCD automation chart (Munroe, "Is It Worth the Time?"), and it provides a useful heuristic for quick triage. Tasks in the upper-left corner (high frequency, small per-occurrence savings) can justify substantial automation investment because the savings compound. Tasks in the lower-right (low frequency, small savings) are almost never worth automating unless the automation is trivial to build. The chart is deliberately conservative — it accounts only for time saved, not for the reduction in human error, the improvement in response consistency, or the morale benefit of eliminating a tedious task. In practice, these qualitative factors often tip the balance toward automation for tasks that the pure time-based calculation would reject.
 
 ```mermaid
 quadrantChart
@@ -301,160 +223,101 @@ quadrantChart
     quadrant-4 "1. Quick wins"
 ```
 
----
+The four quadrants suggest different strategies. **Quick wins** (high frequency, low complexity) should be automated first and fast — these are the tasks where a few hours of scripting can reclaim substantial weekly capacity. **Big impact** (high frequency, high complexity) represents major engineering investments that can transform a team's operational load but require careful planning and testing. **Steady progress** (low frequency, low complexity) is suitable for automation during quieter periods or as onboarding projects for new team members. **Maybe don't automate** (low frequency, high complexity) is the quadrant where automation is often the wrong answer — the build and maintenance cost exceeds the likely savings, and the task may be better handled through improved documentation or occasional manual execution.
 
-## Did You Know?
+### When NOT to Automate
 
-1. **If incident remediation repeatedly requires manual steps**, that's a sign more automation is likely needed.
+Automation is not always the correct response to toil, and several categories of work resist responsible automation. The first is work that requires human judgment in a way that cannot be reduced to rules — determining whether a database schema change is safe to apply in production, for instance, involves assessing the query patterns, data volumes, and potential locking behaviour in ways that resist algorithmic encoding. Attempting to automate such decisions produces brittle systems that either err on the side of caution (blocking legitimate changes) or recklessness (applying dangerous changes automatically). The second category is work that is about to become obsolete. Automating a manual deployment process for a service that is being rewritten and will be replaced in two months is wasted effort — the automation's payback period must fit within the expected remaining lifetime of the process. The third category is work that occurs so rarely that the automation would be more expensive to maintain than the manual task is to perform. An annual compliance report that takes a day to produce and whose format changes each year as regulations evolve is a poor automation target: the automation would need to be updated every year to match the new format, and the update cost alone could exceed the cost of producing the report manually. In all of these cases, the correct response to the toil is not automation but either acceptance (it is cheaper to do it manually than to automate it) or redesign (changing the system so the toil-producing condition no longer exists).
 
-2. **In Google SRE writing, "toil" refers to repetitive operational work**, not all operational work.
+A subtler category involves work that is automatable in principle but carries a failure cost so high that the risk of an automation error outweighs the efficiency gain. Database failover is the canonical example. The procedure is well-defined and repetitive enough to be a candidate for automation, but a false-positive trigger — failing over when the primary database was in fact healthy — can cause a split-brain scenario that is far more expensive to resolve than the 15 minutes of manual intervention would have been. For these operations, the appropriate automation level is often Level 3 (auto-triggered with human confirmation) rather than Level 4 (fully automated), preserving a human gate for the irreversible decision while automating the detection, diagnosis, and execution of the procedure itself. The human is not doing the work; the human is verifying that the automation's assessment is correct before the automation acts. This pattern — automate the process, keep the decision — is underused in practice and represents a pragmatic middle ground between the Scylla of toil and the Charybdis of fragile full automation.
 
-3. **Teams often track toil trends over time**. An upward trend is a warning sign that current automation is not keeping up.
+### Automation as Software
 
-4. **XKCD's "Is It Worth the Time?" chart** offers a back-of-the-envelope way to think about automation ROI.
-
----
-
-## War Story: The Automation That Saved the Team
-
-A team I worked with had a toil problem:
-
-**The Situation:**
-- A small SRE team
-- Multiple critical services
-- Most of the team's time consumed by toil
-- No time for improvements
-- Team morale: terrible
-
-**The Toil Audit:**
-
-| Category | Hours/week | % of Time |
-|---|---|---|
-| Manual deploys | 40 | 28% |
-| Incident response | 35 | 24% |
-| User provisioning | 20 | 14% |
-| Log investigation | 15 | 10% |
-| Certificate mgmt | 8 | 5% |
-| Total toil | Most team time | High |
-
-**The 90-Day Plan:**
-
-Week 1-4: Automate deploys
-- Built CI/CD pipeline
-- Significant weekly time savings
-
-Week 5-8: Auto-remediation
-- Kubernetes for self-healing
-- Auto-scaling policies
-- Significant weekly time savings
-
-Week 9-12: Self-service
-- User provisioning portal
-- Self-service log access
-- Significant weekly time savings
-
-**The Result:**
-```
-Before:
-  Toil: 81%
-  Project time: 19%
-  Team morale: 2/10
-
-After 90 days:
-  Toil: 28%
-  Project time: 72%
-  Team morale: 8/10
-```
-
-**Key lesson**: The team wasn't bad at their jobs — they were drowning in toil. Automation gave them their time back.
+Every automated system carries a maintenance burden of its own, and this burden must be factored into the automation decision from the start. Automated processes must be monitored like any other software component — if an automation that handles certificate renewal stops working, the team needs to know before certificates expire, not three weeks later when a production service goes down with an expired TLS certificate. Automations must be tested when the systems they depend on change — a script that worked against version 3 of an API may break silently against version 4, and the breakage may not be obvious if the script's failure mode is to exit without producing output rather than to crash visibly. Automations must be understood by multiple team members — an automation that only one person can debug is a bus-factor risk that negates some of the reliability benefit the automation was supposed to provide. And automations must have a defined owner, a runbook for what to do when they fail, and a regular review cadence to confirm they are still needed and still working correctly. The SRE approach treats automation not as a set-it-and-forget-it improvement but as a first-class software engineering product with the same expectations for testing, monitoring, documentation, and code review that apply to any production system. When a team views an automation script as a one-off artifact rather than a living piece of software, the script inevitably rots — dependencies change, APIs evolve, assumptions become invalid — and the team discovers the rot only when the manual task it was supposed to replace suddenly reappears during an incident.
 
 ---
 
-## Automation Patterns
+## Patterns, Anti-Patterns, and Decision Framework
 
-### Pattern 1: Runbook to Script
+### Patterns
 
-Transform documentation into code:
+**Runbook to script, script to self-healing.** The most reliable path to automation starts with documentation. Before you automate a task, you must understand it well enough to write down every step, every edge case, and every failure mode. The runbook serves as both the specification for the automation and the fallback if the automation fails. Once the runbook exists and has been verified by multiple team members executing the procedure successfully, converting it to a script is a mechanical exercise. The script eliminates human error in execution but still requires a human trigger. The final step — making the trigger automatic, based on monitoring signals — moves the task to Level 4 on the automation ladder, where the system handles detection, decision, and execution without human involvement.
 
-```bash
-# Before: Runbook
-# "To restart the payment service:
-# 1. SSH to payment-prod
-# 2. Run: sudo systemctl restart payment
-# 3. Verify: curl localhost:8080/health
-# 4. Check logs: tail -f /var/log/payment/app.log"
-
-# After: Script
-#!/bin/bash
-set -e
-
-echo "Restarting payment service..."
-kubectl rollout restart deployment/payment -n production
-
-echo "Waiting for rollout..."
-kubectl rollout status deployment/payment -n production
-
-echo "Verifying health..."
-kubectl exec -n production deploy/payment -- curl -s localhost:8080/health
-
-echo "Service restarted successfully"
-```
-
-### Pattern 2: Chatbot Operations
-
-Let chat trigger safe operations:
+**ChatOps as a half-step toward full automation.** For operations where full automation is technically feasible but the blast radius of a mistake creates organisational resistance, a ChatOps approach provides an intermediate step. The system detects the condition (e.g., a service is unhealthy), posts a message to the team's chat platform describing what it detected and what it proposes to do, and waits for a human to approve or reject. This preserves human oversight for high-stakes operations while eliminating the manual steps of SSHing, running commands, and verifying results. The approval gate can be progressively relaxed as confidence in the automation grows — first requiring a senior engineer's approval, then any team member, then auto-approving after a timeout, and finally removing the gate entirely. The following example illustrates the pattern:
 
 ```
-User: /restart payment-service production
-Bot: ⚠️ Restart payment-service in production?
-     This will cause ~30s of degraded service.
-     [Confirm] [Cancel]
+System: Payment service health check failed (HTTP 500).
+        Proposing: rollout restart deployment/payment -n production
+        Estimated impact: ~20s degraded service
+        [Approve] [Reject] [Details]
 
-User: [Confirm]
-Bot: ✅ Restarting payment-service...
-     - Old pods terminating
-     - New pods starting
-     - Health check passed
-     Restart complete! (took 45s)
+User: [Approve]
+
+System: Restarting payment-service...
+        Old pods draining (3/3)
+        New pods starting (1/3, 2/3, 3/3)
+        Health check passed
+        Restart complete (38s). Service restored.
 ```
 
-### Pattern 3: Self-Healing
-
-Let the system fix itself:
+**Self-healing through platform primitives.** The highest-leverage automation is the kind that uses the platform's built-in self-healing capabilities rather than custom scripts that must be maintained separately. Kubernetes provides liveness probes that restart unhealthy containers, readiness probes that remove unready pods from service, HorizontalPodAutoscalers that adjust replica counts based on resource utilisation, and PodDisruptionBudgets that maintain availability during voluntary disruptions. Each of these is declarative — you specify the desired state and the conditions that constitute health, and the platform continuously works to maintain that state. This is fundamentally different from imperative automation (a script that runs when a human decides to run it) because it is always active. The pod is always being monitored, the health check is always being evaluated, and the corrective action is always available.
 
 ```yaml
-# Kubernetes liveness probe
+# Kubernetes liveness probe — declarative self-healing
 livenessProbe:
   httpGet:
     path: /health
     port: 8080
   initialDelaySeconds: 30
   periodSeconds: 10
-  failureThreshold: 3  # Restart after 3 failures
+  failureThreshold: 3  # Restart after 3 consecutive failures
 
 # Result: Kubernetes automatically restarts
 # unhealthy pods — no human needed
 ```
 
-### Pattern 4: Policy-Based Automation
+### Anti-Patterns
 
-Define policies, let systems enforce them:
+**Automating everything indiscriminately.** The reflex to automate every toil task as soon as it is identified leads to a collection of fragile, poorly-understood scripts that consume more maintenance time than the original manual work. Automation should be prioritised by ROI: the highest-frequency, lowest-complexity tasks first. A team that spends its automation budget on a rare edge case while daily manual restarts continue unchecked has misallocated its engineering effort.
 
-```yaml
-# OPA policy for auto-scaling
-package autoscaling
+**Automating before understanding.** Writing a script for a procedure whose edge cases you do not fully understand produces automation that works in the common case and fails silently or dangerously in the uncommon case. The runbook-first approach is a guardrail against this: if you cannot write down what the procedure does under every condition you can think of, you are not ready to automate it.
 
-default scale_up = false
+**Unmonitored automation.** An automation that runs without monitoring is an incident waiting to happen. Certificate renewal automation that stops working goes unnoticed until certificates expire and services go down. The monitoring for an automation should alert on two conditions: the automation has not run when it should have (absence of expected activity), and the automation has run but produced an unexpected result (presence of an error or anomaly).
 
-scale_up {
-    input.cpu_utilization > 80
-    input.pending_requests > 100
-    input.current_replicas < input.max_replicas
-}
+**Single-owner automation.** When only one person on the team understands how an automation works, the team's reliability posture has actually worsened: you have traded a manual task that anyone could perform (even if slowly) for an automated task that only one person can debug when it breaks. Every automation should have at least two people who understand its design, can read its code, and are confident making changes.
 
-# Result: System scales up automatically
-# when conditions are met
+**Premature full automation.** Jumping directly from manual execution (Level 0) to full automation (Level 4) without passing through the intermediate levels eliminates the learning and trust-building that each step provides. The runbook (Level 1) makes the process explicit and testable. The script (Level 2) validates that the procedure can be encoded correctly. The auto-trigger with confirmation (Level 3) builds organisational trust in the automation's judgment. Skipping these steps produces automation that the team does not trust and will disable at the first sign of trouble.
+
+**Hero-driven toil absorption.** When a single team member voluntarily absorbs a disproportionate share of the team's toil — staying late to handle manual deployments, being the only person who knows how to restart a particular service — the toil becomes invisible to the rest of the team and to management. The hero's good intentions prevent the systemic problem from being recognised and addressed. Toil must be visible and shared for the organisation to feel the pressure to eliminate it.
+
+### Decision Framework
+
+When you encounter a task that might be toil, walk through this decision sequence before deciding how to respond:
+
+```mermaid
+flowchart TD
+    A["Is this task toil?<br/>(manual + repetitive + automatable?)"] -->|No| B["Not toil — manage as overhead or engineering"]
+    A -->|Yes| C["Does it occur >1x/month?"]
+    C -->|No| D["Accept manual execution or document in runbook"]
+    C -->|Yes| E["Is it automatable at reasonable cost?<br/>(ROI ≤ 12 months payback)"]
+    E -->|No| F["Redesign the system to eliminate the need"]
+    E -->|Yes| G["Document → Script → Auto-trigger → Full auto"]
+    G --> H["Monitor the automation like production software"]
 ```
+
+This framework forces the critical branching decisions: is the task actually toil, how frequently does it occur, what is the automation ROI, and — crucially — when automation is not the right answer, what alternative response (acceptance, redesign) is appropriate. The 12-month payback threshold is a reasonable default; teams in high-toil situations may want to accept longer payback periods because the opportunity cost of NOT automating is higher, while teams with low toil may be more selective.
+
+---
+
+## Did You Know?
+
+- **Toil is defined with six specific attributes in the Google SRE book** — manual, repetitive, automatable, tactical, devoid of enduring value, and scaling linearly with service growth. Work must have most of these characteristics to qualify as toil; tedious but creative work (like writing a complex postmortem) is not toil. The precision of the definition matters because conflating toil with "work I dislike" leads to misdirected automation efforts that waste engineering time on tasks that genuinely require human judgment.
+
+- **The SRE workbook estimates that a single SRE automating toil can reclaim 1 to 3 full-time equivalents of manual effort within a year.** This multiplier effect — one engineer's automation work eliminating the manual effort of multiple people — is why the 50% rule is an investment rule as much as a guardrail. The engineering time reserved by the cap funds the automation that makes the entire operation more efficient.
+
+- **XKCD's "Is It Worth the Time?" chart (xkcd.com/1205), while humorous, encodes a real engineering decision framework.** It uses a time-based ROI calculation to determine how much development time a task's automation is worth, given its frequency and per-occurrence time savings. The underlying principle — that the cost of automation must be justified by the cumulative savings over a reasonable horizon — is the same one the SRE book recommends for prioritising toil-elimination projects.
+
+- **The concept of toil as a distinct category of work originated in the Google SRE practice and was first published in the 2016 SRE book.** Before that, the industry lacked a precise vocabulary for distinguishing between necessary operational overhead (on-call response, capacity planning) and the unnecessary, automatable work that consumes capacity without producing lasting improvement. The introduction of the term gave teams a shared language for identifying and justifying automation investments.
 
 ---
 
@@ -462,72 +325,98 @@ scale_up {
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| Automate everything immediately | Wastes time on low-value automation | Prioritize by frequency × time |
-| Automate before understanding | Script breaks in edge cases | Document first, understand, then automate |
-| No monitoring of automation | Automated tasks fail silently | Add alerting to automation |
-| Over-complex automation | Hard to maintain, breaks often | Simple, readable automation |
-| Not tracking toil | Can't prove improvements | Measure before and after |
-| Hero culture | Individual carries toil burden | Distribute and automate together |
+| Automate everything immediately | Wastes time on low-value automation while high-impact toil continues | Prioritise by frequency multiplied by per-occurrence time cost. Automate quick wins first, then tackle the big-impact quadrant |
+| Automate before understanding | Script breaks in edge cases because the author did not fully map the problem space | Document the procedure as a runbook first, have multiple team members execute it, and understand failure modes before writing a single line of automation |
+| No monitoring of automation | Automated tasks fail silently for weeks or months before anyone notices | Add monitoring and alerting to every automated process. Alert on both absence of expected activity and presence of errors or unexpected results |
+| Over-complex automation | Hard to maintain, breaks often, and only one person understands it | Prefer simple, readable automation that multiple team members can debug. Use platform primitives (Kubernetes probes, HPA) over custom scripts where possible |
+| Not tracking toil | Cannot prove automation investments are working or justify continued investment to management | Measure toil before and after every automation project. Track the trend on a shared dashboard visible to the team and leadership |
+| Hero culture | An individual absorbs most of the toil burden, making the problem invisible to the team and organisation | Distribute operational work across the team through a formal on-call rotation. Make toil visible through shared tracking so the systemic cost is apparent |
+| Confusing all ops work with toil | Treating incident investigation, capacity planning, or postmortems as toil leads to misguided attempts to automate work that requires judgment | Apply the toil taxonomy rigorously. If the task requires creative judgment, produces enduring value, or is not meaningfully automatable, it is not toil — manage it, don't try to eliminate it |
+| Automating a process that is about to become obsolete | Investment wasted when the system or procedure is replaced before the automation pays for itself | Check the expected lifetime of the process before automating. If the underlying system is being deprecated within the automation's payback period, invest the engineering time elsewhere |
 
 ---
 
-## Quiz: Check Your Understanding
+## Quiz
 
-### Question 1
-**Scenario:**
-You are an SRE reviewing the weekly task list. One task involves writing a detailed postmortem for a recent database outage, which takes 4 hours. Another task is manually running a database backup verification script every morning, which takes 15 minutes. How do you classify these tasks, and why?
+### Question 1 — Scenario-Based
+
+You are an SRE reviewing the weekly task list. One task involves writing a detailed postmortem for a recent database outage, which takes four hours. Another task is manually running a database backup verification script every morning, which takes 15 minutes. How do you classify these tasks, and why?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-The backup verification is toil, while the postmortem is not.
-
-Toil is defined by work that is manual, repetitive, automatable, and devoid of enduring value, scaling linearly with the system's growth. Verifying backups every morning fits this definition perfectly because it could be automated and requires no special human judgment. In contrast, writing a postmortem requires deep analysis, human judgment, and produces lasting value by improving system reliability. Therefore, the postmortem is considered engineering or operational overhead, not toil.
+The backup verification is toil, while the postmortem is not. Toil is defined by work that is manual, repetitive, automatable, and devoid of enduring value, scaling linearly with the system's growth. Running a backup verification script every morning fits this definition perfectly: it is the same action each day, requires no judgment, and could be replaced by a cron job that sends an alert only when verification fails. The postmortem, in contrast, requires deep analysis of what went wrong, synthesis of evidence from multiple sources, and the production of action items that permanently improve the system. This judgment-intensive, value-creating work is precisely the kind of engineering activity the 50% rule is designed to protect.
 </details>
 
-### Question 2
-**Scenario:**
-Your SRE team has been tracking its time and discovers that over the last quarter, the team spent 70% of its hours executing manual user provisioning, responding to routine paging alerts, and manually scaling infrastructure. The team is proud they kept the system running, but management is concerned. How should this situation be handled according to SRE principles?
+### Question 2 — Scenario-Based
+
+Your SRE team has been tracking its time and discovers that over the last quarter, the team spent 70% of its hours executing manual user provisioning, responding to routine paging alerts, and manually scaling infrastructure. Management is proud the team kept the system running. How should this situation be handled according to SRE principles?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-The team has exceeded the 50% limit for toil and must take immediate action to reduce it.
-
-Google's SRE model strictly limits toil to 50% of an engineer's time to ensure that at least half of their time is dedicated to engineering projects that permanently improve the system. When toil exceeds 50%, the team is trapped in a reactive operations mode and cannot build the automation needed to scale. To fix this, the team should push back on service levels, heavily prioritize automation projects, request additional staffing, or temporarily hand operational responsibilities back to the development team until the toil is manageable.
+The team has substantially exceeded the 50% operational work ceiling and is in a reactive death spiral — too busy fighting fires to build fire prevention. Google's SRE model strictly limits operational work to at most 50% of an engineer's time to ensure that engineering projects which permanently improve the system can proceed. At 70%, the team lacks the capacity to design and execute the automation that would reduce the load. The correct responses are to automate the highest-frequency toil aggressively, push back on the services generating the most operational load (demanding reliability improvements or temporarily returning them to development teams), and consider creating temporary capacity. An engineering sprint where operations are covered by a skeleton rotation can jump-start the automation projects that will permanently reduce the toil.
 </details>
 
-### Question 3
-**Scenario:**
-You manage a legacy reporting service that requires a manual cache clearing process every Friday afternoon. The process takes you 30 minutes to perform safely. You estimate it would take you 20 hours to write, test, and safely deploy a fully automated script to handle this. Using ROI principles, should you prioritize automating this task right now?
+### Question 3 — Scenario-Based
+
+You manage a legacy reporting service that requires a manual cache-clearing process every Friday afternoon, taking 30 minutes. You estimate it would take 20 hours to write, test, and deploy a fully automated solution. Using ROI principles, should you prioritise automating this task, and what factors beyond the raw time calculation should influence your decision?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-Yes, you should prioritize automating this task because the payback period is reasonable and it eliminates a recurring interruption.
-
-The manual task costs you 2 hours per month (30 minutes × 4 weeks). If you invest 20 hours to automate it, the automation will pay for itself in exactly 10 months (20 hours / 2 hours per month). In SRE, calculating the Return on Investment (ROI) for automation helps prioritize engineering effort. Since this task is highly repetitive and the payback period is less than a year, automating it is a sound engineering decision that will permanently free up your Friday afternoons for higher-value work.
+The raw ROI calculation favours automation: the manual task costs 2 hours per month (30 minutes x 4 weeks), and a 20-hour build cost yields a payback period of 10 months — well within the typical 12-month threshold. Beyond the time calculation, several additional factors strengthen the case for automation. The task occurs on a Friday afternoon, meaning it either interrupts an engineer's end-of-week flow or requires someone to be available at a specific time, limiting schedule flexibility. A manual cache-clearing process carries a non-zero error risk — a typo or skipped step could cause a production issue that costs far more than the 30 minutes of manual effort. Finally, automating this task frees the engineer to spend Friday afternoons on higher-value work, which has a compounding effect that a pure time-savings calculation does not capture.
 </details>
 
-### Question 4
-**Scenario:**
-Your team currently handles high CPU alerts by manually SSHing into a server and running a script named `./scale_up.sh`. You want to improve this process. First, you configure an alert system that prompts you in Slack: "High CPU detected. Run scale_up.sh? [Y/n]". Later, you replace this entirely with a Kubernetes HorizontalPodAutoscaler that automatically adds pods when CPU hits 80%. Describe the transitions in automation levels that occurred here.
+### Question 4 — Scenario-Based
+
+Your team currently handles high CPU alerts by manually SSHing into a server and running a script named `./scale_up.sh`. You want to improve this process. First, you configure an alert system that prompts you in Slack: "High CPU detected. Run scale_up.sh? [Y/n]". Later, you replace this entirely with a Kubernetes HorizontalPodAutoscaler that automatically adds pods when CPU reaches 80%. Describe the transitions in automation levels that occurred here, and explain what risk each transition eliminated.
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-The process transitioned from Level 2 (Semi-automated) to Level 3 (Auto-triggered), and finally to Level 4 (Fully automated).
+The process transitioned from Level 2 (Semi-automated) to Level 3 (Auto-triggered), and finally to Level 4 (Fully automated). At Level 2, a human had to detect the CPU spike (presumably through a monitoring dashboard or alert), decide to act, SSH to the server, and run the script — every step was manual except the execution of the scale-up commands themselves. Moving to Level 3 eliminated the detection and SSH steps: the system detected the condition and presented a one-click approval in Slack, reducing response time and eliminating the risk of SSH-related mistakes. Moving to Level 4 with the HorizontalPodAutoscaler removed the human entirely from the loop, eliminating both the latency of waiting for human approval and the risk that the human was asleep, in a meeting, or otherwise unavailable when the alert fired. At Level 4, the system handles detection, decision, and execution continuously, which is particularly important for CPU scaling — by the time a human notices and approves, the service may already be degraded.
+</details>
 
-Initially, the human had to decide when to run the script and trigger it manually, which corresponds to Level 2. By moving the trigger to Slack, where the system detects the issue and asks for human permission, the automation reached Level 3. Finally, implementing the HorizontalPodAutoscaler removed the human from the loop entirely, allowing the system to detect and remediate the issue on its own, achieving Level 4. This progression demonstrates the ideal path for eliminating toil, moving from human-initiated actions to true self-healing systems.
+### Question 5 — Scenario-Based
+
+A teammate proposes building a comprehensive automation framework that would handle every conceivable operational task for a service — restarts, scaling, failover, data recovery, and certificate rotation — in a single unified system. They estimate six months of development time. The service currently has five manual tasks, each performed between once and four times per month, taking 15 to 30 minutes each. Evaluate this proposal using the automation decision framework.
+
+<details>
+<summary>Answer</summary>
+
+This proposal almost certainly represents over-automation. The five manual tasks, even at their maximum frequency and duration, consume roughly 8 to 10 hours per month of manual effort — about 100 to 120 hours per year. A six-month engineering investment is disproportionate: the automation's build cost would likely exceed the cumulative manual effort over the entire expected lifetime of the service. The proposal also violates the principle of progressive automation: rather than climbing the ladder one step at a time (document each task, create individual scripts, then selectively auto-trigger the highest-frequency ones), it attempts to jump from Level 0-1 to a massive Level 4-5 monolith. A unified automation framework also concentrates risk — a bug in the framework could simultaneously break restarts, scaling, and failover. The correct approach is to automate each task independently, starting with the highest-frequency, lowest-complexity ones, and to use platform primitives (Kubernetes liveness probes, HPA, cert-manager) where they already exist rather than building custom replacements.
+</details>
+
+### Question 6 — Conceptual
+
+Explain why "scales linearly with service growth" is the most dangerous attribute of toil, even for a team that currently operates comfortably below the 50% ceiling.
+
+<details>
+<summary>Answer</summary>
+
+The linear-scaling attribute means that toil grows in direct proportion to the operational surface area the team manages. A team supporting 10 services with 20 hours of toil per week will face 40 hours of toil when they support 20 services, assuming no automation improvements. This is dangerous because it makes toil a compounding problem that worsens silently: the team may be comfortable at 35% toil today, but if the organisation adds services faster than the team can automate existing toil, the percentage rises continuously. By the time toil crosses the 50% threshold, the team has already lost the engineering capacity needed to reverse the trend. The linear-scaling property also means that toil cannot be solved by hiring — doubling the team size temporarily halves the toil percentage, but the growth of the service fleet will eventually consume the new capacity as well. The only durable solution is to break the linear relationship by automating toil faster than the service surface area expands.
+</details>
+
+### Question 7 — Scenario-Based
+
+Your team automates user provisioning with a self-service portal, reducing the time spent on account creation from 10 hours per week to near zero. Three months later, the toil tracking dashboard shows that the team's overall toil percentage has not decreased — the time saved on provisioning has been replaced by new manual tasks. What is likely happening, and how should the team respond?
+
+<details>
+<summary>Answer</summary>
+
+This is a classic case of toil displacement: when one toil source is eliminated, other work that was previously deprioritised or done ad-hoc expands to fill the reclaimed capacity. The team may also have taken on additional services or responsibilities during the three-month period, introducing new toil. The time saved by automation must be explicitly protected for engineering work, not passively absorbed by new operational demands. The team's response should be twofold. First, make the reclaimed capacity visible — track it as "engineering hours gained from automation" and ensure those hours are booked against engineering projects, not open-ended operational availability. Second, apply the same toil-measurement discipline to the new tasks that appeared: categorise them, measure their frequency, and prioritise the highest-cost ones for the next round of automation. Toil reduction is not a one-time project but a continuous practice — if you stop eliminating toil, new toil fills the void.
 </details>
 
 ---
 
 ## Hands-On Exercise: Toil Reduction Plan
 
-Create a 30-day toil reduction plan.
+Create a 30-day toil reduction plan for your own environment or, if you do not currently have an operational role, use the hypothetical scenario from the "Why This Module Matters" section: a five-person platform engineering team supporting a dozen production services with common toil sources including manual health checks, cloud-console provisioning, and certificate rotation. The exercise is structured in three parts that mirror the methodology covered in this module — audit, prioritise, and plan — and each part builds on the output of the previous one. Completing all three parts will give you a concrete artefact you can adapt for your own team's toil-reduction programme.
 
 ### Part 1: Toil Audit (15 min)
+
+Begin by listing all the repetitive tasks you or your team performed in the past week. Be specific: "restart payment service" rather than "fix issues," and include the approximate time each task took per occurrence. The goal is to capture the operational work that happens regularly, not one-off emergencies or project work.
 
 List all repetitive tasks from the past week:
 
@@ -542,7 +431,9 @@ List all repetitive tasks from the past week:
 Total weekly toil: ___ hours
 Percentage of work week (40h): ___%
 
-### Part 2: Prioritization (10 min)
+### Part 2: Prioritisation (10 min)
+
+Now score each task from your audit on three dimensions: frequency (how often it occurs, from 1 for annual to 5 for daily), time cost (how long each occurrence takes, from 1 for under a minute to 5 for over an hour), and automation complexity (how straightforward it would be to automate, from 1 for very complex to 5 for trivial). The total score determines which task to attack first — higher totals mean higher automation ROI.
 
 Score each task:
 
@@ -558,6 +449,8 @@ Priority order (highest total first):
 3. _______________
 
 ### Part 3: 30-Day Plan (15 min)
+
+For your top-priority task, build a concrete four-week implementation plan that follows the progressive automation approach: document in week one, script and test in week two, deploy with monitoring and run in parallel in week three, and remove the manual process after validation in week four. The plan should include the current state (what the task costs today), the target state (what automation level you are aiming for and what the expected savings are), and the success metrics you will use to confirm the automation is working.
 
 For your top priority item:
 
@@ -602,63 +495,29 @@ Week 4:
 
 - [ ] Audited at least 5 tasks
 - [ ] Calculated total toil percentage
-- [ ] Prioritized using scoring
+- [ ] Prioritised using scoring
 - [ ] Created detailed plan for #1 priority
 - [ ] Defined success metrics
 
 ---
 
-## Key Takeaways
+## Sources
 
-1. **Toil is repetitive work that doesn't add lasting value** — identify it
-2. **The 50% rule** ensures time for engineering, not just operations
-3. **Measure toil** before and after — you can't improve what you don't track
-4. **Prioritize automation** by frequency × time × simplicity
-5. **Progress through automation levels** — from manual to self-healing
-
----
-
-## Further Reading
-
-**Books**:
-- **"Site Reliability Engineering"** — Chapter 5: Eliminating Toil
-- **"The Site Reliability Workbook"** — Chapter 6: Eliminating Toil
-
-**Articles**:
-- **"Identifying and Tracking Toil"** — Google Cloud blog
-- **"Toil: A Word Every Engineer Should Know"** — Medium
-
-**Tools**:
-- **Ansible**: Automation platform
-- **Terraform**: Infrastructure as code
-- **Kubernetes Operators**: Custom automation
-
----
-
-## Summary
-
-Toil is the repetitive, automatable work that eats your time without making things better. Left unchecked, it consumes all your time and prevents improvement.
-
-SRE's approach:
-- **Measure** toil systematically
-- **Limit** toil to 50% of time
-- **Automate** strategically (ROI-based)
-- **Progress** through automation levels
-
-The goal isn't to eliminate all operational work — it's to eliminate the grinding, repetitive parts so you can focus on work that matters.
+- [SRE Book, Chapter 5: Eliminating Toil — Beyer, Jones, Petoff, Murphy (2016)](https://sre.google/sre-book/eliminating-toil/) — The canonical definition of toil, its six attributes, and the 50% operational work cap. This chapter introduced the term "toil" as a precise category of operational work and established the framework that the rest of the industry has adopted.
+- [SRE Book, Chapter 7: The Evolution of Automation at Google — Beyer, Jones, Petoff, Murphy (2016)](https://sre.google/sre-book/automation-at-google/) — Google's internal history of automation, including the argument that automation is software that must be treated with the same rigor as any production system. Covers the automation value proposition versus consistency and the organisational dynamics of automation adoption.
+- [SRE Workbook, Chapter 6: Eliminating Toil — Beyer, Murphy, Rensin, Kawahara, Thorne (2018)](https://sre.google/workbook/eliminating-toil/) — Practical methods for identifying, measuring, and reducing toil. Includes survey templates, toil-tracking advice, and case studies of toil-reduction programmes in practice.
+- [Identifying and Tracking Toil Using SRE Principles — Google Cloud Blog](https://cloud.google.com/blog/products/management-tools/identifying-and-tracking-toil-using-sre-principles) — Accessible summary of the toil taxonomy and measurement approach, written for practitioners who may not have read the full SRE book.
+- [Meeting Reliability Challenges with SRE Principles — Google Cloud Blog](https://cloud.google.com/blog/products/management-tools/meeting-reliability-challenges-with-sre-principles) — Connects toil reduction to broader SRE reliability practice, including the relationship between operational load management and system reliability outcomes.
+- [XKCD 1205: Is It Worth the Time? — Randall Munroe](https://xkcd.com/1205/) — The classic visualisation of automation ROI by task frequency and per-occurrence time savings. Widely referenced in SRE practice as a quick heuristic for automation prioritisation.
+- [DORA Metrics: The Four Keys — DORA (DevOps Research and Assessment)](https://dora.dev/guides/dora-metrics-four-keys/) — The research foundation connecting deployment frequency, lead time for changes, change failure rate, and time to restore service to organisational performance. These metrics are directly affected by toil levels: high toil raises change failure rate and MTTR.
+- [Kubernetes: HorizontalPodAutoscaler — Kubernetes Documentation](https://kubernetes.io/docs/tasks/run-application/horizontal-pod-autoscale/) — Reference for the HPA, used throughout this module as an example of Level 4 platform-native automation that eliminates scaling toil.
+- [SRE Workbook, Chapter 5: Alerting on SLOs — Beyer, Murphy, Rensin, Kawahara, Thorne (2018)](https://sre.google/workbook/alerting-on-slos/) — Covers burn-rate alerting and the relationship between SLO-based alerting and toil reduction: well-designed alerts fire on symptoms that require human judgment, not on conditions that could be auto-remediated.
+- [SRE Book, Chapter 15: Postmortem Culture — Beyer, Jones, Petoff, Murphy (2016)](https://sre.google/sre-book/postmortem-culture/) — Establishes the blameless postmortem as an engineering practice distinct from toil, and explains why postmortem writing is one of the highest-value investments an SRE team can make.
+- [Prometheus Alerting Rules — Prometheus Documentation](https://prometheus.io/docs/prometheus/latest/configuration/alerting_rules/) — Reference for Prometheus alerting rule syntax, relevant to the self-healing and monitoring automation patterns covered in this module.
+- [Kubernetes: Self-Healing — Kubernetes Documentation](https://kubernetes.io/docs/concepts/architecture/self-healing/) — Documents the Kubernetes self-healing primitives (liveness probes, readiness probes, node auto-repair) that form the foundation of Level 4 automation in containerised environments.
 
 ---
 
 ## Next Module
 
-Continue to [Module 1.5: Incident Management](../module-1.5-incident-management/) to learn how to respond effectively when things go wrong.
-
----
-
-*"Alerts should be actionable, and routine manual intervention is a sign the system or alerting design needs improvement."*
-
-## Sources
-
-- [cloud.google.com: identifying and tracking toil using sre principles](https://cloud.google.com/blog/products/management-tools/identifying-and-tracking-toil-using-sre-principles) — The Google Cloud blog reproduces the SRE Book definition and its key characteristics directly.
-- [Meeting Reliability Challenges with SRE Principles](https://cloud.google.com/blog/products/management-tools/meeting-reliability-challenges-with-sre-principles) — Connects toil reduction to broader SRE reliability practice and operational load management.
-- [Kubernetes Self-Healing](https://kubernetes.io/docs/concepts/architecture/self-healing/) — Useful background for the module's automation and self-healing examples in Kubernetes environments.
+Continue to [Module 1.5: Incident Management](../module-1.5-incident-management/) to learn how to respond effectively when things go wrong — including the incident command frameworks and communication practices that keep responders aligned under pressure.


### PR DESCRIPTION
## Wave 1 — Platform Disciplines → Core Platform → SRE (#1953)
Live-file sweep corrected the stale board: **all 7 SRE modules are sub-floor**. This is the first batch (3 biggest genuine T3→T0 expands).

| Module | Author | Before→After | Review |
|---|---|---|---|
| **1.1 What Is SRE** | cursor | 845→**5097**w · 0→**23** src | opus-inline APPROVE — SRE tenets, SRE-vs-DevOps ("class SRE implements interface DevOps", Vargo/Fong-Jones), four golden signals, 50% cap, Treynor-Sloss origin all ground-checked |
| **1.3 Error Budgets** | codex gpt-5.5 | 692→**5538**w · 0→**15** src | opus-inline APPROVE — **math hard-verified exact**: 99.9%=43.2min/30-day + 8.76h/yr + 43m49s/avg-month; burn rate 6×; SRE Workbook 14.4×/1h=2%, 6×/6h=5%, 1×/3d; error-budget policy + Prometheus burn-rate rules |
| **1.4 Toil & Automation** | deepseek | 705→**5715**w · 0→**12** src | opus-inline APPROVE — 6 toil attributes + toil-vs-overhead per Google SRE ch.5; 50% cap; automation ladder (recovered: deepseek dropped before commit) |

### Review (cross-family, no gemini)
opus-inline R1 on all three. **All 50 source URLs curl-200** (1.4 had a transient verifier-reachability flicker, confirmed reachable on re-verify). War Stories → `Hypothetical scenario:`; no emoji/`47`; `revision_pending` cleared. 1.3's error-budget/burn-rate math checked digit-by-digit against the SRE Workbook.

### Verification
- All three **T0**, 0 failing gates. Full `astro build` green locally (2169p); required CI re-runs here.

Refs #1953 · SRE Wave 2 (1.5/1.6 + the smaller 1.2/1.7 source/expand fixes) to follow.