### PR TITLE
fix: #2099 agy adapter passes --print-timeout for long-form authoring

### DIFF
--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -52,6 +52,15 @@ _RATE_LIMIT_PATTERNS = (
 )
 _RATE_LIMIT_RE = re.compile("|".join(_RATE_LIMIT_PATTERNS), re.IGNORECASE)
 
+# Outer runner hard_timeout default (``runner.invoke``). Used when callers do
+# not pass ``tool_config["hard_timeout"]`` so agy still gets a print-timeout
+# above the CLI's 5m default.
+_DEFAULT_HARD_TIMEOUT_S = 3600
+
+# Let agy's own --print-timeout fire slightly before the runner SIGKILL so
+# long-form authoring fails with a clean CLI error instead of a mid-flush kill.
+_PRINT_TIMEOUT_MARGIN_S = 10
+
 
 # Canonical model display strings accepted by ``agy --model`` (verbatim from
 # ``agy models``). The runtime passes a slug like ``gemini-3.1-pro-high``;
@@ -80,6 +89,11 @@ def _normalize_model(value: str) -> str:
 _AGY_MODEL_BY_NORMALIZED: dict[str, str] = {
     _normalize_model(name): name for name in _AGY_MODEL_NAMES
 }
+
+
+def _agy_print_timeout_s(hard_timeout: int) -> int:
+    """Derive ``agy --print-timeout`` from the outer dispatch hard timeout."""
+    return max(1, hard_timeout - _PRINT_TIMEOUT_MARGIN_S)
 
 
 class AgyAdapter:
@@ -133,6 +147,15 @@ class AgyAdapter:
         # both past "agy fabrication" verdicts. (#1827)
         cmd += ["--add-dir", str(cwd)]
 
+        # ``agy -p`` / ``agy --print`` default to --print-timeout 5m0s. The
+        # runner's hard_timeout only bounds the outer process; without this
+        # flag long-form authoring dies at ~300s before writing output (#2099).
+        tc = tool_config or {}
+        hard_timeout = tc.get("hard_timeout", _DEFAULT_HARD_TIMEOUT_S)
+        if isinstance(hard_timeout, (int, float)) and hard_timeout > 0:
+            print_timeout_s = _agy_print_timeout_s(int(hard_timeout))
+            cmd += ["--print-timeout", f"{print_timeout_s}s"]
+
         resolved_model = self._resolve_model_flag(model)
         if resolved_model:
             cmd += ["--model", resolved_model]
@@ -141,9 +164,8 @@ class AgyAdapter:
             cmd.append(f"--conversation={session_id}")
 
         # Phase 2 follow-up: agy uses `agy plugin` for MCP configuration,
-        # not a per-invocation CLI flag like gemini-cli. The adapter accepts
-        # tool_config for GeminiAdapter API parity but does not act on it yet.
-        _ = tool_config
+        # not a per-invocation CLI flag like gemini-cli. ``mcp_server_names``
+        # is accepted for GeminiAdapter API parity but not acted on yet.
         _ = task_id
 
         return InvocationPlan(

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -378,6 +378,10 @@ def invoke(
         entrypoint,
         tool_config,
     )
+    if agent_name == "agy":
+        tc = dict(effective_tool_config or {})
+        tc.setdefault("hard_timeout", hard_timeout)
+        effective_tool_config = tc
     plan = adapter.build_invocation(
         prompt=prompt,
         mode=mode,

--- a/scripts/agent_runtime/tests/test_agy_adapter.py
+++ b/scripts/agent_runtime/tests/test_agy_adapter.py
@@ -10,7 +10,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
 from agent_runtime.adapters.agy import AgyAdapter
 
 
-def _build(mode: str) -> list[str]:
+def _build(mode: str, *, tool_config: dict | None = None) -> list[str]:
     adapter = AgyAdapter()
     plan = adapter.build_invocation(
         prompt="p",
@@ -19,7 +19,7 @@ def _build(mode: str) -> list[str]:
         model="gemini-3.5-flash-high",
         task_id=None,
         session_id=None,
-        tool_config=None,
+        tool_config=tool_config,
     )
     return plan.cmd
 
@@ -42,12 +42,42 @@ def test_build_invocation_always_includes_dangerously_skip(monkeypatch) -> None:
             "-p",
             "p",
             "--dangerously-skip-permissions",
+            "--add-dir",
+            "/tmp",
+            "--print-timeout",
+            "3590s",
             "--model",
             "Gemini 3.5 Flash (High)",
         ], (
             f"mode={mode} must produce the same cmd because agy has no "
             f"mode-specific permission flag"
         )
+
+
+def test_build_invocation_print_timeout_derived_from_dispatch_hard_timeout(
+    monkeypatch,
+) -> None:
+    """``--print-timeout`` tracks ``tool_config['hard_timeout']`` minus margin.
+
+    Draft-class dispatches use a 3600s outer timeout; agy must receive a
+    matching print-timeout so long-form authoring survives past the CLI's
+    5m default (#2099).
+    """
+    monkeypatch.setattr("agent_runtime.adapters.agy.shutil.which", lambda _: "agy")
+    adapter = AgyAdapter()
+
+    plan = adapter.build_invocation(
+        prompt="p",
+        mode="danger",
+        cwd=Path("/repo/.worktrees/x"),
+        model="gemini-3.1-pro-high",
+        task_id=None,
+        session_id=None,
+        tool_config={"hard_timeout": 3600},
+    )
+
+    idx = plan.cmd.index("--print-timeout")
+    assert plan.cmd[idx + 1] == "3590s"
 
 
 def test_build_invocation_maps_model_slug(monkeypatch) -> None:

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -541,7 +541,7 @@ def dispatch_agy_translate(prompt: str, *, timeout: int = 600) -> tuple[bool, st
                 model=AGY_TRANSLATE_MODEL,
                 task_id=None,
                 session_id=None,
-                tool_config=None,
+                tool_config={"hard_timeout": timeout},
             )
             env = build_agent_env(provider="agy", overrides=_AGENT_ENV_OVERRIDES)
             t0 = time.time()


### PR DESCRIPTION
## What
Fixes #2099 (AC #1, #2, #4). The agy adapter now passes an explicit `--print-timeout` derived from the dispatch hard timeout, so long-form (full-chapter) authoring no longer dies at the CLI's 5-minute `--print-timeout` default before writing its file.

## Changes
- `scripts/agent_runtime/adapters/agy.py` — derive `--print-timeout {hard_timeout - 10}s` (margin so agy's own timeout fires before the runner SIGKILL); `_DEFAULT_HARD_TIMEOUT_S=3600` fallback; guards on type/positivity. Cleans up the now-used `tool_config` discard.
- `scripts/agent_runtime/runner.py` — injects `hard_timeout` into `tool_config` for agy invocations (parallel to how `cwd` feeds `--add-dir` in #1858); `setdefault` so explicit caller config wins.
- `scripts/dispatch.py` — `dispatch_agy_translate` passes `tool_config={"hard_timeout": timeout}`.
- `scripts/agent_runtime/tests/test_agy_adapter.py` — new test (`3600` → `--print-timeout 3590s`); updated stale assertion.

## Out of scope
Phase-2 `sources`-MCP wiring (AC #3) — TODOs at `adapters/agy.py:24,143` left in place.

## Verification
- `ruff check scripts/agent_runtime/adapters/agy.py` — clean
- `pytest scripts/agent_runtime/tests/test_agy_adapter.py -q` — 10 passed

## Review
Authored by cursor (composer-2.5 / Kimi); cross-family reviewed inline by opus (Anthropic) per `docs/review-protocol.md`. Diff verified against #1858 pattern.

Refs #2099, #1911

🤖 Generated with [Claude Code](https://claude.com/claude-code)