### PR TITLE
feat: #2099 harden agy chunked translation (retries + delay + oversized-section split)

### DIFF
--- a/scripts/dispatch.py
+++ b/scripts/dispatch.py
@@ -564,14 +564,105 @@ def _markdown_word_count(text: str) -> int:
     return len(text.split())
 
 
+def _is_markdown_table_row(line: str) -> bool:
+    stripped = line.strip()
+    if not stripped or stripped.startswith("#"):
+        return False
+    return "|" in stripped
+
+
+def _markdown_paragraph_blocks(text: str) -> list[str]:
+    """Partition *text* at blank-line boundaries outside fences and tables."""
+    if not text:
+        return []
+
+    lines = text.splitlines(keepends=True)
+    blocks: list[str] = []
+    current: list[str] = []
+    in_fence = False
+    in_table = False
+
+    def flush() -> None:
+        nonlocal in_table
+        if current:
+            blocks.append("".join(current))
+            current.clear()
+        in_table = False
+
+    for line in lines:
+        stripped = line.strip()
+
+        if stripped.startswith("```"):
+            current.append(line)
+            in_fence = not in_fence
+            continue
+
+        if in_fence:
+            current.append(line)
+            continue
+
+        if _is_markdown_table_row(line):
+            in_table = True
+            current.append(line)
+            continue
+
+        if in_table:
+            in_table = False
+
+        if stripped == "":
+            current.append(line)
+            flush()
+            continue
+
+        current.append(line)
+
+    flush()
+    return blocks
+
+
+def _split_section_at_paragraphs(section: str, max_words: int) -> list[str]:
+    """Split an oversized heading-section at paragraph boundaries."""
+    cap = int(max_words * 1.5)
+    blocks = _markdown_paragraph_blocks(section)
+    if not blocks:
+        return [section]
+
+    sub_chunks: list[str] = []
+    current = ""
+    current_words = 0
+
+    for block in blocks:
+        block_words = _markdown_word_count(block)
+        if block_words > cap:
+            if current:
+                sub_chunks.append(current)
+                current = ""
+                current_words = 0
+            sub_chunks.append(block)
+            continue
+        if current and current_words + block_words > cap:
+            sub_chunks.append(current)
+            current = block
+            current_words = block_words
+        else:
+            current += block
+            current_words += block_words
+
+    if current:
+        sub_chunks.append(current)
+
+    return sub_chunks if sub_chunks else [section]
+
+
 def split_markdown_for_translation(md: str, max_words: int = 800) -> list[str]:
     """Split markdown into ordered translation chunks at heading boundaries.
 
     Chunk 0 is frontmatter plus any preamble before the first heading.
     Later chunks greedily pack consecutive heading-sections up to *max_words*.
-    A single oversized section may exceed *max_words*; sections are never
-    split mid-paragraph. Concatenating the returned chunks reproduces *md*
-    byte-for-byte via ``"".join(chunks)``.
+    A single oversized section is further split at blank-line paragraph
+    boundaries (never inside fenced code or tables) so sub-chunks stay near
+    *max_words*. Concatenating the returned chunks reproduces *md* byte-for-byte
+    via ``"".join(chunks)``.
     """
     if not md:
         return [""]
@@ -585,11 +676,18 @@ def split_markdown_for_translation(md: str, max_words: int = 800) -> list[str]:
         end = heading_positions[i + 1] if i + 1 < len(heading_positions) else len(md)
         sections.append(md[start:end])
 
+    pack_sections: list[str] = []
+    for section in sections[1:]:
+        if _markdown_word_count(section) > max_words:
+            pack_sections.extend(_split_section_at_paragraphs(section, max_words))
+        else:
+            pack_sections.append(section)
+
     chunks: list[str] = [sections[0]]
     current = ""
     current_words = 0
 
-    for section in sections[1:]:
+    for section in pack_sections:
         section_words = _markdown_word_count(section)
         if current and current_words + section_words > max_words:
             chunks.append(current)
@@ -610,7 +708,9 @@ def dispatch_agy_translate_chunked(
     en_markdown: str,
     instruction_header: str,
     *,
-    timeout: int = 900,
+    timeout: int = 240,
+    attempts: int = 4,
+    delay: float = 5.0,
 ) -> tuple[bool, str]:
     """Translate long EN markdown via agy in ≤800-word heading-boundary chunks.
 
@@ -627,8 +727,12 @@ def dispatch_agy_translate_chunked(
     total = len(chunks)
 
     for i, chunk in enumerate(chunks):
+        if i > 0:
+            time.sleep(delay)
         prompt = f"{instruction_header}\n{chunk}"
-        ok, output = dispatch_agy_translate(prompt, timeout=timeout)
+        ok, output = dispatch_agy_translate(
+            prompt, timeout=timeout, attempts=attempts
+        )
         if not ok:
             return False, f"chunk {i + 1}/{total} failed: {output}"
         translated.append(output)
@@ -640,7 +744,9 @@ def dispatch_agy_translate_chunked(
     return True, "\n".join(translated)
 
 
-def dispatch_agy_translate(prompt: str, *, timeout: int = 600) -> tuple[bool, str]:
+def dispatch_agy_translate(
+    prompt: str, *, timeout: int = 600, attempts: int = 4
+) -> tuple[bool, str]:
     """Translate via agy CLI; capture Ukrainian output from stdout.
 
     agy ``-p`` sandboxes file writes to its scratch dir, so the caller
@@ -699,11 +805,18 @@ def dispatch_agy_translate(prompt: str, *, timeout: int = 600) -> tuple[bool, st
             _log("agy-translate", AGY_TRANSLATE_MODEL, prompt, "", False, elapsed, err)
             return False, err or "empty translation stdout"
 
-    ok, output = _run_once()
-    if ok:
-        return True, output
-    print("agy translation failed — retrying once", file=sys.stderr)
-    return _run_once()
+    last_output = ""
+    for attempt in range(1, attempts + 1):
+        ok, output = _run_once()
+        if ok:
+            return True, output
+        last_output = output
+        if attempt < attempts:
+            print(
+                f"agy attempt {attempt}/{attempts} failed — retrying",
+                file=sys.stderr,
+            )
+    return False, last_output
 
 
 _CLAUDE_TEXT_ONLY_DISALLOWED = (
@@ -1279,8 +1392,14 @@ def main():
     afp.add_argument(
         "--timeout",
         type=int,
-        default=900,
-        help="Per-chunk timeout in seconds (default: 900)",
+        default=240,
+        help="Per-chunk timeout in seconds (default: 240)",
+    )
+    afp.add_argument(
+        "--attempts",
+        type=int,
+        default=4,
+        help="Per-chunk agy retry attempts (default: 4)",
     )
 
     # codex
@@ -1352,6 +1471,7 @@ def main():
             en_markdown,
             instruction_header,
             timeout=args.timeout,
+            attempts=args.attempts,
         )
         if ok:
             print(output)

--- a/tests/test_dispatch_agy_translate.py
+++ b/tests/test_dispatch_agy_translate.py
@@ -48,11 +48,33 @@ def test_dispatch_agy_translate_empty_stdout_fails(monkeypatch: pytest.MonkeyPat
 
     with patch.object(dispatch.AgyAdapter, "build_invocation", return_value=plan), patch(
         "dispatch.subprocess.run", return_value=_completed("")
-    ), patch("dispatch._log"):
-        ok, err = dispatch.dispatch_agy_translate("translate X")
+    ) as run_mock, patch("dispatch._log"):
+        ok, err = dispatch.dispatch_agy_translate("translate X", attempts=4)
 
     assert ok is False
     assert err
+    assert run_mock.call_count == 4
+
+
+def test_dispatch_agy_translate_retries_until_success() -> None:
+    plan = SimpleNamespace(cmd=["agy", "-p", "prompt"], cwd=Path("."))
+    call_count = 0
+
+    def fake_run(*_args, **_kwargs) -> CompletedProcess[str]:
+        nonlocal call_count
+        call_count += 1
+        if call_count < 3:
+            return _completed("")
+        return _completed(_TRANSLATION_BODY)
+
+    with patch.object(dispatch.AgyAdapter, "build_invocation", return_value=plan), patch(
+        "dispatch.subprocess.run", side_effect=fake_run
+    ) as run_mock, patch("dispatch._log"):
+        ok, output = dispatch.dispatch_agy_translate("translate X", attempts=4)
+
+    assert ok is True
+    assert output == _TRANSLATION_BODY
+    assert run_mock.call_count == 3
 
 
 def test_extract_agy_translation_from_stdout_unwraps_markdown_fence() -> None:
@@ -114,20 +136,42 @@ def test_split_markdown_never_splits_inside_fence() -> None:
     )
     chunks = dispatch.split_markdown_for_translation(md, max_words=5)
     assert "".join(chunks) == md
-    before_chunk = next(c for c in chunks if "## Before" in c)
-    assert "```bash\n# not a heading\n## also not a heading\n```" in before_chunk
+    fence_chunk = next(c for c in chunks if "```bash" in c)
+    assert "```bash\n# not a heading\n## also not a heading\n```" in fence_chunk
     assert not any(
         c.strip() == "## also not a heading" for c in chunks
     )
 
 
-def test_split_markdown_respects_max_words_except_oversized_section() -> None:
+def test_split_markdown_respects_max_words_with_paragraph_split() -> None:
     big = _words(900)
     md = f"---\ntitle: X\n---\n\n## Huge\n\n{big}\n\n## Small\n\nTail.\n"
     chunks = dispatch.split_markdown_for_translation(md, max_words=800)
-    for chunk in chunks[1:-1]:
-        assert dispatch._markdown_word_count(chunk) <= 800 or big in chunk
-    assert dispatch._markdown_word_count(chunks[-1]) <= 800
+    cap = int(800 * 1.5)
+    for chunk in chunks[1:]:
+        assert dispatch._markdown_word_count(chunk) <= cap
+    assert "".join(chunks) == md
+
+
+def test_split_markdown_splits_oversized_section_at_paragraphs() -> None:
+    big_para1 = _words(1000)
+    big_para2 = _words(1000)
+    md = (
+        "## Huge\n\n"
+        f"{big_para1}\n\n"
+        "```bash\n"
+        "echo hello\n"
+        "```\n\n"
+        f"{big_para2}\n"
+    )
+    chunks = dispatch.split_markdown_for_translation(md, max_words=800)
+    cap = int(800 * 1.5)
+    assert "".join(chunks) == md
+    for chunk in chunks:
+        assert dispatch._markdown_word_count(chunk) <= cap
+    fence_chunks = [c for c in chunks if "```bash" in c]
+    assert len(fence_chunks) == 1
+    assert "```bash\necho hello\n```" in fence_chunks[0]
 
 
 def test_dispatch_agy_translate_chunked_echoes_and_concatenates(
@@ -146,12 +190,16 @@ def test_dispatch_agy_translate_chunked_echoes_and_concatenates(
     header = "HEADER"
     calls: list[str] = []
 
-    def fake_translate(prompt: str, *, timeout: int = 600) -> tuple[bool, str]:
+    def fake_translate(
+        prompt: str, *, timeout: int = 600, attempts: int = 4
+    ) -> tuple[bool, str]:
         calls.append(prompt)
         return True, prompt.removeprefix(f"{header}\n")
 
     monkeypatch.setattr(dispatch, "dispatch_agy_translate", fake_translate)
-    ok, output = dispatch.dispatch_agy_translate_chunked(md, header, timeout=900)
+    ok, output = dispatch.dispatch_agy_translate_chunked(
+        md, header, timeout=900, attempts=4
+    )
 
     assert ok is True
     assert len(calls) >= 2
@@ -176,7 +224,9 @@ def test_dispatch_agy_translate_chunked_fails_when_chunk_fails(
     )
     call_count = 0
 
-    def fake_translate(prompt: str, *, timeout: int = 600) -> tuple[bool, str]:
+    def fake_translate(
+        prompt: str, *, timeout: int = 600, attempts: int = 4
+    ) -> tuple[bool, str]:
         nonlocal call_count
         call_count += 1
         if call_count == 2:
@@ -184,8 +234,48 @@ def test_dispatch_agy_translate_chunked_fails_when_chunk_fails(
         return True, "ok"
 
     monkeypatch.setattr(dispatch, "dispatch_agy_translate", fake_translate)
-    ok, err = dispatch.dispatch_agy_translate_chunked(md, "HDR", timeout=900)
+    ok, err = dispatch.dispatch_agy_translate_chunked(
+        md, "HDR", timeout=900, attempts=4
+    )
 
     assert ok is False
     assert "chunk 2/" in err
     assert "boom" in err
+
+
+def test_dispatch_agy_translate_chunked_sleeps_and_passes_kwargs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    md = (
+        "---\n"
+        "title: Delay\n"
+        "---\n"
+        "\n"
+        "## One\n\n"
+        f"{_words(500)}\n\n"
+        "## Two\n\n"
+        f"{_words(500)}\n"
+    )
+    sleep_calls: list[float] = []
+    translate_kwargs: list[dict[str, int]] = []
+
+    def fake_sleep(delay: float) -> None:
+        sleep_calls.append(delay)
+
+    def fake_translate(
+        prompt: str, *, timeout: int = 600, attempts: int = 4
+    ) -> tuple[bool, str]:
+        translate_kwargs.append({"timeout": timeout, "attempts": attempts})
+        return True, "ok"
+
+    monkeypatch.setattr(dispatch.time, "sleep", fake_sleep)
+    monkeypatch.setattr(dispatch, "dispatch_agy_translate", fake_translate)
+    chunks = dispatch.split_markdown_for_translation(md)
+    ok, _ = dispatch.dispatch_agy_translate_chunked(
+        md, "HDR", timeout=240, attempts=3, delay=2.5
+    )
+
+    assert ok is True
+    assert sleep_calls == [2.5] * (len(chunks) - 1)
+    assert all(k == {"timeout": 240, "attempts": 3} for k in translate_kwargs)
+    assert len(translate_kwargs) == len(chunks)


### PR DESCRIPTION
Additive hardening on the merged agy translation lane (#2104), against agy `-p`'s intermittent stream hangs and oversized sections.

- **Retries** — `dispatch_agy_translate(..., attempts=4)` (was retry-once); logs `agy attempt N/M failed` between tries. So a transient hang is retried instead of failing the run.
- **Fail-fast timeout** — `dispatch_agy_translate_chunked` default `timeout` 900→**240**s (a hang fails fast then retries instead of burning the window); `attempts` threaded through; CLI `--timeout`/`--attempts` defaults 240/4.
- **Inter-chunk delay** — `time.sleep(delay=5.0)` between chunks so agy settles between sequential `-p` calls.
- **Oversized-section split** — `split_markdown_for_translation` now sub-splits a heading-section larger than `max_words` at blank-line boundaries (outside code fences/tables). Verified: the 2823-word `## Exam Design Notes` section in cba/1.1 now splits to max-chunk 1194w; round-trip exact.

12/12 unit tests pass; ruff clean. `AGY_TRANSLATE_MODEL = gemini-3.1-pro-high` and `adapters/agy.py` unchanged.

Note: agy remains a *flaky extra lane*. Primary translation authoring for the marathon uses reliable file-writers (codex/gpt-5.5, deepseek-4-pro, grok-4.*/grok-build). Authored by cursor; reviewed inline by opus. Refs #2099, #1911

🤖 Generated with [Claude Code](https://claude.com/claude-code)