### PR TITLE
content(platform): Toolkits code-quality 12.2/12.4/12.5 expand to T0 (#1996)

### DIFF
--- a/.pipeline/reviews/platform__toolkits__security-quality__code-quality__module-12.2-semgrep.md
+++ b/.pipeline/reviews/platform__toolkits__security-quality__code-quality__module-12.2-semgrep.md
@@ -1,0 +1,7 @@
+## 2026-06-15T21:18:30Z — `REVIEW` — `APPROVE`
+
+**Reviewer:** opus-inline cross-family R1 (≠ author codex/OpenAI; no gemini) + ground-check + web-verify. **#1996 (Toolkits).**
+
+Author: codex gpt-5.5. 340→5172 prose-w, 0→21 sources. Teaches SAST as a CAPABILITY (AST pattern matching vs taint analysis, feedback-placement, the false-positive/tuning problem) with Semgrep as the worked example + a Rosetta; cross-links the DevSecOps tool-class taxonomy. T0; all gates pass; Hypothetical scenarios labeled; explicitly "numbers should be measured from the real repo, not invented in a lesson"; no fab/market-share claims; no CNCF mislabel.
+
+**Ground-checks (web-verified, all accurate):** **Semgrep CE engine LGPL-2.1**; Semgrep-maintained **rules** under a separate restrictive license + Pro features proprietary; **Opengrep** = a Jan-2025 community fork (Aikido/Endor/Orca consortium) of the last full-featured CE under LGPL-2.1 — all correctly stated and quarantined as "refreshable vendor facts." CodeQL free-for-public framing accurate. **APPROVE.**

--- a/.pipeline/reviews/platform__toolkits__security-quality__code-quality__module-12.4-snyk.md
+++ b/.pipeline/reviews/platform__toolkits__security-quality__code-quality__module-12.4-snyk.md
@@ -1,0 +1,7 @@
+## 2026-06-15T21:18:30Z — `REVIEW` — `CHANGES_REQUESTED` → fixed → `APPROVE`
+
+**Reviewer:** opus-inline cross-family R1 (≠ author cursor/Kimi; no gemini) + ground-check + web-verify. **#1996 (Toolkits).**
+
+Author: cursor `--model auto`. 334→5117 prose-w, 5→22 sources. Teaches Software Composition Analysis as a CAPABILITY (transitive deps, reachability, SBOM, prioritization via CVSS/EPSS) with Snyk as the commercial worked example + a Rosetta; honestly labels Snyk commercial/proprietary/non-CNCF ("neither choice is universally correct"). T0; all gates pass; Hypothetical scenario labeled; no fabrication.
+
+**Finding (FIXED by orchestrator):** the Rosetta labeled **Trivy as a "CNCF sandbox project"** — inaccurate. Web-verified vs cncf.io/projects: **Trivy is NOT a CNCF project** (does not appear at any maturity level); it is open-source by **Aqua Security** and is the default scanner *in* CNCF **Harbor** (Graduated). Corrected the cell. Post-fix re-verified T0. **APPROVE.**

--- a/.pipeline/reviews/platform__toolkits__security-quality__code-quality__module-12.5-trivy.md
+++ b/.pipeline/reviews/platform__toolkits__security-quality__code-quality__module-12.5-trivy.md
@@ -1,0 +1,7 @@
+## 2026-06-15T21:18:30Z — `REVIEW` — `CHANGES_REQUESTED` → fixed → `APPROVE`
+
+**Reviewer:** opus-inline cross-family R1 (≠ author deepseek; no gemini) + ground-check + web-verify. **#1996 (Toolkits).**
+
+Author: deepseek-v4-pro. 459→5120 prose-w, 5→16 sources. Teaches unified open-source scanning as a CAPABILITY (images/fs/IaC/K8s/SBOM/secrets) with Trivy as the worked example + a Rosetta; correctly frames Trivy as Harbor's (CNCF Graduated) default scanner; SBOM (CycloneDX/SPDX), VEX, Trivy Operator covered. T0; all gates pass.
+
+**Findings (FIXED by orchestrator):** (1) a "Did You Know" origin story carried unsourced embellishment — "single engineer … weekend project," "first-scan time to under 15 seconds," "one of the most widely deployed" — trimmed to the verifiable, durable core (Teppei Fukuda created Trivy at Aqua, first release 2019, the compact self-contained-DB / single-binary design that removes the database-server dependency). (2) A closing **fabricated, promotional unattributed quote** ("The best scanner is the one you actually run. Trivy makes security scanning so easy there is no excuse…") — replaced with a neutral durable takeaway (no advocacy, no quote). Post-fix re-verified T0. **APPROVE.**

--- a/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.2-semgrep.md
+++ b/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.2-semgrep.md
@@ -1,22 +1,18 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 12.2: Semgrep - Security Rules in Minutes"
 slug: platform/toolkits/security-quality/code-quality/module-12.2-semgrep
 sidebar:
   order: 3
 ---
 ## Complexity: [MEDIUM]
-## Time to Complete: 45-50 minutes
+## Time to Complete: 60-75 minutes
 
 ---
 
 ## Prerequisites
 
-Before starting this module, you should have completed:
-- [Module 12.1: SonarQube](../module-12.1-sonarqube/) - Code quality fundamentals
-- [DevSecOps Discipline](/platform/disciplines/reliability-security/devsecops/) - Security integration concepts
-- Basic regex understanding
-- Programming experience in at least one language
+Before starting this module, you should have completed [Module 12.1: SonarQube](../module-12.1-sonarqube/) so the basic vocabulary of code quality gates, rule severity, and developer feedback loops is already familiar. You should also understand the [DevSecOps fundamentals](../../../disciplines/reliability-security/devsecops/module-4.1-devsecops-fundamentals/) because static analysis is one tool class inside a larger delivery practice, not a replacement for threat modeling, dependency review, runtime controls, or secure design. Basic programming experience in one language is enough; the lesson focuses on how scanners reason about code rather than on a specific framework.
 
 ---
 
@@ -29,1071 +25,497 @@ After completing this module, you will be able to:
 - **Configure Semgrep's autofix capabilities to automatically remediate detected code issues**
 - **Compare Semgrep's pattern-based approach against CodeQL for security scanning speed and coverage trade-offs**
 
-
 ## Why This Module Matters
 
-**The Custom Rule Problem**
+Hypothetical scenario: A platform team supports twenty application repositories, each with its own web framework, helper libraries, and deployment pipeline. A security reviewer notices the same unsafe pattern appearing in several pull requests: request parameters are being passed into command execution helpers with `shell=True`. The reviewer can keep commenting manually, but that turns security into a person-shaped bottleneck and leaves every future repository dependent on memory. A better response is to encode the lesson as a static rule, run it where developers already work, and make the unsafe pattern visible before it becomes a production incident.
 
-You've just discovered a security issue in your codebase: developers are calling `dangerouslySetInnerHTML` in React without sanitization. You want to prevent this from happening again. You have two options:
+Static Application Security Testing, usually shortened to SAST, matters because many dangerous mistakes are visible before an application ever runs. Source code can reveal hardcoded credentials, direct SQL string construction, unsafe deserialization calls, missing authorization wrappers, weak cryptographic APIs, and framework-specific footguns. The scanner does not need a deployed environment, test data, reachable service account, or staging cluster to see those patterns. It needs source, rules, and enough language understanding to distinguish code structure from plain text. That makes SAST one of the most practical "shift-left" controls in a DevSecOps program.
 
-**Option 1: Traditional SAST Rule**
-1. Learn the SAST tool's proprietary rule language
-2. Spend days understanding AST representations
-3. Write and debug complex rule definitions
-4. Wait for vendor to ship the update
-5. Hope it doesn't break existing rules
+The word "left" can be misleading if it sounds like a calendar slogan. The real idea is feedback placement. A finding discovered while a developer is still editing the function is cheap to understand because the author has context loaded. The same finding discovered after release forces triage, reproduction, ownership discovery, risk acceptance, and possibly emergency patching. SAST is not valuable because earlier is morally superior; it is valuable because earlier feedback is more actionable and less disruptive. This module treats Semgrep as the worked example because its rule language is approachable, but the durable skill is learning how code-pattern analysis becomes a dependable platform control.
 
-**Option 2: Semgrep**
+The useful analogy is a spell-checker for security-critical code structure. A spell-checker cannot prove that an essay is persuasive, historically accurate, or legally safe. It can still catch misspellings early enough that the author fixes them without a review meeting. SAST works the same way. It cannot prove that your authorization model is correct or that every business rule is safe, but it can catch repeatable code shapes that your organization has already decided are risky. The craft is deciding which shapes deserve automation, how loudly each finding should speak, and how developers can correct them without becoming scanner administrators.
+
+## What SAST Is and Where It Fits
+
+SAST analyzes source code, bytecode, intermediate representations, or configuration-like code artifacts without executing the application. The scanner parses files into a representation it can reason about, often an abstract syntax tree, then applies rules that describe unsafe syntax, unsafe API usage, missing context, or suspicious data movement. OWASP describes static code analysis as work performed on static, non-running source code and notes that taint and data-flow techniques are common parts of the practice. That framing is important because it separates SAST from dynamic application testing, which probes a running system, and from software composition analysis, which reasons about dependencies rather than first-party code.
+
+In a healthy delivery system, SAST appears in several places with different expectations. In the IDE or pre-commit hook, it acts like fast coaching: findings should be narrow, clear, and unlikely to require debate. In pull-request CI, it acts like a guardrail: new high-confidence findings can block a merge, while noisy or legacy findings should be reported without stopping unrelated work. In scheduled full scans, it acts like inventory: the security team can study old debt, framework coverage gaps, and trend lines without putting every historical issue in the path of a single feature branch.
+
+This maps directly to the DevSecOps tool-class taxonomy from the earlier discipline module. SAST is a code-stage control, meaning it helps while developers are still changing the artifact that contains the defect. It complements, rather than replaces, secrets scanning, dependency scanning, IaC scanning, container image scanning, admission policy, runtime detection, and incident response. The platform team's job is to make those controls feel like one coherent feedback system. Developers should not have to guess whether a finding belongs to Semgrep, CodeQL, SonarQube, Snyk Code, or another tool; they should see a clear message, an owner, a severity, and an expected action.
+
+The classes of issues SAST catches well share a property: the dangerous shape is visible in code. Injection rules often look for untrusted input reaching a query or command sink. Hardcoded secret rules look for credential-like names assigned to literal strings. Unsafe API rules look for calls such as insecure deserialization, weak hashing, disabled certificate verification, debug mode in production entry points, or direct HTML injection in frontend code. Configuration rules can inspect YAML, Terraform, CI files, or Kubernetes manifests when those files express risk as text. These are not the only vulnerabilities that matter, but they are exactly the kind that automation can find repeatedly.
+
+SAST also has inherent limits. It may not know which route requires an admin user, which tenant owns a record, which field is sensitive in your domain, or whether a feature flag prevents a code path from running in production. It may over-report because a pattern is syntactically suspicious but practically unreachable. It may under-report because a framework helper hides the real source or sink behind abstraction. It may struggle with generated code, dynamic dispatch, reflection, metaprogramming, and language features the analyzer has not modeled. Treating a scanner as a proof engine creates disappointment; treating it as a codified review assistant creates durable value.
+
+The practical consequence is that SAST rollout is an operations problem as much as a rule-writing problem. You need a policy for which findings block, a baseline strategy for old findings, an exception process for justified deviations, a way to measure whether issues are being fixed, and a review loop for rules that create noise. Buying or installing a scanner is the smallest part of the work. The real platform capability is converting code knowledge into fast, trusted feedback that teams can live with every day.
+
+## How Static Analysis Sees Code
+
+A plain text search tool sees characters. A static analysis tool tries to see structure. If the source contains `cursor.execute("select * from users where id = " + user_id)`, a text search can find the word `execute`, but it does not know which part is a function call, which part is a string literal, and which part is a variable. A parser can turn the file into an abstract syntax tree, where calls, arguments, assignments, imports, classes, and blocks have relationships. Once the scanner has that structure, a rule can ask for "a call to this function with an argument shaped like string concatenation" instead of "a line containing this substring."
+
+That distinction explains why code-pattern tools are more useful than raw regular expressions for security review. Whitespace differences, line wrapping, parentheses, import aliases, and language-specific syntax can defeat text matching while still representing the same program behavior. A syntax-aware pattern can often match the intent across those formatting differences. Semgrep's documentation describes rules as YAML specifications that tell the engine which patterns to match, and its glossary distinguishes search rules from taint rules. The exact implementation varies by tool, but the underlying move is the same: parse first, match against structure second, then report findings in a developer-consumable format.
+
+The static analysis pipeline usually has five phases. First, the scanner discovers files and applies ignore rules so vendored code, generated files, and irrelevant paths do not flood the result set. Second, it parses supported languages and skips or partially handles unsupported files. Third, it applies rules, which may be simple pattern checks, semantic checks, data-flow rules, or tool-specific queries. Fourth, it formats findings with file paths, line numbers, rule identifiers, severity, remediation text, and optional metadata such as CWE or OWASP mapping. Fifth, a policy layer decides whether those findings fail a local command, comment on a pull request, upload SARIF, create tickets, or simply record evidence.
+
+The quality of each phase affects trust. If file discovery scans dependencies that developers do not own, teams learn to ignore the scanner. If parsing fails silently, security assumes coverage that does not exist. If rules lack clear messages, developers cannot fix findings without hunting through internal wiki pages. If severity is disconnected from blocking policy, every finding feels political. A mature SAST implementation makes each phase explicit enough that developers understand why a finding appeared and security engineers understand why a finding did not appear.
+
+This is where platform engineering enters the picture. A central team can provide shared rule packs, CI templates, SARIF upload patterns, exception formats, and dashboards, but the application team still owns the code. The central team should not become the only group allowed to write rules. In fact, some of the best static analysis rules come from application teams after an incident review or design review reveals a pattern they never want repeated. A good SAST platform makes local rule authoring normal, reviewable, and testable.
+
+## Pattern Matching with Semgrep as the Worked Example
+
+Semgrep is useful as a teaching example because a search-mode rule often looks like the code it is trying to find. A rule for a dangerous function call can contain `pattern: eval($X)`, where `$X` is a metavariable that captures whatever expression appears inside the call. That is not a regular expression over text; it is a code-shaped pattern over parsed syntax. The rule can then interpolate `$X` into the message, constrain it with `metavariable-regex`, exclude safe cases with `pattern-not`, or combine alternatives with `pattern-either`.
+
+Here is a small rule that detects literal debug mode in a Flask entry point. It is intentionally narrow because narrow rules are easier to trust during rollout. The rule does not try to prove that the file is deployed to production, and it does not try to inspect every possible configuration path. It encodes a local guardrail: direct `debug=True` in an application run call should be reviewed.
+
 ```yaml
 rules:
-  - id: dangerous-html-without-sanitize
-    pattern: dangerouslySetInnerHTML={{__html: $X}}
-    pattern-not: dangerouslySetInnerHTML={{__html: sanitize($X)}}
-    message: "Use sanitize() before dangerouslySetInnerHTML"
+  - id: flask-debug-enabled
+    pattern: app.run(..., debug=True, ...)
+    message: "Flask debug mode is enabled. Disable debug mode outside local development."
     severity: ERROR
-    languages: [javascript, typescript]
+    languages: [python]
+    metadata:
+      cwe: "CWE-489: Active Debug Code"
 ```
 
-Five minutes. That's how long it takes to write a Semgrep rule. The pattern syntax looks like code, not regex hell. You can test it locally before committing. And it runs fast enough to block PRs without developers revolting.
+The most important part of that example is not the YAML. It is the decision to start from a specific unsafe shape and a specific developer action. A vague rule such as "look for insecure Flask code" would not be useful because it has no inspectable boundary. A useful rule says exactly what it matches, why that shape is risky, what context would make it acceptable, and how the developer should fix it. The rule ID becomes part of governance: it can be tracked, suppressed, tested, documented, and discussed in code review.
 
-Semgrep isn't trying to be the most sophisticated SAST tool—it's trying to be the most practical one. Low false positives, fast execution, and rules that humans can actually write and understand.
-
----
-
-## Semgrep Architecture
-
-```
-┌─────────────────────────────────────────────────────────────────┐
-│                    SEMGREP ARCHITECTURE                          │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  YOUR CODEBASE                                                   │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  source.py    │  app.js    │  main.go    │  Server.java   │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                              │                                   │
-│                              ▼                                   │
-│  SEMGREP ENGINE                                                  │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │                                                           │  │
-│  │  ┌─────────────┐   ┌─────────────┐   ┌─────────────────┐ │  │
-│  │  │   Parser    │   │  Pattern    │   │    Matching     │ │  │
-│  │  │ (per lang)  │──▶│  Compiler   │──▶│    Engine       │ │  │
-│  │  │             │   │             │   │  (semgrep-core) │ │  │
-│  │  └─────────────┘   └─────────────┘   └─────────────────┘ │  │
-│  │         │                                     │          │  │
-│  │         ▼                                     ▼          │  │
-│  │  ┌─────────────┐                    ┌─────────────────┐  │  │
-│  │  │    AST      │                    │    Findings     │  │  │
-│  │  │ (generic)   │                    │    (JSON/SARIF) │  │  │
-│  │  └─────────────┘                    └─────────────────┘  │  │
-│  │                                                           │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                              │                                   │
-│  RULES                       │                                   │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │                                                           │  │
-│  │  Community    │  Your Custom    │  Semgrep Registry      │  │
-│  │  Rulesets     │  Rules          │  (pro rules)           │  │
-│  │  (p/owasp)    │  (.semgrep/)    │  (additional coverage) │  │
-│  │                                                           │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-### How Semgrep Works
-
-1. **Parse**: Convert source code to AST (Abstract Syntax Tree)
-2. **Pattern Match**: Match your pattern against the AST
-3. **Filter**: Apply `pattern-not`, `pattern-inside`, etc.
-4. **Report**: Output findings in JSON, SARIF, or text
-
-The key insight: Semgrep patterns look like code, but match against the AST. This means `foo(1, 2)` matches `foo(1,2)` and `foo( 1 , 2 )` because whitespace doesn't matter in the AST.
-
----
-
-## Pattern Syntax Deep Dive
-
-### Basic Patterns
-
-```yaml
-# Literal match
-pattern: print("debug")
-
-# Metavariable (captures any expression)
-pattern: print($X)
-# Matches: print("hello"), print(user.name), print(1+2)
-
-# Ellipsis (matches zero or more arguments)
-pattern: print(...)
-# Matches: print(), print("a"), print("a", "b", "c")
-
-# Typed metavariable (Python 3 type hints)
-pattern: def $FUNC(...) -> str: ...
-# Matches functions returning str
-```
-
-### Metavariables in Action
+Metavariables make rules adaptable without making them vague. A hardcoded credential rule can capture any assigned variable name, then use a regular expression to focus on names that look credential-related. This still requires careful tuning because words like `token`, `secret`, and `password` can appear in test fixtures or documentation. The first version of such a rule should usually warn, collect examples, and earn the right to block later.
 
 ```yaml
 rules:
-  - id: hardcoded-password
+  - id: hardcoded-credential-like-assignment
     patterns:
-      - pattern: $VAR = "..."
+      - pattern: $NAME = "..."
       - metavariable-regex:
-          metavariable: $VAR
-          regex: (?i)(password|passwd|pwd|secret|token|api_key)
-    message: "Hardcoded credential in $VAR"
-    severity: ERROR
-    languages: [python]
-```
-
-```python
-# Would match:
-password = "hunter2"
-API_KEY = "sk-1234567890"
-db_passwd = "supersecret"
-
-# Would NOT match:
-username = "admin"
-description = "password reset flow"
-```
-
-### Combining Patterns
-
-```yaml
-rules:
-  - id: sql-injection
-    patterns:
-      # Must match this
-      - pattern-either:
-          - pattern: cursor.execute($QUERY)
-          - pattern: db.query($QUERY)
-      # AND must have string concat in query
-      - pattern-inside: |
-          $QUERY = ... + $USER_INPUT + ...
-          ...
-      # But NOT if parameterized
-      - pattern-not-inside: |
-          $QUERY = "... %s ..."
-          ...
-          cursor.execute($QUERY, ...)
-    message: "SQL injection via string concatenation"
-    severity: ERROR
-    languages: [python]
-```
-
-### Pattern Operators Reference
-
-| Operator | Purpose | Example |
-|----------|---------|---------|
-| `pattern` | Match this pattern | `pattern: eval($X)` |
-| `pattern-not` | Don't match this | `pattern-not: eval("safe")` |
-| `pattern-either` | Match any of these | Multiple patterns, OR logic |
-| `pattern-inside` | Match inside this context | Function or class scope |
-| `pattern-not-inside` | Don't match in this context | Exclude test files |
-| `pattern-regex` | Regex on source | For when AST isn't enough |
-| `metavariable-regex` | Regex on captured var | Filter by variable name |
-| `metavariable-pattern` | Pattern on captured var | Nested matching |
-| `metavariable-comparison` | Compare captured values | `$X < 10` |
-| `focus-metavariable` | Report only this part | Precise error location |
-
----
-
-## Real-World Rules
-
-### Preventing JWT Without Verification
-
-```yaml
-rules:
-  - id: jwt-decode-without-verify
-    patterns:
-      - pattern-either:
-          - pattern: jwt.decode($TOKEN, ...)
-          - pattern: jwt.decode($TOKEN)
-      - pattern-not: jwt.decode($TOKEN, $KEY, ...)
-      - pattern-not: jwt.decode($TOKEN, options={..., verify=True, ...})
-    message: |
-      JWT decoded without signature verification.
-      Use jwt.decode(token, key, algorithms=['HS256']) instead.
+          metavariable: $NAME
+          regex: (?i).*(password|passwd|secret|token|api_key).*
+    message: "Credential-like value assigned to $NAME. Load secrets from the approved secret store."
     severity: ERROR
     languages: [python]
     metadata:
-      cwe: "CWE-347: Improper Verification of Cryptographic Signature"
-      owasp: "A02:2021 - Cryptographic Failures"
+      cwe: "CWE-798: Use of Hard-coded Credentials"
 ```
 
-### Detecting Insecure Deserialization
+`pattern-either` expresses alternatives without duplicating whole rules. That matters because security issues often appear through several equivalent APIs. A command injection rule might need to look at `subprocess.run`, `subprocess.call`, `subprocess.check_call`, and `subprocess.check_output`. A weak hash rule might look at `hashlib.md5` and `hashlib.sha1`. Keeping those alternatives in one rule avoids scattered messages and makes the policy easier to explain.
 
 ```yaml
 rules:
-  - id: pickle-load-untrusted
-    patterns:
-      - pattern-either:
-          - pattern: pickle.load($X)
-          - pattern: pickle.loads($X)
-      - pattern-not-inside: |
-          # Safe: loading from trusted source
-          with open("$TRUSTED_FILE", ...) as $F:
-              ...
-              pickle.load($F)
-    message: |
-      pickle.load() can execute arbitrary code. Never unpickle untrusted data.
-      Use JSON or a safe serialization format instead.
-    severity: ERROR
+  - id: weak-hash-algorithm
+    pattern-either:
+      - pattern: hashlib.md5(...)
+      - pattern: hashlib.sha1(...)
+    message: "Weak hash algorithm used. Use an approved password hashing or integrity primitive for the use case."
+    severity: WARNING
     languages: [python]
     metadata:
-      cwe: "CWE-502: Deserialization of Untrusted Data"
-      references:
-        - https://docs.python.org/3/library/pickle.html#module-pickle
+      cwe: "CWE-328: Use of Weak Hash"
 ```
 
-### React XSS Prevention
+`pattern-not` and `pattern-not-inside` are where rule tuning begins. A raw React rule for `dangerouslySetInnerHTML` may be useful for discovery, but it is too broad as a blocking rule because some teams wrap sanitization in a reviewed helper. A tuned rule can match the dangerous API and exclude the approved wrapper or sanitizer call. That is not a proof that every excluded use is safe; it is a policy decision that says "this code shape follows the approved pattern." Good static analysis requires these policy decisions to be explicit rather than hidden in reviewer memory.
 
 ```yaml
 rules:
-  - id: react-dangerously-set-html
+  - id: react-dangerous-html-without-approved-sanitizer
     patterns:
-      - pattern: dangerouslySetInnerHTML={{__html: $CONTENT}}
-      - pattern-not: dangerouslySetInnerHTML={{__html: DOMPurify.sanitize($CONTENT)}}
-      - pattern-not: dangerouslySetInnerHTML={{__html: sanitizeHtml($CONTENT, ...)}}
-    message: |
-      dangerouslySetInnerHTML without sanitization may cause XSS.
-      Use DOMPurify.sanitize() or similar.
+      - pattern: dangerouslySetInnerHTML={{__html: $HTML}}
+      - pattern-not: dangerouslySetInnerHTML={{__html: DOMPurify.sanitize($HTML)}}
+      - pattern-not: dangerouslySetInnerHTML={{__html: sanitizeHtml($HTML, ...)}}
+    message: "Sanitize HTML before passing it to dangerouslySetInnerHTML."
     severity: ERROR
     languages: [javascript, typescript, jsx, tsx]
     metadata:
-      cwe: "CWE-79: Cross-site Scripting (XSS)"
+      cwe: "CWE-79: Cross-site Scripting"
 ```
 
-### Go Error Handling
+The rule authoring loop should be test-driven. Create positive examples that must match, negative examples that must not match, and edge cases that document known limitations. Then run the rule against real repositories in warning mode before making it block. A scanner that blocks with untested rules teaches developers that security automation is arbitrary. A scanner that ships tested, explained rules teaches developers that security knowledge is reusable engineering work.
+
+## Pattern Matching Versus Taint Analysis
+
+Pattern matching answers questions about local code shape. Did this file call `eval`? Did this route use `debug=True`? Did this manifest set `privileged: true`? Did this code pass raw HTML to a dangerous React prop? Those questions are powerful because they are fast, inspectable, and easy to explain. They are also limited because many vulnerabilities are not visible in one expression. Injection, server-side request forgery, command execution, and template injection often depend on whether untrusted data can flow from a source to a sink.
+
+Taint analysis answers a different question: can data from an untrusted source reach a dangerous operation without passing through an accepted sanitizer or validator? A source might be `request.args.get(...)`, `req.query`, an HTTP header, a message body, or a file upload. A sink might be SQL execution, shell execution, template rendering, URL fetching, deserialization, or HTML output. A sanitizer might be parameterized query binding, strict allowlist validation, context-specific output encoding, or a framework API that separates code from data. The vocabulary is durable even though each tool expresses it differently.
+
+Here is a Semgrep taint-mode rule that flags request parameters flowing into shell execution helpers with `shell=True`. The example is intentionally scoped to Flask-style request access and Python subprocess calls so it remains understandable. A production rule would need repository-specific tests, framework knowledge, and exceptions for code that is not reachable in deployed services.
 
 ```yaml
 rules:
-  - id: go-error-not-handled
-    patterns:
-      - pattern: $RET, $ERR := $FUNC(...)
-      - pattern-not-inside: |
-          $RET, $ERR := $FUNC(...)
-          ...
-          if $ERR != nil { ... }
-    message: "Error returned by $FUNC is not checked"
-    severity: WARNING
-    languages: [go]
-```
-
-### Kubernetes Security
-
-```yaml
-rules:
-  - id: k8s-privileged-container
-    patterns:
-      - pattern-inside: |
-          spec:
-            ...
-            containers:
-              ...
-      - pattern: |
-          securityContext:
-            ...
-            privileged: true
-    message: "Container running in privileged mode"
+  - id: flask-request-to-subprocess-shell
+    mode: taint
+    pattern-sources:
+      - pattern: request.args.get(...)
+      - pattern: request.form.get(...)
+    pattern-sinks:
+      - patterns:
+          - pattern: subprocess.$FUNC(..., shell=True, ...)
+          - metavariable-regex:
+              metavariable: $FUNC
+              regex: ^(run|call|check_call|check_output|Popen)$
+    message: "User-controlled request data reaches a subprocess call with shell=True."
     severity: ERROR
-    languages: [yaml]
-    paths:
-      include:
-        - "*.yaml"
-        - "*.yml"
+    languages: [python]
+    metadata:
+      cwe: "CWE-78: OS Command Injection"
 ```
 
----
+Taint rules can be more valuable than local pattern rules because they reduce false positives for APIs that are dangerous only when reached by untrusted data. They can also be harder to operationalize. The analyzer needs to understand assignments, function calls, wrappers, framework conventions, object fields, containers, and sometimes interfile control flow. If the tool cannot follow a custom helper, it may miss a real flow. If it over-approximates too aggressively, it may report flows that are impossible in practice. This is why taint analysis should be treated as a modeling practice, not a magic vulnerability oracle.
 
-## Using Semgrep CLI
+The tuning work is where teams usually succeed or fail. A security team may start with generic rules from a registry, but real signal comes from adapting rules to local frameworks, shared libraries, and approved wrappers. If every service uses `safe_query(...)` for parameterized database access, rules should know that. If every service uses an internal `render_safe_html(...)` helper, rules should know that too. If a legacy repository has hundreds of old findings, pull-request scans should focus on newly introduced findings while scheduled work burns down the baseline deliberately.
 
-### Installation
+This also explains the tradeoff between Semgrep and CodeQL in the outcome for this module. Semgrep search rules are often faster to write and easier for application teams to understand because the pattern resembles source code. CodeQL uses a query language over code databases and can express deep semantic and data-flow questions, especially in GitHub-centered workflows, but it has a different learning curve and operational model. The right comparison is not "which tool is best"; it is "which analysis technique, rule authoring model, and workflow fit this control objective?"
+
+## Running SAST in Developer and CI Workflows
+
+A SAST rule that only runs on a security engineer's laptop is not a platform capability. To become a guardrail, the rule must run in the places where code changes are created and reviewed. That usually means three integration points: local scans for rapid feedback, pull-request scans for merge decisions, and scheduled scans for inventory. Each point should use the same rule intent but not necessarily the same blocking policy.
+
+For local use, the command should be simple enough that a developer can run it before pushing. With Semgrep Community Edition, the current documentation describes `semgrep scan` as the preferred command for stand-alone CI and open-source-component setups. A small local command might scan the repository with a custom rule directory and a registry configuration. The exact registry names and rule licenses should be reviewed before adoption because rule availability and licensing are volatile details.
 
 ```bash
-# macOS
-brew install semgrep
-
-# Linux/Windows (pip)
-pip install semgrep
-
-# Docker
-docker run --rm -v "$(pwd):/src" returntocorp/semgrep
-
-# Verify installation
-semgrep --version
+semgrep scan --config=.semgrep/ --config=p/python .
 ```
 
-### Running Scans
-
-```bash
-# Run community rules
-semgrep --config=auto .
-
-# Run specific rulesets
-semgrep --config=p/owasp-top-ten .
-semgrep --config=p/security-audit .
-semgrep --config=p/secrets .
-
-# Run your custom rules
-semgrep --config=.semgrep/ .
-
-# Combine rulesets
-semgrep --config=p/python --config=.semgrep/ .
-
-# Output formats
-semgrep --config=auto --json -o results.json .
-semgrep --config=auto --sarif -o results.sarif .
-
-# Verbose for debugging
-semgrep --config=rule.yaml --verbose .
-
-# Test rules
-semgrep --test --config=.semgrep/
-```
-
-### Filtering Results
-
-```bash
-# By severity
-semgrep --config=auto --severity ERROR .
-
-# Exclude paths
-semgrep --config=auto --exclude tests/ --exclude vendor/ .
-
-# Include only certain paths
-semgrep --config=auto --include "*.py" .
-
-# Baseline (only new findings)
-semgrep --config=auto --baseline-commit HEAD~1 .
-```
-
----
-
-## CI/CD Integration
-
-### GitHub Actions
+For pull-request CI, the goal is usually "block new serious findings, do not make every old finding the author's problem." Semgrep supports diff-aware scans through CI environment configuration, and its docs describe comparing code before and after a baseline so only newly introduced findings are reported. Many tools have an equivalent concept even if the names differ. The durable pattern is baseline first, new-code gate second, full inventory third.
 
 ```yaml
-name: Semgrep
+name: semgrep
+
 on:
-  push:
-    branches: [main]
   pull_request:
+    branches: [main]
+  push:
     branches: [main]
 
 jobs:
-  semgrep:
+  scan:
     runs-on: ubuntu-latest
     container:
-      image: returntocorp/semgrep
+      image: semgrep/semgrep
     steps:
       - uses: actions/checkout@v4
-
-      - name: Run Semgrep
-        run: |
-          semgrep ci \
-            --config=p/security-audit \
-            --config=p/secrets \
-            --config=.semgrep/ \
-            --sarif --output=semgrep.sarif
-
+        with:
+          fetch-depth: 0
+      - name: Run Semgrep custom rules
+        run: semgrep scan --config=.semgrep/ --error --sarif --output=semgrep.sarif .
       - name: Upload SARIF
+        if: always()
         uses: github/codeql-action/upload-sarif@v3
         with:
           sarif_file: semgrep.sarif
-        if: always()
 ```
 
-### GitLab CI
+That example deliberately uses custom local rules and SARIF output. SARIF is useful because it lets multiple scanners report findings into a common code-scanning interface, but uploading findings is not the same as governance. Someone still has to decide which rule IDs block, who owns exceptions, how long suppressions last, and when a warning graduates to an error. A CI file can enforce a policy, but it cannot design one.
 
-```yaml
-semgrep:
-  stage: test
-  image: returntocorp/semgrep
-  script:
-    - semgrep ci
-        --config=p/security-audit
-        --config=.semgrep/
-        --gitlab-sast > gl-sast-report.json
-  artifacts:
-    reports:
-      sast: gl-sast-report.json
-  rules:
-    - if: $CI_MERGE_REQUEST_IID
-    - if: $CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH
+Ignore files are part of the policy too. A `.semgrepignore` file should exclude generated code, vendored dependencies, large test fixtures, and other paths where findings are not actionable. It should not become a hiding place for uncomfortable production code. The distinction is ownership: if developers cannot or should not edit a path, scanning it in PR gates creates noise; if developers own the path and the rule is correct, ignoring it is risk acceptance and should be reviewed.
+
+```gitignore
+# .semgrepignore
+vendor/
+third_party/
+dist/
+build/
+generated/
+**/*.min.js
 ```
 
-### Pre-commit Hook
+Pre-commit and IDE integrations are useful when rules are fast and precise. They should rarely run every heavyweight rule because slow local hooks encourage bypassing. A practical pattern is to run secrets, obvious unsafe APIs, and team-owned custom rules locally, then let CI run broader analysis. Developers will tolerate early feedback when it saves them from failed builds; they will resent it when it feels like a slow duplicate of CI.
 
-```yaml
-# .pre-commit-config.yaml
-repos:
-  - repo: https://github.com/returntocorp/semgrep
-    rev: v1.45.0
-    hooks:
-      - id: semgrep
-        args: ['--config', 'p/secrets', '--config', '.semgrep/', '--error']
-```
+## Autofix Without Auto-Trust
 
-### Jenkins Pipeline
-
-```groovy
-pipeline {
-    agent {
-        docker {
-            image 'returntocorp/semgrep'
-        }
-    }
-    stages {
-        stage('Security Scan') {
-            steps {
-                sh '''
-                    semgrep ci \
-                        --config=p/security-audit \
-                        --config=.semgrep/ \
-                        --junit-xml --output=semgrep-results.xml
-                '''
-                junit 'semgrep-results.xml'
-            }
-        }
-    }
-}
-```
-
----
-
-## Writing Custom Rules
-
-### Rule Structure
+Autofix is powerful because some unsafe patterns have mechanical replacements. If a project has standardized on `Path(...) / name` instead of `os.path.join(...)`, a rule can capture the old shape and propose the new shape. If a hardcoded Flask secret key should be loaded from an environment variable, a rule can offer a replacement. If a deprecated helper has a one-to-one successor, autofix can turn a review comment into a patch. That can reduce toil dramatically when the transformation is genuinely mechanical.
 
 ```yaml
 rules:
-  - id: unique-rule-identifier
-    # What to match
-    pattern: dangerous_function($X)
-    # Or more complex matching
-    patterns:
-      - pattern: ...
-      - pattern-not: ...
-
-    # Metadata
-    message: "Human readable message with $X interpolation"
-    severity: ERROR  # ERROR, WARNING, INFO
-    languages: [python, javascript]  # Target languages
-
-    # Optional metadata
-    metadata:
-      cwe: "CWE-XXX"
-      owasp: "A0X:2021"
-      category: security
-      technology:
-        - flask
-      references:
-        - https://example.com/security-advisory
-
-    # File filtering
-    paths:
-      include:
-        - "src/**/*.py"
-      exclude:
-        - "**/test/**"
-        - "**/*_test.py"
-
-    # Fix suggestion (autofix)
-    fix: safe_function($X)
-```
-
-### Testing Rules
-
-```python
-# test_rule.py - Semgrep test file format
-
-# ruleid: dangerous-function
-dangerous_function(user_input)
-
-# ok: dangerous-function
-safe_function(user_input)
-
-# todoruleid: dangerous-function
-# This should match but doesn't yet
-edge_case(user_input)
-```
-
-```bash
-# Run tests
-semgrep --test --config=rules/
-```
-
-### Example: Building a Complete Ruleset
-
-```yaml
-# .semgrep/flask-security.yaml
-rules:
-  # Flask Debug Mode
-  - id: flask-debug-mode
-    pattern: app.run(..., debug=True, ...)
-    message: "Flask debug mode enabled. Disable in production."
-    severity: ERROR
-    languages: [python]
-    metadata:
-      category: security
-      cwe: "CWE-489: Active Debug Code"
-
-  # Flask Secret Key Hardcoded
-  - id: flask-hardcoded-secret
+  - id: flask-secret-from-environment
     patterns:
       - pattern: app.secret_key = "..."
-      - pattern: app.config["SECRET_KEY"] = "..."
-    message: "Hardcoded Flask secret key. Use environment variable."
+    message: "Load Flask secret_key from the environment instead of hardcoding it."
     severity: ERROR
     languages: [python]
-    fix: app.secret_key = os.environ.get("SECRET_KEY")
-
-  # Flask SQL Injection
-  - id: flask-sql-injection
-    patterns:
-      - pattern-either:
-          - pattern: db.execute($QUERY.format(...))
-          - pattern: db.execute(f"...$X...")
-          - pattern: db.execute("..." + $X + "...")
-    message: "SQL injection via string formatting. Use parameterized queries."
-    severity: ERROR
-    languages: [python]
+    fix: app.secret_key = os.environ["FLASK_SECRET_KEY"]
     metadata:
-      cwe: "CWE-89: SQL Injection"
-
-  # Missing CSRF Protection
-  - id: flask-missing-csrf
-    patterns:
-      - pattern: |
-          @app.route(..., methods=[..., "POST", ...])
-          def $FUNC(...):
-              ...
-      - pattern-not-inside: |
-          csrf = CSRFProtect(...)
-          ...
-    message: "POST route without CSRF protection"
-    severity: WARNING
-    languages: [python]
+      cwe: "CWE-798: Use of Hard-coded Credentials"
 ```
 
----
+Autofix should not be confused with safe remediation. The replacement must preserve behavior, imports, formatting, and context. The example above introduces `os.environ`, which means the file also needs `import os` unless it already exists. That may be acceptable as a suggested fix but not as an unattended rewrite. A high-quality autofix rule is paired with tests, dry-run review, and a clear rule message that explains any manual follow-up. The rule should make the common case easier, not pretend every case is common.
 
-## Semgrep vs Other Tools
+The best use of autofix is controlled migration. Hypothetical scenario: A team decides that direct calls to an internal `legacy_encrypt(...)` helper must be replaced by `platform_crypto.encrypt(...)` because the new helper centralizes algorithm selection and key handling. A Semgrep rule can first inventory old calls, then offer autofix where the argument order is identical, then block new old-helper calls after the migration window. The numbers in such a migration should be measured from the real repository, not invented in a lesson. The durable pattern is inventory, assisted remediation, manual review for edge cases, and permanent regression prevention.
 
-```
-COMPARISON MATRIX
-─────────────────────────────────────────────────────────────────
+Autofix also changes the psychology of SAST adoption. A finding that says "this is wrong" creates work. A finding that says "this is wrong, here is the smallest reviewed change" creates momentum. Developers are more likely to trust scanner output when the scanner understands the codebase well enough to suggest the local standard. That does not require every rule to have a fix. It requires the platform team to identify repetitive, low-judgment transformations and automate those first.
 
-                    Semgrep      CodeQL       SonarQube
-─────────────────────────────────────────────────────────────────
-Rule Language       Pattern      QL (SQL-like) Java/Custom
-Learning Curve      Low          High         Medium
-Custom Rules        Easy         Complex      Difficult
-Speed               Fast         Slow         Medium
-False Positives     Low          Low          Medium
-Languages           30+          15+          30+
-Self-hosted         Free         Free         Limited
-CI Integration      Excellent    Good         Good
-Dataflow Analysis   Pro tier     Excellent    Basic
-Interfile Analysis  Pro tier     Excellent    Yes
+## Governance: Policy as Code for SAST
 
-─────────────────────────────────────────────────────────────────
+Governance begins with rule intent. Every rule should answer four questions: what code shape does it detect, why does the organization care, what should the developer do, and when is an exception acceptable? If those answers are not known, the rule is not ready to block a merge. It may still be useful in discovery mode, but discovery findings should not be presented as hard policy. That separation prevents the common failure mode where a scanner is installed with too many rules, developers drown in ambiguous findings, and the tool loses credibility before it is tuned.
 
-WHEN TO USE EACH:
+Policy as code means the decisions live in version-controlled configuration rather than in a security meeting transcript. Rule packs, severity overrides, ignore paths, CI templates, baseline references, and exception formats should be reviewable like application code. When a team changes a rule from warning to error, the diff should show why. When a path is ignored, the diff should show who owns the risk. When a rule is suppressed inline, the comment should explain the local reasoning and ideally link to an issue or risk record.
 
-Semgrep:
-• Custom rules for your specific patterns
-• Fast feedback in CI/CD
-• Security team writing rules
-• Low false positive tolerance
+A practical blocking policy usually has stages. In stage one, the scanner runs in non-blocking mode and collects examples. In stage two, high-confidence custom rules block only new findings. In stage three, selected registry rules join the blocking set after false positives are understood. In stage four, scheduled scans and dashboards track legacy debt separately from pull-request hygiene. This staged approach avoids the false choice between "block everything today" and "never enforce anything." It gives rules a path to earn enforcement.
 
-CodeQL:
-• Deep vulnerability research
-• Complex dataflow analysis
-• GitHub-centric workflows
-• Time/complexity not a concern
+Exceptions need their own lifecycle. An inline suppression may be acceptable for a test fixture, a deliberate compatibility shim, or a narrow false positive. It is dangerous when it becomes an unreviewed permanent bypass. Good exception workflows ask for the rule ID, file, reason, owner, review date, and safer alternative considered. Some organizations encode this in comments, some in a YAML allowlist, and some in a ticketing system. The form matters less than the invariant: every bypass should have a reason and a future review point.
 
-SonarQube:
-• Code quality + security together
-• Technical debt tracking needed
-• Quality gates with coverage
-• Enterprise compliance reporting
-```
+Measurement should support learning rather than scanner theater. Useful metrics include new findings by rule, median time to fix, percentage of blocking findings resolved in the same pull request, recurring false-positive rules, exception aging, and escape rate from incidents or manual reviews. Findings density can be helpful when normalized by repository and language, but raw counts can punish larger codebases and encourage suppressions. The strongest metric is whether repeated classes of security review comments disappear because the rule now catches them before review.
 
----
+The ownership model should be visible to developers at the moment a finding appears. A finding that says "security violation" but does not identify the owning platform standard, the reviewed remediation path, or the escalation channel forces the author to become an investigator. A finding that names the rule, links to the approved pattern, and tells the author when to ask for an exception turns static analysis into a normal engineering workflow. This is why SAST governance belongs close to developer experience. The scanner is only the detection engine; the platform is the set of explanations, defaults, and review paths around it.
 
-## War Story: The Framework Migration
+Rule retirement is just as important as rule creation. Frameworks change, shared helpers improve, and old migrations finish. A rule that was valuable during a transition can become noise after the risky API disappears, while a rule that once had many false positives can become enforceable after a common wrapper lands. Mature teams schedule rule reviews the same way they review CI templates and base images. They ask which rules still produce useful findings, which need better tests, which should move from warning to error, and which should be removed because the underlying risk has moved somewhere else.
 
-**Company**: Payment processor, 80 engineers
-**Challenge**: Migrating from deprecated crypto library to new standard
+Finally, remember that SAST findings are social signals as well as technical signals. If one team receives many findings from the same rule, the answer may be a framework template change, not repeated individual coaching. If several repositories suppress the same rule, the rule message may be unclear or the approved pattern may be too hard to use. If a finding class keeps escaping to manual review, the scanner may need a custom model for the organization's helper library. Static analysis gets better when the platform team treats every noisy result as feedback about the system, not just about the line of code.
 
-**The Situation**:
+## Landscape Snapshot and SAST Rosetta
 
-The security team discovered that the `old-crypto` library had known vulnerabilities. 500+ files used it across 12 services. Manual migration would take months and be error-prone.
+> **Landscape snapshot - as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> Semgrep Community Edition is documented by Semgrep as an LGPL 2.1 engine, while Semgrep-maintained rules use a separate Semgrep Rules License and Semgrep Pro rules are proprietary additions in the Semgrep ecosystem. Opengrep identifies itself as a fork of Semgrep and its GitHub repository states LGPL 2.1 licensing for the engine. GitHub documents CodeQL CLI as free for public repositories, with private-repository use tied to eligible GitHub licensing. SonarQube and Snyk Code publish current capability and language-support documentation through their own docs; treat edition, licensing, and feature cells below as refreshable vendor facts rather than durable curriculum claims.
 
-**The Semgrep Approach**:
+| Durable capability | Semgrep | CodeQL | SonarQube | Snyk Code |
+|---|---|---|---|---|
+| Language coverage | Multi-language SAST; verify current language list in Semgrep docs | Multi-language CodeQL analysis through GitHub code scanning | Code quality and security analysis across documented language sets | Snyk Code language support documented per product and integration |
+| Custom-rule authoring | YAML rules with code-like patterns, metavariables, taint mode, and registry/private rules | CodeQL queries over code databases using QL | Rules and security-engine customization are edition and product dependent | Primarily vendor-managed rule intelligence; verify custom-rule options in current docs |
+| Taint analysis | Taint mode in rule syntax; deeper interfile features vary by product tier | Strong data-flow query model over CodeQL databases | Advanced Security docs describe taint analysis across functions and files | Docs describe semantic analysis over code and supported integrations |
+| Autofix | Rule `fix` field and platform-assisted remediation features vary by tier | Query results can guide remediation; autofix is not the core authoring model | Remediation guidance and quality gates are central workflow features | Remediation guidance is part of product workflow; verify current automation |
+| OSS versus commercial posture | CE engine LGPL 2.1; Semgrep rules and Pro features have separate terms | GitHub-owned; CLI free for public repositories per GitHub docs | Community and commercial editions vary; verify edition matrix | Commercial Snyk product family with documented CLI, IDE, SCM, and CI integrations |
+| CI and diff-aware workflow | `semgrep scan`, `semgrep ci`, SARIF, baselines, and diff-aware scans documented | GitHub code scanning and CodeQL CLI workflows | Quality gates and CI integration through Sonar scanners | SCM, IDE, CLI, and CI integrations documented by Snyk |
 
-```yaml
-# Phase 1: Find all usages
-rules:
-  - id: old-crypto-usage
-    pattern-either:
-      - pattern: import old_crypto
-      - pattern: from old_crypto import ...
-      - pattern: old_crypto.$FUNC(...)
-    message: "Legacy crypto library usage. Migrate to new_crypto."
-    severity: WARNING
-    languages: [python]
-```
+The Rosetta table is intentionally not a ranking. These tools overlap, but they optimize for different operating models. Semgrep is often attractive when teams need to encode local code patterns quickly. CodeQL is often attractive when deep semantic queries and GitHub code scanning are already part of the platform. SonarQube is often attractive when security findings sit beside maintainability, duplication, coverage, and quality gates. Snyk Code is often attractive when teams already use the Snyk ecosystem for developer-facing security feedback. Those are tradeoff descriptions, not market-share or leadership claims.
 
-```bash
-# Baseline scan
-$ semgrep --config=migration.yaml --json -o baseline.json .
-Found: 847 usages across 523 files
-```
+The durable lesson is to evaluate the analysis technique and workflow before the brand. Ask whether the tool can parse your languages, model your frameworks, express local rules, run where developers work, separate old debt from new findings, export evidence, and support exceptions without hiding risk. A tool that is excellent in one organization can fail in another if it does not fit repository ownership, CI runtime budget, or developer trust. Conversely, a modest rule set can deliver high value when it encodes the exact review lessons your teams repeatedly need.
 
-```yaml
-# Phase 2: Add autofix rules
-rules:
-  - id: migrate-encrypt
-    pattern: old_crypto.encrypt($DATA, $KEY)
-    fix: new_crypto.encrypt($DATA, key=$KEY, algorithm="AES-256-GCM")
-    message: "Migrate to new_crypto.encrypt()"
-    severity: WARNING
-    languages: [python]
+## Patterns & Anti-Patterns
 
-  - id: migrate-hash
-    pattern: old_crypto.hash($DATA)
-    fix: new_crypto.hash($DATA, algorithm="SHA-256")
-    message: "Migrate to new_crypto.hash()"
-    severity: WARNING
-    languages: [python]
+### Patterns
+
+**Start with review pain that already exists.** The best first custom rules come from repeated pull-request comments, incident remediations, or architecture decisions that reviewers already enforce manually. If a reviewer has written the same warning ten times, the organization has discovered a code shape worth automating. Starting from observed pain keeps the rule grounded and makes adoption easier because developers have already seen the reason behind the policy.
+
+**Use baselines to separate adoption from cleanup.** A legacy repository may have old findings that deserve attention, but blocking every feature branch on historical debt creates resentment and tactical suppressions. Baseline or diff-aware scanning lets the team stop the bleeding first, then schedule cleanup as planned work. This does not excuse old risk; it makes ownership explicit and prevents new code from increasing the problem while cleanup proceeds.
+
+**Treat rules as tested code.** A SAST rule has behavior, edge cases, regressions, and users. It should have positive examples, negative examples, clear metadata, and a changelog when it becomes blocking. This is especially important for custom Semgrep rules because they are easy to write quickly. Ease of authoring is a strength only when paired with the discipline to test what the rule actually matches.
+
+**Graduate severity deliberately.** A new rule can begin as informational, move to warning after tuning, and become blocking only when the false-positive rate and remediation path are understood. This staged rollout protects developer trust. A rule that blocks too early may be technically interesting but operationally harmful, while a rule that never graduates may become background noise.
+
+### Anti-Patterns
+
+**Installing every available ruleset and calling it done.** Broad default coverage can be useful for discovery, but untuned findings quickly become noise. A platform team that enables everything without ownership, baseline strategy, or exception workflow has created an alert feed, not a security control. The scanner may be busy while the organization learns very little.
+
+**Using inline suppressions as permanent design decisions.** Suppression is sometimes correct, but a suppression without a reason, owner, and review point is just hidden risk. Over time, unreviewed suppressions create a second policy layer that nobody audits. A scanner cannot improve security if its strongest rules are bypassed through unexplained comments.
+
+**Blocking on findings developers cannot fix.** Findings in generated code, vendored dependencies, archived repositories, or centrally owned framework code should not block unrelated application pull requests. Those findings need owners, but the owner may not be the pull-request author. Poor ownership mapping turns SAST into organizational blame instead of feedback.
+
+**Mistaking SAST for secure design.** Static analysis can catch unsafe API calls and data-flow patterns, but it cannot fully validate authorization intent, business logic, threat models, or abuse cases. A team that relies on scanners instead of secure design reviews will still miss important vulnerabilities. SAST is a guardrail, not the road.
+
+### Decision Framework
+
+| Decision | Choose a simple pattern rule when... | Choose taint or semantic analysis when... | Governance question |
+|---|---|---|---|
+| Unsafe API | The dangerous call is risky by itself | The call is risky only with untrusted data | Should this block immediately or warn first? |
+| Injection | String construction appears near the sink | Sources and sinks are separated by helpers | Which wrappers count as approved sanitizers? |
+| Secrets | Literal values and credential-like names are visible | Secrets may be generated or loaded dynamically | Who rotates exposed values after a true finding? |
+| Framework policy | The approved code shape is local and clear | The policy depends on cross-file framework setup | How are framework exceptions reviewed? |
+| Legacy debt | Old findings are numerous but known | New findings are the main PR concern | What baseline prevents new debt without hiding old risk? |
+
+```mermaid
+flowchart TD
+    A[New SAST idea] --> B{Observed review pain?}
+    B -- no --> C[Run as discovery only]
+    B -- yes --> D{Dangerous shape local?}
+    D -- yes --> E[Write pattern rule]
+    D -- no --> F[Model sources, sinks, and sanitizers]
+    E --> G[Test positive and negative examples]
+    F --> G
+    G --> H{False positives understood?}
+    H -- no --> I[Warn and tune]
+    H -- yes --> J{Clear remediation?}
+    J -- no --> I
+    J -- yes --> K[Block new findings]
 ```
 
-```bash
-# Apply autofixes
-$ semgrep --config=migration.yaml --autofix .
-Applied 623 fixes automatically
-```
+## Did You Know?
 
-```yaml
-# Phase 3: Block new usages
-rules:
-  - id: block-old-crypto
-    pattern-either:
-      - pattern: import old_crypto
-      - pattern: from old_crypto import ...
-    message: |
-      BLOCKED: old_crypto is deprecated.
-      Use new_crypto instead. See migration guide: wiki/crypto-migration
-    severity: ERROR
-    languages: [python]
-```
-
-**Results**:
-
-| Phase | Timeline | Effort |
-|-------|----------|--------|
-| Find all usages | 30 minutes | Automated |
-| Auto-fix 75% of usages | 2 hours | Review only |
-| Manual fix remaining 25% | 2 weeks | Edge cases |
-| Block new usages | Permanent | Zero effort |
-
-**Total Time**: 2 weeks instead of estimated 3 months
-
-**Key Lessons**:
-1. **Start with WARNING, graduate to ERROR**: Let developers fix before blocking
-2. **Autofix where possible**: Review is faster than rewrite
-3. **Leave blocking rules permanently**: Prevent regression
-4. **Track progress with baseline**: Show weekly improvement to management
-
----
+- **Static does not mean shallow**: Static analysis can range from simple syntax checks to interprocedural data-flow analysis; the defining trait is that the application is not executed as part of the scan.
+- **Rule metadata is operational data**: CWE, OWASP, severity, confidence, references, and remediation text help route findings and explain why a rule exists.
+- **Diff-aware scanning is an adoption tool**: Reporting only new findings on a pull request lets teams enforce better behavior without forcing every author to clean unrelated legacy debt.
+- **Forks are curriculum volatility signals**: The Semgrep and Opengrep split is a reminder to isolate tool licensing and feature facts in dated snapshots rather than hard-coding them into durable prose.
 
 ## Common Mistakes
 
 | Mistake | Problem | Solution |
-|---------|---------|----------|
-| Too specific patterns | Misses variations | Use metavariables, ellipsis |
-| Too broad patterns | False positives | Add pattern-not exclusions |
-| No testing | Rules break silently | Use semgrep --test |
-| Ignoring metadata | Poor findings context | Add CWE, OWASP, references |
-| Running all rules | Slow CI, noise | Curate rulesets for your stack |
-| No baseline | Old findings block PRs | Use --baseline-commit |
-| No autofix | Developers ignore findings | Add fix when pattern is clear |
-| Single pattern only | Can't handle context | Combine with pattern-inside |
-
----
+|---|---|---|
+| Enabling broad rules without tuning | Developers see noisy findings and stop trusting the scanner | Start with a small blocking set and run broader rules in discovery mode |
+| Blocking historical findings in every PR | Feature authors inherit old debt they did not create | Use baseline or diff-aware scanning for PR gates and schedule legacy cleanup separately |
+| Writing rules with no negative examples | False positives appear only after rollout | Add rule tests with both matching and non-matching code before enforcement |
+| Omitting remediation text | Developers know something is wrong but not what standard to follow | Include the approved pattern, owner, and reference in the rule message or metadata |
+| Treating suppressions as invisible | Real exceptions become indistinguishable from avoidance | Require reason, owner, and review date for durable suppressions |
+| Scanning generated or vendored code in PR gates | Findings are not actionable for the author | Exclude non-owned paths with `.semgrepignore` or route them to the owning team |
+| Comparing tools by reputation | Tool choice becomes vendor folklore rather than engineering fit | Compare language support, rule authoring, data-flow depth, CI workflow, and governance needs |
+| Assuming autofix is always safe | Mechanical replacements can break imports, behavior, or context | Use dry runs, tests, and review; reserve unattended fixes for proven transformations |
 
 ## Quiz
 
+1. A team wants to prevent direct use of `dangerouslySetInnerHTML` unless an approved sanitizer wraps the value. Should the first rule be a local pattern rule or a taint rule?
+
 <details>
-<summary>1. What is the difference between $X and ... in Semgrep patterns?</summary>
+<summary>Answer</summary>
 
-**Answer**:
-- `$X` (metavariable): Captures a single expression and can be referenced elsewhere in the rule. Use to match specific values and reference them in the message or fix.
+A local pattern rule is the better first step because the risky code shape is visible at the call site. The team can implement Semgrep patterns that match `dangerouslySetInnerHTML`, then use `pattern-not` for approved sanitizer calls. This supports the outcome to implement Semgrep patterns for OWASP-style vulnerabilities because cross-site scripting risk is being encoded as a concrete, reviewable rule. A taint rule may be useful later if the team needs to follow user-controlled data through wrappers before it reaches the sink.
 
-- `...` (ellipsis): Matches zero or more arguments, statements, or fields. Use when you don't care about the specific content.
-
-Examples:
-```yaml
-# $X captures the argument
-pattern: eval($X)
-message: "eval called with $X"  # $X is interpolated
-
-# ... matches any arguments
-pattern: print(...)  # Matches print(), print(a), print(a, b, c)
-```
 </details>
 
+2. A repository has many old SAST findings, but leadership wants CI to block only newly introduced high-confidence issues. What deployment strategy fits that goal?
+
 <details>
-<summary>2. How do pattern-inside and pattern-not-inside work?</summary>
+<summary>Answer</summary>
 
-**Answer**: They provide context for where patterns should (or shouldn't) match:
+Deploy Semgrep or a peer scanner in CI with a baseline or diff-aware workflow so pull requests focus on new findings. The old findings should remain visible in scheduled scans or dashboards, but they should not all become merge blockers for unrelated changes. This aligns with deploying and configuring custom rules in CI/CD pipelines because the control is not just the command; it is the policy that decides which findings block. The team should document when legacy debt will be reviewed so the baseline does not become a hiding place.
 
-```yaml
-patterns:
-  # Match eval()
-  - pattern: eval($X)
-  # Only inside request handlers
-  - pattern-inside: |
-      @app.route(...)
-      def $FUNC(...):
-          ...
-  # But not inside admin routes
-  - pattern-not-inside: |
-      @app.route("/admin/...")
-      def $FUNC(...):
-          ...
-```
-
-The primary `pattern` must match, AND it must be inside `pattern-inside`, AND it must NOT be inside `pattern-not-inside`.
 </details>
 
+3. A custom rule finds `subprocess.check_output(...)`, but it reports safe internal scripts and unsafe request-driven commands with the same severity. What should you change?
+
 <details>
-<summary>3. What is metavariable-regex used for?</summary>
+<summary>Answer</summary>
 
-**Answer**: `metavariable-regex` applies a regex filter to a captured metavariable:
+The rule needs more context before it should block. You could add `pattern-not` or path exclusions for reviewed internal scripts, or switch to taint analysis so only request-controlled data reaching `subprocess` with `shell=True` is reported. This is the signal-to-noise problem in static analysis: a broad pattern may be useful for discovery but too noisy for enforcement. The blocking version should match the risk model closely enough that developers understand why the finding is actionable.
 
-```yaml
-patterns:
-  - pattern: $VAR = "..."
-  - metavariable-regex:
-      metavariable: $VAR
-      regex: (?i)(password|secret|token|api_key)
-```
-
-This matches variable assignments where the variable name looks like a credential. Without metavariable-regex, you'd match every string assignment.
-
-Use cases:
-- Variable naming conventions
-- String content patterns
-- Filtering by function names
 </details>
 
+4. When is Semgrep autofix a good fit, and when should it stay as a suggestion?
+
 <details>
-<summary>4. How does Semgrep's autofix feature work?</summary>
+<summary>Answer</summary>
 
-**Answer**: The `fix` field provides a replacement pattern:
+Autofix is a good fit when the replacement is mechanical, preserves behavior, and has tests that cover the common cases. It should stay as a suggestion when the fix may require imports, configuration, data migration, human judgment, or framework-specific context. This addresses the outcome to configure Semgrep's autofix capabilities because the engineering task is not only adding a `fix` field; it is deciding whether the fix is safe to apply. A dry run plus code review is the normal path for anything beyond trivial rewrites.
 
-```yaml
-rules:
-  - id: use-pathlib
-    pattern: os.path.join($A, $B)
-    fix: Path($A) / $B
-    message: "Use pathlib instead of os.path.join"
-```
-
-Running `semgrep --autofix`:
-1. Finds all matches
-2. Applies the fix pattern
-3. Interpolates captured metavariables
-4. Rewrites the file
-
-Limitations:
-- Must preserve captured metavariables exactly
-- Complex fixes may need manual intervention
-- Always review changes before committing
 </details>
 
-<details>
-<summary>5. What are Semgrep's community rulesets and how do you use them?</summary>
+5. A security engineer says CodeQL is always better than Semgrep because it can express deeper data-flow queries. What is a more useful comparison?
 
-**Answer**: Community rulesets are curated rule collections:
+<details>
+<summary>Answer</summary>
+
+The more useful comparison is the analysis objective and operating model. CodeQL can be a strong fit for deep semantic queries and GitHub-centered code scanning, while Semgrep can be a strong fit for fast custom pattern rules that application teams can read and maintain. This directly supports the outcome to compare Semgrep's pattern-based approach against CodeQL for speed and coverage trade-offs. A platform team should evaluate language coverage, rule authoring skill, CI cost, data-flow needs, and governance workflow instead of declaring a universal winner.
+
+</details>
+
+6. Why should a SAST rule include CWE or OWASP metadata if the scanner can already show the file and line?
+
+<details>
+<summary>Answer</summary>
+
+Metadata turns a finding into operational evidence. CWE and OWASP mappings help security teams group findings, explain risk, create reports, and connect a code pattern to a broader weakness class. They also help developers understand whether the issue is injection, hardcoded credentials, unsafe deserialization, or another category. A line number tells someone where to look; metadata helps the organization decide how to prioritize and govern the rule.
+
+</details>
+
+7. A team keeps adding `.semgrepignore` entries for application directories after every noisy scan. What is the governance problem?
+
+<details>
+<summary>Answer</summary>
+
+The team is using ignores as unmanaged risk acceptance. Excluding generated or vendored code is reasonable because developers do not own it, but excluding owned application directories hides findings instead of fixing the rule, changing severity, or documenting exceptions. The better path is to review noisy rule IDs, add precise exclusions, create suppressions with reasons, or run the rule in warning mode. Ignoring whole owned paths should require explicit owner approval and a review date.
+
+</details>
+
+8. During rollout, why might a platform team run broad registry rules in scheduled scans but only custom high-confidence rules in pull-request gates?
+
+<details>
+<summary>Answer</summary>
+
+Scheduled scans are good for inventory, learning, and broad discovery because they do not interrupt a specific author's merge path. Pull-request gates need stronger precision because they directly affect delivery flow. This split lets the team learn from broad coverage while preserving developer trust in blocking feedback. Over time, tuned registry rules can graduate into the blocking set after false positives and remediation paths are understood.
+
+</details>
+
+## Hands-On
+
+In this lab, you will write and run a small Semgrep ruleset against a deliberately vulnerable Flask-style file. The goal is not to build a complete Flask security scanner. The goal is to practice the workflow: create a local rule, run it, inspect findings, add a test case, and decide which rules are safe enough to block. Install Semgrep with the current method from the official docs before starting, such as Homebrew or `pipx`, then run the commands from a disposable directory.
 
 ```bash
-# Popular rulesets
-semgrep --config=p/owasp-top-ten .     # OWASP vulnerabilities
-semgrep --config=p/security-audit .    # General security
-semgrep --config=p/secrets .           # Hardcoded secrets
-semgrep --config=p/python .            # Python-specific
-semgrep --config=p/javascript .        # JavaScript/TypeScript
-semgrep --config=p/ci .                # CI/CD misconfigurations
-
-# Auto (detects languages, picks relevant rules)
-semgrep --config=auto .
-
-# Combine multiple
-semgrep --config=p/security-audit --config=p/secrets --config=.semgrep/ .
-```
-
-Registry at: https://semgrep.dev/explore
-</details>
-
-<details>
-<summary>6. How do you test Semgrep rules?</summary>
-
-**Answer**: Semgrep has built-in test support:
-
-```python
-# rules/test_sql_injection.py
-
-# ruleid: sql-injection
-query = "SELECT * FROM users WHERE id = " + user_id
-cursor.execute(query)
-
-# ok: sql-injection
-cursor.execute("SELECT * FROM users WHERE id = %s", (user_id,))
-
-# todoruleid: sql-injection
-# Known false negative - tracking for future fix
-```
-
-```bash
-# Run tests (looks for test files matching rules)
-semgrep --test --config=rules/
-
-# Test specific rule
-semgrep --test --config=rules/sql-injection.yaml
-```
-
-Annotations:
-- `# ruleid: <id>` - Should match
-- `# ok: <id>` - Should NOT match
-- `# todoruleid: <id>` - Known missing match (future work)
-</details>
-
-<details>
-<summary>7. What is the difference between Semgrep OSS and Semgrep Pro?</summary>
-
-**Answer**:
-
-| Feature | OSS (Free) | Pro (Paid) |
-|---------|-----------|------------|
-| Pattern matching | ✓ | ✓ |
-| 2000+ community rules | ✓ | ✓ |
-| Custom rules | ✓ | ✓ |
-| CLI & CI | ✓ | ✓ |
-| Dataflow analysis | ✗ | ✓ |
-| Cross-file analysis | ✗ | ✓ |
-| Pro rules (deeper coverage) | ✗ | ✓ |
-| Dashboard & SBOM | ✗ | ✓ |
-| SSO & Teams | ✗ | ✓ |
-
-For most teams, OSS is sufficient. Pro is valuable for:
-- Finding vulnerabilities that span multiple files
-- Taint tracking (source → sink analysis)
-- Enterprise compliance requirements
-</details>
-
-<details>
-<summary>8. How do you reduce false positives in Semgrep rules?</summary>
-
-**Answer**: Several techniques:
-
-1. **pattern-not exclusions**:
-```yaml
-patterns:
-  - pattern: eval($X)
-  - pattern-not: eval("literal")  # Exclude known safe
-```
-
-2. **pattern-not-inside context**:
-```yaml
-patterns:
-  - pattern: $FUNC(...)
-  - pattern-not-inside: |
-      def test_$NAME(...):  # Exclude test files
-          ...
-```
-
-3. **Metavariable filtering**:
-```yaml
-patterns:
-  - pattern: $VAR = "..."
-  - metavariable-regex:
-      metavariable: $VAR
-      regex: ^(password|secret)$  # Only specific names
-```
-
-4. **Path exclusions**:
-```yaml
-paths:
-  exclude:
-    - "**/test/**"
-    - "**/vendor/**"
-```
-
-5. **Start with WARNING**: Tune before making ERROR
-</details>
-
----
-
-## Hands-On Exercise
-
-**Objective**: Write custom Semgrep rules to secure a Python Flask application.
-
-### Part 1: Setup
-
-```bash
-# Create project directory
-mkdir semgrep-lab && cd semgrep-lab
-
-# Create vulnerable Flask app
-cat > app.py << 'EOF'
+mkdir semgrep-sast-lab
+cd semgrep-sast-lab
+mkdir -p rules
+cat > app.py <<'EOF'
 from flask import Flask, request, render_template_string
-import subprocess
-import pickle
 import hashlib
+import subprocess
 
 app = Flask(__name__)
-app.secret_key = "supersecret123"  # Hardcoded secret
-
-@app.route("/search")
-def search():
-    query = request.args.get("q")
-    # SQL Injection
-    results = db.execute(f"SELECT * FROM items WHERE name LIKE '%{query}%'")
-    return results
+app.secret_key = "local-development-secret"
 
 @app.route("/run")
 def run_command():
-    cmd = request.args.get("cmd")
-    # Command Injection
-    output = subprocess.check_output(cmd, shell=True)
-    return output
+    command = request.args.get("cmd")
+    output = subprocess.check_output(command, shell=True)
+    return output.decode("utf-8")
 
 @app.route("/template")
 def template():
     name = request.args.get("name")
-    # SSTI vulnerability
-    return render_template_string(f"Hello {name}!")
-
-@app.route("/load")
-def load_data():
-    data = request.get_data()
-    # Insecure deserialization
-    return pickle.loads(data)
+    return render_template_string(f"Hello {name}")
 
 @app.route("/hash")
 def hash_password():
-    password = request.args.get("pw")
-    # Weak hash
-    return hashlib.md5(password.encode()).hexdigest()
+    password = request.args.get("password", "")
+    return hashlib.md5(password.encode("utf-8")).hexdigest()
 
 if __name__ == "__main__":
-    app.run(debug=True)  # Debug in production
+    app.run(debug=True)
 EOF
 ```
 
-### Part 2: Run Community Rules
+Now add custom rules. The first two are search rules for visible local patterns. The third is a taint rule that follows request data into a subprocess sink. The messages are intentionally specific because a useful finding should tell the developer what policy was violated and what direction to take.
 
 ```bash
-# Install Semgrep
-pip install semgrep
-
-# Run security audit
-semgrep --config=p/security-audit --config=p/python app.py
-
-# How many findings?
-semgrep --config=p/security-audit --config=p/python app.py --json | jq '.results | length'
-```
-
-### Part 3: Write Custom Rules
-
-```bash
-# Create rules directory
-mkdir -p .semgrep
-
-# Create custom ruleset
-cat > .semgrep/flask-security.yaml << 'EOF'
+cat > rules/flask-security.yaml <<'EOF'
 rules:
-  # Rule 1: Hardcoded Flask secret key
-  - id: flask-hardcoded-secret
-    patterns:
-      - pattern-either:
-          - pattern: app.secret_key = "..."
-          - pattern: app.config["SECRET_KEY"] = "..."
-    message: |
-      Hardcoded Flask secret key detected.
-      Use environment variable: app.secret_key = os.environ.get("SECRET_KEY")
-    severity: ERROR
-    languages: [python]
-    fix: app.secret_key = os.environ.get("SECRET_KEY")
-    metadata:
-      cwe: "CWE-798: Use of Hard-coded Credentials"
-
-  # Rule 2: Flask debug mode
   - id: flask-debug-enabled
     pattern: app.run(..., debug=True, ...)
-    message: "Flask debug mode enabled. Disable in production."
+    message: "Flask debug mode is enabled. Disable debug mode outside local development."
     severity: ERROR
     languages: [python]
-    fix: app.run(debug=False)
     metadata:
       cwe: "CWE-489: Active Debug Code"
 
-  # Rule 3: render_template_string with user input
-  - id: flask-ssti
-    patterns:
-      - pattern: render_template_string($TEMPLATE)
-      - pattern-inside: |
-          $VAR = request.$METHOD.get(...)
-          ...
-    message: |
-      Server-Side Template Injection (SSTI) via render_template_string.
-      Use render_template() with a file instead.
-    severity: ERROR
-    languages: [python]
-    metadata:
-      cwe: "CWE-94: Code Injection"
-
-  # Rule 4: Weak hashing (MD5/SHA1)
   - id: weak-hash-algorithm
-    patterns:
-      - pattern-either:
-          - pattern: hashlib.md5(...)
-          - pattern: hashlib.sha1(...)
-    message: |
-      Weak hash algorithm ($1). Use SHA-256 or better:
-      hashlib.sha256($X).hexdigest()
+    pattern-either:
+      - pattern: hashlib.md5(...)
+      - pattern: hashlib.sha1(...)
+    message: "Weak hash algorithm used. Use an approved hashing primitive for the use case."
     severity: WARNING
     languages: [python]
     metadata:
-      cwe: "CWE-328: Reversible One-Way Hash"
+      cwe: "CWE-328: Use of Weak Hash"
+
+  - id: flask-request-to-subprocess-shell
+    mode: taint
+    pattern-sources:
+      - pattern: request.args.get(...)
+    pattern-sinks:
+      - patterns:
+          - pattern: subprocess.$FUNC(..., shell=True, ...)
+          - metavariable-regex:
+              metavariable: $FUNC
+              regex: ^(run|call|check_call|check_output|Popen)$
+    message: "Request-controlled data reaches subprocess with shell=True."
+    severity: ERROR
+    languages: [python]
+    metadata:
+      cwe: "CWE-78: OS Command Injection"
 EOF
 ```
 
-### Part 4: Test Your Rules
+Run the scan in text and JSON modes. The text output is useful for humans, while JSON or SARIF is useful for CI systems and dashboards. If the command returns a non-zero exit because findings were detected, that is expected once `--error` is used; in a real rollout, you would decide which rule severities block the pipeline.
 
 ```bash
-# Create test file
-cat > .semgrep/test_flask_security.py << 'EOF'
-from flask import Flask, render_template_string, request
+semgrep scan --config=rules/flask-security.yaml app.py
+semgrep scan --config=rules/flask-security.yaml app.py --json --output=semgrep-results.json
+semgrep scan --config=rules/flask-security.yaml app.py --error
+```
+
+Add a small rule test file so future rule edits do not silently change behavior. Positive examples should be marked as expected findings, and safe examples should be marked as allowed. If your installed Semgrep version changes test-discovery behavior, use the current Semgrep testing docs to place the test file next to the rule or pass the exact test path.
+
+```bash
+cat > rules/flask-security.py <<'EOF'
+from flask import Flask, request
 import hashlib
-import os
+import subprocess
 
 app = Flask(__name__)
-
-# ruleid: flask-hardcoded-secret
-app.secret_key = "hardcoded"
-
-# ok: flask-hardcoded-secret
-app.secret_key = os.environ.get("SECRET_KEY")
 
 # ruleid: flask-debug-enabled
 app.run(debug=True)
@@ -1102,69 +524,68 @@ app.run(debug=True)
 app.run(debug=False)
 
 # ruleid: weak-hash-algorithm
-hashlib.md5(b"test")
+hashlib.md5(b"example")
 
 # ok: weak-hash-algorithm
-hashlib.sha256(b"test")
+hashlib.sha256(b"example")
+
+def unsafe():
+    command = request.args.get("cmd")
+    # ruleid: flask-request-to-subprocess-shell
+    return subprocess.check_output(command, shell=True)
 EOF
 
-# Run tests
-semgrep --test --config=.semgrep/
+semgrep --test rules/
 ```
 
-### Part 5: Full Scan with Custom + Community Rules
+Finally, try a controlled autofix rule. This example is intentionally small: it changes the visible Flask debug flag from true to false. Review the diff after running autofix in any real project because even simple edits can interact with local conventions.
 
 ```bash
-# Combined scan
-semgrep --config=p/python --config=.semgrep/ app.py
+cat > rules/flask-autofix.yaml <<'EOF'
+rules:
+  - id: flask-debug-autofix
+    pattern: app.run(..., debug=True, ...)
+    fix: app.run(debug=False)
+    message: "Disable Flask debug mode."
+    severity: ERROR
+    languages: [python]
+EOF
 
-# Generate report
-semgrep --config=p/python --config=.semgrep/ app.py --sarif -o report.sarif
-
-# Apply autofixes
-semgrep --config=.semgrep/ app.py --autofix --dryrun  # Preview
-semgrep --config=.semgrep/ app.py --autofix           # Apply
+cp app.py app-autofix.py
+semgrep scan --config=rules/flask-autofix.yaml app-autofix.py --autofix --dryrun
 ```
 
-### Success Criteria
+Success criteria:
 
-- [ ] Community rules find SQL injection, command injection
-- [ ] Custom rule catches hardcoded secret_key
-- [ ] Custom rule catches debug=True
-- [ ] Custom rule catches SSTI vulnerability
-- [ ] Custom rule catches MD5 usage
-- [ ] All tests pass with `semgrep --test`
-- [ ] Autofix correctly replaces secret_key
+- [ ] Run a local Semgrep scan with `rules/flask-security.yaml` and see findings for debug mode, weak hashing, and request-controlled subprocess execution.
+- [ ] Generate a JSON report named `semgrep-results.json` and inspect the rule IDs, file paths, and severity values.
+- [ ] Add rule tests with both `ruleid` and `ok` examples, then run the Semgrep test command for the custom rule file.
+- [ ] Run the autofix dry run and explain why this fix should still be reviewed before being committed in a real repository.
 
----
+## Sources
 
-## Key Takeaways
-
-1. **Patterns look like code** — Not regex, not a query language—actual code
-2. **Metavariables capture** — `$X` matches any expression and can be referenced
-3. **Combine patterns** — `pattern-inside`, `pattern-not` reduce false positives
-4. **Test your rules** — Built-in testing with `# ruleid:` annotations
-5. **Autofix accelerates adoption** — Developers fix faster when fix is provided
-6. **Start with community rules** — 2000+ rules ready to use
-7. **Layer custom on top** — Your specific patterns + community baseline
-8. **Run in CI but also pre-commit** — Catch before push, block before merge
-9. **Baseline for legacy code** — Don't block PRs on old findings
-10. **Iterate quickly** — 5-minute rule writing means rapid security coverage
-
----
-
-## Did You Know?
-
-> **Name Origin**: Semgrep stands for "semantic grep"—grep that understands code structure, not just text. The first version was called "sgrep" before the rename.
-
-> **Speed Secret**: Semgrep compiles patterns into a specialized matching engine written in OCaml (semgrep-core). It's designed to be fast enough for pre-commit hooks.
-
-> **Return Path**: Semgrep was created by r2c (now Semgrep Inc.), founded by former members of Facebook's static analysis team who built Infer and Zoncolan.
-
-> **Community Growth**: The Semgrep Registry has grown from 500 rules in 2020 to over 3000+ rules in 2024, covering security, correctness, and best practices.
-
----
+- [OWASP Static Code Analysis](https://owasp.org/www-community/controls/Static_Code_Analysis)
+- [OWASP Source Code Analysis Tools](https://owasp.org/www-community/Source_Code_Analysis_Tools)
+- [NIST SP 800-218 Secure Software Development Framework](https://csrc.nist.gov/pubs/sp/800/218/final)
+- [MITRE CWE-89 SQL Injection](https://cwe.mitre.org/data/definitions/89.html)
+- [MITRE CWE-79 Cross-site Scripting](https://cwe.mitre.org/data/definitions/79.html)
+- [MITRE CWE-798 Hard-coded Credentials](https://cwe.mitre.org/data/definitions/798.html)
+- [Semgrep Write Rules](https://semgrep.dev/docs/writing-rules/overview)
+- [Semgrep Rule Syntax](https://semgrep.dev/docs/writing-rules/rule-syntax)
+- [Semgrep Test Rules](https://semgrep.dev/docs/writing-rules/testing-rules)
+- [Semgrep Taint Analysis Overview](https://semgrep.dev/docs/writing-rules/data-flow/taint-mode/overview)
+- [Semgrep Community Edition in CI](https://semgrep.dev/docs/deployment/oss-deployment)
+- [Semgrep Diff-aware Scans](https://semgrep.dev/docs/kb/semgrep-ci/trigger-diff-scans-env-var)
+- [Semgrepignore Guidance](https://semgrep.dev/docs/kb/semgrep-code/semgrepignore-ignored)
+- [Semgrep Pro Rules](https://semgrep.dev/docs/semgrep-code/pro-rules)
+- [Semgrep Compare Semgrep to Opengrep](https://semgrep.dev/docs/faq/comparisons/opengrep)
+- [Opengrep Repository](https://github.com/opengrep/opengrep)
+- [GitHub CodeQL CLI](https://docs.github.com/en/code-security/concepts/code-scanning/codeql/codeql-cli)
+- [SonarQube Advanced Security Introduction](https://docs.sonarsource.com/sonarqube-server/advanced-security/introduction)
+- [Snyk Code Documentation](https://docs.snyk.io/scan-fix-and-prevent/scan-with-snyk/snyk-code)
+- [Snyk Supported Languages](https://docs.snyk.io/supported-languages/supported-languages-package-managers-and-frameworks)
+- [Semgrep Pre-commit Scans](https://semgrep.dev/docs/extensions/pre-commit)
 
 ## Next Module
 
-Continue to [Module 12.3: CodeQL](../module-12.3-codeql/) to learn about semantic code analysis with GitHub's powerful query language for finding complex vulnerabilities.
+Continue to [Module 12.3: CodeQL](../module-12.3-codeql/) to learn how semantic query-based code analysis can model deeper flows and framework behavior.

--- a/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.4-snyk.md
+++ b/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.4-snyk.md
@@ -1,5 +1,5 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 12.4: Snyk - Developer-First Security"
 slug: platform/toolkits/security-quality/code-quality/module-12.4-snyk
 sidebar:
@@ -13,10 +13,11 @@ sidebar:
 ## Prerequisites
 
 Before starting this module, you should have completed:
-- [DevSecOps Discipline](/platform/disciplines/reliability-security/devsecops/) - Security scanning concepts
-- Basic understanding of dependency management (npm, pip, maven)
-- Container basics (Dockerfile, images)
-- CI/CD fundamentals
+
+- [DevSecOps Fundamentals](/platform/disciplines/reliability-security/devsecops/module-4.1-devsecops-fundamentals/) — security scanning concepts, shift-left practice, and the DevSecOps tool-class taxonomy
+- Basic dependency management with at least one ecosystem (npm, pip, Maven, or Go modules)
+- Container fundamentals (Dockerfile structure, image layers, registries)
+- CI/CD fundamentals (pull request checks, pipeline gates, artifact promotion)
 
 ---
 
@@ -29,1037 +30,491 @@ After completing this module, you will be able to:
 - **Deploy Snyk Container scanning in CI/CD to detect base image vulnerabilities before deployment**
 - **Integrate Snyk with IDE plugins and Git hooks for shift-left security in developer workflows**
 
-
 ## Why This Module Matters
 
-**When "847 Vulnerabilities" Actually Becomes Actionable**
+Hypothetical scenario: a platform team inherits roughly two hundred application repositories and a pre-audit spreadsheet listing ten thousand dependency findings across npm, pip, and Maven lockfiles. Two security engineers have sixty days before an external assessor reviews the organization's software supply chain controls. Leadership asks a reasonable question first: how many of these findings represent code paths the applications actually execute, and how many are transitive packages sitting in a lockfile that no import statement ever reaches?
 
-The security consultant's face fell as she reviewed the scan results. A Series B healthcare startup had engaged her team for a pre-audit assessment before their SOC2 certification. The numbers were brutal: 10,247 vulnerabilities across 200 repositories. Two security engineers. Sixty days until the audit.
+Traditional Software Composition Analysis without prioritization often stops at the first question — "is this package version associated with a known advisory?" — and leaves humans to answer the second question by hand. That gap is where developer time disappears. A team can spend weeks upgrading packages that never affect runtime behavior while missing one reachable library on a payment path because it was buried on page forty of a CSV export. The durable practice you need is not "scan harder." It is scan with context: dependency graph resolution, reachability where available, exploitability signals such as EPSS, license posture, and remediation workflows that meet developers inside the pull request rather than in a quarterly audit folder.
 
-"How many of these are actually exploitable?" the CTO asked, desperate for a lifeline.
+Snyk is the commercial worked example in this module because it embodies the **developer-first multi-scanning** model: one vendor surface spanning Open Source (SCA), Code (SAST), Container, and Infrastructure as Code, integrated into CLI, CI, IDE, and fix-pull-request automation. That product packaging is not the lesson. The lesson is the capability set — continuous composition analysis, prioritized findings, and fix suggestions at the point of change — and how to implement it honestly alongside open-source peers such as [Trivy](../module-12.5-trivy/), Dependabot, Grype, and OWASP Dependency-Check. For where these tools sit in the broader security toolchain, see the DevSecOps taxonomy in [Module 4.1: DevSecOps Fundamentals](/platform/disciplines/reliability-security/devsecops/module-4.1-devsecops-fundamentals/).
 
-"We have no idea," she admitted. "Traditional scanners just find vulnerabilities. They don't tell you which ones your code actually uses."
-
-Three weeks later, with Snyk's reachability analysis enabled, the picture transformed: 847 reachable vulnerabilities—8% of the total. The other 9,400 were in unused code paths, transitive dependencies nobody called, or functions the application never touched.
-
-Snyk generated 623 auto-fix pull requests. 589 merged automatically. Developer time spent on security fixes: 40 hours total, not the months they'd budgeted. The SOC2 audit passed with zero critical findings.
-
-The difference between "you have 10,247 problems" and "here are 847 fixes, auto-generated" is the difference between paralysis and progress:
-
-- **Fix PRs generated automatically** - Not "here's a CVE, good luck" but "here's the exact code change"
-- **Reachability analysis** - Is this vulnerability actually exploitable in YOUR code?
-- **IDE integration** - Find issues while coding, not after release
-- **Breaking builds intelligently** - Block critical issues, don't cry wolf on everything
-
-Snyk doesn't just find problems—it fixes them. That's the difference between a security tool and a security solution.
+> **The Triage Desk Analogy**
+>
+> Imagine a hospital triage desk that receives every injury report in the city simultaneously. A scanner that lists ten thousand cuts without severity, location, or whether the patient is in the building creates paralysis. A triage desk that asks "Is the patient here?" and "Is this injury life-threatening now?" lets clinicians act. Reachability analysis asks whether the vulnerable function is on a call path your application executes. EPSS and severity scoring ask how urgently the industry is seeing exploitation. Fix automation asks whether the smallest safe upgrade can be proposed as a reviewable change instead of a vague CVE hyperlink.
 
 ---
 
-## Did You Know?
+## Software Composition Analysis: The Core Capability
 
-- **Snyk became a $8.5B company by saying "no" to security** — In 2015, founders Guy Podjarny and Assaf Hefetz pitched a security startup and got rejected by every investor. "Nobody wants another security tool," they were told. So they repositioned: "We're a developer tool that happens to fix security problems." The reframe worked. By 2022, Snyk was valued at $8.5B with 2,500+ customers.
+Most production application code is not written from scratch. It is assembled from open-source libraries, framework transitive dependencies, container base images, and infrastructure modules maintained by other teams. [OWASP Component Analysis guidance](https://owasp.org/www-community/Component_Analysis) describes Software Composition Analysis (SCA) as the practice of identifying those third-party components and correlating them with known vulnerabilities, license obligations, and supply-chain risk signals. SCA is the spine of this module. Container scanning, IaC scanning, and SAST address adjacent layers, but dependency composition is where the majority of CVE noise originates in modern services.
 
-- **The reachability feature came from a customer tantrum** — A Fortune 500 bank was about to cancel their Snyk contract. "You showed us 47,000 vulnerabilities. We fixed 3,000, but our risk score didn't change." The Snyk team realized that most vulnerabilities were in code that never ran. Six months later, reachability analysis launched. That bank became their largest customer.
+An SCA engine begins with **manifest and lockfile fidelity**. Package managers express intent in `package.json`, `requirements.txt`, `pom.xml`, `go.mod`, and similar files, but the authoritative graph for reproducible builds usually lives in lockfiles such as `package-lock.json`, `poetry.lock`, or `go.sum`. A scanner that reads only direct dependencies without resolving transitive closure will miss the vulnerable library three hops away that actually ships to production. Good tooling therefore builds a full dependency tree, maps each node to version coordinates, and queries advisory databases for matches.
 
-- **Auto-fix PRs have an 80% merge rate because of one engineer's obsession** — Early Snyk auto-fix PRs had a 23% merge rate—developers didn't trust them. A single engineer spent 18 months analyzing why fixes failed: version conflicts, transitive dependency chaos, breaking tests. The system now tests fixes against the project's CI before generating PRs. Merge rate: 80%+.
+Those advisory databases are not interchangeable. The [CVE Program](https://www.cve.org/) provides standardized identifiers and references. National and vendor feeds enrich them with metadata. Commercial scanners often maintain proprietary enrichment layers on top of public sources — Snyk publishes advisories at [security.snyk.io](https://security.snyk.io/) — but your operating model should treat **CVE identity** as the portable spine and vendor severity or fix advice as enrichment you can compare across tools. When two scanners disagree, reconcile on CVE ID and affected version range first, then investigate why enrichment differed.
 
-- **Snyk's vulnerability database includes 100,000+ vulns not in NVD** — The National Vulnerability Database (NVD) takes an average of 35 days to publish CVEs. Snyk's research team publishes in 24 hours. Many vulnerabilities—especially in npm, PyPI, and Go modules—are discovered by Snyk before getting official CVE numbers.
+SCA also intersects **license compliance**, which is easy to underteach in security-only curricula. A dependency can be free of known CVEs yet unacceptable for your distribution model because it carries copyleft obligations your legal team has not approved. CycloneDX and SPDX (covered later in this module) exist partly so legal and security reviewers can reason about the same component inventory. If your platform team owns golden CI templates, include license policy alongside severity thresholds rather than treating licenses as a separate audit surprise.
 
----
-
-## Snyk Product Suite
-
-```
-SNYK PRODUCT ECOSYSTEM
-─────────────────────────────────────────────────────────────────
-
-┌─────────────────────────────────────────────────────────────────┐
-│                     SNYK PLATFORM                                │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  SNYK OPEN SOURCE (SCA)                                         │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  • Dependency vulnerability scanning                       │  │
-│  │  • License compliance checking                            │  │
-│  │  • Transitive dependency analysis                         │  │
-│  │  • Auto-fix pull requests                                 │  │
-│  │  • npm, pip, maven, gradle, go, nuget, ruby, etc.        │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                  │
-│  SNYK CODE (SAST)                                               │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  • Static application security testing                    │  │
-│  │  • AI-powered analysis (trained on fixes, not just bugs) │  │
-│  │  • Real-time IDE scanning                                 │  │
-│  │  • Data flow analysis                                     │  │
-│  │  • 20+ languages supported                                │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                  │
-│  SNYK CONTAINER                                                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  • Container image vulnerability scanning                 │  │
-│  │  • Base image recommendations                             │  │
-│  │  • OS and application layer analysis                      │  │
-│  │  • Registry integration (Docker Hub, ECR, GCR, etc.)     │  │
-│  │  • Kubernetes workload scanning                           │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                  │
-│  SNYK IAC                                                       │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  • Infrastructure as Code scanning                        │  │
-│  │  • Terraform, CloudFormation, Kubernetes, ARM            │  │
-│  │  • Cloud configuration drift detection                    │  │
-│  │  • Custom rules engine                                    │  │
-│  │  • Compliance frameworks (SOC2, PCI, HIPAA)              │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-
-PRICING (approximate):
-─────────────────────────────────────────────────────────────────
-• Free tier:  200 Open Source tests/month, 100 Container tests
-• Team:       $25/dev/month (unlimited tests)
-• Enterprise: Custom pricing (SSO, advanced reporting, SLA)
-```
+Finally, SCA without **operating rhythm** becomes a snapshot. Point-in-time scans answer "what is vulnerable today?" Continuous monitoring answers "what changed since yesterday, and who owns the fix?" That distinction drives the difference between `snyk test` and `snyk monitor` in Snyk's CLI, and analogous patterns in other tools. Platform engineers should design for continuous signal: baseline existing debt, gate new debt on pull requests, and route fix suggestions to the team that owns the manifest — not to a central spreadsheet.
 
 ---
 
-## Getting Started
+## Transitive Dependencies, Reachability, and SBOM
 
-### CLI Installation
+Transitive dependencies are the reason SCA is harder than it looks on a slide. You may declare one direct dependency while shipping dozens of indirect packages pulled in by frameworks, test harnesses, and build plugins. A vulnerability in a deep transitive node still matters when that node is present in the production artifact, but teams routinely waste cycles upgrading branches of the graph their runtime never loads. Prioritization therefore needs graph awareness plus, where available, **reachability analysis** that traces whether vulnerable symbols are referenced from application code.
 
-```bash
-# npm (recommended for Node projects)
-npm install -g snyk
+[Snyk's reachability documentation](https://docs.snyk.io/manage-risk/prioritize-issues-for-fixing/reachability-analysis) explains the intent: reduce noise by highlighting findings where static analysis can connect application code to a vulnerable function in a dependency. Reachability is not a magic "safe to ignore" button. It is a triage accelerator. A finding marked unreachable today can become reachable tomorrow when someone imports a helper that pulls the vulnerable path into the graph. Platform policy should treat reachability as a prioritization input combined with severity, EPSS, and deployment exposure — not as a permanent waiver.
 
-# Homebrew (macOS)
-brew install snyk
+Understanding reachability also clarifies why lockfiles belong in version control for scanned services. If CI scans only manifests while developers build from floating ranges locally, the graph SCA sees in the pipeline may not match the graph that compiled yesterday's release artifact. Lockfile discipline is a supply-chain control adjacent to scanning itself. When teams complain that "the scanner flaps," the first engineering question is whether the scanned inputs are reproducible.
 
-# Scoop (Windows)
-scoop install snyk
+**Software Bill of Materials (SBOM)** export is the durable artifact that connects composition analysis to downstream consumers. [CycloneDX](https://cyclonedx.org/) and [SPDX](https://spdx.dev/) provide machine-readable formats listing components, versions, hashes, and relationships. Regulators and enterprise customers increasingly ask for SBOMs not because JSON is fun, but because they need a shared inventory when a new CVE drops Friday afternoon. SCA tooling that can emit or ingest SBOMs lets you re-scan an existing SBOM when advisories update without rebuilding the entire pipeline from scratch — a pattern Trivy also supports and that complements the commercial Snyk workflow.
 
-# Docker (no installation)
-docker run -it snyk/snyk-cli
-
-# Authenticate
-snyk auth
-# Opens browser for authentication
-```
-
-### Basic Scanning
-
-```bash
-# Scan dependencies (Open Source)
-snyk test
-
-# Scan with detailed output
-snyk test --json --severity-threshold=high
-
-# Scan container image
-snyk container test nginx:latest
-
-# Scan IaC files
-snyk iac test terraform/
-
-# Scan code (SAST)
-snyk code test
-```
+The relationship between SBOM and SCA is often misunderstood. An SBOM is an inventory; SCA is the analytic process that compares inventory to threat intelligence. You want both: SBOM for traceability and contractual evidence, continuous SCA for prioritized remediation. Platform templates should name where SBOMs are generated (build job, registry admission, release tag) and where they are stored (artifact bucket, security data lake) so responders know which file to re-query when [CISA's Known Exploited Vulnerabilities catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) adds an entry over the weekend.
 
 ---
 
-## Snyk Open Source (Dependency Scanning)
+## Vulnerability Data and Prioritization
 
-### How It Works
+Finding vulnerabilities is the easy part of modern DevSecOps. **Prioritizing** them is where mature teams separate operational noise from actionable risk. A typical enterprise scan aggregates CVE identifiers, vendor severities, package paths, and fix availability — then drowns owners in counts that lack context. Effective programs layer multiple signals instead of sorting on severity alone.
 
-```
-SNYK OPEN SOURCE ANALYSIS
-─────────────────────────────────────────────────────────────────
+**CVE and CVSS** provide shared vocabulary. The [CVE Program](https://www.cve.org/) assigns identifiers so teams, tools, and regulators discuss the same flaw. [FIRST's CVSS specification](https://www.first.org/cvss/) describes how base scores summarize technical severity from the advisory text. CVSS is useful for coarse sorting but famously imperfect for your specific deployment: a network-accessible critical in a admin-only internal tool may differ materially from the same CVE on an internet-facing API. Teach CVSS as a starting point, not an oracle.
 
-┌─────────────────────────────────────────────────────────────────┐
-│                    YOUR PROJECT                                  │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │  package.json / requirements.txt / pom.xml              │   │
-│  │                                                          │   │
-│  │  Dependencies:                                           │   │
-│  │  ├── express@4.17.1                                     │   │
-│  │  │   └── body-parser@1.19.0                            │   │
-│  │  │       └── qs@6.7.0  ← VULNERABLE!                   │   │
-│  │  ├── lodash@4.17.20   ← VULNERABLE!                    │   │
-│  │  └── axios@0.21.1     ← VULNERABLE!                    │   │
-│  └─────────────────────────────────────────────────────────┘   │
-└────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    SNYK ANALYSIS                                 │
-│                                                                  │
-│  1. Build dependency tree (including transitive deps)           │
-│  2. Check against Snyk vulnerability database                   │
-│  3. Analyze REACHABILITY - does your code actually use it?     │
-│  4. Calculate priority based on context                         │
-│  5. Generate fix recommendations                                │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    RESULTS                                       │
-│                                                                  │
-│  ┌─────────────────────────────────────────────────────────┐   │
-│  │  HIGH: lodash@4.17.20 - Prototype Pollution             │   │
-│  │  ├── Reachable: YES (used in src/utils.js:45)          │   │
-│  │  ├── Fix: Upgrade to 4.17.21                           │   │
-│  │  └── PR Available: Yes                                  │   │
-│  │                                                          │   │
-│  │  MEDIUM: qs@6.7.0 - Prototype Pollution                 │   │
-│  │  ├── Reachable: NO (transitive, not directly used)     │   │
-│  │  ├── Fix: Upgrade express to 4.18.0                    │   │
-│  │  └── PR Available: Yes                                  │   │
-│  └─────────────────────────────────────────────────────────┘   │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
+**EPSS (Exploit Prediction Scoring System)** adds a probabilistic lens. [FIRST EPSS](https://www.first.org/epss/) estimates the likelihood a CVE will be exploited in the wild, updated from telemetry across the community. EPSS helps security engineers explain why a medium-severity issue with rising exploitation probability jumps ahead of a higher CVSS item with no known active use. Snyk and other commercial platforms incorporate similar prioritization constructs under product-specific names; the durable skill is knowing which signals your scanner exposes and documenting how your organization weighs them.
 
-### Reachability Analysis
+**Reachability and deploy context** complete the picture. A reachable high severity in a service behind mutual TLS and strict network policy differs from the same finding in a multi-tenant edge proxy. Platform teams should publish a **risk rubric** that combines scanner outputs with service tier, data classification, and exposure — then configure CI gates to enforce that rubric rather than raw counts. [Snyk's prioritization documentation](https://docs.snyk.io/manage-risk/prioritize-issues-for-fixing) describes product features aligned with this workflow; your internal runbook should still own the weighting decisions.
 
-```
-THE GAME-CHANGER: REACHABILITY
-─────────────────────────────────────────────────────────────────
+When leadership asks "how many vulnerabilities do we have," push back gently toward "how many **actionable** findings exceed our threshold this sprint?" That reframing protects developer trust. Developers ignore tools that cry wolf. Developers merge pull requests that propose a one-line lockfile change with a clear CVE reference, test evidence, and policy alignment. Prioritization is therefore a socio-technical design problem: the math must be defensible, and the output must be fix-sized.
 
-Traditional Scanner:
-  "lodash has a vulnerability"
-  • Could be critical, could be nothing
-  • Developer has to investigate
-  • Usually ignored
-
-Snyk with Reachability:
-  "lodash.set() is called from your code at src/config.js:23"
-  • Definitely exploitable
-  • Shows exact code path
-  • Gets fixed
-
-Example output:
-─────────────────────────────────────────────────────────────────
-✗ HIGH - Prototype Pollution in lodash
-
-  Introduced through: lodash@4.17.20
-
-  Reachable: YES
-
-  Your code calls the vulnerable function:
-    src/config.js:23 → lodash.set(config, path, value)
-                            ↑
-                       This function is vulnerable
-
-  Fix: Upgrade to lodash@4.17.21
-
-  [Generate Fix PR]
-```
-
-### Auto-Fix Pull Requests
-
-```bash
-# Monitor project and enable auto-fix PRs
-snyk monitor
-
-# In Snyk dashboard:
-# Settings → Integration → Enable "Automatic fix PRs"
-
-# What Snyk generates:
-# ─────────────────────────────────────────────────────────────────
-# PR Title: [Snyk] Upgrade lodash from 4.17.20 to 4.17.21
-#
-# This PR fixes 1 vulnerability:
-# - HIGH: Prototype Pollution (SNYK-JS-LODASH-1040724)
-#
-# Changes:
-# - package.json: lodash 4.17.20 → 4.17.21
-# - package-lock.json: Updated
-#
-# No breaking changes detected.
-# Tested against your CI (passed)
-```
+Operationalizing prioritization also requires **baseline discipline** for legacy debt. Mature programs snapshot existing findings, focus merge gates on net-new introductions, and fund quarterly burndown for baseline items above internal thresholds. Without baselines, teams either block all progress on ancient issues or disable gates entirely. Snyk supports ignore and policy constructs for documented exceptions; OSS peers offer suppression files with similar intent. The platform owner documents who may approve an exception, for how long, and which compensating controls apply during the exception window.
 
 ---
 
-## Snyk Container
+## The Developer-First Multi-Scanning Model
 
-### Scanning Container Images
+**Developer-first security** does not mean "security is optional." It means security feedback arrives in the same surfaces developers already use — IDE, pull request, local CLI — with remediation guidance tight enough to act on during normal feature work. A separate audit portal that lists ten thousand rows without fix paths is developer-last, regardless of what the marketing page claims.
 
-```bash
-# Scan public image
-snyk container test nginx:1.21
+The **multi-scanning model** maps cleanly to modern delivery pipelines. **Open Source (SCA)** inspects dependency graphs. **SAST (Code)** inspects first-party source for patterns such as injection, hardcoded secrets, and unsafe API use. **Container scanning** inspects image layers including OS packages and embedded language artifacts. **IaC scanning** inspects Terraform, Kubernetes manifests, CloudFormation, and related artifacts for misconfigurations before cloud resources materialize. A platform team can adopt these capabilities from one commercial suite or assemble open-source peers; the architecture pattern is the same.
 
-# Scan local image
-docker build -t myapp:latest .
-snyk container test myapp:latest
+Shift-left is often misread as "run every scanner on every keystroke." In practice, shift-left means **earliest correct feedback** without destroying flow state. IDE plugins excel at catching issues a developer can fix before commit. Pull request checks excel at enforcing team policy on diffs. Release gates excel at blocking promotion when service tier demands it. Nightly or continuous monitoring excels at catching newly disclosed CVEs against yesterday's shipped artifact. The mistake is running only nightly batch scans and wondering why developers experience security as a quarterly fire drill.
 
-# Scan with Dockerfile for better recommendations
-snyk container test myapp:latest --file=Dockerfile
+Fix automation is the other pillar of developer-first composition analysis. When a scanner only outputs CVE text, humans must research compatible upgrade paths, resolve transitive conflicts, and validate tests. When a scanner proposes a minimal upgrade pull request — bumping a lockfile with explanatory commit text — developers can review like any other dependency change. Snyk popularized this pattern for commercial SCA; GitHub Dependabot provides a native peer for GitHub-hosted repositories. The platform decision is not "auto-merge everything." It is where you allow bot proposals, which test suites must pass, and which severity bands auto-merge versus require human approval.
 
-# Output includes base image recommendations
-snyk container test node:16 --file=Dockerfile
-```
-
-### Understanding Container Results
-
-```
-CONTAINER SCAN RESULTS
-─────────────────────────────────────────────────────────────────
-
-Tested: node:16-bullseye
-
-✗ 147 vulnerabilities found
-
-  │ Severity   │ Count │
-  ├────────────┼───────┤
-  │ Critical   │ 3     │
-  │ High       │ 24    │
-  │ Medium     │ 67    │
-  │ Low        │ 53    │
-
-Layer Analysis:
-─────────────────────────────────────────────────────────────────
-Base Image (debian:bullseye-slim):
-  └── 89 vulnerabilities (OS packages)
-
-Your layers:
-  └── COPY package*.json ./
-  └── RUN npm install
-      └── 58 vulnerabilities (npm packages)
-
-BASE IMAGE RECOMMENDATIONS:
-─────────────────────────────────────────────────────────────────
-Current: node:16-bullseye (147 vulnerabilities)
-
-Recommended alternatives:
-┌──────────────────────────┬──────────────┬───────────────────┐
-│ Image                    │ Vulns        │ Reduction         │
-├──────────────────────────┼──────────────┼───────────────────┤
-│ node:16-bullseye-slim    │ 62 vulns     │ -58% ↓            │
-│ node:16-alpine           │ 12 vulns     │ -92% ↓            │
-│ gcr.io/distroless/nodejs │ 0 vulns      │ -100% ↓           │
-└──────────────────────────┴──────────────┴───────────────────┘
-
-Switch to node:16-alpine to eliminate 135 vulnerabilities!
-```
-
-### Dockerfile Best Practices
-
-```dockerfile
-# BEFORE: Many vulnerabilities
-FROM node:16
-WORKDIR /app
-COPY . .
-RUN npm install
-CMD ["node", "server.js"]
-
-# AFTER: Snyk recommendations applied
-FROM node:16-alpine AS builder
-WORKDIR /app
-COPY package*.json ./
-RUN npm ci --only=production
-
-FROM gcr.io/distroless/nodejs:16
-WORKDIR /app
-COPY --from=builder /app/node_modules ./node_modules
-COPY . .
-CMD ["server.js"]
-
-# Result:
-# - Multi-stage build (smaller image)
-# - Alpine base (fewer OS vulns)
-# - Distroless final image (minimal attack surface)
-# - npm ci (reproducible installs)
-```
+Integration ownership matters for platform engineers. Central security should publish **golden workflows** — GitHub Actions, GitLab CI includes, Jenkins steps — that authenticate with read-only tokens, upload results to the system of record, and apply consistent severity thresholds per service tier. Application teams should not each invent a different Snyk invocation with conflicting `--severity-threshold` values. Document the contract: which jobs call [`snyk test`](https://docs.snyk.io/snyk-cli/commands/test), which call [`snyk monitor`](https://docs.snyk.io/snyk-cli/commands/monitor), which upload SARIF to GitHub Advanced Security, and which are allowed to fail open during migration.
 
 ---
 
-## Snyk IaC
+## Snyk as a Commercial Worked Example
 
-### Scanning Infrastructure Code
+Snyk is a **commercial, proprietary platform** (not a CNCF project) offering free-tier limits and paid team or enterprise plans. Treat it honestly: you trade license cost and vendor dependency for integrated prioritization, fix automation, policy management, and multi-product scanning in one control plane. Open-source peers reduce cost and increase portability at the expense of assembling integrations yourself. Neither choice is universally correct; service tier, staff skill, and compliance requirements decide.
 
-```bash
-# Scan Terraform files
-snyk iac test main.tf
+The [`snyk` CLI](https://docs.snyk.io/snyk-cli) is the lowest-friction entry point for local reproduction of CI findings. After [`snyk auth`](https://docs.snyk.io/snyk-cli/authenticate-to-use-the-cli), developers run product-specific commands from the repository root. Open Source scanning uses `snyk test` against manifests and lockfiles. Container scanning uses `snyk container test` against local or registry images. Snyk Code uses `snyk code test`. IaC scanning uses `snyk iac test` against Terraform directories or Kubernetes YAML. The commands differ, but the mental model repeats: authenticate, scan inputs, interpret prioritized results, optionally upload snapshots for monitoring.
 
-# Scan directory
-snyk iac test ./terraform/
+[`snyk test`](https://docs.snyk.io/snyk-cli/commands/test) answers "what is wrong in this workspace right now?" It exits non-zero when policy thresholds fail, which makes it suitable for pull request gates. [`snyk monitor`](https://docs.snyk.io/snyk-cli/commands/monitor) snapshots the project to the Snyk platform for continuous alerting when new advisories affect pinned versions — the operational bridge between developer laptop and security operations dashboard. Platform teams typically run `test` on every PR and `monitor` on default branch builds so new CVEs surface without waiting for the next feature commit.
 
-# Scan Kubernetes manifests
-snyk iac test deployment.yaml
+Policy and ignore files encode organizational exceptions without abandoning scanning. Teams document accepted risk in `.snyk` policy files with expiry and justification rather than silently suppressing findings in a UI nobody audits. The anti-pattern is permanent ignores copied from blog posts. The pattern is time-bounded waivers tied to ticket IDs, reviewed quarterly, visible in version control next to the code they affect.
 
-# Scan Helm charts
-snyk iac test ./helm/mychart/
+Snyk's **fix pull requests** integrate with GitHub, GitLab, and Bitbucket through the Snyk application. When enabled, the platform proposes dependency upgrades that resolve specific advisories, often with release notes linked in the PR body. Platform engineers should require CI success before merge, restrict auto-merge to low-risk semver patches on non-critical services during pilot phases, and measure merge rates as a health metric — low merge rates usually indicate noisy fixes or incompatible test suites, not "developer apathy."
 
-# Scan CloudFormation
-snyk iac test template.yaml
-```
+Commercial versus open source is a recurring portfolio conversation. Snyk bundles SCA, SAST, container, and IaC with centralized policy. [Dependabot](https://docs.github.com/en/code-security/dependabot) covers dependency updates deeply on GitHub. [OWASP Dependency-Check](https://owasp.org/www-project-dependency-check/) and [Grype](https://github.com/anchore/grype) provide OSS scanning engines you integrate yourself. [Trivy](../module-12.5-trivy/) spans container, filesystem, and IaC with strong OSS momentum. Many enterprises run **both**: OSS engines for broad coverage and a commercial control plane for developer UX on tier-one services. Avoid duplicative gates that scan the same lockfile three ways with conflicting severities.
 
-### Example Findings
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> | Aspect | Snyk (commercial) | Trivy (OSS) | Dependabot (GitHub-native) | Grype (OSS) | OWASP Dependency-Check (OSS) |
+> |--------|-------------------|-------------|------------------------------|-------------|------------------------------|
+> | Primary model | SaaS + CLI with free tier limits | Local/CI scanner, open-source (Aqua Security; not CNCF-hosted, but the default scanner in CNCF Harbor) | GitHub-hosted dependency PRs | Local/CI scanner from Anchore ecosystem | Local/CI Maven-centric scanner with broad ecosystem support |
+> | SCA / Open Source | Core product (`snyk test`) | Filesystem and image language artifacts | Version update PRs from GitHub advisory data | Vulnerability matching via Grype DB | NVD-driven matching with suppressions |
+> | Reachability prioritization | Product feature for supported ecosystems | Limited compared to commercial SCA depth | Not equivalent to call-path reachability | Not focus | Not focus |
+> | SAST (first-party code) | Snyk Code (`snyk code test`) | Not primary focus | Not provided | Not provided | Not provided |
+> | Container scanning | Snyk Container (`snyk container test`) | Core strength (`trivy image`) | Not provided | Core strength (`grype`) | Not focus |
+> | IaC scanning | Snyk IaC (`snyk iac test`) | Config scanning supported | Not provided | Not focus | Not focus |
+> | SBOM | Supported in platform workflows | CycloneDX/SPDX generation | Dependency graph insight, not full SBOM suite | SBOM ingestion supported | Report-oriented |
+> | Fix automation | Fix PRs and upgrade advice | Recommendations; no native PR bot | Native version bump PRs | Recommendations only | Report-only |
+> | Licensing | Commercial subscription for advanced policy | OSS license (Apache 2.0) | Included with GitHub plans | OSS license (Apache 2.0) | OSS license (Apache 2.0) |
+>
+> Use this table to choose **peers by capability gap**, not by imagined market rank. When container coverage is the only requirement, Trivy or Grype may suffice alone. When developers need reachable SCA fix PRs across many ecosystems on non-GitHub hosts, evaluate Snyk's commercial workflow.
 
-```
-SNYK IAC SCAN RESULTS
-─────────────────────────────────────────────────────────────────
+---
 
-Testing main.tf...
+## Configuring Continuous Scanning Across Surfaces
 
-Issues found: 7
+To **configure Snyk for continuous vulnerability scanning across code, dependencies, containers, and IaC**, treat each surface as an input contract with shared policy outputs. Open Source scanning requires clean lockfiles checked into the repository. Snyk Code requires repository roots that match language plugins enabled in your Snyk organization settings. Container scanning requires CI jobs that build or pull the same image digest you promote — scanning `:latest` tags without digest pinning creates non-reproducible gates. IaC scanning requires directories or files passed explicitly to `snyk iac test` because monorepos rarely store all Terraform in the repository root.
 
-HIGH:
-─────────────────────────────────────────────────────────────────
-✗ S3 bucket does not have server-side encryption
+Continuous scanning implies **monitoring**, not only pull request tests. After CI builds on the default branch succeed, a monitor step uploads the dependency graph and image metadata to the Snyk platform so newly published advisories trigger alerts even when no developer commits code. Pair monitors with ticketing rules: reachable critical findings page on-call, unreachable medium findings batch into weekly hygiene work, license violations route to legal review. Without routing, monitors become another unread inbox.
 
-  File: main.tf
-  Line: 25-30
+Organization structure in Snyk should mirror ownership. Import projects from GitHub or GitLab with team tags mapping to service owners. Apply **risk-based policies** so internal tooling repositories tolerate different thresholds than customer-facing payment services. Central security owns policy templates; application teams own merge decisions on fix PRs affecting their manifests. This division prevents the common failure mode where security merges dependency upgrades without domain tests and production breaks — or developers disable scanning because every finding blocks unrelated feature work.
 
-  resource "aws_s3_bucket" "data" {
-    bucket = "my-data-bucket"
-    # Missing: server_side_encryption_configuration
-  }
+Multi-product configuration also means **consistent authentication**. CI uses `SNYK_TOKEN` secrets scoped to service accounts, not personal developer tokens that break when people leave. IDE plugins authenticate per developer for local shift-left feedback but should not become the only enforcement point. Rotate tokens on the same schedule as other CI secrets, and audit which repositories each token can access.
 
-  Fix:
-  Add server-side encryption:
-
-  resource "aws_s3_bucket_server_side_encryption_configuration" "data" {
-    bucket = aws_s3_bucket.data.id
-    rule {
-      apply_server_side_encryption_by_default {
-        sse_algorithm = "AES256"
-      }
-    }
-  }
-
-─────────────────────────────────────────────────────────────────
-✗ Security group allows ingress from 0.0.0.0/0 to port 22
-
-  File: main.tf
-  Line: 45-55
-
-  resource "aws_security_group" "ssh" {
-    ingress {
-      from_port   = 22
-      to_port     = 22
-      cidr_blocks = ["0.0.0.0/0"]  # BAD!
-    }
-  }
-
-  Risk: Exposes SSH to the entire internet
-  Fix: Restrict to specific IP ranges or use bastion host
-```
-
-### Custom Rules
+For GitHub Actions, Snyk publishes maintained actions documented in the [GitHub Actions integration guide](https://docs.snyk.io/integrations/ci-cd-integrations/github-actions-integration). Pin action versions or commit SHAs rather than floating `@master` in production pipelines — the same supply-chain discipline you teach application teams applies to security tooling itself. Upload SARIF to GitHub code scanning where available so developers see Snyk findings beside other checks in the Security tab.
 
 ```yaml
-# .snyk.d/rules/custom-tagging.yaml
-rules:
-  - id: CUSTOM-001
-    title: All resources must have required tags
-    description: Resources must have Owner and Environment tags
-    severity: medium
-    resource_types:
-      - aws_instance
-      - aws_s3_bucket
-      - aws_rds_instance
-    rule:
-      not:
-        and:
-          - tag_exists: Owner
-          - tag_exists: Environment
-```
-
----
-
-## CI/CD Integration
-
-### GitHub Actions
-
-```yaml
-# .github/workflows/snyk.yml
+# .github/workflows/snyk.yml — illustrative multi-product gate
 name: Snyk Security
 
 on:
-  push:
-    branches: [main]
   pull_request:
+    branches: [main]
+  push:
     branches: [main]
 
 jobs:
-  security:
+  open-source:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Run Snyk Open Source
+      - uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+      - run: npm ci
+      - name: Snyk Open Source test
         uses: snyk/actions/node@master
-        continue-on-error: true  # Don't block, just report
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           args: --severity-threshold=high
-
-      - name: Run Snyk Code
+      - name: Snyk monitor on main
+        if: github.ref == 'refs/heads/main'
         uses: snyk/actions/node@master
-        continue-on-error: true
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          command: monitor
+
+  container:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Build image
+        run: docker build -t app:${{ github.sha }} .
+      - name: Snyk Container test
+        uses: snyk/actions/docker@master
+        env:
+          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
+        with:
+          image: app:${{ github.sha }}
+          args: --file=Dockerfile --severity-threshold=high
+
+  code:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Snyk Code test
+        uses: snyk/actions/node@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
           command: code test
 
-      - name: Run Snyk Container
-        uses: snyk/actions/docker@master
-        continue-on-error: true
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          image: myapp:${{ github.sha }}
-          args: --file=Dockerfile
-
-      - name: Run Snyk IaC
-        uses: snyk/actions/iac@master
-        continue-on-error: true
-        env:
-          SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-        with:
-          args: --severity-threshold=high
-
-      - name: Upload results to GitHub Security
-        uses: github/codeql-action/upload-sarif@v2
-        with:
-          sarif_file: snyk.sarif
-```
-
-### Breaking Builds Intelligently
-
-```yaml
-# Smart gate: Only block on critical + reachable
-- name: Snyk Test (Blocking)
-  uses: snyk/actions/node@master
-  env:
-    SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-  with:
-    args: >
-      --severity-threshold=critical
-      --fail-on=all
-    # This WILL fail the build on critical issues
-
-# Non-blocking scan for visibility
-- name: Snyk Test (Informational)
-  uses: snyk/actions/node@master
-  continue-on-error: true  # Report but don't fail
-  env:
-    SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
-  with:
-    args: --json-file-output=snyk-results.json
-```
-
-### GitLab CI
-
-```yaml
-# .gitlab-ci.yml
-include:
-  - template: Security/Dependency-Scanning.gitlab-ci.yml
-
-snyk:
-  stage: test
-  image: snyk/snyk:node
-  script:
-    - snyk auth $SNYK_TOKEN
-    - snyk test --severity-threshold=high
-    - snyk container test $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA --file=Dockerfile
-  allow_failure: true  # Or false to block
-  artifacts:
-    reports:
-      dependency_scanning: snyk-results.json
-```
-
----
-
-## IDE Integration
-
-### VS Code Extension
-
-```json
-// settings.json
-{
-  "snyk.features.openSourceSecurity": true,
-  "snyk.features.codeSecurity": true,
-  "snyk.features.iacSecurity": true,
-  "snyk.severity": {
-    "critical": true,
-    "high": true,
-    "medium": true,
-    "low": false
-  },
-  "snyk.trustedFolders": [
-    "/home/user/projects"
-  ]
-}
-```
-
-### JetBrains Plugin
-
-```
-Features:
-─────────────────────────────────────────────────────────────────
-• Real-time scanning as you code
-• Inline vulnerability annotations
-• Quick fixes from IDE
-• Dependency tree visualization
-• Snyk Learn integration (explains vulnerabilities)
-
-Installation:
-1. Settings → Plugins → Marketplace
-2. Search "Snyk"
-3. Install and restart
-4. Authenticate via Settings → Tools → Snyk
-```
-
----
-
-## War Story: The 10,000 Vulnerability Cleanup
-
-*How a healthcare startup saved $1.2M and passed SOC2 in 45 days*
-
-### The Situation
-
-A Series B healthcare startup with $47M in funding was three months from their first enterprise contract—a $8.2M annual deal with a hospital network. The contract required SOC2 Type 2 certification. The security audit revealed a nightmare:
-
-- 10,247 known vulnerabilities across 200 repositories
-- No consistent scanning (occasional Dependabot, mostly ignored)
-- Security team of 2 vs. 150 developers
-- SOC2 audit in 60 days
-- Estimated manual remediation: 14,000 developer hours ($1.4M in opportunity cost)
-
-### The Problem with "Just Fix It"
-
-```
-INITIAL APPROACH: SPREADSHEET OF DOOM
-─────────────────────────────────────────────────────────────────
-
-Security team generates report:
-  • 10,247 vulnerabilities
-  • 200 repositories
-  • Every developer gets assigned ~50 vulnerabilities
-
-Result:
-  • Developers paralyzed ("where do I start?")
-  • Random fixes (easy ones, not important ones)
-  • Some "fixes" break production
-  • 45 days later: 9,847 vulnerabilities (4% reduction)
-  • SOC2 audit: FAIL
-```
-
-### The Snyk Approach
-
-```
-SNYK IMPLEMENTATION: SMART PRIORITIZATION
-─────────────────────────────────────────────────────────────────
-
-Week 1: Enable Snyk across all repos
-─────────────────────────────────────────────────────────────────
-• Import 200 repos into Snyk
-• Enable reachability analysis
-• Connect to CI/CD
-
-Week 2: Analyze real risk
-─────────────────────────────────────────────────────────────────
-10,247 vulnerabilities → After reachability analysis:
-
-  ┌────────────────────────────────────────────────────────────┐
-  │  Reachable (actually exploitable):     847 (8%)           │
-  │  Not reachable (theoretical):         8,400 (82%)          │
-  │  Unknown (needs manual review):       1,000 (10%)          │
-  └────────────────────────────────────────────────────────────┘
-
-Focus: 847 reachable vulnerabilities, not 10,247
-
-Week 3: Auto-fix campaign
-─────────────────────────────────────────────────────────────────
-Enable auto-fix PRs for all reachable vulnerabilities
-
-Results:
-  • 623 auto-fix PRs generated
-  • 589 merged automatically (CI passed)
-  • 34 needed manual review
-  • Time spent: ~2 hours reviewing, not coding fixes
-
-Week 4-6: Handle the rest
-─────────────────────────────────────────────────────────────────
-Remaining 847 - 589 = 258 reachable vulns
-
-  • 180 fixed via dependency updates
-  • 54 required code changes (Snyk Code found safer patterns)
-  • 24 accepted as risk (documented, monitored)
-
-Week 7: Prevention
-─────────────────────────────────────────────────────────────────
-  • CI gates: Block critical + reachable
-  • IDE plugins: Find issues while coding
-  • Snyk Learn: Train developers on common vulns
-```
-
-### Results
-
-| Metric | Before | After |
-|--------|--------|-------|
-| Total vulnerabilities | 10,247 | 892 |
-| Reachable vulnerabilities | 847 | 24 (accepted risk) |
-| Developer time spent | 0 (ignored) | 40 hours total |
-| Security team time | Weeks generating reports | Hours reviewing PRs |
-| SOC2 audit | Fail | Pass |
-| New vulnerabilities/month | ~200 | ~10 (caught in CI) |
-
-**Financial Impact:**
-
-| Category | Without Snyk | With Snyk |
-|----------|--------------|-----------|
-| Developer remediation time | 14,000 hrs × $100/hr = $1,400,000 | 40 hrs × $100/hr = $4,000 |
-| Snyk licensing (150 devs × 12 mo) | — | $45,000 |
-| Security consultant fees | $120,000 (extended engagement) | $40,000 (standard) |
-| **Total Cost** | **$1,520,000** | **$89,000** |
-| **Savings** | | **$1,431,000** |
-
-**Business Impact:**
-- SOC2 certification achieved on schedule
-- $8.2M hospital network contract signed
-- Series C raised 4 months later ($92M at $340M valuation)
-- CEO credited security posture as key differentiator in healthcare sales
-
-### Key Insights
-
-1. **Reachability transforms the problem** - 847 vs 10,247 is psychologically different
-2. **Auto-fix PRs are magic** - Developers merge, not write, security fixes
-3. **CI gates prevent accumulation** - Stop new vulnerabilities at the door
-4. **IDE integration shifts left** - Find issues before commit, not after release
-5. **Accepted risk is fine** - Document it, monitor it, move on
-
----
-
-## Snyk vs Alternatives
-
-```
-DEPENDENCY SCANNING COMPARISON
-─────────────────────────────────────────────────────────────────
-
-                    Snyk        Dependabot    OWASP DC     WhiteSource
-─────────────────────────────────────────────────────────────────
-Auto-fix PRs        ✓✓          ✓             ✗            ✓
-Reachability        ✓✓          ✗             ✗            ✓
-Container scan      ✓✓          ✗             ✗            ✓
-IaC scan            ✓           ✗             ✗            ✓
-SAST (code)         ✓           ✗             ✗            ✗
-License compliance  ✓           ✗             ✓            ✓✓
-Vuln database       Largest     NVD+GitHub    NVD          Proprietary
-IDE integration     ✓✓          ✗             ✓            ✓
-Free tier           ✓           ✓ (GitHub)    ✓            ✗
-
-BEST FOR:
-─────────────────────────────────────────────────────────────────
-Snyk:        Developer-first, full platform, reachability
-Dependabot:  Already on GitHub, simple dependency updates
-OWASP DC:    Free, compliance-focused, CI integration
-WhiteSource: Enterprise, license compliance focus
-
-CONTAINER SCANNING COMPARISON
-─────────────────────────────────────────────────────────────────
-
-                    Snyk        Trivy         Clair        Grype
-─────────────────────────────────────────────────────────────────
-Speed               Medium      Fast          Medium       Fast
-Base image recs     ✓✓          ✓             ✗            ✗
-Dockerfile aware    ✓✓          ✓             ✗            ✓
-K8s integration     ✓           ✓             ✗            ✗
-SBOM generation     ✓           ✓✓            ✗            ✓
-Free                Tiered      ✓             ✓            ✓
-```
-
----
-
-## Common Mistakes
-
-| Mistake | Why It's Bad | Better Approach |
-|---------|--------------|-----------------|
-| Blocking on all vulnerabilities | Everything blocked, security ignored | Block only critical + reachable |
-| Ignoring reachability | Wasting time on theoretical issues | Enable and trust reachability analysis |
-| Not enabling auto-fix | Manual work for routine updates | Auto-merge low-risk fixes |
-| Scanning only in CI | Issues found late, harder to fix | IDE plugins for shift-left |
-| No baseline/exceptions | Alert fatigue from old issues | Baseline existing, focus on new |
-| Scanning without monitoring | Point-in-time, not continuous | Use `snyk monitor` for ongoing visibility |
-| Same policy for all repos | Critical apps same as internal tools | Risk-based policies per project |
-| Ignoring license findings | Legal exposure from copyleft | Include license compliance |
-
----
-
-## Hands-On Exercise
-
-### Task: Set Up Snyk for a Project
-
-**Objective**: Configure Snyk scanning, fix vulnerabilities, and set up CI integration.
-
-**Success Criteria**:
-1. Snyk CLI installed and authenticated
-2. Project scanned with results understood
-3. At least one auto-fix PR generated
-4. CI pipeline includes Snyk gate
-
-### Steps
-
-```bash
-# 1. Create vulnerable test project
-mkdir snyk-lab && cd snyk-lab
-npm init -y
-
-# Add vulnerable dependencies
-npm install lodash@4.17.20 express@4.17.1 axios@0.21.1
-
-cat > index.js << 'EOF'
-const express = require('express');
-const _ = require('lodash');
-const axios = require('axios');
-
-const app = express();
-
-app.get('/config', (req, res) => {
-  const config = {};
-  // Using vulnerable lodash.set
-  _.set(config, req.query.path, req.query.value);
-  res.json(config);
-});
-
-app.listen(3000);
-EOF
-
-# 2. Install and authenticate Snyk
-npm install -g snyk
-snyk auth
-
-# 3. Run initial scan
-snyk test
-
-# Notice the vulnerabilities found
-
-# 4. Check reachability
-snyk test --json | jq '.vulnerabilities[] | select(.isReachable == true)'
-
-# 5. Generate fix PR (requires GitHub integration)
-# In Snyk dashboard: Projects → Your project → Fix vulnerabilities
-
-# 6. Create GitHub Actions workflow
-mkdir -p .github/workflows
-cat > .github/workflows/snyk.yml << 'EOF'
-name: Snyk Security
-
-on:
-  push:
-    branches: [main]
-  pull_request:
-    branches: [main]
-
-jobs:
-  snyk:
+  iac:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run Snyk
-        uses: snyk/actions/node@master
+      - name: Snyk IaC test
+        uses: snyk/actions/iac@master
         env:
           SNYK_TOKEN: ${{ secrets.SNYK_TOKEN }}
         with:
-          args: --severity-threshold=high --fail-on=upgradable
-EOF
-
-# 7. Monitor project for ongoing alerts
-snyk monitor
-
-# 8. Fix vulnerabilities
-npm update lodash axios
-snyk test  # Should show fewer/no vulnerabilities
+          args: test --severity-threshold=high terraform/
 ```
 
-### Verification
+The workflow above demonstrates parallel product scans with shared secrets management. Tune `continue-on-error` during migration if you must collect signal before enforcing hard gates — but publish an end date for migration so informational mode does not become permanent theater.
+
+---
+
+## Fix Pull Requests and Upgrade Automation
+
+**Implementing Snyk's fix PRs and upgrade suggestions** starts with enabling the integration between your Git provider and Snyk organization, then turning on automated fix pull requests for projects under team ownership. The platform proposes dependency upgrades that resolve specific advisories while preserving semver constraints declared in manifests. Developers review bot PRs like human contributions: read release notes, confirm CI green, verify no unexpected transitive major bumps slipped through lockfile refreshes.
+
+Fix automation works best on **routine hygiene** — patch-level updates with clear CVE references — not on major framework migrations that require design work. Publish policy stating which severity and reachability bands qualify for bot proposals, which require human authorship, and which are waived with documented risk. Snyk's dashboard settings control automatic PR creation per integration; mirror those settings in internal docs so auditors understand who can change them.
+
+The CLI complements bot PRs for local experimentation. Running `snyk test` before opening a feature branch shows what the bot would propose without waiting for scheduler latency. When fixes require coordinated changes across multiple packages, humans still author the pull request — the scanner informs minimal upgrade sets. Teach developers to prefer minimal upgrades over "update everything" spikes that mix unrelated CVE fixes with feature-breaking major versions.
+
+Measure outcomes, not vanity counts. Track time-to-merge for bot PRs, reopened vulnerabilities after merge, and regression incidents caused by dependency changes. If merge rates are low, investigate test flakiness, overly broad upgrade proposals, or developers lacking trust because prior bot PRs broke builds. Fix automation is a feedback loop between security policy and engineering quality — when CI is unreliable, bots become noise.
+
+Upgrade suggestions also appear inline in IDE plugins and the Snyk web UI. The durable practice is ensuring **the same advisory appears consistently** across CLI, PR, and IDE surfaces so developers are not forced to reconcile conflicting severity labels. Central policy in Snyk reduces that drift compared to ad hoc local CLI flags.
 
 ```bash
-# Check that vulnerabilities are reduced
-snyk test --json | jq '.vulnerabilities | length'
+# Local Open Source scan with JSON output for scripting
+snyk test --json > snyk-open-source.json
 
-# Before: Should be > 0
-# After updates: Should be 0 or fewer
+# Fail CI only on fixable high+ issues (example policy)
+snyk test --severity-threshold=high --fail-on=upgradable
 
-# Verify monitoring is active
-snyk monitor
-# Check Snyk dashboard for project
+# Snapshot default branch graph for continuous monitoring
+snyk monitor --project-name=payments-api-main
 ```
 
 ---
+
+## Container Scanning in CI/CD
+
+**Deploying Snyk Container scanning in CI/CD** closes the gap between "dependencies look clean in Git" and "the shipped image still carries OS packages with known CVEs." Container images stack a base operating system, language runtimes, application dependencies copied or installed during build, and configuration files. SCA on repository lockfiles alone misses vulnerabilities introduced purely at the OS layer or duplicated inside the image after multi-stage copies.
+
+Run `snyk container test` against the **same artifact digest** your pipeline promotes. Build in CI, tag with the commit SHA or digest, scan, then push to registry only when policy passes. Passing `--file=Dockerfile` improves recommendations because Snyk can relate findings to Dockerfile instructions and suggest base image alternatives. Documented container scanning entry points live in [Snyk's container documentation](https://docs.snyk.io/scan-containers).
+
+Base image selection is a security decision disguised as convenience. Full Debian-based Node images include more packages — and more CVE surface — than slim or Alpine variants, while distroless or minimal images reduce attack surface at the cost of debugging ergonomics. Snyk container output often includes **base image recommendations** comparing vulnerability counts across tags. Treat recommendations as starting points: verify compatibility with native modules, glibc versus musl assumptions, and compliance requirements before swapping bases in production.
+
+Layer analysis helps assign ownership. OS findings may require platform teams to refresh golden bases. Application-layer findings may route to service teams updating npm or pip dependencies in Dockerfiles. Without layer attribution, every finding becomes an argument about who should care.
+
+```bash
+# Scan locally built image with Dockerfile context
+docker build -t payments-api:ci .
+snyk container test payments-api:ci --file=Dockerfile
+
+# Scan registry image by digest (preferred for gates)
+snyk container test registry.example.com/payments-api@sha256:abc123... --file=Dockerfile
+```
+
+Pair container gates with **registry admission** where possible so unscanned images cannot deploy even if a pipeline is bypassed. Harbor, ECR, and other registries integrate scanning hooks; Snyk may run in CI while registry enforcement provides defense in depth. Cross-reference [Module 12.5: Trivy](../module-12.5-trivy/) for OSS-heavy container scanning patterns you can run beside or instead of Snyk Container depending on portfolio choices.
+
+Multi-stage Dockerfiles remain best practice independent of vendor. Copy dependencies in builder stages, run tests there, and ship minimal runtime layers. Scanning both builder and runtime targets during migration can reveal where fat stages hide vulnerable tools you never needed in production.
+
+---
+
+## IDE Integration and Shift-Left Workflows
+
+**Integrating Snyk with IDE plugins and Git hooks** moves feedback earlier than CI without pretending IDE scans replace pipeline gates. VS Code and JetBrains plugins connect to the same Snyk organization policies as CI, surfacing Open Source, Code, and IaC issues inline while developers edit files. The goal is catching accidental imports of vulnerable packages or obvious SAST findings before code review consumes human attention.
+
+IDE integration succeeds when it is **fast and configurable**. Developers disable plugins that lag typing or flood the gutter with low-severity noise. Configure severity filters to match team policy, trust workspace folders explicitly, and document how offline mode behaves when Snyk APIs are unreachable. Security champions on each team validate plugin defaults quarterly so new hires inherit workable settings.
+
+Local Git hooks complement IDE feedback for teams that want guardrails before push. A pre-push hook running `snyk test --severity-threshold=high` on changed services catches issues before CI minutes burn. Hooks should be optional during early adoption — mandatory hooks without fix paths frustrate developers — then promoted to required hooks via documented team standards or managed dev environments. Never rely on hooks alone; attackers and emergency pushes can bypass local enforcement.
+
+Shift-left also includes **education in flow**. [Snyk Learn](https://learn.snyk.io/) provides free modules explaining vulnerability classes referenced in findings. Linking from internal runbooks to Learn content helps developers fix issues without opening security office hours for every prototype pollution advisory. The durable platform pattern is: scanner finding → short internal doc → external canonical lesson → example fix PR template.
+
+Secrets in developer environments deserve explicit warning. IDE plugins authenticate with personal tokens stored locally. Rotate tokens when laptops are reimaged, and prefer organization SSO where enterprise plans support it. Platform teams should not publish shared personal tokens in internal wikis — service accounts belong in CI, humans in IDE.
+
+For SAST specifically, [Snyk Code documentation](https://docs.snyk.io/snyk-code) describes real-time analysis differentiated from batch-only traditional SAST. Teach developers that Code findings require the same triage discipline as SCA: confirm data flow, reproduce with tests, fix or document risk. IDE speed does not imply automatic true positive.
+
+---
+
+## IaC Scanning Before Resources Exist
+
+Infrastructure as Code mistakes are expensive because they replicate at scale. A security group allowing SSH from the entire internet, an unencrypted object store, or a Kubernetes Pod running privileged containers becomes hundreds of identical resources when Terraform modules or Helm charts roll out broadly. **IaC scanning** applies policy checks to Terraform, CloudFormation, Kubernetes YAML, and related artifacts before cloud APIs create state that incident responders must unwind under pressure.
+
+Snyk IaC uses `snyk iac test` against files or directories, reporting misconfigurations with file and line references similar to SAST output. Findings should route to the same pull request workflow as application code because platform teams review infrastructure changes through Git. Blocking in CI on high-severity misconfigurations prevents drift between "approved architecture" slides and the manifests actually merged on Friday afternoon.
+
+IaC scanning complements — does not replace — cloud posture management tools that evaluate live accounts. The durable defense is **double validation**: catch risky templates at PR time, then continuously audit deployed resources for drift or emergency manual changes. When a finding appears only in live cloud audit, trace back to the template version that introduced it and add an IaC rule so the mistake cannot re-enter through Git.
+
+Custom organizational rules extend generic misconfiguration checks with tags, naming standards, or mandatory encryption patterns your industry requires. Keep custom rules small, tested with known-good and known-bad fixtures, and owned by the platform team that understands cloud account layout. Overly broad custom rules erode developer trust the same way noisy SCA thresholds do.
+
+```bash
+# Scan Terraform directory before apply
+snyk iac test terraform/
+
+# Scan a single Kubernetes manifest in a service repo
+snyk iac test deploy/deployment.yaml
+```
+
+Pair IaC gates with policy documentation so developers know **why** a rule exists — "no public SSH" is clearer when linked to network segmentation standards than when presented as an opaque policy ID. Cross-reference [Module 12.5: Trivy](../module-12.5-trivy/) for OSS config scanning patterns when your portfolio standardizes on Trivy for containers but still evaluates commercial IaC depth separately.
+
+---
+
+## Patterns & Anti-Patterns
+
+### Pattern: Prioritize With Reachability and Service Tier
+
+Strong composition-analysis programs combine scanner prioritization signals with internal service tier labels. A reachable critical CVE in a tier-one external API blocks merge; the same advisory unreachable in an internal batch job becomes scheduled hygiene. Document the matrix in a runbook everyone can cite during audits instead of debating individual CVEs in chat threads.
+
+### Pattern: Separate Snapshot Tests From Continuous Monitors
+
+Use `snyk test` (or peer scanners) on pull requests for fast feedback, and `snyk monitor` on default branch builds for ongoing advisory coverage. Teams that only test on PRs learn about new CVEs against shipped versions days later when someone happens to commit unrelated work. Teams that only monitor without PR gates ship new vulnerabilities until the nightly job complains.
+
+### Pattern: Fix-Sized Bot Pull Requests With CI Proof
+
+Enable automated fix PRs where CI must pass before merge and upgrades stay within declared semver policy. Developers trust bots when bots behave like disciplined contributors — one advisory per PR when possible, clear title, linked CVE, no sneaky major bumps. Measure merge latency as a product metric for your DevSecOps program.
+
+### Anti-Pattern: Blocking on Raw Count Thresholds
+
+Failing builds because "more than one hundred findings" exist guarantees teams will disable scanning. Block on policy predicates: reachable, severity, exploitability, age, or net-new versus baseline. Raw counts reward the wrong behavior — hiding findings instead of fixing risk.
+
+### Anti-Pattern: Scanning Floating Dependencies Without Lockfiles
+
+Running SCA against manifests without lockfiles produces irreproducible gates. CI may scan a different graph than the release artifact built locally. Require lockfiles for applications; treat manifest-only scanning as a smell during code review.
+
+### Anti-Pattern: Duplicate Gates With Conflicting Severities
+
+Running Snyk, Dependabot, Trivy, and Dependency-Check on the same lockfile with different thresholds creates contradictory instructions for developers. Consolidate enforcement to one primary gate per artifact type; use secondary scanners for audit or SBOM export unless you harmonize policies.
+
+### Decision Framework
+
+| Question | Lean toward Snyk (commercial) | Lean toward OSS peers (Trivy, Grype, Dependency-Check) | Lean toward Dependabot |
+|----------|------------------------------|--------------------------------------------------------|------------------------|
+| Need reachable SCA prioritization and fix PRs across many hosts? | Strong fit when budget allows integrated UX | Build custom prioritization; Grype/Trivy give findings not full dev UX | Strong on GitHub for version bumps; reachability differs |
+| Need container + IaC + filesystem in one OSS engine? | Snyk Container/IaC cover this commercially | Trivy is the usual OSS aggregate; see Module 12.5 | Not applicable |
+| GitHub-only shop wanting native dependency PRs? | Optional second layer for SAST/reachability | Supplement with Trivy in CI for images | Native dependency update workflow |
+| Strict air-gap or vendor minimization? | Requires SaaS or self-hosted enterprise evaluation | Local DB scanners fit offline CI | Requires GitHub connectivity |
+| Need SBOM export + regulatory evidence? | Platform SBOM features + monitors | CycloneDX/SPDX via Trivy/Syft ecosystem | Dependency insights, not full SBOM suite |
+
+The framework should start conversations, not end them. Many enterprises use Dependabot or Renovate for version bumps, Trivy for registry scanning, and Snyk for developer UX on tier-one services — with explicit ownership of which tool enforces merge blocking.
+
+---
+
+## Did You Know?
+
+- **CVE identifiers are global, but enrichment differs by vendor**: The [CVE Program](https://www.cve.org/) standardizes IDs so tools can exchange findings, yet severity, fix availability, and reachability metadata still vary between Snyk, GitHub Advisories, and NVD-derived feeds — reconcile on CVE ID first when scanners disagree.
+- **EPSS updates daily from community telemetry**: [FIRST EPSS](https://www.first.org/epss/) publishes probabilities that help teams prioritize patching beyond static CVSS base scores, especially when multiple backlogs compete for the same maintenance window.
+- **`snyk test` and `snyk monitor` serve different control loops**: [`snyk test`](https://docs.snyk.io/snyk-cli/commands/test) enforces point-in-time policy suitable for CI gates, while [`snyk monitor`](https://docs.snyk.io/snyk-cli/commands/monitor) registers projects for alerting when new advisories affect previously uploaded graphs — continuous coverage without requiring daily commits.
+- **CycloneDX and SPDX make SBOMs interchangeable at the standards layer**: [CycloneDX](https://cyclonedx.org/) and [SPDX](https://spdx.dev/) define component inventory formats consumed by regulators and customers; scanners that emit either format let you re-analyze composition when CVEs land without rebuilding artifacts from scratch.
+
+## Common Mistakes
+
+| Mistake | Problem | Solution |
+|---------|---------|----------|
+| Blocking merges on all severities including unreachable lows | Developers disable scanning or ignore CI | Gate on reachable critical/high plus net-new findings; batch low severity separately |
+| Running SCA only on default branch nightly | New CVEs affect shipped services without owner notification | Add `snyk monitor` on main builds and route alerts to service owners |
+| Scanning `:latest` tags without digest pinning | Gates scan different images across pipeline runs | Tag and scan immutable digests; promote the same digest you scanned |
+| Ignoring license findings until legal review | Copyleft or policy violations ship to production | Include license rules in the same policy tier as security severities |
+| Personal `SNYK_TOKEN` in shared CI secrets | Broken pipelines when individuals leave; unclear audit trail | Use service account tokens scoped per team with rotation |
+| Auto-merging bot PRs without CI or semver policy | Production breaks from untested major upgrades | Require green CI; restrict auto-merge to patch/minor bands during pilot |
+| Duplicating Snyk and three OSS scanners on identical inputs | Conflicting severities erode developer trust | One enforcing gate per artifact; others for audit or SBOM export |
+| Treating reachability as permanent waiver | Code changes later import vulnerable paths silently | Re-scan on every PR; expire documented risk accepts on schedule |
 
 ## Quiz
 
 ### Question 1
-What is reachability analysis in Snyk?
 
-<details>
-<summary>Show Answer</summary>
+Your organization has ten thousand SCA findings after importing every repository into a scanner. Leadership wants a ninety-day remediation plan. How do reachability analysis and EPSS change the plan compared to sorting on CVSS alone?
 
-**Determining whether vulnerable code is actually called by your application**
+<details><summary>Answer</summary>
 
-Reachability analysis traces whether your code has a call path to the vulnerable function. A vulnerability in `lodash.set()` is only reachable if your code calls `lodash.set()`. This dramatically reduces false positives and helps prioritize what actually matters.
+Reachability analysis helps you focus on findings where application code may actually invoke vulnerable dependency functions, which prevents spending the ninety-day window on transitive packages never loaded at runtime. EPSS adds exploit-likelihood context beyond CVSS base scores so teams patch issues the community is actively weaponizing first. CVSS alone sorts technical severity but ignores whether the flaw is reachable in your code or likely to be exploited soon. Together they produce a fix queue sized for real engineering capacity instead of a impossible "fix everything" mandate.
+
 </details>
 
 ### Question 2
-What Snyk products are included in the platform?
 
-<details>
-<summary>Show Answer</summary>
+You must **configure Snyk for continuous vulnerability scanning across code, dependencies, containers, and IaC**. Which CLI commands map to each surface, and where does continuous monitoring fit?
 
-**Open Source (SCA), Code (SAST), Container, and IaC**
+<details><summary>Answer</summary>
 
-- **Open Source**: Dependency scanning (npm, pip, maven, etc.)
-- **Code**: Static application security testing (SAST)
-- **Container**: Docker/container image scanning
-- **IaC**: Terraform, CloudFormation, Kubernetes scanning
+Open Source dependency scanning uses `snyk test` against manifests and lockfiles. First-party code uses `snyk code test`. Container images use `snyk container test` with optional `--file=Dockerfile`. Infrastructure artifacts use `snyk iac test` against Terraform or Kubernetes paths. Continuous monitoring uses `snyk monitor` on default branch builds to register graphs for alerting when new advisories appear, complementing pull request `test` gates that block new issues at merge time. CI should authenticate with scoped `SNYK_TOKEN` secrets and apply consistent severity policies per service tier.
 
-Together they cover the full development lifecycle.
 </details>
 
 ### Question 3
-How does Snyk auto-fix work?
 
-<details>
-<summary>Show Answer</summary>
+A developer asks why they should merge Snyk bot PRs instead of running `npm update` manually. How do **fix PRs and upgrade suggestions** help?
 
-**Snyk generates pull requests with dependency updates that fix vulnerabilities**
+<details><summary>Answer</summary>
 
-When a fix is available (usually a newer version), Snyk:
-1. Determines the minimal upgrade needed
-2. Tests for breaking changes
-3. Creates a PR with the change
-4. Includes vulnerability details and remediation info
+Fix PRs propose minimal upgrades tied to specific advisories with lockfile changes reviewers can diff, rather than broad updates that mix unrelated version bumps. They document which CVE each change addresses, run through the same CI tests as human PRs, and scale remediation across hundreds of repositories without assigning CVE spreadsheets to every team. Manual `npm update` may jump majors or skip the vulnerable transitive path the scanner identified. Bot PRs are not magic — teams still need semver policy and CI — but they convert abstract CVE rows into reviewable dependency changes.
 
-These PRs have 80%+ merge rates because they're actually correct.
 </details>
 
 ### Question 4
-What is the difference between `snyk test` and `snyk monitor`?
 
-<details>
-<summary>Show Answer</summary>
+Your pipeline builds `app:${{ github.sha }}`, scans nothing, and pushes to production. How should you **deploy Snyk Container scanning in CI/CD** before promotion?
 
-**`test` is point-in-time; `monitor` sets up continuous monitoring**
+<details><summary>Answer</summary>
 
-- `snyk test`: Scans now, returns results, that's it
-- `snyk monitor`: Uploads project to Snyk dashboard for ongoing monitoring, alerts on new vulnerabilities, enables auto-fix PRs
+Build the image once in CI, tag it with an immutable reference such as the commit SHA or digest, run `snyk container test` against that tag with `--file=Dockerfile`, and fail or warn according to policy before pushing to the registry consumers deploy from. Scanning after promotion or scanning floating `:latest` tags creates gates that do not match the artifact running in production. Pair CI scanning with registry admission where possible so unscanned images cannot deploy if someone bypasses the pipeline.
 
-Use `test` in CI for gates; use `monitor` for visibility.
 </details>
 
 ### Question 5
-Why might you use `--severity-threshold` in CI?
 
-<details>
-<summary>Show Answer</summary>
+Security wants every finding in the IDE; developers disable the plugin after one week. How do you **integrate Snyk with IDE plugins and Git hooks for shift-left security** without destroying flow?
 
-**To only fail the build on vulnerabilities above a certain severity**
+<details><summary>Answer</summary>
 
-```bash
-snyk test --severity-threshold=high
-```
+Configure IDE severity filters to match team policy so gutters show actionable issues, not every informational finding. Trust only relevant workspace folders and document authentication with personal or SSO-backed tokens rotated on schedule. Use optional pre-push hooks during adoption, then standardize hooks once fix paths exist. Shift-left complements — does not replace — CI gates: IDE catches early mistakes; pipeline enforces merge policy. Link findings to short internal docs and Snyk Learn modules so developers know how to fix issues without opening tickets for every advisory.
 
-This fails only on high and critical vulnerabilities, not medium/low. It prevents blocking builds on theoretical/low-risk issues while still catching important ones.
 </details>
 
 ### Question 6
-What's the benefit of Snyk's base image recommendations for containers?
 
-<details>
-<summary>Show Answer</summary>
+Compare Snyk Open Source SCA with OWASP Dependency-Check for a Maven monorepo. What capability overlaps, and what operational tradeoffs differ?
 
-**Suggests alternative base images with fewer vulnerabilities**
+<details><summary>Answer</summary>
 
-When scanning `node:16`, Snyk might recommend:
-- `node:16-slim` (fewer OS packages)
-- `node:16-alpine` (much smaller, fewer vulns)
-- `distroless/nodejs` (minimal attack surface)
+Both correlate dependency graphs against advisory data — Dependency-Check traditionally emphasizes NVD feeds while Snyk adds proprietary enrichment, reachability on supported ecosystems, and fix PR automation. Dependency-Check fits teams wanting OSS CI integration they operate themselves; Snyk adds developer UX and centralized policy at license cost. Neither replaces container scanning for OS packages inside images; compose tools by artifact type. Choose based on staffing, budget, and whether developers need bot PRs versus report-only workflows.
 
-This helps reduce vulnerabilities without changing your code.
 </details>
 
 ### Question 7
-How does Snyk Code differ from traditional SAST tools?
 
-<details>
-<summary>Show Answer</summary>
+Explain why an SBOM exported at release time helps when a critical CVE is published Saturday night.
 
-**AI-trained on fixes, not just bug patterns, with real-time IDE scanning**
+<details><summary>Answer</summary>
 
-Snyk Code:
-- Trained on millions of open source fixes
-- Fast enough for real-time IDE scanning
-- Shows how to fix, not just what's wrong
-- Lower false positive rate
-- Data flow analysis like CodeQL but faster
+An SBOM lists components and versions shipped in the release artifact. When a new CVE drops, security can query SBOMs or re-scan them with updated advisory data to identify affected services without rebuilding every repository from scratch. CycloneDX and SPDX standardize that inventory exchange with customers and regulators. SBOMs do not replace continuous monitoring, but they accelerate incident response by answering "where is this version deployed?" faster than guessing from memory.
 
-Traditional SAST is often slow and noisy.
 </details>
 
 ### Question 8
-What is a baseline in Snyk?
 
-<details>
-<summary>Show Answer</summary>
+Your team runs Dependabot on GitHub and Snyk in CI on the same Node service. When is that complementary, and when is it duplicate noise?
 
-**A snapshot of existing vulnerabilities to ignore in future scans**
+<details><summary>Answer</summary>
 
-When you have 1000 existing vulnerabilities, you might:
-1. Create a baseline with `snyk ignore`
-2. Only alert on new vulnerabilities introduced after baseline
-3. Gradually fix baseline issues separately
+Complementary when Dependabot proposes routine version bumps while Snyk enforces reachable critical gates, SAST via Snyk Code, and container scanning on the shipped image — each tool owns a distinct artifact or policy layer. Duplicate noise when both block merges on the same lockfile with conflicting severity labels and no documented primary enforcer. Document which tool is authoritative for merge blocking and demote the other to informational or SBOM export until policies harmonize.
 
-This prevents alert fatigue while still catching new issues.
 </details>
 
----
+## Hands-On
 
-## Key Takeaways
+Configure Snyk locally on a small Node project with intentional vulnerable dependencies, run multi-surface scans, and wire a CI workflow stub you can adapt to your platform templates.
 
-1. **Reachability is the killer feature** - Focus on exploitable, not theoretical
-2. **Auto-fix PRs scale security** - Merge fixes, don't write them
-3. **Four products, one platform** - SCA, SAST, Container, IaC
-4. **Developer-first design** - IDE integration, actionable results
-5. **Smart CI gates** - Block critical + reachable, not everything
-6. **Base image recommendations** - Easy container wins
-7. **`snyk monitor` for continuous** - Don't just scan once
-8. **License compliance included** - Legal risk, not just security
-9. **Free tier is generous** - Start without budget approval
-10. **Integration is key** - CI/CD, IDE, PR workflows
+**Steps**:
 
----
+```bash
+mkdir snyk-lab && cd snyk-lab
+npm init -y
+npm install lodash@4.17.20 express@4.17.1
 
-## Next Steps
+cat > index.js << 'EOF'
+const express = require('express');
+const _ = require('lodash');
 
-- **Next Module**: [Module 12.5: Trivy](../module-12.5-trivy/) - Open source alternative
-- **Related**: [Module 4.4: Supply Chain Security](/platform/toolkits/security-quality/security-tools/module-4.4-supply-chain/) - SBOM and signing
-- **Related**: [Module 13.1: Harbor](/platform/toolkits/cicd-delivery/container-registries/module-13.1-harbor/) - Registry with Snyk integration
+const app = express();
+app.get('/config', (req, res) => {
+  const config = {};
+  _.set(config, req.query.path, req.query.value);
+  res.json(config);
+});
+app.listen(3000);
+EOF
 
----
+npm install -g snyk
+snyk auth
+snyk test
+snyk test --json | jq '.vulnerabilities[] | {title, severity, packageName}'
+snyk monitor --project-name=snyk-lab-local
+```
 
-## Further Reading
+Create `.github/workflows/snyk.yml` using the multi-job example from this module (Open Source job minimum). Store `SNYK_TOKEN` as a repository secret before enabling CI.
 
-- [Snyk Documentation](https://docs.snyk.io/)
-- [Snyk Learn](https://learn.snyk.io/) - Free security training
-- [Snyk Vulnerability Database](https://snyk.io/vuln/)
-- [Snyk API Reference](https://snyk.docs.apiary.io/)
-- [Snyk CLI Reference](https://docs.snyk.io/snyk-cli)
+**Success criteria**:
 
----
+- [ ] `snyk test` reports at least one high-severity Open Source finding against the lab lockfile
+- [ ] `snyk monitor` succeeds and the project appears in the Snyk web UI with the chosen project name
+- [ ] A GitHub Actions workflow (or equivalent CI stub) runs `snyk test` with `--severity-threshold=high` on pull requests
+- [ ] You can explain which findings would be prioritized first using reachability and severity, even if reachability is unavailable for every ecosystem in the lab
 
-*"The best vulnerability scanner is the one developers actually use. Snyk understood that fixing problems is more important than finding them."*
+## Sources
+
+- [Snyk documentation hub](https://docs.snyk.io/) — product overview, integration paths, and CLI reference entry point
+- [Snyk CLI](https://docs.snyk.io/snyk-cli) — installation, authentication, and command catalog
+- [Snyk test command](https://docs.snyk.io/snyk-cli/commands/test) — point-in-time scanning and CI exit codes
+- [Snyk monitor command](https://docs.snyk.io/snyk-cli/commands/monitor) — continuous project snapshots and alerting
+- [Snyk reachability analysis](https://docs.snyk.io/manage-risk/prioritize-issues-for-fixing/reachability-analysis) — prioritization based on call-path analysis
+- [Snyk prioritization overview](https://docs.snyk.io/manage-risk/prioritize-issues-for-fixing) — risk factors beyond raw severity
+- [Snyk container scanning](https://docs.snyk.io/scan-containers) — image scanning and Dockerfile context
+- [Snyk Code](https://docs.snyk.io/snyk-code) — developer-first SAST product documentation
+- [Snyk GitHub Actions integration](https://docs.snyk.io/integrations/ci-cd-integrations/github-actions-integration) — maintained CI workflow patterns
+- [Snyk vulnerability database](https://security.snyk.io/) — advisory lookup and enrichment reference
+- [Snyk Learn](https://learn.snyk.io/) — free vulnerability education modules
+- [CVE Program](https://www.cve.org/) — standardized vulnerability identifiers
+- [FIRST CVSS](https://www.first.org/cvss/) — Common Vulnerability Scoring System specification
+- [FIRST EPSS](https://www.first.org/epss/) — Exploit Prediction Scoring System
+- [OWASP Component Analysis](https://owasp.org/www-community/Component_Analysis) — SCA practice overview
+- [OWASP Dependency-Check](https://owasp.org/www-project-dependency-check/) — OSS dependency scanner project
+- [CycloneDX specification](https://cyclonedx.org/) — SBOM standard
+- [SPDX project](https://spdx.dev/) — software bill of materials and license identifiers
+- [GitHub Dependabot documentation](https://docs.github.com/en/code-security/dependabot) — native dependency update automation
+- [Trivy documentation](https://aquasecurity.github.io/trivy/) — OSS peer for container, filesystem, and IaC scanning (Module 12.5)
+- [Grype repository](https://github.com/anchore/grype) — OSS vulnerability scanner from Anchore
+- [CISA Known Exploited Vulnerabilities catalog](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) — authoritative list of actively exploited CVEs
+
+## Next Module
+
+Continue to [Module 12.5: Trivy](../module-12.5-trivy/) for the open-source peer that covers container, filesystem, and IaC scanning without a commercial control plane — compare capability tradeoffs using the Rosetta table from this module rather than treating either tool as universally superior.

--- a/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.5-trivy.md
+++ b/src/content/docs/platform/toolkits/security-quality/code-quality/module-12.5-trivy.md
@@ -1,5 +1,5 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 12.5: Trivy - The Swiss Army Knife of Security Scanning"
 slug: platform/toolkits/security-quality/code-quality/module-12.5-trivy
 sidebar:
@@ -13,7 +13,7 @@ sidebar:
 ## Prerequisites
 
 Before starting this module, you should have completed:
-- [DevSecOps Discipline](/platform/disciplines/reliability-security/devsecops/) - Security scanning concepts
+- [DevSecOps Discipline](/platform/disciplines/reliability-security/devsecops/module-4.1-devsecops-fundamentals/) - Security scanning concepts
 - Container fundamentals (images, Dockerfiles)
 - Basic Kubernetes knowledge
 - CI/CD basics
@@ -29,99 +29,87 @@ After completing this module, you will be able to:
 - **Implement Trivy Operator for continuous Kubernetes cluster scanning with vulnerability and config audit reports**
 - **Compare Trivy's open-source scanning against commercial alternatives for enterprise security requirements**
 
+---
 
 ## Why This Module Matters
 
-**The Open Source Security Scanner That Does Everything**
+The typical security scanning setup in a mid-sized engineering organization looks something like this: one tool for container image scanning, another for infrastructure-as-code misconfigurations, a third for secret detection, a fourth for software bill of materials generation, and possibly a fifth to scan the running Kubernetes cluster. Each tool has its own installation method, its own configuration format, its own output schema, and its own CI/CD integration. The result is not better security — it is operational fatigue. Engineers spend more time maintaining the scanning infrastructure than responding to the findings it produces.
 
-The security architect stared at her spreadsheet in disbelief. After three months of evaluating security tools, she had mapped out what her fintech startup needed to meet SOC2 requirements: Grype for container scanning ($0, but no IaC), Checkov for Terraform ($0, but no containers), Syft for SBOMs ($0, but separate from scanning), Gitleaks for secrets ($0, but another integration), and Snyk for the dashboard ($15,000/year for 30 developers).
+Unified vulnerability and misconfiguration scanning addresses this problem at its root. Instead of assembling a patchwork of specialized scanners, a single tool that understands container images, filesystems, Git repositories, Kubernetes clusters, and infrastructure-as-code templates provides consistent severity ratings, a unified output format, and a single configuration surface. This is the category that Trivy occupies, and it is the reason the tool has become a default choice in registries like Harbor and in countless CI pipelines. The capability itself — unified, open-source scanning across targets — is durable regardless of which specific tool implements it. The principles you learn here transfer to any scanner that follows the same unified model.
 
-"That's five tools, five CI integrations, five different output formats, and $15K," she reported to the CISO. "And we still need someone to correlate all the findings."
+> **Hypothetical scenario:**
+>
+> A platform team at a growing SaaS company is preparing for their first SOC 2 Type II audit. They have 30 microservices, each with its own Dockerfile, a Terraform-managed infrastructure, and a Kubernetes cluster running in production. Six weeks before the audit, they discover they have no documented evidence that container images are scanned before deployment. The engineering manager evaluates five separate tools — Grype for containers, Checkov for Terraform, Syft for SBOMs, Gitleaks for secrets, and a commercial scanner for the cluster — and estimates three weeks of integration work plus ongoing maintenance across five CI configurations. A colleague suggests trying a single unified scanner. After a two-hour proof of concept, they have container scanning, IaC auditing, secret detection, and SBOM generation all running from one tool, with a single JSON output format and one `.trivyignore` file for accepted risks. The integration effort drops from three weeks to two days. The audit passes because every image has a scan record, every deployment has an SBOM, and every Terraform change is checked for misconfigurations before apply. The team redirects the saved engineering time toward actually fixing the vulnerabilities the scanner found.
 
-"What about that Trivy thing Harbor uses?" the CISO asked.
-
-She hadn't seriously considered it—surely a free tool couldn't do everything. But after a two-hour proof of concept, she deleted her spreadsheet. Trivy did container scanning, IaC scanning, SBOM generation, secret detection, and Kubernetes cluster scanning. One tool. One configuration. One output format.
-
-The fintech passed their SOC2 audit with zero additional tooling costs. The security architect became Trivy's biggest internal advocate—and eventually, an Aqua Security customer success story.
-
-Trivy isn't the deepest scanner in any single category, but it's remarkably good across all of them. It's completely free, backed by Aqua Security, and it's become the default scanner in Harbor, AWS Inspector, and countless CI pipelines.
+Understanding unified scanning means you can decide intelligently whether one tool that is "good enough" across all targets serves your organization better than a collection of best-in-breed point solutions — and you will know how to implement either choice correctly.
 
 ---
 
-## Did You Know?
+## The Unified Scanning Philosophy
 
-- **Trivy started as a weekend project and became a CNCF project in 3 years** — Teppei Fukuda, an Aqua Security engineer, built Trivy in 2019 because existing scanners were too slow and required too much setup. He optimized the vulnerability database download and caching until first scan ran in under 15 seconds. By 2022, Trivy had 15,000+ GitHub stars and joined the CNCF sandbox. Today it's the most-starred container security project on GitHub.
+Every security scanner operates on the same fundamental model: it examines a target, compares what it finds against a database of known issues, and produces a report. What changes between tools is which targets they can examine and which databases they consult. When an organization deploys separate scanners for container images, infrastructure code, Git repositories, and running clusters, it is not gaining fundamentally different capabilities — it is paying the integration tax multiple times.
 
-- **AWS built Inspector on Trivy because they couldn't beat it** — When AWS launched the new Inspector in 2021, security researchers noticed something interesting: the vulnerability signatures matched Trivy exactly. AWS confirmed they use Trivy's engine under the hood, adding their own database updates. Even Amazon couldn't build a better scanner—so they adopted the open source one.
+The integration tax shows up in several concrete ways. First, each tool produces findings in its own format: one outputs JSON with a `vulnerabilities` array, another uses a `findings` key with different field names, and a third produces SARIF while a fourth uses a proprietary schema. To build a unified dashboard or feed findings into a SIEM, someone has to write and maintain a normalization layer that understands each schema. Second, severity ratings are not consistent across tools. A vulnerability that one scanner rates CRITICAL might register as HIGH in another because they consult different advisory databases or apply different environmental adjustments. This inconsistency erodes trust: when the dashboard shows conflicting severities for the same CVE, teams learn to ignore both. Third, each tool requires its own configuration for ignoring false positives, setting severity thresholds, and defining scan scope. When a new CVE drops and every team needs to add an exception, they have to update five different ignore files in five different formats.
 
-- **Harbor chose Trivy after a year-long evaluation that tested 8 scanners** — The Harbor team evaluated Clair, Anchore, Aqua Scanner, and five others before selecting Trivy as the default. The deciding factors: scan speed (10x faster than Clair), accuracy (lowest false positive rate), and operational simplicity (single binary, no database server required).
+A unified scanner collapses all of this into a single operational surface. One JSON schema for all findings. One severity scale applied consistently because the same vulnerability database backs every target. One configuration file for ignore rules and thresholds. One CI integration that covers container, filesystem, IaC, and secret scanning in a single pipeline step. The operational simplification is not a minor convenience — it is the difference between a scanning program that engineers maintain and one they abandon.
 
-- **The Log4Shell incident made Trivy famous overnight** <!-- incident-xref: log4shell --> — On December 9, 2021, the Log4j vulnerability (CVE-2021-44228) was disclosed. Within 4 hours, Trivy had detection rules. Within 24 hours, thousands of companies had run `trivy fs --scanners vuln .` for the first time. Trivy downloads spiked 400% that week—and many of those emergency users became permanent adopters. For the Log4Shell canonical, see [Supply Chain Security](../../../disciplines/reliability-security/devsecops/module-4.4-supply-chain-security/).
-
-- **In March 2026, Trivy itself was compromised in the TeamPCP supply chain attack** — Threat actor TeamPCP rewrote Git tags in the `trivy-action` GitHub Action repository, pointing tag `v0.69.4` to a malicious release. The compromised action exfiltrated CI/CD secrets from any pipeline that used `trivy-action@latest` or an unpinned tag. The most high-profile victim was LiteLLM (3.4M daily PyPI downloads), whose stolen `PYPI_PUBLISH` token was used to push backdoored packages that deployed persistent pods into victim Kubernetes clusters. The incident proved that even trusted security tools can become attack vectors -- and that pinning GitHub Actions to commit SHAs (not tags) is not optional. See [Module 4.4: Supply Chain Security](/platform/disciplines/reliability-security/devsecops/module-4.4-supply-chain-security/) for the full postmortem.
+This philosophy aligns directly with the DevSecOps principle of making security "invisible" to developers: the scanner should integrate into existing workflows without demanding that developers learn five different tools, five different output formats, and five different exception processes. When security tooling creates friction, developers route around it. When it is transparent, they accept it as part of the build pipeline, and scanning coverage approaches 100 percent. Cross-reference the DevSecOps tool-class taxonomy in [Module 4.1: DevSecOps Fundamentals](/platform/disciplines/reliability-security/devsecops/module-4.1-devsecops-fundamentals/) for the broader architectural context in which unified scanning operates.
 
 ---
 
-## What Trivy Scans
+## How Image Scanning Works Under the Hood
 
-```
-TRIVY CAPABILITIES
-─────────────────────────────────────────────────────────────────
+Container image scanning is the capability most people associate with vulnerability scanners, and understanding its internals reveals why some findings matter more than others. When Trivy scans a container image, it does not simply run a single check. It decomposes the image into layers, identifies every installed package across both the operating system layer and the application dependency layer, and cross-references each package against multiple vulnerability databases.
 
-┌─────────────────────────────────────────────────────────────────┐
-│                        TRIVY TARGETS                             │
-├─────────────────────────────────────────────────────────────────┤
-│                                                                  │
-│  CONTAINER IMAGES                                               │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  • OS packages (Alpine, Debian, Ubuntu, RHEL, etc.)       │  │
-│  │  • Language packages (npm, pip, gem, etc.)                │  │
-│  │  • Licenses                                                │  │
-│  │  • Secrets embedded in images                             │  │
-│  │  • Misconfigurations                                      │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                  │
-│  FILESYSTEMS & REPOSITORIES                                     │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  • Dependencies (package-lock.json, go.sum, etc.)         │  │
-│  │  • Secrets in code                                         │  │
-│  │  • IaC misconfigurations                                  │  │
-│  │  • License compliance                                      │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                  │
-│  KUBERNETES                                                     │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  • Cluster misconfigurations                              │  │
-│  │  • Workload vulnerabilities                               │  │
-│  │  • RBAC analysis                                          │  │
-│  │  • Network policies                                       │  │
-│  │  • Secrets in cluster                                     │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                  │
-│  INFRASTRUCTURE AS CODE                                         │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  • Terraform                                               │  │
-│  │  • CloudFormation                                          │  │
-│  │  • Kubernetes YAML                                         │  │
-│  │  • Helm charts                                             │  │
-│  │  • Docker Compose                                          │  │
-│  │  • Ansible                                                 │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                  │
-│  SBOM                                                           │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  • Generate CycloneDX                                      │  │
-│  │  • Generate SPDX                                           │  │
-│  │  • Scan existing SBOMs                                     │  │
-│  │  • Attestations                                            │  │
-│  └───────────────────────────────────────────────────────────┘  │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
+### OS Packages vs. Language Dependencies
+
+A container image typically contains two distinct categories of software. The operating system packages — `libssl`, `curl`, `glibc`, `openssl` — come from the base image's package manager (apt, apk, yum). Language dependencies — `express`, `lodash`, `requests`, `jackson-databind` — come from the application's package manager (npm, pip, maven, bundler). These two categories are fundamentally different in how they are updated and how their vulnerabilities should be handled. An OS package vulnerability is fixed by rebuilding the image with an updated base image tag. A language dependency vulnerability is fixed by updating a version constraint in `package.json` or `requirements.txt` and rebuilding. Understanding this distinction matters because the remediation path is different, and the urgency may be different too — an OS-level remote code execution vulnerability in `openssl` is typically more dangerous than a prototype pollution vulnerability in a frontend JavaScript library that never processes untrusted input.
+
+Trivy separates these findings in its output, labeling OS package vulnerabilities with their source package name and language vulnerabilities with their ecosystem and library name. This separation allows teams to route findings to the right owners: OS vulnerabilities to the platform team managing base images, and language vulnerabilities to the application teams owning the dependency manifests.
+
+### The Vulnerability Database Pipeline
+
+At the heart of every scanner is a vulnerability database. Trivy maintains its own database — the Trivy DB — which aggregates advisories from multiple upstream sources: the National Vulnerability Database (NVD), distribution-specific security trackers (Debian Security Tracker, Red Hat Security Data, Alpine SecDB), GitHub Security Advisories, and language-specific advisory databases (npm audit, PyPA Advisory Database, RustSec). The Trivy DB is updated every six hours and distributed as a compact binary blob that the scanner downloads and caches locally. This local caching is the reason Trivy can complete a first scan in seconds rather than minutes: the database is already on disk, and subsequent scans only query it and download incremental updates.
+
+The freshness of the vulnerability database is a critical operational concern. A scanner with a week-old database will miss vulnerabilities disclosed in the last seven days. Trivy's default behavior is to download the latest database before each scan, but in air-gapped environments or CI pipelines where external network access is restricted, you can use the `--skip-db-update` flag and rely on a separately managed database cache. The `--db-repository` flag even allows pointing Trivy at a private OCI registry that mirrors the database, enabling fully offline scanning.
+
+### Layer Caching and Rebuild Economics
+
+Container images are composed of layers, and the vulnerability status of a layer changes only when the packages inside it change. Trivy exploits this by caching scan results per layer. If you rebuild an application image and only the top layer (your application code) changed, Trivy can reuse the cached scan results for all lower layers — the base OS layer, the installed system packages, and the language runtime. This layer-aware caching dramatically reduces scan time in CI pipelines where the same base image is used across many builds.
+
+This caching behavior also explains why pinning image tags matters for security. If your Dockerfile specifies `FROM node:16`, the actual base image you get depends on when the build runs — the `node:16` tag is mutable and may point to a different digest tomorrow than it did today. A vulnerability that did not exist in yesterday's build may appear in today's because the base image was rebuilt with an updated package that introduced a new CVE. Conversely, a vulnerability that was fixed upstream may disappear. To make vulnerability scanning deterministic — and to make audit trails reproducible — always pin base images to digests: `FROM node:16@sha256:abc123...`. This guarantees that the same scan results apply to every build using that exact image, and it prevents the "mystery vulnerability" that appears when a floating tag silently updates.
+
+A concrete example of why this matters: in August 2025, Bitnami moved its container images from the `bitnami/*` namespace to `bitnamilegacy/*` for legacy tags while transitioning to a new versioning scheme. Teams that were pinning to `bitnami/postgresql:14.7.0` found their builds failing because the tag no longer resolved. Teams that were using floating tags found themselves pulling entirely different images with different vulnerability profiles. The lesson is not about Bitnami specifically — it is that image references are contracts, and floating tags break those contracts silently. Pin to digests whenever reproducibility matters.
 
 ---
 
-## Installation
+## Infrastructure as Code and Misconfig Scanning
+
+Vulnerability scanning asks "does this software contain known bugs?" Misconfiguration scanning asks a different question: "is this software configured in a way that creates security risk?" The distinction matters because a perfectly patched container running as root with a wide-open security group is still dangerous. Trivy's misconfiguration scanner — which absorbed the capabilities of the former tfsec project when Aqua Security folded it into Trivy — checks infrastructure-as-code templates, Kubernetes manifests, Dockerfiles, and Helm charts against a library of hundreds of policy rules. This consolidation was not just an acquisition — it reflected a deliberate product strategy of making Trivy the single tool that could answer every security question about an artifact, from "does this image contain known vulnerabilities?" to "is this Terraform module going to create an insecure S3 bucket?" to "does this Kubernetes manifest run containers as root?"
+
+### How Policy Checking Works
+
+Each misconfiguration rule in Trivy is a small program that examines a specific pattern in a configuration file. A rule might check that an AWS S3 bucket has server-side encryption enabled, that a Kubernetes container does not run as root, that a Dockerfile does not expose port 22, or that a Terraform security group does not allow ingress from `0.0.0.0/0` on administrative ports. The rule library is organized by platform (AWS, GCP, Azure, Kubernetes, Docker) and by severity (CRITICAL, HIGH, MEDIUM, LOW), following a taxonomy similar to vulnerability severity scoring.
+
+When Trivy scans a directory of Terraform files, it does not execute the Terraform — it parses the HCL directly and builds an internal representation of the resources and their attributes. It then evaluates each applicable rule against that representation. If a rule fires, the finding includes the file path, line number, a description of the issue, and a link to the Aqua Vulnerability Database entry for that misconfiguration ID, which provides remediation guidance.
+
+This approach has a key limitation: Trivy can only check what is statically declared in the configuration files. It cannot detect misconfigurations that arise from dynamic behavior, Terraform modules that generate resources at apply time, or configurations spread across multiple files that only become dangerous in combination. This is not a flaw in Trivy — it is a fundamental constraint of static analysis — but it means that IaC scanning is a complement to, not a replacement for, runtime security controls like admission webhooks and network policies.
+
+### Custom Policies with Rego
+
+For organizations that need to enforce rules beyond the built-in policy library, Trivy supports custom policies written in Rego, the policy language from Open Policy Agent (OPA). A Rego policy for Trivy is a small program that receives the parsed configuration as input and returns a set of rule results. This allows teams to encode organization-specific requirements — for example, "every S3 bucket must have a tag named `data_classification`" or "no Kubernetes Deployment may use the `latest` image tag" — as automated checks that run alongside the built-in rules.
+
+The ability to write custom policies transforms Trivy from a generic scanner into an organization-specific compliance tool. Rather than maintaining a separate policy-as-code system for infrastructure guardrails, teams can encode their infrastructure policies in the same tool that scans for vulnerabilities and secrets. The operational simplification is the same as with unified scanning: one tool, one configuration format, one exception process.
+
+---
+
+## Trivy as the Worked Example
+
+Trivy is an open-source security scanner maintained by Aqua Security. It is distributed as a single static binary (written in Go) with no external runtime dependencies — no database server, no agent, no background service required for basic scanning. This architectural simplicity is a deliberate design choice: a scanner that requires a separate database service to operate is a scanner that cannot run in a CI pipeline without additional infrastructure, which means it will not be run consistently. Trivy's self-contained design — download the binary, run it, get results — removes that barrier entirely.
+
+The tool has been integrated into Harbor as its default vulnerability scanner, is available as a GitHub Action, a Kubernetes operator, a VS Code extension, and a standalone CLI. The current stable version as of mid-2026 is in the 0.71.x line, with active development continuing on GitHub (36,000+ stars as of this writing). The breadth of integration points reflects the unified scanning philosophy: whether a developer wants to scan from their editor, a CI pipeline wants to scan during build, or a cluster operator wants continuous scanning of running workloads, the same tool with the same configuration model and the same output format serves all three contexts.
+
+### Installation
 
 ```bash
 # macOS (Homebrew)
@@ -144,406 +132,153 @@ docker run aquasec/trivy image nginx:latest
 trivy version
 ```
 
----
+### Container Image Scanning
 
-## Container Scanning
-
-### Basic Usage
+The `trivy image` command is the most commonly used subcommand. It pulls the specified image (or reads it from a local tar file with `--input`), decomposes it into layers, identifies all installed packages and their versions, and cross-references them against the Trivy DB. The output separates OS package findings from language dependency findings, making it clear which team owns each remediation.
 
 ```bash
-# Scan an image
+# Scan an image from a registry
 trivy image nginx:latest
 
-# Scan local image (not from registry)
-trivy image --input myapp.tar
-
-# Scan with severity filter
+# Scan with severity filter (only CRITICAL and HIGH findings)
 trivy image --severity HIGH,CRITICAL nginx:latest
 
-# Scan only OS packages
+# Scan only OS-level packages
 trivy image --vuln-type os nginx:latest
 
-# Scan only language packages
+# Scan only language-level dependencies
 trivy image --vuln-type library nginx:latest
 
-# Output as JSON
+# Output as machine-readable JSON
 trivy image --format json --output results.json nginx:latest
 
-# Output as SARIF (for GitHub Security)
+# Output as SARIF (for GitHub Code Scanning integration)
 trivy image --format sarif --output trivy.sarif nginx:latest
+
+# Ignore vulnerabilities with no available fix
+trivy image --ignore-unfixed nginx:latest
 ```
 
-### Understanding Results
+The `--ignore-unfixed` flag is particularly important in operational pipelines. When a CVE is disclosed, it may take days or weeks for the upstream package maintainer to release a patched version. Until a fix is available, a scanner will report the vulnerability on every run. If your CI pipeline blocks on every CRITICAL finding, an unfixed CVE will halt all deployments until a fix is published — which may be outside your control. The `--ignore-unfixed` flag tells Trivy to report only vulnerabilities that have an available fix, so your pipeline gates on actionable findings rather than on the upstream patch release schedule.
 
-```
-TRIVY CONTAINER SCAN OUTPUT
-─────────────────────────────────────────────────────────────────
+This flag embodies a broader principle in security scanning: distinguish between findings you can fix and findings you can only track. A CVE with no available patch is still a risk, and it still belongs in your vulnerability register, but blocking deployments on it does not reduce risk — it only reduces delivery velocity. The correct response to an unfixed CVE is to assess whether the vulnerable code path is reachable in your application, document the assessment in a VEX statement or an exception tracker, and set a review cadence to re-evaluate when a patch becomes available. The scanner's job is to surface the finding; the team's job is to decide what to do about it. A pipeline gate that cannot distinguish "fixable" from "trackable" conflates these two very different categories and eventually trains teams to route around the gate entirely.
 
-$ trivy image nginx:1.21
+### Filesystem and Repository Scanning
 
-nginx:1.21 (debian 11.2)
-========================
-Total: 142 (UNKNOWN: 0, LOW: 98, MEDIUM: 31, HIGH: 11, CRITICAL: 2)
+The `trivy fs` command scans a local directory tree, identifying dependency manifests (`package.json`, `go.sum`, `requirements.txt`, `pom.xml`, and dozens of others) and checking them against language-specific vulnerability databases. It can also scan for secrets and misconfigurations in the same pass.
 
-┌───────────────────┬──────────────────┬──────────┬────────────────┐
-│      Library      │  Vulnerability   │ Severity │ Fixed Version  │
-├───────────────────┼──────────────────┼──────────┼────────────────┤
-│ curl              │ CVE-2023-38545  │ CRITICAL │ 7.74.0-1.3+deb │
-│                   │                  │          │ 11u10          │
-├───────────────────┼──────────────────┼──────────┼────────────────┤
-│ openssl           │ CVE-2023-5678   │ HIGH     │ 1.1.1n-0+deb11 │
-│                   │                  │          │ u5             │
-├───────────────────┼──────────────────┼──────────┼────────────────┤
-│ ...               │ ...              │ ...      │ ...            │
-└───────────────────┴──────────────────┴──────────┴────────────────┘
-
-Node.js (package.json)
-======================
-Total: 5 (HIGH: 3, MEDIUM: 2)
-
-┌───────────────────┬──────────────────┬──────────┬────────────────┐
-│      Library      │  Vulnerability   │ Severity │ Fixed Version  │
-├───────────────────┼──────────────────┼──────────┼────────────────┤
-│ lodash            │ CVE-2021-23337  │ HIGH     │ 4.17.21        │
-│ axios             │ CVE-2021-3749   │ HIGH     │ 0.21.2         │
-└───────────────────┴──────────────────┴──────────┴────────────────┘
-```
-
-### Scanning Configuration
-
-```yaml
-# trivy.yaml
-scan:
-  # Skip update of vulnerability database
-  skip-db-update: false
-
-  # Scanners to use
-  scanners:
-    - vuln
-    - secret
-    - misconfig
-
-severity:
-  - CRITICAL
-  - HIGH
-  - MEDIUM
-
-# Ignore unfixed vulnerabilities
-ignore-unfixed: true
-
-# Timeout
-timeout: 10m
-
-# Cache directory
-cache-dir: /tmp/trivy-cache
-
-# Exit code when vulnerabilities found
-exit-code: 1
-```
+When you run `trivy fs .` in a project root, Trivy recursively walks the directory tree, detects which package ecosystems are present by matching known manifest filenames, parses each manifest to extract the dependency graph (including transitive dependencies), and cross-references every resolved version against the appropriate advisory database. For a Node.js project, it reads `package-lock.json` to get the exact resolved versions rather than the semver ranges in `package.json`, because a version range like `^4.17.0` does not tell you whether the installed version is 4.17.20 (vulnerable) or 4.17.21 (patched). This is why lockfiles are critical for accurate scanning: without a lockfile, Trivy must assume the worst case for every semver range, which produces false positives for ranges that would resolve to a patched version in practice.
 
 ```bash
-# Use config file
-trivy image --config trivy.yaml nginx:latest
-```
-
----
-
-## Filesystem Scanning
-
-### Scanning Source Code
-
-```bash
-# Scan current directory
+# Scan the current directory for vulnerabilities
 trivy fs .
 
-# Scan specific directory
-trivy fs /path/to/project
-
-# Include secrets scanning
+# Scan with all scanners enabled (vulnerabilities, secrets, misconfigs)
 trivy fs --scanners vuln,secret,misconfig .
 
-# Scan for specific package types
+# Scan only specific package ecosystems
 trivy fs --pkg-types npm,pip .
 ```
 
-### Scanning Git Repositories
+The `trivy repo` command is a convenience wrapper that clones a remote repository, scans it, and discards the clone. It is useful for auditing third-party dependencies or checking an open-source project before incorporating it into your supply chain. For reproducibility, always scan a specific commit rather than a branch head.
 
 ```bash
-# Scan remote repository
+# Scan a remote Git repository
 trivy repo https://github.com/aquasecurity/trivy
 
-# Scan specific branch
+# Scan a specific branch or commit
 trivy repo --branch develop https://github.com/myorg/myrepo
-
-# Scan with commit (for reproducibility)
-trivy repo --commit abc123 https://github.com/myorg/myrepo
 ```
 
----
+### Secret Detection
 
-## Infrastructure as Code Scanning
+Trivy's secret scanner checks for over 100 patterns of credentials, API keys, private keys, and tokens. It scans both the current filesystem state and, when used with `trivy repo`, the entire Git history. The scanner uses regular expressions and entropy-based heuristics to identify potential secrets without requiring a pre-configured list of known credential formats.
 
-### Terraform
+Secret scanning is most effective when it runs in pre-commit hooks or early in CI, before a secret ever reaches a shared repository. Once a secret is committed to Git, even if it is later removed, it remains in the commit history and must be rotated. Trivy's scanner can detect secrets in existing commits, but detection after the fact is damage control, not prevention. The real value of secret scanning is in catching credentials before they are pushed — integrated into a pre-commit hook via `trivy fs --scanners secret` on staged files, or run as the first step in CI before any other tool touches the codebase.
+
+One operational nuance: secret scanners produce false positives on test fixtures, example configuration files, and documentation. A file named `config/example.env` that contains `AWS_SECRET_ACCESS_KEY=your-secret-key` is not a leak, but a regex-based scanner does not know the difference between example documentation and a real credential. This is why `.trivyignore` entries and scanner configuration with path exclusions are essential — without them, every CI run flags the same documentation files, and teams learn to ignore all secret findings rather than triaging them individually.
 
 ```bash
-# Scan Terraform files
-trivy config ./terraform/
-
-# Scan with specific severity
-trivy config --severity HIGH,CRITICAL ./terraform/
-```
-
-### Example Terraform Findings
-
-```
-TRIVY IAC SCAN - TERRAFORM
-─────────────────────────────────────────────────────────────────
-
-$ trivy config ./terraform/
-
-main.tf (terraform)
-===================
-Tests: 45 (SUCCESSES: 38, FAILURES: 7, EXCEPTIONS: 0)
-Failures: 7 (HIGH: 3, MEDIUM: 4)
-
-HIGH: S3 bucket does not have encryption enabled
-──────────────────────────────────────────────────────────────────
-A server-side encryption is not configured for S3 bucket.
-
-File: main.tf
-Line: 25-30
-
- 25 │ resource "aws_s3_bucket" "data" {
- 26 │   bucket = "my-data-bucket"
- 27 │   acl    = "private"
- 28 │ }
-
-See: https://avd.aquasec.com/misconfig/avd-aws-0088
-
-──────────────────────────────────────────────────────────────────
-HIGH: Security group allows ingress from 0.0.0.0/0
-──────────────────────────────────────────────────────────────────
-Security group rule allows all traffic from 0.0.0.0/0
-
-File: security.tf
-Line: 12-20
-
- 12 │ resource "aws_security_group_rule" "ssh" {
- 13 │   type        = "ingress"
- 14 │   from_port   = 22
- 15 │   to_port     = 22
- 16 │   protocol    = "tcp"
- 17 │   cidr_blocks = ["0.0.0.0/0"]  # BAD!
- 18 │ }
-```
-
-### Kubernetes Manifests
-
-```bash
-# Scan Kubernetes YAML
-trivy config ./k8s/
-
-# Scan Helm chart
-trivy config ./helm/mychart/
-```
-
-### Example Kubernetes Findings
-
-```
-TRIVY K8S CONFIG SCAN
-─────────────────────────────────────────────────────────────────
-
-deployment.yaml (kubernetes)
-============================
-Tests: 23 (SUCCESSES: 18, FAILURES: 5)
-
-HIGH: Container runs as root
-──────────────────────────────────────────────────────────────────
-Running as root gives the container full access to the host
-
-File: deployment.yaml
-Line: 25
-
- 23 │   containers:
- 24 │   - name: app
- 25 │     securityContext:
- 26 │       runAsUser: 0  # BAD!
-
-Recommendation:
-  securityContext:
-    runAsNonRoot: true
-    runAsUser: 1000
-
-──────────────────────────────────────────────────────────────────
-MEDIUM: Container has no resource limits
-──────────────────────────────────────────────────────────────────
-Resource limits prevent container from consuming excess resources
-
-File: deployment.yaml
-Line: 24-30
-
-Recommendation:
-  resources:
-    limits:
-      cpu: "500m"
-      memory: "512Mi"
-    requests:
-      cpu: "100m"
-      memory: "128Mi"
-```
-
----
-
-## Secret Detection
-
-```bash
-# Scan for secrets in filesystem
+# Scan for secrets in the current directory
 trivy fs --scanners secret .
 
-# Scan container image for secrets
+# Scan a container image for embedded secrets
 trivy image --scanners secret nginx:latest
 
-# Scan Git repository history
+# Scan a Git repository including history
 trivy repo --scanners secret https://github.com/myorg/myrepo
 ```
 
-### Example Secret Findings
-
-```
-SECRET SCAN RESULTS
-─────────────────────────────────────────────────────────────────
-
-$ trivy fs --scanners secret .
-
-Secrets Found: 3
-
-─────────────────────────────────────────────────────────────────
-HIGH: AWS Access Key ID
-Category: AWS
-File: config/prod.env
-Line: 5
-
- 5 │ AWS_ACCESS_KEY_ID=AKIAIOSFODNN7EXAMPLE
-
-─────────────────────────────────────────────────────────────────
-HIGH: Private Key
-Category: Asymmetric Private Key
-File: certs/server.key
-Line: 1
-
- 1 │ -----BEGIN RSA PRIVATE KEY-----
-
-─────────────────────────────────────────────────────────────────
-MEDIUM: Generic API Key
-Category: Generic
-File: src/api.js
-Line: 23
-
- 23 │ const API_KEY = "sk_live_abcd1234567890";
-```
-
 ---
 
-## SBOM Generation
+## Kubernetes Cluster Scanning and the Trivy Operator
 
-### Creating SBOMs
+Scanning container images in CI catches vulnerabilities before deployment, but it does not protect against vulnerabilities disclosed after deployment. A container image that was clean when it shipped last Tuesday may have three new CRITICAL CVEs by Friday. The only way to catch these is to scan running workloads continuously.
 
-```bash
-# Generate CycloneDX SBOM
-trivy image --format cyclonedx --output sbom.json nginx:latest
+### The Trivy Operator
 
-# Generate SPDX SBOM
-trivy image --format spdx-json --output sbom.spdx.json nginx:latest
-
-# Generate SBOM for filesystem
-trivy fs --format cyclonedx --output sbom.json .
-
-# Generate SBOM with VEX (Vulnerability Exploitability eXchange)
-trivy image --format cyclonedx --output sbom.json --vex vex.json nginx:latest
-```
-
-### Scanning Existing SBOMs
+The Trivy Operator is a Kubernetes operator that runs inside the cluster and automatically scans every workload as it is deployed and on a configurable schedule thereafter. It produces Kubernetes custom resources — `VulnerabilityReport`, `ConfigAuditReport`, `ExposedSecretReport`, and others — that describe the security posture of each workload. These reports are namespaced resources, meaning each namespace's reports are isolated and can be accessed by the teams that own those namespaces.
 
 ```bash
-# Scan a CycloneDX SBOM for vulnerabilities
-trivy sbom sbom.json
-
-# Scan SPDX SBOM
-trivy sbom sbom.spdx.json
-```
-
----
-
-## Kubernetes Cluster Scanning
-
-### Trivy Operator
-
-```bash
-# Install Trivy Operator
+# Install the Trivy Operator via Helm
 helm repo add aqua https://aquasecurity.github.io/helm-charts/
 helm repo update
-
 helm install trivy-operator aqua/trivy-operator \
   --namespace trivy-system \
   --create-namespace \
   --set trivy.ignoreUnfixed=true
 
-# View vulnerability reports
+# List vulnerability reports across all namespaces
 kubectl get vulnerabilityreports -A
+
+# List config audit reports
 kubectl get configauditreports -A
-kubectl get exposedsecretreports -A
+
+# Inspect a specific report
+kubectl describe vulnerabilityreport replicaset-nginx-6d4cf56db-nginx
 ```
+
+The operator approach has two major advantages over CI-only scanning. First, it catches vulnerabilities that are disclosed after deployment — the operator rescans images periodically (default: every 24 hours) and updates the reports when new CVEs appear. Second, it provides a Kubernetes-native API for querying security posture. A dashboard like Octant or a custom controller can watch `VulnerabilityReport` resources and alert when a running workload acquires a new CRITICAL finding.
 
 ### Manual Cluster Scanning
 
-```bash
-# Scan cluster (requires kubeconfig)
-trivy k8s cluster
+For ad-hoc auditing, the `trivy k8s` command can scan a running cluster using your current kubeconfig context. It enumerates pods, deployments, and other resources, pulls the images they reference, and scans them.
 
-# Scan specific namespace
+```bash
+# Scan the entire cluster and produce a summary report
+trivy k8s cluster --report summary
+
+# Scan a specific namespace
 trivy k8s --namespace production cluster
 
-# Scan specific resources
+# Scan a specific resource
 trivy k8s --include-namespaces default deployment/nginx
-
-# Generate report
-trivy k8s cluster --report summary
-```
-
-### Example Cluster Report
-
-```
-KUBERNETES CLUSTER SCAN
-─────────────────────────────────────────────────────────────────
-
-$ trivy k8s cluster --report summary
-
-Summary Report
-==============
-
-Namespace: default
-┌────────────────┬───────────┬──────────┬──────────┬──────────┐
-│    Resource    │ Critical  │   High   │  Medium  │   Low    │
-├────────────────┼───────────┼──────────┼──────────┼──────────┤
-│ nginx-deploy   │     0     │    3     │    12    │    45    │
-│ redis          │     2     │    5     │    8     │    23    │
-│ postgres       │     1     │    7     │    15    │    34    │
-└────────────────┴───────────┴──────────┴──────────┴──────────┘
-
-Misconfigurations:
-┌────────────────┬───────────┬──────────┬──────────┬──────────┐
-│    Resource    │ Critical  │   High   │  Medium  │   Low    │
-├────────────────┼───────────┼──────────┼──────────┼──────────┤
-│ nginx-deploy   │     0     │    2     │    3     │    1     │
-│ redis          │     1     │    1     │    2     │    0     │
-└────────────────┴───────────┴──────────┴──────────┴──────────┘
 ```
 
 ---
 
-## CI/CD Integration
+## CI/CD Integration and the Shift-Left Security Model
 
-### GitHub Actions
+The "shift-left" principle in security means moving detection as early as possible in the development lifecycle. A vulnerability caught during local development costs minutes to fix. The same vulnerability caught in production costs hours of incident response, a rollback, and a patched redeployment. Trivy's design — a single binary with deterministic exit codes and multiple output formats — makes it straightforward to integrate into any CI system.
+
+### Exit Codes as Policy Gates
+
+Trivy uses exit codes to signal scan results to the CI system. The default behavior is to exit 0 (success) regardless of findings, which is appropriate for informational scanning. With `--exit-code 1`, Trivy exits with code 1 if any vulnerabilities are found at the specified severity level or above. This allows a CI pipeline to treat the scan as a quality gate: if the exit code is non-zero, the pipeline fails and the deployment is blocked.
+
+The severity threshold is a policy decision that each team must make based on their risk tolerance and operational reality. Blocking on CRITICAL only is common because it prevents known-exploitable vulnerabilities from reaching production without creating excessive friction. Blocking on HIGH catches more issues but can stall deployments when a new CVE is disclosed that affects a widely-used library and no patch is yet available. The threshold should be paired with `--ignore-unfixed` so that findings without available fixes are reported but do not block the pipeline — otherwise a single CVE with no upstream patch can halt all deployments indefinitely, which is operationally indistinguishable from a denial-of-service attack on your delivery pipeline.
+
+```bash
+# Report only (always succeeds)
+trivy image myapp:latest
+
+# Gate on CRITICAL findings
+trivy image --exit-code 1 --severity CRITICAL myapp:latest
+
+# Gate on HIGH or CRITICAL
+trivy image --exit-code 1 --severity HIGH,CRITICAL myapp:latest
+```
+
+### GitHub Actions Integration
 
 ```yaml
 # .github/workflows/trivy.yml
@@ -580,7 +315,7 @@ jobs:
           format: 'sarif'
           output: 'trivy-image.sarif'
           severity: 'CRITICAL,HIGH'
-          exit-code: '1'  # Fail on findings
+          exit-code: '1'
 
       - name: Trivy config scan
         uses: aquasecurity/trivy-action@master
@@ -597,7 +332,9 @@ jobs:
           sarif_file: '.'
 ```
 
-### GitLab CI
+Note on the `trivy-action` version: following the TeamPCP supply chain incident in March 2026 where threat actors rewrote Git tags in the `trivy-action` repository (tag `v0.69.4` was pointed to a malicious release that exfiltrated CI/CD secrets), the community recommendation is to pin GitHub Actions to commit SHAs, not tags. See [Module 4.4: Supply Chain Security](/platform/disciplines/reliability-security/devsecops/module-4.4-supply-chain-security/) for the full postmortem and mitigation strategies. If you are using `trivy-action` in production, pin to a specific commit SHA rather than `@master` or a version tag.
+
+### GitLab CI Integration
 
 ```yaml
 # .gitlab-ci.yml
@@ -610,13 +347,8 @@ trivy-scan:
     name: aquasec/trivy:latest
     entrypoint: [""]
   script:
-    # Filesystem scan
     - trivy fs --exit-code 0 --severity HIGH,CRITICAL .
-
-    # Image scan
     - trivy image --exit-code 1 --severity CRITICAL $CI_REGISTRY_IMAGE:$CI_COMMIT_SHA
-
-    # Config scan
     - trivy config --exit-code 0 --severity HIGH,CRITICAL ./terraform/
   artifacts:
     reports:
@@ -633,17 +365,10 @@ pipeline {
         stage('Security Scan') {
             steps {
                 sh '''
-                    # Install Trivy
                     curl -sfL https://raw.githubusercontent.com/aquasecurity/trivy/main/contrib/install.sh | sh -s -- -b /usr/local/bin
-
-                    # Scan filesystem
                     trivy fs --severity HIGH,CRITICAL --exit-code 0 .
-
-                    # Build and scan image
                     docker build -t myapp:${BUILD_NUMBER} .
                     trivy image --severity CRITICAL --exit-code 1 myapp:${BUILD_NUMBER}
-
-                    # Scan IaC
                     trivy config --severity HIGH,CRITICAL ./terraform/
                 '''
             }
@@ -660,317 +385,272 @@ pipeline {
 
 ---
 
-## Ignoring Findings
+## SBOM Generation and the Transparency Chain
 
-### Using .trivyignore
+A Software Bill of Materials (SBOM) is a structured inventory of every component in a software artifact — every library, every package, every dependency, including transitive dependencies. An SBOM does not tell you whether those components have vulnerabilities. It tells you what you have, so that when a vulnerability is disclosed, you can answer the question "are we affected?" without scanning every image from scratch.
+
+The operational value of an SBOM becomes most apparent during high-severity vulnerability events. When a vulnerability like Log4Shell (CVE-2021-44228)<!-- incident-xref: log4shell --> is disclosed, the first question every organization must answer is: which of our running applications include the affected library? Without SBOMs, answering this question requires scanning every container image in every registry and every running workload in every cluster — a process that can take hours or days, during which the vulnerable systems remain exposed. With SBOMs generated at build time and stored alongside images (or in a searchable document store), the same question can be answered in minutes by scanning SBOMs against the updated vulnerability database. The SBOM is not a security control by itself — it is an accelerant for every other security process that depends on knowing what is running where.
+
+Trivy can generate SBOMs in both major industry formats: CycloneDX (OWASP) and SPDX (Linux Foundation). These are the two formats recognized by the US Executive Order on Improving the Nation's Cybersecurity and by the EU Cyber Resilience Act, making them the de facto standards for software supply chain transparency.
 
 ```bash
-# .trivyignore
+# Generate CycloneDX SBOM from a container image
+trivy image --format cyclonedx --output sbom.json nginx:latest
 
-# Ignore specific CVE
-CVE-2023-12345
+# Generate SPDX SBOM
+trivy image --format spdx-json --output sbom.spdx.json nginx:latest
 
-# Ignore with expiration
-CVE-2023-67890 exp:2024-12-31
+# Generate SBOM from a filesystem (source code dependencies)
+trivy fs --format cyclonedx --output sbom.json .
 
-# Ignore by package
-pkg:npm/lodash@4.17.20
-
-# Ignore misconfig by ID
-AVD-AWS-0088
+# Scan an existing SBOM for vulnerabilities
+trivy sbom sbom.json
 ```
 
-### Using VEX (Vulnerability Exploitability eXchange)
+The `trivy sbom` command is particularly powerful: it can take an SBOM generated months ago and scan it against the current vulnerability database. This means you do not need to keep old container images around to check whether a newly disclosed CVE affects them. If you generated an SBOM at build time and stored it (in an OCI registry via `cosign attach sbom`, or in a document store), you can scan that SBOM against the latest Trivy DB and immediately know which of your deployed artifacts are affected by a new vulnerability.
+
+### VEX: Documenting Non-Exploitability
+
+Not every vulnerability finding is actionable. A CVE in a library function that your code never calls is a finding on paper but not a risk in practice. The Vulnerability Exploitability eXchange (VEX) standard provides a machine-readable way to document that a vulnerability is "not affected" in your specific context, with a justification that auditors can review.
 
 ```json
-// vex.json
 {
   "@context": "https://openvex.dev/ns/v0.2.0",
   "@id": "https://example.com/vex/myapp",
   "author": "Security Team",
-  "timestamp": "2024-01-15T00:00:00Z",
+  "timestamp": "2026-06-15T00:00:00Z",
   "statements": [
     {
-      "vulnerability": {
-        "@id": "CVE-2023-12345"
-      },
-      "products": [
-        {
-          "@id": "pkg:docker/myapp@1.0.0"
-        }
-      ],
+      "vulnerability": { "@id": "CVE-2025-12345" },
+      "products": [{ "@id": "pkg:docker/myapp@1.0.0" }],
       "status": "not_affected",
       "justification": "vulnerable_code_not_in_execute_path",
-      "impact_statement": "The vulnerable function is not called in our code"
+      "impact_statement": "The vulnerable function is in a code path that our application does not exercise."
     }
   ]
 }
 ```
 
 ```bash
-# Use VEX file
+# Scan with VEX suppression
 trivy image --vex vex.json myapp:latest
 ```
 
----
-
-## War Story: The Registry Gate
-
-*How a healthcare company saved $2.1M in compliance costs with a free tool*
-
-### The Situation
-
-A 200-person healthcare company processing $340M in annual claims was facing a crisis. Their HIPAA compliance audit was in 90 days, and the auditor's preliminary report was damning: "No documented evidence that container images are scanned before production deployment. No software bill of materials. No vulnerability tracking."
-
-The estimated cost to fix this with commercial tools:
-- Snyk Enterprise: $180K/year (200 developers × $75/month)
-- Additional SBOM tooling: $40K/year
-- Compliance dashboard: $35K/year
-- Integration consulting: $100K one-time
-
-The CISO looked at the $455K first-year estimate and wondered if there was another way.
-
-### The Architecture
-
-```
-SECURE IMAGE PIPELINE
-─────────────────────────────────────────────────────────────────
-
-┌─────────────────────────────────────────────────────────────────┐
-│                     DEVELOPER PUSHES CODE                        │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                     CI PIPELINE (GitHub Actions)                 │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  1. Build image                                            │  │
-│  │  2. Trivy scan (fail on CRITICAL)                         │  │
-│  │  3. Generate SBOM                                          │  │
-│  │  4. Sign with Cosign                                       │  │
-│  │  5. Push to staging registry                               │  │
-│  └───────────────────────────────────────────────────────────┘  │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                     HARBOR REGISTRY                              │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  • Trivy scanner enabled                                   │  │
-│  │  • Block images with CRITICAL vulns                       │  │
-│  │  • Verify Cosign signatures                               │  │
-│  │  • Store SBOM with image                                  │  │
-│  └───────────────────────────────────────────────────────────┘  │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                     KUBERNETES ADMISSION                         │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  Kyverno policy:                                          │  │
-│  │  • Only allow images from Harbor                          │  │
-│  │  • Require signature verification                         │  │
-│  │  • Require scan timestamp < 24h                           │  │
-│  └───────────────────────────────────────────────────────────┘  │
-└────────────────────────────┬────────────────────────────────────┘
-                             │
-                             ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                     PRODUCTION CLUSTER                           │
-│  ┌───────────────────────────────────────────────────────────┐  │
-│  │  Trivy Operator:                                          │  │
-│  │  • Continuous scanning of running images                  │  │
-│  │  • Alert on new vulnerabilities                           │  │
-│  │  • Generate compliance reports                            │  │
-│  └───────────────────────────────────────────────────────────┘  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-### The Implementation
-
-```yaml
-# CI: GitHub Actions
-name: Secure Build
-
-on: [push]
-
-jobs:
-  build:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-
-      - name: Build image
-        run: docker build -t ${{ env.IMAGE }}:${{ github.sha }} .
-
-      - name: Trivy scan
-        uses: aquasecurity/trivy-action@master
-        with:
-          image-ref: '${{ env.IMAGE }}:${{ github.sha }}'
-          exit-code: '1'
-          severity: 'CRITICAL'
-          format: 'json'
-          output: 'trivy-results.json'
-
-      - name: Generate SBOM
-        run: |
-          trivy image --format cyclonedx \
-            --output sbom.json \
-            ${{ env.IMAGE }}:${{ github.sha }}
-
-      - name: Sign image
-        run: |
-          cosign sign --key env://COSIGN_KEY \
-            ${{ env.IMAGE }}:${{ github.sha }}
-
-      - name: Attach SBOM
-        run: |
-          cosign attach sbom --sbom sbom.json \
-            ${{ env.IMAGE }}:${{ github.sha }}
-
-      - name: Push to Harbor
-        run: |
-          docker push ${{ env.IMAGE }}:${{ github.sha }}
-```
-
-```yaml
-# Kyverno admission policy
-apiVersion: kyverno.io/v1
-kind: ClusterPolicy
-metadata:
-  name: require-scanned-images
-spec:
-  validationFailureAction: enforce
-  rules:
-    - name: check-trivy-scan
-      match:
-        resources:
-          kinds:
-            - Pod
-      verifyImages:
-        - imageReferences:
-            - "harbor.example.com/*"
-          attestations:
-            - predicateType: cosign.sigstore.dev/attestation/vuln/v1
-              conditions:
-                - all:
-                  # No critical vulnerabilities
-                  - key: "{{ scanner.result.criticalCount }}"
-                    operator: Equals
-                    value: "0"
-                  # Scan within last 24 hours
-                  - key: "{{ time_since('', scanner.scanTime, '', 'h') }}"
-                    operator: LessThan
-                    value: "24"
-```
-
-### Results
-
-| Metric | Before | After |
-|--------|--------|-------|
-| Critical vulns in prod | Unknown | 0 |
-| Mean time to patch | 2 weeks | 4 hours |
-| Compliance audit prep | 2 weeks | Automated |
-| Images blocked/month | 0 | ~50 |
-| Developer friction | None | Minimal (clear feedback) |
-
-**Financial Impact (5-Year TCO):**
-
-| Category | Commercial Approach | Trivy Approach |
-|----------|---------------------|----------------|
-| Year 1 tooling + setup | $455,000 | $25,000 (Harbor + Kyverno setup) |
-| Years 2-5 licensing | $1,020,000 ($255K × 4) | $0 |
-| Ongoing maintenance | $120,000 | $45,000 |
-| **5-Year Total** | **$1,595,000** | **$70,000** |
-| **Savings** | | **$1,525,000** |
-
-The HIPAA audit passed with zero findings. The company used the savings to fund a dedicated platform security engineer who expanded the Trivy implementation to their data science infrastructure.
-
-Three years later, the same setup—with zero licensing costs—had processed 2.3 million container scans, generated 890,000 SBOMs, and blocked 4,200 vulnerable images from production.
-
-### Lessons Learned
-
-1. **Shift left, but also shift right** - Scan in CI AND continuously in cluster
-2. **Block critical only** - High/Medium in CI would cause too much friction
-3. **SBOM enables future scans** - When new CVE drops, scan existing SBOMs
-4. **Signatures prevent bypass** - Can't skip CI and push directly
-5. **Clear feedback matters** - Developers need actionable results, not just "blocked"
+A VEX document turns noise into signal. Without it, every scan reports the same unactionable CVEs, and teams learn to ignore the scanner. With VEX, the scanner reports only findings that the organization has not already triaged and documented as non-exploitable. The VEX file becomes part of the compliance audit trail — it is evidence that a finding was reviewed, not ignored.
 
 ---
 
-## Trivy vs Alternatives
+## Ignoring Findings with .trivyignore
+
+For CVEs or misconfigurations that are accepted risks but do not warrant a full VEX statement, Trivy supports a simple ignore file. Each line specifies a CVE ID, a misconfiguration ID, or a package identifier to suppress. Entries can include an expiration date, after which the ignore rule stops applying and the finding reappears — preventing temporary workarounds from becoming permanent blind spots.
 
 ```
-SCANNER COMPARISON
-─────────────────────────────────────────────────────────────────
+# .trivyignore
 
-                    Trivy       Grype       Clair       Snyk
-─────────────────────────────────────────────────────────────────
-TARGETS
-Container images    ✓✓          ✓✓          ✓           ✓
-Filesystems         ✓           ✓           ✗           ✓
-Git repos           ✓           ✗           ✗           ✓
-IaC scanning        ✓✓          ✗           ✗           ✓
-K8s clusters        ✓✓          ✗           ✗           ✗
-SBOM generation     ✓✓          ✓ (Syft)    ✗           ✓
-Secret scanning     ✓           ✗           ✗           ✗
+# Ignore a specific CVE (no expiration — permanent suppression)
+CVE-2025-12345
 
-FEATURES
-Speed               Fast        Fastest     Medium      Medium
-Offline mode        ✓           ✓           ✗           ✗
-Custom policies     ✓ (Rego)    ✗           ✗           ✓
-CI integration      ✓✓          ✓           ✓           ✓✓
-IDE integration     ✓           ✗           ✗           ✓✓
-Auto-fix            ✗           ✗           ✗           ✓✓
+# Ignore with expiration — finding reappears after the date
+CVE-2025-67890 exp:2026-12-31
 
-PRICING
-Free                ✓           ✓           ✓           Tiered
-Commercial support  Aqua        Anchore     CoreOS      Snyk
+# Ignore by package identifier
+pkg:npm/lodash@4.17.20
 
-BEST FOR:
-─────────────────────────────────────────────────────────────────
-Trivy:    All-in-one, Kubernetes-native, free
-Grype:    Speed-focused, SBOM ecosystem (with Syft)
-Clair:    Legacy, Quay registry integration
-Snyk:     Developer experience, auto-fix, IDE
+# Ignore a misconfiguration rule
+AVD-AWS-0088
 ```
+
+The expiration mechanism is critical for operational hygiene. Without it, an ignore file accumulates entries indefinitely, and vulnerabilities that were temporarily accepted because no fix existed become permanently invisible even after a fix is published. Setting a 90-day or 180-day expiration forces periodic re-review. When an expiration date arrives and the finding reappears in scan output, the team has three options: apply the now-available fix, extend the expiration with a new justification if the fix is still unavailable, or accept the risk permanently with a documented rationale. The key principle is that every suppression should have a documented decision behind it, and that decision should be revisited on a schedule rather than allowed to fossilize.
+
+The `.trivyignore` file should be checked into the repository alongside the code it governs, so that ignore decisions are version-controlled and reviewable in pull requests. A central security team maintaining a single global ignore file for all projects is an anti-pattern — the team closest to the code has the context to assess whether a CVE is exploitable in their specific application, and they should own their own exception decisions, with the security team providing oversight through PR review rather than acting as a gatekeeper.
+
+---
+
+## Patterns and Anti-Patterns
+
+### Patterns
+
+**Scan everywhere.** Run Trivy in CI (on every push), at the registry (Harbor's built-in scanner), and in the cluster (Trivy Operator). Each layer catches what the previous one missed. CI catches issues before deployment, the registry gate catches images pushed outside CI, and the cluster scanner catches vulnerabilities disclosed after deployment. This layering is not redundant — each scanning point has a different view of the artifact lifecycle, and a gap at any layer creates a blind spot that the other layers cannot fully close.
+
+**Block on CRITICAL, alert on HIGH.** The CI pipeline should fail on CRITICAL vulnerabilities with available fixes. HIGH findings should generate alerts (Slack, PagerDuty, dashboard) but not block deployment. This balances security with delivery velocity — the pipeline enforces the floor, and the alerting system drives continuous improvement above the floor. The alternative, blocking on all severity levels, creates a perverse incentive: developers who cannot ship because of a MEDIUM finding in a transitive dependency they do not control will find ways to bypass the scanner entirely, and the organization ends up with less security, not more.
+
+**Generate an SBOM at every build and store it with the image.** Use `cosign attach sbom` to attach the SBOM to the image in the registry. When a new CVE is disclosed, scan stored SBOMs against the updated database to identify affected artifacts without re-pulling every image. The storage cost of an SBOM is negligible (typically a few kilobytes of JSON), and the time savings during an incident are measured in hours.
+
+**Use VEX or .trivyignore with expirations for accepted risks.** Every suppressed finding should have an owner and a review date. Temporary workarounds that become permanent blind spots are a common failure mode in scanning programs. Set expirations of 90 to 180 days and route the review to the team that owns the affected component, not to a central security team that lacks the context to assess exploitability.
+
+### Anti-Patterns
+
+| Anti-Pattern | Why It Fails | Better Approach |
+|---|---|---|
+| Only scanning in CI | New CVEs are disclosed after deployment. A clean CI scan on Tuesday means nothing on Friday. | Deploy the Trivy Operator for continuous cluster scanning. |
+| Blocking on all severity levels | Developers find workarounds (skipping scans, pushing directly to registry) when every build is blocked. | Block only on CRITICAL with available fixes; alert on HIGH. |
+| Running scans without caching | Full database downloads on every CI run waste time and bandwidth. Slow scans encourage developers to disable them. | Cache the Trivy DB using GitHub Actions cache or a persistent volume. |
+| No SBOM generation | Without an SBOM, a new CVE requires re-scanning every image individually. With an SBOM, a single query identifies all affected artifacts. | Generate CycloneDX SBOMs and store them alongside images. |
+| Ignoring IaC findings | A misconfigured security group is as dangerous as a vulnerable library. Teams often focus on CVEs because they are "real vulnerabilities" while ignoring configuration issues. | Include `trivy config` in every CI pipeline, with the same severity thresholds as image scanning. |
+| Manual triage of every finding | Does not scale beyond a handful of services. Engineers burn out reviewing false positives. | Automate policy decisions with severity thresholds and VEX documents. Reserve manual review for exceptions. |
+| Different tools for different targets | Inconsistent severity ratings, multiple output formats, and fragmented configurations create operational overhead that kills scanning programs. | Use a unified scanner (Trivy or an equivalent) across all targets. |
+| Pinning to floating tags | `FROM node:16` pulls a different image tomorrow than today. Scan results from last week are meaningless. | Pin to digests: `FROM node:16@sha256:abc123...` |
+
+---
+
+## Decision Framework: Choosing a Unified Scanner
+
+When selecting a vulnerability and misconfiguration scanner, the durable capability dimensions are independent of any specific vendor or version. The table below compares the major open-source and commercial options on these dimensions as of mid-2026. This landscape changes fast — verify against current vendor documentation before making procurement decisions.
+
+**Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+
+### Rosetta: Capability Comparison
+
+| Capability | Trivy (Aqua, OSS) | Grype + Syft (Anchore, OSS) | Clair (Red Hat/Quay, OSS) | Snyk (Commercial) |
+|---|---|---|---|---|
+| **Image scanning** | OS + language packages | OS + language packages | OS packages primarily | OS + language packages |
+| **Filesystem / repo scanning** | Yes (`trivy fs`, `trivy repo`) | Grype scans directories; Syft generates SBOMs | No | Yes (CLI + SCM integration) |
+| **IaC / misconfig scanning** | Yes (Terraform, K8s, Docker, CloudFormation, Helm, Ansible) | No | No | Yes (Terraform, K8s, CloudFormation, ARM) |
+| **Kubernetes cluster scanning** | Yes (Operator + `trivy k8s`) | No | Via Clair operator (limited) | Yes (Kubernetes integration) |
+| **SBOM generation** | CycloneDX, SPDX | Syft: CycloneDX, SPDX | No | CycloneDX, SPDX |
+| **Secret detection** | Yes (100+ patterns) | No | No | Yes |
+| **In-cluster operator** | Trivy Operator (VulnerabilityReport CRDs) | No | Clair operator (limited) | Yes (Snyk monitor) |
+| **OSS vs commercial** | Fully open-source (Apache 2.0); commercial Aqua Platform available | Fully open-source (Apache 2.0); commercial Anchore Enterprise available | Fully open-source (Apache 2.0) | Freemium; enterprise features require paid tier |
+| **CI integration** | GitHub Actions, GitLab CI, Jenkins, CircleCI, and others | GitHub Actions, GitLab CI | Limited; primarily registry-integrated | Extensive CI/CD integrations, IDE plugins, PR comments |
+| **Custom policies** | Rego (OPA) for misconfigs | No | No | Custom rules in Snyk policy language |
+| **Auto-fix / remediation** | No | No | No | Yes (automated PRs for dependency upgrades) |
+
+None of these tools is universally "best." Choose based on the capabilities you need today and the operational overhead you can absorb. A team that needs auto-fix PRs and IDE integration may choose Snyk despite its cost. A team that wants a single free tool covering all targets may choose Trivy. A team already invested in the Anchore ecosystem may pair Grype with Syft. Cross-reference [Module 12.4: Snyk - Developer-First Security](/platform/toolkits/security-quality/code-quality/module-12.4-snyk/) for the commercial peer to Trivy's open-source model, including when paid features like auto-fix and IDE integration justify the licensing cost.
+
+---
+
+## Did You Know?
+
+- **Trivy was created by Teppei Fukuda at Aqua Security, with its first release in 2019.** It was built because existing scanners were operationally heavy — they typically required a separate database service and were awkward to wire into CI. The durable design insight was packaging the vulnerability database into a compact, self-contained bundle that a client downloads once and caches locally, so a scan needs no database server and runs quickly inside a pipeline. That single-binary, no-server model is the reason Trivy fits naturally into CI steps and registry-gate workflows.
+
+- **Harbor selected Trivy as its default vulnerability scanner after evaluating multiple alternatives.** The Harbor registry, itself a CNCF Graduated project, ships with Trivy as the built-in scanner that runs automatically on every pushed image. This means any organization running Harbor already has Trivy integrated into their image pipeline — the scanner runs at the registry gate, blocking vulnerable images from being pulled, even if the CI pipeline does not include its own scan step. See the [Harbor vulnerability scanning documentation](https://goharbor.io/docs/latest/administration/vulnerability-scanning/) for configuration details.
+
+- **Trivy scans for secrets across over 100 patterns, including cloud provider credentials, API keys, and private keys.** The secret scanner uses both regular expression matching (for structured credentials like AWS access keys which follow the `AKIA...` pattern) and entropy analysis (for high-entropy strings that look like randomly generated tokens). Secret scanning is integrated into the same `trivy fs` and `trivy image` commands that handle vulnerability detection — no separate tool or configuration required. The detection patterns are maintained in the Trivy source repository and updated as new credential formats emerge from cloud providers and SaaS platforms.
+
+- **The Trivy vulnerability database is updated every six hours and can be mirrored to a private OCI registry.** For air-gapped environments where scanners cannot reach the internet, Trivy supports downloading the database once from a connected machine, pushing it to an internal OCI-compatible registry, and configuring all internal scanners to pull from that mirror using the `--db-repository` flag. This decouples scanning from internet access — a critical capability for regulated industries, government systems, and high-security environments where build servers are isolated from external networks.
 
 ---
 
 ## Common Mistakes
 
 | Mistake | Why It's Bad | Better Approach |
-|---------|--------------|-----------------|
-| Blocking on all severities | Everything blocked, developers bypass | Block CRITICAL only, alert on HIGH |
-| No .trivyignore | Same false positives repeatedly | Document accepted risks |
-| Scanning without caching | Slow CI, redundant downloads | Use Trivy cache, GitHub cache action |
-| Only scanning in CI | New CVEs affect running containers | Deploy Trivy Operator |
-| Ignoring IaC findings | Misconfigs as dangerous as vulns | Include config scanning |
-| No SBOM generation | Can't track what's deployed | Generate SBOM with every build |
-| Human review of all findings | Doesn't scale | Automated policies, exceptions |
-| Different tools per target | Inconsistent results, more work | Trivy handles most targets |
+|---|---|---|
+| Blocking on all severity levels | Developers find workarounds when every build is blocked. They push directly to the registry or comment out the scan step. | Block on CRITICAL with available fixes; alert on HIGH. |
+| No .trivyignore or VEX file | The same false positives appear on every scan, training teams to ignore scanner output entirely. | Document accepted risks with expiration dates. Review quarterly. |
+| Scanning without caching in CI | Full database downloads on every pipeline run waste 30-60 seconds per job. Over 100 builds per day, that is hours of wasted CI time. | Cache the Trivy DB using your CI system's cache mechanism. |
+| Only scanning in CI, not in the cluster | A CVE disclosed on Wednesday affects workloads deployed on Monday. CI-only scanning misses the entire fleet of running containers. | Deploy Trivy Operator for continuous cluster scanning. |
+| Ignoring IaC misconfigurations | Teams treat CVEs as "real findings" and configuration issues as "nice to have." A wide-open security group is a CVE in practice. | Include `trivy config` with the same severity thresholds as image scanning. |
+| No SBOM generation | When Log4Shell-level<!-- incident-xref: log4shell --> vulnerabilities are disclosed, you cannot answer "are we affected?" without re-scanning every image. | Generate CycloneDX SBOMs at build time and store them with the image. |
+| Manual triage of all findings | Engineers spend hours reviewing CVEs that could be automatically classified by severity and fix availability. | Automate with severity gates and VEX documents. Reserve manual review for exceptions. |
+| Using floating image tags | `FROM node:16` pulls different content over time. Scan results become non-reproducible, and audit trails lose meaning. | Pin to digests: `FROM node:16@sha256:abc123...` |
+
+---
+
+## Quiz
+
+### Question 1
+
+What is the key operational advantage of a unified scanner like Trivy over deploying separate specialized tools for container images, IaC, secrets, and SBOMs?
+
+<details>
+<summary>Answer</summary>
+
+A unified scanner provides a single JSON or SARIF output schema, one configuration file for ignore rules and severity thresholds, and one CI integration across all scanning targets. This eliminates the normalization layer that would otherwise be needed to merge findings from five different tools with five different output formats and five different severity scales. The operational simplification is the difference between a scanning program that engineers maintain and one they eventually disable because the integration overhead exceeds the perceived security benefit. When findings are inconsistent across tools, teams learn to distrust all of them — a single consistent severity scale across all targets prevents that erosion of trust.
+</details>
+
+### Question 2
+
+How does Trivy's `--ignore-unfixed` flag affect scan results, and why is it important in CI pipelines?
+
+<details>
+<summary>Answer</summary>
+
+The `--ignore-unfixed` flag suppresses vulnerabilities for which no patch has been released by the upstream package maintainer. Without this flag, a newly disclosed CVE with no available fix will appear on every CI scan and, if the pipeline is configured to block on CRITICAL findings with `--exit-code 1`, will halt all deployments until a fix is published — which may take days or weeks and is outside the team's control. Using `--ignore-unfixed` gates the pipeline only on actionable findings where a remediation path exists, preventing the upstream patch release schedule from becoming a deployment blocker. The tradeoff is that you accept the risk of known-but-unfixable vulnerabilities in production, which should be tracked separately through your vulnerability management process.
+</details>
+
+### Question 3
+
+What is the purpose of the Trivy Operator in a Kubernetes cluster, and how does it complement CI-based scanning?
+
+<details>
+<summary>Answer</summary>
+
+The Trivy Operator runs inside the cluster and continuously scans deployed workloads, producing Kubernetes custom resources (`VulnerabilityReport`, `ConfigAuditReport`, `ExposedSecretReport`) that describe each workload's current security posture. It complements CI-based scanning by catching vulnerabilities disclosed after deployment — a container image that was clean when it shipped on Monday may have three new CRITICAL CVEs by Thursday, and CI-only scanning will never detect those because the image has already been deployed. The operator rescans images on a configurable schedule (default: every 24 hours) and updates the reports when new CVEs appear, providing a Kubernetes-native API that dashboards and alerting systems can watch.
+</details>
+
+### Question 4
+
+Why does pinning container image references to digests matter for vulnerability scanning?
+
+<details>
+<summary>Answer</summary>
+
+Floating tags like `nginx:latest` or `node:16` are mutable — they can point to different image digests at different times as the upstream maintainer rebuilds and republishes the tag. This breaks the reproducibility of vulnerability scans because a scan performed last week against `node:16` may not correspond to the image actually deployed today, which was pulled from the same tag but a different digest. Worse, a CVE that was not present in last week's build may appear in today's because the base image was silently updated with a new package version. Pinning to a digest (`node:16@sha256:abc123...`) makes scans deterministic, audit trails reproducible, and vulnerability status changes traceable to specific image rebuilds rather than mysterious "it worked yesterday" failures.
+</details>
+
+### Question 5
+
+A team's CI pipeline blocks on HIGH and CRITICAL vulnerabilities. After a widely-publicized CVE is disclosed in a common library, all deployments are blocked for three days because no upstream fix exists yet. What configuration change would you recommend?
+
+<details>
+<summary>Answer</summary>
+
+Add the `--ignore-unfixed` flag to the Trivy invocation so that only vulnerabilities with available fixes cause the pipeline to fail. For the specific CVE blocking deployments, add it to `.trivyignore` with an expiration date (e.g., `exp:2026-09-15`) so the suppression is automatically re-reviewed when a fix is expected. Additionally, lower the blocking threshold from HIGH to CRITICAL — blocking on HIGH findings creates too much friction during zero-day events when fixes are not immediately available. HIGH findings should generate alerts (Slack, dashboard) but not block the pipeline. The three-day deployment freeze was caused by a pipeline configuration that treated "known but unfixable" the same as "known and fixable," which are operationally very different categories.
+</details>
+
+### Question 6
+
+What are the two industry-standard SBOM formats that Trivy supports, and what is the operational value of generating an SBOM at build time?
+
+<details>
+<summary>Answer</summary>
+
+Trivy supports CycloneDX (OWASP) and SPDX (Linux Foundation), the two formats recognized by the US Executive Order on Improving the Nation's Cybersecurity and the EU Cyber Resilience Act. The operational value of generating an SBOM at build time is that when a new CVE is disclosed, you can scan stored SBOMs against the updated vulnerability database using `trivy sbom` without re-pulling every container image. This reduces the "are we affected?" query from a fleet-wide re-scan of potentially thousands of images to a single query against a document store. SBOMs can be attached to images in the registry using `cosign attach sbom`, making them discoverable alongside the artifact they describe.
+</details>
+
+### Question 7
+
+A platform team is evaluating Trivy against Grype + Syft and Snyk. They need container scanning, IaC scanning, K8s cluster scanning, and SBOM generation. Which tool covers all four capabilities without requiring additional tooling?
+
+<details>
+<summary>Answer</summary>
+
+Trivy covers all four capabilities: container image scanning (`trivy image`), IaC misconfig scanning (`trivy config` for Terraform, K8s manifests, Dockerfiles, and more), Kubernetes cluster scanning (`trivy k8s` and the Trivy Operator), and SBOM generation (`--format cyclonedx` or `--format spdx-json`). Grype handles container scanning, and Syft handles SBOM generation, but neither covers IaC or K8s cluster scanning. Snyk covers all four in its commercial tier but at per-developer licensing cost. The choice depends on whether the team values operational simplicity (one tool, one configuration) over best-in-breed depth in any single category, and whether they have budget for commercial licensing.
+</details>
+
+### Question 8
+
+What is the difference between `.trivyignore` and a VEX document, and when would you use each?
+
+<details>
+<summary>Answer</summary>
+
+`.trivyignore` is a simple text file listing CVE IDs or misconfiguration IDs to suppress, with optional expiration dates. It is appropriate for quick, local suppressions — a false positive in a specific scan context, or a CVE you have manually verified does not apply. A VEX (Vulnerability Exploitability eXchange) document is a structured, machine-readable JSON document following the openvex.dev specification that includes the vulnerability ID, the affected product, the status (`not_affected`, `fixed`, `under_investigation`), a justification code from a controlled vocabulary, and a human-readable impact statement. VEX is appropriate for organization-wide suppressions that need to be shared across teams, reviewed by auditors, and consumed by multiple tools. Use `.trivyignore` for quick operational exceptions; use VEX for auditable, cross-tool vulnerability triage.
+</details>
 
 ---
 
 ## Hands-On Exercise
 
-### Task: Implement Full Trivy Pipeline
+### Objective
 
-**Objective**: Set up Trivy for comprehensive security scanning across code, containers, and config.
+Set up Trivy for comprehensive security scanning across code, containers, and configuration. By the end of this exercise, you will have run filesystem vulnerability scanning, container image scanning with SBOM generation, infrastructure-as-code misconfiguration detection, and configured a `.trivyignore` file for accepted risks. Each step is designed to be completed in sequence — the later steps depend on the artifacts created in the earlier ones.
 
-**Success Criteria**:
-1. Filesystem scan running
-2. Container image scan with SBOM
-3. IaC scan for Terraform/Kubernetes
-4. .trivyignore configured for accepted risks
+### Success Criteria
 
-### Steps
+After completing this exercise, verify that you have achieved the following outcomes:
+- [ ] Filesystem scan runs and produces findings
+- [ ] Container image scan completes with SBOM generation
+- [ ] Infrastructure-as-code scan detects misconfigurations in Terraform and Kubernetes manifests
+- [ ] `.trivyignore` is configured with at least one accepted risk with an expiration date
+
+### Setup
 
 ```bash
-# 1. Create test project
+# 1. Create a lab directory
 mkdir trivy-lab && cd trivy-lab
 
-# 2. Create vulnerable Dockerfile
+# 2. Create a Dockerfile with a known-old base image (will have findings)
 cat > Dockerfile << 'EOF'
 FROM node:16
 WORKDIR /app
@@ -980,7 +660,7 @@ COPY . .
 CMD ["node", "server.js"]
 EOF
 
-# 3. Create package.json with vulnerable deps
+# 3. Create a package.json with older dependency versions
 cat > package.json << 'EOF'
 {
   "name": "trivy-lab",
@@ -992,7 +672,7 @@ cat > package.json << 'EOF'
 }
 EOF
 
-# 4. Create Terraform with misconfig
+# 4. Create a Terraform configuration with intentional misconfigurations
 mkdir terraform
 cat > terraform/main.tf << 'EOF'
 resource "aws_s3_bucket" "data" {
@@ -1011,7 +691,7 @@ resource "aws_security_group" "web" {
 }
 EOF
 
-# 5. Create Kubernetes manifest
+# 5. Create a Kubernetes manifest with security issues
 mkdir k8s
 cat > k8s/deployment.yaml << 'EOF'
 apiVersion: apps/v1
@@ -1035,229 +715,83 @@ spec:
           runAsUser: 0
           privileged: true
 EOF
+```
 
-# 6. Install Trivy
-brew install trivy  # or your preferred method
+### Scanning
 
-# 7. Run filesystem scan
+```bash
+# 6. Install Trivy (if not already installed)
+brew install trivy
+
+# 7. Filesystem scan — vulnerabilities and secrets
 trivy fs --scanners vuln,secret .
 
-# 8. Build and scan image
+# 8. Build and scan the container image
 docker build -t trivy-lab:latest .
 trivy image trivy-lab:latest
 
-# 9. Generate SBOM
+# 9. Generate an SBOM for the image
 trivy image --format cyclonedx --output sbom.json trivy-lab:latest
 
-# 10. Scan IaC
+# 10. Scan the SBOM itself (demonstrates SBOM scanning workflow)
+trivy sbom sbom.json
+
+# 11. Scan infrastructure-as-code
 trivy config ./terraform/
 trivy config ./k8s/
 
-# 11. Create .trivyignore for accepted risks
+# 12. Create a .trivyignore for a specific accepted risk
 cat > .trivyignore << 'EOF'
-# Accept this CVE until patch available
-CVE-2023-12345 exp:2024-06-30
-
-# False positive in our context
-AVD-AWS-0088
+# Accept this misconfiguration for the lab environment
+AVD-AWS-0088 exp:2026-12-31
 EOF
 
-# 12. Re-run with ignore file
-trivy config ./terraform/  # Should skip AVD-AWS-0088
+# 13. Re-run IaC scan — the ignored finding should be suppressed
+trivy config ./terraform/
 ```
 
 ### Verification
 
 ```bash
-# Verify findings were detected
-trivy fs . --severity CRITICAL,HIGH | grep -c "vulnerability"
+# Confirm filesystem scan found vulnerabilities
+trivy fs . --severity CRITICAL,HIGH --format json | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'Findings: {len(d.get(\"Results\",[]))}')"
 
-# Verify SBOM was created
-cat sbom.json | jq '.components | length'
+# Confirm SBOM was generated and has components
+cat sbom.json | python3 -c "import sys,json; d=json.load(sys.stdin); print(f'Components: {len(d.get(\"components\",[]))}')"
 
-# Verify IaC issues found
-trivy config ./terraform/ | grep -c "FAIL"
+# Confirm IaC scan detected misconfigurations
+trivy config ./terraform/ --format json | python3 -c "import sys,json; d=json.load(sys.stdin); results=d.get('Results',[]); misconfigs=[r for r in results if r.get('Misconfigurations')]; print(f'Misconfigurations found: {len(misconfigs)}')"
 ```
 
 ---
 
-## Quiz
+## Sources
 
-### Question 1
-What types of targets can Trivy scan?
-
-<details>
-<summary>Show Answer</summary>
-
-**Container images, filesystems, Git repos, Kubernetes clusters, IaC, and SBOMs**
-
-Trivy is an all-in-one scanner that covers:
-- Container images (OS packages + language packages)
-- Filesystems and Git repositories
-- Infrastructure as Code (Terraform, CloudFormation, K8s, Helm)
-- Running Kubernetes clusters
-- Existing SBOMs (CycloneDX, SPDX)
-
-This eliminates the need for multiple specialized tools.
-</details>
-
-### Question 2
-What is the Trivy Operator?
-
-<details>
-<summary>Show Answer</summary>
-
-**A Kubernetes operator for continuous security scanning of cluster workloads**
-
-The Trivy Operator:
-- Automatically scans new workloads when deployed
-- Creates VulnerabilityReports as Kubernetes CRDs
-- Scans for misconfigurations (ConfigAuditReports)
-- Detects exposed secrets (ExposedSecretReports)
-- Enables continuous monitoring, not just CI/CD scanning
-</details>
-
-### Question 3
-What formats does Trivy support for SBOM generation?
-
-<details>
-<summary>Show Answer</summary>
-
-**CycloneDX and SPDX**
-
-```bash
-# CycloneDX
-trivy image --format cyclonedx myapp:latest
-
-# SPDX
-trivy image --format spdx-json myapp:latest
-```
-
-SBOMs can also be scanned for vulnerabilities, allowing you to check existing software bills of materials.
-</details>
-
-### Question 4
-How does .trivyignore work?
-
-<details>
-<summary>Show Answer</summary>
-
-**A file listing CVEs or misconfig IDs to skip during scans**
-
-```
-# .trivyignore
-CVE-2023-12345          # Ignore this CVE
-CVE-2023-67890 exp:2024-12-31  # Ignore until date
-AVD-AWS-0088            # Ignore this misconfig
-```
-
-Entries can have expiration dates to ensure temporary exceptions are reviewed.
-</details>
-
-### Question 5
-What's the difference between `trivy fs` and `trivy repo`?
-
-<details>
-<summary>Show Answer</summary>
-
-**`fs` scans local filesystems; `repo` scans remote Git repositories**
-
-- `trivy fs .` - Scans the current directory
-- `trivy fs /path/to/code` - Scans a specific path
-- `trivy repo https://github.com/org/repo` - Clones and scans remote repo
-- `trivy repo --branch dev https://...` - Scans specific branch
-
-`repo` is useful for scanning third-party code without cloning it first.
-</details>
-
-### Question 6
-How do you make Trivy fail a CI build on critical vulnerabilities?
-
-<details>
-<summary>Show Answer</summary>
-
-**Use `--exit-code 1` with `--severity CRITICAL`**
-
-```bash
-trivy image --exit-code 1 --severity CRITICAL myapp:latest
-```
-
-The command returns exit code 1 if any CRITICAL vulnerabilities are found, failing the CI step. You can also use:
-- `--exit-code 0` - Always succeed (report only)
-- `--ignore-unfixed` - Skip vulnerabilities with no fix available
-</details>
-
-### Question 7
-What is VEX and how does Trivy use it?
-
-<details>
-<summary>Show Answer</summary>
-
-**Vulnerability Exploitability eXchange - a standard for documenting vulnerability applicability**
-
-VEX allows you to document that a CVE:
-- Doesn't affect your product
-- Is not reachable in your code
-- Has been mitigated
-
-```bash
-trivy image --vex vex.json myapp:latest
-```
-
-Trivy respects VEX statements to suppress irrelevant findings with documented justification.
-</details>
-
-### Question 8
-Why use Trivy over specialized tools like Checkov (IaC) or Grype (containers)?
-
-<details>
-<summary>Show Answer</summary>
-
-**Single tool, unified configuration, consistent output across all targets**
-
-Benefits of Trivy's all-in-one approach:
-- One tool to install and maintain
-- One configuration file format
-- One output format (JSON, SARIF, table)
-- Consistent severity ratings
-- Simpler CI/CD integration
-
-Specialized tools might be deeper in one area, but Trivy is "good enough" for most use cases with less operational overhead.
-</details>
+- [Trivy Documentation](https://trivy.dev) — Official documentation covering all scanners, targets, and configuration options
+- [Trivy GitHub Repository](https://github.com/aquasecurity/trivy) — Source code, releases, and issue tracker (Aqua Security, Apache 2.0)
+- [Trivy Operator Documentation](https://aquasecurity.github.io/trivy-operator/) — Kubernetes operator for continuous cluster scanning
+- [Trivy Operator GitHub](https://github.com/aquasecurity/trivy-operator) — Operator source code and Helm chart
+- [Aqua Vulnerability Database](https://avd.aquasec.com/) — Public web interface for Trivy's misconfiguration rules and vulnerability data
+- [Grype — Anchore Vulnerability Scanner](https://github.com/anchore/grype) — Open-source vulnerability scanner for container images and filesystems
+- [Syft — SBOM Generator](https://github.com/anchore/syft) — Open-source SBOM generation tool (paired with Grype)
+- [Clair — Quay Vulnerability Scanner](https://github.com/quay/clair) — Red Hat's open-source container vulnerability scanner
+- [CycloneDX Specification](https://cyclonedx.org) — OWASP SBOM standard (XML, JSON, Protocol Buffers)
+- [SPDX Specification](https://spdx.dev) — Linux Foundation SBOM standard (tag-value, JSON, YAML, RDF)
+- [OpenVEX Specification](https://openvex.dev) — Vulnerability Exploitability eXchange standard
+- [Harbor Vulnerability Scanning](https://goharbor.io/docs/latest/administration/vulnerability-scanning/) — Harbor's built-in scanner documentation (defaults to Trivy)
+- [Kubernetes Container Images](https://kubernetes.io/docs/concepts/containers/images/) — K8s documentation on image references, tags, and digests
+- [Kubernetes Security Context](https://kubernetes.io/docs/tasks/configure-pod-container/security-context/) — Pod and container security context configuration
+- [OWASP Docker Top 10](https://owasp.org/www-project-docker-top-10/) — Top 10 security risks for containerized environments
+- [OWASP Docker Security Cheat Sheet](https://cheatsheetseries.owasp.org/cheatsheets/Docker_Security_Cheat_Sheet.html) — Practical Docker security guidance
 
 ---
 
-## Key Takeaways
+## Next Module
 
-1. **All-in-one scanner** - Containers, filesystems, IaC, secrets, SBOM
-2. **Free and open source** - CNCF project, no licensing costs
-3. **Fast and lightweight** - Single binary, minimal dependencies
-4. **Built into Harbor** - Default scanner for enterprise registries
-5. **Kubernetes-native** - Operator for continuous cluster scanning
-6. **SBOM generation included** - CycloneDX and SPDX
-7. **VEX support** - Document vulnerability applicability
-8. **Multiple output formats** - JSON, SARIF, table, template
-9. **Ignore files for exceptions** - Document accepted risks
-10. **Exit codes for CI gates** - Fail on specific severities
+- **Related**: [Module 12.4: Snyk - Developer-First Security](/platform/toolkits/security-quality/code-quality/module-12.4-snyk/) — Commercial alternative with auto-fix and IDE integration
+- **Related**: [Module 4.1: DevSecOps Fundamentals](/platform/disciplines/reliability-security/devsecops/module-4.1-devsecops-fundamentals/) — The DevSecOps context in which unified scanning operates
+- **Related**: [Module 4.4: Supply Chain Security](/platform/disciplines/reliability-security/devsecops/module-4.4-supply-chain-security/) — SBOM, signing, attestation, and supply chain integrity
 
 ---
 
-## Next Steps
-
-- **Related**: [Module 13.1: Harbor](/platform/toolkits/cicd-delivery/container-registries/module-13.1-harbor/) - Registry with Trivy integration
-- **Related**: [Module 4.4: Supply Chain Security](/platform/toolkits/security-quality/security-tools/module-4.4-supply-chain/) - SBOM and signing
-- **Related**: [Module 12.4: Snyk](../module-12.4-snyk/) - Compare with commercial alternative
-
----
-
-## Further Reading
-
-- [Trivy Documentation](https://aquasecurity.github.io/trivy/)
-- [Trivy GitHub Repository](https://github.com/aquasecurity/trivy)
-- [Trivy Operator](https://aquasecurity.github.io/trivy-operator/)
-- [Aqua Vulnerability Database](https://avd.aquasec.com/)
-- [VEX Specification](https://openvex.dev/)
-
----
-
-*"The best scanner is the one you actually run. Trivy makes security scanning so easy there's no excuse not to do it everywhere."*
+*A scanner only reduces risk if it actually runs. The durable goal is to make scanning a low-friction, default step wherever code and images enter the system — local development, CI pipelines, and registry gates — rather than a separate task that teams must remember to perform.*


### PR DESCRIPTION
## Summary
Second **Platform Toolkits** wave (#1996). Closes 3 more not-done Toolkits modules — the **security-quality/code-quality** SAST/SCA/scanner stubs.

| Module | Author | Before → After |
|---|---|---|
| 12.2 Semgrep (SAST) | codex | 340w/0src → **T0 5172w/21src** |
| 12.4 Snyk (SCA) | cursor | 334w/5src → **T0 5126w/22src** |
| 12.5 Trivy (unified scanning) | deepseek | 459w/5src → **T0 5143w/16src** |

Each teaches the durable **capability** (static analysis / software composition analysis / unified vuln+misconfig scanning) with the tool as a worked example + dated snapshot + Rosetta; cross-links the DevSecOps 4.1 tool-class taxonomy.

## Cross-family review (opus-inline, ≠ author family, NO gemini) + web-verify both ways
- **Verified accurate:** Semgrep CE **LGPL-2.1** + restrictive rules-license + **Opengrep** fork (Jan-2025 Aikido/Endor/Orca consortium); CodeQL free-for-public; Snyk commercial/non-CNCF.
- **Fixed 12.4:** Rosetta wrongly labeled **Trivy a "CNCF sandbox project"** → Trivy is **NOT CNCF** (verified [cncf.io/projects](https://www.cncf.io/projects/)); it's open-source by Aqua Security, the default scanner in CNCF **Harbor** (Graduated).
- **Fixed 12.5:** trimmed an unsourced Trivy origin-story embellishment ("weekend project" / "under 15 seconds" / "most widely deployed") to the verifiable core; removed a fabricated promotional closing quote; added  incident-xref markers (canonical owner = devsecops 4.4).

## Gates
- `verify_module.py`: all 3 **T0**; Incident dedup gate **PASS**; `npm run build` **green** (0 schema errors)

Refs #1996