### PR TITLE
fix(agy): fix headless dispatch and linguistic rule (#2099)

### DIFF
--- a/docs/review-protocol.md
+++ b/docs/review-protocol.md
@@ -42,6 +42,7 @@ REVIEW RULES:
 3. "Missing" claims require proof of absence. If you cannot quote the file or show a search proving absence, delete the finding or demote it to a question.
 4. Do not invent line numbers. Every cited line must exist on the reviewed branch.
 5. Self-check before submit: if the code might exist outside the diff, read/search the file before reporting.
+6. cite verify_word output before asserting word/form-existence claims or spelling/declension rules. Stylistic and naturalness judgments (e.g., 'reads as translationese' or 'awkward') do not require verification.
 
 OUTPUT:
 1. Verdict: APPROVE / NEEDS CHANGES / REJECT

--- a/scripts/ai_agent_bridge/_agy.py
+++ b/scripts/ai_agent_bridge/_agy.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import json
 import os
+import time
 
 from agent_runtime import runner as agent_runner
 from agent_runtime.errors import (
@@ -109,45 +110,69 @@ def process_for_agy(
     else:
         print(f"   Hard timeout: {timeout_val}s")
 
-    try:
-        result = agent_runner.invoke(
-            _AGENT_NAME,
-            prompt,
-            mode="read-only",
-            cwd=REPO_ROOT,
-            model=model,
-            task_id=msg["task_id"],
-            session_id=None,
-            tool_config=None,
-            entrypoint="bridge",
-            hard_timeout=timeout_val,
-            stall_timeout=min(600, timeout_val),
-        )
-    except RateLimitedError as exc:
-        _handle_error(msg, message_id, f"{_AGENT_TITLE} rate limited: {exc}")
-        return
-    except AgentStalledError as exc:
-        _handle_error(msg, message_id, f"{_AGENT_TITLE} stalled: {exc}")
-        return
-    except AgentTimeoutError as exc:
-        _handle_error(msg, message_id, f"{_AGENT_TITLE} hard timeout: {exc}")
-        return
-    except AgentUnavailableError as exc:
-        _handle_error(msg, message_id, f"{_AGENT_TITLE} unavailable: {exc}")
-        return
+    max_retries = 3
+    base_delay = 10
+    
+    for attempt in range(max_retries):
+        try:
+            result = agent_runner.invoke(
+                _AGENT_NAME,
+                prompt,
+                mode="read-only",
+                cwd=REPO_ROOT,
+                model=model,
+                task_id=msg["task_id"],
+                session_id=None,
+                tool_config=None,
+                entrypoint="bridge",
+                hard_timeout=timeout_val,
+                stall_timeout=min(600, timeout_val),
+            )
+        except RateLimitedError as exc:
+            if attempt < max_retries - 1:
+                print(f"⚠️  {_AGENT_TITLE} rate limited ({exc}), retrying {attempt+1}/{max_retries}...")
+                time.sleep(base_delay * (2 ** attempt))
+                continue
+            _handle_error(msg, message_id, f"{_AGENT_TITLE} rate limited: {exc}")
+            return
+        except AgentStalledError as exc:
+            if attempt < max_retries - 1:
+                print(f"⚠️  {_AGENT_TITLE} stalled ({exc}), retrying {attempt+1}/{max_retries}...")
+                time.sleep(base_delay * (2 ** attempt))
+                continue
+            _handle_error(msg, message_id, f"{_AGENT_TITLE} stalled: {exc}")
+            return
+        except AgentTimeoutError as exc:
+            if attempt < max_retries - 1:
+                print(f"⚠️  {_AGENT_TITLE} hard timeout ({exc}), retrying {attempt+1}/{max_retries}...")
+                time.sleep(base_delay * (2 ** attempt))
+                continue
+            _handle_error(msg, message_id, f"{_AGENT_TITLE} hard timeout: {exc}")
+            return
+        except AgentUnavailableError as exc:
+            if attempt < max_retries - 1:
+                print(f"⚠️  {_AGENT_TITLE} unavailable ({exc}), retrying {attempt+1}/{max_retries}...")
+                time.sleep(base_delay * (2 ** attempt))
+                continue
+            _handle_error(msg, message_id, f"{_AGENT_TITLE} unavailable: {exc}")
+            return
 
-    if not result.ok:
-        _handle_error(
-            msg,
-            message_id,
-            result.stderr_excerpt or f"{_AGENT_TITLE} returned no final message",
-        )
-        return
+        if not result.ok or not result.response:
+            err_text = result.stderr_excerpt or f"{_AGENT_TITLE} returned no final message"
+            if attempt < max_retries - 1:
+                print(f"⚠️  {_AGENT_TITLE} failed ({err_text}), retrying {attempt+1}/{max_retries}...")
+                time.sleep(base_delay * (2 ** attempt))
+                continue
+            _handle_error(
+                msg,
+                message_id,
+                err_text,
+            )
+            return
+            
+        break
 
     response = result.response
-    if not response:
-        _handle_error(msg, message_id, f"{_AGENT_TITLE} returned no final message")
-        return
 
     print(f"\n✅ {_AGENT_TITLE} finished ({len(response)} chars)")
     reply_id = send_message(

--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -811,22 +811,52 @@ def fire(
         else:
             sys.path.insert(0, str(REPO / "scripts"))
             from agent_runtime.runner import invoke
-
-            result = invoke(
-                agent,
-                prompt,
-                mode=mode,
-                cwd=worktree,
-                model=model,
-                task_id=task_id,
-                tool_config=tool_config,
-                entrypoint="delegate",
-                hard_timeout=timeout_s,
+            from agent_runtime.errors import (
+                AgentStalledError,
+                AgentTimeoutError,
+                AgentUnavailableError,
+                RateLimitedError,
             )
-            ok = bool(result.ok)
-            response = result.response or ""
-            session_id = result.session_id
-            stderr_excerpt = result.stderr_excerpt or ""
+
+            max_retries = 3 if agent == "agy" else 1
+            base_delay = 10
+            
+            for attempt in range(max_retries):
+                try:
+                    result = invoke(
+                        agent,
+                        prompt,
+                        mode=mode,
+                        cwd=worktree,
+                        model=model,
+                        task_id=task_id,
+                        tool_config=tool_config,
+                        entrypoint="delegate",
+                        hard_timeout=timeout_s,
+                    )
+                    ok = bool(result.ok)
+                    response = result.response or ""
+                    session_id = result.session_id
+                    stderr_excerpt = result.stderr_excerpt or ""
+                    
+                    if ok:
+                        break
+                        
+                    if attempt < max_retries - 1:
+                        err_text = stderr_excerpt or "no final message"
+                        print(f"⚠️  {agent} failed ({err_text}), retrying {attempt+1}/{max_retries}...")
+                        time.sleep(base_delay * (2 ** attempt))
+                        continue
+                        
+                except (RateLimitedError, AgentStalledError, AgentTimeoutError, AgentUnavailableError) as exc:
+                    if attempt < max_retries - 1:
+                        print(f"⚠️  {agent} error ({exc}), retrying {attempt+1}/{max_retries}...")
+                        time.sleep(base_delay * (2 ** attempt))
+                        continue
+                    ok = False
+                    response = ""
+                    session_id = None
+                    stderr_excerpt = f"{type(exc).__name__}: {exc}"
     except Exception as exc:  # surface the failure but still log it
         ok = False
         response = ""

--- a/tests/dispatch_smart/test_fire_retry.py
+++ b/tests/dispatch_smart/test_fire_retry.py
@@ -1,0 +1,110 @@
+"""Regression tests for #2099 — agy headless-dispatch retry hardening.
+
+Covers the exponential-backoff retry loop added to ``dispatch_smart.fire`` so a
+transient agy dispatch flake recovers instead of failing the whole run, and
+confirms non-agy agents keep single-attempt behavior.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[2] / "scripts"))
+import dispatch_smart  # noqa: E402
+from agent_runtime.errors import AgentTimeoutError
+
+
+def _stub_dispatch_side_effects(
+    monkeypatch: pytest.MonkeyPatch,
+    task_id: str,
+) -> None:
+    """Avoid slow side effects while still exercising fire() control flow."""
+
+    monkeypatch.setattr(dispatch_smart.time, "sleep", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(dispatch_smart, "append_log", lambda *_args, **_kwargs: None)
+    dummy_path = dispatch_smart.PRIMARY_REPO / "logs" / "dispatch_responses" / f"{task_id}.txt"
+    monkeypatch.setattr(
+        dispatch_smart,
+        "persist_response",
+        lambda *_args, **_kwargs: dummy_path,
+    )
+
+
+def test_dispatch_smart_fire_retries_agy_after_timeout(monkeypatch, capsys: pytest.CaptureFixture[str]) -> None:
+    """agy should retry on transient errors and eventually return a successful result."""
+
+    _stub_dispatch_side_effects(monkeypatch, task_id="agy-retry")
+
+    calls: list[int] = [0]
+
+    def fake_invoke(*_args, **_kwargs):
+        calls[0] += 1
+        if calls[0] == 1:
+            raise AgentTimeoutError("agy", 1)
+        return SimpleNamespace(
+            ok=True,
+            response="OK",
+            session_id="session-1",
+            stderr_excerpt="",
+        )
+
+    monkeypatch.setattr("agent_runtime.runner.invoke", fake_invoke)
+
+    code = dispatch_smart.fire(
+        agent="agy",
+        task_class="review",
+        prompt="test prompt",
+        mode="danger",
+        model="gpt-5.5",
+        worktree=None,
+        task_id="agy-retry",
+        timeout_s=1,
+    )
+    captured = capsys.readouterr()
+
+    assert code == 0
+    assert calls[0] == 2
+    assert "retrying 1/3" in captured.out
+    assert "OK: True" in captured.out
+
+
+def test_dispatch_smart_fire_non_agy_does_not_retry_after_failed_result(
+    monkeypatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """Agents other than agy keep max_retries=1 for failed non-exception results."""
+
+    _stub_dispatch_side_effects(monkeypatch, task_id="codex-no-retry")
+
+    calls: list[int] = [0]
+
+    def fake_invoke(*_args, **_kwargs):
+        calls[0] += 1
+        return SimpleNamespace(
+            ok=False,
+            response="",
+            session_id=None,
+            stderr_excerpt="not ok",
+        )
+
+    monkeypatch.setattr("agent_runtime.runner.invoke", fake_invoke)
+
+    code = dispatch_smart.fire(
+        agent="codex",
+        task_class="draft",
+        prompt="test prompt",
+        mode="danger",
+        model="gpt-5.5",
+        worktree=None,
+        task_id="codex-no-retry",
+        timeout_s=1,
+    )
+    captured = capsys.readouterr()
+
+    assert code == 1
+    assert calls[0] == 1
+    assert "retrying" not in captured.out
+    assert "OK: False" in captured.out


### PR DESCRIPTION
Fixes #2099. Resolves flaky headless agy dispatches, adds exponential backoff, and ensures stylistic linguistic review rules.

Regression test: tests/dispatch_smart/test_fire_retry.py (asserts the agy retry loop recovers after a transient AgentTimeoutError and that non-agy agents keep single-attempt behavior)