### PR TITLE
content(platform): fix Ansible-arc 7.13/7.16/7.17 fabricated Operator-SDK API (#1996)

### DIFF
--- a/.pipeline/reviews/platform__toolkits__infrastructure-networking__iac-tools__module-7.13-advanced-watches-yaml.md
+++ b/.pipeline/reviews/platform__toolkits__infrastructure-networking__iac-tools__module-7.13-advanced-watches-yaml.md
@@ -1,0 +1,10 @@
+## 2026-06-17 — `REVIEW` — `APPROVE`
+**Reviewer:** opus-inline cross-family R2 (Anthropic ≠ codex/OpenAI who applied the fix; ≠ cursor/Kimi R1) + independent web-verification of every disputed API fact against upstream docs BEFORE the fix. **#1996, PR (Ansible-arc fix-pass).** Fix author: codex gpt-5.5 (`9c634bdb8`).
+Cursor R1 (`logs/dispatch_responses/smart-cursor-review-1781649152.txt`) flagged this module NEEDS CHANGES for verifier-blind fabricated/wrong concurrency API. The orchestrator web-verified the corrections, locked them into the fix brief, and confirmed the applied diff matches ground truth.
+**Defects fixed (web-verified vs https://sdk.operatorframework.io/docs/building-operators/ansible/reference/advanced_options/ + watches reference):**
+- `ANSIBLE_WORKERS` env var is **fabricated** — removed everywhere (learning outcome, mermaid "Performance knobs" node, prose, manager-Pod `env:` block, all table cells). Replaced with the real `--max-concurrent-reconciles` manager flag and per-GVK `MAX_CONCURRENT_RECONCILES_<KIND>_<GROUP>` env override (format confirmed: `MAX_CONCURRENT_RECONCILES_WEBAPP_PLATFORM_EXAMPLE_COM`).
+- Default concurrency corrected from a fabricated "1 / single worker" to the real **`runtime.NumCPU()`**. The 10,000-CR throughput-math worked example is preserved by setting `--max-concurrent-reconciles=1` **explicitly** as a deliberate conservative-rollout scenario, not as the default.
+- Lab role variable convention aligned to Module 7.12 (`replicas | default(1)`, `image | default('nginx:1.27-alpine')`) so the drift-restore demo reconciles to the intended state.
+- Stale "Next module coming soon" replaced with a link to 7.14.
+**Ground-checks:** verifier **T0 PASS**, body_words **5645** (floor 5000); 0 residual fabricated tokens (`ANSIBLE_WORKERS`/`dependentWatches`/`ANSIBLE_OPERATOR_PLUGINS`/`AnsibleFailed`/`_demoapp_`); no NEW fabricated API introduced; frontmatter untouched; 11 reachable Sources; war stories carry `Hypothetical scenario:` labels.
+**APPROVE.**

--- a/.pipeline/reviews/platform__toolkits__infrastructure-networking__iac-tools__module-7.16-production-ansible-operator-patterns.md
+++ b/.pipeline/reviews/platform__toolkits__infrastructure-networking__iac-tools__module-7.16-production-ansible-operator-patterns.md
@@ -1,0 +1,11 @@
+## 2026-06-17 — `REVIEW` — `APPROVE`
+**Reviewer:** opus-inline cross-family R2 (Anthropic ≠ codex/OpenAI fix author; ≠ cursor/Kimi R1) + independent upstream web-verification before the fix. **#1996, PR (Ansible-arc fix-pass).** Fix author: codex gpt-5.5 (`9c634bdb8`).
+Cursor R1 flagged this module NEEDS CHANGES for the densest cluster of fabricated API surface in the arc. All blockers corrected and web-verified.
+**Defects fixed (web-verified vs Operator-SDK watches/advanced_options/finalizers/status docs + controller-runtime workqueue metrics):**
+- Fabricated watches.yaml fields removed: `maxConcurrentReconciles:` (a Helm-operator field, not Ansible) and `dependentWatches:` (does not exist) → replaced with the real `watchDependentResources: true`; concurrency moved to the `--max-concurrent-reconciles` flag / `MAX_CONCURRENT_RECONCILES_<KIND>_<GROUP>` env var. The learning outcome, prose, tables, lab, and quiz were all reframed to the real mechanism while keeping the scaling pedagogy. 0 residual `maxConcurrentReconciles`.
+- Fabricated `ANSIBLE_OPERATOR_PLUGINS_*` env vars removed → `MAX_CONCURRENT_RECONCILES_*` (concurrency), `ANSIBLE_VERBOSITY_<KIND>_<GROUP>` (verbosity); reconcile period via watches.yaml `reconcilePeriod` / `--reconcile-period` / the `ansible.sdk.operatorframework.io/reconcile-period` annotation.
+- Finalizer anti-pattern fixed: the deletion role no longer manually patches `finalizers: []`. Prose now correctly states the SDK removes the configured finalizer after the finalizer role/playbook completes successfully; the phantom-deletion and interrupted-reconcile narratives were reframed around SDK-driven removal + idempotent 404 handling.
+- Status condition type `AnsibleFailed` → **`Failure`** (reason `Failed`); `Running` retained.
+- Metric `controller_runtime_reconcile_queue_length` → **`workqueue_depth`** (the real controller-runtime metric, labeled by controller `name`).
+**Ground-checks:** verifier **T0 PASS**, body_words **5238** (floor 5000); 0 residual fabricated tokens; no NEW fabricated API; frontmatter untouched; 17 reachable Sources; `Hypothetical scenario:` labels intact.
+**APPROVE.**

--- a/.pipeline/reviews/platform__toolkits__infrastructure-networking__iac-tools__module-7.17-testing-ansible-operators.md
+++ b/.pipeline/reviews/platform__toolkits__infrastructure-networking__iac-tools__module-7.17-testing-ansible-operators.md
@@ -1,0 +1,9 @@
+## 2026-06-17 — `REVIEW` — `APPROVE`
+**Reviewer:** opus-inline cross-family R2 (Anthropic ≠ codex/OpenAI fix author; ≠ cursor/Kimi R1) + independent upstream web-verification before the fix. **#1996, PR (Ansible-arc fix-pass).** Fix author: codex gpt-5.5 (`9c634bdb8`).
+Cursor R1 flagged this module NEEDS CHANGES because its Molecule/Kuttl test contract did not match how the SDK actually injects CR spec, and the Kuttl asserts used labels the 7.12 role never sets.
+**Defects fixed (web-verified vs Operator-SDK information-flow doc + Module 7.12 canonical role):**
+- The fabricated `_demoapp_` variable prefix removed from every Molecule converge/scenario. The SDK injects spec fields as **top-level snake_case vars** (`replicas`, `image`, `port`) plus the reserved `ansible_operator_meta.name`/`.namespace`; the converge playbooks now mirror those names exactly, with an `ansible_operator_meta:` mock for CR identity. Default image `nginx:1.27-alpine` matches 7.12.
+- The false claim that "the `_demoapp_` prefix convention is not arbitrary — the SDK generates these exact variable names" was corrected to describe the real top-level-snake_case + `ansible_operator_meta` injection.
+- Kuttl `TestAssert` selector labels aligned to what the 7.12 role actually sets: `app.kubernetes.io/name: demoapp` + `app.kubernetes.io/instance: kuttl-test-app` (the CR instance name). The CR object remains named `kuttl-test-app`.
+**Ground-checks:** verifier **T0 PASS**, body_words **5735** (floor 5000); 0 residual fabricated tokens; no NEW fabricated API; frontmatter untouched; 14 reachable Sources; `Hypothetical scenario:` labels intact. Labs now internally consistent with the 7.12 role contract end-to-end.
+**APPROVE.**

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.13-advanced-watches-yaml.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.13-advanced-watches-yaml.md
@@ -28,7 +28,7 @@ After completing this module, you will be able to:
 - **Implement** per-namespace operator scoping using the `WATCH_NAMESPACE` environment variable and articulate the RBAC boundary shift when switching between namespace-scoped and cluster-wide modes.
 - **Diagnose** watch-related reconciliation failures by correlating operator logs, CR status conditions, RBAC denial events, and the specific watches.yaml field responsible for the behavior.
 - **Configure** finalizer mappings in `watches.yaml` and evaluate whether a given cleanup scenario requires a dedicated finalizer role, a deletion-timestamp branch in the main role, or Kubernetes garbage collection alone.
-- **Tune** operator reconciliation throughput by controlling worker concurrency via the `ANSIBLE_WORKERS` environment variable or `--max-concurrent-reconciles` flag, blacklisting high-churn child resource kinds, and choosing `reconcilePeriod` values appropriate to each resource's external drift rate.
+- **Tune** operator reconciliation throughput by controlling worker concurrency with the manager's `--max-concurrent-reconciles` flag or the per-GVK `MAX_CONCURRENT_RECONCILES_<KIND>_<GROUP>` environment override, blacklisting high-churn child resource kinds, and choosing `reconcilePeriod` values appropriate to each resource's external drift rate.
 
 ---
 
@@ -58,7 +58,7 @@ graph TD
 
     NS --> RBAC["Role (namespace)\nvs ClusterRole (cluster)"]
 
-    WY --> PERF["Performance knobs\nANSIBLE_WORKERS, blacklist\nmanageStatus, selector"]
+    WY --> PERF["Performance knobs\nmax-concurrent flag, blacklist\nmanageStatus, selector"]
 
     E1 --> SEL["selector.matchLabels\nfilters watched CRs"]
     E2 --> CS["watchClusterScopedResources\nfor Node, PV, ClusterRole..."]
@@ -266,7 +266,7 @@ For purely Kubernetes-native resources where the watch covers all meaningful cha
 
 The telemetry signal that reveals a reconcile period is causing overload is a flat, clock-like reconciliation rate that does not correlate with cluster activity. If the operator exposes Prometheus metrics via `--metrics-bind-address`, the counter `controller_runtime_reconcile_total{controller="<kind>"}` should grow at a steady rate equal to `CR_count ÷ reconcilePeriod`. Deviations above this baseline indicate that dependent watch events or event storms are layering on top of the timer. The diagnostic procedure is to temporarily set `reconcilePeriod: 0s` on the suspect entry and observe whether the reconciliation rate drops toward zero; if the rate stays elevated, event-driven triggers rather than timers are the dominant source, and the fix is an expanded `blacklist` or setting `watchDependentResources: false`.
 
-Scaling to ten thousand or more custom resources under timer-driven reconciliation requires explicit capacity planning that the default configuration does not provide. At 10,000 CRs with a `reconcilePeriod: 30m`, the timer generates 333 reconciliations per minute—one every 0.18 seconds—sustained continuously regardless of cluster activity. With a single worker (the default when `ANSIBLE_WORKERS` is unset) and an Ansible role that takes 500 milliseconds per run (a reasonable estimate for roles with one or two API calls), the worker saturates at two reconciliations per second maximum, meaning the full CR population cycles in 83 minutes rather than the configured 30. The queue depth grows monotonically under these conditions. The remediation has three levers: lengthen the period if the external drift rate allows, raise the worker count via `ANSIBLE_WORKERS` or `--max-concurrent-reconciles` if CR reconciliations are independent of each other, or optimize the role's no-op path. A well-tuned no-op path—a single `kubernetes.core.k8s_info` task to read current state followed by `meta: end_play` when desired state already matches—can complete in under 100 milliseconds, delivering a five-times throughput improvement without touching worker count.
+Scaling to ten thousand or more custom resources under timer-driven reconciliation requires explicit capacity planning that the default configuration does not provide. At 10,000 CRs with a `reconcilePeriod: 30m`, the timer generates 333 reconciliations per minute—one every 0.18 seconds—sustained continuously regardless of cluster activity. The SDK's default concurrency is `runtime.NumCPU()`, the logical CPU count visible to the manager process, so the exact baseline depends on the controller Pod's CPU environment. If you deliberately cap a lab or production rollout to `--max-concurrent-reconciles=1`, and the Ansible role takes 500 milliseconds per run, that single-worker scenario saturates at two reconciliations per second maximum, meaning the full CR population cycles in 83 minutes rather than the configured 30. The queue depth grows monotonically under those explicit conditions. The remediation has three levers: lengthen the period if the external drift rate allows, raise concurrency with `--max-concurrent-reconciles` or a per-GVK `MAX_CONCURRENT_RECONCILES_<KIND>_<GROUP>` override if CR reconciliations are independent of each other, or optimize the role's no-op path. A well-tuned no-op path—a single `kubernetes.core.k8s_info` task to read current state followed by `meta: end_play` when desired state already matches—can complete in under 100 milliseconds, delivering a five-times throughput improvement without touching worker count.
 
 The interaction between `reconcilePeriod` and `watchDependentResources` compounds. Configuring both a non-zero period and `watchDependentResources: true` without a comprehensive `blacklist` means reconciliation fires from two independent sources: event-driven from child changes and timer-driven from the period. On a cluster with many CRs, the queues grow faster than the workers process them. The rule: use `reconcilePeriod` for resources with external state that cannot be observed through Kubernetes events; disable `watchDependentResources` for purely external operators where no Kubernetes-native drift needs event-driven detection; avoid combining a short period with broad dependent watches and a minimal blacklist.
 
@@ -372,7 +372,7 @@ The `selector` field supports the full Kubernetes label selector syntax, includi
 
 This selector watches resources in `production` or `canary` environments while excluding any resource labeled `skip-operator`—a useful pattern for emergency bypass when a CR needs to be pinned outside operator control temporarily without deleting it.
 
-Ansible operator worker concurrency is controlled at the operator binary level, not per `watches.yaml` entry. The two levers are the `ANSIBLE_WORKERS` environment variable on the manager Pod and the `--max-concurrent-reconciles` flag passed to the manager process. Both apply globally across all CRD entries the operator manages. The default is 1, meaning all reconciliation requests across all entries share one worker pool processed serially. Raising the worker count is appropriate when CRs across different entries are demonstrably independent and reconciliation takes long enough—due to external API calls or long-running Ansible tasks—that the single worker becomes a latency bottleneck:
+Ansible operator worker concurrency is controlled outside `watches.yaml`. The global lever is the `--max-concurrent-reconciles` flag passed to the manager process, and administrators can override a specific GVK with `MAX_CONCURRENT_RECONCILES_<KIND>_<GROUP>` on the manager Pod. The default is `runtime.NumCPU()`, meaning the controller starts with a concurrency value based on the logical CPUs available to the process rather than a fixed value of one. Raising concurrency is appropriate when CRs across different entries are demonstrably independent and reconciliation takes long enough—due to external API calls or long-running Ansible tasks—that queue latency becomes a bottleneck:
 
 <!-- code-verified-against: https://sdk.operatorframework.io/docs/building-operators/ansible/reference/watches/ -->
 ```yaml
@@ -385,12 +385,14 @@ spec:
     spec:
       containers:
       - name: manager
+        args:
+        - "--max-concurrent-reconciles=3"
         env:
-        - name: ANSIBLE_WORKERS
+        - name: MAX_CONCURRENT_RECONCILES_WEBAPP_PLATFORM_EXAMPLE_COM
           value: "3"
 ```
 
-The API server rate limit, not CPU, is almost always the binding constraint when raising worker count. Each concurrent worker issues Kubernetes API calls for every task that uses `kubernetes.core.k8s` or `kubernetes.core.k8s_info`. At three workers, API call frequency triples. Monitor the operator's API server request rate and watch for 429 `TooManyRequests` responses in the operator logs before raising the count above 3. A value above 5 rarely improves throughput in practice because the API server backpressure dominates.
+The API server rate limit, not CPU, is almost always the binding constraint when raising worker count. Each concurrent reconcile issues Kubernetes API calls for every task that uses `kubernetes.core.k8s` or `kubernetes.core.k8s_info`. At three concurrent reconciles, API call frequency can roughly triple. Monitor the operator's API server request rate and watch for 429 `TooManyRequests` responses in the operator logs before raising the count above 3. A value above 5 rarely improves throughput in practice because the API server backpressure dominates.
 
 The `manageStatus` field determines whether the SDK writes `status.conditions` after each Ansible runner invocation. When `manageStatus: true` (the default), the operator automatically records whether the run succeeded and when the last reconcile occurred. When `manageStatus: false`, the status subresource is untouched by the SDK; the Ansible role owns it entirely through explicit `kubernetes.core.k8s` tasks that update the status. Using both simultaneously—`manageStatus: true` and status-writing tasks in the role—creates a last-writer-wins conflict that produces inconsistent status conditions. Choose one ownership model per entry and document the decision in the watches.yaml comment for the team.
 
@@ -414,7 +416,7 @@ The `manageStatus` field determines whether the SDK writes `status.conditions` a
 | `ClusterRole` for a namespace-scoped operator | One bug or exploit has cluster-wide read access | Set `WATCH_NAMESPACE`; use a namespace-scoped `Role` with a `RoleBinding` |
 | Finalizer without idempotent cleanup role | Network failures during cleanup cause the role to fail on retry; CR stuck in `Terminating` | Use `state: absent` with `ignore_errors: true`; verify cleanup tasks are safe to run multiple times |
 | Both `manageStatus: true` and role-managed status | SDK and role write the same status fields; last-writer-wins produces inconsistent conditions | Pick one ownership model; set `manageStatus: false` when the role manages status |
-| `ANSIBLE_WORKERS=10` without rate limit testing | API server returns 429; operator enters exponential backoff; CR reconciliation lags | Start at 1–3 workers; load test with realistic CR counts; monitor for 429 responses |
+| `--max-concurrent-reconciles=10` without rate limit testing | API server returns 429; operator enters exponential backoff; CR reconciliation lags | Start with a modest value such as 2–3; load test with realistic CR counts; monitor for 429 responses |
 | Selector on a shared CRD without label enforcement | New CRs created without the required label are silently ignored forever | Enforce labels via a mutating admission webhook or CRD schema defaulting |
 
 ---
@@ -431,7 +433,7 @@ The central decision when configuring a `watches.yaml` entry is the trust and bl
 | Does the role create external resources (S3, RDS, IAM, DNS)? | Set `reconcilePeriod` matching external drift rate (5–30m) | Set `reconcilePeriod: 0s` (purely event-driven) |
 | Does deletion require cleanup of external resources or ordered teardown? | Add `finalizer.name` + `finalizer.role` for complex cleanup | Rely on Kubernetes garbage collection via owner references |
 | Does the operator share this CRD with another operator instance? | Add `selector.matchLabels` with a labeling convention; enforce via admission | No selector needed |
-| Is reconciliation latency a bottleneck (runs >30s for independent CRs)? | Raise `ANSIBLE_WORKERS` to 2–3; monitor for 429 API errors | Leave `ANSIBLE_WORKERS` unset (default: 1) |
+| Is reconciliation latency a bottleneck (runs >30s for independent CRs)? | Set `--max-concurrent-reconciles=2` or `3`; monitor for 429 API errors | Keep the default `runtime.NumCPU()` value and revisit after profiling |
 | Does the role manage status manually via `kubernetes.core.k8s`? | Set `manageStatus: false` | Leave `manageStatus: true` (default) |
 
 ---
@@ -458,7 +460,7 @@ The central decision when configuring a `watches.yaml` entry is the trust and bl
 | Finalizer cleanup role that does not handle already-deleted resources | External resources are gone after the first cleanup attempt; subsequent retries fail hard; CR stuck in `Terminating` | Use `state: absent` with `ignore_errors: true` on all deletion tasks; verify idempotency by running the role twice on a test CR |
 | `manageStatus: true` with role-managed status tasks | SDK and role both write `status.conditions`; last-writer-wins produces unexpected conditions visible to users | Set `manageStatus: false` when the role writes any status field; ensure the role writes all status fields on every run |
 | Non-zero `reconcilePeriod` on a high-CR-count namespace-scoped deployment | 500 CRs × 1-minute period = 500 reconciliations/minute from timers alone; API server throttles the operator | Audit all `watches.yaml` entries with non-zero periods; use periods matching actual external drift frequency, not a conservative safety margin |
-| `ANSIBLE_WORKERS` above 3 without 429 monitoring | API server rate limiting causes backoff that is invisible without log monitoring | Enable API server error logging in the operator; alert on 429 responses; validate worker count with a load test before production |
+| High `--max-concurrent-reconciles` values without 429 monitoring | API server rate limiting causes backoff that is invisible without log monitoring | Enable API server error logging in the operator; alert on 429 responses; validate worker count with a load test before production |
 | Using a `selector` without enforcing labels at admission | CRs created without the required labels are silently ignored; users see no error and no reconciliation | Add a mutating admission webhook or CRD schema default values to ensure the label is always present on new CRs |
 
 ---
@@ -489,7 +491,7 @@ The most likely explanation is that the finalizer role succeeded on the first at
 <details>
 <summary>You have a `watches.yaml` with two entries: `AppService` (reconcilePeriod 0s, `watchDependentResources: true`, no blacklist) and `AppConfig` (reconcilePeriod 0s, `watchDependentResources: false`). During a batch creation of 50 `AppService` CRs, `AppConfig` CRs stop being reconciled for several minutes. Explain why, and propose a fix.</summary>
 
-The Ansible runner process pool is shared across all entries in `watches.yaml`. When 50 `AppService` CRs are created simultaneously, they flood the reconciliation queue with creation events plus a cascade of Pod and Event events from `watchDependentResources: true`. With a single worker (the default when `ANSIBLE_WORKERS` is unset), only one reconciliation runs at a time, each taking several seconds. The queue grows faster than it drains, and because the queue is shared with `AppConfig` events, those events wait at the back of the combined queue. `AppConfig` reconciliation effectively pauses until the `AppService` burst clears. The fix has two parts: first, add a `blacklist` for `Event` and `Pod` in the `AppService` entry to eliminate the cascade of secondary events from the batch creation. Second, set `ANSIBLE_WORKERS=3` on the manager Pod to drain the reconciliation queue faster during bursts. Monitor API server error rates after the change to ensure the increased concurrency does not trigger 429 throttling.
+The Ansible runner process pool is shared across all entries in `watches.yaml`. When 50 `AppService` CRs are created simultaneously, they flood the reconciliation queue with creation events plus a cascade of Pod and Event events from `watchDependentResources: true`. If this operator was explicitly started with `--max-concurrent-reconciles=1` for a conservative rollout, only one reconciliation runs at a time, each taking several seconds. The queue grows faster than it drains, and because the queue is shared with `AppConfig` events, those events wait at the back of the combined queue. `AppConfig` reconciliation effectively pauses until the `AppService` burst clears. The fix has two parts: first, add a `blacklist` for `Event` and `Pod` in the `AppService` entry to eliminate the cascade of secondary events from the batch creation. Second, raise the manager to `--max-concurrent-reconciles=3` or set the matching per-GVK `MAX_CONCURRENT_RECONCILES_APPSERVICE_PLATFORM_EXAMPLE_COM=3` override to drain the reconciliation queue faster during bursts. Monitor API server error rates after the change to ensure the increased concurrency does not trigger 429 throttling.
 
 </details>
 
@@ -598,39 +600,53 @@ Overwrite the generated `watches.yaml` with a configuration that exercises the p
 
 ### Task 2: Write the reconciliation and cleanup roles
 
-Write the main reconciliation task for `PlatformApp`. This task creates a Deployment owned by the CR using explicit owner references, enabling Kubernetes garbage collection to clean up the Deployment automatically if the finalizer role fails or is bypassed. The `spec.replicas` and `spec.image` fields are read from the CR spec with defaults as fallbacks:
+Write the main reconciliation task for `PlatformApp`. This task creates a Deployment owned by the CR using explicit owner references, enabling Kubernetes garbage collection to clean up the Deployment automatically if the finalizer role fails or is bypassed. The SDK injects CR spec fields as top-level Ansible variables, so the role first derives the same defaults used in Module 7.12: `replicas | default(1)` and `image | default('nginx:1.27-alpine')`.
 
 ```bash
 cat > roles/platformapp/tasks/main.yml << 'EOF'
 ---
+- name: Derive PlatformApp desired values
+  ansible.builtin.set_fact:
+    demoapp_name: "{{ ansible_operator_meta.name }}"
+    demoapp_namespace: "{{ ansible_operator_meta.namespace }}"
+    demoapp_replicas: "{{ replicas | default(1) | int }}"
+    demoapp_image: "{{ image | default('nginx:1.27-alpine') }}"
+
 - name: Deploy application
   kubernetes.core.k8s:
     definition:
       apiVersion: apps/v1
       kind: Deployment
       metadata:
-        name: "{{ ansible_operator_meta.name }}-app"
-        namespace: "{{ ansible_operator_meta.namespace }}"
+        name: "{{ demoapp_name }}-app"
+        namespace: "{{ demoapp_namespace }}"
+        labels:
+          app.kubernetes.io/name: demoapp
+          app.kubernetes.io/instance: "{{ demoapp_name }}"
+          app.kubernetes.io/managed-by: ansible-operator
         ownerReferences:
         - apiVersion: apps.platform.example.com/v1alpha1
           kind: PlatformApp
-          name: "{{ ansible_operator_meta.name }}"
+          name: "{{ demoapp_name }}"
           uid: "{{ ansible_operator_meta.uid }}"
           controller: true
           blockOwnerDeletion: true
       spec:
-        replicas: "{{ spec.replicas | default(1) }}"
+        replicas: "{{ demoapp_replicas }}"
         selector:
           matchLabels:
-            app: "{{ ansible_operator_meta.name }}"
+            app.kubernetes.io/name: demoapp
+            app.kubernetes.io/instance: "{{ demoapp_name }}"
         template:
           metadata:
             labels:
-              app: "{{ ansible_operator_meta.name }}"
+              app.kubernetes.io/name: demoapp
+              app.kubernetes.io/instance: "{{ demoapp_name }}"
+              app.kubernetes.io/managed-by: ansible-operator
           spec:
             containers:
             - name: app
-              image: "{{ spec.image | default('nginx:1.25') }}"
+              image: "{{ demoapp_image }}"
 EOF
 ```
 
@@ -717,7 +733,7 @@ metadata:
     managed-by: watches-lab
 spec:
   replicas: 1
-  image: nginx:1.25
+  image: nginx:1.27-alpine
 EOF
 ```
 
@@ -736,20 +752,20 @@ kubectl scale deployment demo-app-app -n platform-tenants --replicas=3
 Verify that the operator restores the replica count. Because Deployment is not in the `blacklist`, the scale event triggers a reconciliation within seconds rather than waiting for the 5-minute `reconcilePeriod`—this is the core behavioral difference between event-driven and timer-driven reconciliation paths:
 
 ```bash
-kubectl get deployment demo-app-app -n platform-tenants -o jsonpath='{.spec.replicas}'
+kubectl get deployment demo-app-app -n platform-tenants -o go-template='{{ index .spec "replicas" }}'
 ```
 
 <details>
 <summary>Expected behavior and timing</summary>
 
-Because Deployment is not in the `blacklist` and `watchDependentResources: true`, the scale event triggers reconciliation quickly—usually within a few seconds. The operator re-applies the role with `spec.replicas: 1`, restoring the Deployment to one replica. If you had set `watchDependentResources: false`, the operator would only detect the drift after the 5-minute `reconcilePeriod`.
+Because Deployment is not in the `blacklist` and `watchDependentResources: true`, the scale event triggers reconciliation quickly—usually within a few seconds. The operator re-applies the role with the CR's `replicas` variable still set to 1, restoring the Deployment to one replica. If you had set `watchDependentResources: false`, the operator would only detect the drift after the 5-minute `reconcilePeriod`.
 
 </details>
 
 **Success criteria**:
 - [ ] Initial reconciliation creates the Deployment without errors
 - [ ] Scaling the Deployment to 3 triggers reconciliation visible in the logs
-- [ ] After reconciliation, `spec.replicas` returns to 1
+- [ ] After reconciliation, the Deployment replica count returns to 1
 
 ### Task 5: Test the finalizer lifecycle
 
@@ -791,7 +807,7 @@ metadata:
   namespace: platform-tenants
 spec:
   replicas: 1
-  image: nginx:1.25
+  image: nginx:1.27-alpine
 EOF
 ```
 
@@ -828,4 +844,4 @@ The `ignored-app` CR should have no status conditions because the operator never
 
 ## Next Module
 
-*Next module coming soon.*
+[Module 7.14: Ansible Operator with AWX/AAP](../module-7.14-awx-aap-operator-integration/)

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.16-production-ansible-operator-patterns.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.16-production-ansible-operator-patterns.md
@@ -49,7 +49,7 @@ After completing this module, you will be able to:
 
 - **Implement** a production-grade status conditions block on a custom resource that follows the Kubernetes API Conditions convention, distinguishing between a `status.conditions` array and scalar status fields, and preserving `lastTransitionTime` semantics correctly.
 - **Diagnose** and resolve finalizer race conditions including interrupted reconciles, cross-CR ordering deadlocks, and the phantom-deletion pattern where cleanup runs succeed but the finalizer is never removed.
-- **Design** an idempotency strategy for an Ansible Operator managing thousands of custom resource instances, applying `maxConcurrentReconciles`, `RateLimitedRequeue`, and early-exit patterns to bound API server load.
+- **Design** an idempotency strategy for an Ansible Operator managing thousands of custom resource instances, applying `--max-concurrent-reconciles`, per-GVK concurrency overrides, rate-limited requeue behavior, and early-exit patterns to bound API server load.
 - **Configure** CRD upgrade paths and OLM bundle manifests for production operator releases, distinguishing when a conversion webhook is required from when backwards-compatible role field fallbacks suffice, and applying `Manual` approval channels for change-controlled environments.
 - **Instrument** an Ansible Operator with structured JSON logs, controller-runtime Prometheus metrics, and OpenTelemetry span propagation, then verify reconciliation correctness by injecting controlled failures under leader loss, queue bursts, and task-level errors.
 
@@ -78,14 +78,14 @@ status:
       reason: DeploymentUnavailable
       message: "Deployment demoapp-sample has 0/3 ready replicas"
       lastTransitionTime: "2026-05-15T09:32:11Z"
-    - type: ReconcileFailed
+    - type: Failure
       status: "False"
-      reason: ""
+      reason: Failed
       message: ""
       lastTransitionTime: "2026-05-15T09:28:04Z"
 ```
 
-When does an Ansible Operator surface conditions properly versus swallow them? By default, `manageStatus: true` in `watches.yaml` causes the Ansible Operator to publish a generic `Running` condition after each successful role run and an `AnsibleFailed` condition on role failure. This is better than nothing, but it loses the domain semantics that make conditions useful for automation. An external alerting rule cannot fire on `AnsibleFailed` with reason `"TaskFailed"` and distinguish "deployment is unavailable" from "external API rate-limited" without parsing the freeform message string. A well-designed conditions block expresses that distinction in the `reason` field, enabling consuming controllers and alertmanager rules to respond programmatically without fragile string matching.
+When does an Ansible Operator surface conditions properly versus swallow them? By default, `manageStatus: true` in `watches.yaml` causes the Ansible Operator to publish a generic `Running` condition after each successful role run and a `Failure` condition with reason `Failed` on role failure. This is better than nothing, but it loses the domain semantics that make conditions useful for automation. An external alerting rule cannot fire on `Failure` with reason `Failed` and distinguish "deployment is unavailable" from "external API rate-limited" without parsing the freeform message string. A well-designed conditions block expresses that distinction in the `reason` field, enabling consuming controllers and alertmanager rules to respond programmatically without fragile string matching.
 
 The correct approach is to set `manageStatus: false` and publish conditions explicitly with `operator_sdk.util.k8s_status`. The role should maintain the full conditions array rather than overwriting it on each reconcile, preserving conditions set by previous passes or by external controllers. Most critically, the `lastTransitionTime` field must only change when `status` changes — not on every reconcile. If you update `lastTransitionTime` on every run, monitoring systems cannot measure how long a condition has been in its current state, which makes SLO tracking and alerting for stuck resources unreliable.
 
@@ -159,9 +159,9 @@ Pause and predict: if `manageStatus: true` remains enabled but the role also cal
 
 ## Finalizer Race Conditions and Safe Deletion
 
-Finalizers are the mechanism Kubernetes provides for controllers to run cleanup logic before a resource is permanently removed. When a user runs `kubectl delete`, the API server sets `metadata.deletionTimestamp` rather than removing the object immediately. The object remains visible and watchable until every finalizer string is removed from `metadata.finalizers`. A controller that owns a finalizer is responsible for performing its cleanup work and then patching the finalizer away.
+Finalizers are the mechanism Kubernetes provides for controllers to run cleanup logic before a resource is permanently removed. When a user runs `kubectl delete`, the API server sets `metadata.deletionTimestamp` rather than removing the object immediately. The object remains visible and watchable until every finalizer string is removed from `metadata.finalizers`. In an Ansible Operator with `finalizer` configured in `watches.yaml`, the deletion role is responsible for making cleanup idempotently succeed; after that role or playbook completes successfully, the SDK removes the configured finalizer string from the CR.
 
-The failure modes with finalizers appear at two levels: the task level and the ordering level. At the task level, an interrupted reconcile during deletion is the most common source of permanently stuck resources. If an Ansible role removes an external resource and then crashes before removing the finalizer, the next reconciliation must detect that the external cleanup already happened and not attempt it again. This requires the role to inspect actual external state rather than assume that "finalizer still present means cleanup is needed." An idempotent cleanup role handles the "cleanup ran twice" case gracefully by treating a 404 from the external API as a success, not an error.
+The failure modes with finalizers appear at two levels: the task level and the ordering level. At the task level, an interrupted reconcile during deletion is the most common source of permanently stuck resources. If an Ansible role removes an external resource and then crashes before the SDK can observe a successful completion and remove the finalizer, the next reconciliation must detect that the external cleanup already happened and not attempt it again. This requires the role to inspect actual external state rather than assume that "finalizer still present means cleanup is needed." An idempotent cleanup role handles the "cleanup ran twice" case gracefully by treating a 404 from the external API as a success, not an error.
 
 ```yaml
 # roles/demoapp_delete/tasks/main.yml
@@ -183,23 +183,17 @@ The failure modes with finalizers appear at two levels: the task level and the o
   register: dns_delete
   failed_when: "dns_delete.status not in [200, 204, 404]"
 
-- name: Remove finalizer after confirming external cleanup is complete
-  kubernetes.core.k8s:
-    api_version: app.example.com/v1
-    kind: DemoApp
-    name: "{{ demoapp_name }}"
-    namespace: "{{ demoapp_namespace }}"
-    definition:
-      metadata:
-        finalizers: []
+- name: Report cleanup completion for operator logs
+  ansible.builtin.debug:
+    msg: "External DNS cleanup complete for {{ demoapp_name }}.example.com"
 ```
 
 The ordering level is subtler. Deadlocks happen when two resource types have circular finalizer dependencies. Resource A holds a finalizer that waits for Resource B to finalize before the A finalizer is removed. Resource B holds a finalizer that waits for Resource A. This scenario is common in operators that manage parent-child relationships between custom resources: a `DatabaseCluster` CR manages `DatabaseInstance` CRs, and both have finalizers that reference the other. The deadlock prevention rule is to establish a strict ownership hierarchy and ensure that cleanup flows in only one direction — children finalize before parents, and parents never wait for a child to exist before removing their own finalizer.
 
-The phantom deletion pattern is a variant where the controller crashes or loses leadership between removing the external resource and patching the finalizer away. The resource reappears in the reconcile queue on the next watch event. The deletion path runs again, the external resource check returns 404 (it was already removed in the previous partial run), and the finalizer is successfully patched away. This behavior is correct only when the deletion check is idempotent. A deletion role that treats a 404 as a hard error will loop forever on a resource that was partially cleaned up. Always handle absence explicitly with `failed_when: false` and an explicit `when` guard on the cleanup task.
+The phantom deletion pattern is a variant where the controller crashes or loses leadership between removing the external resource and reporting successful finalizer-role completion to the SDK. The resource reappears in the reconcile queue on the next watch event. The deletion path runs again, the external resource check returns 404 because it was already removed in the previous partial run, and then the SDK removes the finalizer after the role completes successfully. This behavior is correct only when the deletion check is idempotent. A deletion role that treats a 404 as a hard error will loop forever on a resource that was partially cleaned up. Always handle absence explicitly with `failed_when: false` and an explicit `when` guard on the cleanup task.
 
 <!-- code-verified-against: controller-runtime workqueue semantics — the per-key exclusion guarantee means only ONE worker processes a given CR key at a time; the race is sequential (interrupted then retried), not concurrent -->
-A related hazard is the interrupted-reconcile sequence. controller-runtime's workqueue guarantees that a given CR key is processed by at most one worker at a time — two workers cannot simultaneously run the cleanup role for the same CR. The real danger arises when a single worker runs the cleanup role, successfully removes the external resource, and then crashes or loses the leader lease before removing the finalizer. On the next watch event the same CR re-enters the queue, a fresh worker picks it up, and the cleanup role runs again. Because the external resource was already deleted in the previous pass, the second run encounters a 404. This sequential re-execution is expected and correct, but only if the cleanup role treats 404 as a success rather than an error. Defence requires idempotent cleanup logic, graceful 404 handling in every delete task, and the understanding that the cleanup role may legitimately run more than once for the same CR across sequential reconcile passes.
+A related hazard is the interrupted-reconcile sequence. controller-runtime's workqueue guarantees that a given CR key is processed by at most one worker at a time — two workers cannot simultaneously run the cleanup role for the same CR. The real danger arises when a single worker runs the cleanup role, successfully removes the external resource, and then crashes or loses the leader lease before the SDK records successful completion and removes the finalizer. On the next watch event the same CR re-enters the queue, a fresh worker picks it up, and the cleanup role runs again. Because the external resource was already deleted in the previous pass, the second run encounters a 404. This sequential re-execution is expected and correct, but only if the cleanup role treats 404 as a success rather than an error. Defence requires idempotent cleanup logic, graceful 404 handling in every delete task, and the understanding that the cleanup role may legitimately run more than once for the same CR across sequential reconcile passes.
 
 ```yaml
 # watches.yaml with finalizer and deletion role wired
@@ -209,7 +203,6 @@ A related hazard is the interrupted-reconcile sequence. controller-runtime's wor
   kind: DemoApp
   role: demoapp
   manageStatus: false
-  maxConcurrentReconciles: 4
   reconcilePeriod: 10m
   finalizer:
     name: app.example.com/cleanup
@@ -222,10 +215,10 @@ The `finalizer.name` and `finalizer.role` keys in `watches.yaml` instruct the An
 
 A single-instance development operator that behaves correctly on five CRs may fail in subtle ways on five thousand. The failure modes differ in kind, not just in degree. When scale increases, the reconcile queue grows faster than it drains, per-run Ansible startup overhead compounds, the Kubernetes API server receives proportionally more traffic from the operator, and resource contention between concurrent reconcile workers becomes a real operational concern. Each of these is a design problem, not an infrastructure problem. Adding more CPU to the controller Pod does not fix an operator that makes three unnecessary API calls per reconcile or runs a full role even when all child resources are already converged.
 
-The first principle at scale is aggressive cache use. Controller-runtime's informer cache is a local, in-memory snapshot of Kubernetes objects that the manager has registered to watch. When an Ansible Operator calls `kubernetes.core.k8s_info`, it reads from the Kubernetes API server by default rather than the local cache. At small scale, this is imperceptible. At ten thousand CRs each reconciling every ten minutes, the accumulated API reads become a measurable load on the API server. The fix is to ensure that informer-backed resource types are declared as dependent watches in `watches.yaml` so controller-runtime subscribes to them, and then to understand when module calls will use the cache versus bypass it.
+The first principle at scale is aggressive cache use. Controller-runtime's informer cache is a local, in-memory snapshot of Kubernetes objects that the manager has registered to watch. When an Ansible Operator calls `kubernetes.core.k8s_info`, it reads from the Kubernetes API server by default rather than the local cache. At small scale, this is imperceptible. At ten thousand CRs each reconciling every ten minutes, the accumulated API reads become a measurable load on the API server. The fix is to enable `watchDependentResources: true` when owned child-resource changes should trigger reconciliation, add `blacklist` entries for high-churn kinds, and then understand when module calls will use the cache versus bypass it.
 
 ```yaml
-# watches.yaml with dependent watches for cache registration
+# watches.yaml with owned child-resource watches enabled
 ---
 - version: v1
   group: app.example.com
@@ -233,17 +226,19 @@ The first principle at scale is aggressive cache use. Controller-runtime's infor
   role: demoapp
   manageStatus: false
   watchDependentResources: true
-  dependentWatches:
+  blacklist:
     - version: v1
-      kind: ConfigMap
-    - apiVersion: apps/v1
-      kind: Deployment
+      group: ""
+      kind: Event
+    - version: v1
+      group: ""
+      kind: Pod
 ```
 
-The second principle is rate-limited requeue. Controller-runtime provides exponential backoff on reconcile errors via `RateLimitedRequeue`, which defers the next reconcile by an increasing interval rather than immediately requeuing on failure. Without rate limiting, a single misbehaving CR can monopolize the worker queue by continuously failing and requeuing. With rate limiting, transient failures back off progressively, and healthy CRs continue to reconcile in parallel. The Ansible Operator exposes per-run requeue control through the `ANSIBLE_OPERATOR_PLUGINS_RECONCILE_PERIOD` environment variable and through the `reconcilePeriod` field in `watches.yaml`.
+The second principle is rate-limited requeue. Controller-runtime provides exponential backoff on reconcile errors via rate-limited workqueue behavior, which defers the next reconcile by an increasing interval rather than immediately requeuing on failure. Without rate limiting, a single misbehaving CR can monopolize the worker queue by continuously failing and requeuing. With rate limiting, transient failures back off progressively, and healthy CRs continue to reconcile in parallel. Periodic reconciliation is configured with the `reconcilePeriod` field in `watches.yaml`, the manager-wide `--reconcile-period` flag, or the `ansible.sdk.operatorframework.io/reconcile-period` annotation on a CR when a specific instance needs a different timer.
 
 ```yaml
-# config/manager/manager.yaml excerpt — concurrency and requeue tuning
+# config/manager/manager.yaml excerpt — concurrency, periodic reconcile, and verbosity tuning
 apiVersion: apps/v1
 kind: Deployment
 metadata:
@@ -253,12 +248,13 @@ spec:
     spec:
       containers:
         - name: manager
+          args:
+            - "--max-concurrent-reconciles=8"
+            - "--reconcile-period=600s"
           env:
-            - name: ANSIBLE_OPERATOR_PLUGINS_MAX_CONCURRENT_RECONCILES
+            - name: MAX_CONCURRENT_RECONCILES_DEMOAPP_EXAMPLE_COM
               value: "8"
-            - name: ANSIBLE_OPERATOR_PLUGINS_RECONCILE_PERIOD
-              value: "600s"
-            - name: ANSIBLE_OPERATOR_PLUGINS_VERBOSITY
+            - name: ANSIBLE_VERBOSITY_DEMOAPP_EXAMPLE_COM
               value: "1"
 ```
 
@@ -285,9 +281,9 @@ The third principle is deduplication of work through early-exit. At scale, many 
 
 Cache invalidation at scale requires special attention when the operator manages external resources that do not produce Kubernetes events. An operator that creates a cloud load balancer for each CR cannot rely on watch events from the load balancer to trigger reconciles when external state drifts. Periodic reconciliation via `reconcilePeriod` fills this gap, but the period must be long enough that it does not flood the queue under normal operation. A useful guideline is to set `reconcilePeriod` to at least twice the expected maximum latency for external state changes to propagate, then add per-CR exponential backoff for resources that are actively failing reconciles.
 
-The `maxConcurrentReconciles` setting controls how many `ansible-runner` processes execute in parallel. The optimal value depends on the controller Pod's CPU and memory limits, the cost of each role run (network calls, collection loading, Ansible startup time), and the rate of incoming events. Setting this too low serializes reconciles and creates queue backpressure at scale. Setting it too high creates CPU contention between workers and may cause API server throttling. A practical starting point for most operators is four to eight concurrent reconciles, measured under realistic load before deploying to production and adjusted based on observed queue depth and error rates.
+The `--max-concurrent-reconciles` flag and `MAX_CONCURRENT_RECONCILES_<KIND>_<GROUP>` override control how many `ansible-runner` processes execute in parallel. The optimal value depends on the controller Pod's CPU and memory limits, the cost of each role run (network calls, collection loading, Ansible startup time), and the rate of incoming events. Setting this too low serializes reconciles and creates queue backpressure at scale. Setting it too high creates CPU contention between workers and may cause API server throttling. A practical starting point for most operators is four to eight concurrent reconciles, measured under realistic load before deploying to production and adjusted based on observed queue depth and error rates.
 
-Pause and predict: if you set `maxConcurrentReconciles: 100` for an operator managing 10,000 CRs that all need reconciliation after a cluster upgrade, what is likely to happen to the Kubernetes API server? One hundred simultaneous `ansible-runner` processes, each making several `k8s` and `k8s_info` calls, will generate a burst of hundreds of API requests per second from a single operator Pod. Most production API servers have admission rate limits that begin throttling the operator, causing reconcile failures that themselves trigger requeue events, amplifying the burst further. The correct response is a lower `maxConcurrentReconciles` combined with a jitter mechanism to spread the reconcile load after burst-inducing events.
+Pause and predict: if you set `--max-concurrent-reconciles=100` for an operator managing 10,000 CRs that all need reconciliation after a cluster upgrade, what is likely to happen to the Kubernetes API server? One hundred simultaneous `ansible-runner` processes, each making several `k8s` and `k8s_info` calls, will generate a burst of hundreds of API requests per second from a single operator Pod. Most production API servers have admission rate limits that begin throttling the operator, causing reconcile failures that themselves trigger requeue events, amplifying the burst further. The correct response is a lower concurrency setting combined with a jitter mechanism to spread the reconcile load after burst-inducing events.
 
 ## Upgrade Safety: CRD Schema Migrations
 
@@ -371,7 +367,7 @@ An Ansible Operator running in a production cluster typically deploys multiple r
 
 Operator SDK wires leader election automatically when `--leader-elect=true` is passed to the manager binary. The lease is stored as a `Lease` object in the same namespace as the operator, named after the operator's `leader-election-id` argument. The holder renews the lease on a schedule derived from `leaseDuration` and `renewDeadline`. If the holder fails to renew within `renewDeadline`, the lease expires and any of the waiting pods can claim it. The default values in controller-runtime are `leaseDuration: 15s`, `renewDeadline: 10s`, `retryPeriod: 2s`, which means a failed leader will be replaced within approximately 15 seconds under normal network conditions.
 
-What happens to a reconcile that is in progress when the leader loses its lease? The outgoing leader's manager receives a context cancellation signal. `ansible-runner` processes that are already executing are not immediately killed; they continue until they complete or until the manager's `terminationGracePeriodSeconds` elapses. If the Ansible role completes before the timeout, it will attempt to patch CR status and remove finalizers. Those API calls use optimistic concurrency via `resourceVersion`, so if the new leader has already patched the same fields, the outgoing leader's write will fail with a conflict error rather than silently overwriting the new leader's work. This is the correct behavior: the conflict error is logged, the resource is requeued, and the new leader reconciles it on the next pass.
+What happens to a reconcile that is in progress when the leader loses its lease? The outgoing leader's manager receives a context cancellation signal. `ansible-runner` processes that are already executing are not immediately killed; they continue until they complete or until the manager's `terminationGracePeriodSeconds` elapses. If the Ansible role completes before the timeout, the manager may still try to publish CR status or record successful finalizer-role completion so the SDK can remove its configured finalizer. Those API calls use optimistic concurrency via `resourceVersion`, so if the new leader has already updated the same fields, the outgoing leader's write will fail with a conflict error rather than silently overwriting the new leader's work. This is the correct behavior: the conflict error is logged, the resource is requeued, and the new leader reconciles it on the next pass.
 
 ```yaml
 # config/manager/manager.yaml with HA and leader election settings
@@ -485,7 +481,7 @@ containers:
       - "--zap-encoder=json"
       - "--zap-stacktrace-level=error"
     env:
-      - name: ANSIBLE_OPERATOR_PLUGINS_VERBOSITY
+      - name: ANSIBLE_VERBOSITY_DEMOAPP_EXAMPLE_COM
         value: "1"
 ```
 
@@ -578,7 +574,7 @@ The Molecule testing framework supports scenario-based testing for Ansible Opera
 | Conditions array with machine-readable `reason` codes | Any operator going to production | Enables alertmanager rules and consuming controllers to respond to specific conditions without parsing message strings |
 | Separate `finalizer.role` for deletion logic | Operators managing any external resources | Isolates deletion path for independent testing; prevents deletion logic from contaminating the create/update path |
 | Early-exit on already-converged state | Operators managing more than 100 CRs | Reduces API write traffic and Ansible overhead for the common "nothing changed" case |
-| `maxConcurrentReconciles` tuned under realistic load | All operators before production | Prevents queue serialization at scale without triggering API server throttling |
+| `--max-concurrent-reconciles` tuned under realistic load | All operators before production | Prevents queue serialization at scale without triggering API server throttling |
 | OLM bundle with `Manual` upgrade approval | Production cluster deployments | Adds a change-control gate before new operator versions reach tenant workloads |
 | `--zap-encoder=json` on the manager binary | All operators in shared clusters | Makes reconcile events queryable by Loki and Elasticsearch without custom log parsing |
 
@@ -587,7 +583,7 @@ The Molecule testing framework supports scenario-based testing for Ansible Opera
 | Overwriting `lastTransitionTime` on every reconcile | Simpler to write; avoids the read-before-write pattern | Read current condition status first; update `lastTransitionTime` only when `status` changes from one value to another |
 | Circular finalizer dependencies between two CR types | Parent-child relationships invite mutual cleanup guards | Establish a strict ownership hierarchy; children always finalize before parents; parents never wait on children |
 | Setting `reconcilePeriod: 30s` for "safety" | Assumption that frequent checks prevent drift | Use dependent watches for child resources; keep period at 10m or longer; rely on watch events for prompt reactions |
-| Not setting `maxConcurrentReconciles` before scaling beyond 200 CRs | Default of 1 feels safe; nobody revisits defaults | Profile queue depth under realistic load at 50 CRs and set concurrency based on measured API throughput budget |
+| Not profiling concurrency before scaling beyond 200 CRs | The default `runtime.NumCPU()` may look adequate in a small test; nobody revisits it under realistic event volume | Profile queue depth under realistic load at 50 CRs and set `--max-concurrent-reconciles` or the per-GVK override based on measured API throughput budget |
 | Skipping `operator-sdk bundle validate` before publishing | Build succeeds; warnings seem cosmetic | OperatorHub rejects bundles with schema warnings; all validate output should be treated as errors before publishing |
 | Using `wait: true` in `kubernetes.core.k8s` without a meaningful timeout | Module default of 120s seems conservative | A 120s block starves other reconciles; set timeout proportional to your SLO and handle `failed` results with rescue blocks |
 | Assuming a "minor" field rename needs no conversion strategy | Rename feels like a backwards-compatible change | Any field name change breaks old CRs unless the role accepts both names; use `x-kubernetes-validations` or a conversion webhook |
@@ -604,7 +600,7 @@ Does this operator create external resources (cloud APIs, DNS, databases)?
     NO  → Owner references plus Kubernetes garbage collection are sufficient.
 
 Does the operator manage more than 50 CRs per cluster?
-    YES → Profile reconcile duration; set maxConcurrentReconciles;
+    YES → Profile reconcile duration; set --max-concurrent-reconciles;
           add early-exit for already-converged resources.
     NO  → SDK defaults are adequate; revisit at 200+ CRs.
 
@@ -643,7 +639,7 @@ Is reconcile observability required for SLO tracking?
 | Embedding deletion logic in the main role with `when: demoapp_deleting` | Seems like fewer files to manage | Move deletion to a separate role via `finalizer.role` in `watches.yaml`; test it independently with a dedicated Molecule scenario |
 | Omitting `demoapps/status` from the ClusterRole | Granting `demoapps` looks sufficient; subresource is easy to miss | Explicitly add `demoapps/status` and `demoapps/finalizers` as separate resources in the RBAC rules |
 | Using the same `--leader-election-id` for two operators in one namespace | Copy-paste from an existing operator deployment template | Each operator must have a unique `leader-election-id` to avoid competing for the same Lease resource |
-| Not profiling or tuning `maxConcurrentReconciles` before production | Default of 1 works fine at 10 CRs; nobody revisits defaults | Profile under realistic CR count and event rates; start at 4, measure API throughput and queue depth, adjust |
+| Not profiling or tuning `--max-concurrent-reconciles` before production | A small test works fine, so nobody revisits concurrency under realistic CR counts | Profile under realistic CR count and event rates; start at 4, measure API throughput and queue depth, adjust |
 | Publishing an OLM bundle with `operator-sdk bundle validate` warnings | Build pipeline passes; warnings appear non-blocking | OperatorHub and many enterprise catalogs reject bundles with schema warnings; run `validate` with `--select-optional name=operatorhub` and treat all output as blocking |
 | Setting `wait: true` without a bounded `wait_timeout` in `kubernetes.core.k8s` | Default seems conservative; explicit timeout feels like extra YAML | A 120s blocking call starves the worker for other CRs; set an explicit timeout matched to your p99 reconcile budget and add a `rescue` block for timeout failures |
 | Treating 404 from an external API as an error in the deletion role | Fail-fast principle; absence seems like a problem | During deletion, 404 means the resource is already gone — that is the success state; use `failed_when: false` with `when: check.status == 200` on the delete task |
@@ -660,7 +656,7 @@ The `lastTransitionTime` for the `Ready` condition is almost certainly being res
 <details>
 <summary>A custom resource with finalizer `app.example.com/cleanup` has had `deletionTimestamp` set for 45 minutes. The resource is still present. Operator logs show no recent errors. What sequence of events should you investigate, and what commands would you run?</summary>
 
-The most common explanation is that the cleanup role ran, handled the external resource (returning success on a 404), but never patched the finalizer away. This can happen if the role exits before reaching the finalizer-removal task due to a `failed_when` mismatch, or if the `kubernetes.core.k8s` task patching `finalizers: []` silently fails because the service account lacks `update` permission on `demoapps/finalizers`. Start by checking the operator service account's RBAC: run `kubectl auth can-i update demoapps/finalizers --as=system:serviceaccount:demoapp-operator-system:demoapp-operator-controller-manager -n <namespace>`. Then check whether the deletion role is being triggered at all by searching operator logs for the CR name around the `deletionTimestamp` time. Finally, verify that `watches.yaml` has a `finalizer.role` entry and that the deletion role includes the `kubernetes.core.k8s` task that patches `finalizers` to an empty list.
+The most common explanation is that the finalizer role is not completing successfully from the SDK's perspective, even if one cleanup task appears to have handled the external resource. Start by checking whether the deletion role is being triggered at all by searching operator logs for the CR name around the `deletionTimestamp` time. Then inspect the role output for any later task failure, undefined variable, missing collection, or `failed_when` mismatch after the external cleanup step. Finally, verify that `watches.yaml` has a `finalizer.role` entry and that the deletion role only deletes external resources idempotently; it should not clear the CR finalizer list itself, because the SDK removes the configured finalizer after the role completes successfully.
 
 </details>
 
@@ -686,9 +682,9 @@ Two distinct risks deserve explicit flags. First, `AllNamespaces` mode with Serv
 </details>
 
 <details>
-<summary>Your operator manages 8,000 DemoApp CRs with maxConcurrentReconciles set to 20. After a cluster version upgrade, all 8,000 CRs are requeued simultaneously. What do you expect to observe, and what changes would you make before the next planned upgrade?</summary>
+<summary>Your operator manages 8,000 DemoApp CRs with `--max-concurrent-reconciles=20`. After a cluster version upgrade, all 8,000 CRs are requeued simultaneously. What do you expect to observe, and what changes would you make before the next planned upgrade?</summary>
 
-With 8,000 CRs queued and 20 concurrent workers, and assuming each reconcile takes approximately 4 seconds, the queue drains at roughly 5 reconciles per second. Full queue drain takes over 26 minutes. During that window, CRs near the end of the queue have stale status, and the operator's status-update metric will show a sustained burst of activity that may look like an incident to any SLO alerts configured on status freshness. The API server will receive 20 simultaneous Ansible-runner processes each making several calls. Before the next upgrade, three changes are worth making: first, add a small random `requeue_after` value to spread the initial burst across the first few minutes instead of hitting the queue simultaneously; second, increase `maxConcurrentReconciles` from 20 to 40 after profiling that the API server can handle the increased throughput; third, add a Prometheus alert on `controller_runtime_reconcile_queue_length` so the team is notified when the queue grows unusually long and can distinguish a planned upgrade burst from an unexpected problem.
+With 8,000 CRs queued and 20 concurrent workers, and assuming each reconcile takes approximately 4 seconds, the queue drains at roughly 5 reconciles per second. Full queue drain takes over 26 minutes. During that window, CRs near the end of the queue have stale status, and the operator's status-update metric will show a sustained burst of activity that may look like an incident to any SLO alerts configured on status freshness. The API server will receive 20 simultaneous Ansible-runner processes each making several calls. Before the next upgrade, three changes are worth making: first, add a small random `requeue_after` value to spread the initial burst across the first few minutes instead of hitting the queue simultaneously; second, increase `--max-concurrent-reconciles` from 20 to 40 only after profiling that the API server can handle the increased throughput; third, add a Prometheus alert on `workqueue_depth` labeled by controller `name` so the team is notified when the queue grows unusually long and can distinguish a planned upgrade burst from an unexpected problem.
 
 </details>
 
@@ -729,11 +725,9 @@ spec:
           args:
             - "--leader-elect=true"
             - "--leader-election-id=demoapp-operator"
+            - "--max-concurrent-reconciles=4"
             - "--zap-log-level=info"
             - "--zap-encoder=json"
-          env:
-            - name: ANSIBLE_OPERATOR_PLUGINS_MAX_CONCURRENT_RECONCILES
-              value: "4"
 ```
 
 Build and deploy.
@@ -813,7 +807,7 @@ Record the total time from first apply to last `Ready` phase. You will compare t
 <details>
 <summary>Solution guidance for Task 3</summary>
 
-With `maxConcurrentReconciles: 4` and assuming each reconcile takes 3-6 seconds including Ansible startup, you should observe the 100 CRs drain over approximately 1.5-3 minutes. If all 100 show `Ready` near-simultaneously, your actual concurrency may be higher than the configured value — check whether the environment variable setting took effect in the deployed Pod. The `uniq -c` output lets you track how many CRs remain in each phase over time.
+With `--max-concurrent-reconciles=4` and assuming each reconcile takes 3-6 seconds including Ansible startup, you should observe the 100 CRs drain over approximately 1.5-3 minutes. If all 100 show `Ready` near-simultaneously, your actual concurrency may be higher than the configured value — check whether the manager argument took effect in the deployed Pod. The `uniq -c` output lets you track how many CRs remain in each phase over time.
 
 </details>
 
@@ -853,12 +847,12 @@ The lease transition should occur within 10-15 seconds. After the new leader acq
 
 ### Task 5: Increase Concurrency and Compare Drain Time
 
-Update `ANSIBLE_OPERATOR_PLUGINS_MAX_CONCURRENT_RECONCILES` to 10, redeploy, and create another 100 CRs in a new namespace to compare drain time against the measurement from Task 3.
+Update the per-GVK concurrency override to 10, redeploy, and create another 100 CRs in a new namespace to compare drain time against the measurement from Task 3.
 
 ```bash
 kubectl set env deployment/demoapp-operator-controller-manager \
   -n demoapp-operator-system \
-  ANSIBLE_OPERATOR_PLUGINS_MAX_CONCURRENT_RECONCILES=10
+  MAX_CONCURRENT_RECONCILES_DEMOAPP_EXAMPLE_COM=10
 
 kubectl rollout status deployment/demoapp-operator-controller-manager \
   -n demoapp-operator-system --timeout=60s
@@ -885,10 +879,10 @@ The drain time should be measurably shorter with 10 concurrent workers compared 
 ### Success Criteria
 
 - [ ] You deployed the operator with two replicas and confirmed leader election by reading `spec.holderIdentity` from the Lease object.
-- [ ] You created 100 DemoApp CRs and measured the full queue drain time with `maxConcurrentReconciles: 4`.
+- [ ] You created 100 DemoApp CRs and measured the full queue drain time with `--max-concurrent-reconciles=4`.
 - [ ] You deleted the leader pod and observed the Lease transition to the standby pod within the `leaseDuration` window.
 - [ ] You verified that all CRs recovered to `Ready` status after the leader transition without manual intervention.
-- [ ] You measured queue drain time again at `maxConcurrentReconciles: 10` and compared the result, noting whether API server throttling was a factor.
+- [ ] You measured queue drain time again at `MAX_CONCURRENT_RECONCILES_DEMOAPP_EXAMPLE_COM=10` and compared the result, noting whether API server throttling was a factor.
 - [ ] You can explain why increasing concurrency beyond the API server's throughput budget produces worse drain times due to retry amplification, not better ones.
 
 ## Sources

--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.17-testing-ansible-operators.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.17-testing-ansible-operators.md
@@ -125,16 +125,18 @@ The `converge.yml` applies your role against localhost with the Ansible connecti
   gather_facts: false
 
   vars:
-    _demoapp_replicas: 2
-    _demoapp_image: "nginx:1.27-alpine"
-    _demoapp_name: "test-app"
-    _demoapp_namespace: "default"
+    replicas: 2
+    image: "nginx:1.27-alpine"
+    port: 80
+    ansible_operator_meta:
+      name: "test-app"
+      namespace: "default"
 
   roles:
     - role: demoapp
 ```
 
-Notice the variable names follow the operator convention: the Ansible Operator SDK passes CR fields as `_<kind_lowercase>_<field>` variables. Replicating that naming in your Molecule scenario means the same role runs identically in tests and in production reconciliation.
+Notice the variable names follow the operator convention from Module 7.12: the Ansible Operator SDK passes CR `spec` fields as top-level Ansible variables, converting camelCase field names to snake_case by default. Replicating `replicas`, `image`, and `port`, plus the reserved `ansible_operator_meta.name` and `ansible_operator_meta.namespace` values, means the same role runs identically in tests and in production reconciliation.
 
 The `verify.yml` asserts the outcomes of the converge. For a delegated scenario, this often means checking rendered template files, checking output registers, or verifying that expected files were written. Since a delegated run does not have a real API server, your role tasks that call `kubernetes.core.k8s` will fail unless you mock the Kubernetes connection. There are two approaches: add `check_mode: true` to skip the actual API calls and only validate the task definitions, or use the `k8s` Molecule driver for the scenario that exercises Kubernetes tasks.
 
@@ -185,10 +187,12 @@ The `converge.yml` for the Kubernetes scenario applies the role with variables d
   gather_facts: false
 
   vars:
-    _demoapp_replicas: 2
-    _demoapp_image: "nginx:1.27-alpine"
-    _demoapp_name: "molecule-test-app"
-    _demoapp_namespace: "molecule-test"
+    replicas: 2
+    image: "nginx:1.27-alpine"
+    port: 80
+    ansible_operator_meta:
+      name: "molecule-test-app"
+      namespace: "molecule-test"
 
   roles:
     - role: demoapp
@@ -232,7 +236,8 @@ The `verify.yml` then uses `kubernetes.core.k8s_info` to read back the child res
       ansible.builtin.assert:
         that:
           - svc_info.resources | length == 1
-          - svc_info.resources[0].spec.selector['app.kubernetes.io/name'] == 'molecule-test-app'
+          - svc_info.resources[0].spec.selector['app.kubernetes.io/name'] == 'demoapp'
+          - svc_info.resources[0].spec.selector['app.kubernetes.io/instance'] == 'molecule-test-app'
         fail_msg: "Service selector does not match expected labels"
 ```
 
@@ -351,7 +356,8 @@ metadata:
   namespace: default
 spec:
   selector:
-    app.kubernetes.io/name: e2e-test-app
+    app.kubernetes.io/name: demoapp
+    app.kubernetes.io/instance: e2e-test-app
 ---
 apiVersion: app.example.com/v1
 kind: DemoApp
@@ -809,7 +815,7 @@ verifier:
   name: ansible
 ```
 
-Create `roles/demoapp/molecule/default/converge.yml`. This playbook is the test driver: it invokes the `demoapp` role with variables that replicate what the Ansible Operator SDK injects from a real CR spec at reconciliation time. The `_demoapp_` prefix convention is not arbitrary — the SDK generates these exact variable names from the CR's `spec` field names, so using the same prefix in the test scenario ensures the role runs with inputs identical to what it would receive from a live CR:
+Create `roles/demoapp/molecule/default/converge.yml`. This playbook is the test driver: it invokes the `demoapp` role with variables that replicate what the Ansible Operator SDK injects from a real CR spec at reconciliation time. The SDK injects spec fields as top-level variables, converting camelCase to snake_case by default, and exposes CR identity through `ansible_operator_meta`. The Molecule scenario mirrors those names directly so the role receives `replicas`, `image`, `port`, and metadata exactly as it would during a live reconcile:
 
 ```yaml
 ---
@@ -818,10 +824,12 @@ Create `roles/demoapp/molecule/default/converge.yml`. This playbook is the test 
   connection: local
   gather_facts: false
   vars:
-    _demoapp_replicas: 2
-    _demoapp_image: "nginx:1.27-alpine"
-    _demoapp_name: "molecule-unit-app"
-    _demoapp_namespace: "default"
+    replicas: 2
+    image: "nginx:1.27-alpine"
+    port: 80
+    ansible_operator_meta:
+      name: "molecule-unit-app"
+      namespace: "default"
     molecule_no_k8s: true
   roles:
     - role: demoapp
@@ -897,10 +905,12 @@ Create `roles/demoapp/molecule/k8s/converge.yml`. This converge playbook omits t
   connection: local
   gather_facts: false
   vars:
-    _demoapp_replicas: 3
-    _demoapp_image: "nginx:1.27-alpine"
-    _demoapp_name: "k8s-test-app"
-    _demoapp_namespace: "molecule-k8s-test"
+    replicas: 3
+    image: "nginx:1.27-alpine"
+    port: 80
+    ansible_operator_meta:
+      name: "k8s-test-app"
+      namespace: "molecule-k8s-test"
   roles:
     - role: demoapp
 ```
@@ -1010,6 +1020,10 @@ metadata:
   name: kuttl-test-app
   namespace: default
 spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: demoapp
+      app.kubernetes.io/instance: kuttl-test-app
   replicas: 2
 ---
 apiVersion: v1
@@ -1017,6 +1031,10 @@ kind: Service
 metadata:
   name: kuttl-test-app
   namespace: default
+spec:
+  selector:
+    app.kubernetes.io/name: demoapp
+    app.kubernetes.io/instance: kuttl-test-app
 ```
 
 Create the delete command manifest for step 02. A `TestStep` resource lets you run arbitrary `kubectl` commands as part of a step, rather than just applying manifests. The `--wait=true` flag ensures the command blocks until the CR's deletion is acknowledged by the API server:


### PR DESCRIPTION
## What

Fix-pass for the **Ansible Operator arc** (Toolkits → infrastructure-networking → iac-tools) deferred in session 158 after a cross-family R1 (cursor) found **verifier-blind fabricated/wrong Operator-SDK API surface**. Flips 7.13/7.16/7.17 to `done`, completing the Ansible-operator arc 7.12–7.17.

Fix author: **codex gpt-5.5** (`9c634bdb8`). Cross-family R2: **opus-inline** (Anthropic ≠ codex/OpenAI; ≠ cursor/Kimi R1), with **every disputed API fact independently web-verified against upstream docs before the fix** and re-confirmed in the diff.

## Defects fixed (all web-verified vs upstream)

**7.13 — Advanced watches.yaml**
- `ANSIBLE_WORKERS` env var is fabricated → real `--max-concurrent-reconciles` flag + per-GVK `MAX_CONCURRENT_RECONCILES_<KIND>_<GROUP>` env var.
- Default concurrency corrected: fabricated "1 / single worker" → real `runtime.NumCPU()` (throughput-math example keeps a single worker by setting `--max-concurrent-reconciles=1` explicitly).
- Lab role vars aligned to Module 7.12 (`replicas|default(1)`, `image|default('nginx:1.27-alpine')`); stale "next module coming soon" → link to 7.14.

**7.16 — Production patterns**
- Fabricated watches.yaml fields `maxConcurrentReconciles:` (Helm-only) and `dependentWatches:` (nonexistent) → real `watchDependentResources: true` + flag/env concurrency.
- Fabricated `ANSIBLE_OPERATOR_PLUGINS_*` env vars → `MAX_CONCURRENT_RECONCILES_*`, `ANSIBLE_VERBOSITY_<KIND>_<GROUP>`, watches.yaml `reconcilePeriod`.
- Finalizer anti-pattern (manual `finalizers: []` patch) → rely on SDK auto-removal after the finalizer role succeeds.
- `AnsibleFailed` → `Failure` (reason `Failed`); `controller_runtime_reconcile_queue_length` → `workqueue_depth`.

**7.17 — Testing (Molecule/Kuttl)**
- Fabricated `_demoapp_` var prefix → top-level `replicas`/`image`/`port` + `ansible_operator_meta` mock (matches how the SDK injects spec).
- Kuttl asserts aligned to the 7.12 role's child labels (`app.kubernetes.io/name: demoapp` + `instance: kuttl-test-app`).

## Verification
- All three: `verify_module.py` **T0 PASS**, body_words **5645 / 5238 / 5735** (floor 5000).
- 0 residual fabricated tokens; no new fabricated API; frontmatter untouched.
- APPROVE review records in `.pipeline/reviews/`.

Refs #1996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)