### PR TITLE
chore(dispatch): retire the --agent gemini lane (Google lane = agy)

### DIFF
--- a/.claude/skills/dispatch-router/SKILL.md
+++ b/.claude/skills/dispatch-router/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dispatch-router
-description: Pick the right KubeDojo agent for a task across ALL activities — write / code / review / research / mechanical, not just review. Activity × lane matrix → agent → model → dispatch command. Roster as of 2026-06-04 (cursor, codex, opus, agy[model-selectable], gemini, deepseek, grok via hermes). Use before any dispatch. Triggers on "which agent", "dispatch", "route to", "who should do this".
+description: Pick the right KubeDojo agent for a task across ALL activities — write / code / review / research / mechanical, not just review. Activity × lane matrix → agent → model → dispatch command. Roster as of 2026-07-01 (cursor, codex, opus/claude-headless, agy[model-selectable, the Google lane — gemini-cli RETIRED], deepseek, grok via grok-CLI/hermes). Use before any dispatch. Triggers on "which agent", "dispatch", "route to", "who should do this".
 last_calibrated: 2026-06-04
 ---
 
@@ -18,12 +18,12 @@ Pick the row for the activity, then the **primary doer**; for any write/author r
 
 | Activity | Primary doer | Cross-family reviewer(s) | Off-load / candidates |
 |---|---|---|---|
-| **Curriculum content — WRITE** (prose modules, expand-to-floor) | **cursor** `--model auto` ‖ **codex** gpt-5.5 (quality-critical first pass) | opus(≤1/wave) + agy(3.1-pro-high) + gemini + deepseek + grok-4.20-0309-reasoning — pick ≥1 of a different family than the author | agy (2nd writer), deepseek, grok-4.3 |
+| **Curriculum content — WRITE** (prose modules, expand-to-floor) | **cursor** `--model auto` ‖ **codex** gpt-5.5 (quality-critical first pass) | opus(≤1/wave) + agy(3.1-pro-high, the Google lane) + deepseek + grok-4.20-0309-reasoning — pick ≥1 of a different family than the author | agy (2nd writer), deepseek, grok-4.3 |
 | **Curriculum content — REVIEW** | — | **opus** (strongest) / **cursor** / **agy** (the Google lane) / **deepseek** (cheap) / **grok-4.20-0309-reasoning** | mix ≥2 families; ≤2 per OAuth; ground-check ALL. ~~gemini-cli~~ RETIRED ~2026-06-15 → use agy |
 | **Code / tooling — WRITE & FIX** (scripts, adapters, pipeline) | **cursor** `--model auto` (strongest fixer, 3/3) | **codex** (danger+worktree) / **opus** / **grok-build-0.1** / **deepseek** | codex |
 | **Code / tooling — REVIEW** | — | **codex** (danger+worktree) / **opus** (best code-correctness) / **grok-build-0.1** / **deepseek** | feed grok-build COMPLETE diffs |
 | **Code-heavy MODULE content** (extending-k8s, tool certs — modules WITH code that must build) | **codex** gpt-5.5 (factual/version/runnability best) | **opus** (route ≥1 here — caught every extending-k8s P1) + **grok-build-0.1** (code) + **deepseek** | cursor, agy |
-| **Research / gap-analysis / architecture** | **codex** (architect/consult) + **opus** (architect class) | `ab discuss --with claude,codex,gemini` for high-leverage ([[.claude/rules/decision-card]]) | deep-research harness; chrome MCP for source fetch |
+| **Research / gap-analysis / architecture** | **codex** (architect/consult) + **opus** (architect class) | `ab discuss --with claude,codex,agy` for high-leverage ([[.claude/rules/decision-card]]) | deep-research harness; chrome MCP for source fetch |
 | **Mechanical / deterministic** (gate fixes, link fixes, batched edits, search) | **cursor** or **codex** (cheap tier: composer-fast / spark / mini) | self-verify (`verify_module.py`, build, health) | — |
 
 **Cross-family map** (reviewer ≠ author family): OpenAI = codex · Anthropic = claude/opus · Google = **agy** (gemini-cli RETIRED ~2026-06-15, user 2026-06-07) · DeepSeek = deepseek · **Cursor Composer = cursor (composer-2.5, built on Kimi K2.5 / Moonshot — its OWN family, NOT xAI)** · xAI = grok-build / grok-4.x. ⚠️ cursor(composer-2.5) and `grok-composer-2.5` are the SAME model (xAI *serves* Cursor's Composer) — they cannot cross-review each other; grok-build / grok-4.x are a distinct xAI line (OK to review cursor-authored). Soft caution: cursor(Kimi) vs deepseek(DeepSeek) are different labs/bases (a valid pair) but both Chinese-origin → prefer a Western-lab reviewer for top-stakes cursor work. (Corrected s140; VentureBeat 2026 — see `feedback_cursor_composer_base_is_kimi_not_xai`.) ⚠️ **xAI and Cursor are now ONE COMPANY (merged, 2026-06) — user s167.** cursor↔grok therefore also carry a **soft shared-org caution** (prefer a different-org reviewer for top-stakes); the hard same-model exclusion (cursor Composer == `grok-composer-2.5-fast`) is unchanged. **The 4 clean independents: OpenAI / Google / Anthropic / DeepSeek.** Keep BOTH the cursor CLI and the grok CLI supported — unclear which becomes the mainstream CLI at the merged co.
@@ -78,7 +78,7 @@ T0 author primary is **codex-or-cursor** depending on codex weekly-cap state —
 
 ### Architect / consult / decision
 1. `dispatch_smart architect --agent codex` (gpt-5.5).
-2. For high-leverage decisions: `scripts/ab discuss --with claude,codex,gemini` ([[.claude/rules/decision-card]]).
+2. For high-leverage decisions: `scripts/ab discuss --with claude,codex,agy` ([[.claude/rules/decision-card]]).
 3. Consult codex on non-trivial scope decisions ([[feedback_consult_codex_on_decisions]]).
 
 ## Pre-flight checklist (before EVERY dispatch)

--- a/.claude/skills/dispatch-router/SKILL.md
+++ b/.claude/skills/dispatch-router/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dispatch-router
 description: Pick the right KubeDojo agent for a task across ALL activities — write / code / review / research / mechanical, not just review. Activity × lane matrix → agent → model → dispatch command. Roster as of 2026-07-01 (cursor, codex, opus/claude-headless, agy[model-selectable, the Google lane — gemini-cli RETIRED], deepseek, grok via grok-CLI/hermes). Use before any dispatch. Triggers on "which agent", "dispatch", "route to", "who should do this".
-last_calibrated: 2026-06-04
+last_calibrated: 2026-07-01
 ---
 
 # Dispatch Router Skill

--- a/agents_extensions/claude/skills/dispatch-router/SKILL.md
+++ b/agents_extensions/claude/skills/dispatch-router/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: dispatch-router
-description: Pick the right KubeDojo agent for a task across ALL activities — write / code / review / research / mechanical, not just review. Activity × lane matrix → agent → model → dispatch command. Roster as of 2026-06-04 (cursor, codex, opus, agy[model-selectable], gemini, deepseek, grok via hermes). Use before any dispatch. Triggers on "which agent", "dispatch", "route to", "who should do this".
+description: Pick the right KubeDojo agent for a task across ALL activities — write / code / review / research / mechanical, not just review. Activity × lane matrix → agent → model → dispatch command. Roster as of 2026-07-01 (cursor, codex, opus/claude-headless, agy[model-selectable, the Google lane — gemini-cli RETIRED], deepseek, grok via grok-CLI/hermes). Use before any dispatch. Triggers on "which agent", "dispatch", "route to", "who should do this".
 last_calibrated: 2026-06-04
 ---
 
@@ -18,12 +18,12 @@ Pick the row for the activity, then the **primary doer**; for any write/author r
 
 | Activity | Primary doer | Cross-family reviewer(s) | Off-load / candidates |
 |---|---|---|---|
-| **Curriculum content — WRITE** (prose modules, expand-to-floor) | **cursor** `--model auto` ‖ **codex** gpt-5.5 (quality-critical first pass) | opus(≤1/wave) + agy(3.1-pro-high) + gemini + deepseek + grok-4.20-0309-reasoning — pick ≥1 of a different family than the author | agy (2nd writer), deepseek, grok-4.3 |
+| **Curriculum content — WRITE** (prose modules, expand-to-floor) | **cursor** `--model auto` ‖ **codex** gpt-5.5 (quality-critical first pass) | opus(≤1/wave) + agy(3.1-pro-high, the Google lane) + deepseek + grok-4.20-0309-reasoning — pick ≥1 of a different family than the author | agy (2nd writer), deepseek, grok-4.3 |
 | **Curriculum content — REVIEW** | — | **opus** (strongest) / **cursor** / **agy** (the Google lane) / **deepseek** (cheap) / **grok-4.20-0309-reasoning** | mix ≥2 families; ≤2 per OAuth; ground-check ALL. ~~gemini-cli~~ RETIRED ~2026-06-15 → use agy |
 | **Code / tooling — WRITE & FIX** (scripts, adapters, pipeline) | **cursor** `--model auto` (strongest fixer, 3/3) | **codex** (danger+worktree) / **opus** / **grok-build-0.1** / **deepseek** | codex |
 | **Code / tooling — REVIEW** | — | **codex** (danger+worktree) / **opus** (best code-correctness) / **grok-build-0.1** / **deepseek** | feed grok-build COMPLETE diffs |
 | **Code-heavy MODULE content** (extending-k8s, tool certs — modules WITH code that must build) | **codex** gpt-5.5 (factual/version/runnability best) | **opus** (route ≥1 here — caught every extending-k8s P1) + **grok-build-0.1** (code) + **deepseek** | cursor, agy |
-| **Research / gap-analysis / architecture** | **codex** (architect/consult) + **opus** (architect class) | `ab discuss --with claude,codex,gemini` for high-leverage ([[.claude/rules/decision-card]]) | deep-research harness; chrome MCP for source fetch |
+| **Research / gap-analysis / architecture** | **codex** (architect/consult) + **opus** (architect class) | `ab discuss --with claude,codex,agy` for high-leverage ([[.claude/rules/decision-card]]) | deep-research harness; chrome MCP for source fetch |
 | **Mechanical / deterministic** (gate fixes, link fixes, batched edits, search) | **cursor** or **codex** (cheap tier: composer-fast / spark / mini) | self-verify (`verify_module.py`, build, health) | — |
 
 **Cross-family map** (reviewer ≠ author family): OpenAI = codex · Anthropic = claude/opus · Google = **agy** (gemini-cli RETIRED ~2026-06-15, user 2026-06-07) · DeepSeek = deepseek · **Cursor Composer = cursor (composer-2.5, built on Kimi K2.5 / Moonshot — its OWN family, NOT xAI)** · xAI = grok-build / grok-4.x. ⚠️ cursor(composer-2.5) and `grok-composer-2.5` are the SAME model (xAI *serves* Cursor's Composer) — they cannot cross-review each other; grok-build / grok-4.x are a distinct xAI line (OK to review cursor-authored). Soft caution: cursor(Kimi) vs deepseek(DeepSeek) are different labs/bases (a valid pair) but both Chinese-origin → prefer a Western-lab reviewer for top-stakes cursor work. (Corrected s140; VentureBeat 2026 — see `feedback_cursor_composer_base_is_kimi_not_xai`.) ⚠️ **xAI and Cursor are now ONE COMPANY (merged, 2026-06) — user s167.** cursor↔grok therefore also carry a **soft shared-org caution** (prefer a different-org reviewer for top-stakes); the hard same-model exclusion (cursor Composer == `grok-composer-2.5-fast`) is unchanged. **The 4 clean independents: OpenAI / Google / Anthropic / DeepSeek.** Keep BOTH the cursor CLI and the grok CLI supported — unclear which becomes the mainstream CLI at the merged co.
@@ -78,7 +78,7 @@ T0 author primary is **codex-or-cursor** depending on codex weekly-cap state —
 
 ### Architect / consult / decision
 1. `dispatch_smart architect --agent codex` (gpt-5.5).
-2. For high-leverage decisions: `scripts/ab discuss --with claude,codex,gemini` ([[.claude/rules/decision-card]]).
+2. For high-leverage decisions: `scripts/ab discuss --with claude,codex,agy` ([[.claude/rules/decision-card]]).
 3. Consult codex on non-trivial scope decisions ([[feedback_consult_codex_on_decisions]]).
 
 ## Pre-flight checklist (before EVERY dispatch)

--- a/agents_extensions/claude/skills/dispatch-router/SKILL.md
+++ b/agents_extensions/claude/skills/dispatch-router/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: dispatch-router
 description: Pick the right KubeDojo agent for a task across ALL activities — write / code / review / research / mechanical, not just review. Activity × lane matrix → agent → model → dispatch command. Roster as of 2026-07-01 (cursor, codex, opus/claude-headless, agy[model-selectable, the Google lane — gemini-cli RETIRED], deepseek, grok via grok-CLI/hermes). Use before any dispatch. Triggers on "which agent", "dispatch", "route to", "who should do this".
-last_calibrated: 2026-06-04
+last_calibrated: 2026-07-01
 ---
 
 # Dispatch Router Skill

--- a/scripts/check_coherence.py
+++ b/scripts/check_coherence.py
@@ -15,7 +15,7 @@ quiz <details>, and the `## Sources` section.
 
 Usage:
     python scripts/check_coherence.py path/to/module.md
-    python scripts/check_coherence.py path/to/module.md --agent agy
+    python scripts/check_coherence.py path/to/module.md --agent codex
     python scripts/check_coherence.py path/to/module.md --dry-run
     python scripts/check_coherence.py path/to/module.md --text
 """

--- a/scripts/check_coherence.py
+++ b/scripts/check_coherence.py
@@ -15,7 +15,7 @@ quiz <details>, and the `## Sources` section.
 
 Usage:
     python scripts/check_coherence.py path/to/module.md
-    python scripts/check_coherence.py path/to/module.md --agent gemini
+    python scripts/check_coherence.py path/to/module.md --agent agy
     python scripts/check_coherence.py path/to/module.md --dry-run
     python scripts/check_coherence.py path/to/module.md --text
 """

--- a/scripts/citation_backfill.py
+++ b/scripts/citation_backfill.py
@@ -8,7 +8,7 @@ calibrated on the 4 pilot modules.
 Usage:
     # Research phase — dispatch Codex, validate URLs, write seed JSON.
     python scripts/citation_backfill.py research <module-key>
-    python scripts/citation_backfill.py research --agent gemini <module-key>
+    python scripts/citation_backfill.py research --agent agy <module-key>
     python scripts/citation_backfill.py research --dry-run <module-key>
         # emits the Codex prompt to stdout, no dispatch, no writes
 

--- a/scripts/citation_backfill.py
+++ b/scripts/citation_backfill.py
@@ -8,7 +8,7 @@ calibrated on the 4 pilot modules.
 Usage:
     # Research phase — dispatch Codex, validate URLs, write seed JSON.
     python scripts/citation_backfill.py research <module-key>
-    python scripts/citation_backfill.py research --agent agy <module-key>
+    python scripts/citation_backfill.py research --agent codex <module-key>
     python scripts/citation_backfill.py research --dry-run <module-key>
         # emits the Codex prompt to stdout, no dispatch, no writes
 

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -98,7 +98,10 @@ PRIMARY_REPO = _primary_checkout_root(REPO)
 LOG_PATH = PRIMARY_REPO / "logs" / "smart_dispatch.jsonl"
 RESPONSE_DIR = PRIMARY_REPO / "logs" / "dispatch_responses"
 MCP_CONFIG_PATH = PRIMARY_REPO / ".mcp.json"
-MCP_SUPPORTED_AGENTS = frozenset({"claude", "gemini"})
+# gemini-cli RETIRED 2026-07-01 (no gemini-cli; the Google lane is now agy).
+# agy loads MCP NATIVELY from ~/.gemini/config/mcp_config.json, so it needs no
+# per-dispatch --mcp flag; claude is the only agent that takes --mcp here.
+MCP_SUPPORTED_AGENTS = frozenset({"claude"})
 
 # Skill auto-loading — R2 follow-up to PR #1575 and the agents_extensions/
 # layout introduced there.
@@ -119,7 +122,8 @@ SUPPORTED_AGENTS = (
     "codex",
     "cursor",
     "deepseek",
-    "gemini",
+    # "gemini" RETIRED 2026-07-01 — no gemini-cli; use "agy" for the Google
+    # lane (agy has its own `--model` display names, e.g. gemini-3.1-pro-high).
     "grok",
     "hermes",
     "opencode",
@@ -149,7 +153,6 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "claude": "claude-haiku-4-5-20251001",
             "codex": "gpt-5.4-mini",
             "deepseek": "deepseek-v4-flash",
-            "gemini": "gemini-3.1-flash-lite-preview",
             "grok": "grok-build",
             "cursor": "composer-2.5-fast",
             "hermes": "qwen-3.6-flash",
@@ -167,7 +170,6 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.3-codex-spark",
             "deepseek": "deepseek-v4-pro",
-            "gemini": "gemini-3.1-pro-preview",
             "grok": "grok-build",
             "cursor": "composer-2.5",
             "hermes": "grok-4.3",
@@ -185,7 +187,6 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",
-            "gemini": "gemini-3.1-pro-preview",
             "grok": "grok-build",
             "cursor": "composer-2.5",
             "hermes": "grok-4.3",
@@ -203,7 +204,6 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "claude": "claude-sonnet-4-6",
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",
-            "gemini": "gemini-3.1-pro-preview",
             "grok": "grok-build",
             "cursor": "auto",
             "hermes": "claude-sonnet-4-6",
@@ -221,7 +221,6 @@ TASK_CLASSES: dict[str, TaskClassConfig] = {
             "claude": "claude-opus-4-8",
             "codex": "gpt-5.5",
             "deepseek": "deepseek-v4-pro",
-            "gemini": "gemini-3.1-pro-preview",
             "grok": "grok-build",
             "cursor": "composer-2.5",
             "hermes": "claude-opus-4-6",
@@ -338,8 +337,6 @@ def _build_mcp_tool_config(agent: str, mcp_server: str) -> dict:
             "mcp_config_path": mcp_config_path,
             "allowed_tools": allowed_tools,
         }
-    if agent == "gemini":
-        return {"mcp_server_names": [mcp_server]}
     return {}
 
 
@@ -382,14 +379,6 @@ def _dry_run_runtime_argv(
 
 def _print_dry_run_mcp(agent: str, tool_config: dict) -> None:
     """Print resolved MCP wiring for ``--dry-run`` verification."""
-    if agent == "gemini":
-        names = tool_config.get("mcp_server_names") or []
-        joined = ",".join(names)
-        print(f"[dry-run] mcp_servers={joined}")
-        if joined:
-            print(f"[dry-run] mcp_flag=--allowed-mcp-server-names {joined}")
-        return
-
     if agent == "claude":
         mcp_config_path = tool_config.get("mcp_config_path")
         allowed_tools = tool_config.get("allowed_tools") or ""
@@ -775,8 +764,8 @@ def main() -> int:
         help=(
             "Enable a named MCP server's read tools for this dispatch "
             "(e.g. --mcp rag for Ukrainian-translation fact-checking). "
-            "Only rag is configured today. Honored for claude and gemini "
-            "agents only."
+            "Only rag is configured today. Honored for the claude agent "
+            "only (agy loads its MCP servers natively; no flag needed)."
         ),
     )
     args = p.parse_args()
@@ -798,8 +787,8 @@ def main() -> int:
             )
         if args.agent not in MCP_SUPPORTED_AGENTS:
             p.error(
-                f"--mcp tool access is only supported for claude and gemini "
-                f"(got agent={args.agent!r})"
+                f"--mcp tool access is only supported for the claude agent "
+                f"(got agent={args.agent!r}); agy loads MCP natively, no flag needed"
             )
         available = _available_mcp_servers()
         if args.mcp not in available:


### PR DESCRIPTION
## What
Retires the stale **`--agent gemini`** lane from `dispatch_smart.py`. gemini-cli is gone; the Google lane is now **agy**, which uses its own `--model` display names (`gemini-3.1-pro-high` → "Gemini 3.1 Pro (High)"). dispatch_smart still exposed `--agent gemini` with the old gemini-cli slugs — confusing, and routes to a dead binary.

## Changes
- **`SUPPORTED_AGENTS`**: drop `"gemini"` → argparse now rejects `--agent gemini`.
- **`TASK_CLASSES`**: drop the `"gemini"` model row from all 5 classes (search/edit/draft/review/architect).
- **MCP**: `MCP_SUPPORTED_AGENTS` → `{"claude"}`; remove the `gemini` branches in `_build_mcp_tool_config` / `_print_dry_run_mcp`; update `--mcp` help + error text (agy loads MCP **natively** from `~/.gemini/config/mcp_config.json`, no flag needed).
- **Docstring examples** (`check_coherence.py`, `citation_backfill.py`): `--agent gemini` → `--agent agy`.
- **dispatch-router skill**: drop the bare `gemini` from the write/review family list, point `ab discuss` recommendations at agy, refresh the roster line. Redeployed to `.claude/` (Extensions-in-sync clean).

## Scope
This PR is the **`--agent gemini` lane only**. The deeper repoint of the legacy `GEMINI_WRITER_MODEL` default writer/reviewer (`dispatch.py`, `registry.py` + `adapters/gemini.py`, `quality/dispatchers.py` + `queue.py`, v1/v2/lab/translation/on-prem pipelines, the `ab` subsystem) is a larger, curriculum-pipeline-co-owned migration tracked in **#2125** — deliberately not bundled here.

## Verification
- ruff clean.
- `--agent gemini` → `error: argument --agent: invalid choice: 'gemini'`.
- `--agent agy draft --dry-run` → `agent=agy … model=gemini-3.1-pro-high` (Google lane intact).
- 8 dispatch_smart MCP tests pass; no dispatch_smart test asserted gemini presence.
- Change is Python + skill-doc only; no Astro-build surface.

Refs #2125

🤖 Generated with [Claude Code](https://claude.com/claude-code)