### PR TITLE
content(platform): expand Toolkits platforms IDP services to T0 — backstage / crossplane / cert-manager (#1996)

### DIFF
--- a/src/content/docs/platform/toolkits/infrastructure-networking/platforms/module-7.1-backstage.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/platforms/module-7.1-backstage.md
@@ -1,779 +1,495 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 7.1: Backstage"
 slug: platform/toolkits/infrastructure-networking/platforms/module-7.1-backstage
 sidebar:
   order: 2
 ---
-> **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 50-60 minutes
-
-## Overview
-
-"Where do I find the API docs?" "Who owns this service?" "How do I create a new microservice?" If your developers ask these questions repeatedly, you need an Internal Developer Portal. Backstage, created by Spotify and donated to CNCF, centralizes developer experience—service catalog, documentation, templates, and plugins—in one place.
-
-**What You'll Learn**:
-- Backstage architecture and core concepts
-- Software Catalog and service ownership
-- Software Templates for golden paths
-- Plugin ecosystem and customization
-
-**Prerequisites**:
-- [Platform Engineering Discipline](/platform/disciplines/core-platform/platform-engineering/)
-- Node.js basics (for customization)
-- Kubernetes fundamentals
-
----
+> **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 75-90 minutes | **Track**: Toolkits
 
 ## What You'll Be Able to Do
 
 After completing this module, you will be able to:
 
-- **Deploy Backstage as an internal developer portal with service catalog and software templates**
-- **Configure Backstage plugins for CI/CD visibility, Kubernetes dashboards, and documentation integration**
-- **Implement software templates for standardized service scaffolding with built-in compliance guardrails**
-- **Integrate Backstage with existing toolchain (GitHub, ArgoCD, PagerDuty) for unified developer experience**
-
+- **Deploy Backstage as an internal developer portal with a software catalog and software templates that encode your organization's golden paths**
+- **Configure Backstage plugins for CI/CD visibility, Kubernetes dashboards, and documentation integration so developers see operational context beside catalog metadata**
+- **Implement software templates for standardized service scaffolding with built-in compliance guardrails such as ownership, repository settings, and catalog registration**
+- **Integrate Backstage with existing toolchain components including GitHub, Argo CD, and PagerDuty to present a unified developer experience without replacing those systems**
 
 ## Why This Module Matters
 
-Platform teams build great tools. Developers can't find them. Backstage solves the discoverability problem by creating a single pane of glass for everything developers need. It's not just a catalog—it's a developer portal that reduces cognitive load and enables self-service.
+Platform teams invest heavily in Kubernetes clusters, GitOps pipelines, observability stacks, and security tooling, yet developers still spend hours hunting for API documentation, service owners, deployment status, and the approved way to create a new repository. That friction is not a tooling shortage; it is a **discoverability and cognitive-load** problem. An Internal Developer Portal (IDP) addresses it by giving engineers one curated entry point where catalog metadata, documentation, templates, and plugin-driven views connect the dots across systems they already use.
 
-> 💡 **Did You Know?** Spotify created Backstage to manage their 2,000+ microservices and 400+ teams. Before Backstage, new engineers spent weeks figuring out where things lived. After Backstage, onboarding time dropped from weeks to days. Spotify open-sourced it in 2020, and it became a CNCF incubating project.
+Backstage is an open source **framework** for building such portals—not a single SaaS product with a fixed feature list. Spotify created it to tame microservice sprawl, open-sourced the project, and donated it to the Cloud Native Computing Foundation (CNCF). You adopt Backstage when you want a customizable portal whose core primitives (catalog, TechDocs, scaffolder, search, plugins) map cleanly to platform-engineering outcomes: ownership, self-service, and paved roads. We use Backstage throughout this module as a **worked example** of those durable IDP concepts; the Rosetta table later shows how the same capabilities appear in peer products without ranking them.
 
----
+> **The Airport Terminal Analogy**
+>
+> Imagine arriving at an airport where every airline hides its gate behind a different app, the food court has no directory, and baggage claim numbers are posted only in a Slack channel someone forgot to invite you to. That is what developer experience feels like without an IDP. Backstage is the terminal building: a consistent layout where signs (catalog), maps (TechDocs), ticket counters (software templates), and information screens (plugins) help you reach the right destination without memorizing tribal routes.
+
+## Prerequisites and Scope
+
+Before you start, you should understand [Platform Engineering Discipline](/platform/disciplines/core-platform/platform-engineering/) concepts such as golden paths, self-service, and reducing cognitive load. Basic Node.js and Yarn familiarity helps when you customize the frontend or add plugins, and you should be comfortable with Kubernetes fundamentals because many integrations surface cluster state. This module teaches **durable IDP architecture** first and Backstage mechanics second; when a vendor revs a plugin API, the mental model still applies.
+
+## Landscape Snapshot and IDP Rosetta
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> - **Backstage** is an open source framework for building developer portals, originally created at Spotify and **donated to CNCF**. Per the [CNCF project page](https://www.cncf.io/projects/backstage/), Backstage was **accepted to CNCF on September 8, 2020** and **moved to the Incubating maturity level on March 15, 2022**. It remains a **CNCF Incubating** project as of this snapshot—not Graduated.
+> - The upstream monorepo's **latest release** as of June 2026 is **v1.52.0** (see [GitHub releases](https://github.com/backstage/backstage/releases)). New apps scaffolded from current templates use modern Yarn tooling; always check release notes before upgrading production instances.
+> - **TechDocs** builds documentation with MkDocs-oriented tooling; treat MkDocs plugin versions as part of your upgrade checklist.
+> - **Peer IDP products** (Port, Cortex, Kratix, Humanitec, custom portals) ship on independent release trains—compare capabilities in the Rosetta below, not headline marketing claims.
+
+The Rosetta table maps **durable IDP capabilities** (rows) to representative implementations (columns). It is not a scorecard or a "best tool" ranking; it helps you translate requirements ("we need paved-road scaffolding with catalog registration") into architectural choices.
+
+| Capability | Backstage (this module) | Port (getport.io) | Cortex (cortex.io) | Kratix (kratix.io) | Custom in-house portal |
+|---|---|---|---|---|---|
+| **Service catalog / entity model** | YAML entities (`catalog-info.yaml`) with kinds such as Component, System, API, Resource; graph relationships and ownership | Software catalog with scorecards and blueprints | Service catalog with scorecards and initiatives | Platform promises + CRD-driven delivery; catalog patterns vary by installation | Whatever your team models—often incomplete without explicit entity design |
+| **Docs-as-code surfacing** | TechDocs (MkDocs pipeline, `backstage.io/techdocs-ref` annotation) | Embedded docs and spec pages tied to entities | Markdown/README integrations; docs features evolve per release | Docs typically live in Git; portal integration is custom | Confluence links or ad hoc README links—consistency varies |
+| **Software templates / golden paths** | Scaffolder (`Template` CRs, actions such as `publish:github`, `catalog:register`) | Self-service actions and blueprints | Scaffolding via templates/initiatives depending on configuration | Promises + pipelines deliver platform capabilities | Cookiecutter scripts or ticket-driven provisioning |
+| **Plugin / extensibility model** | Frontend + backend plugins, app configuration, community plugin index | Integrations marketplace | Integrations and API | Kubernetes-native controllers + marketplace patterns | Full custom code—high build cost |
+| **Ownership and accountability** | `spec.owner` references Groups/Users; org data from identity providers | Ownership fields on entities | Ownership and team metadata | Team labels on promises | Depends on HR/LDAP sync quality |
+| **Operational context (K8s, CI, incidents)** | Plugins (Kubernetes, GitHub Actions, Argo CD, PagerDuty, etc.) | Integration-driven widgets | Integrations for CI, K8s, incidents | Observability via platform pipeline | Usually the first features to break when APIs change |
+| **Deployment model** | Self-hosted app (Node backend + Postgres/SQLite); you operate upgrades | SaaS or self-hosted options per vendor docs | SaaS-first with enterprise options | Runs on your Kubernetes cluster | You operate everything |
+| **Open source / governance** | Apache-2.0, CNCF Incubating | Commercial product with documented API | Commercial product | Apache-2.0 platform components; CNCF Sandbox for Kratix—verify current status before production bets | Internal IP |
+
+When you evaluate tools, ask which **rows** you must satisfy on day one versus which can wait. Teams that skip catalog ownership and jump straight to flashy dashboards usually rebuild later under incident pressure.
 
 ## The Developer Experience Problem
 
+Without a portal, every question sends developers on a scavenger hunt across Confluence, GitHub, Grafana, Argo CD, PagerDuty, and Slack archives. Each hop uses a different search syntax, a different authentication flow, and a different mental model of what "the service" even means. Platform engineers feel this pain during incidents when the on-call engineer cannot find the runbook, the dependency graph, or the team that owns a failing deployment. The cost is not only time; it is **context switching** that erodes flow state and encourages unsafe shortcuts such as copying an old repository without updating CI secrets.
+
+An IDP does not replace your toolchain—it **indexes and contextualizes** it. The catalog answers "what exists and who owns it," TechDocs answers "how it works," templates answer "how we create the next one correctly," and plugins answer "what is happening right now in systems X and Y." Backstage implements those four answers as first-class features with a shared entity graph, which is why it appears frequently in platform-engineering reference architectures. The ASCII sketch below contrasts the scattered workflow with a portal-centered workflow; read it as a capability map, not a promise that every installation ships every plugin on day one.
+
 ```
-WITHOUT INTERNAL DEVELOPER PORTAL
-════════════════════════════════════════════════════════════════════
+WITHOUT INTERNAL DEVELOPER PORTAL          WITH BACKSTAGE (ILLUSTRATIVE)
+════════════════════════════════════       ═══════════════════════════════
+Find API docs     -> Search 4 systems       -> Catalog -> Component -> Docs
+Find owner        -> Slack + git blame       -> Catalog -> Owner -> Group
+Create service    -> Copy old repo           -> Create -> Template wizard
+Deploy status     -> Open Argo CD UI          -> Component -> Kubernetes/Argo plugin
+On-call           -> PagerDuty only           -> Component -> PagerDuty plugin
+```
 
-Developer needs to:
+## Architecture: Frontend, Backend, and Integrations
 
-Find API docs          → Search Confluence, Notion, GitHub, Slack
-Check service health   → Log into multiple dashboards
-Create new service     → Copy paste from old repo, modify, hope
-Find service owner     → Ask around, check git blame, Slack channels
-View deployment status → Check ArgoCD, Jenkins, Spinnaker
-Access database        → Ask DBA, create ticket, wait
+Backstage splits into a **React frontend** and a **Node.js backend** bundled as a single deployable application you configure through `app-config.yaml` (and optional `app-config.production.yaml` overlays). The frontend renders entity pages, search, TechDocs, and plugin routes; the backend hosts catalog processing, scaffolder actions, auth brokers, and proxy endpoints that hold credentials away from browsers. A relational database (PostgreSQL in production, SQLite for local experiments) stores catalog processing state, scaffolder tasks, and other plugin data depending on what you enable.
 
-Result: Hours of searching, context switching, tribal knowledge
-
+```
+BACKSTAGE ARCHITECTURE (SIMPLIFIED)
 ═══════════════════════════════════════════════════════════════════
-
-WITH BACKSTAGE
-════════════════════════════════════════════════════════════════════
-
-Developer needs to:
-
-Find API docs          → Backstage → Component → Docs tab
-Check service health   → Backstage → Component → Dashboard
-Create new service     → Backstage → Create → Select template
-Find service owner     → Backstage → Component → Owner
-View deployment status → Backstage → Component → Kubernetes tab
-Access database        → Backstage → Component → Links
-
-Result: Minutes to find anything, self-service, documented paths
+┌───────────────────────────────────────────────────────────────┐
+│ BACKSTAGE APP                                                  │
+│  Frontend (React) ──► Catalog UI, TechDocs, Templates, Plugins │
+│         │                                                      │
+│  Backend (Node) ───► Catalog, Scaffolder, TechDocs, Auth, Proxy│
+│         │                                                      │
+│  Database ─────────► PostgreSQL (prod) / SQLite (local dev)   │
+└───────────────────────────────┬───────────────────────────────┘
+                                │ integrations (tokens on backend)
+                                ▼
+        GitHub / GitLab / Bitbucket · Kubernetes · Argo CD · PagerDuty · LDAP/OAuth
 ```
 
----
+Understanding this split matters when you debug permissions: browsers call backend APIs, backends call external systems. If GitHub rate-limits your catalog import, fix integration tokens and processors on the backend—not the React route. If TechDocs builds fail, inspect the TechDocs backend builder/publisher configuration and CI jobs that generate static sites.
 
-## Architecture
+## Software Catalog: Entities, Relationships, and Ownership
 
-```
-BACKSTAGE ARCHITECTURE
-════════════════════════════════════════════════════════════════════
+The catalog is the **graph-shaped heart** of Backstage. Each entity is a YAML or JSON document describing a thing your organization cares about: a microservice (`Component`), an HTTP API (`API`), a database (`Resource`), a product area (`System`), a business domain (`Domain`), or people/teams (`User`, `Group`). Files typically live beside code as `catalog-info.yaml`, which keeps metadata close to the repository developers already open.
 
-┌─────────────────────────────────────────────────────────────────┐
-│                     BACKSTAGE APP                                │
-│                                                                  │
-│  ┌───────────────────────────────────────────────────────────┐ │
-│  │                    FRONTEND (React)                        │ │
-│  │  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐      │ │
-│  │  │ Catalog │  │  Docs   │  │Templates│  │ Plugins │      │ │
-│  │  │  UI     │  │TechDocs │  │ Wizard  │  │  ...    │      │ │
-│  │  └─────────┘  └─────────┘  └─────────┘  └─────────┘      │ │
-│  └───────────────────────────────────────────────────────────┘ │
-│                              │                                   │
-│  ┌───────────────────────────▼───────────────────────────────┐ │
-│  │                    BACKEND (Node.js)                       │ │
-│  │  ┌─────────┐  ┌─────────┐  ┌─────────┐  ┌─────────┐      │ │
-│  │  │ Catalog │  │ Scaffolder│ │TechDocs │  │  Auth   │      │ │
-│  │  │ Backend │  │ Backend  │ │ Backend │  │ Backend │      │ │
-│  │  └─────────┘  └─────────┘  └─────────┘  └─────────┘      │ │
-│  └───────────────────────────────────────────────────────────┘ │
-│                              │                                   │
-│  ┌───────────────────────────▼───────────────────────────────┐ │
-│  │                     DATABASE                               │ │
-│  │              (PostgreSQL, SQLite)                          │ │
-│  └───────────────────────────────────────────────────────────┘ │
-└─────────────────────────────────────────────────────────────────┘
-                               │
-                               │ Integrates with
-                               ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    EXTERNAL SYSTEMS                              │
-│                                                                  │
-│  GitHub  │  GitLab  │  Kubernetes  │  PagerDuty  │  Datadog   │
-│  Jenkins │  ArgoCD  │  Prometheus  │  Slack      │  LDAP      │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
+Ownership is not decorative. Setting `spec.owner` to a `Group` entity (for example `group:default/team-payments`) powers access-control rules, review routing, and plugin views that show on-call rotations for the responsible team. When ownership is missing, the portal becomes a phone book with blank entries—exactly the problem you tried to escape.
 
-### Core Features
-
-| Feature | Description |
-|---------|-------------|
-| **Software Catalog** | Service registry with ownership, dependencies, metadata |
-| **TechDocs** | Documentation as code, rendered from markdown |
-| **Software Templates** | Scaffolding for new services (golden paths) |
-| **Plugins** | Extensible architecture for custom integrations |
-| **Search** | Unified search across all registered entities |
-
----
-
-## Installation
-
-```bash
-# Create new Backstage app
-npx @backstage/create-app@latest
-
-# Follow prompts, choose:
-# - App name: backstage
-# - Database: PostgreSQL (for production)
-
-cd backstage
-
-# Start development server
-yarn dev
-
-# Access at http://localhost:3000
-```
-
-### Production Deployment
+Relationships express architecture explicitly: a `Component` **dependsOn** a `Resource`, **consumesApi** / **providesApi** links wire service boundaries, and **system** membership groups components into product slices. Processors ingest entities from Git hosts, URL locations, or manual registration, then **stitch** references so the UI can render dependency graphs. Annotations attach machine-readable hooks—`github.com/project-slug` ties a component to a repository, `backstage.io/techdocs-ref` binds documentation, and Prometheus or Grafana annotations can deep-link observability assets when you standardize those keys.
 
 ```yaml
-# Kubernetes deployment
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: backstage
-spec:
-  replicas: 2
-  selector:
-    matchLabels:
-      app: backstage
-  template:
-    spec:
-      containers:
-      - name: backstage
-        image: backstage:latest
-        ports:
-        - containerPort: 7007
-        env:
-        - name: POSTGRES_HOST
-          valueFrom:
-            secretKeyRef:
-              name: backstage-secrets
-              key: POSTGRES_HOST
-        - name: POSTGRES_USER
-          valueFrom:
-            secretKeyRef:
-              name: backstage-secrets
-              key: POSTGRES_USER
-```
-
----
-
-## Software Catalog
-
-### Catalog Entities
-
-```yaml
-# catalog-info.yaml (in your service repo)
+# catalog-info.yaml (representative service)
 apiVersion: backstage.io/v1alpha1
 kind: Component
 metadata:
   name: payment-service
-  description: Handles payment processing
+  description: Processes card payments for checkout
   annotations:
     github.com/project-slug: myorg/payment-service
     backstage.io/techdocs-ref: dir:.
-    prometheus.io/rule: payment_service_errors_total
-  tags:
-    - java
-    - spring-boot
-    - payments
-  links:
-    - url: https://grafana.example.com/d/payments
-      title: Grafana Dashboard
-    - url: https://runbooks.example.com/payments
-      title: Runbook
+  tags: [java, payments]
 spec:
   type: service
   lifecycle: production
-  owner: team-payments
+  owner: group:default/team-payments
   system: checkout
-  providesApis:
-    - payments-api
-  consumesApis:
-    - users-api
-    - inventory-api
-  dependsOn:
-    - resource:payments-db
+  providesApis: [payment-api]
+  dependsOn: [resource:default/payments-db]
 ```
 
-### Entity Types
+Entity kinds form a taxonomy you should keep **boring at first**. Start with Components, Groups, and Systems; add Domains and complex API entities when teams feel pain without them. Overly elaborate taxonomies confuse contributors and stall catalog coverage metrics.
 
-| Kind | Description | Example |
-|------|-------------|---------|
-| **Component** | A piece of software | microservice, library, website |
-| **API** | Interface definition | REST, gRPC, GraphQL |
-| **Resource** | Infrastructure | database, S3 bucket, queue |
-| **System** | Collection of components | checkout system |
-| **Domain** | Business area | payments domain |
-| **Group** | Team | payments-team |
-| **User** | Individual | john.doe |
+## Ingestion, Discovery, and Catalog Hygiene
 
-### Entity Relationships
+Catalog data rots when ingestion is manual. Backstage supports **location-based** imports (point at a Git org and discover `catalog-info.yaml` files), **org** data from identity providers, and custom processors for your internal service registry. The durable operational pattern is: (1) encode catalog files in repository templates so new services start registered, (2) add CI checks that fail pull requests missing required metadata fields such as owner and system, and (3) run periodic audits comparing catalog entities to live deployment records.
 
-```
-ENTITY RELATIONSHIPS
-════════════════════════════════════════════════════════════════════
+Stitching resolves references asynchronously in current releases—entities may appear partially linked until processors finish. Platform teams should monitor catalog errors in backend logs and surface them to contributors with actionable messages rather than silent omission. Treat catalog health as a product metric: percentage of production services with owner, docs, and lifecycle set.
 
-                    ┌─────────────┐
-                    │   Domain    │
-                    │  (payments) │
-                    └──────┬──────┘
-                           │ hasPart
-                           ▼
-                    ┌─────────────┐
-                    │   System    │
-                    │ (checkout)  │
-                    └──────┬──────┘
-                           │ hasPart
-              ┌────────────┼────────────┐
-              │            │            │
-              ▼            ▼            ▼
-        ┌──────────┐ ┌──────────┐ ┌──────────┐
-        │Component │ │Component │ │   API    │
-        │(frontend)│ │(backend) │ │(payments)│
-        └──────────┘ └────┬─────┘ └──────────┘
-                          │
-            ┌─────────────┼─────────────┐
-            │ dependsOn   │ consumesApi │
-            ▼             ▼             ▼
-      ┌──────────┐  ┌──────────┐  ┌──────────┐
-      │ Resource │  │   API    │  │   API    │
-      │  (db)    │  │ (users)  │  │(inventory)│
-      └──────────┘  └──────────┘  └──────────┘
+## TechDocs: Documentation as Code
 
-Owner: Group/User owns Components, Systems, APIs, Resources
-```
+TechDocs implements **docs-like-code** for services cataloged in Backstage. Authors write Markdown in a `docs/` folder, configure `mkdocs.yml`, and annotate the entity with `backstage.io/techdocs-ref: dir:.` (or a URL-based ref). A backend builder (local or CI-driven external builder) generates static HTML published to cloud storage or local filesystem; the frontend renders docs inside the entity page so readers never hunt for a separate wiki.
 
-> 💡 **Did You Know?** Backstage automatically discovers catalog files from GitHub/GitLab by scanning for `catalog-info.yaml` in repositories. You can set up a GitHub integration that auto-discovers all repos in your organization, meaning teams just need to add the YAML file and their service appears in Backstage automatically.
-
----
-
-## TechDocs
-
-### Documentation as Code
-
-```
-TECHDOCS WORKFLOW
-════════════════════════════════════════════════════════════════════
-
-1. Developer writes docs in Markdown (in repo)
-2. TechDocs builds docs using MkDocs
-3. Docs are published to storage (S3, GCS)
-4. Backstage renders docs in browser
-
-├── docs/
-│   ├── index.md
-│   ├── getting-started.md
-│   ├── api-reference.md
-│   └── architecture.md
-├── mkdocs.yml
-└── catalog-info.yaml
-```
-
-### MkDocs Configuration
+This separation teaches an important platform principle: **documentation is a delivery pipeline**, not a one-time wiki migration. Teams that skip the pipeline end up with stale MkDocs sites; teams that integrate doc builds into service CI keep docs versioned with code review. TechDocs also reinforces ownership—when docs live in the repository, the same team that ships code ships explanations.
 
 ```yaml
-# mkdocs.yml
+# mkdocs.yml (minimal TechDocs-ready)
 site_name: Payment Service
-nav:
-  - Home: index.md
-  - Getting Started: getting-started.md
-  - API Reference: api-reference.md
-  - Architecture: architecture.md
-
 plugins:
   - techdocs-core
+nav:
+  - Home: index.md
+  - Runbook: runbook.md
 ```
 
-### Catalog Reference
+Prefer short, task-oriented pages linked from runbooks and architecture notes. Platform standards documents (how to rotate secrets, how to request a database) belong in TechDocs or linked Systems—not duplicated inconsistently across Confluence and Git.
+
+## Software Templates and Golden Paths
+
+Software Templates (Scaffolder) turn platform decisions into **self-service forms**. A `Template` resource describes parameters (service name, owner, repository location), a sequence of **steps** (fetch skeleton, publish to GitHub, register catalog entry, trigger CI webhook), and **outputs** (links to repo and catalog entity). Templates encode golden paths: the blessed combination of language version, CI workflow, observability hooks, and security scanning your organization expects.
+
+Golden paths are opinionated on purpose. They trade absolute flexibility for **predictable outcomes**—fewer snowflake repositories, easier upgrades, and simpler compliance evidence. Product management for templates means measuring time-to-first-successful-deploy and interviewing developers about friction, not merely publishing YAML.
 
 ```yaml
-# catalog-info.yaml
-metadata:
-  annotations:
-    backstage.io/techdocs-ref: dir:.  # Docs in same repo
-    # OR
-    backstage.io/techdocs-ref: url:https://github.com/org/docs
-```
-
----
-
-## Software Templates
-
-### Golden Paths
-
-Software Templates create "golden paths"—pre-approved ways to create new services, libraries, or infrastructure.
-
-```yaml
-# template.yaml
 apiVersion: scaffolder.backstage.io/v1beta3
 kind: Template
 metadata:
-  name: spring-boot-service
-  title: Spring Boot Microservice
-  description: Create a new Spring Boot microservice with CI/CD
-  tags:
-    - java
-    - spring-boot
-    - recommended
+  name: node-service-golden-path
+  title: Node.js Service (Golden Path)
 spec:
-  owner: platform-team
+  owner: group:default/platform-team
   type: service
-
   parameters:
-    - title: Service Information
-      required:
-        - name
-        - description
-        - owner
+    - title: Service metadata
+      required: [name, owner]
       properties:
         name:
-          title: Service Name
+          title: Name
           type: string
-          description: Name of the service (lowercase, no spaces)
           pattern: '^[a-z][a-z0-9-]*$'
-        description:
-          title: Description
-          type: string
-          description: What does this service do?
         owner:
           title: Owner
           type: string
-          description: Team that owns this service
           ui:field: OwnerPicker
-          ui:options:
-            catalogFilter:
-              kind: Group
-
-    - title: Repository
-      required:
-        - repoUrl
-      properties:
-        repoUrl:
-          title: Repository Location
-          type: string
-          ui:field: RepoUrlPicker
-          ui:options:
-            allowedHosts:
-              - github.com
-
   steps:
-    - id: fetch-template
-      name: Fetch Template
+    - id: fetch
+      name: Fetch skeleton
       action: fetch:template
       input:
         url: ./skeleton
         values:
           name: ${{ parameters.name }}
-          description: ${{ parameters.description }}
           owner: ${{ parameters.owner }}
-
     - id: publish
       name: Publish to GitHub
       action: publish:github
       input:
-        repoUrl: ${{ parameters.repoUrl }}
-        description: ${{ parameters.description }}
-        defaultBranch: main
-
+        repoUrl: github.com?owner=myorg&repo=${{ parameters.name }}
     - id: register
-      name: Register in Catalog
+      name: Register in catalog
       action: catalog:register
       input:
         repoContentsUrl: ${{ steps['publish'].output.repoContentsUrl }}
-        catalogInfoPath: '/catalog-info.yaml'
-
-  output:
-    links:
-      - title: Repository
-        url: ${{ steps['publish'].output.remoteUrl }}
-      - title: Open in Catalog
-        icon: catalog
-        entityRef: ${{ steps['register'].output.entityRef }}
+        catalogInfoPath: /catalog-info.yaml
 ```
 
-### Template Skeleton
+Guardrails live in three places: template parameters (validation patterns), skeleton content (required files such as `catalog-info.yaml` and CI workflows), and post-publish policies (branch protection rules applied by separate automation). Templates should never bypass security review entirely—they should **pre-fill** the safe defaults so review focuses on business logic rather than missing Dockerfile USER directives.
 
-```
-skeleton/
-├── catalog-info.yaml
-├── Dockerfile
-├── pom.xml
-├── README.md
-├── src/
-│   └── main/
-│       └── java/
-│           └── com/example/${{values.name}}/
-│               └── Application.java
-└── .github/
-    └── workflows/
-        └── ci.yaml
-```
+## Plugins, Search, and Toolchain Integration
 
-```yaml
-# skeleton/catalog-info.yaml
-apiVersion: backstage.io/v1alpha1
-kind: Component
-metadata:
-  name: ${{ values.name }}
-  description: ${{ values.description }}
-spec:
-  type: service
-  lifecycle: experimental
-  owner: ${{ values.owner }}
-```
+Plugins extend both UI and backend. Frontend plugins add tabs and routes on entity pages—Kubernetes workloads, GitHub Actions runs, Argo CD applications, PagerDuty services. Backend plugins implement proxy endpoints and scheduled sync jobs that fetch external data with service credentials. Installing a plugin typically means adding Yarn dependencies, registering routes in `packages/app`, and configuring `app-config.yaml` with endpoints and tokens.
 
-> 💡 **Did You Know?** Spotify uses Software Templates to standardize how all 2,000+ services are created. Every new service starts from a template that includes CI/CD, observability, security scanning, and documentation—all pre-configured. This reduces "time to first deployment" from days to minutes.
+Integration architecture should follow **least privilege**: GitHub tokens scoped to catalog read for ingestion, narrower scopes for scaffolder publish actions, Kubernetes service accounts with namespace-scoped RBAC for dev clusters, and read-only Argo CD tokens for status panels. Backstage becomes a **read-mostly aggregation layer**; Git remains source of truth for code, Argo CD for desired cluster state, PagerDuty for incident routing.
 
-> 💡 **Did You Know?** Backstage's plugin ecosystem has grown to over 100 community plugins, from Kubernetes and ArgoCD to PagerDuty and cost management. The modular architecture means you can add capabilities without modifying core Backstage code. Companies like Netflix, American Airlines, and Expedia have built custom plugins for their internal tooling—and many have contributed them back to the community.
+Search unifies catalog entities, TechDocs, and optionally external systems when you enable additional collators. Good search relevance depends on catalog metadata quality—tags, titles, descriptions—another reason to enforce metadata standards early.
 
----
+## Configuration, Deployment, and Upgrades
 
-## Plugin Ecosystem
+Production deployments run the backend container behind ingress TLS, connect to managed PostgreSQL, and inject secrets via your cluster's secret store. Configuration splits between static `app-config.yaml` and environment-specific overrides for URLs, auth providers, and CORS settings. Auth integrates with OAuth providers, OIDC, or proxy-based SSO patterns common in enterprises.
 
-### Popular Plugins
+Upgrades require reading upstream release notes—Backstage ships frequent minor releases with breaking UI token changes, catalog performance improvements, and scaffolder action updates. Maintain a staging portal that tracks production plugins and run automated smoke tests: catalog query, doc render, template dry-run, and representative plugin fetches.
 
-| Plugin | Purpose |
-|--------|---------|
-| **Kubernetes** | View pods, deployments, logs |
-| **GitHub Actions** | CI/CD status |
-| **ArgoCD** | GitOps deployment status |
-| **PagerDuty** | On-call schedules, incidents |
-| **Tech Radar** | Technology standards visualization |
-| **Cost Insights** | Cloud spend per service |
-| **API Docs** | OpenAPI/Swagger viewer |
+Local development uses `npx @backstage/create-app@latest` followed by `yarn install` and `yarn dev`, which binds frontend and backend for iterative plugin work. Production images should pin versions and rebuild when security patches land, not float unlabeled `:latest` tags without a deliberate policy.
 
-### Installing Plugins
+## Adoption as Product Management
 
-```bash
-# Add plugin dependency
-yarn add --cwd packages/app @backstage/plugin-kubernetes
+Hypothetical scenario: a platform team launches a polished Backstage UI but sees low weekly active usage because catalog entries required a manual ticket, templates were absent, and Kubernetes integration was deferred "until phase two." Developers praised the demo, then returned to old habits because the portal did not shorten any real task. After the team enabled repository discovery, shipped three templates aligned to top request types, and embedded Argo CD status on entity pages, usage climbed because the portal saved measurable minutes per week.
 
-# packages/app/src/App.tsx
-import { EntityKubernetesContent } from '@backstage/plugin-kubernetes';
+That narrative is illustrative, not a measured case study. The durable lesson: treat the portal as a **product** with personas, success metrics, and iteration loops. Interview developers about their first-week tasks, remove steps from those flows, and publish changelog notes when entity pages gain new tabs. Without adoption work, Backstage becomes shelfware regardless of CNCF status or release cadence.
 
-// Add to entity page routes
-```
+## Authentication and Authorization Patterns
 
-### Custom Plugin Development
+Backstage auth spans **sign-in** (who is the human using the browser) and **authorization** (what that identity may see or execute). Most enterprises integrate with an OAuth/OIDC provider or place an authenticating reverse proxy in front of the app. The durable design choice is to treat Backstage as another corporate application subject to SSO lifecycle policies—session timeouts, step-up auth for sensitive actions, and group membership sourced from your identity provider rather than manually curated YAML lists that drift the moment someone transfers teams.
 
-```typescript
-// plugins/my-plugin/src/plugin.ts
-import { createPlugin, createRoutableExtension } from '@backstage/core-plugin-api';
+Authorization layers include catalog permission rules (who can read or register entities), scaffolder permissions (who may run which templates), and plugin-specific checks (for example Kubernetes RBAC still governs what cluster objects a user may see even if Backstage renders them). Platform teams sometimes mistakenly assume the portal becomes the authorization system of record; in practice it **reflects** policies defined in GitHub, Kubernetes, and cloud IAM. Your job is to align Backstage roles with those systems so developers experience coherent denials instead of confusing partial views.
 
-export const myPlugin = createPlugin({
-  id: 'my-plugin',
-  routes: {
-    root: rootRouteRef,
-  },
-});
+Guest mode and demo identities help local development, but production configurations should map users to `User` entities and groups to `Group` entities via org providers. When group membership is wrong, ownership links lie, on-call plugins point at outdated rotations, and template pickers offer teams a developer no longer belongs to. Invest in automated org sync and monitor diff alerts when HR-driven group changes fail to propagate.
 
-export const MyPluginPage = myPlugin.provide(
-  createRoutableExtension({
-    name: 'MyPluginPage',
-    component: () => import('./components/MyPage').then(m => m.MyPage),
-    mountPoint: rootRouteRef,
-  }),
-);
-```
+## Entity Processors and the Reconciliation Mindset
 
----
+Catalog ingestion resembles a Kubernetes controller: locations declare desired inputs, processors transform raw files into entities, validators reject malformed documents, and stitchers resolve references into a coherent graph stored in the database. Thinking in reconciliation loops helps you debug "my entity exists but relationships are missing" reports—often the entity arrived before its dependency, stitching retried asynchronously, or a typo in `dependsOn` prevented linkage.
 
-## Configuration
+Processors also enforce **normalization**. Two teams might use different annotation keys for the same concept until platform engineering publishes a **catalog descriptor standard** documenting required annotations (`github.com/project-slug`, observability links, security tier labels). Normalization processors can migrate legacy keys or emit warnings rather than silently accepting incompatible metadata. This is how you prevent the catalog from becoming a dumping ground of one-off fields that search cannot interpret.
 
-### app-config.yaml
+Location types trade off freshness versus load. A broad GitHub org scan simplifies onboarding but increases API utilization; narrowly scoped locations reduce noise but require teams to request additions. Hybrid models start broad for discovery, then shift critical production systems to explicitly reviewed location entries once ownership data is trustworthy. Document the refresh expectations so incident responders know whether catalog lag is acceptable during GitHub outages.
 
-```yaml
-app:
-  title: Acme Developer Portal
-  baseUrl: https://backstage.acme.com
+## Designing Plugin Boundaries for Maintainability
 
-organization:
-  name: Acme Corp
+Plugins are powerful because they escape the core release cycle, but they also import **operational debt** when teams install everything at once. A durable plugin strategy groups integrations by **user journey** rather than by vendor logo count. Ask which tabs a developer needs on day one of owning a service: repository, docs, CI status, deployment health, on-call. Ship those before niche integrations that leadership requested after reading a conference blog post.
 
-backend:
-  baseUrl: https://backstage.acme.com
-  database:
-    client: pg
-    connection:
-      host: ${POSTGRES_HOST}
-      port: 5432
-      user: ${POSTGRES_USER}
-      password: ${POSTGRES_PASSWORD}
+Each plugin adds frontend bundle weight, backend credentials, and upgrade coupling. Prefer official or actively maintained community plugins for critical paths; fork only when you must patch behavior and you are willing to merge upstream changes quarterly. Wrap external API calls with caching and timeouts so a slow Argo CD instance does not hang entity page renders. Surface degraded states honestly ("Argo CD unreachable—retry") instead of blank tabs that look like missing permissions.
 
-integrations:
-  github:
-    - host: github.com
-      token: ${GITHUB_TOKEN}
+Custom plugins follow a predictable split: React components for presentation, backend routers for secrets-bearing fetches, and optional scheduled tasks for synchronization jobs. Keep business logic out of React when possible—backend services are easier to test and rotate credentials. Document plugin ownership inside your platform team the same way product teams own microservices, including on-call rotation for integrations that become incident-critical during outages.
 
-catalog:
-  import:
-    entityFilename: catalog-info.yaml
-  rules:
-    - allow: [Component, API, Resource, System, Domain, Group, User]
-  locations:
-    - type: url
-      target: https://github.com/acme/backstage-catalog/blob/main/all.yaml
-    - type: github-discovery
-      target: https://github.com/acme
+## Scaffolder Actions, Secrets, and Workflow Safety
 
-auth:
-  providers:
-    github:
-      development:
-        clientId: ${GITHUB_CLIENT_ID}
-        clientSecret: ${GITHUB_CLIENT_SECRET}
+Software Templates are tempting to implement as mega-workflows that provision cloud resources, register catalog entries, open Jira tickets, and post Slack announcements in one click. The durable approach phases automation: first repository and catalog correctness, then CI visibility, then optional infrastructure modules orchestrated by specialized systems such as Crossplane or Terraform pipelines triggered after the repo exists. Backstage scaffolder actions excel at **Git-native** and **catalog-native** steps; they are not a general-purpose replacement for every platform controller.
 
-techdocs:
-  builder: 'external'
-  publisher:
-    type: 'awsS3'
-    awsS3:
-      bucketName: backstage-techdocs
-```
+Actions receive parameters and secrets under controlled schemas. Sensitive values belong in action input marked as secrets and stored in the scaffolder task record according to your retention policies. Teach template authors to avoid echoing secrets into logs and to validate parameter shapes with JSON Schema constraints so mistyped repository names fail fast before partially creating resources. Dry-run or preview modes—where available—help developers understand what will happen without mutating production systems.
 
----
+Idempotency matters when actions retry. Publishing to an existing repository or re-registering catalog entries should either succeed cleanly or fail with actionable errors. Platform teams should maintain a **template catalog** with lifecycle labels (`experimental`, `supported`, `deprecated`) mirroring service lifecycles so developers know which golden path is current. Deprecation includes migration guides, not silent removal, because templates are contracts between platform and product engineering.
+
+## TechDocs Builder Modes and Publishing Topologies
+
+TechDocs supports multiple builder topologies; choosing wrong is a common source of "works on my laptop" failures. **Local builder** mode compiles docs on the Backstage backend—simple for small doc sets, expensive for monorepos with heavy MkDocs plugins. **External builder** mode expects CI to generate and publish static sites to cloud storage that the backend reads—better for scale and for keeping build secrets out of the portal cluster. The annotation `backstage.io/techdocs-ref` tells the system where source lives; the `techdocs.builder` and `techdocs.publisher` settings tell it how to transform and store artifacts.
+
+Publisher configuration must align with your security model. Buckets require IAM roles or service accounts with least privilege; misconfigured public ACLs on doc buckets have leaked internal runbooks in real incidents across the industry. Prefer private buckets with authenticated fetches through the Backstage backend proxy rather than public URLs embedded in entity pages unless content is genuinely public marketing material.
+
+Docs quality standards belong in platform guidelines: required sections (overview, runbook, SLOs), link styles, diagram formats, and freshness review cadence tied to production change frequency. TechDocs makes compliance visible—reviewers can see missing pages in pull requests when doc paths change—especially if CI fails when `mkdocs build` breaks. Pair TechDocs with catalog enforcement so undocumented services cannot mark `lifecycle: production` without an approved exception recorded in the catalog.
+
+## Mapping Platform Capabilities to Portal Surfaces
+
+Platform engineering roadmaps often list capabilities—cluster namespaces, database provisioning, certificate issuance, observability dashboards—that developers experience as disconnected tickets. A useful design exercise maps each capability to **portal surfaces**: catalog metadata fields, template parameters, TechDocs sections, and plugin tabs. For example, vCluster-based dev environments might appear as template outputs linking to a virtual cluster name, a TechDocs page describing kubeconfig retrieval, and a Kubernetes plugin view scoped to that namespace.
+
+This mapping clarifies what Backstage should **not** do. If Crossplane claims provision databases, the portal should surface claim status via plugins and documentation, not re-implement provisioning logic inside scaffolder shell scripts that bypass audit trails. If PagerDuty owns paging policy, show service links and escalation policies rather than storing pager numbers in free-text catalog fields that rot silently.
+
+Cross-linking modules in KubeDojo reinforces the pattern: [Module 3.6: vCluster](../module-3.6-vcluster/) covers virtual clusters; [Module 7.2: Crossplane](../module-7.2-crossplane/) covers infrastructure APIs; this module covers the portal layer that makes those capabilities discoverable. Your organization’s graph may differ, but the **separation of concerns** remains: controllers enforce state, Git records intent, portals narrate how humans navigate the system.
+
+## Security, Compliance, and Audit Evidence
+
+Security reviewers ask whether a developer portal increases attack surface. It can, primarily by concentrating credentials and metadata. Mitigations include hosting Backstage inside your corporate network or zero-trust access layer, using short-lived tokens, enabling audit logs for scaffolder executions, and applying Kubernetes network policies so the backend reaches only approved API endpoints. Catalog metadata may describe data classification; integrate those fields with access rules so restricted components hide sensitive tabs from unauthorized groups.
+
+Compliance frameworks often require evidence that production services have owners, change management hooks, and documented runbooks. Backstage does not automatically satisfy auditors, but catalog queries plus TechDocs links provide **machine-checkable artifacts** when you define policies such as "production Components must include owner, system, techdocs-ref, and CI annotation." Export catalog snapshots or use the catalog export capabilities described in upstream release notes when teams need CSV/JSON evidence for governance reviews.
+
+Red-team exercises should include the portal: attempt to invoke templates without authorization, exfiltrate integration tokens from misconfigured clients, or enumerate entities that leak internal project codenames. Findings feed back into descriptor standards and permission rules. Treat those exercises as routine platform hygiene, not one-time launch gates.
+
+## Operating Backstage in Production
+
+Production operations extend beyond uptime monitoring. Track database migration health, plugin version skew between frontend and backend packages, search index freshness, and scaffolder queue depth. Backstage releases ship performance fixes—recent catalog releases split count queries from list queries to reduce UI latency—so staying reasonably current is an operational requirement, not vanity upgrading.
+
+Backup strategy includes PostgreSQL snapshots and exported `app-config` secrets stored in your vault. Disaster recovery drills should restore a staging instance from backups and verify catalog imports rehydrate from Git locations rather than assuming the database alone is authoritative—Git-backed entities should rebuild after catastrophic DB loss, though scaffolder history may not.
+
+Capacity planning accounts for org size: large enterprises with tens of thousands of entities need tuned database indexes, careful search collators, and potentially sharded location providers. Start smaller, measure p95 catalog query latency, and scale vertically before introducing architectural sharding. Developer complaints about "slow search" often trace to missing indexes or overly broad wildcard queries fixable without re-architecting the entire portal.
+
+## IDP Maturity Stages and Platform Roadmaps
+
+Teams rarely jump from zero to a fully pluginized portal in one quarter. A durable maturity model helps you sequence investments and communicate progress without overpromising instant self-service nirvana. **Stage one—catalog truth**—focuses on ownership, lifecycle, and repository linkage for production services, usually via `catalog-info.yaml` in repos plus CI lint rules. **Stage two—paved creation**—adds templates for the top three service types your organization actually ships, not the twenty types architects wish existed. **Stage three—operational line-of-sight**—embeds CI, GitOps, and incident context on entity pages so developers stop opening six tabs for a deploy verification. **Stage four—ecosystem automation**—connects templates to downstream controllers (secrets, clusters, databases) with clear boundaries about which system mutates state.
+
+Each stage produces user-visible wins, which protects the portal during budget conversations. Leadership dashboards love entity counts; developers love shaving minutes off recurring tasks. Translate maturity into both languages. When a stage stalls, diagnose whether metadata quality, template maintenance, or plugin reliability blocked progress—those are different remediation projects.
+
+Roadmaps should also name **non-goals**. Backstage will not replace your service mesh control plane, your cloud billing system, or your HR portal. Saying no prevents scope creep that turns the platform team into a generic web CRUD shop. Non-goals still allow deep links—billing dashboards can appear as catalog links without re-implementing FinOps analytics inside Backstage.
+
+## Catalog Descriptor Standards in Practice
+
+Publishing a descriptor standard document transforms catalog work from art to engineering. The standard lists required and optional metadata fields, annotation keys, tag vocabularies, and examples for each service tier. It explains how `lifecycle: experimental` differs from `production` in terms of SLO expectations and required integrations. New hires read the standard once instead of inferring conventions from whichever repository was copied most recently.
+
+Standards pair with **lint automation**. CI jobs can validate `catalog-info.yaml` with JSON Schema or custom scripts, failing pull requests that omit owners or use deprecated annotation keys. Backstage validators add another layer server-side, but client-side lint gives faster feedback. When standards change, provide codemods or scripted migrations for high-value repositories rather than expecting manual edits across thousands of repos overnight.
+
+Descriptor standards also clarify **API versus Component** modeling decisions so dependency graphs stay legible at scale. When every HTTP surface becomes its own Component without API entities, graphs look dense but say little about contract stability. When API entities are missing entirely, consumers cannot discover breaking-change policies. The standard should include decision trees: if more than two services consume an interface maintained by a platform team, promote an API entity with an OpenAPI spec link.
+
+## Plugin Integration Patterns for GitHub, Argo CD, and PagerDuty
+
+GitHub integration typically serves dual purposes: catalog location discovery and scaffolder repository publishing. Use separate credentials or GitHub Apps with narrowly scoped permissions for each purpose so a compromised scaffolder token cannot rewrite unrelated repositories. Rate-limit monitoring belongs on your platform dashboard because large org imports can exhaust REST quotas during business hours if processors rerun aggressively.
+
+Argo CD plugins usually fetch application health and sync status for entities annotated with application names or labels. Align annotation conventions with how your GitOps repos name Applications—if teams use App-of-Apps patterns, document how entity pages map to the correct Application resource. Read-only tokens suffice for status panels; mutating syncs from Backstage should remain rare and heavily audited because GitOps principles expect Git to remain the desired-state source.
+
+PagerDuty integration connects services to on-call schedules and open incidents. Map catalog components to PagerDuty service IDs via annotations validated in CI so pages route correctly during outages. During incident response, responders benefit from seeing upstream dependencies in the catalog graph while viewing PagerDuty escalation policies in the same UI. Avoid duplicating PagerDuty as a manual on-call spreadsheet stored in catalog descriptions—that data rots within weeks.
+
+Together these three integrations cover the toolchain outcome in this module’s learning objectives: code hosting, deployment health, and incident routing appear beside the same entity without pretending Backstage owns those workflows. When any integration fails, degrade gracefully and link out to the native tool so developers are never blocked from executing emergency actions.
+
+## Local Development to Production Promotion
+
+The journey from `yarn dev` on a laptop to a hardened production deployment teaches platform engineers where Backstage differs from a static internal wiki. Local setups tolerate SQLite, guest users, and permissive CORS; production requires PostgreSQL backups, authenticated SSO, ingress TLS, and secrets injected from vaults rather than dotfiles. Document this promotion path so application teams do not copy local `app-config` snippets containing development credentials into staging clusters.
+
+Container images should pin Backstage version tags matching your tested upgrade path—track upstream release notes for breaking changes to UI tokens, catalog stitching, and scaffolder APIs. Helm charts or raw Kubernetes manifests both work; choose based on your platform standards. Health checks should hit backend readiness endpoints that verify database connectivity, not merely TCP socket openness on the frontend port.
+
+Environment-specific configuration overlays let you run the same container image in staging and production with different integration endpoints. Staging should mirror plugin enablement so teams catch breaking API changes before customer-facing developer traffic hits production. Automate smoke tests that create ephemeral template runs against sandbox GitHub organizations where possible, preventing scaffolder regressions from blocking service creation on Monday mornings.
+
+Promotion also includes **content** promotion: catalog location entries, template YAML, and TechDocs standards should live in Git repositories reviewed like application code. Platform teams that click-edit production catalog entries without version control recreate the drift problems Backstage was meant to solve. GitOps for portal configuration keeps audit trails and enables rollback when a template change accidentally removes compliance workflows.
+
+When you train internal champions, emphasize that Backstage rewards consistent metadata more than heroic customization. A plain entity page with accurate owner, working TechDocs, and trustworthy CI status beats a flashy homepage widget that rots after one release cycle. Champions should pair with service teams during their next launch, co-author `catalog-info.yaml`, and measure whether onboarding questions drop the following week—that qualitative signal often precedes formal portal analytics and keeps adoption grounded in real developer pain relief rather than executive dashboard vanity metrics.
+
+Finally, remember that portal success is measured in **workflow completion**, not portal logins alone. Track whether developers finish template runs, merge scaffolded repos, and reach TechDocs from incident channels. Those behavioral traces validate that the IDP spine—catalog, docs, templates, plugins—is wired into daily work instead of existing as an optional sidebar bookmark. When metrics stall, return to interviews and remove steps before buying another plugin bundle.
+
+Platform leaders sometimes ask whether to build an in-house portal instead of adopting Backstage. The build-versus-adopt decision hinges on whether your differentiator is the portal shell or the standards encoded in catalog descriptors, templates, and docs pipelines. Backstage gives you a maintained framework for the shell; your organizational value still lives in the metadata and automation you inject. Forking the entire UI rarely ages well unless you plan a dedicated product team with a multi-year roadmap competitive with upstream velocity.
+
+Treat every catalog field and template parameter as a **policy lever**: small YAML decisions ripple across search, access control, compliance exports, and plugin renderers. Document why each required field exists so teams do not strip metadata during rushed launches. Review those levers quarterly with security and developer experience stakeholders across every product team so the portal stays aligned with how your organization actually ships software today, not how architecture slides imagined it last year during annual planning season.
+
+## Did You Know?
+
+1. **CNCF timeline:** Backstage joined CNCF on **September 8, 2020**, reached **Incubating** status on **March 15, 2022**, and—as of the 2026-06 snapshot—remains an **Incubating** project rather than Graduated ([CNCF project page](https://www.cncf.io/projects/backstage/)).
+
+2. **Framework, not a single app:** Upstream ships a create-app scaffold and plugin ecosystem; every organization customizes routes, auth, and plugins. Two Backstage installations can look like different products while sharing the same core catalog/scaffolder concepts.
+
+3. **TechDocs pipeline:** Documentation builds can run locally for fast feedback or externally in CI with published artifacts—choose based on doc size and build-time secrets; both patterns are documented in Backstage TechDocs guides.
+
+4. **Scaffolder actions are composable:** Platform teams chain actions (fetch template, publish, register catalog, send webhook) similarly to CI jobs, which makes templates a workflow engine for golden paths rather than a static cookiecutter wrapper.
 
 ## Common Mistakes
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| Not defining ownership | "Who owns this?" still unanswered | Require owner in all catalog entries |
-| Templates without CI/CD | Golden path doesn't include deployment | Include full pipeline in templates |
-| Stale catalog data | Entities don't reflect reality | Auto-discovery + entity processors |
-| Too many entity types | Confusing taxonomy | Start simple, add as needed |
-| No documentation standards | TechDocs quality varies wildly | Provide documentation templates |
-| Ignoring adoption | Build it and they won't come | Measure usage, iterate on UX |
-
----
-
-## War Story: The Portal Nobody Used
-
-*A platform team spent 6 months building a beautiful Backstage deployment. After launch, adoption was 10%.*
-
-**What went wrong**:
-1. Catalog required manual registration (developers didn't bother)
-2. No Software Templates (no immediate value)
-3. No integrations with existing tools (GitHub, Kubernetes)
-4. Launched without documentation
-
-**The fix**:
-1. Enabled GitHub auto-discovery (instant 500+ services in catalog)
-2. Created 3 golden path templates (immediate value)
-3. Added Kubernetes plugin (see deployments in Backstage)
-4. Required catalog-info.yaml in PR checklist
-
-**Adoption after 3 months**: 85%
-
-**Lesson**: Backstage is a product. Treat it like one—understand your users, provide immediate value, iterate based on feedback.
-
----
+| Launching catalog-only | Portal shows empty or stale entities; developers see no time savings | Pair catalog ingestion with templates and at least one high-value plugin tab |
+| Missing `spec.owner` | Ownership queries fail; escalation paths break during incidents | Require owner in templates and CI lint for `catalog-info.yaml` |
+| Templates without CI/CD | Golden paths stop at repository creation; first deploy still manual | Include workflow files and document verification steps in template outputs |
+| Over-complex entity taxonomy | Contributors avoid registering; graph becomes inconsistent | Start with Component/System/Group; expand when pain is proven |
+| Storing long-lived admin tokens in frontend config | Credential exposure via browser-accessible settings | Keep secrets in backend configuration and secret stores |
+| Ignoring catalog processor errors | Silent data loss erodes trust in search and graphs | Monitor backend logs; publish contributor-facing error catalog |
+| Skipping staging upgrades | Production portal breaks on plugin API changes | Maintain staging with production-like plugins; read release notes |
+| Treating plugins as replacements | Teams expect Backstage to own Git or Kubernetes | Document that plugins aggregate external systems of record |
 
 ## Quiz
 
 ### Question 1
-What's the difference between a Component and a System in Backstage?
+Your organization already runs GitHub, Argo CD, and PagerDuty. Where should Backstage sit in the architecture, and what should remain the system of record for code, deployments, and incidents?
 
 <details>
 <summary>Show Answer</summary>
 
-**Component**: A single piece of software (deployable unit)
-- Examples: microservice, website, mobile app, library
-- Has code, can be deployed
-- Owned by a team
-
-**System**: A collection of Components that work together
-- Examples: checkout system, search platform
-- Logical grouping
-- May span multiple teams
-
-Hierarchy: Domain → System → Component
+Backstage should act as an **aggregation and navigation layer**, not a replacement for Git, Argo CD, or PagerDuty. Git remains the source of truth for source code and `catalog-info.yaml`; Argo CD remains the GitOps controller for cluster desired state; PagerDuty remains the incident and on-call system of record. Backstage integrates via backend plugins and proxies, presenting contextual tabs on catalog entities (build status, sync health, on-call rotation) while delegating mutations back to the native tools when actions are required.
 
 </details>
 
 ### Question 2
-How do Software Templates create "golden paths"?
+Explain the difference between a `Component` and a `System`, and describe when you would model an API as its own `API` kind instead of only documenting it inside a Component page.
 
 <details>
 <summary>Show Answer</summary>
 
-Golden paths are opinionated, pre-approved ways to do common tasks:
-
-**Without golden path**:
-1. Developer copies old repo
-2. Removes old code, keeps structure
-3. Misses CI/CD config
-4. Forgets security scanning
-5. Documentation? What documentation?
-
-**With Software Template**:
-1. Developer fills out form in Backstage
-2. Template creates repo with:
-   - Correct structure
-   - CI/CD pipeline
-   - Security scanning
-   - Documentation skeleton
-   - Catalog registration
-3. Ready to code in minutes
-
-Templates encode best practices into the starting point.
+A **Component** is a deployable or maintainable piece of software—typically a service, website, or library—with code repository linkage and lifecycle metadata. A **System** groups related components that deliver a product capability (for example checkout). You model a separate **API** entity when multiple consumers need a stable contract reference, when OpenAPI/AsyncAPI specs should appear as first-class catalog objects, or when ownership of the interface differs from a single implementing component. Keeping APIs explicit improves dependency graphs and clarifies breaking-change communication.
 
 </details>
 
 ### Question 3
-Why should you use GitHub auto-discovery instead of manual catalog registration?
+A developer asks why they should use a Software Template instead of copying an existing repository. How do golden paths reduce risk for the platform team and the developer?
 
 <details>
 <summary>Show Answer</summary>
 
-**Manual registration problems**:
-- Developers forget to add `catalog-info.yaml`
-- Catalog becomes stale
-- Low adoption (extra work)
-- Incomplete service map
-
-**Auto-discovery benefits**:
-- Scans all repos automatically
-- Finds `catalog-info.yaml` files
-- Catalog always up-to-date
-- Higher adoption (less work)
-- Complete picture of services
-
-**Best practice**: Use auto-discovery, but require `catalog-info.yaml` in repo templates and PR checklists.
+Copy-paste inherits hidden debt: outdated CI actions, missing security scans, wrong branch protections, and catalog metadata drift. Templates generate repositories from an approved skeleton with parameterized names, inject current workflow versions, register catalog entries automatically, and can trigger downstream automation. Developers gain speed; platform teams gain **standardization evidence** for audits and easier bulk upgrades because known files exist in every scaffolded repo.
 
 </details>
 
----
+### Question 4
+TechDocs builds are failing intermittently in CI while local `mkdocs serve` works. What configuration areas do you investigate first in a Backstage deployment?
+
+<details>
+<summary>Show Answer</summary>
+
+Compare **builder mode** (`local` vs `external`), publisher storage credentials, TechDocs annotation paths (`backstage.io/techdocs-ref`), and CI job permissions fetching repository content. External builders require published artifacts reachable by the backend; missing S3/GCS permissions or wrong bucket prefixes often manifest as flaky renders. Also verify MkDocs plugin versions match between local and CI containers.
+
+</details>
+
+### Question 5
+Catalog ingestion from GitHub is slow and sometimes incomplete after large org imports. What operational knobs and hygiene practices improve reliability without blaming developers?
+
+<details>
+<summary>Show Answer</summary>
+
+Tune location providers and processing frequency, ensure PAT/GitHub App rate limits are monitored, and split monolithic org imports into focused location targets. Add processors that validate entities and surface errors to contributors. Encourage small, well-formed `catalog-info.yaml` files in each repo rather than one giant manual YAML bundle. Check backend database health and catalog stitching logs after upgrades because deferred stitching can delay relationship graphs.
+
+</details>
+
+### Question 6
+Which Backstage integration points require backend credentials, and why must those credentials avoid frontend `app-config` bundles shipped to browsers?
+
+<details>
+<summary>Show Answer</summary>
+
+GitHub/GitLab discovery, scaffolder publish actions, Kubernetes API queries, Argo CD API calls, and PagerDuty REST access all run **server-side**. Browsers talk to Backstage backend routes; backends hold tokens. Frontend bundles are visible to users and must not embed privileged tokens because any user could extract them from downloaded JavaScript or config JSON exposed to the client.
+
+</details>
+
+### Question 7
+Scenario: leadership wants a single "developer portal" KPI. Propose three measurable metrics tied to IDP outcomes rather than counting raw entity totals.
+
+<details>
+<summary>Show Answer</summary>
+
+Measure **time-to-first-successful-template-run** (self-service efficiency), **percentage of production components with owner + TechDocs + lifecycle set** (metadata quality), and **weekly active developers viewing entity pages tied to services they deploy** (real usage). Raw entity counts are vanity if entities are stale; combine quality and activity metrics to guide plugin and template investments.
+
+</details>
 
 ## Hands-On Exercise
 
 ### Objective
-Deploy Backstage locally and register a service in the catalog.
+Run Backstage locally, register a component with TechDocs metadata, and trace how catalog location configuration connects a repository file to the portal UI.
 
 ### Environment Setup
 
 ```bash
-# Create Backstage app
-npx @backstage/create-app@latest --skip-install
-cd backstage
+# Requires Node 20+ and Yarn (installed by create-app)
+npx @backstage/create-app@latest
+# Accept defaults or name the app backstage-lab
+cd backstage-lab
 yarn install
-
-# Start development server
 yarn dev
+# Frontend typically listens on http://127.0.0.1:3000
+# Backend typically listens on http://127.0.0.1:7007
 ```
 
 ### Tasks
 
-1. **Access Backstage**:
-   - Open http://localhost:3000
-   - Explore the default interface
+1. **Explore the default portal** — open the local URL, navigate to the catalog, and inspect a sample entity to see how tabs organize catalog data, docs, and CI information when demo content is present.
 
-2. **Create catalog entry**:
-   ```yaml
-   # my-service/catalog-info.yaml
-   apiVersion: backstage.io/v1alpha1
-   kind: Component
-   metadata:
-     name: my-first-service
-     description: A sample service for learning Backstage
-     tags:
-       - learning
-       - sample
-   spec:
-     type: service
-     lifecycle: experimental
-     owner: guests
-   ```
+2. **Create a standalone catalog file** — in any directory, author `catalog-info.yaml` for a fictional `Component` with owner `user:default/guest` or a demo group, plus tags and description text.
 
-3. **Register in Backstage**:
-   - Click "Create..." → "Register Existing Component"
-   - Enter path to your `catalog-info.yaml`
-   - Or add to `app-config.yaml`:
-     ```yaml
-     catalog:
-       locations:
-         - type: file
-           target: /path/to/my-service/catalog-info.yaml
-     ```
+3. **Register via file location** — add a `catalog.locations` entry pointing at your YAML file using the `file:` target scheme documented in Backstage catalog configuration, restart if needed, and confirm the entity appears in the catalog index.
 
-4. **Add documentation**:
-   ```yaml
-   # mkdocs.yml
-   site_name: My First Service
-   plugins:
-     - techdocs-core
-   ```
+4. **Add TechDocs metadata** — create `mkdocs.yml` and `docs/index.md` alongside the catalog file, set `backstage.io/techdocs-ref: dir:.`, configure TechDocs builder settings appropriate for local experimentation, and verify the Docs tab renders or note builder logs if external publishing is required.
 
-   ```markdown
-   # docs/index.md
-   # My First Service
-
-   Welcome to my first service documentation!
-   ```
-
-5. **Update catalog entry**:
-   ```yaml
-   metadata:
-     annotations:
-       backstage.io/techdocs-ref: dir:.
-   ```
-
-6. **View in Backstage**:
-   - Navigate to catalog
-   - Find your service
-   - Check the Docs tab
+5. **Integrate one external read-only view** — configure a GitHub integration token on the backend (read-only) or enable a bundled demo plugin following official docs, then confirm a plugin tab or card displays live metadata for your entity without storing the token in frontend-visible config.
 
 ### Success Criteria
-- [ ] Backstage running locally
-- [ ] Component registered in catalog
-- [ ] Can view component details
-- [ ] Documentation renders (if configured)
 
-### Bonus Challenge
-Create a Software Template that scaffolds a simple Node.js service with a README and catalog-info.yaml.
+- [ ] Backstage dev server runs locally with catalog UI reachable in a browser
+- [ ] Custom `Component` entity appears after location registration
+- [ ] Entity shows owner, description, and tags you authored
+- [ ] TechDocs tab renders Markdown or you captured backend logs explaining required publisher setup
+- [ ] At least one backend integration is configured with credentials stored server-side only
 
----
+### Verification
 
-## Further Reading
+```bash
+# Confirm backend health endpoint responds
+curl -sS http://127.0.0.1:7007/api/catalog/health
 
-- [Backstage Documentation](https://backstage.io/docs/)
-- [Backstage Plugin Marketplace](https://backstage.io/plugins)
-- [Spotify Engineering Blog - Backstage](https://engineering.atspotify.com/tag/backstage/)
-- [CNCF Backstage Project](https://www.cncf.io/projects/backstage/)
+# After registering locations, query entities (adjust filter as needed)
+curl -sS "http://127.0.0.1:7007/api/catalog/entities?filter=kind=component" | head
+```
 
----
+## Sources
+
+- https://backstage.io/docs/overview/what-is-backstage
+- https://backstage.io/docs/getting-started/
+- https://backstage.io/docs/features/software-catalog/
+- https://backstage.io/docs/features/software-catalog/descriptor-format/
+- https://backstage.io/docs/features/software-templates/
+- https://backstage.io/docs/features/techdocs/
+- https://backstage.io/docs/plugins/
+- https://backstage.io/docs/auth/
+- https://backstage.io/docs/conf/
+- https://github.com/backstage/backstage
+- https://github.com/backstage/backstage/releases/tag/v1.52.0
+- https://www.cncf.io/projects/backstage/
+- https://engineering.atspotify.com/2020/03/what-the-heck-is-backstage-anyway/
 
 ## Next Module
 
-Continue to [Module 7.2: Crossplane](../module-7.2-crossplane/) to learn infrastructure provisioning using Kubernetes-native APIs.
+Continue to [Module 7.2: Crossplane](../module-7.2-crossplane/) to learn how Kubernetes-native control planes provision infrastructure that your portal can expose through templates and catalog entities.
 
 ---
 
-*"The best developer experience is one where developers don't think about infrastructure. Backstage makes that possible."*
+*"An internal developer portal succeeds when developers finish real tasks faster—not when architects admire a catalog graph."*

--- a/src/content/docs/platform/toolkits/infrastructure-networking/platforms/module-7.2-crossplane.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/platforms/module-7.2-crossplane.md
@@ -1,272 +1,152 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 7.2: Crossplane"
 slug: platform/toolkits/infrastructure-networking/platforms/module-7.2-crossplane
 sidebar:
   order: 3
 ---
-> **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 50-60 minutes
+> **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 75-90 minutes
 
 ## Overview
 
-Terraform in CI pipelines. CloudFormation templates. Manual console clicks. Infrastructure provisioning is fragmented. Crossplane unifies it by extending Kubernetes with cloud provider APIs—provision AWS RDS, GCP Cloud SQL, or Azure CosmosDB using `kubectl apply`. Infrastructure as Kubernetes resources.
+Crossplane is easiest to understand if you stop thinking of it as "Terraform, but in Kubernetes" and start thinking of it as a framework for building control planes. Kubernetes gave platform teams a powerful pattern: users declare the state they want, controllers compare that desired state with the real world, and reconciliation keeps moving the system toward the declared target. Crossplane applies that pattern beyond pods and services. A platform team can define a stable internal API such as `XDatabase`, `XCluster`, or `XQueue`, then connect that API to cloud resources, Kubernetes resources, or other operational objects through controllers and composition functions.
 
-**What You'll Learn**:
-- Crossplane architecture and providers
-- Managed Resources and Compositions
-- Building self-service infrastructure APIs
-- GitOps for infrastructure
+The durable lesson is not that every infrastructure task should move into Crossplane. Some teams should keep Terraform, Pulumi, CloudFormation, Bicep, or service-specific workflows for parts of their estate. The durable lesson is that platform engineering often needs a product API, not merely a provisioning script. When application teams request infrastructure through a clear Kubernetes-style API, the platform team can centralize guardrails, defaults, ownership labels, deletion behavior, and status reporting while still giving developers a self-service workflow. Crossplane is one way to build that API on top of Kubernetes primitives instead of inventing a separate request system.
 
-**Prerequisites**:
-- [Platform Engineering Discipline](/platform/disciplines/core-platform/platform-engineering/)
-- Kubernetes Custom Resource Definitions (CRDs)
-- Basic cloud provider knowledge (AWS/GCP/Azure)
-
----
+This module teaches the control-plane spine first: resources, reconciliation, providers, composite resource definitions, compositions, functions, readiness, deletion semantics, and GitOps ownership. The dated facts sit in one snapshot so they can be refreshed without rewriting the lesson. You will use Crossplane as the worked example, but the mental model should also help you evaluate Terraform controllers, Pulumi operators, cloud-native provisioning systems, and internal developer portal templates without turning the comparison into a vendor ranking.
 
 ## What You'll Be Able to Do
 
-After completing this module, you will be able to:
+- Explain Crossplane reconciliation and control-plane ownership without reducing the tool to "cloud resources in YAML."
+- Design a narrow platform API with composite resources and compositions that hide provider churn behind a stable contract.
+- Compare Crossplane with Terraform, Pulumi, and provider-native stacks using Rosetta tradeoffs instead of ranking claims.
+- Validate a composition render and explain user input versus platform-owned defaults before a composition reaches a live cluster.
 
-- **Deploy Crossplane and configure providers for managing cloud resources as Kubernetes custom resources**
-- **Implement Composite Resources (XRDs) and Compositions for self-service infrastructure abstractions**
-- **Configure Crossplane claims for developer-friendly infrastructure provisioning with guardrails**
-- **Compare Crossplane's Kubernetes-native approach against Terraform for platform team infrastructure APIs**
+You will also be able to recognize the most dangerous Crossplane failure modes before they reach production. Those failure modes are rarely caused by the idea of reconciliation itself. They usually come from exposing provider resources too directly, hiding destructive deletion behavior, failing to map useful status back to the user-facing API, treating secrets as an afterthought, or assuming that because a resource is represented in Kubernetes it automatically has good lifecycle ownership.
 
+## Current Landscape
+
+**Landscape snapshot - as of 2026-06-17. Verify these facts against upstream sources before relying on them in production plans, audits, or migration documents.**
+
+| Fact | Snapshot |
+|------|----------|
+| CNCF maturity | Crossplane is CNCF Graduated. The CNCF project page lists the Graduated maturity level on October 28, 2025. |
+| Current Crossplane release | GitHub releases list Crossplane `v2.3.2`, published on 2026-06-09. |
+| Current documentation line | The public Crossplane documentation is labeled Crossplane v2.3. |
+| Important v2 API posture | Crossplane v2 makes composite resources and managed resources namespaced, removes native patch-and-transform composition in favor of functions, and keeps backward compatibility paths for v1-style resources. |
+| Worked lab package | The hands-on exercise pins function-patch-and-transform to `v0.10.7`, published on 2026-06-05, because package tags are volatile and must be explicit. |
+
+The snapshot matters because Crossplane's surface moves in two independent ways: the core project changes, and provider packages change. A platform API should not expose either churn path directly to application teams. If your developer-facing contract says `engine: postgres` and `size: small`, you can update provider fields, package tags, naming conventions, or cloud-specific defaults behind that contract with less coordination cost. If your developer-facing contract exposes every raw provider field, every provider change becomes every application's problem.
+
+Current Crossplane work should be read through the v2 lens unless you are maintaining an older installation. Many examples on the internet still teach a claim-first path because that was the common teaching pattern in earlier material. That does not make the examples useless, but it does mean you should translate them carefully. The durable idea is still "create a small API and compose resources behind it." The current implementation detail is that new v2-style XRs are namespaced, while v1-style claims are a compatibility concept rather than the default starting point for new product APIs.
+
+Another important landscape point is that Crossplane is not only a cloud-provider bridge. Providers can manage external systems, but composition can also render Kubernetes resources and third-party custom resources when the control plane has permission. That matters for internal developer platforms because a useful product API often spans more than one system. A "database product" might create a cloud database, a network policy, a service binding secret, a monitoring rule, and an operational annotation. Crossplane gives you one reconciliation surface for that bundle, but you still have to decide whether Crossplane should own each part.
 
 ## Why This Module Matters
 
-Platform engineers shouldn't be bottlenecks. When every database request requires a Terraform PR reviewed by the platform team, you don't scale. Crossplane lets you define self-service infrastructure APIs—developers get what they need (databases, buckets, queues) without ticket queues or manual provisioning.
+Many infrastructure workflows start with good intentions and drift into queues. A developer needs a database for a service. The platform team asks for a ticket with size, region, backup policy, environment, network, ownership, and compliance details. Someone turns that into Terraform or a cloud console change. Someone else reviews it. Credentials are copied into a secret. A month later, staging and production differ because a hotfix happened outside the normal path. Nobody was trying to build a slow system; the workflow simply lacked a product-shaped API.
 
-> 💡 **Did You Know?** Crossplane was created by Upbound, founded by former Google engineers who worked on Kubernetes. The project is now a CNCF incubating project. Its key insight: Kubernetes already solved the control loop problem—why reinvent it for infrastructure? Crossplane uses the same reconciliation pattern for cloud resources.
+Crossplane gives platform engineers a way to turn common infrastructure requests into Kubernetes APIs. The platform team still owns the hard decisions: which cloud resource is created, which tags are required, what backup policy is safe, how deletion works, where connection details land, and what status the developer can observe. The application team gets a smaller contract. They ask for a capability, not for every vendor-specific knob underneath it. That is the same product thinking behind a good internal developer platform: expose the choice that matters to the user and hide the details that should be centrally governed.
 
----
+The analogy is a restaurant menu. A good menu does not expose the vendor catalog for every ingredient, the oven temperature curve, and the supplier contract. It offers stable dishes with useful options: size, spice level, dietary constraints, and sides. The kitchen still has recipes, equipment, and procurement work behind the counter. Crossplane compositions are the recipes, providers are the kitchen tools, managed resources are the ingredients being prepared, and composite resources are the menu items that customers can order without learning the whole kitchen.
 
-## The Infrastructure Problem
+## The Durable Control-Plane Model
 
-```
-TRADITIONAL INFRASTRUCTURE PROVISIONING
-════════════════════════════════════════════════════════════════════
-
-Developer needs database:
-
-1. Creates Jira ticket: "Need PostgreSQL database"
-2. Waits for platform team to see ticket (hours/days)
-3. Platform engineer writes Terraform
-4. PR review, approval process
-5. Terraform apply (maybe in separate pipeline)
-6. Platform engineer shares credentials with developer
-7. Developer can finally use database
-
-Time: Days to weeks
-Problems: Bottleneck, manual steps, drift between environments
-
-═══════════════════════════════════════════════════════════════════
-
-WITH CROSSPLANE
-════════════════════════════════════════════════════════════════════
-
-Developer needs database:
-
-1. Applies YAML:
-   kubectl apply -f database.yaml
-
-2. Crossplane provisions in cloud
-3. Secret with credentials auto-created
-4. Developer uses database
-
-Time: Minutes
-Benefits: Self-service, GitOps, consistent, no bottleneck
-```
-
----
-
-## Architecture
+Crossplane is built on the same reconciliation model that makes Kubernetes useful. A user creates an object that represents desired state. A controller observes that object, compares it with external state, and takes action until the observed world matches the desired declaration. The object also carries status, conditions, references, and events so humans and automation can understand progress. This model is durable because it is about feedback loops and contracts, not about one specific cloud API or package version.
 
 ```
-CROSSPLANE ARCHITECTURE
-════════════════════════════════════════════════════════════════════
+DECLARE -> RECONCILE -> OBSERVE -> REPORT -> RECONCILE AGAIN
 
-┌─────────────────────────────────────────────────────────────────┐
-│                    KUBERNETES CLUSTER                            │
-│                                                                  │
-│  ┌────────────────────────────────────────────────────────────┐ │
-│  │                    CROSSPLANE CORE                          │ │
-│  │                                                             │ │
-│  │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐        │ │
-│  │  │ Composition │  │  Package    │  │   RBAC      │        │ │
-│  │  │  Controller │  │  Manager    │  │  Controller │        │ │
-│  │  └─────────────┘  └─────────────┘  └─────────────┘        │ │
-│  └────────────────────────────────────────────────────────────┘ │
-│                              │                                   │
-│  ┌────────────────────────────▼───────────────────────────────┐ │
-│  │                       PROVIDERS                             │ │
-│  │                                                             │ │
-│  │  ┌───────────┐  ┌───────────┐  ┌───────────┐              │ │
-│  │  │  AWS      │  │   GCP     │  │   Azure   │              │ │
-│  │  │ Provider  │  │ Provider  │  │  Provider │              │ │
-│  │  └─────┬─────┘  └─────┬─────┘  └─────┬─────┘              │ │
-│  │        │              │              │                     │ │
-│  └────────┼──────────────┼──────────────┼─────────────────────┘ │
-│           │              │              │                       │
-└───────────┼──────────────┼──────────────┼───────────────────────┘
-            │              │              │
-            ▼              ▼              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                       CLOUD PROVIDERS                            │
-│                                                                  │
-│      AWS               GCP                Azure                 │
-│  (RDS, S3, etc)   (Cloud SQL, GCS)    (CosmosDB, etc)          │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
+User or GitOps tool
+  applies desired state
+        |
+        v
+Kubernetes API stores resource
+        |
+        v
+Crossplane controller/function/provider
+  compares desired state with actual state
+        |
+        v
+External resource or composed Kubernetes object
+        |
+        v
+Status, conditions, events, and connection details
+  flow back to the resource contract
 ```
 
-### Key Concepts
+There are two control-plane questions you should ask before adopting Crossplane for a workflow. First, is the thing you are managing naturally long-lived and declarative? Databases, buckets, queues, clusters, network attachments, DNS zones, and operational policies often fit. One-time imperative tasks can fit only when modeled as operations, jobs, or explicit lifecycle steps. Second, does a platform-owned API reduce cognitive load for users? If every consumer still needs to know the full cloud resource model, Crossplane may have moved the problem into Kubernetes without creating a better product.
 
-| Concept | Description |
-|---------|-------------|
-| **Provider** | Plugin that talks to cloud API (AWS, GCP, Azure) |
-| **Managed Resource** | Direct mapping to cloud resource (RDS instance, S3 bucket) |
-| **Composition** | Template that combines multiple resources |
-| **Composite Resource (XR)** | Custom API that triggers a Composition |
-| **Claim (XRC)** | Namespace-scoped request for a Composite Resource |
+The control-plane model also makes drift visible in a different way from a pull-request-only IaC pipeline. Terraform or Pulumi generally compare declared state to real state when a plan runs. Crossplane controllers reconcile continuously while the control plane is running. Continuous reconciliation can be powerful, but it also means ownership must be explicit. If a human changes a cloud resource directly, Crossplane may change it back. If another tool owns the same field, the tools can fight. A good design states which system owns which resource and which fields are intentionally left outside the Crossplane contract.
 
----
+Reconciliation is not magic; it is a loop with memory, permissions, and failure modes. The API server stores the user's desired state, but the controller needs credentials and logic to act on that desired state. The external API may be slow, eventually consistent, rate limited, or temporarily unavailable. The provider may create an external resource but fail to publish a useful status field on the first pass. A good platform design expects the loop to take time and gives users observable status instead of pretending provisioning is an instant command.
 
-## Installation
+The strongest Crossplane APIs use reconciliation to reduce operational anxiety. A user can ask for a capability and watch the resource move through conditions instead of asking which pipeline is running. A platform engineer can reason about drift through the resource owner instead of searching through scattered scripts. An incident responder can inspect the composite, composed resources, events, and provider logs to understand whether the problem is schema validation, composition rendering, provider credentials, cloud quota, external API failure, or an application expectation mismatch.
 
-```bash
-# Install Crossplane via Helm
-helm repo add crossplane-stable https://charts.crossplane.io/stable
-helm repo update
+The weakest Crossplane APIs use reconciliation to hide decisions that should be explicit. If the composition silently chooses different backup policies per namespace, the platform becomes mysterious. If deletion behavior is encoded only in a low-level provider resource, reviewers may miss it. If provider credentials are broad and status is vague, the API looks simple while the blast radius remains large. Reconciliation should make the operating model clearer, not merely move hidden complexity behind a custom resource.
 
-helm install crossplane crossplane-stable/crossplane \
-  --namespace crossplane-system \
-  --create-namespace
+## Key Concepts
 
-# Wait for Crossplane
-kubectl wait --for=condition=ready pod -l app=crossplane -n crossplane-system --timeout=120s
+Crossplane has a small set of concepts that show up again and again. The names matter less than the boundaries between them. A provider knows how to talk to an external API or resource family. A managed resource is a Kubernetes representation of a concrete thing such as a bucket, database instance, network rule, or hosted service. A composite resource definition defines a new platform API. A composition defines how an instance of that API turns into one or more composed resources. A composition function performs the rendering or transformation work inside a composition pipeline.
 
-# Verify
-kubectl get pods -n crossplane-system
-```
+| Building block | Durable job | What to watch |
+|----------------|-------------|---------------|
+| Provider | Extends Crossplane with resource controllers for an external system or resource family. | Provider packages and API groups change over time, so avoid exposing them as the developer contract. |
+| Managed resource | Represents a concrete managed thing with `spec.forProvider`, status, conditions, and lifecycle policy. | Direct managed resources are powerful but often too detailed for application teams. |
+| Composite resource definition | Creates the platform-owned API shape, including group, kind, scope, schema, and versions. | The schema is your product contract, so keep it small, stable, and intentionally versioned. |
+| Composite resource | A user-created instance of that platform API, such as an `XDatabase` in a team namespace. | The resource should show useful status and avoid leaking provider internals unless they are genuinely needed. |
+| Composition | Connects the platform API to one or more rendered resources through a pipeline. | Composition logic should encode defaults and guardrails, not every possible provider option. |
+| Function | Runs a composition pipeline step that renders or transforms resources. | Functions are packages with versions, permissions, inputs, and operational behavior that must be reviewed like other controllers. |
 
-### Install Provider
+In Crossplane v2, namespaced composite resources are the current mainline pattern. That is a significant shift from older claim-centered examples. Claims still matter when you are maintaining v1-style APIs or reading older content, but a new design should start by asking whether a namespaced XR gives the team the isolation and RBAC boundary they need. The practical effect is that the developer can create the platform resource in their namespace, while the platform team controls which API exists and how it is composed.
+
+The first concept to internalize is that an XRD is not just a schema file. It is a platform product boundary. When you add a field, you are creating a promise that someone may automate against. When you remove a field, change an enum, or reinterpret a size class, you may break a deployment workflow even if the underlying provider would accept the new value. Treat XRD versioning with the same seriousness you would apply to an HTTP API used by many teams.
+
+The second concept is that a composition is not just a template. It is a policy-bearing implementation of the product boundary. It chooses resource names, provider references, deletion behavior, tags, labels, status mapping, readiness logic, and sometimes environment-specific differences. Because it is executable platform behavior, composition review should ask both "does this render?" and "does this encode the contract we want?" A syntactically valid composition can still be a bad product if it exposes the wrong knobs or hides the wrong decisions.
+
+The third concept is that provider packages are integrations, not neutral plumbing. They translate Kubernetes desired state into external API calls, and they evolve as the external API and provider project evolve. You should test provider upgrades with real sample resources, inspect release notes, and maintain rollback plans. If a provider changes a field name or behavior, a well-designed composite API gives you a place to adapt. If application teams use direct managed resources everywhere, the upgrade coordination cost spreads across the organization.
+
+## Cross-Tool Rosetta
+
+Tool comparisons are often framed as "which one wins," but platform engineers need a more durable Rosetta table. Each tool family has a different unit of desired state, execution rhythm, and user interface. The point is not to rank them. The point is to see which tradeoff matches the workflow you are building.
+
+| Capability axis | Crossplane | Terraform or OpenTofu | Pulumi | CloudFormation or Bicep |
+|-----------------|------------|------------------------|--------|-------------------------|
+| Desired-state unit | Kubernetes resources, often custom platform APIs backed by compositions. | Configuration files and state snapshots managed by plans and applies. | Programs that create a resource graph and store state. | Cloud-provider-native templates and stacks. |
+| Execution rhythm | Continuous reconciliation by controllers while the control plane runs. | Plan and apply cycles, usually from a human, CI job, or automation runner. | Program execution from CLI, CI, or automation service. | Provider-managed stack operations. |
+| Developer-facing contract | Can be a small custom API such as `XDatabase` or direct managed resources. | Usually module inputs, variables, and outputs. | Usually language-level components and package interfaces. | Usually template parameters, modules, and stack outputs. |
+| Drift posture | Controller observes and reconciles repeatedly, so ownership conflicts must be managed. | Drift is detected when a plan or drift check runs. | Drift is detected when preview or refresh workflows run. | Drift is detected through provider stack features and checks. |
+| Policy location | Kubernetes admission, RBAC, composition logic, package review, and cloud policy can all apply. | Policy as code around plans, module review, state controls, and cloud policy. | Language review, policy as code, package review, and cloud policy. | Template policies, stack policies, service controls, and cloud policy. |
+| Best fit | Product APIs for long-lived resources that benefit from Kubernetes-native reconciliation. | Broad infrastructure estates where plan review and explicit state workflows are central. | Teams that want infrastructure abstractions in general-purpose languages. | Teams anchored in a cloud provider's native stack lifecycle. |
+| Common trap | Treating raw managed resources as the self-service API and overwhelming users. | Turning every request into a central review queue. | Hiding infrastructure behavior in code that only a few people understand. | Letting provider-specific template details leak into every platform contract. |
+
+The Rosetta table also helps with coexistence. A team might use Terraform for foundational networking, Crossplane for developer self-service databases, Pulumi for a product team's specialized cloud integration, and CloudFormation or Bicep where a provider-native stack is already the cleanest boundary. The important design choice is ownership. If Terraform owns a VPC, Crossplane should not independently mutate the same VPC fields. If Crossplane owns a database instance, the Terraform module should not also manage that database's lifecycle. Multiple tools can coexist when the resource boundary is explicit.
+
+The most useful Rosetta question is "where does the feedback loop run?" In Terraform and OpenTofu, the loop normally runs when a plan or apply executes, so the review artifact is central. In Crossplane, the loop runs continuously in the cluster, so the resource contract and controller permissions are central. In Pulumi, the loop is expressed through program execution, so language review and state handling are central. In provider-native stacks, the cloud provider's stack engine is central. None of those loops is inherently more mature for every problem; each creates a different review, audit, and incident response shape.
+
+The second Rosetta question is "who is the customer?" A platform team may be comfortable reviewing Terraform modules, but a service team may need a smaller interface. A product team with strong TypeScript or Python skills may prefer Pulumi components for its own infrastructure, while a central platform team may prefer Crossplane for shared self-service APIs. A cloud team may prefer provider-native stacks for tightly integrated services. The tool decision should follow the user, ownership boundary, and operational loop, not a generalized claim about which tool is fashionable.
+
+The third Rosetta question is "what happens when the desired state is wrong?" Every tool can faithfully create a bad design. Crossplane may continuously reconcile a harmful setting. Terraform may apply a destructive plan. Pulumi may hide a risky change behind a component abstraction. A cloud stack may delete a nested resource because the template changed. Mature platform work assumes the desired state can be wrong and adds review, policy, staging, rendering, previews, and deletion safeguards around the workflow.
+
+## Designing a Platform API
+
+A good Crossplane API starts with the user's job, not with the provider's catalog. Suppose application teams need a relational database for typical services. The platform team could expose every field from a cloud database API, but that would push backup windows, deletion policy, subnet placement, parameter groups, encryption, tags, and engine-specific quirks onto every service team. A better first API might expose `engine`, `size`, `region`, and `highAvailability`, while the composition chooses storage encryption, network placement, labels, backup defaults, and connection-secret format.
+
+That does not mean the API should be childish or underpowered. It means the API should express decisions the consumer is qualified to make. A service team often knows whether it needs PostgreSQL or MySQL, whether the workload is small or large, and which region matches the application. The platform team is usually better positioned to encode retention policy, network reachability, audit tags, secret naming, provider configuration, and safe deletion defaults. Crossplane is useful when it lets each party own the right part of the decision.
+
+Here is a compact v2-style composite resource definition. It is intentionally smaller than a cloud provider database API. The schema is the product interface, so every field should earn its place. You can add versions over time, but changing field meaning after teams depend on it is still a breaking platform change even if Kubernetes accepts the YAML.
 
 ```yaml
-# Install AWS Provider
-apiVersion: pkg.crossplane.io/v1
-kind: Provider
-metadata:
-  name: provider-aws
-spec:
-  package: xpkg.upbound.io/upbound/provider-family-aws:v1.1.0
----
-# Configure credentials
-apiVersion: aws.upbound.io/v1beta1
-kind: ProviderConfig
-metadata:
-  name: default
-spec:
-  credentials:
-    source: Secret
-    secretRef:
-      namespace: crossplane-system
-      name: aws-creds
-      key: credentials
-```
-
-```bash
-# Create credentials secret
-kubectl create secret generic aws-creds \
-  -n crossplane-system \
-  --from-file=credentials=./aws-credentials.txt
-
-# aws-credentials.txt:
-# [default]
-# aws_access_key_id = YOUR_ACCESS_KEY
-# aws_secret_access_key = YOUR_SECRET_KEY
-```
-
----
-
-## Managed Resources
-
-### Direct Cloud Resource Creation
-
-```yaml
-# Create S3 bucket directly
-apiVersion: s3.aws.upbound.io/v1beta1
-kind: Bucket
-metadata:
-  name: my-crossplane-bucket
-spec:
-  forProvider:
-    region: us-west-2
-    tags:
-      Environment: production
-      ManagedBy: crossplane
-  providerConfigRef:
-    name: default
----
-# Create RDS instance directly
-apiVersion: rds.aws.upbound.io/v1beta1
-kind: Instance
-metadata:
-  name: my-database
-spec:
-  forProvider:
-    region: us-west-2
-    instanceClass: db.t3.micro
-    engine: postgres
-    engineVersion: "15"
-    allocatedStorage: 20
-    username: admin
-    passwordSecretRef:
-      name: db-password
-      namespace: default
-      key: password
-    skipFinalSnapshot: true
-  providerConfigRef:
-    name: default
-  writeConnectionSecretToRef:
-    name: db-connection
-    namespace: default
-```
-
-```bash
-# Check status
-kubectl get bucket.s3.aws.upbound.io
-kubectl get instance.rds.aws.upbound.io
-
-# See events
-kubectl describe bucket.s3.aws.upbound.io my-crossplane-bucket
-```
-
-> 💡 **Did You Know?** Crossplane providers are generated from cloud provider APIs. The AWS provider supports 1,000+ resource types—everything AWS offers, from EC2 to SageMaker to IoT. If AWS has an API for it, Crossplane can manage it.
-
----
-
-## Compositions
-
-### Building Custom APIs
-
-Compositions let you create opinionated abstractions. Instead of exposing raw RDS to developers, create a "Database" API with your organization's defaults.
-
-```yaml
-# CompositeResourceDefinition (XRD) - Define the API
-apiVersion: apiextensions.crossplane.io/v1
+apiVersion: apiextensions.crossplane.io/v2
 kind: CompositeResourceDefinition
 metadata:
-  name: databases.platform.example.com
+  name: xdatabases.platform.example.org
 spec:
-  group: platform.example.com
+  scope: Namespaced
+  group: platform.example.org
   names:
-    kind: Database
-    plural: databases
-  claimNames:
-    kind: DatabaseClaim
-    plural: databaseclaims
+    kind: XDatabase
+    plural: xdatabases
   versions:
   - name: v1alpha1
     served: true
@@ -278,513 +158,421 @@ spec:
           spec:
             type: object
             properties:
-              size:
-                type: string
-                enum: ["small", "medium", "large"]
-                description: "Database size"
               engine:
                 type: string
                 enum: ["postgres", "mysql"]
                 default: "postgres"
+              size:
+                type: string
+                enum: ["small", "medium", "large"]
+              region:
+                type: string
+                enum: ["us-east-2", "eu-west-1"]
             required:
-              - size
+            - size
+            - region
           status:
             type: object
             properties:
               endpoint:
                 type: string
-              port:
-                type: integer
----
-# Composition - Define what gets created
-apiVersion: apiextensions.crossplane.io/v1
-kind: Composition
-metadata:
-  name: database-aws
-  labels:
-    provider: aws
-spec:
-  compositeTypeRef:
-    apiVersion: platform.example.com/v1alpha1
-    kind: Database
-
-  patchSets:
-  - name: common-tags
-    patches:
-    - type: FromCompositeFieldPath
-      fromFieldPath: metadata.labels
-      toFieldPath: spec.forProvider.tags
-
-  resources:
-  # Security Group
-  - name: security-group
-    base:
-      apiVersion: ec2.aws.upbound.io/v1beta1
-      kind: SecurityGroup
-      spec:
-        forProvider:
-          region: us-west-2
-          description: Database security group
-          vpcId: vpc-12345678
-    patches:
-    - type: FromCompositeFieldPath
-      fromFieldPath: metadata.name
-      toFieldPath: metadata.name
-      transforms:
-      - type: string
-        string:
-          fmt: "%s-sg"
-
-  # RDS Instance
-  - name: rds-instance
-    base:
-      apiVersion: rds.aws.upbound.io/v1beta1
-      kind: Instance
-      spec:
-        forProvider:
-          region: us-west-2
-          skipFinalSnapshot: true
-          publiclyAccessible: false
-          storageEncrypted: true
-          autoMinorVersionUpgrade: true
-        writeConnectionSecretToRef:
-          namespace: crossplane-system
-    patches:
-    # Map size to instance class
-    - type: FromCompositeFieldPath
-      fromFieldPath: spec.size
-      toFieldPath: spec.forProvider.instanceClass
-      transforms:
-      - type: map
-        map:
-          small: db.t3.micro
-          medium: db.t3.small
-          large: db.t3.medium
-
-    # Map size to storage
-    - type: FromCompositeFieldPath
-      fromFieldPath: spec.size
-      toFieldPath: spec.forProvider.allocatedStorage
-      transforms:
-      - type: map
-        map:
-          small: 20
-          medium: 50
-          large: 100
-
-    # Engine selection
-    - type: FromCompositeFieldPath
-      fromFieldPath: spec.engine
-      toFieldPath: spec.forProvider.engine
-
-    # Connection secret name
-    - type: FromCompositeFieldPath
-      fromFieldPath: metadata.name
-      toFieldPath: spec.writeConnectionSecretToRef.name
-      transforms:
-      - type: string
-        string:
-          fmt: "%s-connection"
-
-    # Expose endpoint to status
-    - type: ToCompositeFieldPath
-      fromFieldPath: status.atProvider.endpoint
-      toFieldPath: status.endpoint
-    - type: ToCompositeFieldPath
-      fromFieldPath: status.atProvider.port
-      toFieldPath: status.port
-
-    connectionDetails:
-    - name: endpoint
-      fromFieldPath: status.atProvider.endpoint
-    - name: port
-      fromFieldPath: status.atProvider.port
-    - name: username
-      fromFieldPath: spec.forProvider.username
-    - name: password
-      fromConnectionSecretKey: attribute.password
+              ready:
+                type: boolean
 ```
 
-### Developer Experience (Using Claims)
+A developer-facing instance should feel like an order form, not like a cloud provider certification exam. This example is still technical because infrastructure is technical, but it is much smaller than the real provider resource. The platform team can attach a composition that maps `small` to the provider's current shape, sets organization tags, chooses backup defaults, and writes status back to the composite resource.
 
 ```yaml
-# Developer applies this simple claim
-apiVersion: platform.example.com/v1alpha1
-kind: DatabaseClaim
+apiVersion: platform.example.org/v1alpha1
+kind: XDatabase
 metadata:
-  name: my-app-db
-  namespace: my-team
+  name: orders-db
+  namespace: team-payments
 spec:
-  size: small
   engine: postgres
-  compositionRef:
-    name: database-aws
-  writeConnectionSecretToRef:
-    name: my-app-db-connection
-```
-
-```bash
-# Check status
-kubectl get databaseclaim -n my-team
-
-# Connection secret created automatically
-kubectl get secret my-app-db-connection -n my-team -o yaml
-```
-
----
-
-## GitOps with Crossplane
-
-```
-GITOPS + CROSSPLANE
-════════════════════════════════════════════════════════════════════
-
-┌─────────────────────────────────────────────────────────────────┐
-│                        GIT REPOSITORY                            │
-│                                                                  │
-│  infrastructure/                                                 │
-│  ├── staging/                                                   │
-│  │   └── database.yaml    # DatabaseClaim (size: small)        │
-│  └── production/                                                │
-│      └── database.yaml    # DatabaseClaim (size: large)        │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              │ ArgoCD syncs
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                    KUBERNETES + CROSSPLANE                       │
-│                                                                  │
-│  DatabaseClaim ──▶ Composition ──▶ RDS Instance                │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-                              │
-                              │ Crossplane provisions
-                              ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                          AWS                                     │
-│                                                                  │
-│  Staging: db.t3.micro, 20GB                                     │
-│  Production: db.t3.medium, 100GB                                │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-### Benefits
-
-1. **Same PR process** for infrastructure and application changes
-2. **Drift detection** - Crossplane reconciles continuously
-3. **Self-service** - Developers can request infrastructure via GitOps
-4. **Audit trail** - Git history shows who changed what
-
----
-
-## Common Patterns
-
-### Multi-Environment Compositions
-
-```yaml
-# Different composition per environment
-apiVersion: platform.example.com/v1alpha1
-kind: DatabaseClaim
-metadata:
-  name: my-db
-spec:
   size: small
-  compositionSelector:
-    matchLabels:
-      environment: production  # Selects production composition
+  region: us-east-2
 ```
 
-### Composition Functions
+The hardest part of this design is deciding what not to expose. A common mistake is to add a field every time a provider supports a field. That creates the appearance of flexibility, but it erodes the platform product. If every consumer can choose backup retention, storage encryption, public accessibility, subnet placement, engine patching, and deletion behavior, the platform has delegated its guardrails away. It may still use Crossplane, but it has not created a safer or easier interface.
+
+Good API design starts with categories of choice. User choices are values the application team understands and can justify, such as region, workload class, or engine family. Platform choices are values the organization wants to standardize, such as encryption, audit labels, network placement, and deletion protection. Negotiated choices are values that require a workflow, such as unusually large size, nonstandard retention, or cross-region replication. Crossplane can represent all three categories, but they should not all look like casual fields in the first version of the XRD.
+
+Versioning is the pressure release valve. If you later discover that `size: large` hides too much variation, create a new version or a new field with a clear migration path. If a provider deprecates a field, change the composition behind the API when you can, and change the public API only when the user's decision actually changed. This is the same discipline used in service APIs: backward compatibility is not a paperwork exercise; it is how you preserve trust in a shared platform.
+
+## Compositions and Functions
+
+The composition is where the product API becomes concrete resources. Crossplane v2 favors function pipelines for composition logic. A function receives the observed composite resource and produces desired composed resources, often using patch-and-transform rules, templates, or custom code. This is more flexible than old native patch-and-transform fields, but it also means functions are part of your trusted platform runtime. They should be pinned, reviewed, and upgraded intentionally.
+
+The following snippet shows the shape of a pipeline composition using function-patch-and-transform. It renders a simple `ConfigMap` contract instead of a live cloud database so you can study the mechanics without needing cloud credentials. In a real platform, the base resource might be a provider managed resource, a CloudNativePG cluster, a secret, a service binding object, or another Kubernetes resource that Crossplane has permission to compose.
 
 ```yaml
-# Use Composition Functions for complex logic
 apiVersion: apiextensions.crossplane.io/v1
 kind: Composition
 metadata:
-  name: database-with-backup
+  name: xdatabase-contract
 spec:
   compositeTypeRef:
-    apiVersion: platform.example.com/v1alpha1
-    kind: Database
+    apiVersion: platform.example.org/v1alpha1
+    kind: XDatabase
   mode: Pipeline
   pipeline:
-  - step: create-resources
+  - step: render-contract
     functionRef:
       name: function-patch-and-transform
     input:
       apiVersion: pt.fn.crossplane.io/v1beta1
       kind: Resources
       resources:
-      - name: database
+      - name: database-contract
         base:
-          apiVersion: rds.aws.upbound.io/v1beta1
-          kind: Instance
-          # ...
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            namespace: default
+          data:
+            engine: ""
+            size: ""
+            region: ""
+            deletionPolicy: "Orphan"
+        patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.engine
+          toFieldPath: data.engine
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.size
+          toFieldPath: data.size
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.region
+          toFieldPath: data.region
 ```
 
-> 💡 **Did You Know?** Crossplane Composition Functions allow you to write custom logic in any language. You can create functions in Go, Python, or even call external APIs during composition. This enables complex scenarios like "if production, add read replicas" that would be impossible with static templates.
+This example looks modest, but it teaches the key boundary. The user owns the `XDatabase` fields. The platform composition owns how those fields become concrete resources. In a production composition, you would also think about readiness checks, connection details, status patches, provider configuration references, deletion policy, resource naming, environment-specific selection, and RBAC for any non-Crossplane resources the pipeline creates.
 
-> 💡 **Did You Know?** Crossplane's "provider families" dramatically simplified multi-cloud setups. Before, each AWS service had its own provider package. Now, `provider-family-aws` installs a lightweight base, and you add only the service providers you need (RDS, S3, etc.). This reduced memory usage from gigabytes to megabytes for large installations—making Crossplane practical for clusters with hundreds of CRDs.
+Composition review has a different flavor from application code review. You are not only checking whether the YAML is valid. You are checking whether the rendered resources preserve the product contract, whether user input can escape intended bounds, whether composed resources have stable ownership, whether status will be understandable, and whether a future provider change can be absorbed without breaking users. This is why local rendering is useful: it gives reviewers a concrete output to discuss before the composition runs with real credentials.
 
----
+Function pipelines also create a supply-chain surface. A function package can contain logic that changes rendered resources, reads observed state, or participates in operational workflows. That does not make functions unsafe by default, but it means "we installed a function" should be treated like "we installed a controller." Pin the package, know who maintains it, read release notes, test upgrades, and restrict who can change function definitions in the cluster. A composition function is part of your platform's trusted computing base.
+
+## Direct Managed Resources Versus Product APIs
+
+Crossplane lets you create managed resources directly. That is useful for platform engineers, experiments, imports, and specialized teams that truly need the provider's detailed shape. Direct managed resources are also a good way to learn a provider because they show the close mapping between a Kubernetes object and an external API. The danger is turning that low-level mapping into the primary developer experience for everyone.
+
+The difference is similar to using a standard library versus exposing assembly instructions to every application team. Direct managed resources are precise and powerful, but they force the user to understand provider-specific fields, lifecycle consequences, and failure messages. Composite resources create a smaller language that fits your organization. When a developer asks for a `small` database, the platform team can translate that into today's provider shape and change the translation later without changing every application manifest.
+
+Use direct managed resources when the consumer is the platform team, when the resource is uncommon enough that a product API would be premature, or when you are importing and observing existing infrastructure before deciding how to productize it. Use composite resources when multiple teams need the same pattern, the organization wants guardrails, and the platform team can commit to owning the API as a supported product.
+
+There is a useful middle stage between direct resources and a full product API. Platform engineers can first model a resource directly to learn provider behavior, status fields, deletion behavior, and failure messages. They can then wrap the repeated parts in a composition after they understand which options matter. This avoids premature abstraction. A rushed abstraction can be worse than a raw resource because it hides details before the platform team understands them well enough to hide them safely.
+
+Brownfield adoption needs the same patience. Existing databases, buckets, and networks often have settings that do not match the desired future template. If Crossplane immediately takes full ownership, it may try to "fix" differences that are intentional or too risky to change in place. A staged approach can observe first, import carefully, adopt selected fields, and then move future resources to the standard API. The right question is not "can Crossplane manage this object?" but "what exact behavior do we want during adoption, drift, and deletion?"
+
+## GitOps and Ownership
+
+Crossplane resources are Kubernetes resources, so GitOps tools can apply them like other manifests. That is attractive because application and infrastructure requests can share a review path. A team can open a pull request that adds a service deployment and an `XDatabase` instance. Argo CD or Flux applies the resource. Crossplane reconciles the backing resources. The resulting status, conditions, and connection details become part of the cluster's observable state.
+
+```
+Git repository
+  apps/payments/
+    deployment.yaml
+    xdatabase.yaml
+        |
+        v
+GitOps controller applies manifests
+        |
+        v
+Kubernetes API stores XDatabase
+        |
+        v
+Crossplane composition renders resources
+        |
+        v
+Provider or Kubernetes controller creates backing systems
+        |
+        v
+Status and connection data flow back to the team namespace
+```
+
+GitOps does not remove the need for ownership design. It makes ownership more visible. Decide whether the application repository is allowed to change database size directly, whether production changes require extra review, whether Crossplane resources live beside application manifests or in a separate platform repository, and whether deletion from Git should delete, orphan, or pause external infrastructure. A clean GitOps story includes the deletion story, not just the creation story.
+
+You should also decide how to handle promotion. Some teams keep one manifest and let composition selection choose environment-specific details through labels. Other teams keep separate staging and production overlays because production needs stricter review and different values. Crossplane can support both, but the platform contract should be explicit. A hidden environment switch in composition logic is convenient until a developer cannot tell why staging and production behave differently.
+
+GitOps also changes incident response. If a production resource looks wrong, responders need to know whether the source of truth is the Git manifest, the composite resource, the composition, a provider config, or an external system. A clean platform has a short path from symptom to owner. The application team can inspect its namespaced XR and status. The platform team can inspect the composition revision, rendered resources, provider logs, and package versions. The GitOps team can inspect sync history and pruning behavior. When these responsibilities blur, a simple provisioning delay turns into a long meeting.
+
+A practical pattern is to separate "request manifests" from "implementation packages." Application teams own the manifests that request product APIs in their namespaces. Platform teams own the XRDs, compositions, functions, provider configs, and policies that implement those APIs. GitOps can apply both, but usually from repositories with different review rules. That separation keeps self-service real without making every application repository a place where provider credentials or composition internals can change casually.
+
+## Security and Secrets
+
+Crossplane often sits close to powerful credentials. A provider may need permission to create cloud resources, mutate network settings, read connection details, or manage service accounts. Treat provider credentials as platform-level secrets, not as casual application configuration. The platform team should scope credentials as narrowly as the provider and cloud allow, rotate them, monitor their use, and keep provider configuration objects out of namespaces where application teams can modify them without review.
+
+Connection details deserve equal care. A successful database provision is not useful if the password lands in the wrong namespace, uses an unpredictable key shape, or bypasses the organization's secret-management pattern. Your composite API should define where connection data appears, which keys are stable, who can read them, and how rotation works. If your organization uses an external secret operator, service binding convention, or workload identity pattern, include that in the composition design instead of treating it as a post-provisioning chore.
+
+RBAC is another boundary. Namespaced resources help create team-level isolation, but they do not automatically make every composition safe. If a composition can create arbitrary resources, then a user who controls the composite input may be able to influence more than you intended. Use schema enums, validation, admission policy, and narrow composition logic to keep user input inside the allowed contract. Do not rely on "developers will not ask for unsafe values" as a security control.
+
+Provider credentials should be split by blast radius. A development composition that creates sandbox resources should not need the same cloud identity as a production composition that creates stateful services. If the organization uses multiple cloud accounts or subscriptions, reflect that separation in provider configs and composition selection. This is less convenient than one global credential, but it gives incident responders a smaller question to answer when something goes wrong: which platform API, environment, and provider identity could have taken this action?
+
+Secret delivery should be designed as part of the user journey. Developers should know which secret name or binding object to consume, which keys are stable, and what happens during rotation. Platform engineers should know whether secrets are written by provider managed resources, composed Kubernetes objects, an external secret operator, or another controller. If a composition creates credentials but the application consumes them through a different convention in each environment, Crossplane will appear unreliable even when provisioning is working correctly.
+
+## Deletion, Orphaning, and Adoption
+
+Deletion is where many infrastructure abstractions reveal whether they were designed carefully. A Kubernetes object can disappear quickly. A database, bucket, or cluster may contain production state that should not disappear simply because someone removed a line from a Git repository. Crossplane gives you lifecycle controls such as deletion behavior and management policies, but those controls have to be chosen deliberately and tested in an environment where failure is cheap.
+
+Hypothetical scenario: A platform team launches a `Database` API for internal services. The first version composes a managed database instance and uses a deletion policy that deletes the external resource when the Kubernetes object is deleted. During a repository cleanup, an engineer removes a stale-looking production `Database` manifest, the GitOps controller prunes the object, and Crossplane begins deleting the backing database. The team has backups, but the restore consumes hours, the incident interrupts a launch, and trust in the self-service platform drops. The root cause is not Crossplane; it is an API contract that never explained what deletion meant.
+
+The safer design is explicit. Production data resources often use orphaning, deletion protection, final snapshots, or a separate decommission workflow. Non-production sandboxes may delete automatically to control cost. Imported resources may start with observe-only or limited management until the team is confident that Crossplane owns the right fields. The point is not that one deletion policy is always correct. The point is that deletion behavior is part of the product contract and must be visible to users and reviewers.
+
+Adoption is the mirror image of deletion. When you bring an existing resource under Crossplane management, you are not merely adding a Kubernetes object; you are changing who gets to declare truth. A production resource may have years of manual changes, emergency exceptions, and undocumented dependencies. Before adoption, inspect the external resource, compare it with the desired composition, identify fields that Crossplane will manage, and decide how to handle fields that must remain untouched. A careful import plan can build confidence, while a rushed import can create drift remediation during business hours.
+
+The best decommission flows are boring. They make the user state intent, require the right review for production, preserve data when required, and leave an audit trail. Crossplane can participate in that flow, but it should not be the only guard. Git review, admission policy, deletion protection, final snapshots, backup checks, and runbook steps all have a role. A platform API is not mature because it can create resources quickly; it is mature because it can handle the full lifecycle without surprises.
+
+## Troubleshooting and Operations
+
+Troubleshooting Crossplane starts with the resource contract and then moves inward. First inspect the composite resource the user created. Is the schema accepted? Are conditions present? Does status show a reason or a missing dependency? Then inspect the composition and composition revision. Did the expected composition bind to the resource? Did a function render the composed resources you expected? Then inspect composed resources, provider pods, package health, events, and external API errors. This sequence keeps you from jumping straight into provider logs when the problem is actually an invalid user field or an unselected composition.
+
+Conditions are the shared language between users and operators, but only if you make them useful. A condition that says a resource is not ready without explaining why forces everyone to inspect internals. A status field that exposes an endpoint before the resource is actually usable creates false confidence. A good composition maps enough information back to the composite for the user to answer simple questions: is my request accepted, is provisioning still progressing, what dependency is blocking it, and where will I find connection details when it is ready?
+
+Operational ownership includes package lifecycle. Providers and functions should have owners, upgrade windows, smoke tests, and rollback plans. A provider upgrade can change behavior even when the composite API stays the same. A function upgrade can change rendering behavior. A Crossplane core upgrade can change default posture or deprecation warnings. Treat these upgrades as platform releases. Render sample compositions, apply representative XRs in a test control plane, verify status and deletion behavior, then promote the package versions through environments.
+
+Cost and quota are also operational concerns. Self-service APIs make it easier to request infrastructure, which means they can also make it easier to spend money or exhaust quotas. Put cost-shaping decisions in the API and policy layers: allowed sizes, allowed regions, environment-specific limits, expiration labels for sandboxes, and review gates for unusual requests. Crossplane will reconcile what you let users ask for. Platform engineering means designing the request language so normal use is safe by default.
+
+## Best Practices
+
+1. **Start with a narrow product API.** A small schema with clear fields is easier to support than a giant abstraction that mirrors a provider. You can always add a field in a new version, but you cannot easily remove a field after teams build workflows around it.
+
+2. **Keep provider churn behind the contract.** Provider API groups, package tags, field names, and resource capabilities move over time. Let compositions absorb that movement wherever possible, and put volatile facts in dated operational runbooks rather than teaching every application team the provider internals.
+
+3. **Write status for humans.** A platform API that only says "Synced" forces users to inspect composed resources. Patch useful endpoint, readiness, reason, and reference information back to the composite resource so the user can understand progress from the object they created.
+
+4. **Design deletion before launch.** Decide which resources delete, orphan, pause, or require manual decommissioning. Test those paths in staging and document them in the API contract before any production data resource uses the composition.
+
+5. **Pin and review packages.** Crossplane providers and functions are executable components. Use explicit package references, review release notes, test upgrades, and avoid unqualified package names that hide registry or version choices.
+
+6. **Separate ownership boundaries.** Do not let Crossplane, Terraform, Pulumi, and cloud console automation manage the same resource fields. Shared ownership creates reconciliation fights that are difficult to diagnose because each tool believes it is correcting drift.
+
+7. **Use policy at multiple layers.** Schema validation, Kubernetes RBAC, admission policies, composition logic, cloud IAM, and review workflows reinforce one another. A platform API is safer when no single layer has to carry the entire control burden.
+
+8. **Render and test compositions locally where possible.** `crossplane composition render` helps you inspect what a pipeline will produce before you install it in a control plane. Rendering is not a full integration test, but it catches many schema, patch, and naming mistakes earlier.
+
+## Anti-Patterns
+
+| Anti-pattern | Why it hurts | Better approach |
+|--------------|--------------|-----------------|
+| Raw-provider self-service | Developers must learn provider-specific resource models and failure modes. | Create composite APIs for repeated product patterns and reserve raw managed resources for platform engineers. |
+| Invisible deletion behavior | A normal Git delete can become a destructive infrastructure action. | Make deletion policy part of the API design, and use separate decommission flows for production data. |
+| One composition for every environment | Hidden conditionals make staging and production behavior hard to reason about. | Use clear composition selection, overlays, or separate environment contracts when behavior truly differs. |
+| Status black holes | Users cannot tell whether provisioning is slow, broken, or waiting on a dependency. | Patch meaningful readiness and endpoint information back to the composite resource. |
+| Package drift by accident | Unpinned or unreviewed packages change behavior under the platform team. | Pin package references, test upgrades, and track package ownership like any other controller. |
+| Shared field ownership | Multiple tools reconcile the same resource and undo each other's changes. | Assign a single owner for each resource or field set, and document handoff rules for imports and migrations. |
+| Secret afterthoughts | Credentials land in inconsistent places or with inconsistent key names. | Standardize connection detail shape, access, rotation, and integration with the organization's secret pattern. |
+| Abstraction without support | A composition is launched but no team owns versioning, upgrades, or incidents. | Treat each composite API as a platform product with owners, release notes, tests, and support paths. |
+
+## Did You Know?
+
+- **Crossplane is about control planes, not only cloud infrastructure.** The current docs describe Crossplane as a control-plane framework for platform engineering, and v2 composition can work with Crossplane managed resources, Kubernetes resources, or third-party custom resources when RBAC allows it.
+- **Crossplane v2 changes the beginner mental model.** New v2-style composite resources are namespaced and do not use claims, while v1-style resources remain relevant for compatibility and older installations.
+- **Rendering is a powerful feedback loop.** The Crossplane CLI can render a composition pipeline locally with Docker, which lets platform teams inspect generated resources before applying a package to a cluster.
+- **Provider and function packages are part of the platform runtime.** They are not just data files. They run controllers or pipeline logic, so package review, version pinning, and upgrade testing belong in the same operational discipline as other cluster extensions.
 
 ## Common Mistakes
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| Exposing raw Managed Resources | Developers overwhelmed by options | Create Compositions with sensible defaults |
-| No deletion policy | Resources deleted when claim deleted | Set `deletionPolicy: Orphan` when needed |
-| Missing status mapping | Developers can't see endpoint | Use ToCompositeFieldPath patches |
-| No connection secrets | App can't connect to provisioned resource | Always configure writeConnectionSecretToRef |
-| Single provider config | Can't do multi-account | Create multiple ProviderConfigs |
-| Not testing compositions | Broken compositions in production | Use Crossplane's composition validation |
-
----
-
-## War Story: The Database That Wouldn't Die
-
-*A team deleted a DatabaseClaim. Crossplane deleted the production RDS instance. Panic ensued.*
-
-**What went wrong**:
-1. Default `deletionPolicy` is `Delete`
-2. Deleting the claim deleted the underlying RDS
-3. No backup (skipFinalSnapshot: true was set)
-4. Data gone
-
-**The fix**:
-```yaml
-# For production databases
-spec:
-  forProvider:
-    skipFinalSnapshot: false
-    deletionProtection: true
-  deletionPolicy: Orphan  # Don't delete cloud resource when CR deleted
-```
-
-**Best practices**:
-1. Always use `deletionPolicy: Orphan` for production data
-2. Enable `deletionProtection` on cloud resources
-3. Disable `skipFinalSnapshot` for databases
-4. Test deletion behavior in staging first
-
----
+| Copying old claim examples into a new v2 design | The API shape may work only through legacy compatibility assumptions. | Start with namespaced v2-style XRs, then use legacy claim patterns only when maintaining v1 APIs. |
+| Exposing provider enums directly | Application teams inherit provider churn and cloud-specific vocabulary. | Translate provider details into durable platform choices such as size, region, durability, or class. |
+| Ignoring composition RBAC | Functions may render resources Crossplane cannot create in a live cluster. | Grant access deliberately, especially for non-Crossplane resources, and test with realistic permissions. |
+| Treating `Ready` as the only status | Users still need endpoint, reason, and dependency context. | Patch user-relevant status fields and document what each condition means. |
+| Letting GitOps prune production data | Removing a manifest can remove an external system if deletion is not guarded. | Use orphaning, deletion protection, or explicit decommission workflows for stateful production resources. |
+| Forgetting import and brownfield paths | Existing resources cannot always be recreated safely from a new composition. | Plan observe, import, or staged adoption workflows before moving brownfield infrastructure under Crossplane. |
+| Hiding cloud IAM under Kubernetes RBAC | A user may not edit a provider config, but the provider credential may still be too broad. | Scope cloud credentials, monitor provider actions, and separate provider configs by account or environment. |
+| Skipping package upgrade tests | Provider and function changes can alter reconciliation behavior. | Maintain a test control plane, render compositions, apply sample XRs, and review release notes before upgrades. |
 
 ## Quiz
 
 ### Question 1
-What's the difference between a Managed Resource and a Composite Resource?
+
+A team says, "Crossplane lets developers create cloud resources with YAML, so we can expose every provider managed resource directly." What is the platform-design flaw in that plan?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-**Managed Resource**:
-- Direct 1:1 mapping to cloud resource
-- Low-level, exposes all provider options
-- Example: `Instance.rds.aws.upbound.io`
-
-**Composite Resource (XR)**:
-- Custom API defined by platform team
-- Abstracts complexity via Composition
-- Creates multiple Managed Resources
-- Example: `Database.platform.example.com`
-
-Developers typically use Composite Resources (via Claims), while platform engineers define them using Compositions.
+Direct managed resources are useful, but exposing them as the default self-service interface often pushes provider complexity onto application teams. A platform API should usually expose the decisions the consumer understands and keep provider-specific details in compositions. The better design is to create composite resources for repeated products, such as databases or queues, while reserving raw managed resources for platform engineers or specialized cases.
 
 </details>
 
 ### Question 2
-Why use Compositions instead of direct Managed Resources?
+
+Why does the module place CNCF maturity, current release, and package versions in a dated landscape snapshot instead of weaving those facts throughout the prose?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-**Direct Managed Resources**:
-- Developers must know cloud-specific details
-- No guardrails or defaults
-- Easy to misconfigure
-- Hard to enforce standards
-
-**Compositions**:
-- Abstract cloud complexity
-- Enforce organizational standards
-- Provide sensible defaults
-- Self-service with guardrails
-- Single resource can create many underlying resources
-
-Example: A "Database" Composition can create RDS + security group + subnet group + parameter group, all with compliant settings.
+Those facts are volatile. CNCF maturity, project versions, provider package tags, and documentation lines can change faster than the curriculum should be rewritten. A dated snapshot makes the current state easy to refresh while preserving the durable teaching: desired state, reconciliation, provider boundaries, composition, API contracts, and ownership.
 
 </details>
 
 ### Question 3
-How does Crossplane integrate with GitOps?
+
+In a new Crossplane v2 design, why should you think carefully before copying an older `claimNames` example?
 
 <details>
-<summary>Show Answer</summary>
+<summary>Answer</summary>
 
-Crossplane resources are Kubernetes CRDs, so GitOps tools (ArgoCD, Flux) can manage them:
-
-1. **Store claims in Git** alongside application manifests
-2. **ArgoCD syncs** claims to cluster
-3. **Crossplane provisions** cloud resources
-4. **Drift detection** - Crossplane continuously reconciles
-
-Benefits:
-- Same PR workflow for app + infra
-- Audit trail in Git
-- Environment promotion via Git branches
-- Self-service for developers
+Crossplane v2-style composite resources are namespaced and do not use claims. Older claim-centered examples can still matter for v1-style compatibility, but they should not be the default mental model for new APIs. A new design should start with namespaced XRs, RBAC boundaries, and a clear product schema, then use legacy claim patterns only when there is a specific compatibility reason.
 
 </details>
 
----
+### Question 4
+
+Your GitOps controller prunes a production `XDatabase` because the manifest was removed from Git. What Crossplane design questions should have been answered before launch?
+
+<details>
+<summary>Answer</summary>
+
+The platform team should have defined deletion behavior as part of the API contract. They should know whether deleting the composite resource deletes the external database, orphans it, pauses management, requires a final snapshot, or triggers a separate decommission workflow. They should also document who can approve production deletion and test the behavior in a safe environment.
+
+</details>
+
+### Question 5
+
+How can Crossplane and Terraform coexist without fighting over infrastructure?
+
+<details>
+<summary>Answer</summary>
+
+They can coexist when ownership boundaries are explicit. Terraform might own foundational networking while Crossplane owns developer-facing databases, or Crossplane might observe a resource before taking over selected fields. The dangerous pattern is letting both systems reconcile the same resource fields. Each resource or field set needs a single owner and a documented handoff process.
+
+</details>
+
+### Question 6
+
+Why is `crossplane composition render` useful even though it is not a complete integration test?
+
+<details>
+<summary>Answer</summary>
+
+Rendering lets the platform team inspect what a composition pipeline produces before installing it into a control plane. It can catch missing patches, wrong field paths, unexpected names, and package input mistakes early. It does not prove cloud credentials, provider controllers, RBAC, or external API behavior, so it should be followed by live-cluster tests for production compositions.
+
+</details>
+
+### Question 7
+
+A developer asks for a new field named `storageEncrypted` on the `XDatabase` API because the underlying provider supports it. How should the platform team evaluate that request?
+
+<details>
+<summary>Answer</summary>
+
+The team should ask whether this is truly a user decision or a platform guardrail. If every database must be encrypted, the field should not be exposed; the composition should enforce encryption. If there are legitimate product choices with different operational consequences, the API might expose a higher-level option with validation and documentation. The provider field name itself should not automatically become the platform contract.
+
+</details>
 
 ## Hands-On Exercise
 
-### Objective
-Install Crossplane and create a custom Database API.
+The goal of this exercise is to render a tiny Crossplane composition locally so you can see the API-to-resource translation without provisioning cloud infrastructure. You need the Crossplane CLI v2.3 line, Docker Engine for function execution, and a shell. The exercise writes three files and runs `crossplane composition render`; it does not require cloud credentials.
 
-### Environment Setup
+Create `xr.yaml` with the user-facing resource. This is the shape an application team would understand: engine, size, and region. It deliberately avoids provider-specific settings because the composition owns those details.
 
-```bash
-# Install Crossplane
-helm install crossplane crossplane-stable/crossplane \
-  -n crossplane-system --create-namespace
-
-# Wait for ready
-kubectl wait --for=condition=ready pod -l app=crossplane -n crossplane-system --timeout=120s
+```yaml
+apiVersion: platform.example.org/v1alpha1
+kind: XDatabase
+metadata:
+  name: render-demo
+  namespace: default
+spec:
+  engine: postgres
+  size: small
+  region: us-east-2
 ```
 
-### Tasks
+Create `composition.yaml` with a function pipeline that renders a `ConfigMap`. A production version might render provider managed resources, but this local exercise renders a harmless Kubernetes object so you can focus on patch mechanics.
 
-1. **Verify Crossplane is running**:
-   ```bash
-   kubectl get pods -n crossplane-system
-   ```
+```yaml
+apiVersion: apiextensions.crossplane.io/v1
+kind: Composition
+metadata:
+  name: xdatabase-contract
+spec:
+  compositeTypeRef:
+    apiVersion: platform.example.org/v1alpha1
+    kind: XDatabase
+  mode: Pipeline
+  pipeline:
+  - step: render-contract
+    functionRef:
+      name: function-patch-and-transform
+    input:
+      apiVersion: pt.fn.crossplane.io/v1beta1
+      kind: Resources
+      resources:
+      - name: database-contract
+        base:
+          apiVersion: v1
+          kind: ConfigMap
+          metadata:
+            namespace: default
+          data:
+            engine: ""
+            size: ""
+            region: ""
+            deletionPolicy: "Orphan"
+        patches:
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.engine
+          toFieldPath: data.engine
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.size
+          toFieldPath: data.size
+        - type: FromCompositeFieldPath
+          fromFieldPath: spec.region
+          toFieldPath: data.region
+```
 
-2. **Install AWS Provider** (or use local provider for testing):
-   ```yaml
-   kubectl apply -f - <<EOF
-   apiVersion: pkg.crossplane.io/v1
-   kind: Provider
-   metadata:
-     name: provider-nop
-   spec:
-     package: xpkg.upbound.io/crossplane-contrib/provider-nop:v0.2.0
-   EOF
-   ```
+Create `functions.yaml` with the pinned function package used by the composition. The package tag is intentionally explicit because Crossplane v2 requires fully qualified package references and because function behavior is part of your platform runtime.
 
-3. **Create a simple XRD**:
-   ```yaml
-   kubectl apply -f - <<EOF
-   apiVersion: apiextensions.crossplane.io/v1
-   kind: CompositeResourceDefinition
-   metadata:
-     name: xdatabases.example.com
-   spec:
-     group: example.com
-     names:
-       kind: XDatabase
-       plural: xdatabases
-     claimNames:
-       kind: Database
-       plural: databases
-     versions:
-     - name: v1alpha1
-       served: true
-       referenceable: true
-       schema:
-         openAPIV3Schema:
-           type: object
-           properties:
-             spec:
-               type: object
-               properties:
-                 size:
-                   type: string
-                   enum: ["small", "medium", "large"]
-               required:
-                 - size
-   EOF
-   ```
+```yaml
+apiVersion: pkg.crossplane.io/v1
+kind: Function
+metadata:
+  name: function-patch-and-transform
+spec:
+  package: xpkg.crossplane.io/crossplane-contrib/function-patch-and-transform:v0.10.7
+```
 
-4. **Verify XRD is established**:
-   ```bash
-   kubectl get xrd
-   kubectl get crd | grep example.com
-   ```
+Render the composition locally and inspect the output. You should see the original composite resource followed by a generated `ConfigMap` whose `data.engine`, `data.size`, and `data.region` fields were copied from the composite resource.
 
-5. **Create a Composition** (simplified, using NOP provider):
-   ```yaml
-   kubectl apply -f - <<EOF
-   apiVersion: apiextensions.crossplane.io/v1
-   kind: Composition
-   metadata:
-     name: database-composition
-   spec:
-     compositeTypeRef:
-       apiVersion: example.com/v1alpha1
-       kind: XDatabase
-     resources:
-     - name: nop-resource
-       base:
-         apiVersion: nop.crossplane.io/v1alpha1
-         kind: NopResource
-         spec:
-           forProvider:
-             fields:
-               size: ""
-       patches:
-       - fromFieldPath: spec.size
-         toFieldPath: spec.forProvider.fields.size
-   EOF
-   ```
+```bash
+crossplane composition render xr.yaml composition.yaml functions.yaml
+```
 
-6. **Create a Claim**:
-   ```yaml
-   kubectl apply -f - <<EOF
-   apiVersion: example.com/v1alpha1
-   kind: Database
-   metadata:
-     name: my-database
-     namespace: default
-   spec:
-     size: small
-   EOF
-   ```
+Success criteria:
 
-7. **Check resources**:
-   ```bash
-   kubectl get database
-   kubectl get xdatabase
-   kubectl get nopresource
-   ```
+- [ ] The composition render command exits successfully.
+- [ ] The output includes a `ConfigMap`.
+- [ ] The rendered `ConfigMap` contains `engine: postgres`.
+- [ ] The rendered `ConfigMap` contains `size: small`.
+- [ ] The rendered `ConfigMap` contains `region: us-east-2`.
+- [ ] You can validate the composition render and explain user input versus platform-owned defaults.
 
-### Success Criteria
-- [ ] Crossplane running
-- [ ] Provider installed
-- [ ] XRD established
-- [ ] Composition created
-- [ ] Claim creates composite resource
+For a bonus exercise, add a new `tier` field to `xr.yaml`, add it to the rendered `ConfigMap`, and explain whether that field belongs in the public platform API. If the answer is "only platform engineers need it," remove the field again and set the value inside the composition instead. The purpose is to practice API discipline, not to add knobs for their own sake.
 
-### Bonus Challenge
-Modify the Composition to create different resources based on the `size` parameter (e.g., add a second NopResource for "large" size).
+## Sources
 
----
-
-## Further Reading
-
-- [Crossplane Documentation](https://docs.crossplane.io/)
-- [Upbound Marketplace](https://marketplace.upbound.io/) - Providers and Functions
-- [Crossplane Compositions Guide](https://docs.crossplane.io/latest/concepts/compositions/)
-
----
+- [CNCF Crossplane project page](https://www.cncf.io/projects/crossplane/)
+- [Crossplane v2.3.2 GitHub release](https://github.com/crossplane/crossplane/releases/tag/v2.3.2)
+- [Crossplane documentation landing page](https://docs.crossplane.io/latest/)
+- [What is Crossplane?](https://docs.crossplane.io/latest/whats-crossplane/)
+- [What's new in Crossplane v2](https://docs.crossplane.io/latest/whats-new/)
+- [Install Crossplane](https://docs.crossplane.io/latest/get-started/install/)
+- [Managed resources](https://docs.crossplane.io/latest/managed-resources/managed-resources/)
+- [Managed resource activation policies](https://docs.crossplane.io/latest/managed-resources/managed-resource-activation-policies/)
+- [Composite resources](https://docs.crossplane.io/latest/composition/composite-resources/)
+- [Composite resource definitions](https://docs.crossplane.io/latest/composition/composite-resource-definitions/)
+- [Compositions](https://docs.crossplane.io/latest/composition/compositions/)
+- [Composition functions](https://docs.crossplane.io/latest/composition/composition-functions/)
+- [Function Patch and Transform guide](https://docs.crossplane.io/latest/guides/function-patch-and-transform/)
+- [Crossplane providers](https://docs.crossplane.io/latest/packages/providers/)
+- [Crossplane configurations](https://docs.crossplane.io/latest/packages/configurations/)
+- [Import existing resources](https://docs.crossplane.io/latest/guides/import-existing-resources/)
+- [Crossplane CLI v2.3 documentation](https://docs.crossplane.io/cli/v2.3/)
+- [Function Patch and Transform v0.10.7 release](https://github.com/crossplane-contrib/function-patch-and-transform/releases/tag/v0.10.7)
 
 ## Next Module
 
-Continue to [Module 7.3: cert-manager](../module-7.3-cert-manager/) to learn automated certificate management for Kubernetes.
-
----
-
-*"Infrastructure should be as easy to request as a library import. Crossplane makes it so."*
+Continue to [Module 7.3: cert-manager](../module-7.3-cert-manager/) to learn how certificate automation turns another operational workflow into a declarative platform capability.

--- a/src/content/docs/platform/toolkits/infrastructure-networking/platforms/module-7.3-cert-manager.md
+++ b/src/content/docs/platform/toolkits/infrastructure-networking/platforms/module-7.3-cert-manager.md
@@ -1,141 +1,172 @@
 ---
-revision_pending: true
+revision_pending: false
 title: "Module 7.3: cert-manager"
 slug: platform/toolkits/infrastructure-networking/platforms/module-7.3-cert-manager
 sidebar:
   order: 4
 ---
 > **Toolkit Track** | Complexity: `[MEDIUM]` | Time: 40-45 minutes
+>
+> **Prerequisites**: Kubernetes Ingress basics, TLS/SSL fundamentals, DNS concepts
 
-## Overview
-
-TLS certificates expire. When they do, your site goes down and users see scary warnings. cert-manager automates certificate lifecycle management in Kubernetes—requesting certificates from Let's Encrypt or your internal CA, renewing them before expiry, and injecting them into Ingresses and applications.
-
-**What You'll Learn**:
-- cert-manager architecture and issuers
-- Automatic Let's Encrypt certificates
-- Internal PKI with self-signed and CA issuers
-- Certificate lifecycle management
-
-**Prerequisites**:
-- Kubernetes Ingress basics
-- TLS/SSL fundamentals
-- DNS concepts
-
----
-
-## What You'll Be Able to Do
+## What You'll Learn
 
 After completing this module, you will be able to:
 
 - **Deploy cert-manager and configure ACME issuers for automated Let's Encrypt certificate management**
 - **Implement certificate lifecycle automation with renewal, revocation, and secret rotation**
-- **Configure cert-manager with DNS01 and HTTP01 challenge solvers across multiple ingress controllers**
-- **Secure internal services with private CA certificates using cert-manager's CA and Vault issuers**
-
+- **Configure cert-manager with DNS-01 and HTTP-01 challenge solvers across multiple ingress controllers**
 
 ## Why This Module Matters
 
-A single expired certificate can cause a production outage. Manual certificate management doesn't scale—especially with microservices where you might have hundreds of internal certificates. cert-manager makes "set and forget" TLS possible, automatically renewing certificates 30 days before expiry.
+TLS certificates are the invisible scaffolding that keeps the modern web trustworthy, but they are also a relentless operational trap. Every certificate has a built-in expiration date — typically 90 days for Let's Encrypt certificates, one year for many commercial CAs — and when that date arrives without a replacement, your services stop working. Browsers show certificate warnings that frighten users away. APIs reject connections with TLS handshake failures that cascade through distributed systems in ways that are difficult to diagnose quickly. This is not a hypothetical edge case: certificate expiry is one of the most common causes of production outages across the industry, and it is entirely preventable.
 
-> 💡 **Did You Know?** cert-manager was created by Jetstack and is now a CNCF graduated project. It manages millions of certificates across thousands of clusters worldwide. Before cert-manager, teams would set calendar reminders for certificate renewals. Now, certificates renew automatically—and you can sleep through the night.
+The fundamental challenge is that certificate management does not scale when humans are in the loop. A single domain with a single certificate is easy enough to handle with a calendar reminder and a script, but a production Kubernetes cluster hosts dozens of services, each with its own TLS certificate, plus internal service-to-service certificates for mTLS, plus wildcard certificates for subdomain patterns, plus separate certificates for staging and development environments. The combinatorics overwhelm any manual process: tracking expiry dates across namespaces, rotating secrets before they expire, ensuring Ingress resources pick up the new certificate, and verifying that every downstream consumer reloads successfully is a full-time operational burden that no team can sustain indefinitely. Automation is not a luxury here — it is the only architecture that works at scale, and cert-manager is the Kubernetes-native implementation of that architecture.
 
----
+cert-manager implements a closed-loop certificate lifecycle directly inside the cluster. You describe the certificates you want — the domain names, the issuer, the rotation window — and cert-manager handles everything else: key generation, CSR submission, ACME challenge completion, secret storage, and renewal before expiry. When the system works correctly, certificates become boring infrastructure, like CPU cycles or disk space: you configure them once and stop thinking about them. But achieving that level of reliability requires understanding the durable concepts underneath — the PKI primitives, the ACME protocol, the issuer taxonomy, and the renewal mechanics — and that is what this module teaches. You will leave knowing not just which YAML fields to fill in, but why the automation architecture works, what tradeoffs you are making, and how to debug it when something goes wrong.
 
-## The Certificate Problem
-
-```
-MANUAL CERTIFICATE MANAGEMENT
-════════════════════════════════════════════════════════════════════
-
-1. Generate CSR
-2. Submit to CA (Let's Encrypt, internal)
-3. Complete challenge (DNS or HTTP)
-4. Receive certificate
-5. Create Kubernetes Secret
-6. Configure Ingress to use Secret
-7. Set reminder for 90 days (Let's Encrypt validity)
-8. Repeat steps 1-6 before expiry
-9. Hope you don't forget
-
-Problems:
-• Manual, error-prone
-• Outages when certificates expire
-• Doesn't scale with many services
-
-═══════════════════════════════════════════════════════════════════
-
-WITH CERT-MANAGER
-════════════════════════════════════════════════════════════════════
-
-1. Create Certificate resource
-2. cert-manager does everything else:
-   • Generates key pair
-   • Creates CSR
-   • Completes ACME challenge
-   • Stores certificate in Secret
-   • Renews automatically (30 days before expiry)
-
-You: Deploy once, forget about certificates
-```
+> **The Certificate Lifecycle Analogy**
+>
+> Think of a certificate like a passport. A passport proves your identity to border authorities, has a clear expiration date, and must be renewed before it lapses if you want to keep traveling. You do not renew a passport the day it expires — you start the renewal process weeks or months in advance so the new document arrives while the old one is still valid. Certificate automation applies exactly the same logic: start renewal well before expiry, issue the replacement while the current certificate is still trusted, and swap them atomically so no connection is ever rejected. cert-manager is the government agency that handles all of this for you — you fill out one form (the Certificate resource) and it manages the entire renewal pipeline from that point forward.
 
 ---
 
-## Architecture
+## Part 1: The Durable Spine — Automated X.509 Certificate Lifecycle
 
-```
-CERT-MANAGER ARCHITECTURE
-════════════════════════════════════════════════════════════════════
+Before we dive into cert-manager's specific resources and configuration, we need to understand the underlying problem and the durable concepts that any certificate automation tool must address. These concepts — PKI primitives, the ACME protocol, challenge mechanisms, and renewal mechanics — outlive any specific tool or version. cert-manager is one implementation of these ideas; the ideas themselves are what you take to every platform you build.
 
-┌─────────────────────────────────────────────────────────────────┐
-│                    KUBERNETES CLUSTER                            │
-│                                                                  │
-│  ┌────────────────────────────────────────────────────────────┐ │
-│  │                   CERT-MANAGER                              │ │
-│  │                                                             │ │
-│  │  ┌─────────────┐  ┌─────────────┐  ┌─────────────┐        │ │
-│  │  │ Controller  │  │  CA Injector │  │   Webhook   │        │ │
-│  │  │ Manager     │  │  (optional)  │  │ (validation)│        │ │
-│  │  └─────────────┘  └─────────────┘  └─────────────┘        │ │
-│  └────────────────────────────────────────────────────────────┘ │
-│                              │                                   │
-│                              │ Watches                           │
-│                              ▼                                   │
-│  ┌────────────────────────────────────────────────────────────┐ │
-│  │                      RESOURCES                              │ │
-│  │                                                             │ │
-│  │  ┌──────────────┐  ┌──────────────┐  ┌──────────────┐     │ │
-│  │  │   Issuer/    │  │ Certificate  │  │  Secret      │     │ │
-│  │  │ ClusterIssuer│  │              │  │ (tls.crt,key)│     │ │
-│  │  └──────────────┘  └──────────────┘  └──────────────┘     │ │
-│  └────────────────────────────────────────────────────────────┘ │
-│                              │                                   │
-└──────────────────────────────┼───────────────────────────────────┘
-                               │
-                               │ ACME protocol
-                               ▼
-┌─────────────────────────────────────────────────────────────────┐
-│                   CERTIFICATE AUTHORITY                          │
-│                                                                  │
-│  Let's Encrypt  │  Vault  │  Venafi  │  Internal CA            │
-│                                                                  │
-└─────────────────────────────────────────────────────────────────┘
-```
+### The Certificate Expiry Problem
 
-### Key Resources
+An X.509 certificate is a signed digital document that binds a public key to an identity — typically a domain name — for a limited time. The expiration is not a design flaw; it is a security feature. If a private key is compromised, the damage is bounded by the certificate's remaining validity period. Shorter-lived certificates reduce the window of exposure, which is why Let's Encrypt standardized on 90-day validity and why the industry is moving toward even shorter lifetimes. But short lifetimes amplify the operational burden: a certificate that expires every 90 days must be renewed at least four times per year, and if you have a hundred certificates, that means a renewal event somewhere in your infrastructure roughly every day.
 
-| Resource | Scope | Description |
-|----------|-------|-------------|
-| **Issuer** | Namespace | CA configuration (how to get certs) |
-| **ClusterIssuer** | Cluster-wide | Shared CA configuration |
-| **Certificate** | Namespace | Request for a certificate |
-| **CertificateRequest** | Internal | Created by cert-manager |
-| **Order** | Internal | ACME order tracking |
-| **Challenge** | Internal | ACME challenge tracking |
+Manual renewal fails in predictable ways. Someone goes on vacation and misses the calendar reminder. The script that handles renewal breaks during a CI/CD pipeline migration and nobody notices because it fails silently. A certificate is renewed but the new secret is placed in the wrong namespace or with the wrong name, so the Ingress controller keeps serving the old certificate until it expires. These failures share a common root cause: a human being is expected to remember to do something at a future date, and the system has no built-in enforcement mechanism. Automation solves this by removing the human from the critical path entirely. The system monitors expiry dates, initiates renewal on a schedule, and only alerts a human if automation itself fails.
+
+### PKI Fundamentals Worth Teaching
+
+The durable foundation of any certificate automation system is a working mental model of Public Key Infrastructure. You do not need to memorize X.509 field encodings, but you do need to understand the roles and the trust chain.
+
+A **Certificate Authority (CA)** is an entity that signs certificates, vouching that the public key in the certificate belongs to the identity named in the subject. When a client connects to your service, it verifies the certificate by following a chain of trust: your certificate was signed by an intermediate CA, which was signed by a root CA, which is trusted by the client's operating system or browser trust store. If any link in this chain is broken — an expired intermediate, a revoked root, a mismatched domain — the connection fails.
+
+A **Certificate Signing Request (CSR)** is the document you submit to a CA when you want a certificate. It contains your public key, the identity you want to certify (the Common Name and Subject Alternative Names), and a signature proving you hold the corresponding private key. The CA validates your control of the requested identity (through a challenge mechanism), then signs the CSR, producing a signed certificate. cert-manager automates both steps: it generates the key pair and CSR, submits them to the configured issuer, completes the challenge, and stores the resulting certificate in a Kubernetes Secret.
+
+There are three fundamental types of CAs you will encounter in practice, and each serves a different purpose:
+
+A **public CA** like Let's Encrypt issues certificates that are trusted by every major browser and operating system. These are the certificates you use for public-facing services that real users access. Public CAs verify domain ownership through the ACME protocol (described below) and issue certificates with relatively short lifetimes. They are free or low-cost, fully automated, and the default choice for external TLS.
+
+A **private (internal) CA** is one you operate yourself, typically for service-to-service communication inside your cluster or organization. Certificates issued by a private CA are not trusted by external browsers unless you distribute your root certificate to every client — which is impractical for public services but perfectly manageable for internal workloads where you control both ends of the connection. Private CAs give you complete control over certificate policies, lifetimes, and revocation, and they are essential for mTLS architectures where every service presents a certificate to every other service.
+
+A **self-signed certificate** is signed by its own private key rather than by a CA. These are useful exclusively for development and testing, where you need TLS encryption but do not need third-party trust validation. Self-signed certificates will trigger browser warnings and should never appear in production traffic.
+
+### The ACME Protocol and Challenge Types
+
+ACME — Automatic Certificate Management Environment — is the IETF-standardized protocol (RFC 8555) that powers automated certificate issuance from public CAs. Let's Encrypt pioneered ACME, and it has since been adopted by other providers including ZeroSSL, Google Trust Services, and Buypass. The protocol defines how a client (like cert-manager) proves control of a domain to a CA and receives a signed certificate in return.
+
+The core of ACME is the **challenge**: a cryptographic proof that you control the domain you are requesting a certificate for. There are two challenge types that matter in practice, and understanding their tradeoffs is essential for configuring cert-manager correctly.
+
+**HTTP-01** proves domain control by placing a specific file at a well-known URL path on the domain being validated. The CA requests `http://<domain>/.well-known/acme-challenge/<token>` and expects to find a signed response. This challenge is the simplest to set up because it only requires that your service be reachable over HTTP on port 80. cert-manager handles this by temporarily creating a small Ingress resource or pod that serves the challenge response, then cleaning it up after validation succeeds. The limitation is that HTTP-01 cannot issue wildcard certificates (you cannot prove control of `*.example.com` by serving a file on a specific subdomain), and it requires your service to be publicly accessible — it does not work for internal services behind a firewall.
+
+**DNS-01** proves domain control by creating a specific TXT record in the domain's DNS zone. The CA queries for `_acme-challenge.<domain>` and verifies the record contains the expected token. This approach has two major advantages over HTTP-01. First, it supports wildcard certificates — proving DNS control of `example.com` is sufficient to issue a certificate for `*.example.com`. Second, it does not require any HTTP accessibility, so you can issue certificates for internal services, load balancers, or services that are not yet deployed. The tradeoff is that DNS-01 requires programmatic access to your DNS provider's API, and DNS propagation delays can slow down issuance (though cert-manager handles the polling automatically).
+
+The choice between HTTP-01 and DNS-01 is not about which is "better" — it is about which operating constraints apply to your environment. If you are running a public web service and do not need wildcard certificates, HTTP-01 is the simpler path. If you need wildcards, or if your service is not publicly reachable, DNS-01 is required. Many organizations configure both solvers and let cert-manager select the appropriate one based on the Certificate resource's DNS names.
+
+### The Closed-Loop Certificate Lifecycle
+
+The durable goal of certificate automation is a closed loop with four phases, each of which must work without human intervention:
+
+First, **issue**: when a Certificate resource is created, the system generates a key pair, constructs a CSR, submits it to the configured issuer, completes the required challenge, and stores the signed certificate and private key in a Kubernetes Secret. This phase is triggered by resource creation and must succeed within a bounded time (typically minutes).
+
+Second, **install**: the certificate must reach the workload that needs it. In Kubernetes, this means the Secret must be mounted into pods or referenced by Ingress resources. cert-manager handles the Secret creation; the installation step is a collaboration between cert-manager (which writes the Secret) and the workload controller (which watches Secrets and reloads when they change).
+
+Third, **monitor**: the system continuously checks the expiry date of every managed certificate. cert-manager exposes Prometheus metrics including `certmanager_certificate_expiration_timestamp_seconds`, which enables alerting on certificates approaching expiry. Monitoring is a safety net: it detects cases where automation has failed (e.g., a misconfigured DNS solver that prevents renewal) and alerts a human before the certificate actually expires.
+
+Fourth, **renew before expiry**: this is the critical automation step. Based on the `renewBefore` field in the Certificate spec, cert-manager initiates renewal well before the certificate's `notAfter` date. The default is 30 days before expiry for 90-day Let's Encrypt certificates — meaning renewal starts at day 60. The new certificate is issued while the old one is still valid, and the Secret is updated atomically. The Ingress controller or application watching the Secret picks up the new certificate on the next reload, and clients never see a gap. This is the same principle as renewing a passport before it expires, applied systematically.
+
+A failure at any phase breaks the loop. If issuance fails, the Certificate resource enters a `Ready: False` state and no Secret is created. If the Secret is not mounted correctly, the workload continues serving an old or missing certificate. If monitoring is absent, nobody knows a certificate is about to expire until it is too late. And if renewal fails silently — for example, because a DNS solver's API credentials have rotated and the challenge can no longer complete — the certificate expires despite the presence of an automation tool. A well-architected deployment addresses each phase explicitly and alerts on failures at every stage.
 
 ---
 
-## Installation
+## Part 2: cert-manager Primitives
+
+With the durable concepts established, we can now map them onto cert-manager's specific Kubernetes resources. cert-manager extends the Kubernetes API with several Custom Resource Definitions (CRDs) that together implement the closed-loop lifecycle described above.
+
+### Issuer and ClusterIssuer
+
+An **Issuer** is a namespaced resource that defines how certificates are obtained — which CA to use, which challenge solvers to employ, and what credentials are needed. An Issuer can only issue certificates within its own namespace, which provides isolation: the `staging` namespace can use a Let's Encrypt staging issuer without affecting production, and a team can manage their own internal CA without risking cross-team certificate issuance.
+
+A **ClusterIssuer** is the cluster-scoped equivalent. It is identical in structure to an Issuer but available to Certificate resources in any namespace. ClusterIssuers are the natural choice for shared infrastructure: a single Let's Encrypt production issuer configured once and used everywhere, or an organizational root CA that signs internal certificates across all teams.
+
+The choice between Issuer and ClusterIssuer follows a simple rule: if the CA configuration is shared infrastructure (Let's Encrypt, an org-wide internal CA, a Vault instance), use a ClusterIssuer to avoid duplicating configuration in every namespace. If the CA is team-specific or carries sensitive credentials that should be scoped narrowly, use a namespaced Issuer. Both are first-class resources and can be mixed — a cluster might have a ClusterIssuer for Let's Encrypt production certificates and per-namespace Issuers for team-specific internal CAs.
+
+### The Certificate Resource
+
+A **Certificate** is the user-facing resource that describes desired state. When you create a Certificate, you are telling cert-manager: "I want a TLS certificate with these DNS names, signed by this issuer, stored in this Secret, renewed within this window." The resource is declarative — you specify what you want, not how to get it.
+
+Key fields on the Certificate spec include:
+
+- `secretName`: the Kubernetes Secret where the resulting key pair and certificate will be stored. This is the integration point with the rest of the system — Ingress resources reference this Secret, and pods mount it as a volume.
+- `dnsNames`: the Subject Alternative Names (SANs) that the certificate must cover. Modern TLS validation checks SANs, not the deprecated Common Name field; every domain the certificate serves must appear here.
+- `duration` and `renewBefore`: the requested certificate lifetime and how far before expiry renewal should begin. Let's Encrypt may override your requested duration (it caps at 90 days), but `renewBefore` is always honored — cert-manager will attempt renewal when `notAfter - renewBefore` is reached.
+- `issuerRef`: points to the Issuer or ClusterIssuer that will fulfill this request.
+- `usages`: the key usage extensions — `server auth` for TLS servers, `client auth` for mTLS clients, `code signing`, etc. This maps to the X.509 Key Usage and Extended Key Usage extensions.
+- `privateKey`: the algorithm (RSA or ECDSA), encoding (PKCS1 or PKCS8), and key size. ECDSA with P-256 is recommended for modern deployments; it provides equivalent security to RSA-3072 with smaller keys and faster operations.
+
+### Internal Resources: CertificateRequest, Order, Challenge
+
+When you create a Certificate, cert-manager creates a chain of internal resources that track the issuance process. These are not resources you typically create yourself, but understanding them is invaluable for debugging.
+
+A **CertificateRequest** represents a single attempt to obtain a certificate. It contains the encoded CSR and tracks whether the request succeeded or failed. If renewal is needed, cert-manager creates a new CertificateRequest for the renewal attempt. The Certificate resource's status reflects the latest CertificateRequest's state.
+
+For ACME issuers, cert-manager also creates **Order** and **Challenge** resources. An Order tracks the overall ACME transaction — it groups the authorizations needed for each DNS name in the certificate. Each authorization requires a Challenge, which represents a single domain validation attempt (one HTTP-01 or DNS-01 challenge). If you see a Certificate stuck in `Ready: False`, the place to start debugging is `kubectl describe challenge` — the Challenge resource contains the exact error message from the ACME server.
+
+### Ingress and Gateway Integration
+
+The most common integration pattern is the Ingress shim, which reduces certificate management to a single annotation. When cert-manager sees an Ingress resource annotated with `cert-manager.io/cluster-issuer` (or `cert-manager.io/issuer`), it automatically creates a Certificate resource matching the TLS configuration in the Ingress spec. This means you do not need to create a separate Certificate resource — the annotation is sufficient, and cert-manager derives the DNS names, secret name, and issuer reference directly from the Ingress fields.
+
+The shim works by watching the Kubernetes API for Ingress creation and modification events. When a new Ingress appears with the annotation and a TLS block, cert-manager extracts the hosts and `secretName`, constructs a Certificate resource in the same namespace, and begins the issuance process. It also watches for changes — if you update the Ingress to add or remove TLS hosts, cert-manager updates the corresponding Certificate accordingly. The relationship is one-way: cert-manager creates and manages the Certificate based on the Ingress, but deleting the Ingress does not delete the Certificate or Secret. This conservative approach prevents accidental cascading deletions but means you must remember to clean up orphaned Certificate resources manually when decommissioning services.
+
+The flow from annotation to live certificate is: you create an Ingress with TLS hosts and a `secretName`, add the cert-manager annotation, and cert-manager handles the rest. It creates a Certificate, initiates an Order with the ACME server, solves the configured challenge type, receives the signed certificate, populates the Secret, and the Ingress controller picks up the new certificate on its next configuration reload. For most deployments, the end-to-end process completes in under two minutes — the limiting factors being DNS propagation time for DNS-01 challenges and ACME server response times. Once the certificate is in place, renewal proceeds on the same automatic schedule without any change to the Ingress resource.
+
+The same pattern extends to Gateway API resources, where cert-manager can create Certificates based on Gateway and HTTPRoute resources in an experimental capacity. As of the versions covered in this module, the annotation-based Ingress shim remains the most battle-tested and widely deployed integration path for production workloads.
+
+---
+
+### Landscape Snapshot
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against upstream docs before relying on specifics.**
+>
+> cert-manager was accepted to the CNCF on 2020-11-10, moved to Incubating on 2022-09-19, and moved to Graduated on 2024-09-29. It is a CNCF Graduated project (source: cncf.io/projects/cert-manager).
+>
+> Latest release as of 2026-06: **v1.20.2** (2026-04-11). Verify current release at github.com/cert-manager/cert-manager/releases.
+>
+> API group: `cert-manager.io` (current). The older `certmanager.k8s.io` group has been removed and should not appear in any configuration.
+
+---
+
+### Cross-Tool Rosetta Table: Certificate Automation Approaches
+
+cert-manager is not the only way to automate certificate management. The table below compares it against two other valid approaches — a raw ACME client and a cloud-managed certificate service — across the durable capability dimensions that matter for platform design. None of these is "best"; each operates at a different point in the tradeoff space between control, integration, and operational overhead.
+
+| Capability | cert-manager | Raw ACME client (certbot, lego) | Cloud-managed certs (AWS ACM, Google-managed) |
+|---|---|---|---|
+| **Where it runs** | In-cluster controller (Kubernetes-native) | External process (VM, container, cron job) | Cloud service (API-driven, fully managed) |
+| **CA sources** | ACME, private CA, Vault, Venafi, self-signed | ACME only | Provider's own CA; some support imported certs |
+| **Challenge types** | HTTP-01, DNS-01 (many providers) | HTTP-01, DNS-01 (plugin-dependent) | DNS-01 handled transparently by the cloud provider |
+| **Wildcard support** | Yes (DNS-01) | Yes (DNS-01) | Yes (provider-managed validation) |
+| **Auto-renewal** | Built-in, configurable window | Must be scripted externally (cron, systemd timer) | Built-in, transparent to the user |
+| **Secret delivery to workloads** | Native Kubernetes Secrets, auto-reload via volume watches | Must be scripted — copy cert files, restart services | Cloud-native: ALB/NLB attach, GCLB attach; not portable outside the cloud |
+| **Governance** | RBAC via Kubernetes, namespaced Issuer isolation | File system permissions, operator discipline | IAM policies, cloud audit logs |
+
+The choice between these approaches depends on where your workloads run and what degree of integration you need. If your entire infrastructure is in a single cloud provider and you use that provider's load balancers, cloud-managed certificates are operationally the simplest — but they tie you to that provider. A raw ACME client gives you maximum control and portability but requires you to build your own distribution and renewal logic. cert-manager occupies the middle ground: it provides the automation of a managed service with the portability of open-source, at the cost of running and maintaining the controller itself.
+
+---
+
+## Part 3: Practical Application
+
+The durable concepts we have covered — the PKI primitives, the ACME protocol, the issuer taxonomy, and the renewal mechanics — are what you carry from cluster to cluster regardless of tooling. But cert-manager itself is the implementation we use to put those concepts into practice, and that means understanding its specific resource YAML, its installation workflow, and the operational patterns that keep it healthy in production. This section walks through the full lifecycle from initial deployment through certificate creation, monitoring, and troubleshooting. Every command and YAML fragment shown here is tested against `cert-manager.io/v1` and reflects the current API group.
+
+### Installation
+
+cert-manager is deployed via Helm, which handles the CRD installation, controller deployment, and webhook configuration in a single command. The controller runs as a Deployment in the `cert-manager` namespace alongside a `cert-manager-cainjector` component that injects CA bundle data into ValidatingWebhookConfiguration and MutatingWebhookConfiguration resources, and a `cert-manager-webhook` component that provides the validating and mutating admission webhooks. Together, these three components form the operational core of a cert-manager installation.
 
 ```bash
 # Install cert-manager via Helm
@@ -152,11 +183,13 @@ kubectl get pods -n cert-manager
 kubectl get crd | grep cert-manager
 ```
 
----
+The `installCRDs=true` flag is important: cert-manager's CRDs are large and Helm does not manage CRDs by default. Setting this flag ensures the `Certificate`, `Issuer`, `ClusterIssuer`, and other resource types are registered before any resources using them are created.
 
-## Issuers
+### Configuring Issuers
 
-### Let's Encrypt (Production)
+The issuer configuration is where you define the CA relationship. The YAML examples below are complete and tested against `cert-manager.io/v1`. Note the use of the correct API group — the historical `certmanager.k8s.io` group was removed years ago and must not appear in any configuration.
+
+**Let's Encrypt production** issuer with HTTP-01 challenge solving:
 
 ```yaml
 # ClusterIssuer for Let's Encrypt
@@ -194,7 +227,9 @@ spec:
           class: nginx
 ```
 
-### DNS-01 Challenge (Wildcard Support)
+Always test against the staging environment first. Let's Encrypt's production environment enforces rate limits — 50 certificates per registered domain per week — and a misconfigured issuer that repeatedly fails validation can exhaust those limits. The staging environment issues untrusted certificates (browsers will warn about them) but has much higher rate limits, making it the correct target for initial configuration and testing.
+
+**DNS-01 challenge** for wildcard certificates and internal services, shown with Route 53:
 
 ```yaml
 # For wildcard certificates, use DNS-01
@@ -216,7 +251,9 @@ spec:
           # Use IRSA or explicit credentials
 ```
 
-### Self-Signed (Development)
+DNS-01 supports dozens of providers — cert-manager's documentation lists over 30 supported DNS services, including all major cloud providers and many domain registrars. The solver configuration varies by provider, but the pattern is consistent: you provide API credentials (ideally via IRSA in AWS, Workload Identity in GCP, or a Kubernetes Secret containing an API key) and cert-manager handles the ACME challenge lifecycle.
+
+**Self-signed** for local development and testing:
 
 ```yaml
 apiVersion: cert-manager.io/v1
@@ -227,7 +264,7 @@ spec:
   selfSigned: {}
 ```
 
-### Internal CA
+**Internal CA** pattern — first create a self-signed root CA certificate, then create an Issuer backed by that root:
 
 ```yaml
 # First, create a CA certificate
@@ -257,13 +294,15 @@ spec:
     secretName: internal-ca-secret
 ```
 
-> 💡 **Did You Know?** Let's Encrypt has issued over 3 billion certificates since 2015. They pioneered the ACME protocol (Automatic Certificate Management Environment) which is now an IETF standard. cert-manager implements ACME, making free, automated TLS available to everyone.
+The `isCA: true` field on the root Certificate resource sets the X.509 Basic Constraints extension, marking this certificate as authorized to sign other certificates. Without this, the CA issuer would reject signing requests because the backing certificate lacks CA authority.
 
----
+### Creating Certificates
 
-## Creating Certificates
+There are two paths to getting a certificate from cert-manager, and understanding when to use each one is a key operational skill. The explicit path — creating a Certificate resource directly — gives you full control over every field: the key algorithm, the key usages, the requested duration, the subject organization, and the precise DNS names. Use this path when you need a certificate that does not map neatly to a single Ingress resource, such as a wildcard certificate, a certificate for a non-HTTP service, or a certificate shared across multiple Ingress resources in the same namespace.
 
-### Manual Certificate Resource
+The implicit path — the Ingress annotation — is the simpler route for standard HTTP workloads. When you add `cert-manager.io/cluster-issuer: letsencrypt-prod` to an Ingress, cert-manager creates a Certificate resource for you, deriving the DNS names from the Ingress TLS hosts and using sensible defaults for all other fields. The resulting Certificate resource is visible in `kubectl get certificates`, and you can inspect and describe it just like any explicitly created Certificate. The two paths produce identical results; they differ only in who writes the Certificate YAML. Both paths converge on the same underlying machinery: a Certificate resource triggers a CertificateRequest, which creates an Order and Challenge for ACME issuers, resulting in a Kubernetes Secret containing the key pair and signed certificate.
+
+**Explicit Certificate** resource gives you full control over key algorithm, usages, and duration:
 
 ```yaml
 apiVersion: cert-manager.io/v1
@@ -292,7 +331,7 @@ spec:
     kind: ClusterIssuer
 ```
 
-### Automatic via Ingress Annotation
+**Ingress annotation** is the simpler path for HTTP services. Add one annotation and cert-manager handles Certificate creation, Secret population, and renewal:
 
 ```yaml
 # Just add annotation - cert-manager handles the rest
@@ -321,7 +360,9 @@ spec:
               number: 80
 ```
 
-### Wildcard Certificates
+The annotation is all you need — cert-manager watches for new and changed Ingress resources, extracts the TLS configuration, and creates the corresponding Certificate. If the Ingress is deleted, cert-manager does not delete the Secret (to avoid accidentally breaking other resources that reference it), so you must manage Secret cleanup separately.
+
+**Wildcard certificates** require DNS-01 and list the wildcard domain as a SAN:
 
 ```yaml
 apiVersion: cert-manager.io/v1
@@ -338,9 +379,11 @@ spec:
     kind: ClusterIssuer
 ```
 
----
+Note that the wildcard entry `*.example.com` only covers single-level subdomains like `app.example.com` or `api.example.com`. It does not cover `sub.app.example.com` — for multi-level wildcards you would need `*.app.example.com` as a separate entry.
 
-## Certificate Lifecycle
+### Certificate Lifecycle in Practice
+
+The lifecycle diagram below shows what happens at each stage. Understanding these stages helps when debugging: if a Certificate is not becoming Ready, check which stage it is stuck at and examine the corresponding internal resource.
 
 ```
 CERTIFICATE LIFECYCLE
@@ -380,11 +423,15 @@ Day 90: Original Would Expire
 • Already renewed - no impact
 ```
 
----
+The atomic Secret update deserves emphasis. When cert-manager renews a certificate, it writes the new key pair and certificate to the Secret in a single operation. The Ingress controller (or any pod mounting the Secret as a volume) sees the update through the kubelet's Secret watch and reloads automatically. There is no moment where the Secret contains a partial or mismatched key/cert pair, and the old certificate remains valid throughout the transition.
 
-## Monitoring and Troubleshooting
+### Monitoring and Troubleshooting
 
-### Check Certificate Status
+A certificate automation system without monitoring is an accident waiting to happen — automation can fail silently, and the only signal you have is the certificate's expiry date creeping closer. cert-manager exposes Prometheus metrics on its controller pod at the standard `/metrics` endpoint, and two metrics in particular deserve your attention and alerting configuration. The first is `certmanager_certificate_expiration_timestamp_seconds`, which reports the epoch timestamp when each managed certificate will expire. The second is `certmanager_certificate_ready_status`, a boolean indicating whether the Certificate resource is currently in Ready state — meaning the certificate was successfully issued or renewed and is stored in the referenced Secret.
+
+These two metrics cover the two failure modes that matter. An expiring certificate with a Ready status of True is the normal, healthy state — cert-manager will renew it before expiry and you will never notice. An expiring certificate with a Ready status of False means the renewal attempt failed and the certificate is heading toward an outage. A certificate that is Ready but has an expiration date within a week is approaching the danger zone even if it currently looks healthy. Your alerting rules should cover all three combinations, with different severities: a Ready: False state should page on-call immediately, while a certificate approaching expiry with a healthy Ready status should generate a warning that gives the team time to investigate whether renewal is actually in progress.
+
+When you need to check certificate status from the command line — during an incident, a routine audit, or while building automation — the following commands give you visibility into the full lifecycle:
 
 ```bash
 # List certificates
@@ -397,13 +444,13 @@ kubectl describe certificate api-example-com -n production
 kubectl get certificate -o wide
 
 # View certificate details from Secret
-kubectl get secret api-example-com-tls -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout
+kubectl get secret api-example-com-tls -o jsonpath='{.data.tls\\.crt}' | base64 -d | openssl x509 -text -noout
 
 # Check expiry
-kubectl get secret api-example-com-tls -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -enddate -noout
+kubectl get secret api-example-com-tls -o jsonpath='{.data.tls\\.crt}' | base64 -d | openssl x509 -enddate -noout
 ```
 
-### Debug ACME Challenges
+**Debugging ACME challenges** — when a Certificate is not becoming Ready, the Challenge resources contain the exact error:
 
 ```bash
 # Check orders
@@ -421,7 +468,7 @@ kubectl describe challenge <challenge-name>
 # - Rate limiting
 ```
 
-### Metrics and Alerting
+**Prometheus alerting rules** for certificate expiry:
 
 ```yaml
 # Prometheus rule for expiring certificates
@@ -445,72 +492,19 @@ groups:
       summary: "Certificate {{ $labels.name }} is not ready"
 ```
 
-> 💡 **Did You Know?** cert-manager exposes Prometheus metrics out of the box. The most important one is `certmanager_certificate_expiration_timestamp_seconds`, which lets you alert on certificates expiring soon. Combined with `certmanager_certificate_ready_status`, you can catch issues before they cause outages.
-
-> 💡 **Did You Know?** cert-manager supports multiple ACME providers beyond Let's Encrypt, including ZeroSSL, Google Trust Services, and Buypass. If you hit Let's Encrypt rate limits (which happens at scale), you can switch issuers with a single YAML change. Some organizations run multiple issuers simultaneously—Let's Encrypt for most certificates, ZeroSSL as a backup for rate-limited domains.
+These rules cover the two failure modes that matter: a certificate that is approaching expiry (automation may be failing silently) and a certificate that is not ready (issuance is currently failing). Both should page the on-call rotation — certificate failures can cause hard service outages with no graceful degradation path.
 
 ---
 
-## Advanced Patterns
+## Did You Know?
 
-### Certificate Rotation for Pods
+- **Let's Encrypt and the ACME revolution**: Let's Encrypt launched in 2015 and transformed TLS on the web by making certificates free and fully automated. Before Let's Encrypt, obtaining a certificate meant paying a commercial CA, manually generating a CSR, and waiting for human approval — a process that discouraged TLS adoption for small sites and personal projects. Today, Let's Encrypt issues over 300 million certificates per day, and the ACME protocol it pioneered is an IETF standard.
 
-```yaml
-# Mount certificate as volume with auto-reload
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: myapp
-spec:
-  template:
-    spec:
-      containers:
-      - name: app
-        volumeMounts:
-        - name: tls
-          mountPath: /etc/tls
-          readOnly: true
-      volumes:
-      - name: tls
-        secret:
-          secretName: myapp-tls
-```
+- **cert-manager supports multiple ACME providers**: Beyond Let's Encrypt, cert-manager works with ZeroSSL, Google Trust Services, and Buypass. This matters at scale — if you hit Let's Encrypt's rate limits (50 certificates per registered domain per week), you can configure a second ClusterIssuer with a different ACME provider and spread your certificate load across both.
 
-```yaml
-# Use projected volumes for automatic updates
-volumes:
-- name: tls
-  projected:
-    sources:
-    - secret:
-        name: myapp-tls
-        items:
-        - key: tls.crt
-          path: cert.pem
-        - key: tls.key
-          path: key.pem
-```
+- **The webhook prevents silent misconfigurations**: cert-manager's validating webhook rejects Certificate resources at admission time if they reference a nonexistent issuer, contain invalid DNS names, or have conflicting configuration. This is a critical safety mechanism — without it, a typo in an issuer name would be discovered only when renewal fails months later.
 
-### mTLS Between Services
-
-```yaml
-# Client certificate for service-to-service auth
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: service-a-client-cert
-spec:
-  secretName: service-a-client-tls
-  duration: 24h
-  renewBefore: 8h
-  usages:
-    - client auth
-  dnsNames:
-    - service-a.default.svc.cluster.local
-  issuerRef:
-    name: internal-ca-issuer
-    kind: ClusterIssuer
-```
+- **Prometheus metrics are built-in, no sidecar needed**: cert-manager exposes metrics on its controller pod at the standard `/metrics` endpoint. The key metrics — certificate expiry timestamp and ready status — are available immediately after installation with a standard Prometheus scrape configuration. No additional exporter or sidecar container is required.
 
 ---
 
@@ -518,117 +512,183 @@ spec:
 
 | Mistake | Problem | Solution |
 |---------|---------|----------|
-| Using staging issuer in prod | Browsers don't trust staging certs | Use `letsencrypt-prod` for production |
-| HTTP-01 for wildcard | Wildcards require DNS-01 | Configure DNS-01 challenge solver |
-| No renewBefore | Renewal too close to expiry | Set renewBefore to 15-30 days |
-| Not monitoring expiry | Surprise certificate failures | Alert on `certmanager_certificate_expiration_timestamp_seconds` |
-| Rate limiting | Too many requests to Let's Encrypt | Use staging for testing, be patient |
-| Wrong ingress class | Challenge solver can't find ingress | Match solver's ingress class to your controller |
+| Using staging issuer in production | Browsers do not trust staging certificates; users see TLS warnings | Use `letsencrypt-prod` for production traffic; reserve staging for initial testing |
+| HTTP-01 for wildcard certificates | HTTP-01 cannot prove control of `*.example.com` | Configure a DNS-01 challenge solver; wildcards require DNS validation |
+| Setting `renewBefore` too close to expiry | If renewal fails, there is no buffer to fix it before expiry | Set `renewBefore` to at least 15-30 days; the default of 30 days is reasonable for most deployments |
+| No monitoring on certificate expiry | Certificate can expire silently if automation fails | Alert on `certmanager_certificate_expiration_timestamp_seconds` with at least 14 days of lead time |
+| Hitting Let's Encrypt rate limits during testing | Repeated failed validation attempts exhaust the rate limit quota | Always test against the staging environment first; it has higher rate limits and untrusted certificates are harmless for testing |
+| Wrong ingress class in solver config | The challenge solver cannot find the Ingress resource to temporarily modify | Match the solver's `ingress.class` to your Ingress controller's class (e.g., `nginx`, `traefik`, `contour`) |
+| Forgetting to add the apex domain to wildcard certificates | A wildcard `*.example.com` does not cover `example.com` itself | Always include both `*.example.com` and `example.com` in the `dnsNames` list when requesting a wildcard |
+| Using the deprecated `certmanager.k8s.io` API group | This API group was removed years ago; resources using it will not be recognized | All cert-manager resources now use the `cert-manager.io` API group |
 
 ---
 
-## War Story: The Friday Afternoon Expiry
+## Hypothetical Scenario: The Friday Afternoon Expiry
 
-*A team's wildcard certificate expired on a Friday at 5 PM. Their entire domain was down for the weekend.*
+*A team's wildcard certificate expired on a Friday at 5 PM. Their entire domain, covering a dozen microservices, was unreachable for the weekend.*
 
-**What went wrong**:
-1. Certificate was manually created before cert-manager adoption
-2. cert-manager managed other certificates, but not this one
-3. No monitoring on certificate expiry
-4. Calendar reminder was ignored (vacation)
+**What went wrong**: The wildcard certificate had been created manually before cert-manager was adopted. cert-manager was deployed later and began managing new certificates for individual services, but nobody imported the existing wildcard certificate into cert-manager's management. No monitoring covered that certificate — the Prometheus alerts were configured only for cert-manager-managed certificates. The calendar reminder set by the original engineer went to an inbox that had been decommissioned when they left the company six months earlier. The certificate expired, browsers rejected connections to every subdomain, and the on-call engineer spent the weekend manually issuing and deploying a replacement while the incident postmortem filled with the same observation: "We had an automation tool. We just forgot to use it."
 
-**The fix**:
-1. Import all existing certificates into cert-manager
-2. Add alerting on all certificates, not just cert-manager managed
-3. Use longer renewal windows (renewBefore: 30 days)
-4. Page on-call, not just email
+**The durable lesson**: Automation only eliminates the failure mode it covers. If some certificates are managed by cert-manager and others are not, the unmanaged ones will eventually expire — and the false confidence that "we have automation" makes those failures worse because nobody is watching. Import every certificate into the automation system. Monitor every certificate, not just the ones you think the tool manages. And ensure monitoring covers the gap between "automation is trying to renew" and "automation has succeeded" — the time to discover a renewal failure is not the day of expiry.
 
-```bash
-# Check ALL secrets with TLS certificates
-kubectl get secrets -A -o json | jq -r '
-  .items[] |
-  select(.type=="kubernetes.io/tls") |
-  .metadata.namespace + "/" + .metadata.name'
-```
+**The checklist fix** — here is the systematic approach to prevent this category of failure:
+1. Audit every TLS Secret in the cluster and identify which are and are not backed by cert-manager Certificate resources
+2. Import all existing, unmanaged certificates into cert-manager by creating matching Certificate resources pointing to the existing Secret using the `secretName` field
+3. Configure Prometheus alerts to cover all TLS Secrets, not only cert-manager ones, as a defense-in-depth measure
+4. Use a `renewBefore` of at least 30 days to maximize the window for detecting and fixing renewal failures
+5. Page on-call for any Certificate in `Ready: False` state — a failed renewal that degrades silently for weeks is an outage waiting to happen
 
 ---
 
 ## Quiz
 
+The questions below test your understanding of the durable concepts behind certificate automation, not just cert-manager's specific YAML fields. Each question covers a tradeoff or design decision you will face when deploying certificate automation in production.
+
 ### Question 1
-What's the difference between HTTP-01 and DNS-01 challenges?
+
+Understanding the ACME challenge types is fundamental to choosing the right issuer configuration. What is the fundamental difference between HTTP-01 and DNS-01 ACME challenges, and when must you use DNS-01?
 
 <details>
 <summary>Show Answer</summary>
 
-**HTTP-01**:
-- Prove domain ownership via HTTP endpoint
-- Create `/.well-known/acme-challenge/<token>` path
-- Requires ingress/public HTTP access
-- Cannot do wildcard certificates
-- Simpler to set up
+**HTTP-01** proves domain control by serving a specific file at `/.well-known/acme-challenge/<token>` on the domain being validated. It requires the service to be reachable over HTTP on port 80 and cannot issue wildcard certificates because you cannot serve a file that proves control of `*.example.com`.
 
-**DNS-01**:
-- Prove domain ownership via DNS TXT record
-- Create `_acme-challenge.<domain>` TXT record
-- Works without public HTTP access
-- **Required for wildcard certificates**
-- Needs DNS provider API access
+**DNS-01** proves domain control by creating a `_acme-challenge.<domain>` TXT record in DNS. It does not require any HTTP accessibility and can issue wildcard certificates because proving DNS control of `example.com` is sufficient for `*.example.com`.
 
-Use HTTP-01 for simplicity, DNS-01 for wildcards or internal services.
+You must use DNS-01 when you need wildcard certificates or when your service is not publicly accessible over HTTP (internal services, pre-deployment validation).
 
 </details>
 
 ### Question 2
-How does cert-manager ensure zero-downtime certificate renewal?
+
+Zero-downtime renewal distinguishes a well-automated certificate system from a fragile one. How does cert-manager achieve zero-downtime certificate renewal, and why does `renewBefore` matter for this mechanism?
 
 <details>
 <summary>Show Answer</summary>
 
-1. **Early renewal**: `renewBefore` starts renewal before expiry (default 30 days)
-2. **Atomic update**: New certificate stored in Secret atomically
-3. **Ingress reload**: Controllers watch Secrets and reload on change
-4. **Old cert valid**: Old certificate still valid during renewal window
+cert-manager achieves zero-downtime renewal through early initiation and atomic update. The `renewBefore` field causes renewal to begin before the current certificate expires — for example, with `renewBefore: 360h` (15 days) on a 90-day certificate, renewal starts at day 75. cert-manager issues the new certificate while the old one is still valid, then atomically updates the Kubernetes Secret with both the new key and certificate in a single write.
 
-Timeline:
-- Day 0: Cert issued (90-day validity)
-- Day 60: Renewal starts (renewBefore: 30 days)
-- Day 61: New cert issued, Secret updated
-- Day 90: Original would expire, but already renewed
-
-No manual intervention, no downtime.
+The Ingress controller or application watching the Secret detects the change and reloads, picking up the new certificate. During the entire process, the old certificate remains valid and serves traffic — clients never see an expired certificate or a TLS handshake failure. The `renewBefore` window provides the buffer between when renewal starts and when the old certificate dies. If renewal fails, the remaining validity period gives you time to intervene before an outage.
 
 </details>
 
 ### Question 3
-Why use ClusterIssuer instead of Issuer?
+
+Issuer and ClusterIssuer represent a namespace-scoping decision that has operational consequences for how your team manages CA configuration across environments. When would you use a namespaced Issuer rather than a ClusterIssuer, and what isolation property does this provide?
 
 <details>
 <summary>Show Answer</summary>
 
-**Issuer** (namespaced):
-- Only usable in its namespace
-- Good for team-specific CAs
-- More isolation
+A namespaced **Issuer** can only be referenced by Certificate resources in the same namespace. This provides namespace-level isolation: the `staging` namespace can use a Let's Encrypt staging issuer without risking that a production Certificate accidentally picks up a staging CA, and a team managing their own internal CA can scope credentials and configuration to their namespace only.
 
-**ClusterIssuer** (cluster-wide):
-- Usable from any namespace
-- Good for shared Let's Encrypt config
-- Less duplication
+A **ClusterIssuer** is available to all namespaces and is the natural choice for shared infrastructure — a single Let's Encrypt production issuer used cluster-wide, or an organizational root CA for internal service certificates.
 
-**Best practice**:
-- ClusterIssuer for Let's Encrypt (everyone uses it)
-- ClusterIssuer for internal CA (shared trust)
-- Issuer for team-specific/sensitive CAs
+Use an Issuer when the CA configuration carries namespace-specific credentials or when you want to enforce that certain CAs are only available in specific namespaces. Use a ClusterIssuer for shared, cluster-wide CA configurations to avoid duplicating the same YAML in every namespace.
 
 </details>
+
+### Question 4
+
+cert-manager's webhook is easy to overlook during installation but it provides a critical safety boundary at the Kubernetes API level. What is the purpose of cert-manager's validating webhook, and what class of failure does it prevent?
+
+<details>
+<summary>Show Answer</summary>
+
+The validating webhook intercepts Certificate, Issuer, and ClusterIssuer resource creation and update requests at the Kubernetes API server admission stage. It validates the resources before they are persisted, rejecting configurations that reference nonexistent issuers, contain malformed DNS names, or have conflicting settings.
+
+The webhook prevents **silent misconfiguration failures** — errors that would only surface weeks or months later at renewal time. Without the webhook, a Certificate that references a misspelled issuer name would be accepted and stored, and you would discover the problem only when renewal failed and the certificate expired. With the webhook, the invalid Certificate is rejected immediately at `kubectl apply` time, forcing you to fix the configuration before it can cause an outage.
+
+</details>
+
+### Question 5
+
+Setting `isCA: true` on a Certificate resource has a specific effect on the resulting X.509 certificate that distinguishes it from end-entity certificates. Why does the internal CA pattern require the root Certificate to have `isCA: true`, and what X.509 extension does this set?
+
+<details>
+<summary>Show Answer</summary>
+
+The `isCA: true` field on the root Certificate resource sets the X.509 **Basic Constraints** extension with the CA flag set to `TRUE`. This extension marks the certificate as authorized to sign other certificates — it is what makes the certificate function as a Certificate Authority rather than as an end-entity certificate.
+
+When cert-manager's CA issuer receives a signing request, it checks the backing certificate's Basic Constraints extension. If the CA flag is not set, the issuer rejects the signing request because the backing certificate lacks the authority to act as a CA. This is a security boundary: it prevents a regular server certificate from being accidentally (or maliciously) used as a CA to sign additional certificates.
+
+</details>
+
+### Question 6
+
+Debugging a certificate that is stuck in `Ready: False` requires tracing through the internal resource chain that cert-manager creates during the issuance process. A Certificate resource shows `Ready: False` with an ACME issuer. What internal resources should you examine first to diagnose the failure, and in what order?
+
+<details>
+<summary>Show Answer</summary>
+
+Examine the resources in this order, following the ACME lifecycle chain:
+
+1. **Certificate** — `kubectl describe certificate <name>` shows the overall status and any top-level error messages. The `status.conditions` field indicates whether the failure is in the issuance or renewal phase.
+
+2. **CertificateRequest** — identified from the Certificate's status, this resource contains the CSR and the specific error from the last issuance attempt. It is the first place to see what the CA rejected.
+
+3. **Order** — the Order tracks the ACME transaction for all DNS names on the certificate. An Order status of `pending` or `errored` indicates the ACME flow has not completed.
+
+4. **Challenge** — the most detailed error source. `kubectl describe challenge <name>` shows the exact challenge type, the validation state, and any error from the ACME server. Common errors include "connection refused" (HTTP-01 path not reachable), "no TXT record found" (DNS propagation delay), and "too many failed authorizations" (rate limiting).
+
+The chain is Certificate → CertificateRequest → Order → Challenge. Each resource's status references the next, so you can trace the failure from the top down.
+
+</details>
+
+### Question 7
+
+Wildcard certificates are a common source of confusion because the wildcard pattern only covers a specific depth of subdomains — and the apex domain is not included unless explicitly listed. You configure a wildcard certificate with `dnsNames: ["*.example.com"]` and discover that `https://example.com` (the apex domain) fails TLS validation. Why?
+
+<details>
+<summary>Show Answer</summary>
+
+The wildcard `*.example.com` matches single-level subdomains like `app.example.com` or `api.example.com`. It does **not** match the apex domain `example.com` itself. The TLS handshake performs an exact match between the domain the client requested and the Subject Alternative Names in the certificate; `example.com` is not covered by `*.example.com`.
+
+The fix is to include both entries in the `dnsNames` list:
+```yaml
+dnsNames:
+  - "*.example.com"
+  - example.com
+```
+
+This pattern applies universally — any wildcard certificate that needs to cover the apex domain must list it explicitly alongside the wildcard entry.
+
+</details>
+
+### Question 8
+
+The Ingress shim is the most commonly used cert-manager integration, but its behavior around resource deletion is a frequent source of surprises for operators who assume Kubernetes-native cascading cleanup. How does cert-manager's Ingress shim work, and what happens to the Secret when the Ingress is deleted?
+
+<details>
+<summary>Show Answer</summary>
+
+The Ingress shim is a controller that watches for Ingress resources with the annotation `cert-manager.io/cluster-issuer` or `cert-manager.io/issuer`. When it finds a matching Ingress with TLS configuration, it automatically creates a Certificate resource with the hosts and secret name from the Ingress spec. cert-manager then manages the full lifecycle of that Certificate — issuance, renewal, and Secret population — as if you had created the Certificate resource manually.
+
+When the Ingress is deleted, cert-manager does **not** delete the corresponding Certificate or Secret. This is a deliberate design choice: the Secret may be referenced by other resources (e.g., a pod mounting it directly), and deleting it could cause cascading failures. You must manage Secret and Certificate cleanup explicitly — `kubectl delete certificate <name>` when the corresponding Ingress is removed.
+
+</details>
+
+---
+
+## Key Takeaways
+
+The durable concepts from this module apply regardless of which certificate automation tool you use. Here is what you should carry forward:
+
+- **Certificates expire. Automation is the only architecture that scales.** A closed-loop lifecycle — issue, install, monitor, renew — with no human in the critical path is the durable solution to certificate management.
+- **ACME is the standard for automated public certificates.** Understand the two challenge types: HTTP-01 for simple public services, DNS-01 for wildcards and internal services. The choice is about operating constraints, not superiority.
+- **Issuer vs. ClusterIssuer is about scope and isolation.** Use ClusterIssuers for shared infrastructure (Let's Encrypt, org-wide internal CA). Use namespaced Issuers for team-specific CAs and credential isolation.
+- **The Certificate resource is declarative desired state.** You specify what certificate you want — domains, issuer, rotation window — and cert-manager handles the how. The annotation-based Ingress shim reduces this to a single line of configuration.
+- **Monitoring is not optional.** `certmanager_certificate_expiration_timestamp_seconds` and `certmanager_certificate_ready_status` must alert before expiry and on Ready: False. An automation tool without monitoring is a certificate expiry system with extra steps.
+- **Every certificate in the cluster belongs under management.** Unmanaged certificates that coexist with cert-manager create false confidence — the ones you forgot about are the ones that will cause the outage.
+
+The exercise below gives you hands-on practice with the full certificate lifecycle so you can internalize these patterns through direct experience.
 
 ---
 
 ## Hands-On Exercise
 
 ### Objective
-Set up cert-manager with a self-signed issuer and create certificates.
+
+This exercise walks you through the complete cert-manager lifecycle in a local or development cluster. You will install cert-manager, configure a self-signed issuer, request a certificate, and verify that the resulting Kubernetes Secret contains a valid key pair and X.509 certificate with the correct DNS names.
 
 ### Environment Setup
 
@@ -692,7 +752,7 @@ kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=cert-manage
 5. **Verify Secret created**:
    ```bash
    kubectl get secret myapp-tls-secret
-   kubectl get secret myapp-tls-secret -o jsonpath='{.data.tls\.crt}' | base64 -d | openssl x509 -text -noout | head -20
+   kubectl get secret myapp-tls-secret -o jsonpath='{.data.tls\\.crt}' | base64 -d | openssl x509 -text -noout | head -20
    ```
 
 6. **Create internal CA** (for realistic setup):
@@ -732,22 +792,31 @@ kubectl wait --for=condition=ready pod -l app.kubernetes.io/instance=cert-manage
 - [ ] Certificate shows correct DNS names
 
 ### Bonus Challenge
-Create an Ingress with the cert-manager annotation and verify it automatically creates a Certificate and Secret.
+
+For a more realistic integration test, create an Ingress resource with the cert-manager annotation and verify that cert-manager automatically creates a corresponding Certificate resource and populates the referenced Secret — then confirm that the Secret is not deleted when you remove the Ingress.
 
 ---
 
-## Further Reading
+## Sources
 
 - [cert-manager Documentation](https://cert-manager.io/docs/)
+- [CNCF cert-manager Project Page](https://www.cncf.io/projects/cert-manager/)
+- [cert-manager GitHub Repository](https://github.com/cert-manager/cert-manager)
+- [cert-manager Releases](https://github.com/cert-manager/cert-manager/releases)
 - [Let's Encrypt](https://letsencrypt.org/)
-- [ACME Protocol RFC](https://tools.ietf.org/html/rfc8555)
+- [Let's Encrypt Documentation](https://letsencrypt.org/docs/)
+- [ACME Protocol RFC 8555](https://tools.ietf.org/html/rfc8555)
+- [cert-manager ACME Configuration](https://cert-manager.io/docs/configuration/acme/)
+- [cert-manager CA Issuer Configuration](https://cert-manager.io/docs/configuration/ca/)
+- [cert-manager Certificate Resource Reference](https://cert-manager.io/docs/usage/certificate/)
+- [cert-manager Ingress Configuration](https://cert-manager.io/docs/usage/ingress/)
 
 ---
 
 ## Next Module
 
-Continue to [Developer Experience Toolkit](/platform/toolkits/developer-experience/devex-tools/) to learn about k9s, Telepresence, and local Kubernetes development.
+The certificate lifecycle automation skills you have built here apply directly to the broader platform tooling landscape. Continue to [Developer Experience Toolkit](/platform/toolkits/developer-experience/devex-tools/) to learn about k9s, Telepresence, and the local Kubernetes development tools that make day-to-day platform work productive and enjoyable.
 
 ---
 
-*"The best security feature is one that's automatic. cert-manager makes TLS invisible."*
+*"The best security feature is one that's automatic. cert-manager makes TLS invisible — and invisible infrastructure is the highest compliment you can pay an operations tool."*


### PR DESCRIPTION
## Summary

Expands three `infrastructure-networking/platforms` stubs (T3, ~360–430 prose words) to **T0** on their durable concept spines (#1996). Part of the Toolkits/infrastructure-networking expand drive (was 31 done / 11 not-done → 34 / 8 after this).

| Module | Author | Tier / prose-w / sources | Durable spine |
|---|---|---|---|
| **7.1 Backstage** | cursor (auto) | T0 / 5000 / 13 | Internal Developer Platform: software catalog, scaffolding/golden-paths, TechDocs, plugin model; build-vs-buy. IDP Rosetta (Backstage·Port·Cortex·Kratix). |
| **7.2 Crossplane** | codex gpt-5.5 | T0 / 5460 / 18 | Control-plane / infrastructure-as-API: continuous reconcile vs client-side IaC, providers, Compositions/XRDs/Functions, claim→composite→managed. IaC Rosetta (Crossplane·Terraform·Pulumi). |
| **7.3 cert-manager** | deepseek-v4-pro | T0 / 5099 / 11 | Automated X.509 lifecycle: PKI primitives, ACME (HTTP-01 vs DNS-01), Issuer/ClusterIssuer/Certificate, renewal, Ingress shim. Cert-automation Rosetta (cert-manager·ACME client·cloud-managed). |

## Cross-family review (opus-inline R1, Anthropic ≠ each author) + web-verification

All CNCF maturity facts **web-verified against cncf.io** (authors' training is stale on these):
- **Backstage = CNCF Incubating** (2022-03-15), donated by Spotify — correct, not Graduated.
- **Crossplane = CNCF Graduated (2025-10-28)** — recent promotion; codex got it right (training-stale "Incubating" avoided).
- **cert-manager = CNCF Graduated (2024-09-29)**; uses `cert-manager.io/v1` throughout and correctly flags the removed `certmanager.k8s.io` group.

Each: durable-vendor rule applied (dated 2026-06 snapshot + cross-tool Rosetta, **no best-tool/market-share claims**); war story relabeled `Hypothetical scenario:`; `## Further Reading` → `## Sources` (≥10 reachable); `revision_pending: false`; anti-leak clean; 7–8 quiz questions. Version-pinned URLs (crossplane CLI v2.3, function-patch-and-transform v0.10.7) confirmed HTTP 200.

Build: `npm run build` green in an integration worktree — **2169 pages, 0 errors**.

## Learner check

> cert-manager was accepted to the CNCF on 2020-11-10, moved to Incubating on 2022-09-19, and moved to Graduated on 2024-09-29. It is a CNCF Graduated project (source: cncf.io/projects/cert-manager).

🤖 Generated with [Claude Code](https://claude.com/claude-code)