### PR TITLE
content(platform): flip Toolkits 7.8-sst / 7.11-hcp-terraform / 14.8-edge-distros to done (#1996)

### DIFF
--- a/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.8-sst.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/iac-tools/module-7.8-sst.md
@@ -503,7 +503,7 @@ T+0:20  Deploy to production
 TOTAL: 20 minutes, including deployment
 ```
 
-The metrics table should be read as a decision model, not a universal benchmark. If your team deploys twice a day and already has excellent integration tests, SST may still help, but the financial case will be smaller. If your team is shipping dozens of serverless changes daily and spending most debugging time on integration behavior, the return can be substantial because the framework attacks the dominant delay in the workflow.
+The metrics table below holds illustrative figures from a hypothetical migration to make the decision model concrete; they are not measured benchmarks. If your team deploys twice a day and already has excellent integration tests, SST may still help, but the financial case will be smaller. If your team is shipping dozens of serverless changes daily and spending most debugging time on integration behavior, the return can be substantial because the framework attacks the dominant delay in the workflow.
 
 | Metric | Before (Serverless Framework) | After (SST) | Change |
 |--------|-------------------------------|-------------|--------|
@@ -511,7 +511,6 @@ The metrics table should be read as a decision model, not a universal benchmark.
 | Daily wait time | 60-80 min | 10-15 min | -80% |
 | Bugs caught locally | 30% | 95% | +216% |
 | Production incidents | 8/month | 2/month | -75% |
-| Developer satisfaction | "Painful" | "Actually fun" | ∞ |
 
 Financial models are only useful when the assumptions are visible. The table below preserves the original module’s calculation, but a real team should replace every number with local data: engineer cost, deploy count, average wait, defect rate, incident cost, and onboarding time. The exercise is valuable even if the result argues against migration, because it forces the team to describe the problem in operational terms instead of arguing about tool preference.
 


### PR DESCRIPTION
## What

Flips 3 T0-but-never-cross-family-reviewed Toolkits/infrastructure-networking modules to `done` after a genuine web-grounded **opus-inline cross-family R1** (Anthropic ≠ original authors; no gemini). T0 ≠ correct (the s159 Ansible arc proved fabricated API passes the verifier), so each was read in full and its volatile claims web-verified.

## Per-module

**7.8-sst** — accurate (SST `sst dev` live-Lambda model, Console, stages, CI guidance all correct). Orchestrator-inline anti-fab polish: the before/after metrics table is now explicitly framed as **illustrative figures from a hypothetical migration, not measured benchmarks**, and the unprofessional `∞` "Developer satisfaction" row was removed. Re-verified T0.

**7.11-hcp-terraform-workflows** — clean flip. Pricing is textbook durable-content: dated snapshot ("As of May 19, 2026"), tiers Essentials/Standard/Premium at **$0.10 / $0.47 / $0.99 per resource/month** (matches current HCP pricing exactly), Free=500 resources (correct post-March-2026 plan), RUM defined correctly, "use the live pricing page" note. No best-tool/market-share claims ("Best fit" = use-case fit). "sandbox" tokens = Rego policy names.

**14.8-edge-distros-landscape** — clean flip, exemplary durable-content. CNCF maturity web-verified both ways: **KubeEdge Graduated 2024-09-11**, **OpenYurt Incubating 2025-01-10** (DYK cites exact dates). Built on the durable spine (edge continuum, decision criteria, PoC tests, rollout contract, decision record with expiration condition); explicitly rejects ranking ("the winner is not the fastest demo").

## Verification
- All 3 `verify_module.py` **T0 PASS**.
- APPROVE review records in `.pipeline/reviews/`.

Refs #1996.

🤖 Generated with [Claude Code](https://claude.com/claude-code)