### PR TITLE
fix(mermaid): quote 43 unquoted-paren flowchart labels + wire CI gate (#1823)

### DIFF
--- a/.github/workflows/link-check.yml
+++ b/.github/workflows/link-check.yml
@@ -41,3 +41,11 @@ jobs:
 
       - name: Check lab URL convention
         run: python scripts/ci/check_lab_urls.py
+
+      - name: Check Mermaid flowchart labels
+        # Mermaid renders client-side, so neither the astro build nor the
+        # site-health check ever parses diagram syntax. An unquoted '(' in a
+        # flowchart [..]/{..} node label aborts the whole diagram (it renders
+        # as raw code in the browser). This stdlib-only lint closes that gap
+        # deterministically. Author fix: `python scripts/ci/check_mermaid_labels.py --fix`.
+        run: python scripts/ci/check_mermaid_labels.py

--- a/scripts/ci/check_mermaid_labels.py
+++ b/scripts/ci/check_mermaid_labels.py
@@ -52,12 +52,14 @@ DOC_SUFFIXES = {".md", ".mdx"}
 # (``[(``), NOT a subroutine (``[[``), and contains a paren before its ``]``.
 # The label body excludes ``"`` so a *quoted* label anywhere in the construct
 # (e.g. the parallelogram ``[/"...(...)..."/]``) does not match — only a truly
-# unquoted paren is a parse breaker.
-SQUARE = re.compile(r"[A-Za-z0-9_)\]]\[(?![\"(\[])[^\]\"]*[()][^\]\"]*\]")
+# unquoted paren is a parse breaker. Group 1 = the char before ``[`` (a
+# left-context guard, kept verbatim); group 2 = the label body, so ``--fix``
+# can rewrite the match as ``<g1>["<g2>"]``.
+SQUARE = re.compile(r"([A-Za-z0-9_)\]])\[(?![\"(\[])([^\]\"]*[()][^\]\"]*)\]")
 
 # Rhombus/decision node ``id{label}`` whose label is NOT quoted (``{"``), NOT a
-# hexagon (``{{``), and contains a paren before its ``}``.
-RHOMBUS = re.compile(r"[A-Za-z0-9_)\]]\{(?![\"{])[^}\"]*[()][^}\"]*\}")
+# hexagon (``{{``), and contains a paren before its ``}``. Same two groups.
+RHOMBUS = re.compile(r"([A-Za-z0-9_)\]])\{(?![\"{])([^}\"]*[()][^}\"]*)\}")
 
 FLOWCHART_PREFIXES = ("flowchart", "graph")
 
@@ -108,6 +110,85 @@ def scan(root: Path) -> list[tuple[Path, int, str]]:
     return findings
 
 
+def _quote_line(line: str) -> tuple[str, int]:
+    """Wrap every unquoted-paren square/rhombus label on ``line`` in quotes.
+
+    Uses the SAME ``SQUARE``/``RHOMBUS`` patterns as the detector, so a fixed
+    line is, by construction, no longer a violation. Returns (new_line, count).
+    """
+    count = 0
+
+    def sq(m: re.Match) -> str:
+        nonlocal count
+        count += 1
+        return f'{m.group(1)}["{m.group(2)}"]'
+
+    def rh(m: re.Match) -> str:
+        nonlocal count
+        count += 1
+        return f'{m.group(1)}{{"{m.group(2)}"}}'
+
+    line = SQUARE.sub(sq, line)
+    line = RHOMBUS.sub(rh, line)
+    return line, count
+
+
+def fix_text(text: str) -> tuple[str, int]:
+    """Return (new_text, num_fixes) with unquoted-paren labels quoted.
+
+    Mirrors ``scan_text``'s fence/type scoping exactly — only lines inside a
+    ```mermaid flowchart/graph fence are rewritten; everything else (prose,
+    code, non-flowchart diagrams) is passed through byte-for-byte.
+    """
+    out: list[str] = []
+    in_mermaid = False
+    type_decided = False
+    is_flowchart = False
+    fixes = 0
+    for raw in text.splitlines():
+        stripped = raw.strip()
+        if stripped.startswith("```"):
+            in_mermaid = not in_mermaid and stripped.startswith("```mermaid")
+            type_decided = False
+            is_flowchart = False
+            out.append(raw)
+            continue
+        if not in_mermaid or not stripped:
+            out.append(raw)
+            continue
+        if not type_decided:
+            type_decided = True
+            is_flowchart = stripped.lower().startswith(FLOWCHART_PREFIXES)
+            out.append(raw)
+            continue
+        if is_flowchart:
+            new, n = _quote_line(raw)
+            fixes += n
+            out.append(new)
+        else:
+            out.append(raw)
+    new_text = "\n".join(out)
+    if text.endswith("\n"):
+        new_text += "\n"
+    return new_text, fixes
+
+
+def fix(root: Path) -> list[tuple[Path, int]]:
+    """Quote unquoted-paren labels in-place. Returns (path, count) per file."""
+    changed: list[tuple[Path, int]] = []
+    for path in sorted(root.rglob("*")):
+        if path.suffix not in DOC_SUFFIXES or not path.is_file():
+            continue
+        text = path.read_text(encoding="utf-8")
+        if "```mermaid" not in text:
+            continue
+        new_text, n = fix_text(text)
+        if n:
+            path.write_text(new_text, encoding="utf-8")
+            changed.append((path, n))
+    return changed
+
+
 def selftest() -> int:
     # Each snippet is the BODY of a ```mermaid fence; ``fence`` wraps it so the
     # scanner sees a real fenced block (it only inspects ```mermaid regions).
@@ -137,9 +218,19 @@ def selftest() -> int:
         if scan_text(fence(src)):
             print(f"selftest FAIL: false positive on:\n    {src!r}")
             fails += 1
+        # --fix must leave a clean line byte-for-byte unchanged.
+        fixed, n = fix_text(fence(src))
+        if n or fixed != fence(src):
+            print(f"selftest FAIL: --fix altered a clean line:\n    {src!r}")
+            fails += 1
     for src in bad:
         if not scan_text(fence(src)):
             print(f"selftest FAIL: missed violation in:\n    {src!r}")
+            fails += 1
+        # --fix must make the violation disappear (scan finds nothing after).
+        fixed, n = fix_text(fence(src))
+        if n < 1 or scan_text(fixed):
+            print(f"selftest FAIL: --fix did not resolve:\n    {src!r}\n    -> {fixed!r}")
             fails += 1
     if fails:
         print(f"selftest: {fails} failure(s)")
@@ -152,6 +243,11 @@ def main() -> int:
     parser = argparse.ArgumentParser(description=__doc__)
     parser.add_argument("--root", default="src/content/docs", type=Path)
     parser.add_argument("--selftest", action="store_true")
+    parser.add_argument(
+        "--fix",
+        action="store_true",
+        help="Quote unquoted-paren labels in place instead of just reporting.",
+    )
     args = parser.parse_args()
 
     if args.selftest:
@@ -160,6 +256,18 @@ def main() -> int:
     if not args.root.exists():
         print(f"error: root not found: {args.root}", file=sys.stderr)
         return 1
+
+    if args.fix:
+        changed = fix(args.root)
+        total = sum(n for _, n in changed)
+        if not changed:
+            print(f"mermaid label fix: nothing to fix (root={args.root})")
+            return 0
+        print(f"mermaid label fix: quoted {total} label(s) in {len(changed)} file(s)\n")
+        for path, n in changed:
+            print(f"  {path}: {n}")
+        # Re-scan so the command's exit code reflects the post-fix state.
+        return 1 if scan(args.root) else 0
 
     findings = scan(args.root)
     if not findings:

--- a/src/content/docs/cloud/aws-essentials/module-1.8-lambda.md
+++ b/src/content/docs/cloud/aws-essentials/module-1.8-lambda.md
@@ -46,11 +46,11 @@ When an event triggers a Lambda function, AWS must allocate an execution environ
 
 ```mermaid
 graph TD
-    A["Request 1 (Cold Start)"] --> B[INIT Phase<br><i>(billed as part of invocation duration)</i><br>Download code -> Start runtime -> Run init code<br>Extension init -> Runtime init -> Function init<br>~100ms-10s depending on language, package size, VPC]
-    B --> C[INVOKE Phase<br><i>(billed per invocation)</i><br>Run handler function -> Return response<br>This is your actual code executing]
+    A["Request 1 (Cold Start)"] --> B["INIT Phase<br><i>(billed as part of invocation duration)</i><br>Download code -> Start runtime -> Run init code<br>Extension init -> Runtime init -> Function init<br>~100ms-10s depending on language, package size, VPC"]
+    B --> C["INVOKE Phase<br><i>(billed per invocation)</i><br>Run handler function -> Return response<br>This is your actual code executing"]
 
     C --> D["Request 2 (Warm Start - same environment reused)"]
-    D --> E[INVOKE Phase only<br><i>(no INIT)</i><br>Run handler function -> Return response<br>Init code NOT re-executed, connections reused]
+    D --> E["INVOKE Phase only<br><i>(no INIT)</i><br>Run handler function -> Return response<br>Init code NOT re-executed, connections reused"]
 
     E --> F["Request 3 (Warm Start - reused again)"]
     F --> G[INVOKE Phase only<br>Run handler function -> Return response]
@@ -509,8 +509,8 @@ Early in the serverless movement, engineering teams frequently constructed "orch
 
 ```mermaid
 graph TD
-    A[Lambda A (15 min timeout)] --> B[Lambda B (15 min timeout)]
-    B --> C[Lambda C (15 min timeout)]
+    A["Lambda A (15 min timeout)"] --> B["Lambda B (15 min timeout)"]
+    B --> C["Lambda C (15 min timeout)"]
     C --> D[Lambda D]
 ```
 
@@ -533,7 +533,7 @@ graph TD
     S1 -- Failure --> EH1[Error Handler]
 
     S2 -- Success --> S3{State 3: Choice}
-    S2 -- Failure --> R1[Retry (3x)]
+    S2 -- Failure --> R1["Retry (3x)"]
     R1 --> EH2[Error Handler]
 
     S3 -- Condition A --> LC[Invoke Lambda C]

--- a/src/content/docs/cloud/azure-essentials/module-3.9-key-vault.md
+++ b/src/content/docs/cloud/azure-essentials/module-3.9-key-vault.md
@@ -62,7 +62,7 @@ graph TD
         K[Keys<br/>- data-encrypt<br/>- signing-key<br/>- wrapping-key]
         C[Certificates<br/>- api-tls<br/>- mtls-cert<br/>- code-sign]
     end
-    F[Features:<br/>• HSM-backed FIPS 140-2 L2 / 140-3 L3 (HSM Platform 2, current default)<br/>• Versioned updates<br/>• Audit logged access<br/>• Soft delete & purge protection<br/>• Private endpoint support]
+    F["Features:<br/>• HSM-backed FIPS 140-2 L2 / 140-3 L3 (HSM Platform 2, current default)<br/>• Versioned updates<br/>• Audit logged access<br/>• Soft delete & purge protection<br/>• Private endpoint support"]
     Azure Key Vault --- F
     style F text-align:left
 ```

--- a/src/content/docs/cloud/gcp-essentials/module-2.11-cloud-build.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.11-cloud-build.md
@@ -901,7 +901,7 @@ flowchart TD
     Q1{Does your build need to access\\nprivate VPC resources?}
     Q1 -- No --> Q2{Do you have regulatory\\ndedicated-tenancy requirement?}
     Q1 -- Yes --> Private
-    Q2 -- No --> Q3{Is build duration predictability\\ncritical (no cold starts)?}
+    Q2 -- No --> Q3{"Is build duration predictability\\ncritical (no cold starts)?"}
     Q2 -- Yes --> Private
     Q3 -- No --> Default
     Q3 -- Yes --> Private

--- a/src/content/docs/cloud/gcp-essentials/module-2.12-patterns.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.12-patterns.md
@@ -781,7 +781,7 @@ Use the flowchart below when choosing region, compute tier, and managed-versus-s
 ```mermaid
 flowchart TD
     Start[New workload design] --> Region{Data residency<br/>or latency constraint?}
-    Region -- Yes --> PickRegion[Choose allowed region(s)<br/>via org policy + user proximity]
+    Region -- Yes --> PickRegion["Choose allowed region(s)<br/>via org policy + user proximity"]
     Region -- No --> DefaultRegion[Default to single region<br/>with multi-region DR if RTO requires]
     PickRegion --> Compute{Needs full Kubernetes API,<br/>GPU nodes, or StatefulSets?}
     DefaultRegion --> Compute

--- a/src/content/docs/cloud/gcp-essentials/module-2.2-vpc.md
+++ b/src/content/docs/cloud/gcp-essentials/module-2.2-vpc.md
@@ -805,7 +805,7 @@ flowchart TD
     Q_PRIV -->|Yes, inbound from internet| Q_LB{What type<br/>of traffic?}
     Q_PRIV -->|No, private only| Q_EGRESS{Need internet<br/>egress?}
 
-    Q_LB -->|HTTP/HTTPS| EXT_HTTP[Global external HTTP(S) LB]
+    Q_LB -->|HTTP/HTTPS| EXT_HTTP["Global external HTTP(S) LB"]
     Q_LB -->|TCP/UDP (non-HTTP)| EXT_TCP[Regional external TCP/UDP Network LB]
     Q_LB -->|TCP with SSL offload| EXT_SSL[Global external SSL Proxy LB]
 

--- a/src/content/docs/k8s/kcna/part2-container-orchestration/module-2.2-scaling.md
+++ b/src/content/docs/k8s/kcna/part2-container-orchestration/module-2.2-scaling.md
@@ -118,8 +118,8 @@ flowchart TD
             Current_Replicas[Current replicas: 2]
 
             subgraph Calculation
-                Desired_Replicas[Desired = Current Replicas × (Current Metric / Target Metric)]
-                Example_Calc{Example: 2 × (80 / 50) ≈ 4}
+                Desired_Replicas["Desired = Current Replicas × (Current Metric / Target Metric)"]
+                Example_Calc{"Example: 2 × (80 / 50) ≈ 4"}
             end
 
             Target_Metric & Current_Metric & Current_Replicas --> Calculation
@@ -239,7 +239,7 @@ flowchart TD
         VPA_Modes(Modes)
         VPA_Modes --> Mode_Off[Off: Just recommendations]
         VPA_Modes --> Mode_Initial[Initial: Set on Pod creation]
-        VPA_Modes --> Mode_Auto[Auto: Update running Pods (recreates)]
+        VPA_Modes --> Mode_Auto["Auto: Update running Pods (recreates)"]
         VPA_Modes -- Note --> Addon[VPA is NOT built into Kubernetes core - It's an add-on]
     end
 ```
@@ -268,7 +268,7 @@ Scale-down is cautious because removing a node can disrupt workloads. Cluster Au
 flowchart TD
     subgraph Cluster Autoscaler
         subgraph Scale Up
-            A[Pods pending (unschedulable)] --> B(Cluster Autoscaler detects pending Pods)
+            A["Pods pending (unschedulable)"] --> B(Cluster Autoscaler detects pending Pods)
             B --> C(Requests new node from cloud provider)
             C --> D(New node joins cluster)
             D --> E(Pending Pods get scheduled)

--- a/src/content/docs/linux/foundations/networking/module-3.2-dns-linux.md
+++ b/src/content/docs/linux/foundations/networking/module-3.2-dns-linux.md
@@ -48,7 +48,7 @@ graph TD
     A[Application: "Connect to api.example.com"] --> B{1. Check /etc/hosts};
     B -- Not found --> C{2. Check /etc/resolv.conf for DNS server};
     B -- Found --> E[Application connects to 192.168.1.10];
-    C --> D[3. Query DNS server (10.96.0.10)];
+    C --> D["3. Query DNS server (10.96.0.10)"];
     D --> F[4. DNS server returns: 93.184.216.34];
     F --> E[5. Application connects to 93.184.216.34];
 
@@ -295,7 +295,7 @@ graph TD
     P[Pod Query: "my-service.default.svc.cluster.local"] --> C(CoreDNS);
     C -- Cluster queries: *.cluster.local --> K[Answer from Kubernetes API];
     C -- External queries: *.* --> U[Forward to upstream DNS];
-    K --> R[Returns: 10.96.45.123 (Service ClusterIP)];
+    K --> R["Returns: 10.96.45.123 (Service ClusterIP)"];
     U --> R;
 
     subgraph CoreDNS_Server [CoreDNS (10.96.0.10)]
@@ -307,7 +307,7 @@ CoreDNS has two major responsibilities in this path. For cluster names under the
 
 ```mermaid
 graph TD
-    A[Service Fully Qualified Domain Name (FQDN)] --> B("my-service.namespace.svc.cluster.local")
+    A["Service Fully Qualified Domain Name (FQDN)"] --> B("my-service.namespace.svc.cluster.local")
     B --> C{Components of the FQDN}
     C --> D[Service Name: my-service]
     C --> E[Namespace: namespace]

--- a/src/content/docs/linux/foundations/system-essentials/module-1.3-filesystem-hierarchy.md
+++ b/src/content/docs/linux/foundations/system-essentials/module-1.3-filesystem-hierarchy.md
@@ -277,15 +277,15 @@ Filenames are convenient for humans, but the filesystem tracks file identity thr
 
 ```mermaid
 graph TD
-    inode_box[INODE] --> file_type[File type (regular, directory, etc.)]
-    inode_box --> permissions[Permissions (rwx)]
-    inode_box --> owner[Owner (UID)]
-    inode_box --> group[Group (GID)]
+    inode_box[INODE] --> file_type["File type (regular, directory, etc.)"]
+    inode_box --> permissions["Permissions (rwx)"]
+    inode_box --> owner["Owner (UID)"]
+    inode_box --> group["Group (GID)"]
     inode_box --> size[Size]
-    inode_box --> timestamps[Timestamps (atime, mtime, ctime)]
+    inode_box --> timestamps["Timestamps (atime, mtime, ctime)"]
     inode_box --> hard_links[Number of hard links]
     inode_box --> data_pointers[Pointers to data blocks]
-    inode_box -- "(NOT the filename!)" --> data_blocks[DATA BLOCKS<br>(actual file content)]
+    inode_box -- "(NOT the filename!)" --> data_blocks["DATA BLOCKS<br>(actual file content)"]
 ```
 
 Inode pressure produces a distinctive failure mode. A filesystem can show gigabytes free in `df -h` while `touch newfile` fails because there are no free inodes left to describe new files. That usually happens in directories full of tiny files: session stores, package cache fragments, mail spools, extracted dependency trees, or application-generated scratch files. Pause and predict: if inode usage is exhausted but space remains, would deleting one huge file solve the problem? Usually not, because the problem is the count of file records, not the amount of stored data.

--- a/src/content/docs/linux/operations/module-8.1-storage-management.md
+++ b/src/content/docs/linux/operations/module-8.1-storage-management.md
@@ -43,16 +43,16 @@ Storage begins with a layered mental model. The kernel discovers a block device,
 
 ```mermaid
 graph TD
-    A[Physical Disk (/dev/sda)] --> B{Partition 1 (/dev/sda1)}
-    B --> C[/boot (ext4)]
-    A --> D{Partition 2 (/dev/sda2)}
+    A["Physical Disk (/dev/sda)"] --> B{"Partition 1 (/dev/sda1)"}
+    B --> C["/boot (ext4)"]
+    A --> D{"Partition 2 (/dev/sda2)"}
     D --> E[LVM Physical Volume]
-    E --> F[Volume Group (vg_data)]
-    F --> G[Logical Volume (lv_root)]
-    G --> H[/ (ext4)]
-    F --> I[Logical Volume (lv_home)]
-    I --> J[/home (xfs)]
-    A --> K{Partition 3 (/dev/sda3)}
+    E --> F["Volume Group (vg_data)"]
+    F --> G["Logical Volume (lv_root)"]
+    G --> H["/ (ext4)"]
+    F --> I["Logical Volume (lv_home)"]
+    I --> J["/home (xfs)"]
+    A --> K{"Partition 3 (/dev/sda3)"}
     K --> L[swap]
 ```
 
@@ -137,12 +137,12 @@ LVM is the single most important storage abstraction for Linux operations becaus
 
 ```mermaid
 graph TD
-    PV1[Physical Volume (/dev/sdb1)] --> VG[Volume Group (vg_storage)]
-    PV2[Physical Volume (/dev/sdc1)] --> VG
-    VG -- "Total: 50G, Free: 30G" --> LV1[Logical Volume (lv_data)]
-    LV1 --> DataMount[/data (ext4)]
-    VG -- "Total: 50G, Free: 30G" --> LV2[Logical Volume (lv_logs)]
-    LV2 --> LogsMount[/var/log (xfs)]
+    PV1["Physical Volume (/dev/sdb1)"] --> VG["Volume Group (vg_storage)"]
+    PV2["Physical Volume (/dev/sdc1)"] --> VG
+    VG -- "Total: 50G, Free: 30G" --> LV1["Logical Volume (lv_data)"]
+    LV1 --> DataMount["/data (ext4)"]
+    VG -- "Total: 50G, Free: 30G" --> LV2["Logical Volume (lv_logs)"]
+    LV2 --> LogsMount["/var/log (xfs)"]
 ```
 
 The key insight is that the filesystem does not need to know which physical disk provided the extents. That separation is powerful, but it also creates a responsibility to inspect every layer before changing anything. On a busy server, verify the physical volume, volume group, logical volume, filesystem type, mount point, and backup posture before resizing, because a correct command against the wrong LV is still an outage.

--- a/src/content/docs/on-premises/operations/module-7.6-self-hosted-cicd.md
+++ b/src/content/docs/on-premises/operations/module-7.6-self-hosted-cicd.md
@@ -47,7 +47,7 @@ Here is a visual representation of how the Kubernetes-native architecture (speci
 
 ```mermaid
 graph TD
-    A[Git Webhook] --> B[Tekton Triggers (EventListener)]
+    A[Git Webhook] --> B["Tekton Triggers (EventListener)"]
     B --> C[TriggerBinding / TriggerTemplate]
     C --> D[PipelineRun CRD Created]
     D --> E[Tekton Controller]

--- a/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.3-distributed-training.md
+++ b/src/content/docs/platform/disciplines/data-ai/ai-infrastructure/module-1.3-distributed-training.md
@@ -58,7 +58,7 @@ That expectation-setting step also prevents a common budgeting mistake. GPU coun
 graph TD
     subgraph Distributed_Training [Distributed Training]
         DP[<b>Data Parallel</b><br>Same model on every GPU.<br>Different data.<br>Sync gradients after each step.<br>Scales to many GPUs easily.]
-        MP[<b>Model Parallel (Tensor)</b><br>Split layers across GPUs.<br>Each GPU has part of each layer.<br>Forward/backward require all-to-all comms.]
+        MP["<b>Model Parallel (Tensor)</b><br>Split layers across GPUs.<br>Each GPU has part of each layer.<br>Forward/backward require all-to-all comms."]
         PP[<b>Pipeline Parallel</b><br>Split layers into stages.<br>Micro-batches flow through stages.<br>Reduces memory per stage.]
     end
 ```


### PR DESCRIPTION
## Summary

Closes the unquoted-paren mermaid bug class (#1823). Mermaid renders **client-side**, so an unquoted `(` inside a flowchart `[..]`/`{..}` node label aborts the *whole* diagram (raw code shown in the browser) — invisible to `npm run build` and the site-health check. #1824 fixed the acute case + added `scripts/ci/check_mermaid_labels.py` but left it un-wired and the corpus un-swept.

## Changes

- **`--fix` mode** added to the lint, driven by the **same** `SQUARE`/`RHOMBUS` regexes as the detector → a fixed line is, by construction, no longer a violation. Selftest now asserts `--fix` resolves every `bad` case and leaves every `good` case byte-for-byte unchanged.
- **43 labels quoted across 11 files** (cloud, linux, kcna, on-premises, ai-infrastructure) via `--fix`. HTML (`<br>`/`<i>`/`<b>`/`•`) preserved inside the quotes; round nodes `(...)` and bare nodes correctly left untouched.
- **CI gate**: the stdlib-only check is wired into the always-on `link-check` job (no `paths:` filter → required-check-safe), so this class can never regress.

## Verification

- `--selftest`: OK (now exercises `--fix` too)
- `--fix` then re-scan: **0 violations**
- `ruff check`: clean · `zizmor --offline --strict-collection .github/`: no findings
- All edits are inside ```mermaid code fences → astro build unaffected (build-check CI confirms)

Refs #1823