### PR TITLE
fix(ai-ml): codex R1 review fixes for T0 prereq+multimodal modules (#2020)

### DIFF
--- a/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.1-voice-audio-ai.md
+++ b/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.1-voice-audio-ai.md
@@ -1110,7 +1110,7 @@ Audio In -> Normalize -> VAD -> STT -> Reasoning -> TTS -> Audio Out
 
 1. **Did You Know?** Voice-cloning scams and other audio-based social-engineering attacks are a growing security concern, but precise incident counts and loss estimates depend heavily on the reporting source and methodology.
 2. **Did You Know?** [IBM's 1962 SHOEBOX system](https://www.ibm.com/history/voice-recognition) was the world's first true speech recognition tool, capable of recognizing [a vocabulary of exactly 16 words](https://www.ibm.com/history/voice-recognition).
-3. **Did You Know?** OpenAI initially trained the Whisper model on exactly [680,000 hours of diverse, multilingual, and extremely noisy audio scraped from the internet](https://openai.com/index/whisper/), bypassing traditional clean datasets.
+3. **Did You Know?** OpenAI initially trained the Whisper model on exactly [680,000 hours of diverse, multilingual, and extremely noisy audio scraped from the internet](https://arxiv.org/abs/2212.04356), bypassing traditional clean datasets.
 4. **Did You Know?** [Benchmarks published by the faster-whisper project](https://github.com/SYSTRAN/faster-whisper) show meaningful speed and memory improvements over `openai/whisper` under comparable settings, but results depend on hardware and decoding settings.
 
 ## Common Mistakes

--- a/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.1-voice-audio-ai.md
+++ b/src/content/docs/ai-ml-engineering/multimodal-ai/module-1.1-voice-audio-ai.md
@@ -392,6 +392,8 @@ The practical implication is not that Moshi is “better.” It is that Moshi sh
 
 ### 4.5.3 GPT-4o Realtime as a commercial reference baseline
 
+> **Model names and pricing in this section are a dated snapshot — as of 2026-06. The realtime/speech model lineup, token-timing, and rates churn fast (OpenAI has since shipped successor `gpt-realtime` models); verify against the current OpenAI Realtime docs before relying on a specific model id or rate.**
+
 OpenAI’s Realtime docs position `GPT-4o Realtime` as a model capable of text and audio inputs/outputs “in realtime” over **WebRTC or WebSocket**, with a session model built around `session`, `conversation`, and `responses`. From the model pages, this is a speech-to-speech-capable product path where API-level orchestration is managed by the platform, not by your inference graph.
 
 #### Contract and interaction model
@@ -585,6 +587,8 @@ with open("streamed_output.mp3", "wb") as audio_file:
 Open-source TTS is useful when audio cannot leave your environment, when you need predictable unit economics, or when you want full control over the serving stack. The trade-off is operational responsibility. You own model loading, GPU allocation, cold starts, quality tuning, and scaling. That may be exactly right for regulated environments, but it is not automatically cheaper at low traffic.
 
 ```python
+# Install the maintained fork first: pip install coqui-tts
+# (the original `TTS` package is unmaintained and supports only Python <3.12)
 from TTS.api import TTS
 
 tts = TTS(model_name="tts_models/en/ljspeech/tacotron2-DDC")
@@ -851,7 +855,7 @@ spec:
         accelerator: nvidia
       containers:
         - name: api
-          image: ghcr.io/example/whisper-stt:1.0.0
+          image: ghcr.io/example/whisper-stt:1.0.0  # placeholder — build and push your own faster-whisper image; this tag is not published
           imagePullPolicy: IfNotPresent
           ports:
             - name: http
@@ -1306,7 +1310,7 @@ Now that your AI can hear and speak, the next module adds visual perception. You
 - [developers.openai.com: text to speech](https://developers.openai.com/api/docs/guides/text-to-speech) — OpenAI's text-to-speech docs say the endpoint has built-in voices and can provide realtime audio output using streaming.
 - [aws.amazon.com: polly](https://aws.amazon.com/documentation-overview/polly/) — AWS's Polly documentation overview says the API returns audio streams and describes Brand Voice as a custom neural TTS offering.
 - [docs.cloud.google.com: docs](https://docs.cloud.google.com/text-to-speech/docs) — Google's Cloud Text-to-Speech docs say the service converts text or SSML into natural human speech and link supported voices plus streaming guides.
-- [github.com: TTS](https://github.com/coqui-ai/TTS) — The project's GitHub repository describes Coqui TTS as an open-source deep learning toolkit for text-to-speech.
+- [github.com: coqui-tts (maintained idiap fork)](https://github.com/idiap/coqui-ai-TTS) — The project's GitHub repository describes Coqui TTS as an open-source deep learning toolkit for text-to-speech.
 - [github.com: bark](https://github.com/suno-ai/bark) — The Bark repository describes the project as a text-prompted generative audio model.
 - [kubernetes.io: scheduling gpus](https://kubernetes.io/docs/tasks/manage-gpus/scheduling-gpus/) — The Kubernetes GPU scheduling docs explicitly describe stable GPU support via device plugins and schedulable resources such as `nvidia.com/gpu`.
 - [OpenAI Realtime conversations](https://developers.openai.com/api/docs/guides/realtime-conversations) — Official Realtime API guide for sessions, WebRTC/WebSocket transport, function calling, and interruption/truncation behavior.

--- a/src/content/docs/ai-ml-engineering/prerequisites/module-1.3-reproducible-python-cuda-rocm-environments.md
+++ b/src/content/docs/ai-ml-engineering/prerequisites/module-1.3-reproducible-python-cuda-rocm-environments.md
@@ -238,7 +238,7 @@ PY
 
 This smoke test distinguishes several cases. If `torch` is not installed, you are still at the package layer. If `torch.version.cuda` is `None`, you likely installed a CPU build. If CUDA is built in but unavailable, the driver/runtime boundary deserves attention. If the tensor operation succeeds, you have stronger evidence than an import alone.
 
-> **Pause and predict:** Suppose `nvidia-smi` works, `torch.__version__` prints normally, `torch.version.cuda` is `None`, and [`torch.cuda.is_available()`](https://github.com/pytorch/pytorch/blob/main/docs/source/notes/cuda.rst) is `False`. Which layer is probably wrong, and why would reinstalling the NVIDIA driver be a low-value first move?
+> **Pause and predict:** Suppose `nvidia-smi` works, `torch.__version__` prints normally, `torch.version.cuda` is `None`, and [`torch.cuda.is_available()`](https://docs.pytorch.org/docs/stable/notes/cuda.html) is `False`. Which layer is probably wrong, and why would reinstalling the NVIDIA driver be a low-value first move?
 
 The likely problem is the framework package selection. A CPU-only PyTorch build can import perfectly while reporting no CUDA build support. The NVIDIA driver may still be healthy, so reinstalling it would change a lower layer that already passed its first proof.
 
@@ -745,6 +745,6 @@ Success criteria:
 - [Docker documentation: Build with Dockerfile](https://docs.docker.com/build/concepts/dockerfile/) — Provides official background for container image build files.
 - [NVIDIA Container Toolkit documentation](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/) — Explains GPU runtime integration for containers on NVIDIA systems.
 - [github.com: RELEASE.md](https://github.com/pytorch/pytorch/blob/main/RELEASE.md) — PyTorch's upstream RELEASE.md contains the release compatibility matrix with explicit Python, CUDA, and ROCm columns.
-- [github.com: cuda.rst](https://github.com/pytorch/pytorch/blob/main/docs/source/notes/cuda.rst) — PyTorch's CUDA semantics docs explicitly show `torch.cuda.is_available()` in device-selection examples and discuss what that check does.
+- [github.com: cuda.rst](https://docs.pytorch.org/docs/stable/notes/cuda.html) — PyTorch's CUDA semantics docs explicitly show `torch.cuda.is_available()` in device-selection examples and discuss what that check does.
 - [github.com: hip.rst](https://github.com/pytorch/pytorch/blob/main/docs/source/notes/hip.rst) — PyTorch's HIP semantics docs explicitly state that HIP reuses `torch.cuda` interfaces and show `torch.version.hip` versus `torch.version.cuda` checks.
 - [github.com: nvidia container toolkit](https://github.com/NVIDIA/nvidia-container-toolkit) — The NVIDIA Container Toolkit README says the toolkit configures containers to use NVIDIA GPUs and explicitly requires the NVIDIA driver on the host.

--- a/src/content/docs/ai-ml-engineering/prerequisites/module-1.3-reproducible-python-cuda-rocm-environments.md
+++ b/src/content/docs/ai-ml-engineering/prerequisites/module-1.3-reproducible-python-cuda-rocm-environments.md
@@ -745,6 +745,6 @@ Success criteria:
 - [Docker documentation: Build with Dockerfile](https://docs.docker.com/build/concepts/dockerfile/) — Provides official background for container image build files.
 - [NVIDIA Container Toolkit documentation](https://docs.nvidia.com/datacenter/cloud-native/container-toolkit/latest/) — Explains GPU runtime integration for containers on NVIDIA systems.
 - [github.com: RELEASE.md](https://github.com/pytorch/pytorch/blob/main/RELEASE.md) — PyTorch's upstream RELEASE.md contains the release compatibility matrix with explicit Python, CUDA, and ROCm columns.
-- [github.com: cuda.rst](https://docs.pytorch.org/docs/stable/notes/cuda.html) — PyTorch's CUDA semantics docs explicitly show `torch.cuda.is_available()` in device-selection examples and discuss what that check does.
+- [PyTorch CUDA semantics docs](https://docs.pytorch.org/docs/stable/notes/cuda.html) — PyTorch's CUDA semantics docs explicitly show `torch.cuda.is_available()` in device-selection examples and discuss what that check does.
 - [github.com: hip.rst](https://github.com/pytorch/pytorch/blob/main/docs/source/notes/hip.rst) — PyTorch's HIP semantics docs explicitly state that HIP reuses `torch.cuda` interfaces and show `torch.version.hip` versus `torch.version.cuda` checks.
 - [github.com: nvidia container toolkit](https://github.com/NVIDIA/nvidia-container-toolkit) — The NVIDIA Container Toolkit README says the toolkit configures containers to use NVIDIA GPUs and explicitly requires the NVIDIA driver on the host.


### PR DESCRIPTION
## Summary
Part of #2020. Cross-family review fixes for 5 already-T0 AI/ML modules (multimodal 1.1 + prerequisites 1.1–1.4). Only modules needing content changes are touched; clean ones (prereq 1.2/1.3 APPROVE) get review records via the flip.

## Cross-family review
- **codex (OpenAI), R1** — lab-executing review. multimodal 1.1 NEEDS_CHANGES; prereq 1.1/1.2/1.3 APPROVE; prereq 1.4 NEEDS_CHANGES (no concrete finding emitted → assessed independently, no defect found).
- **opus (Anthropic), inline** — ground-checked every codex finding (Coqui/PyPI requires_python confirmed; URLs probed).

## Fixes (multimodal 1.1 — voice-audio-ai)
- **P1** ghcr `whisper-stt` image presented as pullable → ImagePullBackOff. Marked as build-your-own placeholder.
- **P1** Coqui TTS install: original `TTS` PyPI caps at Python `<3.12` (confirmed) → maintained `coqui-tts` (idiap fork, 3.10–3.14); source link updated.
- **durable-vendor**: dated `as of 2026-06` snapshot caveat on the GPT-4o Realtime model/pricing section.
- Whisper citation de-rotted (bot-blocked blog → arXiv 2212.04356).

## Fixes (prereq 1.3)
- PyTorch CUDA docs link 404 (`.../cuda.rst`) → canonical `docs.pytorch.org/.../cuda.html`; label updated.

## Excluded (verified non-defects)
- prereq 1.1 pyenv `3.12.8`: intentional reproducibility pin.
- multimodal `tts-1` / `pyannote 3.1`: valid working models (covered by the snapshot caveat).

## Verification
- `verify_module.py --tier-only` → all touched modules remain **T0**.
- All changed URLs curl-checked → 200/3xx.

## Learner check
> **Active check**: Your team proposes using the most accurate STT model for every request because "accuracy matters most." Before reading further, decide which production metric will degrade first in a live voice assistant and why.

Refs #2020

🤖 Generated with [Claude Code](https://claude.com/claude-code)