### PR TITLE
docs(platform): fix distributed-systems terminal-claim + mlops k8s gate (#2163 #2164)

### DIFF
--- a/src/content/docs/platform/disciplines/data-ai/mlops/index.md
+++ b/src/content/docs/platform/disciplines/data-ai/mlops/index.md
@@ -19,7 +19,7 @@ Before starting this track:
 - Basic machine learning concepts (training, inference, models)
 - Python programming experience
 - Understanding of CI/CD concepts
-- Kubernetes basics (helpful but not required)
+- At least one Kubernetes route, such as Kubernetes Basics, KCNA, CKA, or equivalent production experience; the model-serving and pipeline modules assume Pods, Services, Deployments, namespaces, and YAML are familiar
 
 ## Modules
 

--- a/src/content/docs/platform/foundations/distributed-systems/index.md
+++ b/src/content/docs/platform/foundations/distributed-systems/index.md
@@ -93,7 +93,7 @@ START HERE
 └──────────────────┬──────────────────┘
                    │
                    ▼
-           FOUNDATIONS COMPLETE
+           READY TO APPLY
                    │
     ┌──────────────┼──────────────┐
     │              │              │
@@ -182,9 +182,9 @@ Papers:
 
 ---
 
-## Foundations Complete
+## Applying These Foundations
 
-This is the final track in the Foundations series. You've now covered:
+Distributed Systems is one foundation area, not the end of the Foundations section. It connects several earlier mental models:
 
 1. **Systems Thinking**: See systems as interconnected wholes
 2. **Reliability Engineering**: Design for failure, measure with SLOs
@@ -192,7 +192,7 @@ This is the final track in the Foundations series. You've now covered:
 4. **Security Principles**: Defense in depth, least privilege
 5. **Distributed Systems**: Consensus, consistency, coordination, ordering
 
-These foundations prepare you for the practical Disciplines and Toolkits tracks.
+These foundations prepare you to make practical tradeoffs in Disciplines and Toolkits, while later Foundations topics such as networking, eBPF, and leadership add more depth for specific platform routes.
 
 ---
 


### PR DESCRIPTION
#2163 distributed-systems claimed 'FOUNDATIONS COMPLETE / final track' though it's 1 of 7; #2164 mlops said 'Kubernetes helpful but not required' vs the Disciplines k8s entry gate. Reframed both against the platform hub. Author codex(gpt-5.5); reviewer composer-2.5. Refs #2163 #2164