### PR TITLE
fix(citations)+ci: correct 5 wrong-arXiv-ID citations + ID→title CI guard (#1991)

### DIFF
--- a/.github/workflows/arxiv-citations.yml
+++ b/.github/workflows/arxiv-citations.yml
@@ -1,0 +1,44 @@
+name: arXiv citation check
+
+# Catches "valid-but-wrong" arXiv citations (issue #1991): a link whose ID returns
+# HTTP 200 but points to the WRONG paper. `verify_module.py`'s sources_all_reachable,
+# the link checker, and the Astro Zod schema all pass these (the URL resolves) — only
+# an ID->title correspondence check catches them. Same blind-spot class as the
+# killercoda lab.url check (link-check.yml). Runs on changed *.md files only, needs no
+# secrets and no write scope, so it is safe on fork PRs. No `paths:` filter is needed
+# because the job no-ops cleanly when a PR changes no markdown.
+on:
+  pull_request:
+    branches:
+      - main
+
+permissions:
+  contents: read
+
+jobs:
+  arxiv-citations:
+    name: arXiv citation check
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10  # v6.0.3
+        with:
+          fetch-depth: 0  # need the PR base commit for the changed-files diff
+          persist-credentials: false
+
+      - name: Set up Python
+        uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405  # v6.2.0
+        with:
+          python-version: "3.12"
+
+      - name: Check arXiv citations in changed markdown
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: |
+          files=$(git diff --name-only "$BASE_SHA" HEAD -- '*.md')
+          if [ -z "$files" ]; then
+            echo "No markdown changes — nothing to check."
+            exit 0
+          fi
+          echo "Changed markdown:"; echo "$files"
+          python scripts/quality/check_arxiv_citations.py $files

--- a/scripts/quality/check_arxiv_citations.py
+++ b/scripts/quality/check_arxiv_citations.py
@@ -1,0 +1,199 @@
+#!/usr/bin/env python3
+"""Catch valid-but-wrong arXiv citations: an arXiv link that returns HTTP 200 but
+points to the WRONG paper.
+
+The failure mode (issue #1991): an author writes the correct paper *title* in the
+markdown link text but a wrong arXiv *ID*. The URL still resolves, so
+``verify_module.py``'s ``sources_all_reachable`` gate, link checkers, and the Astro
+Zod schema all pass it. Only an ID->title correspondence check catches it. This is
+the same blind-spot class as the killercoda ``lab.url`` bug (valid URL, wrong
+content) closed by ``scripts/ci/check_lab_urls.py``.
+
+Design goals: PRECISE (≈0 false positives) so it stays load-bearing.
+- Only checks markdown links whose link TEXT is *title-like* (a real claimed title),
+  after stripping ``Author et al. — `` / ``Author, YYYY — `` prefixes.
+- Skips prose-phrase links, bare-URL link text, ``arXiv:1234.5678`` link text,
+  author-year-only citations, and short tags (e.g. ``SimCLR``, ``HNSW paper``) —
+  those carry no title to validate, so they cannot be checked this way.
+- Fetches the real arXiv title and FAILs only on near-zero token overlap.
+- Network-resilient: fetch errors are reported as warnings, never hard failures
+  (so the gate does not flake on arXiv downtime).
+- Escape hatch: put ``<!-- arxiv-ok: 1234.5678 -->`` anywhere in the file to
+  whitelist a specific ID (e.g. a legitimately terse title).
+
+Usage:
+  check_arxiv_citations.py <file.md> [more.md ...]   # explicit files
+  check_arxiv_citations.py --changed                 # changed *.md vs origin/main
+  check_arxiv_citations.py --all                     # every src/content/docs/*.md
+Exit 1 on any confirmed mismatch.
+"""
+from __future__ import annotations
+
+import argparse
+import html
+import re
+import subprocess
+import sys
+import urllib.request
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DOCS = REPO_ROOT / "src" / "content" / "docs"
+
+LINK_RE = re.compile(r"\[([^\]]+)\]\((?:https?://)?arxiv\.org/abs/(\d{4}\.\d{4,5})\)")
+OK_RE = re.compile(r"<!--\s*arxiv-ok:\s*(\d{4}\.\d{4,5})\s*-->")
+# author/citation prefixes we strip to expose the title portion of the link text
+PREFIX_RE = re.compile(
+    r"^[A-Z][^—:]*?et al\.?(,?\s*\d{4})?\s*[—:-]\s*|"  # "Gama et al. — Title" / "X et al.: Title"
+    r"^[A-Z][A-Za-z.'’-]+\s*(&|and)\s*[A-Z][A-Za-z.'’-]+,?\s*\d{4}\s*[—:-]\s*"  # "Kipf & Welling, 2017 — Title"
+)
+AUTHOR_YEAR_ONLY = re.compile(r"^[A-Z][^()]*?et al\.?,?\s*\(?\d{4}\)?\.?$|^[A-Z][A-Za-z.'’-]+\s*(&|and)\s*[A-Z][A-Za-z.'’-]+,?\s*\(?\d{4}\)?$")
+BARE_URL = re.compile(r"^(arxiv\.org|https?://|arxiv:)", re.I)
+# link text that is a method/acronym name, not a paper title: "... (HyDE)", "... (GAN)"
+METHOD_PAREN = re.compile(r"\([A-Z][A-Za-z0-9]{1,7}\)\s*$")
+# prose-sentence signals — a citation sentence, not a title (e.g. "...OpenAI published the X paper")
+PROSE_VERB = re.compile(r"\b(published|introduc\w+|propos\w+|demonstrat\w+|catalog\w+|describ\w+|present\w+|showed)\b", re.I)
+STOP = {"the", "a", "an", "of", "for", "and", "with", "to", "in", "on", "your",
+        "using", "via", "from", "paper", "original", "et", "al", "approach", "study"}
+
+
+def _rel(path: Path) -> str:
+    try:
+        return str(path.resolve().relative_to(REPO_ROOT))
+    except ValueError:
+        return str(path)
+
+
+def _norm_tokens(s: str) -> set[str]:
+    s = re.sub(r"[^a-z0-9]+", " ", s.lower())
+    return {w for w in s.split() if len(w) > 3 and w not in STOP}
+
+
+def _title_like(text: str) -> str | None:
+    """Return the claimed-title portion if the link text is a checkable formal title.
+
+    Returns None (skip) for prose phrases, bare URLs, short tags, and author/citation
+    text — none of which carry a paper title we can validate against arXiv. Keeping
+    this strict is what holds the false-positive rate at ~0.
+    """
+    t = PREFIX_RE.sub("", text).strip().strip("*").strip()
+    if BARE_URL.match(t) or AUTHOR_YEAR_ONLY.match(text.strip()):
+        return None
+    # After stripping a leading author prefix, any remaining author-citation signal
+    # (" & ", "et al", a trailing "(YYYY)") means this is a citation label, not a title.
+    if " & " in t or re.search(r"\bet al\b", t, re.I) or re.search(r"\(\s*\d{4}\s*\)\s*$", t):
+        return None
+    # method/acronym names and prose sentences are not paper titles → cannot validate
+    if METHOD_PAREN.search(t) or PROSE_VERB.search(t):
+        return None
+    words = [w for w in re.split(r"\s+", t) if w]
+    if len(words) < 4:  # short tags / single-concept labels carry no checkable title
+        return None
+    # A real paper title cited in prose is Title Case; lowercase prose phrases are not.
+    sig = [w for w in words if len(re.sub(r"[^A-Za-z]", "", w)) > 3]
+    if not sig:
+        return None
+    capped = sum(1 for w in sig if w[:1].isupper())
+    if capped / len(sig) < 0.5:
+        return None
+    return t
+
+
+def fetch_title(arxiv_id: str, cache: dict) -> str | None:
+    if arxiv_id in cache:
+        return cache[arxiv_id]
+    title = None
+    try:
+        req = urllib.request.Request(
+            f"https://arxiv.org/abs/{arxiv_id}", headers={"User-Agent": "Mozilla/5.0"})
+        body = urllib.request.urlopen(req, timeout=20).read().decode("utf-8", "ignore")
+        m = re.search(r"<title>\s*\[[0-9.]+\]\s*(.*?)</title>", body, re.S)
+        if m:
+            title = html.unescape(re.sub(r"\s+", " ", m.group(1)).strip())
+    except Exception as exc:  # network/transport — warn, do not hard-fail
+        cache[arxiv_id] = ("ERR", str(exc))
+        return cache[arxiv_id]
+    cache[arxiv_id] = title
+    return title
+
+
+def check_file(path: Path, cache: dict) -> tuple[list[str], list[str]]:
+    text = path.read_text(encoding="utf-8", errors="ignore")
+    whitelisted = set(OK_RE.findall(text))
+    violations, warnings = [], []
+    seen = set()
+    for claimed, arxiv_id in LINK_RE.findall(text):
+        title = _title_like(claimed)
+        if title is None or arxiv_id in whitelisted:
+            continue
+        key = (arxiv_id, title)
+        if key in seen:
+            continue
+        seen.add(key)
+        real = fetch_title(arxiv_id, cache)
+        if isinstance(real, tuple):  # ERR
+            warnings.append(f"{_rel(path)}: could not verify {arxiv_id} ({real[1]})")
+            continue
+        if real is None:
+            warnings.append(f"{_rel(path)}: no title parsed for {arxiv_id}")
+            continue
+        ct, rt = _norm_tokens(title), _norm_tokens(real)
+        if not ct:
+            continue
+        overlap = len(ct & rt) / len(ct)
+        if overlap < 0.30:
+            violations.append(
+                f"{_rel(path)}: arXiv {arxiv_id} claimed=\"{title[:60]}\" "
+                f"but real title=\"{real[:60]}\" (overlap {overlap:.0%}) "
+                f"— wrong ID? add `<!-- arxiv-ok: {arxiv_id} -->` if intentional.")
+    return violations, warnings
+
+
+def changed_md() -> list[Path]:
+    try:
+        subprocess.run(["git", "-C", str(REPO_ROOT), "fetch", "-q", "origin", "main"],
+                       check=False, timeout=60)
+        base = subprocess.run(["git", "-C", str(REPO_ROOT), "merge-base", "HEAD", "origin/main"],
+                              capture_output=True, text=True).stdout.strip() or "origin/main"
+        out = subprocess.run(["git", "-C", str(REPO_ROOT), "diff", "--name-only", base, "--"],
+                             capture_output=True, text=True).stdout
+    except Exception:
+        out = ""
+    return [REPO_ROOT / p for p in out.split() if p.endswith(".md") and (REPO_ROOT / p).exists()]
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("files", nargs="*")
+    ap.add_argument("--changed", action="store_true", help="check changed *.md vs origin/main")
+    ap.add_argument("--all", action="store_true", help="check all docs *.md")
+    args = ap.parse_args()
+
+    if args.all:
+        files = sorted(DOCS.rglob("*.md"))
+    elif args.changed:
+        files = changed_md()
+    else:
+        files = [Path(f) for f in args.files]
+    files = [f.resolve() for f in files if f.exists() and f.suffix == ".md"]
+    if not files:
+        print("check_arxiv_citations: no markdown files to check.")
+        return 0
+
+    cache: dict = {}
+    all_v, all_w = [], []
+    for f in files:
+        v, w = check_file(f, cache)
+        all_v += v
+        all_w += w
+    for w in all_w:
+        print(f"WARN  {w}")
+    for v in all_v:
+        print(f"FAIL  {v}")
+    print(f"\ncheck_arxiv_citations: {len(files)} file(s), "
+          f"{len(all_v)} mismatch(es), {len(all_w)} unverifiable.")
+    return 1 if all_v else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/content/docs/ai-ml-engineering/deep-learning/module-1.10-modern-transformers-rope-and-attention.md
+++ b/src/content/docs/ai-ml-engineering/deep-learning/module-1.10-modern-transformers-rope-and-attention.md
@@ -844,7 +844,7 @@ Continue to [Module 1.6: Memory Bandwidth Math](../ai-infrastructure/module-1.6-
 
 - [RoFormer: Enhanced Transformer with Rotary Position Embedding](https://arxiv.org/abs/2104.09864)
 - [ALiBi: Attention with Linear Biases](https://arxiv.org/abs/2108.12409)
-- [GQA: Efficient Implementation of Large Language Model with Grouped-Query Attention](https://arxiv.org/abs/2305.13245)
+- [GQA: Training Generalized Multi-Query Transformer Models from Multi-Head Checkpoints](https://arxiv.org/abs/2305.13245)
 - [YaRN: Effective Context Length Extrapolation](https://arxiv.org/abs/2309.00071)
 - [DeepSeek-V2: A Next-Generation Mixture-of-Experts Language Model](https://arxiv.org/abs/2405.04434)
 - [FlashAttention: Fast and Memory-Efficient Exact Attention with IO-Awareness](https://arxiv.org/abs/2205.14135)

--- a/src/content/docs/ai-ml-engineering/generative-ai/module-1.5-vector-space-visualization.md
+++ b/src/content/docs/ai-ml-engineering/generative-ai/module-1.5-vector-space-visualization.md
@@ -1164,7 +1164,7 @@ Continue to [Module 1.6 — Reasoning Models](/ai-ml-engineering/generative-ai/m
 - [BERT: Pre-training of Deep Bidirectional Transformers](https://arxiv.org/abs/1810.04805) — Devlin et al.; contextual embeddings that supersede static word vectors in many pipelines.
 - [Efficient and robust approximate nearest neighbor search using Hierarchical Navigable Small World graphs](https://arxiv.org/abs/1603.09320) — Malkov and Yashunin; primary reference for HNSW graph indexing.
 - [FAISS: A library for efficient similarity search](https://github.com/facebookresearch/faiss) — Meta's CPU/GPU ANN library used for HNSW, IVF, and product quantization examples.
-- [Product Quantization for Nearest Neighbor Search](https://arxiv.org/abs/1011.3029) — Jégou et al.; foundational PQ paper behind FAISS compression and ADC distance tables.
+- [Product Quantization for Nearest Neighbor Search](https://inria.hal.science/inria-00514462) — Jégou et al.; foundational PQ paper behind FAISS compression and ADC distance tables.
 - [Sentence-BERT (SBERT)](https://arxiv.org/abs/1908.10084) — Reimers and Gurevych; contrastive sentence embeddings that power many `sentence-transformers` retrieval models.
 - [scikit-learn PCA](https://scikit-learn.org/stable/modules/generated/sklearn.decomposition.PCA.html) — Documentation for linear dimensionality reduction used in visualization examples.
 - [scikit-learn t-SNE](https://scikit-learn.org/stable/modules/generated/sklearn.manifold.TSNE.html) — Documentation for non-linear neighborhood-preserving visualization.

--- a/src/content/docs/ai-ml-engineering/mlops/module-1.10-ml-monitoring.md
+++ b/src/content/docs/ai-ml-engineering/mlops/module-1.10-ml-monitoring.md
@@ -980,11 +980,11 @@ Monitoring earns its keep when it triggers action. Define explicit policies: if 
 
 1. The Population Stability Index (PSI), one of the most common drift metrics in production, comes from the credit-scoring industry, not modern MLOps: a PSI below 0.1 conventionally signals no significant shift, 0.1–0.25 a moderate shift worth investigating, and above 0.25 a population change large enough to justify rebuilding the model — thresholds that predate ML monitoring tooling and are still used as defaults today.
 
-2. The formal study of concept drift predates modern MLOps platforms; [Gama et al.'s 2014 survey](https://arxiv.org/abs/1410.5430) catalogs detection and adaptation strategies still referenced in production drift design today.
+2. The formal study of concept drift predates modern MLOps platforms; [Gama et al.'s 2014 survey](https://dl.acm.org/doi/10.1145/2523813) catalogs detection and adaptation strategies still referenced in production drift design today.
 
 3. [Google's "Data Validation for Machine Learning" paper](https://research.google/pubs/pub46555/) introduced schema-based validation patterns that evolved into TensorFlow Data Validation and influenced batch monitoring jobs across the ecosystem.
 
-4. [Underspecification research from Google](https://arxiv.org/abs/1907.10579) showed that models with identical test accuracy can behave differently in deployment — a reminder that monitoring must compare live behavior to baselines, not assume offline metrics guarantee production equivalence.
+4. [Underspecification research from Google](https://arxiv.org/abs/2011.03395) showed that models with identical test accuracy can behave differently in deployment — a reminder that monitoring must compare live behavior to baselines, not assume offline metrics guarantee production equivalence.
 
 ## Common Mistakes
 
@@ -1984,8 +1984,8 @@ Now that you have constructed mathematically rigorous observability around your 
 - [Grafana documentation](https://grafana.com/docs/grafana/latest/) — Dashboard visualization for Prometheus ML metrics.
 - [IBM — Model drift overview](https://www.ibm.com/think/topics/model-drift) — Durable taxonomy of data drift and concept drift.
 - [Microsoft — Monitor datasets in Azure ML](https://learn.microsoft.com/en-us/azure/machine-learning/how-to-monitor-datasets) — Cloud-provider dataset drift monitoring patterns.
-- [Gama et al. — A Survey on Concept Drift Adaptation](https://arxiv.org/abs/1410.5430) — Academic reference for concept drift detection strategies.
-- [D'Amour et al. — Underspecification in ML pipelines](https://arxiv.org/abs/1907.10579) — Why identical test metrics can yield different production behavior.
+- [Gama et al. — A Survey on Concept Drift Adaptation](https://dl.acm.org/doi/10.1145/2523813) — Academic reference for concept drift detection strategies.
+- [D'Amour et al. — Underspecification in ML pipelines](https://arxiv.org/abs/2011.03395) — Why identical test metrics can yield different production behavior.
 - [SHAP — Lundberg & Lee (2017)](https://arxiv.org/abs/1705.07874) — Shapley-value feature attribution for model explanations.
 - [LIME — Ribeiro et al. (2016)](https://arxiv.org/abs/1602.04938) — Local surrogate explanations for individual predictions.
 - [Model Cards — Mitchell et al. (2019)](https://arxiv.org/abs/1810.03993) — Governance documentation pattern used in the module.

--- a/src/content/docs/ai-ml-engineering/vector-rag/module-1.3-advanced-rag-patterns.md
+++ b/src/content/docs/ai-ml-engineering/vector-rag/module-1.3-advanced-rag-patterns.md
@@ -688,4 +688,4 @@ Continue to [Module 1.4: RAG Evaluation & Optimization](./module-1.4-rag-evaluat
 - [Sentence-Transformers cross-encoder documentation](https://www.sbert.net/examples/applications/cross-encoder/README.html) — Bi-encoder versus cross-encoder tradeoffs and usage patterns.
 - [cross-encoder/ms-marco-MiniLM-L-6-v2 (Hugging Face)](https://huggingface.co/cross-encoder/ms-marco-MiniLM-L-6-v2) — Widely used reranking model checkpoint for second-stage retrieval.
 - [LangChain Parent Document Retriever](https://python.langchain.com/docs/how_to/parent_document_retriever/) — Small-to-big chunking pattern for search precision with parent context.
-- [Passage Re-ranking with BERT (NAACL 2019)](https://arxiv.org/abs/1908.10084) — Cross-encoder relevance scoring lineage for passage ranking.
+- [Passage Re-ranking with BERT (NAACL 2019)](https://arxiv.org/abs/1901.04085) — Cross-encoder relevance scoring lineage for passage ranking.

--- a/tests/test_check_arxiv_citations.py
+++ b/tests/test_check_arxiv_citations.py
@@ -1,0 +1,75 @@
+"""Offline precision tests for scripts/quality/check_arxiv_citations.py (issue #1991).
+
+These lock the `_title_like` classifier — the part that decides which arXiv link
+texts are checkable paper titles vs prose/tags/citations. Keeping this strict is
+what holds the false-positive rate at ~0 so the CI gate stays load-bearing. No
+network is used (we never call fetch_title here).
+"""
+import importlib.util
+from pathlib import Path
+
+_SPEC = importlib.util.spec_from_file_location(
+    "check_arxiv_citations",
+    Path(__file__).resolve().parents[1] / "scripts" / "quality" / "check_arxiv_citations.py",
+)
+mod = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(mod)
+
+
+# --- link texts that ARE checkable titles (real paper titles) -> validated ---
+CHECKABLE = [
+    "Isolation Forest (Liu, Ting, Zhou 2008)",
+    "A Survey on Concept Drift Adaptation",
+    "Product Quantization for Nearest Neighbor Search",
+    "Passage Re-ranking with BERT (NAACL 2019)",
+    "Gama et al. — A Survey on Concept Drift Adaptation",      # author prefix stripped
+    "D'Amour et al. — Underspecification in ML pipelines",
+    "Attention Is All You Need",
+    "The SPACE of Developer Productivity",
+]
+
+# --- link texts that are NOT titles -> skipped (cannot validate, must not flag) ---
+SKIPPED = [
+    "arxiv.org/abs/2309.06180",                                # bare url
+    "https://arxiv.org/abs/2307.03172",                        # bare url
+    "arXiv:2404.07143",                                        # bare arxiv ref
+    "Kipf & Welling, 2017",                                    # author-year only
+    "He et al., 2021",                                         # author-year only
+    "SimCLR",                                                  # short tag
+    "HNSW paper",                                              # short tag
+    "MoCo",                                                    # short tag
+    "Hypothetical Document Embeddings (HyDE)",                 # method name (acronym paren)
+    "SHAP — Lundberg & Lee (2017)",                            # tag + author citation
+    "In March 2022, OpenAI published the InstructGPT paper",   # prose sentence (verb)
+    "every active sequence produces a key-value cache entry",  # lowercase prose phrase
+    "the original paper",                                      # generic prose
+]
+
+
+def test_real_titles_are_checkable():
+    for text in CHECKABLE:
+        assert mod._title_like(text) is not None, f"should be checkable: {text!r}"
+
+
+def test_non_titles_are_skipped():
+    for text in SKIPPED:
+        assert mod._title_like(text) is None, f"should be skipped: {text!r}"
+
+
+def test_overlap_helper_flags_offdomain_only():
+    # correct citation: claimed title overlaps the real title -> high overlap
+    claimed = mod._norm_tokens("Isolation Forest")
+    real = mod._norm_tokens("Isolation Forest")
+    assert len(claimed & real) / len(claimed) >= 0.30
+    # wrong id: claimed title vs an unrelated (math) paper -> ~0 overlap
+    wrong = mod._norm_tokens("On polytopes associated to factorisations of prime-powers")
+    assert len(claimed & wrong) / len(claimed) < 0.30
+
+
+def test_arxiv_ok_whitelist_regex():
+    assert mod.OK_RE.findall("text <!-- arxiv-ok: 2203.02155 --> more") == ["2203.02155"]
+
+
+def test_link_regex_extracts_id_and_text():
+    md = "see [Attention Is All You Need](https://arxiv.org/abs/1706.03762) for details"
+    assert mod.LINK_RE.findall(md) == [("Attention Is All You Need", "1706.03762")]


### PR DESCRIPTION
## Closes #1991 — valid-but-wrong arXiv citations + a CI guard to prevent recurrence

**The defect:** an arXiv ID that returns HTTP 200 but points to the *wrong paper*. The author writes the right **title** but a wrong **ID**; the URL resolves, so `verify_module.py`'s `sources_all_reachable`, the link checker, and the Astro Zod schema all pass it. Only an ID→title correspondence check catches it (same blind-spot class as the killercoda `lab.url` bug).

### Blast radius (audited all 526 arXiv citations / 260 distinct IDs)
- Top-18 most-cited IDs (~140 occurrences): all correct.
- 2 caught & fixed pre-merge earlier this session (Isolation Forest, SPACE).
- **4 pre-existing wrong IDs + 1 paraphrased title — fixed here; corpus now 0 mismatches across 1527 files:**

| File | Was | Now |
|---|---|---|
| mlops 1.10 | `1410.5430` (→ astronomy paper) | ACM DOI — Gama "Concept Drift survey" (not on arXiv) |
| mlops 1.10 | `1907.10579` (→ gamma-spectroscopy) | `arxiv.org/abs/2011.03395` — Underspecification (D'Amour) |
| generative-ai 1.5 | `1011.3029` (→ hyperbolicity/physics) | `inria.hal.science/inria-00514462` — Product Quantization |
| vector-rag 1.3 | `1908.10084` (= Sentence-BERT's ID) | `1901.04085` — Passage Re-ranking with BERT |
| deep-learning 1.10 | GQA title paraphrased | corrected to the real title (ID was right) |

### The guard (`scripts/quality/check_arxiv_citations.py` + `.github/workflows/arxiv-citations.yml`)
- Fetches the real arXiv title and FAILs only when a **title-like** link text has near-zero token overlap.
- **Precise — 0 false positives across all 1527 files**: skips bare URLs, author-year citations, short tags, method names (`(HyDE)`), and prose sentences; `<!-- arxiv-ok: ID -->` escape hatch for irreducible cases.
- CI scope = changed `*.md` only, fork-safe (no secrets/write), `zizmor --strict` clean, `base.sha` via `env:` (no template injection).
- 5 offline pytests lock the classifier precision; ruff clean; full Astro build green (2169 pages).

🤖 Generated with [Claude Code](https://claude.com/claude-code)