### PR TITLE
feat(agent-runtime): port MCP-dispatch layer so hermes lanes author with sources MCP (#2131)

### DIFF
--- a/scripts/agent_runtime/adapters/deepseek.py
+++ b/scripts/agent_runtime/adapters/deepseek.py
@@ -39,14 +39,20 @@ Status flagged for the user:
 """
 from __future__ import annotations
 
+import logging
 import os
 import re
 import shutil
 from pathlib import Path
 from typing import Any
 
+import yaml
+
 from ..result import ParseResult
 from .base import InvocationPlan
+
+_logger = logging.getLogger(__name__)
+_HERMES_CONFIG_PATH = Path.home() / ".hermes" / "config.yaml"
 
 # Rate-limit patterns. DeepSeek follows Hermes transport patterns, including
 # standard 429 signaling.
@@ -83,6 +89,29 @@ _HERMES_BANNER_RE = re.compile(
 _TOOLSETS_READ_ONLY = "web,browser"
 _TOOLSETS_WORKSPACE = "web,browser,file,terminal,code_execution,todo"
 _TOOLSETS_DANGER = "web,browser,file,terminal,code_execution,todo,memory,skills"
+
+
+def _read_hermes_config(path: Path = _HERMES_CONFIG_PATH) -> dict[str, Any]:
+    try:
+        data = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _sources_mcp_registered(config: dict[str, Any]) -> bool:
+    servers = config.get("mcp_servers")
+    if not isinstance(servers, dict):
+        return False
+    sources = servers.get("sources")
+    if not isinstance(sources, dict):
+        return False
+    return bool(sources.get("enabled") is not False and sources.get("url"))
+
+
+def translate_mcp_prefix_for_hermes(prompt: str) -> str:
+    """Rewrite ``mcp__sources__X`` to ``mcp_sources_X`` for Hermes routing."""
+    return prompt.replace("mcp__sources__", "mcp_sources_")
 
 
 class DeepSeekAdapter:
@@ -141,6 +170,16 @@ class DeepSeekAdapter:
         final_prompt = prompt
         if effort and effort != "default":
             final_prompt = f"[Reasoning effort hint: {effort}]\n\n{prompt}"
+
+        hermes_mcp_servers = tc.get("hermes_mcp_servers") or []
+        if "sources" in hermes_mcp_servers:
+            config = _read_hermes_config()
+            if not _sources_mcp_registered(config):
+                _logger.warning(
+                    "Hermes DeepSeek did not find enabled mcp_servers.sources in "
+                    "~/.hermes/config.yaml; MCP tool availability depends on Hermes config"
+                )
+            final_prompt = translate_mcp_prefix_for_hermes(final_prompt)
 
         # Model
         cmd.extend(["-m", model or self.default_model])

--- a/scripts/agent_runtime/tool_config.py
+++ b/scripts/agent_runtime/tool_config.py
@@ -1,0 +1,366 @@
+"""Shared MCP tool_config builders for agent_runtime callers."""
+from __future__ import annotations
+
+import json
+import os
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+_REPO_ROOT = Path(__file__).resolve().parents[2]
+_DEFAULT_MCP_CONFIG_PATH = _REPO_ROOT / ".mcp.json"
+_AGY_APP_DATA_ENV = "AGY_APP_DATA_DIR"
+_DEFAULT_AGY_APP_DATA_DIR = "~/.gemini/antigravity-cli"
+_HERMES_CONFIG_PATH = Path.home() / ".hermes" / "config.yaml"
+_RESOLUTION_STATUSES = {"ok", "config_missing", "config_empty", "servers_not_found"}
+_CODEX_MCP_SERVER_FIELDS = frozenset(
+    {
+        "url",
+        "command",
+        "args",
+        "env",
+        "bearer_token_env_var",
+    }
+)
+_HERMES_LANE_AGENTS = frozenset({"deepseek", "grok", "qwen", "hermes"})
+
+
+def _canonical_agent_name(agent: str) -> str | None:
+    """Normalize caller-facing agent labels to runtime adapter names."""
+    if agent.startswith("claude"):
+        return "claude"
+    if agent.startswith("codex"):
+        return "codex"
+    if agent.startswith("grok-build"):
+        return "grok-build"
+    if agent.startswith("grok"):
+        return "grok"
+    if agent.startswith("deepseek"):
+        return "deepseek"
+    if agent.startswith("qwen"):
+        return "qwen"
+    if agent.startswith("hermes"):
+        return "hermes"
+    if agent.startswith("agy"):
+        return "agy"
+    if agent.startswith("cursor"):
+        return "cursor"
+    return None
+
+
+def _resolved_mcp_config_path(mcp_config_path: Path | None) -> Path:
+    """Return the configured ``.mcp.json`` path, defaulting to repo root."""
+    return (mcp_config_path or _DEFAULT_MCP_CONFIG_PATH).resolve()
+
+
+def _resolved_agy_mcp_config_path() -> Path:
+    """Return agy's global Antigravity MCP config path."""
+    app_data_dir = os.environ.get(_AGY_APP_DATA_ENV, _DEFAULT_AGY_APP_DATA_DIR)
+    return (Path(app_data_dir).expanduser() / "mcp_config.json").resolve()
+
+
+def _codex_sanitize_server_config(server_config: dict) -> dict:
+    """Drop fields codex CLI's mcp_servers schema does not recognize."""
+    return {k: v for k, v in server_config.items() if k in _CODEX_MCP_SERVER_FIELDS}
+
+
+@lru_cache(maxsize=1)
+def _load_mcp_config(mcp_config_path: Path) -> dict[str, Any] | None:
+    """Load ``.mcp.json`` once per process for Codex MCP config shaping."""
+    try:
+        raw = json.loads(mcp_config_path.read_text(encoding="utf-8"))
+    except (OSError, json.JSONDecodeError):
+        return None
+    return raw if isinstance(raw, dict) else None
+
+
+def _basic_diagnostics(
+    *,
+    mcp_config_path: Path,
+    requested_servers: list[str] | None,
+    resolved_servers: list[str] | None,
+    resolution_status: str,
+    missing_server_names: list[str] | None = None,
+) -> dict[str, Any]:
+    assert resolution_status in _RESOLUTION_STATUSES
+    return {
+        "requested_servers": list(requested_servers or []),
+        "resolved_servers": list(resolved_servers or []),
+        "config_path": str(mcp_config_path),
+        "resolution_status": resolution_status,
+        "missing_server_names": list(missing_server_names or []),
+    }
+
+
+def _codex_server_is_usable(server_config: Any) -> bool:
+    """Reject known-stale Codex MCP endpoint shapes before dispatch."""
+    if not isinstance(server_config, dict):
+        return False
+    server_type = str(server_config.get("type") or "").strip().lower()
+    url = str(server_config.get("url") or "").strip()
+    command = str(server_config.get("command") or "").strip()
+    if server_type == "sse":
+        return False
+    if url.rstrip("/").endswith("/sse"):
+        return False
+    return bool(url or command)
+
+
+def _codex_mcp_servers(
+    mcp_config_path: Path,
+    requested_servers: list[str] | None,
+) -> tuple[dict[str, Any] | None, dict[str, Any]]:
+    """Return Codex's nested ``mcp_servers`` config plus resolution diagnostics."""
+    requested = list(requested_servers or [])
+
+    def diagnostics(
+        *,
+        resolved_servers: list[str] | None = None,
+        resolution_status: str,
+        missing_server_names: list[str] | None = None,
+    ) -> dict[str, Any]:
+        assert resolution_status in _RESOLUTION_STATUSES
+        return {
+            "requested_servers": requested,
+            "resolved_servers": resolved_servers or [],
+            "config_path": str(mcp_config_path),
+            "resolution_status": resolution_status,
+            "missing_server_names": missing_server_names or [],
+        }
+
+    data = _load_mcp_config(mcp_config_path)
+    if not data:
+        return None, diagnostics(resolution_status="config_missing")
+
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict) or not servers:
+        return None, diagnostics(resolution_status="config_empty")
+
+    usable_servers = {
+        server_name: server_config
+        for server_name, server_config in servers.items()
+        if _codex_server_is_usable(server_config)
+    }
+
+    if not requested:
+        if usable_servers:
+            return (
+                {
+                    name: _codex_sanitize_server_config(cfg)
+                    for name, cfg in usable_servers.items()
+                },
+                diagnostics(
+                    resolved_servers=list(usable_servers),
+                    resolution_status="ok",
+                ),
+            )
+        return None, diagnostics(
+            resolution_status="servers_not_found",
+            missing_server_names=list(servers),
+        )
+
+    selected = {
+        server_name: _codex_sanitize_server_config(usable_servers[server_name])
+        for server_name in requested
+        if server_name in usable_servers
+    }
+    missing = [server_name for server_name in requested if server_name not in selected]
+    if not selected:
+        return None, diagnostics(
+            resolution_status="servers_not_found",
+            missing_server_names=missing,
+        )
+    return selected, diagnostics(
+        resolved_servers=list(selected),
+        resolution_status="ok",
+        missing_server_names=missing,
+    )
+
+
+def _agy_server_is_usable(server_config: Any) -> bool:
+    """Return true for Antigravity streamable-HTTP or stdio MCP server entries."""
+    if not isinstance(server_config, dict):
+        return False
+    http_url = str(server_config.get("httpUrl") or "").strip()
+    url = str(server_config.get("url") or "").strip()
+    command = str(server_config.get("command") or "").strip()
+    return bool(http_url or url or command)
+
+
+def _agy_mcp_servers(
+    mcp_config_path: Path,
+    requested_servers: list[str] | None,
+) -> tuple[dict[str, list[str]] | None, dict[str, Any]]:
+    """Return agy's requested MCP server names plus resolution diagnostics."""
+    requested = list(requested_servers or [])
+
+    data = _load_mcp_config(mcp_config_path)
+    if not data:
+        return None, _basic_diagnostics(
+            mcp_config_path=mcp_config_path,
+            requested_servers=requested,
+            resolved_servers=None,
+            resolution_status="config_empty",
+        )
+
+    servers = data.get("mcpServers")
+    if not isinstance(servers, dict) or not servers:
+        return None, _basic_diagnostics(
+            mcp_config_path=mcp_config_path,
+            requested_servers=requested,
+            resolved_servers=None,
+            resolution_status="config_empty",
+        )
+
+    usable_server_names = [
+        server_name
+        for server_name, server_config in servers.items()
+        if _agy_server_is_usable(server_config)
+    ]
+    if not requested or not usable_server_names:
+        return None, _basic_diagnostics(
+            mcp_config_path=mcp_config_path,
+            requested_servers=requested,
+            resolved_servers=None,
+            resolution_status="config_empty",
+            missing_server_names=requested,
+        )
+
+    usable_servers = set(usable_server_names)
+    selected = [server_name for server_name in requested if server_name in usable_servers]
+    missing = [server_name for server_name in requested if server_name not in usable_servers]
+    if not selected:
+        return None, _basic_diagnostics(
+            mcp_config_path=mcp_config_path,
+            requested_servers=requested,
+            resolved_servers=None,
+            resolution_status="servers_not_found",
+            missing_server_names=missing,
+        )
+
+    return {"mcp_server_names": selected}, _basic_diagnostics(
+        mcp_config_path=mcp_config_path,
+        requested_servers=requested,
+        resolved_servers=selected,
+        resolution_status="ok",
+        missing_server_names=missing,
+    )
+
+
+def _hermes_lane_tool_config(
+    mcp_servers: list[str] | None,
+) -> tuple[dict[str, list[str]] | None, dict[str, Any]]:
+    """Return Hermes-lane MCP observability payload plus diagnostics."""
+    requested = list(mcp_servers or [])
+    if not requested:
+        return None, _basic_diagnostics(
+            mcp_config_path=_HERMES_CONFIG_PATH,
+            requested_servers=requested,
+            resolved_servers=None,
+            resolution_status="config_empty",
+        )
+    return (
+        {"hermes_mcp_servers": requested},
+        _basic_diagnostics(
+            mcp_config_path=_HERMES_CONFIG_PATH,
+            requested_servers=requested,
+            resolved_servers=requested,
+            resolution_status="ok",
+        ),
+    )
+
+
+def build_mcp_tool_config(
+    agent: str,
+    *,
+    mcp_servers: list[str] | None = None,
+    allowed_tools: str | None = None,
+    mcp_config_path: Path | None = None,
+) -> tuple[dict | None, dict[str, Any]]:
+    """Build adapter-appropriate tool_config dict for MCP access.
+
+    Returns ``(None, diagnostics)`` when the requested agent cannot be
+    configured for MCP.
+    """
+    resolved_config_path = _resolved_mcp_config_path(mcp_config_path)
+    canonical_agent = _canonical_agent_name(agent)
+    if canonical_agent is None:
+        return None, _basic_diagnostics(
+            mcp_config_path=resolved_config_path,
+            requested_servers=mcp_servers,
+            resolved_servers=None,
+            resolution_status="servers_not_found",
+            missing_server_names=mcp_servers,
+        )
+
+    if canonical_agent == "claude":
+        if not allowed_tools or not resolved_config_path.exists():
+            return None, _basic_diagnostics(
+                mcp_config_path=resolved_config_path,
+                requested_servers=mcp_servers,
+                resolved_servers=None,
+                resolution_status=(
+                    "config_missing"
+                    if not resolved_config_path.exists()
+                    else "config_empty"
+                ),
+            )
+        return (
+            {
+                "mcp_config_path": str(resolved_config_path),
+                "allowed_tools": allowed_tools,
+            },
+            _basic_diagnostics(
+                mcp_config_path=resolved_config_path,
+                requested_servers=mcp_servers,
+                resolved_servers=mcp_servers,
+                resolution_status="ok",
+            ),
+        )
+
+    if canonical_agent == "agy":
+        return _agy_mcp_servers(_resolved_agy_mcp_config_path(), mcp_servers)
+
+    if canonical_agent in _HERMES_LANE_AGENTS:
+        return _hermes_lane_tool_config(mcp_servers)
+
+    if canonical_agent == "grok-build":
+        if not mcp_servers:
+            return None, _basic_diagnostics(
+                mcp_config_path=Path.home() / ".grok" / "mcp.json",
+                requested_servers=mcp_servers,
+                resolved_servers=None,
+                resolution_status="config_empty",
+            )
+        return (
+            {
+                "always_approve": True,
+                "mcp_server_names": mcp_servers,
+            },
+            _basic_diagnostics(
+                mcp_config_path=Path.home() / ".grok" / "mcp.json",
+                requested_servers=mcp_servers,
+                resolved_servers=mcp_servers,
+                resolution_status="ok",
+            ),
+        )
+
+    if canonical_agent == "cursor":
+        workspace_mcp_path = Path.cwd() / ".cursor" / "mcp.json"
+        return (
+            {
+                "output_format": "stream-json",
+                "approve_mcps": True,
+                "mcp_config_path": str(resolved_config_path),
+                "mcp_server_names": mcp_servers,
+            },
+            _basic_diagnostics(
+                mcp_config_path=workspace_mcp_path,
+                requested_servers=mcp_servers,
+                resolved_servers=mcp_servers,
+                resolution_status="ok" if mcp_servers else "config_empty",
+            ),
+        )
+
+    codex_servers, diagnostics = _codex_mcp_servers(resolved_config_path, mcp_servers)
+    return ({"mcp_servers": codex_servers} if codex_servers else None), diagnostics

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -100,10 +100,14 @@ RESPONSE_DIR = PRIMARY_REPO / "logs" / "dispatch_responses"
 MCP_CONFIG_PATH = PRIMARY_REPO / ".mcp.json"
 # gemini-cli RETIRED 2026-07-01 (no gemini-cli; the Google lane is now agy).
 # agy loads MCP NATIVELY from ~/.gemini/config/mcp_config.json, so it needs no
-# per-dispatch --mcp flag. Claude uses repo .mcp.json; Hermes lanes read
-# ~/.hermes/config.yaml natively and only need observability wiring here.
-MCP_SUPPORTED_AGENTS = frozenset({"claude", "deepseek", "grok", "qwen"})
-HERMES_MCP_AGENTS = frozenset({"deepseek", "grok", "qwen"})
+# per-dispatch --mcp flag. Claude gates on repo .mcp.json; the deepseek Hermes
+# lane gates on ~/.hermes/config.yaml (which it reads natively at runtime).
+# grok/qwen Hermes MCP is DEFERRED (#2131 follow-up): grok routes through the
+# native grok CLI (not Hermes), and qwen's adapter lacks the mcp__sources__ ->
+# mcp_sources_ prompt rewrite — advertising them would let a dry-run claim MCP
+# is on while no MCP path fires. Re-add each once its runtime wiring lands.
+MCP_SUPPORTED_AGENTS = frozenset({"claude", "deepseek"})
+HERMES_MCP_AGENTS = frozenset({"deepseek"})
 HERMES_MCP_TASK_CLASSES = frozenset({"draft", "edit"})
 CLAUDE_MCP_TASK_CLASSES = frozenset({"review", "search"})
 
@@ -310,6 +314,39 @@ def _available_mcp_servers() -> list[str]:
     if not isinstance(servers, dict):
         return []
     return sorted(servers.keys())
+
+
+def _available_hermes_mcp_servers() -> list[str]:
+    """Return MCP server names the Hermes lanes can reach.
+
+    Hermes discovers MCP servers from ``~/.hermes/config.yaml`` at runtime, NOT
+    from the repo ``.mcp.json`` (which is gitignored and absent on clean
+    checkouts). Gating the deepseek ``--mcp`` path on ``.mcp.json`` would reject
+    a valid request on any machine/CI that lacks that local file — so Hermes
+    lanes gate here instead. Returns only servers that are enabled and have a
+    reachable endpoint.
+    """
+    hermes_config = Path.home() / ".hermes" / "config.yaml"
+    if not hermes_config.is_file():
+        return []
+    try:
+        import yaml  # hermes/deepseek adapters already depend on PyYAML
+    except ImportError:
+        return []
+    try:
+        data = yaml.safe_load(hermes_config.read_text(encoding="utf-8"))
+    except (OSError, yaml.YAMLError):
+        return []
+    servers = (data or {}).get("mcp_servers")
+    if not isinstance(servers, dict):
+        return []
+    return sorted(
+        name
+        for name, cfg in servers.items()
+        if isinstance(cfg, dict)
+        and cfg.get("enabled") is not False
+        and (cfg.get("url") or cfg.get("command"))
+    )
 
 
 def _load_claude_translation_tools() -> str:
@@ -789,8 +826,8 @@ def main() -> int:
         help=(
             "Enable a named MCP server for this dispatch "
             "(e.g. --mcp sources for Ukrainian corpus verification). "
-            "Claude: review/search task classes. Hermes lanes (deepseek, "
-            "grok, qwen): draft/edit task classes. agy loads MCP natively."
+            "Claude: review/search task classes. Hermes lane (deepseek): "
+            "draft/edit task classes. agy loads MCP natively."
         ),
     )
     args = p.parse_args()
@@ -825,11 +862,20 @@ def main() -> int:
                 f"{', '.join(sorted(MCP_SUPPORTED_AGENTS))} "
                 f"(got agent={args.agent!r}); agy loads MCP natively, no flag needed"
             )
-        available = _available_mcp_servers()
+        available = (
+            _available_hermes_mcp_servers()
+            if args.agent in HERMES_MCP_AGENTS
+            else _available_mcp_servers()
+        )
         if args.mcp not in available:
+            source = (
+                "~/.hermes/config.yaml"
+                if args.agent in HERMES_MCP_AGENTS
+                else ".mcp.json"
+            )
             p.error(
-                f"unknown MCP server {args.mcp!r}; "
-                f"available: {', '.join(available) or '(none)'}"
+                f"unknown MCP server {args.mcp!r} for agent {args.agent!r}; "
+                f"available in {source}: {', '.join(available) or '(none)'}"
             )
 
     tool_config = (

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -100,8 +100,12 @@ RESPONSE_DIR = PRIMARY_REPO / "logs" / "dispatch_responses"
 MCP_CONFIG_PATH = PRIMARY_REPO / ".mcp.json"
 # gemini-cli RETIRED 2026-07-01 (no gemini-cli; the Google lane is now agy).
 # agy loads MCP NATIVELY from ~/.gemini/config/mcp_config.json, so it needs no
-# per-dispatch --mcp flag; claude is the only agent that takes --mcp here.
-MCP_SUPPORTED_AGENTS = frozenset({"claude"})
+# per-dispatch --mcp flag. Claude uses repo .mcp.json; Hermes lanes read
+# ~/.hermes/config.yaml natively and only need observability wiring here.
+MCP_SUPPORTED_AGENTS = frozenset({"claude", "deepseek", "grok", "qwen"})
+HERMES_MCP_AGENTS = frozenset({"deepseek", "grok", "qwen"})
+HERMES_MCP_TASK_CLASSES = frozenset({"draft", "edit"})
+CLAUDE_MCP_TASK_CLASSES = frozenset({"review", "search"})
 
 # Skill auto-loading — R2 follow-up to PR #1575 and the agents_extensions/
 # layout introduced there.
@@ -329,15 +333,27 @@ def _import_dispatch_mcp_constants() -> tuple[str, str]:
     return str(MCP_CONFIG_PATH), _load_claude_translation_tools()
 
 
-def _build_mcp_tool_config(agent: str, mcp_server: str) -> dict:
-    """Build adapter ``tool_config`` for read-only MCP tool access."""
+def _build_mcp_tool_config(agent: str, mcp_server: str) -> dict | None:
+    """Build adapter ``tool_config`` for MCP tool access."""
+    sys.path.insert(0, str(REPO / "scripts"))
+    from agent_runtime.tool_config import build_mcp_tool_config
+
     if agent == "claude":
         mcp_config_path, allowed_tools = _import_dispatch_mcp_constants()
-        return {
-            "mcp_config_path": mcp_config_path,
-            "allowed_tools": allowed_tools,
-        }
-    return {}
+        tool_config, _diagnostics = build_mcp_tool_config(
+            agent,
+            mcp_servers=[mcp_server],
+            allowed_tools=allowed_tools,
+            mcp_config_path=Path(mcp_config_path),
+        )
+        return tool_config
+
+    tool_config, _diagnostics = build_mcp_tool_config(
+        agent,
+        mcp_servers=[mcp_server],
+        mcp_config_path=MCP_CONFIG_PATH,
+    )
+    return tool_config
 
 
 def _allowed_tools_count(allowed_tools: str) -> int:
@@ -392,6 +408,15 @@ def _print_dry_run_mcp(agent: str, tool_config: dict) -> None:
                 f"[dry-run] mcp_flags=--mcp-config {mcp_config_path} "
                 f"--allowedTools <{count} tools>"
             )
+        return
+
+    if agent in HERMES_MCP_AGENTS:
+        servers = tool_config.get("hermes_mcp_servers") or []
+        print(f"[dry-run] hermes_mcp_servers={servers}")
+        print(
+            "[dry-run] hermes_config=~/.hermes/config.yaml "
+            "(MCP servers discovered natively by Hermes)"
+        )
 
 
 def ensure_worktree(worktree: Path, new_branch: str | None, base: str = "main") -> None:
@@ -762,10 +787,10 @@ def main() -> int:
         metavar="SERVER",
         default=None,
         help=(
-            "Enable a named MCP server's read tools for this dispatch "
-            "(e.g. --mcp rag for Ukrainian-translation fact-checking). "
-            "Only rag is configured today. Honored for the claude agent "
-            "only (agy loads its MCP servers natively; no flag needed)."
+            "Enable a named MCP server for this dispatch "
+            "(e.g. --mcp sources for Ukrainian corpus verification). "
+            "Claude: review/search task classes. Hermes lanes (deepseek, "
+            "grok, qwen): draft/edit task classes. agy loads MCP natively."
         ),
     )
     args = p.parse_args()
@@ -777,17 +802,27 @@ def main() -> int:
     task_id = args.task_id or make_task_id(args.task_class, args.agent)
 
     if args.mcp is not None:
-        if args.task_class not in {"review", "search"}:
+        if args.agent == "claude":
+            if args.task_class not in CLAUDE_MCP_TASK_CLASSES:
+                p.error(
+                    f"--mcp is only supported for read task classes "
+                    f"({', '.join(sorted(CLAUDE_MCP_TASK_CLASSES))}) on claude; "
+                    f"got task_class={args.task_class!r}. Write classes would "
+                    f"either cripple claude (allowedTools restricted to RAG+Read, "
+                    f"no write) or silently scope-creep; use the write-mode "
+                    f"dispatch.py --mcp path for translation authoring."
+                )
+        elif args.agent in HERMES_MCP_AGENTS:
+            if args.task_class not in HERMES_MCP_TASK_CLASSES:
+                p.error(
+                    f"--mcp for Hermes lanes is only supported for write task "
+                    f"classes ({', '.join(sorted(HERMES_MCP_TASK_CLASSES))}); "
+                    f"got agent={args.agent!r} task_class={args.task_class!r}"
+                )
+        elif args.agent not in MCP_SUPPORTED_AGENTS:
             p.error(
-                f"--mcp is only supported for read task classes (review, search); "
-                f"got task_class={args.task_class!r}. Write classes would either "
-                f"cripple claude (allowedTools restricted to RAG+Read, no write) or "
-                f"silently scope-creep; use the write-mode dispatch.py --mcp path for "
-                f"translation authoring."
-            )
-        if args.agent not in MCP_SUPPORTED_AGENTS:
-            p.error(
-                f"--mcp tool access is only supported for the claude agent "
+                f"--mcp tool access is only supported for agents "
+                f"{', '.join(sorted(MCP_SUPPORTED_AGENTS))} "
                 f"(got agent={args.agent!r}); agy loads MCP natively, no flag needed"
             )
         available = _available_mcp_servers()

--- a/tests/dispatch_smart/test_mcp_tool_config.py
+++ b/tests/dispatch_smart/test_mcp_tool_config.py
@@ -1,0 +1,72 @@
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+from agent_runtime.adapters.deepseek import (  # noqa: E402
+    DeepSeekAdapter,
+    translate_mcp_prefix_for_hermes,
+)
+from agent_runtime.tool_config import build_mcp_tool_config  # noqa: E402
+
+
+@pytest.mark.parametrize("agent", ["deepseek", "grok", "qwen"])
+def test_build_mcp_tool_config_hermes_lane(agent: str) -> None:
+    tool_config, diagnostics = build_mcp_tool_config(agent, mcp_servers=["sources"])
+
+    assert tool_config == {"hermes_mcp_servers": ["sources"]}
+    assert diagnostics["resolution_status"] == "ok"
+    assert diagnostics["requested_servers"] == ["sources"]
+    assert diagnostics["resolved_servers"] == ["sources"]
+    assert diagnostics["config_path"].endswith(".hermes/config.yaml")
+
+
+def test_translate_mcp_prefix_for_hermes() -> None:
+    prompt = (
+        "Use mcp__sources__search_text and mcp__sources__verify_word "
+        "before writing."
+    )
+    rewritten = translate_mcp_prefix_for_hermes(prompt)
+
+    assert rewritten == (
+        "Use mcp_sources_search_text and mcp_sources_verify_word "
+        "before writing."
+    )
+    assert "mcp__sources__" not in rewritten
+
+
+def test_deepseek_adapter_rewrites_sources_prefix_when_requested() -> None:
+    adapter = DeepSeekAdapter()
+    plan = adapter.build_invocation(
+        prompt="Call mcp__sources__search_text for corpus lookup.",
+        mode="workspace-write",
+        cwd=Path.cwd(),
+        model="deepseek-v4-pro",
+        task_id="test-task",
+        session_id=None,
+        tool_config={"hermes_mcp_servers": ["sources"]},
+    )
+
+    oneshot_arg = next(arg for arg in plan.cmd if arg.startswith("--oneshot="))
+    assert "mcp_sources_search_text" in oneshot_arg
+    assert "mcp__sources__" not in oneshot_arg
+
+
+def test_deepseek_adapter_leaves_prompt_unmodified_without_sources_mcp() -> None:
+    adapter = DeepSeekAdapter()
+    prompt = "Call mcp__sources__search_text for corpus lookup."
+    plan = adapter.build_invocation(
+        prompt=prompt,
+        mode="workspace-write",
+        cwd=Path.cwd(),
+        model="deepseek-v4-pro",
+        task_id="test-task",
+        session_id=None,
+        tool_config=None,
+    )
+
+    oneshot_arg = next(arg for arg in plan.cmd if arg.startswith("--oneshot="))
+    assert oneshot_arg == f"--oneshot={prompt}"

--- a/tests/dispatch_smart/test_mcp_tool_config.py
+++ b/tests/dispatch_smart/test_mcp_tool_config.py
@@ -70,3 +70,33 @@ def test_deepseek_adapter_leaves_prompt_unmodified_without_sources_mcp() -> None
 
     oneshot_arg = next(arg for arg in plan.cmd if arg.startswith("--oneshot="))
     assert oneshot_arg == f"--oneshot={prompt}"
+
+
+def test_mcp_supported_agents_excludes_unwired_hermes_lanes() -> None:
+    """grok/qwen must NOT be advertised as --mcp-capable until their runtime
+    wiring lands (grok bypasses Hermes; qwen lacks the prompt rewrite). Only
+    claude + the deepseek Hermes lane are supported. Regression lock for #2131.
+    """
+    import importlib
+
+    dispatch_smart = importlib.import_module("dispatch_smart")
+
+    assert dispatch_smart.MCP_SUPPORTED_AGENTS == frozenset({"claude", "deepseek"})
+    assert dispatch_smart.HERMES_MCP_AGENTS == frozenset({"deepseek"})
+    assert "grok" not in dispatch_smart.MCP_SUPPORTED_AGENTS
+    assert "qwen" not in dispatch_smart.MCP_SUPPORTED_AGENTS
+
+
+def test_available_hermes_mcp_servers_ignores_missing_config(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Hermes-lane availability reads ~/.hermes/config.yaml, not .mcp.json, and
+    returns [] cleanly when the config is absent (clean-checkout portability —
+    P1 of the #2131 review). tmp_path has no .hermes/config.yaml.
+    """
+    import importlib
+
+    dispatch_smart = importlib.import_module("dispatch_smart")
+    monkeypatch.setattr(Path, "home", staticmethod(lambda: tmp_path))
+
+    assert dispatch_smart._available_hermes_mcp_servers() == []


### PR DESCRIPTION
Ports learn-ukrainian's MCP-dispatch layer so Hermes-lane authors (deepseek) can author **corpus-grounded** via the `sources` MCP (VESUM/СУМ/r2u/Antonenko/Pravopys), closing the gap that made the s188 author A/B provisional.

## Changes (scoped to 4 files)
- **`scripts/agent_runtime/tool_config.py`** (new) — `build_mcp_tool_config()`; deepseek/grok/qwen → `{"hermes_mcp_servers": [...]}`, claude path preserved, diagnostics.
- **`scripts/agent_runtime/adapters/deepseek.py`** — `sources` registration check against `~/.hermes/config.yaml` + the load-bearing `mcp__sources__X` → `mcp_sources_X` prompt rewrite (Hermes registers single-underscore).
- **`scripts/dispatch_smart.py`** — `MCP_SUPPORTED_AGENTS` extended to the Hermes lanes; `--mcp sources` allowed for `draft`/`edit` on them.
- **`tests/dispatch_smart/test_mcp_tool_config.py`** (new) — 6 tests for the builder + prefix rewrite.

## Verified
- **End-to-end LIVE**: `deepseek draft --mcp sources` fired `mcp__sources__verify_word('наявний')` → returned the real VESUM morphology (`adj:m:v_naz`…, `is_archaic:false`), un-fabricatable. Hermes `mcp_sources_.+` hook registered in the log.
- ruff clean; 6 new + 16 existing dispatch_smart tests pass (no regression to the claude path).

## Follow-up (not blocking — noted on #2131)
- `qwen` adapter: same prefix rewrite not yet applied.
- `grok` in dispatch_smart still routes via native CLI (not Hermes), so the rewrite doesn't apply to grok dispatches yet.

Refs #2131