### PR TITLE
docs(ai): re-level foundations opener to beginner audience + fix section nav (#2138 #2140)

### DIFF
--- a/src/content/docs/ai/foundations/index.md
+++ b/src/content/docs/ai/foundations/index.md
@@ -36,4 +36,4 @@ By the end of this section, you should be able to:
 
 ## Next Section
 
-Continue to [AI-Native Work](../ai-native-work/).
+Continue to [AI Engineering Foundations](../ai-engineering-foundations/).

--- a/src/content/docs/ai/foundations/module-1.1-what-is-ai.md
+++ b/src/content/docs/ai/foundations/module-1.1-what-is-ai.md
@@ -11,7 +11,7 @@ revision_pending: false
 >
 > **Time to Complete**: 60-75 min
 >
-> **Prerequisites**: Basic scripting literacy, basic infrastructure terminology, and curiosity about how automation fails
+> **Prerequisites**: Curiosity, basic computer use, and a willingness to check answers instead of accepting them automatically
 
 ---
 
@@ -19,294 +19,313 @@ revision_pending: false
 
 By the end of this module, you should be able to:
 
-- Classify a given automation system into one of four AI architecture categories by identifying its operational mechanism and boundaries.
-- Compare the risk profiles of rule-based systems, machine learning systems, generative AI, and agentic workflows when applied to infrastructure automation tasks.
-- Design a trust boundary for an agentic workflow by mapping its destructive permissions to required human-approval gates.
-- Evaluate the reliability of an AI-generated operational response by distinguishing between fluent language generation and factually grounded systemic reasoning.
+- Explain in plain language what AI means and how it differs from ordinary rule-following software.
+- Tell the difference between rule-based systems, machine learning, generative AI, and agentic assistants using everyday examples.
+- Identify what an AI tool can see, what it can change, and where a human approval boundary belongs.
+- Check an AI answer by separating confident wording from evidence you can verify yourself.
 
 ## Why This Module Matters
 
-Hypothetical scenario: an infrastructure engineer wakes up during an overnight incident and sees that the primary database is reporting severe query latency. The engineer pastes several pages of logs into a generative assistant and asks for an immediate remediation script. The response is formatted cleanly, names familiar database concepts, and presents the exact confidence of a runbook written by a senior operator. Under pressure, the engineer runs it and discovers too late that the script terminated healthy sessions and triggered a costly index rebuild during peak load.
+Hypothetical scenario: you are planning a weekend trip with friends, and everyone is busy. You ask an AI travel assistant to compare dates, suggest hotels, and draft a shared plan. The assistant writes a confident answer that sounds helpful: it recommends a hotel near the station, says the museum is open late, and offers to book the cheapest non-refundable room. You almost click confirm before noticing that the hotel is in a different city with a similar name.
 
-That failure is not a story about a foolish engineer; it is a story about a missing taxonomy. The engineer treated fluent language as operational evidence, even though language quality and system understanding are different properties. A deterministic script, a statistical classifier, a generative language model, and an autonomous agent can all be sold under the same "AI-powered" label, but they fail in different ways and deserve different boundaries. This module gives you the vocabulary to separate the marketing wrapper from the mechanism that actually makes decisions.
+That mistake does not mean AI is useless, and it does not mean you did anything foolish. It means the tool sounded more certain than its evidence deserved. A beginner can be impressed by the smooth writing, the quick comparison, and the polite tone, while missing the more important question: how did the system reach that answer? This module gives you a simple map for asking that question before the answer affects your time, money, privacy, or decisions.
 
-Modern platform teams are not deciding whether AI exists in their workflow, because it already appears in alert triage, code review, search, anomaly detection, documentation, ticket routing, and experimental remediation tools. The practical question is narrower and more useful: what kind of system is this, what evidence does it use, what can it change, and who remains accountable when it is wrong? If you can answer those questions, you can use AI as an engineering component instead of treating it as magic, novelty, or a blanket ban.
+This track is for people starting from zero AI background, so we will not begin with servers, model training, or advanced system-building. We will begin with familiar experiences: email spam filters, photo apps that group pictures, streaming recommendations, chatbots that draft text, and assistants that can use tools. These examples are ordinary enough to understand, but serious enough to show why AI literacy is a real skill rather than a collection of slogans.
 
-The module is intentionally grounded in infrastructure work rather than abstract philosophy. You will learn how ordinary software differs from probabilistic systems, how four common AI-adjacent architectures behave, why agentic workflows need special scrutiny, and how to place trust boundaries around tools before they touch production. Later modules will go deeper into large language models, prompts, agents, and Kubernetes 1.35+ workflows, so this first lesson builds the safety vocabulary that makes those deeper topics easier to reason about.
+The goal is not to make AI mysterious or magical. The goal is to make it legible. Once you can tell whether a system is following rules, learning from examples, generating new content, or using tools to take actions, you can choose a sensible level of trust. You do not need to know advanced math to start; you need a clear vocabulary, a few reliable questions, and the habit of checking important outputs.
 
-## AI vs Ordinary Software
+## AI in Plain Language
 
-Traditional software engineering relies on explicit decisions written by people. A developer describes the condition, the program checks that condition, and the program performs the corresponding action. This is why ordinary infrastructure automation can be tested with familiar techniques such as unit tests, dry runs, static analysis, code review, and staged rollout. If the same input enters the same deterministic program in the same state, you expect the same output, and when that expectation fails you can usually trace the path through the code.
+Artificial intelligence is a broad name for computer systems that appear to perform tasks we normally associate with judgment, pattern recognition, language, planning, or decision support. That does not mean the computer understands the world the way a person does. It means the system receives input, transforms it using rules or learned patterns, and produces an output such as a label, recommendation, prediction, piece of content, or next action.
 
-That determinism is not primitive or outdated; it is the reason much of production infrastructure works at all. A deployment controller reconciles actual state toward desired state, a linter rejects a known-invalid manifest, and a threshold alert fires when a metric crosses a configured boundary. These systems can still be complicated, buggy, and poorly designed, but their decision logic is inspectable. You can ask where the condition is defined, who changed it, which branch executed, and why the resulting action followed from the input.
+The OECD's updated definition of an AI system describes a machine-based system that infers from input how to generate outputs such as predictions, content, recommendations, or decisions that can influence physical or virtual environments. That wording is useful for beginners because it focuses on the flow of the system rather than the hype around it. Something goes in, a system infers what output fits, and the output may affect what people see or do next.
 
-The simplest form of this thinking looks like the kind of logic many engineers write in scripts, controllers, and runbooks. The code below is intentionally small, but the important property is not its size. The important property is that a human authored the conditions and the resulting behavior is expected to be repeatable.
+In everyday language, AI is easiest to understand as software that handles ambiguity. A calculator does not need AI to add two numbers, because the rule is exact. A photo app that groups pictures of the same person faces a messier task, because faces vary with lighting, angle, age, expression, camera quality, and background. The value of AI often appears where the input is too varied for a simple rule to cover comfortably.
+
+That flexibility is powerful, but it comes with a tradeoff. The more a system relies on learned patterns or generated language, the less you should expect it to behave like a simple calculator. It may be useful without being fully reliable, confident without being correct, and fluent without having evidence. Good AI use begins when you can hold both ideas at once: the tool can save time, and the tool can still be wrong.
+
+Think of AI literacy like learning to read a nutrition label. You do not need to become a chemist before buying food, but you do need to know the difference between calories, ingredients, serving size, and marketing language. In the same way, you do not need to become a machine learning engineer before using AI, but you do need to know the difference between a rule, a learned pattern, a generated answer, and an action taken on your behalf.
+
+## Ordinary Software vs AI
+
+Ordinary software often follows instructions that people wrote directly. If you set an alarm for 7:00 AM, the app does not infer your sleep goals or guess whether tomorrow is important. It checks the time, follows a rule, and plays a sound. That kind of software can still be complex, but its decision path is usually easier to explain because the important conditions were written in advance by humans.
+
+A simple rule-based email filter works the same way. If the sender is on your blocked list, move the message to junk. If the subject contains a phrase you personally blocked, hide it. The computer is not learning what spam means in a broad sense; it is applying instructions someone supplied. When the result is wrong, you can often point to the exact rule that caused the mistake.
 
 ```text
-if (cpu_utilization_percentage > 80) {
-    execute_scale_up_procedure();
-} else if (cpu_utilization_percentage < 20) {
-    execute_scale_down_procedure();
-} else {
-    maintain_current_replica_count();
-}
+if sender_is_blocked:
+    move_message_to_junk()
+else if subject_contains_blocked_phrase:
+    move_message_to_junk()
+else:
+    keep_message_in_inbox()
 ```
 
-Artificial intelligence systems, as the term is used in modern engineering practice, usually introduce statistical generalization. Instead of a human writing every branch, the system is trained, tuned, or prompted to infer patterns from data and apply those patterns to new inputs. The system may classify a support ticket, predict future demand, generate text, summarize logs, recommend a configuration, or decide which tool to call next. That extra flexibility is useful precisely because the space of possible inputs is too large, ambiguous, or fluid for ordinary hand-written rules to cover comfortably.
+Many AI systems work differently because they use patterns learned from examples. A modern spam filter may look at many signals: wording, sender reputation, link patterns, previous user reports, formatting, and similarities to messages seen before. No person writes one explicit rule for every possible spam message. The system learns a pattern from data and then applies that pattern to new messages it has never seen.
 
-The tradeoff is that statistical generalization changes the shape of verification. You no longer prove correctness only by reading a branch and checking a known condition. You also ask what data shaped the model, whether the current situation resembles that data, how the system represents uncertainty, what it does when evidence is incomplete, and whether the output can be independently checked. In other words, AI does not remove engineering discipline; it moves more of that discipline into evaluation, monitoring, and boundary design.
+That shift changes how you check the system. With ordinary software, you ask what rule ran and whether the rule was written correctly. With a learned system, you also ask what examples shaped it, whether the current situation resembles those examples, and how costly a mistake would be. A learned spam filter can catch tricks that a simple rule misses, but it can also hide an important message because the message resembles spam.
 
-Pause and predict: if a deterministic scaling script and a trained forecasting model both face a traffic spike caused by a campaign that has never happened before, which one fails more visibly and which one might fail more persuasively? The deterministic script may be obviously limited because it only checks a current metric, while the model may produce a confident forecast based on historical patterns that no longer apply. That difference matters because obvious brittleness often receives faster skepticism than polished probabilistic output.
+Generative AI adds another twist because it creates new text, images, audio, code, or plans instead of only sorting existing items. A chatbot can write a polite email, summarize a long article, suggest quiz questions, or explain a concept in several styles. That feels conversational, which is why beginners sometimes treat it like a person who knows things. Underneath, it is still a system producing likely output from input and context.
 
-It helps to think of ordinary software as a recipe and many AI systems as an experienced but imperfect taster. A recipe says that if the oven is at a certain temperature and the timer reaches a certain point, you take the dish out. The taster can recognize patterns that are hard to encode, such as smell, texture, and context, but can also be fooled by unfamiliar ingredients or misleading presentation. Good kitchens use both: recipes for repeatability, judgment for ambiguity, and clear rules for when judgment must not override safety.
+Agentic assistants add one more layer: they can use tools. Instead of only saying "Here is a possible trip plan," an assistant might search calendars, compare prices, fill a booking form, send an email, or make a purchase if you give it access. The important beginner question changes from "Is the answer correct?" to "What is this tool allowed to do if it is wrong?" A wrong suggestion is annoying; a wrong purchase may cost money.
 
-The same hybrid mindset belongs in infrastructure. You might use deterministic validation to block dangerous Kubernetes manifests, machine learning to surface unusual metric patterns, a generative model to draft an incident summary, and an agentic workflow to collect diagnostic evidence. Each tool can be valuable, but each belongs behind a boundary that matches its failure mode. The mistake is not using AI; the mistake is giving an ambiguous, probabilistic system the same unchecked authority you would give to a small deterministic script.
+The useful analogy is a kitchen. A rule-based timer rings when the minutes run out. A learned recommendation system notices that you often cook vegetarian meals and suggests similar recipes. A generative assistant drafts a shopping list and rewrites the instructions for beginners. An agentic assistant orders the groceries. Each can help, but each deserves a different level of checking because each can affect your life in a different way.
 
 ## The Four Categories You Will Actually Meet
 
-The word "AI" is too broad to guide operational decisions by itself. A vendor demo, an internal tool name, or a dashboard badge can hide the mechanism that matters most to an engineer. Before you decide whether a system is safe, useful, or overhyped, classify it by how it reaches conclusions and what kind of action it can take. The four categories below are not the only possible taxonomy, but they are practical enough for day-to-day platform work.
-
-```mermaid
-graph TD
-    A[Automation Architecture Taxonomy] --> B[Rule-Based Systems]
-    A --> C[Probabilistic AI Systems]
-    B --> B1[Deterministic Scripts]
-    B --> B2[Static Threshold Alerts]
-    C --> D[Machine Learning Systems]
-    C --> E[Generative AI Systems]
-    C --> F[Agentic Workflows]
-    D --> D1[Classification & Prediction]
-    E --> E1[Text & Asset Creation]
-    F --> F1[Multi-Step Execution with Tools]
-```
-
-Rule-based systems are the familiar foundation. They include scripts, static thresholds, policy checks, hand-authored decision trees, and many conventional controllers. Their strength is traceability: a reviewer can inspect the rule, reproduce the input, and understand why the action happened. Their weakness is that they do not generalize beyond the situations someone anticipated. When a new log format, directory layout, traffic pattern, or workload behavior appears, the rule either misses it, mishandles it, or needs a person to update the logic.
-
-Machine learning systems generalize from examples. In infrastructure contexts, they often classify events, cluster logs, rank alerts, detect anomalies, forecast demand, or estimate risk. These systems are valuable when the relevant signal is distributed across many inputs and would be awkward to capture with static thresholds. Their weakness is not mystical opacity; their weakness is dependence on data quality and representativeness. If current behavior drifts away from training behavior, a once-useful model can become confidently stale.
-
-Generative AI systems produce new content rather than only selecting from a fixed set of labels. A large language model can draft a runbook, explain a stack trace, translate a vague request into a configuration skeleton, or summarize a long incident thread. The attractive property is fluency across many domains, which makes the tool feel like a general collaborator. The dangerous property is the same fluency, because the model can generate plausible statements without having grounded evidence that those statements are true for your environment.
-
-Agentic workflows combine generative or reasoning-oriented models with tools. Instead of only answering a question, the system may plan steps, call APIs, query logs, run commands, inspect results, and choose the next action. This is where the operational blast radius grows quickly. An agent with read-only access to logs is different from an agent that can patch deployments, rotate credentials, delete resources, approve pull requests, or execute database migrations. The model's reasoning quality matters, but the permission boundary matters just as much.
-
-To understand the mechanical contrast between hand-authored logic and learned behavior, compare the earlier branch-based example with a simplified model-driven flow. The model does not contain a neat list of human-written conditions for every possible metric combination. Instead, it applies learned weights to current telemetry and produces a score that another rule may consume.
+The word "AI" is too broad to be useful by itself. It appears on search boxes, writing tools, phones, cameras, learning apps, customer support chats, design tools, and office software. If you treat every AI label as the same thing, you will either trust too much or reject too much. A better habit is to ask what mechanism is doing the work and what kind of output or action follows.
 
 ```text
-historical_model_weights = load_trained_anomaly_model()
-current_system_metrics = fetch_live_telemetry_data()
-anomaly_probability_score = calculate_probability(current_system_metrics, historical_model_weights)
+Everyday AI map
 
-if (anomaly_probability_score > 0.95) {
-    trigger_high_severity_incident_alert()
-}
+Rule-based system
+  -> follows explicit human-written rules
+
+Machine learning system
+  -> learns patterns from examples
+
+Generative AI system
+  -> creates new text, images, audio, code, or plans
+
+Agentic assistant
+  -> uses tools across steps and may take actions
 ```
 
-Notice that the final decision may still contain a deterministic threshold. Many real systems are hybrids, and that is why taxonomy must focus on the decision mechanism rather than the product label. A model may produce a probability score, a rule may decide whether that score triggers a page, and a human may decide whether remediation is appropriate. When you map the chain this way, you can test the deterministic parts, monitor the probabilistic parts, and place approvals around the parts that alter state.
+Rule-based systems are the easiest starting point because they behave like checklists. A thermostat may turn heat on below a chosen temperature and turn it off above another temperature. A banking app may warn you when a password is too short. A form may reject an invalid date. These systems can be frustrating when the rule is too rigid, but their main advantage is that the rule can usually be inspected, tested, and explained.
 
-Which approach would you choose here and why: a static CPU threshold for a small internal service with predictable load, or a forecasting model for a consumer-facing service whose demand changes around public events? The threshold is easier to audit and may be completely adequate for the small service. The forecasting model may be worth its extra complexity for the consumer-facing service, but only if you monitor drift, compare predictions with reality, and keep deterministic safety limits around scaling cost and capacity.
+The main failure of rule-based systems is brittleness. They work well when the situation matches the rule writer's expectations, and they work poorly when reality comes in a shape the rule did not anticipate. A blocked-phrase email filter might hide a harmless newsletter because it contains a suspicious word. A shopping-site rule might reject a valid address because the address format is unusual. The system is not confused; it is simply narrow.
 
-The categories also differ in what evidence should make you trust them. A rule-based system earns trust through code review, explicit tests, and operational history. A machine learning system earns trust through evaluation data, drift monitoring, confidence calibration, and comparison with baselines. A generative system earns narrow trust when its output is checked against authoritative sources or executable tests. An agentic workflow earns permission only when identity, tools, approvals, logs, and rollback paths are designed before autonomy is enabled.
+Machine learning systems learn patterns from examples instead of relying only on rules written one by one. A photo app can learn to group pictures with similar faces. A music service can recommend songs because people with similar listening patterns liked them. A bank can flag unusual card activity because it differs from your normal behavior. These systems are useful when the pattern is real but hard to describe with a tidy rule.
 
-| System Category | Typical Operational Use Case | Primary Failure Domain | Required Trust Boundary |
-|-----------------|------------------------------|------------------------|-------------------------|
-| Rule-Based Systems | Static threshold alerting and deterministic configuration | Brittleness when encountering unprecedented edge cases | Standard peer review and unit testing |
-| Machine Learning | Predictive autoscaling and anomaly detection | Degradation due to training data drift and historical bias | Continuous confidence score monitoring and fallback rules |
-| Generative AI | Documentation synthesis and incident summary drafting | Plausible but completely fabricated technical details | Mandatory independent verification against authoritative sources |
-| Agentic Workflows | Autonomous alert remediation and infrastructure provisioning | Unbounded execution loops and destructive state changes | Strict human-in-the-loop approval gates for all actions |
+The main failure of machine learning is pattern mismatch. The system can learn from examples that are incomplete, outdated, biased, or unlike the current situation. A recommendation system may keep suggesting baby products long after a gift purchase because it learned the wrong meaning from your shopping history. A photo app may group different people together because lighting and angle made them look similar to the model. The output may be statistical rather than certain.
 
-Use the table as a first-pass review checklist, not as a rigid academic definition. Real systems can cross boundaries, and the most interesting operational systems often do. A ticket router might use a machine learning classifier, then ask a language model to draft a response, then let an agent update the ticket. The safe design question is therefore not "Is this AI?" but "Which step uses which mechanism, what evidence supports it, and what action can follow from it?"
+Generative AI systems create new content. A large language model can write a study guide, rewrite a confusing paragraph, propose a packing list, draft a message to a landlord, or explain a technical term in simpler language. Image generators, music generators, and video generators belong to the same broad family of systems that produce new artifacts. They are especially attractive because they can meet you in ordinary language instead of requiring a special interface.
 
-## Worked Example: Debugging an Agentic Failure
+The main failure of generative AI is plausible invention. The answer may be grammatical, polished, and organized while still containing details that are wrong, missing, or made up. A chatbot can invent a book title, misstate a policy, summarize an article it did not actually read, or give outdated advice with calm confidence. Fluency is a writing quality, not proof. The more important the output is, the more you need a way to verify it.
 
-Exercise scenario: a platform team introduces an autonomous remediation workflow for a staging cluster. The workflow watches deployment events, reads application logs, queries metrics, and can roll back a deployment when it concludes that a new release is unhealthy. The team gives it broad permissions because the environment is not production, and they expect the tool to behave like the deterministic rollback step in their existing delivery pipeline. That expectation is the first design error.
+Agentic assistants combine AI with tools, memory, steps, and permissions. A travel assistant might ask clarifying questions, search flights, compare hotels, draft an itinerary, and wait for your approval before booking. A study assistant might gather sources, make flashcards, schedule practice, and quiz you later. A work assistant might read a document, draft an email, and create a calendar invite. The defining feature is not only conversation; it is action across multiple steps.
 
-During a routine release, developers change the application logging format so that verbose diagnostic messages are written to the standard error stream. The application is healthy, request latency is stable, and user-facing error rates are unchanged. The agent, however, asks a generative model to interpret the new logs, receives an alarming summary, and decides that the release is failing. It calls the deployment tool, rolls the service back, observes that the new log pattern disappeared, and treats the disappearance as confirmation that its action was correct.
+The main failure of agentic assistants is that a mistaken conclusion can become a real action. If a chatbot gives you a bad restaurant recommendation, you can ignore it. If an agent books the restaurant, sends invitations, and charges a deposit before you review the details, the mistake has already moved into the world. Agentic systems need clear permission boundaries because usefulness and risk grow together when a tool can act.
 
-The resulting loop is easy to miss if you debug it with the wrong mental model. A deterministic rollback rule would usually point to a visible condition such as "HTTP error rate greater than threshold after rollout." In this case, the harmful condition lives across several layers: a generative interpretation of logs, a planning loop that treats its own action as evidence, and a permission boundary that allows state changes without a second signal. The bug is not only in a prompt, a model, or a threshold. The bug is in the workflow design.
+Real products often combine categories. A shopping app may use rules to block invalid coupons, machine learning to rank products, generative AI to summarize reviews, and an agentic assistant to place an order. The safe question is not "Is this AI?" The safe question is "Which part is rule-based, which part learned from examples, which part generated content, and which part can take action?"
 
-The first diagnostic move is to separate observation from action. Read-only investigation can often be delegated earlier than write access because a mistaken summary is recoverable when a human reviews it before change. State-altering steps deserve stronger evidence, especially when they can undo work, delete data, scale systems aggressively, rotate credentials, or modify network policy. In this scenario, the agent should have been allowed to collect logs and metrics, but a rollback should have required deterministic corroboration and a human approval gate.
+Here is a compact comparison you can reuse whenever you meet a new tool:
 
-The second diagnostic move is to require independent signals before an autonomous workflow concludes that remediation worked. If the agent rolls back a deployment and then says the problem disappeared because the logs changed, it may simply be observing the consequence of its own rollback. A safer design asks whether user-facing health improved, whether the original symptom was real, and whether the action affected the intended causal path. This is ordinary incident thinking applied to a new automation shape.
+| Category | Everyday Example | What It Does Well | What To Check |
+|---|---|---|---|
+| Rule-based system | A password rule that requires a minimum length | Applies clear instructions consistently | Whether the rule fits the situation |
+| Machine learning system | A photo app that groups pictures by person | Finds patterns across many examples | Whether the pattern could be wrong or biased |
+| Generative AI system | A chatbot that drafts a thank-you email | Creates useful first drafts quickly | Whether the facts, tone, and assumptions are correct |
+| Agentic assistant | A travel helper that can book a hotel | Carries work across several steps | What it can see, what it can change, and who approves |
 
-Before running a similar workflow in your own environment, what output would you expect from each stage if the release is healthy but noisy? A good design would show the log summary as uncertain, keep latency and error-rate checks green, refuse rollback because the signals disagree, and ask a human to decide whether the logging change needs cleanup. A poor design would convert scary text into a high-severity conclusion and then let tool access turn that conclusion into state change.
+Use the table as a beginner's safety map rather than a strict academic definition. Some systems blur boundaries, and the labels may change as products evolve. The point is to slow down the moment an AI badge appears and ask what kind of mechanism is behind it. That habit keeps you from trusting a generated answer like a verified fact or letting a tool take action before you understand its permission.
 
-Here is a useful way to review the failure without being distracted by the product interface. The language model produced an interpretation, the planning loop chose an action, the tool permission allowed that action, and the environment produced feedback. Each boundary is a place where engineering controls can be added. You can constrain the model's task, require structured evidence, limit the tool, add approval, log the decision, and enforce rollback limits that stop repeated actions.
+## Worked Example: Planning A Trip
 
-When teams skip this boundary review, agentic systems can inherit the broad permissions of the humans who installed them. That is a bad default because the agent lacks the human's situational awareness, social accountability, and ability to pause when a conclusion feels wrong. Least privilege is not merely a security slogan here; it is a reliability control. The agent should have the smallest set of read and write capabilities needed for the narrow workflow, and destructive permissions should be separated behind explicit approval.
+Imagine you are organizing a short trip for four people. You want a city that is reachable by train, a hotel near the station, one museum visit, and a restaurant that can handle a vegetarian guest. This is a familiar task with enough moving parts to show why AI can be useful. It also contains real risks because a wrong date, location, cancellation policy, or dietary assumption can create stress or cost money.
 
-The practical lesson is that autonomy should be earned in layers. Start with read-only diagnostics, compare the agent's findings with known-good runbooks, measure false positives, add deterministic cross-checks, then consider low-risk actions with automatic rollback. Only after that evidence exists should a team discuss broader write access, and even then the scope should be narrow. If a workflow cannot explain what evidence justified an action, it is not ready to perform that action without review.
+A rule-based tool could help with the parts that are exact. It might reject a hotel check-in date that comes after the check-out date, warn when a password is too short, or show only trains that leave after 8:00 AM because you selected that filter. The tool does not need to understand travel; it needs to follow explicit conditions. If the filter is wrong, the fix is usually to change the rule or selection.
 
-## Evaluating Trust and Establishing Boundaries
+A machine learning tool could help with the parts that involve patterns. It might recommend hotels similar to places travelers liked before, rank restaurants based on many reviews, or suggest destinations that match your past choices. This is useful because the system can compare many signals quickly. It is also risky because "people like you liked this" is not the same as "this matches your exact trip, budget, accessibility needs, and values."
 
-Trust is not a single switch. A tool can be trustworthy for drafting a summary and untrustworthy for executing a migration; useful for suggesting a Kubernetes manifest and unsafe for applying it; excellent at finding related documentation and weak at deciding whether your production database is healthy. The safest teams avoid global judgments such as "we trust this AI" or "we do not use AI." They define task-specific trust, evidence-specific trust, and permission-specific trust.
+A generative AI tool could draft the plan in ordinary language. It might turn scattered notes into a clean itinerary, explain the difference between two neighborhoods, rewrite the plan for a friend who hates long schedules, or create a packing list. This is where AI can feel most impressive because it makes messy information readable. The weak point is that the readable plan may include assumptions the system did not verify.
 
-Begin by naming the task. "Help with incidents" is too vague to secure or evaluate, while "summarize recent log lines from this namespace without changing resources" is concrete. A concrete task tells you which inputs matter, what output format is expected, which checks are possible, and what damage could occur. This is especially important for generative tools because their conversational interface can make a broad request feel harmless even when the implied work spans diagnosis, planning, and execution.
+An agentic assistant could go further by using tools. It might check calendars, search hotel sites, compare prices, put the museum into a shared schedule, draft messages to the group, and prepare a booking. At that point, the assistant is no longer only giving you words. It is moving through a workflow. The same capability that saves time also means you need approval gates before anything irreversible happens.
 
-Next, name the mechanism. If the system uses a rule, you can inspect the rule. If it uses a model, you can ask what data shaped the model and how current inputs are monitored for drift. If it generates text, you can ask what retrieval, citations, tests, or human review ground the output. If it calls tools, you can ask which identity it uses, which commands are allowed, where approvals happen, and how every action is logged for audit and rollback.
+The first approval boundary is information access. Does the assistant need to see your full calendar, all emails, payment details, passport number, or location history to perform this task? Usually it does not. A beginner-friendly boundary is to share the smallest useful amount of information. For travel planning, that might mean dates, city preferences, budget range, and accessibility needs, but not unrelated private messages or saved payment credentials.
 
-Then name the blast radius. A bad recommendation in a draft document wastes review time; a bad recommendation applied to a cluster can delete workloads. A false anomaly alert may wake someone unnecessarily; an autonomous remediation loop may flap a service for an hour. The same model output can be low risk or high risk depending on what follows it. That is why the permission boundary is often more important than the model family when you design production controls.
+The second approval boundary is action. It is usually fine for an assistant to draft an itinerary, summarize options, or prepare a booking form for review. It is much more serious for the assistant to purchase a ticket, reserve a non-refundable hotel, send an email to everyone, or share personal information with a third-party site. When an action costs money, reveals private data, or affects other people, the human should approve it.
 
-Evaluation should also match the category. For rule-based systems, test representative inputs and edge cases. For machine learning systems, compare predictions with labeled examples, track drift, and watch whether confidence remains calibrated over time. For generative systems, verify claims against primary sources, run generated code in isolated environments, and require reviewers to understand the domain. For agentic workflows, test not only the answer quality but the entire loop of planning, tool use, observation, retry, stopping, and escalation.
+The third approval boundary is evidence. If the assistant says the museum is open late on Saturday, you should ask where that claim comes from before building the trip around it. A link to the museum's official hours is stronger evidence than the assistant's memory. A current booking page is stronger evidence than a general travel blog. The more specific the claim, the more specific the check should be.
 
-The most dangerous moment is when a tool moves from advisory to authoritative. Advisory tools can be wrong while still saving time, because a person decides what to accept. Authoritative tools can be wrong and immediately change reality. This does not mean authoritative automation is forbidden; Kubernetes controllers are authoritative automation, and infrastructure depends on them. The difference is that mature controllers are constrained by explicit desired state, well-defined APIs, reconciliation semantics, and extensive operational experience. New AI agents need comparable constraints before they deserve comparable authority.
+The trip example teaches the whole taxonomy without requiring technical background. Rules are good for exact filters, machine learning is good for patterns, generative AI is good for drafts and explanations, and agentic assistants are useful when work spans steps. The same example also shows the basic safety habit: read the output as a proposal, verify important claims, and keep final approval over actions that matter.
 
-For a first review, write a simple boundary statement. A good boundary statement might say: "This assistant may read logs and metrics for the staging namespace, summarize likely causes, and draft a rollback plan, but it may not execute changes; any rollback requires a named human approver and must cite at least two deterministic health signals." That sentence is more valuable than a broad policy slogan because it names scope, action, evidence, and approval. It also gives reviewers something testable.
+## Trust Boundaries For Everyday AI Use
 
-Human approval should not be treated as a decorative checkbox. A tired engineer clicking "approve" on a dense model-generated plan without evidence is not a meaningful control. A useful approval gate presents the proposed action, the evidence, the confidence limits, the affected resources, the rollback path, and the reason alternatives were rejected. The goal is not to slow every workflow forever; the goal is to make dangerous actions legible enough that a responsible person can catch a bad inference before it becomes an outage.
+A trust boundary is a line that says what a tool may do without asking you again. Beginners sometimes hear "trust boundary" and assume it belongs only to engineers, but the idea is ordinary. You already use trust boundaries when you let a maps app suggest a route but not drive your car, let a banking app show a balance but not send money without confirmation, or let a store remember your address but not choose gifts for your friends.
 
-Finally, keep a record of AI-assisted decisions the same way you keep records for deployments and incidents. You want to know which prompt or input triggered a recommendation, what sources or telemetry the system used, which tool calls happened, who approved them, and what changed afterward. Without that audit trail, post-incident review becomes guesswork. With it, AI becomes another observable part of the system, subject to the same engineering habits as any other component.
+The simplest boundary question is "What can it see?" An AI tool may ask for a prompt, a document, a photo, a contact list, a calendar, or a browser session. Each extra source of information can improve the answer, but it also increases privacy risk. Before sharing, ask whether the information is necessary for the task and whether a smaller excerpt would work. You can often get useful help without handing over the whole context.
 
-## Reading AI Outputs Like Operational Evidence
+The second boundary question is "What can it change?" A chatbot that only answers questions is different from an assistant that can send messages, edit files, submit forms, place orders, or delete content. Change is where mistakes become harder to undo. If a tool can alter something, the boundary should be tighter: preview first, approve before sending, confirm before payment, and keep a record of what changed.
 
-An AI output should be read as a claim that needs a support trail, not as a conclusion that arrives fully verified. This is a small mental shift with large practical consequences. When a model says a service is unhealthy, ask which signals support that claim. When it proposes a command, ask which API version, permissions, and preconditions the command assumes. When it summarizes a document, ask which source lines or events are being compressed and which details may have been omitted.
+The third boundary question is "Who approves?" Human approval is not a decorative button. A useful approval step shows the proposed action, the evidence behind it, the cost or consequence, and the way to undo it if possible. If an assistant asks "Confirm booking?" but hides the hotel city, cancellation policy, and total price, the approval is weak. A good approval step makes the decision understandable before you click.
 
-This habit is familiar from incident response. A graph, log line, alert, and user report can each be true while still being incomplete. Engineers learn to correlate evidence because one signal rarely tells the whole story. AI output deserves the same treatment, especially because it often arrives in a smooth narrative that hides uncertainty. A smooth narrative can make weak evidence feel complete, so your job is to pull the evidence back into view before allowing the output to influence action.
+You can sort everyday AI tasks into low, medium, and high stakes. Low-stakes tasks include brainstorming birthday party themes, rewriting a casual note, or suggesting practice questions for a topic you are learning. Medium-stakes tasks include summarizing a lease, comparing health insurance terms, or drafting a work message where tone matters. High-stakes tasks include medical, legal, financial, safety, or irreversible decisions. The higher the stakes, the more outside evidence and human review you need.
 
-For generative systems, the first question is whether the output is grounded in something inspectable. Grounding might be a link to official documentation, a snippet from a repository file, a query result from a monitoring system, or a test run in an isolated environment. Without grounding, the output may still be useful as a brainstorm, but it should not be treated as operational evidence. The more specific and risky the recommendation, the more specific the grounding needs to be.
+The boundary should also match your own expertise. If you ask AI to explain a topic you understand well, you can spot many mistakes. If you ask it about a topic you barely know, you may not recognize false confidence. That does not mean you cannot use it for unfamiliar topics. It means you should ask for sources, compare multiple references, and avoid acting on the answer until a more authoritative source confirms it.
 
-For machine learning systems, the first question is whether the current case resembles the cases used for evaluation. A model trained on weekday traffic may behave poorly during a one-time public launch. A model trained on a previous logging format may overreact after a structured logging migration. A model trained on past support tickets may route new product issues to the wrong team. The model does not need malicious input to fail; ordinary change can be enough to make its learned pattern less reliable.
+A useful beginner rule is "draft freely, decide carefully." Let AI help you explore ideas, organize messy notes, compare options, and create first drafts. Slow down when the output claims facts, affects people, spends money, shares private data, changes a record, or tells you what to do in a serious situation. This rule keeps AI useful while making sure responsibility stays with the person who understands the real-world consequences.
 
-For agentic systems, the first question is whether the workflow can stop. A good agent has a clear goal, limited tools, bounded retries, escalation rules, and logs that show why each step happened. A weak agent keeps trying because every observation becomes an invitation to take another action. This matters because a human operator can notice that a loop has become absurd, while an automated workflow may need an explicit stopping rule. A stop condition is a reliability feature, not an implementation detail.
+The NIST AI Risk Management Framework describes AI risk work through functions such as govern, map, measure, and manage. You do not need the full framework in this first module, but the beginner version is already visible: know who is responsible, map what the tool can see and do, measure whether the answer is reliable enough, and manage the risk before action happens. Serious AI literacy starts with those habits.
 
-You can also evaluate AI output by separating syntax, semantics, and suitability. Syntax asks whether the output is well formed, such as valid YAML or a command that parses. Semantics asks whether the output means what the author intends, such as selecting the correct resource or applying the correct policy. Suitability asks whether the output belongs in this environment at this time, given your cluster version, risk tolerance, maintenance window, and rollback path. Many model-generated artifacts pass syntax while failing suitability.
+## Reading AI Answers
 
-That distinction is especially important in infrastructure education. A generated manifest can look valid while assuming an API field that is not available in your Kubernetes 1.35+ cluster, or it can be technically valid while violating your organization's policy. A generated incident summary can be readable while overemphasizing the loudest log line and ignoring the metric that actually shows user impact. A generated command can be syntactically correct while targeting the wrong namespace. The review must go beyond appearance.
+An AI answer is a claim, not a conclusion delivered from authority. This is especially important with generative AI because the answer often arrives in polished paragraphs that feel complete. A smooth paragraph can make weak evidence feel stronger than it is. Instead of asking "Does this sound smart?" ask "What would prove or disprove this?" That question turns the output into something you can inspect.
 
-Pause and predict: if a model gives you a remediation plan with three commands, which part is most likely to fool a rushed reviewer: invalid syntax, a wrong causal assumption, or an unsafe blast radius? Invalid syntax is often caught quickly by tools. Wrong causal assumptions and unsafe blast radius are harder because they can be hidden behind plausible explanations. That is why strong review asks not only "Will this run?" but also "Why should this action fix this symptom, and what else could it affect?"
+Start by separating wording from evidence. Wording is the style, confidence, and organization of the answer. Evidence is the support behind the claim: a source, a calculation, a current document, an official page, a direct observation, or a test you can repeat. AI is often strong at wording and uneven at evidence. A beginner should enjoy the wording while refusing to treat it as proof.
 
-One practical review technique is to turn the output into a checklist of claims. If the assistant says a deployment failed because readiness probes are timing out, the claims might be: the deployment changed recently, pods are failing readiness, the readiness failure started after the change, user-facing errors correlate with the failure, and rolling back would address the cause. Each claim can be checked independently. If several claims are unverified, the plan is not ready for execution.
+Next, separate general advice from specific claims. "Pack layers because spring weather can change" is a general suggestion that may be reasonable without deep research. "The 9:30 train is the cheapest option this Saturday" is a specific claim that needs a current source. "This article argues that privacy depends on data minimization" needs a link or quotation from the article. Specific claims deserve specific checks.
 
-Another technique is to require a reversible first step. Instead of allowing an assistant to patch production immediately, ask it to propose a read-only query, a dry run, or a staging reproduction that would increase confidence. This keeps the workflow useful while preserving human judgment around irreversible steps. In mature systems, the same idea becomes policy: read widely, write narrowly, and require approval when the proposed change crosses a risk threshold. That policy is how teams convert AI assistance into controlled automation.
+Then look for missing assumptions. If an assistant recommends a restaurant, did it consider distance, price, dietary needs, accessibility, noise level, or whether the place is open that day? If it summarizes a document, did it see the whole document or only a pasted excerpt? If it explains a law, policy, or health topic, is it using current authoritative information? AI answers often sound complete because they omit the uncertainty.
 
-The final review question is accountability. If an AI-assisted action causes damage, the organization still owns the outcome. The model does not attend the post-incident review, explain why permissions were broad, or decide how customers should be informed. People do those things, so people must design the controls before the action happens. Treating AI output as operational evidence keeps accountability where it belongs: with the engineers who decide which systems may act and under what conditions.
+For generated writing, review tone and ownership. An assistant may write an apology that is grammatically correct but too cold for the relationship. It may draft a student paragraph that sounds polished but does not reflect what the learner actually understands. It may produce a work message that is efficient but more aggressive than intended. Correctness is not the only standard; suitability matters too.
 
-## Patterns & Anti-Patterns
+For generated explanations, ask the tool to show the reasoning in simple steps, then check the steps. This does not mean every hidden model process becomes visible. It means you can ask for an explanation that exposes assumptions, definitions, examples, and source needs. If the answer cannot be broken into checkable parts, treat it as a starting point for learning rather than something to rely on.
 
-The strongest pattern is to pair probabilistic judgment with deterministic guardrails. A model can notice that a metric pattern looks unusual, but a rule can cap maximum scale-out, require minimum evidence, or block changes outside an approved maintenance window. This combination gives you flexibility without letting ambiguity make irreversible decisions. It also makes testing easier because you can evaluate the model's recommendation separately from the policy that decides whether action is allowed.
+For agentic assistants, read the proposed action as carefully as the answer. The assistant may summarize why a hotel looks good, but the action might book the wrong dates. It may draft an email well, but the recipient list might include someone unintended. It may prepare a form correctly, but submit it before you review the privacy implications. In agentic workflows, the final action often matters more than the explanation.
 
-A second useful pattern is staged autonomy. Start with suggestions, then read-only investigation, then low-risk changes, then narrowly scoped write actions with approvals, and only later consider broader automation. Each stage should have measured evidence that the previous stage works well enough. This pattern keeps excitement from outrunning observability and gives the team time to learn where the system is brittle. It also creates a natural rollback path for the automation itself.
+The practical review habit is simple: underline the claims, circle the actions, and mark the evidence. Claims are things the answer says are true. Actions are things the tool wants to do or wants you to do. Evidence is what supports the claims or justifies the actions. If an answer has many claims and few evidence marks, it may still be useful for brainstorming, but it is not ready for important decisions.
 
-A third pattern is source-grounded generation. If a generative model drafts a Kubernetes configuration, an incident summary, or a security recommendation, require it to point to primary documentation, live telemetry, repository files, or test results that can be checked. The model's fluency is useful for synthesis, but the grounding evidence is what lets a reviewer decide whether the synthesis is safe. This is especially important for learners, because polished explanations can hide missing assumptions.
+## When To Use AI And When Not To
 
-The first anti-pattern is category collapse: treating every tool with an AI label as the same kind of thing. Teams fall into this because vendor language is broad and internal conversations often optimize for speed. The better approach is to name the mechanism in architecture reviews. Say "a classifier ranks alerts," "a language model drafts the summary," or "an agent calls the deployment API." Specific nouns force specific controls.
+Use rule-based tools when the condition is clear and repeatability matters. A calendar reminder, password rule, form validation, budget limit, or email filter can be simple and reliable precisely because it does not guess. Beginners sometimes assume newer AI is always better, but boring software is often the right answer when the task is exact. If a rule solves the problem cleanly, adding AI may only add uncertainty.
 
-The second anti-pattern is permission inheritance. A human installs a tool, authenticates it with broad credentials, and accidentally gives the automation the same reach the human has. This is convenient during a demo and dangerous in operations. The better approach is to create purpose-specific identities with narrow read scopes, separate write permissions, and visible audit logs. If the tool needs more access later, the request should be reviewed like any other privilege expansion.
+Use machine learning when examples and patterns matter more than hand-written rules. Recommendations, spam detection, photo grouping, speech recognition, and fraud alerts can benefit from learned patterns because the input varies so much. The key question is whether the pattern learned from past examples still fits the current case. If your situation is unusual, new, or underrepresented, the system may be less reliable than it appears.
 
-The third anti-pattern is using AI where the rule is already simple and sufficient. A static threshold, schema validation rule, or policy-as-code check may be boring, but boring is often the right answer when the condition is clear. Adding a model can introduce nondeterminism, training concerns, and new monitoring needs without improving the outcome. Use AI when ambiguity, scale, or language makes ordinary rules impractical, not merely because the interface feels modern.
+Use generative AI when you need drafting, summarizing, rephrasing, translation help, idea generation, or an explanation at a different level of detail. It is especially useful when you can review the output yourself or compare it with a trusted source. It is weakest when you ask it for facts you cannot check, citations it does not actually have, or decisions where a confident mistake would cause harm.
 
-## When You'd Use This vs Alternatives
+Use agentic assistants when the task genuinely needs several steps and tools, and when you can keep approval over important actions. A good early use is asking the assistant to gather options, prepare a draft, or build a checklist for your review. A risky use is letting it spend money, contact people, submit forms, or alter records without a clear preview. Autonomy should grow only after reliability and boundaries are proven.
 
-Use a rule-based system when the condition is explicit, the action is well understood, and predictability matters more than flexibility. Examples include rejecting manifests that lack required labels, blocking privileged containers by policy, or paging when a known saturation metric crosses a defined threshold. The rule may need maintenance, but its behavior can be reviewed before it runs. That reviewability is valuable when the cost of a mistaken action is high.
+Do not use AI as a substitute for professional accountability. Medical, legal, financial, safety, and employment decisions can be supported by AI for organization or preparation, but the output should not become the final authority. The tool does not carry responsibility for the outcome. People do. That is why verification, source checking, and human judgment belong at the center of serious AI use.
 
-Use machine learning when patterns are too large or subtle for comfortable manual rules, and when you can collect enough representative data to evaluate performance. Forecasting demand, clustering noisy logs, ranking related incidents, and detecting unusual combinations of metrics can fit this category. The key requirement is feedback. If nobody measures whether predictions remain useful, the model becomes an expensive source of stale confidence.
+## A Beginner's First AI Conversation
 
-Use generative AI when the task involves language, synthesis, transformation, or drafting, and when a person or deterministic process can verify the result. It is reasonable to ask for a first draft of documentation, a summary of a long thread, or a starting point for a configuration. It is reckless to treat that draft as authoritative without checking it. Generative output should accelerate expert review, not replace the need for expertise where consequences matter.
+The safest way to begin is to choose a low-stakes topic where you can recognize whether the answer helped. Ask for something like a study plan for learning basic spreadsheet formulas, a clearer version of a paragraph you already wrote, or a comparison of two phone settings you can check in the app itself. Low-stakes practice lets you notice the tool's strengths and weaknesses without putting money, privacy, or another person at risk.
 
-Use an agentic workflow when the work genuinely requires multiple steps, tool calls, observation, and adaptation, and when the workflow has been bounded like any other automation with production impact. A read-only diagnostic agent can be a sensible early use case because it gathers context without altering state. A write-capable remediation agent should arrive later, after the team has evidence, guardrails, approval gates, and a clear stop condition. Autonomy is a design choice, not a default setting.
+Start the conversation with context, not a command. Instead of writing "explain AI," write "I am a beginner with no AI background, and I want a plain-language explanation with two everyday examples and one thing to watch out for." That prompt does not require special skill, but it gives the tool a job, an audience, a format, and a safety expectation. Better input usually produces easier output to review.
 
-If you are unsure which category fits, trace the input-to-action path. Ask what data enters, what mechanism transforms it, what output is produced, what action follows, and what evidence can disprove the conclusion. A system that cannot answer those questions clearly should remain advisory until it can. Engineering maturity often looks like slowing down at the exact point where a demo looks effortless.
+After the first answer, do not immediately ask for more content. Ask a checking question. You might write, "Which parts of your answer are definitions, which parts are examples, and which parts would need an outside source?" This forces the conversation away from smooth performance and toward evidence. It also trains you to see that an AI answer has parts, and different parts deserve different levels of trust.
+
+Then ask for a simpler version. If the tool cannot explain the idea without jargon, the explanation may not be serving you yet. A useful assistant should be able to restate a concept for a beginner without losing the main point. When it introduces terms such as model, training, prompt, inference, context, or hallucination, ask for one sentence and one everyday example for each term before moving on.
+
+Next, ask for a mistake check. A strong beginner prompt is "What are three ways someone could misuse this answer?" This works because the tool may be good at listing limitations even when it is not perfect at judging itself. You still need your own review, but the question changes the mode from confident delivery to cautious inspection. That is a healthier relationship with the tool.
+
+When the output includes a claim you might repeat to someone else, ask for sources or a way to verify it. Do not ask only "Are you sure?" because a generative system can answer confidently again. Ask "What source should I check?" or "What exact phrase should I search on an official page?" The goal is to move from the model's wording to something outside the model that can support or correct the claim.
+
+When the output includes a recommendation, ask what would change the recommendation. If an assistant recommends a study schedule, ask how the plan changes for someone with only twenty minutes a day. If it recommends a hotel, ask how the answer changes for a wheelchair user, a strict budget, or a refundable booking requirement. This reveals assumptions that may have been hidden inside a polished first answer.
+
+When the output includes an action, pause. Drafting a message is different from sending it. Preparing a form is different from submitting it. Listing hotels is different from booking one. A beginner's strongest habit is to keep AI on the drafting side until the proposed action is visible, reversible where possible, and approved by the person who owns the consequence. That habit matters long before you learn any advanced AI vocabulary.
+
+Keep a small notebook of misses as well as wins. Write down when the tool saved time, when it confused you, when it made an unsupported claim, and when your prompt was too vague. This is not busywork. It builds judgment. Over time, you will notice which tasks are good fits, which tasks need stronger checking, and which tasks should stay outside AI assistance entirely.
+
+Also notice how the tool behaves when you say no. If it changes the answer gracefully, asks a clarifying question, or narrows the scope, that is useful behavior. If it keeps pushing the same recommendation, invents new confidence, or ignores a constraint you clearly stated, that is a warning sign. You are not only evaluating the first answer. You are evaluating the conversation pattern, because real AI use often involves correction, disagreement, and meaningful revision before the output is good enough.
+
+The point of a first AI conversation is not to get the perfect answer. The point is to practice the loop that makes later AI use safer: give context, inspect the output, separate claims from evidence, ask about assumptions, and keep approval over actions. Once that loop feels natural on everyday tasks, the later modules on language models, prompting, verification, privacy, and AI-supported work will have somewhere solid to land.
 
 ## Did You Know?
 
-- [The OECD updated its definition of an AI system in 2023 to emphasize machine-based systems that infer from inputs and generate outputs such as predictions, content, recommendations, or decisions.](https://oecd.ai/en/wonk/definition-)
-- [The NIST AI Risk Management Framework was released as version 1.0 in January 2023 and organizes AI risk work around govern, map, measure, and manage functions.](https://www.nist.gov/itl/ai-risk-management-framework/nist-ai-rmf-playbook)
-- Many production "AI" features are hybrids: a model may rank or generate, while ordinary rules still decide thresholds, permissions, routing, and final execution.
-- A language model can produce a valid-looking configuration for a version your cluster does not run, which is why these modules assume Kubernetes 1.35+ and still require documentation checks.
+- [The OECD revised its AI system definition in 2023 to emphasize machine-based systems that infer from input and generate outputs such as predictions, content, recommendations, or decisions.](https://oecd.ai/en/wonk/definition-)
+- [The NIST AI RMF Playbook says AI RMF 1.0 was released on January 26, 2023, and organizes work around Govern, Map, Measure, and Manage.](https://www.nist.gov/itl/ai-risk-management-framework/nist-ai-rmf-playbook)
+- The same product can combine several mechanisms, so one "AI assistant" may include rules, learned rankings, generated text, and tool-using steps in a single workflow.
+- A beginner can often reduce risk by asking three plain questions before using a tool: what can it see, what can it change, and what evidence supports the answer?
 
 ## Common Mistakes
 
 | Mistake | Why It Happens | How to Fix It |
 |---------|----------------|---------------|
-| Treating all AI systems as a single, uniform technology category | The product label hides whether the system is a rule, classifier, generator, or agent, so reviewers discuss it too vaguely. | Categorize every new tool by its specific underlying architectural mechanism before approving its use. |
-| Assuming linguistic fluency guarantees technical correctness | Polished prose feels like expertise, especially during incidents when people want a clear answer quickly. | Rigorously verify all generative outputs against official documentation, tests, or live telemetry before acting. |
-| Using "AI" as a shortcut term in architectural design discussions | Broad language avoids hard questions about evidence, permissions, and failure modes. | Explicitly name the actual capability being used, such as "probabilistic classifier" or "tool-calling agent." |
-| Assuming machine learning systems are infallible black boxes | Teams may focus on model novelty and forget that predictions depend on data quality and representativeness. | Implement continuous monitoring of prediction confidence, drift, and baseline comparisons with fallback rules. |
-| Dismissing all probabilistic systems entirely due to marketing hype | Frustration with vague claims can make teams ignore useful classification, forecasting, and summarization tools. | Separate vendor marketing claims from the actual verifiable capabilities and risks of the system. |
-| Trusting generative models most on tasks you understand the least | The model's answer may be the only explanation a learner sees, making errors harder to detect. | Use AI primarily to accelerate tasks you can review, and bring in authoritative references for unfamiliar domains. |
-| Deploying agentic workflows without human approval gates | Demo environments reward fast autonomy, while production environments punish unbounded state changes. | Mandate human-in-the-loop authorization for destructive actions and narrowly scope every tool permission. |
+| Treating every AI label as the same kind of system | Product names hide whether the tool follows rules, learns patterns, generates content, or takes actions. | Ask which mechanism is doing the work before deciding how much to trust the output. |
+| Assuming a fluent answer is a verified answer | Generative systems are good at producing smooth language, and smooth language feels like confidence. | Separate wording from evidence, then check important claims against sources you trust. |
+| Sharing more private context than the task requires | The tool asks for context, and it is tempting to paste the whole message, document, or thread. | Share the smallest useful excerpt, remove sensitive details, and check the tool's data settings. |
+| Letting an assistant act before reviewing the action | Multi-step tools feel efficient, especially when they prepare forms, messages, bookings, or purchases. | Keep preview and approval steps before spending money, sending messages, or changing records. |
+| Using AI where a simple rule would be clearer | Newer tools can make ordinary filters, reminders, and checks feel outdated even when they work well. | Prefer rule-based tools when the condition is exact and the cost of ambiguity is unnecessary. |
+| Trusting AI most on topics you know least | Beginners may not notice when an answer skips assumptions, invents details, or uses outdated information. | Ask for sources, compare with authoritative references, and avoid acting until you understand the evidence. |
+| Rejecting all AI because some tools make mistakes | Bad marketing and visible errors can make every AI feature look equally unreliable. | Separate useful drafting and pattern-finding from high-stakes decisions that require stronger verification. |
 
 ## Quiz
 
 <details>
-<summary>1. Your team wants to deploy a system that automatically categorizes incoming support tickets based on historical resolution data. Which architectural category best describes this tool, and what risk should you test first?</summary>
+<summary>1. A website rejects passwords shorter than twelve characters. Which category best describes this behavior, and why?</summary>
 
-This is a machine learning system because it uses historical examples to classify new tickets. The first risk to test is whether the historical data still represents current support patterns, because new products, new incident types, or changed team ownership can create data drift. A rule-based system would rely on explicit conditions, which is not the main mechanism here. A generative system might draft a response, and an agent might update tickets through tools, but the categorization step is a classifier.
-
-</details>
-
-<details>
-<summary>2. A vendor pitches an "AI DevOps Assistant" that writes infrastructure-as-code templates from natural language prompts. Why is this riskier than a deterministic configuration linter?</summary>
-
-The assistant is a generative AI system, so it can produce plausible new content that has not been validated against your exact platform rules. A deterministic linter checks known conditions and can explain which rule failed, while the generator may invent deprecated fields, omit required constraints, or produce insecure defaults with confident wording. The correct response is not to ban all generation, but to require review, tests, and primary documentation checks before use. The linter and the generator solve different problems and need different trust boundaries.
+This is a rule-based system because the site is applying an explicit condition written in advance. The password is either shorter than twelve characters or it is not, and the software does not need to learn from examples to make that decision. The behavior can still annoy users if the rule is poorly designed, but the mechanism is straightforward. This is different from machine learning, which would infer patterns from data, and different from generative AI, which would create new content.
 
 </details>
 
 <details>
-<summary>3. During an incident, an engineer uses a language model to generate a database recovery plan. The plan is clear, detailed, and full of familiar terms. How should the engineer evaluate the reliability of that AI-generated operational response?</summary>
+<summary>2. A photo app groups pictures that appear to show the same person. Which category is most likely involved, and what should you remember about mistakes?</summary>
 
-The engineer should treat fluency as a presentation quality rather than evidence of correctness. Reliability comes from checking every command against authoritative documentation, current system state, backups, and a peer review path appropriate to the blast radius. The model may still be useful for organizing possibilities, but it cannot prove that the recovery plan matches the live database. The safest next step is to convert the draft into a reviewed runbook, not to run it because it sounds confident.
-
-</details>
-
-<details>
-<summary>4. Your organization wants an autonomous agent to detect vulnerabilities and automatically patch running workloads. What trust boundary must be designed before write access is enabled?</summary>
-
-The workflow needs a human-approval gate for state-changing actions, narrow tool permissions, and deterministic evidence requirements before any patch is applied. Vulnerability detection can involve probabilistic interpretation, and patching can restart workloads, break compatibility, or change security posture. Read-only investigation may be allowed earlier, but automatic remediation needs stronger controls because the action changes production state. A safe design maps each destructive permission to an approver, an audit record, and a rollback plan.
+This is most likely a machine learning system because the app recognizes patterns across many visual examples instead of relying on a simple hand-written rule for every face. The useful caution is that pattern recognition can be wrong. Lighting, age, angle, camera quality, and similar-looking faces can confuse the system. You can use the grouping as a helpful convenience while still checking it before relying on it for anything important.
 
 </details>
 
 <details>
-<summary>5. A legacy alert pages whenever CPU utilization exceeds a threshold for several minutes. A new engineer suggests replacing it with an AI model. What comparison should the team make before changing the design?</summary>
+<summary>3. A chatbot writes a polished school presentation outline about a historical event. What should you check before using it?</summary>
 
-The team should compare the current rule's known limitations with the model's expected benefits and new failure modes. If the threshold is simple, reliable, and easy to tune, replacing it may add drift monitoring, explainability concerns, and operational uncertainty without improving outcomes. If the real problem is complex demand forecasting, a model may be justified, but it should be evaluated against historical and recent incidents. The right question is not whether AI is newer, but whether the mechanism fits the problem.
-
-</details>
-
-<details>
-<summary>6. An agent repeatedly rolls back a healthy deployment because it misreads a noisy log format. Which part of the design should you debug first: the model, the tool permissions, or the evidence gate?</summary>
-
-Start with the evidence gate and permission boundary, because the system should not be able to convert a single uncertain log interpretation into repeated state changes. The model may also need improvement, but model quality alone is a weak control when actions are destructive. The workflow should require independent health signals such as error rate, latency, and readiness before rollback is allowed. It should also limit repeated actions and require human approval when signals disagree.
+You should check the factual claims, dates, names, and sources instead of assuming polish means accuracy. This is a generative AI system because it creates new text from your prompt and context. The outline can be useful as a draft, but it may omit important context or invent details. A good next step is to compare its claims with a textbook, teacher-provided material, library source, or official reference before presenting it as your own understanding.
 
 </details>
 
 <details>
-<summary>7. A generated Kubernetes manifest appears valid, but the assistant does not cite the Kubernetes version or documentation source. What should you do before applying it to a Kubernetes 1.35+ cluster?</summary>
+<summary>4. A travel assistant can search hotels, fill a booking form, and click purchase after you approve. What boundary matters most?</summary>
 
-You should validate the manifest against the Kubernetes 1.35+ API behavior and your cluster policies before applying it. The assistant may have generated a field from an older version, a future proposal, or another tool's schema. A dry run, schema validation, policy check, and review against official documentation provide better evidence than the model's wording. The generated manifest can be a useful draft, but applying it without verification would confuse fluency with compatibility.
+The important boundary is the action approval boundary. The assistant may be useful for searching and preparing options, but booking a hotel spends money and creates a real commitment. Before approval, you should see the city, dates, total price, cancellation policy, room details, and payment method. This is an agentic assistant because it uses tools across steps, so its permissions matter as much as the wording of its recommendation.
+
+</details>
+
+<details>
+<summary>5. Why is "what can it see, what can it change, and who approves?" a useful beginner checklist?</summary>
+
+The checklist turns vague trust into specific boundaries. "What can it see?" helps you control privacy and context. "What can it change?" helps you notice when a tool can affect money, messages, files, or records. "Who approves?" keeps important actions under human review. This checklist works across rule-based tools, machine learning systems, generative AI, and agentic assistants because it focuses on evidence and consequences.
+
+</details>
+
+<details>
+<summary>6. An AI answer sounds confident but gives no source for a specific claim. What should you do with that claim?</summary>
+
+Treat the claim as unverified until you can check it somewhere reliable. Confidence and clear writing are not the same as evidence. If the claim is low-stakes, you may use it as a clue for further research. If the claim affects money, safety, health, law, work, or another person, you should find an authoritative source before acting. The answer may still be useful, but it has not earned trust for that specific claim.
+
+</details>
+
+<details>
+<summary>7. When is ordinary rule-following software better than AI?</summary>
+
+Ordinary rule-following software is often better when the condition is clear, stable, and easy to test. A reminder time, a spending limit, a required form field, or a password length rule does not need a model to guess. Adding AI to an exact task can create uncertainty without adding value. AI becomes more useful when inputs are ambiguous, varied, language-heavy, or difficult to describe with simple rules.
 
 </details>
 
 ## Hands-On Exercise
 
-In this exercise, you will analyze the operational risks of different automation architectures by designing appropriate trust boundaries for a hypothetical production environment. Your platform engineering team manages a fleet of stateless services and is evaluating three tools to reduce operational toil. For each tool, classify the architecture, identify the main failure mode, and decide what constraint must exist before the tool is used near production.
+In this exercise, you will classify everyday tools and set simple boundaries for each one. Choose three tools you already understand: one email or messaging feature, one photo or media feature, and one assistant or chatbot feature. If you do not use one of those categories, imagine a common example such as a spam filter, a photo-tagging app, and a travel-planning assistant.
 
-Exercise scenario: the first tool is a static script that deletes temporary cache files from nodes every Sunday at midnight. The second tool is a dashboard widget that analyzes historical traffic patterns and predicts when the team may need to scale resources for upcoming events. The third tool is an autonomous chat bot that can read alerts, query a production database for context, and independently execute schema migrations when it believes a mismatch exists. Treat the scenario as a design review, not a vendor evaluation.
+For each tool, write a short note in your own words. Do not try to sound technical. The goal is to practice seeing the mechanism behind the label and the consequence behind the output. A strong answer might say that a spam filter uses rules and learned patterns, that a photo app uses pattern recognition, and that a travel assistant becomes higher risk when it can book or send information without review.
 
 ### Tasks
 
-- [ ] Classify each automation system into a category: rule-based system, machine learning system, generative AI system, or agentic workflow.
-- [ ] Compare the risk profiles of the three tools by writing one likely failure mode and one likely blast-radius concern for each tool.
-- [ ] Design a trust boundary for the agentic workflow by mapping every destructive permission to a required human-approval gate.
-- [ ] Evaluate the reliability of any AI-generated operational response by listing the external evidence you would require before acting on it.
-- [ ] Decide which tool, if any, could safely start in advisory or read-only mode and explain what evidence would justify additional autonomy later.
+- [ ] Name the tool and classify it as rule-based, machine learning, generative AI, agentic, or a combination.
+- [ ] Write one sentence explaining what input the tool uses and what output it produces.
+- [ ] Write one sentence identifying the main thing that could go wrong if the output is wrong.
+- [ ] Decide what the tool should be allowed to see for this task and what information should stay private.
+- [ ] Decide what the tool should be allowed to change automatically and what should require human approval.
+- [ ] List one piece of evidence you would want before trusting an important claim from the tool.
 
 <details>
 <summary>Suggested solution</summary>
 
-The cache cleanup script is a rule-based system because a person defines the schedule and deletion behavior explicitly. Its main failure mode is brittleness around unexpected directory structures, unsafe path expansion, or a changed node layout, so the boundary should include dry runs, path allowlists, and review before it runs broadly. The traffic predictor is a machine learning system because it forecasts demand from historical data, so its main failure mode is drift when upcoming events differ from the past; it should remain advisory until predictions are compared with current plans and recent telemetry. The chat bot is an agentic workflow because it interprets alerts, queries tools, plans actions, and can execute migrations. It needs the strongest boundary: read-only access by default, no migration execution without named human approval, deterministic health and schema evidence, audit logs for every tool call, and a rollback plan for any approved change.
+A spam filter may combine rules and machine learning because it can block messages from known senders while also learning patterns from many examples of unwanted mail. The main risk is hiding an important message, so you might keep a junk folder review habit and avoid deleting messages automatically. A photo-tagging app is mainly a machine learning system because it groups images by visual patterns. The main risk is misidentifying people, so you should check names before sharing albums. A travel-planning assistant may be generative when it drafts an itinerary and agentic when it can search sites or prepare bookings. The main risk is turning a wrong assumption into a purchase, so it should show current sources and require your approval before booking.
 
 </details>
 
 ### Success Criteria
 
-- [ ] You have classified the static script as a rule-based system and noted that its primary failure mode is brittleness when encountering unexpected directory structures.
-- [ ] You have classified the traffic predictor as a machine learning system and established a constraint that its predictions must be verified against current event plans to account for data drift.
-- [ ] You have accurately classified the autonomous chat bot as an agentic workflow, recognizing that it carries the highest operational risk.
-- [ ] You have designed a trust boundary that prevents the chat bot from executing a database migration without explicit authorization from a senior engineer.
-- [ ] You have compared the risk profiles of rule-based, machine learning, generative AI, and agentic approaches using mechanism, evidence, and blast radius rather than product labels.
-- [ ] You have explained how to evaluate the reliability of an AI-generated operational response before using it in an infrastructure workflow.
+- [ ] You classified at least three everyday tools using the four-category map from this module.
+- [ ] You explained each tool using ordinary language rather than vendor marketing language.
+- [ ] You identified what each tool can see and what private information should stay outside the task.
+- [ ] You identified what each tool can change and which actions need human approval.
+- [ ] You named at least one external evidence check for an important AI-generated claim.
+- [ ] You can explain why fluency, recommendations, and tool access require different levels of trust.
+
+## Next Module
+
+Continue to [What Are LLMs?](./module-1.2-what-are-llms/) to learn why modern chatbots can respond in natural language and why that ability is useful but not the same as guaranteed understanding.
 
 ## Sources
 
-- [oecd.ai: definition](https://oecd.ai/en/wonk/definition-) — The OECD page directly says the definition was revised in 2023 and quotes the updated wording about inferring from inputs to generate predictions, content, recommendations, or decisions.
-- [nist.gov: nist ai rmf playbook](https://www.nist.gov/itl/ai-risk-management-framework/nist-ai-rmf-playbook) — The NIST Playbook page explicitly states AI RMF 1.0 was released on January 26, 2023 and names the four functions as Govern, Map, Measure, and Manage.
-- [Kubernetes Configuration Overview](https://kubernetes.io/docs/concepts/configuration/overview/) — Useful follow-up for the module's repeated point that generated infrastructure changes still need verification against official platform documentation.
+- [OECD.AI: What is AI? Can you make a clear distinction between AI and non-AI systems?](https://oecd.ai/en/wonk/definition-)
+- [OECD AI Principles](https://oecd.ai/en/ai-principles)
+- [NIST AI Risk Management Framework Playbook](https://www.nist.gov/itl/ai-risk-management-framework/nist-ai-rmf-playbook)
+- [NIST AI Risk Management Framework](https://www.nist.gov/itl/ai-risk-management-framework)
+- [NIST AI Risk Management Framework: Generative Artificial Intelligence Profile](https://www.nist.gov/publications/artificial-intelligence-risk-management-framework-generative-artificial-intelligence-profile)
+- [NIST Trustworthy and Responsible AI](https://www.nist.gov/artificial-intelligence/trustworthy-and-responsible-ai)
+- [Google Machine Learning Crash Course](https://developers.google.com/machine-learning/crash-course)
+- [Google People + AI Guidebook](https://pair.withgoogle.com/guidebook)
+- [Stanford AI Index Report](https://aiindex.stanford.edu/report/)
+- [IBM: What is machine learning?](https://www.ibm.com/topics/machine-learning)

--- a/src/content/docs/ai/foundations/module-1.6-using-ai-for-learning-writing-research-and-coding.md
+++ b/src/content/docs/ai/foundations/module-1.6-using-ai-for-learning-writing-research-and-coding.md
@@ -455,4 +455,4 @@ Success criteria:
 
 ## Next Module
 
-Continue to [AI-Native Work](../../ai-native-work/) to examine how workflows, tools, and team practices change when AI becomes a regular part of engineering delivery.
+Continue to [AI Engineering Foundations](../../ai-engineering-foundations/) to learn the prompt, context, safety, and workflow foundations that bridge AI literacy into disciplined AI-supported engineering work.


### PR DESCRIPTION
## What

AI literacy track — semantic coherence. Authored by **codex (gpt-5.5)**, grounded against OECD AI definition + NIST AI RMF. Cross-family reviewer: **composer-2.5**.

## Fixes

**#2138 — module 1.1 'What Is AI?' was written for SREs, not the zero-background beginners the track promises.**
The track (`ai/index.md:24`) promises *"learners starting from zero AI background"* and (`:114`) a bridge *"without throwing beginners into deep infrastructure too early."* The opener contradicted that: prereqs were *"Basic scripting literacy, basic infrastructure terminology"*, outcomes were all infrastructure-automation / agentic-workflow / trust-boundary, and 'Why This Module Matters' opened on an SRE database-latency incident.
Re-leveled:
- Prerequisites → *"Curiosity, basic computer use"* (no scripting/infra).
- Outcomes rewritten in plain language, keeping the four-category taxonomy (rule-based / ML / generative / agentic) taught from everyday examples (spam filters, photo apps, streaming, chatbots, a travel assistant).
- Opener replaced with a beginner-relatable weekend-trip scenario (`Hypothetical scenario:` label retained per anti-fabrication policy).

**#2140 — foundations 'Next Section' skipped AI Engineering Foundations.**
- `ai/foundations/index.md` and the last module (`module-1.6`) both now point to **AI Engineering Foundations** (were → AI-Native Work).

## Verification
- `npm run build` green; `check_site_health.py` 0 errors.
- `verify_module.py`: **all gates pass** (density median 70 / mean 68.5 wpp, short-para 2.7%, outcomes aligned, anti-fabrication clean, 10 sources 0×404, tier T0).
- No `Complexity`/`sidebar.order` edits (kept for #2141/#2139).

Refs #2138 #2140