### PR TITLE
content(platform): mlops 5.3 + gitops 3.2/3.3 to T0 (closes both sections) (#1953)

### DIFF
--- a/src/content/docs/platform/disciplines/data-ai/mlops/module-5.3-model-training.md
+++ b/src/content/docs/platform/disciplines/data-ai/mlops/module-5.3-model-training.md
@@ -1,19 +1,20 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 5.3: Model Training & Experimentation"
 slug: platform/disciplines/data-ai/mlops/module-5.3-model-training
 sidebar:
   order: 4
 ---
-> **Discipline Track** | Complexity: `[COMPLEX]` | Time: 40-45 min
+> **Discipline Track** | Complexity: `[COMPLEX]` | Time: 55-65 min
 
 ## Prerequisites
 
 Before starting this module:
+
 - [Module 5.1: MLOps Fundamentals](../module-5.1-mlops-fundamentals/)
 - [Module 5.2: Feature Engineering & Stores](../module-5.2-feature-stores/)
-- Experience training ML models (any framework)
-- Basic understanding of hyperparameters
+- Experience training ML models in at least one framework
+- Basic understanding of hyperparameters, validation metrics, and Kubernetes Jobs
 
 ## What You'll Be Able to Do
 
@@ -26,725 +27,684 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-Data scientists run hundreds of experiments. "Try learning rate 0.01... now 0.001... add a layer... remove dropout..." Most of these experiments are lost to time—run in notebooks, results forgotten, impossible to reproduce.
+Hypothetical scenario: a small platform team has eight expensive GPUs, three model teams, and a backlog of training work that arrives in bursts. One team launches a multi-node training run that needs every worker to start together, another launches twenty small tuning trials, and a third keeps a notebook open on a GPU while waiting for code review. The cluster looks busy, the budget looks painful, and yet the largest training job makes no progress because only half of its workers were placed.
 
-When a model works, the question becomes: "What exactly did we do?" Without experiment tracking, the answer is often "I don't remember." You can't reproduce what you can't track.
+Model training is not just "a script that runs for a while." It is a batch workload with unusually sharp edges: large input data, high accelerator demand, long runtime, checkpoint pressure, and a tight relationship between scheduling and correctness. A serving deployment can usually add or remove replicas gradually, but a distributed training job may need a whole group of Pods placed together before useful work can begin. If only part of that group runs, those Pods can hold scarce GPUs while waiting for peers that never arrive.
 
-Experiment tracking isn't just nice-to-have—it's the difference between scientific machine learning and random guessing.
+The platform lesson is that training needs a different operating model from inference. Serving is latency-sensitive, request-driven, and always on. Training is throughput-oriented, bursty, failure-prone, and artifact-producing. A good MLOps platform treats training as a first-class workload: it queues demand, admits work when the full resource shape is available, records evidence for every run, checkpoints state outside the Pod, and gives teams a fair way to share accelerators without turning every experiment into a manual negotiation.
 
-## Did You Know?
+Think of model training as a research kitchen inside a busy restaurant. Serving is the dining room: predictable stations, strict response times, and clear handoffs. Training is the kitchen lab: many attempts, some failures, unusual equipment, and a need to write down exactly which recipe produced the dish that customers will eventually taste. If the lab never labels ingredients, never saves intermediate results, and lets one cook reserve every oven indefinitely, the restaurant cannot turn experiments into repeatable production work.
 
-- **The average ML team runs 1,000+ experiments** before finding a production-worthy model—without tracking, most learnings are lost
-- **Weights & Biases found that teams using experiment tracking** ship models 2x faster because they don't repeat failed experiments
-- **Hyperparameter optimization can improve model performance by 10-50%** but manual tuning rarely explores the full space
-- **Random search beats grid search** for hyperparameter optimization in most cases—and this was only proven through systematic experimentation
-- **Kubernetes 1.35 introduced native Gang Scheduling** (alpha) — ensuring all pods in an ML training job are scheduled together or not at all, eliminating the deadlock problem where partial pod groups hold resources while waiting for the rest
+This module focuses on the durable spine behind the tools. Kubeflow Trainer, Kueue, Volcano, Katib, MLflow, Optuna, and framework-specific APIs will keep changing. The stable ideas are admission control, distributed synchronization, checkpoint durability, experiment evidence, tuning economics, and resource efficiency. Once you understand those ideas, a new training operator or queue controller becomes easier to evaluate because you know which platform promises actually matter.
 
-## The Experiment Tracking Problem
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> Kubeflow Trainer v2 documentation describes `TrainJob`, `ClusterTrainingRuntime`, and `TrainingRuntime` as the unified path for current training jobs, while legacy framework CRDs such as `PyTorchJob`, `TFJob`, and `MPIJob` are documented as older framework-specific APIs. The Kueue documentation currently describes Kubernetes-native quota and job admission with resources such as `Workload`, `LocalQueue`, `ClusterQueue`, and `ResourceFlavor`; its install guide shows released manifests for v0.18.1. Volcano is listed by CNCF as an Incubating project, and Kubeflow is also listed by CNCF as Incubating. KubeDojo targets Kubernetes 1.35; Kubernetes 1.35 introduced alpha workload-aware scheduling with initial native gang scheduling, but platform teams should treat native gang behavior as feature-gated and verify the exact API on their cluster.
 
-Without proper tracking:
+## Model Training as a Platform Workload
 
-```
-DATA SCIENTIST'S NOTEBOOK
-─────────────────────────────────────────────────────────────────
+Training workloads look deceptively simple from the outside because most of them begin life as a single command: run a Python script, read a dataset, write a model artifact. The platform view is different. That command expands into a bundle of storage reads, accelerator reservations, network synchronization, checkpoint writes, metric streams, and exit semantics. A platform that only sees "one more container" misses the reasons training jobs behave differently from web services and background workers.
 
-Experiment 1: accuracy = 0.85
-Experiment 2: accuracy = 0.87  # Better!
-Experiment 3: accuracy = 0.82  # Worse
-...
-Experiment 47: accuracy = 0.91  # Best yet!
+The first difference is demand shape. Training work is bursty because teams launch experiments after data refreshes, research reviews, model architecture changes, or drift investigations. Demand also clusters around deadlines: a batch of tuning runs starts before a release review, or several teams submit retraining jobs after a feature-store backfill. Bursty demand is painful for GPUs because accelerators are high-cost, discrete resources. You cannot schedule half a traditional extended GPU resource request the same way you can schedule a fractional CPU request.
 
-Question: What were the hyperparameters for Experiment 47?
-Answer: "I think learning_rate was 0.01... or 0.001?"
+The second difference is runtime. Many training jobs run long enough that node failures, spot interruptions, image pulls, transient storage errors, and quota changes become normal operating conditions rather than rare accidents. A ten-minute batch job can often restart from the beginning without much concern. A multi-day training job that loses all progress when one Pod is evicted teaches the team to avoid the platform, hoard nodes, or disable preemption entirely. Checkpointing is therefore not a convenience feature; it is the mechanism that lets a platform reclaim or replace capacity without destroying days of useful compute.
 
-Question: Can we reproduce Experiment 47?
-Answer: "The notebook was modified... let me try..."
+The third difference is artifact gravity. A serving deployment usually consumes an already-built artifact, while a training job produces the artifact and the evidence around it. The model file is only one output. The run should also produce parameters, metrics, environment details, code revision, data references, logs, profiling traces, and validation reports. Without that evidence, the model artifact becomes an opaque binary that nobody can audit, compare, or safely promote.
 
-Question: What data version was used?
-Answer: "Um... the current one? Maybe?"
-```
+The fourth difference is the relationship between scheduling and correctness. A single-node training run can often start whenever a suitable node is available. A distributed run may require a coordinator and several workers to start as a group, with predictable rank assignment and network reachability. If the scheduler starts only part of the group, the placed Pods can sit idle while still holding GPUs. The failure is not simply "slow scheduling"; it is a resource deadlock pattern caused by treating a tightly coupled job as independent Pods.
 
-### The Cost of Poor Tracking
+For platform engineers, these differences change the control plane you design. You need queues before Pods, quotas before burst demand, checkpoint policy before preemption, and run identity before model promotion. You also need a clear distinction between a training platform and a model-serving platform. They share Kubernetes primitives, observability tools, and security controls, but they optimize for different SLOs. Training optimizes for throughput, fairness, utilization, and reproducibility; serving optimizes for latency, availability, rollout safety, and request cost.
 
-| Problem | Impact |
-|---------|--------|
-| Can't reproduce results | Best model is lost forever |
-| Repeat failed experiments | Waste time and compute |
-| No comparison baseline | Don't know if new approach is better |
-| Lost institutional knowledge | New team members start from scratch |
-| Debugging in production | "Which experiment is deployed?" |
+The basic training workload contract can be summarized as "admit, run, record, resume, and promote." Admission decides whether the full requested shape can begin without starving other tenants. Running turns a containerized training function into one or more Pods with the right data, accelerator, and network access. Recording captures the run evidence while the work is still fresh. Resume behavior converts failures and preemptions into bounded delays instead of total loss. Promotion connects the resulting artifact to the next stage of validation and serving.
 
-> **Stop and think**: Imagine you just got paged because the new model version is classifying 90% of transactions as fraud. How long would it take your current team to pinpoint exactly which dataset and hyperparameters were used to train that specific artifact?
+```text
+TRAINING WORKLOAD CONTRACT
 
-## Experiment Tracking with MLflow
-
-MLflow is the most popular open-source experiment tracking tool. It tracks:
-
-```mermaid
-flowchart TB
-    subgraph MLflow ["MLflow Tracking: fraud-detection"]
-        direction TB
-        
-        subgraph Run1 ["RUN: abc123"]
-            direction LR
-            Params["Parameters:\n- lr: 0.01\n- epochs: 100\n- batch: 32\n- model: RF\n- seed: 42"]
-            Metrics["Metrics:\n- accuracy: 0.95\n- f1: 0.93\n- auc: 0.97\n- loss: 0.12"]
-            Artifacts["Artifacts:\n- model.pkl\n- confusion_matrix.png\n- feature_importance.csv\n- requirements.txt"]
-            Meta["Metadata:\n- Tags: production-candidate, team-fraud\n- Git: commit abc123, branch main\n- Duration: 45 minutes"]
-            
-            Params ~~~ Metrics ~~~ Artifacts
-            Metrics ~~~ Meta
-        end
-        
-        Run2["RUN: def456"]
-        Run3["RUN: ghi789"]
-        Run4["RUN: jkl012"]
-        
-        Run1 ~~~ Run2 ~~~ Run3 ~~~ Run4
-    end
-    
-    style Params text-align:left
-    style Metrics text-align:left
-    style Artifacts text-align:left
-    style Meta text-align:left
+request -> queue -> admit -> place -> train -> checkpoint
+              |        |       |       |          |
+              |        |       |       |          +--> object storage / artifact store
+              |        |       |       +--> metrics, logs, run evidence
+              |        |       +--> scheduler, GPU plugin, storage mounts
+              |        +--> quota, priority, fairness, gang policy
+              +--> tenant, namespace, experiment, budget context
 ```
 
-### War Story: The Vanishing Model
+Notice what is not in the center of that diagram: a specific vendor product. Tools help implement the contract, but the contract is the durable part. If your platform cannot explain when a training job starts, how it gets its data, where it writes checkpoints, how it resumes, and which run produced the candidate model, then the platform is still relying on human memory at the most expensive point in the ML lifecycle.
 
-A team at a startup had their best fraud model—deployed, working great. Six months later, fraud patterns changed. They needed to retrain.
+## Implement Model Training Pipelines on Kubernetes
 
-"Let's start from the best model." But which was it? The data scientist who trained it had left. Notebooks were scattered across laptops. The model file existed but no one knew what hyperparameters produced it.
+Kubernetes gives you useful primitives for training, but the plain `Pod` abstraction is too small for most platform needs. A Pod can run a container, request resources, mount volumes, and restart according to policy. A training pipeline needs a higher-level object that describes a unit of work, its completion semantics, its retry behavior, and sometimes a group of coordinated workers. The most basic built-in choice is a `Job`, which creates one or more Pods and tracks completion for a task that runs to completion.
 
-They spent two weeks recreating experiments from scratch. MLflow would have saved them with one command: `mlflow.search_runs(order_by=['metrics.f1 DESC'])`
+For simple training, a Kubernetes `Job` is often enough. The training image contains the code and dependencies, the Pod reads input data from a mounted volume or object store, and the script writes artifacts to durable storage before exiting. You can set resource requests, node selectors, tolerations, and environment variables like any other workload. This pattern is valuable because it keeps the first version boring: if one container on one node can train the model, do not start with a distributed operator.
 
-## MLflow in Practice
+For partitioned batch work, Indexed Jobs are a better fit than a pile of manually named Pods. Kubernetes Indexed Jobs are stable and assign each Pod an index that the container can read through the `JOB_COMPLETION_INDEX` environment variable. That index lets each worker process a deterministic shard, such as one fold, one dataset partition, or one evaluation slice. The key design point is that the application must understand the index and make each shard idempotent enough to retry.
 
-### Basic Tracking
-
-```python
-import mlflow
-import mlflow.sklearn
-from sklearn.ensemble import RandomForestClassifier
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
-
-# Set experiment
-mlflow.set_experiment("fraud-detection")
-
-# Training function with tracking
-def train_model(X_train, y_train, X_test, y_test, params):
-    with mlflow.start_run():
-        # Log parameters
-        mlflow.log_params(params)
-
-        # Train model
-        model = RandomForestClassifier(**params)
-        model.fit(X_train, y_train)
-
-        # Evaluate
-        predictions = model.predict(X_test)
-        proba = model.predict_proba(X_test)[:, 1]
-
-        accuracy = accuracy_score(y_test, predictions)
-        f1 = f1_score(y_test, predictions)
-        auc = roc_auc_score(y_test, proba)
-
-        # Log metrics
-        mlflow.log_metric("accuracy", accuracy)
-        mlflow.log_metric("f1", f1)
-        mlflow.log_metric("auc", auc)
-
-        # Log model
-        mlflow.sklearn.log_model(model, "model")
-
-        # Log artifacts (plots, reports, etc.)
-        mlflow.log_artifact("confusion_matrix.png")
-
-        return model, {"accuracy": accuracy, "f1": f1, "auc": auc}
-
-# Run experiments
-params_list = [
-    {"n_estimators": 100, "max_depth": 5, "random_state": 42},
-    {"n_estimators": 200, "max_depth": 10, "random_state": 42},
-    {"n_estimators": 300, "max_depth": 15, "random_state": 42},
-]
-
-for params in params_list:
-    train_model(X_train, y_train, X_test, y_test, params)
+```yaml
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: training-shards
+spec:
+  completions: 4
+  parallelism: 4
+  completionMode: Indexed
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: trainer
+          image: python:3.12-slim
+          command: ["python", "-c"]
+          args:
+            - |
+              import os
+              shard = os.environ["JOB_COMPLETION_INDEX"]
+              print(f"training shard {shard}")
 ```
 
-### Comparing Experiments
+That example is intentionally small, but the platform lesson is important. Indexed Jobs solve static work assignment; they do not automatically solve distributed gradient synchronization, gang placement, experiment tracking, or checkpoint retention. If each shard is independent, a built-in Job may be the right tool. If workers must communicate during training, you need to think about rank assignment, rendezvous, network paths, startup ordering, and all-or-nothing scheduling.
 
-```python
-# Find best run
-from mlflow.tracking import MlflowClient
+Training operators add a higher-level API around those concerns. Kubeflow Trainer v2 is an example of this approach: the current documentation describes a unified `TrainJob` API and reusable runtime resources instead of making users define separate framework-specific resources for every framework. Legacy `PyTorchJob` and `TFJob` still matter in many clusters because real platforms lag migrations, but the durable lesson is not the exact CRD name. The lesson is that the operator should separate platform-owned runtime templates from user-owned training functions.
 
-client = MlflowClient()
-experiment = client.get_experiment_by_name("fraud-detection")
+That separation is a strong platform pattern. Platform teams define runtimes with base images, launcher behavior, security context, storage conventions, scheduling policy, and observability hooks. ML teams provide the training function, parameters, and dataset references. The boundary keeps every model team from reinventing cluster-level details, while still allowing them to iterate on model code. When that boundary is missing, training manifests become long YAML documents copied between teams, and every copy slowly diverges.
 
-runs = client.search_runs(
-    experiment_ids=[experiment.experiment_id],
-    filter_string="metrics.f1 > 0.9",
-    order_by=["metrics.f1 DESC"],
-    max_results=5,
-)
+The same boundary applies when you build a custom operator. A custom operator should not merely wrap `kubectl apply` for a Job. It should encode the parts of the training contract that your organization wants to standardize: how experiments are named, which queue a tenant uses, how checkpoints are configured, which artifacts are required before completion, which metrics are scraped, and which failure modes are retryable. If those rules live only in a wiki, the platform will discover violations after expensive jobs have already run.
 
-print("Top 5 runs by F1 score:")
-for run in runs:
-    print(f"  Run {run.info.run_id[:8]}: F1={run.data.metrics['f1']:.4f}")
+Good Kubernetes training pipelines also avoid treating notebooks as production control planes. Notebooks are excellent for exploration, but they are weak audit boundaries because cells can run out of order, hidden state can survive, and local paths can leak into scripts. A healthy pipeline converts the notebook insight into a containerized training entrypoint with explicit arguments, a declared data source, a stable environment, and a run record. That conversion is where "research code" starts becoming platform work.
+
+The pipeline should preserve a straight line from training request to model candidate. A useful naming pattern is `project / experiment / run / artifact`, where the run ID is created before the job starts and passed into the container. The training process writes metrics and artifacts under that run ID, and the model registry or promotion gate reads from the same identity later. This prevents the common failure where the model file, the metric table, and the validation report all exist but cannot be tied together reliably.
+
+```text
+RUN IDENTITY FLOW
+
+experiment request
+  -> run_id created
+  -> Kubernetes Job or TrainJob receives run_id
+  -> training code logs params, metrics, checkpoints, and final artifact
+  -> validation gate reads the same run_id
+  -> registry entry points back to the run_id
 ```
 
-### MLflow UI
+The final implementation detail is exit behavior. A training job that exits successfully without uploading artifacts should not be considered successful by the platform. The platform should define completion in terms of required evidence: final checkpoint or model artifact present, metrics recorded, validation report written, and lineage metadata available. That evidence-oriented completion model is stricter than container exit code, but it matches the real business question: can we trust and reproduce the model this job produced?
 
-```bash
-# Start UI server
-mlflow ui --port 5000
+## Distributed Training: Parallelism, Synchronization, and Gang Scheduling
 
-# Access at http://localhost:5000
+Distributed training starts with a tradeoff: you add coordination overhead in exchange for more memory, more throughput, or both. The simplest form is data parallelism. Each worker holds a copy of the model, receives a different slice of the batch, computes gradients, and synchronizes updates with the other workers. Data parallelism is attractive because the model code changes less than other strategies, but it still depends on communication performance and consistent worker progress.
+
+Model parallelism is different. Instead of copying the whole model to every worker, you split the model itself across devices. Tensor parallelism splits operations inside layers, pipeline parallelism splits groups of layers into stages, and fully sharded approaches split parameters, gradients, or optimizer state. These techniques exist because some models no longer fit comfortably on one device, or because memory pressure becomes the limiting factor before raw compute does. They usually demand more careful framework support and more sensitivity to topology.
+
+Synchronous and asynchronous training also lead to different platform expectations. In synchronous data parallel training, workers regularly meet at synchronization points, such as gradient all-reduce. The fastest worker waits for the slowest worker, so a single slow node, network path, or storage mount can reduce job throughput. In asynchronous approaches, workers can update shared parameters without waiting for every peer at the same step, which can improve hardware usage but complicate convergence behavior and reproducibility.
+
+All-reduce and parameter-server patterns are the classic communication choices. In an all-reduce pattern, workers collectively combine gradient information so each participant can apply a consistent update. In a parameter-server pattern, one or more server processes hold parameters, and trainers communicate with those servers to retrieve or update state. The platform implication is that both patterns need predictable placement, stable networking, and clear failure semantics, but they stress the network differently.
+
+PyTorch DistributedDataParallel is a common example of synchronous data parallel training. The PyTorch documentation describes DDP as using collective communication to synchronize gradients and buffers across processes, and recommends one process per model replica. That recommendation matters for Kubernetes because the unit you schedule is a Pod and the unit the framework often expects is a process with a rank. The platform must map Pods, containers, ranks, and GPUs in a way the framework can understand.
+
+Rank assignment deserves more attention than it usually gets. A distributed job needs every process to know its global rank, local rank, world size, and rendezvous endpoint. In static environments those values may come from a hostfile or scheduler integration. In Kubernetes they often come from environment variables, operator-generated configuration, DNS names, or launcher containers. If rank assignment is inconsistent, the job can hang in initialization even though every Pod is technically Running.
+
+Gang scheduling exists because distributed training is tightly coupled. If a job needs one coordinator and seven workers, placing four workers is worse than placing none when those workers reserve GPUs and block other jobs. Gang scheduling makes placement all-or-nothing: the scheduler admits or binds the group only when enough resources are available for the group policy. This does not make the cluster larger, but it prevents partial placement from wasting scarce resources while a job waits for the rest of its group.
+
+Partial placement deadlock is easy to miss in dashboards. GPU utilization may show low activity, but allocatable resources look consumed because idle workers are already bound to nodes. The queue grows, smaller jobs cannot start, and the large job cannot make progress. Humans may respond by deleting Pods manually, which turns scheduling into an operations ritual. A platform-level gang policy prevents that class of failure by refusing to start a distributed gang until the minimum group can actually run.
+
+```text
+WITHOUT GANG SCHEDULING
+
+job needs 8 workers
+scheduler places 5 workers
+5 workers hold GPUs and wait for peers
+remaining 3 workers stay Pending
+other jobs cannot use the held GPUs
+
+WITH GANG SCHEDULING
+
+job declares minimum group size
+scheduler waits until the group can be placed
+all workers start together, or none consume GPUs
+other admitted jobs can use resources meanwhile
 ```
 
-The UI provides:
-- Experiment comparison tables
-- Metric visualization (charts, plots)
-- Parameter search and filtering
-- Artifact browsing
-- Run diff comparison
+Kueue, Volcano, scheduler-plugins, and native Kubernetes workload-aware scheduling all approach this problem from different angles. Kueue focuses on admission and quota for jobs before Pods are created or fully admitted. Volcano provides batch scheduling features including gang scheduling and queue management. Kubernetes 1.35 introduced alpha workload-aware scheduling with an initial gang-scheduling implementation. The durable decision is not "which name wins"; it is whether your platform has an explicit job-level admission point before expensive Pods are allowed to reserve resources.
 
-> **Pause and predict**: We've tracked our experiments and found the best model. But how do we communicate to the serving infrastructure *which* model to load without hardcoding paths or risking typos?
+Topology is the next level of scheduling maturity. Distributed training performance can depend on whether GPUs are on the same node, same rack, same network fabric, or attached through a particular accelerator topology. A placement that satisfies raw GPU count can still produce poor throughput if interconnect paths are slow. Advanced platforms therefore consider not only "can I fit eight GPUs?" but also "can I fit the communication pattern in a topology that will not waste most of the run?"
 
-## Model Registry
+Distributed training is also a failure-domain problem. If a synchronous job loses one worker, the remaining workers may fail or wait depending on framework and launcher behavior. Retrying the whole group from the latest checkpoint is often cleaner than trying to patch one missing worker into a running gang. That retry model makes checkpoint cadence, checkpoint durability, and startup time part of the scheduling design. A platform cannot reason about preemption without knowing how much work a training job can safely lose.
 
-The Model Registry manages model versions and lifecycle stages:
+## Configure Training Infrastructure: GPUs, Queues, Storage, and Fault Tolerance
 
-```mermaid
-flowchart TD
-    subgraph Registry ["Model Registry: fraud-detector"]
-        V1["Version 1\nStage: Archived\nF1: 0.89\nDate: Jan 1"]
-        V2["Version 2\nStage: Production\nF1: 0.93\nDate: Feb 1"]
-        V3["Version 3\nStage: Staging\nF1: 0.95\nDate: Mar 1"]
-        
-        Live["Live traffic"]
-        Shadow["Shadow traffic"]
-        
-        V2 --> Live
-        V3 --> Shadow
-    end
-    
-    style V1 fill:#f9f9f9,stroke:#999,stroke-dasharray: 5 5
-    style V2 fill:#d4edda,stroke:#28a745,stroke-width:2px
-    style V3 fill:#fff3cd,stroke:#ffc107,stroke-width:2px
+GPU scheduling in Kubernetes begins with device plugins. Kubernetes device plugins let vendors advertise specialized hardware, such as GPUs, to the kubelet without changing Kubernetes core code. Once a plugin advertises a resource such as `nvidia.com/gpu`, Pods request it through resource limits. That extended-resource model is simple and useful, but it hides several platform decisions behind one number.
+
+A request for `nvidia.com/gpu: 1` does not say whether the workload needs a specific GPU model, memory size, interconnect, driver version, sharing mode, or topology. Platform teams typically add labels, taints, tolerations, node pools, resource flavors, or queue configuration to express those differences. The goal is to keep users from writing hardware folklore into every manifest while still making the differences visible enough for scheduling and cost control.
+
+Multi-Instance GPU and time-slicing show why "GPU count" is not a complete scheduling language. MIG partitions supported GPUs into hardware-isolated slices with separate memory and fault domains. Time-slicing lets multiple workloads share a GPU by interleaving access, but NVIDIA's documentation is explicit that time-sliced replicas do not get memory or fault isolation like MIG. That tradeoff can be reasonable for short experiments or low-risk notebooks, but it is risky for long, memory-heavy training runs that assume exclusive accelerator behavior.
+
+Queueing is the control plane that keeps scarce accelerators from becoming a first-come, first-served accident. Kueue describes a model where workloads wait, are admitted when quota is available, and can be preempted according to policy. `ClusterQueue` objects govern resource pools and fair sharing, while namespaced queues give tenants a place to submit work. The important design point is that queue admission happens at the workload level, not as an afterthought once Pods are already fighting for nodes.
+
+Queues should encode fairness in terms users can understand. A platform can define separate queues for research, retraining, urgent incident response, and low-priority sweeps, but those queues need transparent policy. If nobody knows why one job started and another waited, the platform becomes a social bottleneck. Fair sharing, borrowing, and preemption are useful only when teams can predict how their jobs will behave before they submit them.
+
+Storage is the second scarce resource. Training input data may come from object storage, mounted filesystems, feature stores, or precomputed local caches. The fastest choice is not always the safest choice. Mounting a shared filesystem can make development easy but can become a bottleneck when many workers read the same files. Streaming from object storage can scale better operationally, but training code needs buffering, retry, and locality awareness to avoid starving GPUs while waiting for data.
+
+Checkpoint storage should be durable outside the Pod and outside the node. A checkpoint written only to an emptyDir volume is useful for a container restart on the same Pod, but it does not protect against node loss or job replacement. For long-running training, checkpoints usually belong in object storage or a durable shared volume with a naming scheme that includes run ID, step or epoch, and enough metadata to validate compatibility during resume. The checkpoint writer should make partial writes detectable, commonly by writing to a temporary name and promoting only complete files.
+
+Checkpoint frequency is a cost tradeoff. Frequent checkpoints reduce the amount of lost compute after preemption, but they consume I/O, storage, and sometimes training time. Infrequent checkpoints improve throughput until the first failure, when the job may lose hours of progress. A practical platform default is to checkpoint often enough that the expected lost work is acceptable for the queue class. Spot or preemptible capacity needs a different checkpoint posture from reserved, low-interruption capacity.
+
+Fault tolerance also depends on what the framework can restore. Saving model weights alone may not be enough to resume a training run accurately. Many training jobs also need optimizer state, learning-rate scheduler state, random number generator state, epoch or step counters, tokenizer or preprocessing configuration, and sometimes data-loader position. If the checkpoint omits these details, the resumed run may continue but no longer represent the same experiment.
+
+Spot and preemptible economics are attractive because training is often batch-oriented and can tolerate interruption when checkpointing works. The platform risk is that cheap capacity without resume discipline becomes expensive repeated work. A queue can route tolerant experiments to interruptible nodes and reserve stable nodes for fragile jobs, but that policy only works if the job declares its tolerance and proves it can resume. Otherwise every team has an incentive to claim the safest pool.
+
+Observability closes the loop. A training platform should show queue wait time, admission decisions, pending reasons, GPU allocation, GPU utilization, data throughput, checkpoint age, restart count, loss curves, and artifact completion. CPU and memory metrics are not enough. A job can be Running, healthy, and still waste GPUs because the input pipeline is slow or because all workers are waiting at a synchronization barrier. Training observability must reveal progress, not just liveness.
+
+## Data and Checkpointing: Feeding the Job Without Losing the Run
+
+Data movement is often the hidden bottleneck in model training. A team may spend days tuning batch size and learning rate while the real problem is that each worker repeatedly downloads the same files or waits on a remote filesystem with poor parallel read behavior. The platform should treat data access as part of the workload design, not as an implementation detail left to whichever notebook first loaded the dataset.
+
+The first data question is whether the dataset is immutable for the run. A training job that reads "latest" data from a mutable location cannot be reproduced later unless the storage layer provides a stable version reference. A durable run record should capture a dataset version, content hash, table snapshot, object prefix, feature-store retrieval definition, or other stable pointer. If the data source cannot provide that pointer, the platform should call out the limitation rather than pretending the run is reproducible.
+
+The second data question is how workers divide work. In data parallel training, each worker should receive a distinct slice of data for each step, usually through framework-aware samplers or sharding logic. In Indexed Jobs, each Pod can use its completion index to process a deterministic shard. In hyperparameter tuning, every trial may read the same training set but write different metrics. These patterns need different caching and throttling strategies even if they all read from the same bucket.
+
+Input caching is valuable when it is explicit. Node-local caches, distributed caches, and prefetching can reduce repeated downloads and improve GPU utilization, but they introduce invalidation questions. A stale cache can silently train on old data unless the cache key includes the dataset version. A cache that is too small can churn constantly and hide the real bottleneck. The platform should make cache hit rate and input throughput observable when training jobs depend on cached data.
+
+Checkpoint layout is another data-design problem. A clear layout might separate temporary checkpoints, candidate checkpoints, final artifacts, and validation reports. Temporary checkpoints support resume. Candidate checkpoints support comparison during training. Final artifacts support promotion. Validation reports support review and audit. Mixing all of those outputs in one directory named `model` makes cleanup and governance harder than it needs to be.
+
+```text
+EXAMPLE ARTIFACT LAYOUT
+
+runs/
+  churn-model/
+    run-2026-06-15-a/
+      params.json
+      metrics.jsonl
+      checkpoints/
+        step-000500/
+        step-001000/
+      artifacts/
+        model/
+        feature_importance.json
+      reports/
+        validation.json
+        environment.json
 ```
 
-### Model Stages
+Good checkpointing also has a reader contract. It is not enough to write files; the next process must know how to find the latest complete checkpoint, verify that it matches the current code and data, and resume without overwriting the evidence of the previous attempt. Many teams implement a small manifest file for this purpose. The manifest points to the latest complete checkpoint and records compatibility metadata, while incomplete checkpoint directories can be safely ignored or cleaned up.
 
-| Stage | Purpose |
-|-------|---------|
-| **None** | Just registered, not evaluated |
-| **Staging** | Under evaluation, shadow traffic |
-| **Production** | Live traffic, actively monitored |
-| **Archived** | Deprecated, kept for reference |
+Preemption turns checkpoint quality into a user-visible platform feature. If a job resumes automatically after a node interruption, the team experiences preemption as delay. If the job restarts from the beginning, the team experiences preemption as data loss and may resist any shared scheduling policy that includes it. This is why checkpoint discipline belongs in the platform contract. It allows queue fairness and cheaper capacity strategies without asking every user to absorb unbounded risk.
 
-### Using the Registry
+## Design Experiment Tracking Workflows
 
-```python
-import mlflow
+Experiment tracking is the memory system for model training. It records the inputs and outputs of a run so that a team can compare alternatives, debug regressions, reproduce a candidate, and explain what changed. A useful tracker does not merely store a final metric. It connects static parameters, time-series metrics, artifacts, environment, data references, and run metadata under one identity.
 
-# Register model from run
-model_uri = f"runs:/{best_run.info.run_id}/model"
-model_name = "fraud-detector"
+MLflow's documentation describes runs as executions that record metadata, metrics, parameters, and artifacts. Those categories are durable even if the tracking tool changes. Parameters are the intended inputs, such as learning rate, batch size, model family, seed, and feature set. Metrics are observed outputs, such as validation loss, F1 score, throughput, or calibration error. Artifacts are files, such as checkpoints, plots, confusion matrices, validation reports, and model weights. Tags and metadata supply context, such as Git commit, data version, owner, queue, and hardware shape.
 
-# Register new version
-mlflow.register_model(model_uri, model_name)
+The reason to separate these categories is queryability. If the learning rate is logged as a text file artifact, the team cannot easily filter runs by learning rate. If the loss curve is logged only as a final number, the team cannot see instability during training. If the model weights are stuffed into a parameter field, the tracker becomes unusable. A good run record respects the data model of the tracker so future humans and automation can ask useful questions.
 
-# Transition stages
-client = MlflowClient()
-client.transition_model_version_stage(
-    name=model_name,
-    version=3,
-    stage="Staging"
-)
+Experiment tracking should begin before the Kubernetes workload is created. The orchestrating layer creates or reserves a run identity, passes it to the training job, and expects all outputs to use that identity. This is safer than letting the training process create an unknown local run and later trying to match it to a cluster job. When run identity flows from scheduler to tracker to artifact store, the platform can answer which namespace, queue, image, and Pod produced a candidate model.
 
-# After validation, promote to production
-client.transition_model_version_stage(
-    name=model_name,
-    version=3,
-    stage="Production"
-)
+Reproducibility requires more than a seed. Seeds are useful, but exact reproducibility can depend on framework version, CUDA and driver behavior, nondeterministic kernels, data order, preprocessing code, and hardware. The practical target for many teams is not bit-for-bit replay; it is explainable, bounded variation with enough evidence to rerun the same procedure. The run record should therefore capture the environment and the deterministic controls that were actually used, while being honest about remaining nondeterminism.
 
-# Load production model
-model = mlflow.sklearn.load_model(f"models:/{model_name}/Production")
-```
+Environment pinning starts with the container image. The image should be referenced by immutable digest in production workflows, not only a mutable tag. Dependency lock files, base image digest, CUDA runtime, framework version, and training entrypoint should be recorded with the run. When a team cannot reproduce a result months later, the missing detail is often not the model architecture; it is a seemingly minor library or driver change.
 
-## Hyperparameter Optimization
+Data lineage is the other half of reproducibility. The run should record which dataset snapshot, feature-store point-in-time query, preprocessing code, and split strategy were used. Random train-test splits should be seeded and logged, but seed alone is not enough if the source table changed. A validation metric without a data reference is a number without a specimen. You can admire it, but you cannot study where it came from.
 
-### The Search Space Problem
+Experiment tracking also improves platform operations. Queue wait time, node pool, GPU type, runtime, restarts, checkpoint count, and average throughput can be logged as run metadata. This allows platform teams to compare not just model quality, but training efficiency. A model that gains a tiny metric improvement at a large compute cost may not be a good candidate. Conversely, a run that converges faster with lower GPU hours may be worth promoting even if final quality is similar.
 
-```
-HYPERPARAMETER SEARCH SPACE
-─────────────────────────────────────────────────────────────────
+The model registry is downstream of tracking, not a replacement for it. A registry manages named model versions and lifecycle state, while the tracker explains how a version was produced. If the registry entry does not link back to the run evidence, it becomes another unlabeled file cabinet. Promotion gates should require a registry entry to point to a run with parameters, metrics, artifacts, data lineage, and validation evidence.
 
-Model: Random Forest
-Parameters:
-  n_estimators:  [50, 100, 200, 500, 1000]     = 5 options
-  max_depth:     [3, 5, 10, 15, 20, None]      = 6 options
-  min_samples:   [2, 5, 10, 20]                = 4 options
-  max_features:  ['sqrt', 'log2', None]        = 3 options
+Hypothetical scenario: a fraud model candidate looks better than the current production model on the main validation metric, but the run record shows it used a newer feature snapshot, a different negative-sampling rule, and a smaller evaluation set. Without tracking, the team might promote it based on a single number. With tracking, the review shifts to the right question: did model quality improve, or did the evaluation contract change?
 
-Grid Search: 5 × 6 × 4 × 3 = 360 combinations
-At 5 min/train: 30 hours!
+## Build Automated Hyperparameter Tuning
 
-Random Search: 50 random combinations = 4 hours
-  → Often finds near-optimal in ~60 iterations
-```
+Hyperparameter tuning is controlled experimentation under a compute budget. The search algorithm decides which configurations to try, the scheduler decides when trials run, the tracker records what happened, and the promotion process decides whether any result is worth using. Treating HPO as "launch many jobs" misses the reason it is difficult: every extra trial competes with other work, and every failed trial should still teach the team something.
 
-> **Stop and think**: If adding a new hyperparameter to tune doubles the number of grid search combinations, what happens to your compute budget when you need to tune 10 parameters at once?
+Grid search is the easiest strategy to explain. You define a set of values for each parameter and run every combination. Grid search is useful when the search space is small, the parameters are known to matter, and the team wants exhaustive coverage of a few discrete choices. It becomes inefficient when many parameters are included because it spends equal effort on dimensions that may not matter much.
 
-### Grid vs. Random vs. Bayesian
+Random search samples configurations from defined ranges. The classic lesson from Bergstra and Bengio's random-search paper is that not all hyperparameters matter equally, so random search often explores important dimensions more effectively than a coarse grid with the same budget. The platform lesson is even broader: a tuning system should make the budget explicit. If the team can afford twenty trials, the search strategy should spend those trials intentionally rather than accidentally through nested loops in a notebook.
 
-```mermaid
-flowchart TD
-    subgraph Search Strategies
-        Grid["Grid Search"] -->|Exhaustively tests every predefined combination| GridResult["Slow and scales poorly across many dimensions"]
-        Random["Random Search"] -->|Samples randomly across all dimensions simultaneously| RandomResult["Faster discovery and better parameter coverage"]
-        Bayesian["Bayesian Optimization"] -->|Learns from past evaluations to choose next parameters| BayesianResult["Intelligent exploration clustering near optimal regions"]
-    end
-```
+Bayesian optimization uses previous observations to choose promising next configurations. It can be valuable when trials are expensive and the objective surface is smooth enough for a model to guide exploration. The tradeoff is sequential dependency: the algorithm may want to learn from earlier trials before choosing later ones. That can reduce parallelism compared with random search, which is often easier to fan out across a cluster.
 
-### Optuna for HPO
+Early-stopping strategies such as successive halving and ASHA add another dimension. They start multiple trials, observe partial training results, stop weak performers, and allocate more budget to promising ones. This can save compute when early metrics are predictive, but it can also bias against models that learn slowly and improve later. Platform teams should expose early-stopping policy as a reviewable experiment choice, not a hidden default.
 
-```python
-import optuna
-import mlflow
-
-def objective(trial):
-    # Suggest hyperparameters
-    params = {
-        "n_estimators": trial.suggest_int("n_estimators", 50, 500),
-        "max_depth": trial.suggest_int("max_depth", 3, 20),
-        "min_samples_split": trial.suggest_int("min_samples_split", 2, 20),
-        "max_features": trial.suggest_categorical("max_features", ["sqrt", "log2", None]),
-    }
-
-    with mlflow.start_run(nested=True):
-        mlflow.log_params(params)
-
-        # Train and evaluate
-        model = RandomForestClassifier(**params, random_state=42)
-        model.fit(X_train, y_train)
-        f1 = f1_score(y_test, model.predict(X_test))
-
-        mlflow.log_metric("f1", f1)
-
-        return f1
-
-# Run optimization
-with mlflow.start_run(run_name="hpo-study"):
-    study = optuna.create_study(direction="maximize")
-    study.optimize(objective, n_trials=100)
-
-    # Log best params
-    mlflow.log_params(study.best_params)
-    mlflow.log_metric("best_f1", study.best_value)
-
-print(f"Best F1: {study.best_value:.4f}")
-print(f"Best params: {study.best_params}")
-```
-
-### Katib (Kubernetes-Native HPO)
-
-For Kubernetes environments, Katib provides distributed HPO:
+Katib is a Kubernetes-native worked example for HPO. Its Experiment resource describes the objective metric, algorithm, search space, parallel trial count, maximum trial count, and trial template. The trial template can create a Kubernetes Job or another supported resource, with parameters substituted into the training command. The durable lesson is that HPO needs a controller that owns trial generation and status, while the underlying training workload remains an ordinary, observable unit of work.
 
 ```yaml
 apiVersion: kubeflow.org/v1beta1
 kind: Experiment
 metadata:
-  name: fraud-hpo
+  name: churn-hpo
 spec:
   objective:
-    type: maximize
-    goal: 0.95
-    objectiveMetricName: f1-score
+    type: minimize
+    objectiveMetricName: validation-loss
   algorithm:
-    algorithmName: bayesianoptimization
-  parallelTrialCount: 3
-  maxTrialCount: 30
-  maxFailedTrialCount: 3
+    algorithmName: random
+  parallelTrialCount: 2
+  maxTrialCount: 8
+  maxFailedTrialCount: 2
   parameters:
     - name: learning_rate
       parameterType: double
       feasibleSpace:
-        min: "0.001"
+        min: "0.0001"
         max: "0.1"
-    - name: num_epochs
+    - name: batch_size
       parameterType: int
       feasibleSpace:
-        min: "10"
-        max: "100"
+        min: "32"
+        max: "128"
   trialTemplate:
-    primaryContainerName: training
+    primaryContainerName: trainer
     trialParameters:
       - name: learningRate
         reference: learning_rate
-      - name: epochs
-        reference: num_epochs
+      - name: batchSize
+        reference: batch_size
     trialSpec:
       apiVersion: batch/v1
       kind: Job
       spec:
         template:
           spec:
-            containers:
-              - name: training
-                image: my-training-image
-                command:
-                  - python
-                  - train.py
-                  - --lr=${trialParameters.learningRate}
-                  - --epochs=${trialParameters.epochs}
             restartPolicy: Never
+            containers:
+              - name: trainer
+                image: python:3.12-slim
+                command: ["python", "-c"]
+                args:
+                  - |
+                    print("lr=${trialParameters.learningRate}")
+                    print("batch=${trialParameters.batchSize}")
+                    print("validation-loss=0.5")
 ```
 
-## Reproducibility Best Practices
+That example is deliberately modest because production HPO should use a real training image, a real metrics collector, and durable artifact storage. The important fields are the ones that encode the experiment contract: objective, algorithm, parallelism, total trial budget, failure budget, search space, and trial template. When those fields are explicit, reviewers can discuss whether the experiment is scientifically meaningful and operationally affordable.
 
-### 1. Version Everything
+Optuna is a useful library-level contrast. Instead of using a Kubernetes CRD to define the experiment, application code defines an objective function and asks Optuna to suggest parameters. This can be a better fit for local development, CI validation, or teams that already control orchestration elsewhere. The tradeoff is that the platform must still decide how to distribute trials, persist study state, and connect trial results to the shared run tracker.
 
-```python
-import mlflow
-import subprocess
+HPO parallelism is not automatically good. Running many trials at once can reduce wall-clock time, but it can also starve other teams and reduce the learning efficiency of adaptive algorithms. A queue should treat HPO as a group of related workloads with a budget, not as unrelated jobs that happen to share a name. The HPO controller should make it obvious how many trials are active, how many failed, what metric is being optimized, and when the experiment should stop.
 
-# Log environment
-mlflow.log_artifact("requirements.txt")
+The most common tuning failure is optimizing the wrong thing. If the objective metric ignores latency, memory, fairness, calibration, or business constraints, the search may find a model that is numerically impressive and operationally unusable. A mature platform lets teams log secondary metrics and promotion constraints alongside the primary objective. The HPO system can optimize one metric, but the release process should review the whole evidence set.
 
-# Log git info
-git_commit = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()
-git_branch = subprocess.check_output(["git", "branch", "--show-current"]).decode().strip()
+## Resource Efficiency and Training Observability
 
-mlflow.set_tags({
-    "git.commit": git_commit,
-    "git.branch": git_branch,
-})
+Training efficiency is not the same as high allocation. A cluster can show every GPU allocated while actual GPU utilization is low because jobs are waiting on input data, synchronization, checkpoints, or CPU preprocessing. The utilization trap appears when a platform celebrates "reserved capacity" rather than useful work. For training, useful work means examples processed, tokens processed, steps completed, loss improving, checkpoints written, and artifacts produced.
+
+Right-sizing starts with requests. Under-requested CPU or memory can starve the input pipeline and make GPUs idle. Over-requested GPUs can block other work while providing no speedup. A training platform should collect actual usage and throughput by run so teams can adjust defaults. The goal is not to shame users for imperfect first guesses; the goal is to shorten the feedback loop between resource request and observed training behavior.
+
+Mixed precision is one common efficiency technique. By using lower-precision arithmetic where appropriate, many models can reduce memory pressure and improve throughput on hardware that supports it. The tradeoff is numerical behavior: loss scaling, stability, and metric parity need validation. Mixed precision should be recorded as a run parameter because it affects both performance and sometimes model behavior.
+
+Gradient accumulation is another useful technique. Instead of increasing the per-device batch size beyond memory limits, the training loop accumulates gradients across several smaller microbatches before applying an optimizer step. This can approximate a larger effective batch, but it changes synchronization cadence and can affect learning dynamics. The run record should log accumulation steps, effective batch size, and any learning-rate adjustment tied to batch size.
+
+Throughput metrics should be close to the training loop. Examples per second, tokens per second, step time, data-loader time, checkpoint time, and synchronization time tell different stories. If step time is high because checkpoint writes block the loop, storage is the bottleneck. If data-loader time dominates, preprocessing or input reads are the bottleneck. If synchronization time dominates, topology or straggler behavior may be the problem. A single GPU utilization chart cannot distinguish these causes.
+
+Loss curves are operational signals, not only research artifacts. A flat or exploding loss curve can reveal bad parameters, data bugs, unstable mixed precision, or a resumed checkpoint mismatch. The platform should make current loss and recent trend visible while the job is running, especially for expensive runs. Stopping a clearly broken job early is one of the simplest ways to return capacity to the queue.
+
+Training observability should connect cluster and model views. Kubernetes events explain why Pods are Pending or restarting. Scheduler and queue metrics explain admission and fairness. GPU metrics explain device usage. Training metrics explain learning progress. Artifact metrics explain whether checkpoints and final outputs are being written. When these views are separated, every incident turns into a blame handoff between platform engineers and ML engineers.
+
+Cost control is a product of design, not only a monthly report. Queue policies limit concurrent demand, HPO budgets cap exploration, checkpointing allows interruptible capacity, right-sizing reduces waste, and observability catches idle accelerators. The platform should help teams choose cheaper patterns when they are safe, while preserving stable capacity for fragile or urgent work. That is a better conversation than telling every team to "use fewer GPUs" after the invoice arrives.
+
+## Patterns & Anti-Patterns
+
+The patterns below are durable because they describe responsibilities, not brands. A platform can implement them with Kubeflow Trainer, plain Jobs, Kueue, Volcano, a custom operator, or a managed service. The important question is whether the behavior exists and whether users can rely on it.
+
+### Patterns
+
+**Run identity before workload creation** means the orchestrator creates a run ID before submitting the Kubernetes workload and passes that identity into the container. The training code uses that identity for metrics, parameters, checkpoints, and final artifacts. This pattern prevents later forensic work from depending on log scraping or filename guesses.
+
+**Queue admission before Pod creation** means expensive distributed jobs wait as workloads until the platform can admit the requested shape. This is especially important for multi-worker GPU training because partial placement can waste resources. A queue can also express tenant fairness, borrowing, priority, and preemption in a way raw Pod scheduling cannot.
+
+**Checkpoint to durable storage** means every long-running job can resume from storage outside the Pod and node. The checkpoint should include enough state to continue correctly, and the platform should know where complete checkpoints live. This pattern turns failures and preemption into bounded delay instead of total recomputation.
+
+**Runtime templates owned by the platform** means platform teams define common runtimes for images, launchers, security context, storage, scheduling, and observability, while model teams provide training logic and parameters. This preserves flexibility without forcing every ML engineer to become a scheduler and storage expert.
+
+### Anti-Patterns
+
+**Notebook as production scheduler** is the pattern where a human keeps a notebook session alive to train important models on shared GPUs. The work may succeed once, but it leaves weak lineage, weak retry behavior, and poor fairness. Move the training entrypoint into a containerized job and keep notebooks for exploration and analysis.
+
+**GPU hoarding through idle Pods** happens when teams reserve accelerators before their job can make progress. This often appears with distributed jobs that start partially or with interactive sessions left open. Use queue admission, idle-time policy, and gang scheduling to make progress the condition for holding scarce devices.
+
+**Artifact without evidence** happens when a registry contains model files but no linked run record. The team can deploy the artifact but cannot explain its data, parameters, environment, or validation history. Promotion gates should require a traceable run before a model version can move toward serving.
+
+**HPO without a budget** happens when a tuning loop launches trials until somebody notices the spend. A tuning experiment should declare maximum trials, parallel trial count, objective, early-stopping rules, and failure budget before it starts. Exploration is valuable, but unbounded exploration is not a platform strategy.
+
+### Decision Framework
+
+Use this framework to choose the minimum training architecture that satisfies the workload. The point is not to choose the most advanced controller; it is to match coupling, evidence, and resource risk.
+
+| Workload shape | Good starting point | Scheduling need | Evidence need | Watch out for |
+|---|---|---|---|---|
+| Single-node training | Kubernetes `Job` | Normal Pod scheduling | Run ID, params, metrics, artifact | Local-only checkpoints |
+| Static independent shards | Indexed `Job` | Parallelism and retry policy | Shard index, per-shard metrics | Duplicate or non-idempotent shard writes |
+| Multi-worker synchronous training | Training operator or custom controller | Gang scheduling and topology awareness | Rank map, checkpoints, loss curves | Partial placement and stragglers |
+| Many HPO trials | Katib, Optuna with orchestration, or custom tuner | Queue quota and trial budget | Trial params, objective, secondary metrics | Optimizing a narrow metric |
+| Interruptible capacity training | Job or operator with resume support | Preemption-aware queue policy | Durable checkpoints and resume logs | Restarting from scratch after eviction |
+
+```mermaid
+flowchart TD
+    A["Can one container train the model?"] -->|Yes| B["Use a Kubernetes Job with tracking and durable artifacts"]
+    A -->|No| C["Do workers communicate during training?"]
+    C -->|No| D["Use Indexed Jobs or an HPO controller for independent trials"]
+    C -->|Yes| E["Use a training operator or custom controller"]
+    E --> F["Require gang scheduling, rank assignment, and checkpoint resume"]
+    D --> G["Declare trial budget, objective, and queue policy"]
+    B --> H["Promote only when run evidence is complete"]
+    F --> H
+    G --> H
 ```
 
-### 2. Set Random Seeds
+## Did You Know?
 
-```python
-import numpy as np
-import random
-import torch
-
-def set_seeds(seed=42):
-    """Set all random seeds for reproducibility."""
-    random.seed(seed)
-    np.random.seed(seed)
-    torch.manual_seed(seed)
-    torch.cuda.manual_seed_all(seed)
-
-    # For CUDA determinism
-    torch.backends.cudnn.deterministic = True
-    torch.backends.cudnn.benchmark = False
-```
-
-### 3. Data Versioning with DVC
-
-```bash
-# Initialize DVC
-dvc init
-
-# Track data files
-dvc add data/training.csv
-git add data/training.csv.dvc .gitignore
-git commit -m "Track training data with DVC"
-
-# Push data to remote
-dvc remote add -d storage s3://my-bucket/dvc
-dvc push
-
-# In MLflow, log data version
-mlflow.log_param("data_version", "abc123")  # DVC hash
-```
+- **Kubeflow Trainer v2 uses a unified training API**: Current Kubeflow Trainer documentation describes `TrainJob` and reusable runtimes as the v2 path, while older `PyTorchJob`, `TFJob`, and `MPIJob` APIs remain part of legacy v1 documentation.
+- **Indexed Jobs expose stable shard identity**: Kubernetes Indexed Jobs are stable and expose each Pod's completion index through mechanisms including the `JOB_COMPLETION_INDEX` environment variable.
+- **PyTorch DDP synchronizes gradients across processes**: PyTorch documents DistributedDataParallel as using collective communication to synchronize gradients and buffers, with one process per model replica as the recommended pattern.
+- **GPU sharing modes have different isolation guarantees**: NVIDIA documents that time-sliced GPU replicas interleave access without the memory or fault isolation provided by MIG, which makes the choice workload-dependent.
 
 ## Common Mistakes
 
-| Mistake | Problem | Solution |
-|---------|---------|----------|
-| No experiment names | "What was run xyz?" | Descriptive experiment/run names |
-| Missing parameters | Can't reproduce | Log ALL hyperparameters |
-| No git tracking | Code version unknown | Auto-log git commit |
-| Overwriting runs | History lost | Each run is immutable |
-| No validation data | Overfitting to test | Log train/val/test splits |
-| Ignoring hardware | "Works on my GPU" | Log hardware, CUDA version |
+| Mistake | Problem | Better approach |
+|---|---|---|
+| Treating training like serving | Serving replicas can scale gradually, while distributed training may need all workers together | Design training as a batch workload with admission, completion, and checkpoint semantics |
+| Launching distributed workers without gang scheduling | Partial placement can hold GPUs while the job waits for missing peers | Use queue admission and gang scheduling for tightly coupled multi-worker jobs |
+| Writing checkpoints only to local Pod storage | Node loss or replacement destroys progress | Write complete checkpoints to object storage or durable shared storage |
+| Logging only the final metric | The team cannot diagnose convergence, instability, or bad intermediate behavior | Log parameters, time-series metrics, artifacts, data references, and environment metadata |
+| Running HPO without a declared budget | Trials can consume shared GPUs without a stopping rule | Declare objective, maximum trials, parallelism, early stopping, and failure budget |
+| Requesting GPUs without hardware intent | The scheduler may place work on unsuitable or inefficient nodes | Use resource flavors, labels, tolerations, and queue policy to express hardware needs |
+| Promoting a model artifact without lineage | The registry cannot prove which run, data, code, or parameters produced the model | Require registry entries to link back to complete run evidence |
 
 ## Quiz
 
 Test your understanding:
 
 <details>
-<summary>1. Your team lead asks you to reproduce the model deployed to production last year because a new regulation requires an audit of its training data and parameters. You find a `model_final_v2.pkl` file and a Jupyter notebook named `training_final_USE_THIS.ipynb`. The notebook has been modified since the file creation date. Why is this situation a major compliance risk, and what exact tracking mechanisms would have prevented it?</summary>
+<summary>1. A team submits a distributed PyTorch run that needs eight GPU workers. Five workers start, three stay Pending, and the running workers show almost no GPU utilization. What platform problem is this, and what should you change first?</summary>
 
-**Answer**: This situation is a major compliance risk because there is no cryptographically secure or immutable link between the deployed artifact and the code/data that produced it. The modified notebook means the exact training procedure is lost, making it impossible to definitively prove to auditors how the model learned its behavior or what data it saw. A proper experiment tracking system would have recorded an immutable snapshot. This includes the exact Git commit hash of the code, a DVC hash of the training data, and the precise hyperparameters used, all tied directly to the specific run ID that produced the `model_final_v2.pkl` artifact.
+**Answer**: This is a partial placement problem for a tightly coupled distributed training job. The running workers are holding GPUs while waiting for peers, so the cluster is both busy and unproductive. The first platform change is to use workload-level queue admission and gang scheduling so the job starts only when the minimum worker group can be placed. That change supports the outcome **Configure training infrastructure with proper GPU scheduling, checkpointing, and fault tolerance** because it makes scheduling correctness part of the training contract.
 </details>
 
 <details>
-<summary>2. You are setting up MLflow for a new deep learning project. You need to log the learning rate, the validation loss at each epoch, and the final trained model weights. A junior engineer suggests logging the validation loss as an "artifact" and the model weights as a "parameter". Why is this conceptually incorrect, and how should they be categorized to leverage MLflow's UI effectively?</summary>
+<summary>2. A model registry contains `churn-model-v12`, but nobody can find the data snapshot, hyperparameters, training image, or validation report for the run that produced it. Why is this not just a documentation problem?</summary>
 
-**Answer**: This approach fundamentally misunderstands how experiment tracking tools index and query data. Parameters are static inputs defined *before* training begins (like the learning rate), which allows you to filter and group runs based on configuration. Metrics are dynamic numeric outputs evaluated *during* or *after* training (like validation loss), which MLflow stores as time-series data so you can plot learning curves and compare convergence across runs. Artifacts are bulk files generated by the run (like model weights or plots) stored in blob storage. If you log loss as an artifact, you cannot visualize it in the UI; if you log weights as a parameter, you exceed string limits and cannot download the model for deployment.
+**Answer**: The registry entry is not enough evidence to trust or reproduce the model. A model version should link back to an experiment run that records parameters, metrics, artifacts, code version, environment, and data lineage. Without that link, promotion and rollback decisions depend on memory and guesswork. This directly tests **Design experiment tracking workflows that capture hyperparameters, metrics, and artifacts reproducibly** because the missing run evidence is the real failure.
 </details>
 
 <details>
-<summary>3. You have a compute budget of exactly 100 training runs to tune a Random Forest model with 4 hyperparameters. Your colleague insists on setting up a grid search with 3 values for each parameter (3 × 3 × 3 × 3 = 81 runs), leaving 19 runs unused. You propose using random search for all 100 runs instead. Why is your random search approach likely to yield a better-performing model despite seeming less systematic?</summary>
+<summary>3. Your cluster has a queue for low-priority tuning work on interruptible nodes. A team wants to use that queue for a multi-day training job but has not implemented checkpoint resume. What risk should you raise in review?</summary>
 
-**Answer**: Your random search approach is likely to win because hyperparameter importance is rarely uniform; typically, only one or two parameters strongly influence the model's performance, while others have minimal impact. In your colleague's grid search, even though 81 runs are executed, each individual parameter is only tested at exactly 3 distinct values. With 100 random search runs, every parameter is evaluated at 100 distinct, unique values. This provides vastly superior coverage along the most critical parameter dimensions, allowing the search to discover fine-grained optimal values that fall into the gaps between the predefined steps of a rigid grid.
+**Answer**: Interruptible capacity is only economical when jobs can resume from durable checkpoints. Without checkpoint resume, every interruption can restart the job from the beginning, wasting compute and making completion time unpredictable. The review should require checkpoint state outside the Pod, a resume path, and evidence that the job can load the latest complete checkpoint. This is part of **Configure training infrastructure with proper GPU scheduling, checkpointing, and fault tolerance** because capacity policy and resume behavior must agree.
 </details>
 
 <details>
-<summary>4. A researcher publishes a paper claiming state-of-the-art results. They provide the exact model architecture, the dataset URL, the precise hyperparameter values (learning rate, batch size), and the random seed (`42`). When you run their code on your Kubernetes cluster, you get an accuracy 5% lower than published. Assuming no code bugs, what un-tracked environmental factors are most likely preventing exact reproducibility in this scenario?</summary>
+<summary>4. A data scientist proposes a grid search over six hyperparameters because it feels systematic. The platform can afford only a limited number of trials this week. How would you reason about an alternative?</summary>
 
-**Answer**: Exact reproducibility is fragile and depends on the entire hardware and software execution environment, not just the code and data. The most likely culprit is a difference in library versions (e.g., PyTorch, CUDA, or underlying linear algebra libraries like cuDNN), which can change the order of floating-point operations and lead to divergence. Furthermore, depending on the framework, setting the random seed `42` in Python might not make GPU operations deterministic unless specific backend flags (like `cudnn.deterministic = True` and `cudnn.benchmark = False`) are also enforced. Without containerizing the exact environment and hardware specifications, implicit differences will easily derail exact reproduction.
+**Answer**: Grid search can be useful for small, well-understood spaces, but it spends effort evenly across every dimension. When the budget is limited and parameter importance is uncertain, random search or Bayesian optimization may spend the budget more effectively. The team should declare the objective, maximum trials, parallelism, and secondary metrics before launching. This answer covers **Build automated hyperparameter tuning using Katib or Optuna on Kubernetes clusters** because it connects search strategy to cluster budget and experiment design.
 </details>
 
-## Hands-On Exercise: Complete Experiment Pipeline
+<details>
+<summary>5. A training job requests one GPU and shows the Pod as Running, but the loss curve barely moves and GPU utilization stays low. Which signals would you inspect before increasing the GPU request?</summary>
 
-Build a full experiment tracking setup:
+**Answer**: Increasing the GPU request may make the waste larger if the bottleneck is elsewhere. Inspect data-loader time, examples or tokens per second, checkpoint duration, CPU and memory pressure, network reads, synchronization time, and the loss curve. If the GPU is waiting on input data or distributed synchronization, the resource request is not the first fix. This reinforces **Implement model training pipelines on Kubernetes using Kubeflow, MLflow, or custom operators** because a pipeline must expose progress signals, not only Pod phase.
+</details>
 
-### Setup
+<details>
+<summary>6. You are designing a custom training operator for several ML teams. What should belong in platform-owned runtime templates, and what should remain team-owned?</summary>
+
+**Answer**: Platform-owned templates should define the shared operational contract: base runtime, launcher behavior, security context, queue selection, storage conventions, checkpoint paths, observability hooks, and default failure policy. Team-owned inputs should include training code, model configuration, dataset references, and experiment parameters. Keeping that boundary clear reduces YAML copying while preserving research flexibility. This is a practical version of **Implement model training pipelines on Kubernetes using Kubeflow, MLflow, or custom operators**.
+</details>
+
+<details>
+<summary>7. An HPO experiment finds a model with the best validation loss, but it used a different dataset snapshot and has much higher inference memory than the current model. Should the tuning controller automatically promote it?</summary>
+
+**Answer**: No. The HPO controller can identify a trial that is best for its declared objective, but promotion needs a broader evidence review. Dataset lineage, serving memory, latency, fairness, calibration, and business constraints may invalidate the apparent win. The platform should log secondary metrics and require a promotion gate that reads the run evidence. This answer also supports **Design experiment tracking workflows that capture hyperparameters, metrics, and artifacts reproducibly** because tracking makes the promotion decision reviewable.
+</details>
+
+## Hands-On
+
+In this exercise, you will build a small, copy-runnable training workload that records run evidence, checkpoints progress, resumes from a checkpoint, and emits a Kubernetes Job manifest for the same training entrypoint. The model is intentionally simple and uses only the Python standard library so the exercise focuses on platform behavior rather than a framework install. Keep the same shell open across the steps because the commands reuse the generated scratch directory.
+
+### Step 1: Create a local training script
+
+Run the following commands from the repository root. The script trains a tiny logistic model on synthetic data, writes parameters and metrics, checkpoints every few epochs, and resumes from the latest checkpoint when requested.
 
 ```bash
-mkdir ml-experiments && cd ml-experiments
-python -m venv venv
-source venv/bin/activate
-pip install mlflow scikit-learn optuna pandas matplotlib
-```
+export REPO_ROOT="$(pwd)"
+export DEMO_DIR="$(mktemp -d)"
+cd "$DEMO_DIR"
+cat > train.py <<'PY'
+import argparse
+import json
+import math
+import os
+import random
+import sys
+from pathlib import Path
 
-### Step 1: Create Experiment Script
 
-```python
-# train.py
-import mlflow
-import mlflow.sklearn
-import optuna
-from sklearn.datasets import make_classification
-from sklearn.model_selection import train_test_split, cross_val_score
-from sklearn.ensemble import RandomForestClassifier, GradientBoostingClassifier
-from sklearn.metrics import accuracy_score, f1_score, roc_auc_score
-import numpy as np
-import matplotlib.pyplot as plt
-import subprocess
+def make_dataset(seed, rows):
+    rng = random.Random(seed)
+    data = []
+    for _ in range(rows):
+        x1 = rng.uniform(-1.0, 1.0)
+        x2 = rng.uniform(-1.0, 1.0)
+        logit = (2.0 * x1) - (1.5 * x2) + 0.2
+        y = 1 if logit > 0 else 0
+        data.append((x1, x2, y))
+    return data
 
-def get_git_info():
-    """Get current git info for tracking."""
-    try:
-        commit = subprocess.check_output(["git", "rev-parse", "HEAD"]).decode().strip()[:8]
-        return {"git_commit": commit}
-    except Exception:
-        return {"git_commit": "unknown"}
 
-def create_dataset(n_samples=1000, n_features=20, random_state=42):
-    """Create synthetic classification dataset."""
-    X, y = make_classification(
-        n_samples=n_samples,
-        n_features=n_features,
-        n_informative=10,
-        n_redundant=5,
-        random_state=random_state,
-    )
-    return train_test_split(X, y, test_size=0.2, random_state=random_state)
+def sigmoid(value):
+    return 1.0 / (1.0 + math.exp(-value))
 
-def train_and_evaluate(model, X_train, y_train, X_test, y_test):
-    """Train model and return metrics."""
-    model.fit(X_train, y_train)
-    predictions = model.predict(X_test)
-    proba = model.predict_proba(X_test)[:, 1]
 
-    return {
-        "accuracy": accuracy_score(y_test, predictions),
-        "f1": f1_score(y_test, predictions),
-        "auc": roc_auc_score(y_test, proba),
+def latest_checkpoint(path):
+    checkpoints = sorted(path.glob("checkpoint-*.json"))
+    return checkpoints[-1] if checkpoints else None
+
+
+def load_state(path):
+    checkpoint = latest_checkpoint(path)
+    if checkpoint is None:
+        return 0, [0.0, 0.0], 0.0
+    state = json.loads(checkpoint.read_text())
+    return state["epoch"], state["weights"], state["bias"]
+
+
+def save_state(path, epoch, weights, bias):
+    tmp = path / f"checkpoint-{epoch:03d}.json.tmp"
+    final = path / f"checkpoint-{epoch:03d}.json"
+    tmp.write_text(json.dumps({"epoch": epoch, "weights": weights, "bias": bias}, indent=2))
+    tmp.replace(final)
+
+
+def train(args):
+    run_dir = Path(args.output) / args.run_id
+    checkpoint_dir = run_dir / "checkpoints"
+    artifact_dir = run_dir / "artifacts"
+    checkpoint_dir.mkdir(parents=True, exist_ok=True)
+    artifact_dir.mkdir(parents=True, exist_ok=True)
+
+    params = {
+        "run_id": args.run_id,
+        "seed": args.seed,
+        "epochs": args.epochs,
+        "learning_rate": args.learning_rate,
+        "rows": args.rows,
     }
+    (run_dir / "params.json").write_text(json.dumps(params, indent=2))
 
-def plot_feature_importance(model, n_features=20):
-    """Create and save feature importance plot."""
-    importance = model.feature_importances_
-    indices = np.argsort(importance)[::-1][:10]  # Top 10
+    data = make_dataset(args.seed, args.rows)
+    start_epoch, weights, bias = load_state(checkpoint_dir) if args.resume else (0, [0.0, 0.0], 0.0)
+    metrics_path = run_dir / "metrics.jsonl"
 
-    plt.figure(figsize=(10, 6))
-    plt.title("Feature Importance (Top 10)")
-    plt.bar(range(10), importance[indices])
-    plt.xticks(range(10), [f"Feature {i}" for i in indices])
-    plt.tight_layout()
-    plt.savefig("feature_importance.png")
-    plt.close()
+    for epoch in range(start_epoch + 1, args.epochs + 1):
+        total_loss = 0.0
+        correct = 0
+        for x1, x2, y in data:
+            pred = sigmoid((weights[0] * x1) + (weights[1] * x2) + bias)
+            error = pred - y
+            weights[0] -= args.learning_rate * error * x1
+            weights[1] -= args.learning_rate * error * x2
+            bias -= args.learning_rate * error
+            total_loss += -(y * math.log(pred + 1e-9) + (1 - y) * math.log(1 - pred + 1e-9))
+            correct += int((pred >= 0.5) == bool(y))
 
-def run_experiment(model_type, params, X_train, y_train, X_test, y_test):
-    """Run single experiment with tracking."""
-    with mlflow.start_run():
-        # Log git info
-        mlflow.set_tags(get_git_info())
-        mlflow.set_tag("model_type", model_type)
-
-        # Log parameters
-        mlflow.log_params(params)
-
-        # Create model
-        if model_type == "random_forest":
-            model = RandomForestClassifier(**params, random_state=42)
-        else:
-            model = GradientBoostingClassifier(**params, random_state=42)
-
-        # Train and evaluate
-        metrics = train_and_evaluate(model, X_train, y_train, X_test, y_test)
-
-        # Cross-validation score
-        cv_scores = cross_val_score(model, X_train, y_train, cv=5, scoring='f1')
-        metrics["cv_f1_mean"] = cv_scores.mean()
-        metrics["cv_f1_std"] = cv_scores.std()
-
-        # Log metrics
-        mlflow.log_metrics(metrics)
-
-        # Log artifacts
-        plot_feature_importance(model)
-        mlflow.log_artifact("feature_importance.png")
-
-        # Log model
-        mlflow.sklearn.log_model(model, "model")
-
-        return metrics
-
-def hpo_objective(trial, X_train, y_train, X_test, y_test):
-    """Optuna objective for HPO."""
-    model_type = trial.suggest_categorical("model_type", ["random_forest", "gradient_boosting"])
-
-    if model_type == "random_forest":
-        params = {
-            "n_estimators": trial.suggest_int("n_estimators", 50, 300),
-            "max_depth": trial.suggest_int("max_depth", 3, 15),
-            "min_samples_split": trial.suggest_int("min_samples_split", 2, 10),
+        metric = {
+            "epoch": epoch,
+            "loss": round(total_loss / len(data), 6),
+            "accuracy": round(correct / len(data), 6),
         }
-    else:
-        params = {
-            "n_estimators": trial.suggest_int("n_estimators", 50, 300),
-            "max_depth": trial.suggest_int("max_depth", 3, 10),
-            "learning_rate": trial.suggest_float("learning_rate", 0.01, 0.3),
-        }
+        with metrics_path.open("a") as stream:
+            stream.write(json.dumps(metric) + "\n")
+        if epoch % args.checkpoint_every == 0 or epoch == args.epochs:
+            save_state(checkpoint_dir, epoch, weights, bias)
 
-    with mlflow.start_run(nested=True):
-        mlflow.log_params(params)
-        mlflow.set_tag("model_type", model_type)
+    model = {"weights": weights, "bias": bias}
+    (artifact_dir / "model.json").write_text(json.dumps(model, indent=2))
+    (run_dir / "environment.json").write_text(json.dumps({"python": sys.version.split()[0]}, indent=2))
+    print(json.dumps({"run_id": args.run_id, "model": str(artifact_dir / "model.json")}, indent=2))
 
-        if model_type == "random_forest":
-            model = RandomForestClassifier(**params, random_state=42)
-        else:
-            model = GradientBoostingClassifier(**params, random_state=42)
 
-        metrics = train_and_evaluate(model, X_train, y_train, X_test, y_test)
-        mlflow.log_metrics(metrics)
+def parse_args():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--run-id", required=True)
+    parser.add_argument("--output", default="runs")
+    parser.add_argument("--epochs", type=int, default=10)
+    parser.add_argument("--checkpoint-every", type=int, default=2)
+    parser.add_argument("--learning-rate", type=float, default=0.2)
+    parser.add_argument("--rows", type=int, default=200)
+    parser.add_argument("--seed", type=int, default=42)
+    parser.add_argument("--resume", action="store_true")
+    return parser.parse_args()
 
-        return metrics["f1"]
-
-def main():
-    # Setup
-    mlflow.set_experiment("classification-experiments")
-    X_train, X_test, y_train, y_test = create_dataset()
-
-    # Run HPO study
-    with mlflow.start_run(run_name="hpo-study"):
-        study = optuna.create_study(direction="maximize")
-        study.optimize(
-            lambda trial: hpo_objective(trial, X_train, y_train, X_test, y_test),
-            n_trials=20,
-        )
-
-        # Log best results
-        mlflow.log_params(study.best_params)
-        mlflow.log_metric("best_f1", study.best_value)
-
-        print(f"\nBest F1: {study.best_value:.4f}")
-        print(f"Best params: {study.best_params}")
 
 if __name__ == "__main__":
-    main()
+    train(parse_args())
+PY
 ```
 
-### Step 2: Run and Analyze
+### Step 2: Run, interrupt, and resume the training record
+
+Use the repository virtual environment interpreter. The first command writes an early checkpoint; the second resumes and writes the final model artifact.
 
 ```bash
-# Run experiments
-python train.py
+"$REPO_ROOT/.venv/bin/python" "$DEMO_DIR/train.py" \
+  --run-id demo-run \
+  --output "$DEMO_DIR/runs" \
+  --epochs 4 \
+  --checkpoint-every 2
 
-# Start MLflow UI
-mlflow ui
-
-# Open http://localhost:5000 and explore:
-# - Compare runs side-by-side
-# - View parameter/metric correlations
-# - Download artifacts
+"$REPO_ROOT/.venv/bin/python" "$DEMO_DIR/train.py" \
+  --run-id demo-run \
+  --output "$DEMO_DIR/runs" \
+  --epochs 10 \
+  --checkpoint-every 2 \
+  --resume
 ```
 
-### Step 3: Register Best Model
+### Step 3: Verify the evidence contract
 
-```python
-# register_best.py
-import mlflow
-from mlflow.tracking import MlflowClient
+This verification checks that the run has parameters, metrics, checkpoints, a model artifact, and environment evidence. In a real platform, this kind of check belongs in the completion gate before a model can be promoted.
 
-client = MlflowClient()
-experiment = client.get_experiment_by_name("classification-experiments")
+```bash
+"$REPO_ROOT/.venv/bin/python" - <<'PY'
+import json
+import os
+from pathlib import Path
 
-# Find best run
-runs = client.search_runs(
-    experiment_ids=[experiment.experiment_id],
-    filter_string="tags.model_type IS NOT NULL",
-    order_by=["metrics.f1 DESC"],
-    max_results=1,
-)
+run_dir = Path(os.environ["DEMO_DIR"]) / "runs" / "demo-run"
+required = [
+    run_dir / "params.json",
+    run_dir / "metrics.jsonl",
+    run_dir / "checkpoints" / "checkpoint-010.json",
+    run_dir / "artifacts" / "model.json",
+    run_dir / "environment.json",
+]
+missing = [str(path) for path in required if not path.exists()]
+if missing:
+    raise SystemExit(f"missing evidence: {missing}")
 
-best_run = runs[0]
-print(f"Best run: {best_run.info.run_id}")
-print(f"F1: {best_run.data.metrics['f1']:.4f}")
+metrics = [json.loads(line) for line in (run_dir / "metrics.jsonl").read_text().splitlines()]
+if metrics[-1]["loss"] >= metrics[0]["loss"]:
+    raise SystemExit("loss did not improve")
 
-# Register
-model_uri = f"runs:/{best_run.info.run_id}/model"
-mlflow.register_model(model_uri, "best-classifier")
+print("run evidence complete")
+PY
+```
 
-# Promote to staging
-client.transition_model_version_stage(
-    name="best-classifier",
-    version=1,
-    stage="Staging"
-)
+### Step 4: Render a Kubernetes Job manifest for the same entrypoint
 
-print("Model registered and promoted to Staging")
+The manifest below is a portable sketch of the same training contract. In a real cluster, replace the inline script with your training image, mount or fetch the dataset, write checkpoints to durable object storage, and apply the manifest only after reviewing the namespace, queue, and storage policy.
+
+```bash
+cat > "$DEMO_DIR/training-job.yaml" <<'YAML'
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: demo-training
+  labels:
+    app.kubernetes.io/name: demo-training
+spec:
+  backoffLimit: 1
+  template:
+    spec:
+      restartPolicy: Never
+      containers:
+        - name: trainer
+          image: python:3.12-slim
+          command: ["python", "-c"]
+          args:
+            - |
+              import json
+              from pathlib import Path
+              output = Path("run-evidence")
+              output.mkdir(parents=True, exist_ok=True)
+              (output / "params.json").write_text(json.dumps({"run_id": "demo-training"}))
+              (output / "metrics.jsonl").write_text(json.dumps({"loss": 0.5}) + "\n")
+              (output / "model.json").write_text(json.dumps({"weights": [0.1, 0.2]}))
+              print("training evidence written")
+YAML
+
+"$REPO_ROOT/.venv/bin/python" - <<'PY'
+import os
+from pathlib import Path
+
+import yaml
+
+manifest = yaml.safe_load((Path(os.environ["DEMO_DIR"]) / "training-job.yaml").read_text())
+assert manifest["apiVersion"] == "batch/v1"
+assert manifest["kind"] == "Job"
+assert manifest["spec"]["template"]["spec"]["restartPolicy"] == "Never"
+assert manifest["spec"]["template"]["spec"]["containers"][0]["image"] == "python:3.12-slim"
+print("manifest is a Kubernetes Job")
+PY
 ```
 
 ### Success Criteria
 
-You've completed this exercise when you can:
-- [ ] Run HPO with multiple model types
-- [ ] View experiments in MLflow UI
-- [ ] Compare runs and their parameters
-- [ ] Register the best model
-- [ ] Transition model to Staging stage
+- [ ] You can run the local training script and see a `model.json` artifact under `$DEMO_DIR/runs/demo-run/artifacts/`.
+- [ ] You can resume from a checkpoint and verify that `checkpoint-010.json` exists after the resumed run.
+- [ ] You can explain which files represent parameters, metrics, checkpoints, artifacts, and environment metadata.
+- [ ] You can parse the Kubernetes Job manifest locally and confirm it is a `batch/v1` Job with a `Never` restart policy.
 
-## Key Takeaways
+## Sources
 
-1. **Track everything**: Parameters, metrics, artifacts, code version
-2. **Use HPO**: Random/Bayesian search finds better hyperparameters than manual tuning
-3. **Reproducibility requires discipline**: Seeds, versions, environment—all must be tracked
-4. **Model registry manages lifecycle**: Stage models from development to production
-5. **MLflow is a great starting point**: Open source, flexible, widely adopted
-
-## Further Reading
-
-- [MLflow Documentation](https://mlflow.org/docs/latest/index.html) — Complete MLflow guide
-- [Optuna Documentation](https://optuna.org/) — HPO library
-- [Random Search for Hyper-Parameter Optimization](https://www.jmlr.org/papers/v13/bergstra12a.html) — Foundational paper
-- [DVC Documentation](https://dvc.org/doc) — Data versioning
-
-## Summary
-
-Experiment tracking transforms ML from guesswork into science. By tracking parameters, metrics, and artifacts for every run, you build a searchable history of what works (and what doesn't). Combined with hyperparameter optimization, you systematically explore the search space instead of randomly hoping for good results. The model registry then manages the transition from experiment to production.
-
----
+- [Kubeflow Trainer Overview](https://www.kubeflow.org/docs/components/trainer/overview/)
+- [Migrating to Kubeflow Trainer v2](https://www.kubeflow.org/docs/components/trainer/operator-guides/migration/)
+- [Kubeflow Trainer PyTorch Guide](https://www.kubeflow.org/docs/components/trainer/user-guides/pytorch/)
+- [Kubeflow Trainer Gang Scheduling Overview](https://www.kubeflow.org/docs/components/trainer/operator-guides/job-scheduling/overview/)
+- [Kubeflow Katib Configure Experiment](https://www.kubeflow.org/docs/components/katib/user-guides/hp-tuning/configure-experiment/)
+- [Kueue Overview](https://kueue.sigs.k8s.io/docs/overview/)
+- [Kueue Workload Concept](https://kueue.sigs.k8s.io/docs/concepts/workload/)
+- [Kueue ClusterQueue Concept](https://kueue.sigs.k8s.io/docs/concepts/cluster_queue/)
+- [Kubernetes Jobs](https://kubernetes.io/docs/concepts/workloads/controllers/job/)
+- [Kubernetes Indexed Jobs](https://kubernetes.io/docs/tasks/job/indexed-parallel-processing-static/)
+- [Kubernetes Device Plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/device-plugins/)
+- [Kubernetes v1.35 Workload Aware Scheduling](https://kubernetes.io/blog/2025/12/29/kubernetes-v1-35-introducing-workload-aware-scheduling/)
+- [PyTorch Distributed Overview](https://docs.pytorch.org/tutorials/beginner/dist_overview.html)
+- [PyTorch DistributedDataParallel Tutorial](https://docs.pytorch.org/tutorials/intermediate/ddp_tutorial.html)
+- [PyTorch Parameter Server with Distributed RPC](https://docs.pytorch.org/tutorials/intermediate/rpc_param_server_tutorial.html)
+- [PyTorch Pipeline Parallelism Tutorial](https://docs.pytorch.org/tutorials/intermediate/pipelining_tutorial.html)
+- [MLflow Tracking](https://mlflow.org/docs/latest/ml/tracking/)
+- [MLflow Artifact Stores](https://mlflow.org/docs/latest/self-hosting/architecture/artifact-store/)
+- [NVIDIA GPU Operator Time-Slicing](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-sharing.html)
+- [CNCF Kubeflow Project](https://www.cncf.io/projects/kubeflow/)
+- [CNCF Volcano Project](https://www.cncf.io/projects/volcano/)
+- [Random Search for Hyper-Parameter Optimization](https://www.jmlr.org/papers/v13/bergstra12a.html)
 
 ## Next Module
 

--- a/src/content/docs/platform/disciplines/delivery-automation/gitops/module-3.2-repository-strategies.md
+++ b/src/content/docs/platform/disciplines/delivery-automation/gitops/module-3.2-repository-strategies.md
@@ -1,18 +1,22 @@
 ---
-revision_pending: true
+citations_verified: true
+revision_pending: false
 title: "Module 3.2: Repository Strategies"
 slug: platform/disciplines/delivery-automation/gitops/module-3.2-repository-strategies
 sidebar:
   order: 3
 ---
-> **Discipline Module** | Complexity: `[MEDIUM]` | Time: 30-35 min
+
+> **Discipline Module** | Complexity: `[MEDIUM]` | Time: 45-55 min | Track: Platform Engineering / GitOps
 
 ## Prerequisites
 
-Before starting this module:
-- **Required**: [Module 3.1: What is GitOps?](../module-3.1-what-is-gitops/) — GitOps fundamentals
-- **Required**: Git branching and PR workflow experience
-- **Recommended**: Experience managing multiple services/environments
+Before starting this module, you should already understand the GitOps control loop from [Module 3.1: What is GitOps?](../module-3.1-what-is-gitops/) and be comfortable opening pull requests, reviewing YAML, and explaining why Git should remain the source of truth for cluster state. Repository strategy sits between theory and daily practice: it determines who can propose a change, how that change is reviewed, and how safely it can propagate across environments.
+
+- **Required**: [Module 3.1: What is GitOps?](../module-3.1-what-is-gitops/) — declarative desired state, pull-based reconciliation, and continuous alignment.
+- **Required**: Git branching and pull-request workflow experience.
+- **Recommended**: Familiarity with Kustomize or Helm overlays for environment-specific configuration.
+- **Recommended**: Experience managing more than one Kubernetes cluster or namespace boundary.
 
 ---
 
@@ -25,208 +29,58 @@ After completing this module, you will be able to:
 - **Evaluate repository access patterns to prevent configuration drift and unauthorized changes**
 - **Build repository conventions that make GitOps workflows self-documenting and auditable**
 
+---
+
 ## Why This Module Matters
 
-You've decided to adopt GitOps. Great! Now where do you put things?
+Hypothetical scenario: a platform team adopts GitOps for twelve microservices across development, staging, and production clusters. They store every manifest in the application repository beside the source code, grant all developers write access, and map each environment to a long-lived Git branch. For the first month the model feels simple. By the third month, a staging-only replica patch merges into the production branch during a routine release, CI pipelines rebuild containers when someone only wanted to change an ingress annotation, and nobody can answer which commit actually represents production without diffing three divergent branches.
 
-This seemingly simple question determines:
-- **Who can change what**: Access control
-- **How fast you can deploy**: Sync times, blast radius
-- **How teams collaborate**: Coupling vs autonomy
-- **How you recover from disasters**: What to restore from where
+That failure is architectural, not accidental. In GitOps the repository layout is part of the control system. Structure determines blast radius when a pull request merges, which teams can approve which paths, how promotion works, and whether the Git history you read during an incident matches what the cluster reconciler applies. A controller can only enforce what Git declares; if the repository boundaries are unclear, the controller faithfully automates confusion.
 
-Bad repository structure creates friction. Good structure enables flow.
+Repository strategy also shapes collaboration. Platform engineers need shared baselines for ingress, monitoring, policy, and cluster add-ons. Application teams need autonomy to iterate on their workloads without waiting for unrelated approvals. Security teams need boundaries that prevent a frontend developer from editing a shared certificate issuer. Finance and compliance stakeholders need an audit trail that ties production state to reviewed commits rather than to shell history. None of those needs is solved by picking Argo CD or Flux alone; they are solved by how you partition repositories, directories, and permissions before the first sync succeeds.
 
-This module helps you choose the right structure for your organization.
+The durable lesson is that repository design is a first-class GitOps decision alongside reconciliation policy, secrets handling, and promotion flow. Tools implement the loop described in the [OpenGitOps principles](https://opengitops.dev/); repository structure decides whether that loop remains understandable at scale. This module teaches the durable axes—app versus config separation, monorepo versus polyrepo, environment modeling, multi-app bootstrapping, access control, and secrets placement—so you can evolve tooling without redesigning your operating model every quarter.
+
+> **Stop and think**: If every Kubernetes manifest for your organization lived in one repository with one shared `main` branch, what is the smallest change a developer could merge that would still create a production-impacting blast radius, and which repository boundary would have prevented it?
 
 ---
 
-> **Stop and think**: If you put all your configurations in a single repository, how will you prevent a junior developer from accidentally breaking production infrastructure while updating a staging application?
+## 1. Repository Structure as a First-Class GitOps Decision
 
-## The Core Decision: Monorepo vs Polyrepo
+When teams first adopt GitOps, repository structure is often treated as a housekeeping detail left until after the controller is installed. That ordering creates expensive rework. The GitOps agent watches specific repositories, paths, and revisions; access control is enforced at the Git host; promotion workflows copy or patch files between directories; and incident response begins with `git log`. If those elements were chosen casually, every later improvement fights the grain of the repository itself.
 
-### Monorepo
+Think of the configuration repository as both source of truth and audit log. Each merged pull request becomes a durable record of intent: who approved a replica increase, when an image tag changed, which network policy opened a port, and whether a emergency fix was backported. That record only remains trustworthy when repository boundaries align with ownership boundaries. When unrelated teams share a flat directory without CODEOWNERS rules or path-scoped permissions, the audit log still exists but the social contract breaks down because reviewers cannot confidently know whether a change in one path affects another team's production path.
 
-All configuration in a single repository.
+Repository structure also defines blast radius. A monorepo can make cross-cutting improvements easy—updating a shared monitoring label across thirty services in one reviewed change—but it can also couple unrelated failure domains. A polyrepo can isolate teams, yet it can hide dependencies when a platform repository changes a mutating webhook contract that application repositories assume. Hybrid models exist because real organizations rarely choose pure extremes; they centralize shared platform baselines while decentralizing application overlays. The design task is to make those boundaries explicit enough that a new engineer can predict where a change belongs before opening a pull request.
 
-```text
-gitops-config/
-├── apps/
-│   ├── frontend/
-│   │   ├── base/
-│   │   └── overlays/
-│   │       ├── dev/
-│   │       ├── staging/
-│   │       └── prod/
-│   ├── backend/
-│   │   ├── base/
-│   │   └── overlays/
-│   └── database/
-├── infrastructure/
-│   ├── cert-manager/
-│   ├── ingress-nginx/
-│   └── monitoring/
-└── clusters/
-    ├── dev/
-    ├── staging/
-    └── prod/
+Finally, structure determines review flow. GitOps succeeds when the same change that fixes a problem is the change the controller applies. If developers must edit three repositories, run a manual script, and ping a platform operator to trigger sync, the repository layout is working against the model even if the controller is healthy. Good structure makes the happy path obvious: application continuous integration updates the image tag in the config repository, platform engineers edit shared bases in the platform repository, and environment differences live in overlays that promotion can copy or patch with mechanical precision.
+
+```ascii
++---------------------------+       +---------------------------+
+| Git hosting + RBAC        |       | GitOps controller         |
+| repos, branches, CODEOWNERS| ----> | watches declared paths    |
++---------------------------+       +---------------------------+
+            |                                     |
+            v                                     v
++---------------------------+       +---------------------------+
+| Human review + audit log    |       | Cluster desired state     |
+| PRs, commits, blame         |       | reconciled continuously   |
++---------------------------+       +---------------------------+
 ```
 
-**Pros:**
-- Single place to see everything
-- Easier cross-cutting changes
-- Simplified tooling
-- Single set of access controls
-
-**Cons:**
-- Can become large and slow
-- Tight coupling between teams
-- Harder to scale permissions
-- One repo's issues affect everyone
-
-**Best for:**
-- Smaller organizations (< 50 engineers)
-- Platform teams managing infrastructure
-- Strong central control needed
-
-### Polyrepo
-
-Configuration spread across multiple repositories.
-
-```text
-# Repository: team-a-config
-team-a-config/
-├── service-1/
-│   └── overlays/
-└── service-2/
-    └── overlays/
-
-# Repository: team-b-config
-team-b-config/
-├── api-gateway/
-└── auth-service/
-
-# Repository: platform-config
-platform-config/
-├── infrastructure/
-├── policies/
-└── cluster-addons/
-```
-
-**Pros:**
-- Team autonomy
-- Fine-grained access control
-- Independent scaling
-- Smaller, focused repos
-
-**Cons:**
-- Harder to see full picture
-- Cross-cutting changes need multiple PRs
-- More tooling complexity
-- Potential for drift between repos
-
-**Best for:**
-- Larger organizations
-- Strong team boundaries
-- High autonomy cultures
-
-### Hybrid Approach
-
-Most organizations land somewhere in between:
-
-```text
-# Platform repo (central team)
-platform-config/
-├── infrastructure/
-├── policies/
-└── base-configs/
-
-# Team repos (each team owns)
-team-a-apps/
-├── service-1/
-└── service-2/
-
-team-b-apps/
-├── api/
-└── worker/
-```
-
-**Platform repo**: Shared infrastructure, policies, base configurations
-**Team repos**: Team-specific applications and customizations
+The diagram above is intentionally tool-agnostic. Whether you use Argo CD Applications or Flux Kustomizations, the controller reads Git state that humans already agreed should be authoritative. Repository strategy is the bridge between organizational boundaries and reconciler boundaries. When that bridge is well designed, GitOps feels like acceleration. When it is improvised, GitOps feels like merge conflicts wearing a Kubernetes costume.
 
 ---
 
-> **Pause and predict**: If your application source code and deployment manifests live in the same repository, what happens to your Git history and CI pipeline when you need to scale up replicas without changing any application code?
+## 2. App Code Versus Configuration Separation
 
-## App Repo vs Config Repo
+A recurring early decision is whether application source code and deployment manifests should live in the same repository. Co-location is attractive for small teams because a single pull request can change business logic and the Deployment that runs it, which simplifies local development and code review for beginners. The pattern breaks down as delivery cadence, permissions, and controller boundaries mature. Application repositories change when features ship; configuration repositories change when operators tune replicas, ingress hosts, resource limits, and secrets references. Those are related but not identical lifecycles.
 
-Another key decision: where does configuration live relative to application code?
+Keeping deployment configuration in a separate repository decouples build from deploy in the way GitOps intends. Continuous integration builds and pushes an immutable container image, then updates a manifest field—typically an image digest or semver tag—in the config repository. The GitOps controller observes that commit and reconciles the cluster. No cluster credential needs to live in the application pipeline if the pipeline's final step is a Git commit rather than a `kubectl apply`. That separation also prevents accidental coupling where a documentation-only application change retriggers a full deployment pipeline merely because a YAML file sits beside the code.
 
-### Single Repo (App + Config Together)
+Separate repositories also clarify permissions. Application developers may need write access to service code but only propose configuration changes through pull requests reviewed by a platform or release group. Conversely, on-call engineers may need emergency configuration edits without granting them push access to proprietary application source. When both live together, Git host permissions become coarse: granting write access to fix production replicas also grants write access to business logic unless path-based rules are meticulously maintained.
 
-```text
-my-service/
-├── src/
-│   └── main.go
-├── Dockerfile
-├── Makefile
-└── deploy/
-    ├── base/
-    │   ├── deployment.yaml
-    │   ├── service.yaml
-    │   └── kustomization.yaml
-    └── overlays/
-        ├── dev/
-        ├── staging/
-        └── prod/
-```
-
-**Pros:**
-- Everything in one place
-- App and config versioned together
-- Simpler for small teams
-- Natural code review includes deploy changes
-
-**Cons:**
-- App changes trigger config pipeline
-- Config changes trigger app pipeline
-- Different audiences (dev vs ops)
-- CI/CD complexity
-
-### Separate Repos
-
-```text
-# Repository: my-service (app code)
-my-service/
-├── src/
-├── Dockerfile
-└── Makefile
-
-# Repository: my-service-config (GitOps config)
-my-service-config/
-├── base/
-│   ├── deployment.yaml
-│   └── service.yaml
-└── overlays/
-    ├── dev/
-    ├── staging/
-    └── prod/
-```
-
-**Pros:**
-- Clean separation of concerns
-- Different permissions (devs vs ops)
-- Config changes don't rebuild app
-- Clear GitOps boundary
-
-**Cons:**
-- Two repos to manage
-- Coordination needed
-- More complex CI/CD
-
-### The Common Pattern
-
-Most teams settle on:
+The commit-loop trap appears when teams try to keep a single repository but still automate image updates. Continuous integration builds an image, then writes the tag back into the same repository that triggered the build, which can retrigger pipelines, create noisy commits, or race with feature work on open branches. A dedicated config repository breaks that loop because the application repository merge no longer implies an immediate cluster change until the config repository records the new tag. Image automation controllers—Flux image automation and Argo CD Image Updater are common examples—still commit back to Git, but the write target is the config repository where reviewers expect operational changes.
 
 ```mermaid
 graph TD
@@ -236,57 +90,62 @@ graph TD
     AppRepo -->|Updates image tag| ConfigRepo
 ```
 
----
+The diagram shows the durable spine, not a vendor requirement. Some organizations legitimately co-locate code and config for a small product with one team and one cluster. The senior-level question is whether that simplicity still holds when you add a second environment, a second team, or segregation-of-duty requirements. If the answer is no, separating early is cheaper than migrating under incident pressure.
 
-## Try This: Map Your Current Structure
-
-Draw your current repository structure:
-
-```text
-Current structure:
-├── Where is app code? _________________
-├── Where are Kubernetes manifests? _________________
-├── Where is infrastructure config? _________________
-├── How many repos total? _________________
-
-Questions:
-1. Can a team deploy without touching other teams' repos? Y/N
-2. Can you see all deployed services in one place? Y/N
-3. Do app changes require config changes in separate commits? Y/N
-4. Are permissions appropriately scoped? Y/N
-```
+For Kubernetes 1.35 workloads, the manifest content itself remains standard Deployment, Service, and Ingress objects whether they live beside Go source or in a dedicated `payments-config` repository. The separation decision is operational. Teach your teams a simple rule: the application repository answers "what artifact did we build?" while the configuration repository answers "what should the cluster run right now?" When those questions have different approvers, they should usually have different repositories.
 
 ---
 
-## Directory Structures
+## 3. Monorepo Versus Polyrepo for Configuration
 
-How you organize files within repos matters as much as which repos you use.
+Once you accept a dedicated configuration repository, the next axis is whether to use one repository for the entire organization or many repositories aligned to teams, products, or environments. Monorepos concentrate visibility. A platform engineer can search one tree to see every production overlay, compare how two services configure pod disruption budgets, or refactor a shared label scheme in a single reviewed change. That visibility is powerful during early GitOps adoption when consistency matters more than autonomy.
 
-### Environment-Based Structure
+Monorepos also simplify bootstrapping. A single set of branch protection rules, one CODEOWNERS file with path owners, and one CI policy for YAML linting can cover dozens of services. For platform-led organizations rolling out shared ingress, cert-manager, and monitoring baselines, a monorepo can act as a curriculum for good patterns: new services copy an existing overlay structure rather than inventing one from scratch. The [Kustomize base and overlay model](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/) fits naturally into monorepos because each service directory can repeat the same `base/` and `overlays/` shape without creating new Git hosting projects.
+
+The costs appear as scale and ownership complexity increase. Pull request queues lengthen when many teams watch one repository. A change to a shared Helm values file can require approvals from teams unrelated to the author's intent. Git operations slow down on very large trees unless you invest in sparse checkout, path filters, and selective CI triggers. Permissions become harder because repository-level roles are coarse; path-based CODEOWNERS help but do not replace the psychological overhead of "everyone's production is one merge away."
+
+Polyrepos push autonomy to the foreground. Each team owns a repository scoped to its services, sets its own review rules, and merges on its cadence. Platform teams still publish a shared baseline repository—often read-only to application teams—that provides common labels, network policies, or monitoring patches imported through Kustomize bases or Helm dependencies. Polyrepos map cleanly to organizational boundaries, which matters when compliance requires segregated access between business units or when acquisition integrations must remain isolated until standardized.
+
+Polyrepo tradeoffs include fragmented visibility and cross-cutting friction. Updating a mandatory pod security standard may require coordinated pull requests across fifteen repositories, which defeats the promise of GitOps automation unless you invest in templating, policy-as-code, or a platform-managed base layer. Drift between repositories becomes a social problem: two teams may solve the same ingress annotation differently because no shared search surface exposes the divergence. Tooling can mitigate fragmentation—ApplicationSets and Flux multi-source configurations help—but mitigation is not free.
+
+Most mature organizations land on a hybrid. A platform repository owns cluster add-ons, shared policies, and sometimes cluster-level bootstrapping manifests. Team repositories own application overlays and service-specific resources. A small "catalog" repository may declare which versions of platform bundles teams should import. The hybrid model works because it matches how accountability actually flows: platform teams answer for shared infrastructure; product teams answer for application manifests that instantiate that infrastructure.
+
+When you evaluate monorepo versus polyrepo, count decisions rather than repositories. How many distinct approval policies do you need? How often do engineers ask "where is the canonical copy of this manifest?" How frequently do platform teams publish cross-cutting changes that every service must adopt? If the answers point to many policies, many unrelated approvers, and frequent shared changes, a single monorepo without careful path design will feel slower than several well-named repositories connected by documented import paths. If the answers point to small teams, shared standards, and frequent cross-service refactors, a monorepo may still be the lowest-friction option, especially while the organization is learning GitOps conventions together.
 
 ```text
-my-service/
-├── base/
-│   ├── deployment.yaml
-│   ├── service.yaml
-│   ├── configmap.yaml
-│   └── kustomization.yaml
-└── overlays/
+gitops-config/                     team-a-config/              platform-config/
+├── apps/                          ├── checkout-api/             ├── clusters/
+│   ├── frontend/                  │   ├── base/                 │   ├── dev/
+│   │   ├── base/                  │   └── overlays/             │   └── prod/
+│   │   └── overlays/              └── pricing-api/              ├── addons/
+│   └── backend/                       └── overlays/             │   ├── cert-manager/
+├── infrastructure/                                                    └── ingress-nginx/
+│   ├── cert-manager/
+│   └── monitoring/
+└── clusters/
     ├── dev/
-    │   ├── kustomization.yaml
-    │   ├── replica-patch.yaml
-    │   └── config-patch.yaml
-    ├── staging/
-    │   ├── kustomization.yaml
-    │   └── replica-patch.yaml
     └── prod/
-        ├── kustomization.yaml
-        ├── replica-patch.yaml
-        ├── hpa.yaml
-        └── pdb.yaml
 ```
 
-**How Kustomize works:**
+The tree above illustrates three coexistence patterns, not a mandate to use all three simultaneously. Some enterprises keep everything in the left tree; others split into the three repositories on the right. The design exercise is to decide which changes must be visible together, which changes must be approval-isolated, and which changes should propagate mechanically from a platform publisher to many consumers.
+
+---
+
+## 4. Environment Modeling: Branches, Directories, and Templates
+
+Environment modeling is where repository strategy most often collides with intuition imported from application development. Long-lived environment branches feel natural when teams say "main is production" and "develop is development." That mapping treats Git branches as deployment targets. GitOps at scale treats branches as integration lines for proposed change, while environments are directories, overlays, or Kustomize patches on a single reviewed line such as `main`. The community moved away from branch-per-environment for operational reasons, not because Git hosts forbid branches.
+
+Branches diverge because feature work, hotfixes, and delayed promotions all create unique histories. When each environment is a branch, promotion becomes a merge problem rather than a configuration problem. A hotfix merged directly to production may never return to the staging branch; a feature partially promoted may exist in staging but not development, or the reverse. Cherry-picks multiply, merge conflicts appear in YAML rather than in code, and incident reviewers must compare branch tips instead of comparing two directories that should differ only in controlled ways.
+
+Directory-per-environment on a single branch makes promotion explicit. Development, staging, and production overlays live side by side in Git; promotion copies or patches a known field—often an image tag, replica count, or config map hash—from `overlays/dev` to `overlays/staging` to `overlays/prod`. Pull requests show exactly which environment changed, CODEOWNERS can require platform approval for production paths only, and `git diff overlays/staging overlays/prod` answers readiness questions without invoking merge base algorithms. This is the model [Module 3.3: Environment Promotion](../module-3.3-environment-promotion/) builds on; repository structure either enables or obstructs that flow.
+
+Kustomize remains the durable templating pattern for many GitOps teams because it keeps differences localized in overlays while shared intent lives in bases. A base directory lists common resources; each overlay references the base and adds patches, config map generators, or additional resources such as horizontal pod autoscalers in production only. Helm values files provide a parallel pattern for chart-centric organizations: a shared chart packages Kubernetes objects while environment-specific values files supply replica counts, ingress hosts, and feature flags. Both patterns teach the same lesson: capture sameness once, capture difference in small, reviewable files.
+
+Cluster-based directory layouts add another axis when one environment spans multiple clusters or regions. Instead of naming overlays only `dev`, `staging`, and `prod`, some repositories name overlays after cluster identities such as `prod-us-east` and `prod-eu-west`. That layout helps platform teams answer "what should run in this cluster?" without scanning every application tree. Application-centric layouts invert the priority: each service owns its overlays, and cluster differences appear beneath the service. Choose cluster-centric layouts when cluster operations dominate; choose application-centric layouts when product teams own end-to-end delivery and clusters are fungible targets.
+
+Hypothetical scenario: a retail platform uses `main` for production, `staging` for pre-production, and `develop` for integration testing. After eight weeks, staging is dozens of commits ahead of production while develop contains a feature deliberately excluded from the next release. A production hotfix lands on `main` and resolves an outage, but the same bug reappears after a later "routine" merge from staging because the hotfix never reached the other branches. The team spends a day reconciling branches instead of editing one production overlay file. Relabeling the narrative as hypothetical does not reduce the lesson: branches optimize for parallel feature integration; environments optimize for known, comparable states. Mixing the two confuses both.
+
+When branches might still be acceptable, the scope is narrow: very small teams, at most two environments, and a strict rule that every change flows through identical promotion merges without hotfix exceptions. The moment hotfixes can bypass staging—or production can diverge temporarily—the branch model becomes a liability. Directory overlays on `main` absorb hotfixes as commits that can be copied forward or backward between overlays with mechanical scripts and ordinary pull requests.
 
 ```yaml
 # base/kustomization.yaml
@@ -308,217 +167,158 @@ patches:
   - path: pdb.yaml
 ```
 
-### Cluster-Based Structure
+The manifests above are representative rather than exhaustive; they show how production-only resources stay out of development overlays while still sharing one base Deployment. Repository strategy ensures those paths remain stable so CI, reviewers, and controllers can rely on predictable locations.
 
-When managing multiple clusters:
+---
 
-```text
-clusters/
-├── dev-cluster/
-│   ├── kustomization.yaml
-│   ├── apps/
-│   │   ├── frontend/
-│   │   └── backend/
-│   └── infrastructure/
-│       ├── cert-manager/
-│       └── ingress/
-├── staging-cluster/
-│   └── ...
-└── prod-cluster/
-    ├── us-east/
-    │   └── ...
-    └── eu-west/
-        └── ...
+## 5. Scaling Many Applications: App-of-Apps and Generators
+
+Bootstrapping one Application or Kustomization manually is fine for a lab cluster. Production platforms manage dozens or hundreds of workloads across multiple clusters. The durable pattern on the Argo CD side is app-of-apps: a parent Application points at a directory of child Application manifests, so adding a service often means committing a new child file rather than clicking in a UI. Argo CD Projects further scope what repositories, destinations, and resource kinds child applications may use, which turns repository boundaries into controller-enforced policy.
+
+ApplicationSets generalize bootstrapping by generating child Applications from templates plus generators. A list generator might declare known clusters; a cluster generator discovers registered clusters; a Git generator reads a directory of service folders; a matrix generator combines two dimensions such as cluster times service. The generated Applications remain declarative because the template and inputs live in Git, which preserves the audit properties that motivate GitOps in the first place. When teams outgrow copy-pasted Application YAML, ApplicationSets reduce toil without abandoning review.
+
+Flux expresses similar concepts with composable sources and reconcilers. A GitRepository custom resource tracks a branch and path; a Kustomization or HelmRelease references that source and applies a subset to a cluster namespace. Platform teams often maintain one GitRepository for shared cluster configuration and additional GitRepository objects for team-owned repositories, then attach Kustomizations with dependency ordering so infrastructure installs before applications. Flux multi-tenancy guidance separates controllers by namespace boundaries and credentials so one compromised token cannot reconcile another tenant's paths.
+
+Neither pattern removes the need for thoughtful repository layout. App-of-apps and ApplicationSets amplify whatever structure already exists. If directories are inconsistent, generators produce inconsistent Applications. If repository permissions are too broad, generated Applications expose destinations that should remain isolated. If secrets are stored plaintext in Git, scaling applications scales the secret leak. Repository strategy is the input; generators are multipliers.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+
+Both Argo CD and Flux are [CNCF Graduated projects](https://www.cncf.io/projects/) as of this snapshot. Controllers add features frequently; treat the table below as a capability Rosetta, not a ranking.
+
+| Capability | Argo CD (illustrative) | Flux (illustrative) |
+|---|---|---|
+| Declare app from Git path | Application CR | Kustomization / HelmRelease CR |
+| Bootstrap many apps | App-of-apps parent Application | Multiple Kustomizations sharing GitRepository sources |
+| Generate many apps from templates | ApplicationSet generators | Kustomization + directory layout; limited native templating compared to ApplicationSet matrix |
+| Multi-cluster targeting | Application destination + cluster secrets | kubeconfig secrets + Kustomization spec.kubeConfig |
+| Scope destinations and repos | AppProject allow lists | Multi-tenancy namespaces, ServiceAccount tokens, RBAC |
+| Secrets in Git (encrypted) | Compatible with Sealed Secrets, SOPS, ESO | Compatible with Sealed Secrets, SOPS, ESO |
+| Image tag write-back | Argo CD Image Updater (companion project) | Flux image automation controllers |
+
+Use the Rosetta to translate concepts when your organization runs both tools in different business units or when migrating between them. The durable skill is recognizing which capability you need—multi-app bootstrapping, cluster fan-out, secrets integration—then mapping it to the controller you operate.
+
+---
+
+## 6. Access Control, Ownership, and Multi-Tenancy
+
+Repository strategy fails in production when permissions do not match the boundaries you drew on paper. Git hosting platforms enforce access at the repository and branch level first; path-based rules such as CODEOWNERS add finer grain inside a monorepo. A sensible GitOps access model answers three questions for every path: who may propose a change, who must approve it, and who can break glass during an incident without bypassing audit requirements.
+
+CODEOWNERS files map directories to teams so pull requests automatically request reviewers with domain expertise. Branch protection on `main` ensures checks run and approvals exist before merges land in the branch controllers reconcile. For production overlays, require more approvals than development overlays, or require platform team review only when paths under `overlays/prod/` change. These rules make repository conventions self-documenting: a developer who sees `overlays/prod/` in a diff understands the approval bar without reading a wiki page.
+
+Argo CD Projects and Flux tenancy mechanisms extend Git boundaries into the cluster. An AppProject restricts which Git repositories, which destination clusters or namespaces, and which resource kinds an Application may manage. Flux multi-tenancy patterns isolate credentials and reconcile permissions so team A's controllers cannot apply team B's repositories. The mapping principle is direct: if a team owns a configuration repository, their GitOps scope should not include unrelated namespaces; if a platform team owns shared cluster add-ons, their Applications should not require application team approval for unrelated microservices.
+
+Preventing unauthorized changes also means removing unnecessary human cluster write access. When developers can `kubectl edit` production Deployments but GitOps is supposed to be authoritative, incidents will include manual hotfixes that never return to Git. Repository strategy pairs with role-based access control: break-glass cluster access may remain for emergencies, but the normal path is a pull request to the config repository followed by controller reconciliation. Auditors prefer that story because Git records approvers; kubectl history often does not.
+
+Multi-tenant platforms serving many internal customers should align repository boundaries with chargeback or service catalog entries. A Backstage software template that scaffolds a new service should create not only application code but also the expected config repository layout—base, overlays, CODEOWNERS entry, and Application manifest—so teams start aligned. Without that scaffolding, each team reinvents directory names, confusing search and generator templates.
+
+Auditability improves when repository conventions encode intent in paths and commit messages. Require pull request titles that name the environment overlay touched, such as `promote checkout-api tag v1.8.0 to staging`, so `git log overlays/staging/checkout-api` reads like a release journal. Pair that convention with immutable tags in container registries so Git commits reference digests or semver tags that cannot silently move. Reviewers then approve both the manifest change and the artifact identity in one place, which is difficult to replicate when configuration hides inside application feature branches or long-lived environment branches with unrelated merge noise.
+
+Hypothetical scenario: a fintech organization houses fifty microservices in one GitOps monorepo without path protections. A frontend developer merges a pull request that modifies a shared ingress annotation while fixing a UI service, accidentally widening TLS cipher settings for an unrelated admin API. The change passes CI because YAML lint succeeds, but production behavior shifts for a service the developer did not know shared the ingress class. Splitting repositories or enforcing CODEOWNERS on `infrastructure/` would have routed the change to platform reviewers who understand shared ingress contracts.
+
+---
+
+## 7. Secrets in Git: Never Plaintext, Always Deliberate
+
+GitOps encourages storing desired state in Git, yet many desired fields are sensitive: database passwords, TLS private keys, API tokens, and webhook signing secrets. Plaintext secrets in Git repositories are unacceptable even in private hosting; clones, forks, CI logs, and search indexes multiply exposure. Repository strategy must include where encrypted secrets live, who can decrypt them, and how controllers materialize Kubernetes Secret objects at reconcile time.
+
+Sealed Secrets encrypt Secret manifests so only the cluster controller can decrypt them; encrypted blobs are safe in Git while plaintext exists only inside the cluster. Mozilla SOPS encrypts YAML or JSON fields with age or PGP keys, which suits files that mix public configuration and sensitive values in one manifest. External Secrets Operator keeps Git free of ciphertext entirely by referencing a vault or cloud secret manager; Git declares the desired ExternalSecret custom resource while the operator pulls live material during reconciliation. Each approach trades operational complexity against rotation, audit, and multi-cluster portability.
+
+Repository boundaries interact with secret strategy. Some teams place SealedSecrets beside application overlays in the same repository; others maintain a dedicated secrets repository with tighter permissions and slower review requirements. Dedicated secret repositories reduce accidental exposure during routine application pull requests but add coordination when an image and a credential must change together. External Secrets reduce Git sensitivity but introduce dependency on vault availability and permission models outside Kubernetes.
+
+Rotation is the long-term test. A repository layout that makes secret rotation scary will encourage long-lived credentials. Prefer layouts where rotating a sealed secret or SOPS field follows the same promotion path as non-secret configuration: commit to development overlay, validate, promote to staging, promote to production. Document which team owns rotation—platform or application—alongside CODEOWNERS entries for secret paths. Never commit `.env` files or kubectl-exported Secret YAML with base64-encoded plaintext thinking obfuscation equals encryption; base64 is encoding, not protection.
+
+For Kubernetes 1.35, Secrets remain first-class API objects regardless of encryption tool. GitOps controllers reconcile them like Deployments once decrypted or referenced. Teach teams to treat secret commits as high-risk pull requests even when encrypted: metadata still reveals key names, namespaces, and rotation timing. Combine encryption with branch protection and small reviewer groups.
+
+---
+
+## 8. Promotion Readiness and Image Automation
+
+Repository structure either simplifies or complicates promotion. When development, staging, and production overlays live in predictable paths on `main`, promotion scripts copy tags or patch fields with tools such as `yq`, Kustomize image transformers, or Helm values updates. Pull requests show reviewers exactly which environment will change. That visibility is the operational definition of promotion readiness: you can explain what differs between environments without invoking Git merge semantics.
+
+Image automation writes tags back to Git when continuous integration publishes new container images. Flux image automation controllers and Argo CD Image Updater watch registries, compare semver or digest policies, and commit updates to manifests. This closes the loop begun in the application pipeline but reintroduces the commit-loop risk if automation targets the wrong repository or branch. Automation should commit to the configuration repository path controllers reconcile, usually on `main`, with branch protection still enforcing review if policy requires human approval for production tag bumps.
+
+The commit-loop trap appears when automation creates endless commits on every registry metadata change, when CI triggers on any commit rebuild unrelated artifacts, or when bots compete with human feature branches. Mitigate with path filters in CI, separate bot accounts with scoped tokens, and policies that batch image updates. Some teams allow automatic dev updates while requiring human pull requests for production tag changes; repository layout makes that distinction path-based rather than branch-based.
+
+Promotion readiness also means documenting what must move together. If a new application version requires a ConfigMap hash change and an image tag change, repository conventions should place both in the same overlay directory so promotion copies one coherent unit. Splitting image tags and config across unrelated repositories works only when generators or documentation make coupling explicit. Otherwise staging can run an image with production configuration values, a failure mode that manifests as subtle runtime bugs rather than sync errors.
+
+Connect this module forward to [Module 3.3: Environment Promotion](../module-3.3-environment-promotion/), which assumes you already know where environment differences live. Good repository strategy turns promotion into a disciplined copy-and-review workflow; poor structure turns promotion into archaeology.
+
+Teams sometimes delay repository decisions until after controllers sync successfully in a lab cluster. That sequencing is understandable but expensive. Migrating from co-located app and config repositories after production traffic depends on them requires coordinated CI changes, permission updates, and controller retargeting under time pressure. Migrating from branch-per-environment to directory overlays requires reconciling divergent branch histories before you can trust promotion scripts. Investing a few design sessions up front—sketching repositories, paths, CODEOWNERS, and promotion fields on a whiteboard—prevents those migrations from becoming emergency programs later. Treat that design work as part of GitOps adoption, not as documentation you can defer.
+
+---
+
+## Patterns & Anti-Patterns
+
+### Patterns
+
+1. **Directory-per-environment on a single integration branch** — Keeps environment differences visible side by side, makes promotion a patch or copy between overlays, and preserves a linear audit history on `main` that incident reviewers can search without comparing branch tips.
+
+2. **Hybrid platform plus team repositories** — Centralizes shared cluster add-ons and policy baselines while letting product teams own application overlays, matching how accountability usually splits between platform and service owners.
+
+3. **Separate application and configuration repositories** — Decouples build cadence from deploy cadence, narrows CI credentials, and prevents application feature branches from accidentally changing production manifests before review.
+
+4. **Path-scoped CODEOWNERS with stricter production rules** — Makes repository layout self-enforcing by automatically routing sensitive directories to platform or security reviewers without relying on tribal knowledge.
+
+5. **Encrypted secrets beside overlays with documented rotation** — Keeps GitOps reconciliation unified while avoiding plaintext credentials, provided rotation and emergency access paths are tested regularly.
+
+6. **Generator-friendly consistent directory templates** — Repeats the same `base/` and `overlays/` shape across services so ApplicationSets, Flux Kustomizations, and software templates can bootstrap new workloads without bespoke paths.
+
+### Anti-Patterns
+
+1. **Branch-per-environment promotion** — Encourages divergent histories, painful merges, and lost hotfixes when production and staging branches no longer represent comparable configuration states.
+
+2. **Monolithic monorepo without path ownership** — Creates approval bottlenecks and accidental cross-team blast radius when unrelated services share one unpartitioned tree.
+
+3. **Micro-polyrepo sprawl without a catalog** — Hides dependencies, duplicates patterns, and makes cross-cutting security updates prohibitively expensive to coordinate.
+
+4. **Plaintext secrets committed for convenience** — Expands credential exposure to every clone and CI job; violates basic security expectations even if repositories are private.
+
+5. **Image automation writing into application repositories** — Retriggers build pipelines and blurs the boundary between artifact production and cluster desired state.
+
+6. **Inconsistent directory naming per team** — Breaks generators, confuses reviewers, and prevents platform teams from applying shared lint or policy checks mechanically.
+
+### Decision Framework
+
+Use the matrix below when choosing or refactoring repository layout. Score each axis for your organization honestly; the highest-friction cells indicate where structure must change before adding more tools.
+
+| Question | If "yes" leans toward… | If "no" leans toward… |
+|---|---|---|
+| Do multiple teams need independent approval cadences? | Polyrepo or hybrid with team repos | Monorepo with strong CODEOWNERS |
+| Must platform enforce shared baselines everywhere? | Platform monorepo or shared base repo | Fully decentralized repos |
+| Do you promote by copying known fields between environments? | Directory overlays on one branch | Not long-lived environment branches |
+| Will one service team ever hotfix production without staging? | Directory overlays + path protections | Not branch-per-environment merges |
+| Do auditors require segregated secret history? | Dedicated secrets repo or External Secrets | Mixed secret paths without ownership |
+| Are you bootstrapping more than ~20 similar apps? | App-of-apps / ApplicationSet friendly layout | Manual one-off Application manifests |
+| Do multiple clusters share one Git host org? | Cluster-scoped directories or generators | Single-cluster assumptions in paths |
+
+When answers conflict—common in large enterprises—prefer hybrid models and invest in templates that hide complexity from application developers while keeping platform paths explicit for operators.
+
+```mermaid
+flowchart TD
+    Start["Choose repository strategy"] --> Q1{"Multiple teams with different approvers?"}
+    Q1 -->|Yes| Hybrid["Hybrid: platform repo + team config repos"]
+    Q1 -->|No| Mono["Monorepo with CODEOWNERS paths"]
+    Hybrid --> Q2{"Promotion by directory copy?"}
+    Mono --> Q2
+    Q2 -->|Yes| Dir["Single branch + overlays/dev/staging/prod"]
+    Q2 -->|No| Rethink["Revisit branch-per-env risk"]
+    Dir --> Q3{"Secrets in Git?"}
+    Q3 -->|Encrypted| Seal["Sealed Secrets / SOPS / ESO"]
+    Q3 -->|Never plaintext| Seal
+    Seal --> Done["Document ownership + wire controllers"]
 ```
-
-### Application-Centric Structure
-
-Organized by application, then environment:
-
-```text
-apps/
-├── frontend/
-│   ├── base/
-│   └── overlays/
-│       ├── dev/
-│       ├── staging/
-│       └── prod/
-├── backend/
-│   ├── base/
-│   └── overlays/
-├── worker/
-│   └── ...
-└── infrastructure/
-    ├── monitoring/
-    ├── logging/
-    └── ingress/
-```
-
-### Choosing a Structure
-
-| Factor | Environment-Based | Cluster-Based | App-Centric |
-|--------|-------------------|---------------|-------------|
-| "What's in prod?" | Check each app's prod/ | Check prod-cluster/ | Check each app's prod/ |
-| "What apps in this cluster?" | Check multiple places | One place | Check multiple places |
-| "All configs for this app?" | One place | Multiple clusters | One place |
-| Best for | Single cluster per env | Multi-region/cluster | App-focused teams |
 
 ---
 
 ## Did You Know?
 
-1. **Google's entire codebase lives in one repository** with billions of files. They built custom tooling (Piper) to make this work. Most organizations can't replicate this.
+1. **The OpenGitOps project publishes vendor-neutral principles** that describe declarative state, versioned storage, automated application, and continuous reconciliation—repository layout is how most organizations implement the "versioned and immutable" principle in practice ([OpenGitOps](https://opengitops.dev/)).
 
-2. **The "trunk-based development" pattern** pairs well with directory-per-environment GitOps. Short-lived branches for changes, merge to main, promote through directories.
+2. **Kustomize was designed to separate base configuration from environment-specific patches**, which aligns naturally with directory-per-environment repositories rather than long-lived environment branches ([Kubernetes Kustomize documentation](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/)).
 
-3. **Spotify pioneered many polyrepo patterns** for autonomy, but found they needed strong conventions and tooling to avoid chaos. Their "Golden Path" concept addresses this.
+3. **Argo CD ApplicationSets can generate Applications from Git directory listings**, which means consistent folder naming in your configuration repository directly affects how reliably new services are discovered and synced ([ApplicationSet documentation](https://argo-cd.readthedocs.io/en/stable/user-guide/application-set/)).
 
-4. **Microsoft's Windows codebase moved to Git** in 2017 with over 3.5 million files—they had to create Git Virtual File System (GVFS, now VFS for Git) to make it practical. Repository strategy isn't just about organization, it's about tooling limitations.
-
----
-
-> **Pause and predict**: What happens when the staging environment branch receives three hotfixes that were originally pushed to the development branch, but one of them was deliberately excluded from the upcoming production release?
-
-## War Story: The Branch Strategy That Backfired
-
-A company I worked with tried branch-per-environment GitOps:
-
-**The Setup:**
-```text
-main branch → production
-staging branch → staging
-develop branch → development
-```
-
-**The Theory:**
-- Merge develop → staging to promote
-- Merge staging → main to go to prod
-- Each environment has "its own branch"
-
-**What Actually Happened:**
-
-Week 1: "This is clean!"
-
-Week 4:
-```text
-develop: 127 commits ahead of staging
-staging: 43 commits ahead of main
-```
-
-Week 8:
-- Merging staging → main caused massive conflicts
-- Some features accidentally skipped staging
-- "Which branch has the fix?" became common
-- Cherry-picks created divergence
-- Team spent hours resolving merge conflicts
-
-**The Root Problem:**
-
-Branches diverge. That's what branches do. Environment promotion isn't the same as code development.
-
-**The Fix:**
-
-Switched to directory-per-environment:
-
-```text
-config-repo/
-└── my-service/
-    ├── base/
-    └── overlays/
-        ├── dev/      ← always in main
-        ├── staging/  ← always in main
-        └── prod/     ← always in main
-```
-
-Promotion became:
-```bash
-# Copy dev image tag to staging
-yq eval '.images[0].newTag = "v1.2.3"' -i overlays/staging/kustomization.yaml
-
-# PR, review, merge
-# GitOps agent syncs staging
-```
-
-**Results:**
-- No merge conflicts
-- Clear promotion path
-- All envs visible in one branch
-- PR shows exactly what changes
-
-**Lesson**: Branches are for code development, not environment promotion.
-
----
-
-## Branch Strategies (And Why to Avoid Them)
-
-### The Temptation
-
-Branches feel natural for environments:
-- "main is prod"
-- "develop is dev"
-- "we control promotion with merges"
-
-### The Problems
-
-**Problem 1: Divergence**
-```text
-Branches naturally diverge. Environments shouldn't.
-
-develop: adds feature A, B, C
-staging: only has A, B (C not promoted)
-main: only has A (B pending)
-
-Now you have three different states to reason about.
-```
-
-**Problem 2: Merge Conflicts**
-```text
-Config conflicts are worse than code conflicts.
-Code: "which version of this function?"
-Config: "which version of the cluster state?"
-
-Bad merges → bad deployments.
-```
-
-**Problem 3: Lost Changes**
-```text
-Feature in develop, cherry-picked to main,
-but staging branch never got it.
-
-"Why is this bug in staging but not prod?"
-```
-
-**Problem 4: Audit Complexity**
-```text
-Q: "What changed between staging and prod?"
-A: "Let me diff two branches that have
-    diverged significantly..."
-
-vs. Directory-based:
-A: "Let me diff two directories on main."
-```
-
-### When Branches Might Work
-
-- Very simple setups (2 environments max)
-- Full lockstep promotion (always all changes)
-- Strong discipline and tooling
-- Small teams with clear ownership
-
-### The Recommendation
-
-**Use directories, not branches, for environment separation.**
-
-```bash
-# Instead of:
-git checkout staging
-git merge develop
-
-# Do:
-# Update prod/kustomization.yaml with new image tag
-git commit -m "Promote v1.2.3 to prod"
-git push origin main
-```
+4. **Flux supports multi-tenancy by isolating credentials and reconcile permissions per namespace**, so repository boundaries should usually match the namespace boundaries those credentials are allowed to touch ([Flux multi-tenancy guide](https://fluxcd.io/flux/installation/configuration/multitenancy/)).
 
 ---
 
@@ -526,54 +326,104 @@ git push origin main
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| Branch-per-environment | Divergence, merge hell | Directory-per-environment |
-| Giant monorepo without tooling | Slow, coupled | Split or invest in tooling |
-| Too many small repos | Fragmentation, no visibility | Consolidate by team/domain |
-| Mixing app code and config | Wrong triggers, permissions | Separate config repo |
-| No clear ownership | Confusion, drift | Document who owns what |
-| Inconsistent structure | Hard to automate | Standardize patterns |
+| Branch-per-environment | Divergent histories cause lost hotfixes and merge conflicts during promotion | Directory-per-environment overlays on a single integration branch such as `main` |
+| Giant monorepo without CODEOWNERS | Unrelated teams block one another and shared paths change without expert review | Path-based ownership, platform-only directories, and selective CI triggers |
+| Micro-polyrepo sprawl | No shared visibility; duplicated patterns; hard cross-cutting security updates | Hybrid model with platform base repo and software templates for new services |
+| Mixing app code and config without path rules | Application CI retriggers on manifest edits; permissions become overly broad | Separate config repository or strict path ownership with independent pipelines |
+| Plaintext secrets in Git | Credential exposure via clones, forks, and CI logs | Sealed Secrets, SOPS, or External Secrets Operator with documented rotation |
+| Image automation targeting wrong repo | Commit loops, accidental production promotions, noisy bot commits | Point automation at config repo paths controllers reconcile; protect `main` |
+| Inconsistent overlay naming | Generators and promotion scripts break; reviewers cannot predict paths | Standardize `base/` and `overlays/{dev,staging,prod}` per service |
+| Skipping production-only review rules | Low-risk dev changes merge using the same gates as production | Stricter branch protection and CODEOWNERS for production overlay paths |
 
 ---
 
 ## Quiz: Check Your Understanding
 
 ### Question 1
-Your team currently uses a branching strategy where the `develop` branch deploys to the development environment, and the `main` branch deploys to production. Recently, an urgent hotfix was merged directly into `main` and deployed successfully, but two weeks later, the bug reappeared in production after a routine release. Based on GitOps principles, what architectural flaw in your repository strategy caused this, and how should it be redesigned?
+
+Your team currently uses a branching strategy where the `develop` branch deploys to the development environment, and the `main` branch deploys to production. Recently, an urgent hotfix was merged directly into `main` and deployed successfully, but two weeks later the bug reappeared in production after a routine release. Based on GitOps principles, what architectural flaw in your repository strategy caused this, and how should it be redesigned?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-The root cause of this regression is the use of a branch-per-environment strategy, which inevitably leads to configuration divergence. When the hotfix was applied directly to `main`, the `develop` branch lost sync with production's actual state. Later, when `develop` was merged into `main` for the routine release, the hotfix was overwritten or ignored because the environments were represented by divergent histories rather than a single source of truth. To solve this, the team should adopt a directory-per-environment structure on a single branch (such as `main`). In this model, both the development and production configurations live side-by-side, making promotions a simple file update (like changing an image tag) rather than a complex Git merge, which completely eliminates environment divergence and prevents lost changes.
+The root cause is branch-per-environment modeling, which treats Git branches as deployment targets rather than integration lines. When the hotfix merged only to `main`, staging and develop branches diverged from production reality, so a later merge reintroduced stale configuration without the fix. Redesign around directory-per-environment overlays on a single branch so development, staging, and production states are visible together and promotion updates explicit paths. Hotfixes then land as commits that can be copied or patched across overlays with ordinary pull requests instead of cross-branch merges.
 
 </details>
 
 ### Question 2
-You are the lead architect for a rapidly growing fintech company. Currently, all 50 microservices and the core infrastructure configurations are housed in a single GitOps monorepo. Recently, the platform team has complained that their PRs are being delayed by application team approvals, and application teams are accidentally modifying ingress configurations they shouldn't have access to. Why is the current monorepo failing your organizational needs, and what GitOps repository pattern would better serve your scaling company?
+
+You are the lead architect for a rapidly growing product organization. Currently, all microservices and shared ingress configurations live in one GitOps monorepo. Platform pull requests wait on unrelated application team approvals, and application teams can edit shared ingress paths. Why is the monorepo failing organizational needs, and what pattern fits better?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-The monorepo pattern is failing because it forces tight coupling and centralized access control on an organization that has outgrown it, creating bottlenecks and security risks. As organizations scale, different teams require distinct permission boundaries and independent deployment lifecycles that a single repository cannot easily enforce without highly complex tooling. To resolve this, you should migrate to a hybrid polyrepo strategy where the platform team manages a core infrastructure repository and individual application teams own their specific configuration repositories. This separation naturally enforces fine-grained access control through repository permissions and allows teams to operate with full autonomy, ensuring that platform changes do not block application deployments and vice versa.
+The monorepo fails because it couples unrelated ownership domains without path-enforced review, creating bottlenecks and unsafe shared-resource edits. A hybrid polyrepo pattern fits better: a platform-owned repository for shared ingress, cert-manager, and policy baselines plus team-owned configuration repositories for application overlays. Repository permissions and CODEOWNERS then align with accountability, platform changes no longer require unrelated service approvals, and application teams retain autonomy within scoped repositories.
 
 </details>
 
 ### Question 3
-Your platform engineering team is setting up GitOps for a new product suite consisting of 10 microservices. The services will be deployed across three distinct Kubernetes clusters representing `dev`, `staging`, and `prod` environments. The application developers want a straightforward way to update their services, while the platform team needs to maintain consistent baseline configurations. How should you structure the configuration repository to satisfy both teams while minimizing configuration duplication?
+
+Your platform team is onboarding ten microservices across dev, staging, and prod clusters. Developers want a obvious place to edit their service manifests; platform engineers need shared baselines. How should you structure the configuration repository to minimize duplication while keeping ownership clear?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-You should implement an application-centric directory structure utilizing Kustomize within a single configuration repository. In this setup, each microservice gets its own top-level directory containing a `base` folder for shared configurations and an `overlays` folder containing subdirectories for `dev`, `staging`, and `prod`. This structure minimizes duplication by keeping all common manifests in the base, while allowing environment-specific patches (like replica counts or resource limits) to be cleanly isolated in the overlays. It provides developers with a clear, single location to manage their application's entire lifecycle across all clusters, while enabling the platform team to enforce standard baseline policies that apply to every environment.
+Use an application-centric layout with Kustomize bases and overlays in either a monorepo or team repos: each service gets `base/` for shared manifests and `overlays/dev`, `overlays/staging`, and `overlays/prod` for controlled differences. Platform baselines can live as imported bases or shared components referenced by each service. This minimizes duplication, gives developers one predictable path per service, and lets platform teams publish common patches without mixing unrelated services in the same unowned directory.
 
 </details>
 
 ### Question 4
-A developer on your team is confused about the new deployment pipeline. They just merged a feature into the application repository, and the CI system successfully built and pushed the new Docker image to the registry. However, the developer is asking why the GitOps agent hasn't deployed the new image to the cluster yet. What crucial step is missing in the CI/CD flow, and how does this separation protect the GitOps model?
+
+A developer merged application code and CI built a new container image successfully, but the GitOps controller has not deployed the new image. What missing step protects the GitOps model, and why is that separation intentional?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-The missing step is that the CI pipeline did not update the configuration repository with the newly generated image tag. In a proper GitOps workflow, the CI system never communicates directly with the Kubernetes cluster or the GitOps agent; its final job is to commit the new image tag to the deployment manifests in the configuration repository. Once the configuration repository is updated, the GitOps agent detects the Git commit and automatically syncs the cluster state to match. This strict separation of concerns is vital because it ensures that the Git repository remains the sole, auditable source of truth for the environment, preventing untracked changes and allowing for instant rollbacks by simply reverting a Git commit.
+Continuous integration must commit the new image tag or digest to the configuration repository the GitOps controller reconciles. Controllers pull desired state from Git rather than trusting CI to push cluster changes directly, which keeps production history reviewable and revertible. The separation ensures cluster credentials are not required in application pipelines and prevents undeclared cluster mutations outside the audited Git path.
+
+</details>
+
+### Question 5
+
+Hypothetical scenario: your organization runs Argo CD with fifty Applications created manually in a UI. Adding a cluster requires copying YAML repeatedly and mistakes appear in destination namespaces. Which repository pattern reduces duplication while staying declarative, and what Argo CD feature helps?
+
+<details>
+<summary>Answer</summary>
+
+Move Application manifests into Git using an app-of-apps parent Application that syncs a directory of child Application files, then adopt ApplicationSet generators when services or clusters repeat combinatorially. Repository layout should include a predictable directory such as `clusters/prod/apps/` or `apps/<service>/argocd/` so generators can discover services. This keeps bootstrap declarative, reviewable, and consistent while scaling beyond manual UI entry.
+
+</details>
+
+### Question 6
+
+Hypothetical scenario: a team stores SealedSecrets beside overlays but grants every developer write access to production overlay paths. What risk remains despite encryption, and how should repository strategy mitigate it?
+
+<details>
+<summary>Answer</summary>
+
+Encryption protects confidentiality in Git, but broad write access still allows unauthorized production changes to non-secret fields and can replace sealed objects during incident stress. Mitigate with CODEOWNERS and branch protection on `overlays/prod/`, separate bot accounts for automation, and break-glass procedures that still require follow-up Git commits. Optionally isolate highly sensitive material in a tighter secrets repository while keeping structure parallel to application overlays.
+
+</details>
+
+### Question 7
+
+Your Flux platform uses one GitRepository for platform addons and many team-owned GitRepositories for applications. Platform addons must reconcile before application Kustomizations. What repository and controller ordering practices make that dependency explicit?
+
+<details>
+<summary>Answer</summary>
+
+Keep platform manifests in a dedicated repository path synced by a platform Kustomization with health checks, then declare application Kustomizations with `dependsOn` referencing the platform Kustomization name. Repository strategy supports this by separating platform and application paths clearly so credentials and tenancy rules differ. Document the dependency in repository README files so teams know application repos assume platform baselines are already present.
+
+</details>
+
+### Question 8
+
+Hypothetical scenario: image automation commits tag updates directly to application repositories on every merge, causing CI to rebuild images in a loop and flooding reviewers with bot commits. Which repository boundary breaks, and how should automation be rewired?
+
+<details>
+<summary>Answer</summary>
+
+Automation violates the application versus configuration separation boundary by writing deploy intent into the build repository. Rewire image updaters to commit only to the configuration repository path reconciled by GitOps, with CI scoped to application paths in the application repo. Add branch protection rules so production tag bumps require human approval if policy demands, and filter CI triggers to ignore bot-only manifest commits where safe.
 
 </details>
 
@@ -581,145 +431,76 @@ The missing step is that the CI pipeline did not update the configuration reposi
 
 ## Hands-On Exercise: Design Your Repository Structure
 
-Design a GitOps repository structure for a scenario.
+Design a GitOps repository structure for the scenario below. Write your answers in a notes file or team doc; the value is forcing explicit decisions before production traffic depends on them.
 
 ### Scenario
 
-Your organization has:
-- 3 teams (Platform, Frontend, Backend)
-- 8 services total:
-  - Platform: cert-manager, ingress-nginx, monitoring
-  - Frontend: web-app, mobile-api
-  - Backend: user-service, order-service, notification-service
-- 3 environments: dev, staging, prod
-- Each team wants autonomy over their services
-- Platform team needs to set base policies
+Your organization has three teams (Platform, Frontend, Backend), eight services (Platform: cert-manager, ingress-nginx, monitoring; Frontend: web-app, mobile-api; Backend: user-service, order-service, notification-service), and three environments (dev, staging, prod). Each team wants autonomy over its services while the platform team sets shared baselines.
 
-### Your Task
+### Part 1: Repository Decision
 
-**Part 1: Repository Decision**
+Decide among monorepo, team polyrepos, or hybrid. Document how many repositories you need, who owns each, and why your choice matches the approval boundaries described above.
 
-```markdown
-## Repository Strategy
+Success criteria:
 
-How many repos? [ ] 1 (monorepo) [ ] 4 (team repos) [ ] Other: ___
+- [ ] You chose monorepo, polyrepo, or hybrid with a written rationale tied to ownership—not personal preference alone.
+- [ ] You listed an owner for every repository and explained which paths that owner controls.
+- [ ] You identified at least one risk your choice introduces and how CODEOWNERS or tenancy mitigates it.
 
-Rationale:
-_________________________________________________
-_________________________________________________
+### Part 2: Directory Structure
 
-Who owns each repo?
-- Repo 1: _______________ Owner: _______________
-- Repo 2: _______________ Owner: _______________
-- ...
-```
+Draw the directory tree for at least one repository, including `base/` and `overlays/dev`, `overlays/staging`, and `overlays/prod` for one application service.
 
-**Part 2: Directory Structure**
+Success criteria:
 
-Design the structure for one of the repos:
+- [ ] Your tree shows where platform shared resources live versus application-specific manifests.
+- [ ] You explained how environments differ without using long-lived environment branches.
+- [ ] You pointed to the exact path a developer edits to change only staging replicas.
 
-```markdown
-## Directory Structure for: _______________
+### Part 3: Promotion and Automation Flow
 
-repo-name/
-├──
-├──
-├──
-└──
+Describe how a container image built from application CI reaches production Git state, including where image automation or pull requests update tags.
 
-Explain your choices:
-- Why this structure? _______________
-- How do environments differ? _______________
-- Where are base configs? _______________
-```
+Success criteria:
 
-**Part 3: Promotion Flow**
+- [ ] Your flow names both the application repository and the configuration repository roles.
+- [ ] You showed how a change promotes from dev overlay to staging to prod using directory copies or patches.
+- [ ] You identified where branch protection or CODEOWNERS gates production changes.
 
-How does a change get from dev to prod?
+### Part 4: Secrets and Access Control
 
-```markdown
-## Promotion Flow
+Choose Sealed Secrets, SOPS, or External Secrets for at least one sensitive value and document repository permissions for production paths.
 
-1. Developer makes change: _______________
-2. Change gets to dev: _______________
-3. Promote to staging: _______________
-4. Promote to prod: _______________
+Success criteria:
 
-Automation opportunities:
-- _______________
-- _______________
-```
-
-**Part 4: Access Control**
-
-```markdown
-## Access Control
-
-| Repo | Read Access | Write Access | Admin |
-|------|-------------|--------------|-------|
-|      |             |              |       |
-|      |             |              |       |
-
-Branch protection rules:
-- main: _______________
-```
-
-### Success Criteria
-
-- [ ] Chose monorepo/polyrepo with clear rationale
-- [ ] Designed directory structure for at least one repo
-- [ ] Defined environment promotion flow
-- [ ] Documented access control approach
-- [ ] Avoided branch-per-environment
-
----
-
-## Key Takeaways
-
-1. **Monorepo vs Polyrepo**: Choose based on org size, team autonomy, access needs
-2. **Separate app and config repos**: Different cadences, different permissions
-3. **Directory-per-environment**: Avoid branch-per-environment pattern
-4. **Use Kustomize base/overlays**: Reduce duplication, capture differences
-5. **CI updates Git, GitOps deploys**: Clean separation of concerns
-
----
-
-## Further Reading
-
-**Books**:
-- **"GitOps and Kubernetes"** — Chapter on Repository Strategies
-- **"Monorepo vs Polyrepo"** — Various blog comparisons
-
-**Articles**:
-- **"GitOps Repository Strategies"** — Weaveworks
-- **"Why We Use a Monorepo"** — Various tech blog posts
-- **"Kustomize Best Practices"** — Kubernetes docs
-
-**Tools**:
-- **Kustomize**: kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/
-- **Helm**: For chart-based templating
-- **yq**: YAML manipulation for CI
-
----
-
-## Summary
-
-Repository strategy determines how smoothly GitOps operates.
-
-Key decisions:
-- **Monorepo vs Polyrepo**: Based on org size and autonomy needs
-- **App repo vs Config repo**: Typically separate for GitOps
-- **Directory structure**: Environment-based with base/overlays
-- **Branch strategy**: Avoid branch-per-env; use directory-per-env
-
-There's no universally "right" answer — but there are patterns that work better for different situations. Start simple, evolve as needed.
+- [ ] You rejected plaintext Secret manifests in Git and named an encryption or external reference strategy.
+- [ ] You defined who can propose versus approve production overlay pull requests.
+- [ ] You described how an emergency hotfix returns to Git after break-glass cluster access.
 
 ---
 
 ## Next Module
 
-Continue to [Module 3.3: Environment Promotion](../module-3.3-environment-promotion/) to learn strategies for moving changes safely through environments.
+Continue to [Module 3.3: Environment Promotion](../module-3.3-environment-promotion/) to learn strategies for moving changes safely through environments once your repository layout makes promotion visible.
 
 ---
 
-*"The best repository structure is the one your team can actually follow."* — GitOps Wisdom
+## Sources
+
+- [OpenGitOps Principles](https://opengitops.dev/) — Vendor-neutral definition of declarative, versioned, pull-based, continuously reconciled operations that repository strategy implements.
+- [Kubernetes: Managing Objects with Kustomize](https://kubernetes.io/docs/tasks/manage-kubernetes-objects/kustomization/) — Primary reference for base and overlay directory layouts used throughout GitOps repositories.
+- [Kustomize Reference Documentation](https://kubectl.docs.kubernetes.io/references/kustomize/) — Detailed glossary and configuration options for structuring overlays and components.
+- [Argo CD Cluster Bootstrapping and App-of-Apps](https://argo-cd.readthedocs.io/en/stable/operator-manual/cluster-bootstrapping/) — Official pattern for managing many Applications from a parent Application in Git.
+- [Argo CD ApplicationSet User Guide](https://argo-cd.readthedocs.io/en/stable/user-guide/application-set/) — Generators and templates for scaling Application creation from repository structure.
+- [Argo CD Projects](https://argo-cd.readthedocs.io/en/stable/user-guide/projects/) — Restricting repositories, destinations, and resources to enforce tenancy aligned with repo boundaries.
+- [Flux Kustomization](https://fluxcd.io/flux/components/kustomize/kustomizations/) — Reconciling paths from GitRepository sources; dependency ordering for platform versus application paths.
+- [Flux HelmRelease](https://fluxcd.io/flux/components/helm/helmreleases/) — Chart-based deployments with values files per environment directory.
+- [Flux Multi-Tenancy Configuration](https://fluxcd.io/flux/installation/configuration/multitenancy/) — Isolating credentials and reconcile scope across teams sharing a management cluster.
+- [Flux Image Update Automation Guide](https://fluxcd.io/flux/guides/image-update/) — Writing image tags back to Git safely in configuration repositories.
+- [Argo CD Image Updater Documentation](https://argocd-image-updater.readthedocs.io/en/stable/) — Companion automation that commits image tag changes for Argo CD managed manifests.
+- [Helm Chart Values Best Practices](https://helm.sh/docs/chart_best_practices/values/) — Structuring environment-specific values files alongside charts in GitOps repos.
+- [Sealed Secrets Project](https://github.com/bitnami-labs/sealed-secrets) — Encrypting Secret manifests for safe storage in Git repositories.
+- [Mozilla SOPS](https://github.com/getsops/sops) — Field-level encryption for YAML and JSON configuration files committed to Git.
+- [External Secrets Operator Overview](https://external-secrets.io/latest/introduction/overview/) — Referencing vault or cloud secret managers while keeping Git declarations non-sensitive.
+- [CNCF Argo Project](https://www.cncf.io/projects/argo/) — Graduation status and ecosystem context for Argo CD and related tooling as of authoring verification.
+- [CNCF Flux Project](https://www.cncf.io/projects/flux/) — Graduation status and ecosystem context for Flux controllers as of authoring verification.

--- a/src/content/docs/platform/disciplines/delivery-automation/gitops/module-3.3-environment-promotion.md
+++ b/src/content/docs/platform/disciplines/delivery-automation/gitops/module-3.3-environment-promotion.md
@@ -1,18 +1,15 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 3.3: Environment Promotion"
 slug: platform/disciplines/delivery-automation/gitops/module-3.3-environment-promotion
 sidebar:
   order: 4
 ---
-> **Discipline Module** | Complexity: `[MEDIUM]` | Time: 30-35 min
+> **Discipline Module** | Complexity: `[MEDIUM]` | Time: 45-55 min
 
 ## Prerequisites
 
-Before starting this module:
-- **Required**: [Module 3.2: Repository Strategies](../module-3.2-repository-strategies/) — Repository structure
-- **Required**: [Module 3.1: What is GitOps?](../module-3.1-what-is-gitops/) — GitOps fundamentals
-- **Recommended**: Experience with multi-environment deployments
+Before starting this module, you should understand how Git repositories are structured for multi-environment deployments — the directory-per-environment pattern and Kustomize overlay inheritance model covered in [Module 3.2: Repository Strategies](../module-3.2-repository-strategies/). You also need the foundational GitOps concepts from [Module 3.1: What is GitOps?](../module-3.1-what-is-gitops/), particularly the reconciliation loop and the principle that Git is the single source of truth for cluster state. Experience with multi-environment deployments in any form — even traditional CI/CD promotion — will help you recognize the contrasts that make GitOps promotion different, though it is not strictly required.
 
 ---
 
@@ -20,54 +17,82 @@ Before starting this module:
 
 After completing this module, you will be able to:
 
-- **Design environment promotion pipelines that move changes safely from dev through staging to production**
-- **Implement automated promotion gates with testing, approval, and rollback capabilities**
-- **Build promotion strategies that handle dependencies between microservices during coordinated releases**
-- **Evaluate promotion patterns — image tag updates, Kustomize overlays, Helm value overrides — for your context**
+- **Design environment promotion pipelines that move changes safely from dev through staging to production** using Git operations rather than imperative deployment commands, with each environment transition encoded as a reviewable Git commit
+- **Implement automated promotion gates with testing, approval, and rollback capabilities** by combining CI-based test suites, policy admission checks, SLO-based analysis, and Git-revert rollback within the GitOps reconciliation loop
+- **Build promotion strategies that handle dependencies between microservices during coordinated releases** across multiple repositories, clusters, and regions, using staged rollout patterns and per-cluster promotion sequencing
+- **Evaluate promotion patterns — image tag updates, Kustomize overlays, Helm value overrides — for your specific operational context** by understanding the tradeoffs in auditability, automation surface, and configuration complexity that each pattern brings
+
+---
 
 ## Why This Module Matters
 
-Your new feature works in dev. Now what?
+Your new feature works in dev. Now what? The journey from dev to production is where most deployment problems occur. A change that passes every test in a development environment can fail catastrophically in production because the runtime context differs: different database configurations, different network policies, different resource limits, different secrets. Each environment boundary is a place where assumptions embedded in the code meet the reality of operations, and without a disciplined promotion strategy these collisions are discovered by users rather than by automated verification.
 
-The journey from dev to production is where most deployment problems occur:
-- "It worked in staging!" (but prod is different)
-- "Who promoted this?" (no audit trail)
-- "Can we roll back?" (unclear what to roll back to)
+The visibility problem compounds the reliability problem. When a broken release reaches production, the first question any responder asks is "what changed?" In organizations without structured promotion, answering that question means tracing through CI pipeline logs, checking image registries for ambiguous tags, and hoping someone remembers which commit was actually live. A properly designed GitOps promotion pipeline answers the question before it is even asked: every state change is a Git commit, every commit has an author and a timestamp, and every commit is linked to the exact artifact it promoted.
 
-**Good promotion strategy means:**
-- Changes are tested before reaching users
-- Promotions are auditable and reversible
-- The path to production is clear and consistent
+**Good promotion strategy delivers three guarantees that traditional CI/CD promotion cannot.** First, it guarantees that what was tested is what ships. When you promote an immutable artifact reference rather than rebuilding per environment, you eliminate the class of failures caused by different build outputs, different dependency resolutions, or different compilation flags between environments. The artifact that passed integration tests is bit-for-bit identical to the artifact that lands in production.
 
-This module teaches you how to promote changes safely through environments using GitOps.
+Second, it guarantees that every promotion is auditable and reversible. Because the promotion itself is a Git commit updating a declared configuration, rolling back is a matter of reverting that commit — and the audit trail is the Git history itself, not a separate deployment-tool log that may or may not be accessible during an incident.
 
----
+Third, it guarantees that the path to production is consistent and enforceable. Rather than trusting individual engineers to remember the correct sequence of steps, you encode the promotion path as branch protection rules, required status checks, and automated verification gates that cannot be bypassed by human impatience.
 
-> **Stop and think**: How many manual steps exist in your current deployment process? Every manual step is an opportunity for human error or config drift between environments.
-
-## The Promotion Problem
-
-In traditional deployments, promotion often means:
-1. Run CI/CD pipeline for staging
-2. Wait for manual approval
-3. Run CI/CD pipeline for prod
-4. Hope nothing is different
-
-**What can go wrong:**
-- Different pipeline runs = potentially different results
-- Config drift between environments
-- Manual steps introduce errors
-- No clear record of what was promoted
-
-GitOps changes this by making promotion a **Git operation**.
+> **Hypothetical scenario: The Promotion That Skipped Staging**
+>
+> A platform team manages a customer-facing ordering service. An urgent bug is causing incorrect totals for about 3% of transactions. A developer has a fix ready and the pressure to deploy directly to production is intense.
+>
+> **What happens if they skip staging:**
+>
+> The fix is merged directly to the production overlay and the GitOps controller syncs within seconds. The original bug is resolved. However, the hotfix image was developed against a newer version of the payment gateway client library that exists in the dev environment but was never deployed to staging — and therefore never tested with the authentication setup that production uses. The payment gateway connection fails on startup with a TLS handshake error. The service enters a crash loop. Instead of a partial-impact pricing bug affecting a small percentage of transactions, the entire ordering system is now down.
+>
+> **The better path:**
+>
+> Even under emergency pressure, promotion through staging takes about 12 minutes: 5 minutes for the GitOps controller to sync the staging overlay, 5 minutes for automated smoke tests, and 2 minutes for a reviewer to approve the promotion PR to production. The TLS mismatch is caught in staging smoke tests before a single production request is affected. The fix is rebuilt with the correct library version and promoted cleanly through both environments in 25 minutes total — slower than the direct push, but with zero production impact.
+>
+> The lesson is not that emergencies justify skipping environments. The lesson is that emergencies justify faster promotion through environments, not circumvention of the promotion path itself.
 
 ---
 
-## Directory-Based Promotion
+## What Promotion Means in GitOps
 
-The simplest and most common GitOps promotion pattern.
+In a traditional CI/CD pipeline, promotion means running a deployment job that pushes artifacts to the next environment. The CI/CD server is the actor: it authenticates to the target cluster, invokes an API, and waits for a result. This model works but carries structural problems. The CI/CD server must hold credentials for every target cluster. If the deployment job fails partway through, the state of the cluster is uncertain — some resources may have been applied while others were not. And there is no declarative source of truth: to know what is deployed, you must query the cluster, and the cluster is always one `kubectl apply` away from being out of sync with what anyone documented.
 
-### The Structure
+**GitOps inverts the promotion model.** In GitOps, promotion is a change to the declared desired state in a Git repository. The CI/CD pipeline does not push to the cluster. Instead, it writes a change to a file — updating an image digest, a Helm value, or a Kustomize overlay — and commits that change. A GitOps controller running inside or adjacent to the cluster detects the commit and reconciles the cluster to match. The controller is the deployer; the pipeline is merely a proposal writer.
+
+This inversion confers specific, durable advantages that define the GitOps approach to promotion. **Auditability is a first-class property, not an afterthought.** Every promotion is a Git commit. The commit carries an author, a timestamp, a diff, and — when coupled with a pull request workflow — a review record. During an incident, answering "what version is running?" does not require SSH access to a cluster or access to a deployment tool's audit log. It requires reading the current state of a file in Git, which any team member can do from a browser. Answering "who changed it and when?" is a `git log` invocation.
+
+**Atomicity is guaranteed by the reconciliation loop.** A GitOps controller like Argo CD or Flux applies an entire manifest set as a reconciliation unit. If resource A depends on resource B and resource B fails to apply, the controller can be configured with sync waves, health checks, and retry policies that define the correct ordering and failure behavior. The deployment is not a script that may terminate at an arbitrary intermediate step; it is a convergence toward a fully specified desired state.
+
+**Rollback is a Git operation.** When a promotion introduces a problem, reverting the promotion commit and pushing triggers a reconciliation back to the previous known-good state. This is fundamentally more reliable than imperative rollback because the rollback target is defined declaratively — it is the state of the repository before the promotion commit — rather than being reconstructed from a deployment tool's internal history. There is no ambiguity about which resources to roll back or in which order; the entire manifest set returns to its previous SHA.
+
+**Secrets and credentials stay out of the CI/CD pipeline.** Because the pipeline only writes to Git (not directly to clusters), it does not need cluster credentials. The GitOps controller holds those credentials, and the controller runs in a more constrained, auditable environment than a CI/CD runner that may execute arbitrary build steps from a pull request.
+
+These advantages compound with scale. A single GitOps controller can manage dozens of clusters and hundreds of applications. Adding a new environment means pointing a controller at the same repository with a namespace or cluster-scoped filter, not provisioning a new set of deployment credentials into CI/CD.
+
+---
+
+## Promote the Artifact, Not the Build
+
+The most consequential design decision in a promotion pipeline is whether you rebuild your artifact in each environment or build once and promote the same artifact. The choice determines whether "tested" implies "shipped."
+
+**Rebuilding per environment breaks the equivalence guarantee.** A common anti-pattern in older CI/CD setups runs the full build pipeline separately for dev, staging, and production, often with environment-specific build arguments or dependency versions injected at compile time. The image that runs in production was literally never tested — only a different image built from the same source code at a different time, potentially with a different toolchain version, a different set of cached dependency layers, and different environment variables baked into the final artifact. When issues appear in production that were not caught in staging, the team wastes cycles investigating configuration differences when the root cause is that the artifact itself is different.
+
+**Build once, promote the digest.** The correct GitOps pattern builds the container image and any other deployable artifacts exactly once — typically from the application's source repository on merge to its main branch. The build produces an immutable reference: a container image pinned by SHA256 digest, not by mutable tag. This digest is the artifact. Promoting to staging means writing that digest into the staging overlay's image field. Promoting to production means writing the exact same digest into the production overlay. The bytes that run in production are the same bytes that passed integration tests and staging smoke tests.
+
+The mechanism of pinning by digest deserves emphasis. An image tag like `my-service:v1.2.3` is a mutable pointer — it can be retagged to point to a different digest at any time. A digest like `my-service@sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855` is cryptographically bound to the exact content. Most container registries support both forms, and the GitOps promotion workflow should always resolve the tag to its digest at build time and write the digest into the Git repository. This eliminates the class of failures where a retag between promotion and deployment silently changes the running artifact.
+
+**Environment-specific configuration is overlaid, not baked in.** The objection to build-once is usually that environments legitimately differ: staging uses a smaller database instance pool, production has higher replica counts, dev runs with debug logging enabled. These differences are real and necessary, but they belong in the deployment configuration layer — the Kustomize overlay, the Helm values file, the environment-specific ConfigMap — not in the container image itself. The image should be environment-agnostic; the overlay makes it environment-specific. This separation ensures that when you test the staging overlay and then promote to production, the only thing that changed is the overlay, not the artifact.
+
+**The "tested == shipped" guarantee is what makes canary and blue-green progressive delivery safe.** If you cannot trust that the artifact running in the canary is identical to the artifact you validated in staging, then canary metrics are measuring a different thing than what you validated, and automated promotion/rollback based on those metrics is making decisions about an unvalidated artifact. The entire progressive delivery model rests on the build-once invariant.
+
+---
+
+## Promotion Mechanics
+
+The mechanics of promotion in GitOps reduce to a small set of operations that recur across tools and repository layouts. Understanding the primitives — rather than memorizing one tool's CLI — gives you the ability to design promotion workflows that fit your specific constraints.
+
+### Directory and Overlay Per Environment
+
+The foundational pattern, covered in Module 3.2, uses a directory-per-environment structure backed by Kustomize overlays. Each environment directory declares which version of each service should run there. Promotion is an update to the version field in the target environment's overlay.
 
 ```
 my-service/
@@ -77,45 +102,14 @@ my-service/
 │   └── kustomization.yaml
 └── overlays/
     ├── dev/
-    │   └── kustomization.yaml     # image: v1.2.3
+    │   └── kustomization.yaml     # image: my-service@sha256:abc123...
     ├── staging/
-    │   └── kustomization.yaml     # image: v1.2.2
+    │   └── kustomization.yaml     # image: my-service@sha256:def456...
     └── prod/
-        └── kustomization.yaml     # image: v1.2.1
+        └── kustomization.yaml     # image: my-service@sha256:aaa111...
 ```
 
-### Promotion = Update Image Tag
-
-```yaml
-# overlays/dev/kustomization.yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - ../../base
-images:
-  - name: my-service
-    newTag: v1.2.3  # Latest in dev
-
-# overlays/staging/kustomization.yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - ../../base
-images:
-  - name: my-service
-    newTag: v1.2.2  # Promoted from dev
-
-# overlays/prod/kustomization.yaml
-apiVersion: kustomize.config.k8s.io/v1beta1
-kind: Kustomization
-resources:
-  - ../../base
-images:
-  - name: my-service
-    newTag: v1.2.1  # Promoted from staging
-```
-
-### The Promotion Flow
+The promotion flow itself follows a consistent sequence. A developer or automated pipeline opens a pull request that modifies the staging overlay to reference the new digest. When the PR is reviewed and merged, the GitOps controller watching the staging cluster detects the change and reconciles. After validation in staging — either manual verification or automated smoke tests — a second PR is opened targeting the production overlay with the same digest. That PR may require additional approvals, may only be mergeable during a defined deployment window, and may trigger a canary or blue-green rollout within production rather than an instantaneous full cutover.
 
 ```mermaid
 graph TD
@@ -123,36 +117,27 @@ graph TD
         A[Git Repository]
     end
     
-    A --> D[overlays/dev/<br>image: v1.2.3]
-    A --> S[overlays/staging/<br>image: v1.2.2]
-    A --> P[overlays/prod/<br>image: v1.2.1]
+    A --> D[overlays/dev<br/>digest: abc123]
+    A --> S[overlays/staging<br/>digest: def456]
+    A --> P[overlays/prod<br/>digest: aaa111]
     
-    D -- "Promote: PR to update<br>staging/tag" --> S
-    S -- "Promote: PR to update<br>prod/tag" --> P
-    P -. "Deployed:<br>GitOps syncs" .-> C[Production Cluster]
+    D -- "PR: update staging digest" --> S
+    S -- "PR: update prod digest<br/>(+ approval gates)" --> P
+    P -. "GitOps controller<br/>reconciles" .-> C[Production Cluster]
 ```
 
-### Manual Promotion
+### PR-Based Promotion vs Automated Promotion
 
-```bash
-# Promote v1.2.3 from dev to staging
-cd config-repo
+The choice between requiring a human pull request for each promotion step and fully automating promotion through pre-production environments defines the tempo and risk profile of your pipeline.
 
-# Update staging overlay
-yq eval '.images[0].newTag = "v1.2.3"' -i overlays/staging/kustomization.yaml
+**PR-based promotion** requires a human to open or at least approve a pull request for each environment transition. This provides a natural gating point: the PR itself is the approval mechanism, and branch protection rules can enforce required reviewers, required status checks, and required conversations to be resolved. The tradeoff is latency. A change approved at 2 AM sits in a PR until someone wakes up and clicks merge — which, for non-critical services in low-risk environments, is often the right tradeoff. PR-based promotion is the default choice for production and for any environment where compliance or change-management policy requires human attestation.
 
-# Commit and push
-git add overlays/staging/
-git commit -m "Promote my-service v1.2.3 to staging"
-git push origin main
+**Automated promotion** uses a CI pipeline or a dedicated promotion controller to open and merge PRs when preconditions are met. The most common trigger is a successful test suite completion in the source environment. A change that passes dev integration tests automatically gets a promotion PR to staging. A change that passes staging smoke tests and SLO validation automatically gets a promotion PR to production — though production automation typically requires a human to approve the PR rather than auto-merge it closed. The Flux image automation controllers (`ImageRepository`, `ImagePolicy`, `ImageUpdateAutomation`) implement this pattern natively by watching a container registry for new images matching a policy (semver range, tag pattern) and automatically committing updates to the Git repository when a new image is found.
 
-# GitOps agent syncs staging cluster
-```
-
-### Automated Promotion
+**The hybrid model** — automated promotion to staging, PR-gated promotion to production — is the most common pattern in practice because it balances velocity with safety. Changes reach a production-like environment quickly and automatically, giving fast feedback, while the final step to users still carries a human decision.
 
 ```yaml
-# GitHub Action for auto-promotion
+# GitHub Action skeleton for automated staging promotion
 name: Promote to Staging
 
 on:
@@ -187,135 +172,44 @@ jobs:
             Please review and merge to complete promotion.
 ```
 
----
+### Environment-Specific Overlays That Legitimately Differ
 
-## Try This: Trace a Promotion
+Not everything should be identical across environments. The principle of promoting the same artifact does not mean every Kubernetes resource is a carbon copy. The following differences are legitimate and expected in environment-specific overlays:
 
-Think about a recent deployment to production:
+- **Replica counts**: dev runs 1 replica to save resources; staging runs 2 to test leader election and failover; production runs 5 for load and availability.
+- **Resource limits and requests**: dev and staging can use conservative limits; production limits should be calibrated against observed usage from staging load tests.
+- **Ingress and DNS configuration**: each environment has its own hostname and TLS certificate.
+- **Database connection strings and credentials**: these reference different database instances. The credentials themselves should be managed through an external secrets system (Sealed Secrets, External Secrets Operator, Vault) rather than hardcoded in the overlay, but the *reference* to which credential to use is environment-specific.
+- **Observability configuration**: production may ship traces to a different collector with a higher sampling rate than staging.
 
-```
-1. What version/commit was promoted? _________________
-2. When did it reach each environment?
-   - Dev: _________________
-   - Staging: _________________
-   - Prod: _________________
-3. Who approved each promotion? _________________
-4. What testing happened between environments? _________________
-5. How would you roll back? _________________
-```
+What should NOT differ across environments is the application image, the application configuration that affects behavior (feature flags may legitimately differ, but algorithm parameters and business logic config should not), and any security policy that affects the application's access to resources.
 
-If you can't answer these easily, your promotion process needs work.
+### Helm Value Overrides as Promotion
 
----
+The overlay pattern is not the only mechanism. When using Helm charts, promotion means updating the values file for the target environment. The same invariants apply: the chart version and the image digest in the values file are the promoted artifacts, and they should be the exact same references that were validated in the previous environment.
 
-> **Pause and predict**: If you use the `latest` tag in your deployment files, how does the cluster know when the image has actually changed in the registry?
+```yaml
+# values-staging.yaml
+image:
+  repository: my-service
+  digest: sha256:def456...
+  tag: v1.2.3  # informational only; digest is authoritative
 
-## Image Tag Promotion
-
-The most common artifact to promote is the container image tag.
-
-### Why Image Tags?
-
-```
-Image tag represents:
-- Specific code version
-- Built artifact
-- Immutable (if using proper tagging)
-
-Promoting an image tag = deploying exact same artifact
+# Promotion to prod means updating values-prod.yaml
+# to reference the same digest: sha256:def456...
 ```
 
-### Tag Strategies
-
-**Semantic Versioning:**
-```
-my-service:v1.2.3
-my-service:v1.2.4
-my-service:v2.0.0
-```
-- Clear version progression
-- Works well with release processes
-- Requires version management
-
-**Git SHA:**
-```
-my-service:abc123f
-my-service:def456g
-```
-- Directly traceable to code
-- No version management needed
-- Less human-readable
-
-**Git SHA + Build Number:**
-```
-my-service:abc123f-42
-my-service:def456g-43
-```
-- Traceable + ordering
-- Useful for debugging
-
-**Avoid:**
-```
-my-service:latest    # Mutable, ambiguous
-my-service:staging   # Which version?
-```
-
-### Promotion Script Example
-
-```bash
-#!/bin/bash
-# promote.sh - Promote image tag through environments
-
-set -e
-
-VERSION=$1
-FROM_ENV=$2
-TO_ENV=$3
-
-if [ -z "$VERSION" ] || [ -z "$FROM_ENV" ] || [ -z "$TO_ENV" ]; then
-  echo "Usage: ./promote.sh <version> <from-env> <to-env>"
-  echo "Example: ./promote.sh v1.2.3 dev staging"
-  exit 1
-fi
-
-echo "Promoting $VERSION from $FROM_ENV to $TO_ENV"
-
-# Verify version exists in source environment
-CURRENT=$(yq eval '.images[0].newTag' overlays/$FROM_ENV/kustomization.yaml)
-if [ "$CURRENT" != "$VERSION" ]; then
-  echo "Warning: $FROM_ENV has $CURRENT, not $VERSION"
-  read -p "Continue anyway? (y/n) " -n 1 -r
-  echo
-  if [[ ! $REPLY =~ ^[Yy]$ ]]; then
-    exit 1
-  fi
-fi
-
-# Update target environment
-yq eval ".images[0].newTag = \"$VERSION\"" -i overlays/$TO_ENV/kustomization.yaml
-
-# Show diff
-git diff overlays/$TO_ENV/
-
-# Commit
-git add overlays/$TO_ENV/
-git commit -m "Promote my-service $VERSION to $TO_ENV
-
-Promoted from: $FROM_ENV
-Previous version: $(git show HEAD^:overlays/$TO_ENV/kustomization.yaml | yq '.images[0].newTag')"
-
-echo "Committed. Push to deploy."
-```
+The risk with Helm-based promotion is that the chart itself can change between environments, introducing additional variables beyond the image reference. A disciplined practice pins the chart version explicitly and promotes that version alongside the image digest, ensuring that the exact combination of chart logic and container image is preserved through the pipeline.
 
 ---
-
-> **Stop and think**: If a new deployment introduces a subtle memory leak, how long does it take for your current monitoring to catch it, and how many users are affected in the meantime?
 
 ## Progressive Delivery
 
-Beyond simple environment promotion, progressive delivery gradually shifts traffic.
+Promotion across environments answers the question "which version should run in this environment?" Progressive delivery answers the question "how should traffic reach that version?" The two concepts operate at different granularities — promotion changes the declared state in Git; progressive delivery controls the rollout of that declared state within a single environment — but they compose to form the complete safe-delivery pipeline.
 
 ### Canary Deployments
+
+A canary deployment runs the new version alongside the existing stable version, routing a small percentage of traffic to the canary and monitoring its behavior before increasing the traffic share. If the canary performs within acceptable thresholds, the rollout continues incrementally — typically stepping from 5% to 25% to 50% to 100%. If the canary violates a metric threshold (error rate, latency, throughput), traffic is shifted back to the stable version and the canary is torn down.
 
 ```mermaid
 graph LR
@@ -323,12 +217,9 @@ graph LR
     User -->|5% Traffic| Canary[v1.2.3 Canary]
 ```
 
-Monitor canary for errors...
+The power of canary deployments in a GitOps context is that the canary configuration itself is declared in Git. When the production overlay is updated with a new image digest, the progressive delivery controller (Argo Rollouts or Flagger) reads the declared desired state and executes the canary steps — not because a pipeline script told it to, but because it reconciled the desired state and its own rollout strategy is defined in the Rollout or Canary custom resource.
 
-If OK:   Increase to 25%, 50%, 100%
-If bad:  Roll back canary
-
-**GitOps Canary with Flagger:**
+**Analysis templates are the automation engine.** Both Argo Rollouts and Flagger support metric-driven analysis that runs during the canary. An analysis template defines which metrics to query (from Prometheus, Datadog, New Relic, CloudWatch, and others), what thresholds constitute a pass or failure, how long to run the analysis at each step, and what action to take on failure (pause the rollout, roll back, or alert). This closes the loop: a Git commit changes the desired state, the controller begins the progressive rollout, the analysis validates real production traffic against the new version, and the rollout completes or aborts automatically based on measurement, not on a human watching a dashboard.
 
 ```yaml
 apiVersion: flagger.app/v1beta1
@@ -361,18 +252,13 @@ spec:
 
 ### Blue-Green Deployments
 
+A blue-green deployment provisions an entirely separate environment running the new version — the "green" environment — alongside the existing "blue" environment that continues serving all production traffic. Once the green environment is fully deployed, warmed up, and validated through automated tests, traffic is switched from blue to green in a single operation at the load balancer or ingress layer.
+
 ```mermaid
 graph LR
     User([Users]) -->|100% Traffic| Blue[Blue Environment<br>v1.2.2]
     Test([Tests]) -->|Validation| Green[Green Environment<br>v1.2.3]
 ```
-
-Test Green environment...
-
-If OK:   Switch traffic: Blue=0%, Green=100%
-If bad:  Keep traffic on Blue
-
-**GitOps Blue-Green with Argo Rollouts:**
 
 ```yaml
 apiVersion: argoproj.io/v1alpha1
@@ -393,107 +279,57 @@ spec:
           image: my-service:v1.2.3
 ```
 
-### When to Use Progressive Delivery
+Blue-green trades infrastructure cost for operational simplicity. Because the green environment is a complete, isolated copy of the production stack, you can run full integration tests against it without affecting a single user. The cutover is instantaneous — a single routing rule change — and the rollback is equally instantaneous: switch traffic back to blue. The cost is that during the blue-green window you are running twice the infrastructure, which for large deployments can be significant.
 
-| Scenario | Strategy |
-|----------|----------|
-| Low risk, fast feedback | Direct promotion |
-| Medium risk, need validation | Canary (gradual) |
-| High risk, need full testing | Blue-green (parallel) |
-| Critical services | Canary with automated rollback |
+### Choosing Between Canary, Blue-Green, and Direct Promotion
 
----
+The decision depends on your failure domain, your traffic volume, and the speed at which your monitoring can detect anomalies.
 
-## Did You Know?
+| Scenario | Strategy | Reasoning |
+|----------|----------|-----------|
+| Low risk, fast feedback | Direct promotion | Overhead of progressive delivery exceeds risk of direct cutover |
+| Medium risk, needs traffic validation | Canary (gradual) | Real-user traffic validates behavior incrementally; partial blast radius |
+| High risk, needs comprehensive testing | Blue-green (parallel) | Full environment validation before any user traffic touches new version |
+| Critical service with SLO | Canary with automated rollback | Metric-driven gates prevent SLO breach; rollback is automatic |
 
-1. **Facebook deploys code to 2% of users first**, then gradually rolls out. They call this "gatekeeper" and have done it for over a decade.
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
 
-2. **"GitOps promotion" is fundamentally different from "CI/CD promotion"**. In CI/CD, the pipeline pushes. In GitOps, the change is a Git commit and the cluster pulls.
+| Capability | Argo Rollouts | Flagger | Argo CD (native) |
+|---|---|---|---|
+| Canary deployment | Yes, with step-based weight and pause | Yes, with weight and A/B testing | No |
+| Blue-green deployment | Yes, with preview service | No (canary-focused) | No |
+| Analysis (metric-based promotion/rollback) | Yes (AnalysisTemplate CRD) | Yes (metric templates, webhooks) | No |
+| Supported metric providers | Prometheus, Datadog, New Relic, Wavefront, CloudWatch, Graphite, InfluxDB, SkyWalking, Web | Prometheus, Datadog, CloudWatch, Graphite, InfluxDB, Stackdriver, webhooks | N/A |
+| Traffic routing integration | Service Mesh (Istio, Linkerd), Ingress (NGINX, ALB), SMI | Service Mesh (Istio, Linkerd, App Mesh), Ingress (NGINX, Contour, Gloo, Skipper) | N/A |
+| CNCF status | Graduated | Not in CNCF (Flux project sub-component) | Graduated |
+| GitOps native | Declarative Rollout CR in Git | Declarative Canary CR in Git | Does not do progressive delivery |
 
-3. **Some teams use "promotion bots"** that automatically promote after tests pass and a timer expires. No human approval needed for staging, human approval only for prod.
+### Progressive Delivery Within an Environment vs Promotion Across Environments
 
-4. **LinkedIn's deployment system** promotes changes through 5 stages before reaching all users: canary → early adopters → first tier → second tier → full rollout. Each stage has automated health checks that can halt the promotion.
-
----
-
-> **Pause and predict**: Think of the last "emergency hotfix" your team deployed. Did the rush to fix the problem introduce any new, unexpected issues?
-
-## War Story: The Promotion That Skipped Staging
-
-A team I worked with had an "emergency fix":
-
-**The Situation:**
-- Bug in production causing customer issues
-- Developer had a fix ready
-- "We don't have time for staging!"
-
-**What They Did:**
-```bash
-# Direct to prod (bad idea!)
-git checkout main
-yq eval '.images[0].newTag = "hotfix-123"' -i overlays/prod/kustomization.yaml
-git commit -m "Emergency fix for customer issue"
-git push
-```
-
-**What Happened:**
-
-The fix worked for the original bug. But the hotfix image:
-- Had a different config dependency
-- Config existed in dev (where it was developed)
-- Config didn't exist in prod
-- New bug: service crashed on startup
-
-**Impact:**
-- 15 minutes of downtime
-- Customer issue now worse
-- Emergency rollback
-- 3 AM debugging session
-
-**The Root Cause:**
-
-The fix wasn't tested in an environment that matched prod. Skipping staging meant skipping validation.
-
-**The Better Approach:**
-
-```bash
-# Even for emergencies:
-1. Deploy to staging first (10 min)
-2. Quick smoke test (5 min)
-3. Deploy to prod
-4. Total: 15 min delayed, hours of debugging saved
-```
-
-**Policy Change:**
-
-They implemented:
-1. No direct-to-prod promotions, ever
-2. "Emergency" staging = fast track, not skip
-3. Automated smoke tests in staging
-4. Alert if prod has version not in staging
-
-**Lesson:** Emergencies don't justify skipping environments. They justify faster promotion through environments.
+These two concepts are often conflated but serve different purposes. Progressive delivery answers "how does traffic shift to the new version safely within one environment?" Promotion answers "which version is the desired state for this environment?" They compose: the production overlay declares the desired version, and the progressive delivery controller decides how to route traffic to it. A canary in production is not a separate environment — it is a controlled rollout within the production environment itself, governed by the same GitOps loop that reconciled the overlay change in the first place.
 
 ---
 
-## Approval Workflows
+## Gates and Verification
 
-Promotion often requires human approval, especially for production.
+Promotion without verification is deployment without testing. The verification layer determines whether a version that has reached an environment is healthy enough to be promoted further or to be rolled back. GitOps provides natural gating points at the Git level — pull requests — and at the runtime level — analysis templates and policy admission.
 
-### Pull Request Approvals
+### Automated Verification Gates
 
-```yaml
-# GitHub branch protection for config repo
-# main branch rules:
-- Require pull request before merging
-- Require 1 approval for overlays/staging/
-- Require 2 approvals for overlays/prod/
-- Require status checks to pass
-```
+Automated gates run without human intervention and produce a binary pass/fail result. They are the first line of defense and should be configured to run on every promotion PR before a human is even asked to review.
 
-### GitOps Tool Integration
+**Test suites** are the most fundamental gate. A promotion PR to staging should trigger integration tests that run against the staging environment with the proposed version deployed. If the tests fail, the PR cannot be merged. The test suite should verify not only that the application starts and responds to health checks but that its interactions with its dependencies — databases, message queues, other services — produce correct results under the new version.
 
-**ArgoCD Sync Windows:**
+**Policy admission** checks whether the proposed change violates organizational constraints. Tools like OPA Gatekeeper and Kyverno can be applied to the promotion PR itself through policy-as-code checks in CI. A policy might require that any image promoted to production has been scanned by a vulnerability scanner within the last 24 hours and has no critical CVEs. Another policy might enforce that the image was built from a signed commit by a recognized team member. These policies are declarative, version-controlled in the same Git repository, and cannot be bypassed by individual discretion.
+
+**SLO-based analysis** extends verification beyond binary tests to continuous measurement. A canary or blue-green progressive delivery controller queries the monitoring system for SLO-relevant metrics — request latency, error rate, throughput — and compares the new version's performance to the established baseline. If the canary exceeds the error budget for the canary window, the rollout is aborted automatically. This is the practical intersection of SRE error budgets and GitOps promotion: the error budget is not just a policy document but a runtime enforcement mechanism that blocks promotions that would consume too much of the remaining budget.
+
+### Manual Approval Gates
+
+Manual gates insert human judgment at defined points in the promotion path. The most common manual gate is the pull request review requirement: a promotion PR to production requires approval from a designated set of reviewers, enforced by branch protection rules in the Git hosting platform.
+
+**Argo CD sync windows** provide an additional layer of manual gating at the controller level. A sync window defines time ranges during which automated sync is allowed or denied for specific applications or namespaces. A production application might be configured to sync only during weekday business hours, preventing a promotion merged at 2 AM from taking effect until the window opens and someone is available to respond if something goes wrong.
+
 ```yaml
 apiVersion: argoproj.io/v1alpha1
 kind: AppProject
@@ -511,7 +347,8 @@ spec:
       duration: 24h
 ```
 
-**Flux Notifications:**
+**Flux notifications and alerts** keep humans informed without requiring them to watch dashboards. A Flux Alert can be configured to send a Slack message, a PagerDuty page, or a webhook when a promotion is applied to specific paths in the repository, giving teams visibility into what changed and when.
+
 ```yaml
 apiVersion: notification.toolkit.fluxcd.io/v1beta2
 kind: Alert
@@ -529,14 +366,106 @@ spec:
     - ".*overlays/prod.*"
 ```
 
-### Approval Patterns
+### The Error Budget as a Promotion Governor
 
-| Pattern | How It Works | Best For |
-|---------|--------------|----------|
-| PR approval | Human approves PR | Most teams |
-| Scheduled windows | Auto-approve during windows | Controlled deployments |
-| Test gates | Auto-approve if tests pass | High automation |
-| Change advisory | External approval system | Enterprise/compliance |
+SRE practices define error budgets as the acceptable amount of unreliability over a defined window — typically the complement of the SLO over a rolling 28-day period. When applied to promotion, the error budget becomes a governor: as the remaining error budget shrinks, promotion cadence should slow or halt entirely. If the service is already consuming its error budget faster than planned, introducing a new version — which inherently carries risk — is irresponsible.
+
+In practice, this means the promotion pipeline should query the error budget status before allowing a production promotion to proceed. If the budget is below a threshold (e.g., fewer than 15 minutes of remaining downtime in the window), automated promotion is disabled and any human-driven promotion requires explicit acknowledgment of the budget state. This coupling ensures that the decision to promote is informed by the current reliability posture, not just by the passage of tests.
+
+---
+
+## Rollback: Why Declarative Beats Imperative
+
+Rollback is the promotion pipeline's most important capability because it is the one you will use under pressure, at inconvenient hours, when judgment is impaired by stress and urgency. The design of the rollback mechanism must account for the conditions under which it will be invoked.
+
+**Git revert is the canonical GitOps rollback.** When a promotion commit is identified as problematic, reverting that commit and pushing returns the repository to its previous state. The GitOps controller detects the change and reconciles the cluster back. The rollback itself is a Git commit, carrying the same audit trail properties as any other change: author, timestamp, diff, and review record. A responder investigating the incident can see not only what was rolled back but who initiated the rollback and when.
+
+**Why imperative rollback fails under GitOps.** A `kubectl rollout undo` or an Argo CD UI-driven "rollback" button modifies the cluster state directly. The cluster now diverges from the declared state in Git. The GitOps controller, whose job is to eliminate drift by reconciling the cluster to Git, will detect this divergence and — depending on the sync policy — either overwrite the rollback with the broken version still declared in Git or flag the application as out of sync and refuse to proceed. In either case, the team is fighting the controller. The correct fix is to change Git, not the cluster.
+
+**Sync waves and health checks govern rollback ordering.** When an application consists of multiple Kubernetes resources with dependencies — a Deployment that references a ConfigMap, a Service that targets the Deployment, an Ingress that routes to the Service — the order in which resources are rolled back matters. Argo CD sync waves assign resources to numbered phases (negative waves run first, then zero, then positive), and a rollback commit that reverts all resources simultaneously will be reconciled in the correct order by the controller. Health checks ensure that each wave is healthy before the next wave begins, preventing a partial rollback from leaving the application in a broken intermediate state.
+
+Rollback in GitOps is not an emergency procedure layered on top of the deployment model. It is the deployment model running in reverse, with the same guarantees of atomicity, order, and auditability that forward promotion provides. The promotion and the rollback are the same operation applied to different Git commits — and that symmetry is what makes the system reliable under stress.
+
+---
+
+## Multi-Cluster and Multi-Region Promotion
+
+As deployment footprints grow to span multiple clusters — for geographic distribution, blast-radius isolation, or capacity scaling — promotion must extend from a single-cluster model to a staged multi-cluster rollout.
+
+**The staged rollout pattern** promotes to one cluster or region at a time, validates, and proceeds. A new version is first promoted to a canary cluster (often a low-traffic region or an internal-facing cluster), validated with production traffic for a defined period, and then promoted to subsequent clusters in sequence. Each promotion is a separate Git commit targeting the per-cluster overlay or the per-cluster ApplicationSet parameter. If a rollout fails in one region, only that region is affected; the remaining regions continue running the previous stable version.
+
+**Argo CD ApplicationSets** implement multi-cluster promotion declaratively. An ApplicationSet generator — typically a cluster generator or a list generator — produces an Application resource for each target cluster from a single template. The template references a per-cluster overlay directory or a Helm values file keyed by cluster name. Updating the image digest in the template updates all Applications simultaneously, but progressive sync can be configured with per-cluster sync windows or manual sync policies that stagger the rollout.
+
+**Flux multi-cluster promotion** follows a similar pattern through GitRepository and Kustomization resources per cluster, with the additional capability of image automation controllers that can update per-cluster image references independently. A Flux `ImageUpdateAutomation` can be scoped to a specific cluster's directory, enabling per-cluster promotion automation with cluster-specific validation gates.
+
+**Regional staged rollout** applies the same concept at geographic scale. A change is promoted to `us-east-2` (low traffic), validated for 30 minutes against production traffic and SLO metrics, promoted to `us-west-2`, validated for 15 minutes, and then promoted to the remaining regions. Each stage is a Git commit; each committed digest is the same immutable artifact; and the only difference between regions is the timing of the promotion commit.
+
+---
+
+## Patterns and Anti-Patterns
+
+Recognizing which promotion designs work and which fail under real operational pressure is more valuable than memorizing CLI flags.
+
+### Patterns
+
+**Promote the digest, never the tag.** Resolve mutable image tags to SHA256 digests at build time and write the digest into the Git repository. This eliminates an entire class of "it changed between promotion and deployment" incidents and makes the Git state cryptographically precise about what is running.
+
+**Promotion as pull request.** Every environment transition is a pull request. This makes every promotion reviewable, commentable, and attributable — even if the PR is created and merged automatically by a bot. The PR record is the audit log.
+
+**Immutable promotion path.** The sequence of environments through which a change must pass is encoded in branch protection rules and CI checks, not in documentation. A change cannot reach production without having passed through staging because the CI check on the production PR verifies that the same digest exists in the staging overlay at the time of the production PR.
+
+**Declarative rollback through Git revert.** When something breaks, `git revert` the promotion commit. Do not touch the cluster. Let the controller reconcile.
+
+**Progressive delivery as a promotion step, not an environment.** Treat canary and blue-green as rollout strategies within a single environment rather than as additional environments in the promotion path. This keeps the promotion path (dev → staging → prod) simple while adding progressive-delivery safety inside production.
+
+### Anti-Patterns
+
+**Rebuilding per environment.** Running a separate CI build for each environment produces artifacts that were never tested as the exact bytes that will run. The staging build's compiler flags, dependency versions, and cached layers differ from the production build's. The resulting bugs are irreproducible in staging and impossible to root-cause during an incident.
+
+**Mutable tags in Git.** Writing `my-service:latest` or `my-service:staging` into the repository means the Git state does not specify what is running. Two people reading the same file at different times will see different cluster states. This is the opposite of declarative.
+
+**Skipping environments for emergencies.** The pressure to skip staging during an incident is real, but the risk compounds: the emergency fix was tested in zero environments resembling production, and if it introduces a new failure, the incident is now two problems layered on top of each other. The correct emergency path is accelerated promotion through all environments — staging sync + smoke test + production promotion in a tight automated sequence — not environment bypass.
+
+**Manual cluster edits as rollback.** Using `kubectl apply -f previous-version.yaml` or a controller UI to revert a deployment creates drift between the cluster and Git. The GitOps controller will reconcile the drift away or, worse, flag the application as degraded and refuse further automated sync. The fix must land in Git first.
+
+**Promotion monorepo with shared overlays.** When multiple teams share a single promotion repository and a single overlay directory, a promotion for service A can accidentally carry an unintended change for service B if the PR author is not careful about what is staged. Per-team or per-service overlay directories with CODEOWNERS files prevent this collision.
+
+**No automated smoke tests in staging.** If staging promotion requires a human to manually verify that the new version works, promotions will queue during off-hours and overnight, creating release pressure — multiple changes stacked behind the unverified one — that drives risky behavior. Automated smoke tests that run on the staging cluster and report a go/no-go status to the production promotion PR eliminate this bottleneck.
+
+**Promoting on Friday.** Deploying changes when the team is about to be away for two days maximizes the window during which an undetected problem can accumulate impact. If a Friday promotion is unavoidable, it should be coupled with increased alerting sensitivity and an explicit on-call escalation path for the weekend.
+
+### Decision Framework
+
+Use the following decision flow to select the right promotion strategy for a given service and risk profile.
+
+```mermaid
+graph TD
+    A[New version ready for promotion] --> B{Is the service critical<br/>to business operations?}
+    B -->|No| C[Direct promotion with<br/>automated smoke tests]
+    B -->|Yes| D{Can the service tolerate<br/>partial failure during rollout?}
+    D -->|Yes — stateless,<br/>horizontally scaled| E[Canary deployment with<br/>metric-based analysis]
+    D -->|No — stateful,<br/>slow startup, DB migration| F{Is double infrastructure<br/>cost acceptable?}
+    F -->|Yes| G[Blue-green deployment<br/>with full validation]
+    F -->|No| H[Canary with extended<br/>analysis window<br/>and additional metric checks]
+    E --> I{Error budget available?}
+    G --> I
+    H --> I
+    I -->|Yes — budget > 20% remaining| J[Proceed with promotion]
+    I -->|No — budget critically low| K[Block promotion;<br/>escalate to SRE]
+    C --> J
+```
+
+---
+
+## Did You Know?
+
+1. **Facebook deploys code to 2% of its users first** and then gradually expands the rollout. This internal system, called "Gatekeeper," has operated for over a decade and uses real-user metrics — not pre-production testing — as the primary promotion gate. The logic is straightforward: no staging environment captures real user behavior, so the first real users ARE the final verification.
+
+2. **GitOps promotion is fundamentally different from CI/CD promotion.** In a CI/CD pipeline, the pipeline pushes changes to the target environment. In GitOps, the pipeline writes a change to Git, and a controller running in the cluster pulls and reconciles. The direction of the control flow — push vs. pull — changes the failure modes, the credential model, and the audit trail. A failed push leaves the cluster in an ambiguous state. A failed pull reconciliation leaves a clear record: the desired state in Git, the actual state in the cluster, and a controller status explaining the gap.
+
+3. **Some organizations use promotion bots that auto-promote to staging without human review** but require human approval only for production. The staging environment is treated as a fast-feedback loop where automated test results are the gate, while production adds a human decision to the chain. This balances deployment velocity (staging promotions happen within seconds of test completion) with safety (production promotions require a reviewer to click merge).
+
+4. **LinkedIn's deployment system promotes changes through five distinct stages** before reaching all users: canary, early adopters, first tier, second tier, and full rollout. Each stage has independent automated health checks that measure real-user metrics — latency, error rate, session completion — and automatically halt promotion if any metric deviates from baseline. The system demonstrates that "promotion" is not a binary dev-to-prod event but a graduated process where confidence accumulates through measured exposure to increasingly representative user populations.
 
 ---
 
@@ -544,229 +473,162 @@ spec:
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| Skipping environments | Bugs reach prod untested | Always promote through all envs |
-| Manual copy-paste | Errors, inconsistency | Use scripts/automation |
-| No approval for prod | Risky changes slip through | Require PR approval |
-| Same image tag, different configs | Works in staging, fails in prod | Include config in testing |
-| No rollback plan | Stuck with broken deploy | Always know how to roll back |
-| Promote on Friday | Weekend incidents | Freeze before weekends |
+| Using mutable tags in Git | Git state does not specify what is running; two reads at different times see different cluster states | Pin by SHA256 digest; resolve mutable tags at build time |
+| Skipping environments in emergencies | Untested emergency fix introduces new failures, compounding the original incident | Accelerate the promotion path, never bypass it — staging smoke test in a tight automated sequence |
+| Rebuilding per environment | Each environment runs a different artifact; staging tests do not validate production | Build once, promote the same digest; environment differences go in overlays, not the image |
+| Manual cluster edits as rollback | Creates drift between cluster and Git; controller reconciles the edit away | `git revert` the promotion commit; let the controller reconcile |
+| No automated smoke tests in staging | Promotions queue behind unverified changes; release pressure drives risky shortcuts | Automated smoke tests that report go/no-go status to the production PR |
+| Promoting without error budget awareness | Introducing a new version during a reliability incident compounds risk | Query error budget status before production promotion; block if budget is critically low |
+| Friday or end-of-day promotions | Maximum unremediated impact window if something breaks; minimal team availability | Deploy during business hours with on-call coverage; if unavoidable, increase alert sensitivity |
+| Monorepo with unguarded shared overlays | A promotion for service A accidentally changes service B's configuration | Per-service overlay directories with CODEOWNERS and required reviews per path |
 
 ---
 
 ## Quiz: Check Your Understanding
 
 ### Question 1
+
 **Scenario:** Your team is moving to GitOps and a developer suggests using the `latest` tag for the production image so that the cluster always pulls the most recent build automatically. What is the critical flaw in this approach for a GitOps workflow?
 
 <details>
 <summary>Show Answer</summary>
 
-Using the `latest` tag breaks the core GitOps principle of immutability and reproducibility. Because the `latest` tag constantly points to different image digests over time, you cannot guarantee what exact artifact is running in your cluster just by looking at the Git repository. Furthermore, if a deployment fails, rolling back becomes dangerous and unpredictable because the previous "latest" state is no longer explicitly defined or easily retrievable. Instead, you should always promote immutable artifacts, such as semantic versions (e.g., `v1.2.3`) or Git SHA tags, ensuring that what is tested in staging is the exact identical image deployed to production.
+Using the `latest` tag breaks the core GitOps guarantee that the Git repository is the single source of truth for cluster state. Because `latest` is a mutable pointer — it resolves to different image digests at different times — two people reading the same Git file at different moments would see different cluster states, even though the file itself did not change. Furthermore, if a deployment fails, there is no declarative record of which exact bytes were running before the failure, making rollback ambiguous. The fix is to promote by SHA256 digest, cryptographically bound to the exact artifact content, so the Git state is precise and reproducible at all times.
 
 </details>
 
 ### Question 2
-**Scenario:** A newly promoted version of the `checkout-service` (v2.1.0) is crashing in the production environment. Your GitOps controller (like Argo CD or Flux) is actively syncing the `prod` overlay from your Git repository. What is the safest and most idiomatic GitOps way to restore the service to the previous working version?
+
+**Scenario:** A newly promoted version of the `checkout-service` (v2.1.0) is crashing in the production environment. Your GitOps controller (Argo CD) is actively syncing the `prod` overlay from your Git repository. What is the safest and most idiomatic GitOps way to restore the service, and why does using `kubectl rollout undo` create a new problem?
 
 <details>
 <summary>Show Answer</summary>
 
-The most idiomatic GitOps rollback is to use `git revert` on the commit that promoted the broken version, or to manually update the image tag back to the previous stable version in your Git repository and commit the change. By changing the desired state in Git, you maintain a single source of truth and a clear audit trail of the incident and resolution. If you were to manually use `kubectl rollout undo` or a tool's CLI to force a rollback, the GitOps controller would detect the cluster drift and likely overwrite your fix with the broken state still defined in Git. Reverting in Git ensures the automated controller itself safely applies the rollback.
+The safest approach is to `git revert` the promotion commit that introduced v2.1.0, push the revert commit, and let the GitOps controller reconcile the production cluster back to the previous known-good state. This preserves the audit trail (the revert is a commit with an author and timestamp), keeps the cluster and Git in agreement, and works identically regardless of which GitOps controller you use.
+
+`kubectl rollout undo` modifies the cluster state directly without changing Git. The controller will detect the drift — the cluster is now running a different version than the Git repository declares — and, depending on the sync policy, either overwrite your rollback with v2.1.0 again or flag the application as degraded and refuse to sync. You are now fighting the controller while trying to fix an incident, which is the worst possible time for a tooling conflict.
 
 </details>
 
 ### Question 3
-**Scenario:** Your organization has suffered multiple production outages because developers are merging hotfixes directly into the `prod` branch without testing them in `staging`. You need to implement an automated mechanism to prevent this bypass. How do you ensure staging is always tested before prod?
+
+**Scenario:** Your organization has suffered multiple production outages because developers are merging hotfix PRs directly into the `prod` overlay without the change ever reaching the `staging` overlay. You need to implement an automated mechanism that physically prevents this bypass. What checks would you add to the production promotion PR to enforce the staging-first rule?
 
 <details>
 <summary>Show Answer</summary>
 
-To prevent skipping environments, you should implement branch protection rules and CI pipeline checks that enforce the promotion path. Your CI system can run a check on any Pull Request targeting the production overlay to verify that the exact same image tag or artifact already exists and has successfully passed tests in the staging overlay. Additionally, you can configure your GitOps controllers to only sync production from a specific branch that requires approvals from QA or automated test suites. By embedding these checks directly into the Git repository's merge conditions, you physically prevent untested code from reaching the production environment.
+Add a CI status check on every production promotion PR that queries the staging overlay and verifies that the exact same image digest being proposed for production already exists in the staging overlay's current state. If the staging overlay does not reference this digest, the check fails and the PR cannot be merged. Additionally, enforce a CODEOWNERS rule on the `overlays/prod/` path requiring approval from a designated release manager, and configure Argo CD sync windows so that production sync only occurs during defined business hours. These three layers — programmatic digest verification, human approval, and temporal gating — collectively prevent the staging bypass without relying on anyone remembering the policy during an incident.
 
 </details>
 
 ### Question 4
-**Scenario:** You are deploying a massive architectural update to a legacy monolithic application. The application takes several minutes to start up, and any failure would impact all active users immediately. Which progressive delivery strategy should you use, and why?
+
+**Scenario:** You are deploying a major architectural change to a legacy monolithic application. The application takes approximately 5 minutes to start up, performs a database migration during initialization, and any failure at startup will make the application completely unavailable to all users. Which progressive delivery strategy is appropriate, and what are the tradeoffs?
 
 <details>
 <summary>Show Answer</summary>
 
-For a high-risk, slow-starting application where you need comprehensive testing before any user impact, a Blue-Green deployment is the most appropriate strategy. A Blue-Green deployment provisions an entirely separate environment (the "Green" environment) running the new version, allowing you to run full integration and smoke tests without routing any real user traffic to it. Once the Green environment is fully validated and warmed up, traffic is switched over instantaneously via a load balancer or ingress change. This provides a zero-downtime deployment and an immediate, simple rollback mechanism (switching traffic back to the "Blue" environment) if issues are discovered post-launch.
+A blue-green deployment is the correct choice because it provisions a completely separate "green" environment that can be fully tested before any user traffic is routed to it. The 5-minute startup and database migration can complete without affecting the "blue" environment still serving users. Once the green environment is validated — health checks pass, database migration completed, integration tests against real dependencies succeed — traffic is switched in a single operation. If post-switch issues appear, rollback is equally instantaneous: switch traffic back to blue.
+
+The tradeoff is cost: during the blue-green window, you are running approximately twice the production infrastructure. For a monolith with substantial resource requirements, this can be expensive. The alternative — a canary deployment — is risky here because a monolith that experiences startup failure takes the entire canary slice down, not just a fraction of traffic, and the slow startup makes the canary analysis window impractically long.
+
+</details>
+
+### Question 5
+
+**Scenario:** A developer asks why the team must specify image references by SHA256 digest (`sha256:e3b0...`) in the Git repository instead of by semantic version tag (`v1.2.3`). They argue that tags are more readable and that the CI pipeline only ever pushes a given tag once. What specific failure mode does digest pinning prevent that single-push tag discipline does not?
+
+<details>
+<summary>Show Answer</summary>
+
+Even with a discipline of never retagging, the semantic version tag does not prove that the image in the registry at deployment time is the same image that was tested in staging. Between the time staging was validated and production deployment occurs, a registry compromise, an administrative error, a cache invalidation, or a replication delay could cause the tag to resolve to a different manifest. A digest is a cryptographic hash of the image content and manifest — if the digest matches, the bytes are proven identical. The tag is a human-readable pointer; the digest is a mathematical proof. In a GitOps workflow where the Git repository is supposed to be the single source of truth about what is running, an unverifiable pointer is insufficient.
+
+</details>
+
+### Question 6
+
+**Scenario:** Your team runs a production service with a 99.9% availability SLO (approximately 43 minutes of allowed downtime per 30-day window). The service has already consumed 30 minutes of its error budget this month due to an unrelated incident last week. A new feature version is ready for promotion to production. Should it be promoted, and what additional steps should accompany the promotion if it proceeds?
+
+<details>
+<summary>Show Answer</summary>
+
+With only 13 minutes of remaining error budget for the rest of the window, promoting a new version carries disproportionate risk — any failure from the new version would likely exhaust the remaining budget entirely, violating the SLO. The promotion should be deferred unless there is a compelling business justification that outweighs the reliability risk, and even then, additional safeguards are required: the promotion should go through staging with extended smoke tests, should use a canary deployment with the most aggressive metric thresholds available (tight error rate and latency bounds), should have the analysis window extended beyond normal duration, and the on-call responder should be actively monitoring the rollout with a pre-authorized rollback prepared. If any analysis metric deviates even slightly from baseline during the canary, the rollout must abort immediately, not pause — because the remaining budget does not allow for investigation during the rollout.
+
+</details>
+
+### Question 7
+
+**Scenario:** An organization deploys to three Kubernetes clusters in three AWS regions: `us-east-2` (low-traffic canary region), `eu-west-1`, and `ap-southeast-1`. A new version is promoted to `us-east-2` and runs successfully for 4 hours. The team then promotes to `eu-west-1`, where the same version begins returning elevated error rates within minutes. Why might an identical artifact behave correctly in one region and fail in another, and what does this tell you about multi-region promotion design?
+
+<details>
+<summary>Show Answer</summary>
+
+An identical artifact can behave differently across regions because the artifact is only one component of the runtime environment. Regional differences that affect behavior include: different database replication lag profiles (the `eu-west-1` database replica may be further behind its primary than the `us-east-2` replica), different CDN cache states, different network latency to upstream dependencies, different volumes or patterns of user traffic, and region-specific compliance configurations that modify request paths. The fact that `us-east-2` succeeded for 4 hours is validation of the artifact, not of the full deployment in every region. Multi-region promotion must treat each region as a separate promotion step with its own validation window, rather than assuming that success in one region implies success in all others. The staged rollout pattern — promote, validate, proceed — minimizes the blast radius when a region-specific failure occurs.
 
 </details>
 
 ---
 
-## Hands-On Exercise: Design Promotion Pipeline
+## Hands-On Exercise: Design a Promotion Pipeline
 
-Design a complete promotion pipeline for a service.
+Design a complete promotion pipeline for the `order-service` from first build to multi-region production rollout.
 
 ### Scenario
 
-- **Service**: `order-service`
-- **Environments**: dev, staging, prod
+- **Service**: `order-service` (stateless, horizontally scaled, 4 replicas in production)
+- **Environments**: dev, staging, prod (two regions: `us-east-2` as canary, `eu-west-1` as main)
 - **Requirements**:
-  - Auto-deploy to dev on merge to main
-  - Manual promotion to staging
-  - Approval required for prod
-  - Ability to roll back any environment
+  - Auto-deploy to dev on merge to main in the application repository
+  - Automated promotion to staging with smoke tests
+  - Approval-required promotion to production
+  - Progressive canary rollout within production
+  - Ability to roll back any environment with a single Git operation
+  - Multi-region staged rollout: canary region first, main region after validation
 
-### Part 1: Repository Structure
+### Part 1: Repository Layout
 
-```markdown
-## Repository Structure
+Design the directory structure for both the application repository and the configuration repository. Show where the Kustomize base, overlays, and per-region production overlays live.
 
-config-repo/
-├── order-service/
-│   ├── base/
-│   │   ├── deployment.yaml
-│   │   ├── service.yaml
-│   │   └── kustomization.yaml
-│   └── overlays/
-│       ├── dev/
-│       │   └── kustomization.yaml
-│       ├── staging/
-│       │   └── kustomization.yaml
-│       └── prod/
-│           └── kustomization.yaml
-```
+### Part 2: Promotion Sequence
 
-### Part 2: Promotion Commands
-
-Define the exact commands/steps:
-
-```markdown
-## Promotion Steps
-
-### Dev (automatic)
-Trigger: Merge to main in app repo
-Steps:
-1. CI builds image: order-service:<git-sha>
-2. CI updates: _______________
-3. GitOps agent syncs
-
-### Staging (manual trigger)
-Trigger: Developer initiates promotion
-Steps:
-1. _______________
-2. _______________
-3. _______________
-
-### Prod (with approval)
-Trigger: Release manager initiates
-Steps:
-1. _______________
-2. _______________
-3. _______________
-```
+Define the exact sequence of events from code merge to full production rollout, including which steps are automated and which require human approval.
 
 ### Part 3: Rollback Procedure
 
-```markdown
-## Rollback Procedure
+Write the exact commands — as you would type them during an incident — to identify the broken version, find the previous good version, and roll back production to that version.
 
-### If bad deployment detected:
+### Part 4: Error Budget Integration
 
-**Step 1**: Identify the bad version
-```bash
-# Command to see current deployed version:
-_______________
-```
-
-**Step 2**: Find previous good version
-```bash
-# Command to see version history:
-_______________
-```
-
-**Step 3**: Roll back
-```bash
-# Commands to roll back:
-_______________
-_______________
-```
-
-**Step 4**: Verify
-```bash
-# How to verify rollback successful:
-_______________
-```
-```
-
-### Part 4: Approval Configuration
-
-```markdown
-## Approval Configuration
-
-### Staging
-- Required approvals: ___
-- Who can approve: _______________
-
-### Prod
-- Required approvals: ___
-- Who can approve: _______________
-- Deployment windows: _______________
-- Blackout periods: _______________
-```
+Define the error budget threshold that would block a production promotion, how the pipeline checks it, and what the promotion PR should display when the budget is too low.
 
 ### Success Criteria
 
-- [ ] Defined promotion steps for all three environments
-- [ ] Specified how auto-deploy to dev works
-- [ ] Created rollback procedure with actual commands
-- [ ] Documented approval requirements
-- [ ] Included deployment windows/blackouts for prod
+- [ ] Repository layout separates application source from environment configuration and uses per-region production overlays
+- [ ] Promotion sequence document covers every transition from code merge to full multi-region rollout, marking automated vs. manual steps
+- [ ] Rollback procedure uses `git revert` and lists the exact shell commands a responder should run during an incident
+- [ ] Error budget check is included in the production promotion gate with a defined threshold and a PR status check that blocks promotion when budget is low
 
 ---
 
-## Key Takeaways
+## Sources
 
-1. **Promotion = Git commit**: Change the image tag in the environment directory
-2. **Never skip environments**: Even emergencies go through staging (just faster)
-3. **Use immutable image tags**: semver or git SHA, never `latest`
-4. **Progressive delivery**: Consider canary/blue-green for production
-5. **Approval gates**: PR approvals, sync windows, test gates
-
----
-
-## Further Reading
-
-**Books**:
-- **"GitOps and Kubernetes"** — Chapter on Environment Promotion
-- **"Continuous Delivery"** — Jez Humble (foundational)
-
-**Articles**:
-- **"Progressive Delivery"** — RedMonk
-- **"Canary Deployments with Flagger"** — Flux docs
-
-**Tools**:
-- **Flagger**: Progressive delivery for Kubernetes
-- **Argo Rollouts**: Advanced deployment strategies
-- **Kustomize**: Base/overlay pattern
-
----
-
-## Summary
-
-Environment promotion in GitOps is a Git operation:
-- Update the image tag in the environment's directory
-- Create a PR (for approval)
-- Merge to deploy
-
-This provides:
-- Clear audit trail
-- Easy rollback (git revert)
-- Consistent process
-- Approval integration
-
-The key insight: promotion is declaring "this environment should have this version." The GitOps agent makes it so.
+1. [Argo CD — Sync Waves](https://argo-cd.readthedocs.io/en/stable/user-guide/sync-waves/) — Official documentation on phased sync ordering and health checks
+2. [Argo Rollouts — Progressive Delivery](https://argoproj.github.io/argo-rollouts/) — Canary, blue-green, and analysis-driven promotion
+3. [Argo Rollouts — Analysis Templates](https://argoproj.github.io/argo-rollouts/features/analysis/) — Metric-based promotion and automated rollback
+4. [Flagger — Progressive Delivery for Kubernetes](https://docs.flagger.app/) — Canary deployment with metric analysis and traffic routing
+5. [Flagger — Metrics Analysis](https://docs.flagger.app/usage/metrics) — Supported metric providers and threshold configuration
+6. [Flux — Image Update Automation](https://fluxcd.io/flux/guides/image-update/) — Automated image promotion through Git commits
+7. [Flux — Image Automation Controllers](https://fluxcd.io/flux/components/image/) — ImageRepository, ImagePolicy, ImageUpdateAutomation APIs
+8. [OpenGitOps — Principles](https://opengitops.dev/) — Foundational principles of declarative, version-controlled, pull-based operations
+9. [Kustomize — Overlays](https://kustomize.io/) — Base and overlay pattern for multi-environment configuration
+10. [OPA Gatekeeper — Policy Admission](https://open-policy-agent.github.io/gatekeeper/website/docs/) — Kubernetes-native policy enforcement through CRD-based constraints
+11. [Kyverno — Kubernetes Policy Management](https://kyverno.io/docs/) — Policy-as-code for validation, mutation, and generation
+12. [Kubernetes — Deployments](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) — Core Kubernetes deployment primitive and rollout management
+13. [Helm — Values Files](https://helm.sh/docs/chart_template_guide/values_files/) — Environment-specific configuration overrides for Helm-based promotion
+14. [CNCF Cloud Native Landscape](https://landscape.cncf.io/) — Maturity classification (graduated/incubating/sandbox) for CNCF projects
 
 ---
 
 ## Next Module
 
 Continue to [Module 3.4: Drift Detection and Remediation](../module-3.4-drift-detection/) to learn how to detect and handle when cluster state doesn't match Git.
-
----
-
-*"The best promotion is the one you can roll back in 30 seconds."* — GitOps Wisdom


### PR DESCRIPTION
## #1953 Platform Disciplines — mlops + gitops sections → done

| Module | Author | Before→After | Src | R1 ground-check |
|---|---|---|---|---|
| **mlops 5.3 Model Training** | codex gpt-5.5 | 390→6801 w | 4→22 | Kubeflow Trainer v2 TrainJob/ClusterTrainingRuntime (legacy PyTorchJob/TFJob framed); Kueue v0.18.1; Volcano/Kubeflow CNCF Incubating; K8s 1.35 alpha gang scheduling (feature-gated, hedged); Bergstra random-search paper; de-fabbed |
| **gitops 3.2 Repository Strategies** | cursor | 709→5005 w | 0→17 | app/config separation, mono-vs-poly, overlay-per-env, app-of-apps/ApplicationSet, secrets (Sealed/SOPS/ESO); Argo+Flux CNCF-Graduated as capability Rosetta; de-fabbed |
| **gitops 3.3 Environment Promotion** | deepseek | 605→5555 w | 0→14 | build-once/promote-the-digest (immutable SHA256 vs mutable tag), tested==shipped, PR-based promotion, Argo Rollouts/Flagger progressive delivery, git-revert rollback; de-fabbed |

### Quality gates
- All 3: `verify_module.py` **T0 / passed:true**, density pass, anti-fab clean (de-fabbed), `revision_pending:false`.
- Every source curl-verified (200). Durable-vendor rule applied (dated snapshots + capability Rosettas; no best-tool/leadership claims).
- Local full Astro build green (2169 pages, 0 errors).

### Review
Cross-family R1: opus-inline (≠ each author, no gemini) + ground-check + curl source sweep. No fixes needed this wave.

Closes `data-ai/mlops` (5.3 was the last) and `delivery-automation/gitops` (3.2/3.3 were the last 2).

Refs #1953

🤖 Generated with [Claude Code](https://claude.com/claude-code)