### PR TITLE
chore: guard against runaway astro dev memory leak (auto-stop + stale-server warning)

### DIFF
--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -79,6 +79,17 @@ if [ -f "$MEMORY_FILE" ]; then
   fi
 fi
 
+# 8. Stale `astro dev` server check. Vite/Astro dev servers leak memory over
+# long uptimes — a forgotten one reached ~5.4 GB after 2.5 days (s182). RSS
+# under-reports it (mostly compressed), so flag by UPTIME: any astro dev whose
+# elapsed time shows days (etime contains '-') is almost certainly stale.
+# start-docs.sh now auto-stops after 12h; this catches servers started manually.
+STALE_DEV=$(/bin/ps -axo pid,etime,command 2>/dev/null | grep "astro dev" | grep -v grep | awk '$2 ~ /-/ {print "      PID "$1" (up "$2")"}')
+if [ -n "$STALE_DEV" ]; then
+  ISSUES+=("STALE astro dev server(s) running 1+ day — Vite leaks memory over long uptimes (can reach multi-GB). Kill, then restart only if needed (\`npx astro preview\` for view-only doesn't leak):
+$STALE_DEV")
+fi
+
 # Build output. The AUTO-ORIENT directive is always emitted (interactive sessions
 # only — headless already exited at line 6). Belt-and-suspenders for CLAUDE.md
 # "FIRST ACTION, every session — no exceptions" — the rule still drives, this

--- a/start-docs.sh
+++ b/start-docs.sh
@@ -17,6 +17,12 @@ cd "$PROJECT_DIR"
 PORT=4333
 LOG_FILE="/tmp/astro-kubedojo.log"
 
+# Leak guard: astro dev (Vite) leaks memory over long uptimes — a forgotten
+# server reached ~5.4 GB after 2.5 days (s182). The dev server is meant to be
+# ephemeral, so auto-stop it after MAX_HOURS; it can never balloon again.
+# Override: KUBEDOJO_DEV_MAX_HOURS=24 bash start-docs.sh  (0 = no auto-stop).
+MAX_HOURS="${KUBEDOJO_DEV_MAX_HOURS:-12}"
+
 # Check if port is in use
 if lsof -ti:$PORT > /dev/null 2>&1; then
     echo "Port $PORT is already in use"
@@ -42,10 +48,26 @@ DEV_PID=$!
 sleep 3
 
 # Check if it started successfully
-if ps -p $DEV_PID > /dev/null 2>&1; then
+if /bin/ps -p $DEV_PID > /dev/null 2>&1; then
     echo "Astro dev server running (PID: $DEV_PID)"
     echo "   Documentation: http://localhost:$PORT"
     echo "   Logs: $LOG_FILE"
+
+    # Leak-guard watchdog: stop the dev server after MAX_HOURS so a forgotten
+    # session can't balloon. PID-reuse-safe — only kills if the PID is still
+    # THIS astro dev (re-checks the command before killing). Detached so the
+    # launcher can exit. Set KUBEDOJO_DEV_MAX_HOURS=0 to disable.
+    if [ "$MAX_HOURS" -gt 0 ] 2>/dev/null; then
+        (
+            sleep "$((MAX_HOURS * 3600))"
+            if /bin/ps -p "$DEV_PID" -o command= 2>/dev/null | grep -q "astro dev"; then
+                kill "$DEV_PID" 2>/dev/null
+                echo "[start-docs] leak-guard: auto-stopped astro dev (PID $DEV_PID) after ${MAX_HOURS}h" >> "$LOG_FILE"
+            fi
+        ) >/dev/null 2>&1 &
+        disown 2>/dev/null || true
+        echo "   Leak guard: auto-stops after ${MAX_HOURS}h (override KUBEDOJO_DEV_MAX_HOURS; 0=off)"
+    fi
     echo ""
     echo "To stop: kill $DEV_PID"
     echo "Or: lsof -ti:$PORT | xargs kill"


### PR DESCRIPTION
## Why
A forgotten `astro dev` server reached **~5.4 GB after 2.5 days** (s182), driving system memory pressure (15 G used / 121 M free / 6.4 G compressor). Vite/Astro dev servers leak over long uptimes (HMR module graph, file watchers, esbuild caches) — that's upstream and not fixable here. The avoidable part: `start-docs.sh` launched it detached (`nohup … &`) with **no lifetime bound**, so it ran for days.

## Changes
- **`start-docs.sh`** — PID-reuse-safe leak-guard watchdog: auto-stops the dev server after `KUBEDOJO_DEV_MAX_HOURS` (default **12h**, `0` disables). Re-checks the PID is still `astro dev` before killing, so it can't kill a recycled PID. Bounds the leak window to hours → can't reach multi-GB.
- **`.claude/hooks/session-setup.sh`** — SessionStart now flags any `astro dev` running **1+ day** (RSS under-reports the footprint — it's mostly compressed — so flag by *uptime*). Covers servers started manually outside `start-docs.sh`. Points at `npx astro preview` for leak-free view-only serving.

## Verification
- `bash -n` clean on both scripts.
- Hook still emits valid `hookSpecificOutput` JSON; live-tested it flags the stale dev servers currently running 1+ day.
- `set -e` safe (the `-gt` guard is an `if` condition; `disown … || true`).

Tooling/infra only — no curriculum content.

🤖 Generated with [Claude Code](https://claude.com/claude-code)