### PR TITLE
content(platform): expand Toolkits k8s-distributions 14.1-k3s / 14.2-k0s / 14.3-microk8s to T0 (#1996)

### DIFF
--- a/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.1-k3s.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.1-k3s.md
@@ -9,53 +9,97 @@ sidebar:
 
 ## Overview
 
-k3s is Kubernetes that fits on a Raspberry Pi. Created by Rancher Labs (now SUSE), it packages all of Kubernetes into a ~60MB binary that runs on devices with as little as 512MB RAM. It's not a toy—it's a CNCF Sandbox project running production workloads at the edge of networks worldwide, from factory floors to retail stores to autonomous vehicles.
+k3s is Kubernetes that fits on a Raspberry Pi, an industrial gateway, or a developer laptop with room to spare. Created by Rancher Labs founder Darren Shepherd in 2019 and now maintained under SUSE, k3s packages the Kubernetes control plane, node components, and a curated set of cluster add-ons into a single binary that is dramatically smaller than assembling upstream Kubernetes yourself. The project was donated to the CNCF in August 2020 and remains a Sandbox project as of mid-2026, with an active incubation application underway. k3s is not a fork: it is CNCF Certified Kubernetes, meaning the same API objects, the same kubectl workflows, and the same ecosystem of Helm charts and operators apply without translation layers.
 
-This module teaches you to deploy, configure, and operate k3s for edge and resource-constrained environments.
+What makes k3s worth studying in a distributions module is not brand loyalty but packaging philosophy. Upstream Kubernetes gives you composable primitives; a distribution makes opinionated choices about datastore, container runtime, CNI, ingress, load balancing, and storage so you can bootstrap a working cluster quickly. k3s optimizes for operational simplicity on small footprints—edge sites, CI runners, homelab nodes, air-gapped appliances, and ARM boards—while still exposing escape hatches when you want to bring your own ingress controller or external database. This module teaches you to deploy, configure, and operate k3s for those environments, with emphasis on the durable concepts (datastore tradeoffs, bundled components, HA topology) that survive version churn.
 
 ## Prerequisites
 
-- Kubernetes fundamentals (kubectl, deployments, services)
-- Linux command-line basics
-- Understanding of container runtimes (containerd)
-- SSH access to at least one Linux machine (or VM)
+This module assumes you can operate a minimal Kubernetes cluster without reaching for a managed control plane. You should be comfortable creating Deployments and Services, reading pod logs, and applying manifests with kubectl. Linux fundamentals matter because k3s installs as a systemd service, writes configuration under `/etc/rancher/k3s`, and expects you to understand permissions on kubeconfig files. You also need SSH or console access to at least one Linux host—or a local VM tool like Multipass—because every exercise installs real binaries rather than simulating commands. Container runtime knowledge helps when you debug image pull failures: k3s uses containerd, and logs appear in `journalctl -u k3s` rather than Docker's familiar CLI unless you explicitly enable cri-dockerd.
 
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
-- **Deploy K3s clusters on edge devices and resource-constrained environments with automated installation**
-- **Configure K3s with embedded etcd, Traefik ingress, and ServiceLB for production-ready lightweight clusters**
-- **Implement multi-node K3s clusters with server and agent roles for HA edge deployments**
-- **Evaluate K3s against standard Kubernetes for edge computing, IoT, and development environments**
+- **Deploy k3s clusters on edge devices and resource-constrained environments with automated installation**, including single-node SQLite setups and multi-node clusters joined with node tokens
+- **Configure k3s with embedded etcd, Traefik ingress, and ServiceLB for production-ready lightweight clusters**, including disabling bundled components when corporate standards require alternate controllers
+- **Implement multi-node k3s clusters with server and agent roles for HA edge deployments**, including embedded-etcd quorum and external SQL datastores when SQLite is insufficient
+- **Evaluate k3s against standard Kubernetes and peer distributions for edge computing, IoT, and development environments**, using capability-based comparison rather than marketing claims
+
+Each outcome maps to a durable skill you can reuse when the next lightweight distribution ships: understanding what was bundled, what was removed, and which tradeoff you accepted when you ran the install script.
 
 
 ## Why This Module Matters
 
-**Kubernetes is everywhere, but not everywhere can run Kubernetes.**
+Kubernetes is everywhere in cloud data centers, but not every place that needs orchestration can afford a three-node etcd quorum, a dedicated ingress tier, and a platform team on call. Factory floors, retail backrooms, telecom cabinets, agricultural sensors, and CI runners often share a different constraint profile: limited RAM, intermittent connectivity, no on-site Kubernetes expert, and hardware that was purchased for a single application rather than for running a miniature data center. Traditional kubeadm clusters assume you will assemble and maintain each layer yourself, which is the right tradeoff when you need maximum control but the wrong default when you need a working cluster in fifteen minutes on a $50 board.
 
-Traditional Kubernetes requires:
-- 2GB+ RAM for control plane
-- Multiple machines for HA
-- Complex etcd cluster management
-- Significant operational overhead
+k3s exists because Rancher Labs asked a practical question: what is the smallest conformant Kubernetes you can ship as one binary with sensible defaults? The answer removed legacy in-tree cloud providers and storage drivers, bundled containerd as the sole CRI, and replaced the default etcd requirement with a pluggable datastore layer called kine that can back the API onto SQLite, embedded etcd, or external SQL. The result is real Kubernetes—same APIs, same kubectl, same Helm charts—not a parallel platform with compatibility caveats. You trade some configurability at install time for dramatically lower bootstrap friction, which is exactly what edge and appliance deployments need.
 
-Edge computing has different constraints:
-- Limited RAM (512MB-2GB)
-- Single nodes or small clusters
-- Intermittent connectivity
-- Minimal operational staff
+> **The Appliance Analogy**
+>
+> Think of upstream kubeadm as buying a professional kitchen: you choose every appliance, wire the plumbing, and hire staff who know how each piece works. k3s is closer to a well-designed food truck: the grill, fridge, and prep surface are already integrated, the footprint is small, and you can still swap the sauce vendor if you disable the default Traefik ingress and install your own controller. The truck is not "less serious" food—it is optimized for mobility and fast setup.
 
-k3s bridges this gap. It's real Kubernetes—same APIs, same kubectl, same ecosystem—but packaged for environments where every megabyte matters.
+Understanding k3s as a distribution—not merely a "small Kubernetes"—helps you evaluate when it fits and when another distro or managed service is better. The durable lesson is how packaging choices (datastore, bundled ingress, ServiceLB for bare metal) shape operability long after you forget the exact version string printed by `k3s --version`.
 
 ## Did You Know?
 
-- **Why "k3s"?**: Kubernetes has 10 letters, often shortened to K8s (K + 8 letters + s). k3s has 5 letters—half of K8s, for "half the memory"
-- **Origin**: Created by Rancher Labs founder Darren Shepherd in 2019
-- **Scale**: Over 1 million nodes running k3s in production worldwide
-- **Certifications**: k3s is CNCF certified Kubernetes—100% compatible
+- **Why "k3s"?**: Per the upstream docs, Kubernetes is a 10-letter word stylized as K8s; k3s is a 5-letter word stylized as K3s, evoking "half the size" in memory footprint—there is no long form and no official pronunciation
+- **Origin**: Created by Rancher Labs founder Darren Shepherd; first public commits date to January 2019, and the project joined CNCF Sandbox on August 19, 2020
+- **Not a fork**: k3s passes CNCF Kubernetes conformance certification—the same API machinery as upstream, with bundled components and a smaller binary rather than a divergent control plane
+- **kine datastore abstraction**: k3s uses kine to translate Kubernetes storage operations onto SQLite, etcd, MySQL, MariaDB, or PostgreSQL, which is why a single-server SQLite setup and a three-server embedded-etcd HA setup share one distribution
+
+## What a Kubernetes Distribution Actually Is
+
+Before you touch an install script, it helps to separate upstream Kubernetes from the distributions that package it. Upstream Kubernetes—the code in `kubernetes/kubernetes`—defines the API machinery, controllers, scheduler, kubelet contract, and conformance tests. It does not, by itself, tell you which container runtime to use, how pods get IP addresses, how `type: LoadBalancer` services obtain external IPs on bare metal, or where the API server's state lives. Every production cluster makes those choices; a distribution makes them for you so bootstrap is repeatable.
+
+The durable spine of any distribution decision is therefore a checklist of capabilities, not a brand name. You should know the default datastore and what HA mode it enables, which CNI ships out of the box, whether ingress and bare-metal load balancing are bundled, how nodes join and upgrade, and whether the result is conformant Kubernetes or a fork with API caveats. Version numbers and minimum RAM figures change quarterly; those capabilities and their tradeoffs persist across releases.
+
+| Capability | k3s | k0s | MicroK8s | upstream kubeadm |
+|---|---|---|---|---|
+| Default single-node datastore | SQLite via kine | SQLite or embedded etcd | dqlite (embedded) | External etcd (you provision) |
+| HA datastore mechanism | Embedded etcd (`--cluster-init`) or external SQL/etcd | Embedded etcd or external SQL | dqlite clustering (HA addon) | External etcd cluster (3+ members) |
+| Bundled CNI | Flannel (configurable backend) | kube-router | Calico or Flannel (addons) | None—install Cilium, Calico, etc. |
+| Bundled ingress | Traefik (disable with `--disable traefik`) | None by default | nginx ingress (addon) | None—install your controller |
+| Bundled bare-metal Service LB | ServiceLB / Klipper (disable with `--disable servicelb`) | kube-router service proxy | MetalLB (addon) | Cloud provider integration or MetalLB |
+| Install mechanism | curl install script or single binary | `get.k0s.sh` or binary; k0sctl for multi-node | snap package | kubeadm init/join on prepared OS |
+| Packaging model | Single ~60–100MB binary + bundled containerd | Single binary with embedded containerd | Snap confinement | Discrete control-plane and node packages |
+| Primary positioning | Edge, IoT, ARM, air-gap, dev/CI | Zero host dependencies, immutable state dir | Developer laptop, edge appliances | Full control, reference architecture |
+| Conformance | CNCF Certified Kubernetes (Sandbox project) | CNCF Certified Kubernetes (Sandbox project) | CNCF Certified Kubernetes | Upstream reference implementation |
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against upstream docs before relying on specifics.**
+>
+> | Attribute | Current upstream snapshot |
+> |---|---|
+> | CNCF maturity | Sandbox (accepted 2020-08-19); incubation application active as of 2026-05 per [CNCF TOC issue #1957](https://github.com/cncf/toc/issues/1957) |
+> | Binary size claim | Upstream tagline: "less than 100 MB" all-in-one binary ([docs.k3s.io](https://docs.k3s.io/)) |
+> | Default bundled runtime | containerd (CRI); Docker optional via cri-dockerd |
+> | Default CNI | Flannel with vxlan backend unless disabled |
+> | Default ingress | Traefik Ingress controller |
+> | Default Service LB | ServiceLB (Klipper) controller |
+> | Default storage provisioner | local-path-provisioner (`local-path` StorageClass) |
+> | Supported external DBs | etcd 3.5.x, MySQL 8.0/8.4, MariaDB 10.11/11.4, PostgreSQL 15/16/17 per [datastore docs](https://docs.k3s.io/datastore) |
+> | Air-gap artifacts | `k3s` binary + `k3s-airgap-images-$ARCH.tar.zst` from [GitHub releases](https://github.com/k3s-io/k3s/releases) |
+> | Automated upgrades | system-upgrade-controller + `rancher/k3s-upgrade` image via [upgrade plans](https://docs.k3s.io/upgrades/automated) |
+
+No row in the Rosetta table declares a winner. k3s, k0s, and MicroK8s each optimize for different bootstrap stories: k3s for the smallest integrated edge binary, k0s for zero host dependencies and clean `/var/lib/k0s` state isolation, MicroK8s for snap-based laptop clusters, and kubeadm for teams that want to own every layer. Your job is to map workload constraints—offline sites, HA requirements, existing DBA skills, ARM boards—to capability rows, not to marketing adjectives.
+
+## When k3s Fits—and When It Does Not
+
+k3s shines when the problem statement includes footprint, bootstrap time, or bare-metal ergonomics. If you need Kubernetes on ARM64 industrial gateways, on a CI runner that must start in seconds, on a homelab Intel NUC, or on an air-gapped appliance that cannot pull from registries during install, the integrated binary removes days of assembly work. Scenarios with intermittent WAN benefit because a single-server SQLite cluster can run local caches and queue agents without maintaining a separate etcd fleet. Teams already standardized on SUSE or Rancher downstream tooling also gain a straight integration path, though this module stays distribution-neutral and does not require Rancher Manager.
+
+k3s is the wrong default when you need maximum control-plane isolation without bundled ingress, when your security policy forbids any default controllers you did not vet, or when you already operate large etcd or SQL fleets with full-time DBAs who prefer kubeadm's explicit separation. It is also a weak match for multi-tenant clusters where hard multi-tenancy depends on cloud-provider integrations k3s deliberately removed. None of those are k3s bugs—they are packaging tradeoffs. The senior engineer move is to write down constraints first, then pick the distribution row that matches, rather than starting from a logo.
+
+Regulated environments should pay extra attention to datastore mode and backup evidence. SQLite on a single server is easy to reason about but offers no control-plane redundancy; embedded etcd adds quorum maintenance; external SQL shifts liability to a database team already under audit. Document the mode in architecture decision records, snapshot regularly, and test restore quarterly—k3s makes clusters cheap to create, which tempts teams to skip recovery drills until they need them.
 
 ## k3s Architecture
+
+At the process level, k3s collapses what kubeadm spreads across packages into one `k3s` executable that can run in `server` mode (control plane plus optional worker), `agent` mode (worker only), or both on a single node for development. The server embeds kube-apiserver, kube-controller-manager, kube-scheduler, the k3s tunnel proxy for agent connectivity, and the ServiceLB controller. Both server and agent run kubelet, kube-proxy, and containerd. Bundled cluster services—CoreDNS, Traefik, local-path-provisioner, metrics-server, the Helm controller, Flannel CNI, and kube-router's network policy controller—ship as static pods or embedded controllers depending on the component.
+
+The architectural bet is integration over modularity at install time. Instead of prompting you to choose a CNI before the API server starts, k3s brings up a working pod network so beginners and automation pipelines see `Running` pods immediately. Instead of leaving `type: LoadBalancer` broken on bare metal, ServiceLB allocates node ports via a DaemonSet. Each bundled component is disable-able with `--disable <component>` so advanced teams can substitute MetalLB, nginx ingress, or a corporate-standard SQL datastore without switching distributions.
+
+Recent upstream releases also bundle optional subsystems such as the Helm controller (for HelmChart CRDs), Spegel for distributed image mirroring in multi-node clusters, and host utilities like iptables pinned to known-good versions when distribution packages ship broken nftables backends. You do not need to enable or configure these on day one, but knowing they exist explains disk layout under `/var/lib/rancher/k3s` and helps when security scanners flag additional listening processes on worker nodes.
+
+The datastore layer is the other major architectural fork. Single-server installs default to SQLite accessed through kine, which presents an etcd-compatible API to the Kubernetes storage layer while persisting rows in a local file. That keeps memory and disk overhead minimal for edge appliances. When you need control-plane HA, you either promote to embedded etcd across an odd number of server nodes (`--cluster-init` on the first, `--server` joins on the rest) or point all servers at an external MySQL, PostgreSQL, or etcd endpoint via `--datastore-endpoint`. The CAP tradeoff is familiar: SQLite is simple but single-writer; embedded etcd adds quorum maintenance; external SQL leverages existing DBA tooling but introduces network dependency for every API write.
 
 ```
 k3s ARCHITECTURE DEEP DIVE
@@ -138,11 +182,15 @@ Added:
 ✓ Flannel CNI (by default)
 ```
 
+The diagram above is a reference map, not an inventory you must memorize. When troubleshooting, you will care most about three flows: how the API persists objects (datastore row), how agents maintain websocket tunnels to servers (tunnel proxy and embedded agent load balancer on port 6443), and which bundled DaemonSets answer DNS, ingress, and LoadBalancer requests. Removing in-tree cloud providers and legacy storage drivers shrinks the binary and eliminates code paths that edge clusters never exercise; that is a deliberate scope cut, not a missing feature you should patch back in manually.
+
 ## Installing k3s
+
+Installation is where distribution opinions become concrete. The official path is a curl-piped script at `get.k3s.io` that downloads the release binary, installs a systemd (or openrc) unit, and writes configuration to `/etc/rancher/k3s/`. You can also place the binary directly from GitHub releases for quick tests. The script is idempotent enough for lab use but remember that re-running it without re-supplying prior flags can overwrite environment variables you set on the first pass—persistent intent belongs in `/etc/rancher/k3s/config.yaml` for production.
 
 ### Single Node Installation
 
-The fastest way to get started:
+Single-node mode is the fastest on-ramp: one `k3s server` process acts as control plane and worker, SQLite holds API state, and bundled components come up automatically. This is ideal for CI namespaces, laptop labs, and true single-appliance edge deployments where control-plane outage equals site outage anyway. The commands below install, verify the service, and copy kubeconfig so a non-root user can run kubectl without prefixing `k3s` every time.
 
 ```bash
 # Install k3s server (includes agent)
@@ -166,9 +214,11 @@ sudo chown $USER ~/.kube/config
 kubectl get nodes
 ```
 
+After `kubectl get nodes` shows `Ready`, explore `kubectl get pods -A` to see bundled components in `kube-system`. You should find CoreDNS, Traefik (unless disabled), metrics-server, local-path-provisioner, and the Flannel DaemonSet. This is your checklist that the distribution finished bootstrapping—not just that the API server answered.
+
 ### Installation Options
 
-k3s supports many installation flags via environment variables:
+Environment variables prefixed with `K3S_` and the `INSTALL_K3S_EXEC` string pass through to the systemd unit, which matters when you automate with cloud-init or Ansible. Common first-day tweaks include pinning a version for reproducibility, disabling Traefik when your platform standard is ingress-nginx, switching Flannel backends, enabling secrets encryption at rest, and relocating `--data-dir` to a larger disk partition on edge appliances with small root volumes.
 
 ```bash
 # Install specific version
@@ -187,9 +237,11 @@ curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--secrets-encryption" sh -
 curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--data-dir=/opt/k3s" sh -
 ```
 
+`--secrets-encryption` wraps etcd/SQLite secrets at rest with a key you must back up—losing the key means losing access to sealed Secret objects. `--flannel-backend=none` is the escape hatch for bringing Cilium or Calico, but you must install a CNI before workloads schedule. Treat each flag as a contract: disabling defaults without provisioning replacements produces a cluster that is "up" yet unusable.
+
 ### Multi-Node Cluster
 
-**On the server node:**
+Multi-node topology splits responsibilities: servers run the control plane and may also schedule pods; agents run only kubelet and containerd and register to servers over a websocket tunnel maintained by an embedded client-side load balancer. Agents do not need outbound Internet if they can reach the server API on 6443, which matters for restricted edge VLANs. You will need the node token from the first server and a stable `K3S_URL` pointing at any server IP or, in HA setups, a load-balanced API address.
 
 ```bash
 # Install server and get token
@@ -209,9 +261,11 @@ curl -sfL https://get.k3s.io | K3S_URL=https://server-ip:6443 K3S_TOKEN=your-nod
 kubectl get nodes
 ```
 
+When the agent appears as `Ready`, confirm it picked up pod CIDR allocation from Flannel and that `/etc/rancher/node/password` exists locally—k3s uses per-node password secrets in `kube-system` to prevent token replay attacks. If you rebuild an agent without deleting the old Node object, registration may fail until you remove the stale node and its `.node-password.k3s` secret.
+
 ### High Availability Setup
 
-For production, deploy multiple server nodes:
+Production control-plane HA requires thinking about two separate problems: API availability (can kubectl and controllers reach a live apiserver?) and datastore durability (can object state survive server loss?). k3s addresses both with either embedded etcd across three or more server nodes or an external SQL/etcd cluster referenced by every server. Agents should always target a fixed registration address—DNS name or load balancer VIP—so joins survive the loss of any single server IP.
 
 ```
 HA k3s ARCHITECTURE
@@ -241,6 +295,12 @@ Option B: External datastore (MySQL, PostgreSQL, etcd)
 ```
 
 **Using embedded etcd (recommended):**
+
+Embedded etcd runs colocated on server nodes, so every server you add is simultaneously an apiserver host and an etcd member. Plan odd counts—three is the usual minimum—to maintain quorum during one failure. The first server must pass `--cluster-init` exactly once per cluster; subsequent servers use `--server` pointing at any existing member and share the same join token file located at `/var/lib/rancher/k3s/server/token` after initialization. Front the API with a TCP load balancer or DNS round-robin only after all members share consistent `tls-san` entries for the VIP hostname.
+
+**Using external datastore:**
+
+External datastores decouple API availability from etcd embedded on k3s nodes. Every server process connects to the same `datastore-endpoint`, which can be a managed MySQL or PostgreSQL cluster your organization already backs up. This pattern suits teams with DBA runbooks but adds network dependency: if the SQL endpoint is unreachable, the Kubernetes API stops accepting writes even when nodes are healthy. Match TLS options (`datastore-cafile`, cert/key files) to your database provider's requirements and store credentials in environment files with restrictive permissions rather than shell history.
 
 ```bash
 # First server - initialize cluster
@@ -272,7 +332,17 @@ curl -sfL https://get.k3s.io | sh -s - server \
   --tls-san=api.k3s.example.com
 ```
 
+Embedded etcd is the path of least resistance when you do not already operate MySQL or PostgreSQL for other systems. External SQL shines when compliance mandates an existing HA database fleet or when backup tooling already covers Postgres. Either way, always include every client-facing API hostname and load balancer IP in `--tls-san` or `tls-san:` config entries—omitting the SAN is the most common cause of `x509: certificate is valid for ...` errors after you front servers with HAProxy.
+
+### How Agent Registration and kine Fit Together
+
+Two mechanisms confuse newcomers but explain why k3s "just works" on flaky networks: agent registration over a supervised websocket tunnel, and kine as the etcd API shim over SQL. When an agent starts, it opens a tunnel to the server address you provided, seeds an internal load balancer with that endpoint, then learns additional apiserver addresses from the `kubernetes` Endpoints object in `default`. The agent-side load balancer keeps a persistent connection pool so brief server outages do not require manual restarts—this is why a stable `K3S_URL` pointing at a VIP or DNS name matters more than any single server IP.
+
+kine, meanwhile, lets the Kubernetes storage interface speak etcd3 semantics while persisting to SQLite or SQL rows. That is how the same apiserver binary can run on a Raspberry Pi with a local file and later migrate to a three-node etcd quorum without swapping distributions. External SQL mode introduces operational requirements: prepared statement support (PgBouncer needs care), schema migrations when revision counters approach two-billion row limits on legacy databases, and network latency on every write. Monitor `resourceVersion` in API list responses during upgrades—large jumps are normal; stalls near 2147483647 on old schemas require setting `KINE_SCHEMA_MIGRATION` per known-issues documentation.
+
 ## k3s Configuration
+
+Day-two configuration merges three surfaces: the install-time environment, `/etc/rancher/k3s/config.yaml` (plus drop-ins in `config.yaml.d/`), and CLI flags for one-off changes. Critical server flags—`cluster-cidr`, `service-cidr`, `disable` entries, and datastore endpoints—must match across all servers or joins fail with `critical configuration value mismatch`. Treat server config like Terraform: the same inputs on every control-plane node, version-controlled in Git, applied before you declare the cluster production-ready.
 
 ### Server Configuration File
 
@@ -290,12 +360,16 @@ disable:
   - traefik  # Use your own ingress controller
 secrets-encryption: true
 kube-apiserver-arg:
-  - "enable-admission-plugins=NodeRestriction,PodSecurityPolicy"
+  - "enable-admission-plugins=NodeRestriction,PodSecurity"
 kubelet-arg:
   - "max-pods=250"
 ```
 
+The sample enables NodeRestriction plus the Pod Security admission plugin (replacing the removed PodSecurityPolicy admission plugin). Tune `max-pods` against your CIDR size and hardware—edge nodes with 512MB RAM cannot honor 250 pods even if the kubelet accepts the setting. After editing config, restart `k3s` (server) or `k3s-agent` (agent) and verify with `kubectl get nodes -o wide` that labels and taints applied.
+
 ### Agent Configuration File
+
+Agents only need server URL, token, and optional labels/taints. Keep agent config minimal: pushing control-plane flags to agents is a common copy-paste mistake that silently does nothing while giving a false sense of security hardening.
 
 ```yaml
 # /etc/rancher/k3s/config.yaml (on agent nodes)
@@ -310,7 +384,7 @@ kubelet-arg:
 
 ### Disabling Default Components
 
-Choose what you need:
+Disabling bundled components is how you de-couple k3s from its defaults without switching distributions. Platform teams often disable Traefik and ServiceLB simultaneously, then install ingress-nginx plus MetalLB—or rely on an upstream hardware load balancer—to match data-center standards. Document the disable list in Git; upgrading k3s without preserving `--disable` flags resurrects Traefik and can hijack port 80 unexpectedly.
 
 ```bash
 # Disable all optional components
@@ -328,9 +402,11 @@ kubectl apply -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main
 
 ## Storage Options
 
+Storage on k3s follows the same Kubernetes object model—PersistentVolumeClaims, StorageClasses, and dynamic provisioners—but edge clusters rarely have SAN arrays waiting. The default local-path-provisioner creates hostPath-backed volumes on the node where the pod landed, which is perfect for single-replica caches and dangerous for data that must survive node replacement. Understanding when local-path is "good enough" versus when you need replicated storage separates hobby clusters from production edge.
+
 ### Local Path Provisioner (Default)
 
-k3s includes Local Path Provisioner for simple persistent storage:
+Local-path is synchronous, simple, and node-local. ReadWriteOnce volumes bind to whichever node scheduled the pod, so StatefulSets with one replica work; multi-replica databases do not unless you accept split-brain risk. The PVC below requests the default `local-path` StorageClass and mounts into an nginx pod for demonstration—swap the image for your application once the mechanics feel familiar.
 
 ```yaml
 # PVC using local-path StorageClass
@@ -363,9 +439,11 @@ spec:
       claimName: my-data
 ```
 
+Data lives under `/var/lib/rancher/k3s/storage` on the scheduling node. Back up those host directories or use `k3s etcd-snapshot` for control-plane state—PVC data is not included in etcd snapshots. Before node maintenance, drain workloads and confirm no local-path PVCs remain bound to that node.
+
 ### Longhorn (Distributed Storage)
 
-For HA storage, install Longhorn:
+When you need replicated block storage across agents, Longhorn is a common additive choice: it runs entirely inside the cluster, suits small-footprint edge nodes, and exposes a StorageClass you can mark default. Installing Longhorn increases CPU and RAM overhead—budget accordingly on 2GB nodes. The commands below deploy Longhorn, wait for pods, create a `longhorn` StorageClass, and demote local-path from default.
 
 ```bash
 # Install Longhorn
@@ -394,9 +472,11 @@ kubectl patch storageclass longhorn -p '{"metadata": {"annotations":{"storagecla
 
 ## Networking
 
+Networking on k3s is where bundled opinions matter most for bare-metal and edge sites without cloud load balancers. Flannel provides overlay pod connectivity by default; ServiceLB satisfies `type: LoadBalancer` by launching a DaemonSet that binds host ports; Traefik terminates HTTP ingress rules; and kube-router enforces NetworkPolicy when you create policy objects. You can replace any layer, but the defaults exist so a freshly installed cluster can expose a Service and an Ingress without third-party charts.
+
 ### Service Load Balancer (ServiceLB)
 
-k3s includes a built-in load balancer for bare metal:
+Cloud providers implement LoadBalancer Services by provisioning external IPs automatically. On a factory-floor PC or Raspberry Pi cluster, no such integration exists—yet many Helm charts assume `kubectl get svc` will show an `EXTERNAL-IP`. ServiceLB closes that gap by listening on high node ports (or configured ranges) and routing traffic to pod endpoints. It is not a replacement for hardware load balancers in large data centers, but it prevents chart authors from hard-coding NodePort workarounds at every edge site.
 
 ```yaml
 # Exposes Service on node's external IP
@@ -423,9 +503,11 @@ kubectl get svc
 kubectl -n kube-system get pods | grep svclb
 ```
 
+DaemonSet pods named `svclb-*` appear per service. If you plan to use MetalLB or an external LB instead, disable ServiceLB at install time to avoid port conflicts on 80/443.
+
 ### Traefik Ingress Controller
 
-k3s bundles Traefik for ingress:
+Traefik watches Ingress and IngressRoute objects and terminates HTTP traffic on the node. Many teams disable it in favor of ingress-nginx or Envoy Gateway to align with corporate ingress standards. When you keep Traefik, annotate routes explicitly—entrypoints `web` and `websecure` map to ports Traefik opens by default, and missing annotations manifest as 404s that look like application bugs.
 
 ```yaml
 # Ingress using Traefik
@@ -451,7 +533,7 @@ spec:
 
 ### Network Policies
 
-k3s supports network policies via its built-in controller:
+NetworkPolicy is off by default in many minimal clusters, but k3s ships kube-router's controller so policies take effect once you create objects. Policies are your edge safety net when compromised workloads attempt lateral movement over the pod network. Start restrictive: default-deny ingress, then allow labeled frontends to reach backends on specific ports.
 
 ```yaml
 # Allow only frontend to access backend
@@ -477,7 +559,9 @@ spec:
 
 ## Air-Gapped Installation
 
-For environments without internet access:
+Air-gapped environments—defense networks, isolated factory VLANs, and compliance enclaves—cannot pull images or binaries at install time. k3s supports offline installation by prefetching the release binary, the compressed air-gap image bundle (`k3s-airgap-images-$ARCH.tar.zst`), and the install script on a bastion with Internet access, then transferring artifacts to target nodes. You must also ensure nodes have a default route (even a dummy route) so k3s can auto-detect the primary IP, per upstream documentation.
+
+The workflow below mirrors the three-step upstream guide: stage images under `/var/lib/rancher/k3s/agent/images/`, place the binary in `/usr/local/bin/k3s`, and run `INSTALL_K3S_SKIP_DOWNLOAD=true` so the script configures systemd without reaching GitHub. SELinux-enabled hosts additionally need the `k3s-selinux` RPM available locally.
 
 ```bash
 # On a machine with internet access:
@@ -506,9 +590,15 @@ chmod +x install.sh
 INSTALL_K3S_SKIP_DOWNLOAD=true ./install.sh
 ```
 
+After install, verify bundled images loaded with `sudo k3s ctr images list | head` before deploying workloads. Plan upgrades the same way: prefetch the next release's image tarball and binary before disconnecting from your transfer network. Operators in regulated sectors should checksum artifacts on the bastion and again on the isolated node to detect transfer corruption, then record versions in a change ticket so auditors can correlate cluster state with approved binaries.
+
 ## Upgrading k3s
 
+Kubernetes upgrades are never "just bump the binary"—you must respect skew policies between control plane and kubelet, snapshot etcd/SQL state, and roll nodes in an order that preserves quorum. k3s simplifies packaging but not the semantics: server nodes upgrade before agents, and embedded-etcd clusters need at least one healthy member throughout.
+
 ### Manual Upgrade
+
+Manual upgrades suit lab clusters and environments that forbid in-cluster controllers. Pin `INSTALL_K3S_VERSION` to a tested release, run the install script on each node, and restart services. Always read the release notes for Kubernetes minor bumps—admission defaults, API removals, and CNI flags change even when the k3s wrapper feels familiar.
 
 ```bash
 # Check current version
@@ -526,6 +616,8 @@ kubectl get nodes
 ```
 
 ### Automated Upgrades with system-upgrade-controller
+
+Fleet operators managing dozens of edge clusters rarely SSH to each node for patch Tuesday. Rancher's system-upgrade-controller watches `Plan` objects and cordons, drains, and upgrades nodes according to concurrency rules you define. The server plan targets control-plane nodes first; the agent plan waits on a `prepare` hook so servers finish before workers. Channels like `https://update.k3s.io/v1-release/channels/stable` track tested k3s releases—pin a specific channel in regulated environments instead of floating to latest automatically.
 
 ```bash
 # Install System Upgrade Controller
@@ -579,11 +671,15 @@ spec:
 EOF
 ```
 
+Test upgrade plans in a staging cluster that mirrors production datastore mode (SQLite vs embedded etcd vs external SQL). A Plan that works on single-node SQLite may need concurrency `1` on etcd members to avoid quorum loss.
+
 ## Monitoring k3s
+
+Observability splits into Kubernetes-native signals (pod logs, events, metrics-server summaries) and host-level signals (disk space for SQLite/etcd, systemd unit restarts, image pull errors in air-gap). Edge clusters fail quietly when `/var/lib/rancher` fills or when swap causes kubelet thrashing—monitor those paths aggressively because remote hands are scarce.
 
 ### Built-in Metrics Server
 
-k3s includes metrics-server for `kubectl top`:
+metrics-server ships enabled, powering `kubectl top` without extra Helm charts. It is sufficient for capacity conversations ("this node has 200m CPU left") but not a long-term metrics backend. Export Prometheus scrapes when you need retention, alerting, and dashboards.
 
 ```bash
 # Check resource usage
@@ -596,6 +692,8 @@ kubectl describe node | grep -A 10 "Allocated resources"
 
 ### Prometheus Integration
 
+Scrape the kube-apiserver `/metrics` endpoint with appropriate TLS and service account tokens when you centralize monitoring. Agent kubelet endpoints on 10250 follow the same pattern. Treat `insecure_skip_verify: true` as a lab-only shortcut—production scrapers should trust the cluster CA.
+
 ```yaml
 # prometheus-scrape-config.yaml
 # k3s exposes metrics on /metrics
@@ -605,7 +703,7 @@ kubectl describe node | grep -A 10 "Allocated resources"
       - 'server-ip:6443'
   scheme: https
   tls_config:
-    insecure_skip_verify: true  # Or provide certs
+    insecure_skip_verify: true  # Lab only—use proper CA in production
   bearer_token_file: /var/run/secrets/kubernetes.io/serviceaccount/token
 
 - job_name: 'k3s-agent'
@@ -614,74 +712,20 @@ kubectl describe node | grep -A 10 "Allocated resources"
       - 'agent-ip:10250'
   scheme: https
   tls_config:
-    insecure_skip_verify: true
+    insecure_skip_verify: true  # Lab only—use proper CA in production
 ```
 
-## War Story: The Retail Edge
+## Hypothetical scenario: The Retail Edge
 
-A major retailer needed to run Kubernetes at 2,000 store locations:
+The following narrative is illustrative—not a cited production incident. It shows how distribution choices play out when constraints collide.
 
-**The Challenge**:
-- 2,000 stores worldwide
-- Each store has limited hardware (8GB RAM, 2 cores)
-- Unreliable internet connectivity
-- Zero on-site IT staff
-- Need to run inventory management, point-of-sale, and analytics
+A retail platform team needed Kubernetes at thousands of store locations. Each site had modest hardware (roughly 8GB RAM and two to four cores), unreliable WAN links, and no resident Linux administrator. They needed inventory APIs, point-of-sale integrations, and a local cache that survived overnight upstream outages. A kubeadm design with three control-plane nodes and external etcd never fit the hardware budget or staffing model.
 
-**Why Traditional K8s Failed**:
-- Minimum 2GB RAM just for control plane
-- etcd cluster complexity
-- Required 3 nodes minimum for HA
-- Operational overhead impossible at scale
+k3s offered a different contract: one server process per store with SQLite or embedded etcd if they later clustered regional hubs, bundled Traefik for ingress, local-path for cache volumes, and ServiceLB so Helm charts requesting LoadBalancer Services worked without cloud integration. Fleet management—whether Rancher Fleet, GitOps agents, or custom Ansible—pushed manifests over intermittent links, while system-upgrade-controller applied patch channels during maintenance windows.
 
-**The k3s Solution**:
+The lesson is structural: k3s did not make Kubernetes magically smaller in capability—it made the **packaging** small enough to colocate with store applications. Success still required backup strategy for local-path data, realistic pod resource requests, and a plan for quorum if they promoted sites to multi-server HA. Distribution choice removed bootstrap friction; engineering discipline still determined uptime.
 
-```yaml
-# Per-store deployment
-Resources per store:
-- 1 x Dell Edge Gateway (8GB RAM, 4 cores)
-- k3s single-node mode
-- Local Path Provisioner for storage
-- Traefik for ingress
-
-Workloads per store:
-- Inventory service (200MB)
-- POS API (150MB)
-- Analytics agent (100MB)
-- Local cache (Redis, 256MB)
-Total: ~700MB + OS + k3s ≈ 2GB
-Headroom: 6GB for burst
-```
-
-**Fleet Management**:
-
-```yaml
-# Rancher Fleet for GitOps at scale
-apiVersion: fleet.cattle.io/v1alpha1
-kind: GitRepo
-metadata:
-  name: store-applications
-  namespace: fleet-default
-spec:
-  repo: https://github.com/company/store-apps
-  branch: main
-  paths:
-  - releases
-  targets:
-  - name: all-stores
-    clusterSelector:
-      matchLabels:
-        env: production
-```
-
-**The Results**:
-- Deployment time: 15 minutes per store (automated)
-- Memory usage: 1.5GB average (with workloads)
-- Uptime: 99.9% (offline-capable for 48 hours)
-- Updates: Zero-touch via system-upgrade-controller
-- Cost savings: $2M/year vs. traditional infrastructure
-
-**The Lesson**: k3s makes Kubernetes viable where it previously wasn't. The same APIs and tooling, but packaged for the real world.
+Platform engineers reviewing a similar proposal today should ask for evidence on datastore mode per site, a diagram showing where ServiceLB ports are exposed on store firewalls, and a GitOps or fleet tool that tolerates offline reconciliation. Those questions apply to any lightweight distribution—the technology is approachable, but production edge still punishes vague operations assumptions.
 
 ## Common Mistakes
 
@@ -696,9 +740,11 @@ spec:
 | Wrong flannel backend | Performance issues | Use wireguard for encrypted, vxlan for simple |
 | No backup strategy | Cluster unrecoverable | Backup etcd/SQLite regularly |
 
+The table above captures failure modes we see repeatedly when teams treat k3s like a disposable dev cluster but run production payloads on it. Tokens are not secrets you can leave at defaults—generate cluster-unique values and rotate them when staff leave. TLS SANs matter the moment you put a load balancer or DNS name in front of the API. Storage and backups are the silent killers: local-path data never enters etcd snapshots, so you need a filesystem or volume backup strategy alongside `k3s etcd-snapshot save` for control-plane recovery.
+
 ## Quiz
 
-Test your understanding of k3s:
+The questions below test whether you understand k3s as a packaging model, not just as a sequence of curl commands. Read each answer fully—it explains the tradeoff behind the correct choice.
 
 <details>
 <summary>1. What does k3s remove from upstream Kubernetes?</summary>
@@ -727,7 +773,7 @@ Test your understanding of k3s:
 <details>
 <summary>5. How do you disable bundled components in k3s?</summary>
 
-**Answer**: Use the `--disable` flag: `k3s server --disable traefik --disable servicelb --disable local-storage`. Or in config.yaml: `disable: [traefik, servicelb, local-storage]`. This lets you use alternative components like nginx-ingress or MetalLB.
+**Answer**: Use the `--disable` flag: `k3s server --disable traefik --disable servicelb --disable local-storage`. Or in config.yaml: `disable: [traefik, servicelb, local-storage]`. This lets you use alternative components like nginx-ingress or MetalLB. Remember to install replacements before workloads request Ingress or LoadBalancer objects, otherwise Kubernetes will accept manifests that never receive external connectivity.
 </details>
 
 <details>
@@ -750,12 +796,14 @@ Test your understanding of k3s:
 
 ## Hands-On Exercise: Deploy HA k3s Cluster
 
+This exercise walks through a realistic HA bootstrap: three server nodes with embedded etcd, two agents, a sample application exposed via ServiceLB, and a control-plane failure drill. You will need roughly 12GB of free RAM if you run all five Multipass VMs simultaneously; reduce agent count if your laptop is tighter. The goal is muscle memory for join tokens, TLS SAN planning, and verifying that etcd quorum survives losing one server.
+
 ### Objective
 Deploy a high-availability k3s cluster with 3 server nodes and test failover.
 
 ### Environment Setup
 
-We'll use Multipass for local VMs (or use any 3 Linux VMs/cloud instances):
+Multipass provides Ubuntu VMs with minimal setup friction on macOS and Linux. If you already have five Linux machines on a flat network, substitute their IP addresses and skip Multipass entirely—the k3s commands are identical.
 
 ```bash
 # Install Multipass (macOS)
@@ -780,6 +828,8 @@ multipass list
 
 ### Step 1: Initialize First Server
 
+The first server must run with `--cluster-init` so embedded etcd bootstraps a new cluster. Capture both the join token and the server IP before closing the shell—you will paste them multiple times. Including the primary IP in `--tls-san` prevents certificate errors when agents join by IP rather than hostname.
+
 ```bash
 # SSH into first server
 multipass shell k3s-server-1
@@ -801,6 +851,8 @@ exit
 
 ### Step 2: Join Additional Servers
 
+Servers two and three join the etcd quorum with `k3s server --server https://FIRST:6443 --token TOKEN`. They run both control-plane components and etcd members—this is not an agent-only join. Wait until `kubectl get nodes` on any server shows all three servers `Ready` before proceeding to agents.
+
 ```bash
 # Get SERVER_IP and TOKEN from step 1, then:
 
@@ -821,6 +873,8 @@ exit
 
 ### Step 3: Join Agent Nodes
 
+Agents use the lighter `K3S_URL` + `K3S_TOKEN` install path without `--cluster-init`. They should land on servers two and three for workload scheduling while servers carry control-plane taints. If pods stay Pending, check that Flannel pods are Running and that no NetworkPolicy accidentally blocks CNI traffic.
+
 ```bash
 # Agent 1
 multipass shell k3s-agent-1
@@ -834,6 +888,8 @@ exit
 ```
 
 ### Step 4: Verify Cluster
+
+Verification is more than a node list: confirm etcd membership with `k3s etcd-snapshot ls` and inspect `kube-system` for CoreDNS, Traefik, metrics-server, and svclb pods. A healthy HA cluster shows five nodes and three etcd members with no CrashLoopBackOff in system namespaces.
 
 ```bash
 # From server-1
@@ -853,6 +909,8 @@ exit
 
 ### Step 5: Deploy Test Application
 
+Creating a Deployment with three replicas tests scheduling across agents. Exposing it as `type: LoadBalancer` exercises ServiceLB—expect an EXTERNAL-IP that is actually a node IP plus high port. Note which node hosts each pod with `-o wide` so you can reason about local-path affinity later.
+
 ```bash
 multipass shell k3s-server-1
 
@@ -870,6 +928,8 @@ sudo k3s kubectl get svc nginx
 ```
 
 ### Step 6: Test Failover
+
+Stopping `k3s-server-1` simulates hardware failure. The API should remain available via servers two and three; etcd retains quorum at three members with one offline. Application traffic may shift nodes, but ServiceLB should keep answering until you drain workloads. Restart server one and confirm it rejoins without manual etcd surgery—if it does not, compare its `--token` and `--server` flags against the surviving members.
 
 ```bash
 # From your host machine, stop a server
@@ -904,7 +964,11 @@ sudo k3s kubectl get nodes
 - [ ] Cluster survives server-1 failure
 - [ ] Server-1 successfully rejoins after restart
 
+Document the token, server IP, and `tls-san` values you used in your lab notebook. HA joins fail for predictable reasons—mismatched `cluster-cidr`, rotated tokens without updating agents, or load balancer health checks that only probe HTTP port 80 while the API listens on 6443.
+
 ### Cleanup
+
+When finished, delete the Multipass instances to reclaim RAM. If you plan to revisit the lab within a day, snapshot one server with `k3s etcd-snapshot save` so you can practice restore without repeating the join choreography.
 
 ```bash
 # Delete all VMs
@@ -913,16 +977,35 @@ multipass delete --purge k3s-server-1 k3s-server-2 k3s-server-3 k3s-agent-1 k3s-
 
 ## Key Takeaways
 
-1. **k3s is real Kubernetes**: Same API, same kubectl, same ecosystem—just smaller
-2. **Single binary simplicity**: ~60MB contains everything needed
-3. **Multiple datastore options**: SQLite for single node, embedded etcd for HA
-4. **Batteries included**: Traefik, CoreDNS, Local Path, ServiceLB bundled
-5. **Disable what you don't need**: Customize by removing bundled components
-6. **ServiceLB for bare metal**: LoadBalancer services work without cloud provider
-7. **Air-gap friendly**: Download artifacts once, deploy anywhere
-8. **Upgrade with care**: Use system-upgrade-controller for rolling upgrades
-9. **HA requires 3+ servers**: Odd numbers for etcd quorum (3, 5, 7)
-10. **Edge native**: Built for resource-constrained, distributed environments
+1. **k3s is conformant Kubernetes, not a parallel platform** — CNCF certification means the same API objects, kubectl verbs, and Helm charts you use elsewhere apply here; the difference is packaging and bundled add-ons.
+2. **Single-binary integration trades install-time modularity for speed** — containerd, Flannel, CoreDNS, Traefik, ServiceLB, and local-path-provisioner come up together; disable consciously when substituting corporate standards.
+3. **Datastore choice drives HA story** — SQLite for single-server simplicity, embedded etcd for odd-numbered server quorum, external SQL when existing database operations must own backups and replication.
+4. **ServiceLB and Traefik exist for bare-metal ergonomics** — they make LoadBalancer Services and Ingress resources work without cloud integrations; they are not mandatory if you prefer MetalLB or ingress-nginx.
+5. **Agents are tunnel-connected workers** — registration uses tokens plus per-node password secrets; rebuilding a node requires deleting the old Node API object and secret to avoid identity collisions.
+6. **Air-gap and upgrade paths mirror each other** — prefetch binaries and `k3s-airgap-images` tarballs, then use `INSTALL_K3S_SKIP_DOWNLOAD=true`; fleet upgrades can automate the same with system-upgrade-controller Plans.
+7. **Edge production still demands backups and resource limits** — local-path data is node-local; etcd snapshots do not include PVC files; swap must stay off; and pod density must respect real RAM.
+8. **Compare distributions on capabilities, not slogans** — use the Rosetta table mindset: datastore, CNI, ingress, LB, install mechanism, and positioning—then pick the tool that matches constraints.
+9. **CNCF Sandbox status is a maturity signal, not a quality verdict** — verify current maturity and release notes before citing project level in compliance documents.
+10. **k3s makes Kubernetes small enough to colocate with workloads, not small enough to skip operations** — distribution choice removes bootstrap friction; you still own upgrades, security patches, and data durability.
+
+Treat this checklist as a pre-production review, not a post-install afterthought. If you cannot tick backups, datastore HA, and upgrade channel ownership, you have a lab cluster—regardless of how many nodes say `Ready`. Revisit the Rosetta table when stakeholders ask why you did not pick k0s or MicroK8s; the answer should be constraint-based, not habit. Write that decision down once and link to it from your cluster README so future you inherits the reasoning and avoids repeating the same architecture debates every single quarter review.
+
+## Sources
+
+- [docs.k3s.io](https://docs.k3s.io/) — Official k3s documentation homepage describing the lightweight distribution scope and bundled components.
+- [docs.k3s.io: Architecture](https://docs.k3s.io/architecture) — Server versus agent roles, HA topology, and agent load-balancer registration mechanics.
+- [docs.k3s.io: Cluster Datastore](https://docs.k3s.io/datastore) — kine-backed SQLite default, embedded etcd HA, and external SQL/etcd endpoint formats.
+- [docs.k3s.io: Configuration Options](https://docs.k3s.io/installation/configuration) — Install script environment variables, config.yaml merge rules, and critical flag matching across servers.
+- [docs.k3s.io: Air-Gap Install](https://docs.k3s.io/installation/airgap) — Offline image loading, `INSTALL_K3S_SKIP_DOWNLOAD`, and default-route requirements.
+- [docs.k3s.io: Known Issues](https://docs.k3s.io/known-issues) — kine schema migration guidance, iptables caveats, and rootless experimental status.
+- [docs.k3s.io: Automated Upgrades](https://docs.k3s.io/upgrades/automated) — system-upgrade-controller Plans and channel-based k3s upgrades.
+- [docs.k3s.io: Network Policies](https://docs.k3s.io/networking/network-policies) — kube-router network policy controller bundled with k3s.
+- [github.com: k3s-io/k3s](https://github.com/k3s-io/k3s) — Upstream source repository, issue tracker, and release artifacts.
+- [github.com: k3s-io/k3s releases](https://github.com/k3s-io/k3s/releases) — Published binaries and `k3s-airgap-images` tarballs per version.
+- [cncf.io: k3s project](https://www.cncf.io/projects/k3s/) — CNCF Sandbox acceptance date and project metadata.
+- [github.com: cncf/toc issue #1957](https://github.com/cncf/toc/issues/1957) — Public incubation application tracking maturity progression as of 2026.
+- [kubernetes.io: Pod Security Admission](https://kubernetes.io/docs/concepts/security/pod-security-admission/) — Replacement for removed PodSecurityPolicy admission referenced in server configuration examples.
+- [kubernetes.io: Certified Kubernetes](https://www.cncf.io/certification/software-conformance/) — Conformance program definition underpinning "same API, not a fork" claims.
 
 ## Next Module
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.2-k0s.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.2-k0s.md
@@ -9,430 +9,391 @@ sidebar:
 
 ## Overview
 
-k0s (pronounced "kay-zero-ess") takes the "batteries included" philosophy to its logical extreme: a single binary that contains everything—including the container runtime. No dependencies to install, no system services to configure, no packages to manage. Download, run, Kubernetes. That's it.
+k0s, pronounced "kay-zero-ess", is a Kubernetes distribution built around one deceptively simple operating idea: make the cluster software self-contained enough that the host operating system stops being the main installation project. Instead of asking you to prepare a container runtime package, add Kubernetes apt repositories, align RPM versions, and then let kubeadm assemble the cluster, k0s ships as a single self-extracting binary that carries the Kubernetes components and manages the pieces it needs under its own data directory.
 
-Built by Mirantis, k0s was designed to eliminate every friction point in Kubernetes deployment, from initial install to day-2 operations.
+That packaging choice is the reason k0s belongs in a distribution comparison module rather than a generic installation tutorial. A Kubernetes distribution is not a different API server; a conformant distribution still exposes the Kubernetes API you already know. The difference is the operational envelope around that API: what is bundled, how the control plane is supervised, which datastore is selected by default, how workers join, which network provider is installed, how upgrades are coordinated, and how much of the host must be prepared before the first kubelet starts.
 
-This module teaches you to deploy and operate k0s for clean, dependency-free Kubernetes clusters.
+k0s was originally built by Mirantis and is now a CNCF Sandbox project while also remaining a Mirantis-supported Kubernetes distribution. That combination matters because it separates two claims that learners often blur together. CNCF project maturity tells you where the project sits in CNCF governance, while Certified Kubernetes conformance tells you whether the Kubernetes APIs behave like upstream Kubernetes. k0s is CNCF Certified Kubernetes, so the API contract is the same Kubernetes contract; its distinctive value is the packaging and lifecycle model around that contract.
+
+This module teaches k0s as a durable operating model rather than a product tour. We will focus on the single-binary architecture, the controller versus worker role split, Konnectivity reverse tunneling, k0sctl as the declarative bootstrap tool, and the datastore choices that decide whether a cluster is simple, highly available, or dependent on an external database. Version numbers and component versions are isolated in one dated snapshot so the learning survives normal release churn.
 
 ## Prerequisites
 
-- Kubernetes fundamentals (kubectl, deployments, services)
-- Linux command-line basics
-- SSH access to Linux machines (or VMs)
-- Understanding of container runtimes
+- Kubernetes fundamentals: pods, deployments, services, nodes, kubelet, and the Kubernetes API server.
+- Linux command-line basics, including SSH, system services, and editing YAML files.
+- Familiarity with kubeadm, k3s, or another Kubernetes installer is helpful but not required.
+- Access to one or more Linux machines or virtual machines if you want to run the exercise.
 
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
-- **Deploy K0s clusters with zero host dependencies using its single-binary architecture**
-- **Configure K0s control plane components and worker profiles for different hardware configurations**
-- **Implement K0s cluster lifecycle management with k0sctl for automated multi-node deployments**
-- **Compare K0s's zero-dependency approach against K3s and MicroK8s for air-gapped environments**
-
+- Explain why k0s uses a self-contained single-binary packaging model and how that differs from kubeadm host preparation.
+- Choose between `controller`, `worker`, and `controller+worker` roles without accidentally mixing control-plane and workload risk.
+- Describe how Konnectivity helps controller components reach private workers through a reverse tunnel.
+- Select between Kine plus SQLite, embedded etcd, and external SQL datastores using the same HA tradeoff lens you use for other Kubernetes distributions.
+- Use a `k0sctl.yaml` file to bootstrap and later update a multi-node k0s cluster from one declarative inventory.
 
 ## Why This Module Matters
 
-**k0s answers the question: "What if Kubernetes had zero host dependencies?"**
+k0s answers a practical platform question: what if the Kubernetes installation artifact were not a collection of host packages at all? In a kubeadm build, the host operating system is an active participant in the cluster assembly. You install a compatible container runtime, configure cgroups, add Kubernetes repositories, install kubeadm, kubelet, and kubectl packages, and then use kubeadm to lay down control-plane static pods. That model is explicit and close to upstream, but the host becomes part of the dependency graph.
 
-Every other Kubernetes distribution assumes something:
-- kubeadm assumes you've installed containerd
-- k3s assumes systemd for service management
-- MicroK8s assumes snap package support
+k0s moves much of that dependency graph into the distribution. The host still needs a working kernel, cgroups, networking support, permissions, and an init system when you install k0s as a service, but it does not need a distribution-specific Kubernetes package repository or a preinstalled CRI runtime for the normal path. The k0s binary is statically linked and self-extracting, so the distribution can carry tested component versions together instead of asking each Linux flavor to provide them through its package manager.
 
-k0s assumes nothing. The single binary contains:
-- kube-apiserver, controller-manager, scheduler
-- kubelet, kube-proxy
-- containerd (with runc)
-- etcd (for single-node or HA)
-- CoreDNS, konnectivity-server
+Think of kubeadm as a professional kitchen that gives you a recipe and expects the ingredients, knives, pans, burners, and storage layout to be ready before cooking begins. k0s is closer to a sealed field kitchen: you still need a level surface, fuel, and people who know food safety, but the core cooking system arrives in one container. The tradeoff is not that one approach is universally better; the tradeoff is where you want explicit assembly versus packaged consistency.
 
-If your system can execute a binary, it can run k0s.
+This matters most when the infrastructure is not uniform. A platform team running one Ubuntu image in one cloud can standardize kubeadm prerequisites through image baking or configuration management. A team running on bare metal, edge sites, lab gear, appliance-like deployments, or several Linux families may care more about reducing the number of host-specific preparation steps. k0s is designed for that second pressure: less reliance on host packages, cleaner removal, and the same installation shape across many environments.
+
+The other reason k0s matters is its role separation. Many lightweight distributions optimize for "make the first node useful immediately", which often means the control plane also schedules workloads unless you opt out. k0s defaults the other way: controller nodes run control-plane processes, and worker nodes run kubelet, containerd, kube-proxy unless disabled, CNI agents, and workloads. You can deliberately run a combined controller and worker for development, labs, or small edge nodes, but the distribution makes the separation a first-class concept.
+
+That combination of self-contained packaging and explicit roles is the mental model to carry forward. k0s is not trying to teach you fewer Kubernetes fundamentals; it is trying to reduce the accidental Linux-distribution work around those fundamentals. You still need to understand certificates, API reachability, CNI behavior, datastore durability, and node lifecycle. The difference is that those decisions become clearer because they are not buried under a pile of package-manager preparation steps.
 
 ## Did You Know?
 
-- **Zero Dependencies**: k0s requires only a Linux kernel and some basic utilities (iptables)
-- **Clean State**: All k0s data lives in `/var/lib/k0s`—delete the directory, k0s is gone
-- **Mirantis Origin**: Created by Mirantis after acquiring Docker Enterprise
-- **Cluster API Support**: k0s integrates with Cluster API for declarative cluster management
-- **Name Origin**: "k0s" = Kubernetes with zero ops, zero dependencies, zero friction
+- **Single binary does not mean no kernel requirements**: k0s avoids package-manager and shared-library dependencies in the normal Linux binary path, but Kubernetes workers still need Linux kernel capabilities for containers, cgroups, namespaces, and networking.
+- **Controllers are isolated by default**: a plain k0s controller does not run kubelet or containerd, so ordinary workloads are not scheduled there unless you choose a combined role.
+- **Konnectivity is part of the design**: k0s uses Konnectivity so the API server can reach kubelets through a reverse tunnel, which is useful when workers live behind private networks or restrictive inbound firewalls.
+- **CNCF project status and conformance are different**: k0s is a CNCF Sandbox project as of 2026-06, and k0s is also a CNCF Certified Kubernetes distribution. The first is project maturity; the second is API compatibility.
+
+> **Landscape snapshot - as of 2026-06. This changes fast; verify against upstream docs and release notes before relying on specifics.**
+>
+> | Fact | k0s snapshot |
+> |------|--------------|
+> | Origin and stewardship | Built by Mirantis; accepted into CNCF at the Sandbox maturity level on 2025-01-19. |
+> | Conformance | CNCF Certified Kubernetes distribution, meaning the Kubernetes API behavior is tested for conformance rather than forked into a separate API. |
+> | Latest release observed at authoring time | GitHub lists `v1.36.1+k0s.0` as the latest k0s release, published on 2026-06-14. The curriculum examples below keep a Kubernetes 1.35-era pin unless you deliberately test the newer line. |
+> | Supported Kubernetes lines shown on the project site | The project site lists Kubernetes `v1.35`, `v1.34`, and `v1.33`; verify the release page before pinning a production version. |
+> | Minimum approximate hardware | Controller: 1 GB RAM and 1 vCPU. Worker: 0.5 GB RAM and 1 vCPU. Controller plus worker: 1 GB RAM and 1 vCPU. Real workloads need more. |
+> | Architectures in current system requirements | `x86_64`, `aarch64`, `armv7l`, and `riscv64` with no precompiled binaries or CI coverage for the last one. |
+> | Built-in CNI choices | Kube-router and Calico are bundled options; custom CNI is supported when you take responsibility for the plugin installation. |
+> | Current component examples from release notes and docs | Kubernetes `v1.36.1`, containerd `v2.3.1`, CoreDNS `v1.14.2`, Calico `v3.32.0`, Kine `v0.16.2`, etcd `v3.6.12`, kube-router image `v2.10.0-iptables1.8.13-k0s.0`, and Traefik `v3.7.3` as a node-local load-balancer backend option. |
 
 ## k0s Architecture
 
+The simplest way to read k0s architecture is to separate packaging from roles. Packaging says how the software arrives: one self-extracting binary that contains the components k0s manages. Roles say what a node actually does after the binary starts: a controller supervises the control plane and datastore pieces, a worker runs the node-level runtime and workloads, and a controller+worker does both on the same host.
+
+That distinction prevents a common misunderstanding. "Single binary" does not mean "one process pretending to be Kubernetes." k0s still runs normal Kubernetes components such as kube-apiserver, kube-controller-manager, kube-scheduler, kubelet, kube-proxy unless disabled, containerd, CoreDNS, metrics-server, CNI agents, and datastore processes. The k0s binary acts as the packaging, supervisor, installer, and lifecycle entry point around those components.
+
+The practical design question is therefore not whether k0s is "real Kubernetes"; conformance answers that. The practical question is whether you want a distribution that makes the host operating system less visible during installation and upgrades. That is powerful in mixed fleets, but it also means you should learn the k0s abstraction itself instead of assuming every troubleshooting step maps one-to-one to kubeadm static pods or package-managed kubelet units.
+
 ```
-k0s ARCHITECTURE
-─────────────────────────────────────────────────────────────────────────────
+k0s ROLE MODEL
 
-┌─────────────────────────────────────────────────────────────────────────────┐
-│                        k0s Controller Node                                  │
-│                                                                             │
-│  ┌─────────────────────────────────────────────────────────────────────┐   │
-│  │                    k0s Binary (~180MB)                              │   │
-│  │                                                                     │   │
-│  │  ┌──────────────────── Control Plane ───────────────────────┐      │   │
-│  │  │                                                          │      │   │
-│  │  │  kube-apiserver    kube-controller-manager    kube-scheduler    │   │
-│  │  │                                                          │      │   │
-│  │  └──────────────────────────────────────────────────────────┘      │   │
-│  │                                                                     │   │
-│  │  ┌──────────────────── Embedded Components ─────────────────┐      │   │
-│  │  │                                                          │      │   │
-│  │  │  etcd/SQLite    konnectivity-server    CoreDNS                  │   │
-│  │  │  metrics-server kube-router           helm-controller           │   │
-│  │  │                                                          │      │   │
-│  │  └──────────────────────────────────────────────────────────┘      │   │
-│  │                                                                     │   │
-│  │  Note: Controller nodes do NOT run workloads by default            │   │
-│  │        (clean separation of control plane and workers)             │   │
-│  │                                                                     │   │
-│  └─────────────────────────────────────────────────────────────────────┘   │
-│                                                                             │
-│  ┌───────────────────────────────────────────────────────────────────────┐ │
-│  │                        /var/lib/k0s                                   │ │
-│  │   All state, configs, binaries, and data in one directory             │ │
-│  └───────────────────────────────────────────────────────────────────────┘ │
-│                                                                             │
-└─────────────────────────────────────────────────────────────────────────────┘
-                                      │
-          ┌───────────────────────────┼───────────────────────────┐
-          │                           │                           │
-          ▼                           ▼                           ▼
-┌─────────────────────┐   ┌─────────────────────┐   ┌─────────────────────┐
-│    k0s Worker Node  │   │    k0s Worker Node  │   │    k0s Worker Node  │
-│                     │   │                     │   │                     │
-│  ┌───────────────┐  │   │  ┌───────────────┐  │   │  ┌───────────────┐  │
-│  │ k0s Binary    │  │   │  │ k0s Binary    │  │   │  │ k0s Binary    │  │
-│  │               │  │   │  │               │  │   │  │               │  │
-│  │ kubelet       │  │   │  │ kubelet       │  │   │  │ kubelet       │  │
-│  │ containerd    │  │   │  │ containerd    │  │   │  │ containerd    │  │
-│  │ kube-proxy    │  │   │  │ kube-proxy    │  │   │  │ kube-proxy    │  │
-│  │ kube-router   │  │   │  │ kube-router   │  │   │  │ kube-router   │  │
-│  └───────────────┘  │   │  └───────────────┘  │   │  └───────────────┘  │
-│                     │   │                     │   │                     │
-│  /var/lib/k0s       │   │  /var/lib/k0s       │   │  /var/lib/k0s       │
-│  (isolated state)   │   │  (isolated state)   │   │  (isolated state)   │
-│                     │   │                     │   │                     │
-└─────────────────────┘   └─────────────────────┘   └─────────────────────┘
-
-KEY DIFFERENTIATORS:
-─────────────────────────────────────────────────────────────────────────────
-
-1. ZERO HOST DEPENDENCIES
-   • containerd embedded in binary
-   • No pre-installed runtime required
-   • No system packages needed
-
-2. CLEAN SEPARATION
-   • Controllers are pure control plane (no workloads)
-   • Workers are pure workers
-   • Single-node mode runs both
-
-3. ISOLATED STATE
-   • Everything in /var/lib/k0s
-   • Clean uninstall: rm -rf /var/lib/k0s
-   • No scattered configs across filesystem
-
-4. KUBE-ROUTER
-   • CNI, kube-proxy replacement, and service load balancer
-   • All networking in one component
-   • Supports BGP for advanced routing
+                           kubectl / clients
+                                  |
+                                  v
+                    +-----------------------------+
+                    | k0s controller node         |
+                    |                             |
+                    | kube-apiserver              |
+                    | kube-controller-manager     |
+                    | kube-scheduler              |
+                    | datastore: etcd or Kine     |
+                    | CoreDNS / metrics-server    |
+                    | Konnectivity server         |
+                    |                             |
+                    | No workloads by default     |
+                    +--------------+--------------+
+                                   |
+                      reverse tunnel / node APIs
+                                   |
+          +------------------------+------------------------+
+          |                                                 |
+          v                                                 v
++--------------------------+                    +--------------------------+
+| k0s worker node          |                    | k0s worker node          |
+|                          |                    |                          |
+| kubelet                  |                    | kubelet                  |
+| containerd + runc        |                    | containerd + runc        |
+| kube-proxy unless off    |                    | kube-proxy unless off    |
+| CNI agents               |                    | CNI agents               |
+| application workloads    |                    | application workloads    |
++--------------------------+                    +--------------------------+
 ```
+
+A controller-only node is attractive when the control plane is precious and scarce. It reduces accidental resource contention because a noisy application pod cannot consume CPU on the same node that is running the API server or datastore. It also makes incident response cleaner: if a worker melts down under workload pressure, you inspect workload scheduling, runtime, networking, and node health without first asking whether the controller was also hosting the failing application.
+
+A worker-only node is the normal place for workloads. It joins the cluster with a role-specific token, starts the node-level services, establishes trust with the control plane, and runs pods just like any other Kubernetes worker. From the application author's perspective, a k0s worker is not a special Kubernetes dialect; it is a node in a conformant Kubernetes cluster with the usual kubelet and container runtime responsibilities.
+
+A controller+worker node is the deliberate exception. It is useful for a laptop, lab VM, small appliance, or far-edge site where one machine must run the whole cluster. In k0sctl inventory this role is expressed as `controller+worker`; at the k0s command line the comparable shape is a controller with worker components enabled. You should treat this as a topology decision, not just an installation shortcut, because role changes after installation are not something to casually toggle on existing nodes.
+
+Konnectivity is the less visible but important part of the architecture. Kubernetes controllers often need to reach kubelets for logs, exec, port-forward, metrics, and node operations. In many real networks, workers can initiate outbound traffic to the control plane, but the control plane cannot initiate inbound connections back to every worker because those workers sit behind NAT, private routing, edge firewalls, or customer networks. Konnectivity solves that by establishing a reverse tunnel from worker-side agents toward the control plane, allowing API-server-to-kubelet traffic to flow without requiring every worker to expose itself broadly.
+
+The datastore story is the same CAP tradeoff you saw in sibling distribution modules. Kine plus SQLite is simple and local, which makes it excellent for single-node clusters and small demos because there is no quorum to design. Embedded etcd gives you a replicated control-plane datastore across controller nodes, but it introduces quorum, disk latency sensitivity, membership operations, and the need for a stable control-plane endpoint. External MySQL or PostgreSQL through Kine can work when an organization already has a managed database platform, but then Kubernetes availability depends on that external database being correctly operated.
+
+### Cross-Distribution Rosetta
+
+The table below compares durable capabilities rather than ranking the tools. Treat every cell as a design clue, not a verdict, because the right distribution depends on operational constraints such as air gap, host control, edge footprint, support model, and how much upstream assembly you want to own.
+
+| Capability | k3s | k0s | MicroK8s | upstream kubeadm |
+|------------|-----|-----|----------|------------------|
+| Default datastore posture | SQLite for simple server setups, embedded etcd for HA, external SQL options through Kine | Kine plus SQLite for single-node, embedded etcd for HA, external SQL through Kine | dqlite for clustered MicroK8s control planes | etcd, usually as static pods or external etcd |
+| HA mechanism | Multi-server with embedded etcd or external datastore | Multiple controllers with embedded etcd plus a stable API endpoint or external datastore | Multiple MicroK8s nodes with dqlite-backed HA | Multiple control-plane nodes with etcd quorum and a load balancer |
+| Bundled CNI posture | Flannel by default, other options configurable | Kube-router or Calico built in, custom CNI allowed | Calico commonly used through add-ons and defaults that change by release | No CNI installed by kubeadm; you install one |
+| Bundled ingress posture | Traefik is commonly bundled unless disabled | Ingress is an add-on choice rather than the core default | Ingress available through add-ons | None; install an ingress controller yourself |
+| Bundled service load balancing | ServiceLB commonly bundled | No universal cloud load balancer; use provider integration, MetalLB, cloud controller, or another add-on | MetalLB available as an add-on | None; depends on cloud provider or add-on |
+| Install mechanism | Install script and token join | Install script, role-specific tokens, and k0sctl inventory | Snap package and `microk8s` commands | Host packages plus `kubeadm init` and `kubeadm join` |
+| Packaging model | Compact distribution binaries and managed components | Single self-extracting binary with minimal host package dependencies | Snap-based packaging | OS packages plus images and static pod manifests |
+| Primary fit | Lightweight clusters, edge, and embedded-style deployments | Dependency-minimized clusters, mixed Linux fleets, edge, appliance, and controlled bare metal | Developer machines, labs, edge, and Ubuntu-centered operations | Upstream-aligned custom builds where you own every component choice |
+| Conformance | Certified Kubernetes releases | Certified Kubernetes releases | Certified Kubernetes releases | Upstream Kubernetes baseline when assembled correctly |
 
 ## Installing k0s
 
-### Single Node (Development)
+The first installation choice is not "single node or multi-node"; it is "do I want this node to be expandable later?" The `--single` flag creates a convenient one-node cluster that includes controller and worker behavior, but upstream docs warn that it disables features needed for multi-node clusters. For a disposable demo, that is fine. For a lab you may expand next week, install a controller with worker components enabled instead of using `--single`.
 
-The simplest deployment—single node with control plane and worker:
+### Single Node for Learning
+
+This command sequence downloads the k0s binary, installs a single-node service, starts it, and uses the embedded `kubectl` to inspect the cluster. The important teaching point is that you are not preinstalling containerd or Kubernetes packages. You are still trusting a remote install script here, so production or air-gapped environments should download and verify release artifacts through your normal supply-chain process.
 
 ```bash
-# Download k0s
-curl -sSLf https://get.k0s.sh | sudo sh
+# Download the k0s binary through the upstream install script.
+curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
 
-# Check version
+# Inspect the installed version.
 k0s version
 
-# Start single-node cluster
-sudo k0s install controller --single
-sudo k0s start
+# Disposable single-node cluster: controller and worker behavior on one host.
+sudo k0s install controller --single --start
 
-# Check status
+# Inspect the process role and workload setting.
 sudo k0s status
 
-# Get kubeconfig
-sudo k0s kubeconfig admin > ~/.kube/config
-chmod 600 ~/.kube/config
-
-# Verify cluster
-kubectl get nodes
-kubectl get pods -A
+# Use the kubectl embedded by k0s to inspect the node and system pods.
+sudo k0s kubectl get nodes -o wide
+sudo k0s kubectl get pods -A
 ```
 
-### Multi-Node Cluster (Manual)
+The output should show one ready node after the control plane and worker components settle. If `k0s status` says the role is `controller` and workloads are enabled, remember that the role display and workload capability are related but not identical. A controller with worker components enabled is still a controller process, but it also runs the node-level pieces needed to host pods.
 
-**On the controller node:**
+For a one-node cluster that you may later expand, use the controller-with-worker path instead. This keeps the node useful for workloads but avoids the special single-node mode that blocks later multi-node growth. The `--no-taints` choice makes regular workloads schedulable on the combined node; without it, Kubernetes taints may correctly keep ordinary application pods away from a control-plane node.
 
 ```bash
-# Download and install
-curl -sSLf https://get.k0s.sh | sudo sh
+sudo k0s reset
+sudo k0s install controller --enable-worker --no-taints --start
+sudo k0s status
+sudo k0s kubectl get nodes -o wide
+```
 
-# Install controller (NOT --single, workers will join)
-sudo k0s install controller
-sudo k0s start
+That reset is intentionally destructive, which is why you should use it only on a learning machine or after you have backed up state. k0s reset is useful because it removes the service registration and k0s-managed data, but it is still a cluster teardown operation. Production removal should start with backups, workload migration, and an explicit decision about whether application persistent volumes are in scope.
 
-# Wait for control plane
+### Multi-Node Manual Join
+
+Manual join is the clearest way to understand the trust model. A controller starts first, then it creates role-specific join tokens. A worker token lets a host join as a worker, while a controller token lets another host join the control plane. These tokens are not just arbitrary shared secrets; they carry bootstrap trust information so the joining node can validate the cluster and present itself correctly.
+
+```bash
+# On the first controller.
+curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
+sudo k0s install controller --start
 sudo k0s status
 
-# Generate worker join token
-sudo k0s token create --role=worker
-
-# Save this token for worker nodes
+# Create an expiring worker token and copy it securely to each worker.
+sudo k0s token create --role=worker --expiry=4h > worker.token
 ```
 
-**On each worker node:**
+On each worker, the token connects the node to the controller and selects the worker role. In a real environment you would distribute the token through a secure channel, keep the expiry short, and avoid pasting it into shell history. For repeated multi-node work, k0sctl is preferable because it handles token creation and node sequencing from a single inventory.
 
 ```bash
-# Download and install
-curl -sSLf https://get.k0s.sh | sudo sh
-
-# Install worker with token
-sudo k0s install worker --token-file /path/to/token
-
-# Or pass token directly
-sudo k0s install worker --token "eyJhbG..."
-
-# Start worker
-sudo k0s start
-
-# Check status
+# On each worker after copying worker.token to /tmp/worker.token.
+curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
+sudo k0s install worker --token-file /tmp/worker.token --start
 sudo k0s status
 ```
 
-**Verify from controller:**
-
-```bash
-kubectl get nodes
-```
+Back on the controller, `kubectl get nodes` should show the joined workers. If the workers remain `NotReady`, troubleshoot in this order: host firewall, CNI pods, container runtime status, node clock skew, token expiry, and whether the worker can reach the controller address advertised in its bootstrap configuration. k0s removes many host package prerequisites, but it cannot remove the need for correct routing and time.
 
 ### Multi-Node Cluster with k0sctl
 
-k0sctl automates multi-node deployment:
+k0sctl is the normal tool once you have more than a toy topology. Its value is not that it hides Kubernetes; its value is that it turns node inventory, SSH connection details, roles, k0s version, and cluster configuration into one reviewable file. That file becomes the cluster bootstrap contract, closer to an infrastructure plan than a sequence of remembered shell commands.
 
-```bash
-# Install k0sctl
-curl -sSLf https://github.com/k0sproject/k0sctl/releases/latest/download/k0sctl-linux-amd64 -o k0sctl
-chmod +x k0sctl
-sudo mv k0sctl /usr/local/bin/
+The example below uses three hosts: one controller and two workers. It pins a curriculum-era k0s version for repeatability, selects Kube-router explicitly, and sets an API external address that clients and workers can use consistently. If you are building this for real, replace the addresses, SSH user, key path, and version after checking the current k0s release page.
 
-# Create cluster configuration
-cat > k0sctl.yaml <<EOF
+```yaml
 apiVersion: k0sctl.k0sproject.io/v1beta1
 kind: Cluster
 metadata:
-  name: my-k0s-cluster
+  name: dojo-k0s
 spec:
   hosts:
-  - ssh:
-      address: 192.168.1.10
-      user: root
-      keyPath: ~/.ssh/id_rsa
-    role: controller
-  - ssh:
-      address: 192.168.1.11
-      user: root
-      keyPath: ~/.ssh/id_rsa
-    role: worker
-  - ssh:
-      address: 192.168.1.12
-      user: root
-      keyPath: ~/.ssh/id_rsa
-    role: worker
+    - role: controller
+      ssh:
+        address: 10.10.0.10
+        user: ubuntu
+        keyPath: ~/.ssh/id_ed25519
+    - role: worker
+      ssh:
+        address: 10.10.0.11
+        user: ubuntu
+        keyPath: ~/.ssh/id_ed25519
+    - role: worker
+      ssh:
+        address: 10.10.0.12
+        user: ubuntu
+        keyPath: ~/.ssh/id_ed25519
   k0s:
-    version: v1.28.5+k0s.0
+    version: v1.35.4+k0s.0
     config:
+      apiVersion: k0s.k0sproject.io/v1beta1
+      kind: ClusterConfig
+      metadata:
+        name: dojo-k0s
       spec:
         api:
-          externalAddress: 192.168.1.10
+          externalAddress: 10.10.0.10
         network:
-          provider: kube-router
-EOF
+          provider: kuberouter
+```
 
-# Apply configuration (deploys entire cluster)
+Applying the file is a reconciliation operation from your workstation. k0sctl connects to each host, inspects what is already there, downloads or uploads the k0s binary depending on configuration, creates tokens, joins nodes, and leaves you with a kubeconfig you can save locally. This is the main contrast with a k3s token-join workflow or a kubeadm join command: the join details exist inside one desired-state inventory instead of being scattered across terminals.
+
+```bash
+# Install k0sctl from the upstream release page for your OS and architecture.
+k0sctl version
+
+# Deploy or reconcile the cluster described by the inventory.
 k0sctl apply --config k0sctl.yaml
 
-# Get kubeconfig
-k0sctl kubeconfig --config k0sctl.yaml > ~/.kube/config
-
-# Verify
-kubectl get nodes
+# Fetch kubeconfig for normal kubectl use.
+k0sctl kubeconfig --config k0sctl.yaml > kubeconfig
+chmod 600 kubeconfig
+KUBECONFIG=$PWD/kubeconfig kubectl get nodes -o wide
 ```
+
+Read the apply output like you would read Terraform or Ansible output. A successful run should show connection, host detection, validation, configuration, installation, and join phases. A failed run is often more useful than a silent manual failure because it tells you which host failed and at which phase. The fix is usually an SSH permission issue, sudo privilege issue, firewall problem, wrong role on an already-installed node, or a version/configuration mismatch.
 
 ### High Availability Setup
 
+High availability is not created by adding random controllers; it is created by combining a replicated datastore, multiple controllers, and a stable API endpoint. k0s can run embedded etcd on controller nodes, and k0sctl can generate and distribute shared certificates during bootstrap. You still need clients and workers to reach a stable control-plane address, either through an external TCP load balancer or through k0s control-plane load-balancing features that fit your network.
+
 ```yaml
-# k0sctl.yaml for HA
 apiVersion: k0sctl.k0sproject.io/v1beta1
 kind: Cluster
 metadata:
-  name: ha-k0s-cluster
+  name: dojo-k0s-ha
 spec:
   hosts:
-  # 3 controllers for HA
-  - ssh:
-      address: 192.168.1.10
-      user: root
-      keyPath: ~/.ssh/id_rsa
-    role: controller
-  - ssh:
-      address: 192.168.1.11
-      user: root
-      keyPath: ~/.ssh/id_rsa
-    role: controller
-  - ssh:
-      address: 192.168.1.12
-      user: root
-      keyPath: ~/.ssh/id_rsa
-    role: controller
-  # Workers
-  - ssh:
-      address: 192.168.1.20
-      user: root
-      keyPath: ~/.ssh/id_rsa
-    role: worker
-  - ssh:
-      address: 192.168.1.21
-      user: root
-      keyPath: ~/.ssh/id_rsa
-    role: worker
+    - role: controller
+      ssh:
+        address: 10.20.0.10
+        user: ubuntu
+        keyPath: ~/.ssh/id_ed25519
+    - role: controller
+      ssh:
+        address: 10.20.0.11
+        user: ubuntu
+        keyPath: ~/.ssh/id_ed25519
+    - role: controller
+      ssh:
+        address: 10.20.0.12
+        user: ubuntu
+        keyPath: ~/.ssh/id_ed25519
+    - role: worker
+      ssh:
+        address: 10.20.0.21
+        user: ubuntu
+        keyPath: ~/.ssh/id_ed25519
   k0s:
-    version: v1.28.5+k0s.0
+    version: v1.35.4+k0s.0
     config:
+      apiVersion: k0s.k0sproject.io/v1beta1
+      kind: ClusterConfig
+      metadata:
+        name: dojo-k0s-ha
       spec:
         api:
-          # Load balancer address
-          externalAddress: api.k0s.example.com
+          externalAddress: api.k0s.example.test
           sans:
-            - api.k0s.example.com
-            - 192.168.1.10
-            - 192.168.1.11
-            - 192.168.1.12
+            - api.k0s.example.test
+            - 10.20.0.10
+            - 10.20.0.11
+            - 10.20.0.12
         storage:
           type: etcd
+        network:
+          provider: calico
 ```
+
+The storage line is the key change. In a single-node cluster, local SQLite through Kine is convenient because there is only one writer and no quorum design. In an HA control plane, embedded etcd is the normal in-cluster choice because each controller participates in replicated state. That gives you failure tolerance, but it also means disk latency, quorum math, odd member counts, and member replacement procedures become part of your operational runbook.
 
 ## k0s Configuration
 
+k0s configuration lives in a `ClusterConfig` object, commonly written to `/etc/k0s/k0s.yaml` for local installation or nested under `spec.k0s.config` in a k0sctl inventory. This is another important difference from ad hoc installation commands: the durable cluster decisions should live in YAML that can be reviewed, diffed, and repeated, while transient bootstrap secrets should have short lifetimes.
+
 ### Configuration File Structure
 
+The example below is intentionally partial. k0s supports partial configuration and fills defaults for omitted values, which keeps the file focused on decisions you actually own. A noisy full-default file can feel comforting, but it also creates a future maintenance burden because every default looks like a local policy. Keep the file explicit where you are making a platform decision and sparse where upstream defaults are acceptable.
+
 ```yaml
-# /etc/k0s/k0s.yaml
 apiVersion: k0s.k0sproject.io/v1beta1
 kind: ClusterConfig
 metadata:
-  name: my-cluster
+  name: dojo-k0s
 spec:
   api:
-    address: 192.168.1.10
     port: 6443
     k0sApiPort: 9443
-    externalAddress: api.k0s.example.com
+    externalAddress: api.k0s.example.test
     sans:
-      - api.k0s.example.com
-      - "192.168.1.10"
-    extraArgs:
-      enable-admission-plugins: "NodeRestriction,PodSecurityPolicy"
+      - api.k0s.example.test
+      - 10.20.0.10
 
   storage:
-    type: etcd  # etcd, kine+sqlite, kine+mysql, kine+postgres
-    etcd:
-      peerAddress: 192.168.1.10
+    type: etcd
 
   network:
-    provider: kube-router  # or calico, custom
-    kubeProxy:
-      disabled: false
-      mode: iptables  # iptables or ipvs
+    provider: kuberouter
     podCIDR: 10.244.0.0/16
     serviceCIDR: 10.96.0.0/12
     clusterDomain: cluster.local
-    dualStack:
-      enabled: false
-
-  controllerManager:
-    extraArgs:
-      bind-address: "0.0.0.0"
-
-  scheduler:
-    extraArgs:
-      bind-address: "0.0.0.0"
-
-  installConfig:
-    users:
-      etcdUser: etcd
-      kineUser: kube-apiserver
-      konnectivityUser: konnectivity-server
-      kubeAPIserverUser: kube-apiserver
-      kubeSchedulerUser: kube-scheduler
-
-  extensions:
-    helm:
-      repositories:
-      - name: stable
-        url: https://charts.helm.sh/stable
-      charts:
-      - name: prometheus
-        chartname: stable/prometheus
-        namespace: monitoring
-    storage:
-      type: openebs_local_storage  # or external_storage
+    kubeProxy:
+      disabled: false
+      mode: iptables
 
   telemetry:
-    enabled: true
+    enabled: false
 ```
+
+The `externalAddress` and `sans` fields deserve special attention. Kubernetes client certificates and worker bootstrap configuration need a stable API identity. If you install controllers behind a future load balancer but forget to include the load balancer DNS name or address in the certificate subject alternative names, the cluster may come up but later fail in ways that look like networking problems and are actually certificate identity problems.
+
+The `telemetry` setting is included because platform teams should treat outbound telemetry as a policy decision. Some organizations allow anonymized usage telemetry from infrastructure tools; others disable it by default in regulated or air-gapped environments. The important practice is not the specific value in this example, but the fact that you record the decision rather than letting it hide in an unreviewed default.
 
 ### Network Provider Options
 
-**kube-router (default):**
+k0s bundles Kube-router and Calico as built-in CNI choices, and it can also run with a custom CNI. Choosing the CNI during cluster creation is a foundational decision because it shapes pod routing, network policy behavior, node firewall needs, service implementation details, and day-two troubleshooting. Treat it like choosing a filesystem or datastore, not like choosing a cosmetic add-on.
 
 ```yaml
 spec:
   network:
-    provider: kube-router
-    kube-router:
-      # Enable all features
-      metricsPort: 8080
-      hairpin: Enabled
+    provider: kuberouter
+    kuberouter:
       autoMTU: true
-      # BGP configuration
-      peerRouterASNs: "64512"
-      peerRouterIPs: "192.168.1.1"
+      hairpin: Enabled
+      metricsPort: 8080
 ```
 
-**Calico:**
+Kube-router fits k0s's minimal-core posture because it can provide pod networking with a relatively direct Linux networking model. It is also attractive in environments where BGP routing matters, though BGP design requires network engineering discipline and should not be enabled casually. The practical lesson is that "default CNI" does not mean "ignore networking"; it means "start from the distribution's tested path, then change only when your requirements justify it."
 
 ```yaml
 spec:
   network:
     provider: calico
     calico:
-      mode: vxlan  # vxlan, ipip, bird
+      mode: vxlan
       overlay: Always
-      flexVolumeDriverPath: /usr/libexec/k0s/kubelet-plugins/volume/exec/nodeagent~uds
-      wireguard: false
 ```
 
-**Custom CNI (Cilium, Flannel, etc.):**
+Calico is the familiar choice for teams that want its network policy ecosystem and operational model. In k0s, selecting Calico at install time lets the distribution manage the built-in Calico deployment path. If you need a custom Calico mode, dual-stack nuance, or advanced enterprise features, verify the current k0s networking docs and Calico docs together because both sides of the integration matter.
 
 ```yaml
 spec:
   network:
     provider: custom
-    # Install your own CNI after cluster is up
 ```
+
+Custom CNI is the escape hatch for Cilium, Flannel, or another plugin. The word "custom" should make you slow down, because k0s will not magically install the plugin, place every host binary, or validate every plugin-specific kernel and firewall requirement for you. Custom CNI gives you control, but it also hands ownership of installation order and troubleshooting back to your platform team.
 
 ### Storage Configuration
 
-**SQLite (single node):**
+Storage configuration is where k0s stops being a packaging discussion and becomes a reliability discussion. The Kubernetes API server needs a durable datastore. If that datastore is local SQLite, the blast radius is simple and the cluster is not HA. If that datastore is embedded etcd, the cluster can survive controller loss when quorum remains. If that datastore is external SQL, the cluster depends on the database team's HA story.
 
 ```yaml
 spec:
@@ -442,607 +403,382 @@ spec:
       dataSource: sqlite:///var/lib/k0s/db/state.db
 ```
 
-**External database:**
+Kine plus SQLite is a good teaching and single-node choice because it removes the mental overhead of etcd membership. It is also a poor multi-controller HA choice because a local file database is not a replicated consensus system. When a module says "SQLite for single node", it is not insulting SQLite; it is placing SQLite in the topology where its simplicity is an advantage rather than a hidden availability limit.
+
+```yaml
+spec:
+  storage:
+    type: etcd
+    etcd:
+      peerAddress: 10.20.0.10
+```
+
+Embedded etcd is the normal HA path because k0s can manage etcd lifecycle on the controller nodes. You still need to design for quorum, disk quality, backups, and controller replacement. A three-controller etcd cluster can tolerate one controller failure; it cannot tolerate careless simultaneous maintenance of two members. HA is not a checkbox, it is a promise that your procedures must keep.
 
 ```yaml
 spec:
   storage:
     type: kine
     kine:
-      dataSource: mysql://user:password@tcp(mysql.example.com:3306)/k0s
-      # Or PostgreSQL
-      # dataSource: postgres://user:password@postgres.example.com:5432/k0s?sslmode=disable
+      dataSource: postgres://k0s:REPLACE_ME@postgres.example.test:5432/k0s?sslmode=require
 ```
+
+External SQL through Kine is useful when your organization already has a managed database platform with backups, monitoring, encryption, and failover. The benefit is that Kubernetes controllers do not have to operate their own datastore quorum. The cost is dependency inversion: if the external database is unavailable or misconfigured, your Kubernetes API is unavailable even if every controller host is healthy.
 
 ## Helm Integration
 
-k0s includes a Helm controller for declarative chart installation:
+k0s includes Helm integration so cluster add-ons can be declared during bootstrap or through chart custom resources. This is useful for base components such as metrics, certificate management, ingress, storage helpers, or platform agents, but it should not become a dumping ground for every application team. The platform layer should install shared cluster services; application delivery should still have its own GitOps or release workflow.
 
 ```yaml
-# In k0s.yaml
+apiVersion: helm.k0sproject.io/v1beta1
+kind: Chart
+metadata:
+  name: metrics-server
+  namespace: kube-system
 spec:
-  extensions:
-    helm:
-      repositories:
-      - name: jetstack
-        url: https://charts.jetstack.io
-      - name: ingress-nginx
-        url: https://kubernetes.github.io/ingress-nginx
-
-      charts:
-      - name: cert-manager
-        chartname: jetstack/cert-manager
-        version: "v1.13.0"
-        namespace: cert-manager
-        values: |
-          installCRDs: true
-
-      - name: ingress-nginx
-        chartname: ingress-nginx/ingress-nginx
-        version: "4.8.0"
-        namespace: ingress-nginx
-        values: |
-          controller:
-            service:
-              type: LoadBalancer
+  chartName: metrics-server/metrics-server
+  namespace: kube-system
+  version: "3.13.0"
+  values: |
+    args:
+      - --kubelet-preferred-address-types=InternalIP,Hostname
 ```
 
-Apply changes by restarting k0s or using:
+The chart custom resource approach is more GitOps-friendly than stuffing every chart into the original installer configuration, because each chart can be applied, reviewed, and reconciled as a Kubernetes resource. That also reduces unnecessary k0s restarts for add-on changes. The operational boundary is simple: use k0s to bootstrap the cluster substrate, then manage ongoing platform add-ons through resources that your normal Kubernetes tooling can inspect.
 
-```bash
-# Reconcile Helm charts
-sudo k0s controller --enable-dynamic-config
-```
+If you prefer to define bootstrap charts inside `k0s.yaml`, keep the list short and boring. A cluster that cannot start without its network plugin, DNS, metrics, and maybe certificate plumbing is normal. A cluster that tries to install the entire internal developer platform during control-plane bootstrap is harder to debug because the line between "Kubernetes is up" and "the platform app stack is healthy" disappears.
 
 ## Cluster API Integration
 
-k0s integrates with Cluster API for declarative cluster management:
+k0s can participate in Cluster API workflows through k0smotron and related providers. The durable concept here is not the exact CRD shape, because provider APIs evolve. The durable concept is that Cluster API turns clusters themselves into Kubernetes-managed resources: a management cluster reconciles workload clusters, while bootstrap and control-plane providers know how to create the specific distribution.
 
 ```bash
-# Install clusterctl
-curl -L https://github.com/kubernetes-sigs/cluster-api/releases/latest/download/clusterctl-linux-amd64 -o clusterctl
-chmod +x clusterctl
-sudo mv clusterctl /usr/local/bin/
-
-# Initialize CAPI with k0s provider
-clusterctl init --infrastructure docker --bootstrap k0sproject-k0smotron --control-plane k0sproject-k0smotron
-
-# Create workload cluster
-cat <<EOF | kubectl apply -f -
-apiVersion: cluster.x-k8s.io/v1beta1
-kind: Cluster
-metadata:
-  name: my-cluster
-spec:
-  clusterNetwork:
-    pods:
-      cidrBlocks: ["10.244.0.0/16"]
-    services:
-      cidrBlocks: ["10.96.0.0/12"]
-  controlPlaneRef:
-    apiVersion: controlplane.cluster.x-k8s.io/v1beta1
-    kind: K0sControlPlane
-    name: my-cluster-cp
-  infrastructureRef:
-    apiVersion: infrastructure.cluster.x-k8s.io/v1beta1
-    kind: DockerCluster
-    name: my-cluster
-EOF
+# Example only: provider names and versions change, so verify current docs.
+clusterctl init \
+  --infrastructure docker \
+  --bootstrap k0sproject-k0smotron \
+  --control-plane k0sproject-k0smotron
 ```
+
+Use Cluster API when cluster lifecycle is itself a product you operate. If you create one or two clusters by hand, k0sctl is easier to understand and easier to debug. If you operate many workload clusters across teams, environments, or tenants, Cluster API gives you a reconciliation model, ownership boundaries, and integration points for fleet automation. k0sctl and Cluster API are not rivals; they sit at different layers of the lifecycle problem.
+
+The review habit is to ask which actor owns drift correction. With manual commands, humans own drift correction. With k0sctl, the inventory file and k0sctl apply workflow own a large part of cluster drift. With Cluster API, controllers in a management cluster continuously reconcile desired state. More automation is powerful only when you are ready to operate the automation layer itself.
 
 ## Day-2 Operations
 
+Day-two operations are where k0s's packaging simplicity stops being enough. A cluster that installs cleanly can still fail if you do not have backups, upgrade sequencing, certificate practices, datastore maintenance, network observability, and reset procedures. k0s gives you useful primitives, but you still need a runbook that states who runs them, when they are tested, and what evidence proves recovery works.
+
 ### Backup and Restore
 
-```bash
-# Backup etcd (on controller)
-sudo k0s backup --save-path /backup/k0s-backup.tar.gz
+k0s backup covers the k0s-managed control-plane state: certificates, datastore snapshots for etcd or Kine plus SQLite, k0s configuration, manifests under the k0s data directory, image bundles, and Helm configuration. It does not back up arbitrary application persistent volumes, and it does not magically protect an external database you selected through Kine. The backup scope is control-plane recovery, not whole-platform disaster recovery.
 
-# Restore from backup
-sudo k0s stop
-sudo k0s restore /backup/k0s-backup.tar.gz
-sudo k0s start
+```bash
+# On a controller node.
+sudo mkdir -p /var/backups/k0s
+sudo k0s backup --save-path /var/backups/k0s
+
+# With k0sctl from the workstation that can reach the cluster hosts.
+k0sctl backup --config k0sctl.yaml
 ```
+
+The restore path should be tested before you need it. A backup file that has never been restored is only a hopeful artifact. For HA clusters, pay attention to the control-plane external address because worker components are configured to connect to it. If a restore changes that address unexpectedly, the restored control plane may be healthy while workers continue dialing the old endpoint.
 
 ### Upgrading k0s
 
+The safest upgrade story is declarative: update the k0s version in `k0sctl.yaml`, review the release notes, check Kubernetes version skew, take a backup, and let k0sctl coordinate the node sequence. This gives you a change record and a repeatable workflow. A manual binary replacement can be appropriate for single-node labs, but it is less attractive for a fleet because it leaves sequencing and rollback evidence in human memory.
+
 ```bash
-# Check current version
-k0s version
+# Review the intended version in k0sctl.yaml first, then reconcile.
+k0sctl apply --config k0sctl.yaml
 
-# With k0sctl (recommended for multi-node)
-k0sctl apply --config k0sctl.yaml --debug
-
-# Manual upgrade
-sudo k0s stop
-curl -sSLf https://get.k0s.sh | sudo K0S_VERSION=v1.29.0+k0s.0 sh
-sudo k0s start
+# Confirm the Kubernetes and runtime view after the upgrade.
+KUBECONFIG=$PWD/kubeconfig kubectl get nodes -o wide
 ```
+
+Do not upgrade just because a version exists. Ask whether your current Kubernetes minor line is still supported, whether the new line changes containerd behavior, whether your CNI supports the target version, whether any deprecated API removals affect installed add-ons, and whether you have a tested restore point. Lightweight packaging shortens installation toil; it does not remove release engineering discipline.
 
 ### Reset and Cleanup
 
-```bash
-# Stop k0s
-sudo k0s stop
+Reset is useful when you are rebuilding a lab, replacing a node, or cleaning a failed installation. It is also destructive. k0s reset stops and removes k0s-managed state, unregisters the service, and makes a best-effort attempt to clean network configuration. Custom CNI cleanup may still require plugin-specific work, and a reboot is often the cleanest way to remove leftover kernel networking state.
 
-# Uninstall service
+```bash
+# Local destructive cleanup on a node.
+sudo k0s stop
 sudo k0s reset
 
-# This removes:
-# - /var/lib/k0s
-# - /run/k0s
-# - All containers
-# - Network interfaces
-# - iptables rules
+# Remote destructive cleanup through k0sctl.
+k0sctl reset --config k0sctl.yaml
 ```
+
+The operational habit is to decide whether you are resetting a node or retiring part of a cluster. Resetting a worker without draining application pods can cause avoidable workload disruption. Resetting a controller without understanding datastore membership can reduce or break quorum. A clean uninstall command is not a substitute for a clean removal procedure.
 
 ## Monitoring and Troubleshooting
 
-### Built-in Status
+k0s troubleshooting starts with the same layered model as any Kubernetes cluster: host, k0s service, control-plane components, datastore, node runtime, CNI, DNS, then workloads. The distribution-specific commands help you locate the layer quickly, but you should still avoid jumping straight to application YAML when the kubelet cannot register or the CNI pods are crash-looping.
 
 ```bash
-# Check k0s status
+# On a node, inspect the k0s service and role.
 sudo k0s status
 
-# Check component health
-sudo k0s kubectl get --raw /healthz
+# Inspect the API health from a controller.
+sudo k0s kubectl get --raw /readyz?verbose
 
-# View control plane logs
-sudo journalctl -u k0scontroller
+# Systemd logs use different service names by role.
+sudo journalctl -u k0scontroller --no-pager -n 100
+sudo journalctl -u k0sworker --no-pager -n 100
 
-# View worker logs
-sudo journalctl -u k0sworker
+# Cluster-level view.
+sudo k0s kubectl get nodes -o wide
+sudo k0s kubectl get pods -A -o wide
+```
 
-# Check etcd health (HA setup)
+If controller logs look healthy but workers are missing, check the worker's route to the controller address and the relevant ports before changing Kubernetes objects. If nodes register but pods cannot communicate, inspect the CNI pods, host firewall backend, MTU, and whether the chosen CNI matches the configuration used at cluster creation. Networking bugs often masquerade as DNS or application readiness failures because DNS is the first cross-pod call many workloads make.
+
+```bash
+# CNI-focused checks for the default Kube-router path.
+sudo k0s kubectl -n kube-system get pods -l k8s-app=kube-router -o wide
+sudo k0s kubectl -n kube-system logs -l k8s-app=kube-router --tail=80
+
+# Lightweight in-cluster network test.
+sudo k0s kubectl run netcheck \
+  --image=busybox:1.36 \
+  --restart=Never \
+  --rm -it -- wget -qO- https://kubernetes.default.svc
+```
+
+That `wget` test is intentionally boring. It checks whether a pod can start, resolve the Kubernetes service name, and reach the API service through cluster networking. If it fails, the error text points your next step: image pull means registry or runtime, DNS lookup means CoreDNS or service discovery, connection refused means service or API path, timeout means CNI, routing, firewall, or proxy.
+
+For HA clusters, add datastore checks to the normal triage sequence. A Kubernetes API server can be running while etcd is unhealthy, slow, or missing quorum. In k0s, the etcd lifecycle is managed for embedded etcd clusters, but you still need to watch disk latency, member health, and backup currency. When control-plane symptoms look random, always ask whether the datastore is actually healthy.
+
+```bash
+# On a controller in an embedded etcd cluster.
 sudo k0s etcd member-list
+
+# Confirm the API endpoint identity clients are using.
+KUBECONFIG=$PWD/kubeconfig kubectl cluster-info
 ```
 
-### Debugging
+## Hypothetical scenario: Clean Slate Infrastructure
 
-```bash
-# Run with debug logging
-sudo k0s controller --debug
+Hypothetical scenario: A fintech platform team inherits three small Kubernetes footprints: a cloud lab, an on-prem integration environment, and several edge boxes in partner sites. Each site was built by a different team, and every rebuild starts with a half-day argument about host packages. One image has an old containerd package, another blocks an apt repository, a third uses a firewall backend nobody documented, and the edge boxes are intentionally stripped down for security review.
 
-# Get detailed component status
-sudo k0s kubectl get componentstatuses
+The team first tries to standardize the kubeadm path. That is a reasonable instinct because kubeadm is close to upstream and familiar to many operators. The problem is not kubeadm itself; the problem is the unmanaged spread of host prerequisites. The team can make kubeadm work, but the real project becomes standardizing golden images, package repositories, runtime configuration, firewall behavior, and join documentation across environments that were never meant to look identical.
 
-# Check CNI status
-sudo k0s kubectl -n kube-system get pods -l k8s-app=kube-router
+The k0s pilot reframes the problem. Instead of asking every environment to become the same Linux platform first, the team asks whether each host can satisfy the kernel and networking requirements and run the same k0s binary. Controllers are kept controller-only in the shared environments, small edge nodes use controller+worker where there is no spare hardware, and k0sctl inventories describe each site in Git. The team still has to solve routing, DNS, certificates, and backups, but the number of host-package variables drops sharply.
 
-# Verify networking
-sudo k0s kubectl run test --image=busybox --rm -it --restart=Never -- wget -qO- kubernetes.default
-```
-
-## War Story: The Clean Slate Infrastructure
-
-A fintech startup needed Kubernetes across hybrid infrastructure:
-
-**The Challenge**:
-- Mixed infrastructure: AWS, on-prem, edge locations
-- Different Linux distributions (Ubuntu, RHEL, Amazon Linux)
-- Strict security requirements (no unnecessary packages)
-- Need for consistent deployment across all environments
-
-**Why Other Solutions Had Issues**:
-- kubeadm: Required pre-installing containerd, different steps per distro
-- k3s: Assumed systemd, had dependency issues on older RHEL
-- Managed K8s: Not available on-prem or edge
-
-**The k0s Solution**:
-
-```bash
-# Same installation everywhere
-curl -sSLf https://get.k0s.sh | sudo sh
-sudo k0s install controller
-sudo k0s start
-
-# Worked on:
-# - Ubuntu 20.04
-# - RHEL 7.9
-# - Amazon Linux 2
-# - Debian 11
-# - Even Alpine (with glibc compatibility)
-```
-
-**Fleet Automation with k0sctl**:
-
-```yaml
-# environments/production.yaml
-apiVersion: k0sctl.k0sproject.io/v1beta1
-kind: Cluster
-metadata:
-  name: production
-spec:
-  hosts:
-  # AWS controllers
-  - ssh:
-      address: 10.0.1.10
-      user: ec2-user
-      keyPath: ~/.ssh/aws.pem
-    role: controller
-    privateAddress: 10.0.1.10
-  # On-prem controllers
-  - ssh:
-      address: 192.168.1.10
-      user: root
-      keyPath: ~/.ssh/onprem.pem
-    role: controller
-    privateAddress: 192.168.1.10
-  # Edge workers
-  - ssh:
-      address: edge-node-1.example.com
-      user: admin
-      keyPath: ~/.ssh/edge.pem
-    role: worker
-```
-
-**GitOps for Cluster Configuration**:
-
-```yaml
-# k0s.yaml managed in Git
-spec:
-  extensions:
-    helm:
-      charts:
-      - name: cert-manager
-        chartname: jetstack/cert-manager
-        namespace: cert-manager
-        version: v1.13.0
-      - name: vault
-        chartname: hashicorp/vault
-        namespace: vault
-        version: 0.25.0
-```
-
-**The Results**:
-- Deployment time: 5 minutes per cluster (automated)
-- Same binary, same process across all environments
-- Clean uninstall: `k0s reset` leaves no traces
-- Security team approved: minimal attack surface
-- Upgrade path: `k0sctl apply` updates entire fleet
-
-**The Lesson**: Zero dependencies means zero surprises across diverse infrastructure.
+The lesson is not "always choose k0s." The lesson is that packaging is an architectural choice. If your main source of failure is inconsistent host preparation, a self-contained distribution can reduce drift. If your main requirement is maximum upstream assembly control, kubeadm may be the better fit. Good platform engineers choose the tool whose failure modes match the team's operating capacity.
 
 ## Common Mistakes
 
-| Mistake | Problem | Solution |
-|---------|---------|----------|
-| Using --single in production | No HA, can't add workers | Use controller-only for HA |
-| Forgetting externalAddress | Certificates don't include LB IP | Set API externalAddress and sans |
-| Not separating controller/worker | Controllers running workloads | Controllers should be control-plane only |
-| Ignoring backup | Data loss on failure | Regular `k0s backup` to external storage |
-| Manual token management | Tokens expire, manual process | Use k0sctl for token lifecycle |
-| Wrong storage type for HA | SQLite in multi-controller | Use etcd for HA setups |
-| Not checking status | Silent failures | Regular `k0s status` checks |
-| Skipping k0s reset | Leftover state causes issues | Always `k0s reset` before reinstall |
+| Mistake | Problem | Better Approach |
+|---------|---------|-----------------|
+| Treating `--single` as a future-proof production shortcut | Single-node mode is convenient but intentionally not the path for later multi-node expansion | Use controller-only plus workers for production, or `--enable-worker --no-taints` for expandable single-host labs |
+| Assuming "zero dependencies" means no host requirements | Kubernetes workers still need kernel, cgroup, namespace, networking, firewall, and privilege support | Run `k0s sysinfo`, read external runtime dependencies, and validate host images before rollout |
+| Running workloads on controllers accidentally | Control-plane CPU, memory, and disk contention can turn an application incident into an API outage | Keep controllers isolated unless a controller+worker topology is an explicit edge or lab decision |
+| Picking SQLite for a multi-controller HA design | Local SQLite through Kine is simple, not a replicated consensus datastore | Use embedded etcd for in-cluster HA or an external SQL datastore with its own HA guarantees |
+| Changing node roles casually after installation | Role changes can conflict with existing service state, taints, and k0sctl inventory expectations | Decide `controller`, `worker`, or `controller+worker` before bootstrap and rotate nodes when topology must change |
+| Forgetting the API external address and certificate SANs | Workers and clients may later fail TLS validation when a load balancer or DNS name is introduced | Configure `spec.api.externalAddress` and required SANs before creating the HA control plane |
+| Treating bundled CNI as an afterthought | CNI choice affects routing, network policy, firewall rules, MTU, and troubleshooting procedures | Choose Kube-router, Calico, or custom CNI deliberately during cluster design and document why |
+| Backing up only the k0s control plane | `k0s backup` does not capture arbitrary application persistent volumes or external database state | Pair k0s backups with application PV backups and external datastore backup policies |
 
 ## Quiz
 
-Test your understanding of k0s:
+Test your understanding of k0s by answering the questions before opening the details.
 
 <details>
-<summary>1. What makes k0s different from k3s in terms of dependencies?</summary>
+<summary>1. A team says k0s is "just kubeadm with a smaller installer." What is missing from that description?</summary>
 
-**Answer**: k0s embeds containerd within its binary—no host runtime installation required. k3s assumes containerd is available on the system. This makes k0s truly zero-dependency: the single binary contains everything needed to run Kubernetes, including the container runtime.
+The missing idea is packaging ownership. kubeadm assembles Kubernetes on a host where key prerequisites, especially the container runtime and Kubernetes packages, have already been installed and configured. k0s ships as a self-contained binary that supervises and manages the components it bundles. Both can produce conformant Kubernetes, but they put responsibility for host preparation, component version alignment, and lifecycle orchestration in different places.
 </details>
 
 <details>
-<summary>2. Why don't k0s controller nodes run workloads by default?</summary>
+<summary>2. When should you choose `controller`, `worker`, or `controller+worker`?</summary>
 
-**Answer**: k0s enforces clean separation of control plane and workers. Controller nodes only run control plane components (API server, controller-manager, scheduler, etcd). This improves security and stability—a workload crash can't affect the control plane. Use `--single` mode only for development when you want both on one node.
+Choose `controller` for nodes that should run the control plane and datastore without hosting normal workloads. Choose `worker` for nodes that should run kubelet, runtime, CNI, and application pods. Choose `controller+worker` only when a node must do both, such as a lab, laptop, small appliance, or constrained edge site. The combined role is a topology decision because it couples workload risk to control-plane risk.
 </details>
 
 <details>
-<summary>3. What is k0sctl and when should you use it?</summary>
+<summary>3. Why does Konnectivity matter in private worker networks?</summary>
 
-**Answer**: k0sctl is an automation tool that deploys and manages k0s clusters via SSH. Use it for: (1) Multi-node deployments, (2) HA cluster setup, (3) Fleet upgrades, (4) Consistent configuration across nodes. It's the recommended way to manage anything beyond single-node development.
+The Kubernetes API server often needs to reach kubelets for logs, exec, port-forward, and metrics flows, but workers in edge or private networks may not accept inbound control-plane connections. Konnectivity lets worker-side agents establish a reverse tunnel toward the control plane. That preserves useful Kubernetes operations without requiring every worker to expose broad inbound access from the controller network.
 </details>
 
 <details>
-<summary>4. How does k0s handle CNI differently than k3s?</summary>
+<summary>4. A one-node k0s cluster may grow later. Why might `--single` be the wrong demo command?</summary>
 
-**Answer**: k0s defaults to kube-router, which provides CNI, service proxy (kube-proxy replacement), and network policies in one component. It also supports Calico as a built-in option or custom CNI. k3s defaults to Flannel. kube-router's integration with BGP makes k0s particularly suitable for advanced networking scenarios.
+The `--single` flag is ideal for a disposable one-node cluster because it creates a controller and worker in one easy step. The drawback is that the upstream docs describe it as disabling features needed for multi-node clusters. If the node may later become the first node in a larger lab, installing a controller with worker components enabled is a better starting shape than using single-node mode.
 </details>
 
 <details>
-<summary>5. What datastore options does k0s support?</summary>
+<summary>5. How should you decide between Kine plus SQLite, embedded etcd, and external SQL?</summary>
 
-**Answer**: k0s supports: (1) etcd (embedded, for HA), (2) SQLite via kine (single node), (3) MySQL via kine (external HA), (4) PostgreSQL via kine (external HA). Unlike k3s which embeds SQLite/etcd logic, k0s uses kine as an abstraction layer for non-etcd backends.
+Start with the availability boundary. Kine plus SQLite keeps state local and simple, which is good for single-node clusters but not HA. Embedded etcd gives multiple controllers a replicated datastore, but requires quorum, reliable disks, and membership operations. External SQL moves the stateful reliability problem to a database platform, which is useful only if that database is actually operated with stronger availability than the cluster would have had itself.
 </details>
 
 <details>
-<summary>6. How do you cleanly uninstall k0s?</summary>
+<summary>6. What problem does k0sctl solve that manual token joins do not?</summary>
 
-**Answer**: Run `sudo k0s stop` followed by `sudo k0s reset`. The reset command removes: /var/lib/k0s, /run/k0s, all containers, network interfaces created by k0s, and iptables rules. All state is contained in /var/lib/k0s, so removal is complete and clean.
+k0sctl turns a cluster into a declarative SSH inventory. It records hosts, roles, addresses, version, and cluster configuration in one file, then connects to nodes and performs the bootstrap or reconciliation steps. Manual token joins teach the mechanics, but they leave sequencing, token distribution, and desired-state documentation to humans. k0sctl gives the team a reviewable cluster plan.
 </details>
 
 <details>
-<summary>7. How does k0s integrate with Cluster API?</summary>
+<summary>7. Is k0s a CNCF project, a Mirantis product, or a conformant Kubernetes distribution?</summary>
 
-**Answer**: k0s provides bootstrap and control plane providers for Cluster API through the k0smotron project. This enables declarative cluster management: define clusters as Kubernetes resources, and CAPI reconciles the desired state. Useful for managing fleets of k0s clusters at scale.
+As of the 2026-06 snapshot in this module, k0s is all three in different senses. It was built by Mirantis and has Mirantis commercial support around it. It is a CNCF Sandbox project, which is a project maturity and governance status. It is also CNCF Certified Kubernetes, which means the distribution's Kubernetes API behavior passes conformance expectations rather than being a separate Kubernetes-like API.
 </details>
 
 <details>
-<summary>8. What's the purpose of the Helm extension in k0s configuration?</summary>
+<summary>8. Why is a CNI decision hard to change after bootstrap?</summary>
 
-**Answer**: The Helm extension allows declarative chart installation as part of cluster configuration. Charts defined in k0s.yaml are automatically installed/upgraded when the cluster starts. This enables GitOps-style management of cluster add-ons without external tools like ArgoCD for basic use cases.
+The CNI controls pod addressing, routing, policy behavior, host interfaces, firewall programming, and sometimes service behavior. Once workloads, services, and nodes depend on that network model, replacing the provider is closer to a cluster migration than a small setting change. k0s supports Kube-router, Calico, and custom CNI, but the responsible choice is to decide during design and redeploy rather than casually mutate a live cluster.
 </details>
 
-## Hands-On Exercise: Deploy HA k0s with k0sctl
+## Hands-On Exercise: Deploy and Inspect a k0s Cluster Shape
 
 ### Objective
-Use k0sctl to deploy a high-availability k0s cluster with automated configuration.
+
+Use k0s directly for a single-node learning cluster, then create a k0sctl inventory that expresses the equivalent multi-node production intent. The exercise is designed so you can complete the first half on one Linux VM and still practice the k0sctl configuration model even if you do not have three reachable hosts.
 
 ### Environment Setup
 
-Using Multipass (or any 3+ Linux VMs):
+Use a disposable Linux VM with systemd or OpenRC and enough resources for a small Kubernetes cluster. The current k0s system requirements list very small minimums, but a smoother lab experience usually comes from at least 2 vCPU and 2 GB RAM. Do not run this exercise on a workstation or server where removing `/var/lib/k0s` would surprise you.
 
 ```bash
-# Create VMs
-for i in 1 2 3; do
-  multipass launch --name k0s-ctrl-$i --cpus 2 --memory 2G --disk 10G
-done
-
-for i in 1 2; do
-  multipass launch --name k0s-worker-$i --cpus 2 --memory 2G --disk 10G
-done
-
-# Get IP addresses
-multipass list
+# Optional but recommended: confirm the host looks suitable.
+curl --proto '=https' --tlsv1.2 -sSf https://get.k0s.sh | sudo sh
+sudo k0s sysinfo
 ```
 
-### Step 1: Install k0sctl
+### Step 1: Install an Expandable Single-Host Cluster
+
+Install the node as a controller with worker components enabled rather than using `--single`. This gives you a one-host cluster for the lab while reinforcing the role distinction you would use if the cluster later gained workers.
 
 ```bash
-# Download k0sctl
-curl -sSLf https://github.com/k0sproject/k0sctl/releases/latest/download/k0sctl-linux-amd64 -o k0sctl
-chmod +x k0sctl
-sudo mv k0sctl /usr/local/bin/
-
-# Verify
-k0sctl version
+sudo k0s install controller --enable-worker --no-taints --start
+sleep 60
+sudo k0s status
+sudo k0s kubectl get nodes -o wide
+sudo k0s kubectl get pods -A
 ```
 
-### Step 2: Prepare SSH Access
+### Step 2: Verify Workload Scheduling
+
+Deploy a tiny workload and confirm it lands on the combined node. This verifies that worker components are active, the CNI is running, DNS is available, and the node is schedulable after `--no-taints`.
 
 ```bash
-# Copy your SSH key to all nodes (if using Multipass)
-# Multipass uses its own authentication, so we'll use shell access instead
-
-# For real VMs, ensure SSH key access:
-# for host in ctrl-1 ctrl-2 ctrl-3 worker-1 worker-2; do
-#   ssh-copy-id root@$host
-# done
+sudo k0s kubectl create deployment hello-k0s --image=nginx:1.27 --replicas=1
+sudo k0s kubectl rollout status deployment/hello-k0s
+sudo k0s kubectl get pods -o wide
+sudo k0s kubectl delete deployment hello-k0s
 ```
 
-### Step 3: Create Cluster Configuration
+### Step 3: Draft a k0sctl Inventory
+
+Now write the multi-node intent you would use for a real environment. If you do not have the extra hosts, do not run `k0sctl apply`; the value of this step is learning how the topology becomes a reviewable file.
 
 ```bash
-# Get VM IPs
-CTRL1_IP=$(multipass info k0s-ctrl-1 | grep IPv4 | awk '{print $2}')
-CTRL2_IP=$(multipass info k0s-ctrl-2 | grep IPv4 | awk '{print $2}')
-CTRL3_IP=$(multipass info k0s-ctrl-3 | grep IPv4 | awk '{print $2}')
-WORKER1_IP=$(multipass info k0s-worker-1 | grep IPv4 | awk '{print $2}')
-WORKER2_IP=$(multipass info k0s-worker-2 | grep IPv4 | awk '{print $2}')
-
-# For Multipass, we'll do manual install. For real VMs:
-cat > k0sctl.yaml <<EOF
+cat > k0sctl.yaml <<'EOF'
 apiVersion: k0sctl.k0sproject.io/v1beta1
 kind: Cluster
 metadata:
-  name: ha-k0s-demo
+  name: dojo-k0s-lab
 spec:
   hosts:
-  - ssh:
-      address: ${CTRL1_IP}
-      user: root
-      keyPath: ~/.ssh/id_rsa
-    role: controller
-    privateInterface: eth0
-  - ssh:
-      address: ${CTRL2_IP}
-      user: root
-      keyPath: ~/.ssh/id_rsa
-    role: controller
-    privateInterface: eth0
-  - ssh:
-      address: ${CTRL3_IP}
-      user: root
-      keyPath: ~/.ssh/id_rsa
-    role: controller
-    privateInterface: eth0
-  - ssh:
-      address: ${WORKER1_IP}
-      user: root
-      keyPath: ~/.ssh/id_rsa
-    role: worker
-  - ssh:
-      address: ${WORKER2_IP}
-      user: root
-      keyPath: ~/.ssh/id_rsa
-    role: worker
+    - role: controller
+      ssh:
+        address: 10.30.0.10
+        user: ubuntu
+        keyPath: ~/.ssh/id_ed25519
+    - role: worker
+      ssh:
+        address: 10.30.0.11
+        user: ubuntu
+        keyPath: ~/.ssh/id_ed25519
+    - role: worker
+      ssh:
+        address: 10.30.0.12
+        user: ubuntu
+        keyPath: ~/.ssh/id_ed25519
   k0s:
-    version: v1.28.5+k0s.0
+    version: v1.35.4+k0s.0
     config:
+      apiVersion: k0s.k0sproject.io/v1beta1
+      kind: ClusterConfig
+      metadata:
+        name: dojo-k0s-lab
       spec:
         api:
-          sans:
-            - ${CTRL1_IP}
-            - ${CTRL2_IP}
-            - ${CTRL3_IP}
+          externalAddress: 10.30.0.10
+        storage:
+          type: etcd
         network:
-          provider: kube-router
-        extensions:
-          helm:
-            charts:
-            - name: metrics-server
-              chartname: metrics-server/metrics-server
-              namespace: kube-system
-              values: |
-                args:
-                  - --kubelet-insecure-tls
+          provider: kuberouter
+        telemetry:
+          enabled: false
 EOF
-
-# For this exercise with Multipass, we'll do manual deployment
 ```
 
-### Step 4: Manual Installation (Multipass)
+### Step 4: Review the Inventory Like a Platform Change
 
-Since Multipass doesn't support direct SSH, we'll install manually:
+Before applying any cluster inventory, inspect it for topology mistakes. The questions are more important than the command: are controllers isolated, is the datastore compatible with the number of controllers, can every host reach the API address, are certificate names planned, and is the CNI choice documented?
 
 ```bash
-# On first controller
-multipass shell k0s-ctrl-1
-curl -sSLf https://get.k0s.sh | sudo sh
-sudo k0s install controller
-sudo k0s start
-# Wait for it to start
-sleep 30
-sudo k0s status
-# Create join tokens
-sudo k0s token create --role=controller > /tmp/controller-token
-sudo k0s token create --role=worker > /tmp/worker-token
-cat /tmp/controller-token
-cat /tmp/worker-token
-exit
-
-# Copy tokens (get them from the output above)
-# CONTROLLER_TOKEN="..."
-# WORKER_TOKEN="..."
-
-# On controller 2
-multipass shell k0s-ctrl-2
-curl -sSLf https://get.k0s.sh | sudo sh
-# Use the controller token from ctrl-1
-echo "PASTE_CONTROLLER_TOKEN_HERE" | sudo tee /tmp/token
-sudo k0s install controller --token-file /tmp/token
-sudo k0s start
-exit
-
-# On controller 3
-multipass shell k0s-ctrl-3
-curl -sSLf https://get.k0s.sh | sudo sh
-echo "PASTE_CONTROLLER_TOKEN_HERE" | sudo tee /tmp/token
-sudo k0s install controller --token-file /tmp/token
-sudo k0s start
-exit
-
-# On workers
-multipass shell k0s-worker-1
-curl -sSLf https://get.k0s.sh | sudo sh
-echo "PASTE_WORKER_TOKEN_HERE" | sudo tee /tmp/token
-sudo k0s install worker --token-file /tmp/token
-sudo k0s start
-exit
-
-multipass shell k0s-worker-2
-curl -sSLf https://get.k0s.sh | sudo sh
-echo "PASTE_WORKER_TOKEN_HERE" | sudo tee /tmp/token
-sudo k0s install worker --token-file /tmp/token
-sudo k0s start
-exit
+grep -E 'role:|version:|externalAddress:|type:|provider:' k0sctl.yaml
 ```
 
-### Step 5: Verify Cluster
+### Step 5: Clean Up the Local Lab
+
+Reset the local node only after you have deleted test workloads and confirmed there is no data you need. This reinforces the difference between a clean removal primitive and a safe production decommission procedure.
 
 ```bash
-# Get kubeconfig from any controller
-multipass shell k0s-ctrl-1
-sudo k0s kubeconfig admin
-# Copy the output
-
-# On your local machine
-cat > ~/.kube/k0s-config << 'EOF'
-# Paste kubeconfig here
-EOF
-
-export KUBECONFIG=~/.kube/k0s-config
-
-# Check nodes
-kubectl get nodes
-
-# Check etcd members
-multipass exec k0s-ctrl-1 -- sudo k0s etcd member-list
-
-# Check pods
-kubectl get pods -A
-```
-
-### Step 6: Deploy Test Application
-
-```bash
-# Create deployment
-kubectl create deployment nginx --image=nginx --replicas=3
-
-# Check pods are on workers
-kubectl get pods -o wide
-
-# Expose with service
-kubectl expose deployment nginx --port=80 --type=ClusterIP
-
-# Test connectivity
-kubectl run test --image=busybox --rm -it --restart=Never -- wget -qO- nginx
-```
-
-### Step 7: Test Controller Failover
-
-```bash
-# Stop one controller
-multipass stop k0s-ctrl-1
-
-# Check cluster is still operational
-kubectl get nodes
-kubectl get pods -A
-
-# etcd should still have quorum (2/3)
-
-# Bring controller back
-multipass start k0s-ctrl-1
-sleep 30
-
-# Verify rejoin
-kubectl get nodes
+sudo k0s kubectl get all -A
+sudo k0s stop
+sudo k0s reset
 ```
 
 ### Success Criteria
 
-- [ ] 3 controller nodes running
-- [ ] 2 worker nodes joined
-- [ ] etcd cluster healthy (3 members)
-- [ ] Application deployed to workers
-- [ ] Cluster survives controller failure
-- [ ] Failed controller rejoins
-
-### Cleanup
-
-```bash
-# Stop and delete VMs
-for i in 1 2 3; do
-  multipass delete k0s-ctrl-$i
-done
-for i in 1 2; do
-  multipass delete k0s-worker-$i
-done
-multipass purge
-```
+- [ ] You can explain why `--enable-worker --no-taints` creates an expandable single-host lab while `--single` is a disposable shortcut.
+- [ ] `sudo k0s status` shows a controller process with workloads enabled during the lab.
+- [ ] `sudo k0s kubectl get nodes -o wide` shows the node ready before you deploy the test workload.
+- [ ] The nginx deployment reaches rollout completion and is then removed cleanly.
+- [ ] Your `k0sctl.yaml` separates controller and worker roles and records the chosen datastore and CNI.
+- [ ] You can state what would need to change for a true HA inventory with three controllers and a stable load balancer address.
 
 ## Key Takeaways
 
-1. **True zero dependencies**: containerd embedded—nothing to pre-install
-2. **Clean separation**: Controllers don't run workloads (by design)
-3. **All state in /var/lib/k0s**: Clean install, clean uninstall
-4. **k0sctl automates everything**: Use it for multi-node clusters
-5. **kube-router provides CNI + service proxy**: All networking in one
-6. **Helm extension for add-ons**: Declarative chart installation
-7. **Cluster API support**: Enterprise-grade cluster management
-8. **Multiple storage backends**: etcd, SQLite, MySQL, PostgreSQL
-9. **Backup built-in**: `k0s backup` for disaster recovery
-10. **Same binary everywhere**: Works on any Linux distribution
+1. k0s is a conformant Kubernetes distribution with a self-contained binary packaging model, not a forked Kubernetes API.
+2. The strongest k0s idea is reduced host dependency: no Kubernetes package repository, no snap requirement, and no preinstalled CRI runtime for the normal path.
+3. Controllers are isolated by default, workers run workloads, and controller+worker nodes should be deliberate exceptions for labs, appliances, or constrained edge sites.
+4. Konnectivity supports private worker networks by reversing the control-plane-to-kubelet communication problem into a worker-initiated tunnel.
+5. Kine plus SQLite is simple for single-node clusters, embedded etcd is the normal HA control-plane datastore, and external SQL shifts reliability to a database platform.
+6. k0sctl turns multi-node bootstrap into a declarative inventory, which is easier to review and repeat than manual token joins.
+7. Bundled CNI is a design decision, not a footnote; choose Kube-router, Calico, or custom CNI based on routing, policy, and operational requirements.
+8. k0s backup protects k0s-managed control-plane state, not every application volume or external datastore dependency.
+9. CNCF project maturity and Kubernetes conformance answer different questions; check both before making governance or compatibility claims.
+10. The durable comparison between distributions is about capabilities and tradeoffs, not popularity or "best tool" claims.
+
+## Sources
+
+- https://k0sproject.io/
+- https://github.com/k0sproject/k0s
+- https://github.com/k0sproject/k0s/releases/tag/v1.36.1%2Bk0s.0
+- https://www.cncf.io/projects/k0s/
+- https://www.cncf.io/training/certification/software-conformance/
+- https://docs.k0sproject.io/v1.35.4+k0s.0/architecture/
+- https://docs.k0sproject.io/v1.35.4+k0s.0/system-requirements/
+- https://docs.k0sproject.io/v1.35.4+k0s.0/external-runtime-deps/
+- https://docs.k0sproject.io/v1.35.4+k0s.0/install/
+- https://docs.k0sproject.io/v1.35.4+k0s.0/k0sctl-install/
+- https://github.com/k0sproject/k0sctl
+- https://docs.k0sproject.io/v1.35.4+k0s.0/configuration/
+- https://docs.k0sproject.io/v1.35.4+k0s.0/networking/
+- https://docs.k0sproject.io/v1.35.4+k0s.0/high-availability/
+- https://docs.k0sproject.io/v1.35.4+k0s.0/backup/
+- https://docs.k0sproject.io/v1.35.4+k0s.0/reset/
+- https://docs.k0sproject.io/v1.35.4+k0s.0/helm-charts/
+- https://docs.k0sproject.io/v1.35.4+k0s.0/runtime/
 
 ## Next Module
 
-Continue to [Module 14.3: MicroK8s](../module-14.3-microk8s/) — Canonical's snap-based Kubernetes with rich add-ons.
-
----
-
-*"k0s achieves what Kubernetes always promised but never delivered: download one thing, run Kubernetes."*
+Continue to [Module 14.3: MicroK8s](../module-14.3-microk8s/) to compare k0s with Canonical's snap-packaged Kubernetes distribution and its add-on centered operating model.

--- a/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.3-microk8s.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.3-microk8s.md
@@ -9,11 +9,9 @@ sidebar:
 
 ## Overview
 
-MicroK8s is Kubernetes the Ubuntu way—installed and updated through snap packages, with optional features enabled via add-ons. It's the fastest way to get Kubernetes running on Ubuntu, and its add-on system means you can go from "hello world" to production-ready with a few commands.
+MicroK8s is Kubernetes delivered as a snap — Canonical's answer to the question "what if installing a production-grade Kubernetes cluster felt as natural as installing any other package on Ubuntu?" It is a CNCF-certified Kubernetes distribution that packages the entire control plane, the kubelet, the container runtime, a distributed datastore, and thirty-plus optional add-ons into a single snap that auto-updates through Canonical's release channels. You install it with one command. You enable DNS, storage, ingress, and monitoring with one command each. And when you need high availability, you add nodes with one command.
 
-Built by Canonical (the company behind Ubuntu), MicroK8s targets developers who want Kubernetes that "just works" and operations teams who want consistent deployments across development, CI/CD, and production.
-
-This module teaches you to deploy and operate MicroK8s for development and production environments.
+But MicroK8s is more than convenience. It represents a deliberate architectural bet: that the snap confinement model — a sandboxed, transactionally updated, channel-tracked package format — can deliver Kubernetes with less operational toil than traditional tarball-and-systemd installations, while the dqlite datastore can provide Raft-consensus HA with a fraction of etcd's operational surface. That bet has consequences for how you upgrade, how you debug, and what happens when a node fails. This module teaches you MicroK8s from first principles: not just the commands, but why they exist and what tradeoffs they encode.
 
 ## Prerequisites
 
@@ -34,33 +32,58 @@ After completing this module, you will be able to:
 
 ## Why This Module Matters
 
-**MicroK8s answers: "What if installing Kubernetes add-ons was as easy as `snap install`?"**
+To understand why MicroK8s exists, you first need to understand what a Kubernetes distribution is and why anyone bothers to build one. Upstream Kubernetes — the source code in the kubernetes/kubernetes repository — does not ship as a single installable artifact that you can run on a server and call done. The upstream project produces component binaries: kube-apiserver, kube-controller-manager, kube-scheduler, kubelet, and kube-proxy. To turn those binaries into a working cluster, you must independently choose and configure a container runtime, a CNI networking plugin, a CSI storage driver, an ingress controller, a mechanism for exposing LoadBalancer services, and a datastore for cluster state. Each of those choices cascades into further decisions about certificate management, upgrade sequencing, observability integration, and security posture. Getting all of them right — and keeping them right across upgrades — is the operational burden that a Kubernetes distribution absorbs on your behalf.
 
-Most Kubernetes distributions require separate installation of:
-- CNI (Calico, Cilium, Flannel)
-- Ingress controller (nginx, Traefik)
-- Storage provisioner (local-path, OpenEBS)
-- Monitoring (Prometheus, Grafana)
-- Dashboard
-- Registry
+A distribution is a curated, tested, integrated bundle of these components, shipped with a defined upgrade path, a support model, and a set of opinions about how the pieces should fit together. kubeadm, the reference installer maintained by the upstream Kubernetes project, gives you the closest thing to a "vanilla" assembly experience: it bootstraps the control plane, generates certificates, and leaves the CNI and ingress choices to you. It is the baseline against which every distribution is measured. MicroK8s departs from that baseline in three fundamental ways.
 
-MicroK8s makes this trivial:
+First, it wraps everything in a snap. A snap is not just a package — it is a confined execution environment with transactional updates, automatic rollback on failure, and release channels that map to stability levels. When you install MicroK8s, Snapcraft downloads a signed, verifiable bundle that includes the Kubernetes binaries, containerd, dqlite, and all the add-on manifests. Updates happen automatically within the channel you track (so `1.28/stable` receives patch releases without manual intervention), and if an update breaks something, `snap revert microk8s` takes you back to the previous working revision. This is a fundamentally different operational model from downloading a binary and wiring up systemd units yourself — it outsources packaging discipline to the snap ecosystem and lets you treat Kubernetes version management like any other system package.
 
-```bash
-microk8s enable dns storage ingress prometheus dashboard
-```
+Second, MicroK8s replaces etcd with dqlite for its default datastore. Dqlite is a distributed SQL database built by Canonical on top of SQLite and the Raft consensus algorithm. Each MicroK8s node runs a dqlite process. When you form a cluster of three or more nodes, the dqlite instances elect a leader via Raft, replicate writes to a quorum of followers, and present a familiar SQL interface to the control plane. The rationale is simplicity: SQLite has orders of magnitude fewer lines of code than etcd, it is one of the most heavily tested software libraries in existence, and its operational surface — backups are file copies, recovery is file replacement — is far smaller than etcd's. The tradeoff is scale. Dqlite has not been battle-tested at the extreme cluster sizes that etcd handles (thousands of nodes, tens of thousands of concurrent watches). For the 3-to-20-node clusters that MicroK8s targets — developer workstations, CI runners, edge appliances, small production deployments — dqlite is a pragmatic fit. If you need larger scale, MicroK8s also supports an etcd add-on.
 
-One command enables a production-ready stack.
+Third, MicroK8s takes a curated-extension approach to optional components. In k3s, the default CNI (Flannel), ingress controller (Traefik), service load-balancer (Klipper), and storage provisioner (local-path) are compiled into the single binary and enabled by default. You disable them if you don't want them. MicroK8s inverts this: nothing beyond the core control plane is enabled until you explicitly opt in with `microk8s enable`. Each add-on — DNS, storage, ingress, MetalLB, Prometheus, Grafana, Istio, GPU operator, and thirty more — is a tested, version-locked manifest maintained in the MicroK8s source tree by Canonical. When you enable one, you are not pulling an arbitrary Helm chart from the internet; you are invoking an integration that has been verified against the specific Kubernetes version in your snap channel. This curated-extension model means you only run what you need, but you also get the assurance that what you run has been tested as part of the distribution.
+
+This module teaches you to operate MicroK8s with an understanding of these architectural decisions. By the end, you will not just know the commands — you will know why the snap model matters for upgrade safety, why dqlite changes your HA planning, and when the curated add-on approach serves you better than a bundled-by-default distribution.
+
+## Cross-Distribution Comparison
+
+Before diving into MicroK8s specifics, here is how the three lightweight distributions and the upstream kubeadm baseline compare on the dimensions that matter for cluster operations. Each row represents a capability. The cells tell you what each distribution ships — and, implicitly, what tradeoffs you accept by choosing it.
+
+| Capability | kubeadm (baseline) | k3s | k0s | MicroK8s |
+|---|---|---|---|---|
+| Default datastore | etcd (you deploy) | SQLite (single-node), embedded etcd (HA) | etcd (embedded, no external dependency) | dqlite (distributed SQLite) |
+| HA mechanism | External etcd cluster (manual) | Embedded etcd (3+ servers) | Embedded etcd (3+ controllers) | Dqlite Raft (3+ nodes, `microk8s add-node`) |
+| Bundled CNI | None (you choose) | Flannel (default), Cilium (option) | kube-router (default), Calico (option) | Calico (built-in, no add-on needed) |
+| Bundled ingress | None (you choose) | Traefik (bundled in binary) | None (you add) | nginx (via `microk8s enable ingress`) |
+| Bundled service LB | None (cloud-provider or MetalLB) | Klipper (ServiceLB) | None (you add) | MetalLB (via `microk8s enable metallb`) |
+| Bundled storage | None (you choose) | Local Path Provisioner | None (you add) | hostpath-storage (via `microk8s enable storage`) |
+| Install mechanism | curl + tar + systemd units | curl + script or single binary | Single binary + systemd unit | snap install (transactional, auto-updating) |
+| Packaging model | Component binaries + manifests | Single binary (~60 MB, all-in-one) | Single binary (~160 MB, modular) | Snap package (sandboxed, channel-tracked) |
+| Primary use case | Production reference, custom clusters | Edge, IoT, resource-constrained, dev | Multi-platform, zero host deps | Ubuntu-native dev, CI, appliances, edge |
+| CNCF conformance | Baseline (reference) | Certified | Certified | Certified |
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against upstream docs before relying on specifics.**
+>
+> - MicroK8s latest stable channels: 1.28, 1.29, 1.30 (tracked per minor version)
+> - Minimum resources: 540 MB RAM (idle), recommended 4 GB+ for workloads, 2+ vCPUs
+> - Supported architectures: amd64, arm64 (Raspberry Pi 4+, AWS Graviton, Apple Silicon multipass)
+> - Strict confinement snap variant available for hardened environments (requires manual interface connections)
+> - Snap refresh cadence: patch releases auto-apply within the tracked channel; minor version upgrades require explicit channel switch
+> - Bundled containerd version: pinned per MicroK8s release; verify with `microk8s ctr version`
+> - CNCF maturity: Certified Kubernetes (conformant distribution, passes all conformance tests)
+> - Community support: Ubuntu Discourse, #microk8s on Kubernetes Slack, GitHub issues at canonical/microk8s
 
 ## Did You Know?
 
-- **Snap Delivery**: MicroK8s is delivered via snap—automatic updates, rollbacks, and confined execution
-- **Dqlite**: Uses Dqlite (distributed SQLite) instead of etcd for clustering
-- **CNCF Certified**: Passes all Kubernetes conformance tests
-- **Ubuntu Pro**: Commercial support available through Ubuntu Pro
-- **GPU Support**: Native NVIDIA GPU operator add-on for AI/ML workloads
+- **Snap Delivery**: MicroK8s is delivered via snap — automatic updates, rollbacks, and confined execution. If an update breaks your cluster, `snap revert microk8s` returns you to the previous working revision in seconds.
+- **Dqlite**: Uses Dqlite (distributed SQLite with Raft consensus) instead of etcd for clustering — simpler operational surface, smaller resource footprint, same Raft durability guarantees for clusters up to ~20 nodes.
+- **CNCF Certified**: Passes all Kubernetes conformance tests. Applications written against MicroK8s run identically on any other CNCF-certified Kubernetes — same API, same semantics, no vendor lock-in.
+- **GPU Support**: Ships a native NVIDIA GPU operator add-on for AI/ML workloads. `microk8s enable gpu` configures the NVIDIA container toolkit, device plugin, and GPU feature discovery automatically.
 
 ## MicroK8s Architecture
+
+Before you run `snap install microk8s --classic`, it is worth understanding what that command actually places on your machine. The snap contains the full Kubernetes control plane — kube-apiserver, kube-controller-manager, and kube-scheduler — plus the kubelet as a system daemon, kube-proxy for network rules, and containerd as the container runtime. All of these run inside the snap's confined mount namespace, writing configuration to `/var/snap/microk8s/current/args/` and persistent data to `/var/snap/microk8s/common/`. The `--classic` flag relaxes snap confinement because a Kubernetes node needs to create network interfaces, mount filesystems, and manage cgroups — operations that strict confinement would block. Canonical also ships a strict-confinement variant for environments where security policy demands it, but it requires manually connecting snap interfaces and is not the default path.
+
+The architecture diagram below shows how these components layer together. Notice the add-on system at the bottom: each add-on is a script at `/snap/microk8s/current/addons/<name>/enable` that applies Kubernetes manifests, waits for pods to reach readiness, and configures integration with other add-ons. The add-ons are version-locked to the MicroK8s release — when you track `1.28/stable`, you receive add-on manifests tested against Kubernetes 1.28, and when you refresh to `1.29/stable`, the add-ons update in lockstep.
 
 ```
 MicroK8s ARCHITECTURE
@@ -142,6 +165,12 @@ ADD-ON ARCHITECTURE:
 
 ## Installing MicroK8s
 
+Installation is the first place where the snap model diverges from traditional Kubernetes setup. With kubeadm, you install a container runtime, install kubeadm/kubelet/kubectl packages, run `kubeadm init`, configure a CNI, and then repeat variations of this on each node. With MicroK8s, the snap bundles everything — binaries, runtime, datastore — into one package, and the installation is a single command followed by group membership configuration.
+
+The `--classic` flag matters. Snaps normally run under strict confinement: they see a private `/tmp`, cannot access host files outside designated interfaces, and operate with a restricted system call filter. A Kubernetes control plane cannot function under those constraints — it needs to manage network interfaces (for CNI and kube-proxy), mount volumes (for the kubelet and CSI), write to cgroup filesystems, and bind to privileged ports. The `--classic` flag disables confinement, giving MicroK8s the same access to the host as a traditionally installed service. Canonical provides a strict-confinement variant as an alternative; it requires you to manually connect snap interfaces (`snap connect microk8s:hardware-observe`, `snap connect microk8s:network-control`, and several others), which is more secure but more work to set up. For development and most production use, `--classic` is the recommended path.
+
+After installation, you add your user to the `microk8s` group. This avoids the need to prefix every command with `sudo` — the group membership grants access to the MicroK8s socket that the snap exposes. The `newgrp microk8s` command (or logging out and back in) activates the group membership in your current shell session.
+
 ### Quick Install (Ubuntu)
 
 ```bash
@@ -162,6 +191,8 @@ microk8s enable dns storage
 
 ### Install Specific Version
 
+The snap channel model is one of MicroK8s's strongest operational features. Each Kubernetes minor version has its own set of channels — `1.28/stable`, `1.28/candidate`, `1.28/beta`, `1.28/edge` — and `latest/stable` tracks the most recent stable release. When you install with `--channel=1.28/stable`, you receive the latest patch release on the 1.28 line. When 1.28.4 ships, snap refreshes you automatically. When 1.29.0 ships, you stay on 1.28.x until you explicitly switch channels. This gives you the best of both worlds: automatic patch updates for security and bug fixes, plus deliberate control over minor-version upgrades.
+
 ```bash
 # List available versions
 snap info microk8s
@@ -174,6 +205,8 @@ sudo snap refresh microk8s --channel=1.28/stable
 ```
 
 ### Install on Other Linux Distributions
+
+MicroK8s is Ubuntu-native, but it works on any Linux distribution that supports snapd. The snap daemon itself is available on most major distributions, though the integration quality varies — Ubuntu has the deepest snapd integration, followed by Debian and Fedora. On distributions without native snapd support, you can install it manually, but expect to debug interface connections and AppArmor profiles. The `--classic` flag mitigates most of these issues by disabling confinement, but if strict confinement matters to your environment, use Ubuntu.
 
 ```bash
 # Install snapd first (if not on Ubuntu)
@@ -190,7 +223,19 @@ sudo snap install microk8s --classic
 
 ## Add-ons System
 
+The add-on system is where MicroK8s's curated-extension philosophy becomes concrete. In a distribution like k3s, the CNI, ingress controller, service load-balancer, and storage provisioner are compiled into the single binary — they are present and running from the moment you start the service. This is convenient for getting a fully functional cluster in seconds, but it means you are running components you may not need, each consuming memory and CPU, each representing an attack surface, each requiring updates you may not have opted into. MicroK8s takes the opposite approach: nothing beyond the bare control plane plus Calico CNI is active until you explicitly enable it. Each add-on you enable is tested against your specific Kubernetes version and maintained in the MicroK8s source tree by Canonical.
+
+When you run `microk8s enable dns`, the command invokes a script at `/snap/microk8s/current/addons/dns/enable`. That script applies CoreDNS manifests, waits for the CoreDNS pods to become ready, and registers the DNS service with the cluster. If you later run `microk8s disable dns`, the corresponding `disable` script tears everything down cleanly. The same pattern holds for every add-on: enable, verify, integrate; disable, teardown, clean up. This is not a Helm chart or a raw manifest applied outside the distribution's control — it is a first-class integration tested as part of the release.
+
+The add-ons are categorized by function, and understanding those categories helps you plan your cluster. Core add-ons (DNS, storage, ingress, dashboard) are the ones you enable on almost every cluster. Networking add-ons (MetalLB, Cilium, Multus) extend how pods communicate within and outside the cluster. Observability add-ons (Prometheus, the full observability stack with Loki, Grafana, and Tempo) give you metrics, logs, and traces. Security add-ons (cert-manager, RBAC) handle TLS certificates and access control. CI/CD add-ons (local registry, ArgoCD, FluxCD) turn MicroK8s into a development platform. AI/ML add-ons (GPU operator, Kubeflow) configure hardware acceleration and ML pipelines. The full catalog has over thirty add-ons, and Canonical adds more with each release.
+
+A note on the CNI: MicroK8s ships with Calico enabled by default — you do not need to enable a separate CNI add-on as you do with kubeadm. The built-in Calico provides network policy enforcement in addition to basic pod networking, which is a security advantage over Flannel-only configurations. If you prefer Cilium for its eBPF-based data plane, `microk8s enable cilium` replaces Calico.
+
 ### Core Add-ons
+
+The core add-ons form the foundation that nearly every MicroK8s cluster needs. CoreDNS provides cluster-local name resolution — without it, pods cannot find each other by service name, and practically nothing works. The hostpath storage provisioner creates PersistentVolumes backed by directories on the node's filesystem, which is sufficient for development and single-node deployments but not for multi-node HA (a pod scheduled on node B cannot access a hostpath PV on node A). The Kubernetes Dashboard gives you a web UI for inspecting and managing cluster resources, though you should be aware that it exposes significant cluster access and must be secured behind authentication in any shared environment. The nginx ingress controller translates Kubernetes Ingress resources into nginx configuration, handling TLS termination, path-based routing, and virtual hosting. And the metrics-server collects resource usage data from the kubelet, feeding both `kubectl top` and the Horizontal Pod Autoscaler.
+
+Each of these add-ons solves a specific infrastructure problem that, in a kubeadm cluster, you would solve by finding, installing, configuring, and maintaining a separate component — often from a different vendor with its own release cycle. The MicroK8s add-on system collapses that into a single, tested command, with the tradeoff that you are accepting Canonical's chosen version and configuration defaults. For most development and small-production use cases, that tradeoff is worth it. For production clusters with specific version-pinning or configuration requirements, you may want to deploy your own ingress controller or storage provisioner outside the add-on system — MicroK8s does not prevent this; it is a standard Kubernetes cluster, and you can apply any manifest you choose.
 
 ```bash
 # DNS (CoreDNS) - required for most workloads
@@ -214,6 +259,8 @@ microk8s enable metrics-server
 
 ### Networking Add-ons
 
+MetalLB deserves special attention because it solves a problem that every bare-metal Kubernetes cluster faces: how do you expose a Service of type LoadBalancer without a cloud provider's load-balancer integration? In AWS, the cloud-controller-manager provisions an ELB. In your home lab or on-prem cluster, there is no such integration. MetalLB fills that gap by responding to ARP requests (Layer 2 mode) or speaking BGP to your router (BGP mode), assigning an IP from a range you specify to each LoadBalancer service. The command `microk8s enable metallb:192.168.1.200-192.168.1.220` both enables the add-on and configures the IP pool in one step — no separate ConfigMap to create, no YAML to apply.
+
 ```bash
 # MetalLB (bare-metal load balancer)
 microk8s enable metallb:192.168.1.200-192.168.1.220
@@ -230,6 +277,8 @@ microk8s enable multus
 ```
 
 ### Observability Add-ons
+
+The observability add-on — distinct from the legacy `prometheus` add-on — deploys a full Grafana LGTM stack: Loki for log aggregation, Grafana for visualization, Tempo for distributed tracing, and Mimir (or Prometheus) for metrics. This is a significant operational shortcut compared to assembling these components yourself. A single `microk8s enable observability` command deploys the entire stack, configures scrape targets for your cluster, and pre-loads Kubernetes dashboards in Grafana. The tradeoff is resource consumption — the full stack can consume 2-4 GB of RAM depending on retention settings — so plan your node sizing accordingly. For lighter-weight monitoring, the legacy `prometheus` add-on deploys just Prometheus and Grafana with fewer components.
 
 ```bash
 # Prometheus + Grafana (legacy)
@@ -254,6 +303,8 @@ microk8s enable rbac
 
 ### AI/ML Add-ons
 
+The GPU add-on automates what is otherwise a multi-step manual process: installing the NVIDIA container toolkit, configuring the nvidia-container-runtime as a containerd runtime handler, deploying the NVIDIA device plugin daemonset, and enabling GPU feature discovery for node labelling. After `microk8s enable gpu`, pods that request `nvidia.com/gpu` resources are scheduled to GPU-equipped nodes and have access to the host's NVIDIA drivers through the container runtime. The add-on handles driver compatibility checks and will fail with a clear error message if the NVIDIA drivers are missing or mismatched.
+
 ```bash
 # GPU support (NVIDIA)
 microk8s enable gpu
@@ -263,6 +314,8 @@ microk8s enable kubeflow
 ```
 
 ### CI/CD Add-ons
+
+The local registry add-on is particularly valuable for development workflows. It deploys a Docker Registry v2 instance inside the cluster, exposed on `localhost:32000` on the host. You push images to it from your local Docker daemon, and pods reference those images in their container specs. This eliminates the need for an external registry during development — no Docker Hub rate limits, no AWS ECR authentication, no Harbor instance to manage. The registry uses hostpath storage by default, so images survive MicroK8s restarts but not node destruction. For persistent storage, enable the storage add-on first and the registry will provision a PVC.
 
 ```bash
 # Local registry
@@ -299,35 +352,13 @@ microk8s status
 
 ## Multi-Node Clustering
 
-MicroK8s supports clustering for high availability:
+A single-node MicroK8s cluster is useful for development, but production workloads demand high availability. MicroK8s achieves HA through dqlite, a distributed SQLite implementation built on the Raft consensus algorithm. Understanding how dqlite maintains consistency across nodes will help you plan your cluster topology and debug failures.
 
-### Add Nodes
+Raft works by electing a leader from among the participating nodes. The leader receives all write requests from the API server, appends them to its log, and replicates them to a majority (quorum) of followers. Only after a majority acknowledges the write does the leader commit it and return success to the client. This means a cluster of three nodes can tolerate one node failure and remain operational; a cluster of five can tolerate two. The leader also sends periodic heartbeats to followers — if followers stop hearing from the leader, they initiate a new election. The election happens automatically; MicroK8s handles leader transitions without manual intervention.
 
-**On the first node (primary):**
+The practical implication for MicroK8s clustering is that you need an odd number of nodes (3, 5, 7) for a resilient HA configuration. With two nodes, you have no failure tolerance — if either node goes down, the remaining node cannot form a quorum and the cluster becomes read-only. With three nodes, you can lose one and keep operating. The `microk8s add-node` command on the primary generates a join token; you run `microk8s join <token>` on additional nodes, and they automatically join the dqlite cluster and sync the datastore. The entire operation — from fresh install to three-node HA — takes about five minutes.
 
-```bash
-# Generate join token
-microk8s add-node
-
-# Output:
-# Join node with:
-# microk8s join 192.168.1.10:25000/abc123...
-```
-
-**On additional nodes:**
-
-```bash
-# Install MicroK8s
-sudo snap install microk8s --classic
-
-# Join the cluster
-microk8s join 192.168.1.10:25000/abc123...
-
-# Verify on primary
-microk8s kubectl get nodes
-```
-
-### High Availability with Dqlite
+One important distinction from etcd-based clusters: dqlite does not require you to manage separate etcd certificates, etcd peer URLs, or etcd membership. The `add-node` / `remove-node` / `leave` commands handle cluster membership changes through MicroK8s's clustering API, which manages the dqlite membership behind the scenes. If a node leaves ungracefully (power loss, kernel panic), you run `microk8s remove-node <name>` on a surviving node to evict it from the cluster. The remaining nodes continue operating with the new membership.
 
 MicroK8s uses Dqlite (distributed SQLite) for HA:
 
@@ -355,7 +386,37 @@ Benefits of Dqlite:
 • Raft consensus for durability
 ```
 
+### Add Nodes
+
+Joining a node to a MicroK8s cluster is simpler than any other Kubernetes distribution's equivalent operation, and understanding why reveals the architectural difference dqlite makes. In an etcd-based cluster (whether kubeadm, k3s with embedded etcd, or k0s), adding a control-plane node requires you to generate new certificates for the joining node, configure etcd peer URLs, update the etcd membership, and ensure the new node's API server can reach the existing etcd cluster. MicroK8s collapses all of this into `microk8s add-node` because dqlite is managed by MicroK8s's clustering API rather than by a separate etcd operator. The join token encodes the primary's IP address, port, and a cryptographic secret that proves the joining node is authorized to participate in the Raft group. Once joined, the new node's dqlite instance syncs the full datastore from the leader and begins participating in consensus immediately — no manual certificate distribution, no etcd member list updates, no kubeadm config to propagate.
+
+**On the first node (primary):**
+
+```bash
+# Generate join token
+microk8s add-node
+
+# Output:
+# Join node with:
+# microk8s join 192.168.1.10:25000/abc123...
+```
+
+**On additional nodes:**
+
+```bash
+# Install MicroK8s
+sudo snap install microk8s --classic
+
+# Join the cluster
+microk8s join 192.168.1.10:25000/abc123...
+
+# Verify on primary
+microk8s kubectl get nodes
+```
+
 ### Remove Nodes
+
+Cluster membership hygiene matters for Raft consensus health. When a node leaves the cluster ungracefully — power loss, kernel panic, network partition that outlasts the heartbeat timeout — the remaining nodes continue operating, but the dqlite cluster still considers the departed node a member. This is not catastrophic (Raft tolerates failed nodes as long as a quorum remains), but it does mean the cluster is running in a degraded state: every write must still be replicated to a quorum of the configured membership, and the departed node counts toward that configuration even though it will never acknowledge a write. Running `microk8s remove-node <name>` on a surviving node evicts the departed node from the dqlite cluster, restoring full operational resilience. If the node left cleanly with `microk8s leave`, it removes itself from the membership, and no manual cleanup is needed. The distinction matters: `leave` is a graceful departure; `remove-node` is a forced eviction for ungraceful failures. Use the right one for the situation.
 
 ```bash
 # On the node to remove
@@ -366,6 +427,8 @@ microk8s remove-node <node-name>
 ```
 
 ## Configuration
+
+MicroK8s stores component arguments in flat files under `/var/snap/microk8s/current/args/` — one file per component. This is simpler than kubeadm's cluster configuration, which layers kubelet configuration, kube-proxy configuration, and control-plane configuration across multiple YAML files and ConfigMaps. To change the API server's admission plugins, you edit `/var/snap/microk8s/current/args/kube-apiserver` and restart MicroK8s. There is no `kubeadm upgrade apply` dance, no `kubeadm config migrate` for configuration version changes — MicroK8s handles the component lifecycle directly through snap services. The downside is that these argument files are snap-internal; if you uninstall the snap, they are removed. Back them up if your configuration is non-trivial.
 
 ### Accessing kubeconfig
 
@@ -415,6 +478,8 @@ microk8s start
 
 ### Container Runtime Configuration
 
+MicroK8s uses containerd, and its configuration lives at `/var/snap/microk8s/current/args/containerd-template.toml`. This is a standard containerd configuration file, which means any containerd documentation applies — registry mirrors, snapshotter configuration, runtime handler registration all work the same way they would in a non-snap containerd installation. The only difference is the file path. If you need to add an insecure registry mirror (common in air-gapped or development environments), edit the `plugins."io.containerd.grpc.v1.cri".registry.mirrors` section of this file.
+
 ```bash
 # containerd configuration
 sudo nano /var/snap/microk8s/current/args/containerd-template.toml
@@ -429,6 +494,12 @@ microk8s start
 ```
 
 ## Upgrading MicroK8s
+
+The upgrade experience is where snap's transactional update model pays off most visibly. In a kubeadm-managed cluster, upgrading involves draining nodes, upgrading kubeadm, running `kubeadm upgrade plan` and `kubeadm upgrade apply`, upgrading kubelet and kubectl on each node, and uncordoning. It is a deliberate, multi-step process designed for production clusters where downtime is expensive. MicroK8s, by contrast, updates automatically within your channel — if you track `1.28/stable`, the snap daemon downloads and applies patch releases (1.28.3 → 1.28.4) on its refresh schedule, typically daily. This is convenient but carries risk: a patch release, however well-tested, could introduce a regression that breaks your workloads in the middle of the night.
+
+For production, you should understand three controls: channel selection determines what you receive, refresh holding prevents automatic updates, and rollback gives you a safety net. Track a specific stable channel (`1.28/stable`), not `latest/stable`, so you control when minor-version upgrades happen. Hold refreshes during critical periods with `snap refresh --hold microk8s` and unhold when you are ready to test. And if an update breaks something, `snap revert microk8s` restores the previous revision — the snap keeps the last several revisions cached on disk, so rollback is a matter of seconds, not a multi-node drain-and-rebuild.
+
+The channel naming convention maps directly to upstream Kubernetes versions: `1.28/stable` is Kubernetes 1.28, latest patch. `1.28/candidate` is the release candidate for the next patch. `1.28/beta` is the beta. `1.28/edge` is the bleeding edge — updated on every commit, useful for testing upcoming features but never for production. The `latest` track mirrors the most recent stable upstream release and is reasonable for development environments where you want the newest Kubernetes features as soon as Canonical packages them.
 
 ### Automatic Updates (Default)
 
@@ -471,6 +542,10 @@ snap list --all microk8s
 
 ## Air-Gapped Installation
 
+Environments without internet access — military installations, financial data centers, manufacturing floors — need Kubernetes too. MicroK8s supports air-gapped deployment through snap's offline installation mechanism. On a connected machine, you download the snap and its cryptographic assertion file. The assertion is a signed document that verifies the snap's integrity and publisher — without it, snapd refuses to install. On the air-gapped machine, you acknowledge the assertion and install the snap from the local file. The snap contains all the Kubernetes binaries, so the cluster starts without internet access.
+
+The container image problem is separate. While the snap includes the Kubernetes components, your application images are not bundled. You must export images from a connected registry (`docker save`), transfer them to the air-gapped machine, and import them into containerd with `microk8s ctr image import`. If you have many images, deploy the local registry add-on on a connected machine, push images to it, export the registry's storage directory, and seed the air-gapped registry with the same directory structure. For production air-gapped deployments, combine MicroK8s with a mirrored registry like Harbor or a generic Docker Registry instance.
+
 ```bash
 # On connected machine:
 
@@ -478,16 +553,16 @@ snap list --all microk8s
 snap download microk8s --channel=1.28/stable
 
 # This creates:
-# microk8s_xxxx.snap
-# microk8s_xxxx.assert
+# microk8s_NNNN.snap
+# microk8s_NNNN.assert
 
 # Transfer to air-gapped machine, then:
 
 # Install assertion first
-sudo snap ack microk8s_xxxx.assert
+sudo snap ack microk8s_NNNN.assert
 
 # Install snap
-sudo snap install microk8s_xxxx.snap --classic
+sudo snap install microk8s_NNNN.snap --classic
 
 # Import container images
 # First, export from connected machine:
@@ -498,6 +573,10 @@ microk8s ctr image import myimage.tar.gz
 ```
 
 ## Troubleshooting
+
+When MicroK8s misbehaves, the tooling that snap provides often shortens the diagnostic cycle dramatically compared to a traditional Kubernetes installation. In a kubeadm cluster, debugging a failed API server means checking systemd unit status, grepping through `/var/log/kubernetes`, verifying certificate expiration dates, and cross-referencing kubeadm configuration against running arguments. MicroK8s consolidates most of this into two commands: `microk8s status` tells you which services are running and which add-ons are enabled, and `microk8s inspect` produces a comprehensive diagnostic tarball that Canonical's support team (and the community on Discourse) can use to triage issues without asking you twenty questions about your environment.
+
+The inspect command is worth understanding in detail because it solves a real operational problem: when you post a question to a forum saying "my MicroK8s cluster is broken," the first response is almost always "please run microk8s inspect and attach the report." The report includes the output of `microk8s status`, the contents of every argument file under `/var/snap/microk8s/current/args/`, the dqlite cluster membership state, recent log excerpts from each snap service, containerd configuration, and the current state of all enabled add-ons. It is a point-in-time snapshot that captures the cluster's configuration without requiring you to manually collect a dozen different files. For privacy, it redacts IP addresses and tokens — you can share it publicly without exposing your cluster's internal addresses.
 
 ### Common Issues
 
@@ -524,6 +603,8 @@ microk8s start
 
 ### Network Issues
 
+Network problems in MicroK8s almost always trace to one of three causes: the CNI pods are not running, DNS resolution is failing, or the kube-proxy rules are stale. Verify the CNI pods first — `microk8s kubectl get pods -n kube-system -l k8s-app=calico-node` should show all nodes with running Calico pods. If Calico is not running, pods cannot get IP addresses, and nothing else will work. Next, test DNS resolution from inside the cluster with a disposable pod. If `nslookup kubernetes` fails inside the cluster, the CoreDNS pods are not running or the kube-dns service is misconfigured. Finally, if services are not reachable but pods are running, check whether kube-proxy is applying iptables rules correctly — restarting MicroK8s forces a fresh iptables sync.
+
 ```bash
 # Check CNI pods
 microk8s kubectl get pods -n kube-system -l k8s-app=calico-node
@@ -548,105 +629,15 @@ microk8s kubectl get pvc -A
 microk8s kubectl get pv
 ```
 
-## War Story: The Ubuntu-Native Platform
+## Illustrative Scenario: The Ubuntu-Native Platform
 
-A software company standardized on Ubuntu across their entire stack:
+> **Hypothetical scenario:** This narrative illustrates the operational patterns MicroK8s enables in an Ubuntu-native environment. It is not a specific, dated public incident — if you know of a real, verifiable MicroK8s production incident worth documenting, please open an issue or PR against this module.
 
-**The Setup**:
-- 200+ developers using Ubuntu workstations
-- CI/CD on Ubuntu runners
-- Production on Ubuntu servers (bare metal and cloud)
-- Existing tooling built around snap ecosystem
+A software company standardized on Ubuntu across their entire stack: 200+ developers on Ubuntu workstations, CI/CD on Ubuntu runners, and production on Ubuntu servers spanning both bare metal and cloud. Their existing tooling was built around the snap ecosystem. The challenge was that developers needed local Kubernetes for daily work, CI/CD needed ephemeral Kubernetes clusters for integration tests, and production needed highly available Kubernetes — all three environments had to behave identically, or configuration drift would cause "works on my machine" failures that eroded trust in the deployment pipeline.
 
-**The Challenge**:
-- Developers needed local Kubernetes
-- CI/CD needed ephemeral Kubernetes for tests
-- Production needed HA Kubernetes
-- All environments needed to be consistent
+MicroK8s won because it delivered the same installation command, the same add-on invocation, and the same operational behavior across every environment. A developer's laptop, a GitHub Actions runner, and a production server all ran `sudo snap install microk8s --classic` followed by the same add-on sequence. The add-on advantage showed when the team defined a standard environment configuration: developers enabled `dns storage registry ingress observability` for local debugging, CI enabled `dns storage` for lightweight test clusters, and production enabled `dns storage metallb cert-manager prometheus` for secure, monitored workloads. Each environment added only what it needed, but the core `microk8s enable` commands were identical.
 
-**Why MicroK8s Won**:
-
-```
-ENVIRONMENT CONSISTENCY
-─────────────────────────────────────────────────────────────────────────────
-
-Developer Laptop:
-  sudo snap install microk8s --classic
-  microk8s enable dns storage registry
-  # Ready in 2 minutes
-
-CI/CD Runner:
-  # In GitHub Actions
-  - name: Setup MicroK8s
-    run: |
-      sudo snap install microk8s --classic
-      microk8s status --wait-ready
-      microk8s enable dns storage
-      microk8s kubectl apply -f k8s/
-
-Production:
-  # On each node
-  sudo snap install microk8s --classic
-  microk8s add-node  # On primary
-  microk8s join ...  # On secondaries
-  microk8s enable dns storage metallb:10.0.0.200-10.0.0.250
-
-Same commands, same add-ons, same behavior everywhere.
-```
-
-**The Add-on Advantage**:
-
-```yaml
-# Standard configuration across all environments
-# environments/base/kustomization.yaml
-resources:
-  - namespace.yaml
-  - deployment.yaml
-  - service.yaml
-
-# Developer setup script
-#!/bin/bash
-microk8s enable dns storage registry ingress
-microk8s enable observability  # Local debugging
-
-# Production setup script
-#!/bin/bash
-microk8s enable dns storage metallb:$LB_RANGE
-microk8s enable cert-manager
-microk8s enable prometheus
-```
-
-**GitOps Integration**:
-
-```bash
-# Enable ArgoCD
-microk8s enable argocd
-
-# Configure applications
-microk8s kubectl apply -f - <<EOF
-apiVersion: argoproj.io/v1alpha1
-kind: Application
-metadata:
-  name: my-app
-  namespace: argocd
-spec:
-  project: default
-  source:
-    repoURL: https://github.com/company/app
-    path: k8s
-  destination:
-    server: https://kubernetes.default.svc
-    namespace: default
-EOF
-```
-
-**The Results**:
-- Onboarding time: 2 hours → 15 minutes
-- "Works on my machine" issues: 90% reduction
-- CI/CD pipeline time: Reduced by 40% (snap caching)
-- Production incidents from config drift: Near zero
-
-**The Lesson**: When your entire stack is Ubuntu, MicroK8s eliminates friction that other distributions introduce.
+For GitOps integration, the team enabled ArgoCD on every cluster and pointed it at the same Git repository. The Application custom resources were identical across environments — only the target cluster URL differed. This meant a PR merged to the main branch propagated through development, CI staging, and production with no per-environment modifications to the deployment manifests. The results were dramatic: developer onboarding dropped from two hours to fifteen minutes, "works on my machine" incidents fell by roughly 90%, CI pipeline times improved through snap caching, and production configuration drift — the silent killer of operational confidence — approached zero. When your entire stack runs on Ubuntu and you value operational consistency across environments, the snap-based deployment model eliminates the configuration drift that accumulates when each environment installs Kubernetes through a different mechanism.
 
 ## Common Mistakes
 
@@ -692,7 +683,7 @@ Test your understanding of MicroK8s:
 <details>
 <summary>5. How do you perform an air-gapped installation of MicroK8s?</summary>
 
-**Answer**: On a connected machine: `snap download microk8s --channel=1.28/stable`. Transfer the .snap and .assert files to the air-gapped machine. Install: `sudo snap ack microk8s_xxxx.assert` then `sudo snap install microk8s_xxxx.snap --classic`. Import container images with `microk8s ctr image import`.
+**Answer**: On a connected machine: `snap download microk8s --channel=1.28/stable`. Transfer the .snap and .assert files to the air-gapped machine. Install: `sudo snap ack microk8s_NNNN.assert` then `sudo snap install microk8s_NNNN.snap --classic`. Import container images with `microk8s ctr image import`.
 </details>
 
 <details>
@@ -715,6 +706,8 @@ Test your understanding of MicroK8s:
 
 ## Hands-On Exercise: Full-Stack MicroK8s Deployment
 
+This exercise takes you from an empty Ubuntu machine to a functioning development platform with monitoring, ingress, and a sample application. By the end, you will have executed the complete MicroK8s workflow — install, add-on enablement, application deployment, and observability access — and you will understand what each step provisions and why the ordering matters. DNS must be enabled before any service discovery works. Storage must be enabled before the registry or any PVC-dependent workload. The ingress controller must be running before your Ingress resources do anything. Follow the steps in order; each builds on the previous.
+
 ### Objective
 Deploy a complete development environment with MicroK8s including monitoring, ingress, and a sample application.
 
@@ -735,6 +728,8 @@ microk8s status --wait-ready
 
 ### Step 2: Enable Essential Add-ons
 
+The order here matters. DNS must be running before anything that uses service discovery — which is almost everything. CoreDNS registers itself as the cluster DNS service, and until it is running and its service endpoint is populated, pods cannot resolve service names. Storage must be running before the registry or any application that creates PersistentVolumeClaims, because the hostpath provisioner is what turns a PVC into an actual directory on the node's filesystem. The ingress controller needs to be running and its admission webhook registered before you create Ingress resources — otherwise those resources are accepted by the API server but never acted upon. Metrics-server must be running before `kubectl top` returns data, because `kubectl top` queries the metrics API aggregated by the metrics-server rather than scraping kubelet metrics endpoints directly. Enable them in this sequence and wait for each to reach readiness before moving on.
+
 ```bash
 # Enable core add-ons
 microk8s enable dns
@@ -747,6 +742,8 @@ microk8s kubectl wait --for=condition=ready pod -n kube-system -l k8s-app=kube-d
 ```
 
 ### Step 3: Enable Observability Stack
+
+The observability stack deploys Prometheus for metrics, Loki for logs, Grafana for dashboards, and Tempo for traces. This is resource-intensive — expect 2-4 GB of RAM consumed at steady state — so plan your node size accordingly. If you are on a machine with less than 8 GB of RAM, use the lighter `prometheus` add-on instead. The `--timeout=120s` on the wait command accounts for the large container images and startup time.
 
 ```bash
 # Enable full observability (Prometheus + Grafana + Loki + Tempo)
@@ -770,6 +767,8 @@ microk8s kubectl get pods -n container-registry
 ```
 
 ### Step 5: Deploy Sample Application
+
+This step deploys a complete application — Deployment, Service, and Ingress — into a dedicated namespace. The Deployment creates three nginx replicas with resource requests and limits, which is important for production behavior: without limits, a single runaway pod can consume all node resources. The Ingress configures nginx to route traffic from `web-app.local` to the Service. The `/etc/hosts` entry maps the hostname to localhost so you can test with curl.
 
 ```bash
 # Create namespace
@@ -847,6 +846,8 @@ curl http://web-app.local
 
 ### Step 6: Access Observability
 
+Grafana is deployed with a default admin password stored in a Kubernetes Secret. The `jsonpath` extraction below retrieves it. Port-forwarding is the simplest way to access Grafana from your workstation — in production, you would expose it through the ingress controller with TLS. The pre-loaded dashboards under "Kubernetes / Compute Resources / Namespace" and "Kubernetes / Networking / Namespace" give you immediate visibility into your workload.
+
 ```bash
 # Port-forward Grafana
 microk8s kubectl port-forward -n observability svc/kube-prom-stack-grafana 3000:80 &
@@ -865,6 +866,8 @@ microk8s kubectl get secret -n observability kube-prom-stack-grafana -o jsonpath
 
 ### Step 7: Test Metrics
 
+The metrics-server add-on you enabled in Step 2 collects resource usage from kubelet's built-in metrics endpoint. The `kubectl top` commands query the metrics-server's API, not the kubelet directly, so this also verifies that the metrics-server is running and scraping data successfully. Scaling the deployment to 5 replicas and rechecking the top output demonstrates that the metrics pipeline updates correctly as pods come and go.
+
 ```bash
 # Check node resources
 microk8s kubectl top nodes
@@ -879,7 +882,7 @@ microk8s kubectl top pods -n demo
 
 ### Step 8: Multi-Node Setup (Optional)
 
-If you have additional machines:
+If you have additional machines available, adding nodes demonstrates the full clustering workflow in about five minutes:
 
 ```bash
 # On primary
@@ -893,6 +896,8 @@ microk8s join 192.168.x.x:25000/token...
 # Verify
 microk8s kubectl get nodes
 ```
+
+If you do not have additional machines, skip this step — the single-node cluster you have deployed is fully functional for the remaining exercises. The add-node workflow is covered in detail in the Multi-Node Clustering section earlier in this module.
 
 ### Success Criteria
 
@@ -941,7 +946,7 @@ sudo snap remove microk8s
 
 ## Toolkit Summary
 
-You've completed the Kubernetes Distributions Toolkit! You now understand:
+You have completed the Kubernetes Distributions Toolkit. Across four modules, you have learned how k3s, k0s, MicroK8s, and the kubeadm baseline differ in their approach to packaging Kubernetes — differences that shape your operational experience from installation through upgrades to troubleshooting. The table below distills the decision into its essential tradeoffs:
 
 | Distribution | Best For | Key Feature |
 |--------------|----------|-------------|
@@ -954,6 +959,25 @@ You've completed the Kubernetes Distributions Toolkit! You now understand:
 - Need zero host dependencies? → k0s
 - Using Ubuntu and want batteries-included? → MicroK8s
 - Need vanilla Kubernetes at scale? → kubeadm
+
+## Next Module
+
+Continue to [Module 14.4: Talos](../module-14.4-talos/) — an API-driven, immutable Kubernetes OS that eliminates SSH and the shell entirely.
+
+## Sources
+
+- [microk8s.io: docs](https://microk8s.io/docs) — Official MicroK8s documentation covering installation, add-ons, clustering, and troubleshooting.
+- [github.com: canonical/microk8s](https://github.com/canonical/microk8s) — Source repository for MicroK8s, including add-on manifests, clustering logic, and release tooling.
+- [snapcraft.io: microk8s](https://snapcraft.io/microk8s) — Snap listing showing available channels, version history, and install statistics.
+- [github.com: canonical/dqlite](https://github.com/canonical/dqlite) — Dqlite source repository with Raft consensus implementation and SQLite integration details.
+- [dqlite.io: docs](https://dqlite.io/docs) — Dqlite documentation covering the Raft protocol binding, C API, and clustering semantics.
+- [snapcraft.io: docs](https://snapcraft.io/docs) — Snapcraft documentation on snap confinement, channels, refresh schedules, and interface connections.
+- [cncf.io: software conformance](https://www.cncf.io/certification/software-conformance/) — CNCF Certified Kubernetes program listing and conformance test results.
+- [kubernetes.io: kubeadm](https://kubernetes.io/docs/setup/production-environment/tools/kubeadm/) — Upstream kubeadm reference installation documentation for baseline comparison.
+- [github.com: k3s-io/k3s](https://github.com/k3s-io/k3s) — k3s source repository for cross-distribution comparison of bundled components and architecture.
+- [github.com: k0sproject/k0s](https://github.com/k0sproject/k0s) — k0s source repository for cross-distribution comparison of zero-dependency packaging.
+- [discourse.ubuntu.com: microk8s](https://discourse.ubuntu.com/c/kubernetes/microk8s) — Ubuntu Discourse forum for MicroK8s announcements, troubleshooting, and community support.
+- [canonical.com: blog](https://canonical.com/blog) — Canonical blog with MicroK8s release announcements, architecture deep-dives, and customer case studies.
 
 ---
 

--- a/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.3-microk8s.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/k8s-distributions/module-14.3-microk8s.md
@@ -36,7 +36,7 @@ To understand why MicroK8s exists, you first need to understand what a Kubernete
 
 A distribution is a curated, tested, integrated bundle of these components, shipped with a defined upgrade path, a support model, and a set of opinions about how the pieces should fit together. kubeadm, the reference installer maintained by the upstream Kubernetes project, gives you the closest thing to a "vanilla" assembly experience: it bootstraps the control plane, generates certificates, and leaves the CNI and ingress choices to you. It is the baseline against which every distribution is measured. MicroK8s departs from that baseline in three fundamental ways.
 
-First, it wraps everything in a snap. A snap is not just a package — it is a confined execution environment with transactional updates, automatic rollback on failure, and release channels that map to stability levels. When you install MicroK8s, Snapcraft downloads a signed, verifiable bundle that includes the Kubernetes binaries, containerd, dqlite, and all the add-on manifests. Updates happen automatically within the channel you track (so `1.28/stable` receives patch releases without manual intervention), and if an update breaks something, `snap revert microk8s` takes you back to the previous working revision. This is a fundamentally different operational model from downloading a binary and wiring up systemd units yourself — it outsources packaging discipline to the snap ecosystem and lets you treat Kubernetes version management like any other system package.
+First, it wraps everything in a snap. A snap is not just a package — it is a confined execution environment with transactional updates, automatic rollback on failure, and release channels that map to stability levels. When you install MicroK8s, Snapcraft downloads a signed, verifiable bundle that includes the Kubernetes binaries, containerd, dqlite, and all the add-on manifests. Updates happen automatically within the channel you track (so `1.34/stable` receives patch releases without manual intervention), and if an update breaks something, `snap revert microk8s` takes you back to the previous working revision. This is a fundamentally different operational model from downloading a binary and wiring up systemd units yourself — it outsources packaging discipline to the snap ecosystem and lets you treat Kubernetes version management like any other system package.
 
 Second, MicroK8s replaces etcd with dqlite for its default datastore. Dqlite is a distributed SQL database built by Canonical on top of SQLite and the Raft consensus algorithm. Each MicroK8s node runs a dqlite process. When you form a cluster of three or more nodes, the dqlite instances elect a leader via Raft, replicate writes to a quorum of followers, and present a familiar SQL interface to the control plane. The rationale is simplicity: SQLite has orders of magnitude fewer lines of code than etcd, it is one of the most heavily tested software libraries in existence, and its operational surface — backups are file copies, recovery is file replacement — is far smaller than etcd's. The tradeoff is scale. Dqlite has not been battle-tested at the extreme cluster sizes that etcd handles (thousands of nodes, tens of thousands of concurrent watches). For the 3-to-20-node clusters that MicroK8s targets — developer workstations, CI runners, edge appliances, small production deployments — dqlite is a pragmatic fit. If you need larger scale, MicroK8s also supports an etcd add-on.
 
@@ -63,7 +63,7 @@ Before diving into MicroK8s specifics, here is how the three lightweight distrib
 
 > **Landscape snapshot — as of 2026-06. This changes fast; verify against upstream docs before relying on specifics.**
 >
-> - MicroK8s latest stable channels: 1.28, 1.29, 1.30 (tracked per minor version)
+> - MicroK8s latest stable channels: 1.33, 1.34, 1.35 (most recent stable 1.35/stable, published 2026-04; tracked per minor version)
 > - Minimum resources: 540 MB RAM (idle), recommended 4 GB+ for workloads, 2+ vCPUs
 > - Supported architectures: amd64, arm64 (Raspberry Pi 4+, AWS Graviton, Apple Silicon multipass)
 > - Strict confinement snap variant available for hardened environments (requires manual interface connections)
@@ -83,7 +83,7 @@ Before diving into MicroK8s specifics, here is how the three lightweight distrib
 
 Before you run `snap install microk8s --classic`, it is worth understanding what that command actually places on your machine. The snap contains the full Kubernetes control plane — kube-apiserver, kube-controller-manager, and kube-scheduler — plus the kubelet as a system daemon, kube-proxy for network rules, and containerd as the container runtime. All of these run inside the snap's confined mount namespace, writing configuration to `/var/snap/microk8s/current/args/` and persistent data to `/var/snap/microk8s/common/`. The `--classic` flag relaxes snap confinement because a Kubernetes node needs to create network interfaces, mount filesystems, and manage cgroups — operations that strict confinement would block. Canonical also ships a strict-confinement variant for environments where security policy demands it, but it requires manually connecting snap interfaces and is not the default path.
 
-The architecture diagram below shows how these components layer together. Notice the add-on system at the bottom: each add-on is a script at `/snap/microk8s/current/addons/<name>/enable` that applies Kubernetes manifests, waits for pods to reach readiness, and configures integration with other add-ons. The add-ons are version-locked to the MicroK8s release — when you track `1.28/stable`, you receive add-on manifests tested against Kubernetes 1.28, and when you refresh to `1.29/stable`, the add-ons update in lockstep.
+The architecture diagram below shows how these components layer together. Notice the add-on system at the bottom: each add-on is a script at `/snap/microk8s/current/addons/<name>/enable` that applies Kubernetes manifests, waits for pods to reach readiness, and configures integration with other add-ons. The add-ons are version-locked to the MicroK8s release — when you track `1.34/stable`, you receive add-on manifests tested against Kubernetes 1.34, and when you refresh to `1.35/stable`, the add-ons update in lockstep.
 
 ```
 MicroK8s ARCHITECTURE
@@ -191,17 +191,17 @@ microk8s enable dns storage
 
 ### Install Specific Version
 
-The snap channel model is one of MicroK8s's strongest operational features. Each Kubernetes minor version has its own set of channels — `1.28/stable`, `1.28/candidate`, `1.28/beta`, `1.28/edge` — and `latest/stable` tracks the most recent stable release. When you install with `--channel=1.28/stable`, you receive the latest patch release on the 1.28 line. When 1.28.4 ships, snap refreshes you automatically. When 1.29.0 ships, you stay on 1.28.x until you explicitly switch channels. This gives you the best of both worlds: automatic patch updates for security and bug fixes, plus deliberate control over minor-version upgrades.
+The snap channel model is one of MicroK8s's strongest operational features. Each Kubernetes minor version has its own set of channels — `1.34/stable`, `1.34/candidate`, `1.34/beta`, `1.34/edge` — and `latest/stable` tracks the most recent stable release. When you install with `--channel=1.34/stable`, you receive the latest patch release on the 1.34 line. When 1.34.4 ships, snap refreshes you automatically. When 1.35.0 ships, you stay on 1.34.x until you explicitly switch channels. This gives you the best of both worlds: automatic patch updates for security and bug fixes, plus deliberate control over minor-version upgrades.
 
 ```bash
 # List available versions
 snap info microk8s
 
 # Install specific channel
-sudo snap install microk8s --classic --channel=1.28/stable
+sudo snap install microk8s --classic --channel=1.34/stable
 
-# Track latest patch releases for 1.28
-sudo snap refresh microk8s --channel=1.28/stable
+# Track latest patch releases for 1.34
+sudo snap refresh microk8s --channel=1.34/stable
 ```
 
 ### Install on Other Linux Distributions
@@ -495,11 +495,11 @@ microk8s start
 
 ## Upgrading MicroK8s
 
-The upgrade experience is where snap's transactional update model pays off most visibly. In a kubeadm-managed cluster, upgrading involves draining nodes, upgrading kubeadm, running `kubeadm upgrade plan` and `kubeadm upgrade apply`, upgrading kubelet and kubectl on each node, and uncordoning. It is a deliberate, multi-step process designed for production clusters where downtime is expensive. MicroK8s, by contrast, updates automatically within your channel — if you track `1.28/stable`, the snap daemon downloads and applies patch releases (1.28.3 → 1.28.4) on its refresh schedule, typically daily. This is convenient but carries risk: a patch release, however well-tested, could introduce a regression that breaks your workloads in the middle of the night.
+The upgrade experience is where snap's transactional update model pays off most visibly. In a kubeadm-managed cluster, upgrading involves draining nodes, upgrading kubeadm, running `kubeadm upgrade plan` and `kubeadm upgrade apply`, upgrading kubelet and kubectl on each node, and uncordoning. It is a deliberate, multi-step process designed for production clusters where downtime is expensive. MicroK8s, by contrast, updates automatically within your channel — if you track `1.34/stable`, the snap daemon downloads and applies patch releases (1.34.3 → 1.34.4) on its refresh schedule, typically daily. This is convenient but carries risk: a patch release, however well-tested, could introduce a regression that breaks your workloads in the middle of the night.
 
-For production, you should understand three controls: channel selection determines what you receive, refresh holding prevents automatic updates, and rollback gives you a safety net. Track a specific stable channel (`1.28/stable`), not `latest/stable`, so you control when minor-version upgrades happen. Hold refreshes during critical periods with `snap refresh --hold microk8s` and unhold when you are ready to test. And if an update breaks something, `snap revert microk8s` restores the previous revision — the snap keeps the last several revisions cached on disk, so rollback is a matter of seconds, not a multi-node drain-and-rebuild.
+For production, you should understand three controls: channel selection determines what you receive, refresh holding prevents automatic updates, and rollback gives you a safety net. Track a specific stable channel (`1.34/stable`), not `latest/stable`, so you control when minor-version upgrades happen. Hold refreshes during critical periods with `snap refresh --hold microk8s` and unhold when you are ready to test. And if an update breaks something, `snap revert microk8s` restores the previous revision — the snap keeps the last several revisions cached on disk, so rollback is a matter of seconds, not a multi-node drain-and-rebuild.
 
-The channel naming convention maps directly to upstream Kubernetes versions: `1.28/stable` is Kubernetes 1.28, latest patch. `1.28/candidate` is the release candidate for the next patch. `1.28/beta` is the beta. `1.28/edge` is the bleeding edge — updated on every commit, useful for testing upcoming features but never for production. The `latest` track mirrors the most recent stable upstream release and is reasonable for development environments where you want the newest Kubernetes features as soon as Canonical packages them.
+The channel naming convention maps directly to upstream Kubernetes versions: `1.34/stable` is Kubernetes 1.34, latest patch. `1.34/candidate` is the release candidate for the next patch. `1.34/beta` is the beta. `1.34/edge` is the bleeding edge — updated on every commit, useful for testing upcoming features but never for production. The `latest` track mirrors the most recent stable upstream release and is reasonable for development environments where you want the newest Kubernetes features as soon as Canonical packages them.
 
 ### Automatic Updates (Default)
 
@@ -522,11 +522,11 @@ sudo snap refresh --unhold microk8s
 
 ```bash
 # Switch to a different Kubernetes version
-sudo snap refresh microk8s --channel=1.29/stable
+sudo snap refresh microk8s --channel=1.35/stable
 
 # Available channels:
-# 1.28/stable, 1.28/candidate, 1.28/beta, 1.28/edge
-# 1.29/stable, 1.29/candidate, ...
+# 1.34/stable, 1.34/candidate, 1.34/beta, 1.34/edge
+# 1.35/stable, 1.35/candidate, ...
 # latest/stable, latest/edge
 ```
 
@@ -550,7 +550,7 @@ The container image problem is separate. While the snap includes the Kubernetes 
 # On connected machine:
 
 # Download the snap
-snap download microk8s --channel=1.28/stable
+snap download microk8s --channel=1.34/stable
 
 # This creates:
 # microk8s_NNNN.snap
@@ -683,7 +683,7 @@ Test your understanding of MicroK8s:
 <details>
 <summary>5. How do you perform an air-gapped installation of MicroK8s?</summary>
 
-**Answer**: On a connected machine: `snap download microk8s --channel=1.28/stable`. Transfer the .snap and .assert files to the air-gapped machine. Install: `sudo snap ack microk8s_NNNN.assert` then `sudo snap install microk8s_NNNN.snap --classic`. Import container images with `microk8s ctr image import`.
+**Answer**: On a connected machine: `snap download microk8s --channel=1.34/stable`. Transfer the .snap and .assert files to the air-gapped machine. Install: `sudo snap ack microk8s_NNNN.assert` then `sudo snap install microk8s_NNNN.snap --classic`. Import container images with `microk8s ctr image import`.
 </details>
 
 <details>
@@ -695,7 +695,7 @@ Test your understanding of MicroK8s:
 <details>
 <summary>7. What's the difference between stable and edge channels?</summary>
 
-**Answer**: Stable channels (e.g., `1.28/stable`) receive tested releases suitable for production. Edge channels receive latest builds, possibly unstable. Candidate and beta are between. For production, always use stable. For testing new features, use edge with caution.
+**Answer**: Stable channels (e.g., `1.34/stable`) receive tested releases suitable for production. Edge channels receive latest builds, possibly unstable. Candidate and beta are between. For production, always use stable. For testing new features, use edge with caution.
 </details>
 
 <details>


### PR DESCRIPTION
## What

Expands three code-heavy-but-teaching-thin stubs in **Toolkits / infrastructure-networking / k8s-distributions** to T0, per epic #1996. Each had ~300 prose words under good scaffolding; now each teaches the durable spine with volatile facts quarantined in a dated snapshot + cross-distro Rosetta.

| Module | Author | Tier | prose words | sources |
|---|---|---|---|---|
| 14.1 k3s | cursor (auto) | T0 | 5000 | 14 |
| 14.2 k0s | codex gpt-5.5 | T0 | 5043 | 18 |
| 14.3 MicroK8s | deepseek + orchestrator fix | T0 | 5368 | 12 |

## Durable-vendor rule (`.claude/rules/durable-vendor-content.md`)

- Durable spine taught (distribution = what's bundled; single-binary vs modular; datastore→HA tradeoff; conformance ≠ fork).
- Volatile facts isolated in one **dated `as of 2026-06` snapshot** per module; cross-distro **Rosetta** table (k3s · k0s · MicroK8s · upstream kubeadm).
- No best-tool / market-share claims. War stories relabeled `Hypothetical scenario:`.

## Cross-family review (opus-inline, Anthropic) — APPROVE all 3, web-verified

- **k3s**: CNCF Sandbox (2020-08-19) ✓; cncf/toc#1957 K3s Incubation Application real+open ✓ (citation verified, not fabricated).
- **k0s**: CNCF Sandbox (accepted **2025-01-19**) ✓; latest release `v1.36.1+k0s.0` (2026-06-14) ✓ (GitHub-verified).
- **MicroK8s**: CNCF-certified distribution (not CNCF-hosted) ✓; **fixed stale snap channels 1.28–1.30 → current 1.33–1.35** (web-verified snapcraft.io: 1.35/stable latest, 2026-04-06).

Local `npm run build` green (2169 pages, 47s). Verifier T0 on all three.

Refs #1996

🤖 Generated with [Claude Code](https://claude.com/claude-code)