### PR TITLE
docs(uk): refresh Ukrainian changelog — remove English duplicate + translation-surge entry

### DIFF
--- a/src/content/docs/uk/changelog.md
+++ b/src/content/docs/uk/changelog.md
@@ -5,6 +5,22 @@ sidebar:
   order: 2
 ---
 
+## 25 червня 2026 — Велике оновлення українського перекладу
+
+### Покриття зросло приблизно вдвічі (~14% → ~35%)
+
+Актуальне покриття українською зросло приблизно вдвічі за цей цикл. Повноту ми вимірюємо за **актуальністю** (відповідністю поточній англійській версії), а не за наявністю файлу.
+
+- **Увесь трек сертифікацій Kubernetes** тепер повністю перекладено й перевірено на калькування — CKA, CKAD, CKS, KCNA, KCSA, а також усі сторінки сертифікацій (CGOA, OTCA, CBA та інші). Трек k8s: 261 із 261 сторінок актуальні.
+- Трек **«Передумови» (Prerequisites)** лишається повністю перекладеним і перевіреним на природність української.
+- Розпочато переклад **книги з історії ШІ** — Частини 1 і 2 (перші десять розділів) уже доступні; кожен розділ перевірили три незалежні модельні родини перед злиттям.
+
+### Що далі в черзі на переклад
+
+Наступні на переклад — треки **AI** та **AI/ML Engineering**, далі Platform Engineering і Cloud.
+
+---
+
 ## 14 червня 2026 — Стан перекладу та новий англомовний контент
 
 ### Як ми тепер вимірюємо переклад
@@ -210,26 +226,3 @@ KubeDojo тепер повністю узгоджений з **Kubernetes 1.35**
 ## Грудень 2025 — Початковий випуск
 
 KubeDojo стартував із 311 модулями, що охоплюють усі 5 сертифікацій Kubestronaut, а також платформну інженерію, Linux та поглиблене вивчення IaC. Повну історію проєкту дивіться у [журналі комітів](https://github.com/kube-dojo/kube-dojo.github.io/commits/main).
-## April 17, 2026 — New Top-Level AI Track
-
-### AI Is Now a First-Class Learner Track
-
-New top-level `AI` track:
-- `AI Foundations`
-- `AI-Native Work`
-
-This track is separate from `AI/ML Engineering`:
-- `AI` is the accessible front door
-- `AI/ML Engineering` remains the advanced builder path
-
-### What It Covers
-
-- what AI is
-- what LLMs are
-- prompting basics
-- verification
-- privacy, safety, and trust
-- using AI for learning, writing, research, and coding
-- AI-native work habits, assistants, agents, and workflow design
-
----


### PR DESCRIPTION
Fixes two defects on the published Ukrainian **What's New** page (`/uk/changelog/`), both spotted by the user:

1. **Untranslated English content** — a fully-English `## April 17, 2026 — New Top-Level AI Track` section was appended to the UK page. It duplicates the existing Ukrainian `## 17 квітня 2026 — Новий top-level AI track` entry and was mis-ordered (after the Dec-2025 'initial release' entry). **Removed.**
2. **Stale status** — the UK page was last updated 2026-06-14 and still said `~14% / 51-page core` (the same staleness just fixed on the EN page in #2107). Added a 2026-06-25 entry: coverage ~35%, the **k8s certifications tree fully translated** (261/261), **AI-History book** Parts 1-2 started; next queue = AI / AI-ML.

Why UK ≠ EN: they're separate, independently-maintained files — the UK changelog is a Ukrainian-audience, translation-status-focused doc, not a literal mirror of the EN feature changelog. This keeps that design but removes the cruft + staleness.

Gates: `check_uk_changed` PASS, `uk_calque_v2` clean, 0 forbidden letters. (Note: two duplicate 'Березень 2026' sections remain — pre-existing, left for a separate cleanup.) Refs #1911.