### PR TITLE
feat(agent-runtime): file-change guard for agy headless no-write flake (#2099)

### DIFF
--- a/scripts/agent_runtime/adapters/agy.py
+++ b/scripts/agent_runtime/adapters/agy.py
@@ -106,6 +106,14 @@ class AgyAdapter:
     supported_modes: frozenset[str] = frozenset(
         {"read-only", "workspace-write", "danger"}
     )
+    # agy `-p` can exit 0 having called tools but written NO file (the
+    # intermittent headless no-write flake, #2099). Without this, an empty
+    # authoring run parses ok and passes the runner's HEAD-only danger guard
+    # trivially (agy writes files WITHOUT committing, so HEAD never moves),
+    # producing a silent false-success that an overnight run would trust and
+    # drop the module. Setting this makes the runner flip a write-mode run
+    # that left the worktree byte-identical to outcome=error (retryable).
+    require_file_change_on_write: bool = True
 
     def build_invocation(
         self,

--- a/scripts/agent_runtime/adapters/base.py
+++ b/scripts/agent_runtime/adapters/base.py
@@ -98,6 +98,13 @@ class AgentAdapter(Protocol):
             silent false-success. Set on adapters whose CLI can exit 0 having
             written nothing — e.g. AgyAdapter, for the intermittent headless
             no-write flake (#2099). Defaults to ``False`` when unset.
+
+            Write-class intent assumed: the flag means "a write-mode run is
+            EXPECTED to change the worktree." It is safe because callers route
+            read-class tasks (review/search) to ``read-only`` — where the guard
+            never runs. Do NOT pass a read-class prompt through
+            ``runner.invoke(mode="danger")`` on a flagged adapter: a review that
+            legitimately writes nothing would false-fire as a no-write error.
     """
     name: str
     default_model: str

--- a/scripts/agent_runtime/adapters/base.py
+++ b/scripts/agent_runtime/adapters/base.py
@@ -86,6 +86,18 @@ class AgentAdapter(Protocol):
             doesn't specify one. Example: ``"gpt-5.4"`` for Codex.
         supported_modes: Subset of ``{"read-only", "workspace-write", "danger"}``.
             The runner rejects invocations requesting a mode not in this set.
+
+    Optional class attribute (probed by the runner via ``getattr``, so adapters
+    that don't need it may omit it entirely):
+
+        require_file_change_on_write: If ``True``, the runner treats a
+            write-mode invocation (``mode in {"workspace-write", "danger"}``)
+            that parses ``ok`` but leaves the worktree byte-identical (git HEAD
+            unchanged AND ``git status --porcelain -uall`` identical before/after)
+            as a failure (``outcome="error"``, ``Result.ok=False``) rather than a
+            silent false-success. Set on adapters whose CLI can exit 0 having
+            written nothing — e.g. AgyAdapter, for the intermittent headless
+            no-write flake (#2099). Defaults to ``False`` when unset.
     """
     name: str
     default_model: str

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -95,6 +95,10 @@ def _git_status_porcelain(cwd: Path) -> str | None:
     by the ``require_file_change_on_write`` guard to detect a write-mode run
     that produced no worktree change. Returns None (not "") on git failure so
     the guard can distinguish "couldn't measure" from "measured, empty".
+
+    Uses a 10s timeout (vs ``_git_head_sha``'s 5s) deliberately: ``status
+    -uall`` walks the whole worktree and can be materially slower than a single
+    ``rev-parse`` on a large checkout. A timeout returns None => fail-open.
     """
     try:
         proc = subprocess.run(

--- a/scripts/agent_runtime/runner.py
+++ b/scripts/agent_runtime/runner.py
@@ -87,6 +87,36 @@ def _git_head_sha(cwd: Path) -> str | None:
     return None
 
 
+def _git_status_porcelain(cwd: Path) -> str | None:
+    """Return ``git status --porcelain -uall`` for ``cwd``, or None on failure.
+
+    ``-uall`` lists every individual untracked file (not just their parent
+    dir), so a fresh authored-but-uncommitted file shows up as a change. Used
+    by the ``require_file_change_on_write`` guard to detect a write-mode run
+    that produced no worktree change. Returns None (not "") on git failure so
+    the guard can distinguish "couldn't measure" from "measured, empty".
+    """
+    try:
+        proc = subprocess.run(
+            ["git", "status", "--porcelain", "-uall"],
+            cwd=cwd,
+            capture_output=True,
+            text=True,
+            check=False,
+            timeout=10,
+        )
+        if proc.returncode == 0:
+            return proc.stdout
+    except (subprocess.SubprocessError, OSError):
+        pass
+    return None
+
+
+# Modes in which the agent may mutate the worktree. The
+# ``require_file_change_on_write`` guard only applies to these.
+_WRITE_MODES: frozenset[str] = frozenset({"workspace-write", "danger"})
+
+
 def _load_adapter(name: str) -> AgentAdapter:
     """Import the adapter class for ``name`` and cache the instance.
 
@@ -400,7 +430,21 @@ def invoke(
     env = build_agent_env(provider=agent_name, overrides=plan.env_overrides)
 
     # ---------- 7–9. Run the subprocess with watchdog ----------
-    head_before = _git_head_sha(effective_cwd) if mode == "danger" else None
+    # The file-change guard (require_file_change_on_write) needs a HEAD +
+    # porcelain baseline for any write mode; the push-verify block below needs
+    # a HEAD baseline for danger mode. Snapshot HEAD when either applies.
+    require_file_change = (
+        mode in _WRITE_MODES
+        and bool(getattr(adapter, "require_file_change_on_write", False))
+    )
+    head_before = (
+        _git_head_sha(effective_cwd)
+        if (mode == "danger" or require_file_change)
+        else None
+    )
+    porcelain_before = (
+        _git_status_porcelain(effective_cwd) if require_file_change else None
+    )
     start_time = time.monotonic()
     proc: subprocess.Popen | None = None
     watchdog_state: WatchdogState | None = None
@@ -660,6 +704,41 @@ def invoke(
                 if not push_ok:
                     outcome = "error"
 
+        # File-change guard: adapters that set require_file_change_on_write (agy,
+        # for the #2099 headless no-write flake) must not report a silent
+        # false-success. If a write-mode run parsed ok but left the worktree
+        # byte-identical (HEAD unchanged AND porcelain identical before/after),
+        # downgrade to a retryable error. agy writes files WITHOUT committing, so
+        # the HEAD-only danger guard above passes trivially on an empty run —
+        # this porcelain check is what actually catches it. Gated on parse.ok so
+        # a genuine agent error keeps its own diagnostics.
+        no_file_change_error: str | None = None
+        if require_file_change and parse.ok and push_verify_error is None:
+            head_after = _git_head_sha(effective_cwd)
+            porcelain_after = _git_status_porcelain(effective_cwd)
+            head_unchanged = (
+                head_before is not None
+                and head_after is not None
+                and head_before == head_after
+            )
+            porcelain_unchanged = (
+                porcelain_before is not None
+                and porcelain_after is not None
+                and porcelain_before == porcelain_after
+            )
+            # Only fire when we could actually MEASURE both dimensions and both
+            # show no change. If git failed (None), we can't prove no-write, so
+            # we don't punish the run.
+            if head_unchanged and porcelain_unchanged:
+                no_file_change_error = (
+                    f"{agent_name} reported success but produced no file change "
+                    "in the worktree — likely headless no-write flake (#2099); "
+                    "retry."
+                )
+                outcome = "error"
+
+        verify_error = push_verify_error or no_file_change_error
+
         record = _build_usage_record(
             agent=agent_name,
             entrypoint=entrypoint,
@@ -676,7 +755,7 @@ def invoke(
             outcome=outcome,
             rate_limited=parse.rate_limited,
             stalled=False,
-            stderr_excerpt=push_verify_error or parse.stderr_excerpt,
+            stderr_excerpt=verify_error or parse.stderr_excerpt,
             tokens=parse.tokens,
         )
         write_record(record)
@@ -689,12 +768,12 @@ def invoke(
             )
 
         return Result(
-            ok=parse.ok and push_verify_error is None,
+            ok=parse.ok and verify_error is None,
             agent=agent_name,
             model=effective_model,
             mode=mode,
             response=parse.response,
-            stderr_excerpt=push_verify_error or parse.stderr_excerpt,
+            stderr_excerpt=verify_error or parse.stderr_excerpt,
             duration_s=duration_s,
             stderr=stderr_text,
             session_id=parse.session_id,

--- a/scripts/agent_runtime/tests/test_agy_adapter.py
+++ b/scripts/agent_runtime/tests/test_agy_adapter.py
@@ -219,3 +219,14 @@ def test_parse_response_detects_rate_limit() -> None:
     assert result.rate_limited is True
     assert result.ok is False
     assert result.response == ""
+
+
+def test_adapter_requires_file_change_on_write() -> None:
+    """AgyAdapter opts into the runner's file-change guard.
+
+    agy `-p` can exit 0 having written no file (the #2099 headless no-write
+    flake). The capability flag tells the runner to treat a write-mode run
+    that left the worktree byte-identical as a retryable error instead of a
+    silent false-success.
+    """
+    assert AgyAdapter.require_file_change_on_write is True

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -204,6 +204,128 @@ class TestCodexPushVerification(unittest.TestCase):
         self.assertEqual(result.usage_record["outcome"], "error")
 
 
+class TestRequireFileChangeGuard(unittest.TestCase):
+    """The require_file_change_on_write guard (#2099 agy no-write flake)."""
+
+    @staticmethod
+    def _fake_adapter(require_flag: bool):
+        from agent_runtime.adapters.base import InvocationPlan
+        from agent_runtime.result import ParseResult
+
+        class FakeAdapter:
+            default_model = "agy-test"
+            supported_modes = frozenset({"workspace-write", "danger"})
+            require_file_change_on_write = require_flag
+
+            def build_invocation(self, **kwargs):
+                return InvocationPlan(cmd=["fake-agy"], cwd=kwargs["cwd"])
+
+            def liveness_signal_paths(self, _plan):
+                return ()
+
+            def parse_response(self, **_kwargs):
+                # CLI exited 0 with output => parses ok, even though the
+                # no-write flake means nothing landed on disk.
+                return ParseResult(ok=True, response="wrote the module")
+
+        return FakeAdapter()
+
+    @staticmethod
+    def _fake_proc():
+        class FakeProc:
+            returncode = 0
+            stdin = None
+
+            def poll(self):
+                return 0
+
+            def kill(self):
+                return None
+
+            def wait(self, timeout=None):
+                return 0
+
+        return FakeProc()
+
+    @staticmethod
+    def _fake_watchdog_state():
+        class FakeWatchdogState:
+            stdout_lines = ["wrote the module"]
+            stderr_lines = []
+
+        return FakeWatchdogState()
+
+    def _invoke(self, *, require_flag, head_seq, porcelain_seq):
+        from agent_runtime import runner
+
+        with patch.object(runner, "_load_adapter",
+                          return_value=self._fake_adapter(require_flag)), \
+             patch.object(runner, "has_headroom", return_value=(True, "")), \
+             patch.object(runner, "build_agent_env", return_value={}), \
+             patch.object(runner.subprocess, "Popen",
+                          return_value=self._fake_proc()), \
+             patch.object(runner, "start_watchdog",
+                          return_value=(self._fake_watchdog_state(), [])), \
+             patch.object(runner, "stop_watchdog"), \
+             patch.object(runner, "write_record"), \
+             patch.object(runner, "_git_head_sha", side_effect=head_seq), \
+             patch.object(runner, "_git_status_porcelain", side_effect=porcelain_seq):
+            return runner.invoke(
+                "agy",
+                "write the module",
+                mode="workspace-write",
+                cwd=REPO_ROOT,
+                model="agy-test",
+                skip_headroom_check=True,
+            )
+
+    def test_no_file_change_marks_error(self):
+        """ok parse + zero worktree change => retryable error."""
+        # before + guard-after HEAD; before + guard-after porcelain.
+        result = self._invoke(
+            require_flag=True,
+            head_seq=["sha0", "sha0"],
+            porcelain_seq=["", ""],
+        )
+        self.assertFalse(result.ok)
+        self.assertEqual(result.usage_record["outcome"], "error")
+        self.assertIn("no file change", (result.stderr_excerpt or "").lower())
+        self.assertIn("#2099", result.stderr_excerpt or "")
+
+    def test_file_change_present_stays_ok(self):
+        """A real porcelain change clears the guard."""
+        result = self._invoke(
+            require_flag=True,
+            head_seq=["sha0", "sha0"],
+            porcelain_seq=["", "?? uk/new-module.md\n"],
+        )
+        self.assertTrue(result.ok)
+        self.assertEqual(result.usage_record["outcome"], "ok")
+
+    def test_guard_off_when_adapter_opts_out(self):
+        """No flag => empty worktree is NOT downgraded (legacy behavior)."""
+        # With the flag off in workspace-write mode, neither HEAD nor porcelain
+        # is snapshotted (danger path is not taken either), so both mocks see
+        # zero calls; the extra seq item is just an unused cushion.
+        result = self._invoke(
+            require_flag=False,
+            head_seq=["sha0"],
+            porcelain_seq=[],
+        )
+        self.assertTrue(result.ok)
+        self.assertEqual(result.usage_record["outcome"], "ok")
+
+    def test_git_unmeasurable_does_not_punish(self):
+        """If git status can't be read (None), the guard must not fire."""
+        result = self._invoke(
+            require_flag=True,
+            head_seq=["sha0", "sha0"],
+            porcelain_seq=[None, None],
+        )
+        self.assertTrue(result.ok)
+        self.assertEqual(result.usage_record["outcome"], "ok")
+
+
 # ---------------------------------------------------------------------------
 # Fixtures: known-good and known-bad module content
 # ---------------------------------------------------------------------------

--- a/scripts/test_pipeline.py
+++ b/scripts/test_pipeline.py
@@ -255,7 +255,8 @@ class TestRequireFileChangeGuard(unittest.TestCase):
 
         return FakeWatchdogState()
 
-    def _invoke(self, *, require_flag, head_seq, porcelain_seq):
+    def _invoke(self, *, require_flag, head_seq, porcelain_seq,
+                mode="workspace-write", push_verify=(True, None)):
         from agent_runtime import runner
 
         with patch.object(runner, "_load_adapter",
@@ -268,12 +269,14 @@ class TestRequireFileChangeGuard(unittest.TestCase):
                           return_value=(self._fake_watchdog_state(), [])), \
              patch.object(runner, "stop_watchdog"), \
              patch.object(runner, "write_record"), \
+             patch.object(runner, "verify_current_branch_pushed",
+                          return_value=push_verify), \
              patch.object(runner, "_git_head_sha", side_effect=head_seq), \
              patch.object(runner, "_git_status_porcelain", side_effect=porcelain_seq):
             return runner.invoke(
                 "agy",
                 "write the module",
-                mode="workspace-write",
+                mode=mode,
                 cwd=REPO_ROOT,
                 model="agy-test",
                 skip_headroom_check=True,
@@ -324,6 +327,42 @@ class TestRequireFileChangeGuard(unittest.TestCase):
         )
         self.assertTrue(result.ok)
         self.assertEqual(result.usage_record["outcome"], "ok")
+
+    def test_danger_mode_no_write_marks_error(self):
+        """The production path is danger mode (dispatch_smart forces agy to
+        danger). A no-write danger run must also flip to error, exercising the
+        guard alongside — not instead of — the danger push-verify block."""
+        # HEAD: before, push-verify-after, file-guard-after (all identical, so
+        # push-verify sees no commit and never calls verify_current_branch_pushed).
+        result = self._invoke(
+            require_flag=True,
+            mode="danger",
+            head_seq=["sha0", "sha0", "sha0"],
+            porcelain_seq=["", ""],  # before, file-guard-after
+        )
+        self.assertFalse(result.ok)
+        self.assertEqual(result.usage_record["outcome"], "error")
+        self.assertIn("#2099", result.stderr_excerpt or "")
+
+    def test_push_verify_error_wins_over_file_guard(self):
+        """When agy DOES commit in danger mode but the push fails, the
+        push-verify error must win: the file guard is short-circuited
+        (push_verify_error is not None) so the excerpt is push-related, never
+        the #2099 no-write note."""
+        # HEAD moves (sha0 -> sha1) => push-verify block fires and, because the
+        # push is stale, sets push_verify_error. The file guard is then skipped,
+        # so no file-guard HEAD/porcelain-after reads happen.
+        result = self._invoke(
+            require_flag=True,
+            mode="danger",
+            head_seq=["sha0", "sha1"],  # before, push-verify-after (changed)
+            porcelain_seq=[""],  # before only; file guard never runs
+            push_verify=(False, "origin stale: expected sha1"),
+        )
+        self.assertFalse(result.ok)
+        self.assertEqual(result.usage_record["outcome"], "error")
+        self.assertIn("origin stale", result.stderr_excerpt or "")
+        self.assertNotIn("#2099", result.stderr_excerpt or "")
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Adds an opt-in `require_file_change_on_write` adapter capability so the runner treats an agy write-mode run that produced **no worktree change** as a retryable error instead of a silent false-success.

## Why (#2099)

`agy -p` can exit 0 having called tools but written **no file** (the intermittent headless no-write flake). The runner's existing danger-mode guard only compares the git **HEAD SHA** — but agy authoring writes files **without committing**, so an empty run leaves HEAD unchanged and passes trivially. Result: `OK:True`, `resp_chars ~51`, and no file on disk. An overnight autonomous run trusts that and silently drops the module.

Root-cause diagnosis (s187b infra handoff): the flag/adapter is correct and agy 1.0.14 authors reliably (5/5 multi-thousand-word writes through the real dispatch path). The remaining risk is this rare no-write flake. This guard converts the silent false-success into a detectable, retryable failure so it's safe to route real UK modules to agy.

## Changes

- **`adapters/base.py`** — document the optional `require_file_change_on_write` class attribute (probed via `getattr`, defaults `False`; other adapters untouched).
- **`adapters/agy.py`** — `AgyAdapter.require_file_change_on_write = True`.
- **`runner.py`** — for write modes (`workspace-write`/`danger`) on a require-flag adapter, snapshot git HEAD + `git status --porcelain -uall` before/after. If a parse-ok run leaves the worktree byte-identical, downgrade `outcome=error` / `Result.ok=False` with a retry note. Fires only when **both** dimensions are measurable — a git failure (`None`) never punishes the run. Danger-mode push-verify path is preserved.

## Tests

- New `TestRequireFileChangeGuard` in `test_pipeline.py`: fire on no-change, stay-ok on real porcelain change, opt-out when flag absent, and no-punish when git is unmeasurable.
- `test_agy_adapter.py`: asserts the adapter sets the flag.
- Full `test_pipeline.py` suite: **174 passed**. Ruff clean.
- Change is Python-only under `scripts/agent_runtime/` — zero Astro-build surface; CI build check still runs on the merge state.

Refs #2099, #1911

🤖 Generated with [Claude Code](https://claude.com/claude-code)