### PR TITLE
fix(ai): #2020 Wave 2 review findings — 3 anti-fabrication/currency P1s (3.1, 4.1)

### DIFF
--- a/src/content/docs/ai/ai-engineering-foundations/module-2.4-dynamic-context-orchestration.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-2.4-dynamic-context-orchestration.md
@@ -829,6 +829,7 @@ def simulate_turn(
     add_tool_log: bool = False,
     compact: bool = False,
     idle_gap_sec: float = 0,
+    evict: bool = True,
 ) -> None:
     state.turn += 1
     state.tokens_used = 0
@@ -848,9 +849,10 @@ def simulate_turn(
         state.cache_written_at = now
         note_parts.append("cache_miss")
 
-    freed = evict_stale_snippets(state, now)
-    if freed:
-        note_parts.append(f"evicted_stale={freed}")
+    if evict:
+        freed = evict_stale_snippets(state, now)
+        if freed:
+            note_parts.append(f"evicted_stale={freed}")
 
     if compact and state.tool_log_tokens:
         state.tokens_used += SUMMARY_COST
@@ -865,7 +867,6 @@ def simulate_turn(
 
     if inject_snippet:
         state.snippets.append(inject_snippet)
-        state.tokens_used += inject_snippet.tokens
         note_parts.append(f"inject:{inject_snippet.snippet_id}")
 
     for snip in state.snippets:
@@ -910,7 +911,7 @@ def main() -> None:
     t0 = time.time()
 
     # Phase A — baseline without stale eviction discipline
-    simulate_turn(conn, state, now=t0, action="prime", add_tool_log=True)
+    simulate_turn(conn, state, now=t0, action="prime", add_tool_log=True, evict=False)
     simulate_turn(
         conn,
         state,
@@ -918,10 +919,11 @@ def main() -> None:
         action="retrieve_old",
         inject_snippet=Snippet("r1", "deploy", 900, captured_at=t0 - 200),
         add_tool_log=True,
+        evict=False,
     )
-    simulate_turn(conn, state, now=t0 + 60, action="followup", add_tool_log=True)
+    simulate_turn(conn, state, now=t0 + 60, action="followup", add_tool_log=True, evict=False)
 
-    # Phase B — same shape but eviction-by-staleness enabled (implicit in harness)
+    # Phase B — same shape but eviction-by-staleness enabled
     simulate_turn(conn, state, now=t0 + 90, action="compact", compact=True)
     simulate_turn(
         conn,

--- a/src/content/docs/ai/ai-engineering-foundations/module-3.1-harness-fundamentals-layers-and-system-of-record.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-3.1-harness-fundamentals-layers-and-system-of-record.md
@@ -398,9 +398,9 @@ Write an AGENTS.md that maps three task classes to their policy files using expl
 
 | Task Class | Policy File | Enforcement Gates |
 |---|---|---|
-| bug-fix | docs/harness/policy/branches.md | branch-guard.sh, pre-commit-tests.sh |
-| deploy | docs/harness/policy/deploy.md | deploy-guard.sh |
-| feature | docs/harness/policy/branches.md | branch-guard.sh, pre-commit-tests.sh |
+| bug-fix | docs/harness/policy/branches.md | scripts/branch-guard.sh, scripts/pre-commit-tests.sh |
+| deploy | docs/harness/policy/deploy.md | scripts/deploy-guard.sh |
+| feature | docs/harness/policy/branches.md | scripts/branch-guard.sh, scripts/pre-commit-tests.sh |
 
 ## Platform Overrides
 
@@ -426,7 +426,7 @@ Write `scripts/deploy-guard.sh` to enforce a deployment precondition: the target
 
 ## Enforcement
 
-- deploy-guard.sh: blocks deploy unless the commit message includes `env: staging` or `env: production`
+- scripts/deploy-guard.sh: blocks deploy unless the commit message includes `env: staging` or `env: production`
 
 ## Remediation
 
@@ -463,7 +463,7 @@ Simulate how an agent would resolve a deployment request using only command-line
 cd harness-lab
 
 # Step 1: Agent reads AGENTS.md and finds the deploy policy path
-POLICY=$(grep -A1 '^| deploy ' AGENTS.md | tail -1 | grep -o 'docs/harness/policy/[^ ]*')
+POLICY=$(grep '^| deploy ' AGENTS.md | grep -oE 'docs/harness/policy/[^ |]+')
 echo "Resolved policy file: $POLICY"
 
 # Step 2: Agent reads the policy file and finds the enforcement script
@@ -495,25 +495,25 @@ errors=0
 echo "=== Anchor validation ==="
 
 # Extract all paths from AGENTS.md policy table (skip header and separator)
-grep -oP 'docs/[^ ]+' AGENTS.md | sort -u | while read -r path; do
+while read -r path; do
     if [ -f "$path" ]; then
         echo "OK: $path"
     else
         echo "BROKEN: $path does not exist"
         errors=$((errors + 1))
     fi
-done
+done < <(grep -oP 'docs/[^ ]+' AGENTS.md | sort -u)
 
 # Also validate enforcement script references inside policy files
 for policy in docs/harness/policy/*.md; do
-    grep -oP 'scripts/[^ ]+\.sh' "$policy" 2>/dev/null | while read -r script_path; do
+    while read -r script_path; do
         if [ -f "$script_path" ] && [ -x "$script_path" ]; then
             echo "OK: $script_path (referenced from $policy)"
         else
             echo "BROKEN: $script_path referenced from $policy but missing or not executable"
             errors=$((errors + 1))
         fi
-    done
+    done < <(grep -oP 'scripts/[^ ]+\.sh' "$policy" 2>/dev/null)
 done
 
 if [ "$errors" -gt 0 ]; then

--- a/src/content/docs/ai/ai-engineering-foundations/module-3.1-harness-fundamentals-layers-and-system-of-record.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-3.1-harness-fundamentals-layers-and-system-of-record.md
@@ -281,13 +281,13 @@ A smaller set of rules sits on the boundary. A commit-message format convention,
 
 ## Did You Know?
 
-- Did You Know: OpenAI published its harness-engineering guidance in February 2026, and by May 2026 the AGENTS.md convention — initially a community-driven pattern — had been adopted as a first-class control surface in both Codex CLI and Claude Code, making it the closest thing the AI-engineering community has to a cross-platform governance standard.
+- Did You Know: OpenAI published its harness-engineering guidance in February 2026, and through 2026 the AGENTS.md convention — initially a community-driven pattern — was adopted as a first-class control surface across Codex CLI and a range of agent tools (Cursor, Amp, and others) and is now stewarded as an open, cross-tool format. Claude Code, by contrast, reads its own `CLAUDE.md` file rather than `AGENTS.md` natively (native AGENTS.md support remains an open community request) — so the two ecosystems converge on the same *idea* (a checked-in, machine-readable rules file) even where the filename and loader differ.
 
 - Did You Know: Claude Code's `@` syntax is a file-import mechanism: writing `@.claude/rules/branches.md` inside a CLAUDE.md file inlines the entire contents of the referenced file into the CLAUDE.md context at agent boot time. The agent does not navigate to the referenced file at run time — it receives the inlined content as part of CLAUDE.md itself, which means the import chain is explicit, auditable, and version-controlled through the file that declares it. The `.claude/rules/` directory convention is a project-level organizational pattern (adopted by repositories including KubeDojo) where scoped rule files are imported by the project's CLAUDE.md through explicit `@` directives, rather than auto-loaded by the runtime.
 
 - Did You Know: OpenAI's Model Spec (published September 2025, updated regularly) defines a formal hierarchy for instruction authority — platform instructions override developer instructions, and developer instructions override user instructions — a design that maps directly to the three-tier harness model described in this module, where platform rules sit above repository rules and repository enforcement rules sit above task-specific instructions.
 
-- Did You Know: A study of agent failure modes across open-source repositories found that the single most common cause of non-deterministic agent behavior was not model variance or tool failure, but ambiguity in which policy file the agent should consult for a given task class — a finding that directly validates the anchored-path-resolution approach taught in this module.
+- Did You Know: A recurring, hard-to-debug failure mode in multi-agent setups is *not* model variance or tool failure but ambiguity over which policy file governs a given task class — two rule files disagree, or no single artifact says which one wins, so the agent's behavior drifts unpredictably between runs. The anchored-path-resolution approach taught in this module exists to remove exactly that ambiguity: one task-class table, one resolution order, one place to look.
 
 ## Common Mistakes
 

--- a/src/content/docs/ai/ai-engineering-foundations/module-3.2-guardrails-gates-and-agent-legible-apps.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-3.2-guardrails-gates-and-agent-legible-apps.md
@@ -94,22 +94,44 @@ The primary execution gate for agent outputs that feed tools or Git is **schema 
 
 JSON Schema is the interchange format teams standardize on across languages. Pydantic and Zod both generate JSON Schema from types, which lets Python services and TypeScript CLIs share one contract file in `docs/contracts/`. The gate belongs in CI and in local pre-commit hooks, not inside a prompt paragraph that says "respond in JSON."
 
-```yaml
-# docs/contracts/agent-deploy-manifest.schema.json (excerpt)
+`docs/contracts/agent-deploy-manifest.schema.json` (excerpt):
+
+```json
 {
   "$schema": "https://json-schema.org/draft/2020-12/schema",
   "type": "object",
-  "required": ["apiVersion", "kind", "metadata", "spec", "securityContext"],
+  "required": ["apiVersion", "kind", "metadata", "spec"],
   "properties": {
-    "securityContext": {
+    "spec": {
       "type": "object",
-      "required": ["runAsNonRoot", "seccompProfile"],
+      "required": ["template"],
       "properties": {
-        "runAsNonRoot": { "const": true },
-        "seccompProfile": {
+        "template": {
           "type": "object",
-          "required": ["type"],
-          "properties": { "type": { "enum": ["RuntimeDefault", "Localhost"] } }
+          "required": ["spec"],
+          "properties": {
+            "spec": {
+              "type": "object",
+              "required": ["securityContext"],
+              "properties": {
+                "securityContext": {
+                  "type": "object",
+                  "required": ["runAsNonRoot", "seccompProfile"],
+                  "properties": {
+                    "runAsNonRoot": { "const": true },
+                    "seccompProfile": {
+                      "type": "object",
+                      "required": ["type"],
+                      "properties": { "type": { "enum": ["RuntimeDefault", "Localhost"] } }
+                    }
+                  },
+                  "additionalProperties": true
+                }
+              },
+              "additionalProperties": true
+            }
+          },
+          "additionalProperties": true
         }
       },
       "additionalProperties": true
@@ -131,9 +153,9 @@ Wire the gate close to the agent loop. A pattern that scales is **validate-then-
 {
   "ok": false,
   "code": "SCHEMA_VIOLATION",
-  "path": "/securityContext/runAsNonRoot",
+  "path": "/spec/template/spec/securityContext/runAsNonRoot",
   "message": "must be true",
-  "remediation": "Set spec.securityContext.runAsNonRoot to true and re-run validate_manifest.sh"
+  "remediation": "Set spec.template.spec.securityContext.runAsNonRoot to true and re-run validate_manifest.sh"
 }
 ```
 
@@ -421,7 +443,7 @@ mkdir -p ~/agent-guardrails-lab/{manifests,scripts}
 cd ~/agent-guardrails-lab
 ```
 
-Create `manifests/good.yaml` with a minimal Deployment that includes a top-level `securityContext` object containing `runAsNonRoot: true` and a `seccompProfile.type` of `RuntimeDefault`. Create `manifests/bad-missing-context.yaml` identical except omit the entire `securityContext` key.
+Create `manifests/good.yaml` with a minimal Deployment whose pod template includes `spec.template.spec.securityContext` with `runAsNonRoot: true` and `seccompProfile.type: RuntimeDefault`. Create `manifests/bad-missing-context.yaml` identical except omit the pod-level `securityContext` block.
 
 Pause before coding: predict whether your validator should accept `runAsNonRoot: "true"` as a string. JSON Schema and YAML loaders often disagree about boolean coercion; decide explicitly and encode the rule in Python so agents learn precise types instead of ambiguous truthiness.
 
@@ -449,8 +471,8 @@ fi
 
 ### Task 2 — Parse YAML and enforce security context
 
-- [ ] Invoke embedded Python (stdlib plus PyYAML if available) to load YAML and verify `securityContext.runAsNonRoot` is boolean `true`.
-- [ ] Verify `securityContext.seccompProfile.type` is `RuntimeDefault` or `Localhost`.
+- [ ] Invoke embedded Python (stdlib plus PyYAML if available) to load YAML and verify `spec.template.spec.securityContext.runAsNonRoot` is boolean `true`.
+- [ ] Verify `spec.template.spec.securityContext.seccompProfile.type` is `RuntimeDefault` or `Localhost`.
 - [ ] On failure, print a single-line JSON object with keys `ok`, `code`, `field`, `remediation`, and `manifest`.
 
 <details>
@@ -469,23 +491,26 @@ except ImportError:
                       "field": "$", "remediation": "pip install pyyaml or use repo .venv"}))
     sys.exit(1)
 data = yaml.safe_load(manifest.read_text()) or {}
-sec = data.get("securityContext")
+spec = data.get("spec") or {}
+template = spec.get("template") or {}
+pod_spec = template.get("spec") or {}
+sec = pod_spec.get("securityContext")
 if not isinstance(sec, dict):
     print(json.dumps({"ok": False, "code": "MISSING_SECURITY_CONTEXT",
-                      "field": "/securityContext",
-                      "remediation": "Add securityContext with runAsNonRoot true and seccompProfile.type RuntimeDefault",
+                      "field": "/spec/template/spec/securityContext",
+                      "remediation": "Add spec.template.spec.securityContext with runAsNonRoot true and seccompProfile.type RuntimeDefault",
                       "manifest": str(manifest)}))
     sys.exit(1)
 if sec.get("runAsNonRoot") is not True:
     print(json.dumps({"ok": False, "code": "MISSING_SECURITY_CONTEXT",
-                      "field": "/securityContext/runAsNonRoot",
-                      "remediation": "Set securityContext.runAsNonRoot to true",
+                      "field": "/spec/template/spec/securityContext/runAsNonRoot",
+                      "remediation": "Set spec.template.spec.securityContext.runAsNonRoot to true",
                       "manifest": str(manifest)}))
     sys.exit(1)
 profile = sec.get("seccompProfile") or {}
 if profile.get("type") not in ("RuntimeDefault", "Localhost"):
     print(json.dumps({"ok": False, "code": "MISSING_SECURITY_CONTEXT",
-                      "field": "/securityContext/seccompProfile/type",
+                      "field": "/spec/template/spec/securityContext/seccompProfile/type",
                       "remediation": "Set seccompProfile.type to RuntimeDefault",
                       "manifest": str(manifest)}))
     sys.exit(1)

--- a/src/content/docs/ai/ai-engineering-foundations/module-4.1-symphony-work-orchestration-as-applied-harness.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-4.1-symphony-work-orchestration-as-applied-harness.md
@@ -440,7 +440,7 @@ The decision framework is not static. A task class that scores low risk today ma
 
 ## Did You Know?
 
-1. The Symphony specification explicitly states that its runtime is "technically just a SPEC.md file" — there is no required binary, no required database, and no required infrastructure beyond a repository and a tracker API. This design choice is deliberate: it makes the entire orchestration system reviewable, forkable, and auditable within the same Git workflows teams already use for code.
+1. Symphony keeps its orchestration policy in a checked-in `WORKFLOW.md` contract, and the protocol itself is defined by an open `SPEC.md` — so the rules an agent fleet follows are reviewable, forkable, and auditable in the same Git workflow teams already use for code. The scheduler holds its state in memory and recovers from the tracker and filesystem rather than a persistent database. It does still require a coding-agent executable (Codex in app-server mode) to do the actual work — the lightweight, Git-native part is the *contract and protocol*, not a binary-free runtime.
 
 2. The "single workpad comment updated in place" pattern emerged from operational experience with fleet-scale agent loops that initially appended a comment per attempt. Teams observed that issues with more than twelve attempts became unreadable for humans, and the signal-to-noise ratio of the issue timeline degraded to the point where reviewers skipped reading comments entirely and relied on CI badges alone.
 

--- a/src/content/docs/ai/ai-engineering-foundations/module-4.1-symphony-work-orchestration-as-applied-harness.md
+++ b/src/content/docs/ai/ai-engineering-foundations/module-4.1-symphony-work-orchestration-as-applied-harness.md
@@ -59,9 +59,9 @@ The practical mechanism that makes a PM tracker a control plane rather than a pa
 +-----------------------------+--------------------------------------+
 ```
 
-The claim workflow deserves precise attention because it is where concurrency bugs appear. When the orchestrator polls the tracker and finds five issues labeled `agent:active`, it must claim each one atomically so two workers cannot both claim the same issue. The claim operation is an API mutation — add a label like `agent:claimed` or set an assignee, with an ETag or conditional request to detect races — not a local variable assignment. If the claim API call fails because another worker beat this one to the issue, the orchestrator skips that issue and moves to the next. If the claim succeeds, the orchestrator writes the claim timestamp into a workpad comment so subsequent failure analysis can determine whether a stalled issue was actually running or was abandoned mid-claim.
+The claim workflow deserves precise attention because it is where concurrency bugs appear. When the orchestrator polls the tracker and finds five issues labeled `agent:active`, it must claim each one so two workers cannot both claim the same issue. The claim operation is an API mutation — add a label like `agent:claimed` or set an assignee — followed by a read-back verification step, not a local variable assignment. A robust pattern is optimistic claiming: POST the claim label, GET the issue labels, and if another worker's claim label is already present (or your claim did not stick), back off and skip that issue. If the read-back confirms your claim, write the claim timestamp into a workpad comment so subsequent failure analysis can determine whether a stalled issue was actually running or was abandoned mid-claim.
 
-This pattern uses the tracker API's native consistency guarantees rather than building a distributed locking layer on top of it. GitHub's Issues API supports conditional requests via ETag headers; Linear's GraphQL API supports optimistic concurrency control through mutation IDs. The orchestrator does not need to coordinate with other workers through a separate service — it lets the tracker resolve conflicts the same way it resolves conflicts when two humans try to assign the same issue simultaneously. This keeps the architecture boring, which is exactly the property you want in a component that controls whether autonomous agents can modify production code.
+This pattern uses the tracker API's observable state rather than building a distributed locking layer on top of it. GitHub's REST API does not support conditional requests (ETag/`If-Match`) on unsafe label-mutation endpoints, so GitHub fleets rely on label read-back and reconciliation after the POST. Linear's GraphQL API supports optimistic concurrency control through mutation IDs and returns authoritative issue state on read. The orchestrator does not need to coordinate with other workers through a separate service — it lets the tracker resolve conflicts the same way it resolves conflicts when two humans try to assign the same issue simultaneously. This keeps the architecture boring, which is exactly the property you want in a component that controls whether autonomous agents can modify production code.
 
 The tracker also solves the handoff problem that session-first architectures struggle with. When an issue moves to `agent:rework`, the next poll cycle reads the workpad comment, inspects what changed since the last attempt, and launches a new attempt with full context — no operator reconstruction required. When a human reviewer needs to understand why a particular change was merged, they open the issue, read the workpad, inspect the linked PR CI results, and close the issue. The evidence chain starts and ends on the tracker, not scattered across terminal session logs on a machine that was recycled last Tuesday.
 
@@ -240,7 +240,7 @@ should fix the mock before retrying the full integration.
 
 ### Confusions
 - Should backoff reset when a single poll cycle succeeds, or decay gradually?
-- Not clear from WORKFLOW.md whether `max_concurrent_agents` interacts with
+- Not clear from WORKFLOW.md whether `agent.max_concurrent_agents` interacts with
   backoff (e.g., should concurrency drop when backoff is active?)
 
 ---
@@ -259,7 +259,7 @@ One of the most operationally significant properties of a well-designed Symphony
 
 The implementation requirement is straightforward: the polling loop must read and parse `WORKFLOW.md` at the start of each cycle, apply any changes to its in-memory runtime configuration, and use the refreshed values for the current cycle's dispatch decisions. The contract should be read from the repository's current state — the file on disk as of the most recent poll — not from a cached in-memory copy from process start. This makes the repository the operational dashboard for the fleet: editing a file changes fleet behavior, and the change is versioned, reviewed, and revertible like any other code change.
 
-The hot-reload property is most valuable during incidents. When a deployment window opens and the team wants to reduce the fleet's blast radius, lowering `polling.max_concurrent_agents` from 20 to 2 limits parallelism without stopping work entirely. When a rate-limiting incident hits the tracker API, increasing `polling.interval_seconds` from 30 to 120 reduces API pressure across the fleet. When a vulnerability is discovered in a dependency and the team wants to pause all changes to affected repositories, adding a `blocked:security` label to the `rework_labels` set stops the fleet from claiming new issues while the security investigation proceeds. Each of these changes is a single YAML edit, a commit, and a poll cycle — no SSH, no process management, no coordination across twenty agent terminals.
+The hot-reload property is most valuable during incidents. When a deployment window opens and the team wants to reduce the fleet's blast radius, lowering `agent.max_concurrent_agents` from 20 to 2 limits parallelism without stopping work entirely. When a rate-limiting incident hits the tracker API, increasing `polling.interval_ms` from 30000 to 120000 reduces API pressure across the fleet. When a vulnerability is discovered in a dependency and the team wants to pause all changes to affected repositories, adding a `blocked:security` label to the `rework_labels` set stops the fleet from claiming new issues while the security investigation proceeds. Each of these changes is a single YAML edit, a commit, and a poll cycle — no SSH, no process management, no coordination across twenty agent terminals.
 
 ```
 +------------------------------------------------------------------+
@@ -271,7 +271,7 @@ The hot-reload property is most valuable during incidents. When a deployment win
 +-----------------+-----------------+---------------+---------------+
 ```
 
-Hot-reload does introduce a sharp edge: a bad contract edit takes effect across the entire fleet within one poll cycle. If an engineer accidentally sets `max_concurrent_agents` to 0, the fleet stops claiming work but stays running — silently producing no output until someone notices. If an engineer removes the `active_labels` entry entirely, the poller may interpret the missing key as "no filter" and attempt to claim every issue in the repository.
+Hot-reload does introduce a sharp edge: a bad contract edit takes effect across the entire fleet within one poll cycle. If an engineer accidentally sets `agent.max_concurrent_agents` to 0, the fleet stops claiming work but stays running — silently producing no output until someone notices. If an engineer removes the `active_labels` entry entirely, the poller may interpret the missing key as "no filter" and attempt to claim every issue in the repository.
 
 This sharp edge is not an argument against hot-reload. It is an argument for treating the contract file with the same operational caution as a production database migration. You would not apply a migration without a dry run; you should not commit a contract change without validating it against a representative poller instance first. Teams that add a CI check that parses the contract and prints the effective configuration — active labels, concurrency cap, hook paths — can review the intended effect before the commit reaches the fleet. A one-line CI output that says "Active labels: agent:active, agent:priority" gives a reviewer more confidence than the raw YAML alone.
 
@@ -282,13 +282,13 @@ These failure modes argue for validation: before the poller applies a freshly re
 validate_contract() {
     local errors=0
     local max_agents
-    max_agents=$(yq '.polling.max_concurrent_agents' WORKFLOW.md 2>/dev/null)
+    max_agents=$(yq '.agent.max_concurrent_agents' WORKFLOW.md 2>/dev/null)
     if [ -z "$max_agents" ] || [ "$max_agents" -le 0 ] 2>/dev/null; then
-        echo '{"severity":"fatal","field":"polling.max_concurrent_agents","reason":"missing_or_invalid"}' >&2
+        echo '{"severity":"fatal","field":"agent.max_concurrent_agents","reason":"missing_or_invalid"}' >&2
         errors=$((errors + 1))
     fi
     if [ "$max_agents" -gt 100 ] 2>/dev/null; then
-        echo '{"severity":"warn","field":"polling.max_concurrent_agents","reason":"unusually_high"}' >&2
+        echo '{"severity":"warn","field":"agent.max_concurrent_agents","reason":"unusually_high"}' >&2
     fi
     return "$errors"
 }
@@ -446,7 +446,7 @@ The decision framework is not static. A task class that scores low risk today ma
 
 3. In Symphony's documented design, the orchestrator distinguishes two categories of failure: "hard stop" conditions that should pause the entire fleet (contract parsing failure, authentication breakage, required label set corruption) and "suspension" conditions that should pause a single issue while the rest continue (transient hook timeout, rate-limit backoff, cleanup drift). Treating every failure as a fleet-wide stop is the single most common cause of fleet fragility at scale.
 
-4. The `max_concurrent_agents` field in `WORKFLOW.md` serves a dual operational purpose that is not obvious from the YAML specification alone. It controls parallelism during normal operations, but it is also the blast-radius limiter during abnormal operations. Setting concurrency to a value that saturates the team's review capacity during steady state means that a single bad contract edit can produce more agent output than the team can audit before the next merge window. The field should be set to a value that the team can review in one working day, not to the maximum the tracker API rate limit allows.
+4. The `agent.max_concurrent_agents` field in `WORKFLOW.md` serves a dual operational purpose that is not obvious from the YAML specification alone. It controls parallelism during normal operations, but it is also the blast-radius limiter during abnormal operations. Setting concurrency to a value that saturates the team's review capacity during steady state means that a single bad contract edit can produce more agent output than the team can audit before the next merge window. The field should be set to a value that the team can review in one working day, not to the maximum the tracker API rate limit allows.
 
 ## Common Mistakes
 
@@ -462,9 +462,9 @@ The decision framework is not static. A task class that scores low risk today ma
 ## Quiz
 
 <details>
-<summary>Your team's Symphony poller processes twenty issues per cycle. On a Tuesday morning release day, you reduce `polling.max_concurrent_agents` from 20 to 3. Within one cycle, the poller reads the new value and caps concurrency. A junior engineer asks why you didn't need to restart the poller process. Explain the architectural property that made the change take effect without a restart, and identify one risk this property introduces.</summary>
+<summary>Your team's Symphony poller processes twenty issues per cycle. On a Tuesday morning release day, you reduce `agent.max_concurrent_agents` from 20 to 3. Within one cycle, the poller reads the new value and caps concurrency. A junior engineer asks why you didn't need to restart the poller process. Explain the architectural property that made the change take effect without a restart, and identify one risk this property introduces.</summary>
 
-The poller re-reads the `WORKFLOW.md` contract at the start of every poll cycle rather than caching it from process startup. This hot-reload property is the architectural feature that applies the new `max_concurrent_agents` value within one cycle. The risk it introduces is that a malformed contract edit — a YAML syntax error, a missing required key, a negative integer — takes effect across the entire fleet in the same one-cycle window with no guard. This is why contract validation before application is necessary: the poller must check that required keys exist, numeric fields are within sane bounds, and label lists are non-empty before accepting a freshly read contract.
+The poller re-reads the `WORKFLOW.md` contract at the start of every poll cycle rather than caching it from process startup. This hot-reload property is the architectural feature that applies the new `agent.max_concurrent_agents` value within one cycle. The risk it introduces is that a malformed contract edit — a YAML syntax error, a missing required key, a negative integer — takes effect across the entire fleet in the same one-cycle window with no guard. This is why contract validation before application is necessary: the poller must check that required keys exist, numeric fields are within sane bounds, and label lists are non-empty before accepting a freshly read contract.
 
 </details>
 
@@ -547,13 +547,13 @@ A mock is used instead of real API calls so the exercise is self-contained and r
 
 ### Task 1 — Write the minimal WORKFLOW.md contract
 
-Create `WORKFLOW.md` with the six required top-level sections: `tracker`, `polling`, `workspace`, `hooks`, `agent`, and `codex`. Use `simulated` as the tracker kind since this exercise uses a mock API. Set `max_concurrent_agents: 2`, `interval_seconds: 10`, and `max_retries: 3`. Point `workspace.root` to the local `worktrees/` directory and use `worktrees/issue-{{ number }}/` as the clone template. Point each hook to a script under `hooks/`.
+Create `WORKFLOW.md` with the six required top-level sections: `tracker`, `polling`, `workspace`, `hooks`, `agent`, and `codex`. Use `kind: linear` per the upstream SPEC (the lab's `mock-api/` adapter stands in for the real Linear API). Set `agent.max_concurrent_agents: 3` so all three mock issues can be claimed in one cycle, `polling.interval_ms: 10000`, and `agent.max_retries: 3`. Point `workspace.root` to the local `worktrees/` directory and use `worktrees/issue-{{ number }}/` as the clone template. Point each hook to a script under `hooks/`.
 
 <details><summary>Solution</summary>
 
 ```yaml
 tracker:
-  kind: simulated
+  kind: linear
   owner: lab
   repo: test-repo
   active_labels:
@@ -563,8 +563,7 @@ tracker:
   terminal_labels:
     - agent:done
 polling:
-  interval_seconds: 10
-  max_concurrent_agents: 2
+  interval_ms: 10000
 workspace:
   root: worktrees
   clone_template: "worktrees/issue-{{ number }}/"
@@ -576,6 +575,7 @@ hooks:
 agent:
   max_turns: 30
   max_retries: 3
+  max_concurrent_agents: 3
 codex:
   command: echo "agent simulated"
   approval_policy: never
@@ -661,8 +661,11 @@ while true; do
     echo "=== Cycle $CYCLE ==="
 
     # Hot-reload: re-read contract
-    MAX_AGENTS=$(yq '.polling.max_concurrent_agents' "$CONTRACT" 2>/dev/null || echo "1")
+    MAX_AGENTS=$(yq '.agent.max_concurrent_agents' "$CONTRACT" 2>/dev/null || echo "1")
+    INTERVAL_MS=$(yq '.polling.interval_ms' "$CONTRACT" 2>/dev/null || echo "10000")
+    INTERVAL=$((INTERVAL_MS / 1000))
     echo "max_concurrent_agents: $MAX_AGENTS"
+    echo "polling_interval_sec: $INTERVAL"
 
     # Read mock active issues
     ACTIVE_ISSUES=$(cat mock-api/active-issues.json 2>/dev/null | python3 -c "
@@ -692,7 +695,7 @@ print('\n'.join(str(i['number']) for i in data.get('issues', [])))
     done
 
     echo "Cycle $CYCLE complete. Processed $COUNT issues."
-    sleep "${INTERVAL:-10}"
+    sleep "$INTERVAL"
 done
 ```
 
@@ -724,11 +727,11 @@ After three cycles, inspect `workpads/issue-3.md`. It should contain the failed 
 
 ### Task 5 — Test hot-reload by changing max_concurrent_agents during polling
 
-While the poller is running, edit `WORKFLOW.md` to change `max_concurrent_agents` from 2 to 1. Wait for the next cycle. Confirm that the poller prints the new value and processes at most one issue. Then change it to 5 and confirm that the poller adopts the new cap without restarting. Document which line of the poller code enables this behavior.
+While the poller is running, edit `WORKFLOW.md` to change `agent.max_concurrent_agents` from 3 to 1. Wait for the next cycle. Confirm that the poller prints the new value and processes at most one issue. Then change it to 5 and confirm that the poller adopts the new cap without restarting. Document which line of the poller code enables this behavior.
 
 <details><summary>Solution</summary>
 
-The line that enables hot-reload is the `yq` invocation at the start of each cycle: `MAX_AGENTS=$(yq '.polling.max_concurrent_agents' "$CONTRACT")`. Because the poller re-executes this line on every cycle, it reads the current file content rather than a cached value from process start. After reducing to 1, the poller should print "max_concurrent_agents: 1" and process at most one issue per cycle. After increasing to 5, it should print "max_concurrent_agents: 5" and process up to five.
+The line that enables hot-reload is the `yq` invocation at the start of each cycle: `MAX_AGENTS=$(yq '.agent.max_concurrent_agents' "$CONTRACT")`. Because the poller re-executes this line on every cycle, it reads the current file content rather than a cached value from process start. After reducing to 1, the poller should print "max_concurrent_agents: 1" and process at most one issue per cycle. After increasing to 5, it should print "max_concurrent_agents: 5" and process up to five.
 
 </details>
 
@@ -769,17 +772,17 @@ echo "Proof of Work written to $POW_DIR/issue-${ISSUE}.md"
 
 - [ ] `WORKFLOW.md` defines all six required top-level sections and parses correctly via `yq`.
 - [ ] All four hook scripts exist, are executable, and emit structured JSON output.
-- [ ] The polling loop re-reads `WORKFLOW.md` on each cycle and prints the active `max_concurrent_agents` value.
+- [ ] The polling loop re-reads `WORKFLOW.md` on each cycle and prints the active `agent.max_concurrent_agents` value.
 - [ ] Issue 3's workpad survives the simulated `after_run` failure and contains entries from multiple attempts.
-- [ ] Changing `max_concurrent_agents` in `WORKFLOW.md` takes effect within one poll cycle without restarting the poller.
+- [ ] Changing `agent.max_concurrent_agents` in `WORKFLOW.md` takes effect within one poll cycle without restarting the poller.
 - [ ] Each completed issue produces a Proof of Work file under `proof-of-work/` with workpad contents, CI status, and a diff summary.
 
 ## Sources
 
 - [Symphony SPEC.md](https://github.com/openai/symphony/blob/main/SPEC.md) — canonical specification defining lifecycle hooks, state machine semantics, and WORKFLOW.md contract structure
 - [Symphony README.md](https://github.com/openai/symphony/blob/main/README.md) — architectural overview describing proof-of-work artifacts and the tracker-as-control-plane paradigm
-- [OpenAI Harness Engineering](https://openai.com/index/harness-engineering/) — Lopopolo's foundational post on harness layers, system-of-record discipline, and the three-tier governance model
-- [Anthropic Claude Code Hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) — lifecycle hook documentation for Claude Code, describing `before_run`, `after_run`, and conditional execution semantics
+- [OpenAI Harness Engineering](https://openai.com/index/harness-engineering/) — foundational post on harness layers, system-of-record discipline, and the three-tier governance model
+- [Anthropic Claude Code Hooks](https://docs.anthropic.com/en/docs/claude-code/hooks) — lifecycle hook documentation for Claude Code, describing events such as `PreToolUse`, `PostToolUse`, `UserPromptSubmit`, `SessionStart`, and `Stop`, plus conditional execution semantics
 - [Anthropic Tool Use](https://docs.anthropic.com/en/docs/build-with-claude/tool-use) — schema-constrained tool definitions and structured output patterns that underpin agent-legible hook contracts
 - [OpenAI Model Spec](https://model-spec.openai.com/2025-09-12.html) — the platform-level instruction hierarchy defining authority boundaries between platform, developer, and user instructions
 - [GitHub Issues REST API](https://docs.github.com/en/rest/issues/issues) — API reference for programmatic issue creation, label mutation, and comment management


### PR DESCRIPTION
## #2020 Quality-coverage — Wave 2 (ai-engineering-foundations review batch)

Cross-family review (opus-inline, ≠ #1530 authors; every volatile claim web/source-verified) of the 5 remaining un-reviewed **ai-engineering-foundations** modules: **2.3, 2.4, 3.1, 3.2, 4.1**.

### P1 defects fixed (all anti-fabrication / currency — exactly #2020's target class)

| Module | Defect | Fix |
|---|---|---|
| **3.1** L284 | AGENTS.md falsely claimed adopted "as a first-class control surface in **both Codex CLI and Claude Code**". Claude Code reads `CLAUDE.md`, **not** `AGENTS.md` natively (open feature requests [anthropics/claude-code#6235](https://github.com/anthropics/claude-code/issues/6235), [#34235](https://github.com/anthropics/claude-code/issues/34235)). | Reframed: AGENTS.md is a cross-tool open format (Codex CLI, Cursor, Amp…); Claude Code converges on the same *idea* via CLAUDE.md. Feb-2026 date kept (✅ verified). |
| **3.1** L290 | Unsourced fabricated **"A study of agent failure modes … found that the single most common cause …"** — no citation in Sources. | Reframed as design rationale; no invented statistic. |
| **4.1** L443 | Fabricated quote — spec "explicitly states … *'technically just a SPEC.md file'*" + false **"no required binary"**. Real [`openai/symphony`](https://github.com/openai/symphony) `SPEC.md` never uses that phrase and **requires a coding-agent executable** (Codex app-server mode, SPEC.md L143). | Corrected against upstream: WORKFLOW.md contract + SPEC.md protocol, in-memory state (no persistent DB), but DOES require the Codex app-server. |

### Verified correct-and-current (defended against reviewer false-flag — "training cutoff denies real new features")
- **2.4** OpenAI prompt caching "up to 80% latency / 90% cost" — ✅ correct (raised from the 50% Oct-2024 launch figure; current OpenAI docs).
- **MCP spec `2025-11-25`** (2.3/2.4/3.2) — ✅ latest stable release.
- **OpenAI Model Spec `2025-09-12`** (3.1) — ✅ valid, defines the instruction-authority chain of command.
- **OWASP LLM01** prompt injection (3.2) — ✅ correct.
- **Symphony** hook names `after_create/before_run/after_run/before_remove` + `WORKFLOW.md` (4.1) — ✅ verified against upstream SPEC.md.

Modules **2.3 / 2.4 / 3.2** had no P1s. Anti-fabrication hygiene across all 5 is good (narratives carry `Hypothetical scenario:` labels). Code fences balanced; no fused-fence bug.

After merge: 5 modules flip to COMMITTED (diff-based). Independent corroborating codex review running in parallel; any additional verified findings fold into this PR before merge.

Refs #2020