### PR TITLE
feat+fix(advanced-genai): #2020 final 4 (expand 3 + review 1.12)

### DIFF
--- a/src/content/docs/ai-ml-engineering/advanced-genai/module-1.10-single-gpu-local-fine-tuning.md
+++ b/src/content/docs/ai-ml-engineering/advanced-genai/module-1.10-single-gpu-local-fine-tuning.md
@@ -301,6 +301,46 @@ QLoRA enters when the base model would be too memory-heavy without quantization.
 
 Use QLoRA when it solves a measured memory problem, not because it sounds more advanced. If a small model trains cleanly without quantization, a first workflow demonstration may be easier to debug without QLoRA. Once the process is sound, quantization becomes a controlled change rather than another variable mixed into an already uncertain run.
 
+### QLoRA 4-bit loading, NF4, and the VRAM budget
+
+QLoRA keeps the base model frozen in 4-bit NormalFloat (NF4) quantization while training low-rank adapter matrices in higher precision. bitsandbytes implements the storage format and double-quantization of quantization constants so the frozen weights occupy far less VRAM than fp16 baselines. The durable mental model is a **VRAM ledger** with four major buckets during training:
+
+| Bucket | What it holds | PEFT impact |
+|---|---|---|
+| Model weights | Frozen base parameters | QLoRA shrinks this bucket via 4-bit storage |
+| Optimizer state | Moments for trainable params | LoRA trains only adapter weights, so optimizer state stays small |
+| Activations | Forward/backward tensors per layer | Scales with sequence length, batch, and checkpointing policy |
+| Gradients | Updates for trainable params | LoRA limits gradients to adapter modules only |
+
+Gradient checkpointing trades compute for memory by recomputing activations during the backward pass instead of storing every intermediate tensor. Gradient accumulation simulates a larger batch by summing gradients over several micro-batches before an optimizer step. On a single GPU, the effective batch size is approximately `per_device_train_batch_size × gradient_accumulation_steps`; VRAM is dominated by the micro-batch size, not the effective batch.
+
+A conservative **fit-check** before a long run:
+
+```bash
+# Illustrative — replace model id and lengths with your experiment.
+.venv/bin/python - <<'PY'
+# Estimate whether a 7B-class model might fit with QLoRA on ~24 GB.
+# These are order-of-magnitude checks, not guarantees.
+params_b = 7
+bytes_fp16 = params_b * 2          # GB if fully fp16 weights
+bytes_4bit = params_b * 0.5        # rough NF4 storage
+adapter_mb = 200                   # typical small LoRA adapter + optimizer
+activation_gb = 8                    # highly sequence/batch dependent
+headroom_gb = 2
+needed = bytes_4bit + adapter_mb/1024 + activation_gb + headroom_gb
+print(f"illustrative minimum VRAM (GB): {needed:.1f}")
+print("verify with a short smoke run and nvidia-smi — do not trust this table alone")
+PY
+```
+
+> **Landscape snapshot — as of 2026-06**
+>
+> Library stacks for single-GPU fine-tuning move quickly. **PEFT** exposes `LoraConfig` and QLoRA helpers; **Transformers** `Trainer` and **TRL** `SFTTrainer` wrap training loops; **Accelerate** handles device placement; **bitsandbytes** 4-bit loaders depend on CUDA capability and package version. Confirm argument names (`bnb_4bit_compute_dtype`, `load_in_4bit`) against [PEFT](https://huggingface.co/docs/peft/index), [Transformers Trainer](https://huggingface.co/docs/transformers/en/main_classes/trainer), [TRL](https://huggingface.co/docs/trl/index), and [Accelerate](https://huggingface.co/docs/accelerate/index) for the versions pinned in your environment. Any published "fits in 24 GB" claim is valid only for the cited model, sequence length, batch, and driver stack.
+
+When OOM persists after QLoRA, reduce sequence length and micro-batch before increasing LoRA rank. Rank increases adapter capacity but also grows optimizer state and activation paths through adapted layers. The senior move is to change one pressure source, rerun a fifty-step smoke test, and record peak `memory.used` from `nvidia-smi` rather than chasing ten hyperparameters at once.
+
+Gradient checkpointing deserves an explicit experiment note because it changes the compute/memory trade-off in ways training loss alone will not reveal. Enable checkpointing when activation memory dominates the ledger; disable it when the run is already stable and you need shorter wall-clock time for iteration. Document the flag in `artifacts/config.yaml` so the next engineer knows whether slower steps were intentional frugality or accidental misconfiguration.
+
 A training command should be captured exactly. The command, package versions, GPU state, dataset checksum, and config belong in the experiment notes. If you cannot reproduce the command later, you cannot responsibly compare adapters or explain why one run improved.
 
 ```bash
@@ -991,5 +1031,13 @@ Success criteria:
 
 ## Sources
 
-- [LoRA: Low-Rank Adaptation of Large Language Models](https://arxiv.org/abs/2106.09685) — Original LoRA paper for claims about freezing base weights, training low-rank adapters, parameter-count reduction, memory savings, and PEFT trade-offs versus full fine-tuning.
-- [QLoRA: Efficient Finetuning of Quantized LLMs](https://arxiv.org/abs/2305.14314) — Primary source for 4-bit fine-tuning, NF4, double quantization, paged optimizers, and realistic single-GPU fine-tuning claims under constrained VRAM.
+- [LoRA: Low-Rank Adaptation of Large Language Models](https://arxiv.org/abs/2106.09685) — Original LoRA paper for freezing base weights, training low-rank adapters, and PEFT trade-offs versus full fine-tuning.
+- [QLoRA: Efficient Finetuning of Quantized LLMs](https://arxiv.org/abs/2305.14314) — 4-bit NF4 quantization, double quantization, paged optimizers, and single-GPU memory claims.
+- [PEFT documentation](https://huggingface.co/docs/peft/index) — Library reference for LoRA/QLoRA configuration and adapter saving.
+- [bitsandbytes](https://github.com/bitsandbytes-foundation/bitsandbytes) — 4-bit and 8-bit CUDA kernels used by QLoRA loading paths.
+- [Transformers Trainer](https://huggingface.co/docs/transformers/en/main_classes/trainer) — Training loop, checkpointing, and gradient accumulation integration.
+- [Accelerate](https://huggingface.co/docs/accelerate/index) — Device placement and mixed-precision helpers for local training scripts.
+- [TRL](https://huggingface.co/docs/trl/index) — Supervised fine-tuning trainers commonly paired with PEFT adapters.
+- [PyTorch AMP examples](https://pytorch.org/docs/stable/notes/amp_examples.html) — Autocast and gradient scaling patterns relevant to fp16/bf16 fine-tuning.
+- [Hugging Face Transformers documentation](https://huggingface.co/docs/transformers/index) — Model loading, tokenizers, and generation APIs used throughout the hands-on exercise.
+- [bitsandbytes installation guide](https://huggingface.co/docs/bitsandbytes/installation) — Hardware and CUDA prerequisites for 4-bit loaders used by QLoRA paths.

--- a/src/content/docs/ai-ml-engineering/advanced-genai/module-1.11-multi-gpu-home-lab-fine-tuning.md
+++ b/src/content/docs/ai-ml-engineering/advanced-genai/module-1.11-multi-gpu-home-lab-fine-tuning.md
@@ -28,9 +28,7 @@ The failure starts three weeks later. The second GPU fits physically but runs th
 
 This module teaches the decision discipline behind home-lab multi-GPU fine-tuning. The goal is not to scare you away from multiple GPUs. The goal is to help you know when the extra hardware removes a real bottleneck, when it merely moves the bottleneck somewhere more expensive, and when a simpler design such as workload sharding gives most of the benefit with much less operational risk.
 
-## Core Content
-
-### 1. Start With the Bottleneck, Not the Shopping List
+## 1. Start With the Bottleneck, Not the Shopping List
 
 The first engineering question is not whether another GPU can be added. The first question is which constraint is limiting the learning loop right now. Multi-GPU fine-tuning is useful when it removes a named, repeated constraint, but it is wasteful when the existing workflow is still unclear, unstable, or poorly measured. A learner who cannot name the bottleneck will usually buy complexity instead of capacity.
 
@@ -84,7 +82,7 @@ PY
 
 These commands do not solve scaling by themselves. They establish the habit that every expansion decision starts with evidence. Once you can say what is limiting the run, you can choose between a bigger single box, a small cluster, or functional sharding with much less guessing.
 
-### 2. Understand the Three Home-Lab Expansion Shapes
+## 2. Understand the Three Home-Lab Expansion Shapes
 
 Most home labs grow into one of three shapes: a bigger single workstation, a small cluster of machines, or workload sharding across separate roles. The shapes are not merely physical layouts. They imply different failure modes, operational habits, and scaling ceilings. Choosing the shape is an architecture decision, not a shopping preference.
 
@@ -143,7 +141,7 @@ The simplest architecture that solves the bottleneck is usually the best home-la
 
 The operating model should match the architecture. A single workstation can rely on local scripts and disciplined directories for many learning scenarios. A small cluster needs host inventory, environment parity checks, network tests, and a restart plan. Workload sharding needs clear ownership of artifacts so evaluation, serving, and training do not overwrite each other or compare the wrong checkpoint.
 
-### 3. Choose the Right Parallelism Model
+## 3. Choose the Right Parallelism Model
 
 Parallelism terms are often used loosely, which causes poor design decisions. The useful distinction is what gets split and how tightly the parts must coordinate. Home-lab learners should understand the mechanisms well enough to avoid choosing data parallelism for a memory-fit problem or model parallelism for a workflow-concurrency problem.
 
@@ -191,7 +189,100 @@ CUDA_VISIBLE_DEVICES=0,1 accelerate launch --num_processes 2 train.py \
 
 Use short smoke runs before long fine-tuning runs. A smoke run should prove that both devices are visible, the launcher works, logs are written, checkpoints land where expected, and failure messages are understandable. Do not use a full overnight job as the first test of a new topology. When a long run fails, the blast radius includes time, heat, power, disk writes, and trust in the setup.
 
-### 4. Worked Example: Decide Whether to Add a Second GPU
+### Data parallelism versus FSDP versus DeepSpeed ZeRO
+
+When a LoRA-tuned model already fits on one GPU, **data parallelism (DDP)** is the first multi-GPU lever: each rank holds a full copy of the model, processes a different micro-batch, and all-reduces gradients so every rank applies the same optimizer step. Memory per GPU stays roughly constant; throughput should rise if communication and the input pipeline keep up. Home-lab disappointment usually means PCIe bandwidth, small batch sizes, or checkpoint I/O—not that data parallelism is universally wrong.
+
+When the **full model or optimizer state** does not fit on one device, sharding strategies split memory across ranks:
+
+| Strategy | What is sharded | Memory savings | Communication pattern | Home-lab fit |
+|---|---|---|---|---|
+| DDP | Nothing (replicated weights) | None per rank | All-reduce gradients each step | Best when model fits; simplest ops |
+| FSDP (PyTorch) | Parameters, gradients, optimizer states in shards | High for large models | All-gather params before forward; reduce-scatter grads | Strong on 2–8 GPUs in one box with NVLink/PCIe |
+| ZeRO Stage 1 | Optimizer states | Moderate | Extra gather/scatter around optimizer | Easiest ZeRO entry via DeepSpeed |
+| ZeRO Stage 2 | Optimizer + gradients | Higher | More collectives per step | Useful when optimizer dominates VRAM |
+| ZeRO Stage 3 | Optimizer + gradients + parameters | Highest | Frequent parameter fetches | Needs fast interconnect; fragile on 1 GbE clusters |
+
+**FSDP** (Fully Sharded Data Parallel) wraps layers so each rank stores only a fraction of weights and optimizer state, gathering full parameters just-in-time for the layers about to execute. The durable trade-off is **memory versus communication**: you pay NVLink, PCIe, or Ethernet cycles to move shards, but each GPU's footprint drops. For PEFT fine-tuning, adapter-only training often keeps DDP sufficient; FSDP matters when you full-fine-tune or load very large base models without aggressive quantization.
+
+**DeepSpeed ZeRO** implements a similar sharding philosophy with explicit stages. Stage 1 shards optimizer states across ranks. Stage 2 adds gradient sharding. Stage 3 shards model parameters as well, minimizing per-device memory at the cost of the most collective traffic. ZeRO-Offload can push optimizer states to CPU DRAM—helpful on memory-starved home boxes, slower because PCIe becomes part of the training critical path.
+
+```mermaid
+flowchart LR
+    subgraph DDP["Data Parallel (DDP)"]
+        G0[GPU 0 full model]
+        G1[GPU 1 full model]
+        G0 <-->|all-reduce grads| G1
+    end
+    subgraph FSDP["FSDP / ZeRO-3 style"]
+        S0[GPU 0 shard]
+        S1[GPU 1 shard]
+        S0 <-->|gather / scatter| S1
+    end
+```
+
+### Communication cost versus memory savings
+
+Every sharding step exchanges bytes proportional to model size and batch geometry. A useful heuristic before buying a second GPU: if single-GPU utilization is already high and PCIe link width to the second slot is x4, expect **sub-linear scaling**—perhaps 1.3× throughput, not 2×. Measure `samples_per_second` or `tokens_per_second` on identical short runs rather than trusting marketing curves.
+
+Multi-GPU is worth the operational tax when the model fits per rank and repeated overnight runs block the learning loop, when full weights do not fit and sharding is the only alternative to shrinking the model, or when you have measured that communication time is smaller than the time saved by larger effective batch or faster epochs. Multi-GPU is **not** worth it when the bottleneck is evaluation delay, dirty data, or environment drift—fix those first.
+
+### Launching with Accelerate and torchrun
+
+Modern Hugging Face stacks route multi-GPU launches through **Accelerate**, which can spawn one process per device and configure DDP or FSDP based on a saved config. PyTorch **torchrun** (elastic launch) is the lower-level primitive: it sets `RANK`, `LOCAL_RANK`, and `WORLD_SIZE` so each process binds to one GPU.
+
+> **Landscape snapshot — as of 2026-06**
+>
+> Exact CLI flags (`accelerate launch --multi_gpu --num_processes 2`, FSDP plugin options, DeepSpeed JSON configs) change between Accelerate, Transformers, and DeepSpeed releases. Verify launch recipes against [Accelerate](https://huggingface.co/docs/accelerate/index), [Transformers multi-GPU performance guide](https://huggingface.co/docs/transformers/en/perf_train_gpu_many), [PyTorch FSDP](https://pytorch.org/docs/stable/fsdp.html), [PyTorch DDP tutorial](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html), and [torchrun / elastic](https://pytorch.org/docs/stable/elastic/run.html) for the versions in your `.venv`. Treat any "linear scaling to N GPUs" claim as invalid until you reproduce it on your topology.
+
+```bash
+# Smoke test — two processes on one host (verify flags for your accelerate version).
+accelerate config
+accelerate env
+
+CUDA_VISIBLE_DEVICES=0,1 accelerate launch --num_processes 2 scripts/train_lora.py \
+  --max_steps 50 \
+  --output_dir runs/ddp-smoke
+```
+
+```bash
+# Equivalent torchrun pattern — useful when you need explicit control.
+torchrun --standalone --nproc_per_node=2 scripts/train_lora.py \
+  --max_steps 50 \
+  --output_dir runs/torchrun-smoke
+```
+
+DeepSpeed integration typically adds a JSON config referenced from Accelerate or the Trainer; ZeRO stage selection belongs in that file, not scattered across shell aliases. Keep one launch script under version control so incident responders can see exactly how ranks were created.
+
+When debugging launch failures, read errors from **rank 0 first**, then check whether other ranks died from NCCL timeouts. NCCL logs often implicate firewall rules, wrong `MASTER_ADDR`, or GPUs hidden by `CUDA_VISIBLE_DEVICES` mismatches—problems that look like training bugs but are pure topology issues.
+
+For home-lab learners comparing FSDP inside PyTorch against ZeRO inside DeepSpeed, the decision is rarely "which framework is best." The decision is which stack your training script already supports, which interconnect you actually have, and whether you need optimizer offload because DRAM on the host is plentiful while VRAM is not. A two-GPU workstation with NVLink may justify FSDP for a 13B full fine-tune; a pair of machines on Wi-Fi should default to workload sharding or single-GPU QLoRA until networking is upgraded.
+
+### When multi-GPU is worth it in a home lab
+
+Treat multi-GPU expansion like any other capacity project: justify it with a written threshold and a stop condition. A reasonable home-lab success criterion might read: "Two-GPU DDP must cut an eight-hour LoRA epoch below five hours on the same dataset slice, with peak GPU temperature below 85°C and checkpoint writes under two minutes, for three consecutive smoke runs." Without that specificity, you cannot distinguish a useful upgrade from an expensive space heater.
+
+Conversely, stay on one GPU when any of the following is true: the adapter already fits with QLoRA and the pain is evaluation throughput; your dataset is still changing daily; you have not automated baseline capture; or the second GPU would share a x4 PCIe link and a borderline power supply. In those cases, money often returns more value as faster NVMe storage, a dedicated evaluation box, or cleaner data contracts than as another training rank.
+
+Home labs also hit **social scaling limits** before they hit hardware limits. When three teammates share one cluster without run directories, naming conventions, or cleanup policy, the failure mode is human coordination—not NCCL. Establish a `runs/` prefix per owner, a maximum checkpoint retention count, and a shared spreadsheet of base model plus adapter hashes before adding a fourth GPU.
+
+```bash
+# Pre-flight checklist — run on every host before a multi-GPU job.
+.venv/bin/python - <<'PY'
+import torch
+print("cuda:", torch.cuda.is_available(), "count:", torch.cuda.device_count())
+for i in range(torch.cuda.device_count()):
+    props = torch.cuda.get_device_properties(i)
+    print(i, props.name, f"{props.total_memory // 1024**3} GiB")
+PY
+nvidia-smi topo -m 2>/dev/null || true
+```
+
+The topology matrix printed by `nvidia-smi topo -m` shows whether GPUs communicate over NVLink, PCIe switches, or CPU root complexes—information you need before expecting FSDP or ZeRO to scale. A PHB (PCIe Host Bridge) link between cards is not a moral failure; it is a measurement input.
+
+---
+
+## 4. Worked Example: Decide Whether to Add a Second GPU
 
 Consider a learner with a single workstation, one 24 GB GPU, 64 GB system RAM, a 2 TB NVMe drive, and a stable LoRA fine-tuning script. The model fits at the chosen sequence length, but each 3,000-step experiment takes eight hours. The learner wants to know whether adding a second 24 GB GPU is worthwhile or whether the money should go into storage, evaluation automation, or a separate inference box.
 
@@ -254,7 +345,7 @@ Suppose instead the two-GPU run is substantially faster, temperatures remain sta
 
 This example is deliberately ordinary. Most good home-lab decisions are ordinary decisions made with disciplined evidence. The senior skill is not knowing the flashiest distributed-training term. The senior skill is refusing to add a moving part until you know what work that part is supposed to do.
 
-### 5. Design the Lab Like a Small Production System
+## 5. Design the Lab Like a Small Production System
 
 A home lab does not need datacenter bureaucracy, but multi-GPU fine-tuning does need operational discipline. Once multiple devices or hosts participate in a run, the lab has shared state, dependencies, failure modes, and recovery costs. Treating those as “just home stuff” is how useful experiments turn into unreliable infrastructure.
 
@@ -312,6 +403,8 @@ Failure recovery is the final design layer. A multi-GPU job should have a known 
 
 A strong run directory usually contains the launch command, environment snapshot, selected configuration, training log, hardware watch output, checkpoint timestamps, and final decision notes. This is not excessive ceremony. It is the minimum context needed to learn from a failed distributed run instead of merely repeating it.
 
+For multi-host labs, extend the directory with **network evidence**: `ping` latency to peers, `iperf3` throughput samples, and the NCCL debug level used during the failing run. Many "it worked yesterday" incidents trace to a router firmware update, a VPN that started routing GPU traffic through a slow tunnel, or a teammate who changed `MASTER_PORT` without updating the shared launch script. Capturing network baselines when things are healthy gives you a comparison point when jobs suddenly hang at the first all-reduce.
+
 ```bash
 RUN_DIR="runs/$(date +%Y%m%d-%H%M%S)-two-gpu"
 mkdir -p "$RUN_DIR"
@@ -323,7 +416,7 @@ printf "Command: %s\n" "accelerate launch --num_processes 2 train.py" > "$RUN_DI
 nvidia-smi > "$RUN_DIR/nvidia-smi-start.txt"
 ```
 
-### 6. Measure, Debug, and Decide When to Stop
+## 6. Measure, Debug, and Decide When to Stop
 
 Multi-GPU home-lab work should end each experiment with a decision, not just another log directory. The decision may be to keep the design, simplify it, fix a specific bottleneck, or stop scaling at home. Without a decision habit, the lab becomes a collection of interesting failures that do not improve the model or the learner.
 
@@ -352,6 +445,24 @@ When a run fails, resist the urge to immediately change three things. Read the f
 There is also a point where home-lab scaling should stop. If the lab needs datacenter-style cooling, if several people depend on it, if backup and storage policy consume more attention than model quality, or if failed jobs are too expensive to repeat casually, the architecture has outgrown the learning environment. Moving to managed infrastructure or a more serious private training setup may be the mature decision.
 
 Stopping is not failure. A home lab is valuable because it creates fast, low-friction learning. When the lab becomes slow, fragile, noisy, expensive, and socially dependent, it may no longer be serving that purpose. Senior engineers notice when the system’s operating cost has overtaken its educational value.
+
+Document every multi-GPU experiment with a one-page decision memo stored beside the run logs. The memo should restate the bottleneck, list the launch command, note interconnect type (NVLink, PCIe x16, PCIe x4, 1 GbE), record scaling efficiency as `two_gpu_throughput / single_gpu_throughput`, and end with keep, simplify, or stop. That habit prevents the lab from accumulating hardware whose purpose nobody remembers six months later.
+
+Pair the memo with a short **failure taxonomy** so the team does not relitigate the same incident. Network timeouts belong in infrastructure notes; optimizer state OOM belongs in memory-configuration notes; rank desynchronization after a driver update belongs in environment-parity notes. When each failure class has a default first check, debugging multi-GPU jobs feels less like superstition and more like on-call runbooks for a tiny cluster you actually own.
+
+### Checkpoint and storage policy across ranks
+
+Distributed fine-tuning amplifies checkpoint mistakes because every rank may write partial state unless you configure a single writer rank or use framework helpers that consolidate shards. A home lab should default to **rank-0 checkpoints** with an explicit `save_total_limit` so NVMe does not fill during an overnight ZeRO run. If you resume training, record the global step, random seed, dataset epoch, and git commit hash in the same directory as the checkpoint. Without that bundle, "resume from step 1200" often means "resume from an unlabeled folder named `checkpoint-3`."
+
+When copying checkpoints between hosts for evaluation, prefer `rsync` with checksum verification over ad hoc USB drives. A corrupted optimizer shard produces NaN loss curves that look like hyperparameter failure. Storage policy is therefore part of parallelism design, not an afterthought once training already works on one GPU.
+
+Finally, rehearse **rollback** before you depend on a multi-GPU path for production adapters. Keep the last known-good single-GPU checkpoint, document how to load it without distributed launchers, and time how long rollback takes. If rollback is slower than retraining from scratch, your checkpoint policy is not yet trustworthy enough for shared team use.
+
+The same discipline applies to **hyperparameter sweeps** on multiple GPUs. It is tempting to launch four learning rates in parallel across devices, but without isolated output directories and a summary table, you will compare the wrong logs. Prefix each run with `lr1e-4-rank0` style names, cap parallel jobs below the number of GPUs if you need headroom for desktop display or inference smoke tests, and never share one `output_dir` across processes. Parallel sweeps are a workload-sharding pattern; treat them like separate experiments that happen to share a chassis.
+
+Before declaring a home-lab multi-GPU setup "production ready," run the same evaluation harness you would use for a single-GPU adapter: held-out prompts, baseline comparison, and explicit keep-or-discard notes. Faster training that produces worse adapters is not a win; it only helps you fail sooner. Measure quality first, then celebrate throughput. That ordering keeps multi-GPU expansion tied to model outcomes instead of hardware vanity metrics.
+
+---
 
 ## Did You Know?
 
@@ -592,13 +703,21 @@ Success criteria:
 - [ ] The decision considered throughput, memory fit, checkpoint behavior, thermals, power, storage, and operational complexity.
 - [ ] The final decision clearly chooses keep, simplify, fix another bottleneck first, or stop scaling for now.
 
-## Next Modules
+## Next Module
 
-- [Home AI Operations and Cost Model](../ai-infrastructure/module-1.5-home-ai-operations-cost-model/)
-- [Private AI Training Infrastructure](../../on-premises/ai-ml-infrastructure/module-9.2-private-ai-training/)
-- [Distributed Training Infrastructure](../../platform/disciplines/data-ai/ai-infrastructure/module-1.3-distributed-training/)
+- [Home AI Operations and Cost Model](../ai-infrastructure/module-1.5-home-ai-operations-cost-model/) — Operational cost, cooling, and reliability trade-offs after you expand beyond a single GPU workstation.
+
+See also [Private AI Training Infrastructure](../../on-premises/ai-ml-infrastructure/module-9.2-private-ai-training/) and [Distributed Training Infrastructure](../../platform/disciplines/data-ai/ai-infrastructure/module-1.3-distributed-training/) for datacenter-scale patterns once the home lab outgrows casual experimentation.
 
 ## Sources
 
-- [Accelerate Quicktour](https://huggingface.co/docs/accelerate/v1.9.0/en/quicktour) — Grounds the practical mechanics of moving from single-device training to multi-GPU or multi-node launches.
-- [Schedule GPUs in Kubernetes](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/) — Useful next reading for learners who want to understand how GPU resources are requested and scheduled once workloads move beyond a single box.
+- [Accelerate documentation](https://huggingface.co/docs/accelerate/index) — Multi-GPU launch, FSDP integration, and config workflow.
+- [PyTorch FSDP](https://pytorch.org/docs/stable/fsdp.html) — Fully Sharded Data Parallel API and sharding strategies.
+- [DeepSpeed](https://www.deepspeed.ai/) — ZeRO optimizer stages, offload, and JSON configuration reference.
+- [ZeRO: Memory Optimizations Toward Training Trillion Parameter Models](https://arxiv.org/abs/1910.02054) — Original ZeRO stage definitions and memory/communication trade-offs.
+- [Transformers multi-GPU training performance](https://huggingface.co/docs/transformers/en/perf_train_gpu_many) — Practical guidance for scaling Hugging Face training scripts.
+- [PyTorch DDP tutorial](https://pytorch.org/tutorials/intermediate/ddp_tutorial.html) — Process groups, gradient synchronization, and launcher basics.
+- [PEFT documentation](https://huggingface.co/docs/peft/index) — Adapter training patterns often combined with DDP on home-lab fine-tunes.
+- [torchrun / elastic agent](https://pytorch.org/docs/stable/elastic/run.html) — Low-level multi-process launch and environment variables for distributed jobs.
+- [Kubernetes GPU scheduling](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/) — Reference for learners who later move home-lab models into cluster schedulers with device plugins.
+- [NVIDIA NCCL documentation](https://docs.nvidia.com/deeplearning/nccl/user-guide/docs/index.html) — Collective communication library underlying PyTorch distributed backends; useful when debugging timeout errors.

--- a/src/content/docs/ai-ml-engineering/advanced-genai/module-1.12-reasoning-models-and-grpo.md
+++ b/src/content/docs/ai-ml-engineering/advanced-genai/module-1.12-reasoning-models-and-grpo.md
@@ -48,6 +48,8 @@ RL run starts.
 
 ## Core Content
 
+> **Landscape snapshot — reasoning-RL tooling as of 2026-06.** The model names (DeepSeek-R1 and its `-Zero` variant), method labels (GRPO, RLVR, RLOO), and library surfaces (Hugging Face TRL `GRPOTrainer`, verifier/reward harnesses) named below move fast — methods get renamed, libraries change APIs, and new reasoning models ship monthly. Treat them as concrete illustrations of the *durable* ideas (group-relative advantage instead of a critic, verifiable rewards, KL control against a reference policy), not a fixed roster. Verify any specific API, model name, or paper section against the current upstream docs before relying on it.
+
 ### 1. From RLHF to Reasoning RL
 
 Classical RLHF starts with a model that already follows instructions reasonably well.
@@ -770,9 +772,17 @@ while penalizing large divergence from the reference policy.
 <summary>Solution</summary>
 
 ```python
+import math
+
+
 def add_objective(records: list[dict], beta: float = 0.05) -> list[dict]:
     for record in records:
-        kl_proxy = record["policy_logprob"] - record["reference_logprob"]
+        # Schulman's unbiased, nonnegative KL estimator — the form GRPO/DeepSeekMath use.
+        # KL(policy || ref) ≈ exp(r) - r - 1, where r = log π_ref - log π. It is always
+        # >= 0, so subtracting beta * kl_proxy genuinely penalizes divergence. (A raw
+        # log-prob delta would be signed and could *reward* moving away from the reference.)
+        log_ratio = record["reference_logprob"] - record["policy_logprob"]
+        kl_proxy = math.exp(log_ratio) - log_ratio - 1.0
         record["kl_proxy"] = kl_proxy
         record["objective"] = record["advantage"] * record["policy_logprob"] - beta * kl_proxy
     return records
@@ -825,7 +835,7 @@ Success criteria:
 
 ## Sources
 
-- [DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via Reinforcement Learning](https://arxiv.org/abs/2501.12948) - Primary source for DeepSeek-R1 and DeepSeek-R1-Zero; see Sections 2.2.1 and 2.2.2 for GRPO and rule-based rewards.
+- [DeepSeek-R1: Incentivizing Reasoning Capability in LLMs via Reinforcement Learning](https://arxiv.org/abs/2501.12948) - Primary source for DeepSeek-R1 and DeepSeek-R1-Zero; see Section 2.1 (Group Relative Policy Optimization) and Section 2.2 (Reward Modeling / rule-based rewards) in the current arXiv version.
 - [DeepSeekMath: Pushing the Limits of Mathematical Reasoning in Open Language Models](https://arxiv.org/abs/2402.03300) - Primary GRPO source; see Section 4.1 and Appendix A.1.6 for PPO-to-GRPO and group-relative advantage analysis.
 - [Tulu 3: Pushing Frontiers in Open Language Model Post-Training](https://arxiv.org/abs/2411.15124) - Primary source for the Tulu 3 RLVR recipe; see Section 6 for reinforcement learning with verifiable rewards.
 - [Proximal Policy Optimization Algorithms](https://arxiv.org/abs/1707.06347) - Original PPO paper; see Section 3 for the clipped surrogate objective and Section 4 for adaptive KL penalty variants.

--- a/src/content/docs/ai-ml-engineering/advanced-genai/module-1.3-diffusion-models.md
+++ b/src/content/docs/ai-ml-engineering/advanced-genai/module-1.3-diffusion-models.md
@@ -34,6 +34,8 @@ On the same week, another team ships an AI-assisted code review bot. It catches 
 
 Diffusion models and code generation systems look different on the surface. One starts from noise and denoises continuous latent states into images. The other predicts discrete tokens under strict syntax, type, and repository constraints. For an AI/ML engineer, the shared skill is architectural reasoning: identify what the model is allowed to know, what it is optimizing, where it can fail, and what guardrails convert a clever demo into a dependable system.
 
+The comparison is not academic. Teams that ship both image and code endpoints behind the same API gateway must apply different SLOs, moderation policies, and validation gates to each path. An image endpoint might return HTTP 200 with a mildly off-brand render; a code endpoint that returns HTTP 200 with syntactically valid but malicious SQL still fails the product contract. Designing those gates up front—scheduler budgets for diffusion, execution harnesses for code—is what separates a generative demo from a generative platform.
+
 This module teaches diffusion from the beginner mental model to the senior production trade-offs. It then connects that understanding to advanced code generation architecture because modern generative platforms often serve both media and code workflows under the same reliability, cost, and governance constraints. You will practice reading model behavior as an engineering system rather than a magic endpoint.
 
 ---
@@ -80,6 +82,67 @@ Stable Diffusion 3 Medium adds another architectural layer by using a Multimodal
 | Decoding | Converts final latents back to pixels | Artifacts and memory spikes | Batch size, precision, and offloading |
 
 The important pattern is progressive control. First you learn the denoising mechanism, then the sampler, then the latent representation, then the conditioning path, and finally the deployment envelope. Each layer gives you a lever, but each lever also creates a way to misuse the system. That is why diffusion engineering is less about memorizing model names and more about matching architecture to constraints.
+
+### Forward diffusion, reverse denoising, and the training objective
+
+At the mathematical core, DDPM defines a forward Markov chain that gradually adds Gaussian noise to a data sample \(x_0\) across timesteps \(t = 1 \ldots T\). Each step applies a small variance schedule \(\beta_t\), so \(x_t\) becomes progressively noisier until it resembles an isotropic Gaussian. The reverse process learns to undo that corruption: a neural network \(\epsilon_\theta(x_t, t)\) predicts the noise that was added (or an equivalent score function), and generation starts from pure noise and walks backward toward a plausible image. The training loss is typically a weighted mean-squared error between predicted and actual noise at randomly sampled timesteps. This objective is durable because it does not require adversarial training and it scales to high-resolution data when combined with latent compression.
+
+The engineering consequence is that **quality and cost are tied to how many reverse steps you execute at inference time**, not only to parameter count. A model trained with a thousand-step forward schedule can still be sampled with fewer reverse steps if the scheduler approximates the same marginal distributions. That separation between training objective and inference trajectory is why sampler research (DDIM, DPM-Solver, Euler variants) remains valuable even when the underlying UNet or DiT weights stay fixed.
+
+### DDPM versus DDIM sampling trade-offs
+
+DDPM sampling follows the learned reverse Markov transitions and often needs hundreds of function evaluations per image because each step respects the stochastic forward process. DDIM treats the reverse path as a non-Markovian integration that can skip timesteps while targeting the same endpoint distribution class. In practice, DDIM-style deterministic jumps reduce wall-clock latency and make step count a direct product knob, but aggressive skipping can soften fine detail or shift color calibration. Teams usually benchmark a small matrix: scheduler family × step count × guidance scale × resolution, then pick the Pareto point for their latency budget rather than assuming the research-default step count is production-ready.
+
+| Sampler family | Typical step budget | Latency profile | Quality risk when pushed |
+|---|---|---|---|
+| DDPM / ancestral | High (hundreds+) | Slow, variable | Lower skip risk, high cost |
+| DDIM / deterministic solvers | Medium (20–50) | Predictable | Detail loss if steps too low |
+| Fast ODE solvers | Low (10–30) | Fastest | May need per-model retuning |
+
+### Classifier-free guidance and text conditioning
+
+Classifier-Free Guidance (CFG) strengthens prompt adherence without a separate classifier model. During training, the denoiser sometimes sees the text condition and sometimes sees an empty or null condition. At inference, the prediction blends conditional and unconditional outputs using a guidance scale \(w\): larger \(w\) pulls the sample toward the prompt but can oversaturate colors, amplify artifacts, or reduce diversity. Text conditioning itself usually flows through a frozen or co-trained text encoder (CLIP-style, T5-style, or multimodal transformers) whose token embeddings are injected via cross-attention into the denoising network. The durable lesson is that **prompt engineering and guidance scale are inference-time controls** on the same weights; they are not substitutes for fixing a weak base model or a mis-licensed checkpoint.
+
+### Why latent diffusion uses a VAE
+
+Pixel-space diffusion must denoise tensors with spatial resolution equal to the output image. A variational autoencoder (VAE) learns an encoder that maps pixels to a lower-dimensional latent grid and a decoder that reconstructs pixels from latents. The diffusion model operates in latent space, so each UNet or DiT forward pass touches far fewer values per spatial location. The trade-off is reconstruction fidelity: a weak VAE blurs fine texture or mishandles small text, and those errors survive even a perfect denoiser. Production teams therefore evaluate encoder/decoder quality, not only the denoising checkpoint.
+
+### Practical inference knobs (durable controls)
+
+Regardless of model family, these levers recur in every diffusion serving design:
+
+1. **Inference steps** — direct multiplier on GPU time per request.
+2. **Guidance scale** — trades prompt fidelity against diversity and artifact risk.
+3. **Scheduler / solver** — changes the integration path through noise levels without retraining.
+4. **Resolution and aspect ratio** — quadratic memory growth in pixel space; latent models still pay for larger latent grids.
+5. **Precision and offloading** — fp16/bf16, VAE tiling, and CPU offload reduce VRAM at latency cost.
+
+> **Landscape snapshot — as of 2026-06**
+>
+> Hugging Face **Diffusers** exposes these controls through pipeline objects such as `StableDiffusionPipeline`, `StableDiffusionXLPipeline`, and newer DiT-based pipelines. Exact class names, default schedulers, and memory helpers (`enable_model_cpu_offload`, `enable_vae_slicing`) change between minor releases. Before relying on a snippet from this module or a blog post, verify against the [Diffusers documentation](https://huggingface.co/docs/diffusers/index) for your installed version. Treat any quoted VRAM figure or steps-per-second throughput number as **hardware- and driver-specific** unless you measure it on your cluster.
+
+```python
+# Illustrative pattern — verify API names against your diffusers version.
+from diffusers import StableDiffusionPipeline, DDIMScheduler
+import torch
+
+pipe = StableDiffusionPipeline.from_pretrained(
+    "runwayml/stable-diffusion-v1-5",
+    torch_dtype=torch.float16,
+)
+pipe.scheduler = DDIMScheduler.from_config(pipe.scheduler.config)
+pipe = pipe.to("cuda")
+
+image = pipe(
+    prompt="a schematic diagram of a kubernetes pod",
+    num_inference_steps=30,
+    guidance_scale=7.5,
+).images[0]
+```
+
+The snippet is not a deployment recommendation. It shows how scheduler swap, step count, and guidance scale are ordinary Python arguments that your serving wrapper should expose as validated API fields with defaults tied to measured latency SLOs.
+
+Senior teams also log scheduler name, step count, guidance scale, and seed with every generated asset so incident reviewers can reproduce or diff outputs during quality regressions. Without that metadata, a "the images look worse after the upgrade" report devolves into guessing whether the model weights, the VAE, or the inference integration changed. Treat diffusion serving like any other stateful API: version the pipeline config alongside the container image digest.
 
 ---
 
@@ -161,6 +224,12 @@ k get deployment sd3-diffusers-api -n ai-inference
 | Latency budget | Too many denoising steps can break product UX | Test scheduler and step count under load |
 
 A production diffusion platform should also distinguish offline batch generation from interactive serving. Batch generation can tolerate longer queue times, larger images, and more expensive samplers because users are not waiting in an editor. Interactive serving needs tight timeouts, cancellation, progress feedback, and strict step budgets. When teams mix these workloads in one deployment, batch jobs often consume GPU capacity and make interactive requests unreliable.
+
+Observability for diffusion APIs should expose per-request scheduler metadata, denoising step count, guidance scale, wall-clock phase timings (encode, denoise loop, decode), and peak GPU memory. Those metrics let you correlate user complaints about "blurry faces" with a scheduler change rather than guessing. They also support cost attribution when multiple product teams share one GPU pool.
+
+Capacity planning should separate **cold start** from **steady-state** load. Cold start includes model weight download, CUDA kernel compilation, and first-pass memory allocation; steady-state is dominated by denoising steps times concurrent requests. Autoscaling rules that only watch CPU will miss GPU memory cliffs when ten pods each load a multi-gigabyte checkpoint simultaneously. A safer pattern warms a minimum pool of ready replicas, caps batch concurrency per GPU, and queues overflow requests with explicit timeout messaging rather than letting latency explode silently.
+
+Treat licensing review as part of capacity planning as well. A model that requires attribution or forbids commercial use may be fine for internal R&D replicas but must never share the same deployment pool as customer-facing generation without policy tags on the ingress route.
 
 ---
 
@@ -656,9 +725,9 @@ Syntax-constrained decoding only guarantees that the token sequence remains pars
 </details>
 
 <details>
-<summary><strong>Question 7: A product manager wants to use Stable Diffusion 3 Medium outputs in paid customer campaigns because the prototype works locally. What nontechnical gate must the engineering team enforce before production use?</strong></summary>
+<summary><strong>Question 7: Compare continuous-space diffusion image generation with discrete autoregressive code generation. Why does code require stronger validation than natural language or image output?</strong></summary>
 
-The team must enforce license review and confirm that the intended commercial use is permitted. A model can be technically deployable while legally restricted. Engineering should record the approved model identifier, license terms, and usage scope before allowing the deployment into a commercial workflow.
+Diffusion models denoise continuous latent or pixel values where small errors may be visually tolerable. Code generation predicts discrete tokens where a single syntax error, wrong import, or invalid API name makes the entire output unusable. String similarity metrics therefore fail for code, while execution-based checks (parse, type check, unit tests, repository tests) are mandatory. Image serving can ship with moderation and human spot checks; code serving needs automated validation loops before merge or deployment because the failure modes are brittle and security-sensitive.
 
 </details>
 
@@ -891,6 +960,13 @@ Success criteria:
 
 ## Sources
 
-- [Denoising Diffusion Probabilistic Models](https://arxiv.org/abs/2006.11239) — This is the foundational DDPM paper for the forward/reverse diffusion process and the original CIFAR-10 results.
-- [High-Resolution Image Synthesis with Latent Diffusion Models](https://arxiv.org/abs/2112.10752) — This is the primary source for why latent-space diffusion reduces compute while preserving quality and enabling flexible conditioning.
-- [Diffusers Stable Diffusion 3 Pipeline Docs](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_3) — This is the practical implementation reference for SD3 inference, guidance behavior, and memory/offloading considerations.
+- [Diffusers documentation](https://huggingface.co/docs/diffusers/index) — Primary reference for pipeline APIs, schedulers, and memory/offloading helpers; verify against your installed version before production use.
+- [Denoising Diffusion Probabilistic Models (DDPM)](https://arxiv.org/abs/2006.11239) — Foundational forward/reverse diffusion process and denoising objective.
+- [Denoising Diffusion Implicit Models (DDIM)](https://arxiv.org/abs/2010.02502) — Non-Markovian sampling that accelerates inference without retraining the denoiser.
+- [High-Resolution Image Synthesis with Latent Diffusion Models](https://arxiv.org/abs/2112.10752) — Latent-space diffusion, VAE compression, and flexible conditioning architecture.
+- [Classifier-Free Diffusion Guidance](https://arxiv.org/abs/2207.12598) — Guidance scale mechanism blending conditional and unconditional predictions.
+- [Conditional image generation with Diffusers](https://huggingface.co/docs/diffusers/using-diffusers/conditional_image_generation) — Practical text-conditioning and inference patterns in the Diffusers library.
+- [PyTorch documentation](https://pytorch.org/docs/stable/index.html) — Tensor operations, autocast, and device semantics underlying diffusion training and serving stacks.
+- [Diffusers Stable Diffusion 3 Pipeline](https://huggingface.co/docs/diffusers/api/pipelines/stable_diffusion/stable_diffusion_3) — SD3-specific pipeline reference for multimodal DiT architectures and memory behavior.
+- [Kubernetes GPU scheduling](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/) — How clusters request `nvidia.com/gpu` resources and device plugins for inference deployments covered in Section 2.
+- [Hugging Face Diffusers schedulers overview](https://huggingface.co/docs/diffusers/api/schedulers/overview) — Scheduler taxonomy and configuration objects referenced when tuning inference steps and solvers.


### PR DESCRIPTION
## Summary
Closes the last 4 un-reviewed `ai-ml-engineering/advanced-genai` modules under #2020 — completing the **entire AI/ML Engineering track**. (1.1/1.2/1.4–1.9 were reviewed earlier.)

**Three T3 → T0 expansions** (cursor/Kimi authored, opus ground-checked = cross-family):
- **1.3 diffusion-models** (was 4053w/3src + outcome-align): +DDPM forward/reverse + denoising objective, DDPM-vs-DDIM, classifier-free guidance, latent-diffusion VAE; +7 sources → **T0**.
- **1.10 single-gpu-fine-tuning** (was 4700w/2src): +QLoRA NF4 + VRAM ledger + gradient checkpointing/accumulation; +8 sources → **T0**.
- **1.11 multi-gpu-fine-tuning** (was 3538w/2src + structure): +DDP vs FSDP vs DeepSpeed ZeRO (stages 1/2/3), accelerate/torchrun; **added 5 missing sections** (fixed `structure_order_correct`/`structure_sections_present`); +8 sources → **T0**.

opus verified every added claim accurate (diffusion math, QLoRA/VRAM, FSDP/ZeRO stages all correct), illustrative-labeled code, durable-vendor compliant, no "best framework" claims, all assets preserved.

**1.12 reasoning-models-and-grpo** — codex cross-family review (NEEDS_CHANGES), all P1s ground-checked:
- **KL proxy fix:** the `policy_logprob - reference_logprob` signed delta was mislabeled as a KL penalty (a negative value would *reward* divergence). Replaced with **Schulman's nonnegative k3 estimator** (`exp(r) - r - 1`), the form GRPO/DeepSeekMath use.
- **Citation fix:** "Sections 2.2.1/2.2.2" was stale — web-verified DeepSeek-R1 uses §2.1 (GRPO) / §2.2 (reward modeling).
- Added a dated `Landscape snapshot` for the GRPO/DeepSeek-R1/RLVR/TRL tooling.

All 4 remain **T0 PASS**, 0 unreachable URLs; all Python blocks compile.

## Learner check

> Stage 1 shards optimizer states across ranks. Stage 2 adds gradient sharding. Stage 3 shards model parameters as well, minimizing per-device memory at the cost of the most collective traffic.

(verbatim from module-1.11 — the DeepSpeed ZeRO sharding stages, the durable memory-vs-communication tradeoff.)

Refs #2020

🤖 Generated with [Claude Code](https://claude.com/claude-code)