### PR TITLE
fix(cka): #2020 currency + leak cleanup in cka 0.1/1.1

### DIFF
--- a/src/content/docs/k8s/cka/part0-environment/module-0.1-cluster-setup.md
+++ b/src/content/docs/k8s/cka/part0-environment/module-0.1-cluster-setup.md
@@ -312,10 +312,10 @@ If `kubectl get nodes` returns a connection error, split the problem into layers
 
 Kubernetes defines a networking model but does not ship one mandatory implementation. Every pod should get an IP address, pods should reach other pods without node-level NAT, and services should have stable virtual addresses, but a CNI plugin provides the host-level mechanics. This separation lets different environments choose Calico, Cilium, Flannel, cloud-native plugins, or other implementations without changing the Kubernetes API.
 
-For this lab, use Calico because it is widely documented, works well in kubeadm labs, and exposes the relationship between a cluster manifest and node-level CNI configuration. The command below is the protected setup command from the original module, and it applies a versioned Calico manifest directly from the upstream project. In a production change process, you would usually pin, review, and store manifests instead of applying remote YAML blindly.
+For this lab, use Calico because it is widely documented, works well in kubeadm labs, and exposes the relationship between a cluster manifest and node-level CNI configuration. The command below applies a versioned Calico manifest directly from the upstream project, pinned to a release that supports the Kubernetes version you installed. In a production change process, you would usually pin, review, and store manifests instead of applying remote YAML blindly.
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/calico.yaml
+kubectl apply -f https://raw.githubusercontent.com/projectcalico/calico/v3.32.0/manifests/calico.yaml
 ```
 
 Watch the `kube-system` namespace after applying the CNI. This is not just waiting for green output; it is learning which system pods belong to the base cluster and which ones come from the network plugin. Calico runs as a DaemonSet on nodes because networking must be configured locally on each machine that will run pods.
@@ -781,7 +781,7 @@ Prepare a new VM with the same base setup, join it as `worker-03`, verify it bec
 - [Kubernetes: Network plugins](https://kubernetes.io/docs/concepts/extend-kubernetes/compute-storage-net/network-plugins/)
 - [Kubernetes: Debugging nodes with crictl](https://kubernetes.io/docs/tasks/debug/debug-cluster/crictl/)
 - [Kubernetes Linux package repositories for v1.35](https://pkgs.k8s.io/core:/stable:/v1.35/deb/)
-- [Project Calico installation manifest used in this lab](https://raw.githubusercontent.com/projectcalico/calico/v3.27.0/manifests/calico.yaml)
+- [Project Calico installation manifest used in this lab](https://raw.githubusercontent.com/projectcalico/calico/v3.32.0/manifests/calico.yaml)
 - [containerd documentation](https://containerd.io/docs/)
 - [Killercoda KubeDojo lab scenario](https://killercoda.com/kubedojo/scenario/cka-0.1-cluster-setup)
 

--- a/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.1-control-plane.md
+++ b/src/content/docs/k8s/cka/part1-cluster-architecture/module-1.1-control-plane.md
@@ -631,7 +631,7 @@ When the API server is down, `kubectl logs` depends on the failed path, so it is
 
 ## Hands-On Exercise
 
-This exercise uses the protected command drills from the original module and places them in a safer diagnostic sequence. Run destructive steps only in a disposable practice cluster, such as the linked lab environment, because moving static manifests intentionally breaks control plane components. If you are on a shared cluster, perform only the read-only inspection steps and discuss the recovery tasks instead of executing them.
+This exercise places the control plane command drills in a safer diagnostic sequence. Run destructive steps only in a disposable practice cluster, such as the linked lab environment, because moving static manifests intentionally breaks control plane components. If you are on a shared cluster, perform only the read-only inspection steps and discuss the recovery tasks instead of executing them.
 
 **Task**: Explore your cluster's control plane components and practice mapping symptoms to owners.
 


### PR DESCRIPTION
## What
Cross-family review (opus-inline, #2020) of the two genuinely-unreviewed cka modules — `0.1-cluster-setup` and `1.1-control-plane` (both stage `SKIPPED`, no APPROVE record). One real currency defect + a cosmetic leak cleanup.

## Changes
- **0.1-cluster-setup — Calico `v3.27.0` → `v3.32.0`** (apply command + Sources link). v3.27.0 (Dec 2023) predates Kubernetes 1.35 and is unsupported on it; Calico maintains only its latest ~two releases and tracks upstream k8s. The old manifest URL still resolves (HTTP 200) so the link-check, Zod, and verifier were all blind to the version skew — the classic valid-but-stale blind spot. v3.32.0 manifest web-verified HTTP 200.
- **0.1 + 1.1 — remove authoring-process leak phrasing** ("the protected setup command / command drills from the original module") that surfaced in learner-facing prose.

## Verification
- Both modules remain **T0** post-edit (`verify_module.py --tier-only`).
- k8s 1.35 left as-is (recent/supported; not chasing the absolute-latest minor per the durable-vendor rule).
- 1.1 otherwise clean on review (diagnostic-chain pedagogy, canonical k8s doc sources, etcd v3.6, all scenarios properly labeled).

## Learner check
> Both modules teach the same control-plane→worker separation and static-pod recovery; the only learner-visible change is the Calico manifest now pins a release that actually supports the cluster's Kubernetes version, and two stray "from the original module" phrases are gone.

Refs #2020