### PR TITLE
docs(machine-learning): #2020 rewrite 1.12 Time Series Forecasting (mis-slotted legacy)

### DIFF
--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.12-time-series-forecasting.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.12-time-series-forecasting.md
@@ -4,2031 +4,657 @@ slug: ai-ml-engineering/machine-learning/module-1.12-time-series-forecasting
 sidebar:
   order: 12
 ---
-> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 6-8
-## The Intern Who Beat the Team
 
-**Illustrative AutoML comparison.**
-
-A junior practitioner can sometimes surface an AutoML result that challenges a carefully hand-built baseline.
-
-A team had invested substantial time in a hand-built churn model before comparing it with an AutoML baseline.
-
-Sarah asked a naive question: "Could I try AutoGluon on the same data?"
-
-The senior engineers exchanged knowing glances. "Sure, but don't expect it to beat a model built by experienced engineers."
-
-A short AutoML run can sometimes produce a stronger baseline than a manually tuned model, depending on the dataset and evaluation setup.
-
-"How is that possible?" asked the team lead.
-
-"It evaluated multiple model families, combined strong candidates, and surfaced patterns the manual workflow had not captured," the teammate explained.
-
-The operational lesson is that AutoML can provide a fast, credible baseline before a team commits to more manual modeling work.
-
-> "AutoML doesn't make data scientists obsolete—it makes their time more valuable. Now you can spend six months on problems that actually need human creativity."
-> — Common AutoML perspective
-
-This module teaches you how to use AutoML tools effectively—and why they're not magic, but a powerful force multiplier for any ML practitioner.
+> **AI/ML Engineering Track** | Complexity: `[COMPLEX]` | Time: 90-120 minutes
+>
+> **Prerequisites**: [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../module-1.3-model-evaluation-validation-leakage-and-calibration/), [Module 1.4: Feature Engineering & Preprocessing](../module-1.4-feature-engineering-and-preprocessing/), [Module 1.6: XGBoost & Gradient Boosting](../module-1.6-xgboost-gradient-boosting/), and comfort with pandas indexes, regression metrics, and train/test splits.
 
 ---
 
-## What You'll Be Able to Do
+## Learning Outcomes
 
-By the end of this module, you will:
-- Understand AutoML and when to use it
-- Master AutoGluon for automated machine learning
-- Learn feature store concepts and architecture
-- Implement automated feature engineering
-- Build end-to-end ML pipelines
+By the end of this module, you will be able to:
 
----
+- Diagnose why a forecasting problem needs time-aware validation, stationarity checks, and leakage controls before model choice.
+- Decompose a temporal signal into trend, seasonality, cyclicality, and residual behavior, then use ACF and PACF patterns to propose ARIMA or SARIMA orders.
+- Build statistical forecasts with ARIMA, SARIMA, exponential smoothing, and Prophet while explaining when each family is a reasonable baseline.
+- Reframe forecasting as supervised regression with lag, rolling, calendar, Fourier, and holiday features for tree-based models.
+- Design walk-forward backtests that compare statistical and machine-learning forecasters against naive or seasonal-naive baselines using horizon-aware metrics.
 
-## The AutoML Revolution
+## Why This Module Matters
 
-Imagine you're a chef at a restaurant. Traditional ML is like cooking everything from scratch - you select ingredients (features), decide cooking methods (algorithms), adjust seasoning (hyperparameters), and taste-test constantly (validation). It requires years of expertise.
+Forecasting looks like ordinary regression until time becomes part of the contract. In a normal tabular split, shuffling rows often improves the estimate of average generalization. In forecasting, shuffling rows destroys the question. You do not ask whether the model can predict a randomly hidden observation from the same period. You ask whether it can stand at a decision date, see only the past, and make a useful statement about the future.
 
-AutoML is like having a robot chef that tries hundreds of recipes automatically, learns from each attempt, and presents you with the best dish. You just need to provide the ingredients and describe what you want.
+That one change explains most forecasting failures. A model can look brilliant if it sees target values from next week while building rolling averages for today. A scaler can leak if it estimates the full-period mean before the split. A cross-validation routine can lie if one fold trains on data from the future and evaluates on older observations. Time series work is therefore less about choosing one fashionable algorithm and more about preserving the arrow of time from raw data through evaluation.
 
-```
-TRADITIONAL ML WORKFLOW:
-────────────────────────
-Data → [Manual Feature Eng] → [Choose Algorithm] → [Tune Hyperparameters] → Model
-         ↑                         ↑                      ↑
-         │                         │                      │
-    Requires expertise       Requires expertise     Takes days/weeks
-         │                         │                      │
-         └─────────────────────────┴──────────────────────┘
-                     TIME: Days to Weeks
+Hypothetical scenario: an operations team forecasts daily support tickets for staffing. Their first notebook uses random k-fold validation and centered rolling features, so the validation error looks comfortably low. When the schedule goes live, weekends and holidays are under-staffed because the model learned patterns using information that would not have existed at scheduling time. The fix is not only a different model. The fix is a forecasting protocol that makes impossible information impossible to use.
 
+> **The Sealed Calendar Analogy**
+>
+> A forecasting model is like a planner with sealed calendar pages. When you stand on March 31, every page after March 31 is sealed. You may know recurring holidays, planned promotions, and the calendar structure, but you may not peek at April demand, April residuals, or April rolling averages. Good forecasting engineering is the discipline of keeping those pages sealed in code.
 
-AUTOML WORKFLOW:
-────────────────
-Data → [AutoML System] → Best Model
-            │
-            ├── Tries 100+ algorithms
-            ├── Engineers features automatically
-            ├── Tunes hyperparameters
-            └── Ensembles best models
+> **Landscape snapshot - as of 2026-06. Library versions move fast; verify against the project's release notes before relying on specifics.**
+>
+> - `statsmodels` **0.14.6** includes `statsmodels.tsa` ARIMA, SARIMAX, and `ExponentialSmoothing`.
+> - `prophet` **1.3.0** is the maintained successor to the original `fbprophet`; Python imports use `from prophet import Prophet`.
+> - Tree-based forecasting commonly uses XGBoost **3.3.0**, LightGBM **4.6.0**, or scikit-learn **1.9.0** estimators such as `HistGradientBoostingRegressor`.
 
-       TIME: Minutes to Hours
-```
+## What Makes Time Series Different
 
-**Did You Know?** AutoML systems have reported strong benchmark and competition results under fixed compute budgets, but the exact ranking and runtime depend on the benchmark and configuration.
+A time series is a sequence where order carries information. Yesterday's temperature, last month's revenue, and last year's holiday spike are not independent row labels attached after the fact. They help define what the next value can plausibly be. This dependence is called autocorrelation: nearby values, and sometimes values one seasonal period apart, tend to be related.
 
----
+Temporal ordering changes the basic modeling assumptions. In ordinary supervised learning, you can often assume rows are exchangeable enough for random splitting. In forecasting, rows are not exchangeable because the training set must represent what was known before the forecast origin. A feature computed from the entire series can silently smuggle future information into the past even when the final train/test split looks chronological.
 
-## Why AutoML Matters
+The cardinal rule is simple: the future must never leak into the past. Every transformation, imputation, scaling step, feature, model selection decision, and metric calculation must be written as if the model were running on the forecast date. If a value would not be available to the production system at that date, it cannot be used during validation.
 
-### The ML Expertise Gap
+Time series structure is usually discussed through four components. Trend is the long-run direction, such as atmospheric CO2 rising over decades or active users growing during adoption. Seasonality is a repeating pattern with a known or stable period, such as hourly traffic cycles, weekly staffing rhythms, or annual demand spikes. Cyclicality is a broader rise-and-fall pattern whose length is not fixed, such as business cycles or commodity regimes. Residual behavior is what remains after the structured parts are removed.
 
-```
-REALITY OF ML IN INDUSTRY:
-──────────────────────────
+Those components matter because they suggest different interventions. A strong trend may need differencing, damping, or explicit trend terms. A regular seasonal pattern may need seasonal differencing, Fourier features, seasonal smoothing, or a seasonal-naive baseline. A noisy residual pattern may reveal that the useful signal is exhausted, and a more complex model is only fitting noise more elegantly.
 
-Companies with ML needs:    ████████████████████ 1,000,000+
-Companies with ML experts:  ███                  ~50,000
-Expert ML engineers:        █                    ~300,000
-
-Gap: 95%+ of companies can't hire ML experts!
-
-AutoML bridges this gap:
-- Democratizes ML (anyone can use it)
-- Accelerates expert productivity (10x faster)
-- Establishes strong baselines automatically
+```text
+observed series
+    |
+    +-- trend: long-run movement
+    +-- seasonality: repeated calendar pattern
+    +-- cyclicality: irregular regime movement
+    +-- residual: unexplained remainder
 ```
 
-### When to Use AutoML
+The most useful first plot is rarely a model plot. Start with the raw series, the train/test boundary, and a seasonal view by hour, week, month, or product cycle. Many expensive modeling mistakes become obvious when you can see that the validation window covers a different regime, that timestamps are missing, or that the target has a hard floor near zero.
 
-```
-USE AUTOML:
-───────────
- Establishing baselines quickly
- Tabular data problems
- Time-constrained projects
- Non-expert teams
- Comparing many algorithms
- Hyperparameter optimization
+## Forecast Origins and Data Availability
 
-DON'T USE AUTOML (alone):
-─────────────────────────
- Custom architectures needed
- Domain-specific constraints
- Real-time inference requirements
- Highly specialized problems
- When interpretability is critical
-```
+The most important timestamp in a forecasting project is the forecast origin. That is the moment where the model stands and makes a claim about the future. If a retailer forecasts demand every Sunday night for the next two weeks, then Sunday night is the forecast origin. If a platform team forecasts CPU capacity every morning for the next day, then each morning is a new origin. Write this down explicitly because it defines which data is allowed.
 
----
+Availability is not the same as timestamp. A source record may have an event timestamp of Monday but arrive in the warehouse on Wednesday. A financial adjustment may describe last month but be posted after the forecast was made. A monitoring metric may be timestamped correctly but delayed by an exporter outage. Forecasting pipelines need both event time and availability time when late-arriving data can change what the model would have known.
 
-## AutoML Landscape
+This distinction matters during feature engineering. Suppose a feature named `last_known_inventory` is computed by joining the latest inventory snapshot before the target date. That sounds safe until you learn that snapshots are corrected retroactively after reconciliation. A backtest using corrected snapshots may outperform production because production would have seen the uncorrected version. The leakage is subtle because every row still has a date before the target.
 
-### Major AutoML Frameworks
+Good forecasting datasets therefore include an availability contract. For each column, document whether it is observed history, scheduled future information, slowly updated metadata, or a target-derived artifact. Observed history must be cut off at the origin. Scheduled future information can extend into the horizon only if it is genuinely known. Target-derived artifacts usually need special suspicion because they often encode future outcomes under a harmless business name.
 
-```
-AUTOML FRAMEWORK COMPARISON:
-────────────────────────────
+When that contract is missing, model review becomes guesswork. Reviewers argue about algorithms while the real uncertainty is whether the feature table could have existed at forecast time. A simple availability table prevents many of these arguments. It also makes the project easier to operationalize, because the production feature job can be tested against the same "known by origin" rule used in backtesting.
 
-┌──────────────────────────────────────────────────────────────────┐
-│  FRAMEWORK      │ BEST FOR           │ KEY STRENGTH              │
-├──────────────────────────────────────────────────────────────────┤
-│  AutoGluon      │ Tabular, general   │ Best accuracy, ensembles  │
-│  (Amazon)       │                    │                           │
-├──────────────────────────────────────────────────────────────────┤
-│  auto-sklearn   │ scikit-learn users │ Meta-learning, warm-start │
-│  (Freiburg)     │                    │                           │
-├──────────────────────────────────────────────────────────────────┤
-│  H2O AutoML     │ Enterprise         │ Production-ready, scaling │
-│  (H2O.ai)       │                    │                           │
-├──────────────────────────────────────────────────────────────────┤
-│  FLAML          │ Fast experiments   │ Low compute, fast         │
-│  (Microsoft)    │                    │                           │
-├──────────────────────────────────────────────────────────────────┤
-│  PyCaret        │ Low-code ML        │ Simple API, visualization │
-│  (Open Source)  │                    │                           │
-└──────────────────────────────────────────────────────────────────┘
-```
+## Stationarity, Differencing, ACF, and PACF
 
-### AutoGluon Deep Dive
+Many classical time series methods assume some form of stationarity. A stationary series has statistical behavior that is stable over time: its mean, variance, and autocorrelation structure do not drift wildly as the window moves. Real business and infrastructure series are often not stationary in their raw form, but a transformed version may be close enough to model responsibly.
 
-AutoGluon (from Amazon) has reported strong results on tabular benchmarks and competitions:
+Differencing is the most common transformation. A first difference models the change from one observation to the next rather than the level itself. Seasonal differencing models the change from one seasonal position to the corresponding previous seasonal position, such as this January minus last January. Differencing can remove trend or seasonal persistence, but unnecessary differencing can also erase useful signal and make forecasts unstable.
 
-```
-AUTOGLUON ARCHITECTURE:
-───────────────────────
+Two standard tests help frame the stationarity question. The Augmented Dickey-Fuller test uses a null hypothesis of a unit root, so a low p-value is evidence against non-stationarity. The KPSS test reverses the framing by using a stationarity null, so a low p-value suggests the series is not stationary under the selected level or trend assumption. The tests are not magic judges; they are structured evidence to combine with plots and domain knowledge.
 
-                    Input Data
-                         │
-            ┌────────────┼────────────┐
-            │            │            │
-            ▼            ▼            ▼
-        ┌───────┐   ┌───────┐   ┌───────┐
-        │NN     │   │GBM    │   │Linear │
-        │Models │   │Models │   │Models │
-        └───┬───┘   └───┬───┘   └───┬───┘
-            │           │           │
-            │    ┌──────┼──────┐    │
-            │    │      │      │    │
-            ▼    ▼      ▼      ▼    ▼
-        ┌─────────────────────────────┐
-        │     MULTI-LAYER STACKING    │
-        │  (Ensemble of ensembles)    │
-        └──────────────┬──────────────┘
-                       │
-                       ▼
-                  Best Model
-
-
-MODELS AUTOGLUON TRIES:
-───────────────────────
-Neural Networks:
-  - TabularNN (custom for tabular)
-  - FastAI neural network
-
-Gradient Boosting:
-  - LightGBM
-  - CatBoost
-  - XGBoost
-
-Linear Models:
-  - Ridge/Lasso regression
-  - Linear SVM
-
-Ensemble:
-  - Weighted ensemble
-  - Multi-layer stacking
-```
-
-**Did You Know?** AutoGluon uses stacked ensembles that train later models on earlier model predictions. This can improve accuracy, but the exact gain depends on the dataset, time budget, and evaluation setup.
-
----
-
-## AutoML Under the Hood
-
-### Algorithm Selection
-
-How does AutoML choose which algorithms to try?
-
-```
-ALGORITHM SELECTION STRATEGIES:
-───────────────────────────────
-
-1. EXHAUSTIVE SEARCH
-   Try ALL algorithms, all hyperparameters
-   Problem: Computationally infeasible!
-
-   10 algorithms × 100 hyperparameter combos = 1,000 models
-   If each takes 1 minute = 16+ hours
-
-
-2. META-LEARNING (auto-sklearn approach)
-   Learn from past datasets which algorithms work best
-
-   "This dataset looks like Dataset #4,523 from our database.
-    Random Forest worked best there, let's try that first!"
-
-   Steps:
-   a) Extract meta-features from dataset
-   b) Find similar historical datasets
-   c) Start with algorithms that worked on those
-
-
-3. BAYESIAN OPTIMIZATION
-   Smart search that learns as it goes
-
-   ┌──────────────────────────────────────────────┐
-   │ Iteration 1: Try random config → Score: 0.75 │
-   │ Iteration 2: Try another → Score: 0.82      │
-   │ Iteration 3: Try similar to best → 0.85     │
-   │ ...learns that high learning_rate is bad... │
-   │ Iteration 50: Optimal found → 0.91          │
-   └──────────────────────────────────────────────┘
-
-
-4. BANDIT-BASED (Hyperband/ASHA)
-   Give more resources to promising configs
-
-   Start: 100 configs with 1 epoch each
-   Keep:  Top 25 configs, train for 4 epochs
-   Keep:  Top 6 configs, train for 16 epochs
-   Keep:  Top 2 configs, train to completion
-
-   Result: Find best config with 10x less compute!
-```
-
-### Hyperparameter Optimization
-
-Think of hyperparameter optimization like tuning a guitar. Each hyperparameter is a string that affects the sound. Turn the learning rate too high and you get noise; too low and you barely hear anything. The problem? A neural network has dozens of "strings," and they all interact with each other.
-
-Traditional approach: try every combination. With 10 hyperparameters and 5 values each, that's 5^10 = 9.7 million combinations. Even at 1 minute per trial, that's 18 years.
-
-Smart approach: use Bayesian optimization, which learns from each trial. "High learning rate made things worse? Let's try lower values." It can often find good configurations in far fewer trials than exhaustive search.
-
-```
-HYPERPARAMETER SEARCH SPACE:
-────────────────────────────
-
-LightGBM example:
-┌─────────────────────────────────────────────────┐
-│  Parameter        │  Search Space              │
-├─────────────────────────────────────────────────┤
-│  n_estimators     │  [100, 200, 500, 1000]     │
-│  learning_rate    │  [0.01, 0.05, 0.1, 0.3]    │
-│  max_depth        │  [3, 5, 7, 10, -1]         │
-│  num_leaves       │  [15, 31, 63, 127]         │
-│  min_child_weight │  [1e-3, 1e-2, 0.1, 1]      │
-│  subsample        │  [0.5, 0.7, 0.9, 1.0]      │
-│  colsample_bytree │  [0.5, 0.7, 0.9, 1.0]      │
-└─────────────────────────────────────────────────┘
-
-Total combinations: 4×4×5×4×4×4×4 = 20,480 configs!
-
-Smart search finds good config in ~50 trials
-Exhaustive search needs 20,480 trials
-Speedup: 400x
-```
-
----
-
-## Automated Feature Engineering
-
-### Why This Module Matters
-
-```
-FEATURE ENGINEERING REALITY:
-────────────────────────────
-
-Time spent on ML projects:
-┌──────────────────────────────────────────────────────┐
-│  Data Collection      ████████████         25%       │
-│  Data Cleaning        ████████████████     35%       │
-│  Feature Engineering  ██████████████       30%       │
-│  Model Training       ████                 10%       │
-└──────────────────────────────────────────────────────┘
-
-Feature engineering is:
-- Time-consuming (30% of project time)
-- Requires domain expertise
-- Often repetitive across projects
-- Critical for model performance
-
-"Give me better features, and I'll give you a better model."
-                                    - Every ML Engineer
-```
-
-### Automated Feature Engineering Techniques
-
-```
-AUTO-FEATURE TECHNIQUES:
-────────────────────────
-
-1. AGGREGATION (for relational data)
-   ─────────────────────────────────
-   customer_id → orders table
-
-   Auto-generated features:
-   - count(orders)
-   - sum(order_amount)
-   - avg(order_amount)
-   - max(order_amount)
-   - days_since_last_order
-
-
-2. TRANSFORMATION
-   ───────────────
-   Original: [price, quantity]
-
-   Auto-generated:
-   - log(price)
-   - sqrt(quantity)
-   - price * quantity  (interaction)
-   - price / quantity  (ratio)
-   - price ** 2        (polynomial)
-
-
-3. TIME-BASED (from timestamps)
-   ────────────────────────────
-   Original: purchase_datetime
-
-   Auto-generated:
-   - hour_of_day
-   - day_of_week
-   - is_weekend
-   - month
-   - quarter
-   - days_since_signup
-
-
-4. ENCODING (for categoricals)
-   ───────────────────────────
-   Original: category = ["A", "B", "C"]
-
-   Auto-generated:
-   - One-hot encoding
-   - Target encoding
-   - Frequency encoding
-   - Label encoding
-```
-
-### Featuretools: Deep Feature Synthesis
-
-```
-DEEP FEATURE SYNTHESIS (DFS):
-─────────────────────────────
-
-Given relational tables, automatically generate features:
-
-TABLES:
-  customers(id, signup_date, country)
-  orders(id, customer_id, date, amount)
-  products(id, order_id, product_type, price)
-
-
-DFS GENERATES:
-──────────────
-Depth 1: Simple aggregations
-  - COUNT(orders)
-  - SUM(orders.amount)
-  - AVG(orders.amount)
-
-Depth 2: Stacked aggregations
-  - COUNT(orders.products)
-  - AVG(orders.SUM(products.price))
-  - MODE(orders.MODE(products.product_type))
-
-Depth 3: Triple-stacked!
-  - STD(orders.AVG(products.price))
-
-Result: 100s of features from 3 tables!
-
-
-PRIMITIVES USED:
-────────────────
-Aggregation: sum, mean, count, max, min, std, mode
-Transform: year, month, weekday, cum_sum, diff
-```
-
-**Did You Know?** Automated feature engineering can generate large numbers of relational features quickly, but those features still need regularization, validation, and task-specific judgment to be useful.
-
----
-
-## Feature Stores
-
-### What is a Feature Store?
-
-Think of a feature store as a "data warehouse for ML features" - a centralized repository where teams can share, discover, and reuse features.
-
-Imagine a restaurant where every chef prepares their own spice blends. Chef A makes curry powder. Chef B makes the same curry powder differently. Chef C needs curry powder but doesn't know it already exists, so they make a third version. Different dishes taste inconsistent, ingredients are wasted, and no one knows which recipe is "official."
-
-Now imagine a central spice cabinet with standardized, labeled blends. Every chef uses the same curry powder. New chefs can see what's available. If the curry powder recipe improves, all dishes improve automatically.
-
-That's what a feature store does for ML features—centralizes, standardizes, and shares them across teams.
-
-```
-WITHOUT FEATURE STORE:
-──────────────────────
-
-Team A: Builds "customer_lifetime_value" feature
-        ├── Writes SQL query
-        ├── Schedules daily job
-        └── Stores in their own table
-
-Team B: Needs same feature
-        ├── Doesn't know Team A has it
-        ├── Builds their own version
-        └── Gets slightly different results!
-
-Team C: Needs feature for real-time inference
-        ├── Can't use batch SQL
-        └── Builds third version!
-
-Result: 3 versions of the same feature, inconsistent!
-
-
-WITH FEATURE STORE:
-───────────────────
-
-               ┌─────────────────────────────┐
-               │      FEATURE STORE          │
-               │  ┌─────────────────────┐    │
-               │  │ customer_lifetime_  │    │
-               │  │ value               │    │
-               │  │ - Batch: Daily SQL  │    │
-               │  │ - Online: Redis     │    │
-               │  │ - Owner: Team A     │    │
-               │  │ - Version: 2.3      │    │
-               │  └─────────────────────┘    │
-               └──────────────┬──────────────┘
-                              │
-           ┌──────────────────┼──────────────────┐
-           │                  │                  │
-        Team A             Team B             Team C
-     (training)          (training)        (inference)
-
-All teams use the SAME feature definition!
-```
-
-### Feature Store Architecture
-
-```
-FEATURE STORE COMPONENTS:
-─────────────────────────
-
-┌─────────────────────────────────────────────────────────────────┐
-│                     FEATURE STORE                                │
-│                                                                  │
-│  ┌────────────────────────────────────────────────────────────┐ │
-│  │                  FEATURE REGISTRY                          │ │
-│  │  - Feature definitions (schema, transformations)           │ │
-│  │  - Metadata (owner, description, data lineage)            │ │
-│  │  - Versioning                                              │ │
-│  └────────────────────────────────────────────────────────────┘ │
-│                              │                                   │
-│         ┌────────────────────┴────────────────────┐             │
-│         │                                         │              │
-│  ┌──────▼──────┐                         ┌───────▼───────┐      │
-│  │ OFFLINE     │                         │ ONLINE        │      │
-│  │ STORE       │                         │ STORE         │      │
-│  │             │                         │               │      │
-│  │ - Historical│         Sync            │ - Latest      │      │
-│  │ - Training  │ ◄──────────────────────►│ - Real-time   │      │
-│  │ - BigQuery/ │                         │ - Redis/      │      │
-│  │   S3/HDFS   │                         │   DynamoDB    │      │
-│  └─────────────┘                         └───────────────┘      │
-│         │                                         │              │
-│         │                                         │              │
-│  ┌──────▼──────────────────────────────────────────▼──────┐     │
-│  │                    SERVING LAYER                        │     │
-│  │   - Batch serving (training)                           │     │
-│  │   - Online serving (inference)                         │     │
-│  │   - Point-in-time correctness                          │     │
-│  └────────────────────────────────────────────────────────┘     │
-└─────────────────────────────────────────────────────────────────┘
-```
-
-### Point-in-Time Correctness
-
-This is the MOST important concept in feature stores:
-
-```
-POINT-IN-TIME PROBLEM:
-──────────────────────
-
-Training data preparation:
-  "What was the customer's purchase_count on 2024-01-15?"
-
-WRONG APPROACH (data leakage!):
-  SELECT purchase_count FROM current_features
-  WHERE customer_id = 123
-
-  Problem: Returns TODAY's count, not 2024-01-15's!
-  The model trains on future information = cheating!
-
-
-CORRECT APPROACH (point-in-time join):
-  SELECT purchase_count FROM feature_history
-  WHERE customer_id = 123
-  AND feature_timestamp <= '2024-01-15'
-  ORDER BY feature_timestamp DESC
-  LIMIT 1
-
-  Returns: Value as it was on 2024-01-15 
-
-
-TIMELINE:
-─────────
-          2024-01-15          Today
-              │                 │
-              ▼                 ▼
-    ──────────●─────────────────●──────►
-              │                 │
-        Training event     Don't use
-         Use features      these values!
-         from HERE
-```
-
-**Did You Know?** Feature stores centralize feature definitions, can support online and offline retrieval, and help reduce training-serving inconsistencies.
-
----
-
-## Feast: Open Source Feature Store
-
-### Feast Architecture
-
-```
-FEAST COMPONENTS:
-─────────────────
-
-┌─────────────────────────────────────────────────────────────┐
-│                         FEAST                                │
-│                                                              │
-│  ┌──────────────────────────────────────────────────────┐   │
-│  │                   FEATURE REPO                        │   │
-│  │   feature_store.yaml   # Configuration                │   │
-│  │   features.py          # Feature definitions          │   │
-│  └──────────────────────────────────────────────────────┘   │
-│                            │                                 │
-│                            │ feast apply                     │
-│                            ▼                                 │
-│  ┌──────────────────────────────────────────────────────┐   │
-│  │                   REGISTRY                            │   │
-│  │   - Feature views                                     │   │
-│  │   - Entities                                          │   │
-│  │   - Data sources                                      │   │
-│  └──────────────────────────────────────────────────────┘   │
-│                            │                                 │
-│            ┌───────────────┼───────────────┐                │
-│            │               │               │                 │
-│            ▼               ▼               ▼                 │
-│     ┌───────────┐   ┌───────────┐   ┌───────────┐          │
-│     │ Offline   │   │ Online    │   │ Serving   │          │
-│     │ Store     │   │ Store     │   │ API       │          │
-│     │ (Parquet) │   │ (Redis)   │   │ (gRPC)    │          │
-│     └───────────┘   └───────────┘   └───────────┘          │
-└─────────────────────────────────────────────────────────────┘
-```
-
-### Defining Features in Feast
+ACF and PACF plots help identify autoregressive and moving-average structure after appropriate transformation. The autocorrelation function shows correlation between the series and lagged versions of itself. The partial autocorrelation function estimates the relationship at a lag after accounting for shorter lags. In practice, ACF and PACF are diagnostic tools, not vending machines for perfect `(p, d, q)` orders.
 
 ```python
-# features.py
+import warnings
 
-from feast import Entity, Feature, FeatureView, FileSource
-from feast.types import Float32, Int64
-
-# Define entity (the thing we're building features for)
-customer = Entity(
-    name="customer_id",
-    join_keys=["customer_id"],
-    description="Customer identifier"
-)
-
-# Define data source
-customer_stats_source = FileSource(
-    path="data/customer_stats.parquet",
-    timestamp_field="event_timestamp"
-)
-
-# Define feature view
-customer_stats = FeatureView(
-    name="customer_stats",
-    entities=[customer],
-    ttl=timedelta(days=90),  # How long features are valid
-    schema=[
-        Field(name="total_purchases", dtype=Int64),
-        Field(name="avg_order_value", dtype=Float32),
-        Field(name="days_since_last_order", dtype=Int64),
-    ],
-    online=True,   # Serve from online store
-    source=customer_stats_source,
-)
-```
-
-### Using Feast
-
-```python
-# Training: Get historical features
-from feast import FeatureStore
-
-store = FeatureStore(repo_path=".")
-
-# Entity dataframe (what we want features for)
-entity_df = pd.DataFrame({
-    "customer_id": [1, 2, 3, 4, 5],
-    "event_timestamp": pd.to_datetime(["2024-01-15"] * 5)
-})
-
-# Get training data with point-in-time correctness!
-training_df = store.get_historical_features(
-    entity_df=entity_df,
-    features=[
-        "customer_stats:total_purchases",
-        "customer_stats:avg_order_value",
-        "customer_stats:days_since_last_order"
-    ]
-).to_df()
-
-
-# Inference: Get online features
-feature_vector = store.get_online_features(
-    features=[
-        "customer_stats:total_purchases",
-        "customer_stats:avg_order_value",
-    ],
-    entity_rows=[{"customer_id": 123}]
-).to_dict()
-
-# Returns: {"customer_id": [123], "total_purchases": [47], ...}
-```
-
----
-
-## ML Pipeline Automation
-
-### End-to-End ML Pipeline
-
-```
-AUTOMATED ML PIPELINE:
-──────────────────────
-
-┌─────────┐   ┌─────────┐   ┌─────────┐   ┌─────────┐   ┌─────────┐
-│  Data   │──►│ Feature │──►│ Model   │──►│ Model   │──►│ Deploy  │
-│ Ingest  │   │   Eng   │   │ Train   │   │  Eval   │   │         │
-└─────────┘   └─────────┘   └─────────┘   └─────────┘   └─────────┘
-     │             │             │             │             │
-     ▼             ▼             ▼             ▼             ▼
- Scheduled    Feature       AutoML       Metrics      A/B Test
-   Jobs       Store        Trains       Tracked      or Canary
-
-ORCHESTRATION:
-  - Airflow / Dagster / Prefect
-  - MLflow for experiment tracking
-  - Feature store for features
-  - Model registry for models
-  - CI/CD for deployment
-```
-
-### MLflow Integration
-
-```
-MLFLOW EXPERIMENT TRACKING:
-───────────────────────────
-
-with mlflow.start_run():
-    # Log parameters
-    mlflow.log_param("model_type", "LightGBM")
-    mlflow.log_param("n_estimators", 100)
-
-    # Train model
-    model = train_model(...)
-
-    # Log metrics
-    mlflow.log_metric("accuracy", 0.95)
-    mlflow.log_metric("f1_score", 0.93)
-
-    # Log model
-    mlflow.sklearn.log_model(model, "model")
-
-
-MLFLOW UI shows:
-┌────────────────────────────────────────────────────────────┐
-│  Run ID    │ Model     │ n_estimators │ Accuracy │ F1     │
-├────────────────────────────────────────────────────────────┤
-│  abc123    │ LightGBM  │ 100          │ 0.95     │ 0.93   │
-│  def456    │ XGBoost   │ 200          │ 0.94     │ 0.92   │
-│  ghi789    │ RF        │ 150          │ 0.92     │ 0.90   │
-└────────────────────────────────────────────────────────────┘
-
-Easy comparison across experiments!
-```
-
----
-
-## Practical AutoML Workflow
-
-### Step-by-Step AutoML Process
-
-```
-PRODUCTION AUTOML WORKFLOW:
-───────────────────────────
-
-1. DATA PREPARATION
-   ├── Load data
-   ├── Basic cleaning (handle missing, remove duplicates)
-   ├── Define target variable
-   └── Split train/validation/test
-
-2. QUICK AUTOML RUN (1 hour)
-   ├── Use AutoGluon with time_limit=3600
-   ├── Get baseline performance
-   └── Identify promising models
-
-3. ANALYZE RESULTS
-   ├── Check feature importance
-   ├── Look for data leakage
-   └── Understand model behavior
-
-4. EXTENDED RUN (optional)
-   ├── Run AutoGluon with more time
-   ├── Try different presets (best_quality vs optimize_for_deployment)
-   └── Experiment with hyperparameter ranges
-
-5. MODEL SELECTION
-   ├── Compare accuracy vs inference time
-   ├── Consider interpretability needs
-   └── Check model size for deployment
-
-6. PRODUCTION PREPARATION
-   ├── Export best model
-   ├── Create feature pipeline
-   ├── Set up monitoring
-   └── Deploy with gradual rollout
-```
-
-### AutoGluon Presets
-
-```
-AUTOGLUON PRESETS:
-──────────────────
-
-PRESET: "best_quality"
-  - Maximum accuracy
-  - Uses all algorithms
-  - Deep stacking ensembles
-  - Time: 4-8x longer
-  - Use for: Final production models
-
-PRESET: "high_quality"
-  - Near-optimal accuracy
-  - Good ensemble
-  - Reasonable time
-  - Use for: Most use cases
-
-PRESET: "good_quality"
-  - Good accuracy
-  - Faster training
-  - Use for: Prototyping
-
-PRESET: "medium_quality"
-  - Decent accuracy
-  - Much faster
-  - Use for: Quick baselines
-
-PRESET: "optimize_for_deployment"
-  - Single model (no ensemble)
-  - Fast inference
-  - Smaller model size
-  - Use for: Real-time serving
-```
-
----
-
-## Common Pitfalls and Best Practices
-
-### AutoML Pitfalls
-
-```
-COMMON AUTOML MISTAKES:
-───────────────────────
-
-1. DATA LEAKAGE
-   ───────────────
-   Problem: Target information leaks into features
-
-   Example: Predicting "will customer churn?"
-   Bad feature: "cancellation_date" (directly reveals answer!)
-
-   Solution: Review feature importance, suspicious features
-             that are too predictive are often leaky
-
-
-2. OVERFITTING TO VALIDATION
-   ──────────────────────────
-   Problem: Running AutoML many times, picking best
-
-   Each run: Accuracy = 0.91, 0.92, 0.93, 0.94, 0.90...
-   Pick best: 0.94!
-   Test set:  0.88  (overfit to validation)
-
-   Solution: Hold out a TRUE test set, evaluate once at end
-
-
-3. IGNORING BUSINESS CONSTRAINTS
-   ───────────────────────────────
-   Problem: Best model has 200ms latency, need < 10ms
-
-   AutoGluon best model: Stacked ensemble
-   Inference time: 200ms
-
-   Solution: Use optimize_for_deployment preset
-             or constrain model types
-
-
-4. FEATURE STORE SKEW
-   ────────────────────
-   Problem: Training features differ from serving features
-
-   Training: feature_v1 (old transformation)
-   Serving:  feature_v2 (new transformation)
-
-   Solution: Use feature store with versioning
-```
-
-### Best Practices
-
-```
-AUTOML BEST PRACTICES:
-──────────────────────
-
-1. START SIMPLE
-   - Run quick AutoML first (30 min - 1 hour)
-   - Get baseline before investing more time
-   - Understand what's possible
-
-2. FEATURE ENGINEERING STILL MATTERS
-   - AutoML optimizes models, not features
-   - Domain features often help
-   - Combine AutoML + manual feature eng
-
-3. USE PROPER VALIDATION
-   - Time-based splits for time series
-   - Stratified for imbalanced classes
-   - Group splits for related samples
-
-4. MONITOR IN PRODUCTION
-   - Track feature distributions
-   - Monitor model performance
-   - Set up drift detection
-
-5. DOCUMENT EVERYTHING
-   - Which AutoML settings?
-   - What features used?
-   - Business metrics impact?
-```
-
-**Did You Know?** AutoML systems typically include built-in preprocessing and feature handling for tabular data, but the exact transformations and benchmark outcomes depend on the product and evaluation setup.
-
----
-
-## Summary
-
-```
-KEY CONCEPTS RECAP:
-───────────────────
-
-AUTOML:
-  - Automates algorithm selection + hyperparameter tuning
-  - AutoGluon: Best accuracy, multi-layer stacking
-  - Use presets based on needs (quality vs speed)
-
-FEATURE STORES:
-  - Centralized feature management
-  - Point-in-time correctness for training
-  - Online/offline serving
-  - Feast: Open source, easy to start
-
-AUTOMATED FEATURE ENGINEERING:
-  - Aggregations, transformations, time features
-  - Featuretools for deep feature synthesis
-  - Still combine with domain knowledge
-
-ML PIPELINES:
-  - End-to-end automation
-  - MLflow for experiment tracking
-  - Orchestration (Airflow, Dagster)
-
-
-WHEN TO USE WHAT:
-─────────────────
-
-┌─────────────────────────────────────────────────────────────┐
-│  SCENARIO                  │  RECOMMENDATION                │
-├─────────────────────────────────────────────────────────────┤
-│  Quick baseline            │  AutoGluon, medium_quality     │
-│  Production model          │  AutoGluon, best_quality       │
-│  Real-time serving         │  AutoGluon, optimize_for_deployment│
-│  Feature reuse             │  Feast feature store           │
-│  Relational data           │  Featuretools + AutoML         │
-│  Team collaboration        │  Feature store + MLflow        │
-└─────────────────────────────────────────────────────────────┘
-```
-
----
-
-## Production War Stories: AutoML and Feature Store Lessons
-
-### A Costly Feature Leak
-
-**Illustrative fintech scenario.**
-
-A team can sometimes see a large offline-metric jump from an AutoML run, but that does not guarantee the features are valid for production decisions.
-
-After deployment, a model can fail badly if it learned from leaked or otherwise invalid features.
-
-**The forensic analysis revealed the issue**: a highly ranked feature depended on information that was not actually available at prediction time, which created data leakage.
-
-The AutoML system had found a perfect predictor: a feature that leaked the outcome. It's like trying to predict who will win a race by looking at the finish photo—technically accurate, but useless for making predictions before the race.
-
-**Financial impact**: data leakage can cause severe financial and organizational damage before a team detects it.
-
-**The fix implemented**:
-```python
-# Before: Feature calculated whenever
-days_until_first_payment = payment_date - approval_date
-
-# After: Strict point-in-time feature validation
-def validate_feature_timing(feature_name, feature_timestamp, prediction_timestamp):
-    """Ensure feature was available BEFORE prediction was needed."""
-    if feature_timestamp > prediction_timestamp:
-        raise DataLeakageError(
-            f"Feature '{feature_name}' has timestamp {feature_timestamp} "
-            f"but prediction was needed at {prediction_timestamp}. "
-            f"This is data leakage!"
-        )
-```
-
-**Lesson**: AutoML will find ANY signal, including signals from the future. Point-in-time validation isn't optional—it's essential.
-
-> **Did You Know?** Data leakage is common in production ML, can take time to detect, and point-in-time-correct feature retrieval helps reduce that risk.
-
----
-
-### The Feature Store That Saved Black Friday
-
-**Illustrative retail scenario.**
-
-A high-traffic retail system can fail if feature computation becomes the latency bottleneck during peak demand.
-
-This year, they'd implemented Feast as their feature store. The architecture was different:
-
-```
-LAST YEAR (crashed):
-────────────────────
-Request → Compute Features On-Demand → Model → Response
-          └── SQL query per request
-          └── 200ms latency
-          └── Can't scale past 500 RPS
-
-THIS YEAR (Feast):
-─────────────────
-Pre-computed features → Redis (Online Store)
-Request → Redis lookup (1ms) → Model → Response
-          └── 50,000+ RPS
-          └── 5ms total latency
-```
-
-With precomputed online features, a recommendation stack can handle much higher traffic with lower latency than on-demand feature computation.
-
-**The key insight**: Feature computation is the bottleneck, not model inference. Pre-computing features and serving from an online store changed everything.
-
-**Financial impact**: improving feature serving can materially affect both revenue and operating cost, especially during peak traffic.
-
----
-
-### The AutoML Model That Discriminated
-
-**Illustrative insurance scenario.**
-
-The compliance team found that model decisions were uneven across location-based groups, raising a fairness concern.
-
-Investigation suggested that the model had learned from proxy signals tied to historically biased outcomes, so the issue was not just accuracy but fairness.
-
-**The team's response**:
-
-1. **Removed proxy features**: location-based and other features that acted as strong proxies for protected characteristics
-2. **Added fairness constraints**: introduced explicit checks so model behavior would be reviewed against agreed fairness criteria across groups
-3. **Implemented explainability**: Required human review for any denial with unusual feature weights
-
-```python
-# Fairness-aware AutoML configuration
-from autogluon.tabular import TabularPredictor
-
-predictor = TabularPredictor(
-    label='claim_approved',
-    eval_metric='roc_auc'
-).fit(
-    train_data,
-    # Add fairness constraint
-    hyperparameters={
-        'GBM': {
-            'constraint_type': 'demographic_parity',
-            'fairness_target': 'race_proxy',
-            'fairness_threshold': 0.05
-        }
-    }
-)
-```
-
-**Regulatory outcome**: addressing fairness issues early can reduce legal and regulatory risk.
-
-**Lesson**: AutoML optimizes what you tell it to optimize. If you only optimize for accuracy, it will happily learn discriminatory patterns. Fairness must be an explicit constraint.
-
-> **Did You Know?** Amazon famously scrapped an AI recruiting tool in 2018 after discovering it systematically downgraded women's resumes. The model, trained on 10 years of hiring data, learned that Amazon had historically hired mostly men—and therefore preferred male candidates. This incident led to an industry-wide push for fairness-aware ML.
-
----
-
-## Common Mistakes and How to Avoid Them
-
-### Mistake 1: Trusting AutoML Feature Importance Blindly
-
-**Wrong**:
-```python
-# AutoML found these are the most important features
-# Great, let's use them!
-top_features = model.feature_importance()[:10]
-production_model = train_on(data[top_features])  #  Dangerous!
-```
-
-**Problem**: Feature importance from AutoML can be misleading. A leaky feature will show high importance. A feature that's important for one model type might be useless for another.
-
-**Right**:
-```python
-def validate_feature_importance(feature_name, importance_score, data):
-    """Sanity check for suspiciously important features."""
-
-    # Check for data leakage
-    if importance_score > 0.3:  # Suspiciously high
-        print(f"️ WARNING: {feature_name} has importance {importance_score}")
-        print("Checking for potential leakage...")
-
-        # Check if feature correlates with target timing
-        correlation_with_target = data[feature_name].corr(data['target'])
-        if abs(correlation_with_target) > 0.8:
-            raise LeakageWarning(
-                f"{feature_name} has {correlation_with_target:.2f} correlation "
-                f"with target. Likely data leakage!"
-            )
-
-    # Check if feature is available at prediction time
-    if not is_available_at_prediction_time(feature_name):
-        raise LeakageWarning(
-            f"{feature_name} is not available at prediction time!"
-        )
-
-    return True
-```
-
----
-
-### Mistake 2: Not Setting Time Limits on AutoML
-
-**Wrong**:
-```python
-# "Just let it run until it's done"
-predictor = TabularPredictor(label='target').fit(train_data)
-# 3 days later: still running, $2,000 in cloud costs
-```
-
-**Problem**: AutoML can keep exploring additional models and configurations unless you bound the run. Without explicit time limits, training can take longer and cost more than expected.
-
-**Right**:
-```python
-# Always set explicit time limits
-predictor = TabularPredictor(
-    label='target',
-    eval_metric='roc_auc'
-).fit(
-    train_data,
-    time_limit=3600,  # 1 hour max
-    presets='best_quality',  # Will do its best within time limit
-    # AutoGluon automatically prioritizes promising models
-)
-```
-
----
-
-### Mistake 3: Ignoring Training-Serving Skew
-
-**Wrong**:
-```python
-# Training time
-training_features = compute_features_from_warehouse(training_data)
-model.fit(training_features, labels)
-
-# Serving time (different code path!)
-serving_features = compute_features_from_api(request_data)  #  Different!
-prediction = model.predict(serving_features)
-```
-
-**Problem**: Subtle differences in feature computation between training and serving cause silent model degradation. Think of it as using different thermometers that are calibrated differently—your predictions will be systematically off.
-
-**Right**:
-```python
-# Use feature store for BOTH training and serving
-from feast import FeatureStore
-
-store = FeatureStore(repo_path=".")
-
-# Training time
-training_features = store.get_historical_features(
-    entity_df=training_entities,
-    features=['customer:total_purchases', 'customer:avg_order_value']
-).to_df()
-
-# Serving time (SAME feature definitions!)
-serving_features = store.get_online_features(
-    features=['customer:total_purchases', 'customer:avg_order_value'],
-    entity_rows=[{"customer_id": request.customer_id}]
-).to_dict()
-
-# Features are guaranteed to be computed identically
-```
-
----
-
-### Mistake 4: Not Versioning Features
-
-**Wrong**:
-```python
-# Features.py - Modified directly in production
-customer_value = total_purchases * avg_order_value  # Changed from sum to product
-# Now training data has old definition, production has new...
-```
-
-**Problem**: Changing feature definitions without versioning creates chaos. Models trained on v1 features serving with v2 features will produce garbage.
-
-**Right**:
-```python
-# features_v2.py - Explicit versioning
-class CustomerValueV2(FeatureView):
-    """
-    Customer lifetime value calculation.
-
-    v1 -> v2 changes:
-    - Changed from sum to product formula
-    - Added recency weighting
-    - Breaking change: requires model retraining
-
-    Migration: Models must be retrained before using v2
-    """
-    name = "customer_value_v2"
-    version = "2.0.0"
-    deprecates = "customer_value_v1"  # Mark old version
-    requires_retraining = True
-
-    def compute(self, data):
-        return (data.total_purchases * data.avg_order_value *
-                self.recency_weight(data.days_since_last_order))
-```
-
----
-
-### Mistake 5: Using AutoML for Everything
-
-**Wrong**:
-```python
-# "AutoML is magic, let's use it everywhere!"
-image_model = AutoGluon.fit(image_data)  # Works but suboptimal
-text_model = AutoGluon.fit(text_data)    # Works but suboptimal
-time_series = AutoGluon.fit(ts_data)      # Works but suboptimal
-```
-
-**Problem**: AutoML is often strongest on tabular data, while other modalities frequently benefit from more specialized methods.
-
-**Right**:
-```
-WHEN TO USE AUTOML vs SPECIALIZED TOOLS:
-────────────────────────────────────────
-
-Data Type    │ AutoML Good? │ Better Alternative
-─────────────┼──────────────┼────────────────────────
-Tabular      │  Excellent │ N/A - AutoML is best
-Images       │ ️ OK       │ Transfer learning (ResNet, ViT)
-Text         │ ️ OK       │ Fine-tuned LLMs, BERT
-Time Series  │ ️ OK       │ Prophet, NeuralProphet, DeepAR
-Graph        │  Poor     │ PyTorch Geometric, DGL
-Audio        │  Poor     │ Whisper, wav2vec
-```
-
----
-
-## Economics of AutoML and Feature Stores
-
-### AutoML ROI Calculation
-
-| Scenario | Manual ML | AutoML | Savings |
-|----------|-----------|--------|---------|
-| **Initial Model Development** | | | |
-| Data scientist time | Multiple weeks for a manual first model | About a week for a bounded AutoML baseline | Meaningful time savings |
-| Compute costs | Higher from longer manual experimentation | Lower for a short bounded AutoML run | Modest compute savings |
-| Time to production | Several weeks | Roughly days to a couple of weeks | Faster delivery |
-| **Ongoing Maintenance** | | | |
-| Monthly retraining time | Days of manual work | Hours for a more automated workflow | Lower recurring effort |
-| Model iteration cost | Higher per iteration | Lower per iteration | Lower iteration cost |
-| **Annual Savings** | | | |
-| Initial + 12 months maintenance | Higher manual cost profile | Lower with more automation | **Potential annual savings** |
-
-### Feature Store ROI Calculation
-
-| Metric | Without Feature Store | With Feature Store |
-|--------|----------------------|-------------------|
-| Feature development time | Often measured in weeks | Often faster with reuse |
-| Feature duplication | Multiple teams may rebuild similar features | Shared definitions reduce duplication |
-| Training-serving skew incidents | Can happen repeatedly | Can be reduced with shared feature definitions |
-| Revenue lost to skew | Can be material | Can be reduced when skew is reduced |
-| Engineer time on debugging | Significant | Lower with shared infrastructure |
-| **Total Annual Impact** | | **Potential operational savings** |
-
-### Cost of NOT Using These Tools
-
-```
-REAL COSTS OF MANUAL ML:
-────────────────────────
-
-┌────────────────────────────────────────────────────────────┐
-│  Problem                      │  Typical Cost             │
-├────────────────────────────────────────────────────────────┤
-│  Data leakage in production   │  $1M-10M (depending on    │
-│                               │  time to detect)          │
-├────────────────────────────────────────────────────────────┤
-│  Training-serving skew        │  $100K-500K per incident  │
-│  (silent model degradation)   │  (lost revenue + debug)   │
-├────────────────────────────────────────────────────────────┤
-│  Duplicate feature work       │  $50K-200K/year           │
-│  (multiple teams building     │  (wasted engineer time)   │
-│  same features)               │                           │
-├────────────────────────────────────────────────────────────┤
-│  Slow model iteration         │  $500K-2M/year            │
-│  (opportunity cost of delayed │  (competitors move        │
-│  improvements)                │  faster)                  │
-└────────────────────────────────────────────────────────────┘
-```
-
-> **Did You Know?** Teams often adopt feature stores to speed up model delivery and reduce operational rework, but the exact ROI depends heavily on the organization and workload.
-
----
-
-## Interview Preparation: AutoML & Feature Stores
-
-### Q1: "When would you use AutoML vs. hand-crafted models?"
-
-**Strong Answer**:
-"I use AutoML in three main scenarios. First, for establishing baselines quickly—before investing weeks in manual model development, I run AutoML to understand what's achievable. If AutoML gets 0.75 AUC, I know my hand-crafted model should aim for at least 0.78 to justify the extra effort.
-
-Second, for tabular data problems with clear evaluation metrics—this is a strong use case for AutoML, which can often provide a competitive baseline with far less manual effort.
-
-Third, when the ML isn't the core differentiator—if we're building a feature where ML is a small component, I'd rather spend engineering time on the product, not model tuning.
-
-I wouldn't use AutoML when I need specific architectures like transformers for NLP, when there are strict latency requirements that need optimized single models, or when interpretability is critical and I need to explain every decision."
-
-### Q2: "Explain point-in-time correctness in feature stores."
-
-**Strong Answer**:
-"Point-in-time correctness ensures that when training a model, we only use feature values that were available at the time the prediction would have been made. It prevents data leakage from the future.
-
-Imagine training a model to predict customer churn. If a customer churned on March 15, their training features should reflect their state on March 14 or earlier—not their state after they churned. Without point-in-time correctness, we might accidentally include features like 'days_since_last_login' that jumped to 30+ after they stopped using the product—a clear signal they've churned that wouldn't be available when making a real prediction.
-
-Feature stores implement this by maintaining timestamped feature values and performing point-in-time joins. When you request historical features for training, you provide entity timestamps, and the feature store returns the most recent feature value that existed before each timestamp.
-
-This is critical because models trained with leaked features show fantastic offline metrics but fail dramatically in production—a pattern I've seen called 'suspiciously good AUC syndrome.'"
-
-### Q3: "How does multi-layer stacking work in AutoGluon?"
-
-**Strong Answer**:
-"Multi-layer stacking is AutoGluon's ensemble technique that significantly outperforms simple averaging or voting.
-
-In the first layer, AutoGluon trains diverse base models—gradient boosting (LightGBM, XGBoost, CatBoost), neural networks, and linear models. Each model makes predictions on out-of-fold validation data to avoid leakage.
-
-These first-layer predictions become features for the second layer, which trains new models to combine them. Think of it as learning 'when to trust which model.' If LightGBM is great on numerical features but weak on categoricals, while CatBoost is the opposite, the second layer learns to weight them appropriately based on the input.
-
-AutoGluon can stack multiple layers, but the useful depth depends on the dataset, models, and time budget.
-
-The key insight is that this outperforms simple ensembling because it learns non-linear combinations of model predictions. A weighted average says 'LightGBM gets 40% weight.' Multi-layer stacking says 'LightGBM gets 80% weight when feature X is high, but only 20% when feature Y is low.'
-
-In practice, stacked ensembles can outperform simpler combinations, but the size of that gain depends on the task, dataset, and evaluation setup."
-
-### Q4: "What's the difference between online and offline feature stores?"
-
-**Strong Answer**:
-"They serve different use cases with different latency and storage requirements.
-
-The offline store is optimized for training workloads. It stores historical feature values with timestamps, typically in data warehouses like BigQuery, Snowflake, or object storage like S3. Latency is seconds to minutes, but it can handle huge volumes—millions of feature vectors. I use it when creating training datasets with point-in-time correctness.
-
-The online store is optimized for inference. It stores only the latest feature values in low-latency databases like Redis, DynamoDB, or Bigtable. Latency is single-digit milliseconds. I use it when serving predictions in real-time.
-
-The key architectural insight is that they share the same feature definitions but different storage backends. The feature store materializes features from the offline store to the online store periodically—typically every few minutes to daily, depending on freshness requirements.
-
-This dual architecture solves the training-serving skew problem. My training code uses get_historical_features from the offline store. My serving code uses get_online_features from the online store. Both use identical feature definitions, just different storage optimized for their use case."
-
-### System Design: Design an ML Platform with AutoML and Feature Store
-
-**Prompt**: "Design an ML platform for a fintech company that needs to make real-time credit decisions at 10,000 requests per second."
-
-**Strong Answer**:
-
-"I'd design this with five key components:
-
-**1. Feature Store Architecture**:
-```
-Online Store: Redis Cluster (6 nodes)
-  - Sharded by customer_id
-  - 500K features, 1ms p99 latency
-  - TTL: 24 hours, refreshed hourly
-
-Offline Store: BigQuery
-  - Historical features for training
-  - 2 years of feature history
-  - Point-in-time query support
-
-Feature Computation: Spark on Dataproc
-  - Batch features: daily runs at 2 AM
-  - Real-time features: Kafka Streams
-  - Features: credit_score, payment_history,
-    debt_to_income, account_age, etc.
-```
-
-**2. AutoML Pipeline**:
-```python
-# Monthly retraining pipeline
-def train_credit_model():
-    # Get training data with point-in-time correctness
-    training_data = feature_store.get_historical_features(
-        entity_df=approved_applications_last_6_months,
-        features=CREDIT_FEATURES,
-        label='defaulted_within_90_days'
-    )
-
-    # AutoML with fairness constraints
-    predictor = TabularPredictor(
-        label='defaulted',
-        eval_metric='roc_auc'
-    ).fit(
-        training_data,
-        time_limit=14400,  # 4 hours
-        presets='optimize_for_deployment',  # Single model for latency
-        excluded_model_types=['NN']  # Neural nets too slow
-    )
-
-    # Validate fairness before promotion
-    if passes_fairness_audit(predictor):
-        deploy_to_production(predictor)
-```
-
-**3. Serving Architecture for 10K RPS**:
-```
-Load Balancer (GCP GLB)
-        │
-        ├── Kubernetes Cluster (GKE)
-        │   └── Model Serving Pods (50 replicas)
-        │       - CPU-optimized (LightGBM)
-        │       - 10ms p99 latency per request
-        │       - gRPC for low overhead
-        │
-        └── Feature Store (Redis)
-            - 1ms feature fetch
-            - Pre-computed features only
-```
-
-**4. Monitoring & Safety**:
-- Feature drift detection: alert if distributions shift >10%
-- Model performance monitoring: daily AUC calculation on holdout
-- Fairness monitoring: automated demographic parity checks
-- Circuit breaker: fall back to rules-based model if ML fails
-
-**5. Cost Estimate**:
-- Feature Store (Redis): $15K/month
-- Compute (GKE): $25K/month
-- BigQuery: $5K/month
-- Total: $45K/month = $540K/year
-
-Expected value: At 10K RPS, serving 864M decisions/day. Even 0.1% improvement in precision saves millions in bad debt.
-
-This architecture handles 10K RPS with 15ms end-to-end latency while maintaining feature consistency and enabling rapid model iteration through AutoML."
-
----
-
-## Hands-On Exercises
-
-### Exercise 1: AutoML Baseline Challenge
-
-Build an AutoML baseline and compare it to a hand-crafted model:
-
-```python
-"""
-AutoML vs Manual Model Comparison
-
-Dataset: Credit Card Fraud Detection (Kaggle)
-Goal: Compare development time and accuracy
-"""
-import pandas as pd
-from autogluon.tabular import TabularPredictor
-from sklearn.ensemble import RandomForestClassifier
-from sklearn.model_selection import train_test_split
-from sklearn.metrics import roc_auc_score
-import time
-
-# Load data
-data = pd.read_csv('creditcard.csv')
-X = data.drop('Class', axis=1)
-y = data['Class']
-X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.2, random_state=42)
-
-# MANUAL APPROACH
-print("=" * 50)
-print("MANUAL RANDOM FOREST")
-print("=" * 50)
-manual_start = time.time()
-
-rf = RandomForestClassifier(
-    n_estimators=100,
-    max_depth=10,
-    min_samples_leaf=5,
-    random_state=42,
-    n_jobs=-1
-)
-rf.fit(X_train, y_train)
-rf_predictions = rf.predict_proba(X_test)[:, 1]
-rf_auc = roc_auc_score(y_test, rf_predictions)
-
-manual_time = time.time() - manual_start
-print(f"Time: {manual_time:.1f}s")
-print(f"AUC: {rf_auc:.4f}")
-
-# AUTOML APPROACH
-print("\n" + "=" * 50)
-print("AUTOGLUON")
-print("=" * 50)
-automl_start = time.time()
-
-# Prepare data for AutoGluon
-train_df = X_train.copy()
-train_df['Class'] = y_train.values
-
-predictor = TabularPredictor(
-    label='Class',
-    eval_metric='roc_auc',
-    verbosity=1
-).fit(
-    train_df,
-    time_limit=300,  # 5 minutes
-    presets='medium_quality'
-)
-
-test_df = X_test.copy()
-automl_predictions = predictor.predict_proba(test_df)
-automl_auc = roc_auc_score(y_test, automl_predictions.iloc[:, 1])
-
-automl_time = time.time() - automl_start
-print(f"Time: {automl_time:.1f}s")
-print(f"AUC: {automl_auc:.4f}")
-
-# COMPARISON
-print("\n" + "=" * 50)
-print("COMPARISON")
-print("=" * 50)
-print(f"Manual RF:  {rf_auc:.4f} AUC in {manual_time:.1f}s")
-print(f"AutoGluon:  {automl_auc:.4f} AUC in {automl_time:.1f}s")
-print(f"Improvement: {(automl_auc - rf_auc)*100:.2f} percentage points")
-
-# See what AutoGluon tried
-print("\n" + "=" * 50)
-print("AUTOGLUON LEADERBOARD")
-print("=" * 50)
-print(predictor.leaderboard())
-```
-
-**Expected Learning**: AutoML can outperform a basic manually specified baseline, showing the value of automated model selection and ensembling.
-
----
-
-### Exercise 2: Feature Store Implementation
-
-Build a simple feature store with point-in-time correctness:
-
-```python
-"""
-Simple Feature Store Implementation
-
-This exercise teaches the core concepts of feature stores:
-- Point-in-time correctness
-- Online vs offline serving
-- Feature versioning
-"""
-import pandas as pd
-from datetime import datetime, timedelta
-from typing import Dict, List, Optional
-import json
-import redis  # For online store
-
-class SimpleFeatureStore:
-    """
-    A minimal feature store demonstrating core concepts.
-
-    Production feature stores like Feast add:
-    - Distributed storage
-    - Automatic materialization
-    - Schema validation
-    - Access control
-    """
-
-    def __init__(self):
-        # Offline store: Historical features with timestamps
-        self.offline_store: Dict[str, pd.DataFrame] = {}
-
-        # Online store: Latest features only (simulated with dict)
-        self.online_store: Dict[str, Dict] = {}
-
-        # Feature registry: Metadata about features
-        self.registry: Dict[str, dict] = {}
-
-    def register_feature(
-        self,
-        name: str,
-        entity: str,
-        description: str,
-        version: str = "1.0.0"
-    ):
-        """Register a feature in the registry."""
-        self.registry[name] = {
-            'entity': entity,
-            'description': description,
-            'version': version,
-            'created_at': datetime.now().isoformat()
-        }
-        print(f" Registered feature: {name} v{version}")
-
-    def write_features(
-        self,
-        feature_name: str,
-        data: pd.DataFrame,
-        timestamp_col: str = 'event_timestamp'
-    ):
-        """Write features to both offline and online stores."""
-        if feature_name not in self.registry:
-            raise ValueError(f"Feature {feature_name} not registered!")
-
-        # Write to offline store (full history)
-        if feature_name not in self.offline_store:
-            self.offline_store[feature_name] = data.copy()
-        else:
-            self.offline_store[feature_name] = pd.concat([
-                self.offline_store[feature_name],
-                data
-            ]).drop_duplicates()
-
-        # Write to online store (latest values only)
-        entity_col = self.registry[feature_name]['entity']
-        for _, row in data.iterrows():
-            entity_id = str(row[entity_col])
-            self.online_store[f"{feature_name}:{entity_id}"] = row.to_dict()
-
-        print(f" Wrote {len(data)} rows to {feature_name}")
-
-    def get_historical_features(
-        self,
-        feature_name: str,
-        entity_df: pd.DataFrame,
-        timestamp_col: str = 'event_timestamp'
-    ) -> pd.DataFrame:
-        """
-        Get historical features with point-in-time correctness.
-
-        This is the CRITICAL function that prevents data leakage.
-        """
-        if feature_name not in self.offline_store:
-            raise ValueError(f"Feature {feature_name} not in offline store!")
-
-        feature_data = self.offline_store[feature_name]
-        entity_col = self.registry[feature_name]['entity']
-
-        results = []
-        for _, entity_row in entity_df.iterrows():
-            entity_id = entity_row[entity_col]
-            query_time = entity_row[timestamp_col]
-
-            # Point-in-time filter: only use features from BEFORE query time
-            valid_features = feature_data[
-                (feature_data[entity_col] == entity_id) &
-                (feature_data[timestamp_col] <= query_time)
-            ]
-
-            if len(valid_features) > 0:
-                # Get the most recent valid feature
-                latest = valid_features.sort_values(timestamp_col).iloc[-1]
-                results.append(latest.to_dict())
-            else:
-                # No valid features - use nulls
-                results.append({entity_col: entity_id})
-
-        return pd.DataFrame(results)
-
-    def get_online_features(
-        self,
-        feature_name: str,
-        entity_ids: List[str]
-    ) -> List[Dict]:
-        """Get latest features for real-time inference."""
-        results = []
-        for entity_id in entity_ids:
-            key = f"{feature_name}:{entity_id}"
-            if key in self.online_store:
-                results.append(self.online_store[key])
-            else:
-                results.append({'error': 'not_found'})
-        return results
-
-
-# Demo usage
-if __name__ == "__main__":
-    store = SimpleFeatureStore()
-
-    # Register features
-    store.register_feature(
-        name='customer_stats',
-        entity='customer_id',
-        description='Aggregated customer purchase statistics'
-    )
-
-    # Create some historical feature data
-    feature_data = pd.DataFrame({
-        'customer_id': [1, 1, 1, 2, 2],
-        'total_purchases': [10, 15, 20, 5, 8],
-        'avg_order_value': [50.0, 52.0, 55.0, 30.0, 35.0],
-        'event_timestamp': pd.to_datetime([
-            '2024-01-01', '2024-02-01', '2024-03-01',
-            '2024-01-15', '2024-02-15'
-        ])
-    })
-
-    store.write_features('customer_stats', feature_data)
-
-    # Point-in-time retrieval for training
-    training_entities = pd.DataFrame({
-        'customer_id': [1, 1, 2],
-        'event_timestamp': pd.to_datetime([
-            '2024-01-15',  # Should get Jan 1 features
-            '2024-02-15',  # Should get Feb 1 features
-            '2024-02-01'   # Should get Jan 15 features
-        ])
-    })
-
-    historical = store.get_historical_features(
-        'customer_stats',
-        training_entities
-    )
-    print("\n Historical Features (point-in-time correct):")
-    print(historical)
-
-    # Online retrieval for inference
-    online = store.get_online_features('customer_stats', ['1', '2'])
-    print("\n Online Features (latest values):")
-    for f in online:
-        print(f)
-```
-
-**Expected Learning**: Understanding how point-in-time correctness prevents data leakage and why online/offline stores serve different purposes.
-
----
-
-### Exercise 3: Data Leakage Detection
-
-Build a tool to detect potential data leakage in AutoML results:
-
-```python
-"""
-Data Leakage Detection Tool
-
-Detects common patterns that indicate data leakage in AutoML models.
-"""
-import pandas as pd
 import numpy as np
-from typing import List, Tuple
+from statsmodels.datasets import co2
+from statsmodels.tsa.seasonal import STL
+from statsmodels.tsa.stattools import acf, adfuller, kpss, pacf
 
-class LeakageDetector:
-    """Detects potential data leakage in ML features."""
+series = (
+    co2.load_pandas()
+    .data["co2"]
+    .resample("MS")
+    .mean()
+    .interpolate("time")
+    .asfreq("MS")
+)
 
-    def __init__(self, model, X: pd.DataFrame, y: pd.Series):
-        self.model = model
-        self.X = X
-        self.y = y
-        self.warnings = []
+decomposition = STL(series, period=12, robust=True).fit()
+differenced = series.diff().dropna()
 
-    def check_feature_importance(
-        self,
-        importance_threshold: float = 0.3
-    ) -> List[Tuple[str, float, str]]:
-        """
-        Flag features with suspiciously high importance.
+adf_stat, adf_pvalue, *_ = adfuller(differenced, autolag="AIC")
+with warnings.catch_warnings():
+    warnings.simplefilter("ignore")
+    kpss_stat, kpss_pvalue, *_ = kpss(differenced, regression="c", nlags="auto")
 
-        Leaky features often have unusually high importance because
-        they directly encode the target.
-        """
-        try:
-            importances = self.model.feature_importance()
-        except AttributeError:
-            # For models without built-in feature importance
-            return []
+acf_values = acf(differenced, nlags=12, fft=True)
+pacf_values = pacf(differenced, nlags=12, method="ywm")
 
-        suspicious = []
-        for feature, importance in importances.items():
-            if importance > importance_threshold:
-                suspicious.append((
-                    feature,
-                    importance,
-                    f"️ Unusually high importance ({importance:.3f}). "
-                    f"Check for data leakage!"
-                ))
-                self.warnings.append(f"HIGH_IMPORTANCE: {feature}")
-
-        return suspicious
-
-    def check_correlation_with_target(
-        self,
-        correlation_threshold: float = 0.9
-    ) -> List[Tuple[str, float, str]]:
-        """
-        Flag features with very high correlation to target.
-
-        Perfect or near-perfect correlation often indicates leakage.
-        """
-        suspicious = []
-        for col in self.X.columns:
-            if self.X[col].dtype in ['int64', 'float64']:
-                corr = abs(self.X[col].corr(self.y))
-                if corr > correlation_threshold:
-                    suspicious.append((
-                        col,
-                        corr,
-                        f"️ Very high correlation ({corr:.3f}). "
-                        f"Likely data leakage!"
-                    ))
-                    self.warnings.append(f"HIGH_CORRELATION: {col}")
-
-        return suspicious
-
-    def check_perfect_prediction_features(self) -> List[str]:
-        """
-        Flag features that perfectly predict the target alone.
-
-        If a single feature achieves >99% accuracy, it's usually leakage.
-        """
-        suspicious = []
-        for col in self.X.columns:
-            if self.X[col].nunique() < 100:  # Categorical-ish
-                # Check if any value perfectly predicts target
-                for value in self.X[col].unique():
-                    mask = self.X[col] == value
-                    if mask.sum() > 10:  # Enough samples
-                        target_values = self.y[mask].unique()
-                        if len(target_values) == 1:
-                            suspicious.append(col)
-                            self.warnings.append(
-                                f"PERFECT_PREDICTOR: {col}={value} -> {target_values[0]}"
-                            )
-                            break
-
-        return suspicious
-
-    def check_temporal_leakage(
-        self,
-        date_columns: List[str],
-        target_date_column: str = None
-    ) -> List[str]:
-        """
-        Flag features that might be computed from future data.
-        """
-        suspicious = []
-
-        # Check if any features have dates AFTER the target date
-        if target_date_column and target_date_column in self.X.columns:
-            target_date = pd.to_datetime(self.X[target_date_column])
-            for col in date_columns:
-                if col in self.X.columns and col != target_date_column:
-                    feature_date = pd.to_datetime(self.X[col])
-                    future_rows = (feature_date > target_date).sum()
-                    if future_rows > 0:
-                        suspicious.append(col)
-                        self.warnings.append(
-                            f"TEMPORAL_LEAKAGE: {col} has {future_rows} "
-                            f"rows with dates after target"
-                        )
-
-        return suspicious
-
-    def generate_report(self) -> str:
-        """Generate a comprehensive leakage report."""
-        report = []
-        report.append("=" * 60)
-        report.append("DATA LEAKAGE DETECTION REPORT")
-        report.append("=" * 60)
-
-        # Run all checks
-        importance_issues = self.check_feature_importance()
-        correlation_issues = self.check_correlation_with_target()
-        perfect_predictors = self.check_perfect_prediction_features()
-
-        # Format report
-        if importance_issues:
-            report.append("\n HIGH IMPORTANCE FEATURES:")
-            for feature, importance, msg in importance_issues:
-                report.append(f"  - {feature}: {msg}")
-
-        if correlation_issues:
-            report.append("\n HIGH CORRELATION FEATURES:")
-            for feature, corr, msg in correlation_issues:
-                report.append(f"  - {feature}: {msg}")
-
-        if perfect_predictors:
-            report.append("\n PERFECT PREDICTOR FEATURES:")
-            for feature in perfect_predictors:
-                report.append(f"  - {feature}")
-
-        if not any([importance_issues, correlation_issues, perfect_predictors]):
-            report.append("\n No obvious leakage detected")
-            report.append("   (Note: Some leakage types require domain knowledge to detect)")
-
-        report.append("\n" + "=" * 60)
-        report.append(f"Total warnings: {len(self.warnings)}")
-
-        return "\n".join(report)
-
-
-# Usage example
-if __name__ == "__main__":
-    # Create sample data with intentional leakage
-    np.random.seed(42)
-    n = 1000
-
-    # Normal features
-    X = pd.DataFrame({
-        'age': np.random.randint(18, 80, n),
-        'income': np.random.normal(50000, 20000, n),
-        'credit_score': np.random.randint(300, 850, n),
-    })
-
-    # Target: will customer default?
-    y = pd.Series(np.random.binomial(1, 0.2, n))
-
-    # Add LEAKY feature (computed from outcome!)
-    # This simulates a feature that includes future information
-    X['days_until_default'] = np.where(y == 1, np.random.randint(1, 90, n), -1)
-
-    # This feature is suspicious - high correlation
-    X['default_indicator'] = y * 0.99 + np.random.normal(0, 0.01, n)
-
-    # Create mock model
-    class MockModel:
-        def feature_importance(self):
-            return {
-                'age': 0.05,
-                'income': 0.08,
-                'credit_score': 0.12,
-                'days_until_default': 0.45,  # Suspiciously high!
-                'default_indicator': 0.30
-            }
-
-    # Run detection
-    detector = LeakageDetector(MockModel(), X, y)
-    print(detector.generate_report())
+print("ADF p-value:", round(adf_pvalue, 4))
+print("KPSS p-value:", round(kpss_pvalue, 4))
+print("First seasonal ACF value:", round(float(acf_values[12]), 3))
+print("First seasonal PACF value:", round(float(pacf_values[12]), 3))
+print("STL residual rows:", decomposition.resid.dropna().shape[0])
 ```
 
-**Expected Learning**: Understanding common leakage patterns and how to systematically detect them before they cause production failures.
+Use this kind of diagnostic block before model selection. If the raw series has a clear trend and the first difference looks stable, an ARIMA model with `d=1` may be reasonable. If there is a strong spike at lag 12 on monthly data, a seasonal order or seasonal features should be considered. If the residuals retain strong autocorrelation after fitting, the model has not captured the temporal structure you claimed it captured.
 
----
+## Reading Diagnostics Conservatively
 
-## Key Takeaways
+Diagnostics should narrow the candidate set, not replace judgment. ACF and PACF plots are especially easy to over-read because they feel precise. Real operational data often has calendar effects, interventions, missing periods, and regime changes that make textbook patterns messy. If the ACF tails off slowly, that may indicate trend, seasonal persistence, or an unmodeled level shift. The next move is to test a simpler transformation and inspect residuals, not to add every possible lag.
 
-1. **AutoML is a force multiplier, not a replacement** — It doesn't replace ML engineers; it amplifies their productivity by automating tedious parts (algorithm selection, hyperparameter tuning) so they can focus on harder problems.
+Stationarity tests deserve the same restraint. ADF and KPSS can disagree because they ask different null-hypothesis questions and depend on lag choices, trend settings, and sample length. A low p-value is evidence, not a deployment approval. If plots show a structural break, the right answer may be a regime-aware split or a shorter training window rather than another round of differencing. The purpose is to understand the signal well enough to validate models honestly.
 
-2. **AutoGluon is a strong tabular baseline** — For structured data problems, its stacking approach often performs well and is worth testing before investing in heavier manual tuning.
+Residual diagnostics are the bridge between modeling and engineering. After fitting a statistical model, plot residuals over time, inspect residual ACF, and check whether errors cluster around known calendar or business events. If residuals still have strong seasonal autocorrelation, the model missed repeating structure. If residual variance grows with the level, a transformation or multiplicative model may be more appropriate. If residuals deteriorate in the most recent window, older history may no longer represent current behavior.
 
-3. **Feature stores help reduce training-serving skew** — By using the same feature definitions for training and serving, they reduce a major source of production ML failures.
+This conservative reading also helps compare statistical and machine-learning approaches. A tree model may beat SARIMA because it captures nonlinear calendar interactions. SARIMA may beat a tree model because the tree lacks enough history to learn long seasonal cycles. Diagnostics give you language to explain the difference. Without them, a forecast comparison becomes a leaderboard with no causal story, and the team has little guidance when the next regime change arrives.
 
-4. **Point-in-time correctness is essential** — Future information can leak into ML training data, and timestamp-aware joins help reduce that risk.
+## Classical Statistical Forecasting
 
-5. **Feature reuse compounds over time** — Every feature you add to the store can be used by multiple models. After a year, you have a powerful feature library that accelerates all new projects.
+Classical statistical methods remain the durable core of forecasting because they make temporal assumptions explicit. They are fast, interpretable, and strong baselines for many univariate problems. Even when a tree-based or deep-learning model eventually wins, a disciplined statistical baseline tells you whether that extra complexity bought real forecasting value.
 
-6. **Set time limits on AutoML** — Without constraints, AutoML will run forever. Always specify time_limit and use appropriate presets for your use case.
+### ARIMA and SARIMA
 
-7. **Validate AutoML feature importance** — Suspiciously high importance scores often indicate data leakage. Always sanity-check before trusting AutoML's discoveries.
+ARIMA stands for autoregressive integrated moving average. The `p` term controls autoregressive lag terms, the `d` term controls differencing, and the `q` term controls moving-average error terms. A SARIMA model adds seasonal `P`, `D`, and `Q` terms plus a seasonal period `s`, so monthly data with annual seasonality commonly uses `s=12`.
 
-8. **Online vs offline stores serve different needs** — Offline for training (historical, high volume), online for serving (latest values, low latency). Both share feature definitions.
+Autoregressive terms say that the current value relates to past values. Differencing says the model should learn changes rather than levels. Moving-average terms say that the current value relates to past forecast errors. The combined model is compact, but each term encodes a different belief about how the signal behaves.
 
-9. **AutoML presets matter** — 'best_quality' for maximum accuracy, 'optimize_for_deployment' for production serving. Choose based on your constraints.
+Order identification usually starts with plots, differencing experiments, and ACF/PACF diagnostics. If the raw series trends upward, test a first difference. If monthly residuals still show annual structure, consider seasonal differencing or seasonal AR/MA terms. Then compare a small set of plausible orders with information criteria, residual diagnostics, and honest backtests. Avoid searching a huge order grid until one lucky specification wins a validation split by noise.
 
-10. **The economics can be compelling** — feature stores and AutoML can reduce repetitive work, shorten iteration cycles, and lower some categories of operational error.
+`statsmodels.tsa.arima.model.ARIMA` provides a direct interface for ARIMA-type models, including seasonal components. For many production teams, `SARIMAX` is also important because it can include exogenous regressors, but the same temporal validation rule applies to those regressors. Future exogenous values must either be known at forecast time or forecast by another leakage-safe process.
 
----
+```python
+from statsmodels.datasets import co2
+from statsmodels.tsa.arima.model import ARIMA
 
-## Further Reading
+series = (
+    co2.load_pandas()
+    .data["co2"]
+    .resample("MS")
+    .mean()
+    .interpolate("time")
+    .asfreq("MS")
+)
 
-### Tools
-- **AutoGluon**: https://auto.gluon.ai/ - Amazon's state-of-the-art AutoML framework, excels at tabular data
-- **Feast**: https://feast.dev/ - Open-source feature store, great for getting started
-- **MLflow**: https://mlflow.org/ - Experiment tracking and model registry
-- **Featuretools**: https://featuretools.alteryx.com/ - Automated feature engineering for relational data
+train = series.iloc[:-12]
+test = series.iloc[-12:]
 
-### Papers
-- "AutoGluon-Tabular: Robust and Accurate AutoML for Structured Data" (2020) - The paper behind AutoGluon's design, explains multi-layer stacking
-- "Feast: Feature Store for Machine Learning" (2021) - Architecture and design decisions for Feast
-- "Auto-sklearn 2.0" (2020) - Meta-learning approach to AutoML
-- "Michelangelo: Uber's Machine Learning Platform" (2017) - Original feature store architecture at scale
+model = ARIMA(
+    train,
+    order=(1, 1, 1),
+    seasonal_order=(1, 0, 1, 12),
+    enforce_stationarity=False,
+    enforce_invertibility=False,
+)
+fitted = model.fit()
+forecast = fitted.get_forecast(steps=len(test))
 
----
+print(forecast.predicted_mean.head())
+print(forecast.conf_int().head())
+```
 
-<!-- v4:generated type=no_quiz model=codex turn=1 -->
+`auto_arima` from `pmdarima` is a useful convenience when you want a structured search over ARIMA orders. Treat it as a helper, not as an exemption from diagnostics. You still choose the seasonal period, inspect residuals, verify assumptions, and backtest against simple baselines. Automation can propose candidates, but it cannot know whether your validation window matches the operational decision.
+
+```python
+from pmdarima import auto_arima
+from statsmodels.datasets import co2
+
+series = (
+    co2.load_pandas()
+    .data["co2"]
+    .resample("MS")
+    .mean()
+    .interpolate("time")
+    .asfreq("MS")
+)
+train = series.iloc[:-12]
+
+candidate = auto_arima(
+    train,
+    seasonal=True,
+    m=12,
+    information_criterion="aic",
+    stepwise=True,
+    suppress_warnings=True,
+)
+
+print(candidate.order)
+print(candidate.seasonal_order)
+```
+
+### Exponential Smoothing and Holt-Winters
+
+Exponential smoothing methods forecast by updating level, trend, and seasonal components as new observations arrive. Recent observations receive more weight than older observations, which makes these models intuitive for operational series that evolve gradually. Holt-Winters extends the idea to trend and seasonality, giving you a compact baseline for many business and capacity-planning forecasts.
+
+The additive versus multiplicative choice matters. Additive seasonality assumes the seasonal swing has roughly constant size, such as plus or minus a fixed number of requests. Multiplicative seasonality assumes the seasonal swing scales with the level, such as December demand being a percentage lift over baseline demand. Multiplicative components require positive data and can behave badly near zero.
+
+```python
+from statsmodels.datasets import co2
+from statsmodels.tsa.holtwinters import ExponentialSmoothing
+
+series = (
+    co2.load_pandas()
+    .data["co2"]
+    .resample("MS")
+    .mean()
+    .interpolate("time")
+    .asfreq("MS")
+)
+
+train = series.iloc[:-12]
+test = series.iloc[-12:]
+
+model = ExponentialSmoothing(
+    train,
+    trend="add",
+    seasonal="add",
+    seasonal_periods=12,
+    initialization_method="estimated",
+)
+fitted = model.fit(optimized=True)
+forecast = fitted.forecast(len(test))
+
+print(forecast.head())
+```
+
+Exponential smoothing is often easier to explain than ARIMA because the components map directly to planning language. Level answers "where are we now." Trend answers "how fast are we moving." Seasonality answers "where are we inside the recurring cycle." That clarity is valuable when forecasts support staffing, purchasing, budget, or reliability decisions.
+
+### Prophet
+
+Prophet models a time series as an additive combination of trend, seasonality, holidays, and error. It is designed for analyst-friendly forecasting workflows where calendar effects, missing observations, changepoints, and holiday regressors matter. It can work well when a series has strong multiple seasonalities and a reasonable amount of history for each recurring pattern.
+
+Prophet is not a universal upgrade over ARIMA, exponential smoothing, or tree-based regression. It can struggle when the signal has weak seasonality, very short history, unstable regimes, or high-frequency dependencies that are better expressed through lags. It also needs the same leakage-safe evaluation as every other forecasting method. A convenient API does not make future target values available at prediction time.
+
+```python
+import pandas as pd
+from prophet import Prophet
+from statsmodels.datasets import co2
+
+series = (
+    co2.load_pandas()
+    .data["co2"]
+    .resample("MS")
+    .mean()
+    .interpolate("time")
+    .asfreq("MS")
+)
+
+df = series.reset_index()
+df.columns = ["ds", "y"]
+
+train = df.iloc[:-12]
+
+model = Prophet(
+    yearly_seasonality=True,
+    weekly_seasonality=False,
+    daily_seasonality=False,
+)
+model.fit(train)
+
+future = model.make_future_dataframe(periods=12, freq="MS")
+forecast = model.predict(future)
+
+print(forecast[["ds", "yhat", "yhat_lower", "yhat_upper"]].tail())
+```
+
+Prophet's holiday support is useful when the calendar contains known future events. A holiday flag for next year's public holiday is legitimate because you know that calendar before the forecast. A flag derived from next year's observed demand spike is leakage because it uses the target to explain itself. The difference is not the column name; the difference is whether the information is genuinely known at the forecast origin.
+
+## Machine-Learning Forecasting as Supervised Regression
+
+Machine-learning forecasting reframes the problem as supervised regression. Instead of fitting an explicit stochastic time-series model, you create rows where features summarize what was known at each timestamp and the target is a future value. This framing lets you use familiar tools such as gradient-boosted trees, random forests, regularized linear models, and scikit-learn pipelines.
+
+The feature design carries the forecasting logic. Lag features expose recent target history, such as `lag_1`, `lag_7`, or `lag_12`. Rolling features summarize recent history, such as a trailing mean, trailing maximum, trailing standard deviation, or trailing count. Calendar features expose known future structure, such as hour, day of week, month, quarter, or end-of-month flags. Fourier features encode smooth seasonal patterns without creating one dummy column per calendar value.
+
+Holiday flags are allowed when the holiday calendar is known before prediction. Price, weather, promotion, inventory, or staffing features require more care. If the future value is known at forecast time because it is scheduled, you may use it. If it would only be known later, you must either exclude it or forecast it separately inside the same backtest.
+
+Tree-based models are popular because they handle nonlinear interactions between lag values, rolling summaries, and calendar effects. XGBoost, LightGBM, and scikit-learn's histogram gradient boosting can learn rules such as "January demand is high only when the last quarter was already high" without requiring you to hand-write the interaction. That strength is also a risk, because a powerful model will happily exploit leakage if you give it a leaked feature.
+
+Global models train across many related series in one model. Instead of fitting one model per store, product, metric, or region, you include a series identifier and train on all histories together. A global model can share signal across sparse series and learn common seasonal behavior, but it also needs careful backtesting so that each series is evaluated only on future timestamps.
+
+```text
+forecast origin: 2026-03-31
+
+allowed features for 2026-04:
+  - lagged target values through 2026-03
+  - trailing rolling means ending at 2026-03
+  - known calendar facts for 2026-04
+  - scheduled future events known before 2026-04
+
+not allowed features for 2026-04:
+  - centered rolling means that include 2026-04
+  - scaler parameters fitted on the full year
+  - imputed values learned from the validation period
+  - future target-derived flags created after observing demand
+```
+
+The safest implementation habit is to shift before you roll. A trailing rolling mean for target forecasting should usually start from `y.shift(1).rolling(window).mean()`, not from `y.rolling(window).mean()`. The first version uses only completed observations. The second version includes the current target in the feature row, which is direct target leakage for one-step forecasting.
+
+Feature leakage also appears through preprocessing. A standard scaler fitted on the full series learns the validation-period mean and variance. A target encoder fitted before the split learns validation outcomes for categories that should still be unseen. An imputer fitted across the full timeline can learn future seasonal levels. These errors are not fixed by choosing a different regressor, because the regressor receives already-contaminated features. Time-aware pipelines fit preprocessing inside each training window.
+
+Calendar and Fourier features are safer because their future values are known. The model can know that a future timestamp is a Monday, a month end, or part of a smooth yearly cycle. This is one reason tree-based forecasting often combines target lags with calendar features. The lag features carry recent state, while calendar features let the model condition that state on recurring context. The model still needs a chronological backtest because known future calendar does not protect against leaked target history.
+
+Global models need careful identifiers. A series ID can help the model learn that one store is usually larger than another, but a high-cardinality identifier can also let the model memorize series-specific averages without adapting to recent behavior. Add identifiers deliberately, compare against local baselines, and inspect performance by segment. Aggregate metrics can hide that the global model works for large stable series while failing for small, intermittent, or recently launched series.
+
+Recursive tree forecasts deserve special scrutiny. At horizon one, every lag comes from observed history. At horizon two, some lag values may come from the model's own horizon-one prediction. By horizon twelve, a monthly recursive forecast can be standing on a stack of previous predictions. This is not leakage, but it is a source of error accumulation. Your backtest should implement recursion the same way production will, otherwise the reported horizon accuracy is not meaningful.
+
+Direct forecasting avoids that specific feedback loop by training horizon-specific targets. A direct six-month model learns to predict six months ahead from features known at the origin. It may be more stable at long horizons, but it needs enough examples for each horizon and more operational machinery. Many teams compare recursive, direct, and hybrid strategies on the same folds, then choose the simplest strategy that performs reliably at the horizon that matters.
+
+## Backtesting and Evaluation Without Leakage
+
+Forecasting validation should replay history. Pick several forecast origins, train using data available up to each origin, forecast the next horizon, and score the forecast against the observations that later arrived. This is called walk-forward validation, rolling-origin evaluation, or backtesting. The core idea is the same: your validation procedure should look like production forecasting repeated at earlier dates.
+
+Random k-fold validation is invalid for most forecasting tasks because it lets later observations influence models evaluated on earlier observations. `TimeSeriesSplit` is a safer scikit-learn primitive because each split trains on earlier rows and tests on later rows. Expanding-window validation grows the training set over time. Sliding-window validation keeps a fixed-width training window so old regimes eventually fall out.
+
+```text
+expanding window:
+  train [====] test [--]
+  train [========] test [--]
+  train [============] test [--]
+
+sliding window:
+  train [====] test [--]
+       train [====] test [--]
+            train [====] test [--]
+```
+
+Multi-step forecasting adds another design choice. A recursive strategy trains a one-step model, predicts the next step, appends that prediction to history, and repeats. It is simple, but errors compound because later steps depend on earlier predictions. A direct strategy trains a separate model for each horizon, such as one model for one month ahead and another model for six months ahead. It can reduce error accumulation, but it increases model count and data requirements.
+
+Metrics should match the decision. MAE is easy to explain and robust to occasional large errors. RMSE penalizes large misses more strongly, which matters when a few severe under-forecasts are costly. MAPE is intuitive as a percentage, but it breaks down near zero and can overweight tiny denominators. sMAPE tries to soften that problem, but it still has edge cases when both actual and predicted values are near zero.
+
+MASE compares a model against a naive baseline using scaled absolute error. For seasonal data, the denominator often comes from a seasonal-naive forecast such as "use the value from the same month last year." This makes MASE useful across series with different units because it asks whether the model improves over a simple rule that a serious forecaster should beat.
+
+Baselines are not optional. A naive baseline uses the most recent value. A seasonal-naive baseline uses the value from the previous season. A moving-average baseline uses recent history. If a complex model cannot beat these baselines in a leakage-safe backtest, the correct conclusion is not "tune harder" by default. The correct conclusion is that the added complexity has not yet earned its operational cost.
+
+Backtest results should be read by horizon, segment, and time period. A single average error can hide that the model is excellent one step ahead but weak at longer horizons. It can also hide that a model performs well for high-volume series while failing for low-volume series where decisions are still important. Reporting a table by fold and horizon makes this visible. A plot of error over forecast origin often reveals regime changes faster than another aggregate metric.
+
+Do not let the validation window become a new test set by repeated manual tuning. If you inspect every backtest fold, change features, rerun, and keep the best version, you are still adapting to validation evidence. That may be acceptable during development, but you need a final untouched holdout period or a later live shadow evaluation before claiming generalization. Forecasting projects are especially vulnerable because the most recent period is tempting to reuse many times.
+
+Retraining cadence belongs in evaluation too. A model retrained daily may adapt quickly but cost more to operate and expose the pipeline to more data-quality incidents. A model retrained monthly may be stable but stale after sudden demand shifts. Your backtest can simulate cadence by refitting at each origin, every few origins, or with a fixed window. The best cadence is not just the lowest error; it is the one the team can run reliably when data arrives late and forecasts are needed on schedule.
+
+Finally, compare models by decision impact, not only by metric decimals. A small RMSE improvement may not matter if staffing decisions are rounded to whole shifts. A slightly worse MAE may be preferable if prediction intervals are better calibrated and the model is easier to explain. Forecasting supports decisions under uncertainty, so the winning model is the one that improves the decision process under a realistic operating contract.
+
+## Choosing a Forecasting Workflow
+
+Start with the forecast contract before choosing a library. Write down the decision date, the horizon, the update frequency, the unit of action, and the metric that changes the downstream decision. A forecast for next hour's queue length, next month's inventory order, and next quarter's hiring plan may all use temporal data, but they have different latency, uncertainty, aggregation, and failure-cost requirements.
+
+Then build a ladder of baselines. Use naive, seasonal-naive, and moving-average forecasts first because they reveal whether the series contains easy persistence or seasonal structure. Add exponential smoothing or SARIMA when the signal looks mostly univariate and interpretable. Add tree-based regression when known calendar effects, lag interactions, many related series, or exogenous drivers are likely to matter. Each rung should beat the previous rung in the same walk-forward protocol.
+
+Finally, make the production feature boundary explicit. Store which raw fields are available at the forecast origin, which future calendar fields are scheduled, and which fields would require a separate upstream forecast. This boundary is more durable than any single model choice. It prevents subtle leakage when the project later adds promotions, weather, prices, inventory, or incident labels to improve accuracy.
+
+## Practical Concerns
+
+Missing timestamps are different from missing values. If an hourly system has no row for 03:00, you need to know whether the metric was genuinely absent, the collector failed, or the value should be zero. Resampling to a regular frequency makes gaps visible, but filling them requires domain rules. Forward fill, interpolation, and zero fill each encode a different claim about the world.
+
+Irregular sampling complicates lag features and seasonal periods. A lag of one row is not the same as a lag of one hour when event timing is irregular. Some problems should be resampled to a regular grid before forecasting. Others are better modeled as event processes, survival problems, or point processes rather than forced into a fixed interval forecast.
+
+Multiple and hierarchical series introduce reconciliation questions. Store-level forecasts may need to sum to regional forecasts, and product-level forecasts may need to sum to category forecasts. You can fit independent local models, global models across related series, or hierarchical approaches that reconcile forecasts across levels. The right choice depends on data volume, similarity across series, and the business decision attached to each level.
+
+Prediction intervals are often more useful than point forecasts. Staffing, inventory, capacity planning, and SLO risk decisions need ranges because being slightly wrong is normal. ARIMA and exponential smoothing can provide model-based intervals. Tree-based models often use quantile losses, bootstrapped residuals, conformal prediction, or simulation around recursive forecasts. The interval method should be validated with coverage checks, not merely plotted.
+
+Ecosystems such as `sktime` and `darts` provide forecasting abstractions, model wrappers, backtesting utilities, and probabilistic forecast interfaces. They are peers in the Python forecasting ecosystem rather than a strict ranking. Learn the concepts in this module first, because the same leakage rules, baselines, horizon choices, and metric tradeoffs apply whichever library owns the API.
+
+Forecast monitoring should separate data freshness, feature validity, point error, interval coverage, and decision impact. A forecast can fail because the data feed stopped, because a holiday table was not updated, because the model drifted, or because the downstream planner changed how forecasts are consumed. These failures require different responses. One alert named "forecast bad" is too vague to drive a useful operational action.
+
+Coverage monitoring is especially important when teams publish prediction intervals. If an eighty percent interval only contains the actual value half the time, the interval is underestimating uncertainty. If it contains the actual value nearly all the time, it may be too wide to guide decisions. Coverage should be checked by horizon and segment because long-horizon intervals often degrade before short-horizon intervals, and sparse series may have very different error behavior.
+
+Forecasts also need a fallback plan. If the model job fails at the forecast origin, the system should still produce a reasonable baseline such as seasonal naive, last known plan, or a conservative capacity rule. This fallback is not glamorous, but it prevents a modeling incident from becoming an operations incident. The fallback should be backtested and documented so teams understand what happens when the preferred model is unavailable.
+
+Retraining should be boring by design. Store the training window, forecast origin, model parameters, feature definitions, package versions, and validation summary with each model artifact. When a forecast changes unexpectedly, these records let you distinguish model behavior from data changes and dependency changes. Without that lineage, teams waste time comparing screenshots, rerunning notebooks, and guessing which version generated a decision.
+
+Human override deserves a clear contract too. Planners often know one-off events that are not represented in historical data, such as a migration freeze, a facility closure, or a planned campaign. Overrides can improve decisions, but they should be recorded separately from model forecasts. Mixing them into the target history without annotation teaches future models that the override was observed demand, which can create confusing feedback loops.
+
+A mature forecasting workflow therefore has three products, not one. It produces a point forecast for the expected path, an uncertainty estimate for planning risk, and an audit trail explaining what information was available at the origin. The model is only one part of that workflow. The engineering discipline around data availability, validation, fallbacks, and monitoring is what makes the forecast usable repeatedly.
+
+The final practical habit is to keep a forecast review notebook or report that starts from the business decision rather than the model class. Each review should show the forecast origin, horizon, baseline comparison, interval coverage, largest misses, and any data-quality anomalies for that period. This turns model maintenance into a repeatable operating review. It also helps new team members understand why a simple seasonal baseline may stay in production, why a more accurate model was rejected, or why a retraining rule changed after a regime shift.
+
+Treat every large miss as a classification exercise before treating it as a modeling failure. Some misses are predictable because a known feature was unavailable, some are data incidents, some are structural breaks, and some are ordinary irreducible noise. Labeling misses this way turns error analysis into a backlog. The team can then decide whether to improve data contracts, add known-event features, adjust retraining cadence, or simply widen intervals around inherently volatile periods. This keeps model work connected to the operational cause of error.
+
+## Did You Know?
+
+- **A seasonal-naive baseline can be hard to beat**: monthly, weekly, and daily series often contain enough recurring structure that "same period last season" is a serious benchmark rather than a toy.
+- **ADF and KPSS ask opposite stationarity questions**: ADF looks for evidence against a unit root, while KPSS looks for evidence against stationarity under the chosen regression setting.
+- **Centered windows are usually leakage in forecasting**: a centered rolling mean for today's target uses observations after today, so it belongs in analysis plots more often than in production features.
+- **Forecast intervals need their own validation**: a model can have acceptable point error while its intervals are too narrow, which creates false confidence for capacity and risk decisions.
+
+## Common Mistakes
+
+| Mistake | Problem | Solution |
+|---|---|---|
+| Randomly shuffling time series rows before validation | The model trains on future observations and reports an error estimate that cannot happen in production. | Use chronological holdouts, `TimeSeriesSplit`, or explicit walk-forward backtests with forecast origins. |
+| Computing rolling features before shifting the target | The current target leaks into its own feature row, especially with means, maxima, and standard deviations. | Build target-derived features from shifted history, such as `y.shift(1).rolling(window).mean()`. |
+| Fitting scalers or imputers on the full dataset | Validation-period distribution information changes training-period transformations and inflates backtest scores. | Fit transformations inside each fold using training data only, preferably through a time-aware pipeline. |
+| Treating `auto_arima` as final model selection | Automated order search can optimize information criteria without proving operational forecast quality. | Use it to propose candidates, then inspect residuals and compare against baselines in walk-forward validation. |
+| Ignoring the forecast horizon | A model that works one step ahead may fail badly twelve steps ahead because recursive errors compound. | Score the exact horizon the business needs and compare direct, recursive, and baseline strategies. |
+| Using MAPE when actuals approach zero | Percentage errors explode or become undefined, making the metric unstable and sometimes misleading. | Prefer MAE, RMSE, sMAPE with caution, or MASE against a meaningful naive baseline. |
+| Filling missing timestamps without diagnosis | A fill rule can convert collector outages, true zeros, and irregular events into the same artificial pattern. | Reindex to the expected frequency, inspect gaps, and document the domain-specific fill rule. |
+| Shipping point forecasts without intervals | Planners cannot see uncertainty, so they may treat a fragile forecast as a promise. | Add prediction intervals and validate empirical coverage across backtest folds. |
+
 ## Quiz
 
+1. A team builds a daily demand model with `TimeSeriesSplit`, but creates a feature using `sales.rolling(7, center=True).mean()` before splitting. What is wrong?
 
-**Q1.** Your team has a new tabular churn dataset and only one afternoon to produce a credible baseline before leadership decides whether to fund a larger ML effort. A senior engineer suggests spending two weeks hand-tuning gradient boosting models first. What is the better first step, and why?
+<details><summary>Answer</summary>
 
-<details>
-<summary>Answer</summary>
-Run a quick AutoML baseline first, such as AutoGluon with a bounded `time_limit` and a faster preset like `medium_quality` or `good_quality`.
+The centered rolling window uses observations on both sides of each timestamp, so feature rows near the forecast date contain future target information. The split object cannot repair leakage that was already created before validation. The feature should be based on shifted trailing history, such as `sales.shift(1).rolling(7).mean()`, inside the training window for each fold.
 
-This matches the module's recommended workflow: start simple, get a baseline in 30-60 minutes, and use that result to judge whether more manual effort is justified. AutoML is especially strong for tabular data and time-constrained projects.
 </details>
 
-**Q2.** Your fraud team lets AutoGluon run without a time limit on a large dataset because they want "the best possible model." Two days later, the job is still running and cloud costs have spiked. What should they have done differently?
+2. A monthly series has a strong upward trend and a repeating annual pattern. After first differencing, the ACF still spikes at lag 12. Which model family and terms would you investigate first?
 
-<details>
-<summary>Answer</summary>
-They should have set an explicit `time_limit` before training.
+<details><summary>Answer</summary>
 
-The module warns that AutoML will keep trying more models and configurations unless you constrain it. A practical approach is to start with a limited run, such as one hour, inspect the leaderboard and feature importance, and only extend the run if the extra compute is justified.
+A SARIMA candidate is reasonable because the series has both nonseasonal trend behavior and seasonal dependence. First differencing suggests `d=1`, while the lag-12 ACF spike suggests seasonal AR, seasonal MA, or seasonal differencing terms with `s=12`. You would compare a small set of plausible `(p, d, q)(P, D, Q, 12)` orders, inspect residuals, and backtest against a seasonal-naive baseline.
+
 </details>
 
-**Q3.** A lending platform needs credit decisions in under 10 ms, but AutoGluon's top-scoring model is a deep stacked ensemble with much slower inference. Which preset is the best fit for deployment, and why?
+3. Why is random k-fold cross-validation usually invalid for time series forecasting?
 
-<details>
-<summary>Answer</summary>
-Use `optimize_for_deployment`.
+<details><summary>Answer</summary>
 
-The module explains that deployment-oriented settings can reduce artifact size and simplify deployment, but you still need to validate actual inference latency and serving behavior for your chosen model. `best_quality` may win on offline accuracy, but it often relies on ensembles that can be harder to serve under strict latency constraints.
+Random k-fold validation breaks temporal ordering. Some folds train on observations that happen after the validation observations, which means the model benefits from future regimes, future transformations, and future target patterns. Forecasting validation must replay the production situation by training on the past and evaluating on later timestamps.
+
 </details>
 
-**Q4.** Your team is training a churn model using customer features from a central store. For an event dated `2024-01-15`, one engineer joins against the latest available customer record because it is simpler. Another engineer objects. Who is right, and what is the key concept involved?
+4. A staffing forecast has actual ticket counts near zero on quiet nights. The model team reports excellent MAPE for normal days but extreme percentage errors overnight. What should they change?
 
-<details>
-<summary>Answer</summary>
-The second engineer is right: training must use point-in-time correct features, not the latest record.
+<details><summary>Answer</summary>
 
-The module emphasizes that using current values for past training events causes data leakage because the model sees future information. The correct approach is to retrieve the most recent feature value that existed on or before `2024-01-15`.
+MAPE is unstable near zero because a small absolute miss can become a huge percentage error or undefined value. The team should evaluate with MAE or RMSE for absolute staffing impact, consider sMAPE only with caution, and use MASE against a naive or seasonal-naive baseline so the score remains interpretable across different volume levels.
+
 </details>
 
-**Q5.** Two teams independently build their own versions of `customer_lifetime_value`, and a third team creates yet another version for online inference. After deployment, the same customer receives inconsistent scores across systems. What platform component would have prevented this, and how?
+5. When is a holiday feature legitimate, and when does it become leakage?
 
-<details>
-<summary>Answer</summary>
-A feature store would have prevented this by creating a single, versioned definition of the feature shared across teams.
+<details><summary>Answer</summary>
 
-The module describes feature stores as a centralized system with a registry, metadata, and online/offline serving. That reduces duplication, keeps feature definitions consistent, and helps avoid training-serving skew.
+A holiday feature is legitimate when it comes from a calendar known before the forecast origin, such as next year's public holidays or a scheduled business closure. It becomes leakage when the feature is derived from future observed target behavior, such as labeling a demand spike as a holiday-like event only after seeing the validation period.
+
 </details>
 
-**Q6.** An AutoML model for loan defaults suddenly shows a feature with extremely high importance: `days_until_first_payment`. Offline metrics look amazing, but production defaults rise after launch. Based on the module, what is the most likely problem and what should the team check first?
+6. A tree-based forecaster beats ARIMA one step ahead but loses badly at a six-month horizon. What design issue should you investigate?
 
-<details>
-<summary>Answer</summary>
-The most likely problem is data leakage.
+<details><summary>Answer</summary>
 
-The team should first verify whether `days_until_first_payment` was actually available at prediction time. The module warns that AutoML will exploit any strong signal, including leaked future information, and that suspiciously important features must be sanity-checked before trusting them.
+The first suspect is horizon strategy. A recursive tree model can compound its own errors because each later prediction depends on earlier predicted values. The team should score each horizon separately and compare recursive forecasting with direct horizon-specific models, seasonal-naive baselines, and possibly simpler statistical models that encode seasonal structure more directly.
+
 </details>
 
-**Q7.** Your ML platform supports both model training on months of historical data and real-time recommendations at 50,000 requests per second. A new engineer wants to use the same low-latency online store for both tasks because it is fast. Why is that a bad design choice?
+7. A product team has thousands of short store-product series. Why might a global model be useful, and what extra validation concern does it create?
 
-<details>
-<summary>Answer</summary>
-It is a bad choice because training and inference need different storage behavior.
+<details><summary>Answer</summary>
 
-The module explains that the offline store is for historical, timestamped data used in training and point-in-time joins, while the online store is for the latest feature values used in low-latency inference. Using only the online store would make historical training data incomplete and increase the risk of leakage or skew.
+A global model can share information across related series, which helps when individual histories are too short for reliable local models. The validation concern is that every series still needs chronological evaluation. The model may learn across series, but it must not train on future timestamps for the same series being evaluated, and aggregate metrics should not hide failure on sparse or high-value series.
+
 </details>
 
-<!-- /v4:generated -->
-## Next Steps
+## Hands-On Exercise
 
-You've completed Phase 8: Classical ML! You now understand:
-- Gradient boosting (XGBoost, LightGBM)
-- Time series forecasting (ARIMA, Prophet)
-- AutoML and feature stores
+**Task**: Build an ARIMA/SARIMA forecaster and a tree-based recursive forecaster on bundled CO2 data, then compare both against a seasonal-naive baseline with walk-forward validation.
 
-**Up Next**: Phase 9 - AI Safety & Evaluation
+This lab uses `statsmodels.datasets.co2`, so it does not download external data. It assumes the forecasting libraries are installed in your environment. If you are using the project virtual environment, install any missing optional packages with an explicit venv command such as `.venv/bin/python -m pip install statsmodels scikit-learn pandas numpy`.
 
----
+### Steps
 
-_Module 39 Complete!_
-_"AutoML doesn't replace ML engineers - it multiplies their productivity."_
+- [ ] Load the bundled monthly CO2 series and make the timestamp index regular.
+- [ ] Define a seasonal-naive baseline that repeats the last observed annual cycle.
+- [ ] Fit a SARIMA-style `statsmodels` ARIMA model inside each walk-forward fold.
+- [ ] Fit a recursive `HistGradientBoostingRegressor` using lag, rolling, and calendar features from training history only.
+- [ ] Score all three approaches with MAE, RMSE, and MASE across identical forecast horizons.
+- [ ] Inspect whether either learned model beats the seasonal-naive baseline enough to justify its complexity.
+
+```python
+import warnings
+
+import numpy as np
+import pandas as pd
+from sklearn.ensemble import HistGradientBoostingRegressor
+from sklearn.metrics import mean_absolute_error
+from sklearn.model_selection import TimeSeriesSplit
+from statsmodels.datasets import co2
+from statsmodels.tsa.arima.model import ARIMA
+
+
+def load_monthly_co2():
+    series = (
+        co2.load_pandas()
+        .data["co2"]
+        .resample("MS")
+        .mean()
+        .interpolate("time")
+        .asfreq("MS")
+    )
+    return series.loc["1970":].astype(float)
+
+
+def seasonal_naive(train, steps, season_length=12):
+    last_season = train.iloc[-season_length:].to_numpy()
+    repeats = int(np.ceil(steps / season_length))
+    return np.tile(last_season, repeats)[:steps]
+
+
+def make_training_frame(y):
+    frame = pd.DataFrame({"y": y})
+    frame["lag_1"] = frame["y"].shift(1)
+    frame["lag_12"] = frame["y"].shift(12)
+    frame["roll_3"] = frame["y"].shift(1).rolling(3).mean()
+    frame["roll_12"] = frame["y"].shift(1).rolling(12).mean()
+    month = frame.index.month
+    frame["month_sin"] = np.sin(2 * np.pi * month / 12)
+    frame["month_cos"] = np.cos(2 * np.pi * month / 12)
+    return frame.dropna()
+
+
+def make_future_row(history, timestamp):
+    values = np.asarray(history, dtype=float)
+    month = timestamp.month
+    return pd.DataFrame(
+        {
+            "lag_1": [values[-1]],
+            "lag_12": [values[-12]],
+            "roll_3": [values[-3:].mean()],
+            "roll_12": [values[-12:].mean()],
+            "month_sin": [np.sin(2 * np.pi * month / 12)],
+            "month_cos": [np.cos(2 * np.pi * month / 12)],
+        },
+        index=[timestamp],
+    )
+
+
+def recursive_tree_forecast(train, test_index):
+    training_frame = make_training_frame(train)
+    X_train = training_frame.drop(columns="y")
+    y_train = training_frame["y"]
+
+    model = HistGradientBoostingRegressor(
+        max_iter=200,
+        learning_rate=0.05,
+        l2_regularization=0.01,
+        random_state=7,
+    )
+    model.fit(X_train, y_train)
+
+    history = list(train.to_numpy())
+    predictions = []
+    for timestamp in test_index:
+        row = make_future_row(history, timestamp)
+        prediction = float(model.predict(row)[0])
+        predictions.append(prediction)
+        history.append(prediction)
+    return np.asarray(predictions)
+
+
+def arima_forecast(train, steps):
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        fitted = ARIMA(
+            train,
+            order=(1, 1, 1),
+            seasonal_order=(1, 0, 1, 12),
+            enforce_stationarity=False,
+            enforce_invertibility=False,
+        ).fit()
+    return np.asarray(fitted.forecast(steps=steps))
+
+
+def rmse(y_true, y_pred):
+    errors = np.asarray(y_true) - np.asarray(y_pred)
+    return float(np.sqrt(np.mean(errors**2)))
+
+
+def mase(y_true, y_pred, train, season_length=12):
+    train_values = np.asarray(train, dtype=float)
+    denominator = np.mean(
+        np.abs(train_values[season_length:] - train_values[:-season_length])
+    )
+    return float(mean_absolute_error(y_true, y_pred) / denominator)
+
+
+series = load_monthly_co2()
+horizon = 12
+splitter = TimeSeriesSplit(n_splits=4, test_size=horizon)
+
+rows = []
+for fold, (train_idx, test_idx) in enumerate(splitter.split(series), start=1):
+    train = series.iloc[train_idx]
+    test = series.iloc[test_idx]
+
+    forecasts = {
+        "seasonal_naive": seasonal_naive(train, len(test)),
+        "arima_sarima": arima_forecast(train, len(test)),
+        "tree_recursive": recursive_tree_forecast(train, test.index),
+    }
+
+    for model_name, prediction in forecasts.items():
+        rows.append(
+            {
+                "fold": fold,
+                "model": model_name,
+                "MAE": mean_absolute_error(test, prediction),
+                "RMSE": rmse(test, prediction),
+                "MASE": mase(test, prediction, train),
+            }
+        )
+
+results = pd.DataFrame(rows)
+print(results.groupby("model")[["MAE", "RMSE", "MASE"]].mean().round(3))
+```
+
+### Success Criteria
+
+- [ ] The code prints one aggregate metric row for `seasonal_naive`, `arima_sarima`, and `tree_recursive`.
+- [ ] The ARIMA model is fitted separately inside each fold and never sees validation observations during fitting.
+- [ ] The tree forecaster uses lagged and trailing features only, then recursively feeds its own predictions for multi-step forecasting.
+- [ ] Your written interpretation names the best model, the baseline gap, and whether the improvement justifies the added complexity.
+
+### Verification
+
+```bash
+.venv/bin/python time_series_backtest.py
+```
+
+The exact numeric scores can differ across library versions and optimization settings. The important verification is structural: the same walk-forward folds score all models, the seasonal-naive baseline is present, and the learned models never train on their validation windows.
 
 ## Sources
 
-- [AutoGluon-Tabular: Robust and Accurate AutoML for Structured Data](https://arxiv.org/abs/2003.06505) — Primary source for AutoGluon's stacking approach, benchmark framing, and competition results.
-- [Feast GitHub Repository](https://github.com/feast-dev/feast) — Official upstream overview for online/offline feature serving and point-in-time-correct retrieval.
-- [Auto-Sklearn 2.0: Hands-free AutoML via Meta-Learning](https://arxiv.org/abs/2007.04074) — Primary source for meta-learning and budget-aware AutoML design in a widely cited framework.
+- [statsmodels PyPI project page](https://pypi.org/project/statsmodels/) - release metadata and high-level package scope.
+- [statsmodels Time Series Analysis user guide](https://www.statsmodels.org/stable/tsa.html) - `statsmodels.tsa` model families and forecasting tools.
+- [statsmodels ARIMA API](https://www.statsmodels.org/stable/generated/statsmodels.tsa.arima.model.ARIMA.html) - ARIMA and seasonal ARIMA interface details.
+- [statsmodels ExponentialSmoothing API](https://www.statsmodels.org/stable/generated/statsmodels.tsa.holtwinters.ExponentialSmoothing.html) - Holt-Winters level, trend, and seasonal parameters.
+- [statsmodels STL decomposition API](https://www.statsmodels.org/stable/generated/statsmodels.tsa.seasonal.STL.html) - seasonal-trend decomposition reference.
+- [statsmodels ADF/KPSS stationarity notebook](https://www.statsmodels.org/stable/examples/notebooks/generated/stationarity_detrending_adf_kpss.html) - stationarity test interpretation examples.
+- [statsmodels ACF API](https://www.statsmodels.org/stable/generated/statsmodels.tsa.stattools.acf.html) and [PACF API](https://www.statsmodels.org/stable/generated/statsmodels.tsa.stattools.pacf.html) - autocorrelation and partial autocorrelation functions.
+- [pmdarima `auto_arima` documentation](https://alkaline-ml.com/pmdarima/modules/generated/pmdarima.arima.auto_arima.html) - automated ARIMA order search behavior.
+- [Prophet PyPI project page](https://pypi.org/project/prophet/) and [Prophet quick start](https://facebook.github.io/prophet/docs/quick_start.html) - package metadata and Python usage.
+- [Prophet GitHub release notes](https://github.com/facebook/prophet) - maintained project repository and changelog.
+- [scikit-learn `TimeSeriesSplit` documentation](https://scikit-learn.org/stable/modules/generated/sklearn.model_selection.TimeSeriesSplit.html) - time-ordered cross-validation behavior.
+- [scikit-learn `HistGradientBoostingRegressor` documentation](https://scikit-learn.org/stable/modules/generated/sklearn.ensemble.HistGradientBoostingRegressor.html) - histogram gradient boosting regressor API.
+- [scikit-learn 1.9 release notes](https://scikit-learn.org/stable/whats_new/v1.9.html) - versioned library reference for the dated snapshot.
+- [XGBoost release notes](https://xgboost.readthedocs.io/en/stable/changes/index.html) - versioned release reference for tree-based forecasting options.
+- [LightGBM documentation](https://lightgbm.readthedocs.io/en/latest/) - gradient boosting framework reference.
+- [sktime forecasting API](https://www.sktime.net/en/latest/api_reference/forecasting.html) and [Darts documentation](https://unit8co.github.io/darts/) - Python forecasting ecosystem references.
+
+## Next Module
+
+Next, continue to [Module 2.1: Class Imbalance & Cost-Sensitive Learning](../module-2.1-class-imbalance-and-cost-sensitive-learning/) to handle target distributions where rare outcomes and asymmetric costs change what "good" model behavior means.

--- a/src/content/docs/ai-ml-engineering/machine-learning/module-1.12-time-series-forecasting.md
+++ b/src/content/docs/ai-ml-engineering/machine-learning/module-1.12-time-series-forecasting.md
@@ -80,7 +80,7 @@ Many classical time series methods assume some form of stationarity. A stationar
 
 Differencing is the most common transformation. A first difference models the change from one observation to the next rather than the level itself. Seasonal differencing models the change from one seasonal position to the corresponding previous seasonal position, such as this January minus last January. Differencing can remove trend or seasonal persistence, but unnecessary differencing can also erase useful signal and make forecasts unstable.
 
-Two standard tests help frame the stationarity question. The Augmented Dickey-Fuller test uses a null hypothesis of a unit root, so a low p-value is evidence against non-stationarity. The KPSS test reverses the framing by using a stationarity null, so a low p-value suggests the series is not stationary under the selected level or trend assumption. The tests are not magic judges; they are structured evidence to combine with plots and domain knowledge.
+Two standard tests help frame the stationarity question. The Augmented Dickey-Fuller test uses a null hypothesis of a unit root, so a low p-value rejects the unit-root null and is therefore evidence that the series is stationary. The KPSS test reverses the framing by using a stationarity null, so a low p-value suggests the series is not stationary under the selected level or trend assumption. The tests are not magic judges; they are structured evidence to combine with plots and domain knowledge.
 
 ACF and PACF plots help identify autoregressive and moving-average structure after appropriate transformation. The autocorrelation function shows correlation between the series and lagged versions of itself. The partial autocorrelation function estimates the relationship at a lag after accounting for shorter lags. In practice, ACF and PACF are diagnostic tools, not vending machines for perfect `(p, d, q)` orders.
 
@@ -473,7 +473,7 @@ A global model can share information across related series, which helps when ind
 
 **Task**: Build an ARIMA/SARIMA forecaster and a tree-based recursive forecaster on bundled CO2 data, then compare both against a seasonal-naive baseline with walk-forward validation.
 
-This lab uses `statsmodels.datasets.co2`, so it does not download external data. It assumes the forecasting libraries are installed in your environment. If you are using the project virtual environment, install any missing optional packages with an explicit venv command such as `.venv/bin/python -m pip install statsmodels scikit-learn pandas numpy`.
+This lab uses `statsmodels.datasets.co2`, so it does not download external data. It assumes the forecasting libraries are installed in your environment. If you are using the project virtual environment, install any missing optional packages with an explicit venv command such as `.venv/bin/python -m pip install statsmodels scikit-learn pandas numpy`. Two earlier snippets in this module need extra optional packages: `auto_arima` requires `pmdarima`, and the Prophet example requires `prophet` (which installs `cmdstanpy`). Install them with `.venv/bin/python -m pip install pmdarima prophet` if you want to run those blocks.
 
 ### Steps
 
@@ -629,6 +629,8 @@ print(results.groupby("model")[["MAE", "RMSE", "MASE"]].mean().round(3))
 - [ ] Your written interpretation names the best model, the baseline gap, and whether the improvement justifies the added complexity.
 
 ### Verification
+
+Save the complete script assembled from the Steps above as `time_series_backtest.py`, then run it:
 
 ```bash
 .venv/bin/python time_series_backtest.py


### PR DESCRIPTION
## #2020 — rewrite mis-slotted module 1.12

**Problem:** `module-1.12-time-series-forecasting.md` (slug/title = *Time Series Forecasting*) actually contained **AutoML + Feature-Store** content (AutoGluon, Feast, MLflow) on the legacy fabrication template — "The Intern Who Beat the Team" opener, "$50 Million Inventory Mistake", and Economics / Interview-Prep sections. Surfaced during the #2020 cross-family review of the machine-learning track.

**Rewrite (codex/OpenAI):** from-scratch Time Series Forecasting module on the durable spine — what makes time series different (the arrow of time / leakage), stationarity + differencing + ACF/PACF diagnostics, classical methods (ARIMA/SARIMA, exponential smoothing, Prophet), forecasting-as-supervised-regression with lag/rolling/calendar/Fourier features into gradient-boosted trees, and walk-forward backtesting with horizon-aware metrics vs a seasonal-naive baseline. Properly-labeled `Hypothetical scenario:`, dated `Landscape snapshot` (statsmodels **0.14.6**, prophet **1.3.0**, + XGBoost/LightGBM/sklearn — all web-verified). No fabricated incidents/$/company stats.

**Cross-family review — cursor (Kimi), executed every lab end-to-end → APPROVE (0 P1):**
- Real lab metrics confirmed: arima_sarima MASE 0.376 vs seasonal_naive 1.239 (walk-forward, 4 folds).
- Verified all versions against ground truth; 19/19 sources reachable; topic match clean.
- 3 P2 polish items fixed here: phantom `time_series_backtest.py` (added save-instruction), missing `pmdarima`/`prophet` install note, ADF-interpretation wording.

Verifier: **T0, all gates pass.** Refs #2020.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Learner check

Verbatim from `module-1.12-time-series-forecasting.md` (the Sealed Calendar analogy):

> A forecasting model is like a planner with sealed calendar pages. When you stand on March 31, every page after March 31 is sealed. You may know recurring holidays, planned promotions, and the calendar structure, but you may not peek at April demand, April residuals, or April rolling averages. Good forecasting engineering is the discipline of keeping those pages sealed in code.