### PR TITLE
docs(cloud): break EKS/GKE/AKS prerequisite cycle (#2155)

### DIFF
--- a/src/content/docs/cloud/aks-deep-dive/index.md
+++ b/src/content/docs/cloud/aks-deep-dive/index.md
@@ -26,7 +26,7 @@ AKS is the fastest-growing managed Kubernetes service, tightly integrated with t
 ## Prerequisites
 
 - [Azure DevOps Essentials](../azure-essentials/) -- Entra ID, VNets, VMs, Storage fundamentals
-- [Cloud Architecture Patterns](../architecture-patterns/) -- managed K8s trade-offs, multi-cluster, IAM integration
+- *Recommended companion (not required first):* [Cloud Architecture Patterns](../architecture-patterns/) -- managed K8s trade-offs, multi-cluster, and IAM integration; helpful for deeper cross-cloud tradeoffs after this section
 
 ## What's Next
 

--- a/src/content/docs/cloud/eks-deep-dive/index.md
+++ b/src/content/docs/cloud/eks-deep-dive/index.md
@@ -26,7 +26,7 @@ EKS is the most widely deployed managed Kubernetes service. This track covers th
 ## Prerequisites
 
 - [AWS DevOps Essentials](../aws-essentials/) -- IAM, VPC, EC2, S3 fundamentals
-- [Cloud Architecture Patterns](../architecture-patterns/) -- managed K8s trade-offs, multi-cluster, IAM integration
+- *Recommended companion (not required first):* [Cloud Architecture Patterns](../architecture-patterns/) -- managed K8s trade-offs, multi-cluster, and IAM integration; helpful for deeper cross-cloud tradeoffs after this section
 
 ## What's Next
 

--- a/src/content/docs/cloud/gke-deep-dive/index.md
+++ b/src/content/docs/cloud/gke-deep-dive/index.md
@@ -26,7 +26,7 @@ GKE is the most opinionated managed Kubernetes service, with features like Autop
 ## Prerequisites
 
 - [GCP DevOps Essentials](../gcp-essentials/) -- IAM, VPC, Compute Engine fundamentals
-- [Cloud Architecture Patterns](../architecture-patterns/) -- managed K8s trade-offs, multi-cluster, IAM integration
+- *Recommended companion (not required first):* [Cloud Architecture Patterns](../architecture-patterns/) -- managed K8s trade-offs, multi-cluster, and IAM integration; helpful for deeper cross-cloud tradeoffs after this section
 
 ## What's Next
 


### PR DESCRIPTION
Confirmed structural bug. All 3 deep-dives listed Cloud Architecture Patterns as a hard `## Prerequisites` item, but the hub route places AP *after* the deep-dives → unsatisfiable ordering. Relabeled AP as a *recommended companion (not required first)* in all 3 (eks/gke/aks), hub route untouched. Author cursor(composer-2.5); reviewer codex. Refs #2155