### PR TITLE
fix(machine-learning): #2020 ML wave-1 review fixes — 3 verified P1s + 1.1 sources gate

### DIFF
--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.1-scikit-learn-api-and-pipelines.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.1-scikit-learn-api-and-pipelines.md
@@ -381,8 +381,10 @@ import numpy as np
 
 class GroupMeanEncoder(BaseEstimator, TransformerMixin):
     """Replace a categorical column with the in-group mean of the
-    target. Demonstration only — for production target encoding,
-    prefer category_encoders.TargetEncoder which adds smoothing.
+    target. Demonstration only — for production target encoding, prefer
+    sklearn's built-in `sklearn.preprocessing.TargetEncoder` (added in
+    scikit-learn 1.3, with cross-fitting to limit leakage) or
+    `category_encoders.TargetEncoder` (adds smoothing). Module 1.4 covers both.
     """
 
     def __init__(self, column, default=0.0):
@@ -513,7 +515,7 @@ A practitioner-grade workflow ties every concept above into a single object. Rea
 import joblib
 import numpy as np
 import pandas as pd
-from sklearn.base import BaseEstimator, TransformerMixin, clone
+from sklearn.base import BaseEstimator, TransformerMixin
 from sklearn.compose import ColumnTransformer, make_column_selector
 from sklearn.impute import SimpleImputer
 from sklearn.linear_model import LogisticRegression
@@ -705,6 +707,9 @@ When all six checkboxes are green, you have internalized the contract this modul
 - [Cross-validation: evaluating estimator performance](https://scikit-learn.org/stable/modules/cross_validation.html)
 - [Metrics and scoring (overview)](https://scikit-learn.org/stable/modules/model_evaluation.html)
 - [`sklearn.base` API reference (`BaseEstimator`, `TransformerMixin`, `clone`)](https://scikit-learn.org/stable/api/sklearn.base.html)
+- [`sklearn.pipeline` API reference (`Pipeline`, `FeatureUnion`, `make_pipeline`)](https://scikit-learn.org/stable/api/sklearn.pipeline.html)
+- [`sklearn.compose` API reference (`ColumnTransformer`, `make_column_selector`)](https://scikit-learn.org/stable/api/sklearn.compose.html)
+- [`sklearn.model_selection` API reference (splitters, `GridSearchCV`, `RandomizedSearchCV`)](https://scikit-learn.org/stable/api/sklearn.model_selection.html)
 - [Joblib persistence guide](https://joblib.readthedocs.io/en/stable/persistence.html)
 
 ## Next Module

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.10-dimensionality-reduction.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.10-dimensionality-reduction.md
@@ -462,6 +462,16 @@ import numpy as np
 
 from sklearn.decomposition import IncrementalPCA
 
+rng = np.random.default_rng(0)
+
+
+def stream_of_batches(n_batches=10, batch_size=2000, n_features=100):
+    """Stand-in for a real chunked source (memory-mapped file, DB cursor,
+    Parquet row groups). It only needs to yield fixed-width arrays."""
+    for _ in range(n_batches):
+        yield rng.normal(size=(batch_size, n_features))
+
+
 ipca = IncrementalPCA(n_components=50, batch_size=2000)
 
 for batch in stream_of_batches():
@@ -471,7 +481,8 @@ for batch in stream_of_batches():
 X_reduced = np.vstack([ipca.transform(batch) for batch in stream_of_batches()])
 ```
 
-The `stream_of_batches` placeholder is intentional.
+The `stream_of_batches` generator here is a stand-in: swap it for your real
+chunked source (a memory-mapped array, a database cursor, Parquet row groups).
 The estimator does not care where the batches come from, only that they
 have consistent feature dimensionality and represent the data
 distribution well enough that the components stabilize.
@@ -662,7 +673,9 @@ and lives in the `umap-learn` package, which installs separately from
 scikit-learn but follows the sklearn estimator API.
 
 UMAP has three practical advantages over t-SNE for many datasets.
-It is generally faster.
+It is often faster on large datasets, though the exact margin depends on
+dataset size, dimensionality, and parameter choices, so benchmark on your
+own data rather than assuming a fixed speedup.
 It tends to preserve more global structure, which means inter-cluster
 distances in a UMAP plot are more meaningful than in a t-SNE plot,
 though they are still not literal.
@@ -680,7 +693,9 @@ emphasize local structure, large values blur into global structure.
 values produce dense clusters, larger values produce smoother
 distributions.
 
-A typical exploratory snippet looks like this.
+A typical exploratory snippet looks like this. UMAP is not bundled with
+scikit-learn, so install it first with `pip install umap-learn` (the import
+name is `umap`, not `umap-learn`).
 
 ```python
 import umap
@@ -1025,9 +1040,11 @@ TF-IDF matrix and avoids densifying it into a much larger memory
 footprint.
 It produces a deterministic linear projection with a proper `transform`
 method, so it slots cleanly into a supervised pipeline.
-Regular PCA would force the matrix to dense, and t-SNE or UMAP would
-not be appropriate because they are visualization tools rather than
-generalizing feature extractors.
+Regular PCA would force the sparse matrix to dense. t-SNE would not be
+appropriate either, because it has no out-of-sample `transform` and is a
+visualization tool rather than a feature extractor. UMAP does expose a
+`transform`, but its stochastic non-linear embedding is better suited to
+exploration than to a stable, reproducible production feature pipeline.
 </details>
 
 5. A practitioner sets `n_components=0.95` in PCA and is surprised to

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.8-unsupervised-learning-clustering.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.8-unsupervised-learning-clustering.md
@@ -493,7 +493,7 @@ from sklearn.cluster import DBSCAN
 from sklearn.datasets import make_moons
 from sklearn.preprocessing import StandardScaler
 
-X, _ = make_moons(random_state=0)
+X, _ = make_moons(n_samples=300, noise=0.08, random_state=0)
 
 X_scaled = StandardScaler().fit_transform(X)
 
@@ -1089,7 +1089,7 @@ be only as a supporting exploratory step, not the main detection method.
 
 ### Step 3: Compare DBSCAN on non-convex structure
 
-- [ ] Generate `make_moons` data and apply scaling before fitting.
+- [ ] Generate `make_moons(n_samples=300, noise=0.08, random_state=0)` and apply scaling before fitting (a denser sample gives DBSCAN enough local density to form the two arcs; the very sparse default would label every point as noise).
 - [ ] Fit `DBSCAN(eps=0.3, min_samples=10)`.
 - [ ] Count how many non-noise clusters were found.
 - [ ] Count how many points were assigned label `-1`.

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-2.4-recommender-systems.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-2.4-recommender-systems.md
@@ -95,8 +95,8 @@ the target is visible. They also look cleaner than they usually are.
 
 Explicit feedback was the historical default in much of recommender-system education. That is why many older examples start with a rating matrix. The
 user gave item A five stars and item B two stars. The model predicts missing ratings. The evaluation computes rating error. This is a coherent problem
-when the product really asks users for ratings and uses predicted ratings operationally, but by 2026 it is rare in production compared with behavioral
-signals.
+when the product really asks users for ratings and uses predicted ratings operationally, but it has become much less common in modern production systems
+compared with implicit behavioral signals like clicks, watches, and purchases.
 
 It is less common in production systems now. Many modern surfaces do not ask users for ratings at all. They observe behavior. Clicks, views,
 purchases, dwell time, completed plays, saves, shares, add-to-cart events, skips, and repeat visits are implicit signals. They are abundant. They are
@@ -194,7 +194,10 @@ preference signals with different confidence weights. The common Hu, Koren, and 
 r_ui`, where `r_ui` is an interaction strength. More interactions increase confidence that the positive preference signal is real. Missing
 interactions still influence training, but they are not treated like equally confident negative ratings.
 
-The `implicit` ALS implementation documents this model at https://benfred.github.io/implicit/api/models/cpu/als.html. The library is useful because it
+The `implicit` ALS implementation documents this model at https://benfred.github.io/implicit/api/models/cpu/als.html. One mapping detail matters in
+practice: you do not build the `1 + alpha * r_ui` confidence matrix yourself. You pass `implicit` the raw interaction matrix (the `r_ui` values), and the
+library applies the `alpha` scaling internally while treating unobserved entries as the baseline confidence. Pre-multiplying the `+ 1` into the matrix you
+hand to the library double-counts that baseline. The library is useful because it
 makes the sparse implicit workflow feel like a normal Python workflow. That convenience should not hide the modeling assumption. ALS learns factors
 that reconstruct confidence-weighted preference patterns. It does not discover intent by magic.
 
@@ -705,7 +708,10 @@ popular_items = np.argsort(item_popularity)[::-1]
 
 class PopularityRecommender:
     def __init__(self, ranked_items):
-        self.ranked_items = np.asarray(ranked_items)
+        # implicit's Cython evaluation helpers (ndcg_at_k, precision_at_k) expect
+        # int32 item IDs. np.argsort returns int64 on 64-bit NumPy, so cast here
+        # to avoid a "Buffer dtype mismatch, expected 'int' but got 'long'" crash.
+        self.ranked_items = np.asarray(ranked_items, dtype=np.int32)
 
     def recommend(
         self,


### PR DESCRIPTION
## #2020 quality-coverage — machine-learning track, wave 1 (review fixes)

Cross-family review of the un-reviewed `ai-ml-engineering/machine-learning` track (codex/OpenAI executing labs · cursor/Kimi · deepseek/DeepSeek), with **every P1 ground-checked by the orchestrator and reproduced/fixed-verified locally**.

### Blocking P1s fixed (all reproduced)
| Module | Defect | Fix (verified) |
|---|---|---|
| **1.8** clustering | DBSCAN lab `make_moons()` default → `Clusters found: 0, Noise points: 100` (teaches the opposite lesson) | `make_moons(n_samples=300, noise=0.08)` → 2 clusters, 3 noise; hands-on updated |
| **1.10** dim-reduction | IncrementalPCA `stream_of_batches()` undefined → `NameError` | concrete runnable generator; **+** fixed UMAP "visualization tool / can't generalize" self-contradiction (UMAP has `transform`), added `umap-learn` install note, softened unscoped "faster" claim |
| **2.4** recommenders | `PopularityRecommender` int64 IDs → `implicit` Cython `ndcg_at_k` `Buffer dtype mismatch` crash | cast to `np.int32`; **+** HKV `1+α·r_ui` → `implicit` API mapping clarified; dated market claim softened |
| **1.1** sklearn API | only 7 sources (gate wants 10) | +3 sklearn API-ref sources → 10; removed dead `clone` import; aligned TargetEncoder note with 1.4 |

### Review scoreboard — 17 reviewable modules
**APPROVE (14):** 1.1, 1.2, 1.3, 1.4, 1.5, 1.7, 1.9, 1.11, 2.1, 2.2, 2.3, 2.5, 2.6, 2.7
**NEEDS_CHANGES → fixed here (3):** 1.8, 1.10, 2.4

**Notable reprieve — 1.2:** a reviewer flagged its sklearn `penalty` deprecation + `multi_class` removal as "fabrication." Web-verified against the **scikit-learn 1.9.0** docs: both are real and current (`penalty` deprecated in 1.8 → removed 1.10, migrate to `l1_ratio`+`C`; `multi_class` removed). Stale-reviewer false positive — module left unchanged.

### Out of scope (tracked as follow-ups)
- **1.6** (slug `xgboost-gradient-boosting`) and **1.12** (slug `time-series-forecasting`) are mis-slotted legacy modules (wrong topic + fabrication-template) → being fully rewritten in separate PRs.
- Track-wide P2 polish (`Hypothetical scenario:` labels on archetypal openers; dated Landscape-snapshot wrappers for version pins; `outcomes_aligned` heuristic) — non-blocking, deferred.

Build: green, 2169 pages. Refs #2020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)