### PR TITLE
fix(dispatch): capture opencode run via --format json for clean agentic output (#2171)

### DIFF
--- a/scripts/dispatch_smart.py
+++ b/scripts/dispatch_smart.py
@@ -517,6 +517,65 @@ def _opencode_binary() -> str:
     )
 
 
+def _parse_opencode_json_events(stdout: str) -> str:
+    """Extract the final assistant message from opencode ``--format json`` NDJSON.
+
+  Empirical schema (opencode run --format json, one JSON object per line):
+
+  - ``step_start``: agent turn begins; ``part.messageID`` identifies the turn.
+  - ``tool_use``: tool invocation; ignore for response capture.
+  - ``text``: assistant output chunk; final text is in ``part.text``.
+  - ``step_finish``: turn ends; ``part.reason`` is ``stop`` (final reply) or
+    ``tool-calls`` (intermediate turn).
+
+  Concatenate all ``text`` chunks for the message whose ``step_finish`` has
+  ``reason=stop``. Fall back to the last message that emitted text.
+  """
+    texts_by_message: dict[str, list[str]] = {}
+    message_order: list[str] = []
+    final_message_id: str | None = None
+
+    for line in stdout.splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        try:
+            event = json.loads(line)
+        except json.JSONDecodeError:
+            continue
+        if not isinstance(event, dict):
+            continue
+
+        event_type = event.get("type")
+        part = event.get("part")
+        if not isinstance(part, dict):
+            part = {}
+
+        if event_type == "text":
+            text = part.get("text")
+            if not isinstance(text, str) or not text:
+                continue
+            message_id = part.get("messageID")
+            if not isinstance(message_id, str):
+                message_id = ""
+            if message_id not in texts_by_message:
+                message_order.append(message_id)
+            texts_by_message.setdefault(message_id, []).append(text)
+        elif event_type == "step_finish" and part.get("reason") == "stop":
+            message_id = part.get("messageID")
+            if isinstance(message_id, str):
+                final_message_id = message_id
+
+    if final_message_id and final_message_id in texts_by_message:
+        return "".join(texts_by_message[final_message_id]).strip()
+
+    for message_id in reversed(message_order):
+        chunks = texts_by_message.get(message_id)
+        if chunks:
+            return "".join(chunks).strip()
+    return ""
+
+
 def _hermes_binary() -> str:
     """Resolve the hermes CLI path with an env override for local installs."""
     return (
@@ -571,7 +630,16 @@ def _hermes_cli_model(model: str) -> str:
 def _router_command(agent: str, model: str, prompt: str) -> list[str]:
     """Build the subprocess command for direct router CLIs."""
     if agent == "opencode":
-        return [_opencode_binary(), "run", "-m", model, "-"]
+        # ``--format json`` emits NDJSON events instead of ANSI TUI output.
+        # Reasoning effort can be overridden via opencode's ``--variant`` flag
+        # (e.g. high, max, minimal); plumb with dispatch_smart ``--variant``
+        # or ``KUBEDOJO_OPENCODE_VARIANT`` when we need per-task effort control.
+        cmd = [_opencode_binary(), "run", "--format", "json"]
+        variant = os.environ.get("KUBEDOJO_OPENCODE_VARIANT", "").strip()
+        if variant:
+            cmd.extend(["--variant", variant])
+        cmd.extend(["-m", model, "-"])
+        return cmd
     if agent == "cursor":
         return [
             _cursor_binary(),
@@ -602,6 +670,16 @@ def _router_command(agent: str, model: str, prompt: str) -> list[str]:
     raise ValueError(f"unsupported direct router agent: {agent}")
 
 
+def _router_subprocess_env(agent: str) -> dict[str, str]:
+    """Return env overrides for direct router CLIs."""
+    env = os.environ.copy()
+    if agent == "opencode":
+        # Prevent git tool calls from paging or blocking on credentials.
+        env.setdefault("GIT_PAGER", "cat")
+        env.setdefault("GIT_TERMINAL_PROMPT", "0")
+    return env
+
+
 def _run_router_agent(
     *,
     agent: str,
@@ -620,6 +698,7 @@ def _run_router_agent(
             cmd,
             input=stdin_payload,
             cwd=cwd,
+            env=_router_subprocess_env(agent),
             text=True,
             capture_output=True,
             check=False,
@@ -632,8 +711,12 @@ def _run_router_agent(
     except OSError as exc:
         return False, "", f"{type(exc).__name__}: {exc}"
 
-    response = proc.stdout or ""
+    raw_stdout = proc.stdout or ""
     stderr = proc.stderr or ""
+    if agent == "opencode":
+        response = _parse_opencode_json_events(raw_stdout)
+    else:
+        response = raw_stdout.strip()
     ok = proc.returncode == 0 and bool(response.strip())
     if not ok and not stderr.strip():
         stderr = f"{agent} exited {proc.returncode} with no stdout"

--- a/src/content/docs/linux/foundations/everyday-use/index.md
+++ b/src/content/docs/linux/foundations/everyday-use/index.md
@@ -8,7 +8,7 @@ sidebar:
 
 You've finished Zero to Terminal — you know what a terminal is and can run basic commands. Now it's time to build real muscle memory with the tools you'll use every single day as a DevOps engineer.
 
-These 5 modules bridge the gap between "I can use a terminal" and "I understand how Linux works under the hood." No theory, no kernel internals — just hands-on practice with the tools that matter.
+These 5 modules bridge the gap between "I can use a terminal" and "I understand how Linux works under the hood." Minimal theory, focused on the practical mental models you need — hands-on practice with the tools that matter.
 
 ---
 

--- a/src/content/docs/linux/operations/index.md
+++ b/src/content/docs/linux/operations/index.md
@@ -10,10 +10,13 @@ In this section, you will explore the critical day-to-day operations required to
 
 You will also find advanced sub-sections dedicated to performance analysis, systematic troubleshooting, and automation through shell scripting. Together, these topics ensure you can diagnose issues quickly, optimize resource utilization, and automate repetitive tasks at scale.
 
+After [Security and Hardening](/linux/security/hardening/), follow the modules in this order: **System Administration** (8.x) → **Performance** → **Troubleshooting** → **Shell Scripting**.
+
 ## Sections
 
 | Section | Description |
 |---------|-------------|
+| [System Administration](module-8.1-storage-management/) | Storage, network, package, user, scheduling, and backup administration |
 | [Performance](performance/) | USE method, CPU scheduling, memory management, and I/O performance |
 | [Troubleshooting](troubleshooting/) | Systematic troubleshooting, log analysis, process and network debugging |
 | [Shell Scripting](shell-scripting/) | Bash fundamentals, text processing, practical scripts, and DevOps automation |

--- a/src/content/docs/linux/operations/module-8.2-network-administration.md
+++ b/src/content/docs/linux/operations/module-8.2-network-administration.md
@@ -987,4 +987,4 @@ sudo nmcli connection delete static-eth0
 
 ## Next Module
 
-You've now covered the key LFCS gaps in storage and networking. Return to the [LFCS Learning Path](/k8s/lfcs/) to review remaining study areas, or continue strengthening your Linux fundamentals with [Module 5.1: The USE Method](/linux/operations/performance/module-5.1-use-method/) for performance analysis.
+Continue with [Module 8.3: Package Management & User Administration](../module-8.3-package-user-management/) to manage software packages, users, groups, and sudo access on production Linux hosts.

--- a/src/content/docs/linux/operations/module-8.4-scheduling-backups.md
+++ b/src/content/docs/linux/operations/module-8.4-scheduling-backups.md
@@ -994,4 +994,4 @@ Cleanup is part of the exercise because temporary schedules can become permanent
 
 ## Next Module
 
-You now have the skills to automate recurring work and protect data with restore-tested backups. Return to the [LFCS Learning Path](/k8s/lfcs/) to review remaining study areas, or revisit [Module 8.1: Storage Management](../module-8.1-storage-management/) if you want to combine LVM snapshots with your backup strategy.
+You now have the skills to automate recurring work and protect data with restore-tested backups. Next, continue to [Module 5.1: The USE Method](/linux/operations/performance/module-5.1-use-method/) to analyze how those administered systems behave under real workload pressure. For LFCS exam prep, see the [LFCS Learning Path](/k8s/lfcs/).

--- a/src/content/docs/linux/operations/performance/index.md
+++ b/src/content/docs/linux/operations/performance/index.md
@@ -45,6 +45,6 @@ After completing this section, you'll understand:
 
 ## Related Sections
 
-- **Previous**: [Security Hardening](../../security/hardening/)
+- **Previous**: [System Administration](../module-8.4-scheduling-backups/)
 - **Next**: [Troubleshooting](../troubleshooting/)
 - **CKA/CKAD**: Resource management, pod scheduling

--- a/src/content/docs/linux/security/hardening/index.md
+++ b/src/content/docs/linux/security/hardening/index.md
@@ -46,5 +46,5 @@ After completing this section, you'll understand:
 ## Related Sections
 
 - **Previous**: [Networking](../../foundations/networking/)
-- **Next**: [Operations/Performance](../../operations/performance/)
+- **Next**: [System Administration](../../operations/module-8.1-storage-management/)
 - **CKS**: Directly tested in System Hardening domain

--- a/src/content/docs/linux/security/hardening/module-4.4-seccomp.md
+++ b/src/content/docs/linux/security/hardening/module-4.4-seccomp.md
@@ -753,7 +753,7 @@ The broken profile allows only `exit_group`, so even a simple `echo` cannot perf
 
 ## Next Module
 
-You have completed the Security and Hardening sequence: kernel hardening, AppArmor, SELinux, and seccomp now fit together as layered Linux controls. Next, continue to [Operations and Performance](/linux/operations/) to analyze how hardened systems behave under real workload pressure.
+You have completed the Security and Hardening sequence: kernel hardening, AppArmor, SELinux, and seccomp now fit together as layered Linux controls. Next, continue to [Module 8.1: Storage Management](/linux/operations/module-8.1-storage-management/) to apply those hardened foundations to day-to-day system administration.
 
 ## Sources
 

--- a/tests/test_dispatch_smart.py
+++ b/tests/test_dispatch_smart.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import json
 import subprocess
 import sys
 from pathlib import Path
@@ -73,6 +74,84 @@ def test_hermes_router_argv_handles_flag_like_prompt() -> None:
     argv = _router_command("hermes", "qwen-3.6-flash", "--provider")
     assert "--oneshot=--provider" in argv
     assert "-z" not in argv
+
+
+def test_opencode_router_argv_uses_json_format() -> None:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    from dispatch_smart import _router_command
+
+    cmd = _router_command("opencode", "zai-coding-plan/glm-5.2", "hello")
+    assert cmd[1:4] == ["run", "--format", "json"]
+    assert cmd[-3:] == ["-m", "zai-coding-plan/glm-5.2", "-"]
+
+
+def test_parse_opencode_json_events_extracts_final_assistant_text() -> None:
+    sys.path.insert(0, str(SCRIPTS_DIR))
+    from dispatch_smart import _parse_opencode_json_events
+
+    ndjson = "\n".join(
+        [
+            json.dumps(
+                {
+                    "type": "step_start",
+                    "part": {"messageID": "msg_tool", "type": "step-start"},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "tool_use",
+                    "part": {"messageID": "msg_tool", "type": "tool", "tool": "bash"},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "step_finish",
+                    "part": {
+                        "messageID": "msg_tool",
+                        "reason": "tool-calls",
+                        "type": "step-finish",
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "step_start",
+                    "part": {"messageID": "msg_final", "type": "step-start"},
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "text",
+                    "part": {
+                        "messageID": "msg_final",
+                        "type": "text",
+                        "text": "VERDICT: ",
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "text",
+                    "part": {
+                        "messageID": "msg_final",
+                        "type": "text",
+                        "text": "APPROVE",
+                    },
+                }
+            ),
+            json.dumps(
+                {
+                    "type": "step_finish",
+                    "part": {
+                        "messageID": "msg_final",
+                        "reason": "stop",
+                        "type": "step-finish",
+                    },
+                }
+            ),
+        ]
+    )
+    assert _parse_opencode_json_events(ndjson) == "VERDICT: APPROVE"
 
 
 def test_codex_draft_default_is_gpt_5_5() -> None:


### PR DESCRIPTION
**⚠ INFRA-LANE — needs infra-orchestrator review/gate before merge (touches scripts/dispatch_smart.py).**

Fixes the OpenCode headless capture bug found in s191: `opencode run` default format streamed ANSI/TUI tool-echoes that polluted + truncated stdout, so GLM-via-OpenCode reviews returned garbage (no verdict) despite the lane working (a trivial `opencode run` prompt returned clean 'PONG'). Fix: opencode path now uses `opencode run --format json`, parses the JSON events for the final assistant message, and sets a non-paging git env. Adds 79 lines of tests; ruff clean.

**Follow-up (next session, after merge):** re-run the depth test — `dispatch_smart review --agent opencode --model zai-coding-plan/glm-5.2` on a small diff — and confirm a clean, complete review verdict. If GLM-via-OpenCode then reaches UI-depth, it becomes the automated headless-audit lane. Also: `--variant <effort>` is opencode's reasoning-effort knob (documented in the diff). Local-only (China-hosted → never CI).

Refs #2171