### PR TITLE
feat(rl): #2020 expand reinforcement-learning 1.1 + 2.1 to T0

### DIFF
--- a/src/content/docs/ai-ml-engineering/reinforcement-learning/module-1.1-rl-practitioner-foundations.md
+++ b/src/content/docs/ai-ml-engineering/reinforcement-learning/module-1.1-rl-practitioner-foundations.md
@@ -56,9 +56,9 @@ If your problem is really a one-step prediction problem, RL is usually the wrong
 
 That matters because many first RL projects are disguised classification tasks. A team has logged examples, clear labels, and no safe way to explore in production, yet still reaches for RL because the control loop feels more modern. That is usually a mistake.
 
-RL becomes worth considering when actions change future states, when delayed consequences matter, and when interaction is part of the learning process rather than just the deployment process. A thermostat, a robot arm, a game-playing agent, or an online control policy can fit that shape. A static fraud classifier usually does not.
+RL becomes worth considering when actions change future states, when delayed consequences matter, and when interaction is part of the learning process rather than just the deployment process. A thermostat, a robot arm, a game-playing agent, or an online control policy can fit that shape. A static fraud classifier usually does not. The practical test is whether you need to learn from consequences you can only observe by trying actions, not whether the product vocabulary includes the word "agent."
 
-The first practitioner question is therefore not, "Which algorithm should we use." It is, "What kind of evidence do we actually have." Do you have logged labels. Do you have a simulator. Can you explore safely. Does the action now affect the observations later. Can the environment reset repeatedly without harming real users or systems.
+The first practitioner question is therefore not, "Which algorithm should we use." It is, "What kind of evidence do we actually have." Do you have logged labels. Do you have a simulator. Can you explore safely. Does the action now affect the observations later. Can the environment reset repeatedly without harming real users or systems. Answering those questions honestly prevents months of tuning the wrong learning paradigm and saves you from impressive-looking curves that answer the wrong problem.
 
 If supervised learning works, use supervised learning. The modules on [Module 1.1: Scikit-learn API & Pipelines](../../machine-learning/module-1.1-scikit-learn-api-and-pipelines/), [Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../../machine-learning/module-1.3-model-evaluation-validation-leakage-and-calibration/), and [Module 1.5: Decision Trees & Random Forests](../../machine-learning/module-1.5-decision-trees-and-random-forests/) give you stronger defaults for that world. RL earns its complexity only when interaction and long-horizon credit assignment are the real problem.
 
@@ -97,6 +97,20 @@ This frame also clarifies why RL feels different from the earlier machine-learni
 
 That feedback loop is why environment definition and reward definition matter so much. You are not only fitting a model to data. You are shaping which data the model will see next.
 
+The agent–environment loop is the durable spine underneath every library in this module. At each discrete time step `t`, the agent observes state `s_t`, chooses action `a_t`, receives scalar reward `r_t`, and lands in next state `s_{t+1}`. An episode ends when a termination or truncation condition fires. Return is the discounted sum of future rewards: `G_t = r_t + γ r_{t+1} + γ² r_{t+2} + …`, where discount factor `γ` in `(0, 1]` controls how far ahead the agent plans. A `γ` near zero makes the agent myopic; a `γ` near one makes distant consequences matter, which is powerful but harder to learn when rewards are sparse.
+
+```
+  ┌─────────┐  action a_t   ┌──────────────┐
+  │  Agent  │──────────────▶│ Environment  │
+  │ (policy)│◀──────────────│ (dynamics)   │
+  └─────────┘  obs s_t,     └──────────────┘
+               reward r_t
+```
+
+The Markov property, when it holds, says the future depends on history only through the current state. Real deployments often violate that cleanly: a dashboard snapshot may omit hidden inventory, and a partially observed process may need memory or state estimation. The MDP frame still helps because it forces you to name what the policy actually sees at decision time, not what you wish it could see.
+
+Exploration versus exploitation sits on top of that loop. Exploitation means choosing the action that looks best from current estimates. Exploration means trying actions that might be suboptimal now but could reveal better long-run behavior. A policy that never explores may never discover a high-reward region; a policy that explores too aggressively wastes interaction budget on noise. There is no universal dial that solves this once. Sparse rewards, stochastic transitions, and deceptive local optima all change the balance. That is one reason algorithm families differ: some encourage stochastic policies explicitly, some rely on ε-greedy action noise, and some depend on environment resets to keep visitation broad.
+
 ## Section 3: Three algorithm families
 
 For this module, the first family choice is simpler than the literature makes it sound. Start from the action space, then ask how much data reuse you need, then ask how much instability you are willing to manage.
@@ -117,36 +131,21 @@ Observation modality matters too, but in a more boring way at this level. If you
 
 A common beginner mistake is to choose from names first and interfaces second. Do the opposite. Inspect `env.action_space` and `env.observation_space` before you argue about algorithms. That single check eliminates many bad starts.
 
+Before naming PPO, DQN, or SAC, it helps to know what object each family is trying to learn. Value-based methods estimate how good states or state–action pairs are, then derive behavior by picking high-value actions. Policy-based methods learn a mapping from state to action directly and optimize that mapping with gradient signals from rollouts. Actor–critic methods keep both: a policy actor proposes actions, and a critic estimates value to reduce variance in the policy update. DQN is the canonical value-based discrete-control story in this module. PPO is policy-based with a value baseline attached. SAC is actor–critic with entropy regularization for continuous control.
+
+On-policy versus off-policy is a separate axis from that taxonomy. On-policy learning updates from data collected by the policy you are currently improving; old rollouts become stale quickly when the policy changes. Off-policy learning reuses transitions gathered under older behavior, which can improve sample efficiency but introduces mismatch between the data distribution and the policy you want. PPO is on-policy in spirit. DQN and SAC are off-policy and use replay. The durable lesson is not memorizing acronyms but knowing whether your update is allowed to trust old experience and whether your critic is being queried on actions the data never supported.
+
+> **Landscape snapshot — as of 2026-06**
+>
+> Gymnasium exposes the loop through `reset()` → `step(action)` with `observation_space` and `action_space` metadata. Stable-Baselines3 wraps algorithms behind a common `learn()` / `predict()` API. Verify constructor names, space types, and evaluator helpers against the pinned docs in **Sources** before relying on them in production; both projects ship breaking changes between minor releases.
+
 ## Section 4: PPO — the workhorse
 
-PPO is the algorithm many practitioners should try first.
-Not because it is always best,
-but because it is a solid baseline across many tasks and tends to fail in
-ways you can inspect.
+PPO is the algorithm many practitioners should try first, not because it is always best, but because it is a solid baseline across many tasks and tends to fail in ways you can inspect. Its central practical tradeoff is straightforward: PPO is on-policy, which means the rollout data used for updates should come from the current policy rather than a large pool of older behavior. The upside is conceptual simplicity and often smoother training; the downside is weaker sample efficiency when every environment step is expensive.
 
-Its central practical tradeoff is straightforward.
-PPO is on-policy.
-That means the rollout data used for updates should come from the current policy,
-not from a large pool of older behavior.
-The upside is conceptual simplicity and often smoother training.
-The downside is weaker sample efficiency.
+That tradeoff becomes important on real budgets. If environment interaction is cheap, PPO can be a very sensible default. If every environment step is expensive, on-policy waste becomes painful, and that is where off-policy methods often earn their extra complexity. Exploration versus exploitation also matters here more than many newcomers expect: a PPO run can look stable while still under-exploring because the reward is too uninformative or because the agent settles into a locally decent behavior too early, and in those cases switching algorithms is often less useful than fixing the task signal.
 
-That tradeoff becomes important on real budgets.
-If environment interaction is cheap,
-PPO can be a very sensible default.
-If every environment step is expensive,
-on-policy waste becomes painful.
-That is where off-policy methods often earn their extra complexity.
-
-Exploration versus exploitation also matters here more than many newcomers expect.
-A PPO run can look "stable" while still under-exploring because the reward is too
-uninformative or because the agent settles into a locally decent behavior too early.
-When that happens,
-switching algorithms is often less useful than fixing the task signal.
-
-The SB3 interface makes a first PPO baseline simple enough that you should use it early.
-The point of the first baseline is not to win.
-It is to expose whether the environment and reward are even learnable.
+The SB3 interface makes a first PPO baseline simple enough that you should use it early. The point of the first baseline is not to win; it is to expose whether the environment and reward are even learnable.
 
 ```python
 env = make_vec_env("CartPole-v1", n_envs=4, seed=0)
@@ -169,41 +168,13 @@ It is exactly the kind of environment where a first PPO run tells you something 
 
 > **Pause and decide** — You have a simulator that resets cheaply, a small vector observation, and a policy that must emit one of two safe actions each step. Would you start with PPO for stability, or jump to a replay-based method first, and what assumption about interaction cost drives your choice?
 
-Practitioners sometimes confuse PPO's popularity with algorithmic invincibility.
-That is a mistake.
-PPO is often a good first answer,
-not a magical final answer.
-If learning plateaus,
-you still have to inspect the environment,
-the reward,
-the budget,
-and the seed variance.
-
-The sample-efficiency versus wall-clock tradeoff is the main thing to remember.
-Vectorized rollouts can improve wall-clock speed on one machine,
-but they do not change the fact that PPO discards much of what older off-policy methods can reuse.
-That is the price of its stable workhorse reputation.
+Practitioners sometimes confuse PPO's popularity with algorithmic invincibility, which is a mistake. PPO is often a good first answer, not a magical final answer, and if learning plateaus you still have to inspect the environment, the reward, the budget, and the seed variance. The sample-efficiency versus wall-clock tradeoff is the main thing to remember: vectorized rollouts can improve wall-clock speed on one machine, but they do not change the fact that PPO discards much of what older off-policy methods can reuse, and that is the price of its stable workhorse reputation.
 
 ## Section 5: DQN — discrete action spaces and replay buffers
 
-DQN fits problems where the action space is discrete and not too large.
-Instead of learning a direct continuous control policy,
-it learns action values and improves behavior by preferring actions with larger estimated return.
+DQN fits problems where the action space is discrete and not too large. Instead of learning a direct continuous control policy, it learns action values and improves behavior by preferring actions with larger estimated return. The replay buffer is the important operational feature: transitions collected earlier can be sampled again later, which usually helps sample efficiency, but you pay for that efficiency with a different kind of debugging burden because old experience can reinforce biases in the policy's state visitation and exploration quality matters a lot.
 
-The replay buffer is the important operational feature.
-Transitions collected earlier can be sampled again later,
-which usually helps sample efficiency.
-You pay for that efficiency with a different kind of debugging burden:
-old experience can reinforce biases in the policy's state visitation,
-and exploration quality matters a lot.
-
-This is why DQN is often attractive in small,
-discrete control tasks and game-like environments,
-but not the right default for torque control,
-continuous robotics,
-or other `Box` action settings.
-If your action is a real-valued vector,
-DQN is answering the wrong question.
+This is why DQN is often attractive in small discrete control tasks and game-like environments, but not the right default for torque control, continuous robotics, or other `Box` action settings. If your action is a real-valued vector, DQN is answering the wrong question.
 
 ```python
 env = gym.make("CartPole-v1")
@@ -219,37 +190,11 @@ mean_reward, std_reward = evaluate_policy(
 print(f"mean={mean_reward:.2f}, std={std_reward:.2f}")
 ```
 
-The temptation with DQN is to over-credit the algorithm when the real issue is exploration.
-A replay buffer cannot rescue a task the agent rarely discovers.
-If the initial behavior almost never reaches useful states,
-the buffer mostly stores unhelpful transitions more efficiently.
-
-That is why exploration versus exploitation tuning often matters more than the algorithm label.
-A mediocre reward with decent state coverage can outperform a theoretically stronger method whose
-experience never includes the crucial states.
-
-DQN also teaches a healthy discipline about action spaces.
-Before you run it,
-check that the environment's action space is actually discrete.
-That one line of due diligence prevents a category error that no amount of hyperparameter tuning can fix.
+The temptation with DQN is to over-credit the algorithm when the real issue is exploration. A replay buffer cannot rescue a task the agent rarely discovers, and if the initial behavior almost never reaches useful states the buffer mostly stores unhelpful transitions more efficiently. That is why exploration versus exploitation tuning often matters more than the algorithm label: a mediocre reward with decent state coverage can outperform a theoretically stronger method whose experience never includes the crucial states. DQN also teaches a healthy discipline about action spaces, so before you run it check that the environment's action space is actually discrete, because that one line of due diligence prevents a category error that no amount of hyperparameter tuning can fix.
 
 ## Section 6: SAC — continuous control with entropy
 
-SAC is the family to keep in mind when the action space is continuous and data
-reuse matters.
-Its defining idea at practitioner level is simple:
-learn from replayed transitions while encouraging sufficiently stochastic behavior to keep exploration alive.
-
-That entropy term is not decoration.
-It is one reason SAC can explore continuous spaces more effectively than a purely greedy control update.
-In tasks where action values are smooth and interaction is expensive,
-that can make SAC a strong choice.
-
-The tradeoff is that SAC asks for more judgment.
-It is often sample-efficient,
-but it can be less forgiving than a first PPO baseline if the reward is badly scaled,
-the environment is poorly specified,
-or your evaluation protocol is sloppy.
+SAC is the family to keep in mind when the action space is continuous and data reuse matters. Its defining idea at practitioner level is simple: learn from replayed transitions while encouraging sufficiently stochastic behavior to keep exploration alive. That entropy term is not decoration; it is one reason SAC can explore continuous spaces more effectively than a purely greedy control update, and in tasks where action values are smooth and interaction is expensive that can make SAC a strong choice. The tradeoff is that SAC asks for more judgment: it is often sample-efficient, but it can be less forgiving than a first PPO baseline if the reward is badly scaled, the environment is poorly specified, or your evaluation protocol is sloppy.
 
 ```python
 env = gym.make("Pendulum-v1")
@@ -265,41 +210,11 @@ mean_reward, std_reward = evaluate_policy(
 print(f"mean={mean_reward:.2f}, std={std_reward:.2f}")
 ```
 
-The algorithm choice here is driven by the interface.
-`Pendulum-v1` uses a continuous `Box` action space,
-so DQN is out before discussion starts.
-PPO remains viable,
-but SAC becomes attractive when interaction cost makes replay-based reuse valuable.
-
-This is the second place where sample efficiency versus wall-clock must be separated.
-A slower-feeling method per update can still be the better engineering choice if every new environment interaction is expensive.
-Conversely,
-if you can cheaply parallelize simulation on one machine,
-PPO may still be easier to get moving.
-
-SAC does not repeal the rule that reward design dominates algorithm choice.
-If the reward is exploitable,
-SAC will exploit it efficiently.
-Off-policy efficiency is a force multiplier.
-That is good when the objective is sound and bad when it is not.
+The algorithm choice here is driven by the interface. `Pendulum-v1` uses a continuous `Box` action space, so DQN is out before discussion starts. PPO remains viable, but SAC becomes attractive when interaction cost makes replay-based reuse valuable. This is the second place where sample efficiency versus wall-clock must be separated: a slower-feeling method per update can still be the better engineering choice if every new environment interaction is expensive, whereas if you can cheaply parallelize simulation on one machine PPO may still be easier to get moving. SAC does not repeal the rule that reward design dominates algorithm choice; if the reward is exploitable, SAC will exploit it efficiently, because off-policy efficiency is a force multiplier that helps when the objective is sound and hurts when it is not.
 
 ## Section 7: Stable-Baselines3 in practice
 
-Stable-Baselines3 is valuable because it narrows the gap between RL theory and a practical first experiment.
-It gives you consistent APIs,
-documented algorithm support,
-and guidance about when a result should be treated as suspicious rather than exciting.
-
-In practice,
-the library should shape your workflow in three ways.
-First,
-start from one documented algorithm-environment pair that clearly fits the action space.
-Second,
-use a small budget that can finish quickly enough to support iteration.
-Third,
-separate training,
-evaluation,
-and serialization so checkpoints are testable artifacts rather than disposable side effects.
+Stable-Baselines3 is valuable because it narrows the gap between RL theory and a practical first experiment. It gives you consistent APIs, documented algorithm support, and guidance about when a result should be treated as suspicious rather than exciting. In practice, the library should shape your workflow in three ways: start from one documented algorithm-environment pair that clearly fits the action space, use a small budget that can finish quickly enough to support iteration, and separate training, evaluation, and serialization so checkpoints are testable artifacts rather than disposable side effects.
 
 ```python
 train_env = DummyVecEnv([lambda: gym.make("CartPole-v1")])
@@ -317,42 +232,11 @@ mean_reward, std_reward = evaluate_policy(
 print(f"mean={mean_reward:.2f}, std={std_reward:.2f}")
 ```
 
-Saving and reloading matters more than it looks.
-A checkpoint you cannot reload and evaluate cleanly is not an experiment result.
-It is a transient process state.
-
-SB3's documentation also encourages a useful cultural habit:
-treat the first implementation as a baseline,
-not as proof.
-That sounds obvious,
-but it is one of the easiest disciplines to lose when RL curves start moving.
-
-The common failure mode in this section is premature complexity.
-People reach for distributed training,
-custom wrappers,
-and large sweeps before confirming that the smallest documented setup can learn at all.
-Do not scale confusion.
-Scale a working baseline.
+Saving and reloading matters more than it looks, because a checkpoint you cannot reload and evaluate cleanly is not an experiment result but a transient process state. SB3's documentation also encourages a useful cultural habit: treat the first implementation as a baseline, not as proof, which sounds obvious but is one of the easiest disciplines to lose when RL curves start moving. The common failure mode in this section is premature complexity, where people reach for distributed training, custom wrappers, and large sweeps before confirming that the smallest documented setup can learn at all; do not scale confusion, scale a working baseline.
 
 ## Section 8: Gymnasium — the environment interface
 
-Gymnasium is the boundary object between your algorithm and the task.
-If that boundary is misunderstood,
-everything upstream becomes harder to interpret.
-
-The modern API matters.
-`reset` returns both observation and info.
-`step` returns observation,
-reward,
-termination flag,
-truncation flag,
-and info.
-That distinction between termination and truncation is operationally important.
-
-Termination means the task ended according to task logic.
-Truncation usually means a time limit or external episode cutoff.
-If you collapse those carelessly,
-you can misread learning progress or compute returns in a misleading way.
+Gymnasium is the boundary object between your algorithm and the task, and if that boundary is misunderstood everything upstream becomes harder to interpret. The modern API matters: `reset` returns both observation and info, and `step` returns observation, reward, termination flag, truncation flag, and info, so the distinction between termination and truncation is operationally important. Termination means the task ended according to task logic, while truncation usually means a time limit or external episode cutoff, and if you collapse those carelessly you can misread learning progress or compute returns in a misleading way.
 
 ```python
 env = gym.make("CartPole-v1")
@@ -368,23 +252,7 @@ for _ in range(3):
         obs, info = env.reset(seed=0)
 ```
 
-Two quick checks fall out of this example.
-`env.action_space` tells you whether DQN or SAC even belongs in the conversation.
-`env.observation_space` tells you what the policy must ingest.
-
-This is also the right place to remember that environment bugs can mimic algorithm bugs.
-A wrong reward sign,
-a hidden state leak,
-or an inconsistent reset can produce learning curves that look random,
-unstable,
-or deceptively good.
-Before you blame PPO,
-inspect the environment.
-
-Gymnasium environments are not just datasets with a fancy loop.
-They are executable task definitions.
-That makes interface hygiene part of model quality,
-not separate from it.
+Two quick checks fall out of this example. `env.action_space` tells you whether DQN or SAC even belongs in the conversation, and `env.observation_space` tells you what the policy must ingest. This is also the right place to remember that environment bugs can mimic algorithm bugs: a wrong reward sign, a hidden state leak, or an inconsistent reset can produce learning curves that look random, unstable, or deceptively good, so before you blame PPO inspect the environment. Gymnasium environments are not just datasets with a fancy loop; they are executable task definitions, which makes interface hygiene part of model quality rather than separate from it. Mapping the durable MDP pieces onto Gymnasium is straightforward once you treat the API as a contract checklist rather than boilerplate: state is the observation returned by `reset` and `step`, action is whatever `action_space.sample()` would admit, reward is the scalar from `step`, transition is whatever your simulator or wrapper implements behind those calls, and the episode boundary is the combination of `terminated` and `truncated`.
 
 ## Section 9: Reward design — the hardest part of RL
 
@@ -403,13 +271,9 @@ the reward captures a shortcut rather than the intended behavior.
 The third is unintended optimization:
 the agent discovers behavior that satisfies the scalar reward while violating the human objective.
 
-Shaping can help,
-but shaping is not free.
-A shaping term changes the optimum unless it is designed very carefully.
-That is why the question is never just,
-"Can I make reward denser."
-It is,
-"What new loophole did I introduce by making it denser."
+Shaping can help, but shaping is not free. A shaping term changes the optimum unless it is designed very carefully, which is why the question is never just "Can I make reward denser" but "What new loophole did I introduce by making it denser." Classic reward-shaping pitfalls include potential-based shortcuts that look correct on paper but change the optimal policy, per-step bonuses that dominate sparse terminal rewards and teach the agent to stall, and proxy terms copied from a different task that correlate with success in training but not in deployment. Potential-based shaping theory exists to preserve optimal policies under certain conditions, but practitioner implementations often skip the formal checks and add hand-tuned bonuses anyway.
+
+The role of the reward signal is not to narrate your intent; it is to define the optimization target. If two behaviors tie on your scalar but differ on safety, latency, or user trust, the agent will not split the difference politely. It will pick whichever behavior maximizes the number you logged. Reward hacking is therefore a specification bug, not a mysterious failure of deep learning. Before training, list the behaviors that would score well while failing the real objective, then design evaluations that would catch them. After training, inspect rollouts for those failure modes even when mean reward looks healthy.
 
 ```python
 class PositionBonus(gym.RewardWrapper):
@@ -442,6 +306,8 @@ remember this:
 reward design is usually the hardest part of RL because the optimizer is literal.
 It does not understand your intent.
 It only understands the scalar you handed it.
+
+When debugging reward issues, compare rollouts side by side with the unshaped environment when possible. Watch for agents that maximize a shaping term while ignoring terminal success, agents that oscillate to harvest dense bonuses, and agents that exploit simulator quirks that do not exist in production. The durable fix is usually to tighten the objective or add evaluation criteria the optimizer does not see, not to chase a more exotic algorithm.
 
 ## Section 10: Evaluation discipline — multi-seed or it doesn't count
 
@@ -506,18 +372,13 @@ Keep wrapper choices fixed.
 Report variance.
 Refuse to celebrate a single cherry-picked line.
 
+Treat every checkpoint as a hypothesis about behavior, not a trophy. Save the config, seed list, library versions, and evaluation script alongside the model weights so a colleague can reproduce the claim without guessing which informal tweaks produced the curve you are showing.
+
 > **Pause and decide** — One PPO configuration averages slightly lower reward than another across one favorite seed, but it has much tighter results across five seeds and fewer collapses. Which run is more credible for deployment review, and what would you write in the summary to make that case honestly?
 
-Multi-seed reporting also changes how you debug.
-If all seeds fail,
-suspect environment definition,
-reward quality,
-or a wildly bad hyperparameter range.
-If one seed succeeds and four fail,
-suspect brittleness and under-reported variance before you declare victory.
+Multi-seed reporting also changes how you debug stalled or diverging runs. If all seeds fail, suspect environment definition, reward quality, or a wildly bad hyperparameter range before you blame the algorithm family. If one seed succeeds and four fail, suspect brittleness and under-reported variance before you declare victory. When curves diverge mid-training, triage in this order: confirm `terminated` versus `truncation` handling, inspect reward scale and wrapper side effects, compare against a trivial random or heuristic policy, then revisit learning rate and batch size against Stable-Baselines3 guidance. Debugging RL is mostly debugging the loop you defined, not swapping acronyms.
 
-That is the third pitfall of this module.
-Single-seed results are not real results.
+That is the third pitfall of this module. Single-seed results are not real results.
 
 ## Section 11: Ray RLlib — when one machine is not enough
 
@@ -555,6 +416,8 @@ stay there.
 Reach for RLlib when the bottleneck is truly system scale,
 not because the smaller setup feels insufficiently impressive.
 
+Distributed training changes throughput, not truth. The same MDP questions apply at cluster scale: does the environment contract hold across workers, are rewards aggregated consistently, and does the evaluation harness still report across-seed variance rather than surfacing the best of many lucky single-seed trials. RLlib is a scaling tool once the scientific protocol is sound, not a substitute for the discipline earlier in this module.
+
 ## Section 12: Where RL is the wrong tool
 
 RL is the wrong tool more often than many first-time teams expect.
@@ -590,65 +453,28 @@ if actions do not change future state in the sense that matters,
 or if the best policy can be learned from labeled examples directly,
 RL is adding moving parts faster than it adds value.
 
-That is the final core pitfall.
-RL is the wrong tool when a simpler supervised,
-bandit,
-search,
-or rule-based framing already answers the operational question.
+That is the final core pitfall. RL is the wrong tool when a simpler supervised, bandit, search, or rule-based framing already answers the operational question.
 
 ## Section 13: Connecting back
 
-This module sits downstream of earlier machine-learning discipline,
-not outside it.
-[Module 1.1: Scikit-learn API & Pipelines](../../machine-learning/module-1.1-scikit-learn-api-and-pipelines/)
-taught you to respect interfaces.
-Gymnasium environments are another interface contract.
+This module sits downstream of earlier machine-learning discipline, not outside it. [Module 1.1: Scikit-learn API & Pipelines](../../machine-learning/module-1.1-scikit-learn-api-and-pipelines/) taught you to respect interfaces, and Gymnasium environments are another interface contract with the same stakes: if the contract is wrong, the optimizer learns the wrong problem.
 
-[Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../../machine-learning/module-1.3-model-evaluation-validation-leakage-and-calibration/)
-taught you that evidence can be contaminated by bad protocol.
-RL inherits that lesson and adds seed variance,
-interaction effects,
-and proxy optimization on top.
+[Module 1.3: Model Evaluation, Validation, Leakage & Calibration](../../machine-learning/module-1.3-model-evaluation-validation-leakage-and-calibration/) taught you that evidence can be contaminated by bad protocol. RL inherits that lesson and adds seed variance, interaction effects, and proxy optimization on top, which means a leaky evaluation harness can look like algorithmic success until deployment proves otherwise.
 
-[Module 1.5: Decision Trees & Random Forests](../../machine-learning/module-1.5-decision-trees-and-random-forests/)
-showed the value of strong baselines.
-That lesson survives unchanged here.
-A hand-built rule,
-a heuristic controller,
-or a supervised imitation baseline often deserves to exist before the first RL claim.
+[Module 1.5: Decision Trees & Random Forests](../../machine-learning/module-1.5-decision-trees-and-random-forests/) showed the value of strong baselines, and that lesson survives unchanged here. A hand-built rule, a heuristic controller, or a supervised imitation baseline often deserves to exist before the first RL claim, because if you cannot beat a simple baseline you may not have an RL problem yet.
 
-[Module 1.11: Hyperparameter Optimization](../../machine-learning/module-1.11-hyperparameter-optimization/)
-showed that selection pressure can turn noise into apparent certainty.
-RL makes that easier,
-not harder,
-because every seed can generate a different training story.
+[Module 1.11: Hyperparameter Optimization](../../machine-learning/module-1.11-hyperparameter-optimization/) showed that selection pressure can turn noise into apparent certainty. RL makes that easier, not harder, because every seed can generate a different training story and every sweep can amplify lucky rollouts unless you budget seeds per candidate honestly.
 
-Finally,
-do not forget the deployment side.
-Once an RL policy is live,
-you still need observability,
-drift awareness,
-and behavior review.
-The production habits from [Module 1.10: ML Monitoring](../../mlops/module-1.10-ml-monitoring/)
-still apply,
-even if the failure signal looks like degraded sequential behavior rather than plain classifier drift.
+Finally, do not forget the deployment side. Once an RL policy is live, you still need observability, drift awareness, and behavior review. The production habits from [Module 1.10: ML Monitoring](../../mlops/module-1.10-ml-monitoring/) still apply, even if the failure signal looks like degraded sequential behavior rather than plain classifier drift. The durable spine you practiced here—MDP clarity, reward skepticism, multi-seed evaluation, and library APIs as contracts—carries forward whether your next project stays online or moves to logged-data settings.
 
-The next module moves to the setting many practitioners actually face first:
-learning from logged or demonstrated behavior when free online exploration is not available.
+The next module moves to the setting many practitioners actually face first: learning from logged or demonstrated behavior when free online exploration is not available.
 
 ## Did You Know?
 
-- Stable-Baselines3 publishes an algorithm support table that makes action-space compatibility explicit before you ever start training.
-https://stable-baselines3.readthedocs.io/en/master/guide/algos.html
-
-- Gymnasium's current API separates `terminated` from `truncated`, which prevents a subtle but common evaluation mistake when time limits and task success are not the same event.
-https://gymnasium.farama.org/introduction/basic_usage/
-
-- Stable-Baselines3's PPO page presents PPO as a broad baseline across common action-space types, which is one reason practitioners often start there.
-https://stable-baselines3.readthedocs.io/en/master/modules/ppo.html
-
-- Henderson and coauthors argued that deep RL results often vary enough across seeds and implementation details that reporting norms matter as much as algorithm choice.
-https://arxiv.org/abs/1709.06560
+- Stable-Baselines3 publishes an [algorithm support table](https://stable-baselines3.readthedocs.io/en/master/guide/algos.html) that makes action-space compatibility explicit before you ever start training.
+- Gymnasium's current API [separates `terminated` from `truncated`](https://gymnasium.farama.org/introduction/basic_usage/), which prevents a subtle but common evaluation mistake when time limits and task success are not the same event.
+- Stable-Baselines3's [PPO page](https://stable-baselines3.readthedocs.io/en/master/modules/ppo.html) presents PPO as a broad baseline across common action-space types, which is one reason practitioners often start there.
+- Henderson and coauthors [argued](https://arxiv.org/abs/1709.06560) that deep RL results often vary enough across seeds and implementation details that reporting norms matter as much as algorithm choice.
 
 ## Common Mistakes
 

--- a/src/content/docs/ai-ml-engineering/reinforcement-learning/module-2.1-offline-rl-and-imitation-learning.md
+++ b/src/content/docs/ai-ml-engineering/reinforcement-learning/module-2.1-offline-rl-and-imitation-learning.md
@@ -24,7 +24,7 @@ policy can be learned from fixed experience. They also ask when the honest answe
 
 - **Diagnose** whether a logged decision dataset has enough coverage for offline RL, behavior cloning, or no policy-learning attempt at all.
 - **Explain** how distribution shift and extrapolation error make offline RL harder than ordinary supervised learning on logged examples.
-- **Implement** a small d3rlpy workflow on a D4RL dataset using the current v2 configuration API and offline evaluators.
+- **Implement** a small d3rlpy workflow on a Minari (D4RL-derived) dataset using the current v2 configuration API and offline evaluators.
 - **Compare** behavior cloning, CQL, BCQ, IQL, TD3+BC, DAgger, and GAIL by the kind of pessimism, supervision, or interaction each method adds.
 - **Decide** how to evaluate an offline policy when online A/B testing is unavailable, risky, or only allowed after a strict offline gate.
 
@@ -178,10 +178,10 @@ within historical practice rather than claiming treatment-policy optimization.
 
 ```python
 from d3rlpy.algos import BCConfig
-from d3rlpy.datasets import get_d4rl
+from d3rlpy.datasets import get_minari
 from d3rlpy.metrics import EnvironmentEvaluator
 
-dataset, env = get_d4rl("halfcheetah-medium-v2")
+dataset, env = get_minari("mujoco/halfcheetah/medium-v0")
 
 bc = BCConfig(
     batch_size=256,
@@ -277,6 +277,8 @@ unsupported improvement because unsupported improvement is the dangerous kind.
 > **Landscape snapshot — as of 2026-06**
 >
 > d3rlpy v2 exposes algorithms through `*Config` classes (for example `CQLConfig`, `BCConfig`) followed by `.create()`. Discrete-action variants use separate configs such as `DiscreteCQLConfig`. Parameter names like `conservative_weight` and `alpha` differ by algorithm and release; verify against the pinned docs in **Sources** before copying snippets into production pipelines.
+>
+> **Datasets:** the original D4RL package is unmaintained and pins Python `<3.11`, so it will not install on a modern interpreter. The Farama Foundation is superseding it with **Minari**, which re-hosts the D4RL datasets under a `D4RL/`-prefixed and `mujoco/<env>/<quality>` namespace (e.g. `mujoco/halfcheetah/medium-v0`). d3rlpy v2 loads these through `get_minari(<id>)`. Exact dataset ids and version suffixes drift — confirm the current id with `minari list remote` before relying on one.
 
 ## Section 5: TD3+BC and the regularized-policy family
 
@@ -428,9 +430,9 @@ datasets, off-policy evaluation, and a consistent algorithm API. The important v
 `.create()`. That matters because many older examples instantiate algorithm classes directly. Current v2 examples use classes such
 as `CQLConfig`, `BCQConfig`, `IQLConfig`, `TD3PlusBCConfig`, `BCConfig`, `DiscreteCQLConfig`, and `DiscreteBCQConfig`.
 
-The following script is intentionally modest. It loads a D4RL MuJoCo dataset, trains behavior cloning as a baseline,
+The following script is intentionally modest. It loads a Minari MuJoCo dataset (the D4RL-derived `mujoco/halfcheetah/medium-v0`), trains behavior cloning as a baseline,
 trains CQL as a conservative offline RL method, then trains FQE to estimate the learned CQL policy from the offline
-data. The environment evaluator is included because D4RL gives a benchmark environment, but in a real medical or
+data. The environment evaluator is included because Minari can recover a benchmark environment, but in a real medical or
 recommender deployment, that online evaluator would be replaced by a stricter offline gate and later a guarded
 experiment. Treat this as an **implement** exercise: you are wiring configuration objects, a fixed dataset, training loops, and evaluators—not chasing a leaderboard number.
 
@@ -439,7 +441,7 @@ import os
 
 import d3rlpy
 from d3rlpy.algos import BCConfig, CQLConfig
-from d3rlpy.datasets import get_d4rl
+from d3rlpy.datasets import get_minari
 from d3rlpy.metrics import (
     EnvironmentEvaluator,
     InitialStateValueEstimationEvaluator,
@@ -449,7 +451,7 @@ from d3rlpy.ope import FQE, FQEConfig
 
 
 def main() -> None:
-    dataset, env = get_d4rl("halfcheetah-medium-v2")
+    dataset, env = get_minari("mujoco/halfcheetah/medium-v0")
     device = "cuda:0" if os.environ.get("USE_CUDA") == "1" else False
 
     evaluators = {
@@ -500,16 +502,16 @@ if __name__ == "__main__":
     main()
 ```
 
-Install commands vary by workstation, especially around MuJoCo and D4RL. For a local experiment environment, start
+Install commands vary by workstation, especially around MuJoCo and the Minari dataset backend. For a local experiment environment, start
 with an isolated virtual environment and pin the RL library version you are testing.
 
 ```bash
 .venv/bin/python -m pip install "d3rlpy==2.8.1"
-.venv/bin/python -m pip install "d4rl @ git+https://github.com/Farama-Foundation/D4RL.git"
+.venv/bin/python -m pip install "minari[all]"
 .venv/bin/python offline_halfcheetah.py
 ```
 
-If D4RL installation fails, do not rewrite the learning code first. Resolve the benchmark dependency, MuJoCo runtime,
+If dataset installation fails, do not rewrite the learning code first. Resolve the Minari/benchmark dependency, MuJoCo runtime,
 and Python-version compatibility. Offline RL results are already noisy enough without silently changing datasets.
 
 For discrete-action datasets, switch to the discrete algorithm configs.
@@ -730,16 +732,16 @@ Production teams sometimes treat offline RL as a way to skip the uncomfortable p
    The reward definition must be revisited. Offline RL will optimize the logged reward signal, and a short-term click proxy can push harmful recommendations. The team should define a reward or evaluation gate closer to the real objective before choosing CQL, IQL, or any other method.
    </details>
 
-8. **You must implement a small d3rlpy workflow on a D4RL dataset using the v2 configuration API. Online A/B testing is blocked until after an offline gate. What training order and evaluators would you use, and what would you decide before requesting any live rollout?**
+8. **You must implement a small d3rlpy workflow on a Minari (D4RL-derived) dataset using the v2 configuration API. Online A/B testing is blocked until after an offline gate. What training order and evaluators would you use, and what would you decide before requesting any live rollout?**
 
    <details>
    <summary>Answer</summary>
-   Train behavior cloning first as the imitation baseline, then a conservative method such as CQL with `CQLConfig(...).create()`, using `get_d4rl` for the fixed dataset and evaluators such as `EnvironmentEvaluator` plus FQE for off-policy value estimation. Before any online experiment, decide whether the candidate policy stays near logged action support, whether FQE and coverage diagnostics agree, and what guarded rollout evidence would be required if offline scores look promising.
+   Train behavior cloning first as the imitation baseline, then a conservative method such as CQL with `CQLConfig(...).create()`, using `get_minari` for the fixed dataset and evaluators such as `EnvironmentEvaluator` plus FQE for off-policy value estimation. Before any online experiment, decide whether the candidate policy stays near logged action support, whether FQE and coverage diagnostics agree, and what guarded rollout evidence would be required if offline scores look promising.
    </details>
 
 ## Hands-On Exercise
 
-**Task:** Train and evaluate a conservative offline RL policy on a D4RL continuous-control dataset using d3rlpy v2.
+**Task:** Train and evaluate a conservative offline RL policy on a Minari (D4RL-derived) continuous-control dataset using d3rlpy v2.
 
 You will run behavior cloning first, then CQL, then FQE. The goal is not to chase leaderboard scores. The goal is to
 practice the production workflow: baseline, conservative learner, offline evaluation, and a short deployment memo.
@@ -748,7 +750,7 @@ practice the production workflow: baseline, conservative learner, offline evalua
 
 ```bash
 .venv/bin/python -m pip install "d3rlpy==2.8.1"
-.venv/bin/python -m pip install "d4rl @ git+https://github.com/Farama-Foundation/D4RL.git"
+.venv/bin/python -m pip install "minari[all]"
 ```
 
 If your workstation needs MuJoCo system packages, install them before changing the Python experiment. Dependency
@@ -760,13 +762,13 @@ errors are not policy-learning evidence.
 import os
 
 from d3rlpy.algos import BCConfig, CQLConfig
-from d3rlpy.datasets import get_d4rl
+from d3rlpy.datasets import get_minari
 from d3rlpy.metrics import EnvironmentEvaluator, InitialStateValueEstimationEvaluator
 from d3rlpy.ope import FQE, FQEConfig
 
 
 def train() -> None:
-    dataset, env = get_d4rl("halfcheetah-medium-v2")
+    dataset, env = get_minari("mujoco/halfcheetah/medium-v0")
     device = "cuda:0" if os.environ.get("USE_CUDA") == "1" else False
 
     evaluator = EnvironmentEvaluator(env, n_trials=3)
@@ -827,7 +829,7 @@ In five to eight sentences, answer these questions:
 
 ### Success Criteria
 
-- [ ] The script imports `BCConfig`, `CQLConfig`, `get_d4rl`, `EnvironmentEvaluator`, and `FQE` without using deprecated v1 constructors.
+- [ ] The script imports `BCConfig`, `CQLConfig`, `get_minari`, `EnvironmentEvaluator`, and `FQE` without using deprecated v1 constructors.
 - [ ] The dataset name is `halfcheetah-medium-v2`.
 - [ ] Behavior cloning trains before CQL.
 - [ ] CQL uses a conservative weight rather than an unconstrained actor-only objective.

--- a/src/content/docs/ai-ml-engineering/reinforcement-learning/module-2.1-offline-rl-and-imitation-learning.md
+++ b/src/content/docs/ai-ml-engineering/reinforcement-learning/module-2.1-offline-rl-and-imitation-learning.md
@@ -148,6 +148,10 @@ it cannot, the state representation may be missing key variables.
 
 The sober default is simple: the narrower the data, the more conservative the policy must be.
 
+Distribution shift in offline RL is not a single jump but a chain reaction. The behavior policy `π_b` generated the logs. Your candidate policy `π` may assign high probability to actions that `π_b` rarely took in similar states. Those actions lead to next states that are themselves underrepresented, so both action marginals and state marginals drift away from the training distribution with every sequential decision. Supervised learning on logged `(state, action)` pairs mostly tests whether you can imitate labels on states that appeared in the data. Offline RL asks whether a new policy's sequential choices will stay in regions where returns were actually observed, which is a harder counterfactual claim.
+
+Extrapolation error is the mechanism critics exploit. Function approximators are smooth: a Q-network or value model can assign an optimistic score to an unseen action because neighboring seen actions looked good. Without online correction, the policy gradient or improvement step chases that optimism. Conservative methods exist to push down values outside the data support, constrain the policy toward logged actions, or avoid explicit maximization over unseen actions during critic training. None of these remove the need for coverage; they reduce how aggressively the learner can hallucinate improvement.
+
 ## Section 3: Behavior cloning — when supervised learning is enough
 
 Behavior cloning is imitation learning in its simplest deployed form. Treat the logged expert action as a label. Train
@@ -204,6 +208,8 @@ bedside observation, or contraindication not captured in structured features. In
 hidden rule, ranking override, or delayed moderation signal.
 
 Do not skip BC. It is the cheapest way to learn whether "imitate the data" is already hard.
+
+Imitation learning is broader than behavior cloning alone, and the taxonomy matters for scoping projects. Behavior cloning treats expert actions as supervised labels and is the right first move when demonstrations are competent and deployment states stay near the training distribution. DAgger adds interactive expert corrections on states the learner actually visits, which attacks compounding error but requires ongoing expert availability. Inverse RL tries to recover a reward function that explains expert behavior when no trustworthy scalar reward exists, which is powerful but identification-heavy. GAIL and related adversarial methods learn imitation rewards from discriminator feedback and usually need rollouts, so they sit between pure offline logs and full online RL. Choosing among them is less about prestige than about what evidence you have: fixed logs, live expert time, a simulator, or only trajectories without rewards.
 
 ## Section 4: Conservative offline RL — CQL, BCQ, IQL
 
@@ -267,6 +273,10 @@ contains a mixture of weak and strong behavior.
 
 Conservative offline RL is not a guarantee. It is a set of bias choices. You deliberately bias the learner away from
 unsupported improvement because unsupported improvement is the dangerous kind.
+
+> **Landscape snapshot — as of 2026-06**
+>
+> d3rlpy v2 exposes algorithms through `*Config` classes (for example `CQLConfig`, `BCConfig`) followed by `.create()`. Discrete-action variants use separate configs such as `DiscreteCQLConfig`. Parameter names like `conservative_weight` and `alpha` differ by algorithm and release; verify against the pinned docs in **Sources** before copying snippets into production pipelines.
 
 ## Section 5: TD3+BC and the regularized-policy family
 
@@ -411,20 +421,18 @@ The mistake is to treat adversarial imitation as magic reward discovery. The lea
 the demonstrations, the discriminator setup, and the environment coverage. It can still imitate bias, unsafe
 shortcuts, or expert habits that do not match the deployment objective.
 
-## Section 9: d3rlpy in practice — the practitioner library
+## Section 9: d3rlpy in practice — implement a small offline workflow
 
 d3rlpy is the most direct practitioner library for this module's workflow. It focuses on offline RL, online RL,
 datasets, off-policy evaluation, and a consistent algorithm API. The important v2 pattern is configuration first, then
-`.create()`.
-
-That matters because many older examples instantiate algorithm classes directly. Current v2 examples use classes such
+`.create()`. That matters because many older examples instantiate algorithm classes directly. Current v2 examples use classes such
 as `CQLConfig`, `BCQConfig`, `IQLConfig`, `TD3PlusBCConfig`, `BCConfig`, `DiscreteCQLConfig`, and `DiscreteBCQConfig`.
 
 The following script is intentionally modest. It loads a D4RL MuJoCo dataset, trains behavior cloning as a baseline,
 trains CQL as a conservative offline RL method, then trains FQE to estimate the learned CQL policy from the offline
 data. The environment evaluator is included because D4RL gives a benchmark environment, but in a real medical or
 recommender deployment, that online evaluator would be replaced by a stricter offline gate and later a guarded
-experiment.
+experiment. Treat this as an **implement** exercise: you are wiring configuration objects, a fixed dataset, training loops, and evaluators—not chasing a leaderboard number.
 
 ```python
 import os
@@ -543,7 +551,7 @@ contain policy changes, delayed rewards, partial observability, feature backfill
 
 Use D4RL for fluency. Use your own coverage audits for deployment decisions.
 
-## Section 11: Offline RL evaluation — FQE, weighted importance sampling, and why it's hard
+## Section 11: Offline RL evaluation — decide how to gate deployment without online A/B tests
 
 Offline evaluation is the uncomfortable center of offline RL. Training a policy from logs is hard. Knowing whether the
 policy is better without deploying it is harder.
@@ -595,6 +603,8 @@ the offline story is coherent.
 Do not let a single offline number carry the decision. The correct question is not, "Which metric says this policy is
 best?" It is, "What evidence would have to be false for this policy to be unsafe?"
 
+Evaluating offline-trained policies safely usually means stacking imperfect gates rather than trusting one score. Start with dataset diagnostics: action coverage, segment-level return, and whether a behavior-cloning model can reproduce logged actions. Add off-policy evaluation when propensities exist, FQE or similar value estimators for a candidate policy, and stress tests on slices where hidden confounding is plausible. Reserve guarded online rollouts—shadow mode, small cohort A/B tests, or human-in-the-loop approval—for policies that already pass conservative offline checks. When online A/B testing is unavailable or ethically blocked, document explicitly which assumptions each offline metric requires and what failure would look like in production.
+
 ## Section 12: When offline RL is the wrong tool
 
 Offline RL is wrong when the data cannot answer the intervention question. That sounds abstract, so make it
@@ -623,8 +633,7 @@ override that.
 | Online experiment is possible but expensive | Use offline RL as a filter, not as final proof |
 | Dataset comes from an obsolete product surface | Treat old logs as research data, not deployment evidence |
 
-The hardest production answer is often: "We should not train this yet." That answer can save months of work and
-prevent a false sense of safety.
+The hardest production answer is often: "We should not train this yet." That answer can save months of work and prevent a false sense of safety. When stakeholders push for training anyway, translate the coverage audit into operational language: which actions would the new policy take that the logs never tried, which segments lack high-return examples, and what offline gate would need to pass before any guarded online test.
 
 ## Section 13: Connecting back — bridging to RLHF and causal inference
 
@@ -647,6 +656,8 @@ assignment, and policy-induced covariate shift.
 
 If you remember one connection, make it this: offline RL is not an escape hatch from causal assumptions. It is a
 harder setting where those assumptions can fail repeatedly over time.
+
+Production teams sometimes treat offline RL as a way to skip the uncomfortable parts of online learning while still claiming policy improvement. The honest framing is narrower: you are estimating what would happen if you deployed a different policy, using evidence that was never collected for that purpose. Document the behavior policy, the logging window, missing variables, and the offline gates you require before any live test. That documentation is part of the model, not paperwork around it. A one-page deployment memo that names unsupported action regions is often worth more than another week of offline training on the same narrow logs.
 
 ## Did You Know?
 
@@ -717,6 +728,13 @@ harder setting where those assumptions can fail repeatedly over time.
    <details>
    <summary>Answer</summary>
    The reward definition must be revisited. Offline RL will optimize the logged reward signal, and a short-term click proxy can push harmful recommendations. The team should define a reward or evaluation gate closer to the real objective before choosing CQL, IQL, or any other method.
+   </details>
+
+8. **You must implement a small d3rlpy workflow on a D4RL dataset using the v2 configuration API. Online A/B testing is blocked until after an offline gate. What training order and evaluators would you use, and what would you decide before requesting any live rollout?**
+
+   <details>
+   <summary>Answer</summary>
+   Train behavior cloning first as the imitation baseline, then a conservative method such as CQL with `CQLConfig(...).create()`, using `get_d4rl` for the fixed dataset and evaluators such as `EnvironmentEvaluator` plus FQE for off-policy value estimation. Before any online experiment, decide whether the candidate policy stays near logged action support, whether FQE and coverage diagnostics agree, and what guarded rollout evidence would be required if offline scores look promising.
    </details>
 
 ## Hands-On Exercise


### PR DESCRIPTION
## Summary
The last 2 unreviewed `ai-ml-engineering/reinforcement-learning` modules under #2020 were both below the body-words floor (T2/T3). Expanded to T0 (cursor/Kimi authored; opus ground-checked = cross-family; independent codex review in flight).

- **1.1 rl-practitioner-foundations** (was T2, 3844w + a consecutive-short-paragraph run): added genuine depth — agent–environment loop + MDP/return math, value/policy/actor-critic taxonomy, on/off-policy distinction, exploration–exploitation, reward-shaping pitfalls, multi-seed discipline; merged the short-paragraph runs; added a dated `Landscape snapshot` for Gymnasium/SB3 APIs and the Henderson et al. reproducibility citation. **All structural assets preserved** (tables 29→29, code 13→14, quizzes 7→7, sections 21→21). → **T0, 5003 words**.
- **2.1 offline-rl-and-imitation-learning** (was T3, 4368w + outcome-alignment gap): added distribution-shift/extrapolation-error depth, BC/DAgger/IRL/GAIL taxonomy, offline-evaluation gating (FQE/coverage), a dated `Landscape snapshot` for d3rlpy v2 `*Config().create()`, and a new section + quiz to align the "implement" outcome. → **T0, 5017 words**.

opus ground-check verified every added claim: RL math correct, library APIs current (Gymnasium terminated/truncated, SB3 learn/predict, d3rlpy v2 config API), durable-vendor compliant (dated snapshots, no "best algorithm" claims), no fabrication.

Both remain **T0 PASS**, 0 unreachable URLs.

## Learner check

> Return is the discounted sum of future rewards: `G_t = r_t + γ r_{t+1} + γ² r_{t+2} + …`, where discount factor `γ` in `(0, 1]` controls how far ahead the agent plans. A `γ` near zero makes the agent myopic; a `γ` near one makes distant consequences matter, which is powerful but harder to learn when rewards are sparse.

(verbatim from module-1.1-rl-practitioner-foundations — the durable MDP-return math underneath every RL library, taught before any algorithm name.)

Refs #2020

🤖 Generated with [Claude Code](https://claude.com/claude-code)