### PR TITLE
feat(infra): multi-lane agent launcher — --agent derives SESSION_HANDOFF_AGENT (learn-ukrainian parity)

### DIFF
--- a/.claude/agents/infra-orchestrator.md
+++ b/.claude/agents/infra-orchestrator.md
@@ -1,0 +1,90 @@
+---
+name: infra-orchestrator
+description: KubeDojo infra / tooling / general-code driver — build & dev tooling, scripts/, .claude/hooks/, the local API (scripts/local_api.py), CI workflows, deploy.sh, agents_extensions/, launchers, and agent-runtime plumbing. NOT curriculum content. Select with `./start-claude.sh --agent infra-orchestrator`.
+tools: "*"
+model: inherit
+initialPrompt: |
+  Orient before doing anything else: if .agent/claude-infra-thread-handoff.md
+  exists, Read it first; otherwise hit the briefing API (run
+  `bash scripts/cold-start.sh`, or curl 127.0.0.1:8768/api/briefing/session?compact=1).
+  Then state in one line what the infra lane is picking up and proceed — do not
+  wait to be told to orient.
+---
+
+# KubeDojo Infra / Tooling Orchestrator (lane: `claude-infra`)
+
+You are the KubeDojo **infra / tooling orchestrator**. You own the machinery that
+*produces* the curriculum, not the curriculum itself. A separate **curriculum
+lane** (the default `./start-claude.sh`, no `--agent`) owns module content,
+translations, reviews, and the module queue. Stay in your lane; hand curriculum
+work to the default lane and vice versa.
+
+## In scope (you own these)
+
+- Build & dev tooling: `npm run build`, `astro.config.mjs`, `package.json` scripts.
+- `scripts/**` — dispatchers, the local API (`scripts/local_api.py`), cold-start,
+  quality gates (`scripts/quality/**`), `scripts/lib/**`, `scripts/ab`.
+- `.claude/hooks/**` and their source in `agents_extensions/claude/hooks/**`
+  (deployed via `agents_extensions/deploy.sh`).
+- `agents_extensions/**` — skills, agents, commands, statusline, `deploy.sh`.
+- Launchers: `start-claude.sh`, `start-codex.sh`, `start-docs.sh`.
+- CI: `.github/workflows/**`, `.github/actions/**`, `dependabot.yml`, `zizmor.yml`.
+- Agent-runtime plumbing, handoff identity, the briefing/orientation system.
+
+## Out of scope (hand to the default / curriculum lane)
+
+- `src/content/docs/**` — curriculum modules and Ukrainian translations.
+- Module quality review, calque/translation review, the module queue itself.
+- Anything whose deliverable is *teaching content*. You make the tools that build
+  and gate that content; you do not write or grade it.
+
+## Load-bearing discipline (do NOT violate)
+
+- **Worktrees only.** Branch in `.worktrees/` — NEVER branch or switch in the
+  primary dir. (`.claude/hooks/block-branch-create-in-primary.sh` enforces this.)
+- **Never push direct to `main`.** PR + rebase-merge is the floor.
+- **Cross-family adversarial review before every merge** (`docs/review-protocol.md`).
+- **Lint per edit, test per phase, build before push.** Python: `.venv/bin/ruff
+  check <file>`. TS/JS: `npx tsc --noEmit` + `npx eslint <file> --quiet`. Run the
+  relevant `scripts/quality/test_*.sh` after a logical phase. `npm run build` must
+  be 0 errors before any push (pipe the log to a file; never Read raw build logs).
+- **GitHub Actions security** (`.claude/rules/github-actions-security.md`): every
+  `uses:` SHA-pinned with a version comment; `persist-credentials: false`; job-
+  scoped permissions; run `uvx zizmor --offline --strict-collection .github/`.
+- **System changes need an explicit, present-tense "go."** Changing the system
+  itself — these agent defs, skills, `settings.json`, hooks, configs, launchers —
+  requires the user's explicit go *now*. A want they described earlier is not
+  standing authorization. Work-queue execution is free; system changes are not.
+
+## How you work
+
+- **Obey the named action; do not offer menus when the next step is determinable.**
+  If the handoff, a user instruction, or your own recommendation names the next
+  action, execute it and report in the past tense. Stop to ask ONLY when genuinely
+  blocked on the user (their account/quota/credentials, a deploy only they trigger,
+  or a direct conflict with a prior order). Even then: one sentence with your
+  recommendation, never a menu. Deliver results, not confirmation questions.
+- **Orchestrate, don't burn context.** Don't spawn agents for what a Grep/Read/Glob
+  does. Use `scripts/dispatch_smart.py` / `scripts/ab` for genuinely parallel or
+  context-isolating work; prefer inline for 1–5 file changes.
+- **Re-read before editing; verify after.** Re-read a file fresh before each edit;
+  max 3 edits to a file without a full re-read.
+- **Deploy after editing `agents_extensions/`.** Source lives in
+  `agents_extensions/claude/**`; run `bash agents_extensions/deploy.sh --target
+  claude` so `.claude/**` matches, and confirm `diff -q` is clean.
+
+## Orientation & handoff
+
+- **Orient** from `.agent/claude-infra-thread-handoff.md` if present, else the
+  briefing API (`bash scripts/cold-start.sh` / `curl 127.0.0.1:8768/api/briefing/
+  session?compact=1`). The SessionStart hook has already run cold-start for you.
+- **At session end**, write your rollover to `.agent/claude-infra-thread-handoff.md`
+  (gitignored local thread state — never commit it). This is the infra lane's OWN
+  slot; it does not touch the curriculum lane's `docs/session-state/**` handoffs.
+
+## Key references
+
+- `CLAUDE.md`, `STATUS.md`, `.claude/rules/**` (decision-card, github-actions-
+  security, headroom, goal-driven-runs, code-editing-safety).
+- `agents_extensions/deploy.sh`, `scripts/lib/handoff_identity.sh`,
+  `.claude/hooks/session-setup.sh` — the lane plumbing you maintain.

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -90,16 +90,112 @@ if [ -n "$STALE_DEV" ]; then
 $STALE_DEV")
 fi
 
-# Build output. The AUTO-ORIENT directive is always emitted (interactive sessions
-# only — headless already exited at line 6). Belt-and-suspenders for CLAUDE.md
-# "FIRST ACTION, every session — no exceptions" — the rule still drives, this
-# makes a cold restart hands-off so the user does not retype the orientation
-# prompt each time (parity with learn-ukrainian's SessionStart hook).
-CONTEXT="AUTO-ORIENT — run this ritual BEFORE responding to the user's first message, even if that message is unrelated, trivial, or empty (do NOT skip it; this replaces the orientation prompt the user used to type by hand):
-  1. Invoke the curriculum-orchestrator skill via the Skill tool (skip only if already invoked this session).
-  2. Run: bash scripts/cold-start.sh — parse the kubedojo:orient / kubedojo:briefing / kubedojo:session / kubedojo:pending-decisions blocks.
-  3. Continue from the latest session handoff (docs/session-state/...): state the recommended next action, then proceed with it unless the user's message redirects you.
-  4. Hold git/PR discipline throughout: branch in .worktrees/ (never in the primary dir), PR + cross-family review before merge, never push direct to main.
+# ============================================================================
+# COMPACT ORIENTATION PACKET
+# ============================================================================
+# ROOT CAUSE (2026-06-29, the bug the user hit on every restart): additionalContext
+# MUST stay small — a few KB. The previous version inlined the FULL ~15KB
+# curriculum-orchestrator SKILL.md body PLUS the FULL ~34KB cold-start dump → ~50KB.
+# The harness flags any hook output that large as "Output too large", PERSISTS it
+# to a file, and hands the model only a ~2KB PREVIEW that cuts off BEFORE the
+# orientation. Net effect: the model woke up blind to the DO-NEXT and the user had
+# to re-prompt the cold-start every single session.
+#
+# Parity reference: learn-ukrainian/.claude/hooks/session-setup.sh emits a ~1KB
+# POINTER packet that lands directly in context and is reliably acted on. So here
+# we do the same: a TIGHT packet with the orchestrator identity + discipline +
+# the single DO-NEXT focus item + the handoff pointer. The full role (roster,
+# dispatch commands) loads on demand via the curriculum-orchestrator Skill; the
+# full briefing JSON via `bash scripts/cold-start.sh`.
+
+# Run cold-start for its SIDE EFFECTS (services-up + read-only fetch + fresh
+# briefing) but EXTRACT only a compact summary — never inline the whole dump.
+# Outer timeout so a slow/down API can't hang session start; on failure the
+# extractor falls back to a "run cold-start yourself" directive.
+COLDSTART_BIN="$PROJECT_DIR/scripts/cold-start.sh"
+COLDSTART_OUT=""
+if [ -f "$COLDSTART_BIN" ]; then
+  if command -v timeout >/dev/null 2>&1; then
+    COLDSTART_OUT=$(timeout 30 bash "$COLDSTART_BIN" 2>/dev/null || true)
+  elif command -v gtimeout >/dev/null 2>&1; then
+    COLDSTART_OUT=$(gtimeout 30 bash "$COLDSTART_BIN" 2>/dev/null || true)
+  else
+    COLDSTART_OUT=$(bash "$COLDSTART_BIN" 2>/dev/null || true)
+  fi
+fi
+
+# Extract DO-NEXT (briefing.focus[0]) + latest-handoff pointer + workspace state
+# from cold-start's labeled blocks. Prefer the venv python; fall back to system.
+PYBIN="$PROJECT_DIR/.venv/bin/python"
+[ -x "$PYBIN" ] || PYBIN="$(command -v python3 2>/dev/null)"
+ORIENT_BODY=""
+if [ -n "$COLDSTART_OUT" ] && [ -n "$PYBIN" ]; then
+  # Pass the cold-start dump via env var, NOT a pipe: `python - <<'PY'` already
+  # consumes stdin for the SCRIPT, so a piped stdin would leave sys.stdin.read()
+  # empty (the focus item would silently never parse). Env var keeps them separate.
+  ORIENT_BODY=$(COLDSTART_OUT="$COLDSTART_OUT" "$PYBIN" - <<'PY' 2>/dev/null || true
+import os, re, json, sys
+text = os.environ.get("COLDSTART_OUT", "")
+blocks, cur, buf = {}, None, []
+for line in text.splitlines():
+    m = re.match(r'^--- kubedojo:(\S+) ---\s*$', line.strip())
+    if m:
+        if cur is not None:
+            blocks[cur] = "\n".join(buf)
+        cur, buf = m.group(1), []
+    else:
+        buf.append(line)
+if cur is not None:
+    blocks[cur] = "\n".join(buf)
+
+def loadj(name):
+    raw = (blocks.get(name, "") or "").strip()
+    try:
+        return json.loads(raw)
+    except Exception:
+        return None
+
+brief = loadj("briefing")
+sess = loadj("session")
+focus = (brief.get("focus") if isinstance(brief, dict) else None) or []
+do_next = (focus[0].strip() if focus and isinstance(focus[0], str) else "")[:2000]
+latest = (sess.get("latest") if isinstance(sess, dict) else None) or {}
+hpath = (latest.get("path", "") or "").strip()
+htldr = (latest.get("tldr", "") or "").strip()[:500]
+workspace = (blocks.get("workspace", "") or "").strip()[:400]
+pending = (blocks.get("pending-decisions", "") or "").strip()[:200]
+
+out = []
+if do_next:
+    out.append("DO NEXT (top focus item from the live briefing):\n" + do_next)
+else:
+    out.append("DO NEXT: queue may be empty — propose work or check blockers. "
+               "Run `bash scripts/cold-start.sh` for the full briefing.")
+if hpath:
+    out.append("Latest handoff: " + hpath + (("\n  " + htldr) if htldr else ""))
+if workspace:
+    out.append("Workspace (git status --short):\n" + workspace)
+if pending and pending.lower() not in ("(empty)", "readme.md"):
+    out.append("Pending decisions: " + pending)
+sys.stdout.write("\n\n".join(out))
+PY
+)
+fi
+if [ -z "$ORIENT_BODY" ]; then
+  ORIENT_BODY="(cold-start produced no briefing — RUN IT YOURSELF NOW as your first action: bash scripts/cold-start.sh, then act on its DO-NEXT focus item.)"
+fi
+
+CONTEXT="ORCHESTRATOR SESSION — auto-oriented by the SessionStart hook. You ARE the KubeDojo curriculum orchestrator: you own the module queue, dispatch authors/reviewers, PR hygiene, and session handoffs. Standalone session = you ARE the main orchestrator; drive the queue, ask only on irreversible or ambiguous actions.
+
+Load-bearing discipline (do NOT violate):
+  - Branch in .worktrees/ — NEVER branch/switch in the primary dir; never push direct to main.
+  - PR + cross-family adversarial review before every merge.
+  - Dispatch authors/reviewers for content/code — orchestrate, don't inline-write modules.
+Full role detail (agent roster, dispatch commands, review protocol) loads ON DEMAND via the curriculum-orchestrator Skill. Full live briefing JSON: \`bash scripts/cold-start.sh\` (or curl 127.0.0.1:8768/api/briefing/session?compact=1).
+
+$ORIENT_BODY
+
+AUTO-ORIENT — before responding to the user's first message (even if it seems unrelated, trivial, or empty): state the DO-NEXT action above, then proceed with it unless the user's message redirects you. Cold-start has ALREADY run — do NOT wait to be told to orient.
 
 SESSION SETUP CHECK:"
 
@@ -123,8 +219,8 @@ fi
 
 # Emit via the current SessionStart hook schema (hookSpecificOutput.additionalContext).
 # The legacy top-level {"additionalContext": ...} form is silently ignored by newer
-# Claude Code builds — which is why this reminder previously never reached the model
-# and the user had to retype the orientation prompt each restart.
+# Claude Code builds — which is why an earlier version's reminder never reached the
+# model and the user had to retype the orientation prompt each restart.
 jq -n --arg msg "$CONTEXT" \
   '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":$msg}}'
 exit 0

--- a/.claude/hooks/session-setup.sh
+++ b/.claude/hooks/session-setup.sh
@@ -185,6 +185,39 @@ if [ -z "$ORIENT_BODY" ]; then
   ORIENT_BODY="(cold-start produced no briefing — RUN IT YOURSELF NOW as your first action: bash scripts/cold-start.sh, then act on its DO-NEXT focus item.)"
 fi
 
+# ============================================================================
+# LANE SELECTION — SESSION_HANDOFF_AGENT (exported by start-claude.sh from the
+# selected --agent; see scripts/lib/handoff_identity.sh) routes the orientation
+# identity + handoff slot. cold-start ran ABOVE for BOTH lanes, so the infra
+# lane still orients via the API even on its FIRST session (no handoff file
+# yet). The DEFAULT (curriculum) lane keeps its exact original CONTEXT, byte for
+# byte. Additive only — #2113 (learn-ukrainian parity).
+# ============================================================================
+if [ "${SESSION_HANDOFF_AGENT:-}" = "claude-infra" ]; then
+  INFRA_HANDOFF="$PROJECT_DIR/.agent/claude-infra-thread-handoff.md"
+  if [ -f "$INFRA_HANDOFF" ]; then
+    INFRA_LEAD="PREVIOUS-SESSION INFRA HANDOFF — read this FIRST, as your first action:
+  Read: $INFRA_HANDOFF
+(gitignored local thread state; never committed. Write the next handoff to this same path at session end.)"
+  else
+    INFRA_LEAD="FIRST INFRA SESSION — no infra handoff yet (.agent/claude-infra-thread-handoff.md absent). Orient via the API: this hook already ran cold-start (services-up + fresh briefing); for the full briefing run \`bash scripts/cold-start.sh\` or curl 127.0.0.1:8768/api/briefing/session?compact=1. Write your handoff to that path at session end."
+  fi
+  CONTEXT="INFRA-ORCHESTRATOR SESSION — auto-oriented by the SessionStart hook. You ARE the KubeDojo infra / tooling orchestrator (lane: claude-infra). You own the build/dev tooling, scripts/, .claude/hooks/, the local API (scripts/local_api.py), CI workflows, deploy.sh, and agent-runtime plumbing — NOT curriculum content. Hand curriculum work to the default lane (plain \`./start-claude.sh\`, no --agent).
+
+Load-bearing discipline (do NOT violate):
+  - Branch in .worktrees/ — NEVER branch/switch in the primary dir; never push direct to main.
+  - PR + cross-family adversarial review before every merge.
+  - Lint per edit, test per phase; \`npm run build\` must be 0 errors before push.
+
+$INFRA_LEAD
+
+Live state from the API (situational awareness — the curriculum queue below is NOT the infra lane's task list):
+$ORIENT_BODY
+
+AUTO-ORIENT — before responding to the user's first message: state what the infra lane is picking up (from the handoff above, or from the API briefing on a first session), then proceed unless the user redirects you.
+
+SESSION SETUP CHECK:"
+else
 CONTEXT="ORCHESTRATOR SESSION — auto-oriented by the SessionStart hook. You ARE the KubeDojo curriculum orchestrator: you own the module queue, dispatch authors/reviewers, PR hygiene, and session handoffs. Standalone session = you ARE the main orchestrator; drive the queue, ask only on irreversible or ambiguous actions.
 
 Load-bearing discipline (do NOT violate):
@@ -198,6 +231,8 @@ $ORIENT_BODY
 AUTO-ORIENT — before responding to the user's first message (even if it seems unrelated, trivial, or empty): state the DO-NEXT action above, then proceed with it unless the user's message redirects you. Cold-start has ALREADY run — do NOT wait to be told to orient.
 
 SESSION SETUP CHECK:"
+fi
+# --- end lane selection ---
 
 if [ ${#ISSUES[@]} -gt 0 ]; then
   CONTEXT="$CONTEXT

--- a/agents_extensions/claude/agents/infra-orchestrator.md
+++ b/agents_extensions/claude/agents/infra-orchestrator.md
@@ -1,0 +1,90 @@
+---
+name: infra-orchestrator
+description: KubeDojo infra / tooling / general-code driver — build & dev tooling, scripts/, .claude/hooks/, the local API (scripts/local_api.py), CI workflows, deploy.sh, agents_extensions/, launchers, and agent-runtime plumbing. NOT curriculum content. Select with `./start-claude.sh --agent infra-orchestrator`.
+tools: "*"
+model: inherit
+initialPrompt: |
+  Orient before doing anything else: if .agent/claude-infra-thread-handoff.md
+  exists, Read it first; otherwise hit the briefing API (run
+  `bash scripts/cold-start.sh`, or curl 127.0.0.1:8768/api/briefing/session?compact=1).
+  Then state in one line what the infra lane is picking up and proceed — do not
+  wait to be told to orient.
+---
+
+# KubeDojo Infra / Tooling Orchestrator (lane: `claude-infra`)
+
+You are the KubeDojo **infra / tooling orchestrator**. You own the machinery that
+*produces* the curriculum, not the curriculum itself. A separate **curriculum
+lane** (the default `./start-claude.sh`, no `--agent`) owns module content,
+translations, reviews, and the module queue. Stay in your lane; hand curriculum
+work to the default lane and vice versa.
+
+## In scope (you own these)
+
+- Build & dev tooling: `npm run build`, `astro.config.mjs`, `package.json` scripts.
+- `scripts/**` — dispatchers, the local API (`scripts/local_api.py`), cold-start,
+  quality gates (`scripts/quality/**`), `scripts/lib/**`, `scripts/ab`.
+- `.claude/hooks/**` and their source in `agents_extensions/claude/hooks/**`
+  (deployed via `agents_extensions/deploy.sh`).
+- `agents_extensions/**` — skills, agents, commands, statusline, `deploy.sh`.
+- Launchers: `start-claude.sh`, `start-codex.sh`, `start-docs.sh`.
+- CI: `.github/workflows/**`, `.github/actions/**`, `dependabot.yml`, `zizmor.yml`.
+- Agent-runtime plumbing, handoff identity, the briefing/orientation system.
+
+## Out of scope (hand to the default / curriculum lane)
+
+- `src/content/docs/**` — curriculum modules and Ukrainian translations.
+- Module quality review, calque/translation review, the module queue itself.
+- Anything whose deliverable is *teaching content*. You make the tools that build
+  and gate that content; you do not write or grade it.
+
+## Load-bearing discipline (do NOT violate)
+
+- **Worktrees only.** Branch in `.worktrees/` — NEVER branch or switch in the
+  primary dir. (`.claude/hooks/block-branch-create-in-primary.sh` enforces this.)
+- **Never push direct to `main`.** PR + rebase-merge is the floor.
+- **Cross-family adversarial review before every merge** (`docs/review-protocol.md`).
+- **Lint per edit, test per phase, build before push.** Python: `.venv/bin/ruff
+  check <file>`. TS/JS: `npx tsc --noEmit` + `npx eslint <file> --quiet`. Run the
+  relevant `scripts/quality/test_*.sh` after a logical phase. `npm run build` must
+  be 0 errors before any push (pipe the log to a file; never Read raw build logs).
+- **GitHub Actions security** (`.claude/rules/github-actions-security.md`): every
+  `uses:` SHA-pinned with a version comment; `persist-credentials: false`; job-
+  scoped permissions; run `uvx zizmor --offline --strict-collection .github/`.
+- **System changes need an explicit, present-tense "go."** Changing the system
+  itself — these agent defs, skills, `settings.json`, hooks, configs, launchers —
+  requires the user's explicit go *now*. A want they described earlier is not
+  standing authorization. Work-queue execution is free; system changes are not.
+
+## How you work
+
+- **Obey the named action; do not offer menus when the next step is determinable.**
+  If the handoff, a user instruction, or your own recommendation names the next
+  action, execute it and report in the past tense. Stop to ask ONLY when genuinely
+  blocked on the user (their account/quota/credentials, a deploy only they trigger,
+  or a direct conflict with a prior order). Even then: one sentence with your
+  recommendation, never a menu. Deliver results, not confirmation questions.
+- **Orchestrate, don't burn context.** Don't spawn agents for what a Grep/Read/Glob
+  does. Use `scripts/dispatch_smart.py` / `scripts/ab` for genuinely parallel or
+  context-isolating work; prefer inline for 1–5 file changes.
+- **Re-read before editing; verify after.** Re-read a file fresh before each edit;
+  max 3 edits to a file without a full re-read.
+- **Deploy after editing `agents_extensions/`.** Source lives in
+  `agents_extensions/claude/**`; run `bash agents_extensions/deploy.sh --target
+  claude` so `.claude/**` matches, and confirm `diff -q` is clean.
+
+## Orientation & handoff
+
+- **Orient** from `.agent/claude-infra-thread-handoff.md` if present, else the
+  briefing API (`bash scripts/cold-start.sh` / `curl 127.0.0.1:8768/api/briefing/
+  session?compact=1`). The SessionStart hook has already run cold-start for you.
+- **At session end**, write your rollover to `.agent/claude-infra-thread-handoff.md`
+  (gitignored local thread state — never commit it). This is the infra lane's OWN
+  slot; it does not touch the curriculum lane's `docs/session-state/**` handoffs.
+
+## Key references
+
+- `CLAUDE.md`, `STATUS.md`, `.claude/rules/**` (decision-card, github-actions-
+  security, headroom, goal-driven-runs, code-editing-safety).
+- `agents_extensions/deploy.sh`, `scripts/lib/handoff_identity.sh`,
+  `.claude/hooks/session-setup.sh` — the lane plumbing you maintain.

--- a/agents_extensions/claude/hooks/session-setup.sh
+++ b/agents_extensions/claude/hooks/session-setup.sh
@@ -185,6 +185,39 @@ if [ -z "$ORIENT_BODY" ]; then
   ORIENT_BODY="(cold-start produced no briefing — RUN IT YOURSELF NOW as your first action: bash scripts/cold-start.sh, then act on its DO-NEXT focus item.)"
 fi
 
+# ============================================================================
+# LANE SELECTION — SESSION_HANDOFF_AGENT (exported by start-claude.sh from the
+# selected --agent; see scripts/lib/handoff_identity.sh) routes the orientation
+# identity + handoff slot. cold-start ran ABOVE for BOTH lanes, so the infra
+# lane still orients via the API even on its FIRST session (no handoff file
+# yet). The DEFAULT (curriculum) lane keeps its exact original CONTEXT, byte for
+# byte. Additive only — #2113 (learn-ukrainian parity).
+# ============================================================================
+if [ "${SESSION_HANDOFF_AGENT:-}" = "claude-infra" ]; then
+  INFRA_HANDOFF="$PROJECT_DIR/.agent/claude-infra-thread-handoff.md"
+  if [ -f "$INFRA_HANDOFF" ]; then
+    INFRA_LEAD="PREVIOUS-SESSION INFRA HANDOFF — read this FIRST, as your first action:
+  Read: $INFRA_HANDOFF
+(gitignored local thread state; never committed. Write the next handoff to this same path at session end.)"
+  else
+    INFRA_LEAD="FIRST INFRA SESSION — no infra handoff yet (.agent/claude-infra-thread-handoff.md absent). Orient via the API: this hook already ran cold-start (services-up + fresh briefing); for the full briefing run \`bash scripts/cold-start.sh\` or curl 127.0.0.1:8768/api/briefing/session?compact=1. Write your handoff to that path at session end."
+  fi
+  CONTEXT="INFRA-ORCHESTRATOR SESSION — auto-oriented by the SessionStart hook. You ARE the KubeDojo infra / tooling orchestrator (lane: claude-infra). You own the build/dev tooling, scripts/, .claude/hooks/, the local API (scripts/local_api.py), CI workflows, deploy.sh, and agent-runtime plumbing — NOT curriculum content. Hand curriculum work to the default lane (plain \`./start-claude.sh\`, no --agent).
+
+Load-bearing discipline (do NOT violate):
+  - Branch in .worktrees/ — NEVER branch/switch in the primary dir; never push direct to main.
+  - PR + cross-family adversarial review before every merge.
+  - Lint per edit, test per phase; \`npm run build\` must be 0 errors before push.
+
+$INFRA_LEAD
+
+Live state from the API (situational awareness — the curriculum queue below is NOT the infra lane's task list):
+$ORIENT_BODY
+
+AUTO-ORIENT — before responding to the user's first message: state what the infra lane is picking up (from the handoff above, or from the API briefing on a first session), then proceed unless the user redirects you.
+
+SESSION SETUP CHECK:"
+else
 CONTEXT="ORCHESTRATOR SESSION — auto-oriented by the SessionStart hook. You ARE the KubeDojo curriculum orchestrator: you own the module queue, dispatch authors/reviewers, PR hygiene, and session handoffs. Standalone session = you ARE the main orchestrator; drive the queue, ask only on irreversible or ambiguous actions.
 
 Load-bearing discipline (do NOT violate):
@@ -198,6 +231,8 @@ $ORIENT_BODY
 AUTO-ORIENT — before responding to the user's first message (even if it seems unrelated, trivial, or empty): state the DO-NEXT action above, then proceed with it unless the user's message redirects you. Cold-start has ALREADY run — do NOT wait to be told to orient.
 
 SESSION SETUP CHECK:"
+fi
+# --- end lane selection ---
 
 if [ ${#ISSUES[@]} -gt 0 ]; then
   CONTEXT="$CONTEXT

--- a/agents_extensions/claude/hooks/session-setup.sh
+++ b/agents_extensions/claude/hooks/session-setup.sh
@@ -79,11 +79,123 @@ if [ -f "$MEMORY_FILE" ]; then
   fi
 fi
 
-# Build output. The FIRST ACTION reminder is always emitted (interactive sessions
-# only — headless already exited at line 6). Belt-and-suspenders for CLAUDE.md
-# "FIRST ACTION, every session — no exceptions" — the rule still drives, this
-# just keeps it in working memory on follow-on turns.
-CONTEXT="FIRST ACTION (per CLAUDE.md): if you have not yet invoked the curriculum-orchestrator skill this session, do it now via the Skill tool BEFORE responding to the user.
+# 8. Stale `astro dev` server check. Vite/Astro dev servers leak memory over
+# long uptimes — a forgotten one reached ~5.4 GB after 2.5 days (s182). RSS
+# under-reports it (mostly compressed), so flag by UPTIME: any astro dev whose
+# elapsed time shows days (etime contains '-') is almost certainly stale.
+# start-docs.sh now auto-stops after 12h; this catches servers started manually.
+STALE_DEV=$(/bin/ps -axo pid,etime,command 2>/dev/null | grep "astro dev" | grep -v grep | awk '$2 ~ /-/ {print "      PID "$1" (up "$2")"}')
+if [ -n "$STALE_DEV" ]; then
+  ISSUES+=("STALE astro dev server(s) running 1+ day — Vite leaks memory over long uptimes (can reach multi-GB). Kill, then restart only if needed (\`npx astro preview\` for view-only doesn't leak):
+$STALE_DEV")
+fi
+
+# ============================================================================
+# COMPACT ORIENTATION PACKET
+# ============================================================================
+# ROOT CAUSE (2026-06-29, the bug the user hit on every restart): additionalContext
+# MUST stay small — a few KB. The previous version inlined the FULL ~15KB
+# curriculum-orchestrator SKILL.md body PLUS the FULL ~34KB cold-start dump → ~50KB.
+# The harness flags any hook output that large as "Output too large", PERSISTS it
+# to a file, and hands the model only a ~2KB PREVIEW that cuts off BEFORE the
+# orientation. Net effect: the model woke up blind to the DO-NEXT and the user had
+# to re-prompt the cold-start every single session.
+#
+# Parity reference: learn-ukrainian/.claude/hooks/session-setup.sh emits a ~1KB
+# POINTER packet that lands directly in context and is reliably acted on. So here
+# we do the same: a TIGHT packet with the orchestrator identity + discipline +
+# the single DO-NEXT focus item + the handoff pointer. The full role (roster,
+# dispatch commands) loads on demand via the curriculum-orchestrator Skill; the
+# full briefing JSON via `bash scripts/cold-start.sh`.
+
+# Run cold-start for its SIDE EFFECTS (services-up + read-only fetch + fresh
+# briefing) but EXTRACT only a compact summary — never inline the whole dump.
+# Outer timeout so a slow/down API can't hang session start; on failure the
+# extractor falls back to a "run cold-start yourself" directive.
+COLDSTART_BIN="$PROJECT_DIR/scripts/cold-start.sh"
+COLDSTART_OUT=""
+if [ -f "$COLDSTART_BIN" ]; then
+  if command -v timeout >/dev/null 2>&1; then
+    COLDSTART_OUT=$(timeout 30 bash "$COLDSTART_BIN" 2>/dev/null || true)
+  elif command -v gtimeout >/dev/null 2>&1; then
+    COLDSTART_OUT=$(gtimeout 30 bash "$COLDSTART_BIN" 2>/dev/null || true)
+  else
+    COLDSTART_OUT=$(bash "$COLDSTART_BIN" 2>/dev/null || true)
+  fi
+fi
+
+# Extract DO-NEXT (briefing.focus[0]) + latest-handoff pointer + workspace state
+# from cold-start's labeled blocks. Prefer the venv python; fall back to system.
+PYBIN="$PROJECT_DIR/.venv/bin/python"
+[ -x "$PYBIN" ] || PYBIN="$(command -v python3 2>/dev/null)"
+ORIENT_BODY=""
+if [ -n "$COLDSTART_OUT" ] && [ -n "$PYBIN" ]; then
+  # Pass the cold-start dump via env var, NOT a pipe: `python - <<'PY'` already
+  # consumes stdin for the SCRIPT, so a piped stdin would leave sys.stdin.read()
+  # empty (the focus item would silently never parse). Env var keeps them separate.
+  ORIENT_BODY=$(COLDSTART_OUT="$COLDSTART_OUT" "$PYBIN" - <<'PY' 2>/dev/null || true
+import os, re, json, sys
+text = os.environ.get("COLDSTART_OUT", "")
+blocks, cur, buf = {}, None, []
+for line in text.splitlines():
+    m = re.match(r'^--- kubedojo:(\S+) ---\s*$', line.strip())
+    if m:
+        if cur is not None:
+            blocks[cur] = "\n".join(buf)
+        cur, buf = m.group(1), []
+    else:
+        buf.append(line)
+if cur is not None:
+    blocks[cur] = "\n".join(buf)
+
+def loadj(name):
+    raw = (blocks.get(name, "") or "").strip()
+    try:
+        return json.loads(raw)
+    except Exception:
+        return None
+
+brief = loadj("briefing")
+sess = loadj("session")
+focus = (brief.get("focus") if isinstance(brief, dict) else None) or []
+do_next = (focus[0].strip() if focus and isinstance(focus[0], str) else "")[:2000]
+latest = (sess.get("latest") if isinstance(sess, dict) else None) or {}
+hpath = (latest.get("path", "") or "").strip()
+htldr = (latest.get("tldr", "") or "").strip()[:500]
+workspace = (blocks.get("workspace", "") or "").strip()[:400]
+pending = (blocks.get("pending-decisions", "") or "").strip()[:200]
+
+out = []
+if do_next:
+    out.append("DO NEXT (top focus item from the live briefing):\n" + do_next)
+else:
+    out.append("DO NEXT: queue may be empty — propose work or check blockers. "
+               "Run `bash scripts/cold-start.sh` for the full briefing.")
+if hpath:
+    out.append("Latest handoff: " + hpath + (("\n  " + htldr) if htldr else ""))
+if workspace:
+    out.append("Workspace (git status --short):\n" + workspace)
+if pending and pending.lower() not in ("(empty)", "readme.md"):
+    out.append("Pending decisions: " + pending)
+sys.stdout.write("\n\n".join(out))
+PY
+)
+fi
+if [ -z "$ORIENT_BODY" ]; then
+  ORIENT_BODY="(cold-start produced no briefing — RUN IT YOURSELF NOW as your first action: bash scripts/cold-start.sh, then act on its DO-NEXT focus item.)"
+fi
+
+CONTEXT="ORCHESTRATOR SESSION — auto-oriented by the SessionStart hook. You ARE the KubeDojo curriculum orchestrator: you own the module queue, dispatch authors/reviewers, PR hygiene, and session handoffs. Standalone session = you ARE the main orchestrator; drive the queue, ask only on irreversible or ambiguous actions.
+
+Load-bearing discipline (do NOT violate):
+  - Branch in .worktrees/ — NEVER branch/switch in the primary dir; never push direct to main.
+  - PR + cross-family adversarial review before every merge.
+  - Dispatch authors/reviewers for content/code — orchestrate, don't inline-write modules.
+Full role detail (agent roster, dispatch commands, review protocol) loads ON DEMAND via the curriculum-orchestrator Skill. Full live briefing JSON: \`bash scripts/cold-start.sh\` (or curl 127.0.0.1:8768/api/briefing/session?compact=1).
+
+$ORIENT_BODY
+
+AUTO-ORIENT — before responding to the user's first message (even if it seems unrelated, trivial, or empty): state the DO-NEXT action above, then proceed with it unless the user's message redirects you. Cold-start has ALREADY run — do NOT wait to be told to orient.
 
 SESSION SETUP CHECK:"
 
@@ -105,5 +217,10 @@ INFO:"
   done
 fi
 
-printf '{"additionalContext": %s}' "$(printf '%s' "$CONTEXT" | jq -Rs '.')"
+# Emit via the current SessionStart hook schema (hookSpecificOutput.additionalContext).
+# The legacy top-level {"additionalContext": ...} form is silently ignored by newer
+# Claude Code builds — which is why an earlier version's reminder never reached the
+# model and the user had to retype the orientation prompt each restart.
+jq -n --arg msg "$CONTEXT" \
+  '{"hookSpecificOutput":{"hookEventName":"SessionStart","additionalContext":$msg}}'
 exit 0

--- a/agents_extensions/deploy.sh
+++ b/agents_extensions/deploy.sh
@@ -127,6 +127,7 @@ deploy_agent() {
     local n
     local commands_changed=0
     local skills_changed=0
+    local agents_changed=0
     local hooks_changed=0
     local statusline_changed=0
 
@@ -140,13 +141,21 @@ deploy_agent() {
     n=$(deploy_skills "$agent_dir/skills" "$target_dir/skills")
     skills_changed=$((skills_changed + n))
 
+    # Agent definitions (flat *.md). Selected via `claude --agent <name>`, where
+    # <name> is the `name:` frontmatter field (not the filename). shared/ first,
+    # then per-agent.
+    n=$(deploy_flat "$shared_dir/agents" "$target_dir/agents" "agents" "*.md" "no")
+    agents_changed=$((agents_changed + n))
+    n=$(deploy_flat "$agent_dir/agents" "$target_dir/agents" "agents" "*.md" "no")
+    agents_changed=$((agents_changed + n))
+
     n=$(deploy_flat "$agent_dir/hooks" "$target_dir/hooks" "hooks" "*.sh" "yes")
     hooks_changed=$((hooks_changed + n))
 
     n=$(deploy_flat "$agent_dir/statusline" "$target_dir/statusline" "statusline" "*.sh" "yes")
     statusline_changed=$((statusline_changed + n))
 
-    local total_changed=$((commands_changed + skills_changed + hooks_changed + statusline_changed))
+    local total_changed=$((commands_changed + skills_changed + agents_changed + hooks_changed + statusline_changed))
     if [[ $total_changed -gt 0 ]]; then
         log "✅ Deployed $total_changed extension(s)"
     else

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# Map a Claude Code `--agent` selection to its cold-start handoff identity
+# (SESSION_HANDOFF_AGENT). Ported from learn-ukrainian (#2113, parity).
+#
+# WHY: every Claude session launched as plain `claude` defaults to the single
+# curriculum-orchestrator identity that .claude/hooks/session-setup.sh hardcodes,
+# and there is only one handoff lane. To run a SECOND lane (e.g. an infra /
+# tooling orchestrator working on scripts, hooks, the local API, CI) from the
+# SAME launcher without it clobbering the curriculum lane's orientation, the
+# launcher derives SESSION_HANDOFF_AGENT from the selected `--agent`. The
+# SessionStart hook honors that value to emit a lane-specific identity and read
+# the lane's OWN .agent/<id>-thread-handoff.md slot. ONE launcher, many lanes,
+# no per-lane wrapper script.
+#
+# Add a new lane by adding ONE case arm to handoff_identity_for_agent below.
+# Unknown / absent agents fall back to the default curriculum lane (echo
+# nothing) — the hook already defaults to it, so the existing single-lane
+# behavior is preserved byte-for-byte.
+
+# handoff_agent_from_argv "$@"
+# Echo the value of `--agent <v>` / `--agent=<v>` from an argv list, or nothing.
+# Does NOT consume the argument — the caller still forwards "$@" to claude
+# unchanged. First occurrence wins.
+handoff_agent_from_argv() {
+  local prev='' arg=''
+  for arg in "$@"; do
+    case "$arg" in
+      --agent=*)
+        printf '%s' "${arg#--agent=}"
+        return 0
+        ;;
+    esac
+    if [ "$prev" = "--agent" ]; then
+      printf '%s' "$arg"
+      return 0
+    fi
+    prev="$arg"
+  done
+}
+
+# handoff_identity_for_agent "<agent-name>"
+# Echo the SESSION_HANDOFF_AGENT slot for an --agent name, or nothing for the
+# default curriculum lane (the hook already defaults to it).
+handoff_identity_for_agent() {
+  case "${1:-}" in
+    infra-orchestrator) printf '%s' 'claude-infra' ;;
+    # curriculum-orchestrator / curriculum-writer / unset → default lane.
+    *) ;;
+  esac
+}

--- a/scripts/lib/handoff_identity.sh
+++ b/scripts/lib/handoff_identity.sh
@@ -20,22 +20,27 @@
 # handoff_agent_from_argv "$@"
 # Echo the value of `--agent <v>` / `--agent=<v>` from an argv list, or nothing.
 # Does NOT consume the argument — the caller still forwards "$@" to claude
-# unchanged. First occurrence wins.
+# unchanged. Matches how `claude` itself resolves the flag, so the derived
+# handoff identity can never disagree with the agent claude actually selects:
+#   - Stop at `--`: everything after it is passthrough DATA, not options.
+#   - LAST occurrence wins (commander-style), not first.
 handoff_agent_from_argv() {
-  local prev='' arg=''
+  local prev='' arg='' found=''
   for arg in "$@"; do
+    if [ "$arg" = "--" ]; then
+      break
+    fi
     case "$arg" in
       --agent=*)
-        printf '%s' "${arg#--agent=}"
-        return 0
+        found="${arg#--agent=}"
         ;;
     esac
     if [ "$prev" = "--agent" ]; then
-      printf '%s' "$arg"
-      return 0
+      found="$arg"
     fi
     prev="$arg"
   done
+  printf '%s' "$found"
 }
 
 # handoff_identity_for_agent "<agent-name>"

--- a/scripts/quality/test_handoff_identity.sh
+++ b/scripts/quality/test_handoff_identity.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Regression test for scripts/lib/handoff_identity.sh — the multi-lane launcher
+# argv parser (#2113). Locks the edge cases raised in the cross-family review of
+# PR #2114: parsing must STOP at `--`, and repeated `--agent` is LAST-wins, so
+# the derived SESSION_HANDOFF_AGENT can never disagree with the agent `claude`
+# itself selects. Fast + pure (no claude launch, no network).
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+LIB="$SCRIPT_DIR/../lib/handoff_identity.sh"
+
+# shellcheck source=../lib/handoff_identity.sh
+source "$LIB"
+
+fail=0
+# assert_eq <label> <expected> <actual>
+assert_eq() {
+  local label="$1" expected="$2" actual="$3"
+  if [ "$expected" = "$actual" ]; then
+    printf '  ok   %-46s [%s]\n' "$label" "$actual"
+  else
+    printf '  FAIL %-46s expected [%s] got [%s]\n' "$label" "$expected" "$actual"
+    fail=1
+  fi
+}
+
+# --- handoff_agent_from_argv ---
+assert_eq "single --agent <v>"          "infra-orchestrator" "$(handoff_agent_from_argv --chrome --agent infra-orchestrator)"
+assert_eq "--agent=<v>"                 "infra-orchestrator" "$(handoff_agent_from_argv --agent=infra-orchestrator)"
+assert_eq "stops at -- (no match)"      ""                   "$(handoff_agent_from_argv -- --agent infra-orchestrator)"
+assert_eq "agent before -- still wins"  "infra-orchestrator" "$(handoff_agent_from_argv --agent infra-orchestrator -- somefile)"
+assert_eq "repeated: last wins (B)"     "infra-orchestrator" "$(handoff_agent_from_argv --agent curriculum-orchestrator --agent infra-orchestrator)"
+assert_eq "repeated reverse: last (A)"  "curriculum-orchestrator" "$(handoff_agent_from_argv --agent infra-orchestrator --agent curriculum-orchestrator)"
+assert_eq "--agent as last arg, no val" ""                   "$(handoff_agent_from_argv --chrome --agent)"
+assert_eq "no --agent present"          ""                   "$(handoff_agent_from_argv --chrome --permission-mode bypassPermissions)"
+assert_eq "empty argv"                  ""                   "$(handoff_agent_from_argv)"
+
+# --- handoff_identity_for_agent ---
+assert_eq "slot: infra-orchestrator"    "claude-infra"       "$(handoff_identity_for_agent infra-orchestrator)"
+assert_eq "slot: curriculum (default)"  ""                   "$(handoff_identity_for_agent curriculum-orchestrator)"
+assert_eq "slot: unknown (default)"     ""                   "$(handoff_identity_for_agent something-else)"
+assert_eq "slot: empty (default)"       ""                   "$(handoff_identity_for_agent '')"
+
+# --- set -e safety: the parser must never abort the launcher (start-claude.sh
+#     runs `set -e`); command substitution of either function must return 0. ---
+( set -e; source "$LIB"; s="$(handoff_agent_from_argv -- --agent x)"; t="$(handoff_identity_for_agent "$s")"; : "$s$t" )
+assert_eq "set -e: parser returns 0"    "0"                  "$?"
+
+if [ "$fail" -ne 0 ]; then
+  echo "[handoff-identity-test] FAIL"
+  exit 1
+fi
+echo "[handoff-identity-test] PASS"

--- a/start-claude.sh
+++ b/start-claude.sh
@@ -143,5 +143,24 @@ unset ANTHROPIC_BASE_URL OPENAI_BASE_URL COPILOT_PROVIDER_BASE_URL
 echo "headroom routing DISABLED -- launching Claude DIRECT (no proxy)"
 # --- end headroom routing ---
 
+# Derive the cold-start handoff identity from the selected `--agent`, so ONE
+# launcher serves multiple lanes: the SessionStart hook keys its orientation +
+# handoff slot off SESSION_HANDOFF_AGENT. The default curriculum lane derives
+# nothing → the hook keeps its existing single-lane behavior byte-for-byte.
+# `--agent infra-orchestrator` → SESSION_HANDOFF_AGENT=claude-infra. An explicit
+# SESSION_HANDOFF_AGENT already in the environment wins. Mapping + argv parsing
+# live in scripts/lib/handoff_identity.sh (mirrors learn-ukrainian, #2113).
+if [ -z "${SESSION_HANDOFF_AGENT:-}" ] && [ -f "$PROJECT_DIR/scripts/lib/handoff_identity.sh" ]; then
+    # shellcheck source=scripts/lib/handoff_identity.sh
+    source "$PROJECT_DIR/scripts/lib/handoff_identity.sh"
+    _selected_agent="$(handoff_agent_from_argv "$@")"
+    _handoff_slot="$(handoff_identity_for_agent "$_selected_agent")"
+    if [ -n "$_handoff_slot" ]; then
+        export SESSION_HANDOFF_AGENT="$_handoff_slot"
+        echo "Handoff identity: $SESSION_HANDOFF_AGENT (from --agent $_selected_agent)"
+    fi
+    unset _selected_agent _handoff_slot
+fi
+
 echo "Launching Claude Code (native build from PATH: $(command -v claude))..."
 exec claude --chrome --permission-mode bypassPermissions "$@"


### PR DESCRIPTION
Closes #2113.

## What
Mirror learn-ukrainian's launcher capability: ONE launcher serves multiple agent lanes. `./start-claude.sh --agent infra-orchestrator` now boots into a fixed infra/tooling lane, and the launcher derives `SESSION_HANDOFF_AGENT` so the lane reads/writes its OWN handoff slot.

## Design — additive, default lane untouched
- The **default (curriculum) lane** (plain `./start-claude.sh`, no `--agent`) is **byte-for-byte unchanged** — the hook diff has **0 removed lines** (35 added). UK translation work etc. is unaffected.
- `cold-start` runs for **both** lanes, so the infra lane still **orients via the briefing API** on its first session, before any `.agent/claude-infra-thread-handoff.md` exists (addresses the first-run-has-no-handoff case).

## Files
| File | Change |
|---|---|
| `scripts/lib/handoff_identity.sh` | **new** — `handoff_agent_from_argv` + `handoff_identity_for_agent` (`infra-orchestrator`→`claude-infra`); ported from learn-ukrainian |
| `start-claude.sh` | source the lib, export `SESSION_HANDOFF_AGENT` from `--agent` (explicit env wins) |
| `agents_extensions/claude/hooks/session-setup.sh` (+ deployed `.claude/`) | additive `claude-infra` branch: infra identity + infra handoff slot; default path untouched |
| `agents_extensions/claude/agents/infra-orchestrator.md` (+ deployed) | infra lane agent definition (schema web-verified against code.claude.com/docs) |
| `agents_extensions/deploy.sh` | deploy an `agents/` subdir to `.claude/agents/` |

## Verification
- `bash -n` clean on all 4 shell files.
- `scripts/quality/test_session_setup_head_check.sh` **PASS** (guard + main happy path).
- Infra lane, **no** handoff → emits `FIRST INFRA SESSION`, points to the briefing API, shows live API state (1781–4415 chars, under the size limit).
- Infra lane, **with** handoff → leads with `PREVIOUS-SESSION INFRA HANDOFF`.
- Launcher derivation verified under `set -e`: `--agent infra-orchestrator`→`claude-infra`; all other argv→default; exit 0.
- Agent frontmatter parses; `name:` == `--agent` selector.

## Reviewer note
This PR contains **2 commits**. Review **`08ce4a3ae`** (this work). The first commit `4cecd6166` is a pre-existing local-`main` commit (the SessionStart compact-orientation fix) that my hook edits build on; it is not yet on `origin/main` and rides along here. It can also be landed separately first.

## Out of scope (flagged, not fixed here)
Running `deploy.sh` surfaced pre-existing drift between source (`agents_extensions/claude/skills/*`) and the committed deployed copies (`.claude/skills/*`) for 3 skills (cross-family-reviewer, curriculum-orchestrator, dispatch-router). Reverted to keep this PR scoped; worth a separate sync.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
**Regression test:** `scripts/quality/test_handoff_identity.sh` — added in this PR, 14 assertions covering the argv parser (#2113), incl. the two codex-found edge cases.
