### PR TITLE
feat(on-prem): currency refresh — OpenStack 2026.1 Gazpacho + TMC SaaS EoL (#2020)

### DIFF
--- a/src/content/docs/on-premises/multi-cluster/module-5.8-openstack-on-kubernetes.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.8-openstack-on-kubernetes.md
@@ -10,7 +10,7 @@ sidebar:
 >
 > **Prerequisites**: K8s basics, basic understanding of IaaS concepts, networking fundamentals helpful, and [Module 5.1: Private Cloud Platforms](../module-5.1-private-cloud/) recommended.
 
-All Kubernetes examples use the full `kubectl` command name and assume Kubernetes **1.35** behavior unless a tool-specific note says otherwise. OpenStack service versions in examples align with the **2025.2** (Flamingo) release family used by current OpenStack-Helm and Kolla-Ansible documentation unless your distribution pins a different matrix.
+All Kubernetes examples use the full `kubectl` command name and assume Kubernetes **1.35** behavior unless a tool-specific note says otherwise. OpenStack service versions in examples align with the **2025.2** (Flamingo) release family used by current OpenStack-Helm and Kolla-Ansible documentation; the latest upstream release is **2026.1** (Gazpacho, April 2026), so confirm your distribution's supported matrix before pinning.
 
 ---
 

--- a/src/content/docs/on-premises/multi-cluster/module-5.9-vmware-tanzu.md
+++ b/src/content/docs/on-premises/multi-cluster/module-5.9-vmware-tanzu.md
@@ -11,7 +11,7 @@ sidebar:
 >
 > **Prerequisites**: K8s basics. Basic understanding of VMware vSphere is helpful but not required.
 
-All shell examples use the full `kubectl` command name. Tanzu Kubernetes Grid (TKG) 2.5 standalone is in an end-of-life lifecycle: **2.5.4 is the final enterprise release**, and Broadcom directs new vSphere-integrated Kubernetes work toward **vSphere Kubernetes Service (VKS)** on vSphere Supervisor (formerly TKG Service). vSphere Supervisor and VKS clusters follow the vSphere 8.x and 9.x matrices in TechDocs. Kubernetes examples assume 1.35+ behavior unless a Tanzu release note pins an older supported minor for management clusters.
+All shell examples use the full `kubectl` command name. Tanzu Kubernetes Grid (TKG) 2.5 standalone is in an end-of-life lifecycle: **2.5.4 is the final enterprise release**, and Broadcom directs new vSphere-integrated Kubernetes work toward **vSphere Kubernetes Service (VKS)** on vSphere Supervisor (formerly TKG Service). vSphere Supervisor and VKS clusters follow the vSphere 8.x and 9.x matrices in TechDocs. Tanzu Mission Control's SaaS offering reached end-of-life on **November 15, 2025**, so where this module says "TMC," read it as the **Self-Managed (TMC-SM)** product unless you are migrating off the retired SaaS. Kubernetes examples assume 1.35+ behavior unless a Tanzu release note pins an older supported minor for management clusters.
 
 ---
 


### PR DESCRIPTION
## Summary

Two **web-verified** currency touches surfaced while cross-family reviewing the 6 record-less `on-premises/multi-cluster` modules (#2020 scattered). Both are one-line, dated, durable-vendor-style notes — no structural change; both modules stay **T0**.

| Module | Touch | Source |
|---|---|---|
| 5.8 openstack-on-kubernetes | Note **OpenStack 2026.1 (Gazpacho, Apr 2026)** as latest upstream alongside the 2025.2 Flamingo example baseline | [releases.openstack.org/gazpacho](https://releases.openstack.org/gazpacho/schedule.html) |
| 5.9 vmware-tanzu | Note **TMC SaaS reached EoL 2025-11-15** → read "TMC" as Self-Managed (TMC-SM) | [Broadcom migration guide](https://www.vmware.com/docs/migrate-tanzu-mission-control-saas-to-sm) |

The other 4 modules (5.6 Gardener, 5.7 multi-cluster-on-prem, 5.10 edge-fleet, 5.11 airgapped) reviewed clean — no content change, records committed direct-main. The Tanzu module was otherwise already current (TKG 2.5.4 final → VKS on vSphere 8 U3/VCF 9, 300-500% renewal reports, all verified correct).

## Learner check

> Broadcom completed the VMware acquisition on November 22, 2023, and VMware by Broadcom announced the end of perpetual license sales in December 2023.

🤖 Generated with [Claude Code](https://claude.com/claude-code)