### PR TITLE
docs(uk): #1911 k8s — stamp calque_review on 5 completed stale pages

### DIFF
--- a/src/content/docs/uk/k8s/cba/module-1.1-backstage-dev-workflow.md
+++ b/src/content/docs/uk/k8s/cba/module-1.1-backstage-dev-workflow.md
@@ -3,6 +3,12 @@ title: "Модуль 1.1: Робочий процес розробника в Ba
 slug: uk/k8s/cba/module-1.1-backstage-dev-workflow
 sidebar:
   order: 11
+calque_review:
+  reviewed_at: "2026-06-25"
+  detector_version: "v2"
+  status: "reviewed"
+  flags_resolved: 0
+  content_sha: "23355e69e4e032ec994f890f1feb06b08e0b0a4bd2c9e63a8bdf8ba7275a0bb4"
 ---
 > **Complexity**: `[COMPLEX]` - Повностековий TypeScript-проєкт з інструментами монорепозиторію
 >

--- a/src/content/docs/uk/k8s/cba/module-1.3-backstage-catalog-infrastructure.md
+++ b/src/content/docs/uk/k8s/cba/module-1.3-backstage-catalog-infrastructure.md
@@ -3,6 +3,12 @@ title: "Модуль 1.3: Каталог та інфраструктура Backs
 slug: uk/k8s/cba/module-1.3-backstage-catalog-infrastructure
 sidebar:
   order: 13
+calque_review:
+  reviewed_at: "2026-06-25"
+  detector_version: "v2"
+  status: "reviewed"
+  flags_resolved: 2
+  content_sha: "be13190440df38e0c7b233d1e5a9e353b939a6e9c449bb8d57a5924ad0f43be4"
 ---
 > **Складність**: `[СКЛАДНО]` — Охоплює два екзаменаційні домени (44% CBA разом)
 >

--- a/src/content/docs/uk/k8s/cgoa/index.md
+++ b/src/content/docs/uk/k8s/cgoa/index.md
@@ -3,6 +3,12 @@ title: "CGOA — Сертифікований спеціаліст із GitOps"
 sidebar:
   order: 1
   label: "CGOA"
+calque_review:
+  reviewed_at: "2026-06-25"
+  detector_version: "v2"
+  status: "clean"
+  flags_resolved: 0
+  content_sha: "83c267450c10da80d5dbda3ab1d27dfb02219b5e787a2c41d179a4e4a6768daa"
 ---
 > **Іспит із множинним вибором** | 90 хвилин | Прохідний бал: 75% | $250 USD
 

--- a/src/content/docs/uk/k8s/index.md
+++ b/src/content/docs/uk/k8s/index.md
@@ -3,6 +3,12 @@ title: "Сертифікації Kubernetes"
 sidebar:
   order: 1
   label: "Сертифікації"
+calque_review:
+  reviewed_at: "2026-06-25"
+  detector_version: "v2"
+  status: "clean"
+  flags_resolved: 0
+  content_sha: "0885f56c803f4831332dc42100d68157f35b58a1145439a46925214882f688ea"
 ---
 **Шлях Kubestronaut** — усі 5 сертифікацій, потрібних для статусу [Kubestronaut](https://www.cncf.io/training/kubestronaut/), відзнаки CNCF за складання KCNA, KCSA, CKAD, CKA та CKS.
 

--- a/src/content/docs/uk/k8s/otca/index.md
+++ b/src/content/docs/uk/k8s/otca/index.md
@@ -3,6 +3,12 @@ title: "OTCA — Сертифікований спеціаліст із OpenTele
 sidebar:
   order: 0
   label: "OTCA"
+calque_review:
+  reviewed_at: "2026-06-25"
+  detector_version: "v2"
+  status: "clean"
+  flags_resolved: 0
+  content_sha: "1d58722b079dec2193d74965bcbcd37bc66961016199981e5c4042816715d93a"
 ---
 > **Іспит із множинним вибором** | 90 хвилин | Прохідний бал: 75% | $250 USD | **Сертифікація CNCF**
 


### PR DESCRIPTION
Frontmatter `calque_review` stamps recording the 3-family cross-family review done in #2103 (merged), so the UK board reflects reviewed status and these pages aren't re-reviewed in a future sweep.

- `index.md`, `cgoa/index.md`, `otca/index.md` → status `clean` (no findings)
- `cba/module-1.1`, `cba/module-1.3` → status `reviewed` (v2 detector; module-1.3 = 2 resolved: codex code-switching → deepseek re-translation, ${GRAFANA_TOKEN} restore)

Pure frontmatter metadata; the review itself is recorded in PR #2103's review comment.

Refs #1911