### PR TITLE
content(platform): data-engineering batch 3 — 1.7/1.8 to T0 (closes section) (#1953)

### DIFF
--- a/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.7-event-streaming-fundamentals.md
+++ b/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.7-event-streaming-fundamentals.md
@@ -3,6 +3,7 @@ title: "Module 1.7: Event Streaming Fundamentals"
 slug: platform/disciplines/data-ai/data-engineering/module-1.7-event-streaming-fundamentals
 sidebar:
   order: 8
+revision_pending: false
 ---
 > **Complexity**: `[INTERMEDIATE]`
 >
@@ -24,45 +25,35 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-At first, the outage looked like a normal analytics delay.
+Hypothetical scenario: at first, the incident looks like a normal analytics delay. The checkout service is still accepting orders, the payment provider is still sending settlement events, the warehouse service is still updating inventory, and dashboards are late in the ordinary way dashboards sometimes are. Then support agents notice a deeper problem: shipment notifications mention refunded orders, inventory counts diverge across regions, and fraud review is making decisions from stale account state. The streaming platform is not down, yet the business state built from the stream is no longer trustworthy.
 
-The checkout service was still accepting orders.
-The payment provider was still sending settlement events.
-The warehouse service was still updating inventory.
-Dashboards were late, but nobody expected a dashboard to be perfectly real time.
+The team did not fail because it forgot a command. It failed because it treated streaming as a faster queue instead of a replayable log with explicit semantics. Some consumers retried messages without idempotency keys, some services assumed partitioned logs gave global order, one team changed partition count during a promotion without understanding the ordering boundary, and another team treated rising consumer lag as a broker problem when the real bottleneck was a slow database write behind the consumer. The system kept moving while several projections quietly became different interpretations of the same history.
 
-Then support agents noticed something worse.
-Customers were receiving shipment notifications for orders that had been refunded.
-Inventory counts were drifting in different directions across regions.
-Fraud review was making decisions with stale account state.
+Event streaming is a storage and coordination pattern built around an append-only log. Producers append facts, brokers retain those facts according to a policy, and consumers replay them at their own pace. That design is powerful because it decouples teams and time: fraud detection, billing, support search, machine learning features, and warehouse loading can all derive different views from the same source history without asking the checkout service to call each one synchronously. It is also dangerous because every downstream team now owns correctness questions that a simple request path used to hide.
 
-The team had built "streaming" as if it were just a faster queue.
-Every consumer advanced independently.
-Some services retried failed messages without idempotency keys.
-Other services assumed Kafka ordering was global.
-One team increased partitions during a promotion and accidentally split a customer's events across multiple workers.
-Another team treated a growing consumer lag graph as a broker problem when the real bottleneck was a slow database write behind the consumer.
+This module gives you the map before you operate the tools. You will learn the semantic difference between events, messages, commands, and requests; why the log is the durable primitive; how partition keys define the real ordering guarantee; how at-most-once, at-least-once, and exactly-once processing are assembled from producer, broker, consumer, and sink behavior; and why event time, watermarks, windows, lag, retention, schema evolution, and replay are not optional vocabulary. If you later deploy Kafka with Strimzi in [Module 1.2](../module-1.2-kafka/) or compare NATS JetStream in Module 1.9, this module is the reasoning layer underneath the YAML.
 
-None of those mistakes came from not knowing a command.
-They came from using streaming without a mental model.
+> **The Event Journal Analogy**
+>
+> Think of a streaming log as a shared journal in a busy operations room. A command is somebody asking for action, a request/response call is somebody waiting at the desk for an answer, a queue ticket is a work item assigned to one worker, and an event is a journal entry saying what already happened. The journal does not decide every future use of the entry; it preserves a trustworthy sequence so many readers can build their own view.
 
-Event streaming is not just "send a message and receive it later."
-It is a storage and coordination pattern built around an append-only log.
-Producers append facts.
-Brokers retain those facts.
-Consumers replay them at their own pace.
-Multiple teams can build different projections from the same history without asking the producer to send the same event again.
+## Events, Messages, Commands, and Requests
 
-That design is powerful because it decouples time.
-It is dangerous because the system keeps moving even when one part falls behind.
-The broker can be healthy while a consumer corrupts state.
-The producer can succeed while the downstream database is unavailable.
-"Exactly-once" can protect writes to a stream but still leave duplicate side effects in an email service.
+An event is an immutable fact about the past. `OrderCreated`, `PaymentCaptured`, `UserEmailChanged`, and `TemperatureReadingRecorded` describe something that already happened, so consumers should not interpret them as requests for permission or instructions that may be refused. If a later fact changes the business meaning, you append another event such as `OrderRefunded` or `PaymentReversed` rather than editing the earlier event in place. This is why event streams fit audit trails, projections, replay, and data products: they preserve the history from which many derived states can be rebuilt.
 
-This module gives you the map before you operate the tools.
-You will learn what the log guarantees, what partitions change, why ordering is usually per key rather than global, how delivery semantics are assembled, and when Kafka or NATS JetStream is the right operational shape.
+A command is different because it expresses intent. `CapturePayment`, `ReserveInventory`, and `SendPasswordResetEmail` are requests for a component to do work, and the correct receiver may reject them, validate them, retry them, or turn them into one or more events after the decision is made. Mixing commands and events in one stream creates confusion because consumers cannot tell whether a record is a fact to learn from or an instruction to execute. Good stream names and event type names make that boundary visible to humans, not just to serializers.
 
-If you later deploy Kafka with Strimzi in [Module 1.2](../module-1.2-kafka/), this module is the reasoning layer underneath the YAML.
+A message is the transport envelope that carries either an event, a command, or another payload. A broker can route messages by topic, subject, partition, consumer group, or subscription, but routing does not define the business semantics. A request/response interaction adds a stronger coupling: the caller waits for an answer now, so latency, availability, and authorization sit on the critical path. Streaming is usually a poor substitute for a decision that must complete before the user gets a response; it is strongest when the decision has happened and other systems need a durable fact.
+
+CloudEvents is useful here because it standardizes event metadata such as `id`, `source`, `type`, `subject`, `time`, and `datacontenttype` without requiring one broker or one payload format. The durable lesson is not that every platform must use that exact envelope. The lesson is that event identity, source, type, subject, timestamp, content type, and partitioning metadata are part of the contract. Without them, consumers cannot deduplicate safely, route consistently, trace failures, or decide whether an old event is still within the meaning of its schema.
+
+## Streaming, Batch, and Request/Response
+
+Streaming, batch, and request/response are three integration styles, not a maturity ladder. Batch works with bounded data: a job reads a known input, computes an answer, and finishes. Request/response works when a caller needs a timely answer from a specific service and can tolerate being coupled to that service's availability. Streaming works with unbounded data: events keep arriving, consumers maintain positions, and derived state changes continuously as the log grows. Mature platforms use all three styles because each one optimizes a different shape of work.
+
+Streaming wins when decoupling, replay, and timeliness matter together. A new consumer can start from retained history, a corrected projection can be rebuilt after a bad deployment, and producers can publish facts without knowing every downstream team that will care later. Those benefits are why streaming appears in change data capture, fraud scoring, observability pipelines, lakehouse ingestion, feature generation, alerting, and event-driven application integration. The log becomes a shared source of integration truth, while each consumer controls its own deployment cadence and recovery path.
+
+The costs are equally real. Streaming introduces eventual consistency, partitioning decisions, offset management, retention budgets, schema compatibility, replay blast radius, and operational signals that are easy to misread. A slow consumer does not necessarily stop a producer, which means failure can become delayed, distributed, and surprising. The question is not "can this be streamed?" The better question is "does retained, replayable history reduce coupling enough to justify the operational surface area?"
 
 ## The Log Is the Product
 
@@ -73,10 +64,7 @@ After the worker acknowledges the item, the queue forgets it.
 
 That model is useful for distributing jobs, but it is not the core idea behind event streaming.
 
-In streaming, the durable log is the product.
-Consumers do not "take" an event from the log.
-They read it, remember their own position, and leave the event available for other consumers.
-That one difference changes the architecture.
+In streaming, the durable log is the product. Consumers do not "take" an event from the log in the way a worker takes a job from a queue. They read it, remember their own position, and leave the event available for other consumers, which means the broker becomes more like a shared history than a task dispenser. Jay Kreps' writing on the log popularized this as a unifying abstraction for data integration because a log lets many systems subscribe to the same sequence without demanding point-to-point wiring from the source.
 
 ```text
                   append
@@ -115,7 +103,7 @@ The same event history can feed billing, fraud detection, search indexing, ML fe
 Each consumer group tracks its own offset.
 One group can be caught up while another is deliberately replaying last month.
 
-The log gives you three important properties.
+The log gives you three properties that are easy to understate during design reviews because they sound simple until a recovery depends on them. Append-only history gives you an audit trail, replay gives you a way to rebuild derived state, and fan-out lets teams add consumers without changing the producer's critical path. Every one of those properties depends on retention, schema compatibility, partitioning, and ownership being treated as part of the product contract rather than as broker defaults.
 
 First, it is **append-only**.
 New facts are added at the end.
@@ -183,15 +171,13 @@ The replay works because the stream retained the source facts.
 The consumer's table was not the source of truth.
 It was a projection.
 
-This distinction is not academic.
-When a team treats a projection as the truth, it starts patching derived state directly.
-When a team treats the log as the truth, it asks whether the stream has enough retained history to rebuild the projection correctly.
+This distinction is not academic. When a team treats a projection as the truth, it starts patching derived state directly and soon loses the ability to explain why two views disagree. When a team treats the log as the truth, it asks a sharper question: does the stream contain enough retained, schema-compatible history to rebuild the projection correctly, and can the consumer apply that history deterministically?
 
 > **Check yourself**: Pick a service you know. If its derived database were deleted, which event stream would let you rebuild it? If the answer is "none," that service is not using the log as its source of truth.
 
 ### When a Stream Is Not a Queue
 
-A stream can behave like a queue for one consumer group, but the design intent is different.
+A stream can behave like a queue for one consumer group, but the design intent is different because the event remains valuable after one worker succeeds. A queue is often optimized for work distribution and removal after acknowledgment. A stream is optimized for retained history, independent reader positions, and replay, even when one consumer group uses it in a worker-pool style.
 
 | Question | Queue answer | Stream answer |
 |---|---|---|
@@ -200,27 +186,17 @@ A stream can behave like a queue for one consumer group, but the design intent i
 | Can a new service replay old events? | Usually no, unless dead-letter or archive behavior was added. | Yes, if retention still contains the needed history. |
 | Is the broker the source of truth? | Usually no, it is a work dispatcher. | Often yes, or at least the durable integration source. |
 
-This is why "just use Kafka as a queue" often leads to pain.
-If there is exactly one worker pool, no replay requirement, no fan-out, and no need to retain history, a durable task queue may be simpler.
-Streaming earns its complexity when history has value.
+This is why "just use Kafka as a queue" often leads to pain. If there is exactly one worker pool, no replay requirement, no fan-out, and no need to retain history, a durable task queue may be simpler and easier to reason about. Streaming earns its complexity when the history itself has value: rebuilding projections, auditing facts, adding consumers, comparing new logic against old logic, or replaying data through a corrected processor.
 
 ## Partitions Decide Ordering
 
-No serious streaming platform gives infinite ordering, infinite throughput, and infinite availability at the same time.
-Partitions are the compromise.
-
-A topic or stream is split into ordered shards.
-Each shard has an ordered sequence.
-The broker can place shards across nodes.
-Consumers can process different shards in parallel.
-
-That gives you scale, but it narrows the ordering guarantee.
+No serious streaming platform gives infinite ordering, infinite throughput, and infinite availability at the same time. Partitions are the compromise: the platform splits a topic or stream into ordered shards, places those shards across nodes, and lets consumers process different shards in parallel. That gives you scale, but it narrows the ordering guarantee to the shard that contains a given record.
 
 Kafka orders records within a partition.
 NATS JetStream orders messages within a stream or ordered consumer view, but subject filters and shared pull consumers change how applications observe that order.
 Neither system gives you simple global ordering across all business entities at high scale.
 
-The practical rule is:
+The practical rule is worth memorizing because it prevents a large class of design mistakes:
 
 ```text
 Ordering is per key when the key always maps to the same ordered shard.
@@ -286,8 +262,7 @@ Each choice protects a different invariant.
 | `tenantId` | Tenant-level audit order is preserved. | High-volume tenants become hot spots. | Multi-tenant billing and compliance logs. |
 | Random or round-robin | Maximum distribution. | Business ordering is mostly gone. | Metrics, independent telemetry, fire-and-forget analytics. |
 
-There is no "best" key without a business rule.
-The key is the answer to the question: "Which events would be dangerous to process out of order?"
+There is no "best" key without a business rule. The key is the answer to the question: "Which events would be dangerous to process out of order?" A platform review should force that sentence into the design note because the wrong key can make a stream look healthy while a business invariant breaks quietly downstream.
 
 ### Active Exercise: Predict the Failure
 
@@ -307,14 +282,13 @@ The marketing system might send a campaign before consent revocation is processe
 
 ### Repartitioning Is a Migration
 
-Increasing partitions sounds harmless.
-It is not always harmless.
+Increasing partitions sounds harmless because the change is presented as a scaling knob, but it is not always harmless. In a partitioned log, the count of partitions is part of the mapping from key to ordered shard, so changing that count can change where future records for a key land.
 
 In Kafka, changing a topic from three partitions to six partitions changes the key-to-partition mapping for many keys.
 New events for a key may go to a different partition than old events.
 That can break order for consumers that replay a mixed range of old and new records.
 
-A safe repartition plan usually includes one of these moves:
+A safe repartition plan usually includes one of these moves, and each one should be reviewed as an application migration rather than a broker-only change:
 
 | Strategy | How it works | Trade-off |
 |---|---|---|
@@ -323,17 +297,13 @@ A safe repartition plan usually includes one of these moves:
 | Keep old topic stable | Add throughput by splitting by domain, not by mutating partitions. | Requires topic design work. |
 | Accept the break | Use only when records are independent and order is not a correctness requirement. | Easy to underestimate risk. |
 
-Operators need to treat partition count as an architectural decision, not just a capacity knob.
+Operators need to treat partition count as an architectural decision, not just a capacity knob. The safest moment to choose it is before producers depend on ordering and consumers depend on replay. After that, repartitioning becomes a compatibility problem involving producers, consumers, offsets, retention, and sometimes historical backfills.
 
 ## Delivery Semantics Are a Ladder
 
-Delivery semantics describe what can happen during failures.
-They are not moral grades.
-At-most-once can be correct for telemetry.
-At-least-once can be correct for payments when consumers are idempotent.
-Exactly-once can be necessary for stream-to-stream transformations but still insufficient for side effects outside the transaction boundary.
+Delivery semantics describe what can happen during failures, not moral grades. At-most-once can be correct for disposable telemetry, at-least-once can be correct for payments when consumers are idempotent, and exactly-once processing can be valuable for stream-to-stream transformations. The important phrase is "during failures," because a system that looks duplicate-free on a normal day may reveal its real contract only during producer retry, broker leadership change, consumer crash, or sink timeout.
 
-The ladder looks like this:
+The ladder looks like this, but every rung has a scope that you must state explicitly:
 
 ```text
 At-most-once
@@ -349,10 +319,7 @@ Exactly-once processing
   Scope matters: stream-to-stream is different from stream-to-email.
 ```
 
-The dangerous phrase is "exactly-once delivery."
-In most real systems, the broker can only coordinate the parts it owns or the clients that participate in its protocol.
-If a consumer sends an email and crashes before committing an offset, the broker can redeliver the event.
-The broker cannot unsend the email.
+The dangerous phrase is "exactly-once delivery." In most real systems, the broker can only coordinate the parts it owns or the clients that participate in its protocol. Kafka transactions, for example, can coordinate consumed offsets with produced output records for cooperating clients, but they cannot make a non-transactional email provider forget an email that was already sent. Exactly-once is best understood as effectively-once behavior inside a defined boundary, assembled from idempotent producers, transactions, deterministic processing, idempotent sinks, and careful offset rules.
 
 ### Worked Example: The Same Failure Under Three Semantics
 
@@ -382,14 +349,13 @@ The table below turns those pieces into an operator checklist.
 | Transactional stream-to-stream | `transactional.id` set, idempotence active | `isolation.level=read_committed` for downstream readers | Consumer offsets are sent to the producer transaction | Atomically commits output records and consumed offsets | Does not make arbitrary external calls exactly-once |
 | Application-level exactly-once effect | Same as transactional where possible | Consumer uses idempotency key at sink | Sink records processed `event_id` or equivalent | Gives exactly-once effect in a database or API designed for idempotency | Requires sink support and careful schema design |
 
-For Kafka, remember the three moving parts:
+For Kafka, remember the three moving parts because each one solves a different part of the failure story:
 
 - Idempotent producers prevent duplicate writes caused by producer retries.
 - Transactions coordinate output records and consumed offsets.
 - `isolation.level=read_committed` prevents consumers from reading aborted transactional writes.
 
-Those are necessary for exactly-once stream processing with Kafka.
-They are not enough for every side effect.
+Those are necessary for exactly-once stream processing with Kafka, and they are not enough for every side effect. The moment a consumer writes to a database, calls a webhook, sends an email, or updates a third-party API, the application must decide how that sink detects duplicates and how it recovers from uncertainty.
 
 ### NATS JetStream Semantics Table
 
@@ -411,10 +377,9 @@ The correct choice depends on the failure you are trying to make boring.
 
 ### Idempotency Is the Safety Net
 
-At-least-once systems intentionally allow duplicates.
-That means the consumer must be safe to run twice.
+At-least-once systems intentionally allow duplicates because they prefer repeated work over silent loss. That means the consumer must be safe to run twice, and "safe" must be true at the side effect boundary, not only inside the message handler's memory.
 
-For a database sink, the simplest pattern is to store the event ID with a unique constraint.
+For a database sink, the simplest pattern is to store the event ID with a unique constraint in the same database that receives the business update. The table is not just bookkeeping; it is the durable memory that lets the consumer recognize that a redelivered event already changed state.
 
 ```sql
 CREATE TABLE processed_events (
@@ -423,7 +388,7 @@ CREATE TABLE processed_events (
 );
 ```
 
-Then the consumer makes the side effect conditional on the insert succeeding.
+Then the consumer makes the side effect conditional on the insert succeeding, so a crash after the database commit and before the offset commit turns into a harmless duplicate rather than a second business update.
 
 ```text
 1. Begin database transaction.
@@ -434,16 +399,41 @@ Then the consumer makes the side effect conditional on the insert succeeding.
 6. Acknowledge or commit the stream offset.
 ```
 
-This pattern does not require a magic broker feature.
-It requires the sink to remember which event IDs already changed state.
+This pattern does not require a magic broker feature. It requires the sink to remember which event IDs already changed state and to make that memory transactional with the state change itself. If the event ID insert and the business update can commit separately, the consumer has simply moved the uncertainty from the broker into the database.
+
+## Time and Correctness in Streams
+
+Streaming systems force you to ask which clock you mean. Event time is the time at which the business fact happened, such as when a customer clicked a button or a device measured a temperature. Processing time is the time at which a processor observes the event. Ingestion time sits between them: the time the broker or pipeline first received the event. These clocks often agree in demos, but they diverge in production when mobile clients reconnect, edge devices buffer data, networks partition, producers retry, or a consumer replays old records through new code.
+
+The Dataflow model popularized this distinction because correctness over unbounded, out-of-order data depends on it. If a payment event happened at 10:00 but arrived at 10:07, a processing-time window for 10:05 might miss it while an event-time window for 10:00 can still include it. That difference matters for fraud thresholds, billing summaries, inventory counts, and alerting because the business usually cares when the fact occurred, not when a worker finally saw it. Event time gives you a better semantic target, but it also requires a policy for late and out-of-order data.
+
+Watermarks are that policy's visible signal. A watermark is the system's estimate that it has probably seen all events up to a certain event-time point, so it can close or emit results for windows before that point. Watermarks are not magic truth; they encode assumptions about lateness and completeness. An aggressive watermark gives lower latency but increases the chance of late corrections. A conservative watermark waits longer and produces more complete answers, but it delays results. Streaming correctness is often a tradeoff among completeness, latency, and operational cost rather than a single perfect answer.
+
+Windows turn an unbounded stream into finite pieces that a processor can aggregate. A tumbling window assigns each event to one fixed interval, such as five-minute buckets. A sliding window overlaps intervals, so one event can contribute to multiple rolling views. A session window groups events separated by gaps of inactivity, which is useful when behavior has natural bursts rather than clean clock boundaries. The right window follows the business question: "orders per minute" is not the same as "active checkout sessions" or "suspicious bursts after account change."
+
+Late data should be designed into the output contract instead of treated as an exception. Some systems emit an early estimate, then a corrected result when late events arrive. Some emit only final results after the watermark passes. Some route very late records to a side output for review or compensating repair. The platform does not decide this alone because different consumers have different tolerance for correction. A real-time dashboard may accept provisional numbers, while a billing report may require a slower but more complete result.
+
+```text
+Event time line:
+
+10:00   10:01   10:02   10:03   10:04
+  |------- five-minute tumbling window -------|
+
+Arrival order:
+  event A: happened 10:00, arrived 10:00
+  event C: happened 10:02, arrived 10:02
+  event B: happened 10:01, arrived 10:05
+
+Question:
+  Do you update the 10:00 window when B arrives late,
+  ignore B, or send B to a correction path?
+```
+
+This is where event streaming becomes more than broker administration. A platform team can provide Flink checkpoints, Kafka offsets, or JetStream retention, but the application team still owns the meaning of time. If the stream carries business facts, every aggregation should state its event-time field, window type, allowed lateness, late-data handling, and whether outputs are provisional or final.
 
 ## Backpressure Is a Signal, Not a Panic Button
 
-Backpressure means one part of the pipeline cannot keep up with another.
-In streaming, this is normal.
-The point of a durable log is that consumers can fall behind temporarily without forcing producers to stop immediately.
-
-The question is whether lag is bounded and intentional.
+Backpressure means one part of the pipeline cannot keep up with another, and in streaming this is normal rather than automatically alarming. The point of a durable log is that consumers can fall behind temporarily without forcing producers to stop immediately. The operational question is whether lag is bounded, intentional, and recoverable before retention or downstream correctness is at risk.
 
 ```text
 Producer rate: 20,000 events/sec
@@ -457,7 +447,7 @@ Result:
   The real bottleneck is the sink.
 ```
 
-A healthy operator asks where pressure is accumulating.
+A healthy operator asks where pressure is accumulating before changing capacity. Broker metrics, producer latency, consumer lag, and sink latency describe different failure modes, so a single "streaming is slow" page is rarely enough context for a safe response.
 
 | Pressure location | Symptom | First metric to inspect | Common fix |
 |---|---|---|---|
@@ -471,9 +461,9 @@ Lag during a replay is expected.
 Lag after a planned downstream maintenance window is expected.
 Lag that grows during normal traffic and never drains is a capacity problem.
 
-### Worked War Story: The Lag Was Not Kafka
+### Hypothetical scenario: The Lag Was Not Kafka
 
-A platform team receives an alert:
+A platform team receives an alert that looks dramatic because lag is rising quickly:
 
 ```text
 consumer_group=fraud-score-writer
@@ -486,14 +476,9 @@ consumer_rebalances=0
 db_write_latency_p95=1800ms
 ```
 
-The first instinct is to add Kafka brokers.
-That would not fix the incident.
+A first instinct might be to add Kafka brokers, but that would not fix the incident. The brokers are not saturated, the consumer group is stable, and the database write latency is high. The stream is exposing a slow sink, not causing it.
 
-The brokers are not saturated.
-The consumer group is stable.
-The database write latency is high.
-
-A better response:
+A better response separates each stage of the path and changes only the bottleneck that evidence supports:
 
 ```text
 1. Confirm lag is concentrated in all partitions or only one hot partition.
@@ -504,11 +489,11 @@ A better response:
 6. Throttle noncritical producers if retention risk appears.
 ```
 
-Adding consumers without fixing the sink can make the outage worse by increasing database concurrency.
+Adding consumers without fixing the sink can make the outage worse by increasing database concurrency. Adding brokers without fixing the sink can make the chart look more expensive without making the projection catch up. Backpressure work is disciplined diagnosis, not reflexive scaling.
 
 ### Kafka vs NATS Backpressure
 
-Kafka and NATS JetStream both expose pressure, but they guide operators differently.
+Kafka and NATS JetStream both expose pressure, but they guide operators differently because their consumer and retention models are shaped differently. The durable idea is to look for the point where demand exceeds safe capacity, then decide whether to slow producers, isolate noncritical consumers, add processing parallelism, increase sink capacity, or protect retention.
 
 | Backpressure concern | Kafka posture | NATS JetStream posture | Operator interpretation |
 |---|---|---|---|
@@ -518,8 +503,7 @@ Kafka and NATS JetStream both expose pressure, but they guide operators differen
 | Slow consumer behavior | Lag accumulates in the log until retention removes old records | Push consumers can hit pending limits; pull consumers naturally request what they can handle | Pull-based JetStream consumers are often easier for worker-style backpressure |
 | Replay pressure | Replays can generate high read load across brokers | Replays can be instant or original-rate depending on consumer policy | Replays need SLOs; do not let a backfill starve production consumers |
 
-Backpressure handling is an operations contract.
-The producing team, platform team, and consuming team should agree on these values before the launch:
+Backpressure handling is an operations contract. The producing team, platform team, and consuming team should agree on these values before launch because the first serious lag event is a poor time to negotiate which producer may be throttled or which replay may continue:
 
 - Maximum acceptable lag by consumer group.
 - Retention window large enough to survive expected outages.
@@ -529,14 +513,13 @@ The producing team, platform team, and consuming team should agree on these valu
 
 ## Retention Is Product Policy
 
-Retention is often configured as if it were storage housekeeping.
-It is really product policy.
+Retention is often configured as if it were storage housekeeping, but it is really product policy. A stream's retention setting defines how long the platform can recover from consumer downtime, how far a new service can replay history, how long a projection can be rebuilt without another source, and how long sensitive facts remain on disk.
 
 If the stream is the source of truth for rebuilding a projection, retention defines how far back you can recover without another system.
 If the stream feeds compliance analytics, retention defines what the audit can prove.
 If the stream contains sensitive data, retention also defines how long risk remains on disk.
 
-There are three common retention modes.
+There are three common retention modes, and they answer different questions rather than competing as generic defaults.
 
 | Retention mode | How it works | Choose it when | Avoid it when |
 |---|---|---|---|
@@ -558,109 +541,111 @@ Three teams ask for event storage.
 | `user.preferences` | New services need the latest preference for each user. | Log-compacted by user ID. | Consumers care about current state, not every toggle. |
 | `edge.metrics.raw` | High-volume device metrics used for near-real-time alerts. | Size-based or short time-based retention. | Long-term analytics should be downsampled into another store. |
 
-The mistake is configuring all three the same way.
-They carry different business promises.
+The mistake is configuring all three the same way. They carry different business promises, and those promises should be visible in the stream contract beside owner, schema, key, retention, replay expectation, and access controls.
 
 ### Retention and Replay Must Match
 
 If retention is seven days and the warehouse consumer is down for eight days, the stream cannot fully rebuild the warehouse.
 The missing data may still exist in another source, but the stream contract failed.
 
-That is why production stream reviews should include this question:
+That is why production stream reviews should include this question, stated plainly enough that product owners and incident commanders can both understand the consequence:
 
 ```text
 What is the longest credible outage for each consumer,
 and does retention exceed that outage plus detection and repair time?
 ```
 
-If the answer is no, increase retention, add a cold archive, or stop claiming the stream can rebuild that projection.
+If the answer is no, increase retention, add a cold archive, or stop claiming the stream can rebuild that projection. The worst answer is to keep a short retention window while telling downstream teams that replay is their disaster recovery plan.
 
-## Kafka vs NATS JetStream Operator Postures
+## Architecture Patterns That Reuse the Log
 
-Kafka and NATS JetStream overlap, but they do not feel the same to operate.
-The difference is not simply "big versus small."
-It is the shape of the guarantees, clients, and operational ecosystem.
+Publish/subscribe and queues are often mentioned together, but they solve different coordination problems. In publish/subscribe, a producer publishes a fact once and many independent subscribers may react to it. In a work queue, one item is usually assigned to one worker from one logical pool. Streaming logs can support both shapes, but the platform should name which one a stream is serving. A long-retention order event stream with several consumer groups is a pub/sub and replay primitive; a work-queue stream for image resizing is a durable worker distribution primitive that should not pretend to be the source of business history.
 
-Kafka is a distributed commit log with a large data engineering ecosystem.
-It shines when teams need high-throughput durable logs, partitioned replay, long retention, stream processing integrations, schema governance, and mature Kubernetes automation through Strimzi.
+The log as a shared source of truth is the pattern behind many modern data platforms. A service records domain events, downstream consumers build tables, indexes, feature stores, caches, alerts, and lakehouse tables, and each derived view records how far it has read. Kreps calls out the duality between tables and event logs: a table is the current state at a point in the log, while the log is the sequence of changes that can produce tables. That idea explains why change data capture, event sourcing, and stream processing keep reappearing in different tool ecosystems.
 
-NATS is a connective technology built around subjects, low latency, request/reply, and simple service communication.
-JetStream adds persistence and replay without turning NATS into a Kafka clone.
-It shines when teams want lightweight messaging, edge-to-cloud deployments, pull-based work distribution, request-adjacent workflows, or lower operational surface area.
+Kappa and Lambda architectures are two ways to organize this relationship between historical and real-time computation. Lambda keeps a batch layer for recomputing authoritative views and a speed layer for low-latency updates, then merges the two. Kappa tries to simplify the design by using the same streaming path for live processing and replay, so history is reprocessed by reading the log again. The durable tradeoff is not branding; it is whether one unified processing path can handle both live latency and historical correction without making replay too risky or too slow.
 
-### Decision Table
+Event sourcing and CQRS take the log idea into application architecture. Event sourcing stores state changes as events and derives current state by applying them in order. CQRS separates the write model that validates commands from read models optimized for queries. Those patterns can be powerful, but they also raise hard questions about schema evolution, replay duration, snapshotting, and operational repair. Module 1.8 covers CloudEvents and event-driven architecture more directly; in this module, remember that event sourcing is not required for every event stream, and every event stream is not automatically an event-sourced system.
 
-| Criterion | Kafka posture | NATS JetStream posture | Default choice when this dominates |
+Dead-letter queues and replay paths are part of the architecture, not cleanup afterthoughts. A consumer may reject an event because the payload violates schema, because a referenced entity is missing, because a downstream API is unavailable, or because the handler contains a bug. Retrying forever can block progress, while dropping the event loses history. A dead-letter path preserves the failed record with enough metadata to inspect, repair, and reprocess it. A replay path defines how corrected code reads retained history without overwhelming production sinks or duplicating external side effects.
+
+Backpressure and flow control close the loop between architecture and operations. A pub/sub diagram can make every downstream consumer look independent, but they still share broker storage, network, retention, and sometimes sink capacity. A replaying analytics consumer can starve operational consumers if reads are not limited. A hot key can make one partition the bottleneck while averages look fine. A durable streaming architecture therefore includes not only topics and consumers, but also quotas, priorities, replay windows, owner escalation, and observability for each stage.
+
+## Landscape Snapshot and Tool Rosetta
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> Kafka, Flink, Spark Structured Streaming, Airflow, NATS JetStream, CloudEvents, and lakehouse table formats all appear in cloud-native data platforms, but they are not interchangeable products in one ranked list. Kafka is commonly used as a partitioned replay log, NATS JetStream adds persistence and replay to a subject-based messaging system, Flink and Spark process streams, Airflow orchestrates scheduled workflows, and CloudEvents standardizes event metadata. Treat these as peers in a capability map, then verify current versions, operators, APIs, and deployment guidance in the tool-specific modules or upstream docs before making implementation choices.
+
+| Durable capability | Kafka-shaped option | NATS JetStream-shaped option | Stream processing option | Orchestration or table option |
+|---|---|---|---|---|
+| Replayable transport | Partitioned topics, offsets, retention, consumer groups | Streams, subjects, durable consumers, acknowledgments | Reads from transports and writes derived streams or tables | Airflow may trigger batch jobs; table formats retain analytic history |
+| Ordering and parallelism | Per-partition order controlled by key and partition count | Stream and subject order, with consumer mode shaping delivery | Keyed state and operator parallelism define processing order | Table commits define snapshot order, not message delivery order |
+| Failure recovery | Producer idempotence, replication, transactions, offset commits | Publish acknowledgments, explicit acks, redelivery, duplicate windows | Checkpoints, savepoints, state backends, replay from source | Task retries, idempotent jobs, ACID table commits |
+| Schema and contract | Schema registry patterns and compatibility policies | Envelope discipline and subject conventions | Typed pipelines and compatibility checks at boundaries | Table schema evolution and metadata history |
+| Platform ownership | Broker, topic, schema, quota, retention, and consumer group policy | Server, account, stream, subject, consumer, and limit policy | State storage, checkpoint location, job upgrades, and backfills | DAG ownership, table ownership, compaction, retention, and governance |
+
+Kafka and NATS JetStream overlap, but they do not feel the same to operate because the abstractions lead teams to different first questions. Kafka asks you to reason early about topics, partitions, keys, replication, offsets, consumer groups, and retention. NATS asks you to reason early about subjects, service communication, stream capture, consumers, acknowledgments, and account limits. Neither posture is universally better. The useful decision is to match the workload's ordering model, replay depth, latency target, team skill, Kubernetes operating model, and surrounding ecosystem.
+
+| Criterion | Kafka posture | NATS JetStream posture | Strong fit signal |
 |---|---|---|---|
-| Throughput | Built for sustained high-throughput logs across many partitions and brokers. | Very fast for messaging; persistent streams can scale well but are usually chosen for simpler operational shape and lower latency. | Kafka for very large analytic event logs. |
-| Latency | Low enough for most pipelines, but batching and replication are usually tuned for throughput and durability. | Often chosen for very low-latency service messaging and request/reply with optional persistence. | NATS when tail latency matters more than replay depth. |
-| Ordering model | Strong order within each partition; key choice controls business order. | Order is natural within a stream or ordered consumer view; queue and pull patterns can distribute work without Kafka-style partitions. | Kafka when per-key partitioned logs are the core abstraction. |
-| Operational complexity | More moving parts: brokers, controllers, storage, topic configs, rebalances, quotas, schema ecosystem. | Smaller operational surface for many cases; JetStream still requires storage, replicas, limits, and careful stream design. | NATS for smaller platform teams or edge clusters. |
-| Kubernetes operator maturity | Strimzi is a mature, widely used Kafka operator with Kafka, topic, user, and connector patterns. | Official NATS Helm charts are common; JetStream stream and consumer CRDs exist, but the ecosystem is narrower than Strimzi's Kafka lifecycle coverage. | Kafka when K8s-native Kafka lifecycle automation is a hard requirement. |
-| Ecosystem | Kafka Connect, Kafka Streams, Flink, Spark, Schema Registry patterns, lakehouse ingestion. | NATS services, request/reply, key-value, object store, edge messaging, simple client model. | Match the surrounding platform more than the benchmark. |
-| Failure posture | Durable log first; consumers can be far behind if retention permits. | Messaging fabric first with optional durable streams and explicit ack behavior. | Kafka for replay-heavy data platforms; NATS for service communication with selective durability. |
+| Replay depth | Designed around durable partitioned logs and independent consumer group offsets. | Adds replayable persistence to subject-based messaging. | Use the log-shaped posture when many teams replay history independently. |
+| Latency shape | Often tuned by batching, replication, and throughput goals. | Often attractive for request-adjacent messaging and pull-based workers. | Use the subject-shaped posture when service messaging dominates and replay is selective. |
+| Ordering model | Per-partition order; key choice controls business order. | Stream and consumer configuration shape observed order. | Choose the model whose ordering boundary matches the business invariant. |
+| Operations | Broker storage, partition placement, quotas, rebalances, schemas, and retention need explicit ownership. | Accounts, subjects, streams, replicas, pending limits, and consumers need explicit ownership. | Pick the system your platform can operate during failure, not the one with the shortest demo. |
+| Ecosystem fit | Connectors, stream processors, schema registries, and lakehouse ingestion often expect a Kafka-shaped log. | Service meshes, request/reply, edge messaging, and lightweight workers may fit a NATS-shaped fabric. | Match the neighboring tools and teams before optimizing an isolated benchmark. |
 
-No table replaces a proof of concept.
-But the table prevents a common mistake: choosing Kafka for every message or choosing NATS for a long-retention analytic backbone because the first demo was simpler.
+No table replaces a proof of concept, but the table prevents two common mistakes: choosing Kafka for every message because the data team already runs it, or choosing NATS JetStream for a long-retention analytic backbone because a first demo was simpler. A serious proof of concept should test the specific failure modes you care about: producer retry, broker restart, consumer crash after side effect, hot key, replay under load, late data, schema change, and retention boundary.
 
-### Kubernetes Manifests: Same Intent, Different Posture
-
-In Strimzi, a topic is an explicit Kubernetes resource.
-This example sets partitions, replicas, and retention.
+The manifest-level expression changes by tool, and that is why this conceptual module avoids pinning a CRD as the lesson. The durable contract is the same whether a later module expresses it as a `KafkaTopic`, a NATS stream, a Terraform resource, or a managed-service setting: name the owner, key, ordering invariant, replication or durability target, retention policy, replay expectation, schema compatibility rule, and consumer responsibilities. A concise design sketch like the one below is often more valuable in review than a copied manifest with unclear semantics.
 
 ```yaml
-apiVersion: kafka.strimzi.io/v1beta2
-kind: KafkaTopic
-metadata:
-  name: orders-events
-  labels:
-    strimzi.io/cluster: data-kafka
-spec:
-  partitions: 6
-  replicas: 3
-  config:
-    retention.ms: 604800000
-    cleanup.policy: delete
-    min.insync.replicas: 2
+streamContract:
+  name: orders.events
+  owner: checkout-platform
+  semanticRole: replayable-domain-event-log
+  key: orderId
+  orderingInvariant: "All lifecycle facts for one order are processed in order."
+  retention:
+    mode: time
+    minimum: 35d
+    reason: "Supports fraud replay plus operational recovery buffer."
+  consumers:
+    - name: warehouse-projector
+      deliveryTarget: at-least-once
+      duplicateDefense: "Idempotent projection update keyed by event_id."
+    - name: fraud-experiment-runner
+      deliveryTarget: replayable-at-least-once
+      duplicateDefense: "Experiment output deduplicates by event_id and run_id."
 ```
 
-In JetStream, a stream captures subjects and applies retention limits.
-The exact CRD version can change with the installed controller, so operators should verify it against their cluster.
+## Patterns & Anti-Patterns
 
-```yaml
-apiVersion: jetstream.nats.io/v1beta2
-kind: Stream
-metadata:
-  name: orders-events
-spec:
-  name: ORDERS
-  subjects:
-    - orders.>
-  storage: file
-  replicas: 3
-  retention: limits
-  maxAge: 168h
-  discard: old
-```
+Patterns are useful when they name a repeatable shape and the reason it works. Anti-patterns are useful when they name a tempting shortcut and the failure it creates. Streaming has both because the same broker can support clean event-driven decoupling or hide a fragile chain of distributed side effects.
 
-Both examples are "streaming."
-They express different operator instincts.
-Kafka asks you to reason about partitions early.
-JetStream asks you to reason about subjects, stream capture, consumers, and limits early.
+### Pattern: Publish Facts, Not Instructions
 
-### When Not to Use Streaming
+Publish events when the domain decision has already happened and other systems need to learn from it. `PaymentCaptured` lets accounting, fraud, support, and analytics build their own views without forcing the payment path to call every consumer. The producing service still owns the command validation and transaction that created the fact, while the stream distributes the result. This pattern keeps the source of truth clear: commands ask for change, events record change.
 
-Streaming is attractive because it sounds future-proof.
-It can also be the wrong tool.
+### Pattern: Build Projections From Replayable History
 
-The anti-pattern is not "using Kafka" or "using NATS."
-The anti-pattern is making a simple coordination problem harder by adding replay, partitioning, offset management, retention, and eventual consistency without a business need.
+Use streams to build read models, indexes, lakehouse ingestion jobs, and feature pipelines when those derived views can be rebuilt from retained history. The projection should store its consumed position, apply events idempotently, and have a documented replay plan that protects production sinks from overload. This pattern gives teams a recovery path after bad code, schema mistakes, or lost derived storage because the projection is not the only copy of the facts.
+
+### Pattern: Separate Operational and Experimental Consumers
+
+Give operational consumers and experimental consumers different consumer groups, quotas, alert policies, and replay windows. A warehouse projection that supports support agents has different urgency than a fraud experiment replaying last month's history. Separating them lets the platform protect business-critical lag while still allowing exploration. The anti-pattern is letting a backfill or model experiment compete invisibly with production consumers for broker, network, or sink capacity.
+
+### Pattern: Treat Schemas as Compatibility Contracts
+
+Every event schema is a compatibility promise between a producer and current or future consumers. A producer can add optional fields more safely than it can rename required ones; a consumer can ignore unknown fields more safely than it can assume every producer deploys at the same time. Whether the platform uses a registry or a simpler review process, the durable rule is the same: schema evolution must be deliberate because replay means old events and new code will meet.
+
+### Anti-Pattern: Streaming Because It Sounds Future-Proof
+
+Streaming is attractive because it sounds future-proof, but it can be the wrong tool. The anti-pattern is not "using Kafka" or "using NATS." The anti-pattern is making a simple coordination problem harder by adding replay, partitioning, offset management, retention, schema evolution, and eventual consistency without a business need.
 
 ### Anti-Pattern: Synchronous Request/Response Hidden in a Stream
 
-If a user clicks "Place Order" and the API must return a payment authorization immediately, a stream is usually not the request path.
-Use synchronous HTTP, gRPC, or NATS request/reply for the decision that must happen now.
-Publish an event after the decision.
+If a user clicks "Place Order" and the API must return a payment authorization immediately, a stream is usually not the request path. Use synchronous HTTP, gRPC, or request/reply messaging for the decision that must happen now, then publish an event after the decision. The event records the fact; it should not pretend that an asynchronous consumer is part of the immediate user response.
 
 ```text
 Good shape:
@@ -675,39 +660,59 @@ It does not pretend an asynchronous consumer is part of the immediate user respo
 
 ### Anti-Pattern: Single Durable Worker With No Replay Need
 
-If there is exactly one logical consumer and messages should disappear after work completes, a durable queue may be a better fit.
+If there is exactly one logical consumer and messages should disappear after work completes, a durable queue may be a better fit. You can implement one-off background jobs with a stream, but the stream's extra concepts should pay for themselves through replay, fan-out, auditability, or shared history.
 
-Examples:
+Examples that often do not need a replayable event log include these worker-style tasks:
 
 - Resize uploaded images.
 - Send a password reset email.
 - Run one background export job.
 - Trigger a one-off cache warm task.
 
-You can implement these with a stream.
-But if nobody needs fan-out or replay, the stream's extra concepts may not pay rent.
+You can implement these with a stream, and sometimes that is reasonable if the platform already standardizes on one broker. But if nobody needs fan-out or replay, the stream's extra concepts may not pay rent, and an ordinary work queue can be easier to secure, monitor, and explain during incidents.
 
 ### Anti-Pattern: Replacing OLTP
 
-A stream is not a replacement for the database that enforces current transactional state.
+A stream is not a replacement for the database that enforces current transactional state. The log records facts and distributes change, but the system that validates a command still needs a transactional boundary for uniqueness, balance checks, locks, authorization, and current-state decisions.
 
-Do not ask a stream to answer:
+Do not ask a stream to answer questions that require immediate, authoritative state:
 
 - "Is this username available right now?"
 - "Can this account spend this balance?"
 - "Did this unique invoice number already get issued?"
 - "Which row should this transaction lock?"
 
-Those are OLTP questions.
-Use a database transaction.
-Then publish the event describing what happened.
+Those are OLTP questions. Use a database transaction or another authoritative state system to make the decision, then publish the event describing what happened. The stream can feed projections of that decision, but it should not become the thing that pretends eventual state is immediate state.
 
 ### Anti-Pattern: Infinite Retention Without Ownership
 
-Keeping everything forever sounds safe until storage costs, privacy obligations, and schema drift arrive.
-Every retained stream needs an owner, deletion policy, schema compatibility policy, and replay expectation.
+Keeping everything forever sounds safe until storage costs, privacy obligations, access-control drift, and schema drift arrive. Every retained stream needs an owner, deletion policy, schema compatibility policy, and replay expectation because old data is not just old bytes. It is a long-lived contract with risk attached.
 
-If no team owns those decisions, the stream becomes an expensive archive nobody trusts.
+If no team owns those decisions, the stream becomes an expensive archive nobody trusts. If a team does own them, long retention can be a deliberate product feature rather than a vague hope that storage will make future recovery easy.
+
+## Decision Framework
+
+Use this framework when a team proposes a new stream or wants to move a workflow from request/response or batch into event streaming. The goal is not to force every answer toward streaming. The goal is to make the tradeoff visible before producers, consumers, schemas, retention, and dashboards become hard to change.
+
+| Question | Stream-favoring answer | Non-streaming-favoring answer | Design consequence |
+|---|---|---|---|
+| Is the record a fact about the past? | The producer has already made the domain decision and other systems need to learn it. | The caller needs an immediate decision or a worker needs a private task. | Publish an event only after the authoritative decision. |
+| Does retained history have value? | New consumers, projection rebuilds, audits, or experiments need replay. | The item is useful only until one worker completes it. | Size retention from recovery and replay requirements. |
+| What order must be preserved? | There is a clear entity key such as order, customer, tenant, or device. | Records are independent or require one global sequence. | Key by the invariant or avoid a partitioned stream. |
+| Can consumers tolerate duplicates? | Sinks can deduplicate by event ID or apply idempotent updates. | Duplicate side effects would be unsafe and cannot be guarded. | Use idempotency, transactions, or a different integration pattern. |
+| How late can data arrive? | The business accepts event-time windows, watermarks, and correction policy. | The business needs immediate final answers with no late correction. | Define windowing and lateness before building dashboards. |
+| Who owns operations? | Topic, schema, retention, lag, replay, and dead-letter ownership are named. | Ownership stops at "the platform runs the broker." | Do not launch until the stream has an operating contract. |
+
+```mermaid
+flowchart TD
+    A[Need to communicate between systems] --> B{Is the sender recording a fact that already happened?}
+    B -- No, it needs an immediate decision --> C[Use request/response or command handling]
+    B -- Yes --> D{Do multiple consumers, replay, or audit need the history?}
+    D -- No --> E[Consider a durable queue or simpler async job]
+    D -- Yes --> F{Can you name the ordering key and duplicate strategy?}
+    F -- No --> G[Fix contract: key, idempotency, schema, retention]
+    F -- Yes --> H[Use an event stream with explicit ownership and observability]
+```
 
 ## Did You Know?
 
@@ -866,13 +871,13 @@ The goal is to practice the mental model: log ownership, key choice, delivery se
 
 ### Scenario
 
-You operate three services:
+You operate three services in a small commerce platform, and each one participates in the event design from a different position in the workflow:
 
 - `checkout-api` creates orders and requests payment authorization.
 - `payment-worker` records payment outcomes from a provider.
 - `warehouse-projector` builds a read model for support agents.
 
-The business requirements are:
+The business requirements deliberately mix synchronous decisions, replay needs, duplicate tolerance, and outage recovery so you have to separate integration style from broker preference:
 
 - Support agents must see the correct final state for each order.
 - Fraud analysts need to replay the last thirty days of payment events into experiments.
@@ -885,7 +890,7 @@ The business requirements are:
 Create a short design note with at least two streams.
 For each stream, write the owner, event types, and consumers.
 
-Use this template:
+Use this template as the starting point for your design note, then edit the names and consumers if your reasoning leads to a different stream boundary:
 
 ```yaml
 streams:
@@ -911,9 +916,9 @@ streams:
 
 ### Step 2: Choose Partition Keys
 
-For each stream, choose a key and explain the invariant it protects.
+For each stream, choose a key and explain the invariant it protects. Do not write "hash by ID" without naming the business consequence, because partitioning is how the design turns an abstract ordering requirement into a broker guarantee.
 
-Example:
+The example below chooses `orderId` because the support projection cares about each order's lifecycle being applied in order:
 
 ```yaml
 partitioning:
@@ -925,7 +930,7 @@ partitioning:
     protects: "Payment outcomes for one order are applied in order to the warehouse projection."
 ```
 
-If you choose `customerId` instead, explain what improves and what gets worse.
+If you choose `customerId` instead, explain what improves and what gets worse. Customer-level ordering may help account-wide fraud or entitlement logic, but it may also create hot keys and weaken order-level parallelism.
 
 ### Step 3: Pick Delivery Semantics
 
@@ -947,8 +952,7 @@ consumers:
 
 ### Step 4: Set Retention
 
-Choose retention for each stream.
-Your answer must mention the thirty-day fraud replay and two-day outage requirement.
+Choose retention for each stream, and make the answer trace back to recovery promises rather than storage habit. Your answer must mention the thirty-day fraud replay and two-day outage requirement because both are product requirements expressed as log-retention policy.
 
 ```yaml
 retention:
@@ -964,7 +968,7 @@ retention:
 
 ### Step 5: Define Backpressure Alerts
 
-Add alerts that separate broker pressure from consumer pressure.
+Add alerts that separate broker pressure from consumer pressure. A good alert set should tell responders whether the producer is being throttled, the broker is saturated, the consumer is falling behind, the sink is slow, or retention is close to deleting data a consumer still needs.
 
 ```yaml
 alerts:
@@ -985,7 +989,7 @@ Write a short decision record.
 Use Kafka if your priority is long-retention analytic replay, large fan-out, and mature Strimzi operations.
 Use NATS JetStream if your priority is low-latency service messaging, smaller operational surface, and selective persistence.
 
-Your record should include:
+Your record should include the decision and the risk that would make you revisit it, so the choice remains an operating hypothesis rather than a one-time preference:
 
 - The platform you choose.
 - The reason tied to this scenario.
@@ -1001,6 +1005,23 @@ Your record should include:
 - [ ] Backpressure alerts distinguish lag, retention risk, and producer throttling.
 - [ ] The Kafka vs NATS decision explains operator posture, not only feature preference.
 - [ ] The design explicitly keeps synchronous request/response paths out of the stream.
+
+## Sources
+
+- [Streaming 101: The World Beyond Batch](https://www.oreilly.com/radar/the-world-beyond-batch-streaming-101/)
+- [Streaming 102: The World Beyond Batch](https://www.oreilly.com/radar/the-world-beyond-batch-streaming-102/)
+- [The Dataflow Model](https://research.google/pubs/the-dataflow-model-a-practical-approach-to-balancing-correctness-latency-and-cost-in-massive-scale-unbounded-out-of-order-data-processing/)
+- [The Log: Real-Time Data's Unifying Abstraction](https://engineering.linkedin.com/distributed-systems/log-what-every-software-engineer-should-know-about-real-time-datas-unifying)
+- [Apache Kafka 4.3 Design](https://kafka.apache.org/43/design/design/)
+- [Apache Kafka Streams Core Concepts](https://kafka.apache.org/43/documentation/streams/core-concepts)
+- [Apache Flink: Timely Stream Processing](https://nightlies.apache.org/flink/flink-docs-stable/docs/concepts/time/)
+- [Apache Flink: Stateful Stream Processing](https://nightlies.apache.org/flink/flink-docs-stable/docs/concepts/stateful-stream-processing/)
+- [NATS JetStream Concepts](https://docs.nats.io/nats-concepts/jetstream)
+- [NATS JetStream Model Deep Dive](https://docs.nats.io/using-nats/developer/develop_jetstream/model_deep_dive)
+- [NATS Controllers for Kubernetes](https://github.com/nats-io/nack)
+- [CloudEvents Specification](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md)
+- [Designing Data-Intensive Applications](https://dataintensive.net/)
+- [Kubernetes StatefulSet Documentation](https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/)
 
 ## Next Module
 

--- a/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.8-cloudevents-event-driven-arch.md
+++ b/src/content/docs/platform/disciplines/data-ai/data-engineering/module-1.8-cloudevents-event-driven-arch.md
@@ -3,6 +3,7 @@ title: "Module 1.8: CloudEvents and Event-Driven Architecture on Kubernetes"
 slug: platform/disciplines/data-ai/data-engineering/module-1.8-cloudevents-event-driven-arch
 sidebar:
   order: 9
+revision_pending: false
 ---
 > **Complexity**: Advanced
 >
@@ -24,43 +25,63 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-The checkout team shipped a harmless improvement.
+**Hypothetical scenario:** The checkout team ships a harmless improvement. Instead of calling inventory, billing, fraud, email, loyalty, analytics, and fulfillment directly, the service now emits one `order-placed` event. The architecture diagram looks clean, the checkout API is faster, and the teams are finally decoupled — on paper. Then the first flash sale starts, and the gaps in the event contract become visible under load rather than in a design review.
 
-Instead of calling inventory, billing, fraud, email, loyalty, analytics, and fulfillment directly, the service now emits one `order-placed` event.
-The architecture diagram looks clean.
-The checkout API is faster.
-The teams are finally decoupled.
+Inventory receives the same event twice and reserves two items. Email retries a transient failure and sends customers duplicate receipts. Fraud adds a new field to the payload and the fulfillment consumer crashes because its JSON parser rejects unknown fields. Analytics replays a week of historical orders and accidentally triggers live loyalty credits. The trace in the API gateway ends at the broker, so nobody can see which consumer introduced the delay.
 
-Then the first flash sale starts.
+Nothing in that failure requires Kafka to be broken, and nothing requires Kubernetes to be unhealthy. The system fails because the event contract did not carry enough meaning, the delivery path did not have a failure policy, and the consumers were not safe to run more than once. Event-driven architecture trades synchronous certainty for asynchronous flexibility, and that trade only pays off when the contract, delivery semantics, and consumer safety are designed together rather than assumed.
 
-Inventory receives the same event twice and reserves two items.
-Email retries a transient failure and sends customers duplicate receipts.
-Fraud adds a new field to the payload and the fulfillment consumer crashes because its JSON parser rejects unknown fields.
-Analytics replays a week of historical orders and accidentally triggers live loyalty credits.
-The trace in the API gateway ends at the broker, so nobody can see which consumer introduced the delay.
+CloudEvents fixes the first part by standardizing the envelope so every hop speaks the same metadata language. Knative Eventing fixes much of the Kubernetes wiring by giving platform teams Broker, Trigger, Channel, and Subscription objects that route CloudEvents natively. Idempotent consumer design fixes the uncomfortable truth that event-driven systems usually deliver at least once, not exactly once — and "exactly once" in practice means idempotent side effects plus transactional boundaries, not a magical broker guarantee.
 
-Nothing in that failure requires Kafka to be broken.
-Nothing requires Kubernetes to be unhealthy.
-The system fails because the event contract did not carry enough meaning, the delivery path did not have a failure policy, and the consumers were not safe to run more than once.
-
-CloudEvents fixes the first part by standardizing the envelope.
-Knative Eventing fixes much of the Kubernetes wiring.
-Idempotent consumer design fixes the uncomfortable truth that event-driven systems usually deliver at least once, not exactly once.
-
-This module assumes you already understand the streaming mental model from Module 1.7: logs, partitions, retention, backpressure, and replay.
-Here we move one layer up.
-We design the event contract and the Kubernetes delivery path that make those streaming mechanics usable across teams.
+This module assumes you already understand the streaming mental model from Module 1.7: logs, partitions, retention, backpressure, and replay. Here we move one layer up and design the event contract and the Kubernetes delivery path that make those streaming mechanics usable across teams without turning every integration into a bespoke HTTP callback with incompatible headers and untyped JSON blobs.
 
 > **Stop and think**: If a broker retries an event after a network timeout, how can the consumer know whether the first attempt failed before the business action or after it committed the business action?
 
+## Event-Driven Architecture: Producers, Consumers, and the Event Backbone
+
+Event-driven architecture (EDA) is a style where services communicate by publishing and subscribing to events rather than calling each other synchronously. An **event** is a record that something happened — an order was placed, a payment was captured, a sensor reading crossed a threshold — together with enough metadata for downstream systems to react without the producer knowing who will react or how many consumers exist. The **event backbone** is the durable or semi-durable transport layer — Kafka, NATS JetStream, AMQP brokers, MQTT brokers, or an HTTP-based event mesh such as Knative Eventing — that decouples producers from consumers in time and space.
+
+The durable benefit of EDA is **loose coupling**. The checkout service publishes `order-placed` once; inventory, email, fraud, analytics, and fulfillment each subscribe independently. Adding a new consumer does not require changing the producer's code or redeploying checkout, provided the event contract is stable and extensible. Scaling read-side consumers does not require scaling the writer, because fan-out happens at the broker rather than inside a monolithic orchestrator loop. Teams can deploy on different cadences as long as they honor the published contract for event types they consume.
+
+The durable cost is **eventual consistency** and **debuggability**. When checkout returns success to the customer, inventory may not yet reflect the reservation, email may arrive seconds later, and a failed consumer may leave the system in a partially updated state until retries or human intervention complete. There is no single stack trace that spans "user clicked Buy" through "warehouse picked the item," because work happened asynchronously across services. Operators need correlation identifiers, trace context, and event logs to reconstruct causality — which is exactly why CloudEvents standardizes metadata such as `id`, `source`, `type`, and trace extensions rather than leaving every team to invent header names.
+
+Two coordination styles appear repeatedly in EDA discussions, and conflating them causes design mistakes. **Choreography** means each service reacts to events and may emit further events without a central coordinator: checkout emits `order-placed`, inventory emits `stock-reserved`, billing listens to both and emits `invoice-created`. **Orchestration** means a dedicated process — often a workflow engine or saga coordinator — explicitly commands each step and waits for responses or compensations. Choreography scales team autonomy and avoids a single orchestrator bottleneck; orchestration makes multi-step business processes easier to visualize, timeout, and compensate when one leg fails. Most production systems mix both: choreographed domain events for fan-out, orchestrated sagas for money movement or long-running approvals.
+
+The **distributed monolith trap** is what happens when teams adopt message brokers but keep synchronous coupling disguised as events. If every consumer must receive events in a strict order across the whole company, if payloads are undocumented blobs that only one pair of services understands, or if removing one consumer breaks the producer's assumptions, you have the worst of both worlds — network partitions and retry semantics without independent deployability. A healthy EDA boundary treats events as versioned contracts with explicit delivery semantics (at-least-once by default), idempotent handlers, and schema governance. The backbone stores and routes; it does not magically fix ambiguous business logic.
+
+On Kubernetes, the event backbone often lives partly inside the cluster (Knative Eventing, Strimzi Kafka, NATS operators) and partly outside (managed Kafka, cloud event buses). The platform team's job is to expose a consistent ingress and routing API — CloudEvents over HTTP into a Broker, Kafka headers mapped from CloudEvents attributes, dead-letter sinks with retention — so application teams focus on event types and consumer safety rather than reinventing retry policies per service.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+
+| Capability | CloudEvents | Knative Eventing | Typical backing transport |
+|------------|-------------|------------------|---------------------------|
+| Vendor-neutral event envelope | CNCF Graduated spec v1.0.x | Native CloudEvents routing on Broker/Trigger | N/A (metadata layer) |
+| Kubernetes event mesh API | Bindings for HTTP, Kafka, AMQP, MQTT | Broker, Trigger, Channel, Subscription CRDs | Often Kafka Channel or in-memory MTChannel |
+| Graduation / maturity | Graduated CNCF project (2024) | CNCF incubating project; Eventing GA patterns vary by install | Depends on chosen channel implementation |
+
+CloudEvents answers *what metadata every event carries*; Knative Eventing answers *how Kubernetes routes CloudEvents to subscribers*; Kafka or another broker answers *how events persist and replay*. None replaces the others — they stack.
+
+## EDA Interaction Patterns: Notification, State Transfer, Sourcing, and CQRS
+
+Not every event means the same thing architecturally. Martin Fowler's event-driven taxonomy distinguishes patterns by how much data the event carries and who owns authoritative state. Understanding these patterns prevents teams from using "events" as a synonym for "RPC over Kafka."
+
+**Event notification** is the lightest pattern: the event says that something happened, often with minimal payload, and consumers must call back or query a source of truth if they need details. A `order-placed` event that carries only `orderId` is notification if fulfillment must GET the order from checkout's API. Notification keeps payloads small and reduces coupling to internal data models, but it reintroduces synchronous dependencies and availability requirements on the producer's read API.
+
+**Event-carried state transfer** pushes enough data in the event that consumers can act without a follow-up call. The worked example in this module uses event-carried transfer: the order lines and totals ride in `data`, so inventory can reserve stock without querying checkout. The tradeoff is larger messages, tighter schema coupling, and the need for schema evolution rules — consumers must tolerate unknown fields forward-compatibly and producers must version breaking changes through new `type` or `dataschema` values.
+
+**Event sourcing** goes further: the sequence of events *is* the authoritative state for an aggregate. Instead of updating a row in `orders` and emitting a side event, the system appends `order-placed`, `order-line-added`, `order-cancelled` to an event log and rebuilds current state by replaying them. Event sourcing excels at audit trails, temporal queries ("what did we know at 09:00?"), and replay-driven recovery, but it demands careful handling of schema evolution, snapshotting for read performance, and idempotent projections. CloudEvents fits naturally as the envelope for each appended event: `source` scopes the aggregate stream, `subject` identifies the entity, `sequence` helps detect gaps.
+
+**CQRS (Command Query Responsibility Segregation)** separates the write model from read models optimized for queries. Commands mutate state (or append events); queries hit denormalized projections built by consumers. EDA and CQRS often appear together: write side emits events; read-side projectors build search indexes, dashboards, and cache-friendly views. The failure mode to avoid is treating every read model as authoritative for writes — the write model (or event log) remains source of truth, and projections are eventually consistent.
+
+Two patterns solve the hardest integration problem: **atomic write plus publish**. The **transactional outbox** writes the business row and an outbox row in the same database transaction; a separate relay process reads the outbox and publishes CloudEvents to the broker. That eliminates the race where the database commits but the message never sends (or the message sends and the transaction rolls back). The **saga pattern** coordinates multi-service transactions through a sequence of local transactions plus compensating events: if payment succeeds but inventory fails, emit `payment-refund-requested` rather than holding a distributed lock across services. Sagas can be choreographed (each service knows the next event to emit) or orchestrated (a workflow engine drives steps). Both patterns assume at-least-once delivery and therefore require idempotent consumers and clear correlation IDs in CloudEvents extensions or payload fields.
+
+Schema registries and contract testing belong at this layer. When ten teams consume `com.acme.orders.order-placed.v1`, compatibility modes (backward, forward, full) define whether a new producer can talk to old consumers and vice versa. A backward-compatible change adds optional fields; an incompatible change needs a new event type or schema URI. Consumer-driven contract tests — loading sample CloudEvents from the registry and asserting handlers behave — catch breaking changes before production, which is cheaper than debugging DLQ spikes after a Friday deploy.
+
 ## The Contract: CloudEvents as the Envelope
 
-An event-driven architecture needs two contracts:
+An event-driven architecture needs two contracts working in tandem, and teams that collapse them into one undocumented JSON blob pay for that shortcut during the first serious incident. The **payload contract** describes the business data — fields, types, required versus optional attributes, and semantic meaning of values such as currency codes or SKU identifiers. The **envelope contract** describes the event itself — who emitted it, what kind of occurrence it represents, when it happened, how to deduplicate it, and how to route it without parsing business-specific payloads.
 
-1. The **payload contract** describes the business data.
-2. The **envelope contract** describes the event itself.
-
-Teams often start with only the payload:
+Teams often start with only the payload, which feels expedient because product managers speak in domain objects rather than transport metadata.
 
 ```json
 {
@@ -71,12 +92,11 @@ Teams often start with only the payload:
 }
 ```
 
-That object is useful, but middleware cannot safely route it without understanding your business schema.
-A broker does not know whether `orderId` is an idempotency key, a subject, or just a field.
-A tracing system cannot infer the parent trace.
-A schema registry cannot tell whether this payload is compatible with the previous version.
+That object is useful for a single producer-consumer pair, but middleware cannot safely route it without understanding your business schema. A broker does not know whether `orderId` is an idempotency key, a subject identifier, or just another field among many. A tracing system cannot infer the parent trace from arbitrary JSON. A schema registry cannot tell whether this payload is compatible with the previous version unless you bolt on conventions every team interpre differently.
 
-CloudEvents adds a small, standard envelope:
+CloudEvents is a [CNCF Graduated](https://www.cncf.io/projects/cloudevents/) specification — currently at **v1.0** for production use — that adds a small, standard envelope around your payload. Graduation matters because it signals long-term stewardship across vendors and clouds, not a single company's proprietary header set. The spec defines required context attributes, optional core attributes, extension points, serializations (JSON and others), and protocol bindings so the same logical event can traverse HTTP webhooks, Kafka topics, AMQP exchanges, and MQTT topics without rewriting metadata at every hop.
+
+CloudEvents adds a small, standard envelope. The example below shows JSON structured content with commonly used extensions; your cluster may map these attributes to HTTP `ce-*` headers or Kafka record headers per the binding you choose:
 
 ```json
 {
@@ -107,8 +127,7 @@ CloudEvents adds a small, standard envelope:
 }
 ```
 
-CloudEvents does not force one broker, one language, or one payload format.
-It gives every hop a shared vocabulary:
+CloudEvents does not force one broker, one language, or one payload format. It gives every hop a shared vocabulary so gateways, service meshes, and observability backends can treat events as first-class telemetry rather than opaque POST bodies.
 
 ```text
 +---------------- CloudEvents context ----------------+
@@ -126,13 +145,11 @@ It gives every hop a shared vocabulary:
 +------------------------------------------------------+
 ```
 
-The separation matters because brokers and platform tools can route, filter, trace, and dead-letter events without opening the payload.
-Consumers can evolve payload parsing without changing transport code.
-Operators can inspect failed events and know where they came from.
+The separation matters because brokers and platform tools can route, filter, trace, and dead-letter events without opening the payload. Consumers can evolve payload parsing without changing transport code, and operators can inspect failed events in a DLQ knowing exactly which producer and event type failed rather than guessing from nested JSON fields.
 
 ### Required CloudEvents v1.0 Attributes
 
-Every CloudEvent v1.0 must include four context attributes.
+Every CloudEvents v1.0 event must include four context attributes, and omitting any one of them makes the event non-compliant with the spec regardless of how sensible your custom headers look to your team.
 
 | Attribute | Type | What it means | Operator check |
 |-----------|------|---------------|----------------|
@@ -141,18 +158,13 @@ Every CloudEvent v1.0 must include four context attributes.
 | `specversion` | String | The CloudEvents specification version | Use `1.0` unless you are intentionally testing a newer draft |
 | `type` | String | The semantic event type | Version the meaning, not the transport |
 
-The most important subtlety is `id`.
-It is not required to be globally unique by itself.
-It is unique in combination with `source`.
-That means two producers may both emit `id: "123"`, but `source: "/checkout/orders"` and `source: "/billing/invoices"` make them different event identities.
+The most important subtlety is `id`, which identifies a specific event occurrence rather than the business entity described in the payload. It is not required to be globally unique by itself; uniqueness is defined in combination with `source`, meaning two different producers may both emit `id: "123"` without collision because their `source` values differ. That scoping rule is why idempotency keys must be `source + id` rather than bare `id` or payload business IDs alone.
 
-Use `source + id` for deduplication.
-Do not use only the payload's business ID.
-One order can produce multiple legitimate events: placed, authorized, packed, shipped, refunded.
+Use `source + id` for deduplication at consumers, and treat `type` as the semantic version of meaning — for example `com.acme.orders.order-placed.v1` encodes both domain and contract generation. One order can legitimately produce many events over its lifetime (`order-placed`, `order-authorized`, `order-shipped`), each with a distinct `id` but the same `subject` pointing at `orders/ord-1001`.
 
 ### Optional Core Attributes
 
-Most production systems should use more than the required four.
+Most production systems should use more than the required four attributes because routing, observability, and schema governance all depend on metadata that the spec makes optional but operators quickly treat as mandatory.
 
 | Attribute | Use it when | Common mistake |
 |-----------|-------------|----------------|
@@ -161,13 +173,9 @@ Most production systems should use more than the required four.
 | `subject` | You need to filter or troubleshoot by the business object | Hiding all identity inside `data` |
 | `time` | Consumers need occurrence time, not broker arrival time | Setting it inconsistently across producers |
 
-`subject` is not a replacement for the payload.
-It is a routing and observability hint.
-For an order system, `subject: "orders/ord-1001"` lets a generic trigger select a specific order family without parsing the JSON body.
+`subject` is not a replacement for the payload; it is a routing and observability hint that lets generic infrastructure filter or partition work by business entity without JSON parsing. For an order system, `subject: "orders/ord-1001"` lets a Knative Trigger or Kafka consumer route troubleshooting queries to the correct entity timeline while keeping the full line items inside `data`.
 
-`dataschema` should point to a durable schema identifier.
-That can be an HTTPS URL, a schema registry URI, or an internal catalog path.
-The important behavior is that incompatible changes get a different schema identifier.
+`dataschema` should point to a durable schema identifier — an HTTPS URL, a schema registry URI, or an internal catalog path — and incompatible payload changes must receive a new identifier or a new `type`. Treating schema compatibility as a wiki convention fails the first time a producer deploys on Friday evening and a consumer team is paged because an unknown field appeared.
 
 ### Extension Attributes That Matter in Production
 
@@ -181,38 +189,19 @@ The extensions below are especially useful on Kubernetes.
 | `partitionkey` | String | Communicates the key that should preserve per-entity ordering in partitioned transports |
 | `sequence` | String | Communicates relative ordering within a source-defined sequence |
 
-`traceparent` does not replace protocol headers.
-For a direct HTTP hop, you normally send the W3C `traceparent` HTTP header and the CloudEvents `traceparent` extension when your event may cross transports.
-When the event moves through Kafka or another broker, the CloudEvents extension keeps the original trace context with the event.
+`traceparent` does not replace protocol headers when both are available on the same hop. For a direct HTTP POST into Knative, you normally send the W3C [`traceparent` header](https://www.w3.org/TR/trace-context/) and mirror the value in the CloudEvents `traceparent` extension when the event may later cross transports where HTTP headers no longer exist. When the event moves through Kafka or another broker, the CloudEvents extension keeps the original trace context attached to the message so consumer instrumentation can continue the trace instead of starting an orphan root span.
 
-`partitionkey` is not magic ordering.
-It is a hint that must be mapped into the transport.
-For Kafka, it should become the record key.
-For NATS JetStream, it may become a subject segment or message header depending on your design.
-For HTTP, it is only metadata unless the receiver forwards it into a partitioned system.
+`partitionkey` is a hint that must be mapped into the transport by your producer SDK or bridge — it is not automatic ordering magic. For Kafka, it should become the record key so all events for `ord-1001` land in one partition and preserve per-key order. For NATS JetStream, it may become a subject segment or message header depending on your subject hierarchy design. For HTTP-only paths, it is metadata unless the receiver forwards it into a partitioned downstream system.
 
-`sequence` is also a hint.
-If you need strict order, you still need a single ordered stream for that entity and consumers that process one event at a time for that key.
-The sequence value helps detect gaps, stale updates, or replay mistakes.
+`sequence` helps detect gaps, stale updates, or replay mistakes when a source emits an ordered stream for one entity. If you need strict order, you still need a single ordered stream for that entity and consumers that process one event at a time for that key; sequence numbers alert you when `1003` arrives without `1002`, which is invaluable for inventory projectors and dangerous to ignore for best-effort email senders.
 
 > **Pause and predict**: A consumer sees `sequence: "0000000000001003"` for `subject: "orders/ord-1001"` but never saw sequence `0000000000001002`. Should it process immediately, wait, or alert? What changes if the consumer is an email sender versus an inventory projector?
 
 ## Transport Bindings: Same Event, Different Wire
 
-CloudEvents has event formats and protocol bindings.
-The event format describes how the event is serialized.
-The protocol binding describes how CloudEvents attributes map onto a transport.
+CloudEvents separates **event formats** (how attributes and data serialize) from **protocol bindings** (how those attributes map onto HTTP, Kafka, AMQP, NATS, or MQTT). The same logical CloudEvent can move as HTTP headers plus a JSON body, as Kafka record headers plus value, or as a single JSON envelope in structured mode — and choosing among them is an operational decision about latency, durability, ordering, and who operates the backbone, not a moral judgment about which protocol is fashionable this quarter.
 
-The same event can move as:
-
-- HTTP headers plus a JSON body.
-- Kafka headers plus record value.
-- AMQP message properties plus body.
-- NATS message headers plus body.
-- MQTT user properties plus payload.
-
-The binding choice is an operational decision.
-It should follow workload shape, not fashion.
+The binding choice should follow workload shape and team capabilities. High-volume analytics pipelines that need replay and fan-out usually anchor on Kafka with the [Kafka protocol binding](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/kafka-protocol-binding.md). Webhook-style integrations and Knative ingress favor the [HTTP protocol binding](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/http-protocol-binding.md). Device telemetry may enter through MQTT before normalization. The [CloudEvents primer](https://github.com/cloudevents/spec/blob/main/cloudevents/primer.md) walks through these mappings in vendor-neutral language, which is the right reference when your platform team standardizes one internal mapping table for all application producers.
 
 | Binding | Best fit | Latency posture | Throughput posture | Ordering posture | Kubernetes operator concern |
 |---------|----------|-----------------|--------------------|------------------|-----------------------------|
@@ -222,46 +211,21 @@ It should follow workload shape, not fashion.
 | NATS | Low-latency service events, edge control planes, JetStream durability | Very low for core NATS; JetStream adds durability cost | High for small messages | Subject and stream configuration dependent | Retention, ack wait, and subject hierarchy design |
 | MQTT | IoT, unreliable networks, device telemetry | Low over constrained links | Moderate; optimized for many small device messages | Topic and QoS dependent, not a global log | Session state, retained messages, and device auth |
 
-HTTP is the easiest way into Knative Eventing because Knative sinks receive CloudEvents over HTTP POST.
-That does not mean HTTP should be your durable event store.
-It means HTTP is a clean ingress and delivery shape.
+HTTP is the easiest way into Knative Eventing because Knative sinks receive CloudEvents over HTTP POST with `ce-*` headers in binary mode. That does not mean HTTP should be your durable event store — HTTP ingress is a clean front door, not a substitute for retention, partitioning, and consumer groups when you need replay after outages.
 
-Kafka is usually the durable backbone when the workload needs replay and high fan-out.
-The tradeoff is operational: keys, partitions, retention, and consumer groups become part of your platform contract.
-
-AMQP is often strong when routing topology is rich and messages are work items.
-It is less natural as a long-term analytical event log.
-
-NATS is excellent when the subject namespace is the architecture.
-Core NATS favors speed and simplicity; JetStream adds persistence and replay.
-Do not assume those modes have the same failure behavior.
-
-MQTT shines when the producers are devices.
-CloudEvents over MQTT can normalize device events before they enter the rest of the platform.
+Kafka is usually the durable backbone when the workload needs replay and high fan-out, but the tradeoff is operational ownership: partition keys, retention policies, replication factor, in-sync replica health, and consumer lag become part of your platform contract rather than hidden inside a managed webhook. AMQP shines when routing topology is rich and messages behave like work items in queues, though it is less natural as a long-term analytical event log unless you deliberately architect retention and replay tooling. NATS is excellent when the subject namespace is the architecture — core NATS favors speed and simplicity while JetStream adds persistence and replay with different failure semantics you must not conflate. MQTT fits constrained device networks where QoS levels and session state dominate design conversations before CloudEvents normalization even begins.
 
 ### Binary Versus Structured Mode
 
-CloudEvents bindings often support two modes:
+CloudEvents bindings often support **binary mode**, where context attributes map to transport metadata and `data` remains the raw payload body, and **structured mode**, where the entire CloudEvent including `data` serializes as one envelope document such as `application/cloudevents+json`.
 
-| Mode | Description | Example use |
-|------|-------------|-------------|
-| Binary | CloudEvents attributes map to transport metadata; payload stays as the body | HTTP `ce-type` headers plus JSON body |
-| Structured | The whole CloudEvent, including `data`, is serialized as one envelope | A JSON CloudEvent stored as a message body |
-
-Binary mode is ergonomic when the transport has good metadata support.
-HTTP and Kafka both fit this pattern well.
-
-Structured mode is easier to store, replay, and inspect as a single object.
-It can be useful for DLQs because the failed event remains self-contained.
-
-In practice, many platforms accept both at boundaries but choose one internally.
-For the worked example in this module, we use HTTP binary mode at the Knative ingress because that is how most Knative sinks are exercised.
+Binary mode is ergonomic when the transport has rich metadata support — HTTP and Kafka both map attributes to headers cleanly, which is why Knative sinks commonly expect binary HTTP CloudEvents. Structured mode is easier to store, replay, and inspect as a single self-contained object, which makes it attractive for DLQ archives and object-store retention where you want auditors to fetch one JSON file and see the full context without reassembling headers. Many platforms accept both at boundaries but standardize one mode internally to reduce test matrix size; document that choice for application teams so producers do not mix modes against the same subscriber without explicit conversion.
 
 ## Knative Eventing Primitives
 
-Knative Eventing gives Kubernetes-native objects for event routing.
-It does not remove the need to understand the broker underneath.
-It gives platform teams a standard API surface.
+[Knative Eventing](https://knative.dev/docs/eventing/) provides Kubernetes-native custom resources for routing CloudEvents so application teams publish to a Broker without maintaining a list of subscriber URLs. Knative does not remove the need to understand the broker underneath — Kafka lag, channel capacity, and ingress TLS remain real — but it gives platform teams a consistent API surface that mirrors how developers already think about Kubernetes Services and Deployments.
+
+The mental model is a pipeline from producer to subscriber with filtering in the middle. Producers send CloudEvents over HTTP to a Broker ingress; Triggers attach filters on attributes such as `type` and `source`; subscribers receive HTTP deliveries to Knative Services or plain Kubernetes Services. Channels and Subscriptions appear when you want explicit stream topology rather than the Broker abstraction alone, which is common for audit fan-out or data-platform pipelines that treat the channel name as part of the contract.
 
 ```text
 Producer
@@ -466,17 +430,13 @@ spec:
         namespace: commerce
 ```
 
-Use Broker and Trigger for most application eventing.
-Use Channel and Subscription when you intentionally manage the stream topology.
+Use Broker and Trigger for most application eventing where producers should not know consumers. Use Channel and Subscription when you intentionally manage the stream topology — for example, an `order-audit` channel that multiple compliance consumers attach to with independent delivery policies. Some Broker implementations use channels internally; that detail matters to platform engineers tuning Kafka partitions but not to application developers publishing `order-placed` events.
+
+Delivery configuration on Broker, Trigger, Channel, and Subscription resources — retry counts, exponential backoff, and `deadLetterSink` references — is the platform-level failure policy. It complements but never replaces idempotent consumers: if your inventory service double-reserves on duplicate delivery, no amount of broker tuning fixes that logic bug.
 
 ## Dead-Letter Queue Design
 
-Dead-letter queues are not trash cans.
-They are evidence.
-They hold events that could not be delivered or processed within the allowed retry budget.
-
-The central question is not "Do we need a DLQ?"
-The central question is "Which component owns each retry?"
+Dead-letter queues are not trash cans where failed messages disappear — they are evidence lockers that hold events which could not be delivered or processed within the allowed retry budget, together with enough context for a human or runbook to decide whether replay is safe. The central design question is not "Do we need a DLQ?" but "Which component owns each retry layer, and what metadata do we preserve so replay does not become a second incident?"
 
 ```mermaid
 flowchart TD
@@ -502,17 +462,11 @@ flowchart TD
 | Broker retry | Subscriber unavailable, network timeout, cold start | Business validation failures | Small count with exponential backoff |
 | DLQ replay | Fixed bugs, restored downstream service, manual remediation | Blind automatic reprocessing | Human or runbook gated |
 
-Consumer retries should be tiny.
-If the consumer retries for minutes, the broker sees one long request and cannot route the event elsewhere.
-Long consumer retries also tie up pods and hide backpressure.
+Consumer retries should be tiny — milliseconds to a few seconds for dependency blips inside one HTTP request — because long in-request loops hide backpressure from the broker and tie up pods. If the consumer retries for minutes, Knative sees one hung request, cannot redeliver to another replica promptly, and operator dashboards show misleading "slow consumer" symptoms instead of clear failure signals.
 
-Broker retries should handle delivery failures.
-They should not compensate for non-idempotent consumers.
-If the consumer commits a side effect and then returns `500`, the broker cannot know that the side effect happened.
+Broker retries should handle subscriber unavailability, network timeouts, and cold starts with a small count and exponential backoff configured on the Trigger or Broker `delivery` section. They should not compensate for non-idempotent consumers: if the consumer commits a side effect and then returns `500`, the broker cannot know the side effect happened and will redeliver, which is why business validation failures often belong in a rejection workflow rather than infinite broker retry.
 
-DLQ replay should be explicit.
-The replay tool should preserve the original CloudEvents context unless you intentionally create a new event.
-Add a replay marker such as `replayattempt` or `replayreason` if your platform standard allows it.
+DLQ replay should be explicit, runbook-gated, and preservationist about CloudEvents identity. The replay tool should preserve original `source`, `id`, `type`, and `data` unless you intentionally emit a new event with a new `id` for audit separation. Add replay metadata through extensions such as `replayattempt` when your platform standard supports it so consumers can distinguish live traffic from recovery traffic.
 
 ### DLQ Sink Shape
 
@@ -575,23 +529,17 @@ The DLQ service should store:
 
 ## Idempotent Consumers With Redis `SET NX`
 
-At-least-once delivery means duplicates are normal.
-They are not rare edge cases.
-Every consumer that performs side effects must decide how it behaves when the same CloudEvent arrives again.
+At-least-once delivery means duplicates are normal operating conditions, not rare edge cases reserved for disaster drills. Every consumer that performs side effects — reserving inventory, sending email, posting ledger entries — must decide explicitly how it behaves when the same CloudEvent arrives again because a broker retry, a network timeout, or a pod restart duplicated delivery.
 
-The baseline key is:
+The baseline idempotency identity is `source + id` prefixed for namespacing in your store, for example `ce:/checkout/orders:evt-20260518-000001`. Use the CloudEvents identity, not the payload's business ID alone, because one `orderId` legitimately appears across multiple event types and multiple occurrences within the same type during retries.
 
 ```text
 idempotency key = "ce:" + source + ":" + id
 ```
 
-Use the CloudEvents identity, not the payload identity.
-The payload's `orderId` may be reused across different event types.
-The CloudEvents `source + id` identifies one event occurrence.
-
 ### Worked Example: Lock Then Mark Done
 
-The safest simple Redis pattern uses two keys:
+The safest simple Redis pattern uses two keys to distinguish "another pod is processing this event" from "this event already completed successfully," which matters when two Knative delivery attempts overlap during rolling deploys or partition rebalance storms.
 
 ```text
 done key = ce:done:/checkout/orders:evt-20260518-000001
@@ -607,7 +555,7 @@ Flow:
 5. Set the done key with a long expiry window.
 6. Delete the lock key.
 
-This separates "another pod is processing it" from "this event has already completed."
+This separates "another pod is processing it" from "this event has already completed," and returning `409 Conflict` on lock contention gives the broker a retryable signal without duplicating side effects. Production systems often combine Redis deduplication with database unique constraints on `(source, event_id)` when the side effect itself is a row insert, so dedup survives Redis evictions within the idempotency window.
 
 ```python
 import json
@@ -723,8 +671,7 @@ The window must outlive the longest plausible duplicate.
 | Analytics projection | Retention length | Replay can cover the full retained log |
 | Device telemetry | Short window or sequence check | High volume may make long dedup storage too expensive |
 
-If the event log can be replayed for seven days, a one-hour idempotency window is a bug.
-The consumer will treat older replayed duplicates as new work.
+If the event log can be replayed for seven days, a one-hour idempotency window is a bug waiting for the analytics team's rebuild job. Size windows to the longest plausible duplicate source: broker retries during outages, manual DLQ replays, and log reprocessing jobs should all fall inside the deduplication horizon or be routed through isolated replay infrastructure.
 
 ## End-to-End Worked Example: Order Placed
 
@@ -749,16 +696,15 @@ Checkout HTTP source
 kubectl create namespace commerce
 ```
 
-From here on, this module uses `k` as the common alias for `kubectl`.
-If your shell does not have it, run `alias k=kubectl` or keep typing `kubectl`.
+From here on, this module uses `kubectl` explicitly. Some tutorials alias `k=kubectl`; if your shell defines that alias, the commands below behave the same either way.
 
 ```bash
-k apply -f kafka-channel-config.yaml
-k apply -f commerce-broker.yaml
-k -n commerce get broker commerce
+kubectl apply -f kafka-channel-config.yaml
+kubectl apply -f commerce-broker.yaml
+kubectl -n commerce get broker commerce
 ```
 
-Expected state:
+After apply, confirm the Broker reports `READY True` — the URL column should point at the in-cluster broker ingress, which is the target checkout will POST CloudEvents to once Triggers and consumers exist.
 
 ```text
 NAME       URL                                                                      AGE   READY   REASON
@@ -767,7 +713,7 @@ commerce   http://broker-ingress.knative-eventing.svc.cluster.local/commerce/...
 
 ### Step 2: Idempotent Consumer Service
 
-The Service exposes the consumer to Knative Eventing.
+The Kubernetes Service exposes the consumer pods to Knative Eventing delivery, while the Deployment below configures Redis connectivity and an explicit idempotency window through environment variables that the sample Python handler reads at startup.
 
 ```yaml
 apiVersion: v1
@@ -786,7 +732,7 @@ spec:
       targetPort: 8080
 ```
 
-The Deployment configures Redis and an explicit idempotency window.
+The Deployment runs three replicas so you can observe lock contention when duplicate deliveries arrive during rollouts; scale is not the lesson, but overlapping delivery attempts are.
 
 ```yaml
 apiVersion: apps/v1
@@ -820,21 +766,19 @@ spec:
               value: "604800"
 ```
 
-The OpenTelemetry annotation is intentionally shown because event-driven tracing must be designed.
-Instrumentation alone is not enough if the `traceparent` extension is dropped at the broker boundary.
+The OpenTelemetry annotation is intentionally shown because event-driven tracing must be designed end to end — automatic instrumentation alone is not enough if the `traceparent` extension is dropped at the broker boundary or never extracted in consumer middleware.
 
 ### Step 3: Trigger Routes Only Order-Placed Events
 
 ```bash
-k apply -f order-placed-trigger.yaml
-k -n commerce get trigger order-placed-to-fulfillment
+kubectl apply -f order-placed-trigger.yaml
+kubectl -n commerce get trigger order-placed-to-fulfillment
 ```
 
-Send a CloudEvent into the Broker.
-In a real cluster, the checkout service would post to the Broker URL from inside the cluster or through an ingress policy.
+Send a CloudEvent into the Broker once port-forward exposes the ingress — in a real cluster, the checkout service would post to the Broker URL from inside the cluster or through an ingress policy rather than from your laptop.
 
 ```bash
-k -n knative-eventing port-forward svc/broker-ingress 8080:80
+kubectl -n knative-eventing port-forward svc/broker-ingress 8080:80
 ```
 
 ```bash
@@ -856,7 +800,7 @@ curl -i -X POST http://127.0.0.1:8080/commerce/commerce \
 Inspect the consumer logs:
 
 ```bash
-k -n commerce logs deploy/idempotent-order-consumer
+kubectl -n commerce logs deploy/idempotent-order-consumer
 ```
 
 Send the same curl command again.
@@ -869,8 +813,8 @@ Temporarily configure the consumer to reject a specific order.
 For example, set an environment variable that makes the app return `500` for `ord-1001`.
 
 ```bash
-k -n commerce set env deploy/idempotent-order-consumer FAIL_ORDER_ID=ord-1001
-k -n commerce rollout status deploy/idempotent-order-consumer
+kubectl -n commerce set env deploy/idempotent-order-consumer FAIL_ORDER_ID=ord-1001
+kubectl -n commerce rollout status deploy/idempotent-order-consumer
 ```
 
 Send a new event ID for the same order:
@@ -890,7 +834,7 @@ curl -i -X POST http://127.0.0.1:8080/commerce/commerce \
 Watch the DLQ sink:
 
 ```bash
-k -n commerce logs deploy/order-dlq
+kubectl -n commerce logs deploy/order-dlq
 ```
 
 The DLQ entry should contain the original CloudEvent, not a new event invented by the broker.
@@ -924,82 +868,89 @@ For side-effecting consumers, a replay Broker with narrower Triggers is often sa
 
 ## Production Gotchas
 
+Production event-driven systems fail in predictable ways long after the proof-of-concept demo works. The sections below cover schema evolution, downstream amplification, trace propagation, and replay safety — the same risk categories called out in the learning outcomes — because each category spans tooling choices and organizational process, not just a missing YAML field.
+
 ### Schema Evolution
 
-`dataschema` is only useful when it points to something governed.
-A link to a deleted Git branch is not a schema strategy.
+`dataschema` is only useful when it points to something governed by a registry or catalog with compatibility rules, not a wiki link that rots when someone renames a Git branch. A good schema evolution policy names compatibility modes explicitly: **backward** compatible changes let new producers talk to old consumers (typically adding optional fields), **forward** compatible changes let old producers talk to new consumers, **full** requires both directions, and **none** means breaking changes require a new event type or schema URI rather than silent Friday-night deploys.
 
-A good schema evolution policy includes:
-
-- Compatibility rules: backward, forward, full, or none.
-- A registry or catalog that keeps old schema versions available.
-- A rule that incompatible payload changes create a new `type` or `dataschema`.
-- Consumer tests that load real historical events.
-- A deprecation window for old event types.
-
-Prefer additive changes for a stable event type.
-Adding `discountCode` to an order event is usually safe.
-Changing `total` from a number to a string is not.
+Prefer additive changes for a stable event type — adding `discountCode` to an order event is usually safe when consumers ignore unknown fields. Changing `total` from a number to a nested object is not backward compatible and should bump `type` to `com.acme.orders.order-placed.v2` or publish under a new `dataschema` with consumer contract tests gating rollout. Consumer tests that load real historical CloudEvents from retention or fixture archives catch incompatibilities before they become DLQ avalanches.
 
 ### Downstream Amplification
 
-One event can trigger many consumers.
-Each consumer can call multiple services.
-One `order-placed` event can become inventory reservation, email, fraud scoring, loyalty, billing, search indexing, warehouse loading, and analytics writes.
+One event can trigger many consumers, and each consumer can call multiple downstream services, so one `order-placed` event may become inventory reservation, email, fraud scoring, loyalty updates, billing, search indexing, warehouse loading, and analytics writes without any single team seeing the full blast radius on their architecture slide. Amplification is the point of EDA — fan-out is a feature — but it becomes an incident when platform teams do not model quotas, admission control for new Triggers, and replay impact before approving another subscriber on a critical event type.
 
-Amplification is not automatically bad.
-It is the point of event-driven architecture.
-It becomes bad when platform teams do not model the blast radius.
-
-Ask:
-
-- How many consumers receive this event type?
-- Which consumers call external providers?
-- Which consumers perform irreversible side effects?
-- What happens during replay?
-- What happens if the producer emits ten times the normal rate?
-
-Use quotas and admission rules for high-fan-out event types.
-A new Trigger for a critical event should be reviewed like a new public API consumer.
+Ask during design reviews: how many consumers receive this `type`? Which call external SaaS APIs with rate limits? Which perform irreversible side effects? What happens during log replay or flash-sale traffic spikes? Treat a new Trigger on `order-placed` like approving a new client of a public API, because operationally it is one.
 
 ### Traceparent Propagation
 
-Distributed tracing across events is easy to break.
-Common failure points are:
+Distributed tracing across asynchronous boundaries breaks easily because each hop uses different metadata carriers. Common failure points include HTTP ingress receiving a `traceparent` header but failing to copy it into CloudEvents extensions before Kafka bridging, Brokers forwarding attributes while consumer OpenTelemetry SDKs start a new root trace, replay tools emitting events stripped of original trace context, and Kafka bridges mapping payload bytes while dropping header mappings defined in the CloudEvents Kafka binding.
 
-- The HTTP ingress receives a `traceparent` header but does not copy it to the CloudEvents extension.
-- The Broker forwards CloudEvents attributes but the consumer instrumentation starts a new root trace.
-- A replay tool emits the event without the original trace context or a replay span.
-- A Kafka bridge maps payload but drops headers.
-
-Your standard should say exactly where trace context lives at each boundary.
-For HTTP to Knative, use protocol headers and CloudEvents extensions.
-For Kafka, map the CloudEvents tracing extension to record headers when your SDK supports it.
-For replay, create a new replay trace while preserving the original event context in event metadata.
+Your platform standard should document where trace context lives at each boundary: HTTP headers on ingress, CloudEvents `traceparent` extension inside the broker, Kafka headers on egress, extraction hooks in consumer middleware. For replay, create a distinct replay span linked to the original trace rather than pretending the replay is the same request attempt.
 
 ### Replay Safety
 
-Replay is the feature that turns an event log into an operational tool.
-Replay is also the feature that can send duplicate emails, double-charge accounts, or recreate deleted state.
+Replay turns an event log into an operational recovery tool and simultaneously into a weapon if misused. Classify every consumer before granting replay access: pure projections are usually replay safe; idempotent side effects are replay safe within the deduplication window; non-idempotent side effects such as customer email require compensating workflows or replay isolation; external money movement must never replay blindly through the live Broker without provider idempotency keys.
 
-Classify consumers:
+Every Trigger should carry a replay classification annotation in your platform conventions. If you cannot state how a consumer handles replay, assume it is unsafe and route rebuild traffic through dedicated replay Brokers with narrower Trigger filters.
 
-| Consumer class | Replay posture | Example |
-|----------------|----------------|---------|
-| Pure projection | Usually replay safe | Rebuild search index |
-| Idempotent side effect | Replay safe within window | Inventory reservation with event dedup |
-| Non-idempotent side effect | Replay only through compensating workflow | Customer email |
-| External money movement | Do not replay blindly | Payment capture |
+## Patterns and Anti-Patterns
 
-Every Trigger should have a replay classification.
-If you cannot state how a consumer handles replay, assume it is unsafe.
+The table below collects durable patterns that appear in well-run event platforms, anti-patterns that recreate distributed monoliths with extra steps, and a decision flow for choosing among notification, carried state, outbox, and saga approaches when scoping a new integration.
+
+### Patterns
+
+| Pattern | When to use | CloudEvents hook |
+|---------|-------------|------------------|
+| Transactional outbox | Must atomically commit DB state and publish | Relay publishes fully formed CloudEvents with `source + id` from outbox row |
+| Idempotent consumer | Any at-least-once side effect | Dedup on `source + id`; return success on duplicate |
+| Event-carried state transfer | Consumers should act without callback GET | Rich `data` with governed `dataschema` |
+| Choreographed saga | Multi-step process with compensating events | Correlation via `subject` or extension; distinct `type` per step |
+| Dedicated replay Broker | Rebuild projections without touching email/payments | Same events, different Triggers; replay extensions |
+| Schema registry with compatibility | Many teams share one `type` | `dataschema` URI resolves to versioned schema |
+
+### Anti-Patterns
+
+| Anti-Pattern | Why it fails | Better approach |
+|--------------|--------------|-----------------|
+| Payload-only contracts | Brokers cannot filter or trace generically | Required CloudEvents context on every event |
+| Central orchestrator for everything | Bottleneck and deployment coupling | Choreography for fan-out; orchestration only where needed |
+| Infinite broker retry on validation errors | DLQ fills with permanently bad events | Reject invalid events at edge; short retry for transients |
+| Shared mutable DB between services | Breaks autonomy; hides coupling | Event notification or carried transfer with owned stores |
+| Replay into live Broker blindly | Duplicates side effects | Replay Broker + consumer classification |
+| Dropping trace at Kafka bridge | Incidents become undebuggable | Map CloudEvents trace extensions to record headers |
+
+### Decision Framework
+
+```mermaid
+flowchart TD
+    A[New integration needed] --> B{Must DB write and publish be atomic?}
+    B -->|Yes| C[Transactional outbox + relay]
+    B -->|No| D{Does consumer need full payload?}
+    D -->|No| E[Event notification + query API]
+    D -->|Yes| F[Event-carried state transfer]
+    F --> G{Multi-service transaction?}
+    G -->|Yes| H[Saga with compensating events]
+    G -->|No| I[Single consumer idempotent handler]
+    C --> J[Publish CloudEvents v1.0 with dataschema]
+    E --> J
+    H --> J
+    I --> J
+    J --> K{Side effecting consumer?}
+    K -->|Yes| L[Redis or DB dedup on source+id]
+    K -->|No| M[Projection consumer]
+    L --> N[Knative Trigger + DLQ policy]
+    M --> N
+```
+
+When in doubt, default to at-least-once delivery, explicit CloudEvents contracts, idempotent handlers, and broker-level DLQ — then add orchestration or event sourcing only where the business complexity justifies the operational cost.
 
 ## Did You Know?
 
-- CloudEvents v1.0 standardizes event metadata, not your business payload, so teams can use JSON, Avro, Protobuf, or another payload format behind the same envelope.
-- Knative Eventing routes events by CloudEvents attributes such as `type` and `source`, which lets filters work without payload parsing.
-- A Kafka-backed Knative path still requires good Kafka design: partition keys, retention, replication, and consumer lag remain real operational concerns.
-- DLQs are most valuable when they preserve the original event and enough failure context to support a controlled replay decision.
+- CloudEvents v1.0 standardizes event metadata, not your business payload, so teams can use JSON, Avro, Protobuf, or another payload format behind the same envelope and binding mappings.
+- Knative Eventing routes events by CloudEvents attributes such as `type` and `source`, which lets Triggers filter without payload parsing and keeps routing stable when `data` evolves additively.
+- The transactional outbox pattern predates CloudEvents but pairs naturally with it: the outbox relay emits standards-compliant events so downstream teams consume one envelope shape across services.
+- W3C Trace Context and CloudEvents trace extensions solve different layers — HTTP headers for synchronous hops, CloudEvents attributes for stored and bridged events — and production systems need both mapped explicitly at each boundary.
 
 ## Common Mistakes
 
@@ -1116,6 +1067,16 @@ A small local retry is reasonable for a short blip, but long recovery should be 
 The consumer should fail fast enough for Knative delivery controls to work.
 </details>
 
+### 8. Production risk review before launch
+
+Your team is about to expose `com.acme.orders.order-placed.v1` to three new Triggers owned by different squads. What production risks should you evaluate before merge, and which CloudEvents or platform fields help mitigate them?
+
+<details>
+<summary>Answer</summary>
+
+Evaluate schema evolution (`dataschema` and compatibility tests), downstream amplification (how many side-effecting consumers fan out from one event), trace propagation (`traceparent` preserved across Broker and Kafka bridges), and replay safety (whether each consumer is projection-safe, idempotent, or requires an isolated replay Broker). Mitigations include versioning breaking changes through new `type` values, admission review for new Triggers, explicit DLQ and retry policies on Broker delivery, idempotency keys on `source + id`, and consumer replay classifications documented before go-live.
+</details>
+
 ## Hands-On Exercise
 
 Build a small CloudEvents path for `order-placed` events in a Kubernetes 1.35+ cluster with Knative Eventing installed.
@@ -1158,12 +1119,22 @@ Build a small CloudEvents path for `order-placed` events in a Kubernetes 1.35+ c
 - [ ] You can describe how `partitionkey` maps to Kafka ordering behavior.
 - [ ] You can trace one event from producer to consumer using `traceparent`.
 
-## Further Reading
+## Sources
 
-- [CloudEvents specification](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md)
-- [Knative Eventing overview](https://knative.dev/docs/eventing/)
-- [Knative Broker configuration and delivery](https://knative.dev/docs/eventing/configuration/broker-configuration/)
-- [Knative Subscriptions](https://knative.dev/docs/eventing/channels/subscriptions/)
+- [CloudEvents Specification v1.0](https://github.com/cloudevents/spec/blob/main/cloudevents/spec.md) — normative definition of context attributes, extensions, and serialization.
+- [CloudEvents Primer](https://github.com/cloudevents/spec/blob/main/cloudevents/primer.md) — conceptual introduction to events, formats, and bindings.
+- [CloudEvents HTTP Protocol Binding](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/http-protocol-binding.md) — mapping CloudEvents to HTTP headers and bodies for Knative ingress.
+- [CloudEvents Kafka Protocol Binding](https://github.com/cloudevents/spec/blob/main/cloudevents/bindings/kafka-protocol-binding.md) — mapping attributes to Kafka record headers and values.
+- [CNCF CloudEvents Project](https://www.cncf.io/projects/cloudevents/) — project maturity, governance, and ecosystem context.
+- [Knative Eventing Documentation](https://knative.dev/docs/eventing/) — Brokers, Sources, Sinks, and CloudEvents-native routing on Kubernetes.
+- [Knative Broker Configuration and Delivery](https://knative.dev/docs/eventing/configuration/broker-configuration/) — retry, backoff, and dead-letter sink settings.
+- [Knative Subscriptions](https://knative.dev/docs/eventing/channels/subscriptions/) — Channel fan-out and subscriber delivery policies.
+- [What do you mean by Event-Driven? (Martin Fowler)](https://martinfowler.com/articles/201701-event-driven.html) — notification, carried state transfer, event sourcing, and CQRS taxonomy.
+- [Event Sourcing (Martin Fowler)](https://martinfowler.com/eaaDev/EventSourcing.html) — authoritative state as an append-only event log.
+- [CQRS (Martin Fowler)](https://martinfowler.com/bliki/CQRS.html) — separating write models from read-optimized projections.
+- [Transactional Outbox Pattern](https://microservices.io/patterns/data/transactional-outbox.html) — atomic database commit and event publish.
+- [Saga Pattern](https://microservices.io/patterns/data/saga.html) — distributed transactions through local commits and compensations.
+- [W3C Trace Context](https://www.w3.org/TR/trace-context/) — `traceparent` and `tracestate` propagation across services.
 
 ## Next Module
 


### PR DESCRIPTION
## #1953 Platform Disciplines — `data-ai/data-engineering` batch 3 (of 3) — closes the section

| Module | Author | Before → After | Sources | R1 ground-check |
|---|---|---|---|---|
| **1.7 Event Streaming Fundamentals** | codex gpt-5.5 | 2998 → 6530 w | 0 → 14 | delivery semantics (during failures, not grades; exactly-once = effectively-once within a boundary); Kreps' log; the Dataflow Model paper; event-time/watermarks — concept-first, tool-agnostic |
| **1.8 CloudEvents & EDA** | cursor | 2425 → 5405 w | 4 → 14 | CloudEvents **CNCF Graduated 2024-01-25 web-verified**; spec v1.0; required attributes; protocol bindings; Knative Eventing (incubating); outbox/saga/CQRS/event-sourcing (Fowler/microservices.io) |

### Quality gates
- Both: `verify_module.py` **T0 / passed:true**, density pass, `revision_pending:false`.
- Every source curl-verified (200; O'Reilly Akidau "Streaming 101/102" 403 to bots but real).
- Anti-fab clean (0× `47`, no fused fences). Durable-vendor rule applied.
- Local full Astro build green (2169 pages, 0 errors).

### Closes `data-ai/data-engineering` (8/8 done)
1.1 stateful · 1.2 kafka · 1.3 flink (batch 1) · 1.4 spark · 1.5 airflow · 1.6 lakehouse (batch 2) · 1.7 event-streaming · 1.8 cloudevents (this PR). 1.9 nats-jetstream was already done.

Refs #1953

🤖 Generated with [Claude Code](https://claude.com/claude-code)