### PR TITLE
docs(linux): wire in 8.x sysadmin group + reconcile everyday-use theory promise (#2179 #2180)

### DIFF
--- a/src/content/docs/linux/foundations/everyday-use/index.md
+++ b/src/content/docs/linux/foundations/everyday-use/index.md
@@ -8,7 +8,7 @@ sidebar:
 
 You've finished Zero to Terminal — you know what a terminal is and can run basic commands. Now it's time to build real muscle memory with the tools you'll use every single day as a DevOps engineer.
 
-These 5 modules bridge the gap between "I can use a terminal" and "I understand how Linux works under the hood." No theory, no kernel internals — just hands-on practice with the tools that matter.
+These 5 modules bridge the gap between "I can use a terminal" and "I understand how Linux works under the hood." Minimal theory, focused on the practical mental models you need — hands-on practice with the tools that matter.
 
 ---
 

--- a/src/content/docs/linux/operations/index.md
+++ b/src/content/docs/linux/operations/index.md
@@ -10,10 +10,13 @@ In this section, you will explore the critical day-to-day operations required to
 
 You will also find advanced sub-sections dedicated to performance analysis, systematic troubleshooting, and automation through shell scripting. Together, these topics ensure you can diagnose issues quickly, optimize resource utilization, and automate repetitive tasks at scale.
 
+After [Security and Hardening](/linux/security/hardening/), follow the modules in this order: **System Administration** (8.x) → **Performance** → **Troubleshooting** → **Shell Scripting**.
+
 ## Sections
 
 | Section | Description |
 |---------|-------------|
+| [System Administration](module-8.1-storage-management/) | Storage, network, package, user, scheduling, and backup administration |
 | [Performance](performance/) | USE method, CPU scheduling, memory management, and I/O performance |
 | [Troubleshooting](troubleshooting/) | Systematic troubleshooting, log analysis, process and network debugging |
 | [Shell Scripting](shell-scripting/) | Bash fundamentals, text processing, practical scripts, and DevOps automation |

--- a/src/content/docs/linux/operations/module-8.2-network-administration.md
+++ b/src/content/docs/linux/operations/module-8.2-network-administration.md
@@ -987,4 +987,4 @@ sudo nmcli connection delete static-eth0
 
 ## Next Module
 
-You've now covered the key LFCS gaps in storage and networking. Return to the [LFCS Learning Path](/k8s/lfcs/) to review remaining study areas, or continue strengthening your Linux fundamentals with [Module 5.1: The USE Method](/linux/operations/performance/module-5.1-use-method/) for performance analysis.
+Continue with [Module 8.3: Package Management & User Administration](../module-8.3-package-user-management/) to manage software packages, users, groups, and sudo access on production Linux hosts.

--- a/src/content/docs/linux/operations/module-8.4-scheduling-backups.md
+++ b/src/content/docs/linux/operations/module-8.4-scheduling-backups.md
@@ -994,4 +994,4 @@ Cleanup is part of the exercise because temporary schedules can become permanent
 
 ## Next Module
 
-You now have the skills to automate recurring work and protect data with restore-tested backups. Return to the [LFCS Learning Path](/k8s/lfcs/) to review remaining study areas, or revisit [Module 8.1: Storage Management](../module-8.1-storage-management/) if you want to combine LVM snapshots with your backup strategy.
+You now have the skills to automate recurring work and protect data with restore-tested backups. Next, continue to [Module 5.1: The USE Method](/linux/operations/performance/module-5.1-use-method/) to analyze how those administered systems behave under real workload pressure. For LFCS exam prep, see the [LFCS Learning Path](/k8s/lfcs/).

--- a/src/content/docs/linux/operations/performance/index.md
+++ b/src/content/docs/linux/operations/performance/index.md
@@ -45,6 +45,6 @@ After completing this section, you'll understand:
 
 ## Related Sections
 
-- **Previous**: [Security Hardening](../../security/hardening/)
+- **Previous**: [System Administration](../module-8.4-scheduling-backups/)
 - **Next**: [Troubleshooting](../troubleshooting/)
 - **CKA/CKAD**: Resource management, pod scheduling

--- a/src/content/docs/linux/security/hardening/index.md
+++ b/src/content/docs/linux/security/hardening/index.md
@@ -46,5 +46,5 @@ After completing this section, you'll understand:
 ## Related Sections
 
 - **Previous**: [Networking](../../foundations/networking/)
-- **Next**: [Operations/Performance](../../operations/performance/)
+- **Next**: [System Administration](../../operations/module-8.1-storage-management/)
 - **CKS**: Directly tested in System Hardening domain

--- a/src/content/docs/linux/security/hardening/module-4.4-seccomp.md
+++ b/src/content/docs/linux/security/hardening/module-4.4-seccomp.md
@@ -753,7 +753,7 @@ The broken profile allows only `exit_group`, so even a simple `echo` cannot perf
 
 ## Next Module
 
-You have completed the Security and Hardening sequence: kernel hardening, AppArmor, SELinux, and seccomp now fit together as layered Linux controls. Next, continue to [Operations and Performance](/linux/operations/) to analyze how hardened systems behave under real workload pressure.
+You have completed the Security and Hardening sequence: kernel hardening, AppArmor, SELinux, and seccomp now fit together as layered Linux controls. Next, continue to [Module 8.1: Storage Management](/linux/operations/module-8.1-storage-management/) to apply those hardened foundations to day-to-day system administration.
 
 ## Sources
 


### PR DESCRIPTION
GLM Linux re-audit findings, ground-checked. **#2179**: the System Administration group (module-8.1–8.4) sat loose at `operations/` root, unreachable from the route — now wired in: Security Hardening → **System Administration (8.x)** → Performance → Troubleshooting → Shell Scripting (operations/index route + Next/Previous links across security-hardening, 8.2, 8.4, performance). **#2180**: `everyday-use/index` 'No theory, no kernel internals' softened to 'Minimal theory, focused on the practical mental models you need' (module 0.4 teaches systemd). Author cursor; reviewer GLM-5.2 via **OpenCode** (depth test).

## Learner check
> Before starting this module, make sure you are comfortable reading service state, interpreting basic filesystem layout, and thinking about Unix permissions.

Refs #2179 #2180