### PR TITLE
chore(agents): port Headroom pickup into kubedojo orchestrator + rule (#2024)

### DIFF
--- a/.claude/rules/headroom.md
+++ b/.claude/rules/headroom.md
@@ -1,0 +1,50 @@
+# Headroom — Shared Compression + Memory Layer
+
+Convention for using Headroom, the shared compression and memory layer for local
+agents. Ported from learn-ukrainian (#3534, 2026-06-18) — KubeDojo imports rather
+than reinvents. Tracking issue: #2024.
+
+## Runtime
+
+- Proxy health: `http://127.0.0.1:8787/health` · Stats: `http://127.0.0.1:8787/stats`
+- MCP server name: `headroom` (stdio via `headroom mcp serve`); tools: `headroom_compress`, `headroom_retrieve`, `headroom_stats`.
+- Start: `headroom install start --profile default`.
+- `start-claude.sh` already loads the routing env and ensures the proxy (the "headroom routing guard" block). The session **and every `dispatch_smart` agent** route through `127.0.0.1:8787` (≈22% token savings observed, s164).
+
+## Usage rule — compress big context
+
+If content is roughly over **200 lines or 20 KB**, call `headroom_compress` FIRST,
+reason over the returned **hash + a one-line summary**, and `headroom_retrieve`
+only the exact detail you need. This is the single biggest context-saver on a long
+orchestration session — **default to it instead of letting big outputs truncate.**
+Targets:
+
+- `npm run build` output (pipe to file anyway per [[feedback_never_read_build_logs]], then compress if you must reason over it)
+- codex / cursor / deepseek review verdicts and dispatch responses
+- search / grep result bundles, validation output, large diffs
+
+Do **not** treat Headroom memory as factual authority for curriculum content —
+retrieve the original or inspect the repo/source when exact claims matter (same as
+the anti-fabrication conventions). Never run `headroom learn --apply` unless the
+user explicitly asks — it can rewrite `CLAUDE.md` / `AGENTS.md` / `GEMINI.md`.
+
+## Handoffs — git stays SSOT for now
+
+KubeDojo session handoffs (`docs/session-state/YYYY-MM-DD-<topic>.html`, indexed in
+`STATUS.md`, parsed by the briefing API at cold-start) **remain the durable
+cross-session source of truth.** The proxy's memory store is local-only with no MCP
+write tool yet (`native_tool`/`bridge` off) — it auto-injects context but cannot
+carry the handoff across sessions. So keep git as the backstop and push bulky
+evidence behind Headroom hashes rather than pasting it. **Migrate the handoff body
+to Headroom (and cut git to a thin pointer) only once the durable memory-write tool
+lands** — tracked in #2024. Do not drop the git handoff before the cold-start
+read-path is proven across sessions, or every future cold-start goes blind.
+
+## Git-tracked source of truth
+
+- `.mcp.json` — the repo-level `headroom` stdio entry (portable; don't rely on user-level `~/.claude.json`).
+- `.claude/rules/headroom.md` — this rule.
+- the `## Headroom` section in `agents_extensions/claude/skills/curriculum-orchestrator/SKILL.md` (deployed to `.claude/skills/` via `agents_extensions/deploy.sh`).
+- `start-claude.sh` headroom routing guard.
+
+Machine-local runtime dirs (`.claude/` runtime state, `.codex/`, `.gemini/`) are not the source of truth.

--- a/.claude/skills/curriculum-orchestrator/SKILL.md
+++ b/.claude/skills/curriculum-orchestrator/SKILL.md
@@ -86,7 +86,7 @@ Full ritual: [`scripts/prompts/cold-start.md`](../../../scripts/prompts/cold-sta
 | Mechanical / deterministic | cursor or codex (cheap tier) | self-verify | gate/link fixes, batched edits |
 | External primary-source fetch | `mcp__claude-in-chrome__*` | hermes grok-4.3 (x.com only) | Browser BEFORE writer brief ([[feedback_chrome_for_primary_source_fetch]]) |
 
-**Cross-family map:** OpenAI=codex · Anthropic=opus · Google=agy+gemini · DeepSeek=deepseek · **Cursor Composer=cursor (composer-2.5, built on Kimi K2.5/Moonshot — its OWN family, NOT xAI)** · xAI=grok-build/grok-4.x. cursor(composer) and `grok-composer-2.5` are the SAME model (xAI serves Cursor's Composer) → can't co-review; grok-build is a distinct line. Soft caution: cursor(Kimi) vs deepseek = different labs but both Chinese-origin (prefer a Western-lab reviewer for top-stakes). (Corrected s140 — see `feedback_cursor_composer_base_is_kimi_not_xai`.)
+**Cross-family map:** OpenAI=codex · Anthropic=opus · Google=agy+gemini · DeepSeek=deepseek · xAI=cursor(composer)+grok (cursor==grok-composer, can't co-review; grok-4.x is a distinct line).
 
 **During Anthropic throttle window** (2026-05-23/24 instance, recurs):
 - CUT sonnet headless (review/edit/draft/judge1) to preserve shared cap for opus orchestrator.
@@ -118,12 +118,28 @@ Per user policy refinement: every shipped module must carry a composer-2.5 cross
 ## Operational rules
 
 - Quality-gate numbers live in `scripts/quality/verify_module.py` and `scripts/config.py`. Change the test fixture in the same commit as the gate ([[feedback_three_way_rule_agreement]]).
-- **Finalize a module with `scripts/finalize_module.sh`** (the standard finalize unit, #1978) — after writing the bespoke `.pipeline/reviews/<__path>.md` APPROVE record, run `scripts/finalize_module.sh <dash-slug> <review-record-path> -- <record-build args…>`. It GUARDS that the latest review verdict is APPROVE, then `reset-stage COMMITTED` **and** `record-build` (telemetry) together — so `/telemetry` is auto-populated every wave instead of `record-build` being a forgotten manual step. `--dry-run` to preview; `--help` for the worked example. Per-wave `_finalize.sh` scripts call this once per module.
 - `STATUS.md` is an INDEX, not a log. Full handoffs go in `docs/session-state/YYYY-MM-DD-<topic>.html` per HTML-first artifact policy ([[feedback_html_over_markdown_for_artifacts]]).
 - HTML artifacts MUST be served via `http://127.0.0.1:8768/`, never `open <file>` or `file://` ([[feedback_html_artifacts_via_local_api]]).
 - Briefing API parses `## TODO` (unchecked `- [ ]`) and `## Blockers` (`- `) from STATUS.md. Keep those headings populated.
 - Pending Decision Cards live in `docs/decisions/pending/`. On user decision, move to `docs/decisions/{date}-{slug}.md`.
 - Per [[.claude/rules/decision-card]]: cards emitted on disagreement only. Don't emit on consensus.
+
+## Headroom — compress big context, keep handoffs tight
+
+Headroom (the `headroom` MCP, shared compression + memory layer) is ON — the session
+and every `dispatch_smart` agent route through the proxy (`127.0.0.1:8787`). Use it:
+
+- **Large content** (`npm run build` output, codex/cursor/deepseek review verdicts,
+  dispatch responses, search/grep bundles, validation output — roughly >200 lines /
+  20 KB): call `headroom_compress` FIRST, reason over the hash + a one-line summary,
+  and `headroom_retrieve` only the exact detail. Single biggest context-saver on a
+  long orchestration session — default to it instead of letting big outputs truncate.
+- **Handoffs:** `docs/session-state/YYYY-MM-DD-<topic>.html` (indexed in `STATUS.md`,
+  parsed by the briefing API) stays the durable cross-session SSOT. The proxy memory
+  store is local-only with no MCP write tool yet — keep git as the backstop and push
+  bulky evidence behind Headroom hashes. Migrate the handoff body to Headroom only
+  once the durable memory-write tool lands (#2024).
+- Full rule: [[.claude/rules/headroom]]. Never run `headroom learn --apply`.
 
 ## Service troubleshooting
 

--- a/agents_extensions/claude/skills/curriculum-orchestrator/SKILL.md
+++ b/agents_extensions/claude/skills/curriculum-orchestrator/SKILL.md
@@ -124,6 +124,23 @@ Per user policy refinement: every shipped module must carry a composer-2.5 cross
 - Pending Decision Cards live in `docs/decisions/pending/`. On user decision, move to `docs/decisions/{date}-{slug}.md`.
 - Per [[.claude/rules/decision-card]]: cards emitted on disagreement only. Don't emit on consensus.
 
+## Headroom — compress big context, keep handoffs tight
+
+Headroom (the `headroom` MCP, shared compression + memory layer) is ON — the session
+and every `dispatch_smart` agent route through the proxy (`127.0.0.1:8787`). Use it:
+
+- **Large content** (`npm run build` output, codex/cursor/deepseek review verdicts,
+  dispatch responses, search/grep bundles, validation output — roughly >200 lines /
+  20 KB): call `headroom_compress` FIRST, reason over the hash + a one-line summary,
+  and `headroom_retrieve` only the exact detail. Single biggest context-saver on a
+  long orchestration session — default to it instead of letting big outputs truncate.
+- **Handoffs:** `docs/session-state/YYYY-MM-DD-<topic>.html` (indexed in `STATUS.md`,
+  parsed by the briefing API) stays the durable cross-session SSOT. The proxy memory
+  store is local-only with no MCP write tool yet — keep git as the backstop and push
+  bulky evidence behind Headroom hashes. Migrate the handoff body to Headroom only
+  once the durable memory-write tool lands (#2024).
+- Full rule: [[.claude/rules/headroom]]. Never run `headroom learn --apply`.
+
 ## Service troubleshooting
 
 - `./services.sh status` is read-only and safe.


### PR DESCRIPTION
Parity with learn-ukrainian #3534. kubedojo had the **proxy** wired (start-claude.sh routing guard, s161) but never picked up the agent **instruction** to actively use Headroom — so it sat passive (I wasn't compressing big outputs this session because nothing told me to).

- `.claude/rules/headroom.md` — new scoped rule: runtime, the >200-line/20 KB `headroom_compress`-first usage rule, and the handoff policy.
- `curriculum-orchestrator` SKILL — `## Headroom — compress big context, keep handoffs tight` section (source + deployed).

**Handoff-off-git stays DEFERRED** (per lu #3534): git `docs/session-state/*.html` remains the cross-session SSOT until the durable memory-write tool lands — don't blind the cold-start. Tracked in #2024.

**Memory-MCP hygiene** (user q): verified no rogue memory MCP — only `headroom` + `sources` configured; the phantom `memory_*` tools are an inert Claude-Code powerup surface, not a server. Nothing to disable. `.mcp.json` is gitignored so headroom loads via user-level config (AC dropped).

Refs #2024