### PR TITLE
build(deps): pin vite 7.3.5 + dompurify 3.4.11 + brace-expansion 5.0.6 (security)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3325,9 +3325,9 @@
       "license": "ISC"
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -4339,9 +4339,9 @@
       }
     },
     "node_modules/dompurify": {
-      "version": "3.4.10",
-      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.10.tgz",
-      "integrity": "sha512-0xzNv0e7oYC6yyuOGZIABPM4qtg3QxLFniDNPP4ZP90wR8Yq3zgwpRbrNiT4N3IKqDbbYFEJLV+JWEs19aZ//w==",
+      "version": "3.4.11",
+      "resolved": "https://registry.npmjs.org/dompurify/-/dompurify-3.4.11.tgz",
+      "integrity": "sha512-zhlUV12GsaRzMsf9q5M254YhA4+VuF0fG+QFqu6aYpoGlKtz+w8//jBcGVYBgQkR5GHjUomejY84AV+/uPbWdw==",
       "license": "(MPL-2.0 OR Apache-2.0)",
       "optionalDependencies": {
         "@types/trusted-types": "^2.0.7"
@@ -8917,9 +8917,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.2.tgz",
-      "integrity": "sha512-Bby3NOsna2jsjfLVOHKes8sGwgl4TT0E6vvpYgnAYDIF/tie7MRaFthmKuHx1NSXjiTueXH3do80FMQgvEktRg==",
+      "version": "7.3.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.5.tgz",
+      "integrity": "sha512-KuOaNhcnGFN2zIPGA7wRmzF+lJA1sea7rHq17aiJ++9lzY1WWG6Jpwqwe1KNbRVPIqHmr8GLYx7jbrQcN/7/ww==",
       "license": "MIT",
       "dependencies": {
         "esbuild": "^0.27.0",

--- a/package.json
+++ b/package.json
@@ -23,7 +23,9 @@
   },
   "overrides": {
     "uuid": "^14.0.0",
-    "esbuild": "^0.28.1"
+    "esbuild": "^0.28.1",
+    "vite": "^7.3.5",
+    "dompurify": "^3.4.11"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^8.61.0",


### PR DESCRIPTION
## What
Clears **all 3 open Dependabot alerts** + 1 audit-only finding. `npm audit` → **0 vulnerabilities**.

| Alert | Pkg | Sev | From → To | Issue |
|---|---|---|---|---|
| #22 | vite | **HIGH** | 7.3.2 → 7.3.5 | `server.fs.deny` bypass on Windows alternate paths |
| #23 | vite | medium | 7.3.2 → 7.3.5 | launch-editor NTLMv2 hash disclosure (Windows) |
| #30 | dompurify | medium | 3.4.10 → 3.4.11 | `ALLOWED_ATTR` pollution via `setConfig()` |
| audit-only | brace-expansion | medium | 5.0.5 → 5.0.6 | numeric-range DoS-protection bypass |

## How
All four are **transitive**. vite + dompurify pinned via `package.json` `overrides` (the repo's existing pattern for `uuid`/`esbuild`) — the canonical force-resolve for transitive security fixes. brace-expansion via a targeted lockfile bump (single instance in the tree, no other major line present, so no override needed).

Pinning via `overrides` means **package.json changes alongside the lockfile**, so this passes the supply-chain **lockfile-integrity tripwire** (which fails by design on lockfile-only diffs, and per #2015 the `[lockfile-only]` marker can't suppress it in PR CI). vite stays on the **7.x** line (astro@6.4.4 already resolved 7.3.x — no major bump to 8.x).

## Verification
- `npm audit`: **0 vulnerabilities** (was 1 high + 3 moderate).
- Local `npm run build`: **green**, full render 33s, no schema/render errors.
- Diff scope: package.json (+4 lines) + package-lock.json (version/integrity bumps only).

Supersedes Dependabot **PR #2045** (dompurify-only; will close after merge).