### PR TITLE
docs(k8s): fix CKA/CKAD validity + part3 nav + CKS 5.3 header + cert counts (#2175 #2177 #2178)

### DIFF
--- a/src/content/docs/k8s/cka/index.md
+++ b/src/content/docs/k8s/cka/index.md
@@ -16,23 +16,23 @@ The CKA is a **hands-on, performance-based exam** that validates your skills in 
 | **Duration** | 2 hours |
 | **Questions** | 15-20 tasks |
 | **Passing Score** | 66% |
-| **Validity** | 3 years |
+| **Validity** | 2 years |
 
 ## Curriculum Structure
 
 | Part | Topic | Weight | Modules |
 |------|-------|--------|---------|
-| Part 0 | Environment | - | 6 |
-| Part 1 | Cluster Architecture, Installation & Configuration | 25% | 8 |
-| Part 2 | Workloads & Scheduling | 15% | 8 |
+| Part 0 | Environment | - | 5 |
+| Part 1 | Cluster Architecture, Installation & Configuration | 25% | 7 |
+| Part 2 | Workloads & Scheduling | 15% | 9 |
 | Part 3 | Services & Networking | 20% | 8 |
-| Part 4 | Storage | 10% | 6 |
-| Part 5 | Troubleshooting | 30% | 8 |
-| **Total** | | **100%** | **44** |
+| Part 4 | Storage | 10% | 5 |
+| Part 5 | Troubleshooting | 30% | 7 |
+| **Total** | | **100%** | **41** |
 
 ## Module Overview
 
-### Part 0: Environment (6 modules)
+### Part 0: Environment (5 modules)
 - 0.1 Cluster Setup - Creating practice clusters
 - 0.2 Shell Mastery - bash, aliases, autocompletion
 - 0.3 Vim and YAML - Efficient editing
@@ -40,7 +40,7 @@ The CKA is a **hands-on, performance-based exam** that validates your skills in 
 - 0.5 Exam Strategy - Three-pass approach
 - Part 0 Cumulative Quiz
 
-### Part 1: Cluster Architecture (8 modules)
+### Part 1: Cluster Architecture (7 modules)
 - 1.1 Control Plane - API server, etcd, scheduler
 - 1.2 Extension Interfaces - CNI, CSI, CRI
 - 1.3 Helm - Package management
@@ -50,7 +50,7 @@ The CKA is a **hands-on, performance-based exam** that validates your skills in 
 - 1.7 kubeadm - Cluster bootstrap and upgrades
 - Part 1 Cumulative Quiz
 
-### Part 2: Workloads & Scheduling (8 modules)
+### Part 2: Workloads & Scheduling (9 modules)
 - 2.1 Pods - Core workload unit
 - 2.2 Deployments - Application management
 - 2.3 DaemonSets & StatefulSets - Specialized workloads
@@ -70,9 +70,10 @@ The CKA is a **hands-on, performance-based exam** that validates your skills in 
 - 3.5 Gateway API - Next-gen ingress
 - 3.6 Network Policies - Traffic control
 - 3.7 CNI - Container networking
+- 3.8 Cluster Networking Data Path - Packet flow and node routing
 - Part 3 Cumulative Quiz
 
-### Part 4: Storage (6 modules)
+### Part 4: Storage (5 modules)
 - 4.1 Volumes - Storage basics
 - 4.2 PV and PVC - Persistent storage
 - 4.3 StorageClasses - Dynamic provisioning
@@ -80,7 +81,7 @@ The CKA is a **hands-on, performance-based exam** that validates your skills in 
 - 4.5 Storage Troubleshooting - Common issues
 - Part 4 Cumulative Quiz
 
-### Part 5: Troubleshooting (8 modules)
+### Part 5: Troubleshooting (7 modules)
 - 5.1 Methodology - Systematic approach
 - 5.2 Application Failures - Pod and container issues
 - 5.3 Control Plane - API server, etcd problems

--- a/src/content/docs/k8s/cka/part3-services-networking/module-3.7-cni.md
+++ b/src/content/docs/k8s/cka/part3-services-networking/module-3.7-cni.md
@@ -1008,4 +1008,4 @@ Success criteria:
 
 ## Next Module
 
-Continue to the [Part 3 Cumulative Quiz](../part3-cumulative-quiz/) to test the full Services and Networking stack, including Services, DNS, Ingress, Gateway API, NetworkPolicy, and CNI troubleshooting.
+Continue to [Module 3.8: Cluster Networking Data Path](../module-3.8-cluster-networking-data-path/) to connect CNI behavior with packet flow, routing, NAT, and node-level forwarding.

--- a/src/content/docs/k8s/cka/part3-services-networking/module-3.8-cluster-networking-data-path.md
+++ b/src/content/docs/k8s/cka/part3-services-networking/module-3.8-cluster-networking-data-path.md
@@ -1012,4 +1012,4 @@ kubectl delete svc trace-svc
 
 ## Next Module
 
-[Module 3.3: DNS in Kubernetes](../module-3.3-dns/) - Deep-dive into CoreDNS configuration, custom DNS policies, and advanced troubleshooting.
+Continue to the [Part 3 Cumulative Quiz](../part3-cumulative-quiz/) to test the full Services and Networking stack, including Services, DNS, Ingress, Gateway API, NetworkPolicy, CNI, and the cluster networking data path.

--- a/src/content/docs/k8s/ckad/index.md
+++ b/src/content/docs/k8s/ckad/index.md
@@ -16,42 +16,42 @@ The CKAD is a **hands-on, performance-based exam** that validates your ability t
 | **Duration** | 2 hours |
 | **Questions** | 15-20 tasks |
 | **Passing Score** | 66% |
-| **Validity** | 3 years |
+| **Validity** | 2 years |
 
 ## Curriculum Structure
 
 | Part | Topic | Weight | Modules |
 |------|-------|--------|---------|
-| Part 0 | Environment | - | 3 |
-| Part 1 | Application Design and Build | 20% | 5 |
-| Part 2 | Application Deployment | 20% | 5 |
-| Part 3 | Application Observability and Maintenance | 15% | 6 |
-| Part 4 | Application Environment, Configuration, Security | 25% | 7 |
-| Part 5 | Services and Networking | 20% | 4 |
-| **Total** | | **100%** | **30** |
+| Part 0 | Environment | - | 2 |
+| Part 1 | Application Design and Build | 20% | 4 |
+| Part 2 | Application Deployment | 20% | 4 |
+| Part 3 | Application Observability and Maintenance | 15% | 5 |
+| Part 4 | Application Environment, Configuration, Security | 25% | 6 |
+| Part 5 | Services and Networking | 20% | 3 |
+| **Total** | | **100%** | **24** |
 
 ## Module Overview
 
-### Part 0: Environment (3 modules)
+### Part 0: Environment (2 modules)
 - 0.1 CKAD Overview - Exam format and domains
 - 0.2 Developer Workflow - Setting up your environment
 - Part 0 Cumulative Quiz
 
-### Part 1: Application Design and Build (5 modules)
+### Part 1: Application Design and Build (4 modules)
 - 1.1 Container Images - Building and managing images
 - 1.2 Jobs and CronJobs - Batch workloads
 - 1.3 Multi-Container Pods - Sidecar, init containers
 - 1.4 Volumes - Storage for applications
 - Part 1 Cumulative Quiz
 
-### Part 2: Application Deployment (5 modules)
+### Part 2: Application Deployment (4 modules)
 - 2.1 Deployments - Rolling updates, rollbacks
 - 2.2 Helm - Package management
 - 2.3 Kustomize - Configuration customization
 - 2.4 Deployment Strategies - Blue-green, canary
 - Part 2 Cumulative Quiz
 
-### Part 3: Application Observability and Maintenance (6 modules)
+### Part 3: Application Observability and Maintenance (5 modules)
 - 3.1 Probes - Liveness, readiness, startup
 - 3.2 Logging - Container log management
 - 3.3 Debugging - Troubleshooting applications
@@ -59,7 +59,7 @@ The CKAD is a **hands-on, performance-based exam** that validates your ability t
 - 3.5 API Deprecations - Handling version changes
 - Part 3 Cumulative Quiz
 
-### Part 4: Application Environment (7 modules)
+### Part 4: Application Environment (6 modules)
 - 4.1 ConfigMaps - Application configuration
 - 4.2 Secrets - Sensitive data management
 - 4.3 Resources - Requests and limits
@@ -68,7 +68,7 @@ The CKAD is a **hands-on, performance-based exam** that validates your ability t
 - 4.6 CRDs - Custom Resource Definitions
 - Part 4 Cumulative Quiz
 
-### Part 5: Services and Networking (4 modules)
+### Part 5: Services and Networking (3 modules)
 - 5.1 Services - Exposing applications
 - 5.2 Ingress - HTTP routing
 - 5.3 Network Policies - Traffic control

--- a/src/content/docs/k8s/cks/part5-supply-chain-security/module-5.3-static-analysis.md
+++ b/src/content/docs/k8s/cks/part5-supply-chain-security/module-5.3-static-analysis.md
@@ -4,6 +4,13 @@ slug: k8s/cks/part5-supply-chain-security/module-5.3-static-analysis
 sidebar:
   order: 3
 ---
+> **Complexity**: `[MEDIUM]` - Critical CKS skill
+>
+> **Time to Complete**: 45 minutes
+>
+> **Prerequisites**: Module 5.2 (Image Scanning) and Kubernetes manifests
+
+---
 
 ## What You'll Be Able to Do
 

--- a/src/content/docs/k8s/index.md
+++ b/src/content/docs/k8s/index.md
@@ -98,10 +98,10 @@ Specialist certifications are not a better first move than learning the core Kub
 |------|------|------|---------|------------|
 | [KCNA](/k8s/kcna/) | Kubernetes & Cloud Native Associate | Multiple choice | 28 | [Details](/k8s/kcna/) |
 | [KCSA](/k8s/kcsa/) | Kubernetes & Cloud Native Security Associate | Multiple choice | 26 | [Details](/k8s/kcsa/) |
-| [CKAD](/k8s/ckad/) | Certified Kubernetes Application Developer | Hands-on lab | 30 | [Details](/k8s/ckad/) |
-| [CKA](/k8s/cka/) | Certified Kubernetes Administrator | Hands-on lab | 47 | [Details](/k8s/cka/) |
+| [CKAD](/k8s/ckad/) | Certified Kubernetes Application Developer | Hands-on lab | 24 | [Details](/k8s/ckad/) |
+| [CKA](/k8s/cka/) | Certified Kubernetes Administrator | Hands-on lab | 41 | [Details](/k8s/cka/) |
 | [CKS](/k8s/cks/) | Certified Kubernetes Security Specialist | Hands-on lab | 30 | [Details](/k8s/cks/) |
-| | **Total** | | **161** | |
+| | **Total** | | **149** | |
 
 ---
 

--- a/src/content/docs/k8s/kcna/index.md
+++ b/src/content/docs/k8s/kcna/index.md
@@ -25,11 +25,11 @@ The KCNA is a **multiple-choice exam** (not hands-on) that validates foundationa
 | Part | Topic | Weight | Modules |
 |------|-------|--------|---------|
 | [Part 0](part0-introduction/) | Introduction | - | 2 |
-| [Part 1](part1-kubernetes-fundamentals/) | Kubernetes Fundamentals | 44% | 8 |
+| [Part 1](part1-kubernetes-fundamentals/) | Kubernetes Fundamentals | 44% | 9 |
 | [Part 2](part2-container-orchestration/) | Container Orchestration | 28% | 4 |
-| [Part 3](part3-cloud-native-architecture/) | Cloud Native Architecture | 12% | 8 |
-| [Part 4](part4-application-delivery/) | Application Delivery | 16% | 2 |
-| **Total** | | **100%** | **24** |
+| [Part 3](part3-cloud-native-architecture/) | Cloud Native Architecture | 12% | 10 |
+| [Part 4](part4-application-delivery/) | Application Delivery | 16% | 3 |
+| **Total** | | **100%** | **28** |
 
 ## Module Overview
 
@@ -37,7 +37,7 @@ The KCNA is a **multiple-choice exam** (not hands-on) that validates foundationa
 - [0.1 KCNA Overview](part0-introduction/module-0.1-kcna-overview/) - Exam format and domains
 - [0.2 Study Strategy](part0-introduction/module-0.2-study-strategy/) - Multiple-choice exam techniques
 
-### Part 1: Kubernetes Fundamentals (8 modules) — 44%
+### Part 1: Kubernetes Fundamentals (9 modules) — 44%
 - [1.1 What is Kubernetes](part1-kubernetes-fundamentals/module-1.1-what-is-kubernetes/) - Purpose and architecture
 - [1.2 Container Fundamentals](part1-kubernetes-fundamentals/module-1.2-container-fundamentals/) - Container concepts
 - [1.3 Control Plane](part1-kubernetes-fundamentals/module-1.3-control-plane/) - API server, etcd, scheduler
@@ -46,6 +46,7 @@ The KCNA is a **multiple-choice exam** (not hands-on) that validates foundationa
 - [1.6 Workload Resources](part1-kubernetes-fundamentals/module-1.6-workload-resources/) - Deployments, StatefulSets
 - [1.7 Services](part1-kubernetes-fundamentals/module-1.7-services/) - Service types and discovery
 - [1.8 Namespaces and Labels](part1-kubernetes-fundamentals/module-1.8-namespaces-labels/) - Organization
+- [1.9 Debugging Basics](part1-kubernetes-fundamentals/module-1.9-debugging-basics/) - Basic troubleshooting theory
 
 ### Part 2: Container Orchestration (4 modules) — 28%
 - [2.1 Scheduling](part2-container-orchestration/module-2.1-scheduling/) - How pods get assigned
@@ -53,7 +54,7 @@ The KCNA is a **multiple-choice exam** (not hands-on) that validates foundationa
 - [2.3 Storage](part2-container-orchestration/module-2.3-storage/) - PV, PVC, StorageClass
 - [2.4 Configuration](part2-container-orchestration/module-2.4-configuration/) - ConfigMaps and Secrets
 
-### Part 3: Cloud Native Architecture (8 modules) — 12%
+### Part 3: Cloud Native Architecture (10 modules) — 12%
 *Includes Observability (merged November 2025)*
 
 - [3.1 Cloud Native Principles](part3-cloud-native-architecture/module-3.1-cloud-native-principles/) - 12-factor apps
@@ -61,13 +62,16 @@ The KCNA is a **multiple-choice exam** (not hands-on) that validates foundationa
 - [3.3 Cloud Native Patterns](part3-cloud-native-architecture/module-3.3-patterns/) - Service mesh, GitOps
 - [3.4 Observability Fundamentals](part3-cloud-native-architecture/module-3.4-observability-fundamentals/) - Metrics, logs, traces
 - [3.5 Observability Tools](part3-cloud-native-architecture/module-3.5-observability-tools/) - Prometheus, Grafana, Jaeger
+- [3.6 Security Basics](part3-cloud-native-architecture/module-3.6-security-basics/) - Cloud native security foundations
+- [3.7 Community and Collaboration](part3-cloud-native-architecture/module-3.7-community-collaboration/) - CNCF governance, SIGs, and project collaboration
 - [3.8 AI/ML in Cloud Native](part3-cloud-native-architecture/module-3.8-ai-ml-cloud-native/) - AI/LLM workloads, GPU scheduling, model serving
 - [3.9 WebAssembly](part3-cloud-native-architecture/module-3.9-webassembly/) - Wasm as container alternative, WASI, SpinKube
 - [3.10 Green Computing & Sustainability](part3-cloud-native-architecture/module-3.10-green-computing/) - Carbon-aware scheduling, resource efficiency
 
-### Part 4: Application Delivery (2 modules) — 16%
+### Part 4: Application Delivery (3 modules) — 16%
 - [4.1 CI/CD Fundamentals](part4-application-delivery/module-4.1-ci-cd/) - Pipelines and deployment
 - [4.2 Application Packaging](part4-application-delivery/module-4.2-application-packaging/) - Helm and Kustomize
+- [4.3 Release Strategies](part4-application-delivery/module-4.3-release-strategies/) - Progressive delivery and rollout patterns
 
 ## How to Use This Curriculum
 

--- a/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.5-observability-tools.md
+++ b/src/content/docs/k8s/kcna/part3-cloud-native-architecture/module-3.5-observability-tools.md
@@ -629,4 +629,4 @@ Success criteria:
 
 ## Next Module
 
-Part 3 is complete. Continue to [Part 4: Application Delivery](/k8s/kcna/part4-application-delivery/module-4.1-ci-cd/) to connect cloud native architecture with CI/CD, deployment strategies, and the release workflows that observability helps protect.
+Continue to [Module 3.6: Security Basics](/k8s/kcna/part3-cloud-native-architecture/module-3.6-security-basics/) to connect observability signals with the security foundations that keep cloud native systems trustworthy.

--- a/src/content/docs/k8s/kcsa/index.md
+++ b/src/content/docs/k8s/kcsa/index.md
@@ -27,10 +27,10 @@ The KCSA is a **multiple-choice exam** (not hands-on) that validates foundationa
 | [Part 1](part1-cloud-native-security/) | Overview of Cloud Native Security | 14% | 3 |
 | [Part 2](part2-cluster-component-security/) | Kubernetes Cluster Component Security | 22% | 4 |
 | [Part 3](part3-security-fundamentals/) | Kubernetes Security Fundamentals | 22% | 5 |
-| [Part 4](part4-threat-model/) | Kubernetes Threat Model | 16% | 4 |
+| [Part 4](part4-threat-model/) | Kubernetes Threat Model | 16% | 5 |
 | [Part 5](part5-platform-security/) | Platform Security | 16% | 4 |
 | [Part 6](part6-compliance/) | Compliance and Security Frameworks | 10% | 3 |
-| **Total** | | **100%** | **25** |
+| **Total** | | **100%** | **26** |
 
 ## Module Overview
 
@@ -56,11 +56,12 @@ The KCSA is a **multiple-choice exam** (not hands-on) that validates foundationa
 - [3.4 ServiceAccount Security](part3-security-fundamentals/module-3.4-serviceaccounts/) - Identity and tokens
 - [3.5 Network Policies](part3-security-fundamentals/module-3.5-network-policies/) - Traffic control
 
-### Part 4: Kubernetes Threat Model - 16% (4 modules)
+### Part 4: Kubernetes Threat Model - 16% (5 modules)
 - [4.1 Attack Surfaces](part4-threat-model/module-4.1-attack-surfaces/) - Where vulnerabilities exist
 - [4.2 Common Vulnerabilities](part4-threat-model/module-4.2-vulnerabilities/) - CVEs and misconfigurations
 - [4.3 Container Escape](part4-threat-model/module-4.3-container-escape/) - Breakout scenarios
 - [4.4 Supply Chain Threats](part4-threat-model/module-4.4-supply-chain/) - Image and dependency risks
+- [4.5 Threat Modeling & Supply Chain Theory](part4-threat-model/module-4.5-threat-modeling-supply-chain-theory/) - Supply chain threat analysis
 
 ### Part 5: Platform Security - 16% (4 modules)
 - [5.1 Image Security](part5-platform-security/module-5.1-image-security/) - Scanning and signing


### PR DESCRIPTION
GLM k8s re-audit findings, ground-checked + web-verified. CKA/CKAD validity 3yr→**2yr** (orchestrator web-verified LF: 'Valid for 2 Years'); CKA 3.7→3.8→quiz nav repaired (3.8 was pointing backward to 3.3); KCNA 3.5→3.6 skip repaired; CKS 5.3 header block added; stale cert counts reconciled to disk (CKA 41 / CKAD 24 / KCNA 28 / KCSA 26 / hub 149). Author codex; reviewer GLM-5.2 via Hermes (first fleet dispatch) + orchestrator ground-check.

## Learner check
> Most Kubernetes security failures do not begin with an exotic exploit. They begin with an ordinary manifest that grants more authority than the workload needs, leaves a default open, or assumes that the deployment path is more controlled than it really is.

Refs #2175 #2177 #2178