### PR TITLE
docs(prereq): reconcile route framing + navigation (#2143 #2144 #2148)

### DIFF
--- a/src/content/docs/prerequisites/git-deep-dive/index.md
+++ b/src/content/docs/prerequisites/git-deep-dive/index.md
@@ -37,6 +37,6 @@ Every module uses Kubernetes manifests, Helm charts, and real infrastructure fil
 ## After This Course
 
 You're ready for:
-- [Philosophy & Design](../philosophy-design/) — declarative thinking pairs with git workflows
-- [Modern DevOps](../modern-devops/) — CI/CD and GitOps build directly on this course
+- [Modern DevOps](../modern-devops/) — the next step on the prerequisites route; CI/CD and GitOps build directly on this course
 - [CKA Certification](../../k8s/cka/) — git skills used throughout exam prep
+- [Linux](../linux/) — optional deeper systems knowledge if you skipped the Linux fork earlier

--- a/src/content/docs/prerequisites/git-deep-dive/index.md
+++ b/src/content/docs/prerequisites/git-deep-dive/index.md
@@ -39,4 +39,4 @@ Every module uses Kubernetes manifests, Helm charts, and real infrastructure fil
 You're ready for:
 - [Modern DevOps](../modern-devops/) — the next step on the prerequisites route; CI/CD and GitOps build directly on this course
 - [CKA Certification](../../k8s/cka/) — git skills used throughout exam prep
-- [Linux](../linux/) — optional deeper systems knowledge if you skipped the Linux fork earlier
+- [Linux](/linux/) — optional deeper systems knowledge if you skipped the Linux fork earlier

--- a/src/content/docs/prerequisites/git-deep-dive/module-10-gitops-bridge.md
+++ b/src/content/docs/prerequisites/git-deep-dive/module-10-gitops-bridge.md
@@ -613,4 +613,4 @@ If the output matches your expectations, your directory structure is mathematica
 
 ## Next Module
 
-[Philosophy and Design course](../../philosophy-design/) — Dive deeper into the architectural principles that govern robust, resilient platform engineering.
+[Modern DevOps: Infrastructure as Code](/prerequisites/modern-devops/module-1.1-infrastructure-as-code/) — Apply the Git-as-source-of-truth habits from this course to declarative infrastructure, automated pipelines, and production delivery.

--- a/src/content/docs/prerequisites/modern-devops/index.md
+++ b/src/content/docs/prerequisites/modern-devops/index.md
@@ -6,7 +6,7 @@ sidebar:
 
 The practices and tools that define modern software delivery. Modern DevOps is more than just combining development and operations; it is a cultural and technical shift towards automation, collaboration, and continuous improvement. In this section, we explore the foundational practices that enable teams to deliver software rapidly, reliably, and securely.
 
-Understanding these concepts is critical before diving into container orchestration and cloud-native architecture. Kubernetes and cloud platforms are built to support and accelerate these exact patterns. By mastering the principles of declarative infrastructure, automated pipelines, and comprehensive observability, you will be better equipped to design and manage resilient systems.
+This capstone section consolidates delivery patterns you have already met in Kubernetes—declarative desired state, Git-driven change, automated rollouts, and production feedback loops—and names the wider DevOps practices that surround them. By connecting IaC, GitOps, CI/CD, observability, platform engineering, and DevSecOps to the cluster work you have done, you will be better equipped to design and manage resilient systems end to end.
 
 The modules in this section cover the spectrum of modern delivery, from provisioning infrastructure with code to securing the entire software lifecycle.
 

--- a/src/content/docs/prerequisites/philosophy-design/index.md
+++ b/src/content/docs/prerequisites/philosophy-design/index.md
@@ -4,7 +4,7 @@ sidebar:
   order: 0
 ---
 
-Before diving into the technical mechanics of Kubernetes, it is crucial to understand why it exists and the fundamental shift in thinking it requires. This section explores the historical context of container orchestration and the specific architectural choices that propelled Kubernetes to become the undisputed industry standard. 
+After hands-on work in Cloud Native 101 and Kubernetes Basics, this section steps back to explain why Kubernetes works the way it does and which legacy patterns are not worth your time. It explores the historical context of container orchestration and the architectural choices that propelled Kubernetes to become the undisputed industry standard. 
 
 We will examine the core philosophy of declarative system management over imperative commands, which is the foundation of Kubernetes' resilience, automation, and scalability. By understanding this paradigm shift, you will be better equipped to design, operate, and troubleshoot modern cloud-native applications without fighting the platform's natural design.
 

--- a/src/content/docs/prerequisites/philosophy-design/module-1.1-why-kubernetes-won.md
+++ b/src/content/docs/prerequisites/philosophy-design/module-1.1-why-kubernetes-won.md
@@ -9,7 +9,7 @@ revision_pending: false
 >
 > **Time to Complete**: 45-55 minutes
 >
-> **Prerequisites**: None - this is where everyone starts
+> **Prerequisites**: [Cloud Native 101](/prerequisites/cloud-native-101/) and [Kubernetes Basics](/prerequisites/kubernetes-basics/) — you should already understand containers, orchestration at a high level, and hands-on `kubectl` workflows before examining why Kubernetes won and how its design shapes operations.
 
 ---
 

--- a/src/content/docs/prerequisites/philosophy-design/module-1.4-dead-ends.md
+++ b/src/content/docs/prerequisites/philosophy-design/module-1.4-dead-ends.md
@@ -449,4 +449,4 @@ A strong plan identifies Swarm as the production orchestration risk because it l
 
 ## Next Module
 
-[Cloud Native 101](/prerequisites/cloud-native-101/module-1.1-what-are-containers/) continues with the container fundamentals behind the platform choices you just evaluated.
+[Git Deep Dive: Git Internals](/prerequisites/git-deep-dive/module-1-git-internals/) continues the prerequisites path with professional Git workflows—the foundation for IaC, GitOps, and team delivery in the next section.

--- a/src/content/docs/prerequisites/zero-to-terminal/index.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/index.md
@@ -32,7 +32,7 @@ By the end of this track, you'll be able to:
 - Know what "the cloud" actually means (spoiler: it's not magic)
 - **Deploy a real website using nothing but the terminal**
 
-This track leads to **two paths**: Linux Deep Dive (systems internals) and Cloud Native (containers, Kubernetes). Most senior engineers know both.
+This track leads into the main prerequisites route — **Cloud Native 101** and then **Kubernetes Basics** — with **Linux Deep Dive** as an optional systems-internals fork you can take anytime. Most senior engineers eventually know both.
 
 ---
 

--- a/src/content/docs/prerequisites/zero-to-terminal/index.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/index.md
@@ -85,36 +85,26 @@ This analogy will carry you all the way from here to Kubernetes, where you'll ma
 
 ## What's Next?
 
-After completing Zero to Terminal, the road forks into two paths:
+On the **suggested prerequisites route**, continue straight into Cloud Native 101 and then Kubernetes Basics—the linear spine from terminal skills to hands-on cluster work.
 
-### Path A: Linux Deep Dive
+**Default next step:** [Cloud Native 101](../cloud-native-101/module-1.1-what-are-containers/) — containers, Docker, and the cloud-native ecosystem.
 
-You loved the terminal? Go deeper into how Linux actually works -- the kernel, processes, networking internals, permissions, and security. This is the knowledge that makes you dangerous.
+**Optional fork:** [Linux Fundamentals](../../linux/) if you want deeper operating-system knowledge before operations-heavy work. Linux is not required for the main route; you can return to it anytime.
 
-> Start here: [Linux Fundamentals](../../linux/)
-
-### Path B: Cloud Native
-
-You want to build and deploy apps at scale? Learn containers, Docker, and Kubernetes. This is where the industry is heading.
-
-> Start here: [Cloud Native 101](../cloud-native-101/module-1.1-what-are-containers/)
-
-### Path C: Both
-
-Most senior engineers know both. Start with whichever excites you more -- the other path will be here when you're ready. Both paths converge at **Platform Engineering** (SRE, GitOps, DevSecOps, MLOps).
+Most senior engineers eventually know both Linux depth and cloud-native delivery. If you are unsure where to go, start with Cloud Native 101 and keep the Linux path as a parallel option rather than an equal first choice.
 
 ```text
                Zero to Terminal
                      |
               Module 0.11 (Capstone)
                      |
-          +----------+----------+
-          |                     |
-     Linux Deep Dive      Cloud Native 101
-          |                     |
-          +----------+----------+
+          Cloud Native 101  (default — suggested route)
                      |
-            Platform Engineering
+            Kubernetes Basics
+                     |
+                     ...
+          
+          Linux Deep Dive  (optional fork — anytime)
 ```
 
 ---

--- a/src/content/docs/prerequisites/zero-to-terminal/module-0.11-your-first-server.md
+++ b/src/content/docs/prerequisites/zero-to-terminal/module-0.11-your-first-server.md
@@ -537,18 +537,18 @@ The success criteria are intentionally broader than "the page loaded once." A fi
 
 ## Next Module
 
-You have finished **Zero to Terminal**. From here, choose [Linux Fundamentals](/linux/) if you want to go deeper into operating systems, or start [Cloud Native 101](/prerequisites/cloud-native-101/module-1.1-what-are-containers/) if you want to turn this first server into a foundation for containers and Kubernetes.
+You have finished **Zero to Terminal**. On the suggested prerequisites route, continue into **[Cloud Native 101](/prerequisites/cloud-native-101/module-1.1-what-are-containers/)** and then **[Kubernetes Basics](/prerequisites/kubernetes-basics/module-1.1-first-cluster/)** to turn this first-server capstone into containers and hands-on cluster work.
+
+**Optional:** [Linux Fundamentals](/linux/) deepens kernel, process, networking, and security knowledge if you want a systems fork—not required before Cloud Native 101.
 
 ```mermaid
 graph TD
-    Current(["YOU ARE HERE<br/>Module 0.11 (Capstone)"]) --> PathA["Path A<br/>Linux Deep Dive"]
-    Current --> PathB["Path B<br/>Cloud Native 101"]
+    Current(["YOU ARE HERE<br/>Module 0.11 (Capstone)"]) --> Default["Suggested route<br/>Cloud Native 101"]
+    Default --> K8s["Kubernetes Basics"]
+    Current -.-> Optional["Optional fork<br/>Linux Deep Dive"]
 
-    PathA --> L1["Kernel, processes<br/>Networking internals<br/>Security, hardening"]
-    PathB --> C1["Containers, Docker<br/>Kubernetes basics<br/>CKA certification"]
-
-    L1 --> PE["Platform Engineering<br/>(SRE, GitOps, DevSecOps)"]
-    C1 --> PE
+    K8s --> Route["Philosophy & Design → Git Deep Dive → Modern DevOps"]
+    Optional -.-> LinuxDepth["Kernel, processes<br/>Networking internals<br/>Security, hardening"]
 ```
 
-Both paths build on the same request-response model you practiced here. Linux deepens your understanding of processes, filesystems, permissions, and networking internals, while Cloud Native 101 shows how containers and orchestration turn single-server lessons into repeatable deployment patterns. Pick the path that makes you want to open a terminal again, and keep the habit this module taught: trace the system before you change it.
+Cloud Native 101 shows how containers and orchestration turn single-server lessons into repeatable deployment patterns. Linux deepens the same request-response model at the operating-system layer. If you are following the hub route, start with Cloud Native 101 and treat Linux as a parallel option you can pick up anytime.


### PR DESCRIPTION
## What

Semantic route-coherence fixes for the Fundamentals/Prerequisites track. Framing + navigation only — **no** module rewrites, **no** marker/sidebar edits (those are #2146/#2147/#2142).

Authored by **cursor (composer-2.5)**; orchestrator caught + fixed one broken Linux link path. Cross-family reviewer: **codex**.

## Fixes

**#2143 — backward / orphaned Next-Module links** (each now points forward per the hub route `Zero to Terminal → Cloud Native 101 → Kubernetes Basics → Philosophy → Git Deep Dive → Modern DevOps`):
- `philosophy-design/module-1.4-dead-ends` → was Cloud Native 101 (back 3 steps) → now Git Deep Dive.
- `git-deep-dive/module-10-gitops-bridge` → was Philosophy (back) → now Modern DevOps 1.1.
- `git-deep-dive/index.md` "After This Course" → dropped backward Philosophy link, leads with Modern DevOps.

**#2144 — framing vs placement**:
- `philosophy-design/module-1.1` Prerequisites: "None - this is where everyone starts" → cites Cloud Native 101 + Kubernetes Basics.
- `philosophy-design/index.md` + `modern-devops/index.md` intros: reframed from pre-Kubernetes primers to post-Kubernetes / capstone.

**#2148 — zero-to-terminal exit fork**:
- `zero-to-terminal/index.md` + `module-0.11` capstone: Cloud Native 101 is now the default linear next step; Linux marked as an optional fork (was an equal 3-way fork).

## Verification
- `npm run build` green (2169 pages, 0 errors; pre-existing `uk/` route WARNs unrelated).
- All 9 new link targets verified to resolve.
- Constraint check: no `Complexity`/`sidebar.order`/`complexity:` edits (kept for #2146/#2147/#2142).

Refs #2143 #2144 #2148