### PR TITLE
docs(linux): fix system-essentials false entry-point framing (#2152)

### DIFF
--- a/src/content/docs/linux/foundations/system-essentials/index.md
+++ b/src/content/docs/linux/foundations/system-essentials/index.md
@@ -29,7 +29,7 @@ Every single thing you do on Linux touches these concepts:
 
 ## Prerequisites
 
-None. This is where you start.
+- [Everyday Use](../everyday-use/) — Shell commands, navigation, process tools, and daily workflows
 
 ## Key Takeaways
 


### PR DESCRIPTION
system-essentials/index.md claimed 'None. This is where you start' but the Linux hub places it after Everyday Use. Now cites Everyday Use as prior context. Author deepseek; reviewer opus (inline, cross-family). Refs #2152