### PR TITLE
content(platform): currency snapshots + fixes for final 7 Toolkits stragglers — close #1996

### DIFF
--- a/src/content/docs/platform/toolkits/cicd-delivery/gitops-deployments/module-2.5-dapr-buildpacks.md
+++ b/src/content/docs/platform/toolkits/cicd-delivery/gitops-deployments/module-2.5-dapr-buildpacks.md
@@ -4,6 +4,7 @@ title: "Module 2.5: Dapr and Buildpacks — Application Definition Beyond Helm"
 slug: platform/toolkits/cicd-delivery/gitops-deployments/module-2.5-dapr-buildpacks
 sidebar:
   order: 6
+revision_pending: false
 ---
 
 > **Toolkit Track** | Complexity: `[COMPLEX]` | Time: 60-70 min
@@ -91,6 +92,17 @@ The thesis of this module is direct: Dapr defines runtime concerns as
 platform components; Buildpacks defines build concerns without a Dockerfile;
 together they shift application definition from "imperative template tree" to
 "declarative component graph plus declarative build."
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> **Dapr** is a CNCF **Graduated** project (graduated October 30, 2024).
+> It was accepted into CNCF on November 9, 2021 directly at the Incubating
+> maturity level, bypassing Sandbox — the first CNCF project to do so.
+> **Cloud Native Buildpacks (CNB)** is a separate CNCF **Incubating** project
+> (accepted into Sandbox on October 3, 2018, promoted to Incubating in
+> November 2020). Both projects remain actively maintained and widely used
+> in production. Dapr's current release line is v1.18 (June 2026), which
+> introduced verifiable execution support.
 
 ## 1. Helm's Unfinished Application-Definition Problem
 

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.10-bentoml.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.10-bentoml.md
@@ -1,6 +1,7 @@
 ---
 title: "Module 9.10: BentoML — Python-First Model Packaging and Serving"
 slug: module-9.10-bentoml
+revision_pending: false
 sidebar:
   order: 11
 ---
@@ -32,6 +33,10 @@ The incident did not bankrupt the company, but it forced manual review of more t
 The people who understood the model did not own the request path. The people who owned Kubernetes did not understand the feature transforms. In practice, that ownership split turned every serving change into a translation exercise. The result was a serving architecture where every change required translation.
 
 BentoML matters because many ML teams live in Python first. They train in Python, validate in Python, and write preprocessing logic in Python. When the serving layer asks them to express behavior through a Kubernetes custom resource first, the tool may be powerful but the feedback loop slows down. BentoML starts from the Python service and then packages it for local serving, containerization, and Kubernetes scale-out. This module teaches how that flow works, where it shines, where it gets operationally complicated, and how to deploy it responsibly on K8s 1.35+.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> BentoML is an independent open-source Python framework for building model-inference services, maintained by the BentoML company. It is not a CNCF project. The current release line is v1.4.x; the latest patch release as of mid-2026 is v1.4.39 (May 2026). The v1.4 major release shipped in February 2025, bringing adaptive micro-batching, improved runner separation, and container-build enhancements. BentoML's Python-first serving model contrasts with CRD-driven platforms like KServe (CNCF Incubating) and Seldon Core — it starts from the Python Service and packages it for containerization and scale-out, making it a good fit for ML teams that want to keep their development loop close to training code.
 
 ## BentoML's Python-First Serving Model
 

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.11-bare-metal-mlops.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.11-bare-metal-mlops.md
@@ -1,20 +1,21 @@
 ---
+revision_pending: false
 title: "Module 9.11: Bare-Metal MLOps — Building a Production ML Platform Without Managed Cloud"
 sidebar:
   order: 12
 slug: module-9.11-bare-metal-mlops
 ---
 
-## Complexity: [COMPLEX]
-
-**Time to Complete**: Plan for 60-70 minutes if you already know Kubernetes fundamentals, and reserve extra time if you want to run the production-realistic lab path.
-
-**Prerequisites**: This capstone assumes you can read Kubernetes manifests, recognize common control-plane and workload failures, and connect storage, networking, GPU, and serving behavior into one operational picture.
-
-- Kubernetes basics with a kubeadm cluster or equivalent
-- Module 9.7: GPU Scheduling, because the GPU Operator and MIG appear throughout this module
-- At least one serving module: Module 9.8 KServe, Module 9.9 Seldon Core, or Module 9.10 BentoML
-- Comfort reading Kubernetes manifests, Helm values, and production troubleshooting output
+> **Complexity**: `[COMPLEX]`
+>
+> **Time to Complete**: Plan for 60-70 minutes if you already know Kubernetes fundamentals, and reserve extra time if you want to run the production-realistic lab path.
+>
+> **Prerequisites**: This capstone assumes you can read Kubernetes manifests, recognize common control-plane and workload failures, and connect storage, networking, GPU, and serving behavior into one operational picture.
+>
+> - Kubernetes basics with a kubeadm cluster or equivalent
+> - Module 9.7: GPU Scheduling, because the GPU Operator and MIG appear throughout this module
+> - At least one serving module: Module 9.8 KServe, Module 9.9 Seldon Core, or Module 9.10 BentoML
+> - Comfort reading Kubernetes manifests, Helm values, and production troubleshooting output
 
 For command examples, configure the `kubectl` alias once so the later troubleshooting flow stays readable while still using standard Kubernetes commands underneath:
 
@@ -26,9 +27,9 @@ From here on, commands use `k`, and all Kubernetes examples target Kubernetes **
 
 ---
 
-## Learning Outcomes
+## What You'll Be Able to Do
 
-After completing this module, you will be able to reason about a self-hosted ML platform as a connected system rather than a bag of individually installed tools:
+After completing this module, you will be able to:
 
 - **Design** a seven-layer bare-metal ML platform that replaces managed-cloud services with Kubernetes-native components.
 - **Evaluate** storage, networking, GPU, serving, registry, orchestration, and observability trade-offs for production ML workloads.
@@ -59,6 +60,10 @@ It can give you data sovereignty, predictable cost at scale, direct control over
 It also moves work back onto your team.
 You own the storage layer, load balancer bring-up, CNI policy, GPU operator lifecycle, metrics stack, trace plumbing, and backup story.
 This module is the capstone recipe for assembling the tools you have already met into a coherent production platform.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> **KServe** joined the CNCF as an **Incubating** project on **2025-09-29** after graduating from Kubeflow; it remains a strong Kubernetes-native default for `InferenceService` resources, canary rollouts, and multi-framework predictors when you want CNCF-neutral governance. **MLflow** (Apache-2.0) is still the most common self-hosted experiment tracker and model registry in bare-metal stacks; pair it with PostgreSQL metadata and MinIO or another S3-compatible artifact root rather than pod-local storage. The **NVIDIA GPU Operator** is the practical bare-metal default for driver, device-plugin, DCGM, and MIG lifecycle on supported data-center GPUs — consumer cards such as RTX 4090 lack MIG and usually rely on whole-GPU allocation or time-slicing with weaker isolation. **Serving peers** each fit different shapes: KServe for standard inference endpoints and GitOps-friendly rollouts, Seldon Core for graph-style pipelines and Alibi monitoring when license tier fits your organization, BentoML for developer-packaged services. Compare tools on operational tradeoffs — isolation, autoscaling model, registry integration, and team ownership — rather than treating any single runtime as universally best.
 
 ---
 
@@ -437,6 +442,8 @@ For those nodes, time-slicing can improve utilization for inference and developm
 Time-slicing shares a GPU across multiple pods through software scheduling.
 It does not provide the same memory isolation as MIG, so use it for lower-criticality workloads and set expectations with users.
 
+The NVIDIA device plugin is the Kubernetes-facing half of GPU scheduling: it registers with kubelet, advertises `nvidia.com/gpu` or MIG profile resources on the Node object, and implements Allocate so containers receive the correct device files and libraries at start time. On bare metal you rarely install the device plugin alone because driver version skew, missing container toolkit hooks, or stale DCGM exporters produce the worst class of failures — pods schedule successfully yet CUDA calls fail at runtime. That is why the GPU Operator bundles driver management, toolkit configuration, device plugin, GPU Feature Discovery labels such as `nvidia.com/gpu.product`, DCGM metrics, and MIG manager reconciliation into one upgrade surface. MIG partitioning on A100 or H100 class GPUs exposes finer-grained resources like `nvidia.com/mig-1g.10gb`, which helps platform teams sell predictable inference slices instead of whole accelerators, but reconfiguration is disruptive and must be change-managed like any capacity-altering maintenance. Time-slicing on consumer GPUs improves utilization for dev and batch inference by multiplexing contexts in software, yet two noisy neighbors can still contend for memory bandwidth; treat time-sliced pools as a lower isolation tier with explicit SLO disclaimers. The durable design habit is to match GPU sharing mode to workload criticality before users discover isolation limits during an incident.
+
 ```yaml
 apiVersion: v1
 kind: ConfigMap
@@ -539,6 +546,8 @@ CloudNativePG is a strong production PostgreSQL option when you want operator-ma
 A plain PostgreSQL Helm chart is acceptable for a learning environment.
 The important design point is that the MLflow pod is stateless.
 It can be rescheduled without losing experiments or artifacts.
+
+Registry governance on bare metal fails in predictable ways when teams treat promotion as a spreadsheet exercise instead of a platform contract. A registered model version in MLflow records lineage — which run produced the artifact, which parameters were logged, and which alias such as `Production` or `Staging` should point serving systems at an approved binary — but KServe, Seldon, or BentoML will not automatically reload when someone clicks promote in the UI unless you wired registry events to GitOps or a deployment controller. The durable pattern is to keep human approval in MLflow or your change-management tool, then express the approved artifact URI or model version in Git so ArgoCD reconciles the `InferenceService` or serving manifest. That separation prevents the common outage where registry metadata says version 7 is live while the cluster still pulls version 5 from an old storage path. For multi-team platforms, scope credentials so training jobs can write runs and artifacts but only platform automation or release roles can move aliases; shared MinIO keys make forensics painful after a mistaken delete. Backup drills should restore PostgreSQL and the referenced object keys together, because registry rows without artifact bytes — or buckets without metadata — are both incomplete recovery stories.
 
 ### MLflow Helm Values
 
@@ -1438,6 +1447,12 @@ Tekton is attractive when the organization already uses it for application CI/CD
 Avoid running both for the same team unless there is a clear operational reason.
 </details>
 
+<details>
+<summary>KServe shows Ready, but clients receive HTTP 502 from the public endpoint. How do you diagnose failures across the request path from ingress through the service mesh, transformer, predictor pod, GPU, and response?</summary>
+
+Work from the edge inward instead of restarting random pods. Confirm ingress routes and TLS terminate on the expected host, then verify the service mesh or CNI path allows traffic to the KServe gateway revision. Inspect transformer logs for schema validation errors before the predictor runs, because many 502 responses are actually upstream validation failures masked at the edge. On the predictor pod, check model-load init containers, runtime stack traces, and whether the pod received the expected GPU allocation or hit an OOM event. Use trace spans and structured logs with a shared request ID at ingress, mesh, transformer, predictor, and GPU hops so you can diagnose whether latency or errors originate before or after the model runtime. This systematic diagnose-across-the-path habit turns a vague gateway error into a bounded fix at the layer that actually failed.
+</details>
+
 ---
 
 ## Hands-On Exercise
@@ -1761,6 +1776,13 @@ If Prometheus does not scrape KServe metrics, verify ServiceMonitor labels match
 
 ---
 
+## Next Module
+
+**End of ML Platforms Toolkit.** Continue to the next category in the Data & AI Platforms family:
+[Cloud-Native Databases Toolkit](/platform/toolkits/data-ai-platforms/cloud-native-databases/) — CockroachDB, CloudNativePG, Neon/PlanetScale, and Vitess for production database management on Kubernetes.
+
+---
+
 ## Sources
 
 - NVIDIA GPU Operator documentation: https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/index.html
@@ -1783,8 +1805,3 @@ If Prometheus does not scrape KServe metrics, verify ServiceMonitor labels match
 - OpenTelemetry Python instrumentation documentation: https://opentelemetry.io/docs/instrumentation/python/
 - CloudNativePG documentation: https://cloudnative-pg.io/documentation/current/
 - Velero documentation: https://velero.io/docs/main/
-
----
-
-**End of ML Platforms Toolkit.** Continue to the next category in the Data & AI Platforms family:
-[Cloud-Native Databases Toolkit](/platform/toolkits/data-ai-platforms/cloud-native-databases/) — CockroachDB, CloudNativePG, Neon/PlanetScale, and Vitess for production database management on Kubernetes.

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.8-kserve.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.8-kserve.md
@@ -1,6 +1,7 @@
 ---
 title: "Module 9.8: KServe — Production-Grade Model Inference on Kubernetes"
 slug: platform/toolkits/data-ai-platforms/ml-platforms/module-9.8-kserve
+revision_pending: false
 sidebar:
   order: 9
 ---
@@ -49,6 +50,14 @@ Knative should handle request-driven serverless behavior when that mode is appro
 Istio or another gateway layer should manage ingress, mTLS, and traffic policy.
 Your model runtime should load artifacts and answer inference requests.
 When those boundaries are clear, model serving becomes operable instead of mysterious.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> KServe is now a CNCF Incubating project. CNCF lists September 29, 2025 as the Incubating acceptance date, and the public CNCF project post appeared during the KubeCon North America 2025 week. The lineage matters for trust: KServe began in 2019 as KFServing under Kubeflow through work by Google, IBM, Bloomberg, NVIDIA, and Seldon, moved to LF AI & Data in February 2022, rebranded from KFServing to standalone KServe in September 2022, and later moved into CNCF.
+>
+> The current release train is still the v0.1x line: GitHub marks v0.19.0, published on June 14, 2026, as the latest release, while these exercises remain pinned to v0.17.0 as a lab baseline. Treat that pin as a reproducibility choice for this module, not as production install guidance.
+>
+> The durable idea is that KServe standardizes model inference on Kubernetes for both predictive and generative workloads. It composes with nearby cloud-native layers such as Knative for serverless predictive serving, Istio or Envoy Gateway for traffic and gateway concerns, and vLLM-oriented paths for large language model serving, but it should be evaluated as one serving API in a wider platform design rather than as a universal answer for every team.
 
 ## KServe Architecture: Control Plane and Data Plane
 
@@ -1413,6 +1422,7 @@ Next: Module 9.9: Seldon Core will compare another Kubernetes-native inference p
 ## Sources
 
 - https://kserve.github.io/website/docs/getting-started/quickstart-guide
+- https://kserve.github.io/website/docs/intro
 - https://kserve.github.io/website/docs/concepts/architecture
 - https://kserve.github.io/website/docs/concepts/architecture/control-plane
 - https://kserve.github.io/website/docs/concepts/architecture/data-plane
@@ -1428,7 +1438,10 @@ Next: Module 9.9: Seldon Core will compare another Kubernetes-native inference p
 - https://kserve.github.io/website/docs/model-serving/predictive-inference/explainers/alibi/tabular-explainer
 - https://kserve.github.io/website/docs/admin-guide/serverless
 - https://kserve.github.io/website/docs/admin-guide/kubernetes-deployment
+- https://www.cncf.io/projects/kserve/
+- https://www.cncf.io/blog/2025/11/11/kserve-becomes-a-cncf-incubating-project/
 - https://github.com/kserve/kserve
+- https://github.com/kserve/kserve/releases/tag/v0.19.0
 - https://github.com/kserve/kserve/releases/download/v0.17.0/kserve-knative-mode-full-install-with-manifests.sh
 - https://knative.dev/docs/serving/
 - https://istio.io/latest/docs/tasks/security/authentication/mtls-migration/

--- a/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.9-seldon-core.md
+++ b/src/content/docs/platform/toolkits/data-ai-platforms/ml-platforms/module-9.9-seldon-core.md
@@ -1,4 +1,5 @@
 ---
+revision_pending: false
 title: "Module 9.9: Seldon Core — Multi-Framework Model Serving with Inference Graphs"
 slug: module-9.9-seldon-core
 sidebar:
@@ -101,6 +102,12 @@ Core 2 is the better default when you want shared servers, Kafka-backed dataflow
 That does not make Core 2 simpler in every case.
 It adds moving parts, especially Kafka when pipelines are enabled.
 It earns those moving parts when model serving is no longer a single endpoint.
+
+The control-plane components deserve a closer look because they explain why Core 2 behaves differently from a hand-rolled Deployment. The Scheduler is the placement brain: it watches `Model`, `Server`, `Pipeline`, and `Experiment` objects, decides which server replica should load which artifact, and tracks memory reservations so shared farms do not accept more models than they can hold. The Agent runs beside each runtime pod and performs the mechanical work of downloading artifacts, loading them into MLServer or Triton, unloading evicted models, and exposing per-model metrics. When a model fails to become ready, the first signals usually appear in Agent logs rather than in the client-facing HTTP response. Envoy is the dataplane front door. It terminates inference traffic, applies routing rules for models, pipelines, and experiments, and forwards requests to the correct Agent or pipeline gateway without forcing every client to understand the internal graph. The model gateway and pipeline gateway sit behind Envoy when dataflow is enabled; they translate synchronous HTTP or gRPC calls into step execution while optional Kafka topics preserve intermediate tensors for audit, replay, or asynchronous detector paths. Understanding that split matters during incidents: a Scheduler outage may freeze new placements while already-loaded models keep serving, whereas an Envoy misconfiguration blocks all traffic immediately.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> Since **2024-01-22**, Seldon has licensed **all new releases of Seldon Core (v1 and v2) and the Alibi libraries (Alibi Explain, Alibi Detect)** under the **Business Source License (BSL 1.1)** — a source-available license, not an OSI-open-source license. Each release converts to **Apache-2.0 four years after its release date** per the license parameters in the upstream repositories. **MLServer** remains permissively open-source under Apache-2.0. **Seldon Core+** and the **Enterprise Platform** are commercial-only tiers. Non-production use of Core and Alibi under BSL is free; production use requires a commercial subscription unless your organization qualifies for Seldon's limited additional-use grant for non-profit and educational production workloads. Before adopting Seldon Core 2 or Alibi in a regulated environment, read the current [Seldon licensing FAQs](https://www.seldon.io/licensing-faqs/) and confirm which tier covers your deployment — license posture is the most durable adoption constraint for this stack today.
 
 **Pause and predict:** if you deploy ten sklearn models with nearly identical dependencies, should each one become its own Kubernetes Deployment, or should they share a Seldon `Server` farm?
 Sharing a server farm is usually the better Seldon Core 2 shape because the `Server` owns the runtime capacity and each `Model` declares requirements.
@@ -389,6 +396,8 @@ The reconciliation loop for an `Experiment` is:
 4. Inference requests route according to candidate weights.
 5. Status reflects whether the experiment is active.
 
+At the mesh layer, `Experiment` is how Seldon expresses canary, shadow, and A/B behavior without pushing routing logic into application code. A canary split assigns weighted traffic between candidate models or pipelines — for example 90% to a stable `risk-v1` and 10% to `risk-v2` — while the default endpoint name stays unchanged for downstream consumers. Shadow or mirror traffic sends a copy of live requests to a candidate path that does not return its response to the caller, which is useful when you want to compare latency, error rates, or score distributions before promoting a variant. A/B routing at this layer is declarative: weights live in Kubernetes, show up in `kubectl get experiment`, and can be rolled back by editing one resource instead of redeploying every client SDK. The tradeoff is operational visibility — you must define success metrics, monitor both arms, and know that experiment stickiness headers help route consistency but do not replace stateful-model design when replicas hold session data.
+
 ## Multi-Framework Model Loading
 
 Multi-framework serving is one of the reasons teams choose Seldon.
@@ -563,6 +572,8 @@ If model teams own runtime images independently, you will get fast experimentati
 If the platform owns all runtime images, you will get consistency and slower dependency updates.
 Many organizations split the difference: platform owns the base MLServer and Triton images, while model teams can request a reviewed dependency bundle exposed as a capability.
 
+MLServer and custom inference runtimes solve different problems, and the choice is about ownership boundaries rather than raw performance alone. MLServer is Seldon's default open-source runtime: it implements the Open Inference Protocol, loads many framework artifacts through standard model-settings files, and integrates Alibi explainers and detectors when the server image advertises the matching capabilities. That makes MLServer the low-friction path for sklearn, XGBoost, MLflow pyfunc, and many HuggingFace models when dependencies fit a reviewed base image. Custom runtimes — often Triton model repositories, bespoke Python servers, or vendor-optimized GPU images — earn their place when latency, batching, TensorRT compilation, or proprietary preprocessing cannot be expressed as a capability tag on a shared farm. The platform pattern is to keep MLServer as the default `ServerConfig` and promote a custom `Server` only after a workload proves it needs isolated drivers, non-standard libraries, or GPU shapes that would destabilize a shared pool. Model teams should not treat `storageUri` as a license to install packages at container start; runtime images belong in the platform pipeline, while artifacts stay versioned object storage paths on the `Model`.
+
 **Before running this, what output do you expect?**
 If a `Model` requests `xgboost` but no `Server` exposes `xgboost`, the model should not become ready.
 The failure is a scheduling mismatch, not an HTTP serving failure.
@@ -637,6 +648,8 @@ Walk the request through that graph:
 The important point is that the graph owns the data movement.
 If the feature normalization step changes tensor names, you update the pipeline mapping.
 You do not hide the change in a client library or a web wrapper.
+
+Think of a production inference graph as a directed acyclic pipeline rather than a single model call. A typical credit or fraud flow might chain a transformer step that normalizes raw features, a scoring model that consumes tensor outputs from that step, and a combiner or business-rules model that merges scores with policy outputs before the synchronous response returns. Each step is usually its own `Model` resource with an explicit name; the `Pipeline` CRD wires `inputs`, `tensorMap`, and optional `batch` settings so the Scheduler knows which tensors must exist before a downstream step runs. Join steps merge multiple upstream outputs when a ranker needs both user features and catalog embeddings. Conditional routes branch on tensors emitted by a router model — for example sending retail applicants to one scorer and business applicants to another — while `stepsJoin: any` ensures only the active branch contributes to the response. Detector and explainer steps often sit on side paths so monitoring and explainability observe the same normalized tensors without adding latency to the user-facing prediction. That DAG mental model is what separates a maintainable inference application from a brittle wrapper that encodes graph logic in Python middleware.
 
 ### Chains, Joins, Conditional Routing, and A/B Routing
 
@@ -920,6 +933,8 @@ If an upstream team changes categorical encoding, drift can tell you the input d
 The hard part is response policy: what happens when drift is detected?
 Good teams predefine whether to alert, shadow a fallback model, pause rollout, or start data review.
 
+Alibi Detect deserves explicit WHY-before-HOW treatment because drift and outlier signals are easy to misapply. Outlier detection answers whether a single request looks unlike training data — malformed payloads, sensor glitches, adversarial perturbations, or rare edge cases — and is most valuable when you want fast rejection or alerting before a score influences a decision. Drift detection compares batches or streams of live inputs against a reference distribution and warns when the world changed even though your pods are healthy and HTTP success rates look fine; that is the pattern that catches seasonal shifts, upstream encoding changes, and silent feature pipeline regressions. In Core 2 you deploy both as `Model` resources with `alibi-detect` requirements and place them in pipeline side paths with batching so inference latency stays predictable. The operational lesson is policy, not math: decide in advance whether drift triggers an alert, a human review queue, a paused experiment, or a route to a safer fallback model. Detectors produce evidence; platform teams still own the response playbook.
+
 ## Production Concerns: Kafka, Observability, Tenancy, and Scaling
 
 Seldon Core 2 is a platform, not a tiny library.
@@ -974,7 +989,7 @@ That can be efficient for long-tail model fleets.
 It can also add reload latency when an evicted model receives traffic.
 Use overcommit for workloads that tolerate occasional reload costs, not for strict low-latency paths.
 
-War story: a platform team placed dozens of small tabular models on a shared MLServer farm and saved a meaningful amount of cluster overhead.
+Hypothetical scenario: a platform team placed dozens of small tabular models on a shared MLServer farm and saved a meaningful amount of cluster overhead.
 Then a model team deployed one large NLP model with a low memory estimate.
 The Scheduler accepted it, but the server started evicting active models under load.
 The incident looked like random p95 latency spikes until the team correlated model load events with prediction latency.

--- a/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.11-ebpf-tracing-tools.md
+++ b/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.11-ebpf-tracing-tools.md
@@ -4,6 +4,7 @@ title: "Module 1.11: eBPF Tracing Tools (bpftrace, BCC, Inspektor Gadget)"
 slug: platform/toolkits/observability-intelligence/observability/module-1.11-ebpf-tracing-tools
 sidebar:
   order: 12
+revision_pending: false
 ---
 
 ## Complexity: [MEDIUM]
@@ -69,6 +70,10 @@ That imperative mindset changes the tool choice. bpftrace is the scalpel for one
 Exercise scenario: A checkout endpoint is slow only during traffic spikes. Prometheus shows elevated p99 latency, but CPU and memory are normal. The application team has traces for the checkout process itself, yet the trace usually ends at a generic HTTP client span. A platform engineer lists TCP tracepoints, attaches a short `bpftrace` program to `tracepoint:tcp:tcp_retransmit_skb`, and sees retransmission events climb when the checkout pods call a downstream inventory service. That does not prove root cause by itself, but it changes the incident from "the API is slow" to "the API is waiting behind packet loss or congestion on one dependency path."
 
 The lesson is not that bpftrace magically replaces metrics, logs, or traces. The lesson is that eBPF tracing can reveal behavior at the kernel boundary when the permanent telemetry is too coarse. You still need ordinary observability to decide impact, confirm recovery, and explain user-facing consequences. You still need application instrumentation for business semantics. The ad-hoc eBPF tools help you bridge the missing minutes between a vague symptom and the next precise investigation step.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> **bpftrace** and **BCC** are foundational open-source tracing tools maintained under the iovisor project; they are not CNCF projects. **Cilium** (which includes **Tetragon**) is a CNCF **Graduated** project (graduated October 11, 2023). **Inspektor Gadget** is CNCF **Sandbox** (accepted March 7, 2023). **Pixie** is CNCF **Sandbox** (accepted June 22, 2021). **Parca** is an independent open-source project (Apache 2 License) created by Polar Signals — it is not a CNCF project and has never been accepted into any CNCF maturity level. All of these tools occupy different points on the imperative-to-declarative spectrum: bpftrace and BCC are imperative terminal tools; Inspektor Gadget wraps common probes behind a Kubernetes-aware CLI; Pixie, Parca, and Pyroscope are persistent always-on observability and profiling platforms.
 
 ---
 

--- a/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.12-otel-collector-production.md
+++ b/src/content/docs/platform/toolkits/observability-intelligence/observability/module-1.12-otel-collector-production.md
@@ -2,6 +2,7 @@
 citations_verified: true
 title: "Module 1.12: OpenTelemetry Collector at Production Scale"
 slug: platform/toolkits/observability-intelligence/observability/module-1.12-otel-collector-production
+revision_pending: false
 sidebar:
   order: 13
 ---
@@ -35,6 +36,14 @@ The most expensive mistakes are subtle because telemetry often keeps flowing whi
 The module is intentionally not a runnable operator lab. You will see realistic configuration fragments because production collector work is configuration-heavy, but the goal is design literacy. You should finish with the ability to review a collector pull request and ask the right questions: where does tenant identity come from, which tier owns sampling, what protects memory, which attributes are allowed, and what happens when a backend slows down. Those questions catch more real failures than memorizing every component option.
 
 This is also why the module keeps cost visible from the beginning. Observability platforms often fail socially before they fail technically: the platform team adds more detail because incidents are painful, finance pushes back because the bill grows, security asks for redaction after data has already spread, and application teams bypass shared policy because the default path feels too restrictive. A production Collector design gives those groups a common control surface. Sampling, routing, batching, and attribute policy become explicit platform decisions instead of scattered application defaults.
+
+> **Landscape snapshot — as of 2026-06. This changes fast; verify against vendor docs before relying on specifics.**
+>
+> OpenTelemetry is a CNCF Graduated project. CNCF announced graduation on May 21, 2026 and described OTel as having the second-highest project velocity in CNCF after Kubernetes. That maturity applies to the project as a whole; the Collector still requires per-component review when you build a production distribution.
+>
+> The Collector is versioned separately from the specification and from many language SDKs. As of this snapshot, the core Collector release is v1.60.0/v0.154.0, published on June 8, 2026, and the contrib distribution is v0.154.0, published on June 9, 2026. The paired versioning is intentional: stable core modules can be in the v1.x line while the broader collector distribution and contrib components remain in the v0.1xx line.
+>
+> Component stability is mixed. The OpenTelemetry status page says core collector components have mixed stability levels, and each receiver, processor, exporter, connector, and extension documents its own alpha, beta, stable, deprecated, or unmaintained status in its README. Production reviews should therefore check the exact components you enable, not just the Collector binary version.
 
 ## Collector Deployment Topologies
 
@@ -540,6 +549,10 @@ Continue to the [GitOps & Deployments toolkit](../../cicd-delivery/gitops-deploy
 ## Sources
 
 - [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) - General Collector role and architecture.
+- [CNCF OpenTelemetry graduation announcement](https://www.cncf.io/announcements/2026/05/21/cloud-native-computing-foundation-announces-opentelemetrys-graduation-solidifying-status-as-the-de-facto-observability-standard/) - CNCF maturity and project activity snapshot.
+- [OpenTelemetry project status](https://opentelemetry.io/status/) - Collector mixed stability status and per-component stability guidance.
+- [OpenTelemetry Collector v1.60.0/v0.154.0 release](https://github.com/open-telemetry/opentelemetry-collector/releases/tag/v0.154.0) - Current core Collector release at this snapshot.
+- [OpenTelemetry Collector Contrib v0.154.0 release](https://github.com/open-telemetry/opentelemetry-collector-contrib/releases/tag/v0.154.0) - Current contrib distribution release at this snapshot.
 - [OpenTelemetry Collector configuration](https://opentelemetry.io/docs/collector/configuration/) - Receivers, processors, exporters, connectors, and service pipelines.
 - [OpenTelemetry Collector agent deployment pattern](https://opentelemetry.io/docs/collector/deploy/agent/) - Agent collectors alongside applications or hosts.
 - [OpenTelemetry Collector gateway deployment pattern](https://opentelemetry.io/docs/collector/deploy/gateway/) - Gateway collectors, load balancing, and tail-sampling topology guidance.


### PR DESCRIPTION
Closes the **Platform Toolkits** epic **#1996** (112 modules → 112 done). These 7 were dense T0 but `shipped_unreviewed` (UNAUDITED, score 5.0) in sections other than infrastructure-networking, and **none carried a dated Landscape snapshot** — the durable-vendor-content rule applies HARD to Toolkits (#1996 AC4).

## Changes (all 7 + cross-family review)
| Module | Author | Change |
|---|---|---|
| 9.8 KServe | codex | +snapshot: **CNCF Incubating 2025-09-29** (was missing); v0.19.0 |
| 9.9 Seldon Core | cursor | de-fab War story; +snapshot: **BSL license since 2024-01-22**; floor 4660→5716 |
| 9.10 BentoML | deepseek | +snapshot: not-CNCF, v1.4.39 |
| 9.11 Bare-Metal MLOps | cursor | structure fix (H2→quote, outcomes); floor→5515 |
| 1.11 eBPF Tracing | deepseek | +snapshot: per-tool maturity (Cilium/Tetragon Graduated, IG/Pixie Sandbox) |
| 1.12 OTel Collector | codex | +snapshot: **OTel Graduated 2026-05-21**; Collector v0.154.0 |
| 2.5 Dapr + Buildpacks | deepseek | +snapshot: Dapr Graduated; CNB Incubating |

## Verification
- **opus-inline cross-family R1** on all 7 (Anthropic ≠ authors; **NO gemini**) — APPROVE records in `.pipeline/reviews/`.
- All maturity/version facts **web-verified both ways** vs CNCF/GitHub/PyPI. Web-verify-both-ways wins: BentoML v1.4.39, KServe v0.19.0, OTel graduation (confirmed via CNCF announcement URL) — all fresher than reviewer snapshot, all confirmed correct.
- Seldon **BSL** license currency gap (Core v2 is source-available, not OSI-open) now taught accurately.
- **Build green: 2169 pages, 0 schema errors.** All 7 verify T0, all gates pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)