### PR TITLE
fix: #2099 agy translation lane — stdout capture + section chunking

### DIFF
--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -542,6 +542,104 @@ def _extract_agy_translation_from_stdout(raw: str) -> str:
     return text
 
 
+_HEADING_LINE_RE = re.compile(r"^#{1,6} ")
+
+
+def _markdown_heading_positions(md: str) -> list[int]:
+    """Return start offsets of ATX headings outside fenced code blocks."""
+    positions: list[int] = []
+    in_fence = False
+    pos = 0
+    for line in md.splitlines(keepends=True):
+        if not in_fence and _HEADING_LINE_RE.match(line):
+            positions.append(pos)
+        stripped = line.lstrip()
+        if stripped.startswith("```"):
+            in_fence = not in_fence
+        pos += len(line)
+    return positions
+
+
+def _markdown_word_count(text: str) -> int:
+    return len(text.split())
+
+
+def split_markdown_for_translation(md: str, max_words: int = 800) -> list[str]:
+    """Split markdown into ordered translation chunks at heading boundaries.
+
+    Chunk 0 is frontmatter plus any preamble before the first heading.
+    Later chunks greedily pack consecutive heading-sections up to *max_words*.
+    A single oversized section may exceed *max_words*; sections are never
+    split mid-paragraph. Concatenating the returned chunks reproduces *md*
+    byte-for-byte via ``"".join(chunks)``.
+    """
+    if not md:
+        return [""]
+
+    heading_positions = _markdown_heading_positions(md)
+    if not heading_positions:
+        return [md]
+
+    sections = [md[: heading_positions[0]]]
+    for i, start in enumerate(heading_positions):
+        end = heading_positions[i + 1] if i + 1 < len(heading_positions) else len(md)
+        sections.append(md[start:end])
+
+    chunks: list[str] = [sections[0]]
+    current = ""
+    current_words = 0
+
+    for section in sections[1:]:
+        section_words = _markdown_word_count(section)
+        if current and current_words + section_words > max_words:
+            chunks.append(current)
+            current = section
+            current_words = section_words
+        else:
+            current += section
+            current_words += section_words
+
+    if current:
+        chunks.append(current)
+
+    chunks = [c for c in chunks if c]
+    return chunks if chunks else [md]
+
+
+def dispatch_agy_translate_chunked(
+    en_markdown: str,
+    instruction_header: str,
+    *,
+    timeout: int = 900,
+) -> tuple[bool, str]:
+    """Translate long EN markdown via agy in ≤800-word heading-boundary chunks.
+
+    *instruction_header* should carry glossary / de-russification / keep-code-English
+    rules and also instruct the model to translate ONLY the chunk below, not add or
+    repeat frontmatter unless present in this chunk, and output only the translated
+    markdown for this chunk.
+
+    Returns ``(True, full_translation)`` on success, or ``(False, error_detail)``
+    naming the failing chunk index.
+    """
+    chunks = split_markdown_for_translation(en_markdown)
+    translated: list[str] = []
+    total = len(chunks)
+
+    for i, chunk in enumerate(chunks):
+        prompt = f"{instruction_header}\n{chunk}"
+        ok, output = dispatch_agy_translate(prompt, timeout=timeout)
+        if not ok:
+            return False, f"chunk {i + 1}/{total} failed: {output}"
+        translated.append(output)
+        print(
+            f"chunk {i + 1}/{total} ok ({_markdown_word_count(output)}w)",
+            file=sys.stderr,
+        )
+
+    return True, "\n".join(translated)
+
+
 def dispatch_agy_translate(prompt: str, *, timeout: int = 600) -> tuple[bool, str]:
     """Translate via agy CLI; capture Ukrainian output from stdout.
 
@@ -1167,6 +1265,24 @@ def main():
         help="Timeout in seconds (default: 600)",
     )
 
+    # agy-translate-file (chunked long-module path)
+    afp = subparsers.add_parser(
+        "agy-translate-file",
+        help="Translate an EN markdown file via chunked agy (stdout capture)",
+    )
+    afp.add_argument("--en", required=True, help="Path to English markdown file")
+    afp.add_argument(
+        "--header",
+        required=True,
+        help="Path to instruction header file (glossary + chunk rules)",
+    )
+    afp.add_argument(
+        "--timeout",
+        type=int,
+        default=900,
+        help="Per-chunk timeout in seconds (default: 900)",
+    )
+
     # codex
     xp = subparsers.add_parser("codex", help="Dispatch prompt to Codex CLI (codex exec)")
     xp.add_argument("prompt", help="Prompt text (use '-' to read from stdin)")
@@ -1225,6 +1341,22 @@ def main():
         ok, output = dispatch_agy_translate(prompt, timeout=args.timeout)
         if ok:
             print(output)
+        sys.exit(0 if ok else 1)
+
+    elif args.agent == "agy-translate-file":
+        en_path = Path(args.en)
+        header_path = Path(args.header)
+        en_markdown = en_path.read_text(encoding="utf-8")
+        instruction_header = header_path.read_text(encoding="utf-8")
+        ok, output = dispatch_agy_translate_chunked(
+            en_markdown,
+            instruction_header,
+            timeout=args.timeout,
+        )
+        if ok:
+            print(output)
+        else:
+            print(output, file=sys.stderr)
         sys.exit(0 if ok else 1)
 
     elif args.agent == "qwen":

--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -15,6 +15,7 @@ Usage:
 import argparse
 import json
 import os
+import re
 import signal
 import shutil
 import subprocess
@@ -512,27 +513,46 @@ def dispatch_gemini_with_retry(prompt: str, model: str = GEMINI_DEFAULT_MODEL,
 
 AGY_TRANSLATE_MODEL = "gemini-3.1-pro-high"
 
-_AGY_FILE_WRITE_SUFFIX = (
-    "\n\nWrite your COMPLETE Ukrainian translation as raw Markdown to this "
-    "absolute file path and write NOTHING to stdout: {out_path}. Do NOT abridge, "
-    "summarize, or omit any section — reproduce every paragraph, table row, "
-    "list item, and quiz Q&A. If the source has a `## Sources` section, "
-    "translate and include it."
+_AGY_PRINT_SUFFIX = (
+    "\n\nOutput ONLY the complete translated markdown as your entire response, "
+    "printed to stdout. Do NOT write any files, do NOT create scripts, "
+    "do NOT use any tools — emit the translation directly. "
+    "Do NOT abridge, summarize, or omit any section — reproduce every paragraph, "
+    "table row, list item, quiz Q&A, and any `## Sources` section. "
+    "Do NOT add any preamble, explanation, or code fences around the output — "
+    "the response must BE the markdown document, starting with its frontmatter "
+    "or first line."
 )
 
 
-def dispatch_agy_translate(prompt: str, *, timeout: int = 600) -> tuple[bool, str]:
-    """Translate via agy CLI; read Ukrainian output from a temp file, not stdout.
+def _agy_non_whitespace_len(text: str) -> int:
+    return sum(1 for ch in text if not ch.isspace())
 
-    agy returns a prose summary on stdout. The caller contract matches
-    ``dispatch_gemini_with_retry``: ``(ok, translated_text)``.
+
+def _extract_agy_translation_from_stdout(raw: str) -> str:
+    """Normalize agy stdout; unwrap accidental ```markdown fences."""
+    text = raw.strip()
+    if not text:
+        return text
+    if text.startswith(("---", "#", ">")):
+        return text
+    match = re.search(r"```(?:markdown|md)?\s*\n(.*?)```", text, re.DOTALL | re.IGNORECASE)
+    if match:
+        return match.group(1).strip()
+    return text
+
+
+def dispatch_agy_translate(prompt: str, *, timeout: int = 600) -> tuple[bool, str]:
+    """Translate via agy CLI; capture Ukrainian output from stdout.
+
+    agy ``-p`` sandboxes file writes to its scratch dir, so the caller
+    contract matches ``dispatch_gemini_with_retry``: ``(ok, translated_text)``.
     """
     adapter = AgyAdapter()
 
     def _run_once() -> tuple[bool, str]:
+        full_prompt = prompt + _AGY_PRINT_SUFFIX
         with tempfile.TemporaryDirectory() as td:
-            out_path = os.path.join(td, "translation.md")
-            full_prompt = prompt + _AGY_FILE_WRITE_SUFFIX.format(out_path=out_path)
             cwd = Path(td)
             plan = adapter.build_invocation(
                 prompt=full_prompt,
@@ -566,16 +586,20 @@ def dispatch_agy_translate(prompt: str, *, timeout: int = 600) -> tuple[bool, st
                 return False, "agy CLI not found"
 
             elapsed = time.time() - t0
-            out_file = Path(out_path)
-            if out_file.is_file():
-                text = out_file.read_text()
-                if text.strip():
-                    _log("agy-translate", AGY_TRANSLATE_MODEL, prompt, text, True, elapsed)
-                    return True, text
+            text = _extract_agy_translation_from_stdout(result.stdout or "")
+            if (
+                result.returncode == 0
+                and text
+                and _agy_non_whitespace_len(text) >= 50
+            ):
+                _log("agy-translate", AGY_TRANSLATE_MODEL, prompt, text, True, elapsed)
+                return True, text
 
-            err = redact_text((result.stderr or result.stdout or "no file written").strip())
+            err = redact_text(
+                (result.stderr or result.stdout or "empty translation stdout").strip()
+            )
             _log("agy-translate", AGY_TRANSLATE_MODEL, prompt, "", False, elapsed, err)
-            return False, err or "no file written"
+            return False, err or "empty translation stdout"
 
     ok, output = _run_once()
     if ok:
@@ -1130,6 +1154,19 @@ def main():
     rp.add_argument("--github", type=int, metavar="ISSUE", help="Post output to GitHub issue")
     rp.add_argument("--timeout", type=int, default=900, help="Timeout in seconds (default: 900)")
 
+    # agy-translate
+    ap = subparsers.add_parser(
+        "agy-translate",
+        help="Dispatch Ukrainian translation prompt to agy CLI (stdout capture)",
+    )
+    ap.add_argument("prompt", help="Prompt text (use '-' to read from stdin)")
+    ap.add_argument(
+        "--timeout",
+        type=int,
+        default=600,
+        help="Timeout in seconds (default: 600)",
+    )
+
     # codex
     xp = subparsers.add_parser("codex", help="Dispatch prompt to Codex CLI (codex exec)")
     xp.add_argument("prompt", help="Prompt text (use '-' to read from stdin)")
@@ -1179,6 +1216,13 @@ def main():
     elif args.agent == "codex":
         prompt = sys.stdin.read() if args.prompt == "-" else args.prompt
         ok, output = dispatch_codex(prompt, args.model, args.timeout)
+        if ok:
+            print(output)
+        sys.exit(0 if ok else 1)
+
+    elif args.agent == "agy-translate":
+        prompt = sys.stdin.read() if args.prompt == "-" else args.prompt
+        ok, output = dispatch_agy_translate(prompt, timeout=args.timeout)
         if ok:
             print(output)
         sys.exit(0 if ok else 1)

--- a/tests/test_dispatch_agy_translate.py
+++ b/tests/test_dispatch_agy_translate.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from subprocess import CompletedProcess
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent / "scripts"))
+
+import dispatch
+
+
+_TRANSLATION_BODY = (
+    "## Заголовок\n\n"
+    "Переклад.\n\n"
+    "Додатковий український текст для перевірки мінімальної довжини виводу."
+)
+
+
+def _completed(stdout: str, *, returncode: int = 0) -> CompletedProcess[str]:
+    return CompletedProcess(args=["agy"], returncode=returncode, stdout=stdout, stderr="")
+
+
+def test_dispatch_agy_translate_captures_stdout(monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = SimpleNamespace(cmd=["agy", "-p", "prompt"], cwd=Path("."))
+
+    with patch.object(dispatch.AgyAdapter, "build_invocation", return_value=plan) as build_mock, patch(
+        "dispatch.subprocess.run", return_value=_completed(_TRANSLATION_BODY)
+    ) as run_mock, patch("dispatch._log"):
+        ok, output = dispatch.dispatch_agy_translate("translate X")
+
+    assert ok is True
+    assert output == _TRANSLATION_BODY
+    assert run_mock.call_count == 1
+
+    prompt = build_mock.call_args.kwargs["prompt"]
+    assert "printed to stdout" in prompt
+    assert "Do NOT write any files" in prompt
+    assert "absolute file path" not in prompt
+    assert "{out_path}" not in prompt
+
+
+def test_dispatch_agy_translate_empty_stdout_fails(monkeypatch: pytest.MonkeyPatch) -> None:
+    plan = SimpleNamespace(cmd=["agy", "-p", "prompt"], cwd=Path("."))
+
+    with patch.object(dispatch.AgyAdapter, "build_invocation", return_value=plan), patch(
+        "dispatch.subprocess.run", return_value=_completed("")
+    ), patch("dispatch._log"):
+        ok, err = dispatch.dispatch_agy_translate("translate X")
+
+    assert ok is False
+    assert err
+
+
+def test_extract_agy_translation_from_stdout_unwraps_markdown_fence() -> None:
+    wrapped = "Here is the translation:\n\n```markdown\n## Title\n\nBody.\n```"
+    assert dispatch._extract_agy_translation_from_stdout(wrapped) == "## Title\n\nBody."

--- a/tests/test_dispatch_agy_translate.py
+++ b/tests/test_dispatch_agy_translate.py
@@ -58,3 +58,134 @@ def test_dispatch_agy_translate_empty_stdout_fails(monkeypatch: pytest.MonkeyPat
 def test_extract_agy_translation_from_stdout_unwraps_markdown_fence() -> None:
     wrapped = "Here is the translation:\n\n```markdown\n## Title\n\nBody.\n```"
     assert dispatch._extract_agy_translation_from_stdout(wrapped) == "## Title\n\nBody."
+
+
+def _words(n: int) -> str:
+    return " ".join(f"w{i}" for i in range(n))
+
+
+def test_split_markdown_round_trip_byte_for_byte() -> None:
+    md = (
+        "---\n"
+        "title: Example\n"
+        "---\n"
+        "\n"
+        "Intro paragraph before headings.\n"
+        "\n"
+        "## Section One\n\n"
+        f"{_words(100)}\n\n"
+        "## Section Two\n\n"
+        f"{_words(200)}\n\n"
+        "## Section Three\n\n"
+        "Short tail.\n"
+    )
+    chunks = dispatch.split_markdown_for_translation(md, max_words=150)
+    assert "".join(chunks) == md
+
+
+def test_split_markdown_chunk_zero_holds_frontmatter() -> None:
+    md = (
+        "---\n"
+        "title: Test\n"
+        "sidebar:\n"
+        "  order: 1\n"
+        "---\n"
+        "\n"
+        "Preamble only.\n"
+        "\n"
+        "## First\n\n"
+        "Body.\n"
+    )
+    chunks = dispatch.split_markdown_for_translation(md, max_words=800)
+    assert chunks[0].startswith("---\n")
+    assert "## First" not in chunks[0]
+    assert "Preamble only." in chunks[0]
+
+
+def test_split_markdown_never_splits_inside_fence() -> None:
+    md = (
+        "## Before\n\n"
+        "```bash\n"
+        "# not a heading\n"
+        "## also not a heading\n"
+        "```\n\n"
+        "## After\n\n"
+        "Done.\n"
+    )
+    chunks = dispatch.split_markdown_for_translation(md, max_words=5)
+    assert "".join(chunks) == md
+    before_chunk = next(c for c in chunks if "## Before" in c)
+    assert "```bash\n# not a heading\n## also not a heading\n```" in before_chunk
+    assert not any(
+        c.strip() == "## also not a heading" for c in chunks
+    )
+
+
+def test_split_markdown_respects_max_words_except_oversized_section() -> None:
+    big = _words(900)
+    md = f"---\ntitle: X\n---\n\n## Huge\n\n{big}\n\n## Small\n\nTail.\n"
+    chunks = dispatch.split_markdown_for_translation(md, max_words=800)
+    for chunk in chunks[1:-1]:
+        assert dispatch._markdown_word_count(chunk) <= 800 or big in chunk
+    assert dispatch._markdown_word_count(chunks[-1]) <= 800
+
+
+def test_dispatch_agy_translate_chunked_echoes_and_concatenates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    md = (
+        "---\n"
+        "title: Chunked\n"
+        "---\n"
+        "\n"
+        "## One\n\n"
+        f"{_words(500)}\n\n"
+        "## Two\n\n"
+        f"{_words(500)}\n"
+    )
+    header = "HEADER"
+    calls: list[str] = []
+
+    def fake_translate(prompt: str, *, timeout: int = 600) -> tuple[bool, str]:
+        calls.append(prompt)
+        return True, prompt.removeprefix(f"{header}\n")
+
+    monkeypatch.setattr(dispatch, "dispatch_agy_translate", fake_translate)
+    ok, output = dispatch.dispatch_agy_translate_chunked(md, header, timeout=900)
+
+    assert ok is True
+    assert len(calls) >= 2
+    assert all(call.startswith(f"{header}\n") for call in calls)
+    assert output == "\n".join(
+        call.removeprefix(f"{header}\n") for call in calls
+    )
+
+
+def test_dispatch_agy_translate_chunked_fails_when_chunk_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    md = (
+        "---\n"
+        "title: Fail\n"
+        "---\n"
+        "\n"
+        "## One\n\n"
+        f"{_words(500)}\n\n"
+        "## Two\n\n"
+        f"{_words(500)}\n"
+    )
+    call_count = 0
+
+    def fake_translate(prompt: str, *, timeout: int = 600) -> tuple[bool, str]:
+        nonlocal call_count
+        call_count += 1
+        if call_count == 2:
+            return False, "boom"
+        return True, "ok"
+
+    monkeypatch.setattr(dispatch, "dispatch_agy_translate", fake_translate)
+    ok, err = dispatch.dispatch_agy_translate_chunked(md, "HDR", timeout=900)
+
+    assert ok is False
+    assert "chunk 2/" in err
+    assert "boom" in err


### PR DESCRIPTION
## Problem
The agy translation lane was **broken**: `dispatch_agy_translate` told agy to *write* the translation to a file, but agy's `-p` mode sandboxes file writes to `~/.gemini/antigravity-cli/scratch/` and ignores the target path. agy wrote helper scripts into the sandbox, never wrote the target, then returned exit 0 with a **fabricated** success report (invented word counts). Diagnosed s183 (root cause: sandbox file-write, not the model — `gemini-3.1-pro-high` is fine).

## Fix
1. **stdout capture** — agy is prompted to emit ONLY the translated markdown as its response (no files/scripts/tools); `dispatch_agy_translate` captures `result.stdout`, unwraps accidental ```` ```markdown ```` fences, requires `returncode==0` + ≥50 non-whitespace chars. No file-write path.
2. **section chunking** — agy truncates a single `-p` response at ~900 words (stream-idle limit). `split_markdown_for_translation()` splits the EN at heading boundaries into ≤~800-word chunks (never inside a code fence; frontmatter in chunk 0; round-trip reproduces input). `dispatch_agy_translate_chunked()` translates each chunk via the fixed single-chunk path and concatenates, failing if any chunk fails.
3. **CLI** — `agy-translate-file --en <path> --header <path> [--timeout N]` prints the full translation to stdout.

`AGY_TRANSLATE_MODEL = "gemini-3.1-pro-high"` unchanged; `adapters/agy.py` (the #2099 print-timeout fix) untouched.

## Validation (live)
- agy `-p` print-only → returns a real, faithful Ukrainian translation (verified: `Под — це найменша одиниця розгортання в Kubernetes.`).
- A real 759-word module section → clean 781-word translation, code kept English, glossary terms correct.
- 9 unit tests pass (round-trip, fence-safety, frontmatter-in-chunk-0, chunked concat, failure propagation); ruff clean.

## Known follow-up
- A single heading-section larger than ~900w with no sub-headings (e.g. a huge code-heavy `## Exam Design Notes` = 2823w) still exceeds the cap → add a secondary split at blank-line/paragraph boundaries (outside code fences). Typical pages (≤~2000w) split cleanly already.
- agy `-p` has intermittent stream hangs → mitigated by the per-chunk retry; use a fail-fast per-chunk `--timeout` (~300s) so a transient hang retries instead of burning the full window.

Authored by cursor; cross-family reviewed inline by opus. Refs #2099, #1911

🤖 Generated with [Claude Code](https://claude.com/claude-code)