### PR TITLE
fix(ci): uk_calque_v2 MOJIBAKE_RE false-positives on legit punctuation (#2078)

### DIFF
--- a/scripts/checks/uk_calque_v2.py
+++ b/scripts/checks/uk_calque_v2.py
@@ -36,8 +36,21 @@ THE_FOLLOWING_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
+# A run of characters wedged between two Cyrillic letters is treated as encoding
+# corruption (CJK, soft hyphen, zero-width, box-drawing, replacement char ...). The
+# allowed set must whitelist everything that legitimately appears inside or between
+# Cyrillic words, or the gate false-positives on valid Ukrainian:
+#   - whitespace, Cyrillic, Latin, digits, apostrophes, hyphen/dashes
+#   - sentence punctuation, brackets, guillemets, quote
+#   - technical punctuation / _ = + * | & % @ # ~ ^ < > $  (e.g. "klient/server",
+#     snake_case identifiers, "metrics+traces", "key=value")
+#   - middle dot U+00B7 ("MVt\u00b7god"), degree sign U+00B0
+#   - Unicode combining diacritics U+0300-U+036F (stress marks)
 MOJIBAKE_RE = re.compile(
-    r"[\u0400-\u04FF][^\s\u0400-\u04FFa-zA-Z0-9'’ʼ\-—–—.,;:!?()[\]{}«»\"]+[\u0400-\u04FF]"
+    r"[\u0400-\u04FF]"
+    r"[^\s\u0400-\u04FFa-zA-Z0-9'’ʼ\-—–—.,;:!?()[\]{}«»\""
+    r"/_=+*|&%@#~^<>$\u00b7\u00b0\u0300-\u036f]+"
+    r"[\u0400-\u04FF]"
 )
 
 FALSE_POSITIVE_SUBSTRS = ["являється", "в якості", "вірний"]

--- a/tests/test_uk_calque_v2.py
+++ b/tests/test_uk_calque_v2.py
@@ -131,3 +131,56 @@ def test_mixed_findings_exit_code(tmp_path: Path) -> None:
     assert "THE_FOLLOWING/WARN" in out
     assert "ZNAKHODYTSYA/WARN" in out
     assert code == 1
+
+
+def test_technical_punctuation_not_flagged_as_mojibake(tmp_path: Path) -> None:
+    """Legitimate inline punctuation between Cyrillic letters must not FAIL (#2078).
+
+    main already contains 395 such slash-pairs across 167 merged files; the gate
+    previously false-positived on every one.
+    """
+    uk_dir = tmp_path / "src" / "content" / "docs" / "uk" / "punct"
+    uk_dir.mkdir(parents=True, exist_ok=True)
+    p = uk_dir / "test.md"
+    p.write_text(
+        "Режим читання/запис у моделі клієнт/сервер.\n"
+        "Змінна простір_імен та пара ключ=значення.\n"
+        "Збираємо метрик+трейсів і споживання МВт\u00b7год.\n",
+        encoding="utf-8",
+    )
+    code, out = _run_main_on_files([p])
+    assert "MOJIBAKE" not in out
+    assert code == 0
+
+
+def test_combining_diacritic_not_flagged_as_mojibake(tmp_path: Path) -> None:
+    """Unicode combining stress marks (U+0300-U+036F) are valid, not corruption."""
+    uk_dir = tmp_path / "src" / "content" / "docs" / "uk" / "stress"
+    uk_dir.mkdir(parents=True, exist_ok=True)
+    p = uk_dir / "test.md"
+    p.write_text("Ставте найва\u0301жчу роботу на початок.\n", encoding="utf-8")
+    code, out = _run_main_on_files([p])
+    assert "MOJIBAKE" not in out
+    assert code == 0
+
+
+def test_soft_hyphen_still_flagged(tmp_path: Path) -> None:
+    """Invisible soft hyphen (U+00AD) wedged in a word is genuine corruption."""
+    uk_dir = tmp_path / "src" / "content" / "docs" / "uk" / "sh"
+    uk_dir.mkdir(parents=True, exist_ok=True)
+    p = uk_dir / "test.md"
+    p.write_text("Складіть одно\u00adсторінкову нотатку.\n", encoding="utf-8")
+    code, out = _run_main_on_files([p])
+    assert "MOJIBAKE/FAIL" in out
+    assert code == 1
+
+
+def test_zero_width_and_box_drawing_still_flagged(tmp_path: Path) -> None:
+    """Zero-width chars and box-drawing wedged in Cyrillic are genuine corruption."""
+    uk_dir = tmp_path / "src" / "content" / "docs" / "uk" / "zw"
+    uk_dir.mkdir(parents=True, exist_ok=True)
+    p = uk_dir / "test.md"
+    p.write_text("сло\u200bво та ц\u2502К.\n", encoding="utf-8")
+    code, out = _run_main_on_files([p])
+    assert "MOJIBAKE/FAIL" in out
+    assert code == 1


### PR DESCRIPTION
Closes #2078. Unblocks the #1911 k8s-cert-tree PRs (#2074/#2075/#2076/#2077).

## What

`MOJIBAKE_RE` in `scripts/checks/uk_calque_v2.py` flagged any non-whitelisted character wedged between two Cyrillic letters as a structural **FAIL**. Its allowed-character class omitted legitimate technical punctuation and Unicode combining marks, so the **Ukrainian Russicism check** went red on valid Ukrainian.

Across the 4 #1911 PRs, **1477 of 1563 (94.5%)** `MOJIBAKE/FAIL` hits were `/` in legitimate `X/Y` word-pairs. `main` itself already has **395 slash-between-Cyrillic occurrences in 167 merged files** (`квартири/відділу`, `псевдонім/синонім`) — the path-filtered gate just never re-checked them.

## Fix

Whitelist legitimate inline characters in the mojibake character class:
- technical punctuation `/ _ = + * | & % @ # ~ ^ < > $`
- middle dot `·` (U+00B7), degree sign `°` (U+00B0)
- Unicode combining diacritics U+0300–U+036F (stress marks)

Genuine corruption is **still** flagged: CJK (existing `свою酌свою` fixture), soft hyphen U+00AD, zero-width chars, box-drawing.

## Verification

- `tests/test_uk_calque_v2.py` extended with 4 fixtures (legit-punct + combining-mark negatives; soft-hyphen + zero-width/box-drawing positives). Full suite: **14 passed**. `ruff` clean.
- Fixed detector run against all 4 PR worktrees' changed files: only the 4 genuine soft-hyphens remain as FAIL (stripped separately on the PR branches); w3 already clean.

Refs #1911, #1934