### PR TITLE
chore: auto-orient on SessionStart (hands-off cold restart)

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -79,11 +79,16 @@ if [ -f "$MEMORY_FILE" ]; then
   fi
 fi
 
-# Build output. The FIRST ACTION reminder is always emitted (interactive sessions
+# Build output. The AUTO-ORIENT directive is always emitted (interactive sessions
 # only — headless already exited at line 6). Belt-and-suspenders for CLAUDE.md
 # "FIRST ACTION, every session — no exceptions" — the rule still drives, this
-# just keeps it in working memory on follow-on turns.
-CONTEXT="FIRST ACTION (per CLAUDE.md): if you have not yet invoked the curriculum-orchestrator skill this session, do it now via the Skill tool BEFORE responding to the user.
+# makes a cold restart hands-off so the user does not retype the orientation
+# prompt each time (parity with learn-ukrainian's SessionStart hook).
+CONTEXT="AUTO-ORIENT — run this ritual BEFORE responding to the user's first message, even if that message is unrelated, trivial, or empty (do NOT skip it; this replaces the orientation prompt the user used to type by hand):
+  1. Invoke the curriculum-orchestrator skill via the Skill tool (skip only if already invoked this session).
+  2. Run: bash scripts/cold-start.sh — parse the kubedojo:orient / kubedojo:briefing / kubedojo:session / kubedojo:pending-decisions blocks.
+  3. Continue from the latest session handoff (docs/session-state/...): state the recommended next action, then proceed with it unless the user's message redirects you.
+  4. Hold git/PR discipline throughout: branch in .worktrees/ (never in the primary dir), PR + cross-family review before merge, never push direct to main.
 
 SESSION SETUP CHECK:"
 
@@ -105,5 +110,10 @@ INFO:"
   done
 fi
 
-printf '{"additionalContext": %s}' "$(printf '%s' "$CONTEXT" | jq -Rs '.')"
+# Emit via the current SessionStart hook schema (hookSpecificOutput.additionalContext).
+# The legacy top-level {"additionalContext": ...} form is silently ignored by newer
+# Claude Code builds — which is why this reminder previously never reached the model
+# and the user had to retype the orientation prompt each restart.
+jq -n --arg msg "$CONTEXT" \
+  '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":$msg}}'
 exit 0


### PR DESCRIPTION
## What
Make a fresh `claude` session on KubeDojo self-orient on the first turn, so the user no longer retypes the cold-start / orientation prompt on every restart (parity with learn-ukrainian).

## Why
`.claude/hooks/session-setup.sh` emitted its directive via the **legacy** top-level `{"additionalContext": ...}` form. Newer Claude Code only honors `hookSpecificOutput.additionalContext` for `SessionStart`, so the injected "FIRST ACTION: invoke curriculum-orchestrator" reminder was silently dropped — the model never saw it, and the user had to drive orientation manually.

## Changes
- Switch hook output to the current `hookSpecificOutput.additionalContext` schema.
- Enrich the directive from a thin skill-nudge into the full **AUTO-ORIENT** ritual:
  1. invoke the `curriculum-orchestrator` skill,
  2. run `scripts/cold-start.sh` and parse the orient/briefing/session/pending-decisions blocks,
  3. continue from the latest session handoff,
  4. hold git/PR discipline (worktree branches, PR + cross-family review, no direct push to main).

## Verification
- `bash .claude/hooks/session-setup.sh | jq -e '.hookSpecificOutput.hookEventName=="SessionStart"'` → passes.
- Directive preview confirmed (skill + cold-start + handoff-continue + discipline).
- Headless/pipeline skip path unchanged (early `exit 0` on `CLAUDE_NON_INTERACTIVE`/`KUBEDOJO_PIPELINE`/`GEMINI_SESSION`).

Tooling/infra change only — no curriculum content, no Astro build impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)