### PR TITLE
fix(on-prem): 9.6-high-performance-storage dead links + CSI driver names (T0)

### DIFF
--- a/src/content/docs/on-premises/ai-ml-infrastructure/module-9.6-high-performance-storage-ai.md
+++ b/src/content/docs/on-premises/ai-ml-infrastructure/module-9.6-high-performance-storage-ai.md
@@ -127,7 +127,7 @@ Topology matters because PCIe and NUMA placement shape the real path. If a NIC, 
 | **Complexity** | Extremely High | Moderate | Low (Turnkey, but closed source) |
 | **POSIX Support** | Strict | Strict | Strict |
 | **Small File Perf** | Poor to Moderate | Good | Excellent |
-| **Kubernetes CSI** | `intel/lustre-csi-driver` | `beegfs/beegfs-csi-driver` | `weka/csi-wekafs` |
+| **Kubernetes CSI** | `HewlettPackard/lustre-csi-driver` | `ThinkParQ/beegfs-csi-driver` | `weka/csi-wekafs` |
 
 The table is a starting point, not a universal ranking. Lustre can deliver enormous throughput in environments with storage engineering expertise, but it rewards careful tuning and operational maturity. BeeGFS is often easier for on-premises AI teams to adopt because metadata and storage services are simpler to reason about, though it still needs hardware isolation and monitoring. Commercial systems can reduce operational burden, but they introduce procurement, licensing, and vendor dependency that must be weighed against internal expertise.
 
@@ -552,10 +552,10 @@ If a pod fails to mount the PVC, ensure the `csi-nodeplugin-fluid` DaemonSet is 
 - [Kubernetes generic ephemeral volumes](https://kubernetes.io/docs/concepts/storage/ephemeral-volumes/)
 - [Kubernetes dynamic volume provisioning](https://kubernetes.io/docs/concepts/storage/dynamic-provisioning/)
 - [NVIDIA GPUDirect Storage overview](https://docs.nvidia.com/gpudirect-storage/overview-guide/)
-- [NVIDIA GPU Operator GPUDirect Storage](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-operator-gds.html)
+- [NVIDIA GPU Operator GPUDirect Storage](https://docs.nvidia.com/datacenter/cloud-native/gpu-operator/latest/gpu-operator-rdma.html)
 - [Fluid project repository](https://github.com/fluid-cloudnative/fluid)
 - [Fluid Helm chart repository](https://fluid-cloudnative.github.io/charts)
-- [Alluxio on Kubernetes documentation](https://documentation.alluxio.io/os/user/stable/en/kubernetes/Running-Alluxio-On-Kubernetes.html)
+- [Alluxio on Kubernetes documentation](https://documentation.alluxio.io/os-en/kubernetes/running-alluxio-on-kubernetes)
 - [BeeGFS CSI driver](https://github.com/ThinkParQ/beegfs-csi-driver)
 - [Apache archive source used in the lab](https://archive.apache.org/dist/spark/)
 - [kubernetes.io: volumes](https://kubernetes.io/docs/concepts/storage/volumes/#flexvolume) — The Kubernetes volumes documentation directly marks FlexVolume deprecated in v1.23 and recommends CSI instead.


### PR DESCRIPTION
## What
Cross-family review (opus-inline, s174) of `on-premises/ai-ml-infrastructure/module-9.6-high-performance-storage-ai.md` — the **last genuinely un-reviewed curriculum module** outside the AI-history book (#1876). Board: COMMITTED + score 5.0 but no APPROVE verdict and no `.pipeline/reviews/` record.

The module itself is strong (durable-spine, data-path-first; opener correctly labeled `Hypothetical scenario:`; anti-fab clean; all density/structure gates pass). It was only **T3 on one gate (`sources_all_reachable`)** due to two dead references the verifier couldn't see were wrong, plus one fabricated identifier in a comparison table.

## Fixes (all web-verified)
- **NVIDIA GPU Operator GDS** source 404'd (`gpu-operator-gds.html` removed) → `gpu-operator-rdma.html` (current GPU-Operator page; covers GPUDirect Storage 14× + `nvidia-fs`). 200.
- **Alluxio on Kubernetes** source 307→404 (`documentation.alluxio.io/os/user/stable/...`) → `documentation.alluxio.io/os-en/kubernetes/running-alluxio-on-kubernetes` (clean 200; the path the sibling `1.4-ai-storage` module already uses).
- **Comparison table** cited `intel/lustre-csi-driver` which **does not exist** (404, fabricated) → `HewlettPackard/lustre-csi-driver` (real, 200); `beegfs/beegfs-csi-driver` → `ThinkParQ/beegfs-csi-driver` (correct org, matches the Sources link).

## Verification
- `verify_module.py`: **T0**, all gates pass, `sources_all_reachable: true` (20×200, 0×404).
- Sibling-grepped both dead URLs repo-wide — the only other Alluxio ref (`1.4-ai-storage`) uses the working `os-en` path, no change needed.

Closes the review-coverage spirit of #2020 (now closed). APPROVE record committed to main on merge.