### PR TITLE
fix(ai-native): durable-vendor + currency fixes (4 modules, #2028)

### DIFF
--- a/src/content/docs/ai-ml-engineering/ai-native-development/module-1.10-anthropic-agent-sdk-and-runtime-patterns.md
+++ b/src/content/docs/ai-ml-engineering/ai-native-development/module-1.10-anthropic-agent-sdk-and-runtime-patterns.md
@@ -42,9 +42,16 @@ Hypothetical scenario: a platform team ships an internal agent that looks impres
 
 The problem is not that the team used an AI model. The problem is that they built a chat loop and treated it like an agent runtime. A serious runtime has to decide which tools are available, which actions need approval, how sessions are resumed, how work is observed, and how each action is verified before the agent continues.
 
-The Claude Agent SDK matters because, as of 2026-06, Anthropic describes it as packaging many of the runtime patterns behind Claude Code into a programmable form. Instead of starting with a blank model client and rebuilding tool execution, permissions, hooks, sessions, MCP integration, and context management from scratch, a team can build on a harness designed for iterative agent work.
+The Claude Agent SDK matters because Anthropic describes it as packaging many of the runtime patterns behind Claude Code into a programmable form. Instead of starting with a blank model client and rebuilding tool execution, permissions, hooks, sessions, MCP integration, and context management from scratch, a team can build on a harness designed for iterative agent work.
 
 This module teaches the runtime design behind that harness. You will not only learn what the SDK exposes; you will learn how to reason about when it is appropriate, how to constrain it, and how to recognize the point where explicit workflow code is safer than agent autonomy.
+
+> **Landscape snapshot — Claude Agent SDK, as of 2026-06.** Vendor SDK surfaces churn; verify against Anthropic's current docs before relying on specifics.
+>
+> - **Name:** Claude Agent SDK (formerly the Claude Code SDK) — broadened beyond coding to general agents.
+> - **Languages:** Python and TypeScript.
+> - **Built-in capabilities:** file read / run / search / edit, MCP support, hooks, permissions (allow & deny rules, permission modes, approval callbacks), sessions (IDs, resume, result messages, compact-boundary events), and subagents.
+> - **Durable spine (this module's focus):** the agent-loop lifecycle, the permission/guardrail model, session/state boundaries, and runtime tradeoffs — these outlast any single SDK version.
 
 ---
 
@@ -54,7 +61,7 @@ A plain chat integration asks a model to respond to a user message. A plain clie
 
 That distinction matters because most production failures are not caused by the first prompt being poorly worded. They happen when the system gives the model a powerful tool without a permission boundary, loses track of state across a long task, fails to inspect tool output, or treats a generated answer as done before checking the external reality it claims to change.
 
-The Claude Agent SDK is Anthropic's library form of the agent harness behind Claude Code. As of 2026-06, the official Agent SDK overview describes agents that can read files, run commands, search the web, edit code, connect to MCP servers, use hooks, track sessions, and manage context. The SDK does not remove the need for engineering judgment; it moves many runtime concerns into a structured place where you can design and inspect them.
+The Claude Agent SDK is Anthropic's library form of the agent harness behind Claude Code. The official Agent SDK overview describes agents that can read files, run commands, search the web, edit code, connect to MCP servers, use hooks, track sessions, and manage context. The SDK does not remove the need for engineering judgment; it moves many runtime concerns into a structured place where you can design and inspect them.
 
 That packaging is valuable precisely because it makes the runtime visible. A hand-rolled loop can absolutely be correct, but it often spreads policy across prompt text, helper functions, API wrappers, and ad hoc logs. Once the loop becomes hard to inspect, it becomes hard to answer the operational questions that matter: which tool was called, why was it allowed, what evidence came back, which state was preserved, and what stopped the run from continuing forever.
 
@@ -120,7 +127,7 @@ The verify stage exists because agent reasoning is not self-validating. A model 
 
 This loop is a runtime pattern, not just a planning slogan. A real implementation has to give the agent tools for gathering, tools for acting, and a policy that treats verification as mandatory for meaningful actions. Otherwise the loop exists only in documentation.
 
-As of 2026-06, Anthropic's Agent SDK loop documentation describes a message lifecycle where the SDK initializes session metadata, the model evaluates the prompt, requested tools execute, results are fed back, and the cycle repeats until the agent returns a final result. That is the mechanical form of gather, act, verify. It is not merely "the model thinks again"; it is a stream of messages, tool results, limits, hooks, and session identifiers that your application can inspect.
+Anthropic's Agent SDK loop documentation describes a message lifecycle where the SDK initializes session metadata, the model evaluates the prompt, requested tools execute, results are fed back, and the cycle repeats until the agent returns a final result. That is the mechanical form of gather, act, verify. It is not merely "the model thinks again"; it is a stream of messages, tool results, limits, hooks, and session identifiers that your application can inspect.
 
 The practical implication is that you should design the loop before you design the prompt. If the loop allows unlimited turns, unrestricted Bash, no stop condition, and no audit of tool results, then even a strong prompt is operating inside a weak runtime. If the loop has a turn budget, a cost budget, scoped tools, and a stop policy, then the prompt has a healthier environment to work inside.
 
@@ -266,7 +273,7 @@ The basic permission question is, "What is the agent allowed to do without askin
 
 Hooks provide runtime interception points. They let your application log, validate, block, or transform behavior around tool use and session events. In a serious system, hooks are how you move policy from "the prompt said not to" into executable control.
 
-As of 2026-06, the SDK documentation describes permissions through allow rules, deny rules, permission modes, approval callbacks, and hook decisions. That means the runtime can do more than ask the model to behave. It can pre-approve read-only tools, block specific commands, ask a human before sensitive actions, and return a denial message to the model when a requested tool call crosses the boundary.
+The SDK documentation describes permissions through allow rules, deny rules, permission modes, approval callbacks, and hook decisions. That means the runtime can do more than ask the model to behave. It can pre-approve read-only tools, block specific commands, ask a human before sensitive actions, and return a denial message to the model when a requested tool call crosses the boundary.
 
 A pre-tool hook can block edits outside an allowed path before the write happens. A post-tool hook can log changed files after an edit. A stop hook can reject completion if verification evidence is missing. A session-start hook can attach run metadata, while a session-end hook can emit cost and audit events.
 
@@ -338,7 +345,7 @@ A mature runtime usually needs both prevention and detection. Prevention limits 
 
 Sessions are one of the reasons the Agent SDK is more than a tool wrapper. Real work often spans multiple exchanges, and a useful agent may need to remember what it read, which files it changed, which hypothesis failed, and what goal the user approved. Session continuity can reduce repeated context gathering and preserve momentum.
 
-As of 2026-06, Anthropic's SDK documentation describes session IDs, resume behavior, result messages, and compact-boundary events in the agent stream. Those details matter because session state is not an invisible convenience. It is part of the runtime contract. If your application cannot explain which session was resumed, what facts were carried forward, and where compaction happened, then it cannot reliably debug long-running behavior.
+Anthropic's SDK documentation describes session IDs, resume behavior, result messages, and compact-boundary events in the agent stream. Those details matter because session state is not an invisible convenience. It is part of the runtime contract. If your application cannot explain which session was resumed, what facts were carried forward, and where compaction happened, then it cannot reliably debug long-running behavior.
 
 Continuity also creates risk. If the agent carries forward a weak assumption from early in the run, later decisions may inherit that mistake. If the session grows cluttered with obsolete observations, the model may spend attention on stale context. If the user changes the goal and the runtime does not record that change clearly, the agent may optimize for yesterday's task.
 
@@ -590,7 +597,7 @@ Treat the SDK as a harness, not a guarantee. It can provide a disciplined loop, 
 
 ## Did You Know?
 
-- As of 2026-06, the Claude Agent SDK is the renamed and broader form of the Claude Code SDK, reflecting that the underlying harness can support non-coding agents as well as software-development workflows.
+- The Claude Agent SDK is the renamed and broader form of the Claude Code SDK, reflecting that the underlying harness can support non-coding agents as well as software-development workflows.
 - The SDK supports both Python and TypeScript, which lets teams embed agent loops into backend services, automation scripts, developer tools, and web-facing applications.
 - MCP is not a replacement for local tools; it is a protocol boundary for structured external integrations such as SaaS systems, databases, browsers, and internal APIs.
 - Context compaction can help long-running sessions continue, but it can also preserve stale assumptions unless the runtime separates verified facts from temporary hypotheses.

--- a/src/content/docs/ai-ml-engineering/ai-native-development/module-1.2-local-models-for-ai-coding.md
+++ b/src/content/docs/ai-ml-engineering/ai-native-development/module-1.2-local-models-for-ai-coding.md
@@ -408,7 +408,7 @@ aider --model ollama/qwen2.5-coder:7b src/user_profile.py tests/test_user_profil
 aider --model ollama/deepseek-coder-v2:16b src/billing_rules.py tests/test_billing_rules.py
 
 # API model only when the task needs stronger reasoning or broad context
-aider --model gemini/gemini-2.5-flash src/auth_design.md src/auth_service.py
+aider --model gemini/gemini-3.5-flash src/auth_design.md src/auth_service.py
 ```
 
 Cost control is not only about reducing the bill. It is about making experimentation cheap enough that developers can ask better questions. If a local model can generate ten variants for no token cost, the developer can compare approaches, find edge cases, and sharpen the final prompt before using a paid model. That often improves the paid model's answer because the expensive request becomes more specific.
@@ -519,7 +519,7 @@ aider --model ollama/qwen2.5-coder:7b tests/test_parser.py
 aider --model ollama/deepseek-coder-v2:16b src/parser.py tests/test_parser.py
 
 # API fallback when the reasoning risk is higher than the local model can handle
-aider --model gemini/gemini-2.5-flash src/parser.py tests/test_parser.py docs/parser-contract.md
+aider --model gemini/gemini-3.5-flash src/parser.py tests/test_parser.py docs/parser-contract.md
 ```
 
 The senior move is to make these decisions visible to the team. Document which local model is the daily default, which one is the heavier local option, which API model is approved for escalation, and what kinds of code must not be sent to external providers. Without that shared agreement, each developer invents their own policy, and the team's privacy and cost posture becomes accidental.

--- a/src/content/docs/ai-ml-engineering/ai-native-development/module-1.8-ai-assisted-debugging-optimization.md
+++ b/src/content/docs/ai-ml-engineering/ai-native-development/module-1.8-ai-assisted-debugging-optimization.md
@@ -1325,7 +1325,7 @@ You have learned how to diagnose failures, challenge model-generated fixes, prot
 - [kubectl top reference](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_top) — Official `kubectl top` reference describing its dependency on Metrics Server.
 - [Metrics Server](https://github.com/kubernetes-sigs/metrics-server) — Upstream project documentation explaining Metrics Server's autoscaling focus and default 15-second scrape interval.
 - [kubectl top pod reference](https://kubernetes.io/docs/reference/kubectl/generated/kubectl_top/kubectl_top_pod/) — Kubernetes reference noting Pod metrics availability details and common timing caveats.
-- [OpenAI Function Calling Guide](https://platform.openai.com/docs/guides/function-calling?api-mode=respon) — Primary OpenAI guide for tool-calling flow, strict mode, and structured argument validation.
+- [OpenAI Function Calling Guide](https://platform.openai.com/docs/guides/function-calling?api-mode=responses) — Primary OpenAI guide for tool-calling flow, strict mode, and structured argument validation.
 - [New tools and features in the Responses API](https://openai.com/index/new-tools-and-features-in-the-responses-api/) — OpenAI announcement summarizing Responses API support for remote MCP servers, image generation, Code Interpreter, and file search.
 - [OpenAI Docs MCP](https://platform.openai.com/docs/docs-mcp) — OpenAI documentation for the public read-only MCP server used to access developer docs.
 - [OpenAI Web Search Guide](https://platform.openai.com/docs/guides/tools-web-search?api-mode=responses) — OpenAI guide for Responses web-search tool behavior, supported modes, and model availability constraints.

--- a/src/content/docs/ai-ml-engineering/ai-native-development/module-1.9-building-with-ai-coding-assistants.md
+++ b/src/content/docs/ai-ml-engineering/ai-native-development/module-1.9-building-with-ai-coding-assistants.md
@@ -27,7 +27,7 @@ By the end of this module, you will be able to:
 
 ## Why This Module Matters
 
-A platform team at a healthcare software company adopted AI coding assistants across every repository in one quarter. At first, the story looked like a success. Small endpoints appeared faster, unit tests grew overnight, and junior engineers could navigate unfamiliar services with less waiting. Leadership saw the first metrics and assumed the organization had simply become more productive.
+**Hypothetical scenario:** A platform team at a healthcare software company adopted AI coding assistants across every repository in one quarter. At first, the story looked like a success. Small endpoints appeared faster, unit tests grew overnight, and junior engineers could navigate unfamiliar services with less waiting. Leadership saw the first metrics and assumed the organization had simply become more productive.
 
 Then an incident review told a different story. An AI-generated caching decorator had been accepted during a rushed performance fix, and nobody noticed that it had no eviction policy, no size limit, and no monitoring. The service behaved well in staging, where data volume was small, but production traffic turned the cache into an unbounded memory sink. The outage lasted long enough to trigger contractual penalties, and the most uncomfortable sentence in the review was not technical at all: "The assistant wrote it, and we trusted it."
 
@@ -38,6 +38,8 @@ This module teaches AI-assisted development as an engineering discipline rather 
 The examples in this module are intentionally ordinary: API routes, tests, caches, prompts, and review loops. That is where most teams either gain real leverage or quietly accumulate risk. You will not learn a magic incantation that makes an assistant reliable; you will learn how to surround probabilistic generation with deterministic evidence. When Kubernetes appears in later practice, assume Kubernetes 1.35 or newer and define the standard shortcut with `alias k=kubectl` before using `k` in commands, but the main lesson here is broader than any one platform.
 
 ## 1. The Mental Model: Assistants Are Different Tools, Not One Tool
+
+> **Landscape snapshot — tool names as of 2026-06.** The product roster churns fast; the durable skill is matching the *form factor* (autocomplete · IDE-native · terminal/agentic · general-chat) to the task, not memorizing today's tools. Verify the current roster and capabilities against vendor docs before relying on specifics. See the **AI Coding Harness Rosetta** in [Module 1.1](/ai-ml-engineering/ai-native-development/module-1.1-ai-coding-tools-landscape/) for the cross-tool capability matrix.
 
 The first mistake many teams make is treating every AI coding assistant as a smarter version of autocomplete. That mental model hides the important differences between tools. Some assistants are optimized for fast local suggestions, some for codebase-wide editing, some for terminal-native patching, and some for long-context reasoning. A senior workflow does not ask, "Which assistant is best?" It asks, "Which assistant matches this task, this risk level, and this review budget?"
 
@@ -84,6 +86,10 @@ A useful rule is to spend the least reasoning power that can responsibly solve t
 | Secret-bearing or regulated code | Local model or manual workflow | The exposure risk dominates convenience | The task can be reduced to redacted structure and synthetic examples |
 
 This routing table is not a law. It is a starting point for disciplined judgment. The table becomes useful when you treat each row as a hypothesis: "This tool should be enough because the task has these properties." If the hypothesis fails, you escalate deliberately instead of thrashing between assistants.
+
+### Open standards: the durable anchor
+
+Across every assistant above, the durable anchors are not the products but the open standards they share. **MCP (Model Context Protocol)** is the cross-vendor protocol for connecting tools, data, and services to any assistant, so an integration you build once is portable across harnesses. The rules-file conventions — **`AGENTS.md`** (read by Codex, Cursor, Aider, and others) and **`CLAUDE.md`** (Claude Code) — let a repository declare its own instructions, commands, and boundaries once, independent of which tool a developer runs. Learn these standards and the skill transfers to whichever assistant your team adopts next; see [Module 1.1](/ai-ml-engineering/ai-native-development/module-1.1-ai-coding-tools-landscape/) for the full treatment.
 
 That escalation should be explicit in your notes or pull request summary. If a simple autocomplete-generated test exposed an unclear contract, say that the work moved from local generation to codebase reasoning because the contract was ambiguous. If a terminal agent proposed a dependency that violated your supply-chain policy, say that implementation stopped until the dependency decision was reviewed. These small records make AI-assisted work auditable, and they help the next engineer understand whether the assistant was used as a shortcut, a reviewer, or a reasoning partner.
 


### PR DESCRIPTION
## What
Cross-family review wave on the 4 `ai-native-development` modules that had **no `.pipeline/reviews/` record** — a triage miss under #2020 (the other 5 of 9 were reviewed in the #1835 wave, PR #1837). Tracked as #2028.

## Reviews (mixed families, every finding orchestrator-ground-checked)
| Module | Reviewer | Verdict |
|---|---|---|
| 1.2 local-models | opus (inline) | APPROVE → 1 currency fix |
| 1.8 debugging | deepseek | APPROVE → 1 typo (2 hallucinated FPs excluded) |
| 1.9 building-with | agy (gemini-3.1-pro) | NEEDS_CHANGES → 3 real P1s |
| 1.10 anthropic-sdk | codex (gpt-5.5) | NEEDS_CHANGES → 1 P1 (all SDK facts web-verified correct) |

## Fixes
- **1.2** — `gemini/gemini-2.5-flash` → `gemini/gemini-3.5-flash` (×2). 2.5-flash has an announced shutdown of **2026-10-16** (web-verified); 3.5-flash is current GA.
- **1.8** — truncated Sources URL `?api-mode=respon` → `?api-mode=responses`.
- **1.9** — (a) label the invented healthcare-outage opener `**Hypothetical scenario:**` (anti-fab); (b) add a dated `Landscape snapshot — as of 2026-06` callout quarantining the vendor roster + cross-ref to 1.1's Harness Rosetta; (c) add an `Open standards: the durable anchor` subsection (MCP / AGENTS.md / CLAUDE.md).
- **1.10** — consolidate the 6 scattered inline `as of 2026-06` SDK facts into one `Landscape snapshot` callout (content was correct/current per codex web-verify; this is a durable-vendor *placement* fix).

## Excluded false positives (ground-checked)
- deepseek "3 broken cross-ref links" → the 3 target modules **exist** under `src/content/docs/ai/ai-engineering-foundations/`.
- deepseek "K8s v1.35+ should be v1.36" → the structured `/statusz` Accept-header format **was** introduced in v1.35; text is already hedged ("still maturing / verify the feature-gate state").

Refs #2028 #2020

🤖 Generated with [Claude Code](https://claude.com/claude-code)